### PR TITLE
feat(web): display attachments in issue detail and comments

### DIFF
--- a/apps/web/features/issues/components/attachment-list.tsx
+++ b/apps/web/features/issues/components/attachment-list.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { Download, File, FileText, FileArchive } from "lucide-react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { Attachment } from "@/shared/types";
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function fileIcon(contentType: string) {
+  if (contentType === "application/pdf") return FileText;
+  if (contentType.includes("zip") || contentType.includes("archive"))
+    return FileArchive;
+  return File;
+}
+
+function ImageThumbnail({ attachment }: { attachment: Attachment }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <DialogTrigger
+              render={
+                <img
+                  src={attachment.download_url}
+                  alt={attachment.filename}
+                  className="h-20 w-20 object-cover rounded-md border border-border hover:border-primary cursor-pointer transition-colors"
+                  loading="lazy"
+                />
+              }
+            />
+          }
+        />
+        <TooltipContent>{attachment.filename}</TooltipContent>
+      </Tooltip>
+      <DialogContent
+        className="max-w-4xl p-2"
+        showCloseButton={false}
+      >
+        <img
+          src={attachment.download_url}
+          alt={attachment.filename}
+          className="max-w-full max-h-[80vh] object-contain rounded-md"
+        />
+        <div className="flex items-center justify-between px-1">
+          <span className="text-sm text-muted-foreground truncate">
+            {attachment.filename}
+          </span>
+          <a
+            href={attachment.download_url}
+            download
+            className="text-sm text-primary hover:underline flex items-center gap-1 shrink-0"
+          >
+            <Download className="h-3.5 w-3.5" />
+            Download
+          </a>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function FileChip({ attachment }: { attachment: Attachment }) {
+  const Icon = fileIcon(attachment.content_type);
+  return (
+    <a
+      href={attachment.download_url}
+      download
+      className="inline-flex items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-1.5 text-sm hover:bg-muted transition-colors"
+    >
+      <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
+      <span className="truncate max-w-[200px]">{attachment.filename}</span>
+      <span className="text-xs text-muted-foreground shrink-0">
+        {formatFileSize(attachment.size_bytes)}
+      </span>
+    </a>
+  );
+}
+
+interface AttachmentListProps {
+  attachments: Attachment[];
+  className?: string;
+}
+
+export function AttachmentList({ attachments, className }: AttachmentListProps) {
+  if (!attachments?.length) return null;
+
+  const images = attachments.filter((a) => a.content_type.startsWith("image/"));
+  const files = attachments.filter((a) => !a.content_type.startsWith("image/"));
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {images.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {images.map((att) => (
+            <ImageThumbnail key={att.id} attachment={att} />
+          ))}
+        </div>
+      )}
+      {files.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {files.map((att) => (
+            <FileChip key={att.id} attachment={att} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/features/issues/components/comment-card.tsx
+++ b/apps/web/features/issues/components/comment-card.tsx
@@ -25,6 +25,7 @@ import { Markdown } from "@/components/markdown/Markdown";
 import { FileUploadButton } from "@/components/common/file-upload-button";
 import { useFileUpload } from "@/shared/hooks/use-file-upload";
 import { ReplyInput } from "./reply-input";
+import { AttachmentList } from "./attachment-list";
 import type { TimelineEntry } from "@/shared/types";
 
 // ---------------------------------------------------------------------------
@@ -193,6 +194,9 @@ function CommentRow({
           <div className="mt-1.5 pl-8 text-sm leading-relaxed text-foreground/85">
             <Markdown mode="minimal">{entry.content ?? ""}</Markdown>
           </div>
+          {entry.attachments && entry.attachments.length > 0 && (
+            <AttachmentList attachments={entry.attachments} className="mt-1.5 pl-8" />
+          )}
           {!isTemp && (
             <ReactionBar
               reactions={reactions}
@@ -390,6 +394,9 @@ function CommentCard({
                 <div className="pl-10 text-sm leading-relaxed text-foreground/85">
                   <Markdown mode="minimal">{entry.content ?? ""}</Markdown>
                 </div>
+                {entry.attachments && entry.attachments.length > 0 && (
+                  <AttachmentList attachments={entry.attachments} className="mt-1.5 pl-10" />
+                )}
                 {!isTemp && (
                   <ReactionBar
                     reactions={reactions}

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -44,6 +44,7 @@ import {
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { RichTextEditor } from "@/components/common/rich-text-editor";
 import { FileUploadButton } from "@/components/common/file-upload-button";
+import { AttachmentList } from "./attachment-list";
 import { TitleEditor } from "@/components/common/title-editor";
 import {
   Tooltip,
@@ -196,21 +197,22 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const issue = useIssueStore((s) => s.issues.find((i) => i.id === id)) ?? null;
   const [issueLoading, setIssueLoading] = useState(!issue);
 
-  // If issue isn't in the store yet, fetch and upsert it
+  // Always fetch single issue to get attachments (listIssues doesn't include them).
   useEffect(() => {
-    if (issue) {
-      setIssueLoading(false);
-      return;
-    }
-    setIssueLoading(true);
+    if (!issue) setIssueLoading(true);
     api
       .getIssue(id)
       .then((iss) => {
-        useIssueStore.getState().addIssue(iss);
+        const store = useIssueStore.getState();
+        if (store.issues.some((i) => i.id === iss.id)) {
+          store.updateIssue(iss.id, iss);
+        } else {
+          store.addIssue(iss);
+        }
       })
       .catch(console.error)
       .finally(() => setIssueLoading(false));
-  }, [id, !!issue]);
+  }, [id]);
 
   // Custom hooks — encapsulate timeline, reactions, subscribers
   const {
@@ -577,6 +579,10 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
               onInsert={(result, isImage) => descEditorRef.current?.insertFile(result.filename, result.link, isImage)}
             />
           </div>
+
+          {issue.attachments && issue.attachments.length > 0 && (
+            <AttachmentList attachments={issue.attachments} className="mt-4" />
+          )}
 
           <div className="my-8 border-t" />
 

--- a/apps/web/features/issues/hooks/use-issue-timeline.ts
+++ b/apps/web/features/issues/hooks/use-issue-timeline.ts
@@ -26,6 +26,7 @@ function commentToTimelineEntry(c: Comment): TimelineEntry {
     updated_at: c.updated_at,
     comment_type: c.type,
     reactions: c.reactions ?? [],
+    attachments: c.attachments ?? [],
   };
 }
 

--- a/apps/web/shared/types/issue.ts
+++ b/apps/web/shared/types/issue.ts
@@ -37,6 +37,7 @@ export interface Issue {
   position: number;
   due_date: string | null;
   reactions?: IssueReaction[];
+  attachments?: import("./attachment").Attachment[];
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- Add `AttachmentList` component — image thumbnails with lightbox, file chips with icon/name/size
- Render issue-level attachments below description in issue detail page
- Render comment-level attachments below comment text in comment cards
- Fix `commentToTimelineEntry` dropping attachments field (bug)
- Always fetch single issue on detail page to get inline attachments
- Add `attachments` field to `Issue` TypeScript type

## Test plan
- [x] `pnpm typecheck` — passes with zero errors
- [ ] Upload image + PDF to an issue, verify both render correctly
- [ ] Verify image lightbox opens on click
- [ ] Verify non-image files show icon, filename, size, and are downloadable
- [ ] Add comment with `--attachment`, verify attachment shows below comment text

🤖 Generated with [Claude Code](https://claude.com/claude-code)