### PR TITLE
fix(daemon): support Windows by extracting platform-specific SysProcAttr

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -156,7 +156,7 @@ func runDaemonBackground(cmd *cobra.Command) error {
 	child := exec.Command(exePath, args...)
 	child.Stdout = logFile
 	child.Stderr = logFile
-	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	child.SysProcAttr = daemonSysProcAttr()
 
 	if err := child.Start(); err != nil {
 		logFile.Close()
@@ -297,7 +297,7 @@ func runDaemonForeground(cmd *cobra.Command) error {
 		}
 		child.Stdout = logFile
 		child.Stderr = logFile
-		child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		child.SysProcAttr = daemonSysProcAttr()
 
 		if err := child.Start(); err != nil {
 			logFile.Close()

--- a/server/cmd/multica/daemonattr_unix.go
+++ b/server/cmd/multica/daemonattr_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+// daemonSysProcAttr returns the SysProcAttr used when spawning a detached
+// daemon child process. On Unix systems we create a new session (Setsid) so
+// the child is not terminated when the parent exits.
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/server/cmd/multica/daemonattr_windows.go
+++ b/server/cmd/multica/daemonattr_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+// daemonSysProcAttr returns the SysProcAttr used when spawning a detached
+// daemon child process. On Windows, Setsid is not available; we use
+// CREATE_NEW_PROCESS_GROUP so the child is not terminated when the parent
+// console exits.
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}


### PR DESCRIPTION
## Summary

`syscall.SysProcAttr{Setsid: true}` is Unix-only and causes a compilation error on Windows (`unknown field Setsid`). This PR extracts the attribute into a platform-specific helper function using build tags.

### Changes

- **`daemonattr_unix.go`** — Returns `SysProcAttr{Setsid: true}` for Unix (existing behaviour)
- **`daemonattr_windows.go`** — Returns `SysProcAttr{CreationFlags: CREATE_NEW_PROCESS_GROUP}` for Windows
- **`cmd_daemon.go`** — Replaces two inline `SysProcAttr` assignments with `daemonSysProcAttr()` calls

### Testing

- [x] `go build ./cmd/multica/` passes on macOS (darwin/arm64)
- [x] `GOOS=windows GOARCH=amd64 go build ./cmd/multica/` cross-compilation passes
- [x] Verified daemon runs correctly on Windows 10 (windows-node with i7-9700)

### Context

Discovered while deploying Multica daemon across a Tailscale network with mixed OS nodes (macOS + Linux + Windows). The Windows node could not compile the CLI due to `Setsid` being undefined on `windows/amd64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)