### PR TITLE
feat: improve attachment support across issue and comment APIs

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -123,6 +123,7 @@ func init() {
 	issueCreateCmd.Flags().String("parent", "", "Parent issue ID")
 	issueCreateCmd.Flags().String("due-date", "", "Due date (RFC3339 format)")
 	issueCreateCmd.Flags().String("output", "json", "Output format: table or json")
+	issueCreateCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 
 	// issue update
 	issueUpdateCmd.Flags().String("title", "", "New title")
@@ -276,7 +277,13 @@ func runIssueCreate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	// Use a longer timeout when attachments are present (file uploads can be slow).
+	timeout := 15 * time.Second
+	attachments, _ := cmd.Flags().GetStringSlice("attachment")
+	if len(attachments) > 0 {
+		timeout = 60 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	body := map[string]any{"title": title}
@@ -307,6 +314,19 @@ func runIssueCreate(cmd *cobra.Command, _ []string) error {
 	var result map[string]any
 	if err := client.PostJSON(ctx, "/api/issues", body, &result); err != nil {
 		return fmt.Errorf("create issue: %w", err)
+	}
+
+	// Upload attachments and link them to the newly created issue.
+	issueID := strVal(result, "id")
+	for _, filePath := range attachments {
+		data, readErr := os.ReadFile(filePath)
+		if readErr != nil {
+			return fmt.Errorf("read attachment %s: %w", filePath, readErr)
+		}
+		if _, uploadErr := client.UploadFile(ctx, data, filePath, issueID); uploadErr != nil {
+			return fmt.Errorf("upload attachment %s: %w", filePath, uploadErr)
+		}
+		fmt.Fprintf(os.Stderr, "Uploaded %s\n", filePath)
 	}
 
 	output, _ := cmd.Flags().GetString("output")

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -148,7 +148,9 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		h.linkAttachmentsByIDs(r.Context(), comment.ID, issue.ID, req.AttachmentIDs)
 	}
 
-	resp := commentToResponse(comment, nil, nil)
+	// Fetch linked attachments so the response includes them.
+	groupedAtt := h.groupAttachments(r, []pgtype.UUID{comment.ID})
+	resp := commentToResponse(comment, nil, groupedAtt[uuidToString(comment.ID)])
 	slog.Info("comment created", append(logger.RequestAttrs(r), "comment_id", uuidToString(comment.ID), "issue_id", issueID)...)
 	h.publish(protocol.EventCommentCreated, uuidToString(issue.WorkspaceID), authorType, authorID, map[string]any{
 		"comment":             resp,

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -36,6 +36,7 @@ type IssueResponse struct {
 	CreatedAt          string                  `json:"created_at"`
 	UpdatedAt          string                  `json:"updated_at"`
 	Reactions          []IssueReactionResponse `json:"reactions,omitempty"`
+	Attachments        []AttachmentResponse    `json:"attachments,omitempty"`
 }
 
 type agentTriggerSnapshot struct {
@@ -139,6 +140,18 @@ func (h *Handler) GetIssue(w http.ResponseWriter, r *http.Request) {
 		resp.Reactions = make([]IssueReactionResponse, len(reactions))
 		for i, rx := range reactions {
 			resp.Reactions[i] = issueReactionToResponse(rx)
+		}
+	}
+
+	// Fetch issue-level attachments.
+	attachments, err := h.Queries.ListAttachmentsByIssue(r.Context(), db.ListAttachmentsByIssueParams{
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
+	})
+	if err == nil && len(attachments) > 0 {
+		resp.Attachments = make([]AttachmentResponse, len(attachments))
+		for i, a := range attachments {
+			resp.Attachments[i] = h.attachmentToResponse(a)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `--attachment` flag to `multica issue create` CLI command (mirrors existing `comment add --attachment`)
- Fix `CreateComment` API response to include linked attachments (was returning empty array)
- Include attachments inline in `GetIssue` API response (matching Jira/ClickUp pattern)
- Add `AttachmentList` frontend component — image thumbnails with lightbox, file chips with icon/name/size
- Render attachments in issue detail page (below description) and comment cards (below text)
- Fix `commentToTimelineEntry` dropping attachments (bug)

## Test plan
- [x] `multica issue create --attachment test.pdf` — tested on staging (MUL-152)
- [x] `multica issue comment add --attachment test.pdf` — tested on staging (MUL-150)
- [x] `GET /api/issues/{id}/attachments` — verified attachments linked correctly
- [x] `pnpm typecheck` — passes with zero errors
- [ ] Deploy and verify attachments render in issue detail and comments UI
- [ ] Verify image lightbox opens on click
- [ ] Verify non-image files show icon, filename, size, and are downloadable

🤖 Generated with [Claude Code](https://claude.com/claude-code)