### PR TITLE
Fix Codex ACP content ordering and persistence issues

### DIFF
--- a/src/main/conductor/Conductor.ts
+++ b/src/main/conductor/Conductor.ts
@@ -29,7 +29,7 @@ import type { MessageContent, MessageContentItem } from '../../shared/types/mess
 import { formatHistoryForReplay, hasReplayableHistory } from './historyReplay'
 
 export interface SessionUpdateCallback {
-  (update: SessionNotification): void
+  (update: SessionNotification, sequenceNumber?: number): void
 }
 
 export interface ConductorEvents {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -64,11 +64,12 @@ app.whenReady().then(async () => {
   // Initialize conductor with event handlers
   conductor = new Conductor({
     events: {
-      onSessionUpdate: (params) => {
-        // Forward ALL session updates to renderer
+      onSessionUpdate: (params, sequenceNumber) => {
+        // Forward ALL session updates to renderer with sequence number for ordering
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send(IPC_CHANNELS.AGENT_MESSAGE, {
             sessionId: params.sessionId,
+            sequenceNumber,
             update: params.update,
             done: false
           })

--- a/src/renderer/src/hooks/useApp.ts
+++ b/src/renderer/src/hooks/useApp.ts
@@ -138,9 +138,11 @@ export function useApp(): AppState & AppActions {
 
       // Pass through original update without any accumulation
       // ChatView is responsible for accumulating chunks into complete messages
+      // Include sequence number for proper ordering of concurrent updates
       setSessionUpdates((prev) => {
         const newUpdate = {
           timestamp: new Date().toISOString(),
+          sequenceNumber: message.sequenceNumber,
           update: {
             sessionId: message.sessionId,
             update: message.update

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -12,6 +12,7 @@ import type { MessageContent } from './types/message'
 
 export interface AgentMessage {
   sessionId: string
+  sequenceNumber?: number // Monotonically increasing for ordering concurrent updates
   update: {
     sessionUpdate: string
     content?: { type: string; text: string }

--- a/src/shared/types/session.ts
+++ b/src/shared/types/session.ts
@@ -55,6 +55,7 @@ export interface AskUserQuestionResponseUpdate {
  */
 export interface StoredSessionUpdate {
   timestamp: string // Receive time
+  sequenceNumber?: number // Monotonically increasing sequence number for ordering (added for concurrent update handling)
   update: SessionNotification | { update: AskUserQuestionResponseUpdate } // Raw ACP data or custom update
 }
 


### PR DESCRIPTION
## Summary
- Fixes ENOENT errors when Codex ACP sends many concurrent updates by using unique temp file names with UUID suffix for atomic writes
- Fixes ChatView content appearing out of order in real-time display by assigning and sorting updates by monotonically increasing sequence numbers
- Both issues stem from handling high-frequency async updates from ACP SDK without guaranteed ordering

## Changes
- `SessionStore.ts`: Rewrote `atomicWrite` with proper async serialization and unique temp file names
- Added `sequenceNumber` field to `StoredSessionUpdate` and `AgentMessage` interfaces
- Sequence numbers are assigned per-session in SessionStore and passed through IPC to renderer
- ChatView now sorts updates by sequence number before processing

## Test Results
All 58 tests pass ✅