### PR TITLE
docs(web): add v0.1.5 changelog entry

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -273,6 +273,23 @@ export const en: LandingDict = {
     subtitle: "New updates and improvements to Multica.",
     entries: [
       {
+        version: "0.1.5",
+        date: "2026-04-02",
+        title: "Mentions & Permissions",
+        changes: [
+          "@mention issues in comments with server-side auto-expansion",
+          "@all mention to notify every workspace member",
+          "Inbox auto-scrolls to the referenced comment from a notification",
+          "Repositories extracted into a standalone settings tab",
+          "CLI update support from the web runtime page and direct download for non-Homebrew installs",
+          "CLI commands for viewing issue execution runs and run messages",
+          "Agent permission model — owners and admins manage agents, members manage skills on their own agents",
+          "Per-issue serial execution to prevent concurrent task collisions",
+          "File upload now supports all file types",
+          "README redesign with quickstart guide",
+        ],
+      },
+      {
         version: "0.1.4",
         date: "2026-04-01",
         title: "My Issues & i18n",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -273,6 +273,23 @@ export const zh: LandingDict = {
     subtitle: "Multica \u7684\u6700\u65b0\u66f4\u65b0\u548c\u6539\u8fdb\u3002",
     entries: [
       {
+        version: "0.1.5",
+        date: "2026-04-02",
+        title: "提及与权限",
+        changes: [
+          "评论中支持 @提及 Issue，服务端自动展开",
+          "支持 @all 提及工作区所有成员",
+          "收件箱通知点击后自动滚动到对应评论",
+          "仓库管理独立为设置页单独标签页",
+          "支持从网页端运行时页面更新 CLI，非 Homebrew 安装支持直接下载更新",
+          "新增 CLI 命令查看 Issue 执行记录和运行消息",
+          "Agent 权限模型优化——所有者和管理员管理 Agent，成员可管理自己 Agent 的技能",
+          "每个 Issue 串行执行，防止并发任务冲突",
+          "文件上传支持所有文件类型",
+          "README 重新设计，新增快速入门指南",
+        ],
+      },
+      {
         version: "0.1.4",
         date: "2026-04-01",
         title: "\u6211\u7684 Issue \u4e0e\u56fd\u9645\u5316",


### PR DESCRIPTION
## Summary
- Add v0.1.5 changelog entry (2026-04-02) covering commits `f315e55c..62b7c0cf`
- Both English and Chinese (zh) translations included
- Key updates: @mention issues, @all mentions, inbox auto-scroll, repositories settings tab, CLI update support, agent permission model, per-issue serial execution, all file type uploads, README redesign

Closes MUL-275