### PR TITLE
feat(codex): make sandbox mode configurable per agent

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -111,6 +111,53 @@ function getRuntimeDevice(agent: Agent, runtimes: RuntimeDevice[]): RuntimeDevic
   return runtimes.find((runtime) => runtime.id === agent.runtime_id);
 }
 
+type CodexSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+
+const codexSandboxOptions: Array<{
+  value: CodexSandboxMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "read-only",
+    label: "Read Only",
+    description: "Can only read files. Best for review and read-only analysis.",
+  },
+  {
+    value: "workspace-write",
+    label: "Workspace Write",
+    description: "Default mode. Can only write inside the task workspace.",
+  },
+  {
+    value: "danger-full-access",
+    label: "Danger Full Access",
+    description: "Runs directly on the host environment for trusted self-hosted setups.",
+  },
+];
+
+function isCodexSandboxMode(value: unknown): value is CodexSandboxMode {
+  return (
+    value === "read-only" ||
+    value === "workspace-write" ||
+    value === "danger-full-access"
+  );
+}
+
+function getCodexSandboxMode(runtimeConfig: Record<string, unknown> | undefined): CodexSandboxMode {
+  const value = runtimeConfig?.codex_sandbox_mode;
+  return isCodexSandboxMode(value) ? value : "workspace-write";
+}
+
+function withCodexSandboxMode(
+  runtimeConfig: Record<string, unknown> | undefined,
+  mode: CodexSandboxMode,
+): Record<string, unknown> {
+  return {
+    ...(runtimeConfig ?? {}),
+    codex_sandbox_mode: mode,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Create Agent Dialog
 // ---------------------------------------------------------------------------
@@ -128,6 +175,7 @@ function CreateAgentDialog({
   const [description, setDescription] = useState("");
   const [selectedRuntimeId, setSelectedRuntimeId] = useState(runtimes[0]?.id ?? "");
   const [visibility, setVisibility] = useState<AgentVisibility>("private");
+  const [codexSandboxMode, setCodexSandboxMode] = useState<CodexSandboxMode>("workspace-write");
   const [creating, setCreating] = useState(false);
   const [runtimeOpen, setRuntimeOpen] = useState(false);
 
@@ -147,6 +195,10 @@ function CreateAgentDialog({
         name: name.trim(),
         description: description.trim(),
         runtime_id: selectedRuntime.id,
+        runtime_config:
+          selectedRuntime.provider === "codex"
+            ? withCodexSandboxMode(undefined, codexSandboxMode)
+            : undefined,
         visibility,
         triggers: [
           { id: generateId(), type: "on_assign", enabled: true, config: {} },
@@ -298,6 +350,40 @@ function CreateAgentDialog({
               </PopoverContent>
             </Popover>
           </div>
+
+          {selectedRuntime?.provider === "codex" && (
+            <div>
+              <Label className="text-xs text-muted-foreground">Sandbox Mode</Label>
+              <div className="mt-1.5 space-y-2">
+                {codexSandboxOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setCodexSandboxMode(option.value)}
+                    className={`flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                      codexSandboxMode === option.value
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:bg-muted"
+                    }`}
+                  >
+                    <span
+                      className={`mt-0.5 h-2.5 w-2.5 rounded-full ${
+                        codexSandboxMode === option.value
+                          ? "bg-primary"
+                          : "bg-muted-foreground/40"
+                      }`}
+                    />
+                    <div>
+                      <div className="text-sm font-medium">{option.label}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {option.description}
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         <DialogFooter>
@@ -1193,6 +1279,9 @@ function SettingsTab({
   const [description, setDescription] = useState(agent.description ?? "");
   const [visibility, setVisibility] = useState<AgentVisibility>(agent.visibility);
   const [maxTasks, setMaxTasks] = useState(agent.max_concurrent_tasks);
+  const [runtimeConfig, setRuntimeConfig] = useState<Record<string, unknown>>(
+    agent.runtime_config ?? {},
+  );
   const [saving, setSaving] = useState(false);
   const { upload, uploading } = useFileUpload();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1215,7 +1304,16 @@ function SettingsTab({
     name !== agent.name ||
     description !== (agent.description ?? "") ||
     visibility !== agent.visibility ||
-    maxTasks !== agent.max_concurrent_tasks;
+    maxTasks !== agent.max_concurrent_tasks ||
+    JSON.stringify(runtimeConfig) !== JSON.stringify(agent.runtime_config ?? {});
+
+  useEffect(() => {
+    setName(agent.name);
+    setDescription(agent.description ?? "");
+    setVisibility(agent.visibility);
+    setMaxTasks(agent.max_concurrent_tasks);
+    setRuntimeConfig(agent.runtime_config ?? {});
+  }, [agent]);
 
   const handleSave = async () => {
     if (!name.trim()) {
@@ -1224,7 +1322,13 @@ function SettingsTab({
     }
     setSaving(true);
     try {
-      await onSave({ name: name.trim(), description, visibility, max_concurrent_tasks: maxTasks });
+      await onSave({
+        name: name.trim(),
+        description,
+        visibility,
+        max_concurrent_tasks: maxTasks,
+        runtime_config: runtimeConfig,
+      });
       toast.success("Settings saved");
     } catch {
       toast.error("Failed to save settings");
@@ -1234,6 +1338,8 @@ function SettingsTab({
   };
 
   const runtimeDevice = runtimes.find((r) => r.id === agent.runtime_id);
+  const isCodexRuntime = runtimeDevice?.provider === "codex";
+  const selectedSandboxMode = getCodexSandboxMode(runtimeConfig);
 
   return (
     <div className="max-w-lg space-y-6">
@@ -1346,6 +1452,42 @@ function SettingsTab({
           {runtimeDevice?.name ?? (agent.runtime_mode === "cloud" ? "Cloud" : "Local")}
         </div>
       </div>
+
+      {isCodexRuntime && (
+        <div>
+          <Label className="text-xs text-muted-foreground">Sandbox Mode</Label>
+          <div className="mt-1.5 space-y-2">
+            {codexSandboxOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() =>
+                  setRuntimeConfig((prev) => withCodexSandboxMode(prev, option.value))
+                }
+                className={`flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                  selectedSandboxMode === option.value
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:bg-muted"
+                }`}
+              >
+                <span
+                  className={`mt-0.5 h-2.5 w-2.5 rounded-full ${
+                    selectedSandboxMode === option.value
+                      ? "bg-primary"
+                      : "bg-muted-foreground/40"
+                  }`}
+                />
+                <div>
+                  <div className="text-sm font-medium">{option.label}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {option.description}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       <Button onClick={handleSave} disabled={!dirty || saving} size="sm">
         {saving ? <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" /> : <Save className="h-3.5 w-3.5 mr-1.5" />}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -952,6 +952,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		Cwd:             env.WorkDir,
 		Model:           entry.Model,
 		Timeout:         d.cfg.AgentTimeout,
+		SandboxMode:     codexSandboxModeFromTask(task),
 		ResumeSessionID: task.PriorSessionID,
 	})
 	if err != nil {
@@ -1117,6 +1118,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		}
 		return TaskResult{Status: "blocked", Comment: errMsg}, nil
 	}
+}
+
+func codexSandboxModeFromTask(task Task) string {
+	if task.Agent == nil || task.Agent.RuntimeConfig == nil {
+		return ""
+	}
+	value, _ := task.Agent.RuntimeConfig["codex_sandbox_mode"].(string)
+	return value
 }
 
 // repoDataToInfo converts daemon RepoData to repocache RepoInfo.

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -83,3 +83,54 @@ func TestIsWorkspaceNotFoundError(t *testing.T) {
 		t.Fatal("did not expect 500 to be treated as workspace not found")
 	}
 }
+
+func TestCodexSandboxModeFromTask(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		task Task
+		want string
+	}{
+		{
+			name: "missing agent",
+			task: Task{},
+			want: "",
+		},
+		{
+			name: "missing runtime config",
+			task: Task{
+				Agent: &AgentData{},
+			},
+			want: "",
+		},
+		{
+			name: "missing codex sandbox mode",
+			task: Task{
+				Agent: &AgentData{
+					RuntimeConfig: map[string]any{"other": "value"},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "danger full access",
+			task: Task{
+				Agent: &AgentData{
+					RuntimeConfig: map[string]any{"codex_sandbox_mode": "danger-full-access"},
+				},
+			},
+			want: "danger-full-access",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := codexSandboxModeFromTask(tt.task); got != tt.want {
+				t.Fatalf("codexSandboxModeFromTask() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -23,24 +23,25 @@ type RepoData struct {
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID             string     `json:"id"`
-	AgentID        string     `json:"agent_id"`
-	RuntimeID      string     `json:"runtime_id"`
-	IssueID        string     `json:"issue_id"`
-	WorkspaceID    string     `json:"workspace_id"`
-	Agent          *AgentData `json:"agent,omitempty"`
-	Repos          []RepoData `json:"repos,omitempty"`
-	PriorSessionID   string     `json:"prior_session_id,omitempty"`    // Claude session ID from a previous task on this issue
+	ID               string     `json:"id"`
+	AgentID          string     `json:"agent_id"`
+	RuntimeID        string     `json:"runtime_id"`
+	IssueID          string     `json:"issue_id"`
+	WorkspaceID      string     `json:"workspace_id"`
+	Agent            *AgentData `json:"agent,omitempty"`
+	Repos            []RepoData `json:"repos,omitempty"`
+	PriorSessionID   string     `json:"prior_session_id,omitempty"`   // Claude session ID from a previous task on this issue
 	PriorWorkDir     string     `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on this issue
 	TriggerCommentID string     `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 }
 
 // AgentData holds agent details returned by the claim endpoint.
 type AgentData struct {
-	ID           string      `json:"id"`
-	Name         string      `json:"name"`
-	Instructions string      `json:"instructions"`
-	Skills       []SkillData `json:"skills"`
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Instructions  string         `json:"instructions"`
+	RuntimeConfig map[string]any `json:"runtime_config"`
+	Skills        []SkillData    `json:"skills"`
 }
 
 // SkillData represents a structured skill for task execution.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -93,22 +93,22 @@ type RepoData struct {
 }
 
 type AgentTaskResponse struct {
-	ID             string         `json:"id"`
-	AgentID        string         `json:"agent_id"`
-	RuntimeID      string         `json:"runtime_id"`
-	IssueID        string         `json:"issue_id"`
-	WorkspaceID    string         `json:"workspace_id"`
-	Status         string         `json:"status"`
-	Priority       int32          `json:"priority"`
-	DispatchedAt   *string        `json:"dispatched_at"`
-	StartedAt      *string        `json:"started_at"`
-	CompletedAt    *string        `json:"completed_at"`
-	Result         any            `json:"result"`
-	Error          *string        `json:"error"`
-	Agent          *TaskAgentData `json:"agent,omitempty"`
-	Repos          []RepoData     `json:"repos,omitempty"`
-	CreatedAt      string         `json:"created_at"`
-	PriorSessionID   string         `json:"prior_session_id,omitempty"`    // session ID from a previous task on same issue
+	ID               string         `json:"id"`
+	AgentID          string         `json:"agent_id"`
+	RuntimeID        string         `json:"runtime_id"`
+	IssueID          string         `json:"issue_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Status           string         `json:"status"`
+	Priority         int32          `json:"priority"`
+	DispatchedAt     *string        `json:"dispatched_at"`
+	StartedAt        *string        `json:"started_at"`
+	CompletedAt      *string        `json:"completed_at"`
+	Result           any            `json:"result"`
+	Error            *string        `json:"error"`
+	Agent            *TaskAgentData `json:"agent,omitempty"`
+	Repos            []RepoData     `json:"repos,omitempty"`
+	CreatedAt        string         `json:"created_at"`
+	PriorSessionID   string         `json:"prior_session_id,omitempty"`   // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
 	TriggerCommentID *string        `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 }
@@ -116,10 +116,11 @@ type AgentTaskResponse struct {
 // TaskAgentData holds agent info included in claim responses so the daemon
 // can set up the execution environment (branch naming, skill files, instructions).
 type TaskAgentData struct {
-	ID           string                   `json:"id"`
-	Name         string                   `json:"name"`
-	Instructions string                   `json:"instructions"`
-	Skills       []service.AgentSkillData `json:"skills,omitempty"`
+	ID            string                   `json:"id"`
+	Name          string                   `json:"name"`
+	Instructions  string                   `json:"instructions"`
+	RuntimeConfig any                      `json:"runtime_config"`
+	Skills        []service.AgentSkillData `json:"skills,omitempty"`
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
@@ -128,16 +129,16 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		json.Unmarshal(t.Result, &result)
 	}
 	return AgentTaskResponse{
-		ID:           uuidToString(t.ID),
-		AgentID:      uuidToString(t.AgentID),
-		RuntimeID:    uuidToString(t.RuntimeID),
-		IssueID:      uuidToString(t.IssueID),
-		Status:       t.Status,
-		Priority:     t.Priority,
-		DispatchedAt: timestampToPtr(t.DispatchedAt),
-		StartedAt:    timestampToPtr(t.StartedAt),
-		CompletedAt:  timestampToPtr(t.CompletedAt),
-		Result:       result,
+		ID:               uuidToString(t.ID),
+		AgentID:          uuidToString(t.AgentID),
+		RuntimeID:        uuidToString(t.RuntimeID),
+		IssueID:          uuidToString(t.IssueID),
+		Status:           t.Status,
+		Priority:         t.Priority,
+		DispatchedAt:     timestampToPtr(t.DispatchedAt),
+		StartedAt:        timestampToPtr(t.StartedAt),
+		CompletedAt:      timestampToPtr(t.CompletedAt),
+		Result:           result,
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
@@ -310,8 +311,6 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": resp})
 	writeJSON(w, http.StatusCreated, resp)
 }
-
-
 
 type UpdateAgentRequest struct {
 	Name               *string `json:"name"`

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -238,11 +238,18 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	resp := taskToResponse(*task)
 	if agent, err := h.Queries.GetAgent(r.Context(), task.AgentID); err == nil {
 		skills := h.TaskService.LoadAgentSkills(r.Context(), task.AgentID)
+		var runtimeConfig any = map[string]any{}
+		if agent.RuntimeConfig != nil {
+			if err := json.Unmarshal(agent.RuntimeConfig, &runtimeConfig); err != nil {
+				runtimeConfig = map[string]any{}
+			}
+		}
 		resp.Agent = &TaskAgentData{
-			ID:           uuidToString(agent.ID),
-			Name:         agent.Name,
-			Instructions: agent.Instructions,
-			Skills:       skills,
+			ID:            uuidToString(agent.ID),
+			Name:          agent.Name,
+			Instructions:  agent.Instructions,
+			RuntimeConfig: runtimeConfig,
+			Skills:        skills,
 		}
 	}
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -25,6 +25,7 @@ type ExecOptions struct {
 	SystemPrompt    string
 	MaxTurns        int
 	Timeout         time.Duration
+	SandboxMode     string
 	ResumeSessionID string // if non-empty, resume a previous agent session
 }
 

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -11,10 +11,25 @@ import (
 	"time"
 )
 
+const (
+	codexSandboxReadOnly         = "read-only"
+	codexSandboxWorkspaceWrite   = "workspace-write"
+	codexSandboxDangerFullAccess = "danger-full-access"
+)
+
 // codexBackend implements Backend by spawning `codex app-server --listen stdio://`
 // and communicating via JSON-RPC 2.0 over stdin/stdout.
 type codexBackend struct {
 	cfg Config
+}
+
+func normalizeCodexSandboxMode(mode string) string {
+	switch mode {
+	case codexSandboxReadOnly, codexSandboxWorkspaceWrite, codexSandboxDangerFullAccess:
+		return mode
+	default:
+		return codexSandboxWorkspaceWrite
+	}
 }
 
 func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
@@ -141,20 +156,21 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		c.notify("initialized")
 
 		// 2. Start thread
+		sandboxMode := normalizeCodexSandboxMode(opts.SandboxMode)
 		threadResult, err := c.request(runCtx, "thread/start", map[string]any{
-			"model":                    nilIfEmpty(opts.Model),
-			"modelProvider":            nil,
-			"profile":                  nil,
-			"cwd":                      opts.Cwd,
-			"approvalPolicy":           nil,
-			"sandbox":                  "workspace-write",
-			"config":                   nil,
-			"baseInstructions":         nil,
-			"developerInstructions":    nilIfEmpty(opts.SystemPrompt),
-			"compactPrompt":            nil,
-			"includeApplyPatchTool":    nil,
-			"experimentalRawEvents":    false,
-			"persistExtendedHistory":   true,
+			"model":                  nilIfEmpty(opts.Model),
+			"modelProvider":          nil,
+			"profile":                nil,
+			"cwd":                    opts.Cwd,
+			"approvalPolicy":         nil,
+			"sandbox":                sandboxMode,
+			"config":                 nil,
+			"baseInstructions":       nil,
+			"developerInstructions":  nilIfEmpty(opts.SystemPrompt),
+			"compactPrompt":          nil,
+			"includeApplyPatchTool":  nil,
+			"experimentalRawEvents":  false,
+			"persistExtendedHistory": true,
 		})
 		if err != nil {
 			finalStatus = "failed"
@@ -171,7 +187,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			return
 		}
 		c.threadID = threadID
-		b.cfg.Logger.Info("codex thread started", "thread_id", threadID)
+		b.cfg.Logger.Info("codex thread started", "thread_id", threadID, "sandbox_mode", sandboxMode)
 
 		// 3. Send turn and wait for completion
 		_, err = c.request(runCtx, "turn/start", map[string]any{
@@ -234,14 +250,14 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 // ── codexClient: JSON-RPC 2.0 transport ──
 
 type codexClient struct {
-	cfg       Config
-	stdin     interface{ Write([]byte) (int, error) }
-	mu        sync.Mutex
-	nextID    int
-	pending   map[int]*pendingRPC
-	threadID  string
-	turnID    string
-	onMessage func(Message)
+	cfg        Config
+	stdin      interface{ Write([]byte) (int, error) }
+	mu         sync.Mutex
+	nextID     int
+	pending    map[int]*pendingRPC
+	threadID   string
+	turnID     string
+	onMessage  func(Message)
 	onTurnDone func(aborted bool)
 
 	notificationProtocol string // "unknown", "legacy", "raw"

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"testing"
 )
@@ -65,6 +66,41 @@ func splitLines(s string) []string {
 		lines = append(lines, s[start:])
 	}
 	return lines
+}
+
+func TestNormalizeCodexSandboxMode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "default empty", in: "", want: codexSandboxWorkspaceWrite},
+		{name: "workspace write", in: codexSandboxWorkspaceWrite, want: codexSandboxWorkspaceWrite},
+		{name: "danger full access", in: codexSandboxDangerFullAccess, want: codexSandboxDangerFullAccess},
+		{name: "read only", in: codexSandboxReadOnly, want: codexSandboxReadOnly},
+		{name: "unknown falls back", in: "yolo", want: codexSandboxWorkspaceWrite},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeCodexSandboxMode(tc.in); got != tc.want {
+				t.Fatalf("normalizeCodexSandboxMode(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	allowed := []string{
+		codexSandboxReadOnly,
+		codexSandboxWorkspaceWrite,
+		codexSandboxDangerFullAccess,
+	}
+	if !slices.Contains(allowed, normalizeCodexSandboxMode(codexSandboxDangerFullAccess)) {
+		t.Fatal("expected danger-full-access to remain an allowed sandbox mode")
+	}
 }
 
 func TestCodexHandleResponseSuccess(t *testing.T) {


### PR DESCRIPTION
## Summary
This makes Codex sandbox mode configurable per agent instead of hard-coding `workspace-write`.

- add `codex_sandbox_mode` to the agent runtime config and expose it in the agent create/settings UI
- pass the selected mode through the claim/daemon pipeline to the Codex backend
- normalize unknown values back to `workspace-write`
- keep the default behavior unchanged

## Why
In self-hosted setups, some Codex tasks need host-level access for local CLIs or services that are unavailable inside the task workspace sandbox. The current hard-coded `workspace-write` mode blocks those workflows even when the runtime is fully trusted and self-managed.

This keeps the secure default while making higher-privilege modes an explicit opt-in.

## Notes
- default remains `workspace-write`
- supported values are `read-only`, `workspace-write`, and `danger-full-access`
- higher-privilege modes are intended for trusted self-hosted runtimes

## Validation
- `pnpm typecheck`
- `go test ./internal/daemon ./internal/handler ./pkg/agent`