### PR TITLE
feat(skills): improve import skill UX with source cards

### DIFF
--- a/apps/web/features/skills/components/skills-page.tsx
+++ b/apps/web/features/skills/components/skills-page.tsx
@@ -144,22 +144,39 @@ function CreateSkillDialog({
                 type="text"
                 value={importUrl}
                 onChange={(e) => { setImportUrl(e.target.value); setImportError(""); }}
-                placeholder="https://clawhub.ai/owner/skill-name"
+                placeholder="Paste a skill URL..."
                 className="mt-1"
                 onKeyDown={(e) => e.key === "Enter" && handleImport()}
               />
-              <div className="flex items-center gap-2 mt-1.5">
-                {detectedSource ? (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-accent px-2 py-0.5 text-xs font-medium">
-                    {detectedSource === "clawhub" ? "ClawHub" : "Skills.sh"}
-                  </span>
-                ) : (
-                  <p className="text-xs text-muted-foreground">
-                    Supports <span className="font-medium">clawhub.ai</span> and <span className="font-medium">skills.sh</span>
-                  </p>
-                )}
+            </div>
+
+            {/* Supported sources — highlight on detection */}
+            <div>
+              <p className="text-xs text-muted-foreground mb-2">Supported sources</p>
+              <div className="grid grid-cols-2 gap-2">
+                <div className={`rounded-lg border px-3 py-2.5 transition-colors ${
+                  detectedSource === "clawhub"
+                    ? "border-primary bg-primary/5"
+                    : ""
+                }`}>
+                  <div className="text-xs font-medium">ClawHub</div>
+                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground font-mono">
+                    clawhub.ai/owner/skill
+                  </div>
+                </div>
+                <div className={`rounded-lg border px-3 py-2.5 transition-colors ${
+                  detectedSource === "skills.sh"
+                    ? "border-primary bg-primary/5"
+                    : ""
+                }`}>
+                  <div className="text-xs font-medium">Skills.sh</div>
+                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground font-mono">
+                    skills.sh/owner/repo/skill
+                  </div>
+                </div>
               </div>
             </div>
+
             {importError && (
               <div className="flex items-center gap-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
                 <AlertCircle className="h-3.5 w-3.5 shrink-0" />
@@ -177,8 +194,18 @@ function CreateSkillDialog({
             </Button>
           ) : (
             <Button onClick={handleImport} disabled={loading || !importUrl.trim()}>
-              <Download className="mr-1.5 h-3 w-3" />
-              {loading ? "Importing..." : "Import"}
+              {loading ? (
+                detectedSource === "clawhub"
+                  ? "Importing from ClawHub..."
+                  : detectedSource === "skills.sh"
+                    ? "Importing from Skills.sh..."
+                    : "Importing..."
+              ) : (
+                <>
+                  <Download className="mr-1.5 h-3 w-3" />
+                  Import
+                </>
+              )}
             </Button>
           )}
         </DialogFooter>


### PR DESCRIPTION
## Summary
- Replace the subtle inline source badge in the skill import dialog with two always-visible **source cards** showing URL formats for ClawHub (`clawhub.ai/owner/skill`) and Skills.sh (`skills.sh/owner/repo/skill`)
- Cards highlight with `border-primary` + `bg-primary/5` when the matching source is detected from the user's input
- Import button now shows source-specific loading text (e.g. "Importing from ClawHub...")
- URL input placeholder changed to generic "Paste a skill URL..." since the cards now serve as format reference

## Test plan
- [ ] Open Skills page → click Create → switch to Import tab
- [ ] Verify both source cards are visible with correct URL format hints
- [ ] Paste a ClawHub URL → verify ClawHub card highlights
- [ ] Paste a Skills.sh URL → verify Skills.sh card highlights
- [ ] Click Import → verify source-specific loading text appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)