### PR TITLE
fix(comment-input): restore min-height to prevent buttons floating to top

### DIFF
--- a/apps/web/features/issues/components/comment-input.tsx
+++ b/apps/web/features/issues/components/comment-input.tsx
@@ -41,8 +41,8 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   };
 
   return (
-    <div className="relative flex max-h-56 flex-col rounded-lg bg-card pb-8 ring-1 ring-border">
-      <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
+    <div className="relative rounded-lg bg-card ring-1 ring-border">
+      <div className="min-h-20 max-h-48 overflow-y-auto px-3 py-2 pb-8">
         <RichTextEditor
           ref={editorRef}
           placeholder="Leave a comment..."


### PR DESCRIPTION
## Summary
- Restore `min-h-20` on comment input container so buttons stay at the bottom when editor is empty
- Lost in squash merge of #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)