### PR TITLE
fix(inbox): prevent comment highlight from re-triggering on reply

### DIFF
--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -198,6 +198,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [showScrollBottom, setShowScrollBottom] = useState(false);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const didHighlightRef = useRef<string | null>(null);
 
   // Single source of truth: read issue directly from global store
   const issue = useIssueStore((s) => s.issues.find((i) => i.id === id)) ?? null;
@@ -239,17 +240,16 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
 
   const loading = issueLoading;
 
-  // Scroll to highlighted comment once timeline loads
+  // Scroll to highlighted comment once timeline loads (fire only once per highlightCommentId)
   useEffect(() => {
     if (!highlightCommentId || timeline.length === 0) return;
-    // Find the comment element — could be a top-level comment or a reply
+    if (didHighlightRef.current === highlightCommentId) return;
     const el = document.getElementById(`comment-${highlightCommentId}`);
     if (el) {
-      // Small delay to ensure layout is settled
+      didHighlightRef.current = highlightCommentId;
       requestAnimationFrame(() => {
         el.scrollIntoView({ behavior: "smooth", block: "center" });
         setHighlightedId(highlightCommentId);
-        // Clear highlight after animation
         const timer = setTimeout(() => setHighlightedId(null), 2000);
         return () => clearTimeout(timer);
       });


### PR DESCRIPTION
## Summary
- Fixes the bug where posting a reply causes the parent comment's blue highlight to re-trigger
- Root cause: the `useEffect` that scrolls to and highlights a comment had `timeline.length` in its dependency array, so any change to the timeline (like posting a reply) would re-trigger the animation
- Added a `didHighlightRef` to ensure the scroll+highlight only fires once per `highlightCommentId`

Closes MUL-247

## Test plan
- [ ] From inbox, click a comment notification → comment should scroll into view and highlight once
- [ ] Post a reply in that same thread → highlight should NOT re-trigger
- [ ] Navigate away and back to the same notification → highlight should fire again