### PR TITLE
fix: optimize MessageTimer display during long pauses

### DIFF
--- a/src/renderer/src/components/ui/LiveTimer.tsx
+++ b/src/renderer/src/components/ui/LiveTimer.tsx
@@ -1,0 +1,117 @@
+/**
+ * LiveTimer - Real-time timer with smooth updates during processing
+ *
+ * Key features:
+ * - Event-driven updates: when events are arriving, shows exact value from props
+ * - Timeout projection: when no events for 500ms, projects time forward with variable interval
+ * - Variable interval: 80-180ms using sin wave for natural feel (not mechanical tick)
+ * - Immediate sync: snaps to accurate value when new events arrive
+ */
+import { useState, useEffect, useRef } from 'react'
+import { formatDuration } from '@/lib/utils'
+
+export interface LiveTimerProps {
+  /** Base elapsed time in milliseconds (from events) */
+  baseElapsedMs: number
+  /** Whether the message is still processing */
+  isProcessing: boolean
+  /** Timestamp when the last event was received (Date.now() value) */
+  lastEventTimestamp?: number
+  /** Additional className */
+  className?: string
+}
+
+// Timeout threshold: start projecting after 500ms of no events
+const PROJECTION_THRESHOLD_MS = 500
+// Base update interval for variable timing
+const BASE_INTERVAL_MS = 130
+// Amplitude for sin wave variation (±50ms)
+const INTERVAL_AMPLITUDE_MS = 50
+// Period for sin wave oscillation
+const SIN_PERIOD_MS = 400
+
+export function LiveTimer({
+  baseElapsedMs,
+  isProcessing,
+  lastEventTimestamp,
+  className
+}: LiveTimerProps): React.JSX.Element {
+  // Store the projection offset (time added on top of baseElapsedMs when projecting)
+  const [projectionOffset, setProjectionOffset] = useState(0)
+
+  // Track when we last updated the display (for variable interval)
+  const lastUpdateRef = useRef<number>(0)
+  // Track when projection started
+  const projectionStartRef = useRef<number>(0)
+  // Track the baseElapsedMs that was active when projection started
+  const projectionBaseRef = useRef<number>(baseElapsedMs)
+
+  // Calculate displayed value:
+  // - When processing: base + projection offset (for smooth animation during pauses)
+  // - When not processing: just base (projection offset is irrelevant)
+  // This eliminates the need for a separate effect to reset projectionOffset
+  const displayedMs = isProcessing ? baseElapsedMs + projectionOffset : baseElapsedMs
+
+  // Animation loop for smooth projection during long pauses
+  useEffect(() => {
+    if (!isProcessing) {
+      // Not processing, no animation needed
+      // Note: projectionOffset may be stale, but displayedMs ignores it when !isProcessing
+      return
+    }
+
+    // Reset refs when effect starts (new processing session)
+    projectionStartRef.current = 0
+    lastUpdateRef.current = 0
+    projectionBaseRef.current = baseElapsedMs
+
+    let animationFrameId: number
+
+    const animate = (): void => {
+      const now = performance.now()
+
+      // Calculate time since last event
+      const timeSinceLastEvent = lastEventTimestamp ? Date.now() - lastEventTimestamp : Infinity
+
+      // Only project if we've exceeded the threshold
+      if (timeSinceLastEvent > PROJECTION_THRESHOLD_MS) {
+        // Initialize projection start time if this is the first projection frame
+        if (projectionStartRef.current === 0) {
+          projectionStartRef.current = now
+          lastUpdateRef.current = now
+        }
+
+        // Calculate variable interval using sin wave
+        // This creates a natural, non-mechanical feel: 80-180ms
+        const variableInterval =
+          BASE_INTERVAL_MS + Math.sin(now / SIN_PERIOD_MS) * INTERVAL_AMPLITUDE_MS
+
+        // Check if enough time has passed since last update
+        if (now - lastUpdateRef.current >= variableInterval) {
+          // Calculate projected offset since projection started
+          const newOffset = now - projectionStartRef.current
+
+          setProjectionOffset(newOffset)
+          lastUpdateRef.current = now
+        }
+      } else {
+        // Events are arriving, reset projection (called from callback, so OK)
+        if (projectionStartRef.current !== 0) {
+          projectionStartRef.current = 0
+          setProjectionOffset(0)
+        }
+      }
+
+      animationFrameId = requestAnimationFrame(animate)
+    }
+
+    // Start animation loop
+    animationFrameId = requestAnimationFrame(animate)
+
+    return () => {
+      cancelAnimationFrame(animationFrameId)
+    }
+  }, [isProcessing, lastEventTimestamp, baseElapsedMs])
+
+  return <span className={className}>{displayedMs > 0 ? formatDuration(displayedMs) : null}</span>
+}

--- a/src/renderer/src/components/ui/LoadingIndicator.tsx
+++ b/src/renderer/src/components/ui/LoadingIndicator.tsx
@@ -5,6 +5,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { cn, formatDuration, formatLocalizedDatetime } from '@/lib/utils'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { LiveTimer } from './LiveTimer'
 
 // Re-export Spinner from dedicated component file
 export { Spinner, type SpinnerProps } from './Spinner'
@@ -128,6 +129,8 @@ export interface MessageTimerProps {
   startTime?: string | number
   /** End time (ISO 8601 string or timestamp) - if provided, shows final duration */
   endTime?: string | number
+  /** Timestamp when the last event was received (Date.now() value, for LiveTimer projection) */
+  lastEventTimestamp?: number
   /** Whether the message is still processing */
   isProcessing?: boolean
   /** Label to show (overrides dynamic label) */
@@ -155,6 +158,7 @@ export interface MessageTimerProps {
 export function MessageTimer({
   startTime,
   endTime,
+  lastEventTimestamp,
   isProcessing = false,
   label,
   className,
@@ -224,14 +228,17 @@ export function MessageTimer({
 
   // Processing state: show spinner + time + label
   // Order: [Spinner] [time] [label] - uses smallest font (text-xs)
-  // Time only shown when endTime is available (elapsedMs > 0)
+  // Uses LiveTimer for smooth updates during long pauses (tool execution, permission waits)
   if (isProcessing) {
     return (
       <div className={cn('flex items-center gap-2 text-xs text-muted-foreground', className)}>
         <Spinner className="text-xs" />
-        {elapsedMs > 0 && (
-          <span className="text-muted-foreground/60">{formatDuration(elapsedMs)}</span>
-        )}
+        <LiveTimer
+          baseElapsedMs={elapsedMs}
+          isProcessing={true}
+          lastEventTimestamp={lastEventTimestamp}
+          className="text-muted-foreground/60"
+        />
         <span className="text-muted-foreground/80">{getStatusLabel()}</span>
       </div>
     )

--- a/src/renderer/src/hooks/useApp.ts
+++ b/src/renderer/src/hooks/useApp.ts
@@ -296,9 +296,11 @@ export function useApp(): AppState & AppActions {
       // Pass through original update without any accumulation
       // ChatView is responsible for accumulating chunks into complete messages
       // Include sequence number for proper ordering of concurrent updates
+      const frontendTimestamp = new Date().toISOString()
+
       setSessionUpdates((prev) => {
         const newUpdate = {
-          timestamp: new Date().toISOString(),
+          timestamp: frontendTimestamp,
           sequenceNumber: message.sequenceNumber,
           update: {
             sessionId: message.sessionId,

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -8,12 +8,12 @@ export function cn(...inputs: ClassValue[]): string {
 /**
  * Format duration in human-readable form
  * @param ms Duration in milliseconds
- * @returns "5.23s" for under a minute (with 2 decimal places), "1m 29s" for 1+ minutes
+ * @returns "5.2s" for under a minute (with 1 decimal place), "1m 29s" for 1+ minutes
  */
 export function formatDuration(ms: number): string {
   const totalSeconds = ms / 1000
   if (totalSeconds < 60) {
-    return `${totalSeconds.toFixed(2)}s`
+    return `${totalSeconds.toFixed(1)}s`
   }
   const minutes = Math.floor(totalSeconds / 60)
   const remainingSeconds = Math.floor(totalSeconds % 60)

--- a/tests/unit/renderer/lib/utils.test.ts
+++ b/tests/unit/renderer/lib/utils.test.ts
@@ -5,12 +5,12 @@ import { describe, expect, it } from 'vitest'
 import { formatDuration, formatLocalizedDatetime } from '../../../../src/renderer/src/lib/utils'
 
 describe('formatDuration', () => {
-  it('returns seconds with 2 decimal places for durations under 1 minute', () => {
-    expect(formatDuration(0)).toBe('0.00s')
-    expect(formatDuration(1000)).toBe('1.00s')
-    expect(formatDuration(1230)).toBe('1.23s')
-    expect(formatDuration(45000)).toBe('45.00s')
-    expect(formatDuration(59500)).toBe('59.50s')
+  it('returns seconds with 1 decimal place for durations under 1 minute', () => {
+    expect(formatDuration(0)).toBe('0.0s')
+    expect(formatDuration(1000)).toBe('1.0s')
+    expect(formatDuration(1230)).toBe('1.2s')
+    expect(formatDuration(45000)).toBe('45.0s')
+    expect(formatDuration(59500)).toBe('59.5s')
   })
 
   it('returns minutes only when seconds is zero', () => {


### PR DESCRIPTION
- Add LiveTimer component with event-driven updates + timeout projection
- Track lastEventTimestamp in ChatView for accurate pause detection
- Project time forward after 500ms of no events (variable 80-180ms interval)
- Immediately sync to accurate value when events resume
- Change formatDuration to 1 decimal place for cleaner display
- Remove debug console.log statements

Closes #100