### PR TITLE
fix(runtime): display multica CLI version instead of agent CLI version

### DIFF
--- a/apps/web/features/runtimes/components/runtime-detail.tsx
+++ b/apps/web/features/runtimes/components/runtime-detail.tsx
@@ -6,8 +6,12 @@ import { UpdateSection } from "./update-section";
 import { UsageSection } from "./usage-section";
 
 function getCliVersion(metadata: Record<string, unknown>): string | null {
-  if (metadata && typeof metadata.version === "string" && metadata.version) {
-    return metadata.version;
+  if (
+    metadata &&
+    typeof metadata.cli_version === "string" &&
+    metadata.cli_version
+  ) {
+    return metadata.cli_version;
   }
   return null;
 }

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -263,6 +263,7 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	cfg.CLIVersion = version
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	DaemonID           string
 	DeviceName         string
 	RuntimeName        string
+	CLIVersion         string                // multica CLI version (e.g. "0.1.13")
 	Profile            string                // profile name (empty = default)
 	Agents             map[string]AgentEntry // "claude" -> entry, "codex" -> entry
 	WorkspacesRoot     string                // base path for execution envs (default: ~/multica_workspaces)

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -254,6 +254,7 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 		"workspace_id": workspaceID,
 		"daemon_id":    d.cfg.DaemonID,
 		"device_name":  d.cfg.DeviceName,
+		"cli_version":  d.cfg.CLIVersion,
 		"runtimes":     runtimes,
 	}
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -23,10 +23,11 @@ type DaemonRegisterRequest struct {
 	WorkspaceID string `json:"workspace_id"`
 	DaemonID    string `json:"daemon_id"`
 	DeviceName  string `json:"device_name"`
+	CLIVersion  string `json:"cli_version"` // multica CLI version
 	Runtimes    []struct {
 		Name    string `json:"name"`
 		Type    string `json:"type"`
-		Version string `json:"version"`
+		Version string `json:"version"` // agent CLI version (claude/codex)
 		Status  string `json:"status"`
 	} `json:"runtimes"`
 }
@@ -90,7 +91,8 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			status = "offline"
 		}
 		metadata, _ := json.Marshal(map[string]any{
-			"version": runtime.Version,
+			"version":     runtime.Version,
+			"cli_version": req.CLIVersion,
 		})
 
 		registered, err := h.Queries.UpsertAgentRuntime(r.Context(), db.UpsertAgentRuntimeParams{


### PR DESCRIPTION
## Summary

The Runtime detail page was displaying the agent CLI version (e.g., Claude Code 1.0.51) as "CLI Version" instead of the multica CLI version. This happened because `metadata.version` stored the agent CLI version from `agent.DetectVersion()`, and the multica CLI version was never sent during registration.

**Root cause**: During daemon registration, only the agent CLI version was sent as `version`. The frontend read `metadata.version` which was the wrong value.

**Fix**:
- Daemon now includes `cli_version` (the multica CLI version) in the registration request
- Server stores it as `metadata.cli_version` alongside the existing agent `version`
- Frontend reads `metadata.cli_version` instead of `metadata.version`

## Test plan

- [ ] Verify Runtime detail shows the multica CLI version (e.g., `v0.1.13`), not the agent version
- [ ] `go build ./cmd/server/` and `go build ./cmd/multica/` pass
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)