### PR TITLE
chore(ci): align Go version with go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26.1"
           cache-dependency-path: server/go.sum
 
       - name: Build


### PR DESCRIPTION
## Summary

Align the backend CI job's Go version with `server/go.mod`.

Closes #286.

## What changed

- updated `.github/workflows/ci.yml` backend job from `go-version: "1.24"` to `go-version: "1.26.1"`

## Why

The repository currently declares Go 1.26.1 in `server/go.mod`, but the backend GitHub Actions workflow was still running on Go 1.24. Keeping CI behind the declared toolchain can hide version-specific build and test issues.

## Verification

- checked `server/go.mod` and confirmed it declares `go 1.26.1`
- checked `.github/workflows/ci.yml` and confirmed the backend job now uses `go-version: "1.26.1"`
- ran `docker run --rm golang:1.26-alpine go version` locally and confirmed the current image resolves to `go version go1.26.1 linux/amd64`

## Testing

- did not run the full test suite locally; this PR changes only the GitHub Actions Go toolchain version
