### PR TITLE
fix(api): add credentials include for cross-origin cookie storage

### DIFF
--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -107,6 +107,7 @@ export class ApiClient {
     const res = await fetch(`${this.baseUrl}${path}`, {
       ...init,
       headers,
+      credentials: "include",
     });
 
     if (!res.ok) {
@@ -527,6 +528,7 @@ export class ApiClient {
       method: "POST",
       headers: this.authHeaders(),
       body: formData,
+      credentials: "include",
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Summary
- Add `credentials: "include"` to both `fetch()` calls in ApiClient (general + upload)
- Without this, the browser silently drops `Set-Cookie` headers from cross-origin API responses (`multica-api.copilothub.ai` → `multica-app.copilothub.ai`), so CloudFront signed cookies are never stored

## Root cause
`fetch()` defaults to `credentials: "same-origin"`. The frontend and API are on different subdomains (cross-origin but same-site), so the browser rejects `Set-Cookie` from API responses.

## Test plan
- [x] Upload a file, verify CloudFront cookies appear in browser cookie storage
- [ ] Verify `<img>` tags for uploaded files load without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)