### PR TITLE
feat: Add PlanApprovalUI for ExitPlanMode tool

### DIFF
--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -5,7 +5,14 @@
 import { useState, useMemo } from 'react'
 import type { StoredSessionUpdate } from '../../../shared/types'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { ChevronDown, ChevronRight, CheckCircle2, Circle, Loader2, Folder } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronRight,
+  CheckCircle2,
+  CircleDashed,
+  Loader2,
+  Folder
+} from 'lucide-react'
 import { ToolCallItem, type ToolCall, type AnsweredResponse } from './ToolCallItem'
 import { PermissionRequestItem } from './permission'
 import { usePermissionStore } from '../stores/permissionStore'
@@ -914,7 +921,7 @@ function PlanBlockView({ entries }: { entries: PlanEntry[] }): React.JSX.Element
         ) : completedCount === totalCount ? (
           <CheckCircle2 className="h-3.5 w-3.5 text-[var(--tool-success)]" />
         ) : (
-          <Circle className="h-3.5 w-3.5" />
+          <CircleDashed className="h-3.5 w-3.5 text-muted-foreground" />
         )}
 
         {/* Title with progress */}
@@ -946,7 +953,7 @@ function PlanBlockView({ entries }: { entries: PlanEntry[] }): React.JSX.Element
               ) : entry.status === 'in_progress' ? (
                 <Loader2 className="h-3 w-3 text-[var(--tool-running)] flex-shrink-0 mt-0.5 animate-spin" />
               ) : (
-                <Circle className="h-3 w-3 text-muted-foreground/50 flex-shrink-0 mt-0.5" />
+                <CircleDashed className="h-3 w-3 text-muted-foreground/50 flex-shrink-0 mt-0.5" />
               )}
               {/* Content - smaller text */}
               <span

--- a/src/renderer/src/components/ToolCallItem.tsx
+++ b/src/renderer/src/components/ToolCallItem.tsx
@@ -11,8 +11,10 @@ import {
   Globe,
   Bot,
   ListTodo,
-  Circle,
-  MessageSquare
+  Wrench,
+  MessageSquare,
+  ClipboardCheck,
+  NotebookPen
 } from 'lucide-react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
@@ -210,9 +212,25 @@ function getDisplayInfo(toolCall: ToolCall): {
         stats: isPending ? 'waiting...' : undefined
       }
     }
+    // Plan mode tools
+    case 'exitplanmode':
+    case 'plan_exit': {
+      return {
+        icon: <ClipboardCheck className={iconClass} />,
+        name: 'Ready to Code',
+        stats: isPending ? 'awaiting approval...' : undefined
+      }
+    }
+    case 'enterplanmode': {
+      return {
+        icon: <NotebookPen className={iconClass} />,
+        name: 'Enter Plan Mode',
+        stats: isPending ? 'planning...' : undefined
+      }
+    }
     default: {
       // fallback: use toolName or title or kind
-      return { icon: <Circle className={iconClass} />, name: toolName || title || kind || 'Tool' }
+      return { icon: <Wrench className={iconClass} />, name: toolName || title || kind || 'Tool' }
     }
   }
 }

--- a/src/renderer/src/components/permission/PermissionRequestItem.tsx
+++ b/src/renderer/src/components/permission/PermissionRequestItem.tsx
@@ -3,13 +3,42 @@
  *
  * Routes to appropriate UI based on tool type:
  * - AskUserQuestion: Shows question UI with options
+ * - ExitPlanMode: Shows plan approval UI with markdown rendering
  * - Other tools: Shows standard permission UI
  */
 import { usePermissionStore } from '../../stores/permissionStore'
-import { isQuestionTool } from '../../../../shared/tool-names'
+import { isQuestionTool, isPlanApprovalTool } from '../../../../shared/tool-names'
 import { AskUserQuestionUI, CompletedAnswer } from './AskUserQuestion'
+import { PlanApprovalUI } from './PlanApprovalUI'
 import { StandardPermissionUI } from './StandardPermissionUI'
 import type { PermissionRequestItemProps, AskUserQuestionInput } from './types'
+
+/**
+ * Safely extract plan content from rawInput
+ * Handles various input formats and edge cases
+ */
+function extractPlanContent(rawInput: unknown): string | undefined {
+  if (!rawInput || typeof rawInput !== 'object') return undefined
+
+  const input = rawInput as Record<string, unknown>
+
+  // Try 'plan' field first (expected format)
+  if (typeof input.plan === 'string' && input.plan.trim()) {
+    return input.plan
+  }
+
+  // Fallback: try 'content' field
+  if (typeof input.content === 'string' && input.content.trim()) {
+    return input.content
+  }
+
+  // Fallback: try 'text' field
+  if (typeof input.text === 'string' && input.text.trim()) {
+    return input.text
+  }
+
+  return undefined
+}
 
 export function PermissionRequestItem({ request }: PermissionRequestItemProps): React.JSX.Element {
   const currentRequest = usePermissionStore((s) => s.pendingRequests[0] ?? null)
@@ -26,6 +55,10 @@ export function PermissionRequestItem({ request }: PermissionRequestItemProps): 
   const isAskUserQuestion = isQuestionTool(toolCall.title)
   const rawInput = toolCall.rawInput as AskUserQuestionInput | undefined
   const questions = isAskUserQuestion ? rawInput?.questions : undefined
+
+  // Detect ExitPlanMode tool (plan approval)
+  const isPlanApproval = isPlanApprovalTool(toolCall.title)
+  const planContent = isPlanApproval ? extractPlanContent(toolCall.rawInput) : undefined
 
   // Render AskUserQuestion UI for pending question
   if (isAskUserQuestion && questions && questions.length > 0 && isPending) {
@@ -49,6 +82,11 @@ export function PermissionRequestItem({ request }: PermissionRequestItemProps): 
         firstQuestionHeader={questions[0]?.header}
       />
     )
+  }
+
+  // Render PlanApprovalUI for ExitPlanMode with plan content
+  if (isPlanApproval && planContent && isPending) {
+    return <PlanApprovalUI request={request} planContent={planContent} />
   }
 
   // Standard permission UI

--- a/src/renderer/src/components/permission/PlanApprovalUI.tsx
+++ b/src/renderer/src/components/permission/PlanApprovalUI.tsx
@@ -1,0 +1,97 @@
+/**
+ * Plan approval UI - displays plan content with markdown rendering
+ *
+ * Design: Minimal, follows existing permission UI patterns
+ * Key: Accept button first (primary action), clean hierarchy
+ */
+import { FileText } from 'lucide-react'
+import { usePermissionStore } from '../../stores/permissionStore'
+import { Button } from '@/components/ui/button'
+import { Markdown } from '../markdown/Markdown'
+import type { PlanApprovalUIProps } from './types'
+
+/**
+ * Categorize options into approve and deny groups
+ * Falls back to showing all options if categorization fails
+ */
+function categorizeOptions(options: PlanApprovalUIProps['request']['options']): {
+  approveOptions: typeof options
+  denyOption: (typeof options)[0] | undefined
+} {
+  // Primary action: approve options (by kind first, then by name)
+  const approveOptions = options.filter(
+    (o) =>
+      o.kind === 'allow_once' ||
+      o.kind === 'allow' ||
+      o.name?.toLowerCase().match(/yes|accept|approve|confirm|start/i)
+  )
+
+  // Secondary: keep planning / deny
+  const denyOption = options.find(
+    (o) =>
+      o.kind === 'deny' ||
+      o.kind === 'reject_once' ||
+      o.name?.toLowerCase().match(/no|deny|reject|keep planning|cancel/i)
+  )
+
+  // Fallback: if no categorization worked, treat first as approve, last as deny
+  if (approveOptions.length === 0 && options.length > 0) {
+    return {
+      approveOptions: [options[0]],
+      denyOption: options.length > 1 ? options[options.length - 1] : undefined
+    }
+  }
+
+  return { approveOptions, denyOption }
+}
+
+export function PlanApprovalUI({ request, planContent }: PlanApprovalUIProps): React.JSX.Element {
+  const respondToRequest = usePermissionStore((s) => s.respondToRequest)
+  const { options } = request
+
+  const { approveOptions, denyOption } = categorizeOptions(options)
+
+  // Normalize plan content - handle empty/whitespace
+  const normalizedContent = planContent?.trim() || ''
+  const hasContent = normalizedContent.length > 0
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/30 p-3 space-y-3">
+      {/* Header - consistent with StandardPermissionUI */}
+      <div className="flex items-center gap-2">
+        <FileText className="h-4 w-4 text-blue-500" />
+        <span className="font-medium text-sm text-foreground">Plan Ready</span>
+      </div>
+
+      {/* Plan content */}
+      {hasContent ? (
+        <div className="rounded-md bg-muted/50 p-3 max-h-[50vh] overflow-y-auto scrollbar-thin">
+          <Markdown mode="minimal">{normalizedContent}</Markdown>
+        </div>
+      ) : (
+        <div className="rounded-md bg-muted/50 p-3 text-sm text-muted-foreground">
+          Plan content not available. Please check the plan file.
+        </div>
+      )}
+
+      {/* Action buttons - only first is primary, rest are outline */}
+      <div className="flex flex-wrap gap-2">
+        {approveOptions.map((option, index) => (
+          <Button
+            key={option.optionId}
+            size="sm"
+            variant={index === 0 ? 'default' : 'outline'}
+            onClick={() => respondToRequest(option.optionId)}
+          >
+            {option.name || 'Approve'}
+          </Button>
+        ))}
+        {denyOption && (
+          <Button size="sm" variant="outline" onClick={() => respondToRequest(denyOption.optionId)}>
+            {denyOption.name || 'Deny'}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/permission/types.ts
+++ b/src/renderer/src/components/permission/types.ts
@@ -63,3 +63,16 @@ export interface StandardPermissionUIProps {
   request: PermissionRequest
   isPending: boolean
 }
+
+// PlanApproval rawInput structure
+export interface PlanApprovalInput {
+  plan?: string
+  allowedPrompts?: Array<{ tool: string; prompt: string }>
+  launchSwarm?: boolean
+  pushToRemote?: boolean
+}
+
+export interface PlanApprovalUIProps {
+  request: PermissionRequest
+  planContent: string
+}

--- a/src/shared/tool-names.ts
+++ b/src/shared/tool-names.ts
@@ -32,7 +32,12 @@ export const TOOL_NAMES = {
 
   // Agent tools
   TASK: 'Task',
-  TODO_WRITE: 'TodoWrite'
+  TODO_WRITE: 'TodoWrite',
+
+  // Plan tools
+  EXIT_PLAN_MODE: 'ExitPlanMode',
+  ENTER_PLAN_MODE: 'EnterPlanMode',
+  PLAN_EXIT: 'plan_exit' // OpenCode variant
 } as const
 
 // Type for tool names
@@ -55,5 +60,25 @@ export function isQuestionTool(toolName: string | undefined | null): boolean {
     normalized === 'askuserquestion' ||
     normalized === 'question' ||
     normalized === TOOL_NAMES.MCP_CONDUCTOR_ASK_USER_QUESTION
+  )
+}
+
+/**
+ * Check if a tool name/title represents a plan approval tool (ExitPlanMode)
+ * These tools require user approval before executing the plan
+ *
+ * @param toolName - The tool name or title to check
+ * @returns true if this is a plan approval tool
+ */
+export function isPlanApprovalTool(toolName: string | undefined | null): boolean {
+  if (!toolName) return false
+
+  const normalized = toolName.toLowerCase()
+  return (
+    toolName === TOOL_NAMES.EXIT_PLAN_MODE ||
+    toolName === TOOL_NAMES.PLAN_EXIT ||
+    normalized === 'exitplanmode' ||
+    normalized === 'plan_exit' ||
+    normalized.includes('ready to code') // Claude Code's display title
   )
 }


### PR DESCRIPTION
## Summary
- Add `isPlanApprovalTool()` detection function for ExitPlanMode tool
- Create dedicated `PlanApprovalUI` component with markdown rendering
- Smart option categorization with approve/deny buttons
- Defensive error handling with fallback to StandardPermissionUI
- Replace Circle icons with more contextual icons (Wrench, ClipboardCheck)

## Changes
| File | Description |
|------|-------------|
| `src/shared/tool-names.ts` | Added plan tool constants and `isPlanApprovalTool()` function |
| `src/renderer/src/components/permission/types.ts` | Added `PlanApprovalInput` type |
| `src/renderer/src/components/permission/PlanApprovalUI.tsx` | New component for plan approval |
| `src/renderer/src/components/permission/PermissionRequestItem.tsx` | Route to PlanApprovalUI |
| `src/renderer/src/components/ToolCallItem.tsx` | Icon improvements |
| `src/renderer/src/components/ChatView.tsx` | Icon improvements |

## Test plan
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [ ] ExitPlanMode displays plan with markdown
- [ ] Fallback to StandardPermissionUI when no plan content
- [ ] Unit tests for `isPlanApprovalTool()` function

Closes #113

---
Generated with [Claude Code](https://claude.com/claude-code)