### PR TITLE
fix(agent): restrict agent management to owner and admins

### DIFF
--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -328,21 +328,18 @@ type UpdateAgentRequest struct {
 }
 
 // canManageAgent checks whether the current user can update or delete an agent.
-// Workspace-visible agents can be managed by any workspace member.
-// Private agents can only be managed by their owner or workspace owner/admin.
+// Only the agent owner or workspace owner/admin can manage any agent,
+// regardless of whether it is public or private.
 func (h *Handler) canManageAgent(w http.ResponseWriter, r *http.Request, agent db.Agent) bool {
 	wsID := uuidToString(agent.WorkspaceID)
 	member, ok := h.requireWorkspaceRole(w, r, wsID, "agent not found", "owner", "admin", "member")
 	if !ok {
 		return false
 	}
-	if agent.Visibility != "private" {
-		return true
-	}
 	isAdmin := roleAllowed(member.Role, "owner", "admin")
 	isAgentOwner := uuidToString(agent.OwnerID) == requestUserID(r)
 	if !isAdmin && !isAgentOwner {
-		writeError(w, http.StatusForbidden, "only the agent owner can manage this private agent")
+		writeError(w, http.StatusForbidden, "only the agent owner can manage this agent")
 		return false
 	}
 	return true


### PR DESCRIPTION
## Summary
- Members could previously modify any workspace-visible (public) agent's properties via `canManageAgent`, which only enforced ownership checks on private agents.
- Removed the early-return bypass for non-private agents so that **all** agents (public or private) require the requester to be the agent owner or a workspace owner/admin.

Closes MUL-128

## Test plan
- [ ] As a Member, try to update another member's public agent → should get 403
- [ ] As a Member, update your own agent → should succeed
- [ ] As a workspace Owner/Admin, update any agent → should succeed
- [ ] Existing `TestAgentCRUD` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)