### PR TITLE
fix(web): delay TitleEditor autofocus for Dialog animation

### DIFF
--- a/apps/web/components/common/title-editor.tsx
+++ b/apps/web/components/common/title-editor.tsx
@@ -117,11 +117,13 @@ const TitleEditor = forwardRef<TitleEditorRef, TitleEditorProps>(
       },
     });
 
-    // Auto-focus after mount
+    // Auto-focus after mount — delay to wait for Dialog open animation
     useEffect(() => {
       if (autoFocus && editor) {
-        // Move cursor to end
-        editor.commands.focus("end");
+        const timer = setTimeout(() => {
+          editor.commands.focus("end");
+        }, 50);
+        return () => clearTimeout(timer);
       }
     }, [autoFocus, editor]);
 


### PR DESCRIPTION
## Summary
- Adds a 50ms delay to TitleEditor's autofocus to prevent Dialog open animation from stealing focus
- Fixes issue where title input wasn't auto-focused when opening the create issue modal

## Test plan
- [ ] Open create issue modal and verify title input is auto-focused
- [ ] Verify cursor appears at end of any draft title text

🤖 Generated with [Claude Code](https://claude.com/claude-code)