### PR TITLE
feat: optional task approval for cross-user agent execution

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -69,6 +69,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import { Skeleton } from "@/components/ui/skeleton";
 import { api } from "@/shared/api";
@@ -93,6 +94,7 @@ const statusConfig: Record<AgentStatus, { label: string; color: string; dot: str
 };
 
 const taskStatusConfig: Record<string, { label: string; icon: typeof CheckCircle2; color: string }> = {
+  pending_approval: { label: "Pending Approval", icon: AlertCircle, color: "text-warning" },
   queued: { label: "Queued", icon: Clock, color: "text-muted-foreground" },
   dispatched: { label: "Dispatched", icon: Play, color: "text-info" },
   running: { label: "Running", icon: Loader2, color: "text-success" },
@@ -127,6 +129,7 @@ function CreateAgentDialog({
   const [description, setDescription] = useState("");
   const [selectedRuntimeId, setSelectedRuntimeId] = useState(runtimes[0]?.id ?? "");
   const [visibility, setVisibility] = useState<AgentVisibility>("private");
+  const [approvalRequired, setApprovalRequired] = useState(false);
   const [creating, setCreating] = useState(false);
   const [runtimeOpen, setRuntimeOpen] = useState(false);
 
@@ -147,6 +150,7 @@ function CreateAgentDialog({
         description: description.trim(),
         runtime_id: selectedRuntime.id,
         visibility,
+        approval_required: approvalRequired,
         triggers: [
           { id: generateId(), type: "on_assign", enabled: true, config: {} },
           { id: generateId(), type: "on_comment", enabled: true, config: {} },
@@ -296,6 +300,14 @@ function CreateAgentDialog({
                 ))}
               </PopoverContent>
             </Popover>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border px-3 py-2.5">
+            <div>
+              <div className="text-sm font-medium">Require approval</div>
+              <div className="text-xs text-muted-foreground">Tasks from other members need your approval before running</div>
+            </div>
+            <Switch checked={approvalRequired} onCheckedChange={setApprovalRequired} />
           </div>
         </div>
 
@@ -1192,6 +1204,7 @@ function SettingsTab({
   const [description, setDescription] = useState(agent.description ?? "");
   const [visibility, setVisibility] = useState<AgentVisibility>(agent.visibility);
   const [maxTasks, setMaxTasks] = useState(agent.max_concurrent_tasks);
+  const [approvalRequired, setApprovalRequired] = useState(agent.approval_required);
   const [saving, setSaving] = useState(false);
   const { upload, uploading } = useFileUpload();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1214,7 +1227,8 @@ function SettingsTab({
     name !== agent.name ||
     description !== (agent.description ?? "") ||
     visibility !== agent.visibility ||
-    maxTasks !== agent.max_concurrent_tasks;
+    maxTasks !== agent.max_concurrent_tasks ||
+    approvalRequired !== agent.approval_required;
 
   const handleSave = async () => {
     if (!name.trim()) {
@@ -1223,7 +1237,7 @@ function SettingsTab({
     }
     setSaving(true);
     try {
-      await onSave({ name: name.trim(), description, visibility, max_concurrent_tasks: maxTasks });
+      await onSave({ name: name.trim(), description, visibility, max_concurrent_tasks: maxTasks, approval_required: approvalRequired });
       toast.success("Settings saved");
     } catch {
       toast.error("Failed to save settings");
@@ -1332,6 +1346,14 @@ function SettingsTab({
           onChange={(e) => setMaxTasks(Number(e.target.value))}
           className="mt-1 w-24"
         />
+      </div>
+
+      <div className="flex items-center justify-between rounded-lg border px-3 py-2.5">
+        <div>
+          <div className="text-sm font-medium">Require approval</div>
+          <div className="text-xs text-muted-foreground">Tasks from other members need your approval before running</div>
+        </div>
+        <Switch checked={approvalRequired} onCheckedChange={setApprovalRequired} />
       </div>
 
       <div>

--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -17,6 +17,8 @@ import {
   Archive,
   BookCheck,
   ListChecks,
+  Check,
+  X,
 } from "lucide-react";
 import type { InboxItem, InboxItemType, IssueStatus, IssuePriority } from "@/shared/types";
 import { Button } from "@/components/ui/button";
@@ -54,6 +56,7 @@ const typeLabels: Record<InboxItemType, string> = {
   agent_blocked: "Agent blocked",
   agent_completed: "Agent completed",
   reaction_added: "Reacted",
+  task_approval_required: "Approval required",
 };
 
 function timeAgo(dateStr: string): string {
@@ -133,6 +136,8 @@ function InboxDetailLabel({ item }: { item: InboxItem }) {
       if (emoji) return <span>Reacted {emoji} to your comment</span>;
       return <span>{typeLabels[item.type]}</span>;
     }
+    case "task_approval_required":
+      return <span>Task requires your approval to run</span>;
     default:
       return <span>{typeLabels[item.type] ?? item.type}</span>;
   }
@@ -315,6 +320,36 @@ export default function InboxPage() {
     }
   };
 
+  const handleApproveTask = async (item: InboxItem) => {
+    const taskId = item.details?.task_id;
+    const issueId = item.issue_id;
+    if (!taskId || !issueId) return;
+    try {
+      await api.approveTask(issueId, taskId);
+      await api.archiveInbox(item.id);
+      useInboxStore.getState().archive(item.id);
+      setSelectedKey("");
+      toast.success("Task approved");
+    } catch {
+      toast.error("Failed to approve task");
+    }
+  };
+
+  const handleRejectTask = async (item: InboxItem) => {
+    const taskId = item.details?.task_id;
+    const issueId = item.issue_id;
+    if (!taskId || !issueId) return;
+    try {
+      await api.rejectTask(issueId, taskId);
+      await api.archiveInbox(item.id);
+      useInboxStore.getState().archive(item.id);
+      setSelectedKey("");
+      toast.success("Task rejected");
+    } catch {
+      toast.error("Failed to reject task");
+    }
+  };
+
   if (loading) {
     return (
       <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
@@ -422,16 +457,33 @@ export default function InboxPage() {
       {/* Right column — detail */}
       <div className="flex flex-col min-h-0 h-full">
         {selected?.issue_id ? (
-          <IssueDetail
-            key={selected.id}
-            issueId={selected.issue_id}
-            defaultSidebarOpen={false}
-            layoutId="multica_inbox_issue_detail_layout"
-            highlightCommentId={selected.details?.comment_id ?? undefined}
-            onDelete={() => {
-              handleArchive(selected.id);
-            }}
-          />
+          <>
+            {selected.type === "task_approval_required" && (
+              <div className="flex items-center gap-2 border-b px-4 py-2 bg-amber-50 dark:bg-amber-950/20">
+                <span className="text-sm text-amber-700 dark:text-amber-400 flex-1">
+                  A teammate requested this task on your runtime. Approve to execute.
+                </span>
+                <Button size="sm" variant="outline" onClick={() => handleRejectTask(selected)}>
+                  <X className="mr-1 h-3.5 w-3.5" />
+                  Reject
+                </Button>
+                <Button size="sm" onClick={() => handleApproveTask(selected)}>
+                  <Check className="mr-1 h-3.5 w-3.5" />
+                  Approve
+                </Button>
+              </div>
+            )}
+            <IssueDetail
+              key={selected.id}
+              issueId={selected.issue_id}
+              defaultSidebarOpen={false}
+              layoutId="multica_inbox_issue_detail_layout"
+              highlightCommentId={selected.details?.comment_id ?? undefined}
+              onDelete={() => {
+                handleArchive(selected.id);
+              }}
+            />
+          </>
         ) : selected ? (
           <div className="p-6">
             <h2 className="text-lg font-semibold">{selected.title}</h2>

--- a/apps/web/features/issues/components/agent-live-card.tsx
+++ b/apps/web/features/issues/components/agent-live-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Bot, ChevronRight, Loader2, ArrowDown, Brain, AlertCircle, Clock, CheckCircle2, XCircle, Square } from "lucide-react";
+import { Bot, ChevronRight, Loader2, ArrowDown, Brain, AlertCircle, Clock, CheckCircle2, XCircle, Square, ShieldCheck, X, Check } from "lucide-react";
 import { api } from "@/shared/api";
 import { useWSEvent } from "@/features/realtime";
 import type { TaskMessagePayload, TaskCompletedPayload, TaskFailedPayload, TaskCancelledPayload } from "@/shared/types/events";
@@ -92,6 +92,86 @@ function buildTimeline(msgs: TaskMessagePayload[]): TimelineItem[] {
     });
   }
   return items.sort((a, b) => a.seq - b.seq);
+}
+
+// ─── PendingApprovalCard ───────────────────────────────────────────────────
+
+function PendingApprovalCard({
+  task,
+  issueId,
+  agentName,
+  onApproved,
+  onRejected,
+}: {
+  task: AgentTask;
+  issueId: string;
+  agentName?: string;
+  onApproved: () => void;
+  onRejected: () => void;
+}) {
+  const { getActorName } = useActorName();
+  const [acting, setActing] = useState(false);
+  const name = (task.agent_id ? getActorName("agent", task.agent_id) : agentName) ?? "Agent";
+
+  const handleApprove = async () => {
+    setActing(true);
+    try {
+      await api.approveTask(issueId, task.id);
+      toast.success("Task approved");
+      onApproved();
+    } catch {
+      toast.error("Failed to approve task");
+      setActing(false);
+    }
+  };
+
+  const handleReject = async () => {
+    setActing(true);
+    try {
+      await api.rejectTask(issueId, task.id);
+      toast.success("Task rejected");
+      onRejected();
+    } catch {
+      toast.error("Failed to reject task");
+      setActing(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30">
+      <div className="flex items-center gap-2 px-3 py-2.5">
+        <div className="flex items-center justify-center h-5 w-5 rounded-full bg-amber-100 dark:bg-amber-900 text-amber-600 dark:text-amber-400 shrink-0">
+          <ShieldCheck className="h-3 w-3" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-xs font-medium text-amber-800 dark:text-amber-300">
+            {name} needs approval to run this task
+          </p>
+          <p className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
+            A teammate assigned this task. Approve to execute on your runtime.
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <button
+            onClick={handleReject}
+            disabled={acting}
+            className="flex items-center gap-1 rounded-md border border-amber-300 dark:border-amber-700 bg-white dark:bg-amber-950 px-2 py-1 text-xs text-amber-700 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-900 transition-colors disabled:opacity-50"
+          >
+            <X className="h-3 w-3" />
+            Reject
+          </button>
+          <button
+            onClick={handleApprove}
+            disabled={acting}
+            className="flex items-center gap-1 rounded-md bg-amber-600 px-2 py-1 text-xs text-white hover:bg-amber-700 transition-colors disabled:opacity-50"
+          >
+            <Check className="h-3 w-3" />
+            Approve
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // ─── AgentLiveCard (real-time view) ────────────────────────────────────────
@@ -246,6 +326,22 @@ export function AgentLiveCard({ issueId, agentName }: AgentLiveCardProps) {
   }, [activeTask, issueId, cancelling]);
 
   if (!activeTask) return null;
+
+  if (activeTask.status === "pending_approval") {
+    return (
+      <PendingApprovalCard
+        task={activeTask}
+        issueId={issueId}
+        agentName={agentName}
+        onApproved={() => {
+          api.getActiveTaskForIssue(issueId).then(({ task }) => setActiveTask(task)).catch(console.error);
+        }}
+        onRejected={() => {
+          setActiveTask(null);
+        }}
+      />
+    );
+  }
 
   const toolCount = items.filter((i) => i.type === "tool_use").length;
 

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -389,6 +389,18 @@ export class ApiClient {
     });
   }
 
+  async approveTask(issueId: string, taskId: string): Promise<{ task_id: string; status: string }> {
+    return this.fetch(`/api/issues/${issueId}/tasks/${taskId}/approve`, {
+      method: "POST",
+    });
+  }
+
+  async rejectTask(issueId: string, taskId: string): Promise<{ task_id: string; status: string }> {
+    return this.fetch(`/api/issues/${issueId}/tasks/${taskId}/reject`, {
+      method: "POST",
+    });
+  }
+
   // Inbox
   async listInbox(): Promise<InboxItem[]> {
     return this.fetch("/api/inbox");

--- a/apps/web/shared/types/agent.ts
+++ b/apps/web/shared/types/agent.ts
@@ -6,6 +6,8 @@ export type AgentVisibility = "workspace" | "private";
 
 export type AgentTriggerType = "on_assign" | "on_comment" | "scheduled";
 
+export type RuntimeVisibility = "workspace" | "private";
+
 export interface RuntimeDevice {
   id: string;
   workspace_id: string;
@@ -16,6 +18,8 @@ export interface RuntimeDevice {
   status: "online" | "offline";
   device_info: string;
   metadata: Record<string, unknown>;
+  owner_id: string | null;
+  visibility: RuntimeVisibility;
   last_seen_at: string | null;
   created_at: string;
   updated_at: string;
@@ -44,7 +48,7 @@ export interface AgentTask {
   agent_id: string;
   runtime_id: string;
   issue_id: string;
-  status: "queued" | "dispatched" | "running" | "completed" | "failed" | "cancelled";
+  status: "pending_approval" | "queued" | "dispatched" | "running" | "completed" | "failed" | "cancelled";
   priority: number;
   dispatched_at: string | null;
   started_at: string | null;
@@ -68,6 +72,7 @@ export interface Agent {
   status: AgentStatus;
   max_concurrent_tasks: number;
   owner_id: string | null;
+  approval_required: boolean;
   skills: Skill[];
   tools: AgentTool[];
   triggers: AgentTrigger[];
@@ -86,6 +91,7 @@ export interface CreateAgentRequest {
   runtime_config?: Record<string, unknown>;
   visibility?: AgentVisibility;
   max_concurrent_tasks?: number;
+  approval_required?: boolean;
   tools?: AgentTool[];
   triggers?: AgentTrigger[];
 }
@@ -100,6 +106,7 @@ export interface UpdateAgentRequest {
   visibility?: AgentVisibility;
   status?: AgentStatus;
   max_concurrent_tasks?: number;
+  approval_required?: boolean;
   tools?: AgentTool[];
   triggers?: AgentTrigger[];
 }

--- a/apps/web/shared/types/inbox.ts
+++ b/apps/web/shared/types/inbox.ts
@@ -16,7 +16,8 @@ export type InboxItemType =
   | "task_failed"
   | "agent_blocked"
   | "agent_completed"
-  | "reaction_added";
+  | "reaction_added"
+  | "task_approval_required";
 
 export interface InboxItem {
   id: string;

--- a/apps/web/shared/types/index.ts
+++ b/apps/web/shared/types/index.ts
@@ -4,6 +4,7 @@ export type {
   AgentStatus,
   AgentRuntimeMode,
   AgentVisibility,
+  RuntimeVisibility,
   AgentTriggerType,
   AgentTool,
   AgentTrigger,

--- a/apps/web/test/helpers.tsx
+++ b/apps/web/test/helpers.tsx
@@ -57,6 +57,7 @@ export const mockAgents: Agent[] = [
     visibility: "workspace",
     max_concurrent_tasks: 3,
     owner_id: null,
+    approval_required: false,
     skills: [],
     tools: [],
     triggers: [],

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -171,6 +171,8 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 					r.Post("/unsubscribe", h.UnsubscribeFromIssue)
 					r.Get("/active-task", h.GetActiveTaskForIssue)
 					r.Post("/tasks/{taskId}/cancel", h.CancelTask)
+					r.Post("/tasks/{taskId}/approve", h.ApproveTask)
+					r.Post("/tasks/{taskId}/reject", h.RejectTask)
 					r.Get("/task-runs", h.ListTasksByIssue)
 					r.Post("/reactions", h.AddIssueReaction)
 					r.Delete("/reactions", h.RemoveIssueReaction)

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -27,6 +27,7 @@ type AgentResponse struct {
 	Status             string          `json:"status"`
 	MaxConcurrentTasks int32           `json:"max_concurrent_tasks"`
 	OwnerID            *string         `json:"owner_id"`
+	ApprovalRequired   bool            `json:"approval_required"`
 	Skills             []SkillResponse `json:"skills"`
 	Tools              any             `json:"tools"`
 	Triggers           any             `json:"triggers"`
@@ -75,6 +76,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		Status:             a.Status,
 		MaxConcurrentTasks: a.MaxConcurrentTasks,
 		OwnerID:            uuidToPtr(a.OwnerID),
+		ApprovalRequired:   a.ApprovalRequired,
 		Skills:             []SkillResponse{},
 		Tools:              tools,
 		Triggers:           triggers,
@@ -221,6 +223,7 @@ type CreateAgentRequest struct {
 	RuntimeConfig      any     `json:"runtime_config"`
 	Visibility         string  `json:"visibility"`
 	MaxConcurrentTasks int32   `json:"max_concurrent_tasks"`
+	ApprovalRequired   bool    `json:"approval_required"`
 	Tools              any     `json:"tools"`
 	Triggers           any     `json:"triggers"`
 }
@@ -290,6 +293,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		Visibility:         req.Visibility,
 		MaxConcurrentTasks: req.MaxConcurrentTasks,
 		OwnerID:            parseUUID(ownerID),
+		ApprovalRequired:   req.ApprovalRequired,
 		Tools:              tools,
 		Triggers:           triggers,
 	})
@@ -323,6 +327,7 @@ type UpdateAgentRequest struct {
 	Visibility         *string `json:"visibility"`
 	Status             *string `json:"status"`
 	MaxConcurrentTasks *int32  `json:"max_concurrent_tasks"`
+	ApprovalRequired   *bool   `json:"approval_required"`
 	Tools              any     `json:"tools"`
 	Triggers           any     `json:"triggers"`
 }
@@ -408,6 +413,9 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	if req.Triggers != nil {
 		triggers, _ := json.Marshal(req.Triggers)
 		params.Triggers = triggers
+	}
+	if req.ApprovalRequired != nil {
+		params.ApprovalRequired = pgtype.Bool{Bool: *req.ApprovalRequired, Valid: true}
 	}
 
 	agent, err := h.Queries.UpdateAgent(r.Context(), params)

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -182,7 +182,7 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		if comment.ParentID.Valid {
 			replyTo = comment.ParentID
 		}
-		if _, err := h.TaskService.EnqueueTaskForIssue(r.Context(), issue, replyTo); err != nil {
+		if _, err := h.TaskService.EnqueueTaskForIssue(r.Context(), issue, requestUserID(r), replyTo); err != nil {
 			slog.Warn("enqueue agent task on comment failed", "issue_id", issueID, "error", err)
 		}
 	}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -104,6 +104,7 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			Status:      status,
 			DeviceInfo:  deviceInfo,
 			Metadata:    metadata,
+			OwnerID:     parseUUID(requestUserID(r)),
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to register runtime: "+err.Error())

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -295,7 +295,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	// Only ready issues in todo are enqueued for agents.
 	if issue.AssigneeType.Valid && issue.AssigneeID.Valid {
 		if h.shouldEnqueueAgentTask(r.Context(), issue) {
-			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
+			h.TaskService.EnqueueTaskForIssue(r.Context(), issue, requestUserID(r))
 		}
 	}
 
@@ -448,7 +448,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 
 		if h.shouldEnqueueAgentTask(r.Context(), issue) {
-			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
+			h.TaskService.EnqueueTaskForIssue(r.Context(), issue, requestUserID(r))
 		}
 	}
 
@@ -724,7 +724,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		if assigneeChanged {
 			h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 			if h.shouldEnqueueAgentTask(r.Context(), issue) {
-				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
+				h.TaskService.EnqueueTaskForIssue(r.Context(), issue, requestUserID(r))
 			}
 		}
 

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -21,6 +21,8 @@ type AgentRuntimeResponse struct {
 	Status      string  `json:"status"`
 	DeviceInfo  string  `json:"device_info"`
 	Metadata    any     `json:"metadata"`
+	OwnerID     *string `json:"owner_id"`
+	Visibility  string  `json:"visibility"`
 	LastSeenAt  *string `json:"last_seen_at"`
 	CreatedAt   string  `json:"created_at"`
 	UpdatedAt   string  `json:"updated_at"`
@@ -45,6 +47,8 @@ func runtimeToResponse(rt db.AgentRuntime) AgentRuntimeResponse {
 		Status:      rt.Status,
 		DeviceInfo:  rt.DeviceInfo,
 		Metadata:    metadata,
+		OwnerID:     uuidToPtr(rt.OwnerID),
+		Visibility:  rt.Visibility,
 		LastSeenAt:  timestampToPtr(rt.LastSeenAt),
 		CreatedAt:   timestampToString(rt.CreatedAt),
 		UpdatedAt:   timestampToString(rt.UpdatedAt),

--- a/server/internal/handler/task_approval.go
+++ b/server/internal/handler/task_approval.go
@@ -1,0 +1,67 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ApproveTask transitions a pending_approval task to queued.
+// Only the runtime owner can approve.
+func (h *Handler) ApproveTask(w http.ResponseWriter, r *http.Request) {
+	taskID := chi.URLParam(r, "taskId")
+	if taskID == "" {
+		writeError(w, http.StatusBadRequest, "task_id is required")
+		return
+	}
+
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+
+	task, err := h.TaskService.ApproveTask(r.Context(), parseUUID(taskID), userID)
+	if err != nil {
+		if err.Error() == "only the runtime owner can approve tasks" {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"task_id": uuidToString(task.ID),
+		"status":  task.Status,
+	})
+}
+
+// RejectTask cancels a pending_approval task.
+// Only the runtime owner can reject.
+func (h *Handler) RejectTask(w http.ResponseWriter, r *http.Request) {
+	taskID := chi.URLParam(r, "taskId")
+	if taskID == "" {
+		writeError(w, http.StatusBadRequest, "task_id is required")
+		return
+	}
+
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+
+	task, err := h.TaskService.RejectTask(r.Context(), parseUUID(taskID), userID)
+	if err != nil {
+		if err.Error() == "only the runtime owner can reject tasks" {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"task_id": uuidToString(task.ID),
+		"status":  task.Status,
+	})
+}

--- a/server/internal/handler/task_approval_test.go
+++ b/server/internal/handler/task_approval_test.go
@@ -1,0 +1,439 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Helper to create a full test fixture: user, runtime, agent (with approval_required), issue.
+// Returns cleanup function and IDs.
+type approvalFixture struct {
+	ownerID   string
+	otherID   string
+	runtimeID string
+	agentID   string
+	issueID   string
+}
+
+func setupApprovalFixture(t *testing.T) approvalFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	// Runtime owner
+	var ownerID string
+	err := testPool.QueryRow(ctx, `INSERT INTO "user" (name, email) VALUES ('RuntimeOwner', 'approval-owner@test.ai') RETURNING id`).Scan(&ownerID)
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	_, err = testPool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member')`, testWorkspaceID, ownerID)
+	if err != nil {
+		t.Fatalf("add owner member: %v", err)
+	}
+
+	// Another user (requester)
+	var otherID string
+	err = testPool.QueryRow(ctx, `INSERT INTO "user" (name, email) VALUES ('TaskRequester', 'approval-requester@test.ai') RETURNING id`).Scan(&otherID)
+	if err != nil {
+		t.Fatalf("create requester: %v", err)
+	}
+	_, err = testPool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member')`, testWorkspaceID, otherID)
+	if err != nil {
+		t.Fatalf("add requester member: %v", err)
+	}
+
+	// Runtime owned by owner
+	var runtimeID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, visibility)
+		VALUES ($1, 'approval-daemon', 'Approval Runtime', 'local', 'claude', 'online', '', '{}'::jsonb, $2, 'workspace')
+		RETURNING id
+	`, testWorkspaceID, ownerID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+
+	// Agent with approval_required=true
+	var agentID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id, tools, triggers, approval_required)
+		VALUES ($1, 'Approval Agent', 'local', '{}'::jsonb, $2, 'workspace', 1, $3, '[]'::jsonb, '[{"type":"on_assign","enabled":true}]'::jsonb, true)
+		RETURNING id
+	`, testWorkspaceID, runtimeID, ownerID).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	// Issue created by otherUser, assigned to the agent
+	var issueID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, assignee_type, assignee_id, number, position)
+		VALUES ($1, 'Approval Test Issue', 'todo', 'none', 'member', $2, 'agent', $3, 9950, 0)
+		RETURNING id
+	`, testWorkspaceID, otherID, agentID).Scan(&issueID)
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE agent_id = $1`, agentID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID)
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+		testPool.Exec(ctx, `DELETE FROM member WHERE user_id IN ($1, $2)`, ownerID, otherID)
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id IN ($1, $2)`, ownerID, otherID)
+	})
+
+	return approvalFixture{
+		ownerID:   ownerID,
+		otherID:   otherID,
+		runtimeID: runtimeID,
+		agentID:   agentID,
+		issueID:   issueID,
+	}
+}
+
+// ---------- Cross-user task on approval_required agent -> pending_approval ----------
+
+func TestEnqueueCrossUserTaskCreatesPendingApproval(t *testing.T) {
+	ctx := context.Background()
+	f := setupApprovalFixture(t)
+
+	// EnqueueTaskForIssue should create a pending_approval task when:
+	// - agent.approval_required = true
+	// - requester (otherID) != runtime owner (ownerID)
+	issue, err := testHandler.Queries.GetIssue(ctx, parseUUID(f.issueID))
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+
+	task, err := testHandler.TaskService.EnqueueTaskForIssue(ctx, issue, f.otherID)
+	if err != nil {
+		t.Fatalf("EnqueueTaskForIssue: %v", err)
+	}
+
+	if task.Status != "pending_approval" {
+		t.Fatalf("expected status 'pending_approval', got '%s'", task.Status)
+	}
+	if uuidToString(task.RequestedBy) != f.otherID {
+		t.Fatalf("expected requested_by=%s, got %s", f.otherID, uuidToString(task.RequestedBy))
+	}
+}
+
+// ---------- Self-assigned task skips approval ----------
+
+func TestEnqueueSelfAssignedTaskSkipsApproval(t *testing.T) {
+	ctx := context.Background()
+	f := setupApprovalFixture(t)
+
+	issue, err := testHandler.Queries.GetIssue(ctx, parseUUID(f.issueID))
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+
+	// When the runtime owner triggers the task, it should skip approval
+	task, err := testHandler.TaskService.EnqueueTaskForIssue(ctx, issue, f.ownerID)
+	if err != nil {
+		t.Fatalf("EnqueueTaskForIssue: %v", err)
+	}
+
+	if task.Status != "queued" {
+		t.Fatalf("expected status 'queued' (self-assign skips approval), got '%s'", task.Status)
+	}
+}
+
+// ---------- Agent without approval_required always queues ----------
+
+func TestEnqueueNoApprovalRequiredAlwaysQueues(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a fixture with approval_required=false
+	var ownerID, otherID, runtimeID, agentID, issueID string
+	err := testPool.QueryRow(ctx, `INSERT INTO "user" (name, email) VALUES ('NoApprOwner', 'noappr-owner@test.ai') RETURNING id`).Scan(&ownerID)
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	_, _ = testPool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member')`, testWorkspaceID, ownerID)
+
+	err = testPool.QueryRow(ctx, `INSERT INTO "user" (name, email) VALUES ('NoApprOther', 'noappr-other@test.ai') RETURNING id`).Scan(&otherID)
+	if err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	_, _ = testPool.Exec(ctx, `INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'member')`, testWorkspaceID, otherID)
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'noappr-daemon', 'NoAppr Runtime', 'local', 'claude', 'online', '', '{}'::jsonb, $2) RETURNING id
+	`, testWorkspaceID, ownerID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id, tools, triggers, approval_required)
+		VALUES ($1, 'NoAppr Agent', 'local', '{}'::jsonb, $2, 'workspace', 1, $3, '[]'::jsonb, '[{"type":"on_assign","enabled":true}]'::jsonb, false)
+		RETURNING id
+	`, testWorkspaceID, runtimeID, ownerID).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, assignee_type, assignee_id, number, position)
+		VALUES ($1, 'NoAppr Issue', 'todo', 'none', 'member', $2, 'agent', $3, 9951, 0) RETURNING id
+	`, testWorkspaceID, otherID, agentID).Scan(&issueID)
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE agent_id = $1`, agentID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agentID)
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+		testPool.Exec(ctx, `DELETE FROM member WHERE user_id IN ($1, $2)`, ownerID, otherID)
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id IN ($1, $2)`, ownerID, otherID)
+	})
+
+	issue, err := testHandler.Queries.GetIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+
+	// Cross-user but approval_required=false -> should go straight to queued
+	task, err := testHandler.TaskService.EnqueueTaskForIssue(ctx, issue, otherID)
+	if err != nil {
+		t.Fatalf("EnqueueTaskForIssue: %v", err)
+	}
+
+	if task.Status != "queued" {
+		t.Fatalf("expected status 'queued' (no approval required), got '%s'", task.Status)
+	}
+}
+
+// ---------- Approve task endpoint ----------
+
+func TestApproveTask(t *testing.T) {
+	ctx := context.Background()
+	f := setupApprovalFixture(t)
+
+	issue, _ := testHandler.Queries.GetIssue(ctx, parseUUID(f.issueID))
+	task, err := testHandler.TaskService.EnqueueTaskForIssue(ctx, issue, f.otherID)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if task.Status != "pending_approval" {
+		t.Fatalf("precondition: expected pending_approval, got %s", task.Status)
+	}
+
+	taskID := uuidToString(task.ID)
+
+	// Runtime owner approves
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/tasks/"+taskID+"/approve", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", f.ownerID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	req = withURLParam(req, "taskId", taskID)
+	testHandler.ApproveTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ApproveTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify task is now queued
+	approved, _ := testHandler.Queries.GetAgentTask(ctx, task.ID)
+	if approved.Status != "queued" {
+		t.Fatalf("after approve: expected 'queued', got '%s'", approved.Status)
+	}
+}
+
+// ---------- Reject task endpoint ----------
+
+func TestRejectTask(t *testing.T) {
+	ctx := context.Background()
+	f := setupApprovalFixture(t)
+
+	issue, _ := testHandler.Queries.GetIssue(ctx, parseUUID(f.issueID))
+	task, err := testHandler.TaskService.EnqueueTaskForIssue(ctx, issue, f.otherID)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	taskID := uuidToString(task.ID)
+
+	// Runtime owner rejects
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/tasks/"+taskID+"/reject", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", f.ownerID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	req = withURLParam(req, "taskId", taskID)
+	testHandler.RejectTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("RejectTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify task is cancelled
+	rejected, _ := testHandler.Queries.GetAgentTask(ctx, task.ID)
+	if rejected.Status != "cancelled" {
+		t.Fatalf("after reject: expected 'cancelled', got '%s'", rejected.Status)
+	}
+}
+
+// ---------- Non-owner cannot approve ----------
+
+func TestNonOwnerCannotApprove(t *testing.T) {
+	ctx := context.Background()
+	f := setupApprovalFixture(t)
+
+	issue, _ := testHandler.Queries.GetIssue(ctx, parseUUID(f.issueID))
+	task, _ := testHandler.TaskService.EnqueueTaskForIssue(ctx, issue, f.otherID)
+	taskID := uuidToString(task.ID)
+
+	// Other user (not runtime owner) tries to approve -- should fail
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/tasks/"+taskID+"/approve", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", f.otherID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	req = withURLParam(req, "taskId", taskID)
+	testHandler.ApproveTask(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("ApproveTask by non-owner: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------- pending_approval not claimable by daemon ----------
+
+func TestPendingApprovalNotClaimable(t *testing.T) {
+	ctx := context.Background()
+	f := setupApprovalFixture(t)
+
+	issue, _ := testHandler.Queries.GetIssue(ctx, parseUUID(f.issueID))
+	_, err := testHandler.TaskService.EnqueueTaskForIssue(ctx, issue, f.otherID)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	// Try to claim -- should return nil (no claimable task)
+	claimed, err := testHandler.TaskService.ClaimTaskForRuntime(ctx, parseUUID(f.runtimeID))
+	if err != nil {
+		t.Fatalf("ClaimTaskForRuntime: %v", err)
+	}
+	if claimed != nil {
+		t.Fatalf("pending_approval task should not be claimable, got task %s", uuidToString(claimed.ID))
+	}
+}
+
+// ---------- Agent response includes approval_required ----------
+
+func TestAgentResponseIncludesApprovalRequired(t *testing.T) {
+	f := setupApprovalFixture(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/agents/"+f.agentID, nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", f.ownerID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	req = withURLParam(req, "id", f.agentID)
+	testHandler.GetAgent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetAgent: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+	approvalRequired, ok := body["approval_required"]
+	if !ok {
+		t.Fatal("expected 'approval_required' field in agent response")
+	}
+	if approvalRequired != true {
+		t.Fatalf("expected approval_required=true, got %v", approvalRequired)
+	}
+}
+
+// ---------- Create agent with approval_required ----------
+
+func TestCreateAgentWithApprovalRequired(t *testing.T) {
+	ctx := context.Background()
+	f := setupApprovalFixture(t)
+
+	var runtimeID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'appr-create-daemon', 'Appr Create Runtime', 'local', 'codex', 'online', '', '{}'::jsonb, $2)
+		RETURNING id
+	`, testWorkspaceID, f.ownerID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent WHERE runtime_id = $1`, runtimeID)
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]any{
+		"name":              "Approval Create Agent",
+		"runtime_id":        runtimeID,
+		"approval_required": true,
+	})
+	req := httptest.NewRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", f.ownerID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["approval_required"] != true {
+		t.Fatalf("expected approval_required=true in response, got %v", resp["approval_required"])
+	}
+}
+
+// ---------- Update agent approval_required ----------
+
+func TestUpdateAgentApprovalRequired(t *testing.T) {
+	f := setupApprovalFixture(t)
+
+	// Verify it starts as true
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/agents/"+f.agentID, nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", f.ownerID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	req = withURLParam(req, "id", f.agentID)
+	testHandler.GetAgent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetAgent: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Update approval_required to false
+	w = httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]any{
+		"approval_required": false,
+	})
+	req = httptest.NewRequest("PUT", "/api/agents/"+f.agentID, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", f.ownerID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+	req = withURLParam(req, "id", f.agentID)
+	testHandler.UpdateAgent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateAgent: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updated map[string]any
+	json.NewDecoder(w.Body).Decode(&updated)
+	if updated["approval_required"] != false {
+		t.Fatalf("expected approval_required=false after update, got %v", updated["approval_required"])
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -30,10 +30,11 @@ func NewTaskService(q *db.Queries, hub *realtime.Hub, bus *events.Bus) *TaskServ
 	return &TaskService{Queries: q, Hub: hub, Bus: bus}
 }
 
-// EnqueueTaskForIssue creates a queued task for an agent-assigned issue.
-// No context snapshot is stored — the agent fetches all data it needs at
-// runtime via the multica CLI.
-func (s *TaskService) EnqueueTaskForIssue(ctx context.Context, issue db.Issue, triggerCommentID ...pgtype.UUID) (db.AgentTaskQueue, error) {
+// EnqueueTaskForIssue creates a task for an agent-assigned issue.
+// If the agent has approval_required=true and the requester is not the runtime
+// owner, the task enters "pending_approval" instead of "queued".
+// The requestedBy parameter identifies who triggered the task (for approval logic).
+func (s *TaskService) EnqueueTaskForIssue(ctx context.Context, issue db.Issue, requestedBy string, triggerCommentID ...pgtype.UUID) (db.AgentTaskQueue, error) {
 	if !issue.AssigneeID.Valid {
 		slog.Error("task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", "issue has no assignee")
 		return db.AgentTaskQueue{}, fmt.Errorf("issue has no assignee")
@@ -58,20 +59,124 @@ func (s *TaskService) EnqueueTaskForIssue(ctx context.Context, issue db.Issue, t
 		commentID = triggerCommentID[0]
 	}
 
+	status := "queued"
+	if agent.ApprovalRequired && requestedBy != "" {
+		runtimeOwner, err := s.Queries.GetAgentRuntimeOwner(ctx, agent.RuntimeID)
+		if err == nil && runtimeOwner.Valid && util.UUIDToString(runtimeOwner) != requestedBy {
+			status = "pending_approval"
+		}
+	}
+
+	var reqBy pgtype.UUID
+	if requestedBy != "" {
+		reqBy = util.ParseUUID(requestedBy)
+	}
+
 	task, err := s.Queries.CreateAgentTask(ctx, db.CreateAgentTaskParams{
 		AgentID:          issue.AssigneeID,
 		RuntimeID:        agent.RuntimeID,
 		IssueID:          issue.ID,
+		Status:           status,
 		Priority:         priorityToInt(issue.Priority),
 		TriggerCommentID: commentID,
+		RequestedBy:      reqBy,
 	})
 	if err != nil {
 		slog.Error("task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", err)
 		return db.AgentTaskQueue{}, fmt.Errorf("create task: %w", err)
 	}
 
-	slog.Info("task enqueued", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(issue.AssigneeID))
+	slog.Info("task enqueued", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(issue.ID), "status", status, "agent_id", util.UUIDToString(issue.AssigneeID))
+
+	// Notify runtime owner when approval is needed
+	if status == "pending_approval" {
+		runtimeOwner, _ := s.Queries.GetAgentRuntimeOwner(ctx, agent.RuntimeID)
+		if runtimeOwner.Valid {
+			wsID := util.UUIDToString(issue.WorkspaceID)
+			ownerID := util.UUIDToString(runtimeOwner)
+			details, _ := json.Marshal(map[string]string{
+				"task_id":  util.UUIDToString(task.ID),
+				"agent_id": util.UUIDToString(agent.ID),
+			})
+			inbox, err := s.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+				WorkspaceID:   issue.WorkspaceID,
+				RecipientType: "member",
+				RecipientID:   runtimeOwner,
+				Type:          "task_approval_required",
+				Severity:      "action_required",
+				IssueID:       issue.ID,
+				Title:         "Task approval required: " + issue.Title,
+				Body:          pgtype.Text{String: "A teammate assigned a task to your agent. Approve or reject it.", Valid: true},
+				ActorType:     pgtype.Text{String: "member", Valid: true},
+				ActorID:       reqBy,
+				Details:       details,
+			})
+			if err == nil {
+				s.Bus.Publish(events.Event{
+					Type:        protocol.EventInboxNew,
+					WorkspaceID: wsID,
+					ActorType:   "system",
+					ActorID:     ownerID,
+					Payload:     map[string]any{"inbox_item_id": util.UUIDToString(inbox.ID), "recipient_id": ownerID},
+				})
+			}
+		}
+	}
+
 	return task, nil
+}
+
+// ApproveTask transitions a pending_approval task to queued.
+// Only the runtime owner can approve.
+func (s *TaskService) ApproveTask(ctx context.Context, taskID pgtype.UUID, approverUserID string) (*db.AgentTaskQueue, error) {
+	task, err := s.Queries.GetAgentTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("task not found: %w", err)
+	}
+	if task.Status != "pending_approval" {
+		return nil, fmt.Errorf("task is not pending approval")
+	}
+
+	// Verify approver is the runtime owner
+	runtimeOwner, err := s.Queries.GetAgentRuntimeOwner(ctx, task.RuntimeID)
+	if err != nil || !runtimeOwner.Valid || util.UUIDToString(runtimeOwner) != approverUserID {
+		return nil, fmt.Errorf("only the runtime owner can approve tasks")
+	}
+
+	approved, err := s.Queries.ApproveAgentTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("approve task: %w", err)
+	}
+
+	slog.Info("task approved", "task_id", util.UUIDToString(approved.ID), "approver", approverUserID)
+	s.broadcastTaskEvent(ctx, protocol.EventTaskApproved, approved)
+	return &approved, nil
+}
+
+// RejectTask cancels a pending_approval task.
+// Only the runtime owner can reject.
+func (s *TaskService) RejectTask(ctx context.Context, taskID pgtype.UUID, rejecterUserID string) (*db.AgentTaskQueue, error) {
+	task, err := s.Queries.GetAgentTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("task not found: %w", err)
+	}
+	if task.Status != "pending_approval" {
+		return nil, fmt.Errorf("task is not pending approval")
+	}
+
+	runtimeOwner, err := s.Queries.GetAgentRuntimeOwner(ctx, task.RuntimeID)
+	if err != nil || !runtimeOwner.Valid || util.UUIDToString(runtimeOwner) != rejecterUserID {
+		return nil, fmt.Errorf("only the runtime owner can reject tasks")
+	}
+
+	rejected, err := s.Queries.RejectAgentTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("reject task: %w", err)
+	}
+
+	slog.Info("task rejected", "task_id", util.UUIDToString(rejected.ID), "rejecter", rejecterUserID)
+	s.broadcastTaskEvent(ctx, protocol.EventTaskRejected, rejected)
+	return &rejected, nil
 }
 
 // EnqueueTaskForMention creates a queued task for a mentioned agent on an issue.
@@ -96,6 +201,7 @@ func (s *TaskService) EnqueueTaskForMention(ctx context.Context, issue db.Issue,
 		AgentID:          agentID,
 		RuntimeID:        agent.RuntimeID,
 		IssueID:          issue.ID,
+		Status:           "queued",
 		Priority:         priorityToInt(issue.Priority),
 		TriggerCommentID: triggerCommentID,
 	})
@@ -552,6 +658,7 @@ func agentToMap(a db.Agent) map[string]any {
 		"status":               a.Status,
 		"max_concurrent_tasks": a.MaxConcurrentTasks,
 		"owner_id":             util.UUIDToPtr(a.OwnerID),
+		"approval_required":    a.ApprovalRequired,
 		"skills":               []any{},
 		"tools":                tools,
 		"triggers":             triggers,

--- a/server/migrations/032_runtime_ownership_approval.down.sql
+++ b/server/migrations/032_runtime_ownership_approval.down.sql
@@ -1,0 +1,22 @@
+-- Reverse 032: Runtime ownership, visibility, and task approval
+
+-- Cancel any pending_approval tasks first (can't remove status while rows exist)
+UPDATE agent_task_queue SET status = 'cancelled' WHERE status = 'pending_approval';
+
+-- Restore original unique index
+DROP INDEX IF EXISTS idx_one_pending_task_per_issue;
+CREATE UNIQUE INDEX idx_one_pending_task_per_issue
+    ON agent_task_queue (issue_id)
+    WHERE status IN ('queued', 'dispatched');
+
+-- Restore original status CHECK
+ALTER TABLE agent_task_queue DROP CONSTRAINT agent_task_queue_status_check;
+ALTER TABLE agent_task_queue ADD CONSTRAINT agent_task_queue_status_check
+    CHECK (status IN ('queued', 'dispatched', 'running', 'completed', 'failed', 'cancelled'));
+
+-- Drop new columns
+ALTER TABLE agent_task_queue DROP COLUMN requested_by;
+ALTER TABLE agent DROP COLUMN approval_required;
+ALTER TABLE agent_runtime DROP CONSTRAINT agent_runtime_visibility_check;
+ALTER TABLE agent_runtime DROP COLUMN visibility;
+ALTER TABLE agent_runtime DROP COLUMN owner_id;

--- a/server/migrations/032_runtime_ownership_approval.up.sql
+++ b/server/migrations/032_runtime_ownership_approval.up.sql
@@ -1,0 +1,37 @@
+-- 032: Runtime ownership, visibility, and task approval
+--
+-- Adds:
+--   agent_runtime.owner_id      — who registered this runtime
+--   agent_runtime.visibility    — 'workspace' (default) or 'private'
+--   agent.approval_required     — whether cross-user tasks need approval
+--   agent_task_queue.requested_by — who triggered the task
+--   agent_task_queue.status     — adds 'pending_approval' value
+--   Updated unique index to include pending_approval
+
+-- 1. agent_runtime: owner_id
+ALTER TABLE agent_runtime ADD COLUMN owner_id UUID REFERENCES "user"(id);
+
+-- 2. agent_runtime: visibility with CHECK constraint
+ALTER TABLE agent_runtime ADD COLUMN visibility TEXT NOT NULL DEFAULT 'workspace';
+ALTER TABLE agent_runtime ADD CONSTRAINT agent_runtime_visibility_check
+    CHECK (visibility IN ('workspace', 'private'));
+
+-- 3. agent: approval_required
+ALTER TABLE agent ADD COLUMN approval_required BOOLEAN NOT NULL DEFAULT false;
+
+-- 4. agent_task_queue: requested_by
+ALTER TABLE agent_task_queue ADD COLUMN requested_by UUID REFERENCES "user"(id);
+
+-- 5. agent_task_queue: expand status CHECK to include 'pending_approval'
+ALTER TABLE agent_task_queue DROP CONSTRAINT agent_task_queue_status_check;
+ALTER TABLE agent_task_queue ADD CONSTRAINT agent_task_queue_status_check
+    CHECK (status IN ('pending_approval', 'queued', 'dispatched', 'running', 'completed', 'failed', 'cancelled'));
+
+-- 6. Update unique index to also block duplicate pending_approval tasks per issue
+DROP INDEX IF EXISTS idx_one_pending_task_per_issue;
+CREATE UNIQUE INDEX idx_one_pending_task_per_issue
+    ON agent_task_queue (issue_id)
+    WHERE status IN ('pending_approval', 'queued', 'dispatched');
+
+-- 7. Update cancel queries coverage: also cancel pending_approval in CancelAgentTasksByIssue/Agent
+-- (Handled in SQL query updates, not schema — the CHECK constraint now allows the status)

--- a/server/migrations/migration_032_test.go
+++ b/server/migrations/migration_032_test.go
@@ -1,0 +1,529 @@
+package migrations_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var testPool *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		dbURL = "postgres://multica:multica@localhost:5432/multica?sslmode=disable"
+	}
+
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		fmt.Printf("Skipping tests: could not connect to database: %v\n", err)
+		os.Exit(0)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		fmt.Printf("Skipping tests: database not reachable: %v\n", err)
+		pool.Close()
+		os.Exit(0)
+	}
+	testPool = pool
+	code := m.Run()
+	pool.Close()
+	os.Exit(code)
+}
+
+// ---------- agent_runtime.owner_id ----------
+
+func TestAgentRuntimeHasOwnerID(t *testing.T) {
+	ctx := context.Background()
+	var exists bool
+	err := testPool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent_runtime' AND column_name = 'owner_id'
+		)
+	`).Scan(&exists)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("agent_runtime.owner_id column does not exist")
+	}
+}
+
+func TestAgentRuntimeOwnerIDForeignKey(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a test user
+	var userID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email) VALUES ('migration-test', 'migration-032-test@test.ai') RETURNING id
+	`).Scan(&userID)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+
+	// Create a workspace
+	var wsID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, issue_prefix) VALUES ('mig-test', 'mig-032-test', 'MIG') RETURNING id
+	`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	// Insert runtime with valid owner_id
+	var runtimeID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'test-daemon-032', 'Test Runtime', 'local', 'claude', 'online', '', '{}'::jsonb, $2)
+		RETURNING id
+	`, wsID, userID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("insert runtime with owner_id: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	// Verify it's stored
+	var ownerID *string
+	err = testPool.QueryRow(ctx, `SELECT owner_id::text FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&ownerID)
+	if err != nil {
+		t.Fatalf("read owner_id: %v", err)
+	}
+	if ownerID == nil || *ownerID != userID {
+		t.Fatalf("expected owner_id=%s, got %v", userID, ownerID)
+	}
+
+	// owner_id should accept NULL (backwards compat)
+	var runtimeID2 string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'test-daemon-032-null', 'Test Runtime Null', 'local', 'codex', 'online', '', '{}'::jsonb, NULL)
+		RETURNING id
+	`, wsID).Scan(&runtimeID2)
+	if err != nil {
+		t.Fatalf("insert runtime with NULL owner_id: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID2)
+	})
+
+	// FK constraint: invalid user ID should fail
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'test-daemon-032-bad', 'Bad', 'local', 'claude', 'online', '', '{}'::jsonb, '00000000-0000-0000-0000-000000000099')
+	`, wsID)
+	if err == nil {
+		t.Fatal("expected FK violation for invalid owner_id, got nil")
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE daemon_id = 'test-daemon-032-bad' AND workspace_id = $1`, wsID)
+	}
+}
+
+// ---------- agent_runtime.visibility ----------
+
+func TestAgentRuntimeHasVisibility(t *testing.T) {
+	ctx := context.Background()
+	var exists bool
+	err := testPool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent_runtime' AND column_name = 'visibility'
+		)
+	`).Scan(&exists)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("agent_runtime.visibility column does not exist")
+	}
+}
+
+func TestAgentRuntimeVisibilityDefault(t *testing.T) {
+	ctx := context.Background()
+
+	var wsID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, issue_prefix) VALUES ('vis-test', 'vis-032-test', 'VIS') RETURNING id
+	`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	var runtimeID, visibility string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata)
+		VALUES ($1, 'vis-daemon', 'Vis Runtime', 'local', 'claude', 'online', '', '{}'::jsonb)
+		RETURNING id, visibility
+	`, wsID).Scan(&runtimeID, &visibility)
+	if err != nil {
+		t.Fatalf("insert runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	if visibility != "workspace" {
+		t.Fatalf("expected default visibility 'workspace', got '%s'", visibility)
+	}
+}
+
+func TestAgentRuntimeVisibilityCheckConstraint(t *testing.T) {
+	ctx := context.Background()
+
+	var wsID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, issue_prefix) VALUES ('chk-test', 'chk-032-test', 'CHK') RETURNING id
+	`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	// Valid values: 'workspace' and 'private'
+	for _, vis := range []string{"workspace", "private"} {
+		daemon := fmt.Sprintf("chk-daemon-%s", vis)
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, visibility)
+			VALUES ($1, $2, 'Check', 'local', 'claude', 'online', '', '{}'::jsonb, $3)
+		`, wsID, daemon, vis)
+		if err != nil {
+			t.Fatalf("visibility=%q should be valid, got: %v", vis, err)
+		}
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE daemon_id = $1 AND workspace_id = $2`, daemon, wsID)
+		})
+	}
+
+	// Invalid value should fail
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, visibility)
+		VALUES ($1, 'chk-daemon-bad', 'Bad', 'local', 'claude', 'online', '', '{}'::jsonb, 'invalid')
+	`, wsID)
+	if err == nil {
+		t.Fatal("expected CHECK violation for visibility='invalid', got nil")
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE daemon_id = 'chk-daemon-bad' AND workspace_id = $1`, wsID)
+	}
+}
+
+// ---------- agent.approval_required ----------
+
+func TestAgentHasApprovalRequired(t *testing.T) {
+	ctx := context.Background()
+	var exists bool
+	err := testPool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent' AND column_name = 'approval_required'
+		)
+	`).Scan(&exists)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("agent.approval_required column does not exist")
+	}
+}
+
+func TestAgentApprovalRequiredDefault(t *testing.T) {
+	ctx := context.Background()
+
+	var wsID, runtimeID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, issue_prefix) VALUES ('appr-test', 'appr-032-test', 'APR') RETURNING id
+	`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata)
+		VALUES ($1, 'appr-daemon', 'Appr Runtime', 'local', 'claude', 'online', '', '{}'::jsonb)
+		RETURNING id
+	`, wsID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+
+	var agentID string
+	var approvalRequired bool
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, tools, triggers)
+		VALUES ($1, 'Approval Test Agent', 'local', '{}'::jsonb, $2, 'workspace', 1, '[]'::jsonb, '[]'::jsonb)
+		RETURNING id, approval_required
+	`, wsID, runtimeID).Scan(&agentID, &approvalRequired)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	if approvalRequired != false {
+		t.Fatalf("expected approval_required default false, got %v", approvalRequired)
+	}
+}
+
+// ---------- agent_task_queue.requested_by ----------
+
+func TestAgentTaskQueueHasRequestedBy(t *testing.T) {
+	ctx := context.Background()
+	var exists bool
+	err := testPool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent_task_queue' AND column_name = 'requested_by'
+		)
+	`).Scan(&exists)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("agent_task_queue.requested_by column does not exist")
+	}
+}
+
+// ---------- agent_task_queue.status includes pending_approval ----------
+
+func TestAgentTaskQueuePendingApprovalStatus(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up the full chain: workspace -> runtime -> agent -> issue -> task
+	var wsID, userID, runtimeID, agentID, issueID string
+
+	err := testPool.QueryRow(ctx, `INSERT INTO "user" (name, email) VALUES ('pa-test', 'pa-032-test@test.ai') RETURNING id`).Scan(&userID)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, userID) })
+
+	err = testPool.QueryRow(ctx, `INSERT INTO workspace (name, slug, issue_prefix) VALUES ('pa-test', 'pa-032-test', 'PAT') RETURNING id`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID) })
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata)
+		VALUES ($1, 'pa-daemon', 'PA Runtime', 'local', 'claude', 'online', '', '{}'::jsonb) RETURNING id
+	`, wsID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, tools, triggers)
+		VALUES ($1, 'PA Agent', 'local', '{}'::jsonb, $2, 'workspace', 1, '[]'::jsonb, '[]'::jsonb) RETURNING id
+	`, wsID, runtimeID).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+		VALUES ($1, 'PA Test Issue', 'todo', 'none', 'member', $2, 9900, 0) RETURNING id
+	`, wsID, userID).Scan(&issueID)
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	// Insert task with status 'pending_approval'
+	var taskID, taskStatus string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, requested_by)
+		VALUES ($1, $2, $3, 'pending_approval', 0, $4)
+		RETURNING id, status
+	`, agentID, runtimeID, issueID, userID).Scan(&taskID, &taskStatus)
+	if err != nil {
+		t.Fatalf("insert task with pending_approval: %v", err)
+	}
+
+	if taskStatus != "pending_approval" {
+		t.Fatalf("expected status 'pending_approval', got '%s'", taskStatus)
+	}
+
+	// Verify it's not claimable (ClaimAgentTask only picks 'queued')
+	var claimableCount int
+	err = testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE agent_id = $1 AND status = 'queued'
+	`, agentID).Scan(&claimableCount)
+	if err != nil {
+		t.Fatalf("count claimable: %v", err)
+	}
+	if claimableCount != 0 {
+		t.Fatalf("pending_approval task should not be claimable, got %d queued tasks", claimableCount)
+	}
+
+	// Transition to queued (approve)
+	_, err = testPool.Exec(ctx, `
+		UPDATE agent_task_queue SET status = 'queued' WHERE id = $1 AND status = 'pending_approval'
+	`, taskID)
+	if err != nil {
+		t.Fatalf("approve task: %v", err)
+	}
+
+	// Now it should be claimable
+	err = testPool.QueryRow(ctx, `
+		SELECT count(*) FROM agent_task_queue
+		WHERE agent_id = $1 AND status = 'queued'
+	`, agentID).Scan(&claimableCount)
+	if err != nil {
+		t.Fatalf("count claimable after approve: %v", err)
+	}
+	if claimableCount != 1 {
+		t.Fatalf("after approval, expected 1 queued task, got %d", claimableCount)
+	}
+}
+
+// ---------- Unique index covers pending_approval ----------
+
+func TestUniqueIndexIncludesPendingApproval(t *testing.T) {
+	ctx := context.Background()
+
+	var wsID, userID, runtimeID, agentID, issueID string
+
+	err := testPool.QueryRow(ctx, `INSERT INTO "user" (name, email) VALUES ('idx-test', 'idx-032-test@test.ai') RETURNING id`).Scan(&userID)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, userID) })
+
+	err = testPool.QueryRow(ctx, `INSERT INTO workspace (name, slug, issue_prefix) VALUES ('idx-test', 'idx-032-test', 'IDX') RETURNING id`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID) })
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata)
+		VALUES ($1, 'idx-daemon', 'IDX Runtime', 'local', 'claude', 'online', '', '{}'::jsonb) RETURNING id
+	`, wsID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, tools, triggers)
+		VALUES ($1, 'IDX Agent', 'local', '{}'::jsonb, $2, 'workspace', 1, '[]'::jsonb, '[]'::jsonb) RETURNING id
+	`, wsID, runtimeID).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+		VALUES ($1, 'IDX Test Issue', 'todo', 'none', 'member', $2, 9901, 0) RETURNING id
+	`, wsID, userID).Scan(&issueID)
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	// Insert a pending_approval task
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'pending_approval', 0)
+	`, agentID, runtimeID, issueID)
+	if err != nil {
+		t.Fatalf("insert first pending_approval task: %v", err)
+	}
+
+	// Inserting another pending_approval or queued task for the same issue should fail (unique index)
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, agentID, runtimeID, issueID)
+	if err == nil {
+		t.Fatal("expected unique violation: should not allow both pending_approval and queued for same issue")
+	}
+
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'pending_approval', 0)
+	`, agentID, runtimeID, issueID)
+	if err == nil {
+		t.Fatal("expected unique violation: should not allow two pending_approval for same issue")
+	}
+}
+
+// ---------- Cancel queries include pending_approval ----------
+
+func TestCancelIncludesPendingApproval(t *testing.T) {
+	ctx := context.Background()
+
+	var wsID, userID, runtimeID, agentID, issueID string
+
+	err := testPool.QueryRow(ctx, `INSERT INTO "user" (name, email) VALUES ('cancel-test', 'cancel-032-test@test.ai') RETURNING id`).Scan(&userID)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, userID) })
+
+	err = testPool.QueryRow(ctx, `INSERT INTO workspace (name, slug, issue_prefix) VALUES ('cancel-test', 'cancel-032-test', 'CAN') RETURNING id`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID) })
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata)
+		VALUES ($1, 'cancel-daemon', 'Cancel Runtime', 'local', 'claude', 'online', '', '{}'::jsonb) RETURNING id
+	`, wsID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, tools, triggers)
+		VALUES ($1, 'Cancel Agent', 'local', '{}'::jsonb, $2, 'workspace', 1, '[]'::jsonb, '[]'::jsonb) RETURNING id
+	`, wsID, runtimeID).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+		VALUES ($1, 'Cancel Test Issue', 'todo', 'none', 'member', $2, 9902, 0) RETURNING id
+	`, wsID, userID).Scan(&issueID)
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	// Insert a pending_approval task
+	var taskID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		VALUES ($1, $2, $3, 'pending_approval', 0) RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID)
+	if err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+
+	// CancelAgentTask should be able to cancel pending_approval tasks
+	var cancelledStatus string
+	err = testPool.QueryRow(ctx, `
+		UPDATE agent_task_queue SET status = 'cancelled', completed_at = now()
+		WHERE id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running')
+		RETURNING status
+	`, taskID).Scan(&cancelledStatus)
+	if err != nil {
+		t.Fatalf("cancel pending_approval task: %v", err)
+	}
+	if cancelledStatus != "cancelled" {
+		t.Fatalf("expected cancelled status, got %s", cancelledStatus)
+	}
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -11,10 +11,42 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const approveAgentTask = `-- name: ApproveAgentTask :one
+UPDATE agent_task_queue
+SET status = 'queued'
+WHERE id = $1 AND status = 'pending_approval'
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by
+`
+
+func (q *Queries) ApproveAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, approveAgentTask, id)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.RequestedBy,
+	)
+	return i, err
+}
+
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required
 `
 
 type ArchiveAgentParams struct {
@@ -45,6 +77,7 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.ApprovalRequired,
 	)
 	return i, err
 }
@@ -52,8 +85,8 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
-WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+WHERE id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running')
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by
 `
 
 func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -76,6 +109,7 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedBy,
 	)
 	return i, err
 }
@@ -83,7 +117,7 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 const cancelAgentTasksByAgent = `-- name: CancelAgentTasksByAgent :exec
 UPDATE agent_task_queue
 SET status = 'cancelled'
-WHERE agent_id = $1 AND status IN ('queued', 'dispatched', 'running')
+WHERE agent_id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running')
 `
 
 func (q *Queries) CancelAgentTasksByAgent(ctx context.Context, agentID pgtype.UUID) error {
@@ -94,7 +128,7 @@ func (q *Queries) CancelAgentTasksByAgent(ctx context.Context, agentID pgtype.UU
 const cancelAgentTasksByIssue = `-- name: CancelAgentTasksByIssue :exec
 UPDATE agent_task_queue
 SET status = 'cancelled'
-WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running')
+WHERE issue_id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running')
 `
 
 func (q *Queries) CancelAgentTasksByIssue(ctx context.Context, issueID pgtype.UUID) error {
@@ -117,7 +151,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by
 `
 
 // Claims the next queued task for an agent, enforcing per-issue serialization:
@@ -144,6 +178,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, agentID pgtype.UUID) (Agen
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedBy,
 	)
 	return i, err
 }
@@ -152,7 +187,7 @@ const completeAgentTask = `-- name: CompleteAgentTask :one
 UPDATE agent_task_queue
 SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by
 `
 
 type CompleteAgentTaskParams struct {
@@ -187,6 +222,7 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedBy,
 	)
 	return i, err
 }
@@ -207,9 +243,9 @@ const createAgent = `-- name: CreateAgent :one
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
-    tools, triggers, instructions
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by
+    tools, triggers, instructions, approval_required
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required
 `
 
 type CreateAgentParams struct {
@@ -226,6 +262,7 @@ type CreateAgentParams struct {
 	Tools              []byte      `json:"tools"`
 	Triggers           []byte      `json:"triggers"`
 	Instructions       string      `json:"instructions"`
+	ApprovalRequired   bool        `json:"approval_required"`
 }
 
 func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent, error) {
@@ -243,6 +280,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.Tools,
 		arg.Triggers,
 		arg.Instructions,
+		arg.ApprovalRequired,
 	)
 	var i Agent
 	err := row.Scan(
@@ -265,22 +303,25 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.ApprovalRequired,
 	)
 	return i, err
 }
 
 const createAgentTask = `-- name: CreateAgentTask :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id)
-VALUES ($1, $2, $3, 'queued', $4, $5)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, requested_by)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by
 `
 
 type CreateAgentTaskParams struct {
 	AgentID          pgtype.UUID `json:"agent_id"`
 	RuntimeID        pgtype.UUID `json:"runtime_id"`
 	IssueID          pgtype.UUID `json:"issue_id"`
+	Status           string      `json:"status"`
 	Priority         int32       `json:"priority"`
 	TriggerCommentID pgtype.UUID `json:"trigger_comment_id"`
+	RequestedBy      pgtype.UUID `json:"requested_by"`
 }
 
 func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams) (AgentTaskQueue, error) {
@@ -288,8 +329,10 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		arg.AgentID,
 		arg.RuntimeID,
 		arg.IssueID,
+		arg.Status,
 		arg.Priority,
 		arg.TriggerCommentID,
+		arg.RequestedBy,
 	)
 	var i AgentTaskQueue
 	err := row.Scan(
@@ -309,6 +352,7 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedBy,
 	)
 	return i, err
 }
@@ -317,7 +361,7 @@ const failAgentTask = `-- name: FailAgentTask :one
 UPDATE agent_task_queue
 SET status = 'failed', completed_at = now(), error = $2
 WHERE id = $1 AND status IN ('dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by
 `
 
 type FailAgentTaskParams struct {
@@ -345,6 +389,7 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedBy,
 	)
 	return i, err
 }
@@ -392,7 +437,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required FROM agent
 WHERE id = $1
 `
 
@@ -419,12 +464,13 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.ApprovalRequired,
 	)
 	return i, err
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required FROM agent
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -456,12 +502,13 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.ApprovalRequired,
 	)
 	return i, err
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -485,6 +532,7 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedBy,
 	)
 	return i, err
 }
@@ -530,10 +578,10 @@ func (q *Queries) HasActiveTaskForIssue(ctx context.Context, issueID pgtype.UUID
 
 const hasPendingTaskForIssue = `-- name: HasPendingTaskForIssue :one
 SELECT count(*) > 0 AS has_pending FROM agent_task_queue
-WHERE issue_id = $1 AND status IN ('queued', 'dispatched')
+WHERE issue_id = $1 AND status IN ('pending_approval', 'queued', 'dispatched')
 `
 
-// Returns true if there is a queued or dispatched (but not yet running) task for the issue.
+// Returns true if there is a pending_approval, queued, or dispatched task for the issue.
 // Used by the coalescing queue: allow enqueue when a task is running (so
 // the agent picks up new comments on the next cycle) but skip if a pending
 // task already exists (natural dedup).
@@ -546,7 +594,7 @@ func (q *Queries) HasPendingTaskForIssue(ctx context.Context, issueID pgtype.UUI
 
 const hasPendingTaskForIssueAndAgent = `-- name: HasPendingTaskForIssueAndAgent :one
 SELECT count(*) > 0 AS has_pending FROM agent_task_queue
-WHERE issue_id = $1 AND agent_id = $2 AND status IN ('queued', 'dispatched')
+WHERE issue_id = $1 AND agent_id = $2 AND status IN ('pending_approval', 'queued', 'dispatched')
 `
 
 type HasPendingTaskForIssueAndAgentParams struct {
@@ -554,8 +602,8 @@ type HasPendingTaskForIssueAndAgentParams struct {
 	AgentID pgtype.UUID `json:"agent_id"`
 }
 
-// Returns true if a specific agent already has a queued or dispatched task
-// for the given issue. Used by @mention trigger dedup.
+// Returns true if a specific agent already has a pending_approval, queued,
+// or dispatched task for the given issue. Used by @mention trigger dedup.
 func (q *Queries) HasPendingTaskForIssueAndAgent(ctx context.Context, arg HasPendingTaskForIssueAndAgentParams) (bool, error) {
 	row := q.db.QueryRow(ctx, hasPendingTaskForIssueAndAgent, arg.IssueID, arg.AgentID)
 	var has_pending bool
@@ -564,8 +612,8 @@ func (q *Queries) HasPendingTaskForIssueAndAgent(ctx context.Context, arg HasPen
 }
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
-WHERE issue_id = $1 AND status IN ('dispatched', 'running')
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by FROM agent_task_queue
+WHERE issue_id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running')
 ORDER BY created_at DESC
 `
 
@@ -595,6 +643,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -607,7 +656,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -638,6 +687,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -650,7 +700,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL
 ORDER BY created_at ASC
 `
@@ -684,6 +734,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.Instructions,
 			&i.ArchivedAt,
 			&i.ArchivedBy,
+			&i.ApprovalRequired,
 		); err != nil {
 			return nil, err
 		}
@@ -696,7 +747,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required FROM agent
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -730,6 +781,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.Instructions,
 			&i.ArchivedAt,
 			&i.ArchivedBy,
+			&i.ApprovalRequired,
 		); err != nil {
 			return nil, err
 		}
@@ -742,7 +794,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -773,6 +825,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -785,7 +838,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -816,6 +869,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.SessionID,
 			&i.WorkDir,
 			&i.TriggerCommentID,
+			&i.RequestedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -827,10 +881,42 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 	return items, nil
 }
 
+const rejectAgentTask = `-- name: RejectAgentTask :one
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), error = 'rejected by runtime owner'
+WHERE id = $1 AND status = 'pending_approval'
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by
+`
+
+func (q *Queries) RejectAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, rejectAgentTask, id)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.RequestedBy,
+	)
+	return i, err
+}
+
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -856,6 +942,7 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.ApprovalRequired,
 	)
 	return i, err
 }
@@ -864,7 +951,7 @@ const startAgentTask = `-- name: StartAgentTask :one
 UPDATE agent_task_queue
 SET status = 'running', started_at = now()
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, requested_by
 `
 
 func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -887,6 +974,7 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.SessionID,
 		&i.WorkDir,
 		&i.TriggerCommentID,
+		&i.RequestedBy,
 	)
 	return i, err
 }
@@ -905,9 +993,10 @@ UPDATE agent SET
     tools = COALESCE($11, tools),
     triggers = COALESCE($12, triggers),
     instructions = COALESCE($13, instructions),
+    approval_required = COALESCE($14, approval_required),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required
 `
 
 type UpdateAgentParams struct {
@@ -924,6 +1013,7 @@ type UpdateAgentParams struct {
 	Tools              []byte      `json:"tools"`
 	Triggers           []byte      `json:"triggers"`
 	Instructions       pgtype.Text `json:"instructions"`
+	ApprovalRequired   pgtype.Bool `json:"approval_required"`
 }
 
 func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent, error) {
@@ -941,6 +1031,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.Tools,
 		arg.Triggers,
 		arg.Instructions,
+		arg.ApprovalRequired,
 	)
 	var i Agent
 	err := row.Scan(
@@ -963,6 +1054,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.ApprovalRequired,
 	)
 	return i, err
 }
@@ -970,7 +1062,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, tools, triggers, runtime_id, instructions, archived_at, archived_by, approval_required
 `
 
 type UpdateAgentStatusParams struct {
@@ -1001,6 +1093,7 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.ApprovalRequired,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -39,6 +39,7 @@ type Agent struct {
 	Instructions       string             `json:"instructions"`
 	ArchivedAt         pgtype.Timestamptz `json:"archived_at"`
 	ArchivedBy         pgtype.UUID        `json:"archived_by"`
+	ApprovalRequired   bool               `json:"approval_required"`
 }
 
 type AgentRuntime struct {
@@ -54,6 +55,8 @@ type AgentRuntime struct {
 	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+	OwnerID     pgtype.UUID        `json:"owner_id"`
+	Visibility  string             `json:"visibility"`
 }
 
 type AgentSkill struct {
@@ -79,6 +82,7 @@ type AgentTaskQueue struct {
 	SessionID        pgtype.Text        `json:"session_id"`
 	WorkDir          pgtype.Text        `json:"work_dir"`
 	TriggerCommentID pgtype.UUID        `json:"trigger_comment_id"`
+	RequestedBy      pgtype.UUID        `json:"requested_by"`
 }
 
 type Attachment struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -50,7 +50,7 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context) ([]FailTasksF
 }
 
 const getAgentRuntime = `-- name: GetAgentRuntime :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility FROM agent_runtime
 WHERE id = $1
 `
 
@@ -70,12 +70,14 @@ func (q *Queries) GetAgentRuntime(ctx context.Context, id pgtype.UUID) (AgentRun
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
 	)
 	return i, err
 }
 
 const getAgentRuntimeForWorkspace = `-- name: GetAgentRuntimeForWorkspace :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility FROM agent_runtime
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -100,12 +102,25 @@ func (q *Queries) GetAgentRuntimeForWorkspace(ctx context.Context, arg GetAgentR
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
 	)
 	return i, err
 }
 
+const getAgentRuntimeOwner = `-- name: GetAgentRuntimeOwner :one
+SELECT owner_id FROM agent_runtime WHERE id = $1
+`
+
+func (q *Queries) GetAgentRuntimeOwner(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, getAgentRuntimeOwner, id)
+	var owner_id pgtype.UUID
+	err := row.Scan(&owner_id)
+	return owner_id, err
+}
+
 const listAgentRuntimes = `-- name: ListAgentRuntimes :many
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility FROM agent_runtime
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -132,6 +147,8 @@ func (q *Queries) ListAgentRuntimes(ctx context.Context, workspaceID pgtype.UUID
 			&i.LastSeenAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.OwnerID,
+			&i.Visibility,
 		); err != nil {
 			return nil, err
 		}
@@ -191,7 +208,7 @@ const updateAgentRuntimeHeartbeat = `-- name: UpdateAgentRuntimeHeartbeat :one
 UPDATE agent_runtime
 SET status = 'online', last_seen_at = now(), updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility
 `
 
 func (q *Queries) UpdateAgentRuntimeHeartbeat(ctx context.Context, id pgtype.UUID) (AgentRuntime, error) {
@@ -210,6 +227,8 @@ func (q *Queries) UpdateAgentRuntimeHeartbeat(ctx context.Context, id pgtype.UUI
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
 	)
 	return i, err
 }
@@ -224,8 +243,9 @@ INSERT INTO agent_runtime (
     status,
     device_info,
     metadata,
-    last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+    last_seen_at,
+    owner_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), $9)
 ON CONFLICT (workspace_id, daemon_id, provider)
 DO UPDATE SET
     name = EXCLUDED.name,
@@ -234,8 +254,9 @@ DO UPDATE SET
     device_info = EXCLUDED.device_info,
     metadata = EXCLUDED.metadata,
     last_seen_at = now(),
-    updated_at = now()
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at
+    updated_at = now(),
+    owner_id = COALESCE(agent_runtime.owner_id, EXCLUDED.owner_id)
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility
 `
 
 type UpsertAgentRuntimeParams struct {
@@ -247,6 +268,7 @@ type UpsertAgentRuntimeParams struct {
 	Status      string      `json:"status"`
 	DeviceInfo  string      `json:"device_info"`
 	Metadata    []byte      `json:"metadata"`
+	OwnerID     pgtype.UUID `json:"owner_id"`
 }
 
 func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntimeParams) (AgentRuntime, error) {
@@ -259,6 +281,7 @@ func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntime
 		arg.Status,
 		arg.DeviceInfo,
 		arg.Metadata,
+		arg.OwnerID,
 	)
 	var i AgentRuntime
 	err := row.Scan(
@@ -274,6 +297,8 @@ func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntime
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -20,8 +20,8 @@ WHERE id = $1 AND workspace_id = $2;
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
-    tools, triggers, instructions
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+    tools, triggers, instructions, approval_required
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 RETURNING *;
 
 -- name: UpdateAgent :one
@@ -38,6 +38,7 @@ UPDATE agent SET
     tools = COALESCE(sqlc.narg('tools'), tools),
     triggers = COALESCE(sqlc.narg('triggers'), triggers),
     instructions = COALESCE(sqlc.narg('instructions'), instructions),
+    approval_required = COALESCE(sqlc.narg('approval_required'), approval_required),
     updated_at = now()
 WHERE id = $1
 RETURNING *;
@@ -58,19 +59,19 @@ WHERE agent_id = $1
 ORDER BY created_at DESC;
 
 -- name: CreateAgentTask :one
-INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id)
-VALUES ($1, $2, $3, 'queued', $4, sqlc.narg(trigger_comment_id))
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id, requested_by)
+VALUES ($1, $2, $3, $4, $5, sqlc.narg(trigger_comment_id), sqlc.narg(requested_by))
 RETURNING *;
 
 -- name: CancelAgentTasksByIssue :exec
 UPDATE agent_task_queue
 SET status = 'cancelled'
-WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running');
+WHERE issue_id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running');
 
 -- name: CancelAgentTasksByAgent :exec
 UPDATE agent_task_queue
 SET status = 'cancelled'
-WHERE agent_id = $1 AND status IN ('queued', 'dispatched', 'running');
+WHERE agent_id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running');
 
 -- name: GetAgentTask :one
 SELECT * FROM agent_task_queue
@@ -136,7 +137,7 @@ RETURNING id, agent_id, issue_id;
 -- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
-WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
+WHERE id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running')
 RETURNING *;
 
 -- name: CountRunningTasks :one
@@ -149,18 +150,18 @@ SELECT count(*) > 0 AS has_active FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running');
 
 -- name: HasPendingTaskForIssue :one
--- Returns true if there is a queued or dispatched (but not yet running) task for the issue.
+-- Returns true if there is a pending_approval, queued, or dispatched task for the issue.
 -- Used by the coalescing queue: allow enqueue when a task is running (so
 -- the agent picks up new comments on the next cycle) but skip if a pending
 -- task already exists (natural dedup).
 SELECT count(*) > 0 AS has_pending FROM agent_task_queue
-WHERE issue_id = $1 AND status IN ('queued', 'dispatched');
+WHERE issue_id = $1 AND status IN ('pending_approval', 'queued', 'dispatched');
 
 -- name: HasPendingTaskForIssueAndAgent :one
--- Returns true if a specific agent already has a queued or dispatched task
--- for the given issue. Used by @mention trigger dedup.
+-- Returns true if a specific agent already has a pending_approval, queued,
+-- or dispatched task for the given issue. Used by @mention trigger dedup.
 SELECT count(*) > 0 AS has_pending FROM agent_task_queue
-WHERE issue_id = $1 AND agent_id = $2 AND status IN ('queued', 'dispatched');
+WHERE issue_id = $1 AND agent_id = $2 AND status IN ('pending_approval', 'queued', 'dispatched');
 
 -- name: ListPendingTasksByRuntime :many
 SELECT * FROM agent_task_queue
@@ -169,7 +170,7 @@ ORDER BY priority DESC, created_at ASC;
 
 -- name: ListActiveTasksByIssue :many
 SELECT * FROM agent_task_queue
-WHERE issue_id = $1 AND status IN ('dispatched', 'running')
+WHERE issue_id = $1 AND status IN ('pending_approval', 'queued', 'dispatched', 'running')
 ORDER BY created_at DESC;
 
 -- name: ListTasksByIssue :many
@@ -180,4 +181,16 @@ ORDER BY created_at DESC;
 -- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
+RETURNING *;
+
+-- name: ApproveAgentTask :one
+UPDATE agent_task_queue
+SET status = 'queued'
+WHERE id = $1 AND status = 'pending_approval'
+RETURNING *;
+
+-- name: RejectAgentTask :one
+UPDATE agent_task_queue
+SET status = 'cancelled', completed_at = now(), error = 'rejected by runtime owner'
+WHERE id = $1 AND status = 'pending_approval'
 RETURNING *;

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -21,8 +21,9 @@ INSERT INTO agent_runtime (
     status,
     device_info,
     metadata,
-    last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+    last_seen_at,
+    owner_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), sqlc.narg(owner_id))
 ON CONFLICT (workspace_id, daemon_id, provider)
 DO UPDATE SET
     name = EXCLUDED.name,
@@ -31,8 +32,12 @@ DO UPDATE SET
     device_info = EXCLUDED.device_info,
     metadata = EXCLUDED.metadata,
     last_seen_at = now(),
-    updated_at = now()
+    updated_at = now(),
+    owner_id = COALESCE(agent_runtime.owner_id, EXCLUDED.owner_id)
 RETURNING *;
+
+-- name: GetAgentRuntimeOwner :one
+SELECT owner_id FROM agent_runtime WHERE id = $1;
 
 -- name: UpdateAgentRuntimeHeartbeat :one
 UPDATE agent_runtime

--- a/server/pkg/protocol/events.go
+++ b/server/pkg/protocol/events.go
@@ -29,6 +29,8 @@ const (
 	EventTaskFailed    = "task:failed"
 	EventTaskMessage   = "task:message"
 	EventTaskCancelled = "task:cancelled"
+	EventTaskApproved  = "task:approved"
+	EventTaskRejected  = "task:rejected"
 
 	// Inbox events
 	EventInboxNew           = "inbox:new"


### PR DESCRIPTION
  ## Context
  When multiple teammates share a workspace, any member can assign tasks to any agent — including agents running on someone else's machine. The runtime owner has no say in what runs on their hardware. For teams that want collaborative task assignment while keeping runtime owners in control, there needs to be an opt-in approval gate: "you can assign to my agent, but I approve before it runs."

  ## Summary
  - Add `agent.approval_required` boolean (default false) — opt-in per agent
  - When enabled, tasks triggered by non-runtime-owners enter `pending_approval` status instead of `queued`
  - Self-assigned tasks (requester == runtime owner) skip approval and execute immediately
  - Approve/reject endpoints: `POST /api/issues/{id}/tasks/{taskId}/approve|reject`
  - Only the runtime owner can approve or reject
  - Inbox notification (`task_approval_required`) sent to runtime owner when approval is needed
  - Issue detail page shows approval card with Approve/Reject buttons for `pending_approval` tasks
  - Agent create/edit UI includes "Require approval" toggle

  ## How it works
  1. `EnqueueTaskForIssue` now accepts `requestedBy` parameter (the user who triggered the task)
  2. If `agent.approval_required == true` and requester != runtime owner → status = `pending_approval`
  3. `pending_approval` tasks are invisible to the daemon's claim loop (only `queued` tasks are claimable)
  4. Runtime owner approves → task transitions to `queued` → daemon picks it up
  5. Runtime owner rejects → task transitions to `cancelled`

  ## Migration
  - `agent.approval_required` (BOOLEAN, default false)
  - `agent_task_queue.requested_by` (UUID FK to user)
  - `agent_task_queue.status` CHECK expanded to include `pending_approval`
  - `agent_runtime.owner_id` (UUID FK to user) — needed for approval ownership check
  - Unique index updated to cover `pending_approval`
  - Cancel queries updated to include `pending_approval`

  ## Test plan
  - [x] Cross-user task on approval_required agent → `pending_approval` status
  - [x] Self-assigned task → skips approval, goes to `queued`
  - [x] Agent without approval_required → always `queued` regardless of requester
  - [x] Approve endpoint transitions to `queued`, only runtime owner allowed
  - [x] Reject endpoint transitions to `cancelled`, only runtime owner allowed
  - [x] Non-owner gets 403 on approve/reject
  - [x] `pending_approval` tasks not claimable by daemon
  - [x] Agent response includes `approval_required` field
  - [x] Create/update agent with `approval_required` works
  - [x] Inbox notification created for runtime owner
  - [x] Issue detail page shows approval card with Approve/Reject
  - [x] All 20 Go tests pass, existing tests pass
  - [x] `pnpm typecheck` passes, 42 TS tests pass

  🤖 Generated with [Claude Code](https://claude.com/claude-code)