### PR TITLE
fix(web): filter archived agents from dropdown selectors

### DIFF
--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -513,7 +513,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                         {issue.assignee_type === "member" && issue.assignee_id === m.user_id && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
                       </DropdownMenuItem>
                     ))}
-                    {agents.filter((a) => canAssignAgent(a, user?.id, currentMemberRole)).map((a) => (
+                    {agents.filter((a) => !a.archived_at && canAssignAgent(a, user?.id, currentMemberRole)).map((a) => (
                       <DropdownMenuItem
                         key={a.id}
                         onClick={() => handleUpdateField({ assignee_type: "agent", assignee_id: a.id })}
@@ -742,9 +742,9 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                             })}
                           </CommandGroup>
                         )}
-                        {agents.length > 0 && (
+                        {agents.filter((a) => !a.archived_at).length > 0 && (
                           <CommandGroup heading="Agents">
-                            {agents.map((a) => {
+                            {agents.filter((a) => !a.archived_at).map((a) => {
                               const sub = subscribers.find((s) => s.user_type === "agent" && s.user_id === a.id);
                               const isSubbed = !!sub;
                               return (

--- a/apps/web/features/issues/components/issues-header.tsx
+++ b/apps/web/features/issues/components/issues-header.tsx
@@ -162,7 +162,7 @@ function ActorSubContent({
     m.name.toLowerCase().includes(query),
   );
   const filteredAgents = agents.filter((a) =>
-    a.name.toLowerCase().includes(query),
+    !a.archived_at && a.name.toLowerCase().includes(query),
   );
 
   const isSelected = (type: "member" | "agent", id: string) =>

--- a/apps/web/features/modals/create-issue.tsx
+++ b/apps/web/features/modals/create-issue.tsx
@@ -99,7 +99,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
 
   const assigneeQuery = assigneeFilter.toLowerCase();
   const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(assigneeQuery));
-  const filteredAgents = agents.filter((a) => a.name.toLowerCase().includes(assigneeQuery));
+  const filteredAgents = agents.filter((a) => !a.archived_at && a.name.toLowerCase().includes(assigneeQuery));
 
   const assigneeLabel =
     assigneeType && assigneeId


### PR DESCRIPTION
## Summary
- Filter archived agents (`!a.archived_at`) from dropdown selectors that were missing the check:
  - `create-issue.tsx` — assignee dropdown in create issue modal
  - `issues-header.tsx` — assignee/creator filter panel
  - `issue-detail.tsx` — assignee dropdown and subscriber list

`assignee-picker.tsx` and `mention-suggestion.tsx` already filter correctly on main.

Closes MUL-282.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (42/42)
- [ ] Verify archived agents do not appear in assignee dropdowns
- [ ] Verify archived agents do not appear in subscriber list
- [ ] Verify archived agents do not appear in filter panel