### PR TITLE
fix: resolve race condition causing AI responses not to display

### DIFF
--- a/tests/unit/renderer/hooks/useApp.test.tsx
+++ b/tests/unit/renderer/hooks/useApp.test.tsx
@@ -6,14 +6,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRoot, type Root } from 'react-dom/client'
 import { useApp } from '../../../../src/renderer/src/hooks/useApp'
 import { useDraftStore } from '../../../../src/renderer/src/stores/draftStore'
+import type { StoredSessionUpdate, MulticaSession } from '../../../../src/shared/types'
 
 type AppHandle = {
   deleteSession: (sessionId: string) => Promise<void>
+  selectSession: (sessionId: string) => Promise<void>
+  getSessionUpdates: () => StoredSessionUpdate[]
 }
 
 const AppHarness = React.forwardRef<AppHandle>((_, ref) => {
-  const { deleteSession } = useApp()
-  useImperativeHandle(ref, () => ({ deleteSession }), [deleteSession])
+  const { deleteSession, selectSession, sessionUpdates } = useApp()
+  useImperativeHandle(
+    ref,
+    () => ({
+      deleteSession,
+      selectSession,
+      getSessionUpdates: () => sessionUpdates
+    }),
+    [deleteSession, selectSession, sessionUpdates]
+  )
   return null
 })
 
@@ -37,6 +48,9 @@ describe('useApp deleteSession', () => {
       sessionIds: [],
       processingSessionIds: []
     }),
+    loadSession: vi.fn().mockResolvedValue(null),
+    getSession: vi.fn().mockResolvedValue({ session: null, updates: [] }),
+    startSessionAgent: vi.fn().mockResolvedValue(null),
     getSessionModes: vi.fn().mockResolvedValue(null),
     getSessionModels: vi.fn().mockResolvedValue(null),
     getSessionCommands: vi.fn().mockResolvedValue([]),
@@ -82,4 +96,236 @@ describe('useApp deleteSession', () => {
     const { drafts } = useDraftStore.getState()
     expect(drafts['session-a']).toBeUndefined()
   })
+
+  it('merges reloaded updates with in-memory updates', async () => {
+    let agentMessageHandler:
+      | ((message: {
+          sessionId: string
+          multicaSessionId: string
+          sequenceNumber?: number
+          update: { sessionUpdate: string; content?: { type: string; text: string } }
+          done: boolean
+        }) => void)
+      | undefined
+
+    const session: MulticaSession = {
+      id: 'session-a',
+      agentSessionId: 'agent-1',
+      agentId: 'codex',
+      workingDirectory: '/tmp',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      status: 'active',
+      messageCount: 0
+    }
+
+    const update1: StoredSessionUpdate = {
+      timestamp: '2024-01-01T00:00:01.000Z',
+      sequenceNumber: 1,
+      update: {
+        sessionId: 'agent-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hello' }
+        }
+      }
+    }
+
+    const update2: StoredSessionUpdate = {
+      timestamp: '2024-01-01T00:00:02.000Z',
+      sequenceNumber: 2,
+      update: {
+        sessionId: 'agent-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'world' }
+        }
+      }
+    }
+
+    const modesDeferred = createDeferred<null>()
+    const modelsDeferred = createDeferred<null>()
+    const commandsDeferred = createDeferred<unknown[]>()
+
+    const electronAPI = createElectronApiMock()
+    electronAPI.onAgentMessage.mockImplementation((cb) => {
+      agentMessageHandler = cb
+      return () => {}
+    })
+    const loadSessionDeferred = createDeferred<MulticaSession>()
+    const getSessionDeferred = createDeferred<{
+      session: MulticaSession
+      updates: StoredSessionUpdate[]
+    }>()
+    electronAPI.loadSession.mockImplementation(() => loadSessionDeferred.promise)
+    electronAPI.getAgentStatus.mockResolvedValue({
+      runningSessions: 1,
+      sessionIds: ['session-a'],
+      processingSessionIds: []
+    })
+    electronAPI.getSession
+      .mockImplementationOnce(() => getSessionDeferred.promise)
+      .mockResolvedValueOnce({ session, updates: [update1, update2] })
+    electronAPI.getSessionModes.mockImplementation(() => modesDeferred.promise)
+    electronAPI.getSessionModels.mockImplementation(() => modelsDeferred.promise)
+    electronAPI.getSessionCommands.mockImplementation(() => commandsDeferred.promise)
+    ;(window as unknown as { electronAPI: typeof electronAPI }).electronAPI = electronAPI
+
+    const ref = React.createRef<AppHandle>()
+
+    await act(async () => {
+      root.render(<AppHarness ref={ref} />)
+    })
+
+    await act(async () => {
+      const selectPromise = ref.current?.selectSession('session-a')
+      loadSessionDeferred.resolve(session)
+      getSessionDeferred.resolve({ session, updates: [update1] })
+      await waitForSessionUpdates(ref, 1)
+      agentMessageHandler?.({
+        sessionId: 'agent-1',
+        multicaSessionId: 'session-a',
+        sequenceNumber: 2,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'world' }
+        },
+        done: false
+      })
+      modesDeferred.resolve(null)
+      modelsDeferred.resolve(null)
+      commandsDeferred.resolve([])
+      await selectPromise
+    })
+
+    const updates = ref.current?.getSessionUpdates() ?? []
+    const sequenceNumbers = updates
+      .map((update) => update.sequenceNumber)
+      .filter((seq): seq is number => seq !== undefined)
+    expect(sequenceNumbers).toEqual([1, 2])
+  })
+
+  it('keeps in-memory updates when refreshed updates are empty', async () => {
+    let agentMessageHandler:
+      | ((message: {
+          sessionId: string
+          multicaSessionId: string
+          sequenceNumber?: number
+          update: { sessionUpdate: string; content?: { type: string; text: string } }
+          done: boolean
+        }) => void)
+      | undefined
+
+    const session: MulticaSession = {
+      id: 'session-a',
+      agentSessionId: 'agent-1',
+      agentId: 'codex',
+      workingDirectory: '/tmp',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      status: 'active',
+      messageCount: 0
+    }
+
+    const update1: StoredSessionUpdate = {
+      timestamp: '2024-01-01T00:00:01.000Z',
+      sequenceNumber: 1,
+      update: {
+        sessionId: 'agent-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hello' }
+        }
+      }
+    }
+
+    const modesDeferred = createDeferred<null>()
+    const modelsDeferred = createDeferred<null>()
+    const commandsDeferred = createDeferred<unknown[]>()
+
+    const electronAPI = createElectronApiMock()
+    electronAPI.onAgentMessage.mockImplementation((cb) => {
+      agentMessageHandler = cb
+      return () => {}
+    })
+    const loadSessionDeferred = createDeferred<MulticaSession>()
+    const getSessionDeferred = createDeferred<{
+      session: MulticaSession
+      updates: StoredSessionUpdate[]
+    }>()
+    electronAPI.loadSession.mockImplementation(() => loadSessionDeferred.promise)
+    electronAPI.getAgentStatus.mockResolvedValue({
+      runningSessions: 1,
+      sessionIds: ['session-a'],
+      processingSessionIds: []
+    })
+    electronAPI.getSession
+      .mockImplementationOnce(() => getSessionDeferred.promise)
+      .mockResolvedValueOnce({ session, updates: [] })
+    electronAPI.getSessionModes.mockImplementation(() => modesDeferred.promise)
+    electronAPI.getSessionModels.mockImplementation(() => modelsDeferred.promise)
+    electronAPI.getSessionCommands.mockImplementation(() => commandsDeferred.promise)
+    ;(window as unknown as { electronAPI: typeof electronAPI }).electronAPI = electronAPI
+
+    const ref = React.createRef<AppHandle>()
+
+    await act(async () => {
+      root.render(<AppHarness ref={ref} />)
+    })
+
+    await act(async () => {
+      const selectPromise = ref.current?.selectSession('session-a')
+      loadSessionDeferred.resolve(session)
+      getSessionDeferred.resolve({ session, updates: [update1] })
+      await waitForSessionUpdates(ref, 1)
+      agentMessageHandler?.({
+        sessionId: 'agent-1',
+        multicaSessionId: 'session-a',
+        sequenceNumber: 2,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'world' }
+        },
+        done: false
+      })
+      modesDeferred.resolve(null)
+      modelsDeferred.resolve(null)
+      commandsDeferred.resolve([])
+      await selectPromise
+    })
+
+    const updates = ref.current?.getSessionUpdates() ?? []
+    const sequenceNumbers = updates
+      .map((update) => update.sequenceNumber)
+      .filter((seq): seq is number => seq !== undefined)
+    expect(sequenceNumbers).toEqual([1, 2])
+  })
 })
+
+function createDeferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve: (value: T) => void = () => {}
+  let reject: (error: unknown) => void = () => {}
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function waitForSessionUpdates(
+  ref: React.RefObject<AppHandle>,
+  expectedLength: number
+): Promise<void> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if ((ref.current?.getSessionUpdates().length ?? 0) >= expectedLength) {
+      return
+    }
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- Add `mergeSessionUpdates` helper to deduplicate updates by sequence number, preventing duplicate messages and ensuring correct ordering
- Introduce `updateCurrentSession` helper to synchronously update ref before async operations, fixing race condition where messages arrive before useEffect updates
- Reload session updates after async operations complete to catch messages that arrived during initialization

## Problem
AI responses were not displaying on the UI despite backend logs showing the content was returned. This was caused by a race condition where:
1. Messages arrived via IPC while async operations (loading history, starting agent, loading mode/model) were still in progress
2. The `currentSessionIdRef` was not updated synchronously, causing incoming messages to be filtered out
3. Initial `setSessionUpdates` call could overwrite messages that arrived during async operations

## Test plan
- [x] Added unit tests for `mergeSessionUpdates` behavior with sequence numbers
- [x] Added test for merging reloaded updates with in-memory updates
- [x] Added test for keeping in-memory updates when refreshed updates are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)