### PR TITLE
fix: use queue for permission requests to prevent blocking

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -45,7 +45,7 @@ function AppContent(): React.JSX.Element {
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen)
 
   // Permission state - get the session ID that has a pending permission request
-  const pendingPermission = usePermissionStore((s) => s.pendingRequest)
+  const pendingPermission = usePermissionStore((s) => s.pendingRequests[0] ?? null)
   const permissionPendingSessionId = pendingPermission?.multicaSessionId ?? null
 
   // Modal actions

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -23,7 +23,7 @@ interface ChatViewProps {
 
 export function ChatView({ updates, isProcessing, hasSession, isInitializing, currentSessionId, onSelectFolder }: ChatViewProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
-  const pendingPermission = usePermissionStore((s) => s.pendingRequest)
+  const pendingPermission = usePermissionStore((s) => s.pendingRequests[0] ?? null)
 
   // Only show permission request if it belongs to the current session
   const currentPermission = pendingPermission?.multicaSessionId === currentSessionId

--- a/src/renderer/src/components/permission/PermissionRequestItem.tsx
+++ b/src/renderer/src/components/permission/PermissionRequestItem.tsx
@@ -12,12 +12,12 @@ import { StandardPermissionUI } from './StandardPermissionUI'
 import type { PermissionRequestItemProps, AskUserQuestionInput } from './types'
 
 export function PermissionRequestItem({ request }: PermissionRequestItemProps) {
-  const pendingRequest = usePermissionStore((s) => s.pendingRequest)
+  const currentRequest = usePermissionStore((s) => s.pendingRequests[0] ?? null)
   const currentQuestionIndex = usePermissionStore((s) => s.currentQuestionIndex)
   const getRespondedRequest = usePermissionStore((s) => s.getRespondedRequest)
 
   const { toolCall } = request
-  const isPending = pendingRequest?.requestId === request.requestId
+  const isPending = currentRequest?.requestId === request.requestId
 
   // Get responded data for completed requests
   const respondedData = getRespondedRequest(request.requestId)

--- a/src/renderer/src/hooks/useApp.ts
+++ b/src/renderer/src/hooks/useApp.ts
@@ -158,10 +158,10 @@ export function useApp(): AppState & AppActions {
     })
 
     // Subscribe to permission requests
-    const setPendingRequest = usePermissionStore.getState().setPendingRequest
+    const addPendingRequest = usePermissionStore.getState().addPendingRequest
     const unsubPermission = window.electronAPI.onPermissionRequest((request) => {
       console.log('[useApp] Permission request received:', request)
-      setPendingRequest(request)
+      addPendingRequest(request)
     })
 
     return () => {


### PR DESCRIPTION
Changed pendingRequest from single value to pendingRequests queue. This prevents consecutive permission requests from overwriting each other, which caused the first request's Promise to never resolve.

- permissionStore: pendingRequest → pendingRequests[]
- Added addPendingRequest() and getCurrentRequest()
- respondToRequest() now removes from queue head
- Updated all consumers to use queue[0]