### PR TITLE
feat(runtime): support codex runtimes and local repo selection

### DIFF
--- a/apps/web/app/(dashboard)/settings/_components/repositories-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/repositories-tab.tsx
@@ -42,7 +42,7 @@ export function RepositoriesTab() {
   };
 
   const handleAddRepo = () => {
-    setRepos([...repos, { url: "", description: "" }]);
+    setRepos([...repos, { type: "remote", url: "", local_path: "", description: "" }]);
   };
 
   const handleRemoveRepo = (index: number) => {
@@ -51,6 +51,21 @@ export function RepositoriesTab() {
 
   const handleRepoChange = (index: number, field: keyof WorkspaceRepo, value: string) => {
     setRepos(repos.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+  };
+
+  const handleChooseFolder = async (index: number) => {
+    if (!canManageWorkspace) return;
+
+    try {
+      const { path } = await api.chooseDirectory("Choose a folder");
+      setRepos(repos.map((repo, i) => (
+        i === index
+          ? { ...repo, type: "local", local_path: path }
+          : repo
+      )));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to choose folder");
+    }
   };
 
   if (!workspace) return null;
@@ -63,26 +78,73 @@ export function RepositoriesTab() {
         <Card>
           <CardContent className="space-y-3">
             <p className="text-xs text-muted-foreground">
-              GitHub repositories associated with this workspace. Agents use these to clone and work on code.
+              Configure remote repositories or existing local git directories. Remote repos use clone and fetch; local repos create worktrees directly from the path you provide.
             </p>
 
             {repos.map((repo, index) => (
               <div key={index} className="flex gap-2">
                 <div className="flex-1 space-y-1.5">
-                  <Input
-                    type="url"
-                    value={repo.url}
-                    onChange={(e) => handleRepoChange(index, "url", e.target.value)}
-                    disabled={!canManageWorkspace}
-                    placeholder="https://github.com/org/repo"
-                    className="text-sm"
-                  />
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      disabled={!canManageWorkspace}
+                      onClick={() => handleRepoChange(index, "type", "remote")}
+                      className={`rounded-md border px-3 py-2 text-xs font-medium transition-colors ${
+                        (repo.type ?? "remote") === "remote"
+                          ? "border-primary bg-primary/5"
+                          : "border-border text-muted-foreground"
+                      }`}
+                    >
+                      Remote
+                    </button>
+                    <button
+                      type="button"
+                      disabled={!canManageWorkspace}
+                      onClick={() => handleRepoChange(index, "type", "local")}
+                      className={`rounded-md border px-3 py-2 text-xs font-medium transition-colors ${
+                        repo.type === "local"
+                          ? "border-primary bg-primary/5"
+                          : "border-border text-muted-foreground"
+                      }`}
+                    >
+                      Local Path
+                    </button>
+                  </div>
+                  {(repo.type ?? "remote") === "local" ? (
+                    <div className="flex gap-2">
+                      <Input
+                        type="text"
+                        value={repo.local_path ?? ""}
+                        onChange={(e) => handleRepoChange(index, "local_path", e.target.value)}
+                        disabled={!canManageWorkspace}
+                        placeholder="Folder path"
+                        className="text-sm"
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => void handleChooseFolder(index)}
+                        disabled={!canManageWorkspace}
+                      >
+                        Choose Folder
+                      </Button>
+                    </div>
+                  ) : (
+                    <Input
+                      type="url"
+                      value={repo.url}
+                      onChange={(e) => handleRepoChange(index, "url", e.target.value)}
+                      disabled={!canManageWorkspace}
+                      placeholder="https://github.com/org/repo"
+                      className="text-sm"
+                    />
+                  )}
                   <Input
                     type="text"
                     value={repo.description}
                     onChange={(e) => handleRepoChange(index, "description", e.target.value)}
                     disabled={!canManageWorkspace}
-                    placeholder="Description (e.g. Go backend + Next.js frontend)"
+                    placeholder="Description"
                     className="text-sm"
                   />
                 </div>

--- a/apps/web/app/(dashboard)/settings/_components/tokens-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/tokens-tab.tsx
@@ -33,6 +33,11 @@ export function TokensTab() {
   const [newToken, setNewToken] = useState<string | null>(null);
   const [tokenCopied, setTokenCopied] = useState(false);
   const [tokenRevoking, setTokenRevoking] = useState<string | null>(null);
+  const [appOrigin, setAppOrigin] = useState("http://localhost:3000");
+
+  useEffect(() => {
+    setAppOrigin(window.location.origin);
+  }, []);
 
   const loadTokens = useCallback(async () => {
     try {
@@ -160,6 +165,25 @@ export function TokensTab() {
               Copy your personal access token now. You won&apos;t be able to see it again.
             </DialogDescription>
           </DialogHeader>
+          <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground space-y-2">
+            <p className="font-medium text-foreground">Connect the CLI (local dev)</p>
+            <p>
+              Point the CLI at this server (skip if already set in{" "}
+              <code className="rounded bg-muted px-1">~/.multica/config.json</code>):
+            </p>
+            <pre className="overflow-x-auto rounded bg-muted px-2 py-1.5 text-[11px] leading-relaxed text-foreground">
+              {`multica config set server_url ${process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8080/ws"}
+multica config set app_url ${appOrigin}`}
+            </pre>
+            <p>Then paste the token:</p>
+            <pre className="overflow-x-auto rounded bg-muted px-2 py-1.5 text-[11px] text-foreground">
+              multica login --token
+            </pre>
+            <p>Finally start the daemon:</p>
+            <pre className="overflow-x-auto rounded bg-muted px-2 py-1.5 text-[11px] text-foreground">
+              multica daemon start
+            </pre>
+          </div>
           <div className="flex items-center gap-2">
             <code className="flex-1 rounded-md border bg-muted/50 px-3 py-2 text-sm break-all select-all">
               {newToken}

--- a/apps/web/app/(dashboard)/settings/_components/workspace-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/workspace-tab.tsx
@@ -112,7 +112,6 @@ export function WorkspaceTab() {
 
   return (
     <div className="space-y-8">
-      {/* Workspace settings */}
       <section className="space-y-4">
         <h2 className="text-sm font-semibold">General</h2>
 
@@ -175,7 +174,6 @@ export function WorkspaceTab() {
         </Card>
       </section>
 
-      {/* Danger Zone */}
       <section className="space-y-4">
         <div className="flex items-center gap-2">
           <LogOut className="h-4 w-4 text-muted-foreground" />

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { User, Palette, Key, Settings, Users, FolderGit2 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useWorkspaceStore } from "@/features/workspace";
@@ -22,16 +24,43 @@ const workspaceTabs = [
   { value: "members", label: "Members", icon: Users },
 ];
 
-export default function SettingsPage() {
+const VALID_TABS = new Set([
+  "profile",
+  "appearance",
+  "tokens",
+  "workspace",
+  "repositories",
+  "members",
+]);
+
+function tabFromSearchParams(searchParams: URLSearchParams): string {
+  const t = searchParams.get("tab");
+  return t && VALID_TABS.has(t) ? t : "profile";
+}
+
+function SettingsPageContent() {
+  const searchParams = useSearchParams();
   const workspaceName = useWorkspaceStore((s) => s.workspace?.name);
+  const [activeTab, setActiveTab] = useState(() =>
+    tabFromSearchParams(searchParams),
+  );
+
+  useEffect(() => {
+    setActiveTab(tabFromSearchParams(searchParams));
+  }, [searchParams]);
 
   return (
-    <Tabs defaultValue="profile" orientation="vertical" className="flex-1 min-h-0 gap-0">
-      {/* Left nav */}
+    <Tabs
+      value={activeTab}
+      onValueChange={(v) => {
+        if (v) setActiveTab(v);
+      }}
+      orientation="vertical"
+      className="flex-1 min-h-0 gap-0"
+    >
       <div className="w-52 shrink-0 border-r overflow-y-auto p-4">
         <h1 className="text-sm font-semibold mb-4 px-2">Settings</h1>
         <TabsList variant="line" className="flex-col items-stretch">
-          {/* My Account group */}
           <span className="px-2 pb-1 pt-2 text-xs font-medium text-muted-foreground">
             My Account
           </span>
@@ -42,7 +71,6 @@ export default function SettingsPage() {
             </TabsTrigger>
           ))}
 
-          {/* Workspace group */}
           <span className="px-2 pb-1 pt-4 text-xs font-medium text-muted-foreground truncate">
             {workspaceName ?? "Workspace"}
           </span>
@@ -55,7 +83,6 @@ export default function SettingsPage() {
         </TabsList>
       </div>
 
-      {/* Right content */}
       <div className="flex-1 min-w-0 overflow-y-auto">
         <div className="w-full max-w-3xl mx-auto p-6">
           <TabsContent value="profile"><AccountTab /></TabsContent>
@@ -67,5 +94,13 @@ export default function SettingsPage() {
         </div>
       </div>
     </Tabs>
+  );
+}
+
+export default function SettingsPage() {
+  return (
+    <Suspense fallback={null}>
+      <SettingsPageContent />
+    </Suspense>
   );
 }

--- a/apps/web/features/runtimes/components/runtime-list.tsx
+++ b/apps/web/features/runtimes/components/runtime-list.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Server } from "lucide-react";
 import type { AgentRuntime } from "@/shared/types";
 import { RuntimeModeIcon } from "./shared";
@@ -64,12 +65,24 @@ export function RuntimeList({
           <p className="mt-3 text-sm text-muted-foreground">
             No runtimes registered
           </p>
-          <p className="mt-1 text-xs text-muted-foreground text-center">
-            Run{" "}
-            <code className="rounded bg-muted px-1 py-0.5">
-              multica daemon start
-            </code>{" "}
-            to register a local runtime.
+          <p className="mt-2 max-w-sm text-xs text-muted-foreground text-center leading-relaxed">
+            The web app and the CLI use separate credentials. After signing in here, connect the CLI once:
+            open{" "}
+            <Link
+              href="/settings?tab=tokens"
+              className="text-primary underline-offset-2 hover:underline"
+            >
+              Settings → API Tokens
+            </Link>
+            , create a token, then run{" "}
+            <code className="rounded bg-muted px-1 py-0.5">multica login --token</code>{" "}
+            and paste it (this also watches your workspaces). Finally run{" "}
+            <code className="rounded bg-muted px-1 py-0.5">multica daemon start</code>.
+          </p>
+          <p className="mt-3 text-xs text-muted-foreground text-center">
+            Or run{" "}
+            <code className="rounded bg-muted px-1 py-0.5">multica login</code>{" "}
+            and finish in the browser (click Authorize if you are already signed in).
           </p>
         </div>
       ) : (

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -42,6 +42,10 @@ export interface LoginResponse {
   user: User;
 }
 
+export interface ChooseDirectoryResponse {
+  path: string;
+}
+
 export class ApiClient {
   private baseUrl: string;
   private token: string | null = null;
@@ -150,6 +154,13 @@ export class ApiClient {
     return this.fetch("/api/me", {
       method: "PATCH",
       body: JSON.stringify(data),
+    });
+  }
+
+  async chooseDirectory(prompt?: string): Promise<ChooseDirectoryResponse> {
+    return this.fetch("/api/system/choose-directory", {
+      method: "POST",
+      body: JSON.stringify({ prompt }),
     });
   }
 

--- a/apps/web/shared/types/workspace.ts
+++ b/apps/web/shared/types/workspace.ts
@@ -1,7 +1,9 @@
 export type MemberRole = "owner" | "admin" | "member";
 
 export interface WorkspaceRepo {
+  type?: "remote" | "local";
   url: string;
+  local_path?: string;
   description: string;
 }
 

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -162,14 +162,18 @@ func runDaemonBackground(cmd *cobra.Command) error {
 		logFile.Close()
 		return fmt.Errorf("start daemon: %w", err)
 	}
+	childPID := child.Process.Pid
 	logFile.Close()
 
 	// Detach: we don't Wait() on the child — it runs independently.
-	child.Process.Release()
+	// Capture PID before Release: after Release, Process.Pid may be invalid (-1) on some platforms.
+	if err := child.Process.Release(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: release daemon process: %v\n", err)
+	}
 
 	// Write PID file.
 	pidPath := daemonPIDPathForProfile(profile)
-	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0o644); err != nil {
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(childPID)), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not write PID file: %v\n", err)
 	}
 
@@ -184,9 +188,9 @@ func runDaemonBackground(cmd *cobra.Command) error {
 	}
 
 	if profile != "" {
-		fmt.Fprintf(os.Stderr, "Daemon [%s] started (pid %d)\n", profile, child.Process.Pid)
+		fmt.Fprintf(os.Stderr, "Daemon [%s] started (pid %d)\n", profile, childPID)
 	} else {
-		fmt.Fprintf(os.Stderr, "Daemon started (pid %d)\n", child.Process.Pid)
+		fmt.Fprintf(os.Stderr, "Daemon started (pid %d)\n", childPID)
 	}
 	fmt.Fprintf(os.Stderr, "Logs: %s\n", logPath)
 	return nil

--- a/server/cmd/multica/cmd_repo.go
+++ b/server/cmd/multica/cmd_repo.go
@@ -18,9 +18,9 @@ var repoCmd = &cobra.Command{
 }
 
 var repoCheckoutCmd = &cobra.Command{
-	Use:   "checkout <url>",
+	Use:   "checkout <repo>",
 	Short: "Check out a repository into the working directory",
-	Long:  "Creates a git worktree from the daemon's bare clone cache. Used by agents to check out repos on demand.",
+	Long:  "Creates a git worktree from a configured workspace repository. Remote repos use the daemon cache; local repos use the configured local path directly.",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runRepoCheckout,
 }
@@ -30,7 +30,9 @@ func init() {
 }
 
 func runRepoCheckout(cmd *cobra.Command, args []string) error {
-	repoURL := args[0]
+	repoRef := args[0]
+	repoType := os.Getenv("MULTICA_REPO_TYPE")
+	localPath := os.Getenv("MULTICA_REPO_LOCAL_PATH")
 
 	daemonPort := os.Getenv("MULTICA_DAEMON_PORT")
 	if daemonPort == "" {
@@ -48,7 +50,9 @@ func runRepoCheckout(cmd *cobra.Command, args []string) error {
 	}
 
 	reqBody := map[string]string{
-		"url":          repoURL,
+		"type":         repoType,
+		"repo":         repoRef,
+		"local_path":   localPath,
 		"workspace_id": workspaceID,
 		"workdir":      workDir,
 		"agent_name":   agentName,
@@ -86,7 +90,7 @@ func runRepoCheckout(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(os.Stdout, "%s\n", result.Path)
-	fmt.Fprintf(os.Stderr, "Checked out %s → %s (branch: %s)\n", repoURL, result.Path, result.BranchName)
+	fmt.Fprintf(os.Stderr, "Checked out %s → %s (branch: %s)\n", repoRef, result.Path, result.BranchName)
 
 	return nil
 }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -113,6 +113,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 		// --- User-scoped routes (no workspace context required) ---
 		r.Get("/api/me", h.GetMe)
 		r.Patch("/api/me", h.UpdateMe)
+		r.Post("/api/system/choose-directory", h.ChooseDirectory)
 		r.Post("/api/upload-file", h.UploadFile)
 
 		r.Route("/api/workspaces", func(r chi.Router) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 type workspaceState struct {
 	workspaceID string
 	runtimeIDs  []string
+	repos       []RepoData
 }
 
 // Daemon is the local agent runtime that polls for and executes tasks.
@@ -126,8 +127,8 @@ func (d *Daemon) resolveAuth() error {
 		if d.cfg.Profile != "" {
 			loginHint = fmt.Sprintf("'multica login --profile %s'", d.cfg.Profile)
 		}
-		d.logger.Warn("not authenticated — run " + loginHint + " to authenticate, then restart the daemon")
-		return fmt.Errorf("not authenticated: run %s first", loginHint)
+		d.logger.Warn("not authenticated — browser login does not configure the CLI; run " + loginHint + " (or create a token under Settings → API Tokens, then run 'multica login --token'), then restart the daemon")
+		return fmt.Errorf("not authenticated: run %s, or use Settings → API Tokens with multica login --token", loginHint)
 	}
 	d.client.SetToken(cfg.Token)
 	d.logger.Info("authenticated")
@@ -158,7 +159,7 @@ func (d *Daemon) loadWatchedWorkspaces(ctx context.Context) error {
 			d.logger.Info("registered runtime", "workspace_id", ws.ID, "runtime_id", rt.ID, "provider", rt.Provider)
 		}
 		d.mu.Lock()
-		d.workspaces[ws.ID] = &workspaceState{workspaceID: ws.ID, runtimeIDs: runtimeIDs}
+		d.workspaces[ws.ID] = &workspaceState{workspaceID: ws.ID, runtimeIDs: runtimeIDs, repos: resp.Repos}
 		for _, rt := range resp.Runtimes {
 			d.runtimeIndex[rt.ID] = rt
 		}
@@ -211,6 +212,22 @@ func (d *Daemon) providerToRuntimeMap() map[string]string {
 		m[rt.Provider] = id
 	}
 	return m
+}
+
+func (d *Daemon) findWorkspaceRepo(workspaceID, repoRef string) (RepoData, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	ws, ok := d.workspaces[workspaceID]
+	if !ok {
+		return RepoData{}, false
+	}
+	for _, repo := range ws.repos {
+		if repo.URL == repoRef || repo.LocalPath == repoRef {
+			return repo, true
+		}
+	}
+	return RepoData{}, false
 }
 
 func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, error) {
@@ -382,7 +399,7 @@ func (d *Daemon) reloadWorkspaces(ctx context.Context) {
 				runtimeIDs[i] = rt.ID
 			}
 			d.mu.Lock()
-			d.workspaces[id] = &workspaceState{workspaceID: id, runtimeIDs: runtimeIDs}
+			d.workspaces[id] = &workspaceState{workspaceID: id, runtimeIDs: runtimeIDs, repos: resp.Repos}
 			for _, rt := range resp.Runtimes {
 				d.runtimeIndex[rt.ID] = rt
 			}
@@ -1021,7 +1038,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 func repoDataToInfo(repos []RepoData) []repocache.RepoInfo {
 	info := make([]repocache.RepoInfo, len(repos))
 	for i, r := range repos {
-		info[i] = repocache.RepoInfo{URL: r.URL, Description: r.Description}
+		info[i] = repocache.RepoInfo{
+			Type:        r.Type,
+			URL:         r.URL,
+			LocalPath:   r.LocalPath,
+			Description: r.Description,
+		}
 	}
 	return info
 }
@@ -1032,7 +1054,12 @@ func convertReposForEnv(repos []RepoData) []execenv.RepoContextForEnv {
 	}
 	result := make([]execenv.RepoContextForEnv, len(repos))
 	for i, r := range repos {
-		result[i] = execenv.RepoContextForEnv{URL: r.URL, Description: r.Description}
+		result[i] = execenv.RepoContextForEnv{
+			Type:        r.Type,
+			URL:         r.URL,
+			LocalPath:   r.LocalPath,
+			Description: r.Description,
+		}
 	}
 	return result
 }

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -12,17 +12,19 @@ import (
 
 // RepoContextForEnv describes a workspace repo available for checkout.
 type RepoContextForEnv struct {
+	Type        string // "remote" or "local"
 	URL         string // remote URL
+	LocalPath   string // absolute path to an existing local git repo
 	Description string // human-readable description
 }
 
 // PrepareParams holds all inputs needed to set up an execution environment.
 type PrepareParams struct {
-	WorkspacesRoot string           // base path for all envs (e.g., ~/multica_workspaces)
-	WorkspaceID    string           // workspace UUID — tasks are grouped under this
-	TaskID         string           // task UUID — used for directory name
-	AgentName      string           // for git branch naming only
-	Provider       string           // agent provider ("claude", "codex") — determines skill injection paths
+	WorkspacesRoot string            // base path for all envs (e.g., ~/multica_workspaces)
+	WorkspaceID    string            // workspace UUID — tasks are grouped under this
+	TaskID         string            // task UUID — used for directory name
+	AgentName      string            // for git branch naming only
+	Provider       string            // agent provider ("claude", "codex") — determines skill injection paths
 	Task           TaskContextForEnv // context data for writing files
 }
 

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -61,15 +61,23 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	if len(ctx.Repos) > 0 {
 		b.WriteString("## Repositories\n\n")
 		b.WriteString("The following code repositories are available in this workspace.\n")
-		b.WriteString("Use `multica repo checkout <url>` to check out a repository into your working directory.\n\n")
-		b.WriteString("| URL | Description |\n")
-		b.WriteString("|-----|-------------|\n")
+		b.WriteString("Use `multica repo checkout <repo>` to check out a repository into your working directory.\n\n")
+		b.WriteString("| Type | Repo | Description |\n")
+		b.WriteString("|------|------|-------------|\n")
 		for _, repo := range ctx.Repos {
 			desc := repo.Description
 			if desc == "" {
 				desc = "—"
 			}
-			fmt.Fprintf(&b, "| %s | %s |\n", repo.URL, desc)
+			repoRef := repo.URL
+			if strings.TrimSpace(repo.Type) == "local" {
+				repoRef = repo.LocalPath
+			}
+			repoType := repo.Type
+			if repoType == "" {
+				repoType = "remote"
+			}
+			fmt.Fprintf(&b, "| %s | %s | %s |\n", repoType, repoRef, desc)
 		}
 		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed.\n\n")
 	}
@@ -93,7 +101,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("3. Read comments for additional context or human instructions\n")
 		b.WriteString("4. If the task requires code changes:\n")
 		if len(ctx.Repos) > 0 {
-			b.WriteString("   a. Run `multica repo checkout <url>` to check out the appropriate repository\n")
+			b.WriteString("   a. Run `multica repo checkout <repo>` to check out the appropriate repository\n")
 			b.WriteString("   b. `cd` into the checked-out directory\n")
 			b.WriteString("   c. Implement the changes and commit\n")
 		} else {

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -42,7 +42,9 @@ func (d *Daemon) listenHealth() (net.Listener, error) {
 
 // repoCheckoutRequest is the body of a POST /repo/checkout request.
 type repoCheckoutRequest struct {
-	URL         string `json:"url"`
+	Type        string `json:"type,omitempty"`
+	Repo        string `json:"repo"`
+	LocalPath   string `json:"local_path,omitempty"`
 	WorkspaceID string `json:"workspace_id"`
 	WorkDir     string `json:"workdir"`
 	AgentName   string `json:"agent_name"`
@@ -95,8 +97,8 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 			http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		if req.URL == "" {
-			http.Error(w, "url is required", http.StatusBadRequest)
+		if req.Repo == "" {
+			http.Error(w, "repo is required", http.StatusBadRequest)
 			return
 		}
 		if req.WorkDir == "" {
@@ -109,15 +111,28 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 			return
 		}
 
+		repo := repocache.RepoInfo{
+			Type:      req.Type,
+			URL:       req.Repo,
+			LocalPath: req.LocalPath,
+		}
+		if repo.Type == "" && repo.LocalPath == "" {
+			if configured, ok := d.findWorkspaceRepo(req.WorkspaceID, req.Repo); ok {
+				repo.Type = configured.Type
+				repo.URL = configured.URL
+				repo.LocalPath = configured.LocalPath
+			}
+		}
+
 		result, err := d.repoCache.CreateWorktree(repocache.WorktreeParams{
 			WorkspaceID: req.WorkspaceID,
-			RepoURL:     req.URL,
+			Repo:        repo,
 			WorkDir:     req.WorkDir,
 			AgentName:   req.AgentName,
 			TaskID:      req.TaskID,
 		})
 		if err != nil {
-			d.logger.Error("repo checkout failed", "url", req.URL, "error", err)
+			d.logger.Error("repo checkout failed", "repo", req.Repo, "type", req.Type, "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -16,20 +16,24 @@ import (
 
 // RepoInfo describes a repository to cache.
 type RepoInfo struct {
+	Type        string
 	URL         string
+	LocalPath   string
 	Description string
 }
 
 // CachedRepo describes a cached bare clone ready for worktree creation.
 type CachedRepo struct {
+	Type        string // "remote" or "local"
 	URL         string // remote URL
+	SourcePath  string // absolute path to the local repo when type=local
 	Description string // human-readable description
-	LocalPath   string // absolute path to the bare clone
+	CachePath   string // absolute path to the bare clone when type=remote
 }
 
 // Cache manages bare git clones for workspace repositories.
 type Cache struct {
-	root   string       // base directory for all caches (e.g. ~/multica_workspaces/.repos)
+	root   string // base directory for all caches (e.g. ~/multica_workspaces/.repos)
 	logger *slog.Logger
 	mu     sync.Mutex
 }
@@ -37,6 +41,17 @@ type Cache struct {
 // New creates a new repo cache rooted at the given directory.
 func New(root string, logger *slog.Logger) *Cache {
 	return &Cache{root: root, logger: logger}
+}
+
+func normalizeRepoType(repoType string) string {
+	switch strings.TrimSpace(repoType) {
+	case "", "remote":
+		return "remote"
+	case "local":
+		return "local"
+	default:
+		return repoType
+	}
 }
 
 // Sync ensures all repos for a workspace are cloned (or fetched if already cached).
@@ -53,8 +68,26 @@ func (c *Cache) Sync(workspaceID string, repos []RepoInfo) error {
 
 	var firstErr error
 	for _, repo := range repos {
-		if repo.URL == "" {
+		switch normalizeRepoType(repo.Type) {
+		case "local":
+			if strings.TrimSpace(repo.LocalPath) == "" {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("local repo path is required")
+				}
+				continue
+			}
+			if !isGitRepo(repo.LocalPath) {
+				err := fmt.Errorf("local repo is not a git repository: %s", repo.LocalPath)
+				c.logger.Warn("repo cache: invalid local repo", "path", repo.LocalPath, "error", err)
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
 			continue
+		default:
+			if repo.URL == "" {
+				continue
+			}
 		}
 		barePath := filepath.Join(wsDir, bareDirName(repo.URL))
 
@@ -127,6 +160,11 @@ func isBareRepo(path string) bool {
 	return err == nil
 }
 
+func isGitRepo(path string) bool {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--git-dir")
+	return cmd.Run() == nil
+}
+
 func gitCloneBare(url, dest string) error {
 	cmd := exec.Command("git", "clone", "--bare", url, dest)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -154,7 +192,7 @@ func gitFetch(barePath string) error {
 // WorktreeParams holds inputs for creating a worktree from a cached bare clone.
 type WorktreeParams struct {
 	WorkspaceID string // workspace that owns the repo
-	RepoURL     string // remote URL to look up in the cache
+	Repo        RepoInfo
 	WorkDir     string // parent directory for the worktree (e.g. task workdir)
 	AgentName   string // for branch naming
 	TaskID      string // for branch naming uniqueness
@@ -169,28 +207,43 @@ type WorktreeResult struct {
 // CreateWorktree looks up the bare cache for a repo, fetches latest, and creates
 // a git worktree in the agent's working directory.
 func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
-	barePath := c.Lookup(params.WorkspaceID, params.RepoURL)
-	if barePath == "" {
-		return nil, fmt.Errorf("repo not found in cache: %s (workspace: %s)", params.RepoURL, params.WorkspaceID)
-	}
+	repoType := normalizeRepoType(params.Repo.Type)
+	gitRoot := ""
+	repoLabel := strings.TrimSpace(params.Repo.URL)
+	if repoType == "local" {
+		gitRoot = strings.TrimSpace(params.Repo.LocalPath)
+		repoLabel = gitRoot
+		if gitRoot == "" {
+			return nil, fmt.Errorf("local repo path is required")
+		}
+		if !isGitRepo(gitRoot) {
+			return nil, fmt.Errorf("local repo is not a git repository: %s", gitRoot)
+		}
+	} else {
+		barePath := c.Lookup(params.WorkspaceID, params.Repo.URL)
+		if barePath == "" {
+			return nil, fmt.Errorf("repo not found in cache: %s (workspace: %s)", params.Repo.URL, params.WorkspaceID)
+		}
+		gitRoot = barePath
 
-	// Fetch latest from origin.
-	if err := gitFetch(barePath); err != nil {
-		c.logger.Warn("repo checkout: fetch failed (continuing with cached state)", "url", params.RepoURL, "error", err)
+		// Fetch latest from origin.
+		if err := gitFetch(barePath); err != nil {
+			c.logger.Warn("repo checkout: fetch failed (continuing with cached state)", "url", params.Repo.URL, "error", err)
+		}
 	}
 
 	// Determine the default branch to base the worktree on.
-	baseRef := getRemoteDefaultBranch(barePath)
+	baseRef := getRemoteDefaultBranch(gitRoot)
 
 	// Build branch name: agent/{sanitized-name}/{short-task-id}
 	branchName := fmt.Sprintf("agent/%s/%s", sanitizeName(params.AgentName), shortID(params.TaskID))
 
-	// Derive directory name from repo URL.
-	dirName := repoNameFromURL(params.RepoURL)
+	// Derive directory name from repo identifier.
+	dirName := repoNameFromURL(repoLabel)
 	worktreePath := filepath.Join(params.WorkDir, dirName)
 
 	// Create the worktree.
-	if err := createWorktree(barePath, worktreePath, branchName, baseRef); err != nil {
+	if err := createWorktree(gitRoot, worktreePath, branchName, baseRef); err != nil {
 		return nil, fmt.Errorf("create worktree: %w", err)
 	}
 
@@ -200,7 +253,8 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 	}
 
 	c.logger.Info("repo checkout: worktree created",
-		"url", params.RepoURL,
+		"repo", repoLabel,
+		"type", repoType,
 		"path", worktreePath,
 		"branch", branchName,
 		"base", baseRef,

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -207,7 +207,7 @@ func TestCreateWorktree(t *testing.T) {
 	workDir := t.TempDir()
 	result, err := cache.CreateWorktree(WorktreeParams{
 		WorkspaceID: "ws-1",
-		RepoURL:     sourceRepo,
+		Repo:        RepoInfo{URL: sourceRepo},
 		WorkDir:     workDir,
 		AgentName:   "Code Reviewer",
 		TaskID:      "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
@@ -244,7 +244,7 @@ func TestCreateWorktreeNotCached(t *testing.T) {
 
 	_, err := cache.CreateWorktree(WorktreeParams{
 		WorkspaceID: "ws-1",
-		RepoURL:     "https://github.com/org/nonexistent",
+		Repo:        RepoInfo{URL: "https://github.com/org/nonexistent"},
 		WorkDir:     t.TempDir(),
 		AgentName:   "Agent",
 		TaskID:      "test-task-id",

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -16,21 +16,23 @@ type Runtime struct {
 
 // RepoData holds repository information from the workspace.
 type RepoData struct {
+	Type        string `json:"type,omitempty"`
 	URL         string `json:"url"`
+	LocalPath   string `json:"local_path,omitempty"`
 	Description string `json:"description"`
 }
 
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID             string     `json:"id"`
-	AgentID        string     `json:"agent_id"`
-	RuntimeID      string     `json:"runtime_id"`
-	IssueID        string     `json:"issue_id"`
-	WorkspaceID    string     `json:"workspace_id"`
-	Agent          *AgentData `json:"agent,omitempty"`
-	Repos          []RepoData `json:"repos,omitempty"`
-	PriorSessionID   string     `json:"prior_session_id,omitempty"`    // Claude session ID from a previous task on this issue
+	ID               string     `json:"id"`
+	AgentID          string     `json:"agent_id"`
+	RuntimeID        string     `json:"runtime_id"`
+	IssueID          string     `json:"issue_id"`
+	WorkspaceID      string     `json:"workspace_id"`
+	Agent            *AgentData `json:"agent,omitempty"`
+	Repos            []RepoData `json:"repos,omitempty"`
+	PriorSessionID   string     `json:"prior_session_id,omitempty"`   // Claude session ID from a previous task on this issue
 	PriorWorkDir     string     `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on this issue
 	TriggerCommentID string     `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 }

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -84,27 +84,29 @@ func agentToResponse(a db.Agent) AgentResponse {
 // RepoData holds repository information included in claim responses so the
 // daemon can set up worktrees for each workspace repo.
 type RepoData struct {
+	Type        string `json:"type,omitempty"`
 	URL         string `json:"url"`
+	LocalPath   string `json:"local_path,omitempty"`
 	Description string `json:"description"`
 }
 
 type AgentTaskResponse struct {
-	ID             string         `json:"id"`
-	AgentID        string         `json:"agent_id"`
-	RuntimeID      string         `json:"runtime_id"`
-	IssueID        string         `json:"issue_id"`
-	WorkspaceID    string         `json:"workspace_id"`
-	Status         string         `json:"status"`
-	Priority       int32          `json:"priority"`
-	DispatchedAt   *string        `json:"dispatched_at"`
-	StartedAt      *string        `json:"started_at"`
-	CompletedAt    *string        `json:"completed_at"`
-	Result         any            `json:"result"`
-	Error          *string        `json:"error"`
-	Agent          *TaskAgentData `json:"agent,omitempty"`
-	Repos          []RepoData     `json:"repos,omitempty"`
-	CreatedAt      string         `json:"created_at"`
-	PriorSessionID   string         `json:"prior_session_id,omitempty"`    // session ID from a previous task on same issue
+	ID               string         `json:"id"`
+	AgentID          string         `json:"agent_id"`
+	RuntimeID        string         `json:"runtime_id"`
+	IssueID          string         `json:"issue_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Status           string         `json:"status"`
+	Priority         int32          `json:"priority"`
+	DispatchedAt     *string        `json:"dispatched_at"`
+	StartedAt        *string        `json:"started_at"`
+	CompletedAt      *string        `json:"completed_at"`
+	Result           any            `json:"result"`
+	Error            *string        `json:"error"`
+	Agent            *TaskAgentData `json:"agent,omitempty"`
+	Repos            []RepoData     `json:"repos,omitempty"`
+	CreatedAt        string         `json:"created_at"`
+	PriorSessionID   string         `json:"prior_session_id,omitempty"`   // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
 	TriggerCommentID *string        `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 }
@@ -124,16 +126,16 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		json.Unmarshal(t.Result, &result)
 	}
 	return AgentTaskResponse{
-		ID:           uuidToString(t.ID),
-		AgentID:      uuidToString(t.AgentID),
-		RuntimeID:    uuidToString(t.RuntimeID),
-		IssueID:      uuidToString(t.IssueID),
-		Status:       t.Status,
-		Priority:     t.Priority,
-		DispatchedAt: timestampToPtr(t.DispatchedAt),
-		StartedAt:    timestampToPtr(t.StartedAt),
-		CompletedAt:  timestampToPtr(t.CompletedAt),
-		Result:       result,
+		ID:               uuidToString(t.ID),
+		AgentID:          uuidToString(t.AgentID),
+		RuntimeID:        uuidToString(t.RuntimeID),
+		IssueID:          uuidToString(t.IssueID),
+		Status:           t.Status,
+		Priority:         t.Priority,
+		DispatchedAt:     timestampToPtr(t.DispatchedAt),
+		StartedAt:        timestampToPtr(t.StartedAt),
+		CompletedAt:      timestampToPtr(t.CompletedAt),
+		Result:           result,
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
@@ -300,8 +302,6 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": resp})
 	writeJSON(w, http.StatusCreated, resp)
 }
-
-
 
 type UpdateAgentRequest struct {
 	Name               *string `json:"name"`

--- a/server/internal/handler/system.go
+++ b/server/internal/handler/system.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+type ChooseDirectoryRequest struct {
+	Prompt string `json:"prompt"`
+}
+
+type ChooseDirectoryResponse struct {
+	Path string `json:"path"`
+}
+
+func (h *Handler) ChooseDirectory(w http.ResponseWriter, r *http.Request) {
+	if !isLoopbackRequest(r) {
+		writeError(w, http.StatusForbidden, "directory chooser is only available from localhost")
+		return
+	}
+
+	if runtime.GOOS != "darwin" {
+		writeError(w, http.StatusNotImplemented, "directory chooser is only supported on macOS")
+		return
+	}
+
+	var req ChooseDirectoryRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+	}
+
+	prompt := strings.TrimSpace(req.Prompt)
+	if prompt == "" {
+		prompt = "Choose a folder"
+	}
+
+	script := fmt.Sprintf(`POSIX path of (choose folder with prompt %q)`, prompt)
+	cmd := exec.Command("osascript", "-e", script)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			msg := strings.TrimSpace(string(exitErr.Stderr))
+			if strings.Contains(msg, "-128") {
+				writeError(w, http.StatusConflict, "directory selection was cancelled")
+				return
+			}
+		}
+		writeError(w, http.StatusInternalServerError, "failed to choose directory")
+		return
+	}
+
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		writeError(w, http.StatusInternalServerError, "directory chooser returned an empty path")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, ChooseDirectoryResponse{Path: path})
+}
+
+func isLoopbackRequest(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	ip := net.ParseIP(strings.TrimSpace(host))
+	return ip != nil && ip.IsLoopback()
+}


### PR DESCRIPTION
## Summary

This PR improves local runtime and repository workflows in three ways:

- add Codex runtime support alongside existing Claude runtime detection/registration
- support local workspace repositories in addition to remote Git repositories
- add a macOS-native folder picker bridge for selecting local repository paths in Settings

## Details

### Runtime support
- register Codex runtimes when the `codex` CLI is available
- keep runtime/provider metadata available through the existing runtime flow

### Local repositories
- extend workspace repo definitions to support both `remote` and `local` repo types
- allow daemon checkout flow to create worktrees directly from an existing local git repository
- keep existing clone/fetch behavior unchanged for remote repositories

### Settings UI
- add local repo configuration to the Repositories settings tab
- support switching between remote URL and local path modes
- add a `Choose Folder` action backed by a local server bridge on macOS

## Notes

- remote repository behavior remains unchanged
- local folder selection currently uses a macOS-native implementation (`osascript`)
