### PR TITLE
feat: add comprehensive test suite with Vitest

### DIFF
--- a/docs/plans/2026-01-15-testing-strategy.md
+++ b/docs/plans/2026-01-15-testing-strategy.md
@@ -1,0 +1,68 @@
+# Testing Strategy Design
+
+## Goals
+- Prevent regression when modifying code
+- Verify core logic (Conductor, SessionStore, etc.)
+- UI testing deferred
+
+## Approach
+- **Mixed granularity**: Unit tests for utilities, integration tests for business flows
+- **Framework**: Vitest
+
+## Test Structure
+
+```
+tests/
+├── unit/                    # Pure functions and utilities
+│   ├── main/
+│   │   └── session/
+│   │       └── SessionStore.test.ts
+│   └── shared/
+│       └── utils.test.ts
+│
+├── integration/             # Module collaboration
+│   ├── conductor/
+│   │   └── Conductor.test.ts
+│   └── ipc/
+│       └── handlers.test.ts
+│
+└── setup/
+    ├── vitest.setup.ts
+    └── mocks/
+        ├── electron.ts
+        └── acp-sdk.ts
+```
+
+## Test Targets
+
+### Unit Tests
+- SessionStore: create, save, load, list, error handling
+- Utility functions: agent-check, cn()
+
+### Integration Tests
+- Conductor: init flow, session lifecycle, message chain, cancellation
+- IPC Handlers: channel validation, error propagation, permission flow
+
+## Mock Strategy
+
+| Real | Mocked |
+|------|--------|
+| SessionStore internals | File system (fs) |
+| Conductor logic | ACP SDK |
+| IPC handler logic | Electron IPC |
+
+## Configuration
+
+### Dependencies
+```bash
+pnpm add -D vitest @vitest/coverage-v8
+```
+
+### Scripts
+```json
+{
+  "test": "vitest",
+  "test:run": "vitest run",
+  "test:coverage": "vitest run --coverage"
+}
+```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
     "cli": "tsx src/main/cli.ts",
-    "test:acp": "tsx src/main/cli.ts prompt"
+    "test:acp": "tsx src/main/cli.ts prompt",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.13.0",
@@ -53,6 +56,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.0.17",
     "autoprefixer": "^10.4.23",
     "electron": "^39.2.6",
     "electron-builder": "^26.0.12",
@@ -69,7 +73,8 @@
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
-    "vite": "^7.2.6"
+    "vite": "^7.2.6",
+    "vitest": "^4.0.17"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.1
         version: 5.1.2(vite@7.3.1(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.0.17
+        version: 4.0.17(vitest@4.0.17(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.23
         version: 10.4.23(postcss@8.5.6)
@@ -144,6 +147,9 @@ importers:
       vite:
         specifier: ^7.2.6
         version: 7.3.1(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vitest:
+        specifier: ^4.0.17
+        version: 4.0.17(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
 packages:
 
@@ -243,6 +249,10 @@ packages:
   '@babel/types@7.28.6':
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -1265,6 +1275,9 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -1374,8 +1387,14 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1501,6 +1520,44 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@4.0.17':
+    resolution: {integrity: sha512-/6zU2FLGg0jsd+ePZcwHRy3+WpNTBBhDY56P4JTRqUN/Dp6CvOEa9HrikcQ4KfV2b2kAHUFB4dl1SuocWXSFEw==}
+    peerDependencies:
+      '@vitest/browser': 4.0.17
+      vitest: 4.0.17
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.0.17':
+    resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
+
+  '@vitest/mocker@4.0.17':
+    resolution: {integrity: sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.17':
+    resolution: {integrity: sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==}
+
+  '@vitest/runner@4.0.17':
+    resolution: {integrity: sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==}
+
+  '@vitest/snapshot@4.0.17':
+    resolution: {integrity: sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==}
+
+  '@vitest/spy@4.0.17':
+    resolution: {integrity: sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==}
+
+  '@vitest/utils@4.0.17':
+    resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
+
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
@@ -1595,6 +1652,13 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.10:
+    resolution: {integrity: sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1713,6 +1777,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1999,6 +2067,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2118,9 +2189,16 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -2357,6 +2435,9 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -2563,6 +2644,18 @@ packages:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -2581,6 +2674,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -2740,6 +2836,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.1:
+    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
@@ -3047,6 +3150,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3110,6 +3216,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
@@ -3398,6 +3507,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3452,9 +3564,15 @@ packages:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3555,9 +3673,20 @@ packages:
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -3754,6 +3883,40 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.0.17:
+    resolution: {integrity: sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.17
+      '@vitest/browser-preview': 4.0.17
+      '@vitest/browser-webdriverio': 4.0.17
+      '@vitest/ui': 4.0.17
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -3781,6 +3944,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3985,6 +4153,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@develar/schema-utils@2.6.5':
     dependencies:
@@ -4848,6 +5018,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -4948,9 +5120,16 @@ snapshots:
       '@types/node': 22.19.6
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -5119,6 +5298,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.0.17(vitest@4.0.17(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.17
+      ast-v8-to-istanbul: 0.3.10
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.17(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
+  '@vitest/expect@4.0.17':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.17
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.0.17':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.17':
+    dependencies:
+      '@vitest/utils': 4.0.17
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.17':
+    dependencies:
+      '@vitest/pretty-format': 4.0.17
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.17': {}
+
+  '@vitest/utils@4.0.17':
+    dependencies:
+      '@vitest/pretty-format': 4.0.17
+      tinyrainbow: 3.0.3
+
   '@xmldom/xmldom@0.8.11': {}
 
   abbrev@3.0.1: {}
@@ -5260,6 +5492,14 @@ snapshots:
 
   assert-plus@1.0.0:
     optional: true
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.10:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   astral-regex@2.0.0:
     optional: true
@@ -5409,6 +5649,8 @@ snapshots:
   caniuse-lite@1.0.30001764: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5794,6 +6036,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -6000,7 +6244,13 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -6286,6 +6536,8 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  html-escaper@2.0.2: {}
+
   html-url-attributes@3.0.1: {}
 
   http-cache-semantics@4.2.0: {}
@@ -6484,6 +6736,19 @@ snapshots:
 
   isexe@3.1.1: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -6508,6 +6773,8 @@ snapshots:
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -6641,6 +6908,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.1:
+    dependencies:
+      '@babel/parser': 7.28.6
+      '@babel/types': 7.28.6
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
 
   make-fetch-happen@14.0.3:
     dependencies:
@@ -7168,6 +7445,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -7243,6 +7522,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  pathe@2.0.3: {}
 
   pe-library@0.4.1: {}
 
@@ -7604,6 +7885,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7657,7 +7940,11 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7800,10 +8087,16 @@ snapshots:
     dependencies:
       semver: 5.7.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -8002,6 +8295,43 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
 
+  vitest@4.0.17(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.17
+      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.17
+      '@vitest/runner': 4.0.17
+      '@vitest/snapshot': 4.0.17
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.6
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -8054,6 +8384,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/tests/integration/conductor/Conductor.test.ts
+++ b/tests/integration/conductor/Conductor.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+// Mock AgentProcess to avoid spawning real processes
+vi.mock('../../../src/main/conductor/AgentProcess', () => {
+  return {
+    AgentProcess: class MockAgentProcess {
+      start = vi.fn().mockResolvedValue(undefined)
+      stop = vi.fn().mockResolvedValue(undefined)
+      isRunning = vi.fn().mockReturnValue(true)
+      onExit = vi.fn()
+      getPid = vi.fn().mockReturnValue(12345)
+      getStdinWeb = vi.fn().mockReturnValue(new WritableStream())
+      getStdoutWeb = vi.fn().mockReturnValue(new ReadableStream())
+    },
+  }
+})
+
+// Mock ACP SDK
+vi.mock('@agentclientprotocol/sdk', () => {
+  return {
+    PROTOCOL_VERSION: '1.0',
+    ndJsonStream: vi.fn().mockReturnValue({}),
+    ClientSideConnection: class MockClientSideConnection {
+      initialize = vi.fn().mockResolvedValue({
+        protocolVersion: '1.0',
+        agentInfo: { name: 'mock-agent' },
+      })
+      newSession = vi.fn().mockResolvedValue({
+        sessionId: 'mock-acp-session-id',
+      })
+      prompt = vi.fn().mockResolvedValue({
+        stopReason: 'end_turn',
+      })
+      cancel = vi.fn().mockResolvedValue(undefined)
+    },
+  }
+})
+
+// Import after mocks are set up
+import { Conductor } from '../../../src/main/conductor/Conductor'
+
+describe('Conductor', () => {
+  let tempDir: string
+  let conductor: Conductor
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'conductor-test-'))
+  })
+
+  afterEach(async () => {
+    if (conductor) {
+      await conductor.stopAllSessions()
+    }
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('initialization', () => {
+    it('should initialize without errors', async () => {
+      conductor = new Conductor({ storagePath: tempDir })
+      await expect(conductor.initialize()).resolves.not.toThrow()
+    })
+
+    it('should work in CLI mode (skip persistence)', async () => {
+      conductor = new Conductor({ skipPersistence: true })
+      await expect(conductor.initialize()).resolves.not.toThrow()
+    })
+  })
+
+  describe('session management', () => {
+    const mockAgentConfig = {
+      id: 'opencode',
+      name: 'OpenCode',
+      command: 'opencode',
+      args: ['--mcp'],
+      enabled: true,
+    }
+
+    beforeEach(async () => {
+      conductor = new Conductor({ storagePath: tempDir })
+      await conductor.initialize()
+    })
+
+    it('should create a new session', async () => {
+      const session = await conductor.createSession('/test/project', mockAgentConfig)
+
+      expect(session).toMatchObject({
+        id: expect.any(String),
+        agentId: 'opencode',
+        workingDirectory: '/test/project',
+        status: 'active',
+      })
+    })
+
+    it('should list created sessions', async () => {
+      await conductor.createSession('/test/project1', mockAgentConfig)
+      await conductor.createSession('/test/project2', mockAgentConfig)
+
+      const sessions = await conductor.listSessions()
+      expect(sessions.length).toBe(2)
+    })
+
+    it('should get session data', async () => {
+      const session = await conductor.createSession('/test/project', mockAgentConfig)
+
+      const data = await conductor.getSessionData(session.id)
+      expect(data).not.toBeNull()
+      expect(data?.session.id).toBe(session.id)
+    })
+
+    it('should delete a session', async () => {
+      const session = await conductor.createSession('/test/project', mockAgentConfig)
+
+      await conductor.deleteSession(session.id)
+
+      const sessions = await conductor.listSessions()
+      expect(sessions.find((s) => s.id === session.id)).toBeUndefined()
+    })
+
+    it('should track running sessions', async () => {
+      const session = await conductor.createSession('/test/project', mockAgentConfig)
+
+      expect(conductor.isSessionRunning(session.id)).toBe(true)
+      expect(conductor.getRunningSessionIds()).toContain(session.id)
+    })
+
+    it('should stop a session', async () => {
+      const session = await conductor.createSession('/test/project', mockAgentConfig)
+
+      await conductor.stopSession(session.id)
+
+      expect(conductor.getRunningSessionIds()).not.toContain(session.id)
+    })
+
+    it('should stop all sessions', async () => {
+      await conductor.createSession('/test/project1', mockAgentConfig)
+      await conductor.createSession('/test/project2', mockAgentConfig)
+
+      expect(conductor.getRunningSessionIds().length).toBe(2)
+
+      await conductor.stopAllSessions()
+
+      expect(conductor.getRunningSessionIds().length).toBe(0)
+    })
+  })
+
+  describe('CLI mode (in-memory)', () => {
+    const mockAgentConfig = {
+      id: 'opencode',
+      name: 'OpenCode',
+      command: 'opencode',
+      args: ['--mcp'],
+      enabled: true,
+    }
+
+    beforeEach(async () => {
+      conductor = new Conductor({ skipPersistence: true })
+      await conductor.initialize()
+    })
+
+    it('should create in-memory session', async () => {
+      const session = await conductor.createSession('/test/project', mockAgentConfig)
+
+      expect(session.id).toBeDefined()
+      expect(session.agentId).toBe('opencode')
+    })
+
+    it('should list in-memory session', async () => {
+      await conductor.createSession('/test/project', mockAgentConfig)
+
+      const sessions = await conductor.listSessions()
+      expect(sessions.length).toBe(1)
+    })
+
+    it('should not support session resumption in CLI mode', async () => {
+      await expect(conductor.resumeSession('some-id')).rejects.toThrow(
+        'Session resumption not available in CLI mode'
+      )
+    })
+  })
+
+  describe('event callbacks', () => {
+    const mockAgentConfig = {
+      id: 'opencode',
+      name: 'OpenCode',
+      command: 'opencode',
+      args: ['--mcp'],
+      enabled: true,
+    }
+
+    it('should call onStatusChange when session starts processing', async () => {
+      const onStatusChange = vi.fn()
+      conductor = new Conductor({
+        storagePath: tempDir,
+        events: { onStatusChange },
+      })
+      await conductor.initialize()
+
+      const session = await conductor.createSession('/test/project', mockAgentConfig)
+
+      // sendPrompt should trigger status changes
+      await conductor.sendPrompt(session.id, 'Hello')
+
+      // Should be called at least twice (start processing, end processing)
+      expect(onStatusChange).toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/integration/ipc/handlers.test.ts
+++ b/tests/integration/ipc/handlers.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as path from 'path'
+import * as fs from 'fs'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// Mock electron modules
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  clipboard: {
+    writeText: vi.fn(),
+  },
+  shell: {
+    showItemInFolder: vi.fn(),
+  },
+}))
+
+// Mock child_process spawn
+vi.mock('child_process', () => ({
+  spawn: vi.fn().mockReturnValue({
+    on: vi.fn((event, callback) => {
+      if (event === 'close') {
+        callback(0)
+      }
+    }),
+  }),
+}))
+
+// Mock agent-check
+vi.mock('../../../src/main/utils/agent-check', () => ({
+  checkAgents: vi.fn().mockReturnValue([
+    { id: 'opencode', name: 'OpenCode', installed: true },
+  ]),
+}))
+
+import { ipcMain, dialog, clipboard, shell } from 'electron'
+import { spawn } from 'child_process'
+import { registerIPCHandlers } from '../../../src/main/ipc/handlers'
+
+// Create mock conductor
+const createMockConductor = () => ({
+  sendPrompt: vi.fn().mockResolvedValue('end_turn'),
+  cancelRequest: vi.fn().mockResolvedValue(undefined),
+  getRunningSessionIds: vi.fn().mockReturnValue(['session-1']),
+  getProcessingSessionIds: vi.fn().mockReturnValue([]),
+  createSession: vi.fn().mockResolvedValue({ id: 'new-session' }),
+  listSessions: vi.fn().mockResolvedValue([]),
+  getSessionData: vi.fn().mockResolvedValue(null),
+  loadSession: vi.fn().mockResolvedValue({ id: 'loaded-session' }),
+  resumeSession: vi.fn().mockResolvedValue({ id: 'resumed-session' }),
+  deleteSession: vi.fn().mockResolvedValue(undefined),
+  updateSessionMeta: vi.fn().mockResolvedValue({ id: 'updated-session' }),
+})
+
+describe('IPC Handlers', () => {
+  let tempDir: string
+  let handlers: Map<string, Function>
+  let mockConductor: ReturnType<typeof createMockConductor>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    handlers = new Map()
+    mockConductor = createMockConductor()
+
+    // Capture all registered handlers
+    vi.mocked(ipcMain.handle).mockImplementation((channel: string, handler: Function) => {
+      handlers.set(channel, handler)
+    })
+
+    // Register handlers with mock conductor
+    registerIPCHandlers(mockConductor as any)
+
+    // Create temp directory for file system tests
+    tempDir = mkdtempSync(join(tmpdir(), 'ipc-test-'))
+  })
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('handler registration', () => {
+    it('should register all expected handlers', () => {
+      const expectedChannels = [
+        'agent:prompt',
+        'agent:cancel',
+        'agent:status',
+        'session:create',
+        'session:list',
+        'session:get',
+        'session:load',
+        'session:resume',
+        'session:delete',
+        'session:update',
+        'config:get',
+        'config:update',
+        'dialog:select-directory',
+        'system:check-agents',
+        'fs:list-directory',
+        'fs:detect-apps',
+        'fs:open-with',
+      ]
+
+      for (const channel of expectedChannels) {
+        expect(handlers.has(channel), `Handler for ${channel} should be registered`).toBe(true)
+      }
+    })
+  })
+
+  describe('agent handlers', () => {
+    it('agent:prompt should call conductor.sendPrompt', async () => {
+      const handler = handlers.get('agent:prompt')!
+      await handler({}, 'session-1', 'Hello')
+
+      expect(mockConductor.sendPrompt).toHaveBeenCalledWith('session-1', 'Hello')
+    })
+
+    it('agent:cancel should call conductor.cancelRequest', async () => {
+      const handler = handlers.get('agent:cancel')!
+      await handler({}, 'session-1')
+
+      expect(mockConductor.cancelRequest).toHaveBeenCalledWith('session-1')
+    })
+
+    it('agent:status should return running session info', async () => {
+      const handler = handlers.get('agent:status')!
+      const result = await handler({})
+
+      expect(result).toMatchObject({
+        runningSessions: 1,
+        sessionIds: ['session-1'],
+        processingSessionIds: [],
+      })
+    })
+  })
+
+  describe('session handlers', () => {
+    it('session:create should create a session with valid agent', async () => {
+      const handler = handlers.get('session:create')!
+      await handler({}, '/test/dir', 'opencode')
+
+      expect(mockConductor.createSession).toHaveBeenCalled()
+    })
+
+    it('session:create should throw for unknown agent', async () => {
+      const handler = handlers.get('session:create')!
+
+      await expect(handler({}, '/test/dir', 'unknown-agent')).rejects.toThrow('Unknown agent')
+    })
+
+    it('session:list should call conductor.listSessions', async () => {
+      const handler = handlers.get('session:list')!
+      await handler({}, { limit: 10 })
+
+      expect(mockConductor.listSessions).toHaveBeenCalledWith({ limit: 10 })
+    })
+
+    it('session:delete should call conductor.deleteSession', async () => {
+      const handler = handlers.get('session:delete')!
+      const result = await handler({}, 'session-1')
+
+      expect(mockConductor.deleteSession).toHaveBeenCalledWith('session-1')
+      expect(result).toEqual({ success: true })
+    })
+  })
+
+  describe('config handlers', () => {
+    it('config:get should return default config', async () => {
+      const handler = handlers.get('config:get')!
+      const result = await handler({})
+
+      expect(result).toMatchObject({
+        version: '0.1.0',
+        defaultAgentId: 'opencode',
+      })
+      expect(result.agents).toBeDefined()
+    })
+  })
+
+  describe('file system handlers', () => {
+    it('fs:list-directory should list files and directories', async () => {
+      // Create test files
+      mkdirSync(join(tempDir, 'subdir'))
+      writeFileSync(join(tempDir, 'file.txt'), 'content')
+      writeFileSync(join(tempDir, 'script.js'), 'code')
+
+      const handler = handlers.get('fs:list-directory')!
+      const result = await handler({}, tempDir)
+
+      expect(result.length).toBe(3)
+      // Directories should come first
+      expect(result[0].type).toBe('directory')
+      expect(result[0].name).toBe('subdir')
+      // Files should be sorted alphabetically
+      const files = result.filter((n: any) => n.type === 'file')
+      expect(files[0].name).toBe('file.txt')
+      expect(files[0].extension).toBe('txt')
+    })
+
+    it('fs:list-directory should reject invalid paths', async () => {
+      const handler = handlers.get('fs:list-directory')!
+
+      // Relative path
+      const result1 = await handler({}, 'relative/path')
+      expect(result1).toEqual([])
+
+      // Path with traversal
+      const result2 = await handler({}, '/some/path/../other')
+      expect(result2).toEqual([])
+    })
+
+    it('fs:list-directory should return empty array for non-existent directory', async () => {
+      const handler = handlers.get('fs:list-directory')!
+      const result = await handler({}, '/nonexistent/path/that/does/not/exist')
+
+      expect(result).toEqual([])
+    })
+
+    it('fs:detect-apps should return available apps', async () => {
+      const handler = handlers.get('fs:detect-apps')!
+      const result = await handler({})
+
+      // Should always include Finder, Terminal, and Copy path
+      const appIds = result.map((a: any) => a.id)
+      expect(appIds).toContain('finder')
+      expect(appIds).toContain('terminal')
+      expect(appIds).toContain('copy-path')
+    })
+
+    it('fs:open-with should reject invalid paths', async () => {
+      const handler = handlers.get('fs:open-with')!
+
+      await expect(handler({}, { path: 'relative/path', appId: 'finder' })).rejects.toThrow(
+        'Invalid path'
+      )
+    })
+
+    it('fs:open-with with finder should call shell.showItemInFolder', async () => {
+      const handler = handlers.get('fs:open-with')!
+      const testPath = join(tempDir, 'test.txt')
+      writeFileSync(testPath, 'test')
+
+      await handler({}, { path: testPath, appId: 'finder' })
+
+      expect(shell.showItemInFolder).toHaveBeenCalledWith(testPath)
+    })
+
+    it('fs:open-with with copy-path should call clipboard.writeText', async () => {
+      const handler = handlers.get('fs:open-with')!
+      const testPath = join(tempDir, 'test.txt')
+      writeFileSync(testPath, 'test')
+
+      await handler({}, { path: testPath, appId: 'copy-path' })
+
+      expect(clipboard.writeText).toHaveBeenCalledWith(testPath)
+    })
+  })
+
+  describe('dialog handlers', () => {
+    it('dialog:select-directory should return selected path', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: ['/selected/path'],
+      })
+
+      const handler = handlers.get('dialog:select-directory')!
+      const result = await handler({})
+
+      expect(result).toBe('/selected/path')
+    })
+
+    it('dialog:select-directory should return null if canceled', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: true,
+        filePaths: [],
+      })
+
+      const handler = handlers.get('dialog:select-directory')!
+      const result = await handler({})
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('system handlers', () => {
+    it('system:check-agents should return agent check results', async () => {
+      const handler = handlers.get('system:check-agents')!
+      const result = await handler({})
+
+      expect(result).toEqual([
+        { id: 'opencode', name: 'OpenCode', installed: true },
+      ])
+    })
+  })
+})

--- a/tests/setup/mocks/acp-sdk.ts
+++ b/tests/setup/mocks/acp-sdk.ts
@@ -1,0 +1,21 @@
+import { vi } from 'vitest'
+
+export const createMockAcpClient = () => ({
+  createSession: vi.fn().mockResolvedValue({
+    sessionId: 'mock-session-id',
+  }),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  cancelSession: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+})
+
+export const createMockSessionNotification = (
+  type: 'agent_message_chunk' | 'user_message_chunk' | 'session_end',
+  data: Record<string, unknown> = {}
+) => ({
+  sessionId: 'mock-session-id',
+  update: {
+    sessionUpdate: type,
+    ...data,
+  },
+})

--- a/tests/setup/mocks/electron.ts
+++ b/tests/setup/mocks/electron.ts
@@ -1,0 +1,19 @@
+import { vi } from 'vitest'
+
+export const mockElectron = {
+  app: {
+    getPath: vi.fn().mockReturnValue('/mock/user/data'),
+    getName: vi.fn().mockReturnValue('multica'),
+    getVersion: vi.fn().mockReturnValue('0.1.0'),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+    on: vi.fn(),
+  },
+  BrowserWindow: vi.fn().mockImplementation(() => ({
+    loadURL: vi.fn(),
+    webContents: {
+      send: vi.fn(),
+    },
+  })),
+}

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -1,0 +1,8 @@
+import { vi } from 'vitest'
+
+// Mock electron module globally
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/mock/user/data'),
+  },
+}))

--- a/tests/unit/main/session/SessionStore.test.ts
+++ b/tests/unit/main/session/SessionStore.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'path'
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { SessionStore } from '../../../../src/main/session/SessionStore'
+
+describe('SessionStore', () => {
+  let tempDir: string
+  let store: SessionStore
+
+  beforeEach(async () => {
+    // Create a real temp directory for each test
+    tempDir = mkdtempSync(join(tmpdir(), 'sessionstore-test-'))
+    store = new SessionStore(tempDir)
+    await store.initialize()
+  })
+
+  afterEach(() => {
+    // Clean up temp directory
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('initialize', () => {
+    it('should create storage directories', async () => {
+      expect(existsSync(tempDir)).toBe(true)
+      expect(existsSync(join(tempDir, 'data'))).toBe(true)
+    })
+
+    it('should handle empty storage gracefully', async () => {
+      const sessions = await store.list()
+      expect(sessions).toEqual([])
+    })
+  })
+
+  describe('create', () => {
+    it('should create a session with correct structure', async () => {
+      const session = await store.create({
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test/project',
+      })
+
+      expect(session).toMatchObject({
+        id: expect.any(String),
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test/project',
+        status: 'active',
+        messageCount: 0,
+      })
+      expect(session.createdAt).toBeDefined()
+      expect(session.updatedAt).toBeDefined()
+    })
+
+    it('should persist session to disk', async () => {
+      const session = await store.create({
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test/project',
+      })
+
+      // Check index file exists
+      const indexPath = join(tempDir, 'index.json')
+      expect(existsSync(indexPath)).toBe(true)
+
+      // Check session data file exists
+      const dataPath = join(tempDir, 'data', `${session.id}.json`)
+      expect(existsSync(dataPath)).toBe(true)
+    })
+
+    it('should generate unique IDs for each session', async () => {
+      const session1 = await store.create({
+        agentSessionId: 'agent-1',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+      const session2 = await store.create({
+        agentSessionId: 'agent-2',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      expect(session1.id).not.toBe(session2.id)
+    })
+  })
+
+  describe('list', () => {
+    it('should return all sessions sorted by updatedAt descending', async () => {
+      // Create first session
+      await store.create({
+        agentSessionId: 'agent-1',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      // Small delay to ensure different timestamps
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      // Create second session (more recent)
+      await store.create({
+        agentSessionId: 'agent-2',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      const sessions = await store.list()
+      expect(sessions.length).toBe(2)
+      // Most recent (session2) should be first
+      expect(sessions[0].agentSessionId).toBe('agent-2')
+      expect(sessions[1].agentSessionId).toBe('agent-1')
+    })
+
+    it('should filter by agentId', async () => {
+      await store.create({
+        agentSessionId: 'agent-1',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+      await store.create({
+        agentSessionId: 'agent-2',
+        agentId: 'gemini',
+        workingDirectory: '/test',
+      })
+
+      const sessions = await store.list({ agentId: 'opencode' })
+      expect(sessions.length).toBe(1)
+      expect(sessions[0].agentId).toBe('opencode')
+    })
+
+    it('should filter by status', async () => {
+      const session1 = await store.create({
+        agentSessionId: 'agent-1',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+      await store.create({
+        agentSessionId: 'agent-2',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      await store.updateMeta(session1.id, { status: 'completed' })
+
+      const activeSessions = await store.list({ status: 'active' })
+      expect(activeSessions.length).toBe(1)
+
+      const completedSessions = await store.list({ status: 'completed' })
+      expect(completedSessions.length).toBe(1)
+    })
+
+    it('should support pagination', async () => {
+      for (let i = 0; i < 5; i++) {
+        await store.create({
+          agentSessionId: `agent-${i}`,
+          agentId: 'opencode',
+          workingDirectory: '/test',
+        })
+      }
+
+      const page1 = await store.list({ limit: 2, offset: 0 })
+      expect(page1.length).toBe(2)
+
+      const page2 = await store.list({ limit: 2, offset: 2 })
+      expect(page2.length).toBe(2)
+
+      const page3 = await store.list({ limit: 2, offset: 4 })
+      expect(page3.length).toBe(1)
+    })
+  })
+
+  describe('get', () => {
+    it('should return session data for existing session', async () => {
+      const created = await store.create({
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      const sessionData = await store.get(created.id)
+      expect(sessionData).not.toBeNull()
+      expect(sessionData?.session.id).toBe(created.id)
+      expect(sessionData?.updates).toEqual([])
+    })
+
+    it('should return null for non-existent session', async () => {
+      const sessionData = await store.get('non-existent-id')
+      expect(sessionData).toBeNull()
+    })
+
+    it('should cache loaded sessions', async () => {
+      const created = await store.create({
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      // First get loads from disk
+      const data1 = await store.get(created.id)
+      // Second get should return cached data
+      const data2 = await store.get(created.id)
+
+      expect(data1).toBe(data2) // Same reference
+    })
+  })
+
+  describe('updateMeta', () => {
+    it('should update allowed fields', async () => {
+      const created = await store.create({
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      const updated = await store.updateMeta(created.id, {
+        title: 'My Session',
+        status: 'completed',
+      })
+
+      expect(updated.title).toBe('My Session')
+      expect(updated.status).toBe('completed')
+      expect(new Date(updated.updatedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(created.updatedAt).getTime()
+      )
+    })
+
+    it('should throw for non-existent session', async () => {
+      await expect(
+        store.updateMeta('non-existent', { title: 'Test' })
+      ).rejects.toThrow('Session not found')
+    })
+  })
+
+  describe('delete', () => {
+    it('should remove session from index and disk', async () => {
+      const session = await store.create({
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      const dataPath = join(tempDir, 'data', `${session.id}.json`)
+      expect(existsSync(dataPath)).toBe(true)
+
+      await store.delete(session.id)
+
+      // Should be removed from list
+      const sessions = await store.list()
+      expect(sessions.find((s) => s.id === session.id)).toBeUndefined()
+
+      // File should be deleted
+      expect(existsSync(dataPath)).toBe(false)
+    })
+  })
+
+  describe('getByAgentSessionId', () => {
+    it('should find session by agent session ID', async () => {
+      await store.create({
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+
+      const found = store.getByAgentSessionId('agent-123')
+      expect(found).not.toBeNull()
+      expect(found?.agentSessionId).toBe('agent-123')
+    })
+
+    it('should return null for unknown agent session ID', async () => {
+      const found = store.getByAgentSessionId('unknown')
+      expect(found).toBeNull()
+    })
+  })
+
+  describe('persistence across instances', () => {
+    it('should load sessions from disk on new instance', async () => {
+      // Create session with first store instance
+      const created = await store.create({
+        agentSessionId: 'agent-123',
+        agentId: 'opencode',
+        workingDirectory: '/test',
+      })
+      await store.updateMeta(created.id, { title: 'Persistent Session' })
+
+      // Create new store instance pointing to same directory
+      const newStore = new SessionStore(tempDir)
+      await newStore.initialize()
+
+      // Should find the session
+      const sessions = await newStore.list()
+      expect(sessions.length).toBe(1)
+      expect(sessions[0].title).toBe('Persistent Session')
+    })
+  })
+})

--- a/tests/unit/main/utils/agent-check.test.ts
+++ b/tests/unit/main/utils/agent-check.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { commandExists, checkAgents } from '../../../../src/main/utils/agent-check'
+
+// Mock child_process
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+// Mock os module
+vi.mock('node:os', () => ({
+  platform: vi.fn().mockReturnValue('darwin'),
+}))
+
+import { execSync } from 'node:child_process'
+import { platform } from 'node:os'
+
+const mockExecSync = vi.mocked(execSync)
+const mockPlatform = vi.mocked(platform)
+
+describe('agent-check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('commandExists', () => {
+    it('should return exists: true when command is found', () => {
+      mockExecSync
+        .mockReturnValueOnce('/usr/local/bin/node\n') // which command
+        .mockReturnValueOnce('v18.0.0\n') // --version command
+
+      const result = commandExists('node')
+
+      expect(result).toEqual({
+        exists: true,
+        path: '/usr/local/bin/node',
+        version: 'v18.0.0',
+      })
+    })
+
+    it('should return exists: false when command is not found', () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('Command not found')
+      })
+
+      const result = commandExists('nonexistent')
+
+      expect(result).toEqual({ exists: false })
+    })
+
+    it('should handle missing version gracefully', () => {
+      mockExecSync
+        .mockReturnValueOnce('/usr/local/bin/myapp\n') // which command
+        .mockImplementationOnce(() => {
+          throw new Error('--version not supported')
+        })
+
+      const result = commandExists('myapp')
+
+      expect(result).toEqual({
+        exists: true,
+        path: '/usr/local/bin/myapp',
+        version: undefined,
+      })
+    })
+
+    it('should use "where" command on Windows', () => {
+      mockPlatform.mockReturnValue('win32')
+      mockExecSync
+        .mockReturnValueOnce('C:\\Program Files\\node\\node.exe\n')
+        .mockReturnValueOnce('v18.0.0\n')
+
+      commandExists('node')
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'where node',
+        expect.any(Object)
+      )
+    })
+
+    it('should use "which" command on Unix-like systems', () => {
+      mockPlatform.mockReturnValue('darwin')
+      mockExecSync
+        .mockReturnValueOnce('/usr/local/bin/node\n')
+        .mockReturnValueOnce('v18.0.0\n')
+
+      commandExists('node')
+
+      expect(mockExecSync).toHaveBeenCalledWith(
+        'which node',
+        expect.any(Object)
+      )
+    })
+
+    it('should truncate long version strings', () => {
+      const longVersion = 'v'.padEnd(100, '1')
+      mockExecSync
+        .mockReturnValueOnce('/usr/local/bin/node\n')
+        .mockReturnValueOnce(longVersion + '\n')
+
+      const result = commandExists('node')
+
+      expect(result.version?.length).toBeLessThanOrEqual(50)
+    })
+
+    it('should handle multiline which output', () => {
+      mockExecSync
+        .mockReturnValueOnce('/usr/local/bin/node\n/usr/bin/node\n')
+        .mockReturnValueOnce('v18.0.0\n')
+
+      const result = commandExists('node')
+
+      // Should return first path
+      expect(result.path).toBe('/usr/local/bin/node')
+    })
+  })
+
+  describe('checkAgents', () => {
+    it('should check all default agents', () => {
+      // Mock all commands as not found for simplicity
+      mockExecSync.mockImplementation(() => {
+        throw new Error('Command not found')
+      })
+
+      const results = checkAgents()
+
+      // Should have entries for each configured agent
+      expect(results.length).toBeGreaterThan(0)
+      expect(results.every((r) => r.id && r.name && r.command)).toBe(true)
+    })
+
+    it('should mark installed agents correctly', () => {
+      mockExecSync
+        // First agent check (claude-code)
+        .mockReturnValueOnce('/usr/local/bin/claude-code\n')
+        .mockReturnValueOnce('1.0.0\n')
+        // Second agent check - not found
+        .mockImplementationOnce(() => {
+          throw new Error('not found')
+        })
+        // Third agent check - not found
+        .mockImplementationOnce(() => {
+          throw new Error('not found')
+        })
+        // Fourth agent check - not found
+        .mockImplementationOnce(() => {
+          throw new Error('not found')
+        })
+
+      const results = checkAgents()
+
+      // At least one should be installed
+      const installedAgents = results.filter((r) => r.installed)
+      expect(installedAgents.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('should include install hints', () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('Command not found')
+      })
+
+      const results = checkAgents()
+
+      // Check that at least some have install hints
+      const withHints = results.filter((r) => r.installHint)
+      expect(withHints.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    setupFiles: ['tests/setup/vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/main/**', 'src/shared/**'],
+      exclude: ['src/renderer/**', 'src/preload/**'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@main': resolve(__dirname, 'src/main'),
+      '@shared': resolve(__dirname, 'src/shared'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Implemented comprehensive testing framework with 60 tests achieving 31.74% coverage on core business logic. Tests focus on preventing regressions and verifying critical paths.

## Changes

- **Vitest Setup**: Configuration with TypeScript support and path aliases
- **Unit Tests**: SessionStore persistence (18 tests), agent detection (10 tests)  
- **Integration Tests**: Conductor orchestration (13 tests), IPC handlers (19 tests)
- **Mock Layer**: Electron and ACP SDK mocks for isolated testing

## Test Coverage

| Module | Coverage |
|--------|----------|
| SessionStore | 81.65% |
| IPC Handlers | 73.63% |
| Conductor | 52.34% |
| Agent Check | 100% |

## Running Tests

```bash
pnpm test        # Watch mode
pnpm test:run    # Single run
pnpm test:coverage  # With coverage report
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)