### PR TITLE
fix(inbox): skip inbox notification for task:completed events

### DIFF
--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -543,42 +543,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 		)
 	})
 
-	// task:completed — notify all subscribers except the agent
-	bus.Subscribe(protocol.EventTaskCompleted, func(e events.Event) {
-		payload, ok := e.Payload.(map[string]any)
-		if !ok {
-			return
-		}
-		agentID, _ := payload["agent_id"].(string)
-		issueID, _ := payload["issue_id"].(string)
-		if issueID == "" {
-			return
-		}
-
-		// Look up issue to get the title
-		issue, err := queries.GetIssue(ctx, parseUUID(issueID))
-		if err != nil {
-			slog.Error("task:completed notification: failed to get issue", "issue_id", issueID, "error", err)
-			return
-		}
-
-		// Use the agent ID as an exclusion (since the agent did the work)
-		exclude := map[string]bool{}
-		if agentID != "" {
-			exclude[agentID] = true
-		}
-
-		notifySubscribers(ctx, queries, bus, issueID, issue.Status, e.WorkspaceID,
-			events.Event{
-				Type:        e.Type,
-				WorkspaceID: e.WorkspaceID,
-				ActorType:   "agent",
-				ActorID:     agentID,
-			},
-			exclude, "task_completed", "attention",
-			issue.Title, "",
-			emptyDetails)
-	})
+	// task:completed — no inbox notification (completion is visible from status change)
 
 	// task:failed — notify all subscribers except the agent
 	bus.Subscribe(protocol.EventTaskFailed, func(e events.Event) {

--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -471,8 +471,8 @@ func TestNotification_AssigneeChanged(t *testing.T) {
 	}
 }
 
-// TestNotification_TaskCompleted verifies that subscribers get a "task_completed"
-// notification when a task completes, excluding the agent.
+// TestNotification_TaskCompleted verifies that task:completed events do NOT
+// create inbox notifications (completion is visible from the status change).
 func TestNotification_TaskCompleted(t *testing.T) {
 	queries := db.New(testPool)
 	bus := newNotificationBus(t, queries)
@@ -503,16 +503,10 @@ func TestNotification_TaskCompleted(t *testing.T) {
 		},
 	})
 
-	// Creator should get a task_completed notification
+	// No inbox notification should be created for task:completed
 	creatorItems := inboxItemsForRecipient(t, queries, testUserID)
-	if len(creatorItems) != 1 {
-		t.Fatalf("expected 1 inbox item for creator, got %d", len(creatorItems))
-	}
-	if creatorItems[0].Type != "task_completed" {
-		t.Fatalf("expected type 'task_completed', got %q", creatorItems[0].Type)
-	}
-	if creatorItems[0].Severity != "attention" {
-		t.Fatalf("expected severity 'attention', got %q", creatorItems[0].Severity)
+	if len(creatorItems) != 0 {
+		t.Fatalf("expected 0 inbox items for creator on task:completed, got %d", len(creatorItems))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove inbox notification for `task:completed` events — task completion is already visible from the issue status change, making a separate inbox notification unnecessary noise.
- Updated test to verify no inbox item is created on task completion.

Closes MUL-55

## Test plan
- [x] Go build passes
- [ ] `TestNotification_TaskCompleted` verifies no inbox items are created
- [ ] Other notification tests remain unaffected