### PR TITLE
feat: add drag-to-resize sidebar and right panel

### DIFF
--- a/src/renderer/src/components/MessageInput.tsx
+++ b/src/renderer/src/components/MessageInput.tsx
@@ -76,7 +76,7 @@ export function MessageInput({
             {/* Folder selection prompt */}
             <div className="flex items-center gap-3">
               <Folder className="h-5 w-5 text-muted-foreground flex-shrink-0" />
-              <span className="text-muted-foreground flex-1">Select a folder to start...</span>
+              <span className="text-sm text-muted-foreground flex-1">Select a folder to start...</span>
               <Button
                 variant="outline"
                 size="sm"

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -25,7 +25,7 @@ export function StatusBar({
   return (
     <div className={cn(
       "titlebar-drag-region flex h-11 items-center justify-between px-4",
-      needsTrafficLightPadding && "pl-20"
+      needsTrafficLightPadding && "pl-24"
     )}>
       {/* Left: Sidebar trigger + Session info */}
       <div className="titlebar-no-drag flex items-center gap-3">

--- a/src/renderer/src/hooks/useResize.ts
+++ b/src/renderer/src/hooks/useResize.ts
@@ -1,0 +1,91 @@
+/**
+ * Hook for drag-to-resize functionality
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface UseResizeOptions {
+  /** Current width */
+  width: number
+  /** Minimum width */
+  minWidth: number
+  /** Maximum width */
+  maxWidth: number
+  /** Callback when width changes */
+  onWidthChange: (width: number) => void
+  /** Direction of resize: 'left' means drag from left edge, 'right' means drag from right edge */
+  direction: 'left' | 'right'
+}
+
+interface UseResizeReturn {
+  /** Whether currently resizing */
+  isResizing: boolean
+  /** Props to spread on the resize handle element */
+  handleProps: {
+    onMouseDown: (e: React.MouseEvent) => void
+    style: React.CSSProperties
+  }
+}
+
+export function useResize({
+  width,
+  minWidth,
+  maxWidth,
+  onWidthChange,
+  direction,
+}: UseResizeOptions): UseResizeReturn {
+  const [isResizing, setIsResizing] = useState(false)
+  const startXRef = useRef(0)
+  const startWidthRef = useRef(0)
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      setIsResizing(true)
+      startXRef.current = e.clientX
+      startWidthRef.current = width
+    },
+    [width]
+  )
+
+  useEffect(() => {
+    if (!isResizing) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const delta = e.clientX - startXRef.current
+      // For left sidebar, dragging right increases width
+      // For right panel, dragging left increases width
+      const newWidth =
+        direction === 'right'
+          ? startWidthRef.current + delta
+          : startWidthRef.current - delta
+      const clampedWidth = Math.max(minWidth, Math.min(maxWidth, newWidth))
+      onWidthChange(clampedWidth)
+    }
+
+    const handleMouseUp = () => {
+      setIsResizing(false)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    // Add cursor style to body during resize
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+  }, [isResizing, minWidth, maxWidth, onWidthChange, direction])
+
+  return {
+    isResizing,
+    handleProps: {
+      onMouseDown: handleMouseDown,
+      style: { cursor: 'col-resize' },
+    },
+  }
+}

--- a/src/renderer/src/stores/uiStore.ts
+++ b/src/renderer/src/stores/uiStore.ts
@@ -5,16 +5,29 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
+// Width constraints
+export const SIDEBAR_MIN_WIDTH = 200
+export const SIDEBAR_MAX_WIDTH = 400
+export const SIDEBAR_DEFAULT_WIDTH = 256
+
+export const RIGHT_PANEL_MIN_WIDTH = 240
+export const RIGHT_PANEL_MAX_WIDTH = 480
+export const RIGHT_PANEL_DEFAULT_WIDTH = 320
+
 interface UIStore {
   // Sidebar state
   sidebarOpen: boolean
+  sidebarWidth: number
   toggleSidebar: () => void
   setSidebarOpen: (open: boolean) => void
+  setSidebarWidth: (width: number) => void
 
   // Right panel state
   rightPanelOpen: boolean
+  rightPanelWidth: number
   toggleRightPanel: () => void
   setRightPanelOpen: (open: boolean) => void
+  setRightPanelWidth: (width: number) => void
 }
 
 export const useUIStore = create<UIStore>()(
@@ -22,13 +35,19 @@ export const useUIStore = create<UIStore>()(
     (set) => ({
       // Sidebar - default open
       sidebarOpen: true,
+      sidebarWidth: SIDEBAR_DEFAULT_WIDTH,
       toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
       setSidebarOpen: (open) => set({ sidebarOpen: open }),
+      setSidebarWidth: (width) =>
+        set({ sidebarWidth: Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, width)) }),
 
       // Right panel - default open
       rightPanelOpen: true,
+      rightPanelWidth: RIGHT_PANEL_DEFAULT_WIDTH,
       toggleRightPanel: () => set((state) => ({ rightPanelOpen: !state.rightPanelOpen })),
       setRightPanelOpen: (open) => set({ rightPanelOpen: open }),
+      setRightPanelWidth: (width) =>
+        set({ rightPanelWidth: Math.max(RIGHT_PANEL_MIN_WIDTH, Math.min(RIGHT_PANEL_MAX_WIDTH, width)) }),
     }),
     {
       name: 'ui-state', // localStorage key


### PR DESCRIPTION
## Summary

- Add dynamic width state management for sidebar and right panel with drag-to-resize functionality
- Improve UI spacing by increasing sidebar toggle padding and matching text sizes
- Panels now persist their widths across sessions via localStorage

## Changes

- Implement drag-to-resize with smooth interactions (resize handle appears on hover)
- Sidebar width: 200-400px (default 256px)
- Right panel width: 240-480px (default 320px)
- Fix "Select a folder to start..." font size to match textarea
- Remove redundant close button from RightPanelHeader
- Increase sidebar toggle padding to avoid macOS traffic lights

🤖 Generated with Claude