### PR TITLE
feat(inbox): hide issue detail sidebar by default

### DIFF
--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -384,6 +384,8 @@ export default function InboxPage() {
         {selected?.issue_id ? (
           <IssueDetail
             issueId={selected.issue_id}
+            defaultSidebarOpen={false}
+            layoutId="multica_inbox_issue_detail_layout"
             onDelete={() => {
               handleArchive(selected.id);
             }}

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -167,13 +167,15 @@ function PropRow({
 interface IssueDetailProps {
   issueId: string;
   onDelete?: () => void;
+  defaultSidebarOpen?: boolean;
+  layoutId?: string;
 }
 
 // ---------------------------------------------------------------------------
 // IssueDetail
 // ---------------------------------------------------------------------------
 
-export function IssueDetail({ issueId, onDelete }: IssueDetailProps) {
+export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout" }: IssueDetailProps) {
   const id = issueId;
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
@@ -188,10 +190,10 @@ export function IssueDetail({ issueId, onDelete }: IssueDetailProps) {
   const nextIssue = currentIndex < allIssues.length - 1 ? allIssues[currentIndex + 1] : null;
   const { getActorName, getActorInitials } = useActorName();
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: "multica_issue_detail_layout",
+    id: layoutId,
   });
   const sidebarRef = usePanelRef();
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(defaultSidebarOpen);
   const [issue, setIssue] = useState<Issue | null>(null);
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
   const [subscribers, setSubscribers] = useState<IssueSubscriber[]>([]);
@@ -948,7 +950,7 @@ export function IssueDetail({ issueId, onDelete }: IssueDetailProps) {
       <ResizableHandle />
       <ResizablePanel
         id="sidebar"
-        defaultSize={320}
+        defaultSize={defaultSidebarOpen ? 320 : 0}
         minSize={260}
         maxSize={420}
         collapsible


### PR DESCRIPTION
## Summary
- Hide the properties sidebar by default when viewing issues in the inbox view
- Add `defaultSidebarOpen` and `layoutId` props to `IssueDetail` so the inbox can start collapsed and persist its layout independently from the issues view
- Users can still manually expand the sidebar via the toggle button

## Test plan
- [ ] Open inbox, select an issue — sidebar should be collapsed
- [ ] Toggle sidebar open in inbox — it should persist on next visit
- [ ] Open the same issue from the issues view — sidebar should still default to open