### PR TITLE
fix(editor): use correct getMarkdown API for @tiptap/markdown

### DIFF
--- a/apps/web/components/common/rich-text-editor.tsx
+++ b/apps/web/components/common/rich-text-editor.tsx
@@ -160,10 +160,10 @@ const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>(
     const onUpdateRef = useRef(onUpdate);
     const onSubmitRef = useRef(onSubmit);
 
-    // Helper to get markdown from tiptap-markdown storage
+    // Helper to get markdown from @tiptap/markdown extension
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const getEditorMarkdown = (ed: any): string =>
-      ed?.storage?.markdown?.getMarkdown?.() ?? "";
+      ed?.getMarkdown?.() ?? "";
 
     // Keep refs in sync without recreating editor
     onUpdateRef.current = onUpdate;

--- a/apps/web/features/issues/hooks/use-issue-timeline.ts
+++ b/apps/web/features/issues/hooks/use-issue-timeline.ts
@@ -202,7 +202,7 @@ export function useIssueTimeline(issueId: string, userId?: string) {
         setSubmitting(false);
       }
     },
-    [issueId, userId, submitting],
+    [issueId, userId],
   );
 
   const submitReply = useCallback(


### PR DESCRIPTION
## Summary

- Fix comment creation being completely broken after the `tiptap-markdown` → `@tiptap/markdown` migration (38e92040)
- The official `@tiptap/markdown` package adds `getMarkdown()` to the editor instance (`editor.getMarkdown()`), not to `editor.storage.markdown.getMarkdown()` like the old community package
- This caused the markdown helper to always return `""`, making the submit button permanently disabled
- Also fix stale `submitting` in `useIssueTimeline` `submitComment` dependency array

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (43 tests)
- [ ] Manual: open an issue, type a comment, verify submit button enables and comment posts successfully