### PR TITLE
fix: support new MessageContent format in history replay

### DIFF
--- a/tests/integration/conductor/Conductor.test.ts
+++ b/tests/integration/conductor/Conductor.test.ts
@@ -203,7 +203,7 @@ describe('Conductor', () => {
       const session = await conductor.createSession('/test/project', mockAgentConfig)
 
       // sendPrompt should trigger status changes
-      await conductor.sendPrompt(session.id, 'Hello')
+      await conductor.sendPrompt(session.id, [{ type: 'text', text: 'Hello' }])
 
       // Should be called at least twice (start processing, end processing)
       expect(onStatusChange).toHaveBeenCalled()


### PR DESCRIPTION
## Summary

Fixes history replay for resumed sessions. When commit 913cccc changed user message storage from `{ text: string }` to `MessageContent[]` arrays, the history replay extraction logic was not updated, causing `hasReplayableHistory()` to return false and preventing conversation history from being restored.

Added backward-compatible extraction helper to support both old and new formats. Updated integration test to use new MessageContent format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)