### PR TITLE
fix(cli): always update server_url on login

### DIFF
--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -202,9 +202,7 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	// Save to config.
 	cfg, _ := cli.LoadCLIConfig()
 	cfg.Token = patResp.Token
-	if cfg.ServerURL == "" {
-		cfg.ServerURL = serverURL
-	}
+	cfg.ServerURL = serverURL
 	if err := cli.SaveCLIConfig(cfg); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
@@ -243,9 +241,7 @@ func runAuthLoginToken(cmd *cobra.Command) error {
 
 	cfg, _ := cli.LoadCLIConfig()
 	cfg.Token = token
-	if cfg.ServerURL == "" {
-		cfg.ServerURL = serverURL
-	}
+	cfg.ServerURL = serverURL
 	if err := cli.SaveCLIConfig(cfg); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}


### PR DESCRIPTION
## Summary
- `multica login` previously only saved `server_url` to `~/.multica/config.json` when the field was empty
- A stale value from a prior session (e.g. pointing at the wrong host) was never overwritten, causing the token creation POST to hit the wrong server and fail with a 405
- Now both browser and token login flows always update `server_url` to the resolved value

## Test plan
- [ ] Run `multica login` with a stale `server_url` in config and verify it gets overwritten
- [ ] Run `multica login` with a fresh config and verify `server_url` is saved correctly