### PR TITLE
feat(web): comprehensive mobile responsive overhaul

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -183,7 +183,7 @@ function LoginPageContent() {
   // CLI confirm step: user is already logged in, just authorize.
   if (step === "cli_confirm" && existingUser) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-screen items-center justify-center px-4">
         <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
             <CardTitle className="text-2xl">Authorize CLI</CardTitle>
@@ -222,7 +222,7 @@ function LoginPageContent() {
 
   if (step === "code") {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-screen items-center justify-center px-4">
         <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
             <CardTitle className="text-2xl">Check your email</CardTitle>
@@ -283,7 +283,7 @@ function LoginPageContent() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex min-h-screen items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">Multica</CardTitle>

--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -79,6 +79,9 @@ import { useRuntimeStore } from "@/features/runtimes";
 import { useIssueStore } from "@/features/issues";
 import { ActorAvatar } from "@/components/common/actor-avatar";
 import { useFileUpload } from "@/shared/hooks/use-file-upload";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { MobileListDetail } from "@/components/layout/mobile-list-detail";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 
 
 // ---------------------------------------------------------------------------
@@ -1451,12 +1454,12 @@ function AgentDetail({
       </div>
 
       {/* Tabs */}
-      <div className="flex border-b px-6">
+      <div className="flex border-b px-6 overflow-x-auto">
         {detailTabs.map((tab) => (
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
-            className={`flex items-center gap-1.5 border-b-2 px-3 py-2.5 text-xs font-medium transition-colors ${
+            className={`flex shrink-0 items-center gap-1.5 border-b-2 px-3 py-2.5 text-xs font-medium whitespace-nowrap transition-colors ${
               activeTab === tab.id
                 ? "border-primary text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground"
@@ -1542,6 +1545,7 @@ function AgentDetail({
 // ---------------------------------------------------------------------------
 
 export default function AgentsPage() {
+  const isMobile = useIsMobile();
   const isLoading = useAuthStore((s) => s.isLoading);
   const workspace = useWorkspaceStore((s) => s.workspace);
   const agents = useWorkspaceStore((s) => s.agents);
@@ -1652,87 +1656,38 @@ export default function AgentsPage() {
     );
   }
 
-  return (
-    <ResizablePanelGroup
-      orientation="horizontal"
-      className="flex-1 min-h-0"
-      defaultLayout={defaultLayout}
-      onLayoutChanged={onLayoutChanged}
-    >
-      <ResizablePanel id="list" defaultSize={280} minSize={240} maxSize={400} groupResizeBehavior="preserve-pixel-size">
-        {/* Left column — agent list */}
-        <div className="overflow-y-auto h-full border-r">
-          <div className="flex h-12 items-center justify-between border-b px-4">
-            <h1 className="text-sm font-semibold">Agents</h1>
-            <div className="flex items-center gap-1">
-              {archivedCount > 0 && (
-                <Button
-                  variant={showArchived ? "secondary" : "ghost"}
-                  size="icon-xs"
-                  onClick={() => setShowArchived(!showArchived)}
-                  title={showArchived ? "Show active agents" : "Show archived agents"}
-                >
-                  <Archive className="h-4 w-4 text-muted-foreground" />
-                </Button>
-              )}
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={() => setShowCreate(true)}
-              >
-                <Plus className="h-4 w-4 text-muted-foreground" />
-              </Button>
-            </div>
-          </div>
-          {filteredAgents.length === 0 ? (
-            <div className="flex flex-col items-center justify-center px-4 py-12">
-              <Bot className="h-8 w-8 text-muted-foreground/40" />
-              <p className="mt-3 text-sm text-muted-foreground">
-                {showArchived ? "No archived agents" : archivedCount > 0 ? "No active agents" : "No agents yet"}
-              </p>
-              {!showArchived && (
-                <Button
-                  onClick={() => setShowCreate(true)}
-                  size="xs"
-                  className="mt-3"
-                >
-                  <Plus className="h-3 w-3" />
-                  Create Agent
-                </Button>
-              )}
-            </div>
-          ) : (
-            <div className="divide-y">
-              {filteredAgents.map((agent) => (
-                <AgentListItem
-                  key={agent.id}
-                  agent={agent}
-                  isSelected={agent.id === selectedId}
-                  onClick={() => setSelectedId(agent.id)}
-                />
-              ))}
-            </div>
+  const agentListContent = (
+    <div className="overflow-y-auto h-full border-r">
+      <div className="flex h-12 items-center justify-between border-b px-4">
+        <SidebarTrigger className="md:hidden" />
+          <h1 className="text-sm font-semibold">Agents</h1>
+        <div className="flex items-center gap-1">
+          {archivedCount > 0 && (
+            <Button
+              variant={showArchived ? "secondary" : "ghost"}
+              size="icon-xs"
+              onClick={() => setShowArchived(!showArchived)}
+              title={showArchived ? "Show active agents" : "Show archived agents"}
+            >
+              <Archive className="h-4 w-4 text-muted-foreground" />
+            </Button>
           )}
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => setShowCreate(true)}
+          >
+            <Plus className="h-4 w-4 text-muted-foreground" />
+          </Button>
         </div>
-      </ResizablePanel>
-
-      <ResizableHandle />
-
-      <ResizablePanel id="detail" minSize="50%">
-        {/* Right column — agent detail */}
-        {selected ? (
-          <AgentDetail
-            key={selected.id}
-            agent={selected}
-            runtimes={runtimes}
-            onUpdate={handleUpdate}
-            onArchive={handleArchive}
-            onRestore={handleRestore}
-          />
-        ) : (
-          <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
-            <Bot className="h-10 w-10 text-muted-foreground/30" />
-            <p className="mt-3 text-sm">Select an agent to view details</p>
+      </div>
+      {filteredAgents.length === 0 ? (
+        <div className="flex flex-col items-center justify-center px-4 py-12">
+          <Bot className="h-8 w-8 text-muted-foreground/40" />
+          <p className="mt-3 text-sm text-muted-foreground">
+            {showArchived ? "No archived agents" : archivedCount > 0 ? "No active agents" : "No agents yet"}
+          </p>
+          {!showArchived && (
             <Button
               onClick={() => setShowCreate(true)}
               size="xs"
@@ -1741,17 +1696,88 @@ export default function AgentsPage() {
               <Plus className="h-3 w-3" />
               Create Agent
             </Button>
-          </div>
-        )}
+          )}
+        </div>
+      ) : (
+        <div className="divide-y">
+          {filteredAgents.map((agent) => (
+            <AgentListItem
+              key={agent.id}
+              agent={agent}
+              isSelected={agent.id === selectedId}
+              onClick={() => setSelectedId(agent.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  const agentDetailContent = selected ? (
+    <AgentDetail
+      key={selected.id}
+      agent={selected}
+      runtimes={runtimes}
+      onUpdate={handleUpdate}
+      onArchive={handleArchive}
+      onRestore={handleRestore}
+    />
+  ) : (
+    <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
+      <Bot className="h-10 w-10 text-muted-foreground/30" />
+      <p className="mt-3 text-sm">Select an agent to view details</p>
+      <Button
+        onClick={() => setShowCreate(true)}
+        size="xs"
+        className="mt-3"
+      >
+        <Plus className="h-3 w-3" />
+        Create Agent
+      </Button>
+    </div>
+  );
+
+  const createDialog = showCreate ? (
+    <CreateAgentDialog
+      runtimes={runtimes}
+      onClose={() => setShowCreate(false)}
+      onCreate={handleCreate}
+    />
+  ) : null;
+
+  if (isMobile) {
+    return (
+      <>
+        <MobileListDetail
+          showDetail={!!selectedId}
+          onBack={() => setSelectedId("")}
+          headerTitle={selected?.name ?? "Agent"}
+          list={agentListContent}
+          detail={agentDetailContent}
+        />
+        {createDialog}
+      </>
+    );
+  }
+
+  return (
+    <ResizablePanelGroup
+      orientation="horizontal"
+      className="flex-1 min-h-0"
+      defaultLayout={defaultLayout}
+      onLayoutChanged={onLayoutChanged}
+    >
+      <ResizablePanel id="list" defaultSize={280} minSize={240} maxSize={400} groupResizeBehavior="preserve-pixel-size">
+        {agentListContent}
       </ResizablePanel>
 
-      {showCreate && (
-        <CreateAgentDialog
-          runtimes={runtimes}
-          onClose={() => setShowCreate(false)}
-          onCreate={handleCreate}
-        />
-      )}
+      <ResizableHandle />
+
+      <ResizablePanel id="detail" minSize="50%">
+        {agentDetailContent}
+      </ResizablePanel>
+
+      {createDialog}
     </ResizablePanelGroup>
   );
 }

--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -17,6 +17,7 @@ import {
   Archive,
   BookCheck,
   ListChecks,
+  ChevronLeft,
 } from "lucide-react";
 import type { InboxItem, InboxItemType, IssueStatus, IssuePriority } from "@/shared/types";
 import { Button } from "@/components/ui/button";
@@ -34,6 +35,8 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { api } from "@/shared/api";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -192,7 +195,7 @@ function InboxListItem({
                   onArchive();
                 }
               }}
-              className="hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground group-hover:inline-flex"
+              className="hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground group-hover:inline-flex coarse:inline-flex"
             >
               <Archive className="h-3.5 w-3.5" />
             </span>
@@ -219,6 +222,7 @@ function InboxListItem({
 // ---------------------------------------------------------------------------
 
 export default function InboxPage() {
+  const isMobile = useIsMobile();
   const searchParams = useSearchParams();
   const urlIssue = searchParams.get("issue") ?? "";
 
@@ -315,26 +319,173 @@ export default function InboxPage() {
     }
   };
 
+  const loadingSkeleton = (
+    <div className="flex flex-col border-r h-full">
+      <div className="flex h-12 shrink-0 items-center border-b px-4">
+        <Skeleton className="h-5 w-16" />
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto space-y-1 p-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 px-4 py-2.5">
+            <Skeleton className="h-7 w-7 shrink-0 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  const inboxListContent = (
+    <div className="flex flex-col border-r h-full">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
+        <div className="flex items-center gap-2">
+          <SidebarTrigger className="md:hidden" />
+          <h1 className="text-sm font-semibold">Inbox</h1>
+          {unreadCount > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {unreadCount}
+            </span>
+          )}
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="text-muted-foreground"
+              />
+            }
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-auto">
+            <DropdownMenuItem onClick={handleMarkAllRead}>
+              <CheckCheck className="h-4 w-4" />
+              Mark all as read
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={handleArchiveAll}>
+              <Archive className="h-4 w-4" />
+              Archive all
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleArchiveAllRead}>
+              <BookCheck className="h-4 w-4" />
+              Archive all read
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleArchiveCompleted}>
+              <ListChecks className="h-4 w-4" />
+              Archive completed
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+      {items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <Inbox className="mb-3 h-8 w-8 text-muted-foreground/50" />
+          <p className="text-sm">No notifications</p>
+        </div>
+      ) : (
+        <div>
+          {items.map((item) => (
+            <InboxListItem
+              key={item.id}
+              item={item}
+              isSelected={(item.issue_id ?? item.id) === selectedKey}
+              onClick={() => handleSelect(item)}
+              onArchive={() => handleArchive(item.id)}
+            />
+          ))}
+        </div>
+      )}
+      </div>
+    </div>
+  );
+
+  const inboxDetailContent = (
+    <div className="flex flex-col min-h-0 h-full">
+      {selected?.issue_id ? (
+        <IssueDetail
+          key={selected.id}
+          issueId={selected.issue_id}
+          defaultSidebarOpen={!isMobile}
+          layoutId="multica_inbox_issue_detail_layout"
+          highlightCommentId={selected.details?.comment_id ?? undefined}
+          onDelete={() => {
+            handleArchive(selected.id);
+          }}
+        />
+      ) : selected ? (
+        <div className="p-6">
+          <h2 className="text-lg font-semibold">{selected.title}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {typeLabels[selected.type]} · {timeAgo(selected.created_at)}
+          </p>
+          {selected.body && (
+            <div className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-foreground/80">
+              {selected.body}
+            </div>
+          )}
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleArchive(selected.id)}
+            >
+              <Archive className="mr-1.5 h-3.5 w-3.5" />
+              Archive
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
+          <Inbox className="mb-3 h-10 w-10 text-muted-foreground/30" />
+          <p className="text-sm">
+            {items.length === 0
+              ? "Your inbox is empty"
+              : "Select a notification to view details"}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+
+  // Mobile: list/detail navigation
+  if (isMobile) {
+    if (loading) return loadingSkeleton;
+
+    if (selectedKey) {
+      return (
+        <div className="flex flex-col h-full min-h-0">
+          <div className="flex h-12 shrink-0 items-center gap-1 border-b px-2">
+            <Button variant="ghost" size="icon-sm" onClick={() => setSelectedKey("")}>
+              <ChevronLeft className="h-5 w-5" />
+            </Button>
+            <span className="text-sm font-medium truncate">
+              {selected?.title ?? "Notification"}
+            </span>
+          </div>
+          <div className="flex-1 min-h-0 overflow-hidden">
+            {inboxDetailContent}
+          </div>
+        </div>
+      );
+    }
+
+    return inboxListContent;
+  }
+
+  // Desktop: resizable two-column
   if (loading) {
     return (
       <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
         <ResizablePanel id="list" defaultSize={320} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
-          <div className="flex flex-col border-r h-full">
-            <div className="flex h-12 shrink-0 items-center border-b px-4">
-              <Skeleton className="h-5 w-16" />
-            </div>
-            <div className="flex-1 min-h-0 overflow-y-auto space-y-1 p-2">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i} className="flex items-center gap-3 px-4 py-2.5">
-                  <Skeleton className="h-7 w-7 shrink-0 rounded-full" />
-                  <div className="flex-1 space-y-2">
-                    <Skeleton className="h-4 w-3/4" />
-                    <Skeleton className="h-3 w-1/2" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
+          {loadingSkeleton}
         </ResizablePanel>
         <ResizableHandle />
         <ResizablePanel id="detail" minSize="40%">
@@ -350,121 +501,11 @@ export default function InboxPage() {
   return (
     <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
       <ResizablePanel id="list" defaultSize={320} minSize={240} maxSize={480} groupResizeBehavior="preserve-pixel-size">
-      {/* Left column — inbox list */}
-      <div className="flex flex-col border-r h-full">
-        <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
-          <div className="flex items-center gap-2">
-            <h1 className="text-sm font-semibold">Inbox</h1>
-            {unreadCount > 0 && (
-              <span className="text-xs text-muted-foreground">
-                {unreadCount}
-              </span>
-            )}
-          </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  className="text-muted-foreground"
-                />
-              }
-            >
-              <MoreHorizontal className="h-4 w-4" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-auto">
-              <DropdownMenuItem onClick={handleMarkAllRead}>
-                <CheckCheck className="h-4 w-4" />
-                Mark all as read
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleArchiveAll}>
-                <Archive className="h-4 w-4" />
-                Archive all
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleArchiveAllRead}>
-                <BookCheck className="h-4 w-4" />
-                Archive all read
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleArchiveCompleted}>
-                <ListChecks className="h-4 w-4" />
-                Archive completed
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-
-        <div className="flex-1 min-h-0 overflow-y-auto">
-        {items.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-            <Inbox className="mb-3 h-8 w-8 text-muted-foreground/50" />
-            <p className="text-sm">No notifications</p>
-          </div>
-        ) : (
-          <div>
-            {items.map((item) => (
-              <InboxListItem
-                key={item.id}
-                item={item}
-                isSelected={(item.issue_id ?? item.id) === selectedKey}
-                onClick={() => handleSelect(item)}
-                onArchive={() => handleArchive(item.id)}
-              />
-            ))}
-          </div>
-        )}
-        </div>
-      </div>
+        {inboxListContent}
       </ResizablePanel>
       <ResizableHandle />
       <ResizablePanel id="detail" minSize="40%">
-      {/* Right column — detail */}
-      <div className="flex flex-col min-h-0 h-full">
-        {selected?.issue_id ? (
-          <IssueDetail
-            key={selected.id}
-            issueId={selected.issue_id}
-            defaultSidebarOpen={false}
-            layoutId="multica_inbox_issue_detail_layout"
-            highlightCommentId={selected.details?.comment_id ?? undefined}
-            onDelete={() => {
-              handleArchive(selected.id);
-            }}
-          />
-        ) : selected ? (
-          <div className="p-6">
-            <h2 className="text-lg font-semibold">{selected.title}</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              {typeLabels[selected.type]} · {timeAgo(selected.created_at)}
-            </p>
-            {selected.body && (
-              <div className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-foreground/80">
-                {selected.body}
-              </div>
-            )}
-            <div className="mt-4">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleArchive(selected.id)}
-              >
-                <Archive className="mr-1.5 h-3.5 w-3.5" />
-                Archive
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
-            <Inbox className="mb-3 h-10 w-10 text-muted-foreground/30" />
-            <p className="text-sm">
-              {items.length === 0
-                ? "Your inbox is empty"
-                : "Select a notification to view details"}
-            </p>
-          </div>
-        )}
-      </div>
+        {inboxDetailContent}
       </ResizablePanel>
     </ResizablePanelGroup>
   );

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -3,6 +3,8 @@
 import { User, Palette, Key, Settings, Users, FolderGit2 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useWorkspaceStore } from "@/features/workspace";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { AccountTab } from "./_components/account-tab";
 import { AppearanceTab } from "./_components/general-tab";
 import { TokensTab } from "./_components/tokens-tab";
@@ -23,7 +25,54 @@ const workspaceTabs = [
 ];
 
 export default function SettingsPage() {
+  const isMobile = useIsMobile();
   const workspaceName = useWorkspaceStore((s) => s.workspace?.name);
+
+  const tabContent = (
+    <>
+      <TabsContent value="profile"><AccountTab /></TabsContent>
+      <TabsContent value="appearance"><AppearanceTab /></TabsContent>
+      <TabsContent value="tokens"><TokensTab /></TabsContent>
+      <TabsContent value="workspace"><WorkspaceTab /></TabsContent>
+      <TabsContent value="repositories"><RepositoriesTab /></TabsContent>
+      <TabsContent value="members"><MembersTab /></TabsContent>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Tabs defaultValue="profile" className="flex flex-col flex-1 min-h-0 gap-0">
+        {/* Top: scrollable horizontal tabs */}
+        <div className="shrink-0 border-b px-3 pt-3 pb-0">
+          <div className="flex items-center gap-2 mb-3 px-1">
+            <SidebarTrigger className="md:hidden" />
+            <h1 className="text-sm font-semibold">Settings</h1>
+          </div>
+          <TabsList variant="line" className="overflow-x-auto whitespace-nowrap w-full justify-start gap-0">
+            {accountTabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value} className="text-xs px-2.5 py-1.5">
+                <tab.icon className="h-3.5 w-3.5" />
+                {tab.label}
+              </TabsTrigger>
+            ))}
+            {workspaceTabs.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value} className="text-xs px-2.5 py-1.5">
+                <tab.icon className="h-3.5 w-3.5" />
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <div className="w-full p-4">
+            {tabContent}
+          </div>
+        </div>
+      </Tabs>
+    );
+  }
 
   return (
     <Tabs defaultValue="profile" orientation="vertical" className="flex-1 min-h-0 gap-0">
@@ -58,12 +107,7 @@ export default function SettingsPage() {
       {/* Right content */}
       <div className="flex-1 min-w-0 overflow-y-auto">
         <div className="w-full max-w-3xl mx-auto p-6">
-          <TabsContent value="profile"><AccountTab /></TabsContent>
-          <TabsContent value="appearance"><AppearanceTab /></TabsContent>
-          <TabsContent value="tokens"><TokensTab /></TabsContent>
-          <TabsContent value="workspace"><WorkspaceTab /></TabsContent>
-          <TabsContent value="repositories"><RepositoriesTab /></TabsContent>
-          <TabsContent value="members"><MembersTab /></TabsContent>
+          {tabContent}
         </div>
       </div>
     </Tabs>

--- a/apps/web/app/custom.css
+++ b/apps/web/app/custom.css
@@ -39,3 +39,49 @@
 [data-sonner-toast] [data-icon] {
   margin-top: 2.5px;
 }
+
+/* =============================================================================
+ * Mobile / Touch device optimizations
+ * ============================================================================= */
+
+@media (pointer: coarse) {
+  /* Icon buttons: minimum 44×44px touch target */
+  [data-slot="button"]:is(
+    .size-6,
+    .size-7,
+    .size-8,
+    .size-9
+  ) {
+    position: relative;
+  }
+
+  [data-slot="button"]:is(
+    .size-6,
+    .size-7,
+    .size-8
+  )::after {
+    content: "";
+    position: absolute;
+    inset: -4px;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* Text inputs: minimum 44px height */
+  [data-slot="input"] {
+    min-height: 44px;
+  }
+
+  /* Hover-only actions: always visible on touch */
+  .touch\:visible {
+    display: inline-flex !important;
+  }
+}
+
+/* Safe area padding for fixed-bottom elements on notched devices */
+@supports (padding-bottom: env(safe-area-inset-bottom)) {
+  [data-slot="drawer-content"],
+  [data-slot="sheet-content"][data-side="bottom"] {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,6 +4,8 @@
 @import "./custom.css";
 
 @custom-variant dark (&:is(.dark *));
+@custom-variant coarse (@media (pointer: coarse));
+@custom-variant mobile (@media (max-width: 767px));
 
 @theme inline {
     --font-heading: var(--font-sans);

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -15,6 +15,7 @@ const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-mono" });
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  viewportFit: "cover",
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#ffffff" },
     { media: "(prefers-color-scheme: dark)", color: "#05070b" },

--- a/apps/web/components/layout/mobile-list-detail.tsx
+++ b/apps/web/components/layout/mobile-list-detail.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface MobileListDetailProps {
+  list: React.ReactNode;
+  detail: React.ReactNode;
+  showDetail: boolean;
+  onBack: () => void;
+  headerTitle?: string;
+}
+
+/**
+ * Mobile list→detail navigation pattern.
+ * Shows the list by default. When `showDetail` is true, shows the detail
+ * view full-screen with a back button.
+ */
+export function MobileListDetail({
+  list,
+  detail,
+  showDetail,
+  onBack,
+  headerTitle,
+}: MobileListDetailProps) {
+  if (showDetail) {
+    return (
+      <div className="flex flex-col h-full min-h-0">
+        <div className="flex h-12 shrink-0 items-center gap-1 border-b px-2">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onBack}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </Button>
+          {headerTitle && (
+            <span className="text-sm font-medium truncate">{headerTitle}</span>
+          )}
+        </div>
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {detail}
+        </div>
+      </div>
+    );
+  }
+
+  return <>{list}</>;
+}

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -37,7 +37,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "z-50 flex w-72 max-w-[calc(100vw-2rem)] origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             className
           )}
           {...props}

--- a/apps/web/components/ui/responsive-modal.tsx
+++ b/apps/web/components/ui/responsive-modal.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import * as React from "react";
+import { useIsMobile } from "@/hooks/use-mobile";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerClose,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// ResponsiveModal — renders Dialog on desktop, bottom Drawer on mobile
+// ---------------------------------------------------------------------------
+
+interface ResponsiveModalProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+function ResponsiveModal({ open, onOpenChange, children }: ResponsiveModalProps) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        {children}
+      </Drawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {children}
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Trigger
+// ---------------------------------------------------------------------------
+
+function ResponsiveModalTrigger({
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogTrigger>) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return <DrawerTrigger {...(props as React.ComponentProps<typeof DrawerTrigger>)}>{children}</DrawerTrigger>;
+  }
+
+  return <DialogTrigger {...props}>{children}</DialogTrigger>;
+}
+
+// ---------------------------------------------------------------------------
+// Content
+// ---------------------------------------------------------------------------
+
+interface ResponsiveModalContentProps {
+  className?: string;
+  children: React.ReactNode;
+  showCloseButton?: boolean;
+}
+
+function ResponsiveModalContent({
+  className,
+  children,
+  showCloseButton = true,
+}: ResponsiveModalContentProps) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <DrawerContent className={cn("max-h-[90vh]", className)}>
+        {children}
+      </DrawerContent>
+    );
+  }
+
+  return (
+    <DialogContent className={className} showCloseButton={showCloseButton}>
+      {children}
+    </DialogContent>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
+function ResponsiveModalHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return <DrawerHeader className={className} {...props} />;
+  }
+
+  return <DialogHeader className={className} {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Footer
+// ---------------------------------------------------------------------------
+
+function ResponsiveModalFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return <DrawerFooter className={className} {...props} />;
+  }
+
+  return <DialogFooter className={className} {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Title
+// ---------------------------------------------------------------------------
+
+function ResponsiveModalTitle({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"h2"> & { className?: string }) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <DrawerTitle className={className} {...(props as React.ComponentProps<typeof DrawerTitle>)}>
+        {children}
+      </DrawerTitle>
+    );
+  }
+
+  return (
+    <DialogTitle className={className} {...(props as React.ComponentProps<typeof DialogTitle>)}>
+      {children}
+    </DialogTitle>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Description
+// ---------------------------------------------------------------------------
+
+function ResponsiveModalDescription({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"p"> & { className?: string }) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <DrawerDescription className={className} {...(props as React.ComponentProps<typeof DrawerDescription>)}>
+        {children}
+      </DrawerDescription>
+    );
+  }
+
+  return (
+    <DialogDescription className={className} {...(props as React.ComponentProps<typeof DialogDescription>)}>
+      {children}
+    </DialogDescription>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Close
+// ---------------------------------------------------------------------------
+
+function ResponsiveModalClose({
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogClose>) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return <DrawerClose {...(props as React.ComponentProps<typeof DrawerClose>)}>{children}</DrawerClose>;
+  }
+
+  return <DialogClose {...props}>{children}</DialogClose>;
+}
+
+export {
+  ResponsiveModal,
+  ResponsiveModalTrigger,
+  ResponsiveModalContent,
+  ResponsiveModalHeader,
+  ResponsiveModalFooter,
+  ResponsiveModalTitle,
+  ResponsiveModalDescription,
+  ResponsiveModalClose,
+};

--- a/apps/web/features/editor/extensions/mention-suggestion.tsx
+++ b/apps/web/features/editor/extensions/mention-suggestion.tsx
@@ -125,7 +125,7 @@ const MentionList = forwardRef<MentionListRef, MentionListProps>(
     let globalIndex = 0;
 
     return (
-      <div className="rounded-md border bg-popover py-1 shadow-md w-72 max-h-[300px] overflow-y-auto">
+      <div className="rounded-md border bg-popover py-1 shadow-md w-72 max-w-[calc(100vw-2rem)] max-h-[300px] overflow-y-auto">
         {groups.map((group) => (
           <div key={group.label}>
             <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground">

--- a/apps/web/features/issues/components/batch-action-toolbar.tsx
+++ b/apps/web/features/issues/components/batch-action-toolbar.tsx
@@ -83,7 +83,7 @@ export function BatchActionToolbar() {
 
   return (
     <>
-      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg">
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg mobile:bottom-[calc(1.5rem+env(safe-area-inset-bottom))] mobile:px-3 mobile:gap-0.5">
         <div className="flex items-center gap-1.5 pl-1 pr-2 border-r mr-1">
           <span className="text-sm font-medium">{count} selected</span>
           <button

--- a/apps/web/features/issues/components/board-column.tsx
+++ b/apps/web/features/issues/components/board-column.tsx
@@ -23,9 +23,11 @@ import { DraggableBoardCard } from "./board-card";
 export function BoardColumn({
   status,
   issues,
+  fullWidth,
 }: {
   status: IssueStatus;
   issues: Issue[];
+  fullWidth?: boolean;
 }) {
   const cfg = STATUS_CONFIG[status];
   const { setNodeRef, isOver } = useDroppable({ id: status });
@@ -44,7 +46,7 @@ export function BoardColumn({
   );
 
   return (
-    <div className={`flex w-[280px] shrink-0 flex-col rounded-xl ${cfg.columnBg} p-2`}>
+    <div className={`flex ${fullWidth ? "w-full" : "w-[280px] shrink-0"} flex-col rounded-xl ${cfg.columnBg} p-2`}>
       <div className="mb-2 flex items-center justify-between px-1.5">
         {/* Left: status badge + count */}
         <div className="flex items-center gap-2">

--- a/apps/web/features/issues/components/board-view.tsx
+++ b/apps/web/features/issues/components/board-view.tsx
@@ -14,6 +14,7 @@ import {
   type DragEndEvent,
 } from "@dnd-kit/core";
 import { Eye, MoreHorizontal } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-mobile";
 import type { Issue, IssueStatus } from "@/shared/types";
 import { Button } from "@/components/ui/button";
 import {
@@ -70,7 +71,9 @@ export function BoardView({
     newPosition?: number
   ) => void;
 }) {
+  const isMobile = useIsMobile();
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
+  const [mobileActiveStatus, setMobileActiveStatus] = useState<IssueStatus>(visibleStatuses[0]!);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -162,6 +165,62 @@ export function BoardView({
     },
     [issues, issuesByStatus, onMoveIssue, visibleStatuses]
   );
+
+  if (isMobile) {
+    return (
+      <DndContext
+        sensors={sensors}
+        collisionDetection={kanbanCollision}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="flex flex-col flex-1 min-h-0">
+          {/* Status tab bar */}
+          <div className="flex shrink-0 gap-1 overflow-x-auto px-3 py-2 border-b">
+            {visibleStatuses.map((status) => {
+              const cfg = STATUS_CONFIG[status];
+              const count = issues.filter((i) => i.status === status).length;
+              const isActive = status === mobileActiveStatus;
+              return (
+                <button
+                  key={status}
+                  type="button"
+                  onClick={() => setMobileActiveStatus(status)}
+                  className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    isActive
+                      ? `${cfg.badgeBg} ${cfg.badgeText}`
+                      : "bg-muted/50 text-muted-foreground hover:bg-muted"
+                  }`}
+                >
+                  <StatusIcon status={status} className="h-3 w-3" inheritColor={isActive} />
+                  {cfg.label}
+                  <span className="text-[10px] opacity-60">{count}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Single full-width column */}
+          <div className="flex-1 min-h-0 overflow-y-auto p-3">
+            <BoardColumn
+              key={mobileActiveStatus}
+              status={mobileActiveStatus}
+              issues={issues.filter((i) => i.status === mobileActiveStatus)}
+              fullWidth
+            />
+          </div>
+        </div>
+
+        <DragOverlay>
+          {activeIssue ? (
+            <div className="w-full max-w-sm rotate-1 cursor-grabbing opacity-95 shadow-md">
+              <BoardCardContent issue={activeIssue} />
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    );
+  }
 
   return (
     <DndContext

--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -44,6 +44,9 @@ import {
   DropdownMenuSubContent,
 } from "@/components/ui/dropdown-menu";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { ContentEditor, type ContentEditorRef } from "@/features/editor";
 import { FileUploadButton } from "@/components/common/file-upload-button";
 import { TitleEditor } from "@/features/editor";
@@ -172,6 +175,7 @@ interface IssueDetailProps {
 
 export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
   const id = issueId;
+  const isMobile = useIsMobile();
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
   const workspace = useWorkspaceStore((s) => s.workspace);
@@ -191,6 +195,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   });
   const sidebarRef = usePanelRef();
   const [sidebarOpen, setSidebarOpen] = useState(defaultSidebarOpen);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [propertiesOpen, setPropertiesOpen] = useState(true);
@@ -372,16 +377,15 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
     );
   }
 
-  return (
-    <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
-      <ResizablePanel id="content" minSize="50%">
-      {/* LEFT: Content area */}
+  const contentPanel = (
+      /* LEFT: Content area */
       <div className="flex h-full flex-col">
         {/* Header bar */}
         <div className="flex h-12 shrink-0 items-center justify-between border-b bg-background px-4 text-sm">
           <div className="flex items-center gap-1.5 min-w-0">
+            <SidebarTrigger className="md:hidden shrink-0" />
             {workspace && (
-              <>
+              <span className="hidden md:contents">
                 <Link
                   href="/issues"
                   className="text-muted-foreground hover:text-foreground transition-colors truncate shrink-0"
@@ -389,18 +393,18 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                   {workspace.name}
                 </Link>
                 <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
-              </>
+              </span>
             )}
-            <span className="truncate text-muted-foreground">
+            <span className="truncate text-muted-foreground shrink-0">
               {issue.identifier}
             </span>
             <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
             <span className="truncate">{issue.title}</span>
           </div>
           <div className="flex items-center gap-1 shrink-0">
-            {/* Issue navigation */}
+            {/* Issue navigation — hidden on mobile */}
             {allIssues.length > 1 && (
-              <div className="flex items-center gap-0.5 mr-1">
+              <div className="hidden md:flex items-center gap-0.5 mr-1">
                 <Tooltip>
                   <TooltipTrigger
                     render={
@@ -586,10 +590,14 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
               <TooltipTrigger
                 render={
                   <Button
-                    variant={sidebarOpen ? "secondary" : "ghost"}
+                    variant={(isMobile ? mobileSidebarOpen : sidebarOpen) ? "secondary" : "ghost"}
                     size="icon-xs"
-                    className={sidebarOpen ? "" : "text-muted-foreground"}
+                    className={(isMobile ? mobileSidebarOpen : sidebarOpen) ? "" : "text-muted-foreground"}
                     onClick={() => {
+                      if (isMobile) {
+                        setMobileSidebarOpen(true);
+                        return;
+                      }
                       const panel = sidebarRef.current;
                       if (!panel) return;
                       if (panel.isCollapsed()) panel.expand();
@@ -600,7 +608,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                   </Button>
                 }
               />
-              <TooltipContent side="bottom">Toggle sidebar</TooltipContent>
+              <TooltipContent side="bottom">Properties</TooltipContent>
             </Tooltip>
           </div>
 
@@ -934,6 +942,132 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
         )}
         </div>
       </div>
+  );
+
+  const sidebarContent = (
+          <div className="overflow-y-auto h-full">
+            <div className="p-4 space-y-5">
+              {/* Properties section */}
+              <div>
+                <button
+                  className={`flex w-full items-center gap-1 text-xs font-medium transition-colors mb-2 ${propertiesOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
+                  onClick={() => setPropertiesOpen(!propertiesOpen)}
+                >
+                  <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${propertiesOpen ? "rotate-90" : ""}`} />
+                  Properties
+                </button>
+
+                {propertiesOpen && <div className="space-y-0.5 pl-2">
+                  {/* Status */}
+                  <PropRow label="Status">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors overflow-hidden">
+                        <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">{STATUS_CONFIG[issue.status].label}</span>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start" className="w-44">
+                        {ALL_STATUSES.map((s) => (
+                          <DropdownMenuItem key={s} onClick={() => handleUpdateField({ status: s })}>
+                            <StatusIcon status={s} className="h-3.5 w-3.5" />
+                            {STATUS_CONFIG[s].label}
+                            {s === issue.status && <Check className="ml-auto h-3.5 w-3.5" />}
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </PropRow>
+
+                  {/* Priority */}
+                  <PropRow label="Priority">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors overflow-hidden">
+                        <PriorityIcon priority={issue.priority} className="shrink-0" />
+                        <span className="truncate">{PRIORITY_CONFIG[issue.priority].label}</span>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start" className="w-44">
+                        {PRIORITY_ORDER.map((p) => (
+                          <DropdownMenuItem key={p} onClick={() => handleUpdateField({ priority: p })}>
+                            <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${PRIORITY_CONFIG[p].badgeBg} ${PRIORITY_CONFIG[p].badgeText}`}>
+                              <PriorityIcon priority={p} className="h-3 w-3" inheritColor />
+                              {PRIORITY_CONFIG[p].label}
+                            </span>
+                            {p === issue.priority && <Check className="ml-auto h-3.5 w-3.5" />}
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </PropRow>
+
+                  {/* Assignee */}
+                  <PropRow label="Assignee">
+                    <AssigneePicker
+                      assigneeType={issue.assignee_type}
+                      assigneeId={issue.assignee_id}
+                      onUpdate={handleUpdateField}
+                      align="start"
+                    />
+                  </PropRow>
+
+                  {/* Due date */}
+                  <PropRow label="Due date">
+                    <DueDatePicker
+                      dueDate={issue.due_date}
+                      onUpdate={handleUpdateField}
+                    />
+                  </PropRow>
+                </div>}
+              </div>
+
+              {/* Details section */}
+              <div>
+                <button
+                  className={`flex w-full items-center gap-1 text-xs font-medium transition-colors mb-2 ${detailsOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
+                  onClick={() => setDetailsOpen(!detailsOpen)}
+                >
+                  <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${detailsOpen ? "rotate-90" : ""}`} />
+                  Details
+                </button>
+
+                {detailsOpen && <div className="space-y-0.5 pl-2">
+                  <PropRow label="Created by">
+                    <ActorAvatar
+                      actorType={issue.creator_type}
+                      actorId={issue.creator_id}
+                      size={18}
+                    />
+                    <span className="truncate">{getActorName(issue.creator_type, issue.creator_id)}</span>
+                  </PropRow>
+                  <PropRow label="Created">
+                    <span className="text-muted-foreground">{shortDate(issue.created_at)}</span>
+                  </PropRow>
+                  <PropRow label="Updated">
+                    <span className="text-muted-foreground">{shortDate(issue.updated_at)}</span>
+                  </PropRow>
+                </div>}
+              </div>
+
+            </div>
+          </div>
+        );
+
+  if (isMobile) {
+    return (
+      <>
+        {contentPanel}
+        <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+          <SheetContent side="bottom" className="max-h-[70vh] overflow-y-auto" showCloseButton>
+            <SheetTitle className="sr-only">Issue Properties</SheetTitle>
+            {sidebarContent}
+          </SheetContent>
+        </Sheet>
+      </>
+    );
+  }
+
+  return (
+    <ResizablePanelGroup orientation="horizontal" className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChanged={onLayoutChanged}>
+      <ResizablePanel id="content" minSize="50%">
+        {contentPanel}
       </ResizablePanel>
       <ResizableHandle />
       <ResizablePanel
@@ -946,110 +1080,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
         panelRef={sidebarRef}
         onResize={(size) => setSidebarOpen(size.inPixels > 0)}
       >
-      {/* RIGHT: Properties sidebar */}
-      <div className="overflow-y-auto border-l h-full">
-        <div className="p-4 space-y-5">
-          {/* Properties section */}
-          <div>
-            <button
-              className={`flex w-full items-center gap-1 text-xs font-medium transition-colors mb-2 ${propertiesOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
-              onClick={() => setPropertiesOpen(!propertiesOpen)}
-            >
-              <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${propertiesOpen ? "rotate-90" : ""}`} />
-              Properties
-            </button>
-
-            {propertiesOpen && <div className="space-y-0.5 pl-2">
-              {/* Status */}
-              <PropRow label="Status">
-                <DropdownMenu>
-                  <DropdownMenuTrigger className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors overflow-hidden">
-                    <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
-                    <span className="truncate">{STATUS_CONFIG[issue.status].label}</span>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="w-44">
-                    {ALL_STATUSES.map((s) => (
-                      <DropdownMenuItem key={s} onClick={() => handleUpdateField({ status: s })}>
-                        <StatusIcon status={s} className="h-3.5 w-3.5" />
-                        {STATUS_CONFIG[s].label}
-                        {s === issue.status && <Check className="ml-auto h-3.5 w-3.5" />}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </PropRow>
-
-              {/* Priority */}
-              <PropRow label="Priority">
-                <DropdownMenu>
-                  <DropdownMenuTrigger className="flex items-center gap-1.5 cursor-pointer rounded px-1 -mx-1 hover:bg-accent/30 transition-colors overflow-hidden">
-                    <PriorityIcon priority={issue.priority} className="shrink-0" />
-                    <span className="truncate">{PRIORITY_CONFIG[issue.priority].label}</span>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="w-44">
-                    {PRIORITY_ORDER.map((p) => (
-                      <DropdownMenuItem key={p} onClick={() => handleUpdateField({ priority: p })}>
-                        <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${PRIORITY_CONFIG[p].badgeBg} ${PRIORITY_CONFIG[p].badgeText}`}>
-                          <PriorityIcon priority={p} className="h-3 w-3" inheritColor />
-                          {PRIORITY_CONFIG[p].label}
-                        </span>
-                        {p === issue.priority && <Check className="ml-auto h-3.5 w-3.5" />}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </PropRow>
-
-              {/* Assignee */}
-              <PropRow label="Assignee">
-                <AssigneePicker
-                  assigneeType={issue.assignee_type}
-                  assigneeId={issue.assignee_id}
-                  onUpdate={handleUpdateField}
-                  align="start"
-                />
-              </PropRow>
-
-              {/* Due date */}
-              <PropRow label="Due date">
-                <DueDatePicker
-                  dueDate={issue.due_date}
-                  onUpdate={handleUpdateField}
-                />
-              </PropRow>
-            </div>}
-          </div>
-
-          {/* Details section */}
-          <div>
-            <button
-              className={`flex w-full items-center gap-1 text-xs font-medium transition-colors mb-2 ${detailsOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
-              onClick={() => setDetailsOpen(!detailsOpen)}
-            >
-              <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${detailsOpen ? "rotate-90" : ""}`} />
-              Details
-            </button>
-
-            {detailsOpen && <div className="space-y-0.5 pl-2">
-              <PropRow label="Created by">
-                <ActorAvatar
-                  actorType={issue.creator_type}
-                  actorId={issue.creator_id}
-                  size={18}
-                />
-                <span className="truncate">{getActorName(issue.creator_type, issue.creator_id)}</span>
-              </PropRow>
-              <PropRow label="Created">
-                <span className="text-muted-foreground">{shortDate(issue.created_at)}</span>
-              </PropRow>
-              <PropRow label="Updated">
-                <span className="text-muted-foreground">{shortDate(issue.updated_at)}</span>
-              </PropRow>
-            </div>}
-          </div>
-
-        </div>
-      </div>
+        <div className="border-l h-full">{sidebarContent}</div>
       </ResizablePanel>
     </ResizablePanelGroup>
   );

--- a/apps/web/features/issues/components/issues-header.tsx
+++ b/apps/web/features/issues/components/issues-header.tsx
@@ -55,6 +55,7 @@ import {
   useIssuesScopeStore,
   type IssuesScope,
 } from "@/features/issues/stores/issues-scope-store";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { filterIssues } from "@/features/issues/utils/filter";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import type { Issue } from "@/shared/types";
@@ -273,6 +274,7 @@ function ActorSubContent({
 // ---------------------------------------------------------------------------
 
 export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
+  const isMobile = useIsMobile();
   const scope = useIssuesScopeStore((s) => s.scope);
   const setScope = useIssuesScopeStore((s) => s.setScope);
 
@@ -302,30 +304,51 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
     SORT_OPTIONS.find((o) => o.value === sortBy)?.label ?? "Manual";
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between px-4">
+    <div className="flex h-12 shrink-0 items-center justify-between px-4 gap-2">
       {/* Left: scope buttons */}
       <div className="flex items-center gap-1">
-        {SCOPES.map((s) => (
-          <Tooltip key={s.value}>
-            <TooltipTrigger
+        {isMobile ? (
+          /* Mobile: compact dropdown for scope */
+          <DropdownMenu>
+            <DropdownMenuTrigger
               render={
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className={
-                    scope === s.value
-                      ? "bg-accent text-accent-foreground hover:bg-accent/80"
-                      : "text-muted-foreground"
-                  }
-                  onClick={() => setScope(s.value)}
-                >
-                  {s.label}
+                <Button variant="outline" size="xs">
+                  {SCOPES.find((s) => s.value === scope)?.label ?? "All"}
+                  <ChevronDown className="size-3 ml-1 text-muted-foreground" />
                 </Button>
               }
             />
-            <TooltipContent side="bottom">{s.description}</TooltipContent>
-          </Tooltip>
-        ))}
+            <DropdownMenuContent align="start" className="w-auto">
+              {SCOPES.map((s) => (
+                <DropdownMenuItem key={s.value} onClick={() => setScope(s.value)}>
+                  {s.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          SCOPES.map((s) => (
+            <Tooltip key={s.value}>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className={
+                      scope === s.value
+                        ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                        : "text-muted-foreground"
+                    }
+                    onClick={() => setScope(s.value)}
+                  >
+                    {s.label}
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom">{s.description}</TooltipContent>
+            </Tooltip>
+          ))
+        )}
       </div>
 
       {/* Right: filter + display + view toggle */}

--- a/apps/web/features/issues/components/issues-page.tsx
+++ b/apps/web/features/issues/components/issues-page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
-import { ChevronRight, ListTodo } from "lucide-react";
+import { ChevronRight, ListTodo, Plus } from "lucide-react";
 import type { IssueStatus } from "@/shared/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useIssueStore } from "@/features/issues/store";
@@ -13,8 +13,11 @@ import { filterIssues } from "@/features/issues/utils/filter";
 import { BOARD_STATUSES } from "@/features/issues/config";
 import { useWorkspaceStore } from "@/features/workspace";
 import { WorkspaceAvatar } from "@/features/workspace";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { api } from "@/shared/api";
 import { useIssueSelectionStore } from "@/features/issues/stores/selection-store";
+import { useModalStore } from "@/features/modals";
+import { Button } from "@/components/ui/button";
 import { IssuesHeader } from "./issues-header";
 import { BoardView } from "./board-view";
 import { ListView } from "./list-view";
@@ -117,13 +120,24 @@ export function IssuesPage() {
   return (
     <div className="flex flex-1 min-h-0 flex-col">
       {/* Header 1: Workspace breadcrumb */}
-      <div className="flex h-12 shrink-0 items-center gap-1.5 border-b px-4">
-        <WorkspaceAvatar name={workspace?.name ?? "W"} size="sm" />
-        <span className="text-sm text-muted-foreground">
-          {workspace?.name ?? "Workspace"}
-        </span>
-        <ChevronRight className="h-3 w-3 text-muted-foreground" />
-        <span className="text-sm font-medium">Issues</span>
+      <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
+        <div className="flex items-center gap-1.5">
+          <SidebarTrigger className="md:hidden" />
+          <WorkspaceAvatar name={workspace?.name ?? "W"} size="sm" className="hidden md:flex" />
+          <span className="text-sm text-muted-foreground hidden md:inline">
+            {workspace?.name ?? "Workspace"}
+          </span>
+          <ChevronRight className="h-3 w-3 text-muted-foreground hidden md:inline" />
+          <span className="text-sm font-medium">Issues</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="md:hidden text-muted-foreground"
+          onClick={() => useModalStore.getState().open("create-issue")}
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
       </div>
 
       {/* Header 2: Scope tabs + filters */}

--- a/apps/web/features/issues/components/list-row.tsx
+++ b/apps/web/features/issues/components/list-row.tsx
@@ -20,21 +20,21 @@ export const ListRow = memo(function ListRow({ issue }: { issue: Issue }) {
 
   return (
     <div
-      className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/50 ${
+      className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/50 coarse:h-11 ${
         selected ? "bg-accent/30" : ""
       }`}
     >
       <div className="relative flex shrink-0 items-center justify-center w-4 h-4">
         <PriorityIcon
           priority={issue.priority}
-          className={selected ? "hidden" : "group-hover/row:hidden"}
+          className={selected ? "hidden" : "group-hover/row:hidden coarse:hidden"}
         />
         <input
           type="checkbox"
           checked={selected}
           onChange={() => toggle(issue.id)}
           className={`absolute inset-0 cursor-pointer accent-primary ${
-            selected ? "" : "hidden group-hover/row:block"
+            selected ? "" : "hidden group-hover/row:block coarse:block"
           }`}
         />
       </div>

--- a/apps/web/features/landing/components/features-section.tsx
+++ b/apps/web/features/landing/components/features-section.tsx
@@ -882,7 +882,7 @@ function RuntimesVisual() {
             </div>
 
             {/* Token summary cards — same as real TokenCard */}
-            <div className="grid grid-cols-4 gap-2">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
               {[
                 { label: "Input", value: formatTokens(totals.input) },
                 { label: "Output", value: formatTokens(totals.output) },

--- a/apps/web/features/modals/create-issue.tsx
+++ b/apps/web/features/modals/create-issue.tsx
@@ -12,6 +12,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useIsMobile } from "@/hooks/use-mobile";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -67,6 +73,7 @@ function PillButton({
 
 export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?: Record<string, unknown> | null }) {
   const router = useRouter();
+  const isMobile = useIsMobile();
   const workspaceName = useWorkspaceStore((s) => s.workspace?.name);
   const members = useWorkspaceStore((s) => s.members);
   const agents = useWorkspaceStore((s) => s.agents);
@@ -173,6 +180,271 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
     }
   };
 
+  const modalContent = (
+    <>
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 pt-3 pb-2 shrink-0">
+        <div className="flex items-center gap-1.5 text-xs">
+          <span className="text-muted-foreground">{workspaceName}</span>
+          <ChevronRight className="size-3 text-muted-foreground/50" />
+          <span className="font-medium">New issue</span>
+        </div>
+        <div className="flex items-center gap-1">
+          {!isMobile && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
+                  >
+                    {isExpanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+                  </button>
+                }
+              />
+              <TooltipContent side="bottom">{isExpanded ? "Collapse" : "Expand"}</TooltipContent>
+            </Tooltip>
+          )}
+          {!isMobile && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    onClick={onClose}
+                    className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
+                  >
+                    <XIcon className="size-4" />
+                  </button>
+                }
+              />
+              <TooltipContent side="bottom">Close</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+
+      {/* Title */}
+      <div className="px-5 pb-2 shrink-0">
+        <TitleEditor
+          autoFocus
+          defaultValue={draft.title}
+          placeholder="Issue title"
+          className="text-lg font-semibold"
+          onChange={(v) => updateTitle(v)}
+          onSubmit={handleSubmit}
+        />
+      </div>
+
+      {/* Description — takes remaining space */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-5">
+        <ContentEditor
+          ref={descEditorRef}
+          defaultValue={draft.description}
+          placeholder="Add description..."
+          onUpdate={(md) => setDraft({ description: md })}
+          onUploadFile={handleUpload}
+          debounceMs={500}
+        />
+      </div>
+
+      {/* Property toolbar */}
+      <div className="flex items-center gap-1.5 px-4 py-2 shrink-0 flex-wrap">
+        {/* Status */}
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <PillButton>
+                <StatusIcon status={status} className="size-3.5" />
+                <span>{STATUS_CONFIG[status].label}</span>
+              </PillButton>
+            }
+          />
+          <DropdownMenuContent align="start" className="w-44">
+            {ALL_STATUSES.map((s) => (
+              <DropdownMenuItem key={s} onClick={() => updateStatus(s)}>
+                <StatusIcon status={s} className="size-3.5" />
+                <span>{STATUS_CONFIG[s].label}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Priority */}
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <PillButton>
+                <PriorityIcon priority={priority} />
+                <span>{PRIORITY_CONFIG[priority].label}</span>
+              </PillButton>
+            }
+          />
+          <DropdownMenuContent align="start" className="w-44">
+            {PRIORITY_ORDER.map((p) => (
+              <DropdownMenuItem key={p} onClick={() => updatePriority(p)}>
+                <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${PRIORITY_CONFIG[p].badgeBg} ${PRIORITY_CONFIG[p].badgeText}`}>
+                  <PriorityIcon priority={p} className="h-3 w-3" inheritColor />
+                  {PRIORITY_CONFIG[p].label}
+                </span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Assignee — Popover for search support */}
+        <Popover open={assigneeOpen} onOpenChange={(v) => { setAssigneeOpen(v); if (!v) setAssigneeFilter(""); }}>
+          <PopoverTrigger
+            render={
+              <PillButton>
+                {assigneeType && assigneeId ? (
+                  <>
+                    <ActorAvatar actorType={assigneeType} actorId={assigneeId} size={16} />
+                    <span>{assigneeLabel}</span>
+                  </>
+                ) : (
+                  <span className="text-muted-foreground">Assignee</span>
+                )}
+              </PillButton>
+            }
+          />
+          <PopoverContent align="start" className="w-52 p-0">
+            <div className="px-2 py-1.5 border-b">
+              <input
+                type="text"
+                value={assigneeFilter}
+                onChange={(e) => setAssigneeFilter(e.target.value)}
+                placeholder="Assign to..."
+                className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
+              />
+            </div>
+            <div className="p-1 max-h-60 overflow-y-auto">
+              {/* Unassigned */}
+              <button
+                type="button"
+                onClick={() => {
+                  updateAssignee(undefined, undefined);
+                  setAssigneeOpen(false);
+                }}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+              >
+                <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-muted-foreground">Unassigned</span>
+              </button>
+
+              {/* Members */}
+              {filteredMembers.length > 0 && (
+                <>
+                  <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">Members</div>
+                  {filteredMembers.map((m) => (
+                    <button
+                      type="button"
+                      key={m.user_id}
+                      onClick={() => {
+                        updateAssignee("member", m.user_id);
+                        setAssigneeOpen(false);
+                      }}
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                    >
+                      <ActorAvatar actorType="member" actorId={m.user_id} size={16} />
+                      <span>{m.name}</span>
+                    </button>
+                  ))}
+                </>
+              )}
+
+              {/* Agents */}
+              {filteredAgents.length > 0 && (
+                <>
+                  <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">Agents</div>
+                  {filteredAgents.map((a) => (
+                    <button
+                      type="button"
+                      key={a.id}
+                      onClick={() => {
+                        updateAssignee("agent", a.id);
+                        setAssigneeOpen(false);
+                      }}
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                    >
+                      <ActorAvatar actorType="agent" actorId={a.id} size={16} />
+                      <span>{a.name}</span>
+                    </button>
+                  ))}
+                </>
+              )}
+
+              {filteredMembers.length === 0 && filteredAgents.length === 0 && assigneeFilter && (
+                <div className="px-2 py-3 text-center text-sm text-muted-foreground">No results</div>
+              )}
+            </div>
+          </PopoverContent>
+        </Popover>
+
+        {/* Due date */}
+        <Popover open={dueDateOpen} onOpenChange={setDueDateOpen}>
+          <PopoverTrigger
+            render={
+              <PillButton>
+                <CalendarDays className="size-3.5 text-muted-foreground" />
+                {dueDateObj ? (
+                  <span>{dueDateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })}</span>
+                ) : (
+                  <span className="text-muted-foreground">Due date</span>
+                )}
+              </PillButton>
+            }
+          />
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              mode="single"
+              selected={dueDateObj}
+              onSelect={(d: Date | undefined) => {
+                updateDueDate(d ? d.toISOString() : null);
+                setDueDateOpen(false);
+              }}
+            />
+            {dueDateObj && (
+              <div className="border-t px-3 py-2">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => {
+                    updateDueDate(null);
+                    setDueDateOpen(false);
+                  }}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  Clear date
+                </Button>
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between px-4 py-3 border-t shrink-0 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+        <FileUploadButton
+          onSelect={(file) => descEditorRef.current?.uploadFile(file)}
+        />
+        <Button size="sm" onClick={handleSubmit} disabled={!title.trim() || submitting}>
+          {submitting ? "Creating..." : "Create Issue"}
+        </Button>
+      </div>
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open onOpenChange={(v) => { if (!v) onClose(); }}>
+        <DrawerContent className="max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden">
+          <DrawerTitle className="sr-only">New Issue</DrawerTitle>
+          {modalContent}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
   return (
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
       <DialogContent
@@ -187,252 +459,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         )}
       >
         <DialogTitle className="sr-only">New Issue</DialogTitle>
-
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 pt-3 pb-2 shrink-0">
-          <div className="flex items-center gap-1.5 text-xs">
-            <span className="text-muted-foreground">{workspaceName}</span>
-            <ChevronRight className="size-3 text-muted-foreground/50" />
-            <span className="font-medium">New issue</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    onClick={() => setIsExpanded(!isExpanded)}
-                    className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
-                  >
-                    {isExpanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
-                  </button>
-                }
-              />
-              <TooltipContent side="bottom">{isExpanded ? "Collapse" : "Expand"}</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    onClick={onClose}
-                    className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
-                  >
-                    <XIcon className="size-4" />
-                  </button>
-                }
-              />
-              <TooltipContent side="bottom">Close</TooltipContent>
-            </Tooltip>
-          </div>
-        </div>
-
-        {/* Title */}
-        <div className="px-5 pb-2 shrink-0">
-          <TitleEditor
-            autoFocus
-            defaultValue={draft.title}
-            placeholder="Issue title"
-            className="text-lg font-semibold"
-            onChange={(v) => updateTitle(v)}
-            onSubmit={handleSubmit}
-          />
-        </div>
-
-        {/* Description — takes remaining space */}
-        <div className="flex-1 min-h-0 overflow-y-auto px-5">
-          <ContentEditor
-            ref={descEditorRef}
-            defaultValue={draft.description}
-            placeholder="Add description..."
-            onUpdate={(md) => setDraft({ description: md })}
-            onUploadFile={handleUpload}
-            debounceMs={500}
-          />
-        </div>
-
-        {/* Property toolbar */}
-        <div className="flex items-center gap-1.5 px-4 py-2 shrink-0 flex-wrap">
-          {/* Status */}
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <PillButton>
-                  <StatusIcon status={status} className="size-3.5" />
-                  <span>{STATUS_CONFIG[status].label}</span>
-                </PillButton>
-              }
-            />
-            <DropdownMenuContent align="start" className="w-44">
-              {ALL_STATUSES.map((s) => (
-                <DropdownMenuItem key={s} onClick={() => updateStatus(s)}>
-                  <StatusIcon status={s} className="size-3.5" />
-                  <span>{STATUS_CONFIG[s].label}</span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* Priority */}
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <PillButton>
-                  <PriorityIcon priority={priority} />
-                  <span>{PRIORITY_CONFIG[priority].label}</span>
-                </PillButton>
-              }
-            />
-            <DropdownMenuContent align="start" className="w-44">
-              {PRIORITY_ORDER.map((p) => (
-                <DropdownMenuItem key={p} onClick={() => updatePriority(p)}>
-                  <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${PRIORITY_CONFIG[p].badgeBg} ${PRIORITY_CONFIG[p].badgeText}`}>
-                    <PriorityIcon priority={p} className="h-3 w-3" inheritColor />
-                    {PRIORITY_CONFIG[p].label}
-                  </span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* Assignee — Popover for search support */}
-          <Popover open={assigneeOpen} onOpenChange={(v) => { setAssigneeOpen(v); if (!v) setAssigneeFilter(""); }}>
-            <PopoverTrigger
-              render={
-                <PillButton>
-                  {assigneeType && assigneeId ? (
-                    <>
-                      <ActorAvatar actorType={assigneeType} actorId={assigneeId} size={16} />
-                      <span>{assigneeLabel}</span>
-                    </>
-                  ) : (
-                    <span className="text-muted-foreground">Assignee</span>
-                  )}
-                </PillButton>
-              }
-            />
-            <PopoverContent align="start" className="w-52 p-0">
-              <div className="px-2 py-1.5 border-b">
-                <input
-                  type="text"
-                  value={assigneeFilter}
-                  onChange={(e) => setAssigneeFilter(e.target.value)}
-                  placeholder="Assign to..."
-                  className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
-                />
-              </div>
-              <div className="p-1 max-h-60 overflow-y-auto">
-                {/* Unassigned */}
-                <button
-                  type="button"
-                  onClick={() => {
-                    updateAssignee(undefined, undefined);
-                    setAssigneeOpen(false);
-                  }}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                >
-                  <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
-                  <span className="text-muted-foreground">Unassigned</span>
-                </button>
-
-                {/* Members */}
-                {filteredMembers.length > 0 && (
-                  <>
-                    <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">Members</div>
-                    {filteredMembers.map((m) => (
-                      <button
-                        type="button"
-                        key={m.user_id}
-                        onClick={() => {
-                          updateAssignee("member", m.user_id);
-                          setAssigneeOpen(false);
-                        }}
-                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                      >
-                        <ActorAvatar actorType="member" actorId={m.user_id} size={16} />
-                        <span>{m.name}</span>
-                      </button>
-                    ))}
-                  </>
-                )}
-
-                {/* Agents */}
-                {filteredAgents.length > 0 && (
-                  <>
-                    <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">Agents</div>
-                    {filteredAgents.map((a) => (
-                      <button
-                        type="button"
-                        key={a.id}
-                        onClick={() => {
-                          updateAssignee("agent", a.id);
-                          setAssigneeOpen(false);
-                        }}
-                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                      >
-                        <ActorAvatar actorType="agent" actorId={a.id} size={16} />
-                        <span>{a.name}</span>
-                      </button>
-                    ))}
-                  </>
-                )}
-
-                {filteredMembers.length === 0 && filteredAgents.length === 0 && assigneeFilter && (
-                  <div className="px-2 py-3 text-center text-sm text-muted-foreground">No results</div>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-
-          {/* Due date */}
-          <Popover open={dueDateOpen} onOpenChange={setDueDateOpen}>
-            <PopoverTrigger
-              render={
-                <PillButton>
-                  <CalendarDays className="size-3.5 text-muted-foreground" />
-                  {dueDateObj ? (
-                    <span>{dueDateObj.toLocaleDateString("en-US", { month: "short", day: "numeric" })}</span>
-                  ) : (
-                    <span className="text-muted-foreground">Due date</span>
-                  )}
-                </PillButton>
-              }
-            />
-            <PopoverContent className="w-auto p-0" align="start">
-              <Calendar
-                mode="single"
-                selected={dueDateObj}
-                onSelect={(d: Date | undefined) => {
-                  updateDueDate(d ? d.toISOString() : null);
-                  setDueDateOpen(false);
-                }}
-              />
-              {dueDateObj && (
-                <div className="border-t px-3 py-2">
-                  <Button
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => {
-                      updateDueDate(null);
-                      setDueDateOpen(false);
-                    }}
-                    className="text-muted-foreground hover:text-foreground"
-                  >
-                    Clear date
-                  </Button>
-                </div>
-              )}
-            </PopoverContent>
-          </Popover>
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-between px-4 py-3 border-t shrink-0">
-          <FileUploadButton
-            onSelect={(file) => descEditorRef.current?.uploadFile(file)}
-          />
-          <Button size="sm" onClick={handleSubmit} disabled={!title.trim() || submitting}>
-            {submitting ? "Creating..." : "Create Issue"}
-          </Button>
-        </div>
+        {modalContent}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/features/my-issues/components/my-issues-header.tsx
+++ b/apps/web/features/my-issues/components/my-issues-header.tsx
@@ -48,6 +48,7 @@ import {
 import { filterIssues } from "@/features/issues/utils/filter";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import type { Issue } from "@/shared/types";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { myIssuesViewStore, type MyIssuesScope } from "../stores/my-issues-view-store";
 
 // ---------------------------------------------------------------------------
@@ -111,6 +112,7 @@ const SCOPES: { value: MyIssuesScope; label: string; description: string }[] = [
 // ---------------------------------------------------------------------------
 
 export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
+  const isMobile = useIsMobile();
   const viewMode = useStore(myIssuesViewStore, (s) => s.viewMode);
   const statusFilters = useStore(myIssuesViewStore, (s) => s.statusFilters);
   const priorityFilters = useStore(myIssuesViewStore, (s) => s.priorityFilters);
@@ -129,30 +131,50 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
     SORT_OPTIONS.find((o) => o.value === sortBy)?.label ?? "Manual";
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between px-4">
+    <div className="flex h-12 shrink-0 items-center justify-between px-4 gap-2">
       {/* Left: scope buttons */}
       <div className="flex items-center gap-1">
-        {SCOPES.map((s) => (
-          <Tooltip key={s.value}>
-            <TooltipTrigger
+        {isMobile ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger
               render={
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className={
-                    scope === s.value
-                      ? "bg-accent text-accent-foreground hover:bg-accent/80"
-                      : "text-muted-foreground"
-                  }
-                  onClick={() => act.setScope(s.value)}
-                >
-                  {s.label}
+                <Button variant="outline" size="xs">
+                  {SCOPES.find((s) => s.value === scope)?.label ?? "Assigned"}
+                  <ChevronDown className="size-3 ml-1 text-muted-foreground" />
                 </Button>
               }
             />
-            <TooltipContent side="bottom">{s.description}</TooltipContent>
-          </Tooltip>
-        ))}
+            <DropdownMenuContent align="start" className="w-auto">
+              {SCOPES.map((s) => (
+                <DropdownMenuItem key={s.value} onClick={() => act.setScope(s.value)}>
+                  {s.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          SCOPES.map((s) => (
+            <Tooltip key={s.value}>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className={
+                      scope === s.value
+                        ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                        : "text-muted-foreground"
+                    }
+                    onClick={() => act.setScope(s.value)}
+                  >
+                    {s.label}
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom">{s.description}</TooltipContent>
+            </Tooltip>
+          ))
+        )}
       </div>
 
       {/* Right: filter + display + view toggle */}

--- a/apps/web/features/my-issues/components/my-issues-page.tsx
+++ b/apps/web/features/my-issues/components/my-issues-page.tsx
@@ -3,11 +3,14 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useStore } from "zustand";
 import { toast } from "sonner";
-import { ChevronRight, ListTodo } from "lucide-react";
+import { ChevronRight, ListTodo, Plus } from "lucide-react";
 import type { IssueStatus } from "@/shared/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAuthStore } from "@/features/auth";
 import { useWorkspaceStore, WorkspaceAvatar } from "@/features/workspace";
+import { Button } from "@/components/ui/button";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { useModalStore } from "@/features/modals";
 import { useIssueStore } from "@/features/issues/store";
 import { filterIssues } from "@/features/issues/utils/filter";
 import { BOARD_STATUSES } from "@/features/issues/config";
@@ -157,13 +160,24 @@ export function MyIssuesPage() {
   return (
     <div className="flex flex-1 min-h-0 flex-col">
       {/* Header 1: Workspace breadcrumb */}
-      <div className="flex h-12 shrink-0 items-center gap-1.5 border-b px-4">
-        <WorkspaceAvatar name={workspace?.name ?? "W"} size="sm" />
-        <span className="text-sm text-muted-foreground">
-          {workspace?.name ?? "Workspace"}
-        </span>
-        <ChevronRight className="h-3 w-3 text-muted-foreground" />
-        <span className="text-sm font-medium">My Issues</span>
+      <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
+        <div className="flex items-center gap-1.5">
+          <SidebarTrigger className="md:hidden" />
+          <WorkspaceAvatar name={workspace?.name ?? "W"} size="sm" className="hidden md:flex" />
+          <span className="text-sm text-muted-foreground hidden md:inline">
+            {workspace?.name ?? "Workspace"}
+          </span>
+          <ChevronRight className="h-3 w-3 text-muted-foreground hidden md:inline" />
+          <span className="text-sm font-medium">My Issues</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="md:hidden text-muted-foreground"
+          onClick={() => useModalStore.getState().open("create-issue")}
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
       </div>
 
       {/* Header: scope tabs (left) + controls (right) */}

--- a/apps/web/features/runtimes/components/runtime-detail.tsx
+++ b/apps/web/features/runtimes/components/runtime-detail.tsx
@@ -42,7 +42,7 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
         {/* Info grid */}
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <InfoField label="Runtime Mode" value={runtime.runtime_mode} />
           <InfoField label="Provider" value={runtime.provider} />
           <InfoField label="Status" value={runtime.status} />

--- a/apps/web/features/runtimes/components/runtime-list.tsx
+++ b/apps/web/features/runtimes/components/runtime-list.tsx
@@ -1,5 +1,6 @@
 import { Server } from "lucide-react";
 import type { AgentRuntime } from "@/shared/types";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { RuntimeModeIcon } from "./shared";
 
 function RuntimeListItem({
@@ -52,7 +53,10 @@ export function RuntimeList({
   return (
     <div className="overflow-y-auto h-full border-r">
       <div className="flex h-12 items-center justify-between border-b px-4">
-        <h1 className="text-sm font-semibold">Runtimes</h1>
+        <div className="flex items-center gap-2">
+          <SidebarTrigger className="md:hidden" />
+          <h1 className="text-sm font-semibold">Runtimes</h1>
+        </div>
         <span className="text-xs text-muted-foreground">
           {runtimes.filter((r) => r.status === "online").length}/
           {runtimes.length} online

--- a/apps/web/features/runtimes/components/runtimes-page.tsx
+++ b/apps/web/features/runtimes/components/runtimes-page.tsx
@@ -9,6 +9,8 @@ import {
   ResizableHandle,
 } from "@/components/ui/resizable";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { MobileListDetail } from "@/components/layout/mobile-list-detail";
 import { useAuthStore } from "@/features/auth";
 import { useWorkspaceStore } from "@/features/workspace";
 import { useWSEvent } from "@/features/realtime";
@@ -17,6 +19,7 @@ import { RuntimeList } from "./runtime-list";
 import { RuntimeDetail } from "./runtime-detail";
 
 export default function RuntimesPage() {
+  const isMobile = useIsMobile();
   const isLoading = useAuthStore((s) => s.isLoading);
   const workspace = useWorkspaceStore((s) => s.workspace);
   const runtimes = useRuntimeStore((s) => s.runtimes);
@@ -79,6 +82,37 @@ export default function RuntimesPage() {
     );
   }
 
+  const emptyDetail = (
+    <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
+      <Server className="h-10 w-10 text-muted-foreground/30" />
+      <p className="mt-3 text-sm">Select a runtime to view details</p>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <MobileListDetail
+        showDetail={!!selectedId}
+        onBack={() => setSelectedId("")}
+        headerTitle={selected?.name ?? "Runtime"}
+        list={
+          <RuntimeList
+            runtimes={runtimes}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+          />
+        }
+        detail={
+          selected ? (
+            <RuntimeDetail key={selected.id} runtime={selected} />
+          ) : (
+            emptyDetail
+          )
+        }
+      />
+    );
+  }
+
   return (
     <ResizablePanelGroup
       orientation="horizontal"
@@ -106,10 +140,7 @@ export default function RuntimesPage() {
         {selected ? (
           <RuntimeDetail key={selected.id} runtime={selected} />
         ) : (
-          <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
-            <Server className="h-10 w-10 text-muted-foreground/30" />
-            <p className="mt-3 text-sm">Select a runtime to view details</p>
-          </div>
+          emptyDetail
         )}
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/apps/web/features/skills/components/file-tree.tsx
+++ b/apps/web/features/skills/components/file-tree.tsx
@@ -100,7 +100,7 @@ function TreeNodeItem({
         <button
           onClick={() => setExpanded(!expanded)}
           className="flex w-full items-center gap-1.5 py-1 text-left text-xs hover:bg-accent/50 rounded-sm"
-          style={{ paddingLeft: `${depth * 12 + 8}px` }}
+          style={{ paddingLeft: `${Math.min(depth, 5) * 12 + 8}px` }}
         >
           <ChevronIcon className="h-3 w-3 shrink-0 text-muted-foreground" />
           <FolderIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
@@ -134,7 +134,7 @@ function TreeNodeItem({
           ? "bg-accent text-accent-foreground"
           : "hover:bg-accent/50",
       )}
-      style={{ paddingLeft: `${depth * 12 + 8 + 16}px` }}
+      style={{ paddingLeft: `${Math.min(depth, 5) * 12 + 8 + 16}px` }}
     >
       <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       <span className="truncate">{node.name}</span>

--- a/apps/web/features/skills/components/skills-page.tsx
+++ b/apps/web/features/skills/components/skills-page.tsx
@@ -38,6 +38,9 @@ import { useWorkspaceStore } from "@/features/workspace";
 
 import { FileTree } from "./file-tree";
 import { FileViewer } from "./file-viewer";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { MobileListDetail } from "@/components/layout/mobile-list-detail";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 
 // ---------------------------------------------------------------------------
 // Create Skill Dialog
@@ -609,6 +612,7 @@ function SkillDetail({
 // ---------------------------------------------------------------------------
 
 export default function SkillsPage() {
+  const isMobile = useIsMobile();
   const isLoading = useAuthStore((s) => s.isLoading);
   const skills = useWorkspaceStore((s) => s.skills);
   const refreshSkills = useWorkspaceStore((s) => s.refreshSkills);
@@ -711,6 +715,108 @@ export default function SkillsPage() {
     );
   }
 
+  const skillListContent = (
+    <div className="overflow-y-auto h-full border-r">
+      <div className="flex h-12 items-center justify-between border-b px-4">
+        <div className="flex items-center gap-2">
+            <SidebarTrigger className="md:hidden" />
+            <h1 className="text-sm font-semibold">Skills</h1>
+          </div>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setShowCreate(true)}
+              >
+                <Plus className="h-4 w-4 text-muted-foreground" />
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom">Create skill</TooltipContent>
+        </Tooltip>
+      </div>
+      {skills.length === 0 ? (
+        <div className="flex flex-col items-center justify-center px-4 py-12">
+          <Sparkles className="h-8 w-8 text-muted-foreground/40" />
+          <p className="mt-3 text-sm text-muted-foreground">No skills yet</p>
+          <p className="mt-1 text-xs text-muted-foreground text-center">
+            Skills define reusable instructions for agents.
+          </p>
+          <Button
+            onClick={() => setShowCreate(true)}
+            size="xs"
+            className="mt-3"
+          >
+            <Plus className="h-3 w-3" />
+            Create Skill
+          </Button>
+        </div>
+      ) : (
+        <div className="divide-y">
+          {skills.map((skill) => (
+            <SkillListItem
+              key={skill.id}
+              skill={skill}
+              isSelected={skill.id === selectedId}
+              onClick={() => setSelectedId(skill.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  const skillDetailContent = (
+    <div className="flex-1 overflow-hidden h-full">
+      {selected ? (
+        <SkillDetail
+          key={selected.id}
+          skill={selected}
+          onUpdate={handleUpdate}
+          onDelete={handleDelete}
+        />
+      ) : (
+        <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
+          <Sparkles className="h-10 w-10 text-muted-foreground/30" />
+          <p className="mt-3 text-sm">Select a skill to view details</p>
+          <Button
+            onClick={() => setShowCreate(true)}
+            size="xs"
+            className="mt-3"
+          >
+            <Plus className="h-3 w-3" />
+            Create Skill
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+
+  const createDialog = showCreate ? (
+    <CreateSkillDialog
+      onClose={() => setShowCreate(false)}
+      onCreate={handleCreate}
+      onImport={handleImport}
+    />
+  ) : null;
+
+  if (isMobile) {
+    return (
+      <>
+        <MobileListDetail
+          showDetail={!!selectedId}
+          onBack={() => setSelectedId("")}
+          headerTitle={selected?.name ?? "Skill"}
+          list={skillListContent}
+          detail={skillDetailContent}
+        />
+        {createDialog}
+      </>
+    );
+  }
+
   return (
     <ResizablePanelGroup
       orientation="horizontal"
@@ -719,92 +825,16 @@ export default function SkillsPage() {
       onLayoutChanged={onLayoutChanged}
     >
       <ResizablePanel id="list" defaultSize={280} minSize={240} maxSize={400} groupResizeBehavior="preserve-pixel-size">
-        {/* Left column — skill list */}
-        <div className="overflow-y-auto h-full border-r">
-          <div className="flex h-12 items-center justify-between border-b px-4">
-            <h1 className="text-sm font-semibold">Skills</h1>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    onClick={() => setShowCreate(true)}
-                  >
-                    <Plus className="h-4 w-4 text-muted-foreground" />
-                  </Button>
-                }
-              />
-              <TooltipContent side="bottom">Create skill</TooltipContent>
-            </Tooltip>
-          </div>
-          {skills.length === 0 ? (
-            <div className="flex flex-col items-center justify-center px-4 py-12">
-              <Sparkles className="h-8 w-8 text-muted-foreground/40" />
-              <p className="mt-3 text-sm text-muted-foreground">No skills yet</p>
-              <p className="mt-1 text-xs text-muted-foreground text-center">
-                Skills define reusable instructions for agents.
-              </p>
-              <Button
-                onClick={() => setShowCreate(true)}
-                size="xs"
-                className="mt-3"
-              >
-                <Plus className="h-3 w-3" />
-                Create Skill
-              </Button>
-            </div>
-          ) : (
-            <div className="divide-y">
-              {skills.map((skill) => (
-                <SkillListItem
-                  key={skill.id}
-                  skill={skill}
-                  isSelected={skill.id === selectedId}
-                  onClick={() => setSelectedId(skill.id)}
-                />
-              ))}
-            </div>
-          )}
-        </div>
+        {skillListContent}
       </ResizablePanel>
 
       <ResizableHandle />
 
       <ResizablePanel id="detail" minSize="50%">
-        {/* Right column — skill detail */}
-        <div className="flex-1 overflow-hidden h-full">
-          {selected ? (
-            <SkillDetail
-              key={selected.id}
-              skill={selected}
-              onUpdate={handleUpdate}
-              onDelete={handleDelete}
-            />
-          ) : (
-            <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
-              <Sparkles className="h-10 w-10 text-muted-foreground/30" />
-              <p className="mt-3 text-sm">Select a skill to view details</p>
-              <Button
-                onClick={() => setShowCreate(true)}
-                size="xs"
-                className="mt-3"
-              >
-                <Plus className="h-3 w-3" />
-                Create Skill
-              </Button>
-            </div>
-          )}
-        </div>
+        {skillDetailContent}
       </ResizablePanel>
 
-      {showCreate && (
-        <CreateSkillDialog
-          onClose={() => setShowCreate(false)}
-          onCreate={handleCreate}
-          onImport={handleImport}
-        />
-      )}
+      {createDialog}
     </ResizablePanelGroup>
   );
 }


### PR DESCRIPTION
## Summary

Complete mobile responsive overhaul for the Multica web frontend. All changes are gated behind `useIsMobile()` or responsive CSS — zero desktop regressions.

### Navigation
- Add **SidebarTrigger** (hamburger menu) to all 8 dashboard pages for mobile navigation
- Add mobile **"+" create issue button** to Issues and My Issues pages
- Issues/MyIssues headers: scope buttons collapse to **dropdown** on mobile

### Layout Adaptation
- Convert **ResizablePanel** two-column layouts to **list→detail navigation** on mobile (Inbox, Agents, Runtimes, Skills)
- **Issue detail**: properties sidebar opens as bottom **Sheet**, breadcrumb simplified, prev/next nav hidden
- **Board/Kanban**: single full-width column with **status tab bar** on mobile
- **Settings**: horizontal scrollable tabs replacing fixed sidebar
- **Create Issue modal**: renders as bottom **Drawer** on mobile

### Touch & Polish
- **Touch targets**: `@media (pointer: coarse)` CSS for 44px minimum hit areas
- **Hover-only interactions** (inbox archive, list checkboxes) always visible on touch devices
- **Safe area** support: `viewport-fit:cover`, `env(safe-area-inset-bottom)` padding
- **Popover** max-width constraint to prevent viewport overflow
- **Runtime detail**: responsive grid (1 col on mobile)
- **Landing page**: responsive feature grid (2 cols on mobile)
- **Login**: horizontal padding for mobile
- **Mention popup** / **file tree indent** / **agent tabs**: mobile overflow fixes

### New Components
- `components/ui/responsive-modal.tsx` — Dialog on desktop, Drawer on mobile
- `components/layout/mobile-list-detail.tsx` — Reusable list→detail mobile navigation

## Test plan

- [x] Verify sidebar opens via hamburger on all dashboard pages (Issues, My Issues, Inbox, Agents, Runtimes, Skills, Settings, Issue Detail)
- [x] Verify create issue button (+) visible on mobile Issues/My Issues pages
- [x] Verify create issue opens as bottom Drawer on mobile
- [x] Verify board view shows status tabs + single column on mobile
- [x] Verify settings page shows horizontal scrollable tabs on mobile
- [x] Verify issue detail properties open as bottom Sheet on mobile
- [x] Verify inbox/agents/runtimes/skills use list→detail navigation on mobile
- [x] Verify all pages render correctly on desktop (no regressions)
- [x] `pnpm typecheck` passes