### PR TITLE
feat(web): support REMOTE_API_URL for remote backend proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,7 @@ FRONTEND_PORT=3000
 FRONTEND_ORIGIN=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:8080
 NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
+
+# Remote API (optional) — set to proxy local frontend to a remote backend
+# Leave empty to use local backend (localhost:8080)
+# REMOTE_API_URL=https://multica-api.copilothub.ai

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from "next";
+import { config } from "dotenv";
+import { resolve } from "path";
 
-const remoteApiUrl = process.env.REMOTE_API_URL ?? "https://multica-api.copilothub.ai";
+// Load root .env so REMOTE_API_URL is available to next.config.ts
+config({ path: resolve(__dirname, "../../.env") });
+
+const remoteApiUrl = process.env.REMOTE_API_URL || "http://localhost:8080";
 
 const nextConfig: NextConfig = {
   async rewrites() {


### PR DESCRIPTION
## Summary
- Load root `.env` in `next.config.ts` via dotenv so `REMOTE_API_URL` is available
- Next.js rewrites proxy `/api/*`, `/ws`, `/auth/*` to `REMOTE_API_URL`
- Default fallback is `localhost:8080` — no impact on existing local dev setups
- Add `REMOTE_API_URL` to `.env.example` with usage docs

## Usage
To connect local frontend to cloud backend:
```bash
# In .env
REMOTE_API_URL=https://multica-api.copilothub.ai
NEXT_PUBLIC_API_URL=
NEXT_PUBLIC_WS_URL=
```

## Test plan
- [ ] Existing local dev (`NEXT_PUBLIC_API_URL=http://localhost:8080`) works unchanged
- [ ] Setting `REMOTE_API_URL` proxies requests to remote backend
- [ ] Login, WebSocket, and API calls work through proxy