### PR TITLE
feat: update release skill for complete build artifacts

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -108,8 +108,11 @@ This will:
 - Build x64 (Intel) version
 - Automatically notarize with Apple (notarize: true in config)
 - Output files to `dist/` directory:
-  - `Multica-{version}-arm64.dmg`
-  - `Multica-{version}-x64.dmg`
+  - `Multica-{version}-arm64.dmg` and `.blockmap`
+  - `Multica-{version}-x64.dmg` and `.blockmap`
+  - `Multica-{version}-arm64-mac.zip` and `.blockmap`
+  - `Multica-{version}-x64-mac.zip` and `.blockmap`
+  - `latest-mac.yml` (auto-updater manifest)
 
 ### Step 6: Commit Version Change
 
@@ -165,15 +168,28 @@ Format example:
 
 ### Step 8: Create GitHub Release
 
-1. Create the release with generated notes:
+1. Create the release with generated notes and all build artifacts:
 
    ```bash
    gh release create v{version} \
      --title "v{version}" \
      --notes "{release_notes}" \
      dist/Multica-{version}-arm64.dmg \
-     dist/Multica-{version}-x64.dmg
+     dist/Multica-{version}-arm64.dmg.blockmap \
+     dist/Multica-{version}-x64.dmg \
+     dist/Multica-{version}-x64.dmg.blockmap \
+     dist/Multica-{version}-arm64-mac.zip \
+     dist/Multica-{version}-arm64-mac.zip.blockmap \
+     dist/Multica-{version}-x64-mac.zip \
+     dist/Multica-{version}-x64-mac.zip.blockmap \
+     dist/latest-mac.yml
    ```
+
+   The uploaded files include:
+   - **DMG files**: Primary installers for each architecture
+   - **ZIP files**: Alternative distribution format (required by auto-updater)
+   - **Blockmap files**: Enable incremental/delta updates
+   - **latest-mac.yml**: Manifest file for electron-updater to check for new versions
 
 2. Confirm the release was created successfully
 3. Provide the release URL to the user

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
-    "build:mac": "electron-vite build && electron-builder --mac",
+    "build:mac": "electron-vite build && electron-builder --mac --arm64 --x64",
     "build:linux": "electron-vite build && electron-builder --linux",
     "cli": "tsx src/main/cli.ts",
     "test:acp": "tsx src/main/cli.ts prompt",


### PR DESCRIPTION
## Summary

- Update `build:mac` script to build both arm64 and x64 architectures simultaneously
- Update release skill documentation to include all build artifacts (DMG, ZIP, blockmap files, and latest-mac.yml)
- Add explanations for each artifact type in the release workflow

## Test plan

- [ ] Run `pnpm build:mac` and verify both arm64 and x64 artifacts are generated
- [ ] Check that `dist/` contains all expected files (DMG, ZIP, blockmap, latest-mac.yml)
- [ ] Verify `latest-mac.yml` contains information for both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)