### PR TITLE
feat(issues): batch operations in list view

### DIFF
--- a/apps/web/features/issues/components/batch-action-toolbar.tsx
+++ b/apps/web/features/issues/components/batch-action-toolbar.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useState } from "react";
+import { X, Trash2, Bot, UserMinus } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import type { UpdateIssueRequest } from "@/shared/types";
+import { ALL_STATUSES, STATUS_CONFIG, PRIORITY_ORDER, PRIORITY_CONFIG } from "@/features/issues/config";
+import { useWorkspaceStore, useActorName } from "@/features/workspace";
+import { useIssueStore } from "@/features/issues/store";
+import { useIssueSelectionStore } from "@/features/issues/stores/selection-store";
+import { api } from "@/shared/api";
+import { StatusIcon } from "./status-icon";
+import { PriorityIcon } from "./priority-icon";
+
+export function BatchActionToolbar() {
+  const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
+  const clear = useIssueSelectionStore((s) => s.clear);
+  const count = selectedIds.size;
+
+  const [statusOpen, setStatusOpen] = useState(false);
+  const [priorityOpen, setPriorityOpen] = useState(false);
+  const [assigneeOpen, setAssigneeOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  if (count === 0) return null;
+
+  const ids = Array.from(selectedIds);
+
+  const handleBatchUpdate = async (updates: UpdateIssueRequest) => {
+    setLoading(true);
+    try {
+      await api.batchUpdateIssues(ids, updates);
+      for (const id of ids) {
+        useIssueStore.getState().updateIssue(id, updates);
+      }
+      toast.success(`Updated ${count} issue${count > 1 ? "s" : ""}`);
+    } catch {
+      toast.error("Failed to update issues");
+      api.listIssues({ limit: 200 }).then((res) => {
+        useIssueStore.getState().setIssues(res.issues);
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBatchDelete = async () => {
+    setLoading(true);
+    try {
+      await api.batchDeleteIssues(ids);
+      for (const id of ids) {
+        useIssueStore.getState().removeIssue(id);
+      }
+      clear();
+      toast.success(`Deleted ${count} issue${count > 1 ? "s" : ""}`);
+    } catch {
+      toast.error("Failed to delete issues");
+      api.listIssues({ limit: 200 }).then((res) => {
+        useIssueStore.getState().setIssues(res.issues);
+      });
+    } finally {
+      setLoading(false);
+      setDeleteOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg">
+        <div className="flex items-center gap-1.5 pl-1 pr-2 border-r mr-1">
+          <span className="text-sm font-medium">{count} selected</span>
+          <button
+            type="button"
+            onClick={clear}
+            className="rounded p-0.5 hover:bg-accent transition-colors"
+          >
+            <X className="size-3.5 text-muted-foreground" />
+          </button>
+        </div>
+
+        {/* Status */}
+        <Popover open={statusOpen} onOpenChange={setStatusOpen}>
+          <PopoverTrigger
+            render={
+              <Button variant="ghost" size="sm" disabled={loading} />
+            }
+          >
+            <StatusIcon status="todo" className="h-3.5 w-3.5 mr-1" />
+            Status
+          </PopoverTrigger>
+          <PopoverContent align="center" className="w-44 p-1">
+            {ALL_STATUSES.map((s) => {
+              const cfg = STATUS_CONFIG[s];
+              return (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => {
+                    handleBatchUpdate({ status: s });
+                    setStatusOpen(false);
+                  }}
+                  className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm ${cfg.hoverBg} transition-colors`}
+                >
+                  <StatusIcon status={s} className="h-3.5 w-3.5" />
+                  <span>{cfg.label}</span>
+                </button>
+              );
+            })}
+          </PopoverContent>
+        </Popover>
+
+        {/* Priority */}
+        <Popover open={priorityOpen} onOpenChange={setPriorityOpen}>
+          <PopoverTrigger
+            render={
+              <Button variant="ghost" size="sm" disabled={loading} />
+            }
+          >
+            <PriorityIcon priority="high" className="mr-1" />
+            Priority
+          </PopoverTrigger>
+          <PopoverContent align="center" className="w-44 p-1">
+            {PRIORITY_ORDER.map((p) => {
+              const cfg = PRIORITY_CONFIG[p];
+              return (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => {
+                    handleBatchUpdate({ priority: p });
+                    setPriorityOpen(false);
+                  }}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                >
+                  <PriorityIcon priority={p} />
+                  <span>{cfg.label}</span>
+                </button>
+              );
+            })}
+          </PopoverContent>
+        </Popover>
+
+        {/* Assignee */}
+        <BatchAssigneePicker
+          open={assigneeOpen}
+          onOpenChange={setAssigneeOpen}
+          onUpdate={handleBatchUpdate}
+          loading={loading}
+        />
+
+        {/* Delete */}
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={loading}
+          onClick={() => setDeleteOpen(true)}
+          className="text-destructive hover:text-destructive"
+        >
+          <Trash2 className="size-3.5 mr-1" />
+          Delete
+        </Button>
+      </div>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {count} issue{count > 1 ? "s" : ""}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete the
+              selected issue{count > 1 ? "s" : ""} and all associated data.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleBatchDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function BatchAssigneePicker({
+  open,
+  onOpenChange,
+  onUpdate,
+  loading,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onUpdate: (updates: UpdateIssueRequest) => void;
+  loading: boolean;
+}) {
+  const [filter, setFilter] = useState("");
+  const members = useWorkspaceStore((s) => s.members);
+  const agents = useWorkspaceStore((s) => s.agents);
+  const { getActorInitials } = useActorName();
+
+  const query = filter.toLowerCase();
+  const filteredMembers = members.filter((m) =>
+    m.name.toLowerCase().includes(query),
+  );
+  const filteredAgents = agents.filter((a) =>
+    a.name.toLowerCase().includes(query),
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(v) => {
+        onOpenChange(v);
+        if (!v) setFilter("");
+      }}
+    >
+      <PopoverTrigger
+        render={
+          <Button variant="ghost" size="sm" disabled={loading} />
+        }
+      >
+        Assignee
+      </PopoverTrigger>
+      <PopoverContent align="center" className="w-52 p-0">
+        <div className="px-2 py-1.5 border-b">
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Assign to..."
+            className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
+          />
+        </div>
+        <div className="p-1 max-h-60 overflow-y-auto">
+          <button
+            type="button"
+            onClick={() => {
+              onUpdate({ assignee_type: null, assignee_id: null });
+              onOpenChange(false);
+            }}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+          >
+            <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-muted-foreground">Unassigned</span>
+          </button>
+
+          {filteredMembers.length > 0 && (
+            <div>
+              <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Members
+              </div>
+              {filteredMembers.map((m) => (
+                <button
+                  key={m.user_id}
+                  type="button"
+                  onClick={() => {
+                    onUpdate({ assignee_type: "member", assignee_id: m.user_id });
+                    onOpenChange(false);
+                  }}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                >
+                  <div className="inline-flex size-4.5 shrink-0 items-center justify-center rounded-full bg-muted text-[8px] font-medium text-muted-foreground">
+                    {getActorInitials("member", m.user_id)}
+                  </div>
+                  <span>{m.name}</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {filteredAgents.length > 0 && (
+            <div>
+              <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Agents
+              </div>
+              {filteredAgents.map((a) => (
+                <button
+                  key={a.id}
+                  type="button"
+                  onClick={() => {
+                    onUpdate({ assignee_type: "agent", assignee_id: a.id });
+                    onOpenChange(false);
+                  }}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                >
+                  <div className="inline-flex size-4.5 shrink-0 items-center justify-center rounded-full bg-info/10 text-info">
+                    <Bot className="size-2.5" />
+                  </div>
+                  <span>{a.name}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/features/issues/components/issues-page.tsx
+++ b/apps/web/features/issues/components/issues-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { ChevronRight } from "lucide-react";
 import type { IssueStatus } from "@/shared/types";
@@ -10,9 +10,11 @@ import { useIssueViewStore } from "@/features/issues/stores/view-store";
 import { useWorkspaceStore } from "@/features/workspace";
 import { WorkspaceAvatar } from "@/features/workspace";
 import { api } from "@/shared/api";
+import { useIssueSelectionStore } from "@/features/issues/stores/selection-store";
 import { IssuesHeader } from "./issues-header";
 import { BoardView } from "./board-view";
 import { ListView } from "./list-view";
+import { BatchActionToolbar } from "./batch-action-toolbar";
 
 const BOARD_STATUSES: IssueStatus[] = [
   "backlog",
@@ -31,6 +33,9 @@ export function IssuesPage() {
   const statusFilters = useIssueViewStore((s) => s.statusFilters);
   const priorityFilters = useIssueViewStore((s) => s.priorityFilters);
 
+  useEffect(() => {
+    useIssueSelectionStore.getState().clear();
+  }, [viewMode]);
 
   const issues = useMemo(() => {
     return allIssues.filter((issue) => {
@@ -133,6 +138,7 @@ export function IssuesPage() {
           <ListView issues={issues} visibleStatuses={visibleStatuses} />
         )}
       </div>
+      {viewMode === "list" && <BatchActionToolbar />}
     </div>
   );
 }

--- a/apps/web/features/issues/components/list-row.tsx
+++ b/apps/web/features/issues/components/list-row.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type { Issue } from "@/shared/types";
 import { ActorAvatar } from "@/components/common/actor-avatar";
+import { useIssueSelectionStore } from "@/features/issues/stores/selection-store";
 import { PriorityIcon } from "./priority-icon";
 
 function formatDate(date: string): string {
@@ -13,28 +14,50 @@ function formatDate(date: string): string {
 }
 
 export function ListRow({ issue }: { issue: Issue }) {
+  const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
+  const toggle = useIssueSelectionStore((s) => s.toggle);
+
   return (
-    <Link
-      href={`/issues/${issue.id}`}
-      className="flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/50"
+    <div
+      className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/50 ${
+        selected ? "bg-accent/30" : ""
+      }`}
     >
-      <PriorityIcon priority={issue.priority} />
-      <span className="w-16 shrink-0 text-xs text-muted-foreground">
-        {issue.identifier}
-      </span>
-      <span className="min-w-0 flex-1 truncate">{issue.title}</span>
-      {issue.due_date && (
-        <span className="shrink-0 text-xs text-muted-foreground">
-          {formatDate(issue.due_date)}
-        </span>
-      )}
-      {issue.assignee_type && issue.assignee_id && (
-        <ActorAvatar
-          actorType={issue.assignee_type}
-          actorId={issue.assignee_id}
-          size={20}
+      <div className="relative flex shrink-0 items-center justify-center w-4 h-4">
+        <PriorityIcon
+          priority={issue.priority}
+          className={selected ? "hidden" : "group-hover/row:hidden"}
         />
-      )}
-    </Link>
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={() => toggle(issue.id)}
+          className={`absolute inset-0 cursor-pointer accent-primary ${
+            selected ? "" : "hidden group-hover/row:block"
+          }`}
+        />
+      </div>
+      <Link
+        href={`/issues/${issue.id}`}
+        className="flex flex-1 items-center gap-2 min-w-0"
+      >
+        <span className="w-16 shrink-0 text-xs text-muted-foreground">
+          {issue.identifier}
+        </span>
+        <span className="min-w-0 flex-1 truncate">{issue.title}</span>
+        {issue.due_date && (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {formatDate(issue.due_date)}
+          </span>
+        )}
+        {issue.assignee_type && issue.assignee_id && (
+          <ActorAvatar
+            actorType={issue.assignee_type}
+            actorId={issue.assignee_id}
+            size={20}
+          />
+        )}
+      </Link>
+    </div>
   );
 }

--- a/apps/web/features/issues/components/list-view.tsx
+++ b/apps/web/features/issues/components/list-view.tsx
@@ -9,6 +9,7 @@ import type { Issue, IssueStatus } from "@/shared/types";
 import { STATUS_CONFIG } from "@/features/issues/config";
 import { useModalStore } from "@/features/modals";
 import { useIssueViewStore } from "@/features/issues/stores/view-store";
+import { useIssueSelectionStore } from "@/features/issues/stores/selection-store";
 import { sortIssues } from "@/features/issues/utils/sort";
 import { StatusIcon } from "./status-icon";
 import { ListRow } from "./list-row";
@@ -28,6 +29,9 @@ export function ListView({
   const toggleListCollapsed = useIssueViewStore(
     (s) => s.toggleListCollapsed
   );
+  const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
+  const select = useIssueSelectionStore((s) => s.select);
+  const deselect = useIssueSelectionStore((s) => s.deselect);
 
   const issuesByStatus = useMemo(() => {
     const map = new Map<IssueStatus, Issue[]>();
@@ -65,10 +69,32 @@ export function ListView({
         {visibleStatuses.map((status) => {
           const cfg = STATUS_CONFIG[status];
           const statusIssues = issuesByStatus.get(status) ?? [];
+          const statusIssueIds = statusIssues.map((i) => i.id);
+          const selectedCount = statusIssueIds.filter((id) => selectedIds.has(id)).length;
+          const allSelected = statusIssues.length > 0 && selectedCount === statusIssues.length;
+          const someSelected = selectedCount > 0;
+
           return (
             <Accordion.Item key={status} value={status}>
               <Accordion.Header className="group/header flex h-10 items-center rounded-lg bg-muted/40 transition-colors hover:bg-accent/30">
-                <Accordion.Trigger className="group/trigger flex flex-1 items-center gap-2 px-3 h-full text-left outline-none">
+                <div className="pl-3 flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    ref={(el) => {
+                      if (el) el.indeterminate = someSelected && !allSelected;
+                    }}
+                    onChange={() => {
+                      if (allSelected) {
+                        deselect(statusIssueIds);
+                      } else {
+                        select(statusIssueIds);
+                      }
+                    }}
+                    className="cursor-pointer accent-primary"
+                  />
+                </div>
+                <Accordion.Trigger className="group/trigger flex flex-1 items-center gap-2 px-2 h-full text-left outline-none">
                   <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-aria-expanded/trigger:rotate-90" />
                   <StatusIcon status={status} className="h-3.5 w-3.5" />
                   <span className="text-sm font-medium">{cfg.label}</span>

--- a/apps/web/features/issues/stores/selection-store.ts
+++ b/apps/web/features/issues/stores/selection-store.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { create } from "zustand";
+
+interface IssueSelectionState {
+  selectedIds: Set<string>;
+  toggle: (id: string) => void;
+  select: (ids: string[]) => void;
+  deselect: (ids: string[]) => void;
+  clear: () => void;
+}
+
+export const useIssueSelectionStore = create<IssueSelectionState>()((set) => ({
+  selectedIds: new Set<string>(),
+  toggle: (id) =>
+    set((state) => {
+      const next = new Set(state.selectedIds);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return { selectedIds: next };
+    }),
+  select: (ids) =>
+    set((state) => {
+      const next = new Set(state.selectedIds);
+      for (const id of ids) next.add(id);
+      return { selectedIds: next };
+    }),
+  deselect: (ids) =>
+    set((state) => {
+      const next = new Set(state.selectedIds);
+      for (const id of ids) next.delete(id);
+      return { selectedIds: next };
+    }),
+  clear: () => set({ selectedIds: new Set() }),
+}));

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -180,6 +180,20 @@ export class ApiClient {
     await this.fetch(`/api/issues/${id}`, { method: "DELETE" });
   }
 
+  async batchUpdateIssues(issueIds: string[], updates: UpdateIssueRequest): Promise<{ updated: number }> {
+    return this.fetch("/api/issues/batch-update", {
+      method: "POST",
+      body: JSON.stringify({ issue_ids: issueIds, updates }),
+    });
+  }
+
+  async batchDeleteIssues(issueIds: string[]): Promise<{ deleted: number }> {
+    return this.fetch("/api/issues/batch-delete", {
+      method: "POST",
+      body: JSON.stringify({ issue_ids: issueIds }),
+    });
+  }
+
   // Comments
   async listComments(issueId: string): Promise<Comment[]> {
     return this.fetch(`/api/issues/${issueId}/comments`);

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -113,6 +113,8 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 		r.Route("/api/issues", func(r chi.Router) {
 			r.Get("/", h.ListIssues)
 			r.Post("/", h.CreateIssue)
+			r.Post("/batch-update", h.BatchUpdateIssues)
+			r.Post("/batch-delete", h.BatchDeleteIssues)
 			r.Route("/{id}", func(r chi.Router) {
 				r.Get("/", h.GetIssue)
 				r.Put("/", h.UpdateIssue)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -486,3 +486,186 @@ func (h *Handler) DeleteIssue(w http.ResponseWriter, r *http.Request) {
 	slog.Info("issue deleted", append(logger.RequestAttrs(r), "issue_id", id, "workspace_id", uuidToString(issue.WorkspaceID))...)
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// ---------------------------------------------------------------------------
+// Batch operations
+// ---------------------------------------------------------------------------
+
+type BatchUpdateIssuesRequest struct {
+	IssueIDs []string           `json:"issue_ids"`
+	Updates  UpdateIssueRequest `json:"updates"`
+}
+
+func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+
+	var req BatchUpdateIssuesRequest
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if len(req.IssueIDs) == 0 {
+		writeError(w, http.StatusBadRequest, "issue_ids is required")
+		return
+	}
+
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+
+	// Detect which fields in "updates" were explicitly set (including null).
+	var rawTop map[string]json.RawMessage
+	json.Unmarshal(bodyBytes, &rawTop)
+	var rawUpdates map[string]json.RawMessage
+	if raw, exists := rawTop["updates"]; exists {
+		json.Unmarshal(raw, &rawUpdates)
+	}
+
+	updated := 0
+	for _, issueID := range req.IssueIDs {
+		prevIssue, err := h.Queries.GetIssue(r.Context(), parseUUID(issueID))
+		if err != nil {
+			continue
+		}
+		workspaceID := uuidToString(prevIssue.WorkspaceID)
+		if _, ok := h.requireWorkspaceMember(w, r, workspaceID, ""); !ok {
+			continue
+		}
+
+		params := db.UpdateIssueParams{
+			ID:           prevIssue.ID,
+			AssigneeType: prevIssue.AssigneeType,
+			AssigneeID:   prevIssue.AssigneeID,
+			DueDate:      prevIssue.DueDate,
+		}
+
+		if req.Updates.Title != nil {
+			params.Title = pgtype.Text{String: *req.Updates.Title, Valid: true}
+		}
+		if req.Updates.Description != nil {
+			params.Description = pgtype.Text{String: *req.Updates.Description, Valid: true}
+		}
+		if req.Updates.Status != nil {
+			params.Status = pgtype.Text{String: *req.Updates.Status, Valid: true}
+		}
+		if req.Updates.Priority != nil {
+			params.Priority = pgtype.Text{String: *req.Updates.Priority, Valid: true}
+		}
+		if req.Updates.Position != nil {
+			params.Position = pgtype.Float8{Float64: *req.Updates.Position, Valid: true}
+		}
+		if _, ok := rawUpdates["assignee_type"]; ok {
+			if req.Updates.AssigneeType != nil {
+				params.AssigneeType = pgtype.Text{String: *req.Updates.AssigneeType, Valid: true}
+			} else {
+				params.AssigneeType = pgtype.Text{Valid: false}
+			}
+		}
+		if _, ok := rawUpdates["assignee_id"]; ok {
+			if req.Updates.AssigneeID != nil {
+				params.AssigneeID = parseUUID(*req.Updates.AssigneeID)
+			} else {
+				params.AssigneeID = pgtype.UUID{Valid: false}
+			}
+		}
+		if _, ok := rawUpdates["due_date"]; ok {
+			if req.Updates.DueDate != nil && *req.Updates.DueDate != "" {
+				t, err := time.Parse(time.RFC3339, *req.Updates.DueDate)
+				if err != nil {
+					continue
+				}
+				params.DueDate = pgtype.Timestamptz{Time: t, Valid: true}
+			} else {
+				params.DueDate = pgtype.Timestamptz{Valid: false}
+			}
+		}
+
+		issue, err := h.Queries.UpdateIssue(r.Context(), params)
+		if err != nil {
+			slog.Warn("batch update issue failed", "issue_id", issueID, "error", err)
+			continue
+		}
+
+		prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
+		resp := issueToResponse(issue, prefix)
+		actorType, actorID := h.resolveActor(r, userID, workspaceID)
+
+		assigneeChanged := (req.Updates.AssigneeType != nil || req.Updates.AssigneeID != nil) &&
+			(prevIssue.AssigneeType.String != issue.AssigneeType.String || uuidToString(prevIssue.AssigneeID) != uuidToString(issue.AssigneeID))
+		statusChanged := req.Updates.Status != nil && prevIssue.Status != issue.Status
+		priorityChanged := req.Updates.Priority != nil && prevIssue.Priority != issue.Priority
+
+		h.publish(protocol.EventIssueUpdated, workspaceID, actorType, actorID, map[string]any{
+			"issue":            resp,
+			"assignee_changed": assigneeChanged,
+			"status_changed":   statusChanged,
+			"priority_changed": priorityChanged,
+		})
+
+		if assigneeChanged {
+			h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
+			if h.shouldEnqueueAgentTask(r.Context(), issue) {
+				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
+			}
+		}
+
+		updated++
+	}
+
+	slog.Info("batch update issues", append(logger.RequestAttrs(r), "count", updated)...)
+	writeJSON(w, http.StatusOK, map[string]any{"updated": updated})
+}
+
+type BatchDeleteIssuesRequest struct {
+	IssueIDs []string `json:"issue_ids"`
+}
+
+func (h *Handler) BatchDeleteIssues(w http.ResponseWriter, r *http.Request) {
+	var req BatchDeleteIssuesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if len(req.IssueIDs) == 0 {
+		writeError(w, http.StatusBadRequest, "issue_ids is required")
+		return
+	}
+
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+
+	deleted := 0
+	for _, issueID := range req.IssueIDs {
+		issue, err := h.Queries.GetIssue(r.Context(), parseUUID(issueID))
+		if err != nil {
+			continue
+		}
+		workspaceID := uuidToString(issue.WorkspaceID)
+		if _, ok := h.requireWorkspaceMember(w, r, workspaceID, ""); !ok {
+			continue
+		}
+
+		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
+
+		if err := h.Queries.DeleteIssue(r.Context(), parseUUID(issueID)); err != nil {
+			slog.Warn("batch delete issue failed", "issue_id", issueID, "error", err)
+			continue
+		}
+
+		actorType, actorID := h.resolveActor(r, userID, workspaceID)
+		h.publish(protocol.EventIssueDeleted, workspaceID, actorType, actorID, map[string]any{"issue_id": issueID})
+		deleted++
+	}
+
+	slog.Info("batch delete issues", append(logger.RequestAttrs(r), "count", deleted)...)
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": deleted})
+}


### PR DESCRIPTION
## Summary
- Add multi-select support in the issue list view with per-row checkboxes (hover to reveal) and per-status-group select-all checkboxes with indeterminate state
- Add a floating batch action toolbar (status, priority, assignee, delete) that appears when issues are selected
- Add backend `POST /api/issues/batch-update` and `POST /api/issues/batch-delete` endpoints with full event broadcasting and agent task lifecycle handling
- Add `useIssueSelectionStore` (Zustand) for ephemeral selection state, cleared on view mode switch

## Test plan
- [ ] Switch to list view, hover a row — checkbox replaces priority icon
- [ ] Click checkbox to select, verify row highlights and toolbar appears
- [ ] Use status group checkbox — select all / deselect all / indeterminate states
- [ ] Batch update status, priority, assignee via toolbar pickers
- [ ] Batch delete with confirmation dialog
- [ ] Switch to board view — selection clears, toolbar disappears
- [ ] Verify WebSocket sync updates reflected after batch operations