### PR TITLE
feat: add slash command support for ACP agents

### DIFF
--- a/src/main/conductor/AcpClientFactory.ts
+++ b/src/main/conductor/AcpClientFactory.ts
@@ -15,7 +15,11 @@ import type { AvailableCommand } from '@agentclientprotocol/sdk/dist/schema/type
 import type { ISessionStore } from './types'
 
 export interface AcpClientCallbacks {
-  onSessionUpdate?: (update: SessionNotification, sequenceNumber?: number) => void
+  onSessionUpdate?: (
+    update: SessionNotification,
+    multicaSessionId: string,
+    sequenceNumber?: number
+  ) => void
   onPermissionRequest?: (params: RequestPermissionRequest) => Promise<RequestPermissionResponse>
   /** Called when server sends a mode update notification */
   onModeUpdate?: (modeId: SessionModeId) => void
@@ -94,9 +98,9 @@ export function createAcpClient(sessionId: string, options: AcpClientFactoryOpti
         }
       }
 
-      // Trigger UI callback with sequence number for ordering
+      // Trigger UI callback with Multica session ID and sequence number for ordering
       if (callbacks.onSessionUpdate) {
-        callbacks.onSessionUpdate(params, sequenceNumber)
+        callbacks.onSessionUpdate(params, sessionId, sequenceNumber)
       }
     },
 

--- a/src/main/conductor/AcpClientFactory.ts
+++ b/src/main/conductor/AcpClientFactory.ts
@@ -11,6 +11,7 @@ import type {
   SessionModeId,
   ModelId
 } from '@agentclientprotocol/sdk'
+import type { AvailableCommand } from '@agentclientprotocol/sdk/dist/schema/types.gen'
 import type { SessionStore } from '../session/SessionStore'
 
 export interface AcpClientCallbacks {
@@ -20,6 +21,8 @@ export interface AcpClientCallbacks {
   onModeUpdate?: (modeId: SessionModeId) => void
   /** Called when server sends a model update notification */
   onModelUpdate?: (modelId: ModelId) => void
+  /** Called when server sends available commands update */
+  onAvailableCommandsUpdate?: (commands: AvailableCommand[]) => void
 }
 
 export interface AcpClientFactoryOptions {
@@ -67,6 +70,13 @@ export function createAcpClient(sessionId: string, options: AcpClientFactoryOpti
           const modeUpdate = update as { currentModeId?: SessionModeId }
           if (modeUpdate.currentModeId) {
             callbacks.onModeUpdate(modeUpdate.currentModeId)
+          }
+        }
+        // Handle available commands update notification
+        if (updateType === 'available_commands_update' && callbacks.onAvailableCommandsUpdate) {
+          const commandsUpdate = update as { availableCommands?: AvailableCommand[] }
+          if (commandsUpdate.availableCommands) {
+            callbacks.onAvailableCommandsUpdate(commandsUpdate.availableCommands)
           }
         }
       } else {

--- a/src/main/conductor/AgentProcessManager.ts
+++ b/src/main/conductor/AgentProcessManager.ts
@@ -76,6 +76,13 @@ export class AgentProcessManager implements IAgentProcessManager {
               if (sessionAgent?.sessionModelState) {
                 sessionAgent.sessionModelState.currentModelId = modelId
               }
+            },
+            // Handle available commands updates
+            onAvailableCommandsUpdate: (commands) => {
+              const sessionAgent = this.sessions.get(sessionId)
+              if (sessionAgent) {
+                sessionAgent.availableCommands = commands
+              }
             }
           }
         }),
@@ -124,7 +131,8 @@ export class AgentProcessManager implements IAgentProcessManager {
       agentSessionId: acpResult.sessionId,
       needsHistoryReplay: isResumed, // True when resuming, agent needs conversation context
       sessionModeState,
-      sessionModelState
+      sessionModelState,
+      availableCommands: [] // Will be populated by available_commands_update
     }
     this.sessions.set(sessionId, sessionAgent)
 

--- a/src/main/conductor/AgentProcessManager.ts
+++ b/src/main/conductor/AgentProcessManager.ts
@@ -10,6 +10,7 @@
 import { ClientSideConnection, ndJsonStream, PROTOCOL_VERSION } from '@agentclientprotocol/sdk'
 import { AgentProcess } from './AgentProcess'
 import { createAcpClient } from './AcpClientFactory'
+import type { AvailableCommand } from '@agentclientprotocol/sdk/dist/schema/types.gen'
 import type { AgentConfig } from '../../shared/types'
 import type {
   IAgentProcessManager,
@@ -22,6 +23,7 @@ import type {
 export class AgentProcessManager implements IAgentProcessManager {
   private sessionStore: ISessionStore | null
   private events: AgentProcessManagerOptions['events']
+  private pendingAvailableCommands: Map<string, AvailableCommand[]> = new Map()
 
   /**
    * Map of Multica sessionId -> agent state (each session has its own process)
@@ -82,7 +84,18 @@ export class AgentProcessManager implements IAgentProcessManager {
               const sessionAgent = this.sessions.get(sessionId)
               if (sessionAgent) {
                 sessionAgent.availableCommands = commands
+                console.log(
+                  `[AgentProcessManager] Available commands updated for session ${sessionId} (${commands.length})`
+                )
+                return
               }
+
+              // Some agents (e.g., Codex) may emit available_commands_update before
+              // the session is fully registered. Cache and apply after session creation.
+              console.log(
+                `[AgentProcessManager] Caching available commands for session ${sessionId} (${commands.length})`
+              )
+              this.pendingAvailableCommands.set(sessionId, commands)
             }
           }
         }),
@@ -117,6 +130,7 @@ export class AgentProcessManager implements IAgentProcessManager {
         `[AgentProcessManager] Agent for session ${sessionId} exited (code: ${code}, signal: ${signal})`
       )
       this.sessions.delete(sessionId)
+      this.pendingAvailableCommands.delete(sessionId)
     })
 
     // Extract modes and models from ACP response (like Zed does)
@@ -136,6 +150,15 @@ export class AgentProcessManager implements IAgentProcessManager {
     }
     this.sessions.set(sessionId, sessionAgent)
 
+    const pendingCommands = this.pendingAvailableCommands.get(sessionId)
+    if (pendingCommands) {
+      sessionAgent.availableCommands = pendingCommands
+      this.pendingAvailableCommands.delete(sessionId)
+      console.log(
+        `[AgentProcessManager] Applied cached available commands for session ${sessionId} (${pendingCommands.length})`
+      )
+    }
+
     return { connection, agentSessionId: acpResult.sessionId }
   }
 
@@ -150,6 +173,7 @@ export class AgentProcessManager implements IAgentProcessManager {
       )
       await sessionAgent.agentProcess.stop()
       this.sessions.delete(sessionId)
+      this.pendingAvailableCommands.delete(sessionId)
       console.log(`[AgentProcessManager] Session ${sessionId} agent stopped`)
     }
   }
@@ -183,6 +207,7 @@ export class AgentProcessManager implements IAgentProcessManager {
    */
   remove(sessionId: string): void {
     this.sessions.delete(sessionId)
+    this.pendingAvailableCommands.delete(sessionId)
   }
 
   /**

--- a/src/main/conductor/G3Workaround.ts
+++ b/src/main/conductor/G3Workaround.ts
@@ -93,7 +93,7 @@ export class G3Workaround implements IG3Workaround {
           sessionId,
           update: update.update
         } as SessionNotification,
-        undefined
+        sessionId // Pass Multica session ID for stable filtering
       )
     }
   }

--- a/src/main/conductor/PromptHandler.ts
+++ b/src/main/conductor/PromptHandler.ts
@@ -216,7 +216,7 @@ export class PromptHandler implements IPromptHandler {
               }
             }
           } as SessionNotification,
-          undefined
+          sessionId // Pass Multica session ID for stable filtering
         )
       }
 

--- a/src/main/conductor/types.ts
+++ b/src/main/conductor/types.ts
@@ -69,9 +69,12 @@ export interface AgentStartResult {
 
 /**
  * Session update callback signature
+ * @param update - The session notification from ACP
+ * @param multicaSessionId - The Multica session ID (stable, set before agent starts)
+ * @param sequenceNumber - Optional sequence number for ordering
  */
 export interface SessionUpdateCallback {
-  (update: SessionNotification, sequenceNumber?: number): void
+  (update: SessionNotification, multicaSessionId: string, sequenceNumber?: number): void
 }
 
 /**

--- a/src/main/conductor/types.ts
+++ b/src/main/conductor/types.ts
@@ -12,6 +12,7 @@ import type {
   SessionModeState,
   SessionModelState
 } from '@agentclientprotocol/sdk'
+import type { AvailableCommand } from '@agentclientprotocol/sdk/dist/schema/types.gen'
 import type { AgentProcess } from './AgentProcess'
 import type {
   AgentConfig,
@@ -42,6 +43,8 @@ export interface SessionAgent {
   sessionModeState: SessionModeState | null
   /** Model state from ACP server (available models and current model) */
   sessionModelState: SessionModelState | null
+  /** Available slash commands from ACP server */
+  availableCommands: AvailableCommand[]
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -76,11 +76,13 @@ app.whenReady().then(async () => {
   // Initialize conductor with event handlers
   conductor = new Conductor({
     events: {
-      onSessionUpdate: (params, sequenceNumber) => {
+      onSessionUpdate: (params, multicaSessionId, sequenceNumber) => {
         // Forward ALL session updates to renderer with sequence number for ordering
+        // Include multicaSessionId for stable filtering (avoids race condition with agentSessionId)
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send(IPC_CHANNELS.AGENT_MESSAGE, {
-            sessionId: params.sessionId,
+            sessionId: params.sessionId, // ACP agent session ID
+            multicaSessionId, // Multica session ID (stable)
             sequenceNumber,
             update: params.update,
             done: false

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -211,6 +211,11 @@ export function registerIPCHandlers(conductor: Conductor): void {
     return sessionAgent?.sessionModelState ?? null
   })
 
+  ipcMain.handle(IPC_CHANNELS.SESSION_GET_COMMANDS, async (_event, sessionId: string) => {
+    const sessionAgent = conductor.getSessionAgent(sessionId)
+    return sessionAgent?.availableCommands ?? []
+  })
+
   ipcMain.handle(
     IPC_CHANNELS.SESSION_SET_MODE,
     async (_event, sessionId: string, modeId: SessionModeId) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,6 +46,10 @@ const electronAPI: ElectronAPI = {
   getSessionModels: (sessionId: string) =>
     ipcRenderer.invoke(IPC_CHANNELS.SESSION_GET_MODELS, sessionId),
 
+  // Slash commands
+  getSessionCommands: (sessionId: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.SESSION_GET_COMMANDS, sessionId),
+
   setSessionMode: (sessionId: string, modeId: SessionModeId) =>
     ipcRenderer.invoke(IPC_CHANNELS.SESSION_SET_MODE, sessionId, modeId),
 

--- a/src/renderer/src/components/MessageInput.tsx
+++ b/src/renderer/src/components/MessageInput.tsx
@@ -79,7 +79,7 @@ export function MessageInput({
   onCancel,
   isProcessing,
   disabled,
-  placeholder = 'Type a message...',
+  placeholder = 'Type a message, or / for commands',
   workingDirectory,
   currentAgentId,
   onAgentChange,

--- a/src/renderer/src/components/MessageInput.tsx
+++ b/src/renderer/src/components/MessageInput.tsx
@@ -1,19 +1,22 @@
 /**
- * Message input component with image upload support
+ * Message input component with image upload and slash command support
  */
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { ArrowUp, Square, Paperclip, X, AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { AgentSelector } from './AgentSelector'
 import { ModeSelector } from './ModeSelector'
 import { ModelSelector } from './ModelSelector'
+import { SlashCommandMenu, parseSlashCommand, validateCommand } from './SlashCommandMenu'
+import { useCommandStore } from '../stores/commandStore'
 import type { MessageContent, ImageContentItem } from '../../../shared/types/message'
 import type {
   SessionModeState,
   SessionModelState,
   SessionModeId,
-  ModelId
+  ModelId,
+  AvailableCommand
 } from '../../../shared/types'
 
 interface MessageInputProps {
@@ -87,8 +90,38 @@ export function MessageInput({
   const [value, setValue] = useState('')
   const [isComposing, setIsComposing] = useState(false)
   const [images, setImages] = useState<ImageContentItem[]>([])
+  const [showCommandMenu, setShowCommandMenu] = useState(false)
+  const [commandMenuIndex, setCommandMenuIndex] = useState(0)
+  const [commandError, setCommandError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const inputContainerRef = useRef<HTMLDivElement>(null)
+
+  // Get available commands from store
+  const availableCommands = useCommandStore((state) => state.availableCommands)
+
+  // Parse current slash command state
+  const parsedCommand = useMemo(() => parseSlashCommand(value), [value])
+  const commandFilter = parsedCommand?.command || ''
+  const isInCommandMode = parsedCommand !== null && parsedCommand.argument === undefined
+
+  // Update command menu visibility when typing
+  useEffect(() => {
+    if (isInCommandMode && availableCommands.length > 0) {
+      setShowCommandMenu(true)
+      setCommandMenuIndex(0)
+      setCommandError(null)
+    } else {
+      setShowCommandMenu(false)
+      // Validate command when not in autocomplete mode (has argument or space after command)
+      if (parsedCommand && parsedCommand.command && availableCommands.length > 0) {
+        const error = validateCommand(value, availableCommands)
+        setCommandError(error)
+      } else {
+        setCommandError(null)
+      }
+    }
+  }, [isInCommandMode, availableCommands, parsedCommand, value])
 
   // Auto-resize textarea
   useEffect(() => {
@@ -192,10 +225,26 @@ export function MessageInput({
     setImages((prev) => prev.filter((_, i) => i !== index))
   }, [])
 
+  // Handle slash command selection from menu
+  const handleCommandSelect = useCallback((command: AvailableCommand) => {
+    // Replace the current "/" text with the selected command
+    const hasInput = command.input
+    setValue(`/${command.name}${hasInput ? ' ' : ''}`)
+    setShowCommandMenu(false)
+    setCommandError(null)
+    // Focus back on textarea
+    textareaRef.current?.focus()
+  }, [])
+
   // Handle submit
   const handleSubmit = useCallback(() => {
     const trimmed = value.trim()
     if ((!trimmed && images.length === 0) || disabled || isProcessing) return
+
+    // Check for command errors before sending
+    if (commandError) {
+      return
+    }
 
     // Build message content array
     const content: MessageContent = []
@@ -213,9 +262,14 @@ export function MessageInput({
     onSend(content)
     setValue('')
     setImages([])
-  }, [value, images, disabled, isProcessing, onSend])
+    setCommandError(null)
+  }, [value, images, disabled, isProcessing, onSend, commandError])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Don't handle Enter/Tab/arrows while command menu is open (SlashCommandMenu handles these)
+    if (showCommandMenu && ['Enter', 'Tab', 'ArrowUp', 'ArrowDown', 'Escape'].includes(e.key)) {
+      return
+    }
     // Don't submit while IME is composing
     if (e.key === 'Enter' && !e.shiftKey && !isComposing) {
       e.preventDefault()
@@ -223,7 +277,7 @@ export function MessageInput({
     }
   }
 
-  const canSubmit = !disabled && (value.trim().length > 0 || images.length > 0)
+  const canSubmit = !disabled && !commandError && (value.trim().length > 0 || images.length > 0)
   const hasFolder = !!workingDirectory
 
   // Don't render when no folder is selected
@@ -235,7 +289,18 @@ export function MessageInput({
   return (
     <div className="pb-2">
       {directoryExists === false && <DirectoryWarningBanner onDeleteSession={onDeleteSession} />}
-      <div>
+      <div ref={inputContainerRef} className="relative">
+        {/* Slash command autocomplete menu */}
+        <SlashCommandMenu
+          commands={availableCommands}
+          filter={commandFilter}
+          selectedIndex={commandMenuIndex}
+          onSelect={handleCommandSelect}
+          onIndexChange={setCommandMenuIndex}
+          onClose={() => setShowCommandMenu(false)}
+          visible={showCommandMenu}
+        />
+
         <div className="bg-card transition-colors duration-200 rounded-xl p-3 border border-border">
           {/* Image previews */}
           {images.length > 0 && (
@@ -275,6 +340,9 @@ export function MessageInput({
             rows={2}
             className="w-full resize-none bg-transparent px-1 py-1 text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
           />
+
+          {/* Command error message */}
+          {commandError && <div className="px-1 py-1 text-xs text-destructive">{commandError}</div>}
 
           {/* Hidden file input */}
           <input

--- a/src/renderer/src/components/SlashCommandMenu.tsx
+++ b/src/renderer/src/components/SlashCommandMenu.tsx
@@ -118,8 +118,8 @@ export function SlashCommandMenu({
             }}
             onClick={() => onSelect(command)}
             className={cn(
-              'w-full text-left px-3 py-2 flex flex-col gap-0.5 transition-colors',
-              index === clampedIndex ? 'bg-accent' : 'hover:bg-accent/50'
+              'w-full text-left px-3 flex flex-col gap-0.5 transition-colors',
+              index === clampedIndex ? 'bg-accent py-2' : 'hover:bg-accent/50 py-1.5'
             )}
           >
             <div className="flex items-center gap-2">
@@ -128,8 +128,8 @@ export function SlashCommandMenu({
                 <span className="text-xs text-muted-foreground">{'{argument}'}</span>
               )}
             </div>
-            {command.description && (
-              <span className="text-xs text-muted-foreground line-clamp-1">
+            {index === clampedIndex && command.description && (
+              <span className="text-xs text-muted-foreground line-clamp-2">
                 {command.description}
               </span>
             )}

--- a/src/renderer/src/components/SlashCommandMenu.tsx
+++ b/src/renderer/src/components/SlashCommandMenu.tsx
@@ -1,0 +1,141 @@
+/**
+ * Slash command autocomplete menu
+ *
+ * Displays a list of available commands when the user types "/" in the message input.
+ * Supports keyboard navigation and command selection.
+ */
+import { useEffect, useRef, useCallback } from 'react'
+import type { AvailableCommand } from '../../../shared/types'
+import { cn } from '@/lib/utils'
+
+// Re-export utility functions for convenience
+export { parseSlashCommand, validateCommand } from '../utils/slashCommand'
+
+interface SlashCommandMenuProps {
+  /** Available commands to display */
+  commands: AvailableCommand[]
+  /** Current filter string (after the "/") */
+  filter: string
+  /** Currently selected index */
+  selectedIndex: number
+  /** Callback when an index is selected */
+  onSelect: (command: AvailableCommand) => void
+  /** Callback when selected index changes */
+  onIndexChange: (index: number) => void
+  /** Callback when menu should close */
+  onClose: () => void
+  /** Whether the menu is visible */
+  visible: boolean
+}
+
+export function SlashCommandMenu({
+  commands,
+  filter,
+  selectedIndex,
+  onSelect,
+  onIndexChange,
+  onClose,
+  visible
+}: SlashCommandMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
+
+  // Filter commands based on input
+  const filteredCommands = commands.filter((cmd) =>
+    cmd.name.toLowerCase().startsWith(filter.toLowerCase())
+  )
+
+  // Clamp selected index to valid range
+  const clampedIndex = Math.max(0, Math.min(selectedIndex, filteredCommands.length - 1))
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const selectedItem = itemRefs.current.get(clampedIndex)
+    if (selectedItem && menuRef.current) {
+      selectedItem.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    }
+  }, [clampedIndex])
+
+  // Handle keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!visible || filteredCommands.length === 0) return
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          onIndexChange((clampedIndex + 1) % filteredCommands.length)
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          onIndexChange((clampedIndex - 1 + filteredCommands.length) % filteredCommands.length)
+          break
+        case 'Enter':
+        case 'Tab':
+          e.preventDefault()
+          if (filteredCommands[clampedIndex]) {
+            onSelect(filteredCommands[clampedIndex])
+          }
+          break
+        case 'Escape':
+          e.preventDefault()
+          onClose()
+          break
+      }
+    },
+    [visible, filteredCommands, clampedIndex, onIndexChange, onSelect, onClose]
+  )
+
+  // Register keyboard listener
+  useEffect(() => {
+    if (visible) {
+      document.addEventListener('keydown', handleKeyDown, true)
+      return () => document.removeEventListener('keydown', handleKeyDown, true)
+    }
+    return undefined
+  }, [visible, handleKeyDown])
+
+  // Don't render if not visible or no matching commands
+  if (!visible || filteredCommands.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute bottom-full left-0 mb-2 w-full max-w-md bg-popover border border-border rounded-lg shadow-lg overflow-hidden z-50"
+    >
+      <div className="max-h-[240px] overflow-y-auto py-1">
+        {filteredCommands.map((command, index) => (
+          <button
+            key={command.name}
+            ref={(el) => {
+              if (el) {
+                itemRefs.current.set(index, el)
+              } else {
+                itemRefs.current.delete(index)
+              }
+            }}
+            onClick={() => onSelect(command)}
+            className={cn(
+              'w-full text-left px-3 py-2 flex flex-col gap-0.5 transition-colors',
+              index === clampedIndex ? 'bg-accent' : 'hover:bg-accent/50'
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-foreground">/{command.name}</span>
+              {command.input && (
+                <span className="text-xs text-muted-foreground">{'{argument}'}</span>
+              )}
+            </div>
+            {command.description && (
+              <span className="text-xs text-muted-foreground line-clamp-1">
+                {command.description}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/SlashCommandMenu.tsx
+++ b/src/renderer/src/components/SlashCommandMenu.tsx
@@ -8,9 +8,6 @@ import { useEffect, useRef, useCallback } from 'react'
 import type { AvailableCommand } from '../../../shared/types'
 import { cn } from '@/lib/utils'
 
-// Re-export utility functions for convenience
-export { parseSlashCommand, validateCommand } from '../utils/slashCommand'
-
 interface SlashCommandMenuProps {
   /** Available commands to display */
   commands: AvailableCommand[]
@@ -36,7 +33,7 @@ export function SlashCommandMenu({
   onIndexChange,
   onClose,
   visible
-}: SlashCommandMenuProps) {
+}: SlashCommandMenuProps): React.JSX.Element | null {
   const menuRef = useRef<HTMLDivElement>(null)
   const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
 

--- a/src/renderer/src/stores/commandStore.ts
+++ b/src/renderer/src/stores/commandStore.ts
@@ -1,0 +1,32 @@
+/**
+ * Slash command state management
+ *
+ * Stores available commands for the current session, updated via:
+ * 1. Initial fetch when switching sessions (getSessionCommands)
+ * 2. Real-time updates from available_commands_update events
+ */
+import { create } from 'zustand'
+import type { AvailableCommand } from '../../../shared/types'
+
+interface CommandStore {
+  /** Available slash commands for the current session */
+  availableCommands: AvailableCommand[]
+
+  /** Set available commands (replaces all) */
+  setAvailableCommands: (commands: AvailableCommand[]) => void
+
+  /** Clear available commands (on session switch) */
+  clearCommands: () => void
+}
+
+export const useCommandStore = create<CommandStore>((set) => ({
+  availableCommands: [],
+
+  setAvailableCommands: (commands) => {
+    set({ availableCommands: commands })
+  },
+
+  clearCommands: () => {
+    set({ availableCommands: [] })
+  }
+}))

--- a/src/renderer/src/utils/slashCommand.ts
+++ b/src/renderer/src/utils/slashCommand.ts
@@ -1,0 +1,41 @@
+/**
+ * Slash command utility functions
+ */
+import type { AvailableCommand } from '../../../shared/types'
+
+/**
+ * Parse slash command from input text
+ * Returns the command name and optional argument if input starts with "/"
+ */
+export function parseSlashCommand(text: string): { command?: string; argument?: string } | null {
+  if (!text.startsWith('/')) return null
+  const match = text.match(/^\/(\S*)(?:\s+(.*))?$/)
+  if (!match) return null
+  return { command: match[1], argument: match[2] }
+}
+
+/**
+ * Validate if a command is available
+ * Returns error message if invalid, null if valid
+ */
+export function validateCommand(
+  text: string,
+  availableCommands: AvailableCommand[]
+): string | null {
+  const parsed = parseSlashCommand(text)
+  if (!parsed) return null // Not a command
+
+  // Empty command name is ok during typing
+  if (!parsed.command) return null
+
+  // If no commands available, skip validation (agent doesn't support slash commands)
+  if (availableCommands.length === 0) return null
+
+  // Check if command exists
+  const isValid = availableCommands.some((cmd) => cmd.name === parsed.command)
+  if (!isValid) {
+    return `/${parsed.command} is not a valid command`
+  }
+
+  return null
+}

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -10,7 +10,8 @@ import type {
   SessionModeState,
   SessionModelState,
   SessionModeId,
-  ModelId
+  ModelId,
+  AvailableCommand
 } from './types'
 import type { MessageContent } from './types/message'
 
@@ -176,6 +177,9 @@ export interface ElectronAPI {
   getSessionModels(sessionId: string): Promise<SessionModelState | null>
   setSessionMode(sessionId: string, modeId: SessionModeId): Promise<void>
   setSessionModel(sessionId: string, modelId: ModelId): Promise<void>
+
+  // Slash commands
+  getSessionCommands(sessionId: string): Promise<AvailableCommand[]>
 
   // Configuration
   getConfig(): Promise<AppConfig>

--- a/src/shared/electron-api.d.ts
+++ b/src/shared/electron-api.d.ts
@@ -15,7 +15,8 @@ import type {
 import type { MessageContent } from './types/message'
 
 export interface AgentMessage {
-  sessionId: string
+  sessionId: string // ACP agent session ID
+  multicaSessionId: string // Multica session ID (stable, for filtering)
   sequenceNumber?: number // Monotonically increasing for ordering concurrent updates
   update: {
     sessionUpdate: string

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -24,6 +24,7 @@ export const IPC_CHANNELS = {
   SESSION_GET_MODELS: 'session:get-models', // Get current session's available models
   SESSION_SET_MODE: 'session:set-mode', // Set session mode
   SESSION_SET_MODEL: 'session:set-model', // Set session model
+  SESSION_GET_COMMANDS: 'session:get-commands', // Get current session's available slash commands
 
   // Configuration
   CONFIG_GET: 'config:get',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -85,3 +85,6 @@ export * from './types/session'
 // Re-export mode/model types from ACP SDK for frontend use
 export * from './types/mode'
 export * from './types/model'
+
+// Re-export AvailableCommand type from ACP SDK
+export type { AvailableCommand } from '@agentclientprotocol/sdk/dist/schema/types.gen'

--- a/tests/unit/main/conductor/G3Workaround.test.ts
+++ b/tests/unit/main/conductor/G3Workaround.test.ts
@@ -116,7 +116,7 @@ describe('G3Workaround', () => {
             response
           }
         },
-        undefined
+        'session-1' // multicaSessionId is same as sessionId here
       )
     })
 

--- a/tests/unit/main/conductor/PromptHandler.test.ts
+++ b/tests/unit/main/conductor/PromptHandler.test.ts
@@ -195,7 +195,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
 
@@ -372,7 +372,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
 
@@ -393,7 +393,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
 
@@ -412,7 +412,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
 
@@ -431,7 +431,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
 
@@ -452,7 +452,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
 
       // Verify the error text doesn't exceed expected length
@@ -477,7 +477,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
 
@@ -496,7 +496,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
 
@@ -515,7 +515,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
 
@@ -534,7 +534,7 @@ describe('PromptHandler', () => {
             })
           })
         }),
-        undefined
+        'session-1' // multicaSessionId
       )
     })
   })

--- a/tests/unit/renderer/components/SlashCommandMenu.test.ts
+++ b/tests/unit/renderer/components/SlashCommandMenu.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for slash command utility functions
+ */
+import { describe, it, expect } from 'vitest'
+import { parseSlashCommand, validateCommand } from '../../../../src/renderer/src/utils/slashCommand'
+import type { AvailableCommand } from '../../../../src/shared/types'
+
+describe('SlashCommandMenu', () => {
+  describe('parseSlashCommand', () => {
+    it('should return null for non-command input', () => {
+      expect(parseSlashCommand('hello')).toBeNull()
+      expect(parseSlashCommand(' /hello')).toBeNull()
+      expect(parseSlashCommand('')).toBeNull()
+    })
+
+    it('should parse command without argument', () => {
+      expect(parseSlashCommand('/')).toEqual({ command: '', argument: undefined })
+      expect(parseSlashCommand('/help')).toEqual({ command: 'help', argument: undefined })
+      expect(parseSlashCommand('/create_plan')).toEqual({
+        command: 'create_plan',
+        argument: undefined
+      })
+    })
+
+    it('should parse command with argument', () => {
+      expect(parseSlashCommand('/help me')).toEqual({ command: 'help', argument: 'me' })
+      expect(parseSlashCommand('/search hello world')).toEqual({
+        command: 'search',
+        argument: 'hello world'
+      })
+    })
+
+    it('should handle command with empty argument after space', () => {
+      expect(parseSlashCommand('/help ')).toEqual({ command: 'help', argument: '' })
+    })
+  })
+
+  describe('validateCommand', () => {
+    const mockCommands: AvailableCommand[] = [
+      { name: 'help', description: 'Show help' },
+      { name: 'search', description: 'Search the codebase' },
+      { name: 'create_plan', description: 'Create a plan' }
+    ]
+
+    it('should return null for non-command input', () => {
+      expect(validateCommand('hello', mockCommands)).toBeNull()
+      expect(validateCommand('', mockCommands)).toBeNull()
+    })
+
+    it('should return null for valid command', () => {
+      expect(validateCommand('/help', mockCommands)).toBeNull()
+      expect(validateCommand('/help me', mockCommands)).toBeNull()
+      expect(validateCommand('/search query', mockCommands)).toBeNull()
+    })
+
+    it('should return null for incomplete command (empty name)', () => {
+      expect(validateCommand('/', mockCommands)).toBeNull()
+    })
+
+    it('should return error for invalid command', () => {
+      expect(validateCommand('/invalid', mockCommands)).toBe('/invalid is not a valid command')
+      expect(validateCommand('/unknown command', mockCommands)).toBe(
+        '/unknown is not a valid command'
+      )
+    })
+
+    it('should return null when no commands available', () => {
+      expect(validateCommand('/help', [])).toBeNull()
+    })
+  })
+})

--- a/tests/unit/renderer/stores/commandStore.test.ts
+++ b/tests/unit/renderer/stores/commandStore.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for commandStore
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCommandStore } from '../../../../src/renderer/src/stores/commandStore'
+import type { AvailableCommand } from '../../../../src/shared/types'
+
+describe('commandStore', () => {
+  beforeEach(() => {
+    // Reset store before each test
+    useCommandStore.getState().clearCommands()
+  })
+
+  describe('setAvailableCommands', () => {
+    it('should set available commands', () => {
+      const commands: AvailableCommand[] = [
+        { name: 'help', description: 'Show help' },
+        { name: 'search', description: 'Search the codebase' }
+      ]
+
+      useCommandStore.getState().setAvailableCommands(commands)
+
+      expect(useCommandStore.getState().availableCommands).toEqual(commands)
+    })
+
+    it('should replace existing commands', () => {
+      const initialCommands: AvailableCommand[] = [{ name: 'help', description: 'Show help' }]
+      const newCommands: AvailableCommand[] = [
+        { name: 'search', description: 'Search the codebase' },
+        { name: 'create', description: 'Create something' }
+      ]
+
+      useCommandStore.getState().setAvailableCommands(initialCommands)
+      useCommandStore.getState().setAvailableCommands(newCommands)
+
+      expect(useCommandStore.getState().availableCommands).toEqual(newCommands)
+    })
+  })
+
+  describe('clearCommands', () => {
+    it('should clear all commands', () => {
+      const commands: AvailableCommand[] = [{ name: 'help', description: 'Show help' }]
+
+      useCommandStore.getState().setAvailableCommands(commands)
+      useCommandStore.getState().clearCommands()
+
+      expect(useCommandStore.getState().availableCommands).toEqual([])
+    })
+  })
+
+  describe('initial state', () => {
+    it('should start with empty commands', () => {
+      expect(useCommandStore.getState().availableCommands).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add support for slash commands defined by ACP agents
- Commands are validated client-side and sent as plain text for agents to parse and execute
- Includes autocomplete menu with keyboard navigation when typing "/"

## Changes

### Main Process
- Handle `available_commands_update` events from ACP SDK
- Store available commands in `SessionAgent` state
- Add IPC handler for fetching session commands

### Renderer
- Create `commandStore` for available commands state management
- Create `SlashCommandMenu` component with keyboard navigation (↑/↓/Enter/Tab/Esc)
- Integrate slash command detection and validation in `MessageInput`
- Show error for invalid commands before sending

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes (0 errors)
- [x] All 191 tests pass (including 13 new tests for slash commands)
- [ ] Manual testing: Type "/" in message input, verify autocomplete appears
- [ ] Manual testing: Select command from menu, verify it's inserted
- [ ] Manual testing: Send invalid command, verify error is shown

🤖 Generated with [Claude Code](https://claude.ai/claude-code)