### PR TITLE
feat(web): show toast with link after creating an issue

### DIFF
--- a/apps/web/features/modals/create-issue.tsx
+++ b/apps/web/features/modals/create-issue.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { Bot, CalendarDays, ChevronRight, Maximize2, Minimize2, UserMinus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
@@ -62,6 +63,7 @@ function PillButton({
 // ---------------------------------------------------------------------------
 
 export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?: Record<string, unknown> | null }) {
+  const router = useRouter();
   const workspaceName = useWorkspaceStore((s) => s.workspace?.name);
   const members = useWorkspaceStore((s) => s.members);
   const agents = useWorkspaceStore((s) => s.agents);
@@ -125,6 +127,12 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
       useIssueStore.getState().addIssue(issue);
       clearDraft();
       onClose();
+      toast.success(`${issue.identifier} created`, {
+        action: {
+          label: "View issue",
+          onClick: () => router.push(`/issues/${issue.id}`),
+        },
+      });
     } catch {
       toast.error("Failed to create issue");
     } finally {


### PR DESCRIPTION
## Summary
- After creating an issue, a success toast now appears in the bottom-right corner showing the issue identifier (e.g. "MUL-72 created") with a "View issue" action button
- Clicking the action button navigates directly to the issue detail page
- Matches Linear's UX pattern so users don't have to search the sidebar for newly created issues

Closes MUL-72

## Test plan
- [ ] Create a new issue → verify toast appears with correct identifier
- [ ] Click "View issue" on the toast → verify it navigates to the issue detail page
- [ ] Verify toast auto-dismisses after timeout if not clicked
- [ ] Verify error toast still shows on creation failure