### PR TITLE
fix(agent): allow members to manage skills on their own agents

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -959,7 +959,7 @@ func (h *Handler) SetAgentSkills(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if _, ok := h.requireWorkspaceRole(w, r, uuidToString(agent.WorkspaceID), "agent not found", "owner", "admin"); !ok {
+	if !h.canManageAgent(w, r, agent) {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- `SetAgentSkills` (PUT `/api/agents/{id}/skills`) previously only allowed workspace owner/admin roles, returning 403 for members even on their own agents.
- Replaced `requireWorkspaceRole("owner", "admin")` with `canManageAgent()`, which allows the agent's owner (member) in addition to workspace owner/admin.

Follow-up to #320 (MUL-128).

## Test plan
- [ ] As a Member, add a skill to your own agent → should succeed (was 403 before)
- [ ] As a Member, add a skill to another member's agent → should get 403
- [ ] As a workspace Owner/Admin, add a skill to any agent → should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)