### PR TITLE
chore: rename super-multica references to multica

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ brews:
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
-    homepage: "https://github.com/multica-ai/super-multica"
+    homepage: "https://github.com/multica-ai/multica"
     description: "Multica CLI — local agent runtime and management tool for the Multica platform"
     license: "MIT"
     install: |

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -72,11 +72,11 @@ make worktree-env
 That generates values like:
 
 ```bash
-POSTGRES_DB=multica_super_multica_702
+POSTGRES_DB=multica_my_feature_702
 POSTGRES_PORT=5432
 PORT=18782
 FRONTEND_PORT=13702
-DATABASE_URL=postgres://multica:multica@localhost:5432/multica_super_multica_702?sslmode=disable
+DATABASE_URL=postgres://multica:multica@localhost:5432/multica_my_feature_702?sslmode=disable
 ```
 
 Notes:
@@ -169,8 +169,8 @@ make check-main
 Use a worktree when you want isolated data and separate app ports.
 
 ```bash
-git worktree add ../super-multica-feature -b feat/my-change main
-cd ../super-multica-feature
+git worktree add ../multica-feature -b feat/my-change main
+cd ../multica-feature
 make worktree-env
 make setup-worktree
 make start-worktree
@@ -195,7 +195,7 @@ Example:
   - backend: `8080`
   - frontend: `3000`
 - worktree checkout
-  - database: `multica_super_multica_702`
+  - database: `multica_my_feature_702`
   - backend: generated worktree port such as `18782`
   - frontend: generated worktree port such as `13702`
 
@@ -442,8 +442,8 @@ make start-main
 ### Feature Worktree
 
 ```bash
-git worktree add ../super-multica-feature -b feat/my-change main
-cd ../super-multica-feature
+git worktree add ../multica-feature -b feat/my-change main
+cd ../multica-feature
 make worktree-env
 make setup-worktree
 make start-worktree
@@ -452,7 +452,7 @@ make start-worktree
 ### Return to a Previously Configured Worktree
 
 ```bash
-cd ../super-multica-feature
+cd ../multica-feature
 make start-worktree
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make start-worktree
 Every checkout shares the same PostgreSQL container on `localhost:5432`. Isolation now happens at the database level:
 
 - `.env` typically uses `POSTGRES_DB=multica`
-- each `.env.worktree` gets its own `POSTGRES_DB`, such as `multica_super_multica_702`
+- each `.env.worktree` gets its own `POSTGRES_DB`, such as `multica_my_feature_702`
 - backend/frontend ports still stay unique per worktree
 
 That keeps one Docker container and one volume, while still isolating schema and data per worktree.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-name: super_multica
+name: multica
 
 services:
   postgres:


### PR DESCRIPTION
## Summary
- Renamed all remaining "super-multica" / "super_multica" references to "multica" across docker-compose, goreleaser config, README, and local development docs.
- Updated worktree example directory names and database name examples accordingly.

## Test plan
- [ ] Verify `docker compose up` still works with the new project name
- [ ] Verify `make worktree-env` generates correct DB names

🤖 Generated with [Claude Code](https://claude.com/claude-code)