### PR TITLE
fix: format terminal command array with spaces

### DIFF
--- a/src/renderer/src/components/ToolCallItem.tsx
+++ b/src/renderer/src/components/ToolCallItem.tsx
@@ -67,6 +67,14 @@ function formatPath(path: string | undefined): string | undefined {
   return parts[parts.length - 1]
 }
 
+// Format command (handle array format)
+function formatCommand(command: unknown): string {
+  if (Array.isArray(command)) {
+    return command.join(' ')
+  }
+  return String(command || '')
+}
+
 // Get tool display info (icon + name + subtitle + stats)
 function getDisplayInfo(toolCall: ToolCall): {
   icon: ReactNode
@@ -116,7 +124,7 @@ function getDisplayInfo(toolCall: ToolCall): {
       return {
         icon: <Terminal className={iconClass} />,
         name: 'Terminal',
-        subtitle: (input.description as string) || (input.command as string)?.slice(0, 50),
+        subtitle: (input.description as string) || formatCommand(input.command).slice(0, 50),
         stats: isPending ? 'running...' : undefined
       }
     }


### PR DESCRIPTION
## Summary
- Fixed Terminal tool display issue where array commands were shown without spaces
- Added `formatCommand` helper function to properly join array elements
- Example: `["/bin/zsh", "-lc", "git checkout main"]` now displays as `/bin/zsh -lc git checkout main` instead of `/bin/zsh-lcgit checkout main`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (167 tests)
- [ ] Manual verification: Start dev server and execute a Terminal command to verify correct display

🤖 Generated with [Claude Code](https://claude.com/claude-code)