### PR TITLE
feat(auth): add registration controls with open/invite_only/closed modes

### DIFF
--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -202,6 +202,32 @@ func (h *Handler) findOrCreateUser(ctx context.Context, email string) (db.User, 
 	return user, nil
 }
 
+func registrationMode() string {
+	mode := os.Getenv("MULTICA_REGISTRATION_MODE")
+	if mode == "" {
+		return "open"
+	}
+	return mode
+}
+
+func isEmailDomainAllowed(email string) bool {
+	domains := os.Getenv("MULTICA_ALLOWED_DOMAINS")
+	if domains == "" {
+		return true
+	}
+	at := strings.Index(email, "@")
+	if at < 0 {
+		return false
+	}
+	emailDomain := strings.ToLower(email[at+1:])
+	for _, d := range strings.Split(domains, ",") {
+		if strings.ToLower(strings.TrimSpace(d)) == emailDomain {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *Handler) SendCode(w http.ResponseWriter, r *http.Request) {
 	var req SendCodeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -213,6 +239,31 @@ func (h *Handler) SendCode(w http.ResponseWriter, r *http.Request) {
 	if email == "" {
 		writeError(w, http.StatusBadRequest, "email is required")
 		return
+	}
+
+	mode := registrationMode()
+
+	if mode == "closed" {
+		writeError(w, http.StatusForbidden, "registration is closed")
+		return
+	}
+	if !isEmailDomainAllowed(email) {
+		writeError(w, http.StatusForbidden, "email domain is not allowed")
+		return
+	}
+
+	// In invite_only mode, reject upfront if user doesn't exist or has no workspace
+	if mode == "invite_only" {
+		user, err := h.Queries.GetUserByEmail(r.Context(), email)
+		if err != nil {
+			writeError(w, http.StatusForbidden, "registration is invite-only; ask a workspace admin to add you first")
+			return
+		}
+		workspaces, err := h.Queries.ListWorkspaces(r.Context(), user.ID)
+		if err != nil || len(workspaces) == 0 {
+			writeError(w, http.StatusForbidden, "registration is invite-only; ask a workspace admin to add you first")
+			return
+		}
 	}
 
 	// Rate limit: max 1 code per 10 seconds per email
@@ -282,15 +333,31 @@ func (h *Handler) VerifyCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	mode := registrationMode()
+	if mode == "invite_only" {
+		existingUser, lookupErr := h.Queries.GetUserByEmail(r.Context(), email)
+		if lookupErr != nil {
+			writeError(w, http.StatusForbidden, "registration is invite-only; ask a workspace admin to add you first")
+			return
+		}
+		workspaces, wsErr := h.Queries.ListWorkspaces(r.Context(), existingUser.ID)
+		if wsErr != nil || len(workspaces) == 0 {
+			writeError(w, http.StatusForbidden, "registration is invite-only; ask a workspace admin to add you first")
+			return
+		}
+	}
+
 	user, err := h.findOrCreateUser(r.Context(), email)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create user")
 		return
 	}
 
-	if err := h.ensureUserWorkspace(r.Context(), user); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to provision workspace")
-		return
+	if mode != "invite_only" {
+		if err := h.ensureUserWorkspace(r.Context(), user); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to provision workspace")
+			return
+		}
 	}
 
 	tokenString, err := h.issueJWT(user)

--- a/server/internal/handler/registration_test.go
+++ b/server/internal/handler/registration_test.go
@@ -1,0 +1,276 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestRegistrationModeOpen(t *testing.T) {
+	os.Unsetenv("MULTICA_REGISTRATION_MODE")
+	os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	t.Cleanup(func() {
+		os.Unsetenv("MULTICA_REGISTRATION_MODE")
+		os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	})
+
+	const email = "reg-open-test@multica.ai"
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM verification_code WHERE email = $1`, email)
+		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SendCode in open mode: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegistrationModeInviteOnly(t *testing.T) {
+	os.Setenv("MULTICA_REGISTRATION_MODE", "invite_only")
+	os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	t.Cleanup(func() {
+		os.Unsetenv("MULTICA_REGISTRATION_MODE")
+		os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	})
+
+	const email = "reg-invite-new@multica.ai"
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM verification_code WHERE email = $1`, email)
+		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	// SendCode itself should reject — no email wasted
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("SendCode invite_only (new user): expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegistrationModeInviteOnlyAllowsExistingMember(t *testing.T) {
+	os.Setenv("MULTICA_REGISTRATION_MODE", "invite_only")
+	os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	t.Cleanup(func() {
+		os.Unsetenv("MULTICA_REGISTRATION_MODE")
+		os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	})
+
+	// The handler test fixture already created a user (handlerTestEmail) who is a
+	// member of a workspace. Use that email to verify invite_only allows existing members.
+	const email = handlerTestEmail
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM verification_code WHERE email = $1`, email)
+	})
+
+	// Send code
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SendCode: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Read code from DB
+	ctx := context.Background()
+	dbCode, err := testHandler.Queries.GetLatestVerificationCode(ctx, email)
+	if err != nil {
+		t.Fatalf("GetLatestVerificationCode: %v", err)
+	}
+
+	// VerifyCode should succeed because user exists and has a workspace
+	w = httptest.NewRecorder()
+	buf.Reset()
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email, "code": dbCode.Code})
+	req = httptest.NewRequest("POST", "/auth/verify-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.VerifyCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("VerifyCode for existing member in invite_only: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp LoginResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Token == "" {
+		t.Fatal("VerifyCode: expected non-empty token")
+	}
+}
+
+func TestRegistrationModeClosed(t *testing.T) {
+	os.Setenv("MULTICA_REGISTRATION_MODE", "closed")
+	os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	t.Cleanup(func() {
+		os.Unsetenv("MULTICA_REGISTRATION_MODE")
+		os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	})
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": "reg-closed@multica.ai"})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("SendCode in closed mode: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "registration is closed" {
+		t.Fatalf("expected error 'registration is closed', got %q", resp["error"])
+	}
+}
+
+func TestAllowedDomainsAccepted(t *testing.T) {
+	os.Unsetenv("MULTICA_REGISTRATION_MODE")
+	os.Setenv("MULTICA_ALLOWED_DOMAINS", "multica.ai,example.com")
+	t.Cleanup(func() {
+		os.Unsetenv("MULTICA_REGISTRATION_MODE")
+		os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	})
+
+	const email = "domain-ok@multica.ai"
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM verification_code WHERE email = $1`, email)
+		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SendCode with allowed domain: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAllowedDomainsRejected(t *testing.T) {
+	os.Unsetenv("MULTICA_REGISTRATION_MODE")
+	os.Setenv("MULTICA_ALLOWED_DOMAINS", "multica.ai,example.com")
+	t.Cleanup(func() {
+		os.Unsetenv("MULTICA_REGISTRATION_MODE")
+		os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	})
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": "blocked@evil.com"})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("SendCode with blocked domain: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "email domain is not allowed" {
+		t.Fatalf("expected error 'email domain is not allowed', got %q", resp["error"])
+	}
+}
+
+func TestAllowedDomainsEmptyMeansAll(t *testing.T) {
+	os.Unsetenv("MULTICA_REGISTRATION_MODE")
+	os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	t.Cleanup(func() {
+		os.Unsetenv("MULTICA_REGISTRATION_MODE")
+		os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	})
+
+	const email = "anyone@anydomain.org"
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM verification_code WHERE email = $1`, email)
+		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SendCode with no domain restriction: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegistrationModeInviteOnlyNoAutoWorkspace(t *testing.T) {
+	os.Setenv("MULTICA_REGISTRATION_MODE", "invite_only")
+	os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	t.Cleanup(func() {
+		os.Unsetenv("MULTICA_REGISTRATION_MODE")
+		os.Unsetenv("MULTICA_ALLOWED_DOMAINS")
+	})
+
+	// Use the existing fixture user who already has a workspace.
+	const email = handlerTestEmail
+	ctx := context.Background()
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM verification_code WHERE email = $1`, email)
+	})
+
+	// Count workspaces before
+	user, err := testHandler.Queries.GetUserByEmail(ctx, email)
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	wsBefore, err := testHandler.Queries.ListWorkspaces(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListWorkspaces before: %v", err)
+	}
+
+	// Send code
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SendCode: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Read code from DB
+	dbCode, err := testHandler.Queries.GetLatestVerificationCode(ctx, email)
+	if err != nil {
+		t.Fatalf("GetLatestVerificationCode: %v", err)
+	}
+
+	// Verify
+	w = httptest.NewRecorder()
+	buf.Reset()
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email, "code": dbCode.Code})
+	req = httptest.NewRequest("POST", "/auth/verify-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.VerifyCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("VerifyCode: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Count workspaces after — should be unchanged (no auto-creation)
+	wsAfter, err := testHandler.Queries.ListWorkspaces(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListWorkspaces after: %v", err)
+	}
+	if len(wsAfter) != len(wsBefore) {
+		t.Fatalf("invite_only should not auto-create workspace: had %d before, got %d after", len(wsBefore), len(wsAfter))
+	}
+}


### PR DESCRIPTION
  ## Context
  Self-hosted Multica instances are open by default — anyone who knows the URL can create an account and a workspace. For small teams hosting on their own infrastructure, there's no way to restrict who can sign up without putting an auth proxy in front. This is the first layer of a three-layer access model: server-level auth gating (this PR), workspace creation policy (future), and per-workspace membership (already exists via Settings > Members).

  ## Summary
  - Add `MULTICA_REGISTRATION_MODE` env var: `open` (default), `invite_only`, `closed`
  - Add `MULTICA_ALLOWED_DOMAINS` env var: comma-separated domain whitelist (empty = all allowed)
  - **open**: current behavior — anyone can sign up and gets a workspace
  - **invite_only**: only users pre-added as members to a workspace can log in. Rejected at SendCode before any email is sent
  - **closed**: SendCode itself returns 403 — no new accounts
  - Domain filter applies on top of any mode (e.g. invite_only + only `@company.com`)
  - No auto-workspace creation in invite_only mode

  ## How it works
  1. `SendCode` checks mode + domain before generating/sending verification code
  2. In `invite_only`, looks up user by email and checks workspace membership — rejects before sending email if not found
  3. `VerifyCode` has a secondary check for `invite_only` (defense in depth)
  4. `ensureUserWorkspace` skipped in `invite_only` mode — users only see workspaces they were invited to

  ## Test plan
  - [x] Default (open): signup works as before, workspace auto-created
  - [x] `MULTICA_REGISTRATION_MODE=invite_only`: new email gets 403 at SendCode (no email sent)
  - [x] invite_only: pre-added member can log in successfully
  - [x] invite_only: no extra workspace auto-created for existing members
  - [x] `MULTICA_REGISTRATION_MODE=closed`: SendCode returns 403
  - [x] `MULTICA_ALLOWED_DOMAINS=company.com`: allowed domain succeeds
  - [x] `MULTICA_ALLOWED_DOMAINS=company.com`: other domain gets 403
  - [x] Empty `MULTICA_ALLOWED_DOMAINS`: all domains allowed
  - [x] All 8 Go tests pass, existing handler tests pass

  🤖 Generated with [Claude Code](https://claude.com/claude-code)