### PR TITLE
Add download link to releases page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A native desktop client that brings coding agent capabilities to everyone throug
 
 English | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md)
 
+[**Download the latest release**](https://github.com/multica-ai/multica/releases)
+
 ![Multica Screenshot](docs/images/screenshot.png)
 
 ## Why "Multica"?


### PR DESCRIPTION
Added a prominent download link to the releases page in the README, positioned after the language selector and before the screenshot. This makes it easier for users to find and download Multica.