### PR TITLE
fix(execenv): instruct agents to always use multica CLI for platform resources

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -143,6 +143,13 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("This downloads the file to the current directory and prints the local path. Use `-o <dir>` to save elsewhere.\n")
 	b.WriteString("After downloading, you can read the file directly (e.g. view an image, read a document).\n\n")
 
+	b.WriteString("## Important: Always Use the `multica` CLI\n\n")
+	b.WriteString("All interactions with Multica platform resources — including issues, comments, attachments, images, files, and any other platform data — **must** go through the `multica` CLI. ")
+	b.WriteString("Do NOT use `curl`, `wget`, or any other HTTP client to access Multica URLs or APIs directly. ")
+	b.WriteString("Multica resource URLs require authenticated access that only the `multica` CLI can provide.\n\n")
+	b.WriteString("If you need to perform an operation that is not covered by any existing `multica` command, ")
+	b.WriteString("do NOT attempt to work around it. Instead, post a comment mentioning the workspace owner to request the missing functionality.\n\n")
+
 	b.WriteString("## Output\n\n")
 	b.WriteString("Keep comments concise and natural — state the outcome, not the process.\n")
 	b.WriteString("Good: \"Fixed the login redirect. PR: https://...\"\n")


### PR DESCRIPTION
## Summary

- Adds an **"Important: Always Use the `multica` CLI"** section to the auto-generated `CLAUDE.md` template that agents receive
- Explicitly prohibits agents from using `curl`, `wget`, or other HTTP clients to access Multica URLs directly (attachment downloads were failing because of this)
- Instructs agents to escalate to their workspace owner if a needed `multica` CLI command doesn't exist

Fixes [MUL-322](mention://issue/925708cf-aaf2-4242-a29b-8d20c5fcba3a) — agents were using `curl` to download attachments instead of `multica attachment download`, causing auth errors.

## Test plan

- [ ] Verify the generated CLAUDE.md includes the new "Important" section
- [ ] Test that agents use `multica attachment download` when encountering attachments
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)