### PR TITLE
feat: add Google and GitHub OAuth login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,10 @@ RESEND_FROM_EMAIL=noreply@multica.ai
 # Google OAuth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
 
 # S3 / CloudFront
 S3_BUCKET=

--- a/apps/web/app/(auth)/auth/callback/page.tsx
+++ b/apps/web/app/(auth)/auth/callback/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useAuthStore } from "@/features/auth";
+import { useWorkspaceStore } from "@/features/workspace";
+import { api } from "@/shared/api";
+import { setLoggedInCookie } from "@/features/auth/auth-cookie";
+
+function OAuthCallbackContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const setUser = useAuthStore((s) => s.setUser);
+  const hydrateWorkspace = useWorkspaceStore((s) => s.hydrateWorkspace);
+  const hasRun = useRef(false);
+
+  useEffect(() => {
+    if (hasRun.current) return;
+    hasRun.current = true;
+
+    const token = searchParams.get("token");
+    const next = searchParams.get("next") || "/issues";
+    const error = searchParams.get("error");
+
+    // Strip token from URL to prevent leaking via Referer/history.
+    window.history.replaceState({}, "", window.location.pathname);
+
+    if (error) {
+      router.replace(`/login?error=${encodeURIComponent(error)}`);
+      return;
+    }
+
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+
+    // Store the token and initialize the session.
+    localStorage.setItem("multica_token", token);
+    api.setToken(token);
+    setLoggedInCookie();
+
+    api
+      .getMe()
+      .then(async (user) => {
+        setUser(user);
+        const wsList = await api.listWorkspaces();
+        const lastWsId = localStorage.getItem("multica_workspace_id");
+        await hydrateWorkspace(wsList, lastWsId);
+        router.replace(next);
+      })
+      .catch(() => {
+        // Token was invalid — clear and redirect to login.
+        localStorage.removeItem("multica_token");
+        api.setToken(null);
+        router.replace("/login");
+      });
+  }, [searchParams, router, setUser, hydrateWorkspace]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-muted-foreground">Signing you in...</p>
+    </div>
+  );
+}
+
+export default function OAuthCallbackPage() {
+  return (
+    <Suspense fallback={null}>
+      <OAuthCallbackContent />
+    </Suspense>
+  );
+}

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -68,6 +68,20 @@ function LoginPageContent() {
   const [cooldown, setCooldown] = useState(0);
   const [existingUser, setExistingUser] = useState<User | null>(null);
 
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+  const handleOAuth = (provider: string) => {
+    const next = searchParams.get("next") || "";
+    const cliCallback = searchParams.get("cli_callback") || "";
+    const cliState = searchParams.get("cli_state") || "";
+    const params = new URLSearchParams();
+    if (next) params.set("next", next);
+    if (cliCallback) params.set("cli_callback", cliCallback);
+    if (cliState) params.set("cli_state", cliState);
+    const qs = params.toString();
+    window.location.href = `${apiUrl}/auth/${provider}${qs ? "?" + qs : ""}`;
+  };
+
   // Check for existing session when CLI callback is present.
   useEffect(() => {
     const cliCallback = searchParams.get("cli_callback");
@@ -98,6 +112,14 @@ function LoginPageContent() {
     const timer = setTimeout(() => setCooldown((c) => c - 1), 1000);
     return () => clearTimeout(timer);
   }, [cooldown]);
+
+  // Show OAuth error if redirected back with error param.
+  useEffect(() => {
+    const oauthError = searchParams.get("error");
+    if (oauthError === "oauth_denied") {
+      setError("Authentication was cancelled or denied.");
+    }
+  }, [searchParams]);
 
   const handleCliAuthorize = async () => {
     const cliCallback = searchParams.get("cli_callback");
@@ -302,10 +324,59 @@ function LoginPageContent() {
                 required
               />
             </div>
-            {error && (
-              <p className="text-sm text-destructive">{error}</p>
-            )}
           </form>
+          <div className="relative my-4">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-card px-2 text-muted-foreground">
+                Or continue with
+              </span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOAuth("google")}
+              disabled={submitting}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
+              Google
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOAuth("github")}
+              disabled={submitting}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              GitHub
+            </Button>
+          </div>
+          {error && (
+            <p className="mt-4 text-sm text-destructive">{error}</p>
+          )}
         </CardContent>
         <CardFooter>
           <Button

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -23,6 +23,12 @@ import {
 } from "@/components/ui/input-otp";
 import type { User } from "@/shared/types";
 
+interface AuthConfig {
+  email: boolean;
+  google: boolean;
+  github: boolean;
+}
+
 function validateCliCallback(cliCallback: string): boolean {
   try {
     const cbUrl = new URL(cliCallback);
@@ -60,6 +66,7 @@ function LoginPageContent() {
     }
   }, [isLoading, user, router, searchParams]);
 
+  const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
   const [step, setStep] = useState<"email" | "code" | "cli_confirm">("email");
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
@@ -69,6 +76,17 @@ function LoginPageContent() {
   const [existingUser, setExistingUser] = useState<User | null>(null);
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+  // Fetch auth config on mount.
+  useEffect(() => {
+    fetch(`${apiUrl}/auth/config`)
+      .then((res) => res.json())
+      .then((data: AuthConfig) => setAuthConfig(data))
+      .catch(() => {
+        // Fallback: show all methods if config endpoint is unreachable.
+        setAuthConfig({ email: true, google: true, github: true });
+      });
+  }, [apiUrl]);
 
   const handleOAuth = (provider: string) => {
     const next = searchParams.get("next") || "";
@@ -304,6 +322,12 @@ function LoginPageContent() {
     );
   }
 
+  // Derive which sections to show.
+  const showEmail = authConfig?.email ?? true;
+  const showGoogle = authConfig?.google ?? false;
+  const showGithub = authConfig?.github ?? false;
+  const hasOAuth = showGoogle || showGithub;
+
   return (
     <div className="flex min-h-screen items-center justify-center">
       <Card className="w-full max-w-sm">
@@ -311,84 +335,96 @@ function LoginPageContent() {
           <CardTitle className="text-2xl">Multica</CardTitle>
           <CardDescription>Turn coding agents into real teammates</CardDescription>
         </CardHeader>
-        <CardContent>
-          <form id="login-form" onSubmit={handleSendCode} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="you@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
+        <CardContent className="space-y-4">
+          {hasOAuth && (
+            <div className={`grid gap-2 ${showGoogle && showGithub ? "grid-cols-2" : "grid-cols-1"}`}>
+              {showGoogle && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOAuth("google")}
+                  disabled={submitting}
+                >
+                  <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                    <path
+                      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                      fill="#4285F4"
+                    />
+                    <path
+                      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                      fill="#34A853"
+                    />
+                    <path
+                      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                      fill="#FBBC05"
+                    />
+                    <path
+                      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                      fill="#EA4335"
+                    />
+                  </svg>
+                  Google
+                </Button>
+              )}
+              {showGithub && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOAuth("github")}
+                  disabled={submitting}
+                >
+                  <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                  </svg>
+                  GitHub
+                </Button>
+              )}
             </div>
-          </form>
-          <div className="relative my-4">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
+          )}
+          {hasOAuth && showEmail && (
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-card px-2 text-muted-foreground">
+                  Or continue with email
+                </span>
+              </div>
             </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-card px-2 text-muted-foreground">
-                Or continue with
-              </span>
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleOAuth("google")}
-              disabled={submitting}
-            >
-              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                <path
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                  fill="#4285F4"
+          )}
+          {showEmail && (
+            <form id="login-form" onSubmit={handleSendCode} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
                 />
-                <path
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                  fill="#34A853"
-                />
-                <path
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                  fill="#FBBC05"
-                />
-                <path
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                  fill="#EA4335"
-                />
-              </svg>
-              Google
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleOAuth("github")}
-              disabled={submitting}
-            >
-              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-              </svg>
-              GitHub
-            </Button>
-          </div>
+              </div>
+            </form>
+          )}
           {error && (
-            <p className="mt-4 text-sm text-destructive">{error}</p>
+            <p className="text-sm text-destructive">{error}</p>
           )}
         </CardContent>
-        <CardFooter>
-          <Button
-            type="submit"
-            form="login-form"
-            disabled={submitting}
-            className="w-full"
-            size="lg"
-          >
-            {submitting ? "Sending code..." : "Continue"}
-          </Button>
-        </CardFooter>
+        {showEmail && (
+          <CardFooter>
+            <Button
+              type="submit"
+              form="login-form"
+              disabled={submitting}
+              className="w-full"
+              size="lg"
+            >
+              {submitting ? "Sending code..." : "Continue"}
+            </Button>
+          </CardFooter>
+        )}
       </Card>
     </div>
   );

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -80,6 +80,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 	})
 
 	// Auth (public)
+	r.Get("/auth/config", h.AuthConfig)
 	r.Post("/auth/send-code", h.SendCode)
 	r.Post("/auth/verify-code", h.VerifyCode)
 	r.Get("/auth/callback", h.OAuthCallback)

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -82,6 +82,8 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 	// Auth (public)
 	r.Post("/auth/send-code", h.SendCode)
 	r.Post("/auth/verify-code", h.VerifyCode)
+	r.Get("/auth/callback", h.OAuthCallback)
+	r.Get("/auth/{provider}", h.OAuthStart)
 
 	// Daemon API routes (all require a valid token)
 	r.Route("/api/daemon", func(r chi.Router) {

--- a/server/go.mod
+++ b/server/go.mod
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
@@ -40,6 +41,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
@@ -79,6 +81,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -377,3 +377,20 @@ func (h *Handler) UpdateMe(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, userToResponse(updatedUser))
 }
+
+// AuthConfig handles GET /auth/config — returns which authentication methods are available.
+func (h *Handler) AuthConfig(w http.ResponseWriter, r *http.Request) {
+	isDev := os.Getenv("APP_ENV") != "production"
+
+	// Email login is available in dev (codes print to stdout) or when Resend is configured.
+	emailEnabled := isDev || os.Getenv("RESEND_API_KEY") != ""
+
+	googleEnabled := os.Getenv("GOOGLE_CLIENT_ID") != "" && os.Getenv("GOOGLE_CLIENT_SECRET") != ""
+	githubEnabled := os.Getenv("GITHUB_CLIENT_ID") != "" && os.Getenv("GITHUB_CLIENT_SECRET") != ""
+
+	writeJSON(w, http.StatusOK, map[string]bool{
+		"email":  emailEnabled,
+		"google": googleEnabled,
+		"github": githubEnabled,
+	})
+}

--- a/server/internal/handler/oauth.go
+++ b/server/internal/handler/oauth.go
@@ -1,0 +1,475 @@
+package handler
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
+	"golang.org/x/oauth2/google"
+
+	"github.com/multica-ai/multica/server/internal/logger"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// maxOAuthResponseSize limits provider API responses to 1 MB.
+const maxOAuthResponseSize = 1 << 20
+
+// oauthParams holds redirect parameters stored in the oauth_params cookie.
+type oauthParams struct {
+	NextURL     string `json:"next_url,omitempty"`
+	CLICallback string `json:"cli_callback,omitempty"`
+	CLIState    string `json:"cli_state,omitempty"`
+}
+
+// oauthRedirectURL constructs the OAuth callback URL from MULTICA_SERVER_URL.
+// MULTICA_SERVER_URL is always set (e.g. "ws://localhost:8080/ws") —
+// we convert ws(s):// → http(s):// and replace the path with /auth/callback.
+func oauthRedirectURL() string {
+	return oauthRedirectURLFrom(os.Getenv("MULTICA_SERVER_URL"))
+}
+
+// oauthRedirectURLFrom derives the OAuth callback URL from the given server URL.
+// Exported for testing via the unexported function name convention (tested directly).
+func oauthRedirectURLFrom(serverURL string) string {
+	if serverURL == "" {
+		return "http://localhost:8080/auth/callback"
+	}
+
+	// Convert ws(s) scheme to http(s).
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return "http://localhost:8080/auth/callback"
+	}
+
+	switch u.Scheme {
+	case "wss":
+		u.Scheme = "https"
+	case "ws":
+		u.Scheme = "http"
+	}
+
+	// Replace any path (e.g. "/ws") with our callback path.
+	u.Path = "/auth/callback"
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	return u.String()
+}
+
+// oauthProviderConfig returns the oauth2.Config for the given provider name.
+// Returns nil if the provider is unknown or not configured.
+func oauthProviderConfig(provider string) *oauth2.Config {
+	switch provider {
+	case "google":
+		clientID := os.Getenv("GOOGLE_CLIENT_ID")
+		clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
+		if clientID == "" || clientSecret == "" {
+			return nil
+		}
+		return &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Endpoint:     google.Endpoint,
+			RedirectURL:  oauthRedirectURL(),
+			Scopes:       []string{"openid", "email", "profile"},
+		}
+	case "github":
+		clientID := os.Getenv("GITHUB_CLIENT_ID")
+		clientSecret := os.Getenv("GITHUB_CLIENT_SECRET")
+		if clientID == "" || clientSecret == "" {
+			return nil
+		}
+		return &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Endpoint:     github.Endpoint,
+			RedirectURL:  oauthRedirectURL(),
+			Scopes:       []string{"user:email"},
+		}
+	default:
+		return nil
+	}
+}
+
+func generateOAuthState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// isSecureRequest returns true if the request was made over HTTPS,
+// accounting for reverse proxies that set X-Forwarded-Proto.
+func isSecureRequest(r *http.Request) bool {
+	return r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+}
+
+// isValidCLICallback validates that a CLI callback URL points to localhost.
+func isValidCLICallback(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" {
+		return false
+	}
+	host := u.Hostname()
+	return host == "localhost" || host == "127.0.0.1"
+}
+
+// isValidNextPath validates that a redirect path is a relative path (no open redirect).
+func isValidNextPath(path string) bool {
+	return strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "//")
+}
+
+// OAuthStart handles GET /auth/{provider} — redirects the user to the provider's consent screen.
+func (h *Handler) OAuthStart(w http.ResponseWriter, r *http.Request) {
+	provider := r.PathValue("provider")
+	cfg := oauthProviderConfig(provider)
+	if cfg == nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported or unconfigured oauth provider: %s", provider))
+		return
+	}
+
+	state, err := generateOAuthState()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate state")
+		return
+	}
+
+	// Encode the provider in the state so the callback knows which provider was used.
+	// Format: "provider:randomState"
+	stateWithProvider := provider + ":" + state
+
+	// Preserve next and cli_callback query params through the OAuth flow via the state cookie.
+	nextURL := r.URL.Query().Get("next")
+	cliCallback := r.URL.Query().Get("cli_callback")
+	cliState := r.URL.Query().Get("cli_state")
+
+	// Validate cli_callback to prevent open redirect attacks.
+	if cliCallback != "" && !isValidCLICallback(cliCallback) {
+		writeError(w, http.StatusBadRequest, "invalid cli_callback URL: must be http://localhost or http://127.0.0.1")
+		return
+	}
+
+	// Validate next path to prevent open redirect attacks.
+	if nextURL != "" && !isValidNextPath(nextURL) {
+		nextURL = ""
+	}
+
+	secure := isSecureRequest(r)
+
+	// Store state in a short-lived cookie for CSRF validation.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "oauth_state",
+		Value:    stateWithProvider,
+		Path:     "/",
+		MaxAge:   600, // 10 minutes
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   secure,
+	})
+
+	// Store redirect params in a separate cookie (base64-encoded JSON for safe encoding).
+	if nextURL != "" || cliCallback != "" {
+		paramsJSON, _ := json.Marshal(oauthParams{
+			NextURL:     nextURL,
+			CLICallback: cliCallback,
+			CLIState:    cliState,
+		})
+		http.SetCookie(w, &http.Cookie{
+			Name:     "oauth_params",
+			Value:    base64.RawURLEncoding.EncodeToString(paramsJSON),
+			Path:     "/",
+			MaxAge:   600,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   secure,
+		})
+	}
+
+	url := cfg.AuthCodeURL(stateWithProvider)
+	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+}
+
+// OAuthCallback handles GET /auth/callback — exchanges the code for a token, fetches user info, issues JWT.
+func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request) {
+	// Read and validate state.
+	stateCookie, err := r.Cookie("oauth_state")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "missing oauth state cookie")
+		return
+	}
+
+	stateParam := r.URL.Query().Get("state")
+	if stateParam == "" || stateParam != stateCookie.Value {
+		writeError(w, http.StatusBadRequest, "invalid oauth state")
+		return
+	}
+
+	// Extract provider from state ("provider:random").
+	parts := strings.SplitN(stateParam, ":", 2)
+	if len(parts) != 2 {
+		writeError(w, http.StatusBadRequest, "malformed oauth state")
+		return
+	}
+	provider := parts[0]
+
+	cfg := oauthProviderConfig(provider)
+	if cfg == nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported provider: %s", provider))
+		return
+	}
+
+	// Check for error from provider.
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		desc := r.URL.Query().Get("error_description")
+		slog.Warn("oauth provider returned error", "provider", provider, "error", errParam, "description", desc)
+		frontendURL := os.Getenv("MULTICA_APP_URL")
+		if frontendURL == "" {
+			frontendURL = "http://localhost:3000"
+		}
+		http.Redirect(w, r, frontendURL+"/login?error=oauth_denied", http.StatusTemporaryRedirect)
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		writeError(w, http.StatusBadRequest, "missing authorization code")
+		return
+	}
+
+	// Exchange code for token.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	oauthToken, err := cfg.Exchange(ctx, code)
+	if err != nil {
+		slog.Error("oauth token exchange failed", "provider", provider, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to exchange authorization code")
+		return
+	}
+
+	// Fetch user email from provider.
+	email, name, avatarURL, err := fetchOAuthUserInfo(ctx, provider, cfg, oauthToken)
+	if err != nil {
+		slog.Error("failed to fetch oauth user info", "provider", provider, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to fetch user info from provider")
+		return
+	}
+
+	if email == "" {
+		writeError(w, http.StatusBadRequest, "could not retrieve email from oauth provider")
+		return
+	}
+
+	// Find or create user (reuses existing auth logic — auto-links by email).
+	user, err := h.findOrCreateUser(r.Context(), email)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create user")
+		return
+	}
+
+	// Update name and avatar if user was just created (name matches email prefix pattern).
+	if name != "" && user.Name == strings.Split(email, "@")[0] {
+		updated, updateErr := h.Queries.UpdateUser(r.Context(), db.UpdateUserParams{
+			ID:        user.ID,
+			Name:      name,
+			AvatarUrl: strToText(avatarURL),
+		})
+		if updateErr == nil {
+			user = updated
+		}
+	} else if avatarURL != "" && !user.AvatarUrl.Valid {
+		updated, updateErr := h.Queries.UpdateUser(r.Context(), db.UpdateUserParams{
+			ID:        user.ID,
+			Name:      user.Name,
+			AvatarUrl: strToText(avatarURL),
+		})
+		if updateErr == nil {
+			user = updated
+		}
+	}
+
+	if err := h.ensureUserWorkspace(r.Context(), user); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to provision workspace")
+		return
+	}
+
+	jwtToken, err := h.issueJWT(user)
+	if err != nil {
+		slog.Warn("oauth login failed to issue jwt", append(logger.RequestAttrs(r), "error", err, "email", email)...)
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+
+	// Set CloudFront signed cookies for CDN access.
+	if h.CFSigner != nil {
+		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(72 * time.Hour)) {
+			http.SetCookie(w, cookie)
+		}
+	}
+
+	// Read redirect params from cookie (base64-encoded JSON).
+	nextURL := ""
+	cliCallback := ""
+	cliState := ""
+	if paramsCookie, paramErr := r.Cookie("oauth_params"); paramErr == nil {
+		if decoded, decErr := base64.RawURLEncoding.DecodeString(paramsCookie.Value); decErr == nil {
+			var params oauthParams
+			if json.Unmarshal(decoded, &params) == nil {
+				nextURL = params.NextURL
+				cliCallback = params.CLICallback
+				cliState = params.CLIState
+			}
+		}
+	}
+
+	// Clear OAuth cookies.
+	http.SetCookie(w, &http.Cookie{Name: "oauth_state", Path: "/", MaxAge: -1})
+	http.SetCookie(w, &http.Cookie{Name: "oauth_params", Path: "/", MaxAge: -1})
+
+	slog.Info("user logged in via oauth", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email, "provider", provider)...)
+
+	// For CLI callback flow, redirect directly to the CLI.
+	if cliCallback != "" {
+		if !isValidCLICallback(cliCallback) {
+			writeError(w, http.StatusBadRequest, "invalid cli_callback URL")
+			return
+		}
+		sep := "?"
+		if strings.Contains(cliCallback, "?") {
+			sep = "&"
+		}
+		http.Redirect(w, r, cliCallback+sep+"token="+url.QueryEscape(jwtToken)+"&state="+url.QueryEscape(cliState), http.StatusTemporaryRedirect)
+		return
+	}
+
+	// Redirect to frontend with token in query param.
+	frontendURL := os.Getenv("MULTICA_APP_URL")
+	if frontendURL == "" {
+		frontendURL = "http://localhost:3000"
+	}
+	redirectPath := "/login"
+	if nextURL != "" && isValidNextPath(nextURL) {
+		redirectPath = nextURL
+	}
+	http.Redirect(w, r, frontendURL+"/auth/callback?token="+url.QueryEscape(jwtToken)+"&next="+url.QueryEscape(redirectPath), http.StatusTemporaryRedirect)
+}
+
+// fetchOAuthUserInfo retrieves the user's email, display name, and avatar URL from the OAuth provider.
+func fetchOAuthUserInfo(ctx context.Context, provider string, cfg *oauth2.Config, token *oauth2.Token) (email, name, avatarURL string, err error) {
+	client := cfg.Client(ctx, token)
+
+	switch provider {
+	case "google":
+		resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo")
+		if err != nil {
+			return "", "", "", fmt.Errorf("google userinfo request failed: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return "", "", "", fmt.Errorf("google userinfo API returned %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxOAuthResponseSize))
+		if err != nil {
+			return "", "", "", fmt.Errorf("reading google response: %w", err)
+		}
+		var info struct {
+			Email   string `json:"email"`
+			Name    string `json:"name"`
+			Picture string `json:"picture"`
+		}
+		if err := json.Unmarshal(body, &info); err != nil {
+			return "", "", "", fmt.Errorf("parsing google userinfo: %w", err)
+		}
+		return strings.ToLower(strings.TrimSpace(info.Email)), info.Name, info.Picture, nil
+
+	case "github":
+		// Fetch user profile.
+		resp, err := client.Get("https://api.github.com/user")
+		if err != nil {
+			return "", "", "", fmt.Errorf("github user request failed: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return "", "", "", fmt.Errorf("github user API returned %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxOAuthResponseSize))
+		if err != nil {
+			return "", "", "", fmt.Errorf("reading github response: %w", err)
+		}
+		var ghUser struct {
+			Email     string `json:"email"`
+			Name      string `json:"name"`
+			Login     string `json:"login"`
+			AvatarURL string `json:"avatar_url"`
+		}
+		if err := json.Unmarshal(body, &ghUser); err != nil {
+			return "", "", "", fmt.Errorf("parsing github user: %w", err)
+		}
+
+		ghEmail := strings.ToLower(strings.TrimSpace(ghUser.Email))
+		displayName := ghUser.Name
+		if displayName == "" {
+			displayName = ghUser.Login
+		}
+
+		// If email is empty (private), fetch from /user/emails endpoint.
+		if ghEmail == "" {
+			emailResp, emailErr := client.Get("https://api.github.com/user/emails")
+			if emailErr != nil {
+				return "", "", "", fmt.Errorf("github emails request failed: %w", emailErr)
+			}
+			defer emailResp.Body.Close()
+			if emailResp.StatusCode != http.StatusOK {
+				return "", "", "", fmt.Errorf("github emails API returned %d", emailResp.StatusCode)
+			}
+			emailBody, emailErr := io.ReadAll(io.LimitReader(emailResp.Body, maxOAuthResponseSize))
+			if emailErr != nil {
+				return "", "", "", fmt.Errorf("reading github emails response: %w", emailErr)
+			}
+			var emails []struct {
+				Email    string `json:"email"`
+				Primary  bool   `json:"primary"`
+				Verified bool   `json:"verified"`
+			}
+			if err := json.Unmarshal(emailBody, &emails); err != nil {
+				return "", "", "", fmt.Errorf("parsing github emails: %w", err)
+			}
+			// Pick the primary verified email.
+			for _, e := range emails {
+				if e.Primary && e.Verified {
+					ghEmail = strings.ToLower(strings.TrimSpace(e.Email))
+					break
+				}
+			}
+			// Fallback: any verified email.
+			if ghEmail == "" {
+				for _, e := range emails {
+					if e.Verified {
+						ghEmail = strings.ToLower(strings.TrimSpace(e.Email))
+						break
+					}
+				}
+			}
+		}
+
+		return ghEmail, displayName, ghUser.AvatarURL, nil
+
+	default:
+		return "", "", "", fmt.Errorf("unsupported provider: %s", provider)
+	}
+}

--- a/server/internal/handler/oauth_test.go
+++ b/server/internal/handler/oauth_test.go
@@ -1,0 +1,322 @@
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOAuthRedirectURLFrom(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverURL string
+		want      string
+	}{
+		{
+			name:      "empty falls back to default",
+			serverURL: "",
+			want:      "http://localhost:8080/auth/callback",
+		},
+		{
+			name:      "ws with path",
+			serverURL: "ws://localhost:8080/ws",
+			want:      "http://localhost:8080/auth/callback",
+		},
+		{
+			name:      "wss with path",
+			serverURL: "wss://example.com/ws",
+			want:      "https://example.com/auth/callback",
+		},
+		{
+			name:      "ws no path",
+			serverURL: "ws://localhost:8080",
+			want:      "http://localhost:8080/auth/callback",
+		},
+		{
+			name:      "wss with port and path",
+			serverURL: "wss://api.example.com:443/ws",
+			want:      "https://api.example.com:443/auth/callback",
+		},
+		{
+			name:      "http URL passes through",
+			serverURL: "http://localhost:8080/api",
+			want:      "http://localhost:8080/auth/callback",
+		},
+		{
+			name:      "https URL passes through",
+			serverURL: "https://api.example.com",
+			want:      "https://api.example.com/auth/callback",
+		},
+		{
+			name:      "invalid URL falls back to default",
+			serverURL: "://not-valid",
+			want:      "http://localhost:8080/auth/callback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := oauthRedirectURLFrom(tt.serverURL)
+			if got != tt.want {
+				t.Errorf("oauthRedirectURLFrom(%q) = %q, want %q", tt.serverURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidCLICallback(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   bool
+	}{
+		{
+			name:   "localhost with port",
+			rawURL: "http://localhost:12345/callback",
+			want:   true,
+		},
+		{
+			name:   "127.0.0.1 with port",
+			rawURL: "http://127.0.0.1:54321/auth",
+			want:   true,
+		},
+		{
+			name:   "localhost no port",
+			rawURL: "http://localhost/callback",
+			want:   true,
+		},
+		{
+			name:   "https not allowed",
+			rawURL: "https://localhost:12345/callback",
+			want:   false,
+		},
+		{
+			name:   "remote host rejected",
+			rawURL: "http://evil.com:12345/callback",
+			want:   false,
+		},
+		{
+			name:   "empty string",
+			rawURL: "",
+			want:   false,
+		},
+		{
+			name:   "relative path",
+			rawURL: "/callback",
+			want:   false,
+		},
+		{
+			name:   "javascript scheme",
+			rawURL: "javascript:alert(1)",
+			want:   false,
+		},
+		{
+			name:   "ftp scheme",
+			rawURL: "ftp://localhost/file",
+			want:   false,
+		},
+		{
+			name:   "localhost as subdomain of external host",
+			rawURL: "http://localhost.evil.com:8080/callback",
+			want:   false,
+		},
+		{
+			name:   "IPv6 loopback rejected (only explicit localhost/127.0.0.1)",
+			rawURL: "http://[::1]:8080/callback",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidCLICallback(tt.rawURL)
+			if got != tt.want {
+				t.Errorf("isValidCLICallback(%q) = %v, want %v", tt.rawURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidNextPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "root path",
+			path: "/",
+			want: true,
+		},
+		{
+			name: "dashboard path",
+			path: "/dashboard",
+			want: true,
+		},
+		{
+			name: "nested path",
+			path: "/issues/123",
+			want: true,
+		},
+		{
+			name: "path with query",
+			path: "/issues?status=open",
+			want: true,
+		},
+		{
+			name: "protocol-relative URL (open redirect)",
+			path: "//evil.com",
+			want: false,
+		},
+		{
+			name: "protocol-relative with path",
+			path: "//evil.com/steal-token",
+			want: false,
+		},
+		{
+			name: "absolute URL",
+			path: "https://evil.com",
+			want: false,
+		},
+		{
+			name: "empty string",
+			path: "",
+			want: false,
+		},
+		{
+			name: "relative path no leading slash",
+			path: "dashboard",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidNextPath(tt.path)
+			if got != tt.want {
+				t.Errorf("isValidNextPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSecureRequest(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*http.Request)
+		want  bool
+	}{
+		{
+			name:  "plain HTTP",
+			setup: func(r *http.Request) {},
+			want:  false,
+		},
+		{
+			name: "X-Forwarded-Proto https",
+			setup: func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Proto", "https")
+			},
+			want: true,
+		},
+		{
+			name: "X-Forwarded-Proto HTTPS (case insensitive)",
+			setup: func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Proto", "HTTPS")
+			},
+			want: true,
+		},
+		{
+			name: "X-Forwarded-Proto http",
+			setup: func(r *http.Request) {
+				r.Header.Set("X-Forwarded-Proto", "http")
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			tt.setup(r)
+			got := isSecureRequest(r)
+			if got != tt.want {
+				t.Errorf("isSecureRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOAuthParamsRoundTrip(t *testing.T) {
+	// Verify that the oauthParams struct can round-trip through base64-encoded JSON
+	// (the format used in the oauth_params cookie).
+	tests := []struct {
+		name   string
+		params oauthParams
+	}{
+		{
+			name: "all fields",
+			params: oauthParams{
+				NextURL:     "/dashboard",
+				CLICallback: "http://localhost:12345/callback",
+				CLIState:    "some-random-state",
+			},
+		},
+		{
+			name: "only next URL",
+			params: oauthParams{
+				NextURL: "/issues/abc-123",
+			},
+		},
+		{
+			name: "cli state with pipe characters",
+			params: oauthParams{
+				CLICallback: "http://localhost:8080/cb",
+				CLIState:    "state|with|pipes",
+			},
+		},
+		{
+			name: "cli state with special characters",
+			params: oauthParams{
+				CLICallback: "http://127.0.0.1:9999/auth",
+				CLIState:    "key=value&foo=bar|baz",
+			},
+		},
+		{
+			name:   "empty params",
+			params: oauthParams{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Encode (same as OAuthStart)
+			paramsJSON, err := json.Marshal(tt.params)
+			if err != nil {
+				t.Fatalf("json.Marshal failed: %v", err)
+			}
+			encoded := base64.RawURLEncoding.EncodeToString(paramsJSON)
+
+			// Decode (same as OAuthCallback)
+			decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+			if err != nil {
+				t.Fatalf("base64 decode failed: %v", err)
+			}
+			var got oauthParams
+			if err := json.Unmarshal(decoded, &got); err != nil {
+				t.Fatalf("json.Unmarshal failed: %v", err)
+			}
+
+			if got.NextURL != tt.params.NextURL {
+				t.Errorf("NextURL = %q, want %q", got.NextURL, tt.params.NextURL)
+			}
+			if got.CLICallback != tt.params.CLICallback {
+				t.Errorf("CLICallback = %q, want %q", got.CLICallback, tt.params.CLICallback)
+			}
+			if got.CLIState != tt.params.CLIState {
+				t.Errorf("CLIState = %q, want %q", got.CLIState, tt.params.CLIState)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add OAuth2 authorization code flow for Google and GitHub alongside
existing email OTP login. If an OAuth email matches an existing user,
the accounts are automatically linked.

It also helps self-hosted environments avoid needing to apply for a resend API key.