### PR TITLE
feat: agent-level model configuration

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -1193,6 +1193,7 @@ function SettingsTab({
   const [description, setDescription] = useState(agent.description ?? "");
   const [visibility, setVisibility] = useState<AgentVisibility>(agent.visibility);
   const [maxTasks, setMaxTasks] = useState(agent.max_concurrent_tasks);
+  const [model, setModel] = useState<string>((agent.runtime_config?.model as string) ?? "");
   const [saving, setSaving] = useState(false);
   const { upload, uploading } = useFileUpload();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1215,7 +1216,8 @@ function SettingsTab({
     name !== agent.name ||
     description !== (agent.description ?? "") ||
     visibility !== agent.visibility ||
-    maxTasks !== agent.max_concurrent_tasks;
+    maxTasks !== agent.max_concurrent_tasks ||
+    model !== ((agent.runtime_config?.model as string) ?? "");
 
   const handleSave = async () => {
     if (!name.trim()) {
@@ -1224,7 +1226,7 @@ function SettingsTab({
     }
     setSaving(true);
     try {
-      await onSave({ name: name.trim(), description, visibility, max_concurrent_tasks: maxTasks });
+      await onSave({ name: name.trim(), description, visibility, max_concurrent_tasks: maxTasks, runtime_config: { ...agent.runtime_config, model: model || undefined } });
       toast.success("Settings saved");
     } catch {
       toast.error("Failed to save settings");
@@ -1332,6 +1334,19 @@ function SettingsTab({
           value={maxTasks}
           onChange={(e) => setMaxTasks(Number(e.target.value))}
           className="mt-1 w-24"
+        />
+      </div>
+
+      <div>
+        <Label className="text-xs text-muted-foreground">Model</Label>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Override the default model. Leave empty to use the daemon default.
+        </p>
+        <Input
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder="Default (from daemon)"
+          className="mt-1"
         />
       </div>
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -935,11 +935,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)
 	}
 
+	model := resolveModel(entry, task.Agent)
+
 	reused := task.PriorWorkDir != "" && env.WorkDir == task.PriorWorkDir
 	taskLog.Info("starting agent",
 		"provider", provider,
 		"workdir", env.WorkDir,
-		"model", entry.Model,
+		"model", model,
 		"reused", reused,
 	)
 	if task.PriorSessionID != "" {
@@ -950,7 +952,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 
 	session, err := backend.Execute(ctx, prompt, agent.ExecOptions{
 		Cwd:             env.WorkDir,
-		Model:           entry.Model,
+		Model:           model,
 		Timeout:         d.cfg.AgentTimeout,
 		ResumeSessionID: task.PriorSessionID,
 	})

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -83,3 +83,55 @@ func TestIsWorkspaceNotFoundError(t *testing.T) {
 		t.Fatal("did not expect 500 to be treated as workspace not found")
 	}
 }
+
+func TestResolveModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		entry AgentEntry
+		agent *AgentData
+		want  string
+	}{
+		{
+			name:  "agent model overrides entry model",
+			entry: AgentEntry{Model: "env-model"},
+			agent: &AgentData{Model: "agent-model"},
+			want:  "agent-model",
+		},
+		{
+			name:  "falls back to entry model when agent model empty",
+			entry: AgentEntry{Model: "env-model"},
+			agent: &AgentData{Model: ""},
+			want:  "env-model",
+		},
+		{
+			name:  "falls back to entry model when agent nil",
+			entry: AgentEntry{Model: "env-model"},
+			agent: nil,
+			want:  "env-model",
+		},
+		{
+			name:  "both empty returns empty",
+			entry: AgentEntry{Model: ""},
+			agent: &AgentData{Model: ""},
+			want:  "",
+		},
+		{
+			name:  "agent model with no entry model",
+			entry: AgentEntry{Model: ""},
+			agent: &AgentData{Model: "agent-model"},
+			want:  "agent-model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveModel(tt.entry, tt.agent)
+			if got != tt.want {
+				t.Fatalf("resolveModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -23,14 +23,14 @@ type RepoData struct {
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID             string     `json:"id"`
-	AgentID        string     `json:"agent_id"`
-	RuntimeID      string     `json:"runtime_id"`
-	IssueID        string     `json:"issue_id"`
-	WorkspaceID    string     `json:"workspace_id"`
-	Agent          *AgentData `json:"agent,omitempty"`
-	Repos          []RepoData `json:"repos,omitempty"`
-	PriorSessionID   string     `json:"prior_session_id,omitempty"`    // Claude session ID from a previous task on this issue
+	ID               string     `json:"id"`
+	AgentID          string     `json:"agent_id"`
+	RuntimeID        string     `json:"runtime_id"`
+	IssueID          string     `json:"issue_id"`
+	WorkspaceID      string     `json:"workspace_id"`
+	Agent            *AgentData `json:"agent,omitempty"`
+	Repos            []RepoData `json:"repos,omitempty"`
+	PriorSessionID   string     `json:"prior_session_id,omitempty"`   // Claude session ID from a previous task on this issue
 	PriorWorkDir     string     `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on this issue
 	TriggerCommentID string     `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 }
@@ -41,6 +41,7 @@ type AgentData struct {
 	Name         string      `json:"name"`
 	Instructions string      `json:"instructions"`
 	Skills       []SkillData `json:"skills"`
+	Model        string      `json:"model,omitempty"`
 }
 
 // SkillData represents a structured skill for task execution.
@@ -54,6 +55,15 @@ type SkillData struct {
 type SkillFileData struct {
 	Path    string `json:"path"`
 	Content string `json:"content"`
+}
+
+// resolveModel returns the model to use for a task, preferring the agent-level
+// override (from runtime_config) over the daemon-level default (from env var).
+func resolveModel(entry AgentEntry, agent *AgentData) string {
+	if agent != nil && agent.Model != "" {
+		return agent.Model
+	}
+	return entry.Model
 }
 
 // TaskResult is the outcome of executing a task.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -93,22 +93,22 @@ type RepoData struct {
 }
 
 type AgentTaskResponse struct {
-	ID             string         `json:"id"`
-	AgentID        string         `json:"agent_id"`
-	RuntimeID      string         `json:"runtime_id"`
-	IssueID        string         `json:"issue_id"`
-	WorkspaceID    string         `json:"workspace_id"`
-	Status         string         `json:"status"`
-	Priority       int32          `json:"priority"`
-	DispatchedAt   *string        `json:"dispatched_at"`
-	StartedAt      *string        `json:"started_at"`
-	CompletedAt    *string        `json:"completed_at"`
-	Result         any            `json:"result"`
-	Error          *string        `json:"error"`
-	Agent          *TaskAgentData `json:"agent,omitempty"`
-	Repos          []RepoData     `json:"repos,omitempty"`
-	CreatedAt      string         `json:"created_at"`
-	PriorSessionID   string         `json:"prior_session_id,omitempty"`    // session ID from a previous task on same issue
+	ID               string         `json:"id"`
+	AgentID          string         `json:"agent_id"`
+	RuntimeID        string         `json:"runtime_id"`
+	IssueID          string         `json:"issue_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Status           string         `json:"status"`
+	Priority         int32          `json:"priority"`
+	DispatchedAt     *string        `json:"dispatched_at"`
+	StartedAt        *string        `json:"started_at"`
+	CompletedAt      *string        `json:"completed_at"`
+	Result           any            `json:"result"`
+	Error            *string        `json:"error"`
+	Agent            *TaskAgentData `json:"agent,omitempty"`
+	Repos            []RepoData     `json:"repos,omitempty"`
+	CreatedAt        string         `json:"created_at"`
+	PriorSessionID   string         `json:"prior_session_id,omitempty"`   // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
 	TriggerCommentID *string        `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 }
@@ -120,6 +120,23 @@ type TaskAgentData struct {
 	Name         string                   `json:"name"`
 	Instructions string                   `json:"instructions"`
 	Skills       []service.AgentSkillData `json:"skills,omitempty"`
+	Model        string                   `json:"model,omitempty"`
+}
+
+// extractModelFromRuntimeConfig returns the "model" string from a
+// runtime_config JSONB blob, or "" if absent/invalid.
+func extractModelFromRuntimeConfig(raw []byte) string {
+	if raw == nil {
+		return ""
+	}
+	var rc map[string]any
+	if json.Unmarshal(raw, &rc) != nil {
+		return ""
+	}
+	if m, ok := rc["model"].(string); ok {
+		return m
+	}
+	return ""
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
@@ -128,16 +145,16 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		json.Unmarshal(t.Result, &result)
 	}
 	return AgentTaskResponse{
-		ID:           uuidToString(t.ID),
-		AgentID:      uuidToString(t.AgentID),
-		RuntimeID:    uuidToString(t.RuntimeID),
-		IssueID:      uuidToString(t.IssueID),
-		Status:       t.Status,
-		Priority:     t.Priority,
-		DispatchedAt: timestampToPtr(t.DispatchedAt),
-		StartedAt:    timestampToPtr(t.StartedAt),
-		CompletedAt:  timestampToPtr(t.CompletedAt),
-		Result:       result,
+		ID:               uuidToString(t.ID),
+		AgentID:          uuidToString(t.AgentID),
+		RuntimeID:        uuidToString(t.RuntimeID),
+		IssueID:          uuidToString(t.IssueID),
+		Status:           t.Status,
+		Priority:         t.Priority,
+		DispatchedAt:     timestampToPtr(t.DispatchedAt),
+		StartedAt:        timestampToPtr(t.StartedAt),
+		CompletedAt:      timestampToPtr(t.CompletedAt),
+		Result:           result,
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
@@ -310,8 +327,6 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": resp})
 	writeJSON(w, http.StatusCreated, resp)
 }
-
-
 
 type UpdateAgentRequest struct {
 	Name               *string `json:"name"`

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -243,6 +243,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			Name:         agent.Name,
 			Instructions: agent.Instructions,
 			Skills:       skills,
+			Model:        extractModelFromRuntimeConfig(agent.RuntimeConfig),
 		}
 	}
 

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -656,11 +656,11 @@ func TestResolveActor(t *testing.T) {
 	})
 
 	tests := []struct {
-		name            string
-		agentIDHeader   string
-		taskIDHeader    string
-		wantActorType   string
-		wantIsAgent     bool
+		name          string
+		agentIDHeader string
+		taskIDHeader  string
+		wantActorType string
+		wantIsAgent   bool
 	}{
 		{
 			name:          "no headers returns member",
@@ -737,5 +737,61 @@ func TestDaemonRegisterMissingWorkspaceReturns404(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "workspace not found") {
 		t.Fatalf("DaemonRegister: expected workspace not found error, got %s", w.Body.String())
+	}
+}
+
+func TestExtractModelFromRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{
+			name: "extracts model from valid config",
+			raw:  []byte(`{"model":"claude-sonnet-4-20250514"}`),
+			want: "claude-sonnet-4-20250514",
+		},
+		{
+			name: "returns empty for nil",
+			raw:  nil,
+			want: "",
+		},
+		{
+			name: "returns empty for empty object",
+			raw:  []byte(`{}`),
+			want: "",
+		},
+		{
+			name: "returns empty for invalid JSON",
+			raw:  []byte(`not-json`),
+			want: "",
+		},
+		{
+			name: "returns empty when model is not a string",
+			raw:  []byte(`{"model":123}`),
+			want: "",
+		},
+		{
+			name: "preserves other keys",
+			raw:  []byte(`{"model":"gpt-5.4","other":"value"}`),
+			want: "gpt-5.4",
+		},
+		{
+			name: "returns empty for empty string model",
+			raw:  []byte(`{"model":""}`),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractModelFromRuntimeConfig(tt.raw)
+			if got != tt.want {
+				t.Fatalf("extractModelFromRuntimeConfig() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add per-agent model override stored in existing runtime_config JSONB column. Priority chain: agent.runtime_config.model → daemon env var → CLI default.

Server: extract model from runtime_config in claim response (TaskAgentData.Model)
Daemon: prefer agent model over env var in resolveModel()
Frontend: plain text model input in agent SettingsTab
Tests: 12 unit tests for model extraction and resolution logic

No migrations needed.

screenshot:

<img width="634" height="820" alt="Screenshot 2026-04-04 at 16 17 08" src="https://github.com/user-attachments/assets/cba2d69b-0e7c-4e5c-bd89-21e5c1a10d50" />

daemon log:
```
16:14:22.471 INF execenv: reusing env component=daemon workdir=/Users/quake/multica_workspaces/0a465172-f575-4942-a43e-c762ea2f3ea3/7a6c6f9f/workdir
16:14:22.471 INF starting agent component=daemon task=a1d6d128 provider=opencode workdir=/Users/quake/multica_workspaces/0a465172-f575-4942-a43e-c762ea2f3ea3/7a6c6f9f/workdir model=github-copilot/claude-sonnet-4.6 reused=true
16:14:22.471 INF resuming session component=daemon task=a1d6d128 session_id=ses_2b232543fffeSsNnrLP6y5qwIv
```

related issue: https://github.com/multica-ai/multica/issues/392