### PR TITLE
fix(auth): make JWT and CloudFront cookie expiration configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ DATABASE_URL=postgres://multica:multica@localhost:5432/multica?sslmode=disable
 # Server
 PORT=8080
 JWT_SECRET=change-me-in-production
+JWT_EXPIRATION=720h
 MULTICA_SERVER_URL=ws://localhost:8080/ws
 MULTICA_APP_URL=http://localhost:3000
 MULTICA_DAEMON_CONFIG=

--- a/server/internal/auth/config.go
+++ b/server/internal/auth/config.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultJWTExpiration is the default JWT token lifetime.
+	// 30 days is reasonable for a productivity tool — users shouldn't need to
+	// re-authenticate every few days.
+	DefaultJWTExpiration = 30 * 24 * time.Hour // 720h
+)
+
+var (
+	jwtExpiration     time.Duration
+	jwtExpirationOnce sync.Once
+)
+
+// JWTExpiration returns the configured JWT token lifetime.
+// Reads from JWT_EXPIRATION env var (Go duration string, e.g. "720h", "168h").
+// Falls back to DefaultJWTExpiration (30 days).
+func JWTExpiration() time.Duration {
+	jwtExpirationOnce.Do(func() {
+		jwtExpiration = DefaultJWTExpiration
+		if v := strings.TrimSpace(os.Getenv("JWT_EXPIRATION")); v != "" {
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				slog.Error("invalid JWT_EXPIRATION, using default", "value", v, "error", err, "default", DefaultJWTExpiration)
+				return
+			}
+			if d <= 0 {
+				slog.Error("JWT_EXPIRATION must be positive, using default", "value", v, "default", DefaultJWTExpiration)
+				return
+			}
+			jwtExpiration = d
+			slog.Info(fmt.Sprintf("JWT expiration set to %s", d))
+		}
+	})
+	return jwtExpiration
+}

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -175,7 +175,7 @@ func (h *Handler) issueJWT(user db.User) (string, error) {
 		"sub":   uuidToString(user.ID),
 		"email": user.Email,
 		"name":  user.Name,
-		"exp":   time.Now().Add(72 * time.Hour).Unix(),
+		"exp":   time.Now().Add(auth.JWTExpiration()).Unix(),
 		"iat":   time.Now().Unix(),
 	})
 	return token.SignedString(auth.JWTSecret())
@@ -302,7 +302,7 @@ func (h *Handler) VerifyCode(w http.ResponseWriter, r *http.Request) {
 
 	// Set CloudFront signed cookies for CDN access.
 	if h.CFSigner != nil {
-		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(72 * time.Hour)) {
+		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(auth.JWTExpiration())) {
 			http.SetCookie(w, cookie)
 		}
 	}

--- a/server/internal/middleware/cloudfront.go
+++ b/server/internal/middleware/cloudfront.go
@@ -18,7 +18,7 @@ func RefreshCloudFrontCookies(signer *auth.CloudFrontSigner) func(http.Handler) 
 		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if _, err := r.Cookie("CloudFront-Policy"); err != nil {
-				for _, cookie := range signer.SignedCookies(time.Now().Add(72 * time.Hour)) {
+				for _, cookie := range signer.SignedCookies(time.Now().Add(auth.JWTExpiration())) {
 					http.SetCookie(w, cookie)
 				}
 			}


### PR DESCRIPTION
## Summary
- Replace hardcoded 72-hour JWT expiration with configurable `JWT_EXPIRATION` env var (Go duration string, e.g. `720h`, `168h`)
- Default increased from 72 hours (3 days) to 720 hours (30 days) — more appropriate for a productivity tool
- CloudFront signed cookie expiration is now automatically synced with JWT expiration, eliminating the previous duplication of magic values across 3 files

## Changes
- **New**: `server/internal/auth/config.go` — `JWTExpiration()` function with env var override and validation
- **Updated**: `server/internal/handler/auth.go` — JWT token and CloudFront cookie issuance use `auth.JWTExpiration()`
- **Updated**: `server/internal/middleware/cloudfront.go` — cookie refresh uses `auth.JWTExpiration()`
- **Updated**: `.env.example` — added `JWT_EXPIRATION=720h`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/auth/ ./internal/handler/ ./internal/middleware/` all pass
- [ ] Verify login issues a JWT with ~30-day expiry (decode the token and check `exp` claim)
- [ ] Verify `JWT_EXPIRATION=24h` env var correctly overrides the default
- [ ] Verify CloudFront cookies match JWT expiry

Closes MUL-151