### PR TITLE
feat(daemon): include device name in runtime display name

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -210,8 +210,12 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 			d.logger.Warn("skip registering runtime", "name", name, "error", err)
 			continue
 		}
+		displayName := strings.ToUpper(name[:1]) + name[1:]
+		if d.cfg.DeviceName != "" {
+			displayName = fmt.Sprintf("%s (%s)", displayName, d.cfg.DeviceName)
+		}
 		runtimes = append(runtimes, map[string]string{
-			"name":    fmt.Sprintf("Local %s", strings.ToUpper(name[:1])+name[1:]),
+			"name":    displayName,
 			"type":    name,
 			"version": version,
 			"status":  "online",


### PR DESCRIPTION
## Summary
- Change runtime default name from `Local Claude` to `Claude (hostname)` so team members can distinguish each other's runtimes in shared workspaces.
- Uses the existing `DeviceName` from daemon config (defaults to machine hostname).

## Test plan
- [ ] Start daemon, verify runtime registers with name like `Claude (MacBook-Pro)` instead of `Local Claude`
- [ ] Verify runtime list in UI shows the new name correctly