### PR TITLE
fix(web): remember last selected workspace after re-login

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -153,7 +153,8 @@ function LoginPageContent() {
 
         await verifyCode(email, value);
         const wsList = await api.listWorkspaces();
-        await hydrateWorkspace(wsList);
+        const lastWsId = localStorage.getItem("multica_workspace_id");
+        await hydrateWorkspace(wsList, lastWsId);
         router.push(searchParams.get("next") || "/issues");
       } catch (err) {
         setError(

--- a/apps/web/features/auth/store.ts
+++ b/apps/web/features/auth/store.ts
@@ -36,7 +36,6 @@ export const useAuthStore = create<AuthState>((set) => ({
       api.setToken(null);
       api.setWorkspaceId(null);
       localStorage.removeItem("multica_token");
-      localStorage.removeItem("multica_workspace_id");
       set({ user: null, isLoading: false });
     }
   },
@@ -56,7 +55,6 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   logout: () => {
     localStorage.removeItem("multica_token");
-    localStorage.removeItem("multica_workspace_id");
     api.setToken(null);
     api.setWorkspaceId(null);
     clearLoggedInCookie();

--- a/apps/web/features/workspace/store.ts
+++ b/apps/web/features/workspace/store.ts
@@ -233,7 +233,6 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
 
   clearWorkspace: () => {
     api.setWorkspaceId(null);
-    localStorage.removeItem("multica_workspace_id");
     set({ workspace: null, workspaces: [], members: [], agents: [], skills: [] });
   },
 }));


### PR DESCRIPTION
## Summary
- Stop clearing `multica_workspace_id` from localStorage on logout — it's a user preference, not session state
- On fresh login, pass the stored workspace ID to `hydrateWorkspace` so the user returns to their last workspace

## What was happening
When a user logged out and back in, `multica_workspace_id` was removed from localStorage during logout (in both `auth/store.ts` and `workspace/store.ts`). The login page then called `hydrateWorkspace(wsList)` without a preferred ID, so it always defaulted to the first workspace in the list.

## What this changes
- `auth/store.ts`: Removed `localStorage.removeItem("multica_workspace_id")` from `logout()` and `initialize()` error handler
- `workspace/store.ts`: Removed `localStorage.removeItem("multica_workspace_id")` from `clearWorkspace()`
- `login/page.tsx`: Read the persisted workspace ID and pass it to `hydrateWorkspace(wsList, lastWsId)`

If the stored workspace ID is stale (workspace deleted or user no longer has access), `hydrateWorkspace` already falls back to `wsList[0]`.

Closes MUL-346

## Test plan
- [x] Log in, switch to a non-default workspace
- [x] Log out, then log back in — should land on the previously selected workspace
- [ ] Delete localStorage manually, log in — should fall back to first workspace