### PR TITLE
fix: make setup-worktree preserve existing .env.worktree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,12 @@ check-main:
 	@ENV_FILE=$(MAIN_ENV_FILE) bash scripts/check.sh
 
 setup-worktree:
-	@echo "==> Generating $(WORKTREE_ENV_FILE) with unique ports..."
-	@FORCE=1 bash scripts/init-worktree-env.sh $(WORKTREE_ENV_FILE)
+	@if [ ! -f "$(WORKTREE_ENV_FILE)" ]; then \
+		echo "==> Generating $(WORKTREE_ENV_FILE) with unique ports..."; \
+		bash scripts/init-worktree-env.sh $(WORKTREE_ENV_FILE); \
+	else \
+		echo "==> Using existing $(WORKTREE_ENV_FILE)"; \
+	fi
 	@$(MAKE) setup ENV_FILE=$(WORKTREE_ENV_FILE)
 
 start-worktree:


### PR DESCRIPTION
## Summary
- `make setup-worktree` was using `FORCE=1` to unconditionally regenerate `.env.worktree`, which overwrites any manual edits (e.g. agent switching to the main DB via `sed`)
- Now it only generates the file if it doesn't exist, preserving any customizations

## Context
Relates to [MUL-311](https://github.com/multica-ai/multica/issues/311) — agent test environments were not connecting to the main DB because `make setup-worktree` overwrote the `sed` changes made in the previous step.

## Test plan
- [ ] Run `make worktree-env` to generate `.env.worktree`
- [ ] Edit `.env.worktree` (e.g. change `POSTGRES_DB`)
- [ ] Run `make setup-worktree` — verify it says "Using existing .env.worktree" and does NOT overwrite the edit
- [ ] Delete `.env.worktree` and run `make setup-worktree` — verify it generates a new one