### PR TITLE
fix(realtime): prevent full refetch on issue/inbox WS events

### DIFF
--- a/apps/web/features/realtime/use-realtime-sync.ts
+++ b/apps/web/features/realtime/use-realtime-sync.ts
@@ -14,6 +14,9 @@ import type {
   WorkspaceDeletedPayload,
   MemberRemovedPayload,
   IssueUpdatedPayload,
+  IssueCreatedPayload,
+  IssueDeletedPayload,
+  InboxNewPayload,
 } from "@/shared/types";
 
 const logger = createLogger("realtime-sync");
@@ -34,8 +37,12 @@ export function useRealtimeSync(ws: WSClient | null) {
   useEffect(() => {
     if (!ws) return;
 
+    // Event types handled by specific handlers below — skip generic refresh
+    const specificEvents = new Set([
+      "issue:updated", "issue:created", "issue:deleted", "inbox:new",
+    ]);
+
     const refreshMap: Record<string, () => void> = {
-      issue: () => void useIssueStore.getState().fetch(),
       inbox: () => void useInboxStore.getState().fetch(),
       agent: () => void useWorkspaceStore.getState().refreshAgents(),
       member: () => void useWorkspaceStore.getState().refreshMembers(),
@@ -74,20 +81,39 @@ export function useRealtimeSync(ws: WSClient | null) {
         logger.debug("skipping self-event", msg.type);
         return;
       }
+      if (specificEvents.has(msg.type)) return;
       const prefix = msg.type.split(":")[0] ?? "";
       const refresh = refreshMap[prefix];
       if (refresh) debouncedRefresh(prefix, refresh);
     });
 
-    // --- Side-effect handlers (toast, navigation, cross-store sync) ---
+    // --- Specific event handlers (granular updates, no full refetch) ---
 
-    // Keep inbox issue_status in sync when issues change
     const unsubIssueUpdated = ws.on("issue:updated", (p) => {
       const { issue } = p as IssueUpdatedPayload;
-      if (issue?.id && issue?.status) {
+      if (!issue?.id) return;
+      useIssueStore.getState().updateIssue(issue.id, issue);
+      if (issue.status) {
         useInboxStore.getState().updateIssueStatus(issue.id, issue.status);
       }
     });
+
+    const unsubIssueCreated = ws.on("issue:created", (p) => {
+      const { issue } = p as IssueCreatedPayload;
+      if (issue) useIssueStore.getState().addIssue(issue);
+    });
+
+    const unsubIssueDeleted = ws.on("issue:deleted", (p) => {
+      const { issue_id } = p as IssueDeletedPayload;
+      if (issue_id) useIssueStore.getState().removeIssue(issue_id);
+    });
+
+    const unsubInboxNew = ws.on("inbox:new", (p) => {
+      const { item } = p as InboxNewPayload;
+      if (item) useInboxStore.getState().addItem(item);
+    });
+
+    // --- Side-effect handlers (toast, navigation) ---
 
     const unsubWsDeleted = ws.on("workspace:deleted", (p) => {
       const { workspace_id } = p as WorkspaceDeletedPayload;
@@ -123,6 +149,9 @@ export function useRealtimeSync(ws: WSClient | null) {
     return () => {
       unsubAny();
       unsubIssueUpdated();
+      unsubIssueCreated();
+      unsubIssueDeleted();
+      unsubInboxNew();
       unsubWsDeleted();
       unsubMemberRemoved();
       unsubMemberAdded();


### PR DESCRIPTION
## Summary

- **issue:updated**, **issue:created**, **issue:deleted**, and **inbox:new** WS events now update the Zustand stores in-place using the event payload, instead of triggering full `listIssues`/`listInbox` API refetches
- Removes `issue` from the generic `refreshMap` — all issue events are handled by specific handlers
- Prevents the loading flash when viewing an issue in the inbox while status updates arrive

## Root Cause

The `onAny` WS handler matched `issue:*` events to a full `useIssueStore.fetch()`, which replaced the entire issues array. This caused the `IssueDetail` component to lose its issue reference and flash a loading state. Similarly, `inbox:new` triggered a full inbox refetch instead of simply adding the new item.

## Test plan

- [ ] Open the Inbox and select an issue
- [ ] Have another actor (agent or user) change the issue's status
- [ ] Verify the status updates in-place without any loading flash or skeleton
- [ ] Verify new inbox notifications appear without a full reload
- [ ] Verify issue creation/deletion from another actor updates the issue list correctly
- [ ] Verify WS reconnection still does a full refetch (recovery path unchanged)

Closes MUL-244

🤖 Generated with [Claude Code](https://claude.com/claude-code)