### PR TITLE
fix(inbox): parse issue query param on initial page load

### DIFF
--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import { useDefaultLayout } from "react-resizable-panels";
 import { useInboxStore } from "@/features/inbox";
@@ -219,11 +220,20 @@ function InboxListItem({
 
 export default function InboxPage() {
   const searchParams = useSearchParams();
-  const selectedKey = searchParams.get("issue") ?? "";
-  const setSelectedKey = (key: string) => {
+  const urlIssue = searchParams.get("issue") ?? "";
+
+  const [selectedKey, setSelectedKeyState] = useState(() => urlIssue);
+
+  // Sync from URL when searchParams change (e.g. Next.js navigation)
+  useEffect(() => {
+    setSelectedKeyState(urlIssue);
+  }, [urlIssue]);
+
+  const setSelectedKey = useCallback((key: string) => {
+    setSelectedKeyState(key);
     const url = key ? `/inbox?issue=${key}` : "/inbox";
     window.history.replaceState(null, "", url);
-  };
+  }, []);
 
   const items = useInboxStore((s) => s.dedupedItems());
   const loading = useInboxStore((s) => s.loading);


### PR DESCRIPTION
## Summary
- Fixed inbox links like `/inbox?issue=<id>` showing empty detail panel when opened directly
- Root cause: `selectedKey` was derived directly from `useSearchParams()`, but `window.history.replaceState()` doesn't reliably sync back to Next.js's `useSearchParams()` hook
- Fix: use `useState` for `selectedKey`, initialized from URL params on mount, with `useEffect` sync for subsequent navigations

## Test plan
- [ ] Open an inbox link with `?issue=<id>` in a new tab — issue detail should appear
- [ ] Click different inbox items — selection should update immediately
- [ ] Copy the URL while an item is selected, open in new tab — same item should be selected

Closes MUL-250