### PR TITLE
feat(activity): enrich task_completed/task_failed with contextual details

### DIFF
--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -133,6 +133,24 @@ function InboxDetailLabel({ item }: { item: InboxItem }) {
       if (emoji) return <span>Reacted {emoji} to your comment</span>;
       return <span>{typeLabels[item.type]}</span>;
     }
+    case "task_completed": {
+      const label = details.trigger === "comment" ? "Completed follow-up" : "Task completed";
+      if (details.pr_url) {
+        return (
+          <span className="inline-flex items-center gap-1">
+            {label} —{" "}
+            <a href={details.pr_url} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">
+              PR
+            </a>
+          </span>
+        );
+      }
+      return <span>{label}</span>;
+    }
+    case "task_failed": {
+      if (details.error) return <span>Task failed: {details.error}</span>;
+      return <span>{typeLabels[item.type]}</span>;
+    }
     default:
       return <span>{typeLabels[item.type] ?? item.type}</span>;
   }

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, memo } from "react";
+import { useState, useEffect, useCallback, useRef, memo, type ReactNode } from "react";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -93,7 +93,7 @@ function priorityLabel(priority: string): string {
 function formatActivity(
   entry: TimelineEntry,
   resolveActorName?: (type: string, id: string) => string,
-): string {
+): ReactNode {
   const details = (entry.details ?? {}) as Record<string, string>;
   switch (entry.action) {
     case "created":
@@ -121,10 +121,24 @@ function formatActivity(
       return `renamed this issue from "${details.from ?? "?"}" to "${details.to ?? "?"}"`;
     case "description_updated":
       return "updated the description";
-    case "task_completed":
-      return "completed the task";
-    case "task_failed":
+    case "task_completed": {
+      const label = details.trigger === "comment" ? "completed the follow-up" : "completed the task";
+      if (details.pr_url) {
+        return (
+          <>
+            {label} —{" "}
+            <a href={details.pr_url} target="_blank" rel="noopener noreferrer" className="text-foreground underline underline-offset-2 hover:text-foreground/80">
+              PR
+            </a>
+          </>
+        );
+      }
+      return label;
+    }
+    case "task_failed": {
+      if (details.error) return `task failed: ${details.error}`;
       return "task failed";
+    }
     default:
       return entry.action ?? "";
   }

--- a/server/cmd/server/activity_listeners.go
+++ b/server/cmd/server/activity_listeners.go
@@ -230,11 +230,12 @@ func handleTaskActivity(ctx context.Context, bus *events.Bus, queries *db.Querie
 	}
 	agentID, _ := payload["agent_id"].(string)
 	issueID, _ := payload["issue_id"].(string)
+	taskID, _ := payload["task_id"].(string)
 	if issueID == "" {
 		return
 	}
 
-	// Look up issue to get workspace_id
+	// Look up issue to get workspace_id and title
 	issue, err := queries.GetIssue(ctx, parseUUID(issueID))
 	if err != nil {
 		slog.Error("activity: failed to get issue for task event",
@@ -242,13 +243,46 @@ func handleTaskActivity(ctx context.Context, bus *events.Bus, queries *db.Querie
 		return
 	}
 
+	// Build enriched details from the task record
+	detailsMap := map[string]string{
+		"issue_title": issue.Title,
+	}
+
+	if taskID != "" {
+		if task, err := queries.GetAgentTask(ctx, parseUUID(taskID)); err == nil {
+			// Trigger type: comment-triggered vs assignment-triggered
+			if task.TriggerCommentID.Valid {
+				detailsMap["trigger"] = "comment"
+			}
+
+			if action == "task_completed" && len(task.Result) > 0 {
+				var completed protocol.TaskCompletedPayload
+				if err := json.Unmarshal(task.Result, &completed); err == nil {
+					if completed.PRURL != "" {
+						detailsMap["pr_url"] = completed.PRURL
+					}
+				}
+			}
+			if action == "task_failed" && task.Error.Valid && task.Error.String != "" {
+				// Truncate long error messages for the activity summary
+				errMsg := task.Error.String
+				if len(errMsg) > 200 {
+					errMsg = errMsg[:200] + "…"
+				}
+				detailsMap["error"] = errMsg
+			}
+		}
+	}
+
+	details, _ := json.Marshal(detailsMap)
+
 	activity, err := queries.CreateActivity(ctx, db.CreateActivityParams{
 		WorkspaceID: issue.WorkspaceID,
 		IssueID:     parseUUID(issueID),
 		ActorType:   util.StrToText("agent"),
 		ActorID:     parseUUID(agentID),
 		Action:      action,
-		Details:     []byte("{}"),
+		Details:     details,
 	})
 	if err != nil {
 		slog.Error("activity: failed to record task activity",

--- a/server/cmd/server/activity_listeners_test.go
+++ b/server/cmd/server/activity_listeners_test.go
@@ -308,6 +308,15 @@ func TestActivityTaskCompleted(t *testing.T) {
 	if util.UUIDToString(activities[0].ActorID) != agentID {
 		t.Fatalf("expected actor_id %s, got %s", agentID, util.UUIDToString(activities[0].ActorID))
 	}
+
+	// Verify enriched details contain issue_title
+	var details map[string]string
+	if err := json.Unmarshal(activities[0].Details, &details); err != nil {
+		t.Fatalf("failed to unmarshal details: %v", err)
+	}
+	if details["issue_title"] != "subscriber test issue" {
+		t.Fatalf("expected issue_title 'subscriber test issue', got %q", details["issue_title"])
+	}
 }
 
 func TestActivityTaskFailed(t *testing.T) {
@@ -342,5 +351,14 @@ func TestActivityTaskFailed(t *testing.T) {
 	}
 	if activities[0].Action != "task_failed" {
 		t.Fatalf("expected action 'task_failed', got %q", activities[0].Action)
+	}
+
+	// Verify enriched details contain issue_title
+	var details map[string]string
+	if err := json.Unmarshal(activities[0].Details, &details); err != nil {
+		t.Fatalf("failed to unmarshal details: %v", err)
+	}
+	if details["issue_title"] != "subscriber test issue" {
+		t.Fatalf("expected issue_title 'subscriber test issue', got %q", details["issue_title"])
 	}
 }


### PR DESCRIPTION
## Summary
- Activity entries for task completion/failure now include enriched details: issue title, trigger type (comment vs assignment), PR URL, and error message
- Frontend displays richer activity text: "completed the follow-up" for comment-triggered tasks, clickable PR link, and error summary for failures
- Inbox detail labels also updated with the same enriched information

Closes MUL-307

## Test plan
- [x] Go tests pass (`TestActivityTaskCompleted`, `TestActivityTaskFailed` — both verify enriched details)
- [x] TypeScript typecheck passes
- [ ] Verify in UI: complete a task with a PR → activity shows "completed the task — PR" with clickable link
- [ ] Verify in UI: complete a comment-triggered task → shows "completed the follow-up"
- [ ] Verify in UI: fail a task → shows "task failed: <error>"
- [ ] Verify inbox shows enriched labels for task_completed/task_failed items