### PR TITLE
fix(web): clear comment/reply input immediately on submit

### DIFF
--- a/apps/web/components/common/rich-text-editor.tsx
+++ b/apps/web/components/common/rich-text-editor.tsx
@@ -35,6 +35,7 @@ interface RichTextEditorProps {
 interface RichTextEditorRef {
   getMarkdown: () => string;
   clearContent: () => void;
+  setMarkdown: (md: string) => void;
   focus: () => void;
 }
 
@@ -226,6 +227,9 @@ const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>(
       getMarkdown: () => getEditorMarkdown(editor),
       clearContent: () => {
         editor?.commands.clearContent();
+      },
+      setMarkdown: (md: string) => {
+        editor?.commands.setContent(md);
       },
       focus: () => {
         editor?.commands.focus();

--- a/apps/web/features/issues/components/comment-input.tsx
+++ b/apps/web/features/issues/components/comment-input.tsx
@@ -18,10 +18,13 @@ function CommentInput({ onSubmit }: CommentInputProps) {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
     if (!content || submitting) return;
     setSubmitting(true);
+    editorRef.current?.clearContent();
+    setIsEmpty(true);
     try {
       await onSubmit(content);
-      editorRef.current?.clearContent();
-      setIsEmpty(true);
+    } catch {
+      editorRef.current?.setMarkdown(content);
+      setIsEmpty(false);
     } finally {
       setSubmitting(false);
     }

--- a/apps/web/features/issues/components/reply-input.tsx
+++ b/apps/web/features/issues/components/reply-input.tsx
@@ -37,10 +37,13 @@ function ReplyInput({
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
     if (!content || submitting) return;
     setSubmitting(true);
+    editorRef.current?.clearContent();
+    setIsEmpty(true);
     try {
       await onSubmit(content);
-      editorRef.current?.clearContent();
-      setIsEmpty(true);
+    } catch {
+      editorRef.current?.setMarkdown(content);
+      setIsEmpty(false);
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Summary
- Clear editor content **before** the async `onSubmit` call instead of after, eliminating the brief period where the same text appears in both the input box and the comment timeline
- If the API call fails, restore the original content back to the editor so the user doesn't lose their text
- Added `setMarkdown` method to `RichTextEditorRef` to support restoring content on error

Fixes MUL-86

## Test plan
- [ ] Submit a comment and verify input clears instantly (no duplicate text visible)
- [ ] Submit a reply and verify same behavior
- [ ] Simulate API failure (e.g. network disconnect) and verify content is restored to the editor