### PR TITLE
fix: text overflow in chat bubbles - content not wrapping correctly

### DIFF
--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -669,7 +669,7 @@ function MessageBubble({
 
     return (
       <div className="flex justify-end">
-        <div className="max-w-[85%] rounded-lg bg-[#f9f7f5] dark:bg-muted px-4 py-3 text-[15px]">
+        <div className="max-w-[85%] rounded-lg bg-[#f9f7f5] dark:bg-muted px-4 py-3 text-[15px] break-words overflow-hidden">
           {/* Render images first */}
           {imageBlocks.length > 0 && (
             <div className="flex flex-wrap gap-2 mb-2">
@@ -895,7 +895,7 @@ function TextContentBlock({ content }: { content: string }): React.JSX.Element |
   if (!content) return null
 
   return (
-    <div className="prose prose-invert max-w-none text-[15px] leading-[1.7]">
+    <div className="prose prose-invert max-w-none text-[15px] leading-[1.7] break-words overflow-hidden [&_*]:break-words">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={TEXT_MARKDOWN_COMPONENTS}>
         {content}
       </ReactMarkdown>


### PR DESCRIPTION
## Summary
- Add `break-words` and `overflow-hidden` CSS classes to user message bubbles to ensure proper text wrapping
- Add `break-words`, `overflow-hidden`, and `[&_*]:break-words` to `TextContentBlock` for proper word breaking in nested markdown elements (like links, code spans, etc.)

Closes #83

## Test plan
- [ ] Send a message with a very long URL (e.g., `https://example.com/very/long/path/that/should/wrap/properly`)
- [ ] Send a message with continuous text without spaces
- [ ] Verify text wraps properly within chat bubble boundaries
- [ ] Verify markdown content (links, code) also wraps correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)