### PR TITLE
fix(issues): fix kanban drag-drop bugs

### DIFF
--- a/apps/web/features/issues/components/board-view.tsx
+++ b/apps/web/features/issues/components/board-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -23,7 +23,7 @@ import {
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
 import { ALL_STATUSES, STATUS_CONFIG } from "@/features/issues/config";
-import { useIssueViewStore } from "@/features/issues/stores/view-store";
+import { useIssueViewStore, type SortField, type SortDirection } from "@/features/issues/stores/view-store";
 import { StatusIcon } from "./status-icon";
 import { BoardColumn } from "./board-column";
 import { BoardCardContent } from "./board-card";
@@ -71,6 +71,7 @@ export function BoardView({
   ) => void;
 }) {
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
+  const prevSortRef = useRef<{ sortBy: SortField; sortDirection: SortDirection } | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -92,14 +93,35 @@ export function BoardView({
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
       const issue = issues.find((i) => i.id === event.active.id);
-      if (issue) setActiveIssue(issue);
+      if (issue) {
+        // Auto-switch to position sort so visual order matches position order,
+        // ensuring correct position calculation during drag.
+        const viewState = useIssueViewStore.getState();
+        if (viewState.sortBy !== "position" || viewState.sortDirection !== "asc") {
+          prevSortRef.current = { sortBy: viewState.sortBy, sortDirection: viewState.sortDirection };
+          viewState.setSortBy("position");
+          viewState.setSortDirection("asc");
+        }
+        setActiveIssue(issue);
+      }
     },
     [issues]
   );
 
+  const handleDragCancel = useCallback(() => {
+    setActiveIssue(null);
+    if (prevSortRef.current) {
+      const { sortBy, sortDirection } = prevSortRef.current;
+      prevSortRef.current = null;
+      useIssueViewStore.getState().setSortBy(sortBy);
+      useIssueViewStore.getState().setSortDirection(sortDirection);
+    }
+  }, []);
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       setActiveIssue(null);
+      prevSortRef.current = null;
       const { active, over } = event;
       if (!over || active.id === over.id) return;
 
@@ -169,6 +191,7 @@ export function BoardView({
       collisionDetection={kanbanCollision}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div className="flex flex-1 min-h-0 gap-4 overflow-x-auto p-4">
         {visibleStatuses.map((status) => (


### PR DESCRIPTION
## Summary
- **Missing `onDragCancel` handler**: pressing Escape during a drag left the `DragOverlay` ghost card visible because `activeIssue` was never reset on cancel
- **Sort mismatch in position calculation**: when sort was not "Manual" (e.g. priority, due date), dnd-kit collision detection used the visual sort order but position computation used position-sorted order, causing cards to land at wrong positions after the auto-switch to position sort
- Fix: auto-switch to position sort at drag **start** (instead of drag end) so visual order matches position order during the entire drag. Previous sort is restored if the drag is cancelled via Escape.

## Test plan
- [ ] Drag a card within the same column (sort = Manual) — verify card lands where dropped
- [ ] Set sort to Priority, then drag a card — verify sort switches to Manual on drag start and card lands correctly
- [ ] Set sort to Priority, start dragging, then press Escape — verify sort restores to Priority and overlay disappears
- [ ] Drag a card between columns — verify status changes and position is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)