### PR TITLE
fix(editor): use correct getMarkdown API for @tiptap/markdown

### DIFF
--- a/apps/web/components/common/rich-text-editor.tsx
+++ b/apps/web/components/common/rich-text-editor.tsx
@@ -160,10 +160,10 @@ const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>(
     const onUpdateRef = useRef(onUpdate);
     const onSubmitRef = useRef(onSubmit);
 
-    // Helper to get markdown from tiptap-markdown storage
+    // Helper to get markdown from @tiptap/markdown extension
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const getEditorMarkdown = (ed: any): string =>
-      ed?.storage?.markdown?.getMarkdown?.() ?? "";
+      ed?.getMarkdown?.() ?? "";
 
     // Keep refs in sync without recreating editor
     onUpdateRef.current = onUpdate;


### PR DESCRIPTION
## Summary
- Fixes issue where description (and all markdown content) was not being saved when creating or editing issues and comments
- The migration from `tiptap-markdown` to `@tiptap/markdown` (38e92040) changed the `getMarkdown` API: old package stored it at `editor.storage.markdown.getMarkdown()`, but the official `@tiptap/markdown` adds it directly as `editor.getMarkdown()`
- The stale accessor caused `getEditorMarkdown()` to silently return `""`, so descriptions were always empty

## Test plan
- [x] TypeScript typecheck passes
- [x] Unit tests pass (43/43)
- [ ] Create an issue with a description and verify it persists on the detail page
- [ ] Edit an existing issue's description and verify the update saves
- [ ] Post a comment with rich text and verify markdown is preserved