### PR TITLE
feat(web): update SEO metadata based on landing page

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -277,7 +277,7 @@ function LoginPageContent() {
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">Multica</CardTitle>
-          <CardDescription>AI-native task management</CardDescription>
+          <CardDescription>Turn coding agents into real teammates</CardDescription>
         </CardHeader>
         <CardContent>
           <form id="login-form" onSubmit={handleSendCode} className="space-y-4">

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
@@ -11,12 +11,68 @@ import "./globals.css";
 const geist = Geist({ subsets: ["latin"], variable: "--font-sans" });
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-mono" });
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  userScalable: true,
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
+};
+
 export const metadata: Metadata = {
-  title: "Multica",
-  description: "AI-native task management",
+  metadataBase: new URL("https://multica.ai"),
+  title: {
+    default: "Multica — Turn Coding Agents into Real Teammates",
+    template: "%s | Multica",
+  },
+  description:
+    "Multica is an open-source platform that turns coding agents into real teammates. Assign tasks, track progress, compound skills — manage your human + agent workforce in one place.",
+  keywords: [
+    "AI task management",
+    "coding agents",
+    "AI teammates",
+    "agent workforce",
+    "open source project management",
+    "AI-native task management",
+    "Linear alternative",
+  ],
   icons: {
     icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
     shortcut: ["/favicon.svg"],
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "https://multica.ai",
+    siteName: "Multica",
+    title: "Multica — Turn Coding Agents into Real Teammates",
+    description:
+      "Assign tasks, track progress, compound skills — manage your human + agent workforce in one place.",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Multica — AI-native task management platform",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Multica — Turn Coding Agents into Real Teammates",
+    description:
+      "Assign tasks, track progress, compound skills — manage your human + agent workforce in one place.",
+    images: ["/og-image.png"],
+  },
+  alternates: {
+    canonical: "/",
+  },
+  robots: {
+    index: true,
+    follow: true,
   },
 };
 

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = "https://multica.ai";
+
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/_next/", "/issues/", "/agents/", "/runtimes/", "/skills/", "/settings/", "/inbox/", "/my-issues/"],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://multica.ai";
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Updated root layout metadata: title, description, keywords, Open Graph, and Twitter Card tags aligned with the landing page messaging ("Turn coding agents into real teammates")
- Updated login page tagline from "AI-native task management" to "Turn coding agents into real teammates"
- Added `sitemap.ts` for search engine crawling
- Added `robots.ts` to disallow indexing of app-internal routes (issues, agents, settings, etc.)
- Added `viewport` export with theme color support

## Test plan
- [ ] Verify `<title>` and `<meta name="description">` in page source
- [ ] Verify Open Graph tags render correctly (use Facebook Sharing Debugger or similar)
- [ ] Verify `/sitemap.xml` and `/robots.txt` routes resolve correctly
- [ ] Verify login page shows updated tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)