### PR TITLE
refactor: remove colors from file tree icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -827,6 +826,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -848,6 +848,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -864,6 +865,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -878,6 +880,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3641,7 +3644,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.6.tgz",
       "integrity": "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3663,7 +3665,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3674,7 +3675,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3757,7 +3757,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -4184,7 +4183,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4218,7 +4216,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4778,7 +4775,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5458,7 +5454,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5765,7 +5762,6 @@
       "integrity": "sha512-ce4Ogns4VMeisIuCSK0C62umG0lFy012jd8LMZ6w/veHUeX4fqfDrGe+HTWALAEwK6JwKP+dhPvizhArSOsFbg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.4.0",
         "builder-util": "26.3.4",
@@ -5928,7 +5924,6 @@
       "integrity": "sha512-KU0uFS6LSTh4aOIC3miolcbizOFP7N1M46VTYVfqIgFiuA2ilfNaOHLDS9tCMvwwHRowAsvqBrh9NgMXcTOHCQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -6117,6 +6112,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6137,6 +6133,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6465,7 +6462,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6526,7 +6522,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10697,7 +10692,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10750,7 +10744,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10774,6 +10767,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -10791,6 +10785,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10811,7 +10806,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10927,7 +10921,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10937,7 +10930,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11311,6 +11303,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -12266,6 +12259,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -12329,6 +12323,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -13093,7 +13088,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13421,7 +13415,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13981,7 +13974,6 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -14323,7 +14315,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/renderer/src/components/FileIcons.tsx
+++ b/src/renderer/src/components/FileIcons.tsx
@@ -7,35 +7,35 @@ interface IconProps {
   className?: string
 }
 
-// TypeScript icon (blue TS box)
+// TypeScript icon (TS box)
 export function TypeScriptIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none">
-      <rect width="16" height="16" rx="2" fill="#3178C6" />
+      <rect width="16" height="16" rx="2" fill="currentColor" fillOpacity="0.2" />
       <path
         d="M4.5 8.5H7V9.5H5.5V12.5H4.5V8.5Z"
-        fill="white"
+        fill="currentColor"
       />
       <path
         d="M7.5 9.5V8.5H11V9.5H9.75V12.5H8.75V9.5H7.5Z"
-        fill="white"
+        fill="currentColor"
       />
     </svg>
   )
 }
 
-// JavaScript icon (yellow JS box)
+// JavaScript icon (JS box)
 export function JavaScriptIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none">
-      <rect width="16" height="16" rx="2" fill="#F7DF1E" />
+      <rect width="16" height="16" rx="2" fill="currentColor" fillOpacity="0.2" />
       <path
         d="M5.5 8.5V11.5C5.5 12 5.25 12.5 4.5 12.5C3.75 12.5 3.5 12 3.5 11.5H4.25C4.25 11.75 4.375 12 4.5 12C4.625 12 4.75 11.75 4.75 11.5V8.5H5.5Z"
-        fill="#323330"
+        fill="currentColor"
       />
       <path
         d="M7 12.5C6.25 12.5 6 12 6 11.5H6.75C6.75 11.75 6.875 12 7.25 12C7.625 12 7.75 11.75 7.75 11.5C7.75 10.5 6 11 6 9.75C6 9.25 6.375 8.5 7.25 8.5C8 8.5 8.5 9 8.5 9.5H7.75C7.75 9.25 7.5 9 7.25 9C7 9 6.75 9.25 6.75 9.75C6.75 10.75 8.5 10.25 8.5 11.5C8.5 12.25 8 12.5 7 12.5Z"
-        fill="#323330"
+        fill="currentColor"
       />
     </svg>
   )
@@ -45,14 +45,14 @@ export function JavaScriptIcon({ className }: IconProps) {
 export function JsonIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none">
-      <rect width="16" height="16" rx="2" fill="#CBCB41" />
+      <rect width="16" height="16" rx="2" fill="currentColor" fillOpacity="0.2" />
       <path
         d="M5 5C5 4.5 5.5 4 6 4V5C5.75 5 5.75 5.25 5.75 5.5V7C5.75 7.5 5.25 8 5 8C5.25 8 5.75 8.5 5.75 9V10.5C5.75 10.75 5.75 11 6 11V12C5.5 12 5 11.5 5 11V9.5C5 9 4.5 8.5 4 8.5V7.5C4.5 7.5 5 7 5 6.5V5Z"
-        fill="#323330"
+        fill="currentColor"
       />
       <path
         d="M11 5C11 4.5 10.5 4 10 4V5C10.25 5 10.25 5.25 10.25 5.5V7C10.25 7.5 10.75 8 11 8C10.75 8 10.25 8.5 10.25 9V10.5C10.25 10.75 10.25 11 10 11V12C10.5 12 11 11.5 11 11V9.5C11 9 11.5 8.5 12 8.5V7.5C11.5 7.5 11 7 11 6.5V5Z"
-        fill="#323330"
+        fill="currentColor"
       />
     </svg>
   )
@@ -62,8 +62,8 @@ export function JsonIcon({ className }: IconProps) {
 export function YamlIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none">
-      <rect width="16" height="16" rx="2" fill="#CB171E" />
-      <text x="2" y="12" fontSize="7" fill="white" fontFamily="system-ui" fontWeight="600">
+      <rect width="16" height="16" rx="2" fill="currentColor" fillOpacity="0.2" />
+      <text x="2" y="12" fontSize="7" fill="currentColor" fontFamily="system-ui" fontWeight="600">
         yml
       </text>
     </svg>
@@ -74,14 +74,14 @@ export function YamlIcon({ className }: IconProps) {
 export function MarkdownIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none">
-      <rect width="16" height="16" rx="2" fill="#083FA1" />
+      <rect width="16" height="16" rx="2" fill="currentColor" fillOpacity="0.2" />
       <path
         d="M3 5V11H4.5V8L6 10L7.5 8V11H9V5H7.5L6 7.5L4.5 5H3Z"
-        fill="white"
+        fill="currentColor"
       />
       <path
         d="M11 8V5H12.5V8L14 6.5V8.5L12.5 10L11 8.5V10H9.5L11 8Z"
-        fill="white"
+        fill="currentColor"
       />
     </svg>
   )
@@ -91,8 +91,8 @@ export function MarkdownIcon({ className }: IconProps) {
 export function CssIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none">
-      <rect width="16" height="16" rx="2" fill="#264DE4" />
-      <text x="2" y="11" fontSize="6" fill="white" fontFamily="system-ui" fontWeight="600">
+      <rect width="16" height="16" rx="2" fill="currentColor" fillOpacity="0.2" />
+      <text x="2" y="11" fontSize="6" fill="currentColor" fontFamily="system-ui" fontWeight="600">
         CSS
       </text>
     </svg>
@@ -103,8 +103,8 @@ export function CssIcon({ className }: IconProps) {
 export function HtmlIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none">
-      <rect width="16" height="16" rx="2" fill="#E44D26" />
-      <text x="1" y="11" fontSize="5.5" fill="white" fontFamily="system-ui" fontWeight="600">
+      <rect width="16" height="16" rx="2" fill="currentColor" fillOpacity="0.2" />
+      <text x="1" y="11" fontSize="5.5" fill="currentColor" fontFamily="system-ui" fontWeight="600">
         HTML
       </text>
     </svg>
@@ -124,9 +124,9 @@ export function ConfigIcon({ className }: IconProps) {
 export function GitIcon({ className }: IconProps) {
   return (
     <svg className={className} viewBox="0 0 16 16" fill="none">
-      <rect width="16" height="16" rx="2" fill="#F05032" />
-      <circle cx="8" cy="8" r="2" fill="white" />
-      <path d="M8 4V6M8 10V12M4 8H6M10 8H12" stroke="white" strokeWidth="1.5" strokeLinecap="round" />
+      <rect width="16" height="16" rx="2" fill="currentColor" fillOpacity="0.2" />
+      <circle cx="8" cy="8" r="2" fill="currentColor" />
+      <path d="M8 4V6M8 10V12M4 8H6M10 8H12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   )
 }

--- a/src/renderer/src/components/FileTree.tsx
+++ b/src/renderer/src/components/FileTree.tsx
@@ -59,9 +59,9 @@ function FileTreeIcon({
       return <GitIcon className={className} />
     }
     return isExpanded ? (
-      <FolderOpenIcon className={cn(className, 'text-sky-500')} />
+      <FolderOpenIcon className={cn(className, 'text-muted-foreground')} />
     ) : (
-      <FolderIcon className={cn(className, 'text-sky-500')} />
+      <FolderIcon className={cn(className, 'text-muted-foreground')} />
     )
   }
 
@@ -83,7 +83,7 @@ function FileTreeIcon({
 
   // Image files
   if (['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico'].includes(node.extension || '')) {
-    return <ImageIcon className={cn(className, 'text-green-500')} />
+    return <ImageIcon className={cn(className, 'text-muted-foreground')} />
   }
 
   // Default file icon


### PR DESCRIPTION
## Summary
Removes hardcoded colors from file tree icons in the right sidebar, creating a unified monochrome appearance that inherits the text color from the parent context.

## Changes
- Update all file type SVG icons to use `currentColor` instead of hardcoded hex colors
- Change folder and image icons from colored variants to muted foreground color
- Icon backgrounds now use transparent overlays with `fillOpacity="0.2"`

This simplifies the visual design and makes icons more consistent with the app's color scheme.