### PR TITLE
feat(issues): add context menu to all comments with copy support

### DIFF
--- a/apps/web/features/issues/components/comment-card.tsx
+++ b/apps/web/features/issues/components/comment-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { MoreHorizontal } from "lucide-react";
+import { Copy, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -103,7 +103,7 @@ function CommentRow({
           </TooltipContent>
         </Tooltip>
 
-        {!isTemp && isOwn && (
+        {!isTemp && (
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -113,11 +113,27 @@ function CommentRow({
               }
             />
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={startEdit}>Edit</DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => onDelete(entry.id)} variant="destructive">
-                Delete
+              <DropdownMenuItem onClick={() => {
+                navigator.clipboard.writeText(entry.content ?? "");
+                toast.success("Copied");
+              }}>
+                <Copy className="h-3.5 w-3.5" />
+                Copy
               </DropdownMenuItem>
+              {isOwn && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={startEdit}>
+                    <Pencil className="h-3.5 w-3.5" />
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => onDelete(entry.id)} variant="destructive">
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Delete
+                  </DropdownMenuItem>
+                </>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}


### PR DESCRIPTION
## Summary
- All comments now show a three-dot context menu (previously only own comments had one)
- **Own comments**: Copy / Edit / Delete
- **Others' comments**: Copy only
- Added icons (Copy, Pencil, Trash2) to menu items for consistency with other dropdown menus

## Test plan
- [ ] Open an issue with comments from multiple users
- [ ] Verify own comments show Copy / Edit / Delete in the menu
- [ ] Verify others' comments show only Copy
- [ ] Click Copy and confirm content is copied + "Copied" toast appears
- [ ] Verify Edit and Delete still work as before on own comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)