### PR TITLE
fix: use enhanced PATH when spawning agent processes

### DIFF
--- a/src/main/conductor/AgentProcess.ts
+++ b/src/main/conductor/AgentProcess.ts
@@ -4,6 +4,7 @@
 import { spawn, ChildProcess } from 'node:child_process'
 import { Writable, Readable } from 'node:stream'
 import type { AgentConfig } from '../../shared/types'
+import { getEnhancedPath } from '../utils/path'
 
 export class AgentProcess {
   private process: ChildProcess | null = null
@@ -29,7 +30,7 @@ export class AgentProcess {
     const t1 = Date.now()
     this.process = spawn(command, args, {
       stdio: ['pipe', 'pipe', 'inherit'], // stdin, stdout piped; stderr inherited
-      env: { ...process.env, ...env },
+      env: { ...process.env, ...env, PATH: getEnhancedPath() },
     })
     console.log(`[AgentProcess] [TIMING] spawn() took ${Date.now() - t1}ms`)
 

--- a/src/main/utils/agent-check.ts
+++ b/src/main/utils/agent-check.ts
@@ -3,25 +3,11 @@
  */
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
-import { platform, homedir } from 'node:os'
+import { platform } from 'node:os'
 import { DEFAULT_AGENTS } from '../config/defaults'
+import { getEnhancedPath } from './path'
 
 const execAsync = promisify(exec)
-
-/**
- * Get enhanced PATH that includes common custom installation directories
- */
-function getEnhancedPath(): string {
-  const home = homedir()
-  const customPaths = [
-    `${home}/.opencode/bin`,
-    `${home}/.claude/local/bin`,
-    `${home}/.local/bin`,
-    '/opt/homebrew/bin',
-    '/usr/local/bin',
-  ]
-  return `${customPaths.join(':')}:${process.env.PATH || ''}`
-}
 
 export interface CommandInfo {
   command: string

--- a/src/main/utils/path.ts
+++ b/src/main/utils/path.ts
@@ -1,0 +1,20 @@
+/**
+ * Path utilities for agent process management
+ */
+import { homedir } from 'node:os'
+
+/**
+ * Get enhanced PATH that includes common custom installation directories
+ * Used by both agent-check and AgentProcess to ensure consistent command resolution
+ */
+export function getEnhancedPath(): string {
+  const home = homedir()
+  const customPaths = [
+    `${home}/.opencode/bin`,
+    `${home}/.claude/local/bin`,
+    `${home}/.local/bin`,
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+  ]
+  return `${customPaths.join(':')}:${process.env.PATH || ''}`
+}


### PR DESCRIPTION
## Summary
- Extract `getEnhancedPath()` to shared `src/main/utils/path.ts` module
- Use enhanced PATH in `AgentProcess.spawn()` to match `agent-check.ts` behavior
- Fixes ENOENT error when creating sessions for agents installed in custom locations (e.g., `~/.opencode/bin`)

## Problem
The agent check used an enhanced PATH (including `~/.opencode/bin`, `~/.claude/local/bin`, etc.) to find commands, but `AgentProcess.spawn()` used only the default `process.env.PATH`. This caused `spawn opencode ENOENT` errors when creating sessions.

## Test plan
- [ ] Build the project: `pnpm build`
- [ ] Launch app and create an Open Code session
- [ ] Verify no ENOENT error occurs
- [ ] Test Claude Code and Codex sessions as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)