### PR TITLE
fix(server): allow @agent mentions to trigger regardless of issue status

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -208,11 +208,6 @@ func (h *Handler) commentMentionsOthersButNotAssignee(content string, issue db.I
 // are already the issue's assignee (handled by on_comment), and agents with
 // on_mention trigger disabled.
 func (h *Handler) enqueueMentionedAgentTasks(ctx context.Context, issue db.Issue, comment db.Comment, authorType, authorID string) {
-	// Don't trigger on terminal statuses.
-	if issue.Status == "done" || issue.Status == "cancelled" {
-		return
-	}
-
 	mentions := util.ParseMentions(comment.Content)
 	for _, m := range mentions {
 		if m.Type != "agent" {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -162,8 +162,6 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 
 // ClaimTaskForRuntime claims the next runnable task for a runtime while
 // still respecting each agent's max_concurrent_tasks limit.
-// Tasks whose issues are in a terminal status (done/cancelled) are
-// automatically cancelled and skipped.
 func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.UUID) (*db.AgentTaskQueue, error) {
 	tasks, err := s.Queries.ListPendingTasksByRuntime(ctx, runtimeID)
 	if err != nil {
@@ -172,15 +170,6 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 
 	triedAgents := map[string]struct{}{}
 	for _, candidate := range tasks {
-		// Skip tasks whose issues have reached a terminal status.
-		if issue, err := s.Queries.GetIssue(ctx, candidate.IssueID); err == nil {
-			if issue.Status == "done" || issue.Status == "cancelled" {
-				slog.Info("skipping task for terminal issue", "task_id", util.UUIDToString(candidate.ID), "issue_status", issue.Status)
-				_ = s.Queries.CancelAgentTasksByIssue(ctx, candidate.IssueID)
-				continue
-			}
-		}
-
 		agentKey := util.UUIDToString(candidate.AgentID)
 		if _, seen := triedAgents[agentKey]; seen {
 			continue


### PR DESCRIPTION
## Summary

- Removed terminal status (`done`/`cancelled`) check in `enqueueMentionedAgentTasks` — @agent mentions in comments now trigger agents regardless of issue status
- Removed terminal status check in `ClaimTaskForRuntime` — tasks enqueued via @mentions on done/cancelled issues are no longer auto-cancelled at claim time
- `shouldEnqueueOnComment` (assigned agent auto-trigger) retains its status check as that's a separate concern

## Locations changed

- `server/internal/handler/comment.go` — removed lines 211-214 (status gate in `enqueueMentionedAgentTasks`)
- `server/internal/service/task.go` — removed lines 174-182 (terminal issue skip + cancel in `ClaimTaskForRuntime`)

## Test plan

- [ ] @mention an agent on a `done` issue → agent should be triggered
- [ ] @mention an agent on a `cancelled` issue → agent should be triggered
- [ ] @mention an agent on an active issue → still works as before
- [ ] Assigned agent's on_comment trigger on `done` issue → still blocked (unchanged)

Closes MUL-142