### PR TITLE
perf(web): parallelize auth init and non-blocking dashboard layout

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -38,12 +38,20 @@ export default function DashboardLayout({
     );
   }
 
-  if (!user || !workspace) return null;
+  if (!user) return null;
 
   return (
     <SidebarProvider className="h-svh">
       <AppSidebar />
-      <SidebarInset className="overflow-hidden">{children}</SidebarInset>
+      <SidebarInset className="overflow-hidden">
+        {workspace ? (
+          children
+        ) : (
+          <div className="flex flex-1 items-center justify-center">
+            <MulticaIcon className="size-6 animate-pulse" />
+          </div>
+        )}
+      </SidebarInset>
     </SidebarProvider>
   );
 }

--- a/apps/web/features/auth/initializer.tsx
+++ b/apps/web/features/auth/initializer.tsx
@@ -10,26 +10,37 @@ const logger = createLogger("auth");
 
 /**
  * Initializes auth + workspace state from localStorage on mount.
- * Must wrap the app to ensure stores are hydrated before children render.
+ * Fires getMe() and listWorkspaces() in parallel when a cached token exists.
  */
 export function AuthInitializer({ children }: { children: ReactNode }) {
-  const initialize = useAuthStore((s) => s.initialize);
-  const user = useAuthStore((s) => s.user);
-  const isLoading = useAuthStore((s) => s.isLoading);
-  const hydrateWorkspace = useWorkspaceStore((s) => s.hydrateWorkspace);
-
   useEffect(() => {
-    initialize();
-  }, [initialize]);
+    const token = localStorage.getItem("multica_token");
+    if (!token) {
+      useAuthStore.setState({ isLoading: false });
+      return;
+    }
 
-  useEffect(() => {
-    if (isLoading || !user) return;
+    api.setToken(token);
     const wsId = localStorage.getItem("multica_workspace_id");
 
-    api.listWorkspaces().then((wsList) => {
-      hydrateWorkspace(wsList, wsId);
-    }).catch((err) => logger.error("workspace hydration failed", err));
-  }, [user, isLoading, hydrateWorkspace]);
+    // Fire getMe and listWorkspaces in parallel
+    const mePromise = api.getMe();
+    const wsPromise = api.listWorkspaces();
+
+    Promise.all([mePromise, wsPromise])
+      .then(([user, wsList]) => {
+        useAuthStore.setState({ user, isLoading: false });
+        useWorkspaceStore.getState().hydrateWorkspace(wsList, wsId);
+      })
+      .catch((err) => {
+        logger.error("auth init failed", err);
+        api.setToken(null);
+        api.setWorkspaceId(null);
+        localStorage.removeItem("multica_token");
+        localStorage.removeItem("multica_workspace_id");
+        useAuthStore.setState({ user: null, isLoading: false });
+      });
+  }, []);
 
   return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- **Parallelize auth initialization**: `getMe()` and `listWorkspaces()` now fire concurrently via `Promise.all`, eliminating one serial network round-trip (~200ms on cloud)
- **Non-blocking dashboard layout**: Sidebar shell renders immediately once user is authenticated; content area shows a loading indicator while workspace hydrates, instead of rendering nothing

## Context
Issue detail page loads slowly on cloud (MUL-41). Root cause: waterfall-style serial requests during auth init are amplified by network latency. Locally each call is ~1-5ms so it's imperceptible, but on cloud each is ~100-200ms making the serial chain noticeable.

## Test plan
- [ ] Verify login flow still works correctly (fresh login + page refresh)
- [ ] Verify sidebar appears before workspace data fully loads on cloud
- [ ] Verify issue detail page loads faster on cloud environment
- [ ] Verify workspace switching still works
- [ ] TypeScript typecheck passes
- [ ] Unit tests pass (43/43)

Closes MUL-41