### PR TITLE
fix: on_comment triggered tasks should set issue status to in_progress

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -417,6 +417,30 @@ func TestInjectRuntimeConfigCodex(t *testing.T) {
 	}
 }
 
+func TestInjectRuntimeConfigCommentTriggerSetsInProgress(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID:          "test-issue-id",
+		TriggerCommentID: "test-comment-id",
+	}
+
+	if err := InjectRuntimeConfig(dir, "codex", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("failed to read AGENTS.md: %v", err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "multica issue status test-issue-id in_progress") {
+		t.Error("comment-triggered runtime config should instruct agent to set status to in_progress")
+	}
+}
+
 func TestInjectRuntimeConfigNoSkills(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -84,9 +84,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		fmt.Fprintf(&b, "1. Run `multica issue get %s --output json` to understand the issue context\n", ctx.IssueID)
 		fmt.Fprintf(&b, "2. Run `multica issue comment list %s --output json` to read the conversation\n", ctx.IssueID)
 		fmt.Fprintf(&b, "3. Find the triggering comment (ID: `%s`) and understand what is being asked\n", ctx.TriggerCommentID)
-		fmt.Fprintf(&b, "4. Reply: `multica issue comment add %s --parent %s --content \"...\"`\n", ctx.IssueID, ctx.TriggerCommentID)
-		b.WriteString("5. If the comment requests code changes or further work, do the work first, then reply with your results\n")
-		b.WriteString("6. Do NOT change the issue status unless the comment explicitly asks for it\n\n")
+		fmt.Fprintf(&b, "4. If the comment requests work beyond a quick answer, run `multica issue status %s in_progress` before starting\n", ctx.IssueID)
+		fmt.Fprintf(&b, "5. Reply: `multica issue comment add %s --parent %s --content \"...\"`\n", ctx.IssueID, ctx.TriggerCommentID)
+		b.WriteString("6. If the comment requests code changes or further work, do the work first, then reply with your results\n\n")
 	} else {
 		// Assignment-triggered: full workflow
 		b.WriteString("You are responsible for managing the issue status throughout your work.\n\n")


### PR DESCRIPTION
This pull request introduces an improvement to the runtime configuration instructions for agents triggered by comments, ensuring that agents explicitly set the issue status to "in_progress" when a comment requests work beyond a quick answer. The changes also add a test to verify this behavior.

**Enhancements to agent runtime instructions:**

* Updated `buildMetaSkillContent` in `runtime_config.go` to instruct agents to run `multica issue status <issue_id> in_progress` before starting work if the triggering comment requests more than a quick answer, clarifying the workflow for comment-triggered tasks.

**Testing improvements:**

* Added `TestInjectRuntimeConfigCommentTriggerSetsInProgress` in `execenv_test.go` to verify that the generated runtime config for comment-triggered tasks includes instructions to set the issue status to "in_progress".