### PR TITLE
Add dark mode background to user message input

### DIFF
--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -323,7 +323,7 @@ function MessageBubble({ message }: MessageBubbleProps) {
 
     return (
       <div className="flex justify-end">
-        <div className="max-w-[85%] rounded-lg bg-[#f9f7f5] px-4 py-3 text-[15px]">
+        <div className="max-w-[85%] rounded-lg bg-[#f9f7f5] dark:bg-muted px-4 py-3 text-[15px]">
           {/* Render images first */}
           {imageBlocks.length > 0 && (
             <div className="flex flex-wrap gap-2 mb-2">


### PR DESCRIPTION
User input messages now display with appropriate background colors in both light and dark modes. Light mode shows a warm beige (#f9f7f5) while dark mode uses the muted dark gray for consistency with the design system.

- Added dark:bg-muted class to user message bubble
- Improves readability and visual consistency in dark mode