### PR TITLE
fix(db): make inbox_actor migration idempotent

### DIFF
--- a/server/migrations/012_inbox_actor.up.sql
+++ b/server/migrations/012_inbox_actor.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE inbox_item ADD COLUMN actor_type TEXT;
-ALTER TABLE inbox_item ADD COLUMN actor_id UUID;
+ALTER TABLE inbox_item ADD COLUMN IF NOT EXISTS actor_type TEXT;
+ALTER TABLE inbox_item ADD COLUMN IF NOT EXISTS actor_id UUID;


### PR DESCRIPTION
## Summary
- Adds `IF NOT EXISTS` to the `012_inbox_actor` migration's `ADD COLUMN` statements
- Fixes migration failure on databases where the old `009_inbox_actor` migration was already applied before it was renumbered to 012

## Test plan
- [x] Verified `make setup` completes successfully on a database with pre-existing columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)