### PR TITLE
fix(realtime): update issue in-place on WS event to prevent inbox loading flash

### DIFF
--- a/apps/web/features/realtime/use-realtime-sync.ts
+++ b/apps/web/features/realtime/use-realtime-sync.ts
@@ -74,6 +74,20 @@ export function useRealtimeSync(ws: WSClient | null) {
         logger.debug("skipping self-event", msg.type);
         return;
       }
+
+      // issue:updated — update in-place using WS payload instead of full
+      // refetch.  Replacing the entire issues array causes every consumer
+      // (including IssueDetail in the inbox) to re-render, which can flash
+      // a loading state.  The payload already contains the full issue object
+      // so a surgical merge is safe.
+      if (msg.type === "issue:updated") {
+        const { issue } = (msg.payload ?? {}) as IssueUpdatedPayload;
+        if (issue?.id) {
+          useIssueStore.getState().updateIssue(issue.id, issue);
+        }
+        return;
+      }
+
       const prefix = msg.type.split(":")[0] ?? "";
       const refresh = refreshMap[prefix];
       if (refresh) debouncedRefresh(prefix, refresh);


### PR DESCRIPTION
## Summary

- `issue:updated` WS events now update the issue in-place via `updateIssue()` instead of triggering a full `useIssueStore.fetch()`
- Other issue events (`issue:created`, `issue:deleted`) still use the full refetch path
- WS reconnect recovery path unchanged

## Root Cause

When viewing an issue in the inbox, `issue:updated` WS events triggered `useIssueStore.fetch()` via the generic `refreshMap`. This replaced the entire `issues` array, causing all consumers (including `IssueDetail` in the inbox) to re-render, which produced a loading flash.

The fix intercepts `issue:updated` in the `onAny` handler and uses the WS payload (which contains the full issue object) to surgically update just the affected issue. This avoids replacing the array reference and prevents unnecessary re-renders.

## Test plan

- [ ] Open the Inbox and select an issue
- [ ] Have another actor change the issue's status
- [ ] Verify the status updates in-place without loading flash
- [ ] Verify issue creation/deletion from another actor still updates the list (full refetch)
- [ ] Verify WS reconnection still does a full refetch

Closes MUL-244

🤖 Generated with [Claude Code](https://claude.com/claude-code)