### PR TITLE
fix(email): use Multica <verify@multica.ai> as verification email sender

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ MULTICA_CODEX_TIMEOUT=20m
 
 # Email (Resend)
 RESEND_API_KEY=
-RESEND_FROM_EMAIL=noreply@multica.ai
+RESEND_FROM_EMAIL=Multica <verify@multica.ai>
 
 # Google OAuth
 GOOGLE_CLIENT_ID=

--- a/server/internal/service/email.go
+++ b/server/internal/service/email.go
@@ -16,7 +16,7 @@ func NewEmailService() *EmailService {
 	apiKey := os.Getenv("RESEND_API_KEY")
 	from := os.Getenv("RESEND_FROM_EMAIL")
 	if from == "" {
-		from = "noreply@multica.ai"
+		from = "Multica <verify@multica.ai>"
 	}
 
 	var client *resend.Client


### PR DESCRIPTION
## Summary
- Changed the verification email `From` address from `noreply@multica.ai` to `Multica <verify@multica.ai>`
- Adds a proper display name "Multica" so recipients see the brand name instead of just "verify"
- Updated both the code default and `.env.example`

## Test plan
- [ ] Send a test verification code email and confirm the sender shows as `Multica` in the inbox
- [ ] Verify the `RESEND_FROM_EMAIL` env var still overrides the default when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes MUL-241