### PR TITLE
fix(web): prevent Archive Agent button text from wrapping

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -1437,7 +1437,7 @@ function AgentDetail({
             >
               <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent align="end" className="w-auto">
               <DropdownMenuItem
                 className="text-destructive"
                 onClick={() => setConfirmArchive(true)}


### PR DESCRIPTION
## Summary
- Added `w-auto` class to the `DropdownMenuContent` on the agent detail panel's action dropdown
- The default `w-(--anchor-width)` was constraining the dropdown popup width to match the small icon button trigger, causing "Archive Agent" text to wrap to two lines
- This matches the pattern already used by other dropdowns in the codebase (issues-header, comment-card, inbox, etc.)

## Test plan
- [ ] Open the agents page, click on an agent to open the detail panel
- [ ] Click the "..." menu button — "Archive Agent" should appear on a single line