### PR TITLE
fix(ci): update backend Go version from 1.24 to 1.26.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26.1"
           cache-dependency-path: server/go.sum
 
       - name: Build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ make db-down          # Stop shared PostgreSQL
 
 ### CI Requirements
 
-CI runs on Node 22 and Go 1.24 with a `pgvector/pgvector:pg17` PostgreSQL service. See `.github/workflows/ci.yml`.
+CI runs on Node 22 and Go 1.26.1 with a `pgvector/pgvector:pg17` PostgreSQL service. See `.github/workflows/ci.yml`.
 
 ### Worktree Support
 


### PR DESCRIPTION
## Summary

- Update `go-version` in `.github/workflows/ci.yml` from `"1.24"` to `"1.26.1"` to match `server/go.mod` and the Dockerfile (`golang:1.26-alpine`)
- Update the Go version reference in `CLAUDE.md` accordingly

Closes #286

## Test plan

- [ ] CI backend job installs Go 1.26.1 and passes build + test steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)