### PR TITLE
fix(test): use auth.JWTSecret() in integration tests

### DIFF
--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/realtime"
 )
@@ -29,7 +30,8 @@ var (
 	testWorkspaceID string
 )
 
-var jwtSecret = []byte("multica-dev-secret-change-in-production")
+// jwtSecret is resolved at runtime via auth.JWTSecret() so it respects
+// the JWT_SECRET env var (set in .env) and stays in sync with the server.
 
 const (
 	integrationTestEmail         = "integration-test@multica.ai"
@@ -196,7 +198,7 @@ func generateTestJWT(userID, email, name string) (string, error) {
 		"exp":   time.Now().Add(72 * time.Hour).Unix(),
 		"iat":   time.Now().Unix(),
 	})
-	return token.SignedString(jwtSecret)
+	return token.SignedString(auth.JWTSecret())
 }
 
 // ---- Health ----
@@ -417,7 +419,7 @@ func TestInvalidJWT(t *testing.T) {
 		}()},
 		{"expired token", func() string {
 			claims := jwt.MapClaims{"sub": "test", "exp": time.Now().Add(-time.Hour).Unix()}
-			t, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(jwtSecret)
+			t, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(auth.JWTSecret())
 			return t
 		}()},
 	}


### PR DESCRIPTION
## Summary
- Integration tests hardcoded an old default JWT secret (`multica-dev-secret-change-in-production`) while `.env` sets `JWT_SECRET=change-me-in-production`, causing all 7 authenticated integration tests to fail with 401
- Replaced hardcoded secret with `auth.JWTSecret()` so tests always use the same secret as the server

## Test plan
- [x] All 7 previously failing tests pass (`TestIssuesCRUDThroughRouter`, `TestCommentsThroughRouter`, 5x `TestCommentTrigger*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)