### PR TITLE
fix: resolve chat message duplication and empty thinking blocks

### DIFF
--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -377,6 +377,9 @@ function TextContentBlock({ content }: { content: string }) {
 
 // Thought block view - expanded, collapsible
 function ThoughtBlockView({ text }: { text: string }) {
+  // Skip rendering if content is empty or only whitespace
+  if (!text || !text.trim()) return null
+
   const [isExpanded, setIsExpanded] = useState(false)
   const isLong = text.length > 200
 


### PR DESCRIPTION
  - Refactor useApp.ts to pass through original data without accumulation
  - ChatView is now the single source of truth for chunk accumulation
  - Add empty content check in ThoughtBlockView to skip rendering whitespace-only thoughts

  Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>