### PR TITLE
feat(agents): hide archived agents from default list

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -1688,7 +1688,7 @@ export default function AgentsPage() {
             <div className="flex flex-col items-center justify-center px-4 py-12">
               <Bot className="h-8 w-8 text-muted-foreground/40" />
               <p className="mt-3 text-sm text-muted-foreground">
-                {showArchived ? "No archived agents" : "No agents yet"}
+                {showArchived ? "No archived agents" : archivedCount > 0 ? "No active agents" : "No agents yet"}
               </p>
               {!showArchived && (
                 <Button


### PR DESCRIPTION
## Summary

- Archived agents are now hidden from the default agent list, showing only active agents
- Added an archive toggle button in the list header (visible when archived agents exist) to switch between active and archived views
- Empty states adapt to the current filter ("No agents yet" vs "No archived agents")
- Auto-selects first visible agent when switching filters
- The @mention suggestion list already correctly filters out archived agents — no changes needed there

Resolves MUL-259

## Test plan

- [ ] Verify active agents show by default, archived agents are hidden
- [ ] Click the archive icon toggle to see only archived agents
- [ ] Verify empty states show correct messages for each filter
- [ ] Verify @mention list does not show archived agents
- [ ] Archive/restore an agent and confirm list updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)