### PR TITLE
feat: wire allowedDevOrigins from CORS_ALLOWED_ORIGINS for non-localhost dev access

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -13,7 +13,7 @@ const allowedDevOrigins = process.env.CORS_ALLOWED_ORIGINS
   ? process.env.CORS_ALLOWED_ORIGINS.split(",")
       .map((origin) => {
         try {
-          return new URL(origin.trim()).hostname;
+          return new URL(origin.trim()).host;
         } catch {
           return origin.trim();
         }


### PR DESCRIPTION
## Summary
- Adds `allowedDevOrigins` to the Next.js config (`apps/web/next.config.ts`), reading from the existing `CORS_ALLOWED_ORIGINS` environment variable
- Parses hostnames from the comma-separated URL list so Next.js 16 allows cross-origin HMR/webpack requests from non-localhost IPs (e.g. Tailscale)
- When `CORS_ALLOWED_ORIGINS` is not set, behavior is unchanged (no `allowedDevOrigins` added)

## Context
When accessing the dev server over Tailscale (or any non-localhost IP), Next.js 16 blocks cross-origin requests to `/_next/webpack-hmr`, showing a spinning loader. The backend CORS was already handled via `CORS_ALLOWED_ORIGINS`, but the Next.js dev server needs its own `allowedDevOrigins` config.

With this change, setting `CORS_ALLOWED_ORIGINS=http://localhost:3000,http://100.x.x.x:3000` will configure both the backend CORS and the Next.js dev origins automatically.

Fixes #317

## Test plan
- [ ] Set `CORS_ALLOWED_ORIGINS=http://localhost:3000,http://<tailscale-ip>:3000`
- [ ] Run `make start` and access the app from the Tailscale IP
- [ ] Verify HMR works without "Blocked cross-origin request" errors
- [ ] Verify localhost access still works normally
- [ ] Verify behavior without `CORS_ALLOWED_ORIGINS` set (should be unchanged)