### PR TITLE
fix(web): daily token chart Y-axis truncated at large values

### DIFF
--- a/apps/web/features/runtimes/components/charts/daily-token-chart.tsx
+++ b/apps/web/features/runtimes/components/charts/daily-token-chart.tsx
@@ -42,7 +42,7 @@ export function DailyTokenChart({ data }: { data: DailyTokenData[] }) {
             axisLine={false}
             tickMargin={8}
             tickFormatter={(v: number) => formatTokens(v)}
-            width={50}
+            width={60}
           />
           <ChartTooltip
             content={

--- a/apps/web/features/runtimes/utils.ts
+++ b/apps/web/features/runtimes/utils.ts
@@ -14,8 +14,14 @@ export function formatLastSeen(lastSeenAt: string | null): string {
 }
 
 export function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return m >= 100 ? `${Math.round(m)}M` : `${m.toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    const k = n / 1_000;
+    return k >= 100 ? `${Math.round(k)}K` : `${k.toFixed(1)}K`;
+  }
   return n.toLocaleString();
 }
 


### PR DESCRIPTION
## Bug

The **Daily Token Usage** chart on the `/runtimes` page shows garbled Y-axis labels (e.g. `00` instead of `100.0M`) when token counts exceed 100 million.

### Root Cause

Two compounding issues:

1. **`formatTokens()` output too wide** — For values >= 100M, `(100000000 / 1_000_000).toFixed(1)` produces `"100.0M"` (6 characters). Similarly, values >= 100K produce strings like `"150.0K"`.

2. **Y-axis width too narrow** — The `<YAxis>` component is hardcoded to `width={50}` (50px), which is insufficient to render 6-character labels. Recharts clips the text, so only the trailing `"00"` portion remains visible.

### Reproduction

1. Navigate to `/runtimes` and select a runtime with > 100M daily token usage
2. Observe the Y-axis labels on the "Daily Token Usage" chart
3. Labels like `100.0M` are truncated to `00`

## Fix

- **`formatTokens()`**: Drop the unnecessary `.0` decimal place for values >= 100. `100M` instead of `100.0M`, `150K` instead of `150.0K`. Values below 100 still show one decimal (e.g. `1.5M`, `42.3K`).
- **`<YAxis>`**: Widen from `50px` to `60px` for additional breathing room.

## Test plan

- [ ] Verify Y-axis labels render correctly with values > 100M tokens
- [ ] Verify tooltip formatting still works as expected
- [ ] Verify smaller values (e.g. `1.5M`, `42.3K`) still show one decimal place

🤖 Generated with [Claude Code](https://claude.com/claude-code)