### PR TITLE
fix(issues): use Markdown component for read-only comment display

### DIFF
--- a/apps/web/features/issues/components/comment-card.tsx
+++ b/apps/web/features/issues/components/comment-card.tsx
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils";
 import { useActorName } from "@/features/workspace";
 import { timeAgo } from "@/shared/utils";
 import { RichTextEditor, type RichTextEditorRef } from "@/components/common/rich-text-editor";
+import { Markdown } from "@/components/markdown/Markdown";
 import { FileUploadButton } from "@/components/common/file-upload-button";
 import { useFileUpload } from "@/shared/hooks/use-file-upload";
 import { ReplyInput } from "./reply-input";
@@ -190,7 +191,7 @@ function CommentRow({
       ) : (
         <>
           <div className="mt-1.5 pl-8 text-sm leading-relaxed text-foreground/85">
-            <RichTextEditor defaultValue={entry.content ?? ""} editable={false} />
+            <Markdown mode="minimal">{entry.content ?? ""}</Markdown>
           </div>
           {!isTemp && (
             <ReactionBar
@@ -387,7 +388,7 @@ function CommentCard({
             ) : (
               <>
                 <div className="pl-10 text-sm leading-relaxed text-foreground/85">
-                  <RichTextEditor defaultValue={entry.content ?? ""} editable={false} />
+                  <Markdown mode="minimal">{entry.content ?? ""}</Markdown>
                 </div>
                 {!isTemp && (
                   <ReactionBar


### PR DESCRIPTION
## Summary
- Switch read-only comment display from `<RichTextEditor editable={false}>` to `<Markdown mode="minimal">` in comment-card.tsx
- The RichTextEditor in read-only mode renders mentions as plain `<span>` elements, which doesn't support the `IssueMentionCard` component for showing issue status, title, and click-to-navigate
- The Markdown component properly handles `mention://issue/` links and renders them as `IssueMentionCard` with status icon, identifier, title, and navigation

Already tested on dev (PR #244 merged).

## Test plan
- [x] Verified on dev environment
- [ ] Post a comment mentioning an issue — verify status icon, identifier, title display
- [ ] Click the mention — verify navigation to issue detail page

Fixes MUL-91