### PR TITLE
chore(ci): enforce zero ESLint warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,7 @@ jobs:
         run: pnpm typecheck
 
       - name: ESLint
-        # TODO: Reduce --max-warnings to 0 as pre-existing issues are fixed
-        run: pnpm lint --max-warnings 250
+        run: pnpm lint --max-warnings 0
 
       - name: Prettier check
         run: pnpm format:check


### PR DESCRIPTION
## Summary
- Update CI to reject any ESLint warnings by setting `--max-warnings 0`
- Remove the TODO comment since all pre-existing warnings have been fixed

## Test plan
- [ ] CI passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)