### PR TITLE
feat(web): issue cross-reference parsing in comments

### DIFF
--- a/apps/web/components/markdown/Markdown.tsx
+++ b/apps/web/components/markdown/Markdown.tsx
@@ -41,6 +41,10 @@ export interface MarkdownProps {
    * Callback when a file path is clicked
    */
   onFileClick?: (path: string) => void
+  /**
+   * Callback when an issue reference is clicked (e.g. MUL-18)
+   */
+  onIssueClick?: (identifier: string) => void
 }
 
 // File path detection regex - matches paths starting with /, ~/, or ./
@@ -53,7 +57,8 @@ const FILE_PATH_REGEX =
 function createComponents(
   mode: RenderMode,
   onUrlClick?: (url: string) => void,
-  onFileClick?: (path: string) => void
+  onFileClick?: (path: string) => void,
+  onIssueClick?: (identifier: string) => void
 ): Partial<Components> {
   const baseComponents: Partial<Components> = {
     // Links: Make clickable with callbacks, or render as mention
@@ -64,6 +69,23 @@ function createComponents(
           <span
             className="text-primary font-medium"
             style={{ background: 'color-mix(in srgb, var(--primary) 8%, transparent)', padding: '0 0.2em', borderRadius: 'calc(var(--radius) * 0.5)' }}
+          >
+            {children}
+          </span>
+        )
+      }
+
+      // Issue reference links: issue://PREFIX-NUMBER
+      if (href?.startsWith('issue://')) {
+        const identifier = href.replace('issue://', '')
+        return (
+          <span
+            className="text-primary font-medium cursor-pointer hover:underline"
+            style={{ background: 'color-mix(in srgb, var(--primary) 8%, transparent)', padding: '0 0.2em', borderRadius: 'calc(var(--radius) * 0.5)' }}
+            onClick={(e) => {
+              e.preventDefault()
+              onIssueClick?.(identifier)
+            }}
           >
             {children}
           </span>
@@ -269,11 +291,12 @@ export function Markdown({
   mode = 'minimal',
   className,
   onUrlClick,
-  onFileClick
+  onFileClick,
+  onIssueClick
 }: MarkdownProps): React.JSX.Element {
   const components = React.useMemo(
-    () => createComponents(mode, onUrlClick, onFileClick),
-    [mode, onUrlClick, onFileClick]
+    () => createComponents(mode, onUrlClick, onFileClick, onIssueClick),
+    [mode, onUrlClick, onFileClick, onIssueClick]
   )
 
   // Preprocess to convert raw URLs and file paths to markdown links

--- a/apps/web/components/markdown/linkify.ts
+++ b/apps/web/components/markdown/linkify.ts
@@ -15,8 +15,12 @@ const linkify = new LinkifyIt()
 const FILE_PATH_REGEX =
   /(?:^|[\s([{<])((\/|~\/|\.\/)[\w\-./@]+\.(?:ts|tsx|js|jsx|mjs|cjs|md|json|yaml|yml|py|go|rs|css|scss|less|html|htm|txt|log|sh|bash|zsh|swift|kt|java|c|cpp|h|hpp|rb|php|xml|toml|ini|cfg|conf|env|sql|graphql|vue|svelte|astro|prisma|dockerfile|makefile|gitignore))(?=[\s)\]}.,;:!?>]|$)/gi
 
+// Issue identifier regex - detects PREFIX-NUMBER patterns (e.g. MUL-18, JIA-5)
+// 2-5 uppercase letters + hyphen + digits, with word boundary checks
+const ISSUE_REF_REGEX = /(?:^|[\s([{<])([A-Z]{2,5}-\d+)(?=[\s)\]}.,;:!?>]|$)/g
+
 interface DetectedLink {
-  type: 'url' | 'email' | 'file'
+  type: 'url' | 'email' | 'file' | 'issue'
   text: string
   url: string
   start: number
@@ -161,6 +165,31 @@ export function detectLinks(text: string): DetectedLink[] {
     })
   }
 
+  // 3. Detect issue references (PREFIX-NUMBER)
+  ISSUE_REF_REGEX.lastIndex = 0
+  let issueMatch
+  while ((issueMatch = ISSUE_REF_REGEX.exec(text)) !== null) {
+    const identifier = issueMatch[1]
+    if (!identifier) continue
+
+    const fullMatch = issueMatch[0]
+    const identifierOffset = fullMatch.indexOf(identifier)
+    const start = issueMatch.index + identifierOffset
+
+    // Check for overlaps with existing matches
+    const refRange = { start, end: start + identifier.length }
+    const overlaps = links.some((link) => rangesOverlap(refRange, link))
+    if (overlaps) continue
+
+    links.push({
+      type: 'issue',
+      text: identifier,
+      url: `issue://${identifier}`,
+      start,
+      end: start + identifier.length
+    })
+  }
+
   // Sort by position
   return links.sort((a, b) => a.start - b.start)
 }
@@ -171,7 +200,7 @@ export function detectLinks(text: string): DetectedLink[] {
  */
 export function preprocessLinks(text: string): string {
   // Quick check - if no potential links, return early
-  if (!linkify.pretest(text) && !/[~/.]\//.test(text)) {
+  if (!linkify.pretest(text) && !/[~/.]\//.test(text) && !/[A-Z]{2,5}-\d+/.test(text)) {
     return text
   }
 
@@ -211,5 +240,5 @@ export function preprocessLinks(text: string): string {
  * Useful for optimization - skip preprocessing if no links present
  */
 export function hasLinks(text: string): boolean {
-  return linkify.pretest(text) || /[~/.]\/[\w]/.test(text)
+  return linkify.pretest(text) || /[~/.]\/[\w]/.test(text) || /[A-Z]{2,5}-\d+/.test(text)
 }

--- a/apps/web/features/issues/components/comment-card.tsx
+++ b/apps/web/features/issues/components/comment-card.tsx
@@ -31,6 +31,7 @@ interface CommentCardProps {
   onReply: (parentId: string, content: string) => Promise<void>;
   onEdit: (commentId: string, content: string) => Promise<void>;
   onDelete: (commentId: string) => void;
+  onIssueClick?: (identifier: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -42,11 +43,13 @@ function CommentRow({
   currentUserId,
   onEdit,
   onDelete,
+  onIssueClick,
 }: {
   entry: TimelineEntry;
   currentUserId?: string;
   onEdit: (commentId: string, content: string) => Promise<void>;
   onDelete: (commentId: string) => void;
+  onIssueClick?: (identifier: string) => void;
 }) {
   const { getActorName } = useActorName();
   const [editing, setEditing] = useState(false);
@@ -137,7 +140,7 @@ function CommentRow({
         </form>
       ) : (
         <div className="mt-1.5 pl-8 text-sm leading-relaxed text-foreground/85">
-          <Markdown mode="minimal">{entry.content ?? ""}</Markdown>
+          <Markdown mode="minimal" onIssueClick={onIssueClick}>{entry.content ?? ""}</Markdown>
         </div>
       )}
     </div>
@@ -155,6 +158,7 @@ function CommentCard({
   onReply,
   onEdit,
   onDelete,
+  onIssueClick,
 }: CommentCardProps) {
   // Collect all nested replies recursively into a flat list
   const allNestedReplies: TimelineEntry[] = [];
@@ -176,6 +180,7 @@ function CommentCard({
           currentUserId={currentUserId}
           onEdit={onEdit}
           onDelete={onDelete}
+          onIssueClick={onIssueClick}
         />
       </div>
 
@@ -187,6 +192,7 @@ function CommentCard({
             currentUserId={currentUserId}
             onEdit={onEdit}
             onDelete={onDelete}
+            onIssueClick={onIssueClick}
           />
         </div>
       ))}

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -314,6 +314,18 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
     }
   };
 
+  const handleIssueClick = useCallback(
+    (identifier: string) => {
+      const target = allIssues.find((i) => i.identifier === identifier);
+      if (target) {
+        router.push(`/issues/${target.id}`);
+      } else {
+        toast.error(`Issue ${identifier} not found`);
+      }
+    },
+    [allIssues, router],
+  );
+
   const handleUpdateField = useCallback(
     (updates: Partial<UpdateIssueRequest>) => {
       if (!issue) return;
@@ -917,6 +929,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                         onReply={handleSubmitReply}
                         onEdit={handleEditComment}
                         onDelete={handleDeleteComment}
+                        onIssueClick={handleIssueClick}
                       />
                     );
                   }


### PR DESCRIPTION
## Summary
- Detect `PREFIX-NUMBER` patterns (e.g. `MUL-18`, `JIA-5`) in markdown content and render them as clickable styled links
- Clicking an issue reference navigates to the referenced issue detail page
- Only affects comment rendering for now (description uses RichTextEditor, can be a follow-up)

### Changes
- **linkify.ts**: Added `ISSUE_REF_REGEX` detection, emits `issue://` protocol links, skips code blocks and already-linked content
- **Markdown.tsx**: Handles `issue://` links with new `onIssueClick` callback, renders as styled pill (same style as mentions)
- **comment-card.tsx**: Passes `onIssueClick` through to Markdown renderer
- **issue-detail.tsx**: Looks up identifier in the issue store and navigates via `router.push`

## Test plan
- [ ] Create two issues (e.g. `JIA-1` and `JIA-2`)
- [ ] Add a comment on `JIA-1` mentioning `JIA-2`
- [ ] Verify `JIA-2` renders as a styled clickable link
- [ ] Click the link and verify navigation to `JIA-2` detail page
- [ ] Verify references inside code blocks are NOT linked
- [ ] Verify existing markdown links containing identifiers are not double-linked

Closes JIA-18