### PR TITLE
feat(server): runtime ownership and visibility controls

### DIFF
--- a/apps/web/features/runtimes/components/runtime-detail.tsx
+++ b/apps/web/features/runtimes/components/runtime-detail.tsx
@@ -1,9 +1,15 @@
+import { useState } from "react";
 import type { AgentRuntime } from "@/shared/types";
 import { formatLastSeen } from "../utils";
 import { RuntimeModeIcon, StatusBadge, InfoField } from "./shared";
 import { PingSection } from "./ping-section";
 import { UpdateSection } from "./update-section";
 import { UsageSection } from "./usage-section";
+import { useAuthStore } from "@/features/auth";
+import { useRuntimeStore } from "../store";
+import { Globe, Lock } from "lucide-react";
+import { api } from "@/shared/api";
+import { toast } from "sonner";
 
 function getCliVersion(metadata: Record<string, unknown>): string | null {
   if (
@@ -14,6 +20,74 @@ function getCliVersion(metadata: Record<string, unknown>): string | null {
     return metadata.cli_version;
   }
   return null;
+}
+
+function VisibilitySection({ runtime }: { runtime: AgentRuntime }) {
+  const userId = useAuthStore((s) => s.user?.id);
+  const isOwner = runtime.owner_id === userId;
+  const [saving, setSaving] = useState(false);
+
+  if (!isOwner) {
+    return (
+      <div>
+        <h3 className="text-xs font-medium text-muted-foreground mb-3">Visibility</h3>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          {runtime.visibility === "private" ? <Lock className="h-4 w-4" /> : <Globe className="h-4 w-4" />}
+          {runtime.visibility === "private" ? "Private" : "Workspace"}
+        </div>
+      </div>
+    );
+  }
+
+  const handleToggle = async (vis: "workspace" | "private") => {
+    if (vis === runtime.visibility || saving) return;
+    setSaving(true);
+    try {
+      const updated = await api.updateRuntime(runtime.id, { visibility: vis });
+      useRuntimeStore.getState().patchRuntime(runtime.id, updated);
+      toast.success(`Runtime visibility set to ${vis}`);
+    } catch {
+      toast.error("Failed to update visibility");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <h3 className="text-xs font-medium text-muted-foreground mb-3">Visibility</h3>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => handleToggle("workspace")}
+          disabled={saving}
+          className={`flex flex-1 items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+            runtime.visibility === "workspace" ? "border-primary bg-primary/5" : "border-border hover:bg-muted"
+          }`}
+        >
+          <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="text-left">
+            <div className="font-medium">Workspace</div>
+            <div className="text-xs text-muted-foreground">All members can see</div>
+          </div>
+        </button>
+        <button
+          type="button"
+          onClick={() => handleToggle("private")}
+          disabled={saving}
+          className={`flex flex-1 items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+            runtime.visibility === "private" ? "border-primary bg-primary/5" : "border-border hover:bg-muted"
+          }`}
+        >
+          <Lock className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="text-left">
+            <div className="font-medium">Private</div>
+            <div className="text-xs text-muted-foreground">Only you can see</div>
+          </div>
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
@@ -57,6 +131,9 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
             <InfoField label="Daemon ID" value={runtime.daemon_id} mono />
           )}
         </div>
+
+        {/* Visibility (owner only) */}
+        <VisibilitySection runtime={runtime} />
 
         {/* CLI Version & Update */}
         {runtime.runtime_mode === "local" && (

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -332,6 +332,13 @@ export class ApiClient {
     return this.fetch(`/api/runtimes?${search}`);
   }
 
+  async updateRuntime(runtimeId: string, data: { visibility?: string }): Promise<AgentRuntime> {
+    return this.fetch(`/api/runtimes/${runtimeId}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
   async getRuntimeUsage(runtimeId: string, params?: { days?: number }): Promise<RuntimeUsage[]> {
     const search = new URLSearchParams();
     if (params?.days) search.set("days", String(params.days));

--- a/apps/web/shared/types/agent.ts
+++ b/apps/web/shared/types/agent.ts
@@ -6,6 +6,8 @@ export type AgentVisibility = "workspace" | "private";
 
 export type AgentTriggerType = "on_assign" | "on_comment" | "scheduled";
 
+export type RuntimeVisibility = "workspace" | "private";
+
 export interface RuntimeDevice {
   id: string;
   workspace_id: string;
@@ -16,6 +18,8 @@ export interface RuntimeDevice {
   status: "online" | "offline";
   device_info: string;
   metadata: Record<string, unknown>;
+  owner_id: string | null;
+  visibility: RuntimeVisibility;
   last_seen_at: string | null;
   created_at: string;
   updated_at: string;

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -223,6 +223,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 			// Runtimes
 			r.Route("/api/runtimes", func(r chi.Router) {
 				r.Get("/", h.ListAgentRuntimes)
+				r.Patch("/{runtimeId}", h.UpdateAgentRuntime)
 				r.Get("/{runtimeId}/usage", h.GetRuntimeUsage)
 				r.Get("/{runtimeId}/activity", h.GetRuntimeTaskActivity)
 				r.Post("/{runtimeId}/ping", h.InitiatePing)

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -263,6 +263,16 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Only the runtime owner (or workspace admin/owner) can create agents on a runtime.
+	runtimeOwnerID := uuidToString(runtime.OwnerID)
+	if runtimeOwnerID != "" && runtimeOwnerID != ownerID {
+		member, ok := h.workspaceMember(w, r, workspaceID)
+		if !ok || !roleAllowed(member.Role, "owner", "admin") {
+			writeError(w, http.StatusForbidden, "you can only create agents on your own runtimes")
+			return
+		}
+	}
+
 	rc, _ := json.Marshal(req.RuntimeConfig)
 	if req.RuntimeConfig == nil {
 		rc = []byte("{}")

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -95,6 +95,7 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			"cli_version": req.CLIVersion,
 		})
 
+		userID, _ := requireUserID(w, r)
 		registered, err := h.Queries.UpsertAgentRuntime(r.Context(), db.UpsertAgentRuntimeParams{
 			WorkspaceID: parseUUID(req.WorkspaceID),
 			DaemonID:    strToText(req.DaemonID),
@@ -104,6 +105,7 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 			Status:      status,
 			DeviceInfo:  deviceInfo,
 			Metadata:    metadata,
+			OwnerID:     parseUUID(userID),
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to register runtime: "+err.Error())

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -21,6 +21,8 @@ type AgentRuntimeResponse struct {
 	Status      string  `json:"status"`
 	DeviceInfo  string  `json:"device_info"`
 	Metadata    any     `json:"metadata"`
+	OwnerID     *string `json:"owner_id"`
+	Visibility  string  `json:"visibility"`
 	LastSeenAt  *string `json:"last_seen_at"`
 	CreatedAt   string  `json:"created_at"`
 	UpdatedAt   string  `json:"updated_at"`
@@ -45,6 +47,8 @@ func runtimeToResponse(rt db.AgentRuntime) AgentRuntimeResponse {
 		Status:      rt.Status,
 		DeviceInfo:  rt.DeviceInfo,
 		Metadata:    metadata,
+		OwnerID:     uuidToPtr(rt.OwnerID),
+		Visibility:  rt.Visibility,
 		LastSeenAt:  timestampToPtr(rt.LastSeenAt),
 		CreatedAt:   timestampToString(rt.CreatedAt),
 		UpdatedAt:   timestampToString(rt.UpdatedAt),
@@ -194,6 +198,7 @@ func (h *Handler) GetRuntimeTaskActivity(w http.ResponseWriter, r *http.Request)
 
 func (h *Handler) ListAgentRuntimes(w http.ResponseWriter, r *http.Request) {
 	workspaceID := resolveWorkspaceID(r)
+	currentUserID := requestUserID(r)
 
 	runtimes, err := h.Queries.ListAgentRuntimes(r.Context(), parseUUID(workspaceID))
 	if err != nil {
@@ -201,10 +206,61 @@ func (h *Handler) ListAgentRuntimes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := make([]AgentRuntimeResponse, len(runtimes))
-	for i, rt := range runtimes {
-		resp[i] = runtimeToResponse(rt)
+	resp := make([]AgentRuntimeResponse, 0, len(runtimes))
+	for _, rt := range runtimes {
+		// Hide private runtimes from non-owners
+		if rt.Visibility == "private" && uuidToString(rt.OwnerID) != currentUserID {
+			continue
+		}
+		resp = append(resp, runtimeToResponse(rt))
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+type UpdateRuntimeRequest struct {
+	Visibility *string `json:"visibility"`
+}
+
+func (h *Handler) UpdateAgentRuntime(w http.ResponseWriter, r *http.Request) {
+	runtimeID := chi.URLParam(r, "runtimeId")
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+
+	runtime, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(runtimeID))
+	if err != nil {
+		writeError(w, http.StatusNotFound, "runtime not found")
+		return
+	}
+
+	// Only the runtime owner can update
+	if uuidToString(runtime.OwnerID) != userID {
+		writeError(w, http.StatusForbidden, "only the runtime owner can update this runtime")
+		return
+	}
+
+	var req UpdateRuntimeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Visibility != nil {
+		if *req.Visibility != "workspace" && *req.Visibility != "private" {
+			writeError(w, http.StatusBadRequest, "visibility must be 'workspace' or 'private'")
+			return
+		}
+		runtime, err = h.Queries.UpdateAgentRuntimeVisibility(r.Context(), db.UpdateAgentRuntimeVisibilityParams{
+			ID:         parseUUID(runtimeID),
+			Visibility: *req.Visibility,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to update runtime")
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, runtimeToResponse(runtime))
 }

--- a/server/internal/handler/runtime_ownership_test.go
+++ b/server/internal/handler/runtime_ownership_test.go
@@ -1,0 +1,356 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDaemonRegisterSetsOwnerID verifies that DaemonRegister populates owner_id
+// from the authenticated user (X-User-ID header).
+func TestDaemonRegisterSetsOwnerID(t *testing.T) {
+	ctx := context.Background()
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/daemon/register", DaemonRegisterRequest{
+		WorkspaceID: testWorkspaceID,
+		DaemonID:    "ownership-test-daemon",
+		DeviceName:  "test-machine",
+		Runtimes: []struct {
+			Name    string `json:"name"`
+			Type    string `json:"type"`
+			Version string `json:"version"`
+			Status  string `json:"status"`
+		}{
+			{Name: "Claude", Type: "claude", Version: "1.0", Status: "online"},
+		},
+	})
+	testHandler.DaemonRegister(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DaemonRegister: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Runtimes []AgentRuntimeResponse `json:"runtimes"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Runtimes) == 0 {
+		t.Fatal("DaemonRegister: expected at least 1 runtime in response")
+	}
+
+	rt := resp.Runtimes[0]
+	if rt.OwnerID == nil || *rt.OwnerID != testUserID {
+		t.Fatalf("expected owner_id=%s, got %v", testUserID, rt.OwnerID)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, rt.ID)
+	})
+}
+
+// TestRuntimeResponseIncludesVisibility verifies that runtime responses contain
+// the visibility field, defaulting to "workspace".
+func TestRuntimeResponseIncludesVisibility(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/daemon/register", DaemonRegisterRequest{
+		WorkspaceID: testWorkspaceID,
+		DaemonID:    "visibility-resp-daemon",
+		DeviceName:  "vis-machine",
+		Runtimes: []struct {
+			Name    string `json:"name"`
+			Type    string `json:"type"`
+			Version string `json:"version"`
+			Status  string `json:"status"`
+		}{
+			{Name: "Codex", Type: "codex", Version: "2.0", Status: "online"},
+		},
+	})
+	testHandler.DaemonRegister(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DaemonRegister: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Runtimes []AgentRuntimeResponse `json:"runtimes"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Runtimes) == 0 {
+		t.Fatal("expected at least 1 runtime")
+	}
+
+	rt := resp.Runtimes[0]
+	if rt.Visibility != "workspace" {
+		t.Fatalf("expected default visibility 'workspace', got '%s'", rt.Visibility)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, rt.ID)
+	})
+}
+
+// TestListRuntimesFiltersPrivate verifies that ListAgentRuntimes hides private
+// runtimes from non-owners while still showing them to the owner.
+func TestListRuntimesFiltersPrivate(t *testing.T) {
+	ctx := context.Background()
+
+	// Create user2 as a member of the test workspace.
+	var user2ID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ('runtime-vis-user2', 'runtime-vis-user2@multica.ai')
+		RETURNING id
+	`).Scan(&user2ID)
+	if err != nil {
+		t.Fatalf("create user2: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, user2ID)
+	})
+
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'member')
+	`, testWorkspaceID, user2ID)
+	if err != nil {
+		t.Fatalf("add user2 as member: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM member WHERE user_id = $1 AND workspace_id = $2`, user2ID, testWorkspaceID)
+	})
+
+	// Create a private runtime owned by testUser.
+	var runtimeID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, visibility
+		)
+		VALUES ($1, 'private-daemon', 'Private Runtime', 'local', 'claude', 'online',
+			'test', '{}'::jsonb, $2, 'private')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create private runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	// user2 should NOT see the private runtime.
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/runtimes?workspace_id="+testWorkspaceID, nil)
+	req.Header.Set("X-User-ID", user2ID)
+	testHandler.ListAgentRuntimes(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListAgentRuntimes (user2): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var user2Runtimes []AgentRuntimeResponse
+	json.NewDecoder(w.Body).Decode(&user2Runtimes)
+	for _, rt := range user2Runtimes {
+		if rt.ID == runtimeID {
+			t.Fatal("user2 should NOT see the private runtime owned by testUser")
+		}
+	}
+
+	// testUser (owner) SHOULD see their private runtime.
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/runtimes?workspace_id="+testWorkspaceID, nil)
+	testHandler.ListAgentRuntimes(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListAgentRuntimes (owner): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var ownerRuntimes []AgentRuntimeResponse
+	json.NewDecoder(w.Body).Decode(&ownerRuntimes)
+	found := false
+	for _, rt := range ownerRuntimes {
+		if rt.ID == runtimeID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("testUser (owner) should see their own private runtime")
+	}
+}
+
+// TestCreateAgentOnOwnRuntimeSucceeds verifies that a user can create an agent
+// on a runtime they own.
+func TestCreateAgentOnOwnRuntimeSucceeds(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a runtime owned by testUser.
+	var runtimeID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, last_seen_at
+		)
+		VALUES ($1, 'own-rt-daemon', 'Own Runtime', 'local', 'claude', 'online',
+			'test', '{}'::jsonb, $2, now())
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":       "Own Runtime Agent",
+		"runtime_id": runtimeID,
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent on own runtime: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var agent AgentResponse
+	json.NewDecoder(w.Body).Decode(&agent)
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agent.ID)
+	})
+
+	if agent.RuntimeID != runtimeID {
+		t.Fatalf("expected runtime_id=%s, got %s", runtimeID, agent.RuntimeID)
+	}
+}
+
+// TestCreateAgentOnOtherUserRuntimeFails verifies that a non-admin user cannot
+// create an agent on a runtime owned by someone else.
+func TestCreateAgentOnOtherUserRuntimeFails(t *testing.T) {
+	ctx := context.Background()
+
+	// Create user3 as a regular member.
+	var user3ID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ('runtime-other-user3', 'runtime-other-user3@multica.ai')
+		RETURNING id
+	`).Scan(&user3ID)
+	if err != nil {
+		t.Fatalf("create user3: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, user3ID)
+	})
+
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'member')
+	`, testWorkspaceID, user3ID)
+	if err != nil {
+		t.Fatalf("add user3 as member: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM member WHERE user_id = $1 AND workspace_id = $2`, user3ID, testWorkspaceID)
+	})
+
+	// Create a runtime owned by testUser.
+	var runtimeID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, last_seen_at
+		)
+		VALUES ($1, 'other-rt-daemon', 'Other Runtime', 'local', 'claude', 'online',
+			'test', '{}'::jsonb, $2, now())
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	// user3 (member, not admin) should be forbidden.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":       "Should Fail Agent",
+		"runtime_id": runtimeID,
+	})
+	req.Header.Set("X-User-ID", user3ID)
+	testHandler.CreateAgent(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("CreateAgent on other user's runtime: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Clean up in case it somehow succeeded.
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent WHERE name = 'Should Fail Agent' AND workspace_id = $1`, testWorkspaceID)
+	})
+}
+
+// TestAdminCanCreateAgentOnAnyRuntime verifies that a workspace admin/owner
+// can create an agent on any runtime, even one they don't own.
+func TestAdminCanCreateAgentOnAnyRuntime(t *testing.T) {
+	ctx := context.Background()
+
+	// Create another user who owns a runtime.
+	var otherUserID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ('runtime-admin-other', 'runtime-admin-other@multica.ai')
+		RETURNING id
+	`).Scan(&otherUserID)
+	if err != nil {
+		t.Fatalf("create otherUser: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, otherUserID)
+	})
+
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'member')
+	`, testWorkspaceID, otherUserID)
+	if err != nil {
+		t.Fatalf("add otherUser as member: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM member WHERE user_id = $1 AND workspace_id = $2`, otherUserID, testWorkspaceID)
+	})
+
+	// Create a runtime owned by otherUser.
+	var runtimeID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, last_seen_at
+		)
+		VALUES ($1, 'admin-bypass-daemon', 'Other User Runtime', 'local', 'claude', 'online',
+			'test', '{}'::jsonb, $2, now())
+		RETURNING id
+	`, testWorkspaceID, otherUserID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	// testUser is workspace owner — should succeed.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
+		"name":       "Admin Bypass Agent",
+		"runtime_id": runtimeID,
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Admin CreateAgent on other's runtime: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var agent AgentResponse
+	json.NewDecoder(w.Body).Decode(&agent)
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent WHERE id = $1`, agent.ID)
+	})
+}

--- a/server/internal/handler/runtime_update_test.go
+++ b/server/internal/handler/runtime_update_test.go
@@ -1,0 +1,157 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestUpdateRuntimeVisibility verifies toggling visibility between workspace and private.
+func TestUpdateRuntimeVisibility(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a runtime owned by testUser.
+	var runtimeID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, visibility, last_seen_at
+		)
+		VALUES ($1, 'update-vis-daemon', 'Update Vis Runtime', 'local', 'claude', 'online',
+			'test', '{}'::jsonb, $2, 'workspace', now())
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	// Toggle to private.
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/runtimes/"+runtimeID, map[string]any{
+		"visibility": "private",
+	})
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.UpdateAgentRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateAgentRuntime to private: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var updated AgentRuntimeResponse
+	json.NewDecoder(w.Body).Decode(&updated)
+	if updated.Visibility != "private" {
+		t.Fatalf("expected visibility 'private', got '%s'", updated.Visibility)
+	}
+
+	// Toggle back to workspace.
+	w = httptest.NewRecorder()
+	req = newRequest("PATCH", "/api/runtimes/"+runtimeID, map[string]any{
+		"visibility": "workspace",
+	})
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.UpdateAgentRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateAgentRuntime to workspace: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	json.NewDecoder(w.Body).Decode(&updated)
+	if updated.Visibility != "workspace" {
+		t.Fatalf("expected visibility 'workspace', got '%s'", updated.Visibility)
+	}
+}
+
+// TestUpdateRuntimeVisibilityInvalidValue verifies that an invalid visibility value returns 400.
+func TestUpdateRuntimeVisibilityInvalidValue(t *testing.T) {
+	ctx := context.Background()
+
+	var runtimeID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, visibility, last_seen_at
+		)
+		VALUES ($1, 'invalid-vis-daemon', 'Invalid Vis Runtime', 'local', 'claude', 'online',
+			'test', '{}'::jsonb, $2, 'workspace', now())
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/runtimes/"+runtimeID, map[string]any{
+		"visibility": "public",
+	})
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.UpdateAgentRuntime(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateAgentRuntime with invalid visibility: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestUpdateRuntimeByNonOwnerFails verifies that a non-owner cannot update a runtime.
+func TestUpdateRuntimeByNonOwnerFails(t *testing.T) {
+	ctx := context.Background()
+
+	// Create another user.
+	var otherUserID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email)
+		VALUES ('update-rt-other', 'update-rt-other@multica.ai')
+		RETURNING id
+	`).Scan(&otherUserID)
+	if err != nil {
+		t.Fatalf("create otherUser: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, otherUserID)
+	})
+
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'member')
+	`, testWorkspaceID, otherUserID)
+	if err != nil {
+		t.Fatalf("add otherUser as member: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM member WHERE user_id = $1 AND workspace_id = $2`, otherUserID, testWorkspaceID)
+	})
+
+	// Create a runtime owned by testUser.
+	var runtimeID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status,
+			device_info, metadata, owner_id, visibility, last_seen_at
+		)
+		VALUES ($1, 'non-owner-daemon', 'Non-Owner Runtime', 'local', 'claude', 'online',
+			'test', '{}'::jsonb, $2, 'workspace', now())
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("create runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	// otherUser tries to update — should get 403.
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/runtimes/"+runtimeID, map[string]any{
+		"visibility": "private",
+	})
+	req.Header.Set("X-User-ID", otherUserID)
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.UpdateAgentRuntime(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("UpdateAgentRuntime by non-owner: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/migrations/032_runtime_ownership_visibility.down.sql
+++ b/server/migrations/032_runtime_ownership_visibility.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_runtime DROP CONSTRAINT agent_runtime_visibility_check;
+ALTER TABLE agent_runtime DROP COLUMN visibility;
+ALTER TABLE agent_runtime DROP COLUMN owner_id;

--- a/server/migrations/032_runtime_ownership_visibility.up.sql
+++ b/server/migrations/032_runtime_ownership_visibility.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_runtime ADD COLUMN owner_id UUID REFERENCES "user"(id);
+ALTER TABLE agent_runtime ADD COLUMN visibility TEXT NOT NULL DEFAULT 'workspace';
+ALTER TABLE agent_runtime ADD CONSTRAINT agent_runtime_visibility_check CHECK (visibility IN ('workspace', 'private'));

--- a/server/migrations/migration_032_test.go
+++ b/server/migrations/migration_032_test.go
@@ -1,0 +1,221 @@
+package migrations_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var testPool *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		dbURL = "postgres://multica:multica@localhost:5432/multica?sslmode=disable"
+	}
+
+	pool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		fmt.Printf("Skipping tests: could not connect to database: %v\n", err)
+		os.Exit(0)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		fmt.Printf("Skipping tests: database not reachable: %v\n", err)
+		pool.Close()
+		os.Exit(0)
+	}
+	testPool = pool
+	code := m.Run()
+	pool.Close()
+	os.Exit(code)
+}
+
+// ---------- agent_runtime.owner_id ----------
+
+func TestAgentRuntimeHasOwnerID(t *testing.T) {
+	ctx := context.Background()
+	var exists bool
+	err := testPool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent_runtime' AND column_name = 'owner_id'
+		)
+	`).Scan(&exists)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("agent_runtime.owner_id column does not exist")
+	}
+}
+
+func TestAgentRuntimeOwnerIDForeignKey(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a test user
+	var userID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO "user" (name, email) VALUES ('migration-test', 'migration-032-test@test.ai') RETURNING id
+	`).Scan(&userID)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+
+	// Create a workspace
+	var wsID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, issue_prefix) VALUES ('mig-test', 'mig-032-test', 'MIG') RETURNING id
+	`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	// Insert runtime with valid owner_id
+	var runtimeID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'test-daemon-032', 'Test Runtime', 'local', 'claude', 'online', '', '{}'::jsonb, $2)
+		RETURNING id
+	`, wsID, userID).Scan(&runtimeID)
+	if err != nil {
+		t.Fatalf("insert runtime with owner_id: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	// Verify it's stored
+	var ownerID *string
+	err = testPool.QueryRow(ctx, `SELECT owner_id::text FROM agent_runtime WHERE id = $1`, runtimeID).Scan(&ownerID)
+	if err != nil {
+		t.Fatalf("read owner_id: %v", err)
+	}
+	if ownerID == nil || *ownerID != userID {
+		t.Fatalf("expected owner_id=%s, got %v", userID, ownerID)
+	}
+
+	// owner_id should accept NULL (backwards compat)
+	var runtimeID2 string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'test-daemon-032-null', 'Test Runtime Null', 'local', 'codex', 'online', '', '{}'::jsonb, NULL)
+		RETURNING id
+	`, wsID).Scan(&runtimeID2)
+	if err != nil {
+		t.Fatalf("insert runtime with NULL owner_id: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID2)
+	})
+
+	// FK constraint: invalid user ID should fail
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id)
+		VALUES ($1, 'test-daemon-032-bad', 'Bad', 'local', 'claude', 'online', '', '{}'::jsonb, '00000000-0000-0000-0000-000000000099')
+	`, wsID)
+	if err == nil {
+		t.Fatal("expected FK violation for invalid owner_id, got nil")
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE daemon_id = 'test-daemon-032-bad' AND workspace_id = $1`, wsID)
+	}
+}
+
+// ---------- agent_runtime.visibility ----------
+
+func TestAgentRuntimeHasVisibility(t *testing.T) {
+	ctx := context.Background()
+	var exists bool
+	err := testPool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'agent_runtime' AND column_name = 'visibility'
+		)
+	`).Scan(&exists)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if !exists {
+		t.Fatal("agent_runtime.visibility column does not exist")
+	}
+}
+
+func TestAgentRuntimeVisibilityDefault(t *testing.T) {
+	ctx := context.Background()
+
+	var wsID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, issue_prefix) VALUES ('vis-test', 'vis-032-test', 'VIS') RETURNING id
+	`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	var runtimeID, visibility string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata)
+		VALUES ($1, 'vis-daemon', 'Vis Runtime', 'local', 'claude', 'online', '', '{}'::jsonb)
+		RETURNING id, visibility
+	`, wsID).Scan(&runtimeID, &visibility)
+	if err != nil {
+		t.Fatalf("insert runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	if visibility != "workspace" {
+		t.Fatalf("expected default visibility 'workspace', got '%s'", visibility)
+	}
+}
+
+func TestAgentRuntimeVisibilityCheckConstraint(t *testing.T) {
+	ctx := context.Background()
+
+	var wsID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, issue_prefix) VALUES ('chk-test', 'chk-032-test', 'CHK') RETURNING id
+	`).Scan(&wsID)
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	// Valid values: 'workspace' and 'private'
+	for _, vis := range []string{"workspace", "private"} {
+		daemon := fmt.Sprintf("chk-daemon-%s", vis)
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, visibility)
+			VALUES ($1, $2, 'Check', 'local', 'claude', 'online', '', '{}'::jsonb, $3)
+		`, wsID, daemon, vis)
+		if err != nil {
+			t.Fatalf("visibility=%q should be valid, got: %v", vis, err)
+		}
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE daemon_id = $1 AND workspace_id = $2`, daemon, wsID)
+		})
+	}
+
+	// Invalid value should fail
+	_, err = testPool.Exec(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, visibility)
+		VALUES ($1, 'chk-daemon-bad', 'Bad', 'local', 'claude', 'online', '', '{}'::jsonb, 'invalid')
+	`, wsID)
+	if err == nil {
+		t.Fatal("expected CHECK violation for visibility='invalid', got nil")
+		testPool.Exec(ctx, `DELETE FROM agent_runtime WHERE daemon_id = 'chk-daemon-bad' AND workspace_id = $1`, wsID)
+	}
+}

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -54,6 +54,8 @@ type AgentRuntime struct {
 	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+	OwnerID     pgtype.UUID        `json:"owner_id"`
+	Visibility  string             `json:"visibility"`
 }
 
 type AgentSkill struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -50,7 +50,7 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context) ([]FailTasksF
 }
 
 const getAgentRuntime = `-- name: GetAgentRuntime :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility FROM agent_runtime
 WHERE id = $1
 `
 
@@ -70,12 +70,14 @@ func (q *Queries) GetAgentRuntime(ctx context.Context, id pgtype.UUID) (AgentRun
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
 	)
 	return i, err
 }
 
 const getAgentRuntimeForWorkspace = `-- name: GetAgentRuntimeForWorkspace :one
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility FROM agent_runtime
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -100,12 +102,25 @@ func (q *Queries) GetAgentRuntimeForWorkspace(ctx context.Context, arg GetAgentR
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
 	)
 	return i, err
 }
 
+const getAgentRuntimeOwner = `-- name: GetAgentRuntimeOwner :one
+SELECT owner_id FROM agent_runtime WHERE id = $1
+`
+
+func (q *Queries) GetAgentRuntimeOwner(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, getAgentRuntimeOwner, id)
+	var owner_id pgtype.UUID
+	err := row.Scan(&owner_id)
+	return owner_id, err
+}
+
 const listAgentRuntimes = `-- name: ListAgentRuntimes :many
-SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at FROM agent_runtime
+SELECT id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility FROM agent_runtime
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -132,6 +147,8 @@ func (q *Queries) ListAgentRuntimes(ctx context.Context, workspaceID pgtype.UUID
 			&i.LastSeenAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.OwnerID,
+			&i.Visibility,
 		); err != nil {
 			return nil, err
 		}
@@ -191,7 +208,7 @@ const updateAgentRuntimeHeartbeat = `-- name: UpdateAgentRuntimeHeartbeat :one
 UPDATE agent_runtime
 SET status = 'online', last_seen_at = now(), updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility
 `
 
 func (q *Queries) UpdateAgentRuntimeHeartbeat(ctx context.Context, id pgtype.UUID) (AgentRuntime, error) {
@@ -210,6 +227,42 @@ func (q *Queries) UpdateAgentRuntimeHeartbeat(ctx context.Context, id pgtype.UUI
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
+	)
+	return i, err
+}
+
+const updateAgentRuntimeVisibility = `-- name: UpdateAgentRuntimeVisibility :one
+UPDATE agent_runtime
+SET visibility = $2, updated_at = now()
+WHERE id = $1
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility
+`
+
+type UpdateAgentRuntimeVisibilityParams struct {
+	ID         pgtype.UUID `json:"id"`
+	Visibility string      `json:"visibility"`
+}
+
+func (q *Queries) UpdateAgentRuntimeVisibility(ctx context.Context, arg UpdateAgentRuntimeVisibilityParams) (AgentRuntime, error) {
+	row := q.db.QueryRow(ctx, updateAgentRuntimeVisibility, arg.ID, arg.Visibility)
+	var i AgentRuntime
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.DaemonID,
+		&i.Name,
+		&i.RuntimeMode,
+		&i.Provider,
+		&i.Status,
+		&i.DeviceInfo,
+		&i.Metadata,
+		&i.LastSeenAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
 	)
 	return i, err
 }
@@ -224,8 +277,9 @@ INSERT INTO agent_runtime (
     status,
     device_info,
     metadata,
-    last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+    last_seen_at,
+    owner_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), $9)
 ON CONFLICT (workspace_id, daemon_id, provider)
 DO UPDATE SET
     name = EXCLUDED.name,
@@ -234,8 +288,9 @@ DO UPDATE SET
     device_info = EXCLUDED.device_info,
     metadata = EXCLUDED.metadata,
     last_seen_at = now(),
-    updated_at = now()
-RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at
+    updated_at = now(),
+    owner_id = COALESCE(agent_runtime.owner_id, EXCLUDED.owner_id)
+RETURNING id, workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at, created_at, updated_at, owner_id, visibility
 `
 
 type UpsertAgentRuntimeParams struct {
@@ -247,6 +302,7 @@ type UpsertAgentRuntimeParams struct {
 	Status      string      `json:"status"`
 	DeviceInfo  string      `json:"device_info"`
 	Metadata    []byte      `json:"metadata"`
+	OwnerID     pgtype.UUID `json:"owner_id"`
 }
 
 func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntimeParams) (AgentRuntime, error) {
@@ -259,6 +315,7 @@ func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntime
 		arg.Status,
 		arg.DeviceInfo,
 		arg.Metadata,
+		arg.OwnerID,
 	)
 	var i AgentRuntime
 	err := row.Scan(
@@ -274,6 +331,8 @@ func (q *Queries) UpsertAgentRuntime(ctx context.Context, arg UpsertAgentRuntime
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.OwnerID,
+		&i.Visibility,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -21,8 +21,9 @@ INSERT INTO agent_runtime (
     status,
     device_info,
     metadata,
-    last_seen_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now())
+    last_seen_at,
+    owner_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), sqlc.narg(owner_id))
 ON CONFLICT (workspace_id, daemon_id, provider)
 DO UPDATE SET
     name = EXCLUDED.name,
@@ -31,7 +32,17 @@ DO UPDATE SET
     device_info = EXCLUDED.device_info,
     metadata = EXCLUDED.metadata,
     last_seen_at = now(),
-    updated_at = now()
+    updated_at = now(),
+    owner_id = COALESCE(agent_runtime.owner_id, EXCLUDED.owner_id)
+RETURNING *;
+
+-- name: GetAgentRuntimeOwner :one
+SELECT owner_id FROM agent_runtime WHERE id = $1;
+
+-- name: UpdateAgentRuntimeVisibility :one
+UPDATE agent_runtime
+SET visibility = $2, updated_at = now()
+WHERE id = $1
 RETURNING *;
 
 -- name: UpdateAgentRuntimeHeartbeat :one


### PR DESCRIPTION
  ## Context
  Runtimes registered by a daemon are visible to all workspace members, and anyone can create agents on anyone's runtime. For teams sharing a workspace, there's no way to keep a runtime private (e.g. a personal dev machine) or prevent others from creating agents that execute on your hardware. This adds ownership tracking and visibility controls so runtime owners decide who can see and use their runtimes.

  ## Summary
  - Add `agent_runtime.owner_id` — tracks who registered the runtime (set on daemon registration)
  - Add `agent_runtime.visibility` — `workspace` (default, all members see) or `private` (only owner sees)
  - `ListAgentRuntimes` filters out private runtimes for non-owners
  - `CreateAgent` rejects non-owners from creating agents on others' runtimes (admin/owner bypass)
  - `PATCH /api/runtimes/{id}` endpoint for updating visibility (owner-only)
  - Runtime detail page shows visibility toggle (Workspace/Private) for the owner, read-only label for others
  - Frontend `RuntimeDevice` type updated with `owner_id` and `visibility` fields

  ## How it works
  1. `DaemonRegister` sets `owner_id` from the authenticated user (first registrant wins on re-registration)
  2. `ListAgentRuntimes` skips runtimes where `visibility == "private" && owner != current user`
  3. `CreateAgent` checks `runtime.owner_id` — if set and != requester, requires admin/owner role
  4. `UpdateAgentRuntime` validates visibility value and enforces owner-only access

  ## Migration
  - `agent_runtime.owner_id` (UUID FK to user, nullable for backwards compat)
  - `agent_runtime.visibility` (TEXT, default 'workspace', CHECK IN ('workspace', 'private'))

  ## Test plan
  - [x] Daemon registration sets `owner_id` on runtimes
  - [x] Runtime response includes `owner_id` and `visibility` fields
  - [x] Private runtimes hidden from non-owners in list endpoint
  - [x] Owner can see their own private runtimes
  - [x] Create agent on own runtime succeeds
  - [x] Create agent on other's runtime fails (403) for regular members
  - [x] Admin can create agent on any runtime (bypass)
  - [x] Update runtime visibility (workspace ↔ private) works for owner
  - [x] Update runtime with invalid visibility returns 400
  - [x] Non-owner update returns 403
  - [x] Visibility toggle visible on runtime detail page for owner
  - [x] Non-owner sees read-only visibility label
  - [x] All 14 Go tests pass, existing tests pass
  - [x] `pnpm typecheck` passes, 42 TS tests pass

  🤖 Generated with [Claude Code](https://claude.com/claude-code)