### PR TITLE
fix: issue mentions should not suppress on_comment trigger

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -201,8 +201,16 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 // is announcing to everyone, not specifically requesting work from the agent.
 func (h *Handler) commentMentionsOthersButNotAssignee(content string, issue db.Issue) bool {
 	mentions := util.ParseMentions(content)
+	// Filter out issue mentions — they are cross-references, not @people.
+	filtered := mentions[:0]
+	for _, m := range mentions {
+		if m.Type != "issue" {
+			filtered = append(filtered, m)
+		}
+	}
+	mentions = filtered
 	if len(mentions) == 0 {
-		return false // No mentions — normal on_comment behavior
+		return false // No mentions (or only issue refs) — normal on_comment behavior
 	}
 	// @all is a broadcast to all members — suppress agent trigger.
 	if util.HasMentionAll(mentions) {

--- a/server/internal/handler/trigger_test.go
+++ b/server/internal/handler/trigger_test.go
@@ -86,6 +86,16 @@ func TestCommentMentionsOthersButNotAssignee(t *testing.T) {
 			content: fmt.Sprintf("[@All](mention://all/all) [@Agent](mention://agent/%s) fyi", agentAssigneeID),
 			want:    true,
 		},
+		{
+			name:    "issue mention only → allow trigger (cross-reference, not @person)",
+			content: "[PAN-1](mention://issue/44c266e7-f6dd-4be3-9140-5ac40233f79c) is related",
+			want:    false,
+		},
+		{
+			name:    "issue mention + other agent → suppress (agent mention matters)",
+			content: fmt.Sprintf("[PAN-1](mention://issue/44c266e7-f6dd-4be3-9140-5ac40233f79c) cc [@Other](mention://agent/%s)", otherAgentID),
+			want:    true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request improves the logic for detecting user mentions in comment handling, ensuring that only person mentions (not issue cross-references) are considered when deciding whether to trigger agent notifications. It also adds new test cases to verify this behavior.

**Improvements to mention handling:**

* Updated the `commentMentionsOthersButNotAssignee` function in `comment.go` to filter out issue mentions, so only @person mentions are considered when determining if a comment should trigger agent behavior.

**Test coverage enhancements:**

* Added new test cases in `trigger_test.go` to ensure that comments with only issue mentions do not trigger agent notifications, and that comments with both issue and person mentions are handled correctly.