### PR TITLE
fix(handler): set issue_prefix when auto-creating workspace on first login

### DIFF
--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -133,10 +133,12 @@ func (h *Handler) ensureUserWorkspace(ctx context.Context, user db.User) error {
 		return nil
 	}
 
+	wsName := defaultWorkspaceName(user)
 	workspace, err := qtx.CreateWorkspace(ctx, db.CreateWorkspaceParams{
-		Name:        defaultWorkspaceName(user),
+		Name:        wsName,
 		Slug:        defaultWorkspaceSlug(user),
 		Description: pgtype.Text{},
+		IssuePrefix: generateIssuePrefix(wsName),
 	})
 	if err != nil {
 		if isUniqueViolation(err) {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -250,12 +250,17 @@ func splitIdentifier(id string) *identifierParts {
 }
 
 // getIssuePrefix fetches the issue_prefix for a workspace.
+// Falls back to generating a prefix from the workspace name if the stored
+// prefix is empty (e.g. workspaces created before the prefix was introduced).
 func (h *Handler) getIssuePrefix(ctx context.Context, workspaceID pgtype.UUID) string {
 	ws, err := h.Queries.GetWorkspace(ctx, workspaceID)
 	if err != nil {
 		return ""
 	}
-	return ws.IssuePrefix
+	if ws.IssuePrefix != "" {
+		return ws.IssuePrefix
+	}
+	return generateIssuePrefix(ws.Name)
 }
 
 func (h *Handler) loadAgentForUser(w http.ResponseWriter, r *http.Request, agentID string) (db.Agent, bool) {

--- a/server/migrations/024_backfill_empty_issue_prefix.down.sql
+++ b/server/migrations/024_backfill_empty_issue_prefix.down.sql
@@ -1,0 +1,1 @@
+-- No-op: we cannot reliably determine which workspaces previously had empty prefixes.

--- a/server/migrations/024_backfill_empty_issue_prefix.up.sql
+++ b/server/migrations/024_backfill_empty_issue_prefix.up.sql
@@ -1,0 +1,8 @@
+-- Backfill workspaces that have an empty issue_prefix (e.g. auto-created
+-- during first login before the prefix was wired up in ensureUserWorkspace).
+UPDATE workspace SET issue_prefix = UPPER(
+    LEFT(REGEXP_REPLACE(name, '[^a-zA-Z]', '', 'g'), 3)
+) WHERE issue_prefix = '';
+
+-- Fallback for workspaces whose name has no alphabetic characters.
+UPDATE workspace SET issue_prefix = 'WS' WHERE issue_prefix = '';


### PR DESCRIPTION
## Summary

- **Root cause**: `ensureUserWorkspace` in `auth.go` omitted the `IssuePrefix` field when creating a default workspace during first login, causing `issue_prefix` to default to `""` in the database
- When identifier is built as `prefix + "-" + number`, an empty prefix produces `"-16"` instead of `"JIA-16"` — which looks like a negative number
- Added `generateIssuePrefix(wsName)` to the auto-created workspace params
- Added a fallback in `getIssuePrefix` to regenerate from workspace name if the stored prefix is empty
- Added migration 024 to backfill empty prefixes on existing workspaces

## Test plan
- [x] All Go tests pass (`go test ./...`)
- [ ] Verify migration 024 backfills empty prefixes correctly
- [ ] Verify new workspaces created on first login get proper issue prefixes