### PR TITLE
fix(server): broadcast task:dispatch for mention-triggered tasks

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -105,6 +105,7 @@ func (s *TaskService) EnqueueTaskForMention(ctx context.Context, issue db.Issue,
 	}
 
 	slog.Info("mention task enqueued", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(issue.ID), "agent_id", util.UUIDToString(agentID))
+	s.broadcastTaskDispatch(ctx, task)
 	return task, nil
 }
 


### PR DESCRIPTION
## Summary
- `EnqueueTaskForMention` was missing the `broadcastTaskDispatch` call
- When an agent was triggered via @mention in comments, no `task:dispatch` WebSocket event was sent
- The frontend `AgentLiveCard` never received the event, so the "agent is running" state didn't appear until page refresh
- Fix: add `s.broadcastTaskDispatch(ctx, task)` after mention task creation, matching the existing behavior in `EnqueueTaskForIssue`

## Test plan
- [ ] @mention an agent in a comment → AgentLiveCard shows running state immediately without refresh
- [ ] Existing assignee-triggered tasks still work correctly
- [ ] Go tests pass