### PR TITLE
feat(daemon): group task directories by workspace ID

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -744,6 +744,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		var err error
 		env, err = execenv.Prepare(execenv.PrepareParams{
 			WorkspacesRoot: d.cfg.WorkspacesRoot,
+			WorkspaceID:    task.WorkspaceID,
 			TaskID:         task.ID,
 			AgentName:      agentName,
 			Provider:       provider,

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -19,6 +19,7 @@ type RepoContextForEnv struct {
 // PrepareParams holds all inputs needed to set up an execution environment.
 type PrepareParams struct {
 	WorkspacesRoot string           // base path for all envs (e.g., ~/multica_workspaces)
+	WorkspaceID    string           // workspace UUID — tasks are grouped under this
 	TaskID         string           // task UUID — used for directory name
 	AgentName      string           // for git branch naming only
 	Provider       string           // agent provider ("claude", "codex") — determines skill injection paths
@@ -66,11 +67,14 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	if params.WorkspacesRoot == "" {
 		return nil, fmt.Errorf("execenv: workspaces root is required")
 	}
+	if params.WorkspaceID == "" {
+		return nil, fmt.Errorf("execenv: workspace ID is required")
+	}
 	if params.TaskID == "" {
 		return nil, fmt.Errorf("execenv: task ID is required")
 	}
 
-	envRoot := filepath.Join(params.WorkspacesRoot, shortID(params.TaskID))
+	envRoot := filepath.Join(params.WorkspacesRoot, params.WorkspaceID, shortID(params.TaskID))
 
 	// Remove existing env if present (defensive — task IDs are unique).
 	if _, err := os.Stat(envRoot); err == nil {

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -75,6 +75,7 @@ func TestPrepareDirectoryMode(t *testing.T) {
 
 	env, err := Prepare(PrepareParams{
 		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-test-001",
 		TaskID:         "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
 		AgentName:      "Test Agent",
 		Task: TaskContextForEnv{
@@ -131,6 +132,7 @@ func TestPrepareWithRepoContext(t *testing.T) {
 	}
 	env, err := Prepare(PrepareParams{
 		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-test-002",
 		TaskID:         "b2c3d4e5-f6a7-8901-bcde-f12345678901",
 		AgentName:      "Code Reviewer",
 		Provider:       "claude",
@@ -322,6 +324,7 @@ func TestCleanupPreservesLogs(t *testing.T) {
 
 	env, err := Prepare(PrepareParams{
 		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-test-003",
 		TaskID:         "d4e5f6a7-b8c9-0123-defa-234567890123",
 		AgentName:      "Preserve Test",
 		Task:           TaskContextForEnv{IssueID: "preserve-test-id"},


### PR DESCRIPTION
## Summary
- Task execution environments were previously created flat under `WorkspacesRoot`, mixing tasks from all workspaces in one directory.
- Now tasks are nested under their workspace ID: `{WorkspacesRoot}/{workspace_id}/{task_id_short}/`.
- Added `WorkspaceID` to `PrepareParams` with a required validation check.

## Test plan
- [x] Existing `execenv` unit tests updated and passing
- [ ] Verify daemon creates task dirs under the correct workspace subdirectory