### PR TITLE
fix(web): archive all inbox items for same issue

### DIFF
--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -252,12 +252,20 @@ export default function InboxPage() {
 
   const handleArchive = async (id: string) => {
     try {
-      await api.archiveInbox(id);
-      useInboxStore.getState().archive(id);
-      const archived = items.find((i) => i.id === id);
-      if (archived && (archived.issue_id ?? archived.id) === selectedKey) setSelectedKey("");
+      const item = items.find((i) => i.id === id);
+      const issueId = item?.issue_id;
+      if (issueId) {
+        useInboxStore.getState().archiveByIssue(issueId);
+        if (issueId === selectedKey) setSelectedKey("");
+        await api.archiveInboxByIssue(issueId);
+      } else {
+        useInboxStore.getState().archive(id);
+        if (item && item.id === selectedKey) setSelectedKey("");
+        await api.archiveInbox(id);
+      }
     } catch {
       toast.error("Failed to archive");
+      useInboxStore.getState().fetch();
     }
   };
 

--- a/apps/web/features/inbox/store.ts
+++ b/apps/web/features/inbox/store.ts
@@ -50,6 +50,7 @@ interface InboxState {
   addItem: (item: InboxItem) => void;
   markRead: (id: string) => void;
   archive: (id: string) => void;
+  archiveByIssue: (issueId: string) => void;
   markAllRead: () => void;
   archiveAll: () => void;
   archiveAllRead: () => void;
@@ -90,6 +91,12 @@ export const useInboxStore = create<InboxState>((set, get) => ({
   archive: (id) =>
     set((s) => ({
       items: s.items.map((i) => (i.id === id ? { ...i, archived: true } : i)),
+    })),
+  archiveByIssue: (issueId: string) =>
+    set((s) => ({
+      items: s.items.map((i) =>
+        i.issue_id === issueId && !i.archived ? { ...i, archived: true } : i
+      ),
     })),
   markAllRead: () =>
     set((s) => ({

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -379,6 +379,10 @@ export class ApiClient {
     return this.fetch(`/api/inbox/${id}/archive`, { method: "POST" });
   }
 
+  async archiveInboxByIssue(issueId: string): Promise<{ count: number }> {
+    return this.fetch(`/api/inbox/by-issue/${issueId}/archive`, { method: "POST" });
+  }
+
   async getUnreadInboxCount(): Promise<{ count: number }> {
     return this.fetch("/api/inbox/unread-count");
   }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -234,6 +234,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 				r.Post("/archive-all", h.ArchiveAllInbox)
 				r.Post("/archive-all-read", h.ArchiveAllReadInbox)
 				r.Post("/archive-completed", h.ArchiveCompletedInbox)
+				r.Post("/by-issue/{issueId}/archive", h.ArchiveInboxByIssue)
 				r.Post("/{id}/read", h.MarkInboxRead)
 				r.Post("/{id}/archive", h.ArchiveInboxItem)
 			})

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -154,6 +154,32 @@ func (h *Handler) ArchiveInboxItem(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+func (h *Handler) ArchiveInboxByIssue(w http.ResponseWriter, r *http.Request) {
+	issueID := chi.URLParam(r, "issueId")
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+
+	count, err := h.Queries.ArchiveInboxByIssue(r.Context(), db.ArchiveInboxByIssueParams{
+		IssueID:     parseUUID(issueID),
+		RecipientID: parseUUID(userID),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to archive inbox by issue")
+		return
+	}
+
+	workspaceID := r.Header.Get("X-Workspace-ID")
+	h.publish(protocol.EventInboxBatchArchived, workspaceID, "member", userID, map[string]any{
+		"recipient_id": userID,
+		"issue_id":     issueID,
+		"count":        count,
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{"count": count})
+}
+
 func (h *Handler) CountUnreadInbox(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(w, r)
 	if !ok {

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -66,6 +66,24 @@ func (q *Queries) ArchiveCompletedInbox(ctx context.Context, arg ArchiveComplete
 	return result.RowsAffected(), nil
 }
 
+const archiveInboxByIssue = `-- name: ArchiveInboxByIssue :execrows
+UPDATE inbox_item SET archived = true
+WHERE issue_id = $1 AND recipient_type = 'member' AND recipient_id = $2 AND archived = false
+`
+
+type ArchiveInboxByIssueParams struct {
+	IssueID     pgtype.UUID `json:"issue_id"`
+	RecipientID pgtype.UUID `json:"recipient_id"`
+}
+
+func (q *Queries) ArchiveInboxByIssue(ctx context.Context, arg ArchiveInboxByIssueParams) (int64, error) {
+	result, err := q.db.Exec(ctx, archiveInboxByIssue, arg.IssueID, arg.RecipientID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const archiveInboxItem = `-- name: ArchiveInboxItem :one
 UPDATE inbox_item SET archived = true
 WHERE id = $1

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -32,6 +32,10 @@ UPDATE inbox_item SET archived = true
 WHERE id = $1
 RETURNING *;
 
+-- name: ArchiveInboxByIssue :execrows
+UPDATE inbox_item SET archived = true
+WHERE issue_id = $1 AND recipient_type = 'member' AND recipient_id = $2 AND archived = false;
+
 -- name: CountUnreadInbox :one
 SELECT count(*) FROM inbox_item
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false;


### PR DESCRIPTION
## Problem

Clicking archive on an inbox item only archived a single notification, but the UI groups notifications by `issue_id` via `dedupedItems()`. After archiving one item, another notification for the same issue would immediately appear (possibly unread).

## Root Cause

`ArchiveInboxItem` uses `WHERE id = $1` (single item), but the inbox UI deduplicates by `issue_id`. When an issue has multiple notifications, archiving one causes the next to surface.

## Solution

- Added `ArchiveInboxByIssue` SQL query (`WHERE issue_id = $1 AND recipient_id = $2`)
- Added `POST /api/inbox/by-issue/{issueId}/archive` endpoint
- Frontend `handleArchive` now archives all items for the same issue with optimistic update

## Changes

- `server/pkg/db/queries/inbox.sql` — new query
- `server/pkg/db/generated/inbox.sql.go` — generated Go code
- `server/internal/handler/inbox.go` — new handler
- `server/cmd/server/router.go` — new route
- `apps/web/shared/api/client.ts` — new API method
- `apps/web/features/inbox/store.ts` — new `archiveByIssue` action
- `apps/web/app/(dashboard)/inbox/page.tsx` — updated `handleArchive`
