### PR TITLE
fix(build): include migrate binary in make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 build:
 	cd server && go build -o bin/server ./cmd/server
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/multica ./cmd/multica
+	cd server && go build -o bin/migrate ./cmd/migrate
 
 test:
 	$(REQUIRE_ENV)


### PR DESCRIPTION
## Summary

Update `make build` to generate `server/bin/migrate` alongside `server/bin/server` and `server/bin/multica`.

This keeps the build output consistent with the expected self-hosting workflow, where database migrations can be run from the built binaries.

## Testing

- Ran `make build`
- Confirmed `server/bin/migrate` is generated