### PR TITLE
fix(trigger): skip parent mention inheritance when reply @mentions only members

### DIFF
--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -381,6 +381,34 @@ func TestCommentTriggerThreadInheritedMention(t *testing.T) {
 			t.Errorf("expected 1 pending task (no duplicate), got %d", n)
 		}
 	})
+
+	t.Run("reply mentioning only a member does not inherit agent mention", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// Top-level comment @mentions the agent.
+		content := fmt.Sprintf("[@Agent](mention://agent/%s) can you help?", agentID)
+		threadID := postComment(t, issueID, content, nil)
+		clearTasks(t, issueID)
+		// Reply mentions only a member — should NOT inherit parent's agent mention.
+		reply := fmt.Sprintf("cc [@Someone](mention://member/%s)", testUserID)
+		postComment(t, issueID, reply, strPtr(threadID))
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (member-only reply should not inherit agent mention), got %d", n)
+		}
+	})
+
+	t.Run("reply mentioning agent and member still inherits", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// Top-level comment @mentions the agent.
+		content := fmt.Sprintf("[@Agent](mention://agent/%s) review this", agentID)
+		threadID := postComment(t, issueID, content, nil)
+		clearTasks(t, issueID)
+		// Reply mentions both agent and member — should still trigger.
+		reply := fmt.Sprintf("[@Agent](mention://agent/%s) and cc [@Someone](mention://member/%s)", agentID, testUserID)
+		postComment(t, issueID, reply, strPtr(threadID))
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (reply mentions agent explicitly), got %d", n)
+		}
+	})
 }
 
 // TestCommentTriggerCoalescing verifies that rapid-fire comments don't create

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -262,7 +262,9 @@ func (h *Handler) isReplyToMemberThread(parent *db.Comment, content string, issu
 // enqueues a task for each mentioned agent. When parentComment is non-nil
 // (i.e. the comment is a reply), mentions from the parent (thread root) are
 // also included so that agents mentioned in the top-level comment are
-// re-triggered by subsequent replies in the same thread.
+// re-triggered by subsequent replies in the same thread — unless the reply
+// explicitly @mentions only non-agent entities (members, issues), which
+// signals the user is talking to other people and not the agent.
 // Skips self-mentions, agents that are already the issue's assignee (handled
 // by on_comment), agents with on_mention trigger disabled, and private agents
 // mentioned by non-owner members (only the agent owner or workspace
@@ -274,16 +276,30 @@ func (h *Handler) enqueueMentionedAgentTasks(ctx context.Context, issue db.Issue
 	mentions := util.ParseMentions(comment.Content)
 	// When replying in a thread, also include mentions from the parent comment
 	// so that agents mentioned in the thread root are triggered by replies.
+	// However, skip inheritance when the reply explicitly @mentions only
+	// non-agent entities (members, issues) — the user is directing the reply
+	// at other people, not requesting work from agents in the parent thread.
 	if parentComment != nil {
-		parentMentions := util.ParseMentions(parentComment.Content)
-		seen := make(map[string]bool, len(mentions))
+		hasAgentMention := false
+		hasNonAgentMention := false
 		for _, m := range mentions {
-			seen[m.Type+":"+m.ID] = true
+			if m.Type == "agent" {
+				hasAgentMention = true
+			} else {
+				hasNonAgentMention = true
+			}
 		}
-		for _, m := range parentMentions {
-			if !seen[m.Type+":"+m.ID] {
-				mentions = append(mentions, m)
+		if hasAgentMention || !hasNonAgentMention {
+			parentMentions := util.ParseMentions(parentComment.Content)
+			seen := make(map[string]bool, len(mentions))
+			for _, m := range mentions {
 				seen[m.Type+":"+m.ID] = true
+			}
+			for _, m := range parentMentions {
+				if !seen[m.Type+":"+m.ID] {
+					mentions = append(mentions, m)
+					seen[m.Type+":"+m.ID] = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- When a reply in a thread explicitly `@mentions` only non-agent entities (members/issues), parent comment's agent mentions are no longer inherited
- This prevents false agent triggers when a user is directing their reply at other people (e.g. `cc @Yushen`) rather than requesting work from agents in the thread root
- Plain text replies (no mentions) and replies that include agent mentions continue to inherit normally

## Root Cause
PR #375 (`c9c82302`) introduced thread-root mention inheritance so agents mentioned in a top-level comment get re-triggered by replies. However, it unconditionally merged parent mentions without checking whether the reply was directed at other people. A reply like `cc @Yushen` (member-only mention) would inherit `@Lambda` from the parent, falsely triggering the agent.

## Fix
In `enqueueMentionedAgentTasks`, before inheriting parent mentions, check if the current reply has explicit mentions. If it mentions only non-agent entities (members, issues) but no agents, skip inheritance — the user is talking to people, not agents.

| Reply content | Has agent mention | Has non-agent mention | Inherits parent? |
|---|---|---|---|
| `cc @Yushen` | No | Yes | **No** (fixed) |
| `here is more context` | No | No | Yes |
| `@Lambda any update?` | Yes | No | Yes |
| `@Lambda cc @Yushen` | Yes | Yes | Yes |

## Test plan
- [x] Added integration test: reply mentioning only a member does not inherit agent mention
- [x] Added integration test: reply mentioning agent and member still inherits
- [x] Existing tests pass (reply with no mentions still inherits, re-mentioning same agent deduplicates)