### PR TITLE
fix(MUL-76): add --force to npm install commands to handle partial installs

### DIFF
--- a/src/main/utils/agent-install.ts
+++ b/src/main/utils/agent-install.ts
@@ -8,16 +8,18 @@ import type { InstallResult } from '../../shared/electron-api'
 
 // Install commands for each agent
 // Claude Code and Codex need both CLI and ACP installed
+// Note: --force is used for npm installs to handle cases where one package
+// is already installed (avoids EEXIST errors when binary already exists)
 export const INSTALL_COMMANDS: Record<string, string> = {
   // Claude Code: Install official CLI first, then ACP adapter
   'claude-code':
-    'curl -fsSL https://claude.ai/install.sh | bash && npm install -g @zed-industries/claude-code-acp',
+    'curl -fsSL https://claude.ai/install.sh | bash && npm install -g @zed-industries/claude-code-acp --force',
   // OpenCode: Official install script
   opencode: 'curl -fsSL https://opencode.ai/install | bash',
-  // Codex: Install CLI and ACP adapter together
-  codex: 'npm install -g @openai/codex @zed-industries/codex-acp',
+  // Codex: Install CLI and ACP adapter together (--force handles partial installs)
+  codex: 'npm install -g @openai/codex @zed-industries/codex-acp --force',
   // Gemini: Single npm package
-  gemini: 'npm install -g @google/gemini-cli'
+  gemini: 'npm install -g @google/gemini-cli --force'
 }
 
 // Update commands for individual commands (not agents)

--- a/tests/unit/main/utils/agent-install.test.ts
+++ b/tests/unit/main/utils/agent-install.test.ts
@@ -60,18 +60,18 @@ describe('agent-install', () => {
 
   describe('INSTALL_COMMANDS', () => {
     it('should have install commands for supported agents', () => {
-      // Claude Code: CLI + ACP
+      // Claude Code: CLI + ACP (--force to handle partial installs)
       expect(INSTALL_COMMANDS['claude-code']).toBe(
-        'curl -fsSL https://claude.ai/install.sh | bash && npm install -g @zed-industries/claude-code-acp'
+        'curl -fsSL https://claude.ai/install.sh | bash && npm install -g @zed-industries/claude-code-acp --force'
       )
       // OpenCode: official install script
       expect(INSTALL_COMMANDS['opencode']).toBe('curl -fsSL https://opencode.ai/install | bash')
-      // Codex: CLI + ACP in one command
+      // Codex: CLI + ACP in one command (--force to handle partial installs)
       expect(INSTALL_COMMANDS['codex']).toBe(
-        'npm install -g @openai/codex @zed-industries/codex-acp'
+        'npm install -g @openai/codex @zed-industries/codex-acp --force'
       )
-      // Gemini: single package
-      expect(INSTALL_COMMANDS['gemini']).toBe('npm install -g @google/gemini-cli')
+      // Gemini: single package (--force for consistency)
+      expect(INSTALL_COMMANDS['gemini']).toBe('npm install -g @google/gemini-cli --force')
     })
   })
 


### PR DESCRIPTION
## Problem

When a user already has `@openai/codex` installed but not `@zed-industries/codex-acp`, npm install fails with EEXIST error:

```
npm error code EEXIST
npm error path /opt/homebrew/bin/codex
npm error EEXIST: file already exists
```

## Solution

Add `--force` flag to npm install commands to allow overwriting existing files and continue installing the missing packages.

## Changes

- Added `--force` to codex install command
- Added `--force` to claude-code ACP install command  
- Added `--force` to gemini install command for consistency
- Updated corresponding tests

## Testing

- All 367 tests pass ✅
- Lint passes with no warnings ✅

Fixes MUL-76