### PR TITLE
fix: add await to IPC handlers to properly catch errors

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -113,7 +113,7 @@ export function registerIPCHandlers(conductor: Conductor): void {
         if (!config) {
           throw new Error(`Unknown agent: ${agentId}`)
         }
-        return conductor.createSession(workingDirectory, config)
+        return await conductor.createSession(workingDirectory, config)
       } catch (err) {
         throw new Error(extractErrorMessage(err))
       }
@@ -152,7 +152,7 @@ export function registerIPCHandlers(conductor: Conductor): void {
     IPC_CHANNELS.SESSION_SWITCH_AGENT,
     async (_event, sessionId: string, newAgentId: string) => {
       try {
-        return conductor.switchSessionAgent(sessionId, newAgentId)
+        return await conductor.switchSessionAgent(sessionId, newAgentId)
       } catch (err) {
         throw new Error(extractErrorMessage(err))
       }
@@ -212,7 +212,7 @@ export function registerIPCHandlers(conductor: Conductor): void {
       if (!window) {
         throw new Error('No focused window')
       }
-      return installAgent({ window, agentId })
+      return await installAgent({ window, agentId })
     } catch (err) {
       throw new Error(extractErrorMessage(err))
     }


### PR DESCRIPTION
In async try-catch blocks, `return promise` bypasses the catch block. Changed to `return await promise` so errors are properly caught and processed by extractErrorMessage(), fixing the [object Object] display.

Affected handlers:
- SESSION_CREATE
- SESSION_SWITCH_AGENT
- AGENT_INSTALL