### PR TITLE
fix: correct PATH separator for Windows in agent detection

### DIFF
--- a/src/main/utils/path.ts
+++ b/src/main/utils/path.ts
@@ -1,7 +1,7 @@
 /**
  * Path utilities for agent process management
  */
-import { homedir } from 'node:os'
+import { homedir, platform } from 'node:os'
 
 /**
  * Get enhanced PATH that includes common custom installation directories
@@ -9,6 +9,8 @@ import { homedir } from 'node:os'
  */
 export function getEnhancedPath(): string {
   const home = homedir()
+  const isWindows = platform() === 'win32'
+  const separator = isWindows ? ';' : ':'
   const customPaths = [
     `${home}/.opencode/bin`,
     `${home}/.claude/local/bin`,
@@ -16,5 +18,5 @@ export function getEnhancedPath(): string {
     '/opt/homebrew/bin',
     '/usr/local/bin'
   ]
-  return `${customPaths.join(':')}:${process.env.PATH || ''}`
+  return `${customPaths.join(separator)}${separator}${process.env.PATH || ''}`
 }

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -302,11 +302,13 @@ function AgentItem({
   // Determine status: checking -> setup/selected/ready
   const status = isChecking
     ? 'checking'
-    : !agent?.installed
-      ? 'setup'
-      : isSelected
-        ? 'selected'
-        : 'ready'
+    : agent === undefined
+      ? 'checking' // Still loading agent status
+      : !agent?.installed
+        ? 'setup'
+        : isSelected
+          ? 'selected'
+          : 'ready'
 
   // Auto-expand when waiting for install
   useEffect(() => {


### PR DESCRIPTION
- Fix getEnhancedPath() to use ';' instead of ':' on Windows
- This resolves opencode detection failure on Windows systems
- Platform-aware separator selection ensures cross-platform compatibility

Fixes multica-ai/multica issue where opencode showed as not installed despite being properly installed and available in PATH.