### PR TITLE
fix(editor): prevent link mark from sticking to cursor

### DIFF
--- a/apps/web/components/common/rich-text-editor.tsx
+++ b/apps/web/components/common/rich-text-editor.tsx
@@ -50,9 +50,10 @@ interface RichTextEditorRef {
   insertFile: (filename: string, url: string, isImage: boolean) => void;
 }
 
-const LinkExtension = Link.configure({
+const LinkExtension = Link.extend({ inclusive: false }).configure({
   openOnClick: true,
   autolink: true,
+  linkOnPaste: false,
   HTMLAttributes: {
     class: "text-primary hover:underline cursor-pointer",
   },


### PR DESCRIPTION
## Summary
- Override Link extension `inclusive: false` via `.extend()` — Tiptap ties `inclusive` to `autolink`, causing typed text after a link to inherit the link mark
- Set `linkOnPaste: false` — autolink's PasteRule still auto-detects pasted URLs without the sticky cursor issue

Refs: ueberdosis/tiptap#2571, ueberdosis/tiptap#4249

## Test plan
- [ ] Paste a URL into comment editor → auto-linked
- [ ] Type text after the link → text is NOT part of the link
- [ ] Type a URL + space → auto-linked via autolink

🤖 Generated with [Claude Code](https://claude.com/claude-code)