### PR TITLE
Standardize Chinese README naming to use script codes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 ビジュアルインターフェースを通じて、コーディングエージェントの能力をすべての人に届けるネイティブデスクトップクライアント。
 
-[English](./README.md) | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md) | 日本語 | [한국어](./README.ko.md)
+[English](./README.md) | [简体中文](./README.zh-Hans.md) | [繁體中文](./README.zh-Hant.md) | 日本語 | [한국어](./README.ko.md)
 
 ## なぜ "Multica" という名前なのか？
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@
 
 시각적 인터페이스를 통해 코딩 에이전트의 기능을 모든 사람에게 제공하는 네이티브 데스크톱 클라이언트.
 
-[English](./README.md) | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md) | [日本語](./README.ja.md) | 한국어
+[English](./README.md) | [简体中文](./README.zh-Hans.md) | [繁體中文](./README.zh-Hant.md) | [日本語](./README.ja.md) | 한국어
 
 ## 왜 "Multica"인가?
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A native desktop client that brings coding agent capabilities to everyone through a visual interface.
 
-English | [简体中文](./README.zh-CN.md) | [繁體中文](./README.zh-TW.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md)
+English | [简体中文](./README.zh-Hans.md) | [繁體中文](./README.zh-Hant.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md)
 
 [**Download the latest release**](https://github.com/multica-ai/multica/releases)
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -4,7 +4,7 @@
 
 一个原生桌面客户端，通过可视化界面将编程智能体的能力带给每一个人。
 
-[English](./README.md) | 简体中文 | [繁體中文](./README.zh-TW.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md)
+[English](./README.md) | 简体中文 | [繁體中文](./README.zh-Hant.md) | [日本語](./README.ja.md) | [한국어](./README.ko.md)
 
 ## 为什么叫 "Multica"？
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -4,7 +4,7 @@
 
 一個原生桌面客戶端，透過視覺化介面將程式智能體的能力帶給每一個人。
 
-[English](./README.md) | [简体中文](./README.zh-CN.md) | 繁體中文 | [日本語](./README.ja.md) | [한국어](./README.ko.md)
+[English](./README.md) | [简体中文](./README.zh-Hans.md) | 繁體中文 | [日本語](./README.ja.md) | [한국어](./README.ko.md)
 
 ## 為什麼叫 "Multica"？
 


### PR DESCRIPTION
Rename Chinese README files from region codes (zh-CN, zh-TW) to BCP 47 standard script codes (zh-Hans for simplified Chinese, zh-Hant for traditional Chinese). This is the recommended approach for distinguishing between simplified and traditional Chinese text. Update all language-specific README files to point to the new file names.

🤖 Generated with Claude Code