### PR TITLE
fix: update agent settings copy and status label

### DIFF
--- a/src/main/config/defaults.ts
+++ b/src/main/config/defaults.ts
@@ -15,7 +15,7 @@ export const DEFAULT_AGENTS: Record<string, AgentConfig> = {
   },
   opencode: {
     id: 'opencode',
-    name: 'OpenCode',
+    name: 'opencode',
     command: 'opencode',
     args: ['acp'],
     enabled: true,

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -163,7 +163,7 @@ function AgentItem({ agent, isSelected, onSelect }: AgentItemProps) {
 
         {/* Right side: status or button */}
         {status === 'selected' ? (
-          <span className="text-xs text-green-600">Default</span>
+          <span className="text-xs text-green-600">Selected</span>
         ) : status === 'ready' ? (
           <button
             onClick={handleSelectClick}


### PR DESCRIPTION
Update agent settings UI copy for clarity and consistency.

- Change opencode agent display name to lowercase
- Update selected agent status from "Default" to "Selected"

Fixes incorrect terminology in agent settings that could confuse users about the difference between selected agents and default agents.