### PR TITLE
rebrand: Multica - Multiplexed Information and Computing Agent

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,178 @@
+# Multica
+
+**Multiplexed Information and Computing Agent**
+
+ビジュアルインターフェースを通じて、コーディングエージェントの能力をすべての人に届けるネイティブデスクトップクライアント。
+
+[English](./README.md) | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md) | 日本語 | [한국어](./README.ko.md)
+
+## なぜ "Multica" という名前なのか？
+
+この名前は [Multics](https://en.wikipedia.org/wiki/Multics)（Multiplexed Information and Computing Service）に由来しています。Multicsは1964年に作られた先駆的なオペレーティングシステムです。Multicsは広く普及することはありませんでしたが、階層型ファイルシステムなど、現代のオペレーティングシステムの基礎を築きました。Unix自体もMulticsから派生したものです（Uniplexed Information and Computing Service -> Unics -> Unix）。
+
+**メタファー：** Multicsがマルチユーザーのタイムシェアリング問題を解決するために作られたように、Multicaはナレッジワーカーのためのマルチモデル/マルチエージェント協調の問題を解決するために設計されています。
+
+## 解決する課題
+
+コーディングエージェント（Claude Code、Codex、Gemini CLIなど）は2025年に非常に強力になり、単なるコード作成をはるかに超えた複雑なタスクを解決できるようになりました。しかし、95%のナレッジワーカーは3つの主要な障壁によってこれらの能力を利用できません：
+
+**1. インタラクションのミスマッチ**
+- CLIベースのツールは、ターミナルの概念、ファイルパス、環境変数の理解を必要とする
+- 現在のツールはビジネス成果ではなく、コード出力（差分、コミット、リンティング）に焦点を当てている
+- ナレッジワーカーが気にするのは結果（チャート、レポート、分析）であり、それらを生成するスクリプトではない
+
+**2. ローカル環境の課題**
+- Webベースのエージェントはローカルファイル、フォルダ、ネイティブアプリケーションにアクセスできない
+- Python、Node.js、その他の依存関係のセットアップは大きな障壁となる
+- すべての依存関係を処理する「すぐに使える」サンドボックス環境がない
+
+**3. プライバシーと信頼**
+- 機密性の高いビジネスデータ（財務分析、法的文書、医療記録）はサードパーティのサーバーにアップロードできない
+- データはローカルに保持し、インテリジェンスはクラウドから得るモデルが必要
+
+Multicaは、データをローカルに保持しながらコーディングエージェントの能力を活用する、ビジュアルなネイティブデスクトップインターフェースを提供することでこのギャップを埋めます。
+
+## 機能
+
+- クリーンで直感的なインターフェースを持つネイティブmacOSアプリケーション
+- [Agent Client Protocol (ACP)](https://github.com/anthropics/agent-client-protocol) を通じた複数のAIエージェントのサポート
+- ローカルファースト：データはあなたのマシンから離れることはありません
+- 履歴と再開機能を備えたセッション管理
+- パワーユーザーとテスト用の組み込みCLI
+
+## サポートされているエージェント
+
+| エージェント | コマンド | インストール |
+|-------|---------|---------|
+| [OpenCode](https://github.com/opencode-ai/opencode) | `opencode acp` | `go install github.com/opencode-ai/opencode@latest` |
+| [Codex CLI (ACP)](https://github.com/zed-industries/codex-acp) | `codex-acp` | `npm install -g codex-acp` |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini acp` | `npm install -g @google/gemini-cli` |
+
+## クイックスタート
+
+```bash
+# 依存関係をインストール
+pnpm install
+
+# インストールされているエージェントを確認
+pnpm cli doctor
+
+# デスクトップアプリを起動
+pnpm dev
+```
+
+## CLI
+
+Multicaには、エージェントのテストと対話のための包括的なCLIが含まれています：
+
+```bash
+pnpm cli                          # インタラクティブモード
+pnpm cli prompt "メッセージ"        # ワンショットプロンプト
+pnpm cli sessions                 # セッション一覧
+pnpm cli resume <id>              # セッションを再開
+pnpm cli agents                   # 利用可能なエージェント一覧
+pnpm cli doctor                   # エージェントのインストール状況を確認
+```
+
+### インタラクティブモード
+
+インタラクティブなREPLセッションを開始：
+
+```bash
+pnpm cli
+```
+
+利用可能なコマンド：
+
+| コマンド | 説明 |
+|---------|-------------|
+| `/help` | ヘルプを表示 |
+| `/new [cwd]` | 新しいセッションを作成（デフォルト：カレントディレクトリ） |
+| `/sessions` | すべてのセッションを一覧表示 |
+| `/resume <id>` | IDプレフィックスでセッションを再開 |
+| `/delete <id>` | セッションを削除 |
+| `/history` | 現在のセッションのメッセージ履歴を表示 |
+| `/agent <name>` | 別のエージェントに切り替え |
+| `/agents` | 利用可能なエージェントを一覧表示 |
+| `/doctor` | エージェントのインストール状況を確認 |
+| `/status` | 現在のステータスを表示 |
+| `/cancel` | 現在のリクエストをキャンセル |
+| `/quit` | CLIを終了 |
+
+### ワンショットプロンプト
+
+単一のプロンプトを送信して終了：
+
+```bash
+pnpm cli prompt "2+2は何ですか？"
+pnpm cli prompt "ファイルを一覧表示" --cwd=/tmp
+```
+
+### オプション
+
+| オプション | 説明 |
+|--------|-------------|
+| `--cwd=PATH` | エージェントの作業ディレクトリ |
+| `--log` | セッションログを `logs/` ディレクトリに保存 |
+| `--log=PATH` | セッションログを指定したファイルに保存 |
+
+## 開発
+
+```bash
+# 開発モードでElectronアプリを起動
+pnpm dev
+
+# 型チェック
+pnpm typecheck
+
+# テストを実行
+pnpm test
+```
+
+## ビルド
+
+```bash
+pnpm build:mac      # macOS
+pnpm build:win      # Windows
+pnpm build:linux    # Linux
+```
+
+## アーキテクチャ
+
+```
+Multica (Electron)
++-- レンダラープロセス (React)
+|   +-- UIコンポーネント（チャット、設定など）
+|
++-- メインプロセス
+|   +-- Conductor（エージェント通信の調整）
+|   |   +-- SessionStore（セッションの永続化）
+|   |   +-- ClientSideConnection（ACP SDK）
+|   |         +-- AgentProcess（サブプロセス管理）
+|   |               +-- opencode/codex-acp/gemini (stdio)
+|   |
+|   +-- IPCハンドラー（セッション、エージェント、設定）
+|
++-- Preload (contextBridge)
+    +-- electronAPI（レンダラーに公開）
+```
+
+### セッション管理
+
+MulticaはACPの上に独自のセッションレイヤーを維持します：
+
+```
+~/.multica/sessions/
++-- index.json              # セッションリスト（高速ロード）
++-- data/
+    +-- {session-id}.json   # 完全なセッションデータ + 更新
+```
+
+**主要な設計上の決定：**
+- **クライアントサイドストレージ**：MulticaはUI表示用に生の `session/update` データを保存
+- **エージェント非依存**：各エージェントは独自の内部状態を個別に管理
+- **再開動作**：新しいACPセッションを作成し、保存された履歴をUIに表示
+
+## ライセンス
+
+MIT

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,178 @@
+# Multica
+
+**Multiplexed Information and Computing Agent**
+
+시각적 인터페이스를 통해 코딩 에이전트의 기능을 모든 사람에게 제공하는 네이티브 데스크톱 클라이언트.
+
+[English](./README.md) | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md) | [日本語](./README.ja.md) | 한국어
+
+## 왜 "Multica"인가?
+
+이 이름은 1964년에 만들어진 선구적인 운영 체제인 [Multics](https://en.wikipedia.org/wiki/Multics)(Multiplexed Information and Computing Service)에서 영감을 받았습니다. Multics는 널리 보급되지는 않았지만, 계층적 파일 시스템과 같은 현대 운영 체제의 기반을 마련했습니다. Unix 자체도 Multics에서 파생되었습니다(Uniplexed Information and Computing Service -> Unics -> Unix).
+
+**메타포:** Multics가 다중 사용자 시분할 컴퓨팅 자원 문제를 해결하기 위해 만들어진 것처럼, Multica는 지식 근로자를 위한 다중 모델/다중 에이전트 협업 문제를 해결하기 위해 설계되었습니다.
+
+## 해결하는 문제
+
+코딩 에이전트(Claude Code, Codex, Gemini CLI 등)는 2025년에 매우 강력해져서 단순한 코드 작성을 훨씬 넘어서는 복잡한 작업을 해결할 수 있게 되었습니다. 그러나 95%의 지식 근로자들은 세 가지 핵심 장벽으로 인해 이러한 기능을 활용하지 못하고 있습니다:
+
+**1. 상호작용 불일치**
+- CLI 기반 도구는 터미널 개념, 파일 경로, 환경 변수에 대한 이해를 요구함
+- 현재 도구들은 비즈니스 결과가 아닌 코드 출력(diff, 커밋, 린팅)에 초점을 맞춤
+- 지식 근로자들이 관심 있는 것은 결과(차트, 보고서, 분석)이지, 그것을 생성하는 스크립트가 아님
+
+**2. 로컬 환경 문제**
+- 웹 기반 에이전트는 로컬 파일, 폴더 또는 네이티브 애플리케이션에 접근할 수 없음
+- Python, Node.js 또는 기타 종속성 설정은 상당한 장벽임
+- 모든 종속성을 처리하는 "바로 사용 가능한" 샌드박스 환경이 없음
+
+**3. 개인정보 보호 및 신뢰**
+- 민감한 비즈니스 데이터(재무 분석, 법률 문서, 의료 기록)는 타사 서버에 업로드할 수 없음
+- 데이터는 로컬에 유지하고 인텔리전스는 클라우드에서 가져오는 모델이 필요함
+
+Multica는 데이터를 로컬에 유지하면서 코딩 에이전트의 기능을 활용하는 시각적 네이티브 데스크톱 인터페이스를 제공하여 이 격차를 해소합니다.
+
+## 기능
+
+- 깔끔하고 직관적인 인터페이스를 갖춘 네이티브 macOS 애플리케이션
+- [Agent Client Protocol (ACP)](https://github.com/anthropics/agent-client-protocol)를 통한 여러 AI 에이전트 지원
+- 로컬 우선: 데이터가 절대 기기를 떠나지 않음
+- 기록 및 재개 기능이 있는 세션 관리
+- 파워 유저 및 테스트를 위한 내장 CLI
+
+## 지원되는 에이전트
+
+| 에이전트 | 명령어 | 설치 |
+|-------|---------|---------|
+| [OpenCode](https://github.com/opencode-ai/opencode) | `opencode acp` | `go install github.com/opencode-ai/opencode@latest` |
+| [Codex CLI (ACP)](https://github.com/zed-industries/codex-acp) | `codex-acp` | `npm install -g codex-acp` |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini acp` | `npm install -g @google/gemini-cli` |
+
+## 빠른 시작
+
+```bash
+# 종속성 설치
+pnpm install
+
+# 설치된 에이전트 확인
+pnpm cli doctor
+
+# 데스크톱 앱 시작
+pnpm dev
+```
+
+## CLI
+
+Multica에는 에이전트 테스트 및 상호작용을 위한 포괄적인 CLI가 포함되어 있습니다:
+
+```bash
+pnpm cli                          # 대화형 모드
+pnpm cli prompt "메시지"           # 단일 프롬프트
+pnpm cli sessions                 # 세션 목록
+pnpm cli resume <id>              # 세션 재개
+pnpm cli agents                   # 사용 가능한 에이전트 목록
+pnpm cli doctor                   # 에이전트 설치 확인
+```
+
+### 대화형 모드
+
+대화형 REPL 세션 시작:
+
+```bash
+pnpm cli
+```
+
+사용 가능한 명령어:
+
+| 명령어 | 설명 |
+|---------|-------------|
+| `/help` | 도움말 표시 |
+| `/new [cwd]` | 새 세션 생성 (기본값: 현재 디렉토리) |
+| `/sessions` | 모든 세션 나열 |
+| `/resume <id>` | ID 접두사로 세션 재개 |
+| `/delete <id>` | 세션 삭제 |
+| `/history` | 현재 세션의 메시지 기록 표시 |
+| `/agent <name>` | 다른 에이전트로 전환 |
+| `/agents` | 사용 가능한 에이전트 나열 |
+| `/doctor` | 에이전트 설치 확인 |
+| `/status` | 현재 상태 표시 |
+| `/cancel` | 현재 요청 취소 |
+| `/quit` | CLI 종료 |
+
+### 단일 프롬프트
+
+단일 프롬프트를 보내고 종료:
+
+```bash
+pnpm cli prompt "2+2는 무엇인가요?"
+pnpm cli prompt "파일 목록" --cwd=/tmp
+```
+
+### 옵션
+
+| 옵션 | 설명 |
+|--------|-------------|
+| `--cwd=PATH` | 에이전트의 작업 디렉토리 |
+| `--log` | 세션 로그를 `logs/` 디렉토리에 저장 |
+| `--log=PATH` | 세션 로그를 지정된 파일에 저장 |
+
+## 개발
+
+```bash
+# 개발 모드로 Electron 앱 시작
+pnpm dev
+
+# 타입 체크
+pnpm typecheck
+
+# 테스트 실행
+pnpm test
+```
+
+## 빌드
+
+```bash
+pnpm build:mac      # macOS
+pnpm build:win      # Windows
+pnpm build:linux    # Linux
+```
+
+## 아키텍처
+
+```
+Multica (Electron)
++-- 렌더러 프로세스 (React)
+|   +-- UI 컴포넌트 (채팅, 설정 등)
+|
++-- 메인 프로세스
+|   +-- Conductor (에이전트 통신 조율)
+|   |   +-- SessionStore (세션 영속성)
+|   |   +-- ClientSideConnection (ACP SDK)
+|   |         +-- AgentProcess (서브프로세스 관리)
+|   |               +-- opencode/codex-acp/gemini (stdio)
+|   |
+|   +-- IPC 핸들러 (세션, 에이전트, 설정)
+|
++-- Preload (contextBridge)
+    +-- electronAPI (렌더러에 노출)
+```
+
+### 세션 관리
+
+Multica는 ACP 위에 자체 세션 레이어를 유지합니다:
+
+```
+~/.multica/sessions/
++-- index.json              # 세션 목록 (빠른 로드)
++-- data/
+    +-- {session-id}.json   # 전체 세션 데이터 + 업데이트
+```
+
+**주요 설계 결정:**
+- **클라이언트 측 저장소**: Multica는 UI 표시를 위해 원시 `session/update` 데이터를 저장
+- **에이전트 독립적**: 각 에이전트가 자체 내부 상태를 별도로 관리
+- **재개 동작**: 새 ACP 세션을 생성하고 저장된 기록을 UI에 표시
+
+## 라이선스
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,8 +1,44 @@
 # Multica
 
-A GUI client for ACP-compatible coding agents.
+**Multiplexed Information and Computing Agent**
 
-Multica uses the [Agent Client Protocol (ACP)](https://github.com/anthropics/agent-client-protocol) to communicate with various coding agents like OpenCode, Codex, and Gemini CLI.
+A native desktop client that brings coding agent capabilities to everyone through a visual interface.
+
+English | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md)
+
+## Why "Multica"?
+
+The name is inspired by [Multics](https://en.wikipedia.org/wiki/Multics) (Multiplexed Information and Computing Service), a pioneering operating system created in 1964. Although Multics never achieved widespread adoption, it laid the foundation for modern operating systems, including concepts like the hierarchical file system. Unix itself was derived from Multics (Uniplexed Information and Computing Service -> Unics -> Unix).
+
+**The metaphor:** Just as Multics was created to solve the problem of multi-user time-sharing on computing resources, Multica is designed to solve the problem of multi-model/multi-agent collaboration for knowledge workers.
+
+## The Problem
+
+Coding agents (like Claude Code, Codex, Gemini CLI) have become incredibly powerful in 2025, capable of solving complex tasks far beyond just writing code. However, 95% of knowledge workers are locked out of these capabilities due to three core barriers:
+
+**1. Interaction Mismatch**
+- CLI-based tools require understanding of terminal concepts, file paths, and environment variables
+- Current tools focus on code output (diffs, commits, linting) rather than business outcomes
+- Knowledge workers care about results (charts, reports, analysis), not the scripts that generate them
+
+**2. Local Environment Challenges**
+- Web-based agents can't access local files, folders, or native applications
+- Setting up Python, Node.js, or other dependencies is a significant barrier
+- Missing the "just works" sandbox environment that handles all dependencies
+
+**3. Privacy & Trust**
+- Sensitive business data (financial analysis, legal documents, medical records) can't be uploaded to third-party servers
+- Need a model where data stays local while intelligence comes from the cloud
+
+Multica bridges this gap by providing a visual, native desktop interface that leverages coding agents' capabilities while keeping your data local.
+
+## Features
+
+- Native macOS application with a clean, intuitive interface
+- Support for multiple AI agents through the [Agent Client Protocol (ACP)](https://github.com/anthropics/agent-client-protocol)
+- Local-first: your data never leaves your machine
+- Session management with history and resume capabilities
+- Built-in CLI for power users and testing
 
 ## Supported Agents
 
@@ -21,8 +57,8 @@ pnpm install
 # Check which agents are installed
 pnpm cli doctor
 
-# Start interactive mode
-pnpm cli
+# Start the desktop app
+pnpm dev
 ```
 
 ## CLI
@@ -72,16 +108,6 @@ pnpm cli prompt "What is 2+2?"
 pnpm cli prompt "List files" --cwd=/tmp
 ```
 
-### Doctor
-
-Check if agents are installed on your system:
-
-```bash
-pnpm cli doctor
-```
-
-Shows installation status, binary path, version, and install hints for missing agents.
-
 ### Options
 
 | Option | Description |
@@ -89,11 +115,6 @@ Shows installation status, binary path, version, and install hints for missing a
 | `--cwd=PATH` | Working directory for the agent |
 | `--log` | Save session log to `logs/` directory |
 | `--log=PATH` | Save session log to specified file |
-
-### Cancellation
-
-- Press `Ctrl+C` once to send a cancel request to the agent
-- Press `Ctrl+C` twice to force quit
 
 ## Development
 
@@ -103,6 +124,9 @@ pnpm dev
 
 # Type check
 pnpm typecheck
+
+# Run tests
+pnpm test
 ```
 
 ## Build
@@ -117,20 +141,20 @@ pnpm build:linux    # Linux
 
 ```
 Multica (Electron)
-├── Renderer Process (React)
-│   └── UI Components (Chat, Settings, etc.)
-│
-├── Main Process
-│   ├── Conductor (orchestrates agent communication)
-│   │   ├── SessionStore (session persistence)
-│   │   └── ClientSideConnection (ACP SDK)
-│   │         └── AgentProcess (subprocess management)
-│   │               └── opencode/codex-acp/gemini (stdio)
-│   │
-│   └── IPC Handlers (session, agent, config)
-│
-└── Preload (contextBridge)
-    └── electronAPI (exposed to renderer)
++-- Renderer Process (React)
+|   +-- UI Components (Chat, Settings, etc.)
+|
++-- Main Process
+|   +-- Conductor (orchestrates agent communication)
+|   |   +-- SessionStore (session persistence)
+|   |   +-- ClientSideConnection (ACP SDK)
+|   |         +-- AgentProcess (subprocess management)
+|   |               +-- opencode/codex-acp/gemini (stdio)
+|   |
+|   +-- IPC Handlers (session, agent, config)
+|
++-- Preload (contextBridge)
+    +-- electronAPI (exposed to renderer)
 ```
 
 ### Session Management
@@ -139,32 +163,15 @@ Multica maintains its own session layer on top of ACP:
 
 ```
 ~/.multica/sessions/
-├── index.json              # Session list (fast load)
-└── data/
-    └── {session-id}.json   # Full session data + updates
++-- index.json              # Session list (fast load)
++-- data/
+    +-- {session-id}.json   # Full session data + updates
 ```
 
 **Key design decisions:**
 - **Client-side storage**: Multica stores raw `session/update` data for UI display
 - **Agent-agnostic**: Each agent manages its own internal state separately
 - **Resume behavior**: Creates new ACP session, displays stored history in UI
-
-### IPC API
-
-```typescript
-// Session management
-electronAPI.createSession(cwd)
-electronAPI.listSessions(options?)
-electronAPI.getSession(id)
-electronAPI.resumeSession(id)
-electronAPI.deleteSession(id)
-
-// Agent control
-electronAPI.startAgent(agentId)
-electronAPI.stopAgent()
-electronAPI.sendPrompt(sessionId, content)
-electronAPI.cancelRequest(sessionId)
-```
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,178 @@
+# Multica
+
+**Multiplexed Information and Computing Agent**
+
+一个原生桌面客户端，通过可视化界面将编程智能体的能力带给每一个人。
+
+[English](./README.md) | 简体中文 | [繁體中文](./README.zh-TW.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md)
+
+## 为什么叫 "Multica"？
+
+这个名字的灵感来自于 [Multics](https://en.wikipedia.org/wiki/Multics)（Multiplexed Information and Computing Service，多路复用信息与计算服务），这是一个创建于 1964 年的开创性操作系统。尽管 Multics 最终没有广泛普及，但它奠定了现代操作系统的基础，包括层级文件系统等概念。Unix 本身就是从 Multics 衍生而来的（Uniplexed Information and Computing Service -> Unics -> Unix）。
+
+**隐喻：** 正如 Multics 当年是为了解决多用户分时共享计算资源的问题，Multica 旨在解决多模型/多智能体协作的问题，服务于知识工作者。
+
+## 解决的问题
+
+编程智能体（如 Claude Code、Codex、Gemini CLI）在 2025 年变得极其强大，其能力已经远远超出了单纯的代码编写。然而，95% 的知识工作者因为三个核心障碍而无法使用这些能力：
+
+**1. 交互形态的错配**
+- 基于命令行的工具需要理解终端概念、文件路径和环境变量
+- 现有工具聚焦于代码输出（差异对比、提交、代码检查），而非业务成果
+- 知识工作者关心的是结果（图表、报告、分析），而不是生成这些结果的脚本
+
+**2. 本地环境的挑战**
+- 基于网页的智能体无法访问本地文件、文件夹或原生应用
+- 设置 Python、Node.js 或其他依赖是一个巨大的障碍
+- 缺少一个"开箱即用"、处理好所有依赖的沙盒环境
+
+**3. 隐私与信任**
+- 敏感的业务数据（财务分析、法律文件、医疗记录）不能上传到第三方服务器
+- 需要一种数据留在本地、智能来自云端的模式
+
+Multica 通过提供可视化的原生桌面界面来弥合这一鸿沟，在保持数据本地化的同时，充分利用编程智能体的能力。
+
+## 特性
+
+- 原生 macOS 应用，界面简洁直观
+- 通过 [Agent Client Protocol (ACP)](https://github.com/anthropics/agent-client-protocol) 支持多种 AI 智能体
+- 本地优先：数据永远不会离开你的设备
+- 会话管理，支持历史记录和恢复功能
+- 内置 CLI，适合高级用户和测试使用
+
+## 支持的智能体
+
+| 智能体 | 命令 | 安装方式 |
+|-------|---------|---------|
+| [OpenCode](https://github.com/opencode-ai/opencode) | `opencode acp` | `go install github.com/opencode-ai/opencode@latest` |
+| [Codex CLI (ACP)](https://github.com/zed-industries/codex-acp) | `codex-acp` | `npm install -g codex-acp` |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini acp` | `npm install -g @google/gemini-cli` |
+
+## 快速开始
+
+```bash
+# 安装依赖
+pnpm install
+
+# 检查已安装的智能体
+pnpm cli doctor
+
+# 启动桌面应用
+pnpm dev
+```
+
+## 命令行工具
+
+Multica 包含一个完整的 CLI，用于测试和与智能体交互：
+
+```bash
+pnpm cli                          # 交互模式
+pnpm cli prompt "消息"             # 单次提问
+pnpm cli sessions                 # 列出会话
+pnpm cli resume <id>              # 恢复会话
+pnpm cli agents                   # 列出可用智能体
+pnpm cli doctor                   # 检查智能体安装状态
+```
+
+### 交互模式
+
+启动交互式 REPL 会话：
+
+```bash
+pnpm cli
+```
+
+可用命令：
+
+| 命令 | 描述 |
+|---------|-------------|
+| `/help` | 显示帮助 |
+| `/new [cwd]` | 创建新会话（默认：当前目录） |
+| `/sessions` | 列出所有会话 |
+| `/resume <id>` | 通过 ID 前缀恢复会话 |
+| `/delete <id>` | 删除会话 |
+| `/history` | 显示当前会话的消息历史 |
+| `/agent <name>` | 切换到其他智能体 |
+| `/agents` | 列出可用智能体 |
+| `/doctor` | 检查智能体安装状态 |
+| `/status` | 显示当前状态 |
+| `/cancel` | 取消当前请求 |
+| `/quit` | 退出 CLI |
+
+### 单次提问
+
+发送单个提示并退出：
+
+```bash
+pnpm cli prompt "2+2等于多少？"
+pnpm cli prompt "列出文件" --cwd=/tmp
+```
+
+### 选项
+
+| 选项 | 描述 |
+|--------|-------------|
+| `--cwd=PATH` | 智能体的工作目录 |
+| `--log` | 将会话日志保存到 `logs/` 目录 |
+| `--log=PATH` | 将会话日志保存到指定文件 |
+
+## 开发
+
+```bash
+# 以开发模式启动 Electron 应用
+pnpm dev
+
+# 类型检查
+pnpm typecheck
+
+# 运行测试
+pnpm test
+```
+
+## 构建
+
+```bash
+pnpm build:mac      # macOS
+pnpm build:win      # Windows
+pnpm build:linux    # Linux
+```
+
+## 架构
+
+```
+Multica (Electron)
++-- 渲染进程 (React)
+|   +-- UI 组件（聊天、设置等）
+|
++-- 主进程
+|   +-- Conductor（协调智能体通信）
+|   |   +-- SessionStore（会话持久化）
+|   |   +-- ClientSideConnection（ACP SDK）
+|   |         +-- AgentProcess（子进程管理）
+|   |               +-- opencode/codex-acp/gemini (stdio)
+|   |
+|   +-- IPC 处理器（会话、智能体、配置）
+|
++-- Preload (contextBridge)
+    +-- electronAPI（暴露给渲染进程）
+```
+
+### 会话管理
+
+Multica 在 ACP 之上维护自己的会话层：
+
+```
+~/.multica/sessions/
++-- index.json              # 会话列表（快速加载）
++-- data/
+    +-- {session-id}.json   # 完整会话数据 + 更新
+```
+
+**关键设计决策：**
+- **客户端存储**：Multica 存储原始的 `session/update` 数据用于 UI 展示
+- **智能体无关**：每个智能体独立管理自己的内部状态
+- **恢复行为**：创建新的 ACP 会话，在 UI 中显示存储的历史记录
+
+## 许可证
+
+MIT

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,178 @@
+# Multica
+
+**Multiplexed Information and Computing Agent**
+
+一個原生桌面客戶端，透過視覺化介面將程式智能體的能力帶給每一個人。
+
+[English](./README.md) | [简体中文](./README.zh-CN.md) | 繁體中文 | [日本語](./README.ja.md) | [한국어](./README.ko.md)
+
+## 為什麼叫 "Multica"？
+
+這個名字的靈感來自於 [Multics](https://en.wikipedia.org/wiki/Multics)（Multiplexed Information and Computing Service，多工資訊與運算服務），這是一個創建於 1964 年的開創性作業系統。儘管 Multics 最終沒有廣泛普及，但它奠定了現代作業系統的基礎，包括階層式檔案系統等概念。Unix 本身就是從 Multics 衍生而來的（Uniplexed Information and Computing Service -> Unics -> Unix）。
+
+**隱喻：** 正如 Multics 當年是為了解決多使用者分時共享運算資源的問題，Multica 旨在解決多模型/多智能體協作的問題，服務於知識工作者。
+
+## 解決的問題
+
+程式智能體（如 Claude Code、Codex、Gemini CLI）在 2025 年變得極其強大，其能力已經遠遠超出了單純的程式碼編寫。然而，95% 的知識工作者因為三個核心障礙而無法使用這些能力：
+
+**1. 互動形態的錯配**
+- 基於命令列的工具需要理解終端機概念、檔案路徑和環境變數
+- 現有工具聚焦於程式碼輸出（差異比對、提交、程式碼檢查），而非業務成果
+- 知識工作者關心的是結果（圖表、報告、分析），而不是產生這些結果的腳本
+
+**2. 本機環境的挑戰**
+- 基於網頁的智能體無法存取本機檔案、資料夾或原生應用程式
+- 設定 Python、Node.js 或其他相依套件是一個巨大的障礙
+- 缺少一個「開箱即用」、處理好所有相依套件的沙盒環境
+
+**3. 隱私與信任**
+- 敏感的業務資料（財務分析、法律文件、醫療紀錄）不能上傳到第三方伺服器
+- 需要一種資料留在本機、智能來自雲端的模式
+
+Multica 透過提供視覺化的原生桌面介面來彌合這一鴻溝，在保持資料本機化的同時，充分利用程式智能體的能力。
+
+## 特性
+
+- 原生 macOS 應用程式，介面簡潔直觀
+- 透過 [Agent Client Protocol (ACP)](https://github.com/anthropics/agent-client-protocol) 支援多種 AI 智能體
+- 本機優先：資料永遠不會離開你的裝置
+- 工作階段管理，支援歷史紀錄和恢復功能
+- 內建 CLI，適合進階使用者和測試使用
+
+## 支援的智能體
+
+| 智能體 | 命令 | 安裝方式 |
+|-------|---------|---------|
+| [OpenCode](https://github.com/opencode-ai/opencode) | `opencode acp` | `go install github.com/opencode-ai/opencode@latest` |
+| [Codex CLI (ACP)](https://github.com/zed-industries/codex-acp) | `codex-acp` | `npm install -g codex-acp` |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini acp` | `npm install -g @google/gemini-cli` |
+
+## 快速開始
+
+```bash
+# 安裝相依套件
+pnpm install
+
+# 檢查已安裝的智能體
+pnpm cli doctor
+
+# 啟動桌面應用程式
+pnpm dev
+```
+
+## 命令列工具
+
+Multica 包含一個完整的 CLI，用於測試和與智能體互動：
+
+```bash
+pnpm cli                          # 互動模式
+pnpm cli prompt "訊息"             # 單次提問
+pnpm cli sessions                 # 列出工作階段
+pnpm cli resume <id>              # 恢復工作階段
+pnpm cli agents                   # 列出可用智能體
+pnpm cli doctor                   # 檢查智能體安裝狀態
+```
+
+### 互動模式
+
+啟動互動式 REPL 工作階段：
+
+```bash
+pnpm cli
+```
+
+可用命令：
+
+| 命令 | 描述 |
+|---------|-------------|
+| `/help` | 顯示說明 |
+| `/new [cwd]` | 建立新工作階段（預設：目前目錄） |
+| `/sessions` | 列出所有工作階段 |
+| `/resume <id>` | 透過 ID 前綴恢復工作階段 |
+| `/delete <id>` | 刪除工作階段 |
+| `/history` | 顯示目前工作階段的訊息歷史 |
+| `/agent <name>` | 切換到其他智能體 |
+| `/agents` | 列出可用智能體 |
+| `/doctor` | 檢查智能體安裝狀態 |
+| `/status` | 顯示目前狀態 |
+| `/cancel` | 取消目前請求 |
+| `/quit` | 退出 CLI |
+
+### 單次提問
+
+傳送單個提示並退出：
+
+```bash
+pnpm cli prompt "2+2等於多少？"
+pnpm cli prompt "列出檔案" --cwd=/tmp
+```
+
+### 選項
+
+| 選項 | 描述 |
+|--------|-------------|
+| `--cwd=PATH` | 智能體的工作目錄 |
+| `--log` | 將工作階段日誌儲存到 `logs/` 目錄 |
+| `--log=PATH` | 將工作階段日誌儲存到指定檔案 |
+
+## 開發
+
+```bash
+# 以開發模式啟動 Electron 應用程式
+pnpm dev
+
+# 型別檢查
+pnpm typecheck
+
+# 執行測試
+pnpm test
+```
+
+## 建置
+
+```bash
+pnpm build:mac      # macOS
+pnpm build:win      # Windows
+pnpm build:linux    # Linux
+```
+
+## 架構
+
+```
+Multica (Electron)
++-- 渲染程序 (React)
+|   +-- UI 元件（聊天、設定等）
+|
++-- 主程序
+|   +-- Conductor（協調智能體通訊）
+|   |   +-- SessionStore（工作階段持久化）
+|   |   +-- ClientSideConnection（ACP SDK）
+|   |         +-- AgentProcess（子程序管理）
+|   |               +-- opencode/codex-acp/gemini (stdio)
+|   |
+|   +-- IPC 處理器（工作階段、智能體、設定）
+|
++-- Preload (contextBridge)
+    +-- electronAPI（暴露給渲染程序）
+```
+
+### 工作階段管理
+
+Multica 在 ACP 之上維護自己的工作階段層：
+
+```
+~/.multica/sessions/
++-- index.json              # 工作階段列表（快速載入）
++-- data/
+    +-- {session-id}.json   # 完整工作階段資料 + 更新
+```
+
+**關鍵設計決策：**
+- **客戶端儲存**：Multica 儲存原始的 `session/update` 資料用於 UI 展示
+- **智能體無關**：每個智能體獨立管理自己的內部狀態
+- **恢復行為**：建立新的 ACP 工作階段，在 UI 中顯示儲存的歷史紀錄
+
+## 授權條款
+
+MIT

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
-appId: com.electron.app
-productName: multica-temp
+appId: com.multica.app
+productName: Multica
 directories:
   buildResources: build
 files:
@@ -12,7 +12,7 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: multica-temp
+  executableName: multica
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "multica",
   "version": "0.1.0",
-  "description": "A GUI client for ACP-compatible coding agents",
+  "description": "Multiplexed Information and Computing Agent - A GUI client that brings coding agent capabilities to everyone",
   "main": "./out/main/index.js",
   "author": "Multica",
-  "homepage": "https://github.com/multica/multica",
+  "homepage": "https://github.com/multica-ai/multica",
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --cache .",


### PR DESCRIPTION
## Summary
- Rebrand product to Multica with full name expansion: Multiplexed Information and Computing Agent
- Updated metadata in package.json and electron-builder.yml with proper naming and GitHub organization
- Completely rewrote README with comprehensive vision, origin story, and problem statement
- Added translations in 4 languages (Simplified Chinese, Traditional Chinese, Japanese, Korean)

## Test Plan
- Verify all README files are syntactically correct and accessible
- Check that language links work correctly across all README versions
- Review metadata in package.json and electron-builder.yml for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)