### PR TITLE
fix(ui): restore issue identifier in breadcrumb

### DIFF
--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -484,6 +484,10 @@ export function IssueDetail({ issueId, onDelete }: IssueDetailProps) {
                 <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
               </>
             )}
+            <span className="truncate text-muted-foreground">
+              {issue.identifier}
+            </span>
+            <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
             <span className="truncate">{issue.title}</span>
           </div>
           <div className="flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## Summary
- Re-add `issue.identifier` (e.g. `MUL-42`) to the issue detail breadcrumb, which was incorrectly removed during a merge conflict resolution in #169

## Test plan
- [ ] Open an issue detail page and verify breadcrumb shows: `Workspace > MUL-42 > Issue Title`

🤖 Generated with [Claude Code](https://claude.com/claude-code)