### PR TITLE
fix(inbox): fix inbox items unclickable after page refresh

### DIFF
--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchParams, useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useDefaultLayout } from "react-resizable-panels";
 import { useInboxStore } from "@/features/inbox";
 import { IssueDetail, StatusIcon, PriorityIcon } from "@/features/issues/components";
@@ -191,14 +191,10 @@ function InboxListItem({
 
 export default function InboxPage() {
   const searchParams = useSearchParams();
-  const router = useRouter();
   const selectedId = searchParams.get("id") ?? "";
   const setSelectedId = (id: string) => {
-    if (id) {
-      router.replace(`/inbox?id=${id}`, { scroll: false });
-    } else {
-      router.replace("/inbox", { scroll: false });
-    }
+    const url = id ? `/inbox?id=${id}` : "/inbox";
+    window.history.replaceState(null, "", url);
   };
 
   const items = useInboxStore((s) => s.dedupedItems());


### PR DESCRIPTION
## Summary
- Replace `router.replace()` with `window.history.replaceState()` for inbox item selection URL updates
- In Next.js 15+, `router.replace()` triggers a full server navigation cycle which can stall after a hard refresh (no client route cache), causing `useSearchParams()` to not update and making inbox items unclickable
- `window.history.replaceState()` updates the URL synchronously without server navigation — the recommended approach for URL state management since Next.js 14.1+

## Test plan
- [ ] Navigate to Inbox, click an item to select it (URL shows `?id=xxx`)
- [ ] Hard refresh the page (Cmd+R / F5)
- [ ] Click a different inbox item — verify it selects correctly and the detail panel updates
- [ ] Verify URL updates to the new item's ID
- [ ] Verify archiving an item clears selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)