### PR TITLE
feat(cli): add multica attachment download command

### DIFF
--- a/server/cmd/multica/cmd_attachment.go
+++ b/server/cmd/multica/cmd_attachment.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var attachmentCmd = &cobra.Command{
+	Use:   "attachment",
+	Short: "Manage attachments",
+}
+
+var attachmentDownloadCmd = &cobra.Command{
+	Use:   "download <attachment-id>",
+	Short: "Download an attachment file by ID",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAttachmentDownload,
+}
+
+func init() {
+	attachmentCmd.AddCommand(attachmentDownloadCmd)
+	attachmentDownloadCmd.Flags().StringP("output-dir", "o", ".", "Directory to save the downloaded file")
+}
+
+func runAttachmentDownload(cmd *cobra.Command, args []string) error {
+	attachmentID := args[0]
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Fetch attachment metadata to get the download URL and filename.
+	var att map[string]any
+	if err := client.GetJSON(ctx, "/api/attachments/"+attachmentID, &att); err != nil {
+		return fmt.Errorf("get attachment: %w", err)
+	}
+
+	downloadURL := strVal(att, "download_url")
+	if downloadURL == "" {
+		return fmt.Errorf("attachment has no download URL")
+	}
+
+	filename := strVal(att, "filename")
+	if filename == "" {
+		filename = attachmentID
+	}
+
+	outDir, _ := cmd.Flags().GetString("output-dir")
+	destPath := filepath.Join(outDir, filename)
+
+	// Download the file.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("create download request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("create file %s: %w", destPath, err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	abs, _ := filepath.Abs(destPath)
+	fmt.Println(abs)
+	return nil
+}

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -33,6 +33,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(issueCmd)
 	rootCmd.AddCommand(repoCmd)
+	rootCmd.AddCommand(attachmentCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(updateCmd)
 }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -179,6 +179,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 			})
 
 			// Attachments
+			r.Get("/api/attachments/{id}", h.GetAttachment)
 			r.Delete("/api/attachments/{id}", h.DeleteAttachment)
 
 			// Comments

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -51,7 +51,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica workspace get --output json` — Get workspace details and context\n")
 	b.WriteString("- `multica agent list --output json` — List agents in workspace\n")
 	b.WriteString("- `multica issue runs <issue-id> --output json` — List all execution runs for an issue (status, timestamps, errors)\n")
-	b.WriteString("- `multica issue run-messages <task-id> [--since <seq>] --output json` — List messages for a specific execution run (supports incremental fetch)\n\n")
+	b.WriteString("- `multica issue run-messages <task-id> [--since <seq>] --output json` — List messages for a specific execution run (supports incremental fetch)\n")
+	b.WriteString("- `multica attachment download <id> [-o <dir>]` — Download an attachment file locally by ID\n\n")
 
 	b.WriteString("### Write\n")
 	b.WriteString("- `multica issue comment add <issue-id> --content \"...\" [--parent <comment-id>]` — Post a comment (use --parent to reply to a specific comment)\n")
@@ -133,6 +134,13 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- **Member**: `[@Name](mention://member/<user-id>)` — renders as a styled mention and sends a notification\n")
 	b.WriteString("- **Agent**: `[@Name](mention://agent/<agent-id>)` — renders as a styled mention\n\n")
 	b.WriteString("Use `multica issue list --output json` to look up issue IDs, and `multica workspace members --output json` for member IDs.\n\n")
+
+	b.WriteString("## Attachments\n\n")
+	b.WriteString("Issues and comments may include file attachments (images, documents, etc.).\n")
+	b.WriteString("Use the download command to fetch attachment files locally:\n\n")
+	b.WriteString("```\nmultica attachment download <attachment-id>\n```\n\n")
+	b.WriteString("This downloads the file to the current directory and prints the local path. Use `-o <dir>` to save elsewhere.\n")
+	b.WriteString("After downloading, you can read the file directly (e.g. view an image, read a document).\n\n")
 
 	b.WriteString("## Output\n\n")
 	b.WriteString("Keep comments concise and natural — state the outcome, not the process.\n")

--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -218,6 +218,30 @@ func (h *Handler) ListAttachments(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
+// GetAttachment — GET /api/attachments/{id}
+// ---------------------------------------------------------------------------
+
+func (h *Handler) GetAttachment(w http.ResponseWriter, r *http.Request) {
+	attachmentID := chi.URLParam(r, "id")
+	workspaceID := resolveWorkspaceID(r)
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id is required")
+		return
+	}
+
+	att, err := h.Queries.GetAttachment(r.Context(), db.GetAttachmentParams{
+		ID:          parseUUID(attachmentID),
+		WorkspaceID: parseUUID(workspaceID),
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "attachment not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, h.attachmentToResponse(att))
+}
+
+// ---------------------------------------------------------------------------
 // DeleteAttachment — DELETE /api/attachments/{id}
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Agents were using `curl` to download attachments because there was no CLI command and the generated CLAUDE.md didn't document one, causing auth failures with signed URLs
- Added `GET /api/attachments/{id}` endpoint to fetch single attachment metadata (including signed download URL)
- Added `multica attachment download <id> [-o <dir>]` CLI command that fetches metadata then downloads the file
- Updated the agent CLAUDE.md template (`runtime_config.go`) to document the command and added an Attachments section explaining usage

## Test plan
- [ ] Verify `multica attachment download <id>` downloads an attachment file correctly
- [ ] Verify `-o <dir>` flag saves to custom directory
- [ ] Verify `GET /api/attachments/{id}` returns correct metadata with signed download URL
- [ ] Verify agents now see the `multica attachment download` command in their generated CLAUDE.md
- [ ] Run `make check` to ensure all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes [MUL-322](mention://issue/925708cf-aaf2-4242-a29b-8d20c5fcba3a)