### PR TITLE
feat: add agent selector and fix session persistence

### DIFF
--- a/docs/plans/2026-01-15-chatbox-agent-selector-design.md
+++ b/docs/plans/2026-01-15-chatbox-agent-selector-design.md
@@ -1,0 +1,79 @@
+# Chatbox Agent Selector Design
+
+## Overview
+
+Add an inline agent selector to the MessageInput chatbox, allowing users to switch the current session's agent mid-conversation.
+
+## Behavior
+
+- **Scope**: Changes the current session's agent (restarts agent process)
+- **Disabled during**: Active processing only (users can switch when agent is idle)
+- **No session**: Changes default agent for next session (syncs with localStorage)
+
+## UI Design
+
+### Trigger Button
+
+- Position: Bottom-left of MessageInput, left of folder indicator
+- Layout: `[Sparkles icon] [Agent name] [ChevronDown icon]`
+- Style: Ghost button (transparent bg, subtle hover)
+- Text: `text-sm text-muted-foreground`
+- Icons: 14px, muted color
+
+### Dropdown Menu
+
+- Type: Radix UI DropdownMenu
+- Position: Above trigger (`side="top"`)
+- Width: Auto, min-width matches trigger
+
+### Dropdown Items
+
+- Layout: `[Agent name] [status dot]`
+- Status dot: 8px circle
+  - Green (`bg-green-500`): Installed
+  - Grey (`bg-muted`): Needs setup
+- Disabled items: Reduced opacity, tooltip explaining setup needed
+- Selected item: Highlighted background
+
+## Component Structure
+
+### New Component: `AgentSelector.tsx`
+
+```typescript
+interface AgentSelectorProps {
+  currentAgentId: string
+  onAgentChange: (agentId: string) => void
+  disabled?: boolean
+}
+```
+
+### Integration
+
+Add to MessageInput.tsx in the bottom toolbar, positioned left of folder indicator.
+
+## Data Flow
+
+1. Fetch agents via `window.electronAPI.checkAgents()` on mount
+2. Store in local component state
+3. On agent change:
+   - Call `onAgentChange(newAgentId)`
+   - Parent stops current agent process
+   - Parent updates session's agentId
+   - Parent starts new agent process (same working directory)
+   - Show toast: "Switched to [Agent Name]"
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No session active | Changes default agent for next session |
+| Agent switch fails | Error toast, revert to previous agent |
+| All agents unavailable | Disabled selector with tooltip |
+| Loading agents | Show spinner instead of chevron |
+
+## Files to Modify
+
+1. **Create**: `src/renderer/src/components/AgentSelector.tsx`
+2. **Modify**: `src/renderer/src/components/MessageInput.tsx` - Add AgentSelector to bottom toolbar
+3. **Modify**: `src/renderer/src/hooks/useApp.ts` - Add `switchAgent` function
+4. **Modify**: `src/renderer/src/App.tsx` - Wire up agent switching to session management

--- a/docs/plans/2026-01-15-chatbox-agent-selector.md
+++ b/docs/plans/2026-01-15-chatbox-agent-selector.md
@@ -1,0 +1,670 @@
+# Chatbox Agent Selector Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an inline agent selector to MessageInput that lets users switch the current session's agent mid-conversation.
+
+**Architecture:** Create a new AgentSelector component using Radix UI DropdownMenu. Add backend support to switch a session's agent (stop old agent, update agentId, start new agent). Wire up through useApp hook.
+
+**Tech Stack:** React, TypeScript, Radix UI DropdownMenu, Tailwind CSS, lucide-react icons
+
+---
+
+### Task 1: Create DropdownMenu UI Component
+
+**Files:**
+- Create: `src/renderer/src/components/ui/dropdown-menu.tsx`
+
+**Step 1: Install Radix UI dropdown-menu package**
+
+Run: `npm install @radix-ui/react-dropdown-menu`
+Expected: Package added to package.json
+
+**Step 2: Create the DropdownMenu component**
+
+```tsx
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
+}
+```
+
+**Step 3: Verify build passes**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 4: Commit**
+
+```bash
+git add src/renderer/src/components/ui/dropdown-menu.tsx package.json package-lock.json
+git commit -m "feat: add DropdownMenu UI component"
+```
+
+---
+
+### Task 2: Add switchSessionAgent to Backend
+
+**Files:**
+- Modify: `src/main/conductor/Conductor.ts:468-476` (add new method after updateSessionMeta)
+- Modify: `src/main/ipc/handlers.ts:106-111` (add IPC handler after SESSION_UPDATE)
+- Modify: `src/shared/ipc-channels.ts` (add new channel)
+- Modify: `src/shared/electron-api.d.ts:106` (add new API method)
+- Modify: `src/preload/preload.ts` (add preload binding)
+
+**Step 1: Add IPC channel constant**
+
+In `src/shared/ipc-channels.ts`, add after `SESSION_UPDATE`:
+
+```typescript
+SESSION_SWITCH_AGENT: 'session:switch-agent',
+```
+
+**Step 2: Add Conductor method**
+
+In `src/main/conductor/Conductor.ts`, add after `updateSessionMeta` method (around line 476):
+
+```typescript
+/**
+ * Switch a session's agent (stops current, updates, starts new)
+ */
+async switchSessionAgent(sessionId: string, newAgentId: string): Promise<MulticaSession> {
+  if (!this.sessionStore) {
+    throw new Error('Session agent switch not available in CLI mode')
+  }
+
+  const data = await this.sessionStore.get(sessionId)
+  if (!data) {
+    throw new Error(`Session not found: ${sessionId}`)
+  }
+
+  // Get new agent config
+  const newAgentConfig = DEFAULT_AGENTS[newAgentId]
+  if (!newAgentConfig) {
+    throw new Error(`Unknown agent: ${newAgentId}`)
+  }
+
+  console.log(`[Conductor] Switching session ${sessionId} from ${data.session.agentId} to ${newAgentId}`)
+
+  // Stop current agent if running
+  await this.stopSession(sessionId)
+
+  // Update session's agentId
+  let updatedSession = await this.sessionStore.updateMeta(sessionId, {
+    agentId: newAgentId,
+  })
+
+  // Start new agent (isResumed = true to replay history)
+  const { agentSessionId } = await this.startAgentForSession(
+    sessionId,
+    newAgentConfig,
+    data.session.workingDirectory,
+    true
+  )
+
+  // Update agentSessionId
+  updatedSession = await this.sessionStore.updateMeta(sessionId, {
+    agentSessionId,
+    status: 'active',
+  })
+
+  // Notify frontend
+  if (this.events.onSessionMetaUpdated) {
+    this.events.onSessionMetaUpdated(updatedSession)
+  }
+
+  console.log(`[Conductor] Session ${sessionId} switched to ${newAgentId} (agent session: ${agentSessionId})`)
+
+  return updatedSession
+}
+```
+
+**Step 3: Add IPC handler**
+
+In `src/main/ipc/handlers.ts`, add after the SESSION_UPDATE handler (around line 111):
+
+```typescript
+ipcMain.handle(
+  IPC_CHANNELS.SESSION_SWITCH_AGENT,
+  async (_event, sessionId: string, newAgentId: string) => {
+    return conductor.switchSessionAgent(sessionId, newAgentId)
+  }
+)
+```
+
+**Step 4: Add ElectronAPI type**
+
+In `src/shared/electron-api.d.ts`, add after `updateSession` (around line 106):
+
+```typescript
+switchSessionAgent(sessionId: string, newAgentId: string): Promise<MulticaSession>
+```
+
+**Step 5: Add preload binding**
+
+In `src/preload/preload.ts`, add to the electronAPI object:
+
+```typescript
+switchSessionAgent: (sessionId: string, newAgentId: string) =>
+  ipcRenderer.invoke(IPC_CHANNELS.SESSION_SWITCH_AGENT, sessionId, newAgentId),
+```
+
+**Step 6: Verify build passes**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 7: Commit**
+
+```bash
+git add src/main/conductor/Conductor.ts src/main/ipc/handlers.ts src/shared/ipc-channels.ts src/shared/electron-api.d.ts src/preload/preload.ts
+git commit -m "feat: add switchSessionAgent backend support"
+```
+
+---
+
+### Task 3: Add switchSessionAgent to useApp Hook
+
+**Files:**
+- Modify: `src/renderer/src/hooks/useApp.ts:27-41` (add to AppActions interface)
+- Modify: `src/renderer/src/hooks/useApp.ts:293-297` (add implementation before clearError)
+- Modify: `src/renderer/src/hooks/useApp.ts:299-317` (add to return object)
+
+**Step 1: Add to AppActions interface**
+
+In `src/renderer/src/hooks/useApp.ts`, add to AppActions interface (around line 36):
+
+```typescript
+switchSessionAgent: (newAgentId: string) => Promise<void>
+```
+
+**Step 2: Add implementation**
+
+In `src/renderer/src/hooks/useApp.ts`, add before `clearError` (around line 295):
+
+```typescript
+const switchSessionAgent = useCallback(async (newAgentId: string) => {
+  if (!currentSession) {
+    setError('No active session')
+    return
+  }
+
+  try {
+    setError(null)
+    const updatedSession = await window.electronAPI.switchSessionAgent(currentSession.id, newAgentId)
+    setCurrentSession(updatedSession)
+    await loadRunningStatus()
+  } catch (err) {
+    setError(`Failed to switch agent: ${err}`)
+  }
+}, [currentSession, loadRunningStatus])
+```
+
+**Step 3: Add to return object**
+
+In the return statement, add `switchSessionAgent` to the Actions section.
+
+**Step 4: Verify build passes**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/src/hooks/useApp.ts
+git commit -m "feat: add switchSessionAgent to useApp hook"
+```
+
+---
+
+### Task 4: Create AgentSelector Component
+
+**Files:**
+- Create: `src/renderer/src/components/AgentSelector.tsx`
+
+**Step 1: Create the component**
+
+```tsx
+/**
+ * Agent selector dropdown for MessageInput
+ */
+import { useState, useEffect } from 'react'
+import { Sparkles, ChevronDown, Loader2 } from 'lucide-react'
+import type { AgentCheckResult } from '../../../shared/electron-api'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+interface AgentSelectorProps {
+  currentAgentId: string
+  onAgentChange: (agentId: string) => void
+  disabled?: boolean
+}
+
+export function AgentSelector({
+  currentAgentId,
+  onAgentChange,
+  disabled = false,
+}: AgentSelectorProps) {
+  const [agents, setAgents] = useState<AgentCheckResult[]>([])
+  const [loading, setLoading] = useState(true)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    loadAgents()
+  }, [])
+
+  async function loadAgents() {
+    setLoading(true)
+    try {
+      const results = await window.electronAPI.checkAgents()
+      setAgents(results)
+    } catch (err) {
+      console.error('Failed to check agents:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const currentAgent = agents.find((a) => a.id === currentAgentId)
+  const currentAgentName = currentAgent?.name || currentAgentId
+
+  function handleSelect(agentId: string) {
+    if (agentId !== currentAgentId) {
+      onAgentChange(agentId)
+    }
+    setOpen(false)
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild disabled={disabled || loading}>
+        <button
+          className={cn(
+            "flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-background/50",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+          <span className="max-w-[100px] truncate">{currentAgentName}</span>
+          {loading ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="start" className="min-w-[140px]">
+        {agents.map((agent) => {
+          const isSelected = agent.id === currentAgentId
+          const isDisabled = !agent.installed
+
+          if (isDisabled) {
+            return (
+              <Tooltip key={agent.id}>
+                <TooltipTrigger asChild>
+                  <div>
+                    <DropdownMenuItem
+                      disabled
+                      className="flex items-center justify-between"
+                    >
+                      <span>{agent.name}</span>
+                      <span className="h-2 w-2 rounded-full bg-muted" />
+                    </DropdownMenuItem>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  Setup required in Settings
+                </TooltipContent>
+              </Tooltip>
+            )
+          }
+
+          return (
+            <DropdownMenuItem
+              key={agent.id}
+              onClick={() => handleSelect(agent.id)}
+              className="flex items-center justify-between"
+            >
+              <span>{agent.name}</span>
+              <span
+                className={cn(
+                  "h-2 w-2 rounded-full",
+                  isSelected ? "bg-green-500" : "bg-green-500/50"
+                )}
+              />
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+```
+
+**Step 2: Verify build passes**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/AgentSelector.tsx
+git commit -m "feat: create AgentSelector component"
+```
+
+---
+
+### Task 5: Integrate AgentSelector into MessageInput
+
+**Files:**
+- Modify: `src/renderer/src/components/MessageInput.tsx:5-6` (add import)
+- Modify: `src/renderer/src/components/MessageInput.tsx:9-17` (update props interface)
+- Modify: `src/renderer/src/components/MessageInput.tsx:122-135` (add AgentSelector to toolbar)
+
+**Step 1: Add import**
+
+At top of file, add:
+
+```typescript
+import { AgentSelector } from './AgentSelector'
+```
+
+**Step 2: Update props interface**
+
+Add new props to MessageInputProps:
+
+```typescript
+currentAgentId?: string
+onAgentChange?: (agentId: string) => void
+```
+
+**Step 3: Update component signature**
+
+Add the new props to the function parameters with defaults:
+
+```typescript
+currentAgentId,
+onAgentChange,
+```
+
+**Step 4: Add AgentSelector to bottom toolbar**
+
+In the normal chat input mode, modify the bottom toolbar (around line 122) to include AgentSelector before the folder indicator:
+
+```tsx
+{/* Bottom toolbar */}
+<div className="flex items-center justify-between pt-2">
+  <div className="flex items-center gap-1">
+    {/* Agent selector */}
+    {currentAgentId && onAgentChange && (
+      <AgentSelector
+        currentAgentId={currentAgentId}
+        onAgentChange={onAgentChange}
+        disabled={isProcessing}
+      />
+    )}
+
+    {/* Folder indicator */}
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={onSelectFolder}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-background/50"
+        >
+          <Folder className="h-3.5 w-3.5" />
+          <span className="max-w-[150px] truncate">{folderName}</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top">Change folder</TooltipContent>
+    </Tooltip>
+  </div>
+
+  {/* Send button */}
+  <Tooltip>
+    {/* ... existing send button code ... */}
+  </Tooltip>
+</div>
+```
+
+**Step 5: Verify build passes**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 6: Commit**
+
+```bash
+git add src/renderer/src/components/MessageInput.tsx
+git commit -m "feat: integrate AgentSelector into MessageInput"
+```
+
+---
+
+### Task 6: Wire Up AgentSelector in App.tsx
+
+**Files:**
+- Modify: `src/renderer/src/App.tsx:31-38` (add switchSessionAgent to useApp destructuring)
+- Modify: `src/renderer/src/App.tsx:126-133` (add props to MessageInput)
+
+**Step 1: Add switchSessionAgent to useApp destructuring**
+
+In the useApp() destructuring, add `switchSessionAgent` to the Actions section.
+
+**Step 2: Pass props to MessageInput**
+
+Update the MessageInput component to include the new props:
+
+```tsx
+<MessageInput
+  onSend={sendPrompt}
+  onCancel={cancelRequest}
+  isProcessing={isProcessing}
+  disabled={!currentSession}
+  workingDirectory={currentSession?.workingDirectory}
+  onSelectFolder={handleSelectFolder}
+  currentAgentId={currentSession?.agentId}
+  onAgentChange={switchSessionAgent}
+/>
+```
+
+**Step 3: Verify build passes**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 4: Commit**
+
+```bash
+git add src/renderer/src/App.tsx
+git commit -m "feat: wire up AgentSelector in App.tsx"
+```
+
+---
+
+### Task 7: Add Toast Notification on Agent Switch
+
+**Files:**
+- Modify: `src/renderer/src/hooks/useApp.ts` (add toast import and notification)
+
+**Step 1: Add toast import**
+
+At top of file, add:
+
+```typescript
+import { toast } from 'sonner'
+```
+
+**Step 2: Add toast to switchSessionAgent**
+
+In the switchSessionAgent function, after successful switch, add:
+
+```typescript
+toast.success(`Switched to ${newAgentId}`)
+```
+
+**Step 3: Verify build passes**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 4: Manual test**
+
+1. Start the app: `npm run dev`
+2. Create a session
+3. Click on the agent selector in the bottom left of the chat input
+4. Select a different agent
+5. Verify toast notification appears
+6. Send a message to verify new agent responds
+
+**Step 5: Commit**
+
+```bash
+git add src/renderer/src/hooks/useApp.ts
+git commit -m "feat: add toast notification on agent switch"
+```
+
+---
+
+### Task 8: Export AgentSelector from Components Index
+
+**Files:**
+- Modify: `src/renderer/src/components/index.ts` (add export)
+
+**Step 1: Add export**
+
+Add to the exports:
+
+```typescript
+export { AgentSelector } from './AgentSelector'
+```
+
+**Step 2: Verify build passes**
+
+Run: `npm run build`
+Expected: Build succeeds without errors
+
+**Step 3: Commit**
+
+```bash
+git add src/renderer/src/components/index.ts
+git commit -m "feat: export AgentSelector from components index"
+```
+
+---
+
+## Summary
+
+After completing all tasks, the chatbox will have an inline agent selector that:
+- Shows current agent name with sparkle icon and dropdown chevron
+- Displays available agents with green status dots (installed) or grey dots (needs setup)
+- Disables uninstalled agents with tooltip
+- Switches the current session's agent when selected
+- Shows toast notification on successful switch
+- Disables during processing to prevent mid-response switching

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-toggle": "^1.1.10",
@@ -2189,6 +2190,35 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-toggle": "^1.1.10",

--- a/src/main/conductor/Conductor.ts
+++ b/src/main/conductor/Conductor.ts
@@ -509,6 +509,59 @@ export class Conductor {
   }
 
   /**
+   * Switch a session's agent (stops current, updates, starts new)
+   */
+  async switchSessionAgent(sessionId: string, newAgentId: string): Promise<MulticaSession> {
+    if (!this.sessionStore) {
+      throw new Error('Session agent switch not available in CLI mode')
+    }
+
+    const data = await this.sessionStore.get(sessionId)
+    if (!data) {
+      throw new Error(`Session not found: ${sessionId}`)
+    }
+
+    // Get new agent config
+    const newAgentConfig = DEFAULT_AGENTS[newAgentId]
+    if (!newAgentConfig) {
+      throw new Error(`Unknown agent: ${newAgentId}`)
+    }
+
+    console.log(`[Conductor] Switching session ${sessionId} from ${data.session.agentId} to ${newAgentId}`)
+
+    // Stop current agent if running
+    await this.stopSession(sessionId)
+
+    // Update session's agentId
+    let updatedSession = await this.sessionStore.updateMeta(sessionId, {
+      agentId: newAgentId,
+    })
+
+    // Start new agent (isResumed = true to replay history)
+    const { agentSessionId } = await this.startAgentForSession(
+      sessionId,
+      newAgentConfig,
+      data.session.workingDirectory,
+      true
+    )
+
+    // Update agentSessionId
+    updatedSession = await this.sessionStore.updateMeta(sessionId, {
+      agentSessionId,
+      status: 'active',
+    })
+
+    // Notify frontend
+    if (this.events.onSessionMetaUpdated) {
+      this.events.onSessionMetaUpdated(updatedSession)
+    }
+
+    console.log(`[Conductor] Session ${sessionId} switched to ${newAgentId} (agent session: ${agentSessionId})`)
+
+    return updatedSession
+  }
+
+  /**
    * Get agent config for a session
    */
   getSessionAgent(sessionId: string): AgentConfig | null {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -111,6 +111,13 @@ export function registerIPCHandlers(conductor: Conductor): void {
     }
   )
 
+  ipcMain.handle(
+    IPC_CHANNELS.SESSION_SWITCH_AGENT,
+    async (_event, sessionId: string, newAgentId: string) => {
+      return conductor.switchSessionAgent(sessionId, newAgentId)
+    }
+  )
+
   // --- Configuration handlers ---
 
   ipcMain.handle(IPC_CHANNELS.CONFIG_GET, async () => {

--- a/src/main/session/SessionStore.ts
+++ b/src/main/session/SessionStore.ts
@@ -209,6 +209,9 @@ export class SessionStore {
     if (updates.agentSessionId !== undefined) {
       sessionData.session.agentSessionId = updates.agentSessionId
     }
+    if (updates.agentId !== undefined) {
+      sessionData.session.agentId = updates.agentId
+    }
 
     // Update timestamp
     sessionData.session.updatedAt = new Date().toISOString()

--- a/src/main/session/SessionStore.ts
+++ b/src/main/session/SessionStore.ts
@@ -12,7 +12,7 @@
 import { join } from 'path'
 import { homedir } from 'os'
 import { existsSync, mkdirSync } from 'fs'
-import { readFile, writeFile, unlink } from 'fs/promises'
+import { readFile, writeFile, unlink, rename } from 'fs/promises'
 import { randomUUID } from 'crypto'
 import type { SessionNotification } from '@agentclientprotocol/sdk'
 import type {
@@ -47,6 +47,9 @@ export class SessionStore {
   // In-memory cache
   private sessionsIndex: Map<string, MulticaSession> = new Map()
   private loadedSessions: Map<string, SessionData> = new Map()
+
+  // Write locks to prevent concurrent writes
+  private writeLocks: Map<string, Promise<void>> = new Map()
 
   constructor(basePath?: string) {
     this.basePath = basePath ?? getDefaultStoragePath()
@@ -281,8 +284,10 @@ export class SessionStore {
   }
 
   private async saveIndex(): Promise<void> {
-    const sessions = Array.from(this.sessionsIndex.values())
-    await writeFile(this.indexPath, JSON.stringify(sessions, null, 2))
+    await this.atomicWrite('__index__', this.indexPath, async () => {
+      const sessions = Array.from(this.sessionsIndex.values())
+      return JSON.stringify(sessions, null, 2)
+    })
   }
 
   private async saveSessionData(sessionId: string): Promise<void> {
@@ -290,7 +295,55 @@ export class SessionStore {
     if (!sessionData) return
 
     const dataPath = this.getSessionDataPath(sessionId)
-    await writeFile(dataPath, JSON.stringify(sessionData, null, 2))
+    await this.atomicWrite(sessionId, dataPath, async () => {
+      return JSON.stringify(sessionData, null, 2)
+    })
+  }
+
+  /**
+   * Atomic write with lock to prevent concurrent writes and corruption
+   */
+  private async atomicWrite(
+    lockKey: string,
+    filePath: string,
+    getData: () => Promise<string>
+  ): Promise<void> {
+    // Wait for any pending write to complete
+    const pendingWrite = this.writeLocks.get(lockKey)
+    if (pendingWrite) {
+      await pendingWrite
+    }
+
+    // Create new write promise
+    const writePromise = (async () => {
+      const tempPath = `${filePath}.tmp.${Date.now()}`
+      try {
+        const data = await getData()
+        await writeFile(tempPath, data)
+        await rename(tempPath, filePath)
+      } catch (err) {
+        // Clean up temp file on error
+        try {
+          if (existsSync(tempPath)) {
+            await unlink(tempPath)
+          }
+        } catch {
+          // Ignore cleanup errors
+        }
+        throw err
+      }
+    })()
+
+    this.writeLocks.set(lockKey, writePromise)
+
+    try {
+      await writePromise
+    } finally {
+      // Only delete if this is still our promise
+      if (this.writeLocks.get(lockKey) === writePromise) {
+        this.writeLocks.delete(lockKey)
+      }
+    }
   }
 
   private countMessages(updates: StoredSessionUpdate[]): number {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,9 @@ const electronAPI: ElectronAPI = {
   updateSession: (sessionId: string, updates: Partial<MulticaSession>) =>
     ipcRenderer.invoke(IPC_CHANNELS.SESSION_UPDATE, sessionId, updates),
 
+  switchSessionAgent: (sessionId: string, newAgentId: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.SESSION_SWITCH_AGENT, sessionId, newAgentId),
+
   // Configuration
   getConfig: () => ipcRenderer.invoke(IPC_CHANNELS.CONFIG_GET),
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -36,6 +36,7 @@ function AppContent(): React.JSX.Element {
     clearCurrentSession,
     sendPrompt,
     cancelRequest,
+    switchSessionAgent,
     clearError,
   } = useApp()
 
@@ -140,6 +141,8 @@ function AppContent(): React.JSX.Element {
             disabled={!currentSession}
             workingDirectory={currentSession?.workingDirectory}
             onSelectFolder={handleSelectFolder}
+            currentAgentId={currentSession?.agentId}
+            onAgentChange={switchSessionAgent}
           />
         </main>
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -27,6 +27,7 @@ function AppContent(): React.JSX.Element {
     runningSessionsStatus,
     isProcessing,
     isInitializing,
+    isSwitchingAgent,
     error,
 
     // Actions
@@ -143,6 +144,7 @@ function AppContent(): React.JSX.Element {
             onSelectFolder={handleSelectFolder}
             currentAgentId={currentSession?.agentId}
             onAgentChange={switchSessionAgent}
+            isSwitchingAgent={isSwitchingAgent}
           />
         </main>
 

--- a/src/renderer/src/components/AgentSelector.tsx
+++ b/src/renderer/src/components/AgentSelector.tsx
@@ -1,0 +1,120 @@
+/**
+ * Agent selector dropdown for MessageInput
+ */
+import { useState, useEffect } from 'react'
+import { Sparkles, ChevronDown, Loader2 } from 'lucide-react'
+import type { AgentCheckResult } from '../../../shared/electron-api'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+interface AgentSelectorProps {
+  currentAgentId: string
+  onAgentChange: (agentId: string) => void
+  disabled?: boolean
+}
+
+export function AgentSelector({
+  currentAgentId,
+  onAgentChange,
+  disabled = false,
+}: AgentSelectorProps) {
+  const [agents, setAgents] = useState<AgentCheckResult[]>([])
+  const [loading, setLoading] = useState(true)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    loadAgents()
+  }, [])
+
+  async function loadAgents() {
+    setLoading(true)
+    try {
+      const results = await window.electronAPI.checkAgents()
+      setAgents(results)
+    } catch (err) {
+      console.error('Failed to check agents:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const currentAgent = agents.find((a) => a.id === currentAgentId)
+  const currentAgentName = currentAgent?.name || currentAgentId
+
+  function handleSelect(agentId: string) {
+    if (agentId !== currentAgentId) {
+      onAgentChange(agentId)
+    }
+    setOpen(false)
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild disabled={disabled || loading}>
+        <button
+          className={cn(
+            "flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-background/50",
+            disabled && "opacity-50 cursor-not-allowed"
+          )}
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+          <span className="max-w-[100px] truncate">{currentAgentName}</span>
+          {loading ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="start" className="min-w-[140px]">
+        {agents.map((agent) => {
+          const isSelected = agent.id === currentAgentId
+          const isDisabled = !agent.installed
+
+          if (isDisabled) {
+            return (
+              <Tooltip key={agent.id}>
+                <TooltipTrigger asChild>
+                  <div>
+                    <DropdownMenuItem
+                      disabled
+                      className="flex items-center justify-between"
+                    >
+                      <span>{agent.name}</span>
+                      <span className="h-2 w-2 rounded-full bg-muted" />
+                    </DropdownMenuItem>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  Setup required in Settings
+                </TooltipContent>
+              </Tooltip>
+            )
+          }
+
+          return (
+            <DropdownMenuItem
+              key={agent.id}
+              onClick={() => handleSelect(agent.id)}
+              className="flex items-center justify-between"
+            >
+              <span>{agent.name}</span>
+              <span
+                className={cn(
+                  "h-2 w-2 rounded-full",
+                  isSelected ? "bg-green-500" : "bg-green-500/50"
+                )}
+              />
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/AgentSelector.tsx
+++ b/src/renderer/src/components/AgentSelector.tsx
@@ -17,12 +17,14 @@ interface AgentSelectorProps {
   currentAgentId: string
   onAgentChange: (agentId: string) => void
   disabled?: boolean
+  isSwitching?: boolean
 }
 
 export function AgentSelector({
   currentAgentId,
   onAgentChange,
   disabled = false,
+  isSwitching = false,
 }: AgentSelectorProps) {
   const [agents, setAgents] = useState<AgentCheckResult[]>([])
   const [loading, setLoading] = useState(true)
@@ -54,18 +56,20 @@ export function AgentSelector({
     setOpen(false)
   }
 
+  const isLoading = loading || isSwitching
+
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild disabled={disabled || loading}>
+      <DropdownMenuTrigger asChild disabled={disabled || isLoading}>
         <button
           className={cn(
             "flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-background/50",
-            disabled && "opacity-50 cursor-not-allowed"
+            (disabled || isLoading) && "opacity-50 cursor-not-allowed"
           )}
         >
           <Sparkles className="h-3.5 w-3.5" />
           <span className="max-w-[100px] truncate">{currentAgentName}</span>
-          {loading ? (
+          {isLoading ? (
             <Loader2 className="h-3 w-3 animate-spin" />
           ) : (
             <ChevronDown className="h-3 w-3" />

--- a/src/renderer/src/components/AppSidebar.tsx
+++ b/src/renderer/src/components/AppSidebar.tsx
@@ -99,9 +99,9 @@ function SessionItem({ session, isActive, isProcessing, needsPermission, onSelec
                 ) : null}
               </div>
 
-              {/* Line 2: Agent + Timestamp */}
+              {/* Line 2: Timestamp */}
               <span className="text-xs text-muted-foreground/60">
-                {session.agentId} · {formatDate(session.updatedAt)}
+                {formatDate(session.updatedAt)}
               </span>
             </div>
 

--- a/src/renderer/src/components/MessageInput.tsx
+++ b/src/renderer/src/components/MessageInput.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { ArrowUp, Square, Folder, Paperclip, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { AgentSelector } from './AgentSelector'
 import type { MessageContent, ImageContentItem } from '../../../shared/types/message'
 
 interface MessageInputProps {
@@ -15,6 +16,8 @@ interface MessageInputProps {
   placeholder?: string
   workingDirectory?: string | null
   onSelectFolder: () => Promise<void>
+  currentAgentId?: string
+  onAgentChange?: (agentId: string) => void
 }
 
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB
@@ -28,6 +31,8 @@ export function MessageInput({
   placeholder = 'Type a message...',
   workingDirectory,
   onSelectFolder,
+  currentAgentId,
+  onAgentChange,
 }: MessageInputProps) {
   const [value, setValue] = useState('')
   const [isComposing, setIsComposing] = useState(false)
@@ -255,8 +260,17 @@ export function MessageInput({
 
           {/* Bottom toolbar */}
           <div className="flex items-center justify-between pt-2">
-            {/* Left side: folder and image button */}
+            {/* Left side: agent selector, folder, and image button */}
             <div className="flex items-center gap-1">
+              {/* Agent selector */}
+              {currentAgentId && onAgentChange && (
+                <AgentSelector
+                  currentAgentId={currentAgentId}
+                  onAgentChange={onAgentChange}
+                  disabled={isProcessing}
+                />
+              )}
+
               {/* Folder indicator */}
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/src/renderer/src/components/MessageInput.tsx
+++ b/src/renderer/src/components/MessageInput.tsx
@@ -42,6 +42,11 @@ export function MessageInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  // Get folder name from path
+  const folderName = workingDirectory
+    ? workingDirectory.split('/').filter(Boolean).pop() || workingDirectory
+    : null
+
   // Auto-resize textarea
   useEffect(() => {
     const textarea = textareaRef.current

--- a/src/renderer/src/components/MessageInput.tsx
+++ b/src/renderer/src/components/MessageInput.tsx
@@ -40,11 +40,6 @@ export function MessageInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  // Get folder name from path
-  const folderName = workingDirectory
-    ? workingDirectory.split('/').filter(Boolean).pop() || workingDirectory
-    : null
-
   // Auto-resize textarea
   useEffect(() => {
     const textarea = textareaRef.current

--- a/src/renderer/src/components/MessageInput.tsx
+++ b/src/renderer/src/components/MessageInput.tsx
@@ -18,6 +18,7 @@ interface MessageInputProps {
   onSelectFolder: () => Promise<void>
   currentAgentId?: string
   onAgentChange?: (agentId: string) => void
+  isSwitchingAgent?: boolean
 }
 
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB
@@ -33,6 +34,7 @@ export function MessageInput({
   onSelectFolder,
   currentAgentId,
   onAgentChange,
+  isSwitchingAgent = false,
 }: MessageInputProps) {
   const [value, setValue] = useState('')
   const [isComposing, setIsComposing] = useState(false)
@@ -172,7 +174,7 @@ export function MessageInput({
     return (
       <div className="p-4">
         <div className="mx-auto max-w-3xl">
-          <div className="bg-secondary/50 hover:bg-secondary transition-colors duration-200 rounded-xl p-3 border border-border">
+          <div className="bg-[#fdfdfc] hover:bg-[#fdfdfc] transition-colors duration-200 rounded-xl p-3 border border-border">
             {/* Folder selection prompt */}
             <div className="flex items-center gap-3">
               <Folder className="h-5 w-5 text-muted-foreground flex-shrink-0" />
@@ -203,7 +205,7 @@ export function MessageInput({
   return (
     <div className="p-4">
       <div className="mx-auto max-w-3xl">
-        <div className="bg-secondary/50 hover:bg-secondary focus-within:bg-secondary transition-colors duration-200 rounded-xl p-3 border border-border">
+        <div className="bg-[#fdfdfc] hover:bg-[#fdfdfc] focus-within:bg-[#fdfdfc] transition-colors duration-200 rounded-xl p-3 border border-border">
           {/* Image previews */}
           {images.length > 0 && (
             <div className="flex flex-wrap gap-2 mb-3 pb-3 border-b border-border/50">
@@ -263,6 +265,7 @@ export function MessageInput({
                   currentAgentId={currentAgentId}
                   onAgentChange={onAgentChange}
                   disabled={isProcessing}
+                  isSwitching={isSwitchingAgent}
                 />
               )}
 

--- a/src/renderer/src/components/index.ts
+++ b/src/renderer/src/components/index.ts
@@ -1,3 +1,4 @@
+export { AgentSelector } from './AgentSelector'
 export { AppSidebar } from './AppSidebar'
 export { ChatView } from './ChatView'
 export { MessageInput } from './MessageInput'

--- a/src/renderer/src/components/ui/dropdown-menu.tsx
+++ b/src/renderer/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { CheckIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
+}

--- a/src/renderer/src/hooks/useApp.ts
+++ b/src/renderer/src/hooks/useApp.ts
@@ -10,6 +10,7 @@ import type { RunningSessionsStatus } from '../../../shared/electron-api'
 import type { MessageContent } from '../../../shared/types/message'
 import { usePermissionStore } from '../stores/permissionStore'
 import { useFileChangeStore } from '../stores/fileChangeStore'
+import { toast } from 'sonner'
 
 export interface AppState {
   // Sessions
@@ -37,6 +38,7 @@ export interface AppActions {
   // Agent actions (per-session)
   sendPrompt: (content: MessageContent) => Promise<void>
   cancelRequest: () => Promise<void>
+  switchSessionAgent: (newAgentId: string) => Promise<void>
 
   // UI actions
   clearError: () => void
@@ -282,6 +284,23 @@ export function useApp(): AppState & AppActions {
     }
   }, [currentSession])
 
+  const switchSessionAgent = useCallback(async (newAgentId: string) => {
+    if (!currentSession) {
+      setError('No active session')
+      return
+    }
+
+    try {
+      setError(null)
+      const updatedSession = await window.electronAPI.switchSessionAgent(currentSession.id, newAgentId)
+      setCurrentSession(updatedSession)
+      await loadRunningStatus()
+      toast.success(`Switched to ${newAgentId}`)
+    } catch (err) {
+      setError(`Failed to switch agent: ${err}`)
+    }
+  }, [currentSession, loadRunningStatus])
+
   const clearError = useCallback(() => {
     setError(null)
   }, [])
@@ -304,6 +323,7 @@ export function useApp(): AppState & AppActions {
     clearCurrentSession,
     sendPrompt,
     cancelRequest,
+    switchSessionAgent,
     clearError,
   }
 }

--- a/src/renderer/src/hooks/useApp.ts
+++ b/src/renderer/src/hooks/useApp.ts
@@ -25,6 +25,7 @@ export interface AppState {
 
   // UI
   error: string | null
+  isSwitchingAgent: boolean
 }
 
 export interface AppActions {
@@ -56,6 +57,7 @@ export function useApp(): AppState & AppActions {
   })
   const [error, setError] = useState<string | null>(null)
   const [isInitializing, setIsInitializing] = useState(false)
+  const [isSwitchingAgent, setIsSwitchingAgent] = useState(false)
 
   // Derive isProcessing from processingSessionIds (per-session isolation)
   const isProcessing = currentSession
@@ -292,12 +294,15 @@ export function useApp(): AppState & AppActions {
 
     try {
       setError(null)
+      setIsSwitchingAgent(true)
       const updatedSession = await window.electronAPI.switchSessionAgent(currentSession.id, newAgentId)
       setCurrentSession(updatedSession)
       await loadRunningStatus()
       toast.success(`Switched to ${newAgentId}`)
     } catch (err) {
       setError(`Failed to switch agent: ${err}`)
+    } finally {
+      setIsSwitchingAgent(false)
     }
   }, [currentSession, loadRunningStatus])
 
@@ -313,6 +318,7 @@ export function useApp(): AppState & AppActions {
     runningSessionsStatus,
     isProcessing,
     isInitializing,
+    isSwitchingAgent,
     error,
 
     // Actions

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -105,6 +105,7 @@ export interface ElectronAPI {
   resumeSession(sessionId: string): Promise<MulticaSession>
   deleteSession(sessionId: string): Promise<{ success: boolean }>
   updateSession(sessionId: string, updates: Partial<MulticaSession>): Promise<MulticaSession>
+  switchSessionAgent(sessionId: string, newAgentId: string): Promise<MulticaSession>
 
   // Configuration
   getConfig(): Promise<AppConfig>

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -17,6 +17,7 @@ export const IPC_CHANNELS = {
   SESSION_RESUME: 'session:resume',
   SESSION_DELETE: 'session:delete',
   SESSION_UPDATE: 'session:update',
+  SESSION_SWITCH_AGENT: 'session:switch-agent',
   SESSION_META_UPDATED: 'session:meta-updated', // Push event when session metadata changes (e.g., agentSessionId)
 
   // Configuration


### PR DESCRIPTION
## Summary
Add an inline agent selector dropdown to the MessageInput component, allowing users to switch agents mid-conversation. Implement atomic file writes to prevent session data corruption from concurrent updates.

## Changes
- New AgentSelector component with Radix UI DropdownMenu for switching agents
- Backend switchSessionAgent method to handle agent switching with history replay
- Update chatbox styling to use #fdfdfc color
- Fix race condition in SessionStore with write locks and atomic operations

## Testing
- Agent switching works with loading indicator
- Sessions persist correctly across restarts

🤖 Generated with Claude Code