### PR TITLE
fix(inbox): remove hardcoded 50-item limit from inbox list query

### DIFF
--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -21,8 +21,6 @@ func inboxItemsForRecipient(t *testing.T, queries *db.Queries, recipientID strin
 		WorkspaceID:   util.ParseUUID(testWorkspaceID),
 		RecipientType: "member",
 		RecipientID:   util.ParseUUID(recipientID),
-		Limit:         100,
-		Offset:        0,
 	})
 	if err != nil {
 		t.Fatalf("ListInboxItems: %v", err)

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -93,25 +92,10 @@ func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 	}
 	workspaceID := r.Header.Get("X-Workspace-ID")
 
-	limit := 50
-	offset := 0
-	if l := r.URL.Query().Get("limit"); l != "" {
-		if v, err := strconv.Atoi(l); err == nil {
-			limit = v
-		}
-	}
-	if o := r.URL.Query().Get("offset"); o != "" {
-		if v, err := strconv.Atoi(o); err == nil {
-			offset = v
-		}
-	}
-
 	items, err := h.Queries.ListInboxItems(r.Context(), db.ListInboxItemsParams{
 		WorkspaceID:   parseUUID(workspaceID),
 		RecipientType: "member",
 		RecipientID:   parseUUID(userID),
-		Limit:         int32(limit),
-		Offset:        int32(offset),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list inbox")

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -239,15 +239,12 @@ FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
 ORDER BY i.created_at DESC
-LIMIT $4 OFFSET $5
 `
 
 type ListInboxItemsParams struct {
 	WorkspaceID   pgtype.UUID `json:"workspace_id"`
 	RecipientType string      `json:"recipient_type"`
 	RecipientID   pgtype.UUID `json:"recipient_id"`
-	Limit         int32       `json:"limit"`
-	Offset        int32       `json:"offset"`
 }
 
 type ListInboxItemsRow struct {
@@ -270,13 +267,7 @@ type ListInboxItemsRow struct {
 }
 
 func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) ([]ListInboxItemsRow, error) {
-	rows, err := q.db.Query(ctx, listInboxItems,
-		arg.WorkspaceID,
-		arg.RecipientType,
-		arg.RecipientID,
-		arg.Limit,
-		arg.Offset,
-	)
+	rows, err := q.db.Query(ctx, listInboxItems, arg.WorkspaceID, arg.RecipientType, arg.RecipientID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -4,8 +4,7 @@ SELECT i.*,
 FROM inbox_item i
 LEFT JOIN issue iss ON iss.id = i.issue_id
 WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
-ORDER BY i.created_at DESC
-LIMIT $4 OFFSET $5;
+ORDER BY i.created_at DESC;
 
 -- name: GetInboxItem :one
 SELECT * FROM inbox_item


### PR DESCRIPTION
## Summary
- The `ListInbox` endpoint had a hardcoded `LIMIT 50` default, while the frontend fetches all items without pagination — items beyond 50 were silently dropped
- Removed `LIMIT/OFFSET` from the `ListInboxItems` SQL query and handler, so all non-archived inbox items are returned

## Test plan
- [ ] Verify inbox displays all items when a user has more than 50 notifications
- [ ] Verify inbox still loads correctly with fewer items
- [ ] Verify real-time sync still updates inbox correctly

Fixes MUL-95