### PR TITLE
feat(web): server-side redirect / → /issues for logged-in users

### DIFF
--- a/apps/web/features/auth/auth-cookie.ts
+++ b/apps/web/features/auth/auth-cookie.ts
@@ -1,0 +1,9 @@
+const COOKIE_NAME = "multica_logged_in";
+
+export function setLoggedInCookie() {
+  document.cookie = `${COOKIE_NAME}=1; path=/; max-age=31536000; samesite=lax`;
+}
+
+export function clearLoggedInCookie() {
+  document.cookie = `${COOKIE_NAME}=; path=/; max-age=0`;
+}

--- a/apps/web/features/auth/initializer.tsx
+++ b/apps/web/features/auth/initializer.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from "./store";
 import { useWorkspaceStore } from "@/features/workspace";
 import { api } from "@/shared/api";
 import { createLogger } from "@/shared/logger";
+import { setLoggedInCookie, clearLoggedInCookie } from "./auth-cookie";
 
 const logger = createLogger("auth");
 
@@ -16,6 +17,7 @@ export function AuthInitializer({ children }: { children: ReactNode }) {
   useEffect(() => {
     const token = localStorage.getItem("multica_token");
     if (!token) {
+      clearLoggedInCookie();
       useAuthStore.setState({ isLoading: false });
       return;
     }
@@ -29,6 +31,7 @@ export function AuthInitializer({ children }: { children: ReactNode }) {
 
     Promise.all([mePromise, wsPromise])
       .then(([user, wsList]) => {
+        setLoggedInCookie();
         useAuthStore.setState({ user, isLoading: false });
         useWorkspaceStore.getState().hydrateWorkspace(wsList, wsId);
       })
@@ -38,6 +41,7 @@ export function AuthInitializer({ children }: { children: ReactNode }) {
         api.setWorkspaceId(null);
         localStorage.removeItem("multica_token");
         localStorage.removeItem("multica_workspace_id");
+        clearLoggedInCookie();
         useAuthStore.setState({ user: null, isLoading: false });
       });
   }, []);

--- a/apps/web/features/auth/store.ts
+++ b/apps/web/features/auth/store.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import type { User } from "@/shared/types";
 import { api } from "@/shared/api";
+import { setLoggedInCookie, clearLoggedInCookie } from "./auth-cookie";
 
 interface AuthState {
   user: User | null;
@@ -48,6 +49,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     const { token, user } = await api.verifyCode(email, code);
     localStorage.setItem("multica_token", token);
     api.setToken(token);
+    setLoggedInCookie();
     set({ user });
     return user;
   },
@@ -57,6 +59,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     localStorage.removeItem("multica_workspace_id");
     api.setToken(null);
     api.setWorkspaceId(null);
+    clearLoggedInCookie();
     set({ user: null });
   },
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const loggedIn = request.cookies.has("multica_logged_in");
+  if (loggedIn) {
+    return NextResponse.redirect(new URL("/issues", request.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/"],
+};


### PR DESCRIPTION
## Summary
- Add lightweight `multica_logged_in` cookie set on login, cleared on logout
- Add Next.js 16 `proxy.ts` that 302-redirects `/` → `/issues` when cookie is present
- Unauthenticated users and search crawlers continue to see the full landing page (zero SEO impact)

## Test plan
- [ ] Login → visit `/` → should 302 to `/issues` (no flash)
- [ ] Logout → visit `/` → should show landing page normally
- [ ] Check browser cookies: `multica_logged_in=1` present when logged in, gone after logout
- [ ] Google bot (no cookie) → sees full landing page content on `/`
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)