### PR TITLE
fix: address PR #149 review findings

### DIFF
--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/cli"
@@ -122,7 +123,7 @@ func TestResolveAssignee(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for ambiguous match")
 		}
-		if got := err.Error(); !contains(got, "ambiguous") {
+		if got := err.Error(); !strings.Contains(got, "ambiguous") {
 			t.Errorf("expected ambiguous error, got: %s", got)
 		}
 	})
@@ -156,15 +157,3 @@ func TestValidIssueStatuses(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -584,9 +584,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string) (TaskR
 
 	prompt := BuildPrompt(task)
 
+	// Pass the daemon's auth credentials so the spawned agent CLI can call
+	// the Multica API (e.g. `multica issue get`, `multica issue comment add`).
 	backend, err := agent.New(provider, agent.Config{
 		ExecutablePath: entry.Path,
-		Logger:         d.logger,
+		Env: map[string]string{
+			"MULTICA_TOKEN":      d.client.Token(),
+			"MULTICA_SERVER_URL": d.cfg.ServerBaseURL,
+		},
+		Logger: d.logger,
 	})
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -215,8 +215,8 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 		params.Settings = s
 	}
 	if req.Repos != nil {
-		r, _ := json.Marshal(req.Repos)
-		params.Repos = r
+		reposJSON, _ := json.Marshal(req.Repos)
+		params.Repos = reposJSON
 	}
 
 	ws, err := h.Queries.UpdateWorkspace(r.Context(), params)

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -201,47 +201,6 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 	return i, err
 }
 
-const createAgentTaskWithContext = `-- name: CreateAgentTaskWithContext :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, context)
-VALUES ($1, $2, $3, 'queued', $4, $5)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id
-`
-
-type CreateAgentTaskWithContextParams struct {
-	AgentID   pgtype.UUID `json:"agent_id"`
-	RuntimeID pgtype.UUID `json:"runtime_id"`
-	IssueID   pgtype.UUID `json:"issue_id"`
-	Priority  int32       `json:"priority"`
-	Context   []byte      `json:"context"`
-}
-
-func (q *Queries) CreateAgentTaskWithContext(ctx context.Context, arg CreateAgentTaskWithContextParams) (AgentTaskQueue, error) {
-	row := q.db.QueryRow(ctx, createAgentTaskWithContext,
-		arg.AgentID,
-		arg.RuntimeID,
-		arg.IssueID,
-		arg.Priority,
-		arg.Context,
-	)
-	var i AgentTaskQueue
-	err := row.Scan(
-		&i.ID,
-		&i.AgentID,
-		&i.IssueID,
-		&i.Status,
-		&i.Priority,
-		&i.DispatchedAt,
-		&i.StartedAt,
-		&i.CompletedAt,
-		&i.Result,
-		&i.Error,
-		&i.CreatedAt,
-		&i.Context,
-		&i.RuntimeID,
-	)
-	return i, err
-}
-
 const deleteAgent = `-- name: DeleteAgent :exec
 DELETE FROM agent WHERE id = $1
 `

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -54,11 +54,6 @@ WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running');
 SELECT * FROM agent_task_queue
 WHERE id = $1;
 
--- name: CreateAgentTaskWithContext :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, context)
-VALUES ($1, $2, $3, 'queued', $4, $5)
-RETURNING *;
-
 -- name: ClaimAgentTask :one
 UPDATE agent_task_queue
 SET status = 'dispatched', dispatched_at = now()


### PR DESCRIPTION
## Summary
- Replace custom `contains`/`searchString` with `strings.Contains` in issue command tests
- Fix `r` variable shadowing `*http.Request` param in workspace handler → renamed to `reposJSON`
- Wire daemon's auth token (`MULTICA_TOKEN`) and server URL (`MULTICA_SERVER_URL`) into spawned agent env vars so CLI commands authenticate correctly
- Remove dead `CreateAgentTaskWithContext` sqlc query (superseded by `CreateAgentTask` after context snapshot removal)

Addresses review items 2–6 from PR #149. Item 1 (split repos feature) is not retroactively actionable since #149 is already merged.

## Test plan
- [x] `go test ./cmd/multica/` — passes (strings.Contains replacement works)
- [x] `go test ./internal/daemon/` — passes
- [x] `go test ./internal/daemon/execenv/` — passes
- [x] `go build ./...` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)