### PR TITLE
feat(deploy): Docker full self-hosting including frontend, and optional Cloudflare tunnel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.git
+.env
+.env.*
+*.md
+e2e
+scripts
+server/bin
+**/.DS_Store

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,43 @@
+# --- Dependencies stage ---
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/package.json ./apps/web/
+
+RUN pnpm install --frozen-lockfile
+
+# --- Build stage ---
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+COPY apps/web/ ./apps/web/
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+ENV DOCKER_BUILD=1
+
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_WS_URL
+
+RUN pnpm --filter @multica/web build
+
+# --- Runtime stage ---
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /app/apps/web/public ./apps/web/public
+
+EXPOSE 3000
+
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -8,6 +8,7 @@ config({ path: resolve(__dirname, "../../.env") });
 const remoteApiUrl = process.env.REMOTE_API_URL || "http://localhost:8080";
 
 const nextConfig: NextConfig = {
+  output: process.env.DOCKER_BUILD ? "standalone" : undefined,
   images: {
     formats: ["image/avif", "image/webp"],
     qualities: [75, 80, 85],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,76 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-multica}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-multica}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-multica}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  migrate:
+    build: .
+    entrypoint: ["./migrate", "up"]
+    profiles: [self-host]
+    environment:
+      - DATABASE_URL
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  server:
+    build: .
+    profiles: [self-host]
+    environment:
+      - PORT
+      - DATABASE_URL
+      - JWT_SECRET
+      - MULTICA_APP_URL
+      - MULTICA_SERVER_URL=ws://server:8080/ws
+      - GOOGLE_CLIENT_ID
+      - GOOGLE_CLIENT_SECRET
+      - GOOGLE_REDIRECT_URI
+      - RESEND_API_KEY
+      - RESEND_FROM_EMAIL
+      - S3_BUCKET
+      - S3_REGION
+      - CLOUDFRONT_KEY_PAIR_ID
+      - CLOUDFRONT_PRIVATE_KEY
+      - CLOUDFRONT_DOMAIN
+      - COOKIE_DOMAIN
+      - FRONTEND_ORIGIN
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+        NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL}
+    profiles: [self-host]
+    environment:
+      - REMOTE_API_URL=http://server:8080
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server
+
+  tunnel:
+    image: cloudflare/cloudflared:latest
+    command: tunnel run
+    profiles: [tunnel]
+    environment:
+      - TUNNEL_TOKEN
+    depends_on:
+      - server
+      - web
 
 volumes:
   pgdata:


### PR DESCRIPTION
  ## Context
  Multica's SELF_HOSTING.md documents running the server binary and `pnpm start` directly on the host. This works but requires Go, Node.js, and pnpm installed on the host machine. For teams who want full isolation — or who want everything in a single `docker compose up` — there's no containerized frontend option, and no turnkey tunnel integration.

  ## Summary
  - Add full self-hosting support via Docker Compose profiles — no changes to existing dev workflow
  - `docker compose up -d` — dev mode (just postgres, unchanged)
  - `docker compose --profile self-host up -d` — full stack (postgres, migrations, Go server, Next.js frontend)
  - `docker compose --profile self-host --profile tunnel up -d` — adds optional Cloudflare Tunnel
  - `Dockerfile.web`: multi-stage Next.js standalone build (deps → build → minimal runtime)
  - `next.config.ts`: conditional `output: "standalone"` when `DOCKER_BUILD=1` is set
  - `.dockerignore`: keeps images lean

  ## Test plan
  - [x] `docker compose up -d` still starts only postgres (existing dev behavior preserved)
  - [x] `docker compose --profile self-host up -d --build` starts postgres + migrations + server + frontend
  - [x] Frontend serves on port 3000, proxies API to server:8080
  - [x] `docker compose --profile self-host --profile tunnel up -d` connects via Cloudflare Tunnel
  - [x] `pnpm typecheck` passes
  - [x] `pnpm test` passes (42 tests)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)