### PR TITLE
fix(web): unify header button style consistency

### DIFF
--- a/apps/web/features/issues/components/issues-header.tsx
+++ b/apps/web/features/issues/components/issues-header.tsx
@@ -337,7 +337,7 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
               render={
                 <TooltipTrigger
                   render={
-                    <Button variant="outline" size="icon-sm" className="relative">
+                    <Button variant="outline" size="icon-sm" className="relative text-muted-foreground">
                       <Filter className="size-4" />
                       {hasActiveFilters && (
                         <span className="absolute top-0 right-0 size-1.5 rounded-full bg-brand" />
@@ -485,7 +485,7 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
               render={
                 <TooltipTrigger
                   render={
-                    <Button variant="outline" size="icon-sm">
+                    <Button variant="outline" size="icon-sm" className="text-muted-foreground">
                       <SlidersHorizontal className="size-4" />
                     </Button>
                   }
@@ -571,7 +571,7 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
               render={
                 <TooltipTrigger
                   render={
-                    <Button variant="outline" size="icon-sm">
+                    <Button variant="outline" size="icon-sm" className="text-muted-foreground">
                       {viewMode === "board" ? (
                         <Columns3 className="size-4" />
                       ) : (

--- a/apps/web/features/my-issues/components/my-issues-header.tsx
+++ b/apps/web/features/my-issues/components/my-issues-header.tsx
@@ -164,7 +164,7 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
               render={
                 <TooltipTrigger
                   render={
-                    <Button variant="outline" size="icon-sm" className="relative">
+                    <Button variant="outline" size="icon-sm" className="relative text-muted-foreground">
                       <Filter className="size-4" />
                       {hasActiveFilters && (
                         <span className="absolute top-0 right-0 size-1.5 rounded-full bg-brand" />
@@ -268,7 +268,7 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
               render={
                 <TooltipTrigger
                   render={
-                    <Button variant="outline" size="icon-sm">
+                    <Button variant="outline" size="icon-sm" className="text-muted-foreground">
                       <SlidersHorizontal className="size-4" />
                     </Button>
                   }
@@ -356,7 +356,7 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
               render={
                 <TooltipTrigger
                   render={
-                    <Button variant="outline" size="icon-sm">
+                    <Button variant="outline" size="icon-sm" className="text-muted-foreground">
                       {viewMode === "board" ? (
                         <Columns3 className="size-4" />
                       ) : (


### PR DESCRIPTION
## Summary
- Right-side icon buttons (filter, display, view) in Issues and My Issues headers were visually heavier than left-side scope buttons
- Added `text-muted-foreground` to all 6 right-side icon buttons to match the left-side inactive scope button style

## Test plan
- [ ] Open Issues page — verify left scope buttons and right icon buttons have consistent color
- [ ] Open My Issues page — verify same consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)