### PR TITLE
refactor: make each session run its own agent process

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -77,6 +77,17 @@ app.whenReady().then(async () => {
           })
         }
       },
+      onStatusChange: () => {
+        // Broadcast status change to renderer (for isProcessing state)
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          const status = {
+            runningSessions: conductor.getRunningSessionIds().length,
+            sessionIds: conductor.getRunningSessionIds(),
+            processingSessionIds: conductor.getProcessingSessionIds(),
+          }
+          mainWindow.webContents.send(IPC_CHANNELS.AGENT_STATUS, status)
+        }
+      },
     },
   })
   await conductor.initialize()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,13 +5,7 @@ import type { ListSessionsOptions, MulticaSession } from '../shared/types'
 
 // Electron API exposed to renderer process
 const electronAPI: ElectronAPI = {
-  // Agent lifecycle
-  startAgent: (agentId: string) => ipcRenderer.invoke(IPC_CHANNELS.AGENT_START, agentId),
-
-  stopAgent: () => ipcRenderer.invoke(IPC_CHANNELS.AGENT_STOP),
-
-  switchAgent: (agentId: string) => ipcRenderer.invoke(IPC_CHANNELS.AGENT_SWITCH, agentId),
-
+  // Agent status (per-session agents)
   getAgentStatus: () => ipcRenderer.invoke(IPC_CHANNELS.AGENT_STATUS),
 
   // Agent communication
@@ -20,14 +14,16 @@ const electronAPI: ElectronAPI = {
 
   cancelRequest: (sessionId: string) => ipcRenderer.invoke(IPC_CHANNELS.AGENT_CANCEL, sessionId),
 
-  // Session management
-  createSession: (workingDirectory: string) =>
-    ipcRenderer.invoke(IPC_CHANNELS.SESSION_CREATE, workingDirectory),
+  // Session management (agent starts when session is created)
+  createSession: (workingDirectory: string, agentId: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.SESSION_CREATE, workingDirectory, agentId),
 
   listSessions: (options?: ListSessionsOptions) =>
     ipcRenderer.invoke(IPC_CHANNELS.SESSION_LIST, options),
 
   getSession: (sessionId: string) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_GET, sessionId),
+
+  loadSession: (sessionId: string) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_LOAD, sessionId),
 
   resumeSession: (sessionId: string) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_RESUME, sessionId),
 

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -1,25 +1,23 @@
 /**
- * Status bar component - shows agent status and current session info
+ * Status bar component - shows session info and running status
  */
-import type { AgentStatus, MulticaSession } from '../../../shared/types'
+import type { MulticaSession } from '../../../shared/types'
 import { Button } from '@/components/ui/button'
 import { SidebarTrigger, useSidebar } from '@/components/ui/sidebar'
 import { cn } from '@/lib/utils'
 import { Settings } from 'lucide-react'
 
 interface StatusBarProps {
-  agentStatus: AgentStatus
+  runningSessionsCount: number
   currentSession: MulticaSession | null
-  onStartAgent: () => void
-  onStopAgent: () => void
+  isCurrentSessionRunning: boolean
   onOpenSettings: () => void
 }
 
 export function StatusBar({
-  agentStatus,
+  runningSessionsCount,
   currentSession,
-  onStartAgent,
-  onStopAgent,
+  isCurrentSessionRunning,
   onOpenSettings,
 }: StatusBarProps) {
   const { state, isMobile } = useSidebar()
@@ -49,19 +47,12 @@ export function StatusBar({
         )}
       </div>
 
-      {/* Right: Agent status */}
+      {/* Right: Status + Settings */}
       <div className="titlebar-no-drag flex items-center gap-3">
-        <AgentStatusBadge status={agentStatus} />
-
-        {agentStatus.state === 'stopped' ? (
-          <Button size="sm" onClick={onStartAgent}>
-            Start Agent
-          </Button>
-        ) : agentStatus.state === 'running' ? (
-          <Button size="sm" variant="secondary" onClick={onStopAgent}>
-            Stop
-          </Button>
-        ) : null}
+        <SessionStatusBadge
+          isRunning={isCurrentSessionRunning}
+          runningCount={runningSessionsCount}
+        />
 
         <Button variant="ghost" size="icon-sm" onClick={onOpenSettings} title="Settings">
           <Settings className="h-4 w-4" />
@@ -71,32 +62,18 @@ export function StatusBar({
   )
 }
 
-interface AgentStatusBadgeProps {
-  status: AgentStatus
+interface SessionStatusBadgeProps {
+  isRunning: boolean
+  runningCount: number
 }
 
-function AgentStatusBadge({ status }: AgentStatusBadgeProps) {
-  let dotColor = 'bg-gray-500'
-  let text = 'Stopped'
-
-  switch (status.state) {
-    case 'starting':
-      dotColor = 'bg-yellow-500 animate-pulse'
-      text = `Starting ${status.agentId}...`
-      break
-    case 'running':
-      dotColor = 'bg-green-500'
-      text = status.agentId
-      break
-    case 'error':
-      dotColor = 'bg-red-500'
-      text = 'Error'
-      break
-    case 'stopped':
-      dotColor = 'bg-gray-500'
-      text = 'Stopped'
-      break
-  }
+function SessionStatusBadge({ isRunning, runningCount }: SessionStatusBadgeProps) {
+  const dotColor = isRunning ? 'bg-green-500' : 'bg-gray-500'
+  const text = isRunning
+    ? `Running (${runningCount} session${runningCount !== 1 ? 's' : ''})`
+    : runningCount > 0
+      ? `${runningCount} running`
+      : 'No sessions'
 
   return (
     <div className="flex items-center gap-2">

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -35,21 +35,25 @@ export interface AgentCheckResult {
   installHint?: string
 }
 
+export interface RunningSessionsStatus {
+  runningSessions: number
+  sessionIds: string[]
+  processingSessionIds: string[] // Sessions currently handling a request
+}
+
 export interface ElectronAPI {
-  // Agent lifecycle
-  startAgent(agentId: string): Promise<{ success: boolean; agentId: string }>
-  stopAgent(): Promise<{ success: boolean }>
-  switchAgent(agentId: string): Promise<{ success: boolean; agentId: string }>
-  getAgentStatus(): Promise<AgentStatus>
+  // Agent status (per-session agents)
+  getAgentStatus(): Promise<RunningSessionsStatus>
 
   // Agent communication
   sendPrompt(sessionId: string, content: string): Promise<{ stopReason: string }>
   cancelRequest(sessionId: string): Promise<{ success: boolean }>
 
-  // Session management
-  createSession(workingDirectory: string): Promise<MulticaSession>
+  // Session management (agent starts when session is created)
+  createSession(workingDirectory: string, agentId: string): Promise<MulticaSession>
   listSessions(options?: ListSessionsOptions): Promise<MulticaSession[]>
   getSession(sessionId: string): Promise<SessionData | null>
+  loadSession(sessionId: string): Promise<MulticaSession> // Load without starting agent
   resumeSession(sessionId: string): Promise<MulticaSession>
   deleteSession(sessionId: string): Promise<{ success: boolean }>
   updateSession(sessionId: string, updates: Partial<MulticaSession>): Promise<MulticaSession>
@@ -66,7 +70,7 @@ export interface ElectronAPI {
 
   // Event listeners (return unsubscribe function)
   onAgentMessage(callback: (message: AgentMessage) => void): () => void
-  onAgentStatus(callback: (status: AgentStatus) => void): () => void
+  onAgentStatus(callback: (status: RunningSessionsStatus) => void): () => void
   onAgentError(callback: (error: Error) => void): () => void
 }
 

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -2,20 +2,18 @@
  * IPC Channel definitions for communication between main and renderer processes
  */
 export const IPC_CHANNELS = {
-  // Agent communication
+  // Agent communication (per-session)
   AGENT_PROMPT: 'agent:prompt',
   AGENT_CANCEL: 'agent:cancel',
-  AGENT_SWITCH: 'agent:switch',
-  AGENT_START: 'agent:start',
-  AGENT_STOP: 'agent:stop',
   AGENT_MESSAGE: 'agent:message',
   AGENT_ERROR: 'agent:error',
-  AGENT_STATUS: 'agent:status',
+  AGENT_STATUS: 'agent:status', // Returns status of all running sessions
 
   // Session management
   SESSION_CREATE: 'session:create',
   SESSION_LIST: 'session:list',
   SESSION_GET: 'session:get',
+  SESSION_LOAD: 'session:load', // Load session without starting agent (lazy)
   SESSION_RESUME: 'session:resume',
   SESSION_DELETE: 'session:delete',
   SESSION_UPDATE: 'session:update',


### PR DESCRIPTION
## Summary
- Refactor from shared agent to per-session agent architecture
- Each session now independently starts and stops its own agent process
- Rename `/agent` command to `/default` for setting default agent for new sessions
- Simplify IPC handlers and frontend state management

## Test plan
- [ ] Create multiple sessions and verify each runs its own agent
- [ ] Test `/default` command to change default agent
- [ ] Verify session cleanup properly stops agent process
- [ ] Test UI state updates correctly reflect session status

🤖 Generated with [Claude Code](https://claude.com/claude-code)