### PR TITLE
fix(inbox): archive at issue level instead of event level

### DIFF
--- a/apps/web/features/inbox/store.ts
+++ b/apps/web/features/inbox/store.ts
@@ -90,9 +90,17 @@ export const useInboxStore = create<InboxState>((set, get) => ({
       items: s.items.map((i) => (i.id === id ? { ...i, read: true } : i)),
     })),
   archive: (id) =>
-    set((s) => ({
-      items: s.items.map((i) => (i.id === id ? { ...i, archived: true } : i)),
-    })),
+    set((s) => {
+      const target = s.items.find((i) => i.id === id);
+      const issueId = target?.issue_id;
+      return {
+        items: s.items.map((i) =>
+          i.id === id || (issueId && i.issue_id === issueId)
+            ? { ...i, archived: true }
+            : i,
+        ),
+      };
+    }),
   markAllRead: () =>
     set((s) => ({
       items: s.items.map((i) => (!i.archived ? { ...i, read: true } : i)),

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -143,10 +143,21 @@ func (h *Handler) ArchiveInboxItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Archive all sibling inbox items for the same issue (issue-level archive)
+	if item.IssueID.Valid {
+		h.Queries.ArchiveInboxByIssue(r.Context(), db.ArchiveInboxByIssueParams{
+			WorkspaceID:   item.WorkspaceID,
+			RecipientType: item.RecipientType,
+			RecipientID:   item.RecipientID,
+			IssueID:       item.IssueID,
+		})
+	}
+
 	userID := requestUserID(r)
 	workspaceID := uuidToString(item.WorkspaceID)
 	h.publish(protocol.EventInboxArchived, workspaceID, "member", userID, map[string]any{
 		"item_id":      uuidToString(item.ID),
+		"issue_id":     uuidToPtr(item.IssueID),
 		"recipient_id": uuidToString(item.RecipientID),
 	})
 

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -66,6 +66,31 @@ func (q *Queries) ArchiveCompletedInbox(ctx context.Context, arg ArchiveComplete
 	return result.RowsAffected(), nil
 }
 
+const archiveInboxByIssue = `-- name: ArchiveInboxByIssue :execrows
+UPDATE inbox_item SET archived = true
+WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND issue_id = $4 AND archived = false
+`
+
+type ArchiveInboxByIssueParams struct {
+	WorkspaceID   pgtype.UUID `json:"workspace_id"`
+	RecipientType string      `json:"recipient_type"`
+	RecipientID   pgtype.UUID `json:"recipient_id"`
+	IssueID       pgtype.UUID `json:"issue_id"`
+}
+
+func (q *Queries) ArchiveInboxByIssue(ctx context.Context, arg ArchiveInboxByIssueParams) (int64, error) {
+	result, err := q.db.Exec(ctx, archiveInboxByIssue,
+		arg.WorkspaceID,
+		arg.RecipientType,
+		arg.RecipientID,
+		arg.IssueID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const archiveInboxItem = `-- name: ArchiveInboxItem :one
 UPDATE inbox_item SET archived = true
 WHERE id = $1

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -32,6 +32,10 @@ UPDATE inbox_item SET archived = true
 WHERE id = $1
 RETURNING *;
 
+-- name: ArchiveInboxByIssue :execrows
+UPDATE inbox_item SET archived = true
+WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND issue_id = $4 AND archived = false;
+
 -- name: CountUnreadInbox :one
 SELECT count(*) FROM inbox_item
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false;


### PR DESCRIPTION
## Summary
- Fixes MUL-309: clicking archive in the inbox now archives **all** notifications for the same issue, not just the single visible event
- Added `ArchiveInboxByIssue` SQL query that archives all inbox items matching a given `issue_id` + recipient
- Backend `ArchiveInboxItem` handler now also archives sibling items when the archived item has an `issue_id`
- Frontend store's `archive` action updated to optimistically archive all items sharing the same `issue_id`

## Context
The inbox UI deduplicates notifications by `issue_id`, showing only the latest event per issue. Previously, archiving only removed the visible item — older events for the same issue would reappear on the next fetch.

## Test plan
- [ ] Open inbox with an issue that has multiple notifications (e.g., assigned + status changed + comment)
- [ ] Verify only one row shows per issue (deduplication)
- [ ] Click archive on that row
- [ ] Verify the notification disappears and does not reappear on refresh
- [ ] Verify "archive all", "archive all read", and "archive completed" still work correctly