### PR TITLE
feat: add hidden files toggle and improve file tree UX

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,7 +15,7 @@ import { RightPanel, RightPanelHeader, RightPanelContent } from './components/la
 import { FileTree } from './components/FileTree'
 import { Toaster } from '@/components/ui/sonner'
 import { useChatScroll } from './hooks/useChatScroll'
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, Eye, EyeOff } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 function AppContent(): React.JSX.Element {
@@ -46,6 +46,8 @@ function AppContent(): React.JSX.Element {
   // UI state
   const sidebarOpen = useUIStore((s) => s.sidebarOpen)
   const setSidebarOpen = useUIStore((s) => s.setSidebarOpen)
+  const showHiddenFiles = useUIStore((s) => s.showHiddenFiles)
+  const toggleShowHiddenFiles = useUIStore((s) => s.toggleShowHiddenFiles)
 
   // Permission state - get the session ID that has a pending permission request
   const pendingPermission = usePermissionStore((s) => s.pendingRequests[0] ?? null)
@@ -218,14 +220,31 @@ function AppContent(): React.JSX.Element {
 
         {/* Right panel - file tree */}
         <RightPanel>
-          <RightPanelHeader>
+          <RightPanelHeader className="justify-between">
             <span className="text-sm font-medium">All files</span>
+            <button
+              onClick={toggleShowHiddenFiles}
+              className={cn(
+                'p-1 rounded hover:bg-accent transition-colors',
+                showHiddenFiles ? 'text-foreground' : 'text-muted-foreground'
+              )}
+              title={showHiddenFiles ? 'Hide hidden files' : 'Show hidden files'}
+              aria-label={showHiddenFiles ? 'Hide hidden files' : 'Show hidden files'}
+              aria-pressed={showHiddenFiles}
+            >
+              {showHiddenFiles ? (
+                <Eye className="h-3.5 w-3.5" />
+              ) : (
+                <EyeOff className="h-3.5 w-3.5" />
+              )}
+            </button>
           </RightPanelHeader>
           <RightPanelContent className="p-0">
             {currentSession ? (
               <FileTree
                 rootPath={currentSession.workingDirectory}
                 directoryExists={currentSession.directoryExists}
+                onCreateSession={handleCreateSession}
               />
             ) : (
               <div className="flex h-full items-center justify-center text-muted-foreground p-4">

--- a/src/renderer/src/stores/uiStore.ts
+++ b/src/renderer/src/stores/uiStore.ts
@@ -28,6 +28,10 @@ interface UIStore {
   toggleRightPanel: () => void
   setRightPanelOpen: (open: boolean) => void
   setRightPanelWidth: (width: number) => void
+
+  // Hidden files visibility
+  showHiddenFiles: boolean
+  toggleShowHiddenFiles: () => void
 }
 
 export const useUIStore = create<UIStore>()(
@@ -49,7 +53,11 @@ export const useUIStore = create<UIStore>()(
       setRightPanelWidth: (width) =>
         set({
           rightPanelWidth: Math.max(RIGHT_PANEL_MIN_WIDTH, Math.min(RIGHT_PANEL_MAX_WIDTH, width))
-        })
+        }),
+
+      // Hidden files - default hidden
+      showHiddenFiles: false,
+      toggleShowHiddenFiles: () => set((state) => ({ showHiddenFiles: !state.showHiddenFiles }))
     }),
     {
       name: 'ui-state' // localStorage key

--- a/src/renderer/src/utils/fileTree.ts
+++ b/src/renderer/src/utils/fileTree.ts
@@ -1,0 +1,10 @@
+/**
+ * Utility functions for file tree operations
+ */
+import type { FileTreeNode } from '../../../shared/electron-api'
+
+/**
+ * Exclude hidden files (those starting with '.') from the list
+ */
+export const excludeHiddenFiles = (nodes: FileTreeNode[]): FileTreeNode[] =>
+  nodes.filter((n) => !n.name.startsWith('.'))

--- a/tests/unit/renderer/components/FileTree.test.ts
+++ b/tests/unit/renderer/components/FileTree.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for FileTree helper functions
+ */
+import { describe, expect, it } from 'vitest'
+import { excludeHiddenFiles } from '../../../../src/renderer/src/utils/fileTree'
+import type { FileTreeNode } from '../../../../src/shared/electron-api'
+
+describe('excludeHiddenFiles', () => {
+  const createNode = (name: string, type: 'file' | 'directory' = 'file'): FileTreeNode => ({
+    name,
+    path: `/test/${name}`,
+    type,
+    extension: type === 'file' ? name.split('.').pop() : undefined
+  })
+
+  it('returns an empty array when given an empty array', () => {
+    const result = excludeHiddenFiles([])
+    expect(result).toEqual([])
+  })
+
+  it('removes files starting with a dot', () => {
+    const nodes = [createNode('.gitignore'), createNode('README.md'), createNode('.env')]
+
+    const result = excludeHiddenFiles(nodes)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('README.md')
+  })
+
+  it('removes directories starting with a dot', () => {
+    const nodes = [
+      createNode('.git', 'directory'),
+      createNode('src', 'directory'),
+      createNode('.vscode', 'directory'),
+      createNode('node_modules', 'directory')
+    ]
+
+    const result = excludeHiddenFiles(nodes)
+
+    expect(result).toHaveLength(2)
+    expect(result.map((n) => n.name)).toEqual(['src', 'node_modules'])
+  })
+
+  it('keeps all nodes when none are hidden', () => {
+    const nodes = [
+      createNode('index.ts'),
+      createNode('package.json'),
+      createNode('src', 'directory')
+    ]
+
+    const result = excludeHiddenFiles(nodes)
+
+    expect(result).toHaveLength(3)
+    expect(result).toEqual(nodes)
+  })
+
+  it('removes all nodes when all are hidden', () => {
+    const nodes = [createNode('.gitignore'), createNode('.env'), createNode('.git', 'directory')]
+
+    const result = excludeHiddenFiles(nodes)
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles mixed hidden files and directories', () => {
+    const nodes = [
+      createNode('.git', 'directory'),
+      createNode('.gitignore'),
+      createNode('src', 'directory'),
+      createNode('README.md'),
+      createNode('.env'),
+      createNode('package.json'),
+      createNode('.vscode', 'directory')
+    ]
+
+    const result = excludeHiddenFiles(nodes)
+
+    expect(result).toHaveLength(3)
+    expect(result.map((n) => n.name)).toEqual(['src', 'README.md', 'package.json'])
+  })
+
+  it('does not modify the original array', () => {
+    const nodes = [createNode('.gitignore'), createNode('README.md')]
+    const originalLength = nodes.length
+
+    excludeHiddenFiles(nodes)
+
+    expect(nodes).toHaveLength(originalLength)
+  })
+
+  it('handles files with dots in the middle of the name', () => {
+    const nodes = [
+      createNode('file.test.ts'),
+      createNode('component.spec.tsx'),
+      createNode('.hidden.file'),
+      createNode('normal.config.js')
+    ]
+
+    const result = excludeHiddenFiles(nodes)
+
+    expect(result).toHaveLength(3)
+    expect(result.map((n) => n.name)).toEqual([
+      'file.test.ts',
+      'component.spec.tsx',
+      'normal.config.js'
+    ])
+  })
+})

--- a/tests/unit/renderer/stores/uiStore.test.ts
+++ b/tests/unit/renderer/stores/uiStore.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for uiStore - specifically showHiddenFiles state
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  useUIStore,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  RIGHT_PANEL_MIN_WIDTH,
+  RIGHT_PANEL_MAX_WIDTH
+} from '../../../../src/renderer/src/stores/uiStore'
+
+describe('uiStore', () => {
+  beforeEach(() => {
+    // Reset to default state
+    useUIStore.setState({
+      sidebarOpen: true,
+      sidebarWidth: 256,
+      rightPanelOpen: true,
+      rightPanelWidth: 320,
+      showHiddenFiles: false
+    })
+  })
+
+  describe('showHiddenFiles', () => {
+    it('defaults to false (hidden files are not shown)', () => {
+      expect(useUIStore.getState().showHiddenFiles).toBe(false)
+    })
+
+    it('toggles showHiddenFiles from false to true', () => {
+      useUIStore.getState().toggleShowHiddenFiles()
+      expect(useUIStore.getState().showHiddenFiles).toBe(true)
+    })
+
+    it('toggles showHiddenFiles from true to false', () => {
+      useUIStore.setState({ showHiddenFiles: true })
+      useUIStore.getState().toggleShowHiddenFiles()
+      expect(useUIStore.getState().showHiddenFiles).toBe(false)
+    })
+
+    it('toggles multiple times correctly', () => {
+      expect(useUIStore.getState().showHiddenFiles).toBe(false)
+
+      useUIStore.getState().toggleShowHiddenFiles()
+      expect(useUIStore.getState().showHiddenFiles).toBe(true)
+
+      useUIStore.getState().toggleShowHiddenFiles()
+      expect(useUIStore.getState().showHiddenFiles).toBe(false)
+
+      useUIStore.getState().toggleShowHiddenFiles()
+      expect(useUIStore.getState().showHiddenFiles).toBe(true)
+    })
+  })
+
+  describe('sidebar state', () => {
+    it('toggles sidebar open state', () => {
+      expect(useUIStore.getState().sidebarOpen).toBe(true)
+      useUIStore.getState().toggleSidebar()
+      expect(useUIStore.getState().sidebarOpen).toBe(false)
+    })
+
+    it('sets sidebar open state directly', () => {
+      useUIStore.getState().setSidebarOpen(false)
+      expect(useUIStore.getState().sidebarOpen).toBe(false)
+    })
+
+    it('clamps sidebar width to min/max constraints', () => {
+      useUIStore.getState().setSidebarWidth(100) // below min
+      expect(useUIStore.getState().sidebarWidth).toBe(SIDEBAR_MIN_WIDTH)
+
+      useUIStore.getState().setSidebarWidth(1000) // above max
+      expect(useUIStore.getState().sidebarWidth).toBe(SIDEBAR_MAX_WIDTH)
+
+      useUIStore.getState().setSidebarWidth(300) // within range
+      expect(useUIStore.getState().sidebarWidth).toBe(300)
+    })
+  })
+
+  describe('right panel state', () => {
+    it('toggles right panel open state', () => {
+      expect(useUIStore.getState().rightPanelOpen).toBe(true)
+      useUIStore.getState().toggleRightPanel()
+      expect(useUIStore.getState().rightPanelOpen).toBe(false)
+    })
+
+    it('sets right panel open state directly', () => {
+      useUIStore.getState().setRightPanelOpen(false)
+      expect(useUIStore.getState().rightPanelOpen).toBe(false)
+    })
+
+    it('clamps right panel width to min/max constraints', () => {
+      useUIStore.getState().setRightPanelWidth(100) // below min
+      expect(useUIStore.getState().rightPanelWidth).toBe(RIGHT_PANEL_MIN_WIDTH)
+
+      useUIStore.getState().setRightPanelWidth(1000) // above max
+      expect(useUIStore.getState().rightPanelWidth).toBe(RIGHT_PANEL_MAX_WIDTH)
+
+      useUIStore.getState().setRightPanelWidth(350) // within range
+      expect(useUIStore.getState().rightPanelWidth).toBe(350)
+    })
+  })
+})


### PR DESCRIPTION
- Add eye icon toggle to show/hide hidden files (dotfiles)
- Replace emoji icons with Lucide icons in context menu
- Add "Open in Multica" context menu option for directories
- Optimize file filtering with on-demand approach
- Add aria-label/aria-pressed for accessibility
- Add unit tests for uiStore and excludeHiddenFiles