### PR TITLE
feat(web): change Done status label color to purple

### DIFF
--- a/apps/web/app/(dashboard)/issues/page.test.tsx
+++ b/apps/web/app/(dashboard)/issues/page.test.tsx
@@ -167,7 +167,7 @@ vi.mock("@/features/issues/config", () => ({
     todo: { label: "Todo", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
     in_progress: { label: "In Progress", iconColor: "text-warning", hoverBg: "hover:bg-warning/10" },
     in_review: { label: "In Review", iconColor: "text-success", hoverBg: "hover:bg-success/10" },
-    done: { label: "Done", iconColor: "text-info", hoverBg: "hover:bg-info/10" },
+    done: { label: "Done", iconColor: "text-done", hoverBg: "hover:bg-done/10" },
     blocked: { label: "Blocked", iconColor: "text-destructive", hoverBg: "hover:bg-destructive/10" },
     cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent" },
   },

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -29,6 +29,7 @@
     --color-success: var(--success);
     --color-warning: var(--warning);
     --color-info: var(--info);
+    --color-done: var(--done);
     --color-brand: var(--brand);
     --color-brand-foreground: var(--brand-foreground);
     --color-priority: var(--priority);
@@ -95,6 +96,7 @@
     --success: oklch(0.55 0.16 145);
     --warning: oklch(0.75 0.16 85);
     --info: oklch(0.55 0.18 250);
+    --done: oklch(0.55 0.18 300);
     --priority: oklch(0.65 0.18 50);
     --scrollbar-thumb: oklch(0 0 0 / 10%);
     --scrollbar-thumb-hover: oklch(0 0 0 / 18%);
@@ -139,6 +141,7 @@
     --success: oklch(0.65 0.15 145);
     --warning: oklch(0.70 0.16 85);
     --info: oklch(0.65 0.18 250);
+    --done: oklch(0.65 0.18 300);
     --priority: oklch(0.70 0.18 50);
     --scrollbar-thumb: oklch(1 0 0 / 8%);
     --scrollbar-thumb-hover: oklch(1 0 0 / 18%);

--- a/apps/web/features/issues/config/status.ts
+++ b/apps/web/features/issues/config/status.ts
@@ -46,7 +46,7 @@ export const STATUS_CONFIG: Record<
   todo: { label: "Todo", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", badgeBg: "bg-muted", badgeText: "text-muted-foreground", columnBg: "bg-muted/40" },
   in_progress: { label: "In Progress", iconColor: "text-warning", hoverBg: "hover:bg-warning/10", dividerColor: "bg-warning", badgeBg: "bg-warning", badgeText: "text-white", columnBg: "bg-warning/5" },
   in_review: { label: "In Review", iconColor: "text-success", hoverBg: "hover:bg-success/10", dividerColor: "bg-success", badgeBg: "bg-success", badgeText: "text-white", columnBg: "bg-success/5" },
-  done: { label: "Done", iconColor: "text-info", hoverBg: "hover:bg-info/10", dividerColor: "bg-info", badgeBg: "bg-info", badgeText: "text-white", columnBg: "bg-info/5" },
+  done: { label: "Done", iconColor: "text-done", hoverBg: "hover:bg-done/10", dividerColor: "bg-done", badgeBg: "bg-done", badgeText: "text-white", columnBg: "bg-done/5" },
   blocked: { label: "Blocked", iconColor: "text-destructive", hoverBg: "hover:bg-destructive/10", dividerColor: "bg-destructive", badgeBg: "bg-destructive", badgeText: "text-white", columnBg: "bg-destructive/5" },
   cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", badgeBg: "bg-muted", badgeText: "text-muted-foreground", columnBg: "bg-muted/40" },
 };


### PR DESCRIPTION
## Summary
- Added a dedicated `--done` CSS color token (`oklch(0.55 0.18 300)` light / `oklch(0.65 0.18 300)` dark) for the Done status, using a purple hue (300) instead of the shared `--info` blue token (hue 250).
- Updated `STATUS_CONFIG` for the `done` status to use `bg-done`, `text-done`, etc.
- Updated the test mock to match.

Closes MUL-318

## Test plan
- [ ] Verify Done badge/tag on the board view renders in purple
- [ ] Verify Done status icon is purple
- [ ] Verify other `info`-colored elements (agent cards, toasts, etc.) are still blue
- [ ] Check both light and dark modes