### PR TITLE
fix(auth): extend JWT and CloudFront cookie expiration from 72h to 30 days

### DIFF
--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -175,7 +175,7 @@ func (h *Handler) issueJWT(user db.User) (string, error) {
 		"sub":   uuidToString(user.ID),
 		"email": user.Email,
 		"name":  user.Name,
-		"exp":   time.Now().Add(72 * time.Hour).Unix(),
+		"exp":   time.Now().Add(30 * 24 * time.Hour).Unix(),
 		"iat":   time.Now().Unix(),
 	})
 	return token.SignedString(auth.JWTSecret())
@@ -302,7 +302,7 @@ func (h *Handler) VerifyCode(w http.ResponseWriter, r *http.Request) {
 
 	// Set CloudFront signed cookies for CDN access.
 	if h.CFSigner != nil {
-		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(72 * time.Hour)) {
+		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(30 * 24 * time.Hour)) {
 			http.SetCookie(w, cookie)
 		}
 	}

--- a/server/internal/middleware/cloudfront.go
+++ b/server/internal/middleware/cloudfront.go
@@ -18,7 +18,7 @@ func RefreshCloudFrontCookies(signer *auth.CloudFrontSigner) func(http.Handler) 
 		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if _, err := r.Cookie("CloudFront-Policy"); err != nil {
-				for _, cookie := range signer.SignedCookies(time.Now().Add(72 * time.Hour)) {
+				for _, cookie := range signer.SignedCookies(time.Now().Add(30 * 24 * time.Hour)) {
 					http.SetCookie(w, cookie)
 				}
 			}


### PR DESCRIPTION
Reduces login frequency for users by increasing token lifetime. 72 hours are so short that users have to login 2 times a week.