### PR TITLE
Improve agent display names in MessageInput

### DIFF
--- a/src/main/config/defaults.ts
+++ b/src/main/config/defaults.ts
@@ -15,14 +15,14 @@ export const DEFAULT_AGENTS: Record<string, AgentConfig> = {
   },
   opencode: {
     id: 'opencode',
-    name: 'opencode',
+    name: 'OpenCode',
     command: 'opencode',
     args: ['acp'],
     enabled: true
   },
   codex: {
     id: 'codex',
-    name: 'Codex CLI (ACP)',
+    name: 'Codex',
     command: 'codex-acp',
     args: [],
     enabled: true


### PR DESCRIPTION
Simplify agent display names for better UI clarity:
- "opencode" → "OpenCode" (consistent capitalization)
- "Codex CLI (ACP)" → "Codex" (simplified display, keeps "(ACP)" in settings)

Improves visual consistency and readability in the agent selector dropdown.