### PR TITLE
feat(repo): configurable default merge branch per repository

### DIFF
--- a/apps/web/app/(dashboard)/settings/_components/repositories-tab.tsx
+++ b/apps/web/app/(dashboard)/settings/_components/repositories-tab.tsx
@@ -1,15 +1,125 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Save, Plus, Trash2 } from "lucide-react";
+import { Save, Plus, Trash2, GitBranch, Check, ChevronsUpDown } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
 import { toast } from "sonner";
 import { useAuthStore } from "@/features/auth";
 import { useWorkspaceStore } from "@/features/workspace";
 import { api } from "@/shared/api";
 import type { WorkspaceRepo } from "@/shared/types";
+
+const BRANCH_SUGGESTIONS = [
+  { value: "", label: "Auto-detect", description: "Use remote default branch" },
+  { value: "main", label: "main", description: "" },
+  { value: "develop", label: "develop", description: "" },
+  { value: "staging", label: "staging", description: "" },
+  { value: "master", label: "master", description: "" },
+];
+
+function BranchPicker({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const displayLabel = value || "Auto-detect";
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 w-full justify-between text-xs font-normal"
+            disabled={disabled}
+          >
+            <span className="flex items-center gap-1.5 truncate">
+              <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+              <span className={value ? "" : "text-muted-foreground"}>{displayLabel}</span>
+            </span>
+            <ChevronsUpDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+          </Button>
+        }
+      />
+      <PopoverContent className="w-56 p-0" align="start">
+        <Command>
+          <CommandInput
+            value={search}
+            onValueChange={setSearch}
+            placeholder="Branch name..."
+            className="text-xs"
+          />
+          <CommandList>
+            <CommandEmpty>
+              {search.trim() ? (
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-2 py-1.5 text-sm hover:bg-accent rounded-sm transition-colors"
+                  onClick={() => {
+                    onChange(search.trim());
+                    setOpen(false);
+                    setSearch("");
+                  }}
+                >
+                  <GitBranch className="h-3.5 w-3.5 text-muted-foreground" />
+                  Use &ldquo;{search.trim()}&rdquo;
+                </button>
+              ) : (
+                <span className="text-muted-foreground text-xs">Type a branch name</span>
+              )}
+            </CommandEmpty>
+            <CommandGroup>
+              {BRANCH_SUGGESTIONS.map((branch) => (
+                <CommandItem
+                  key={branch.value}
+                  value={branch.label}
+                  onSelect={() => {
+                    onChange(branch.value);
+                    setOpen(false);
+                    setSearch("");
+                  }}
+                  className="text-xs"
+                >
+                  <div className="flex items-center gap-2 flex-1">
+                    <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    <span>{branch.label}</span>
+                    {branch.description && (
+                      <span className="text-muted-foreground ml-auto text-[10px]">{branch.description}</span>
+                    )}
+                  </div>
+                  {value === branch.value && <Check className="h-3 w-3 shrink-0" />}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 export function RepositoriesTab() {
   const user = useAuthStore((s) => s.user);
@@ -42,7 +152,7 @@ export function RepositoriesTab() {
   };
 
   const handleAddRepo = () => {
-    setRepos([...repos, { url: "", description: "" }]);
+    setRepos([...repos, { url: "", description: "", default_branch: "" }]);
   };
 
   const handleRemoveRepo = (index: number) => {
@@ -85,6 +195,16 @@ export function RepositoriesTab() {
                     placeholder="Description (e.g. Go backend + Next.js frontend)"
                     className="text-sm"
                   />
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground shrink-0">PR target branch</span>
+                    <div className="w-48">
+                      <BranchPicker
+                        value={repo.default_branch ?? ""}
+                        onChange={(v) => handleRepoChange(index, "default_branch", v)}
+                        disabled={!canManageWorkspace}
+                      />
+                    </div>
+                  </div>
                 </div>
                 {canManageWorkspace && (
                   <Button

--- a/apps/web/shared/types/workspace.ts
+++ b/apps/web/shared/types/workspace.ts
@@ -3,6 +3,7 @@ export type MemberRole = "owner" | "admin" | "member";
 export interface WorkspaceRepo {
   url: string;
   description: string;
+  default_branch?: string;
 }
 
 export interface Workspace {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1123,7 +1123,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 func repoDataToInfo(repos []RepoData) []repocache.RepoInfo {
 	info := make([]repocache.RepoInfo, len(repos))
 	for i, r := range repos {
-		info[i] = repocache.RepoInfo{URL: r.URL, Description: r.Description}
+		info[i] = repocache.RepoInfo{URL: r.URL, Description: r.Description, DefaultBranch: r.DefaultBranch}
 	}
 	return info
 }
@@ -1134,7 +1134,7 @@ func convertReposForEnv(repos []RepoData) []execenv.RepoContextForEnv {
 	}
 	result := make([]execenv.RepoContextForEnv, len(repos))
 	for i, r := range repos {
-		result[i] = execenv.RepoContextForEnv{URL: r.URL, Description: r.Description}
+		result[i] = execenv.RepoContextForEnv{URL: r.URL, Description: r.Description, DefaultBranch: r.DefaultBranch}
 	}
 	return result
 }

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -12,8 +12,9 @@ import (
 
 // RepoContextForEnv describes a workspace repo available for checkout.
 type RepoContextForEnv struct {
-	URL         string // remote URL
-	Description string // human-readable description
+	URL           string // remote URL
+	Description   string // human-readable description
+	DefaultBranch string // user-configured merge target branch (empty = auto-detect)
 }
 
 // PrepareParams holds all inputs needed to set up an execution environment.

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -29,6 +29,15 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error 
 
 // buildMetaSkillContent generates the meta skill markdown that teaches the agent
 // about the Multica runtime environment and available CLI tools.
+func reposHaveConfiguredBranch(repos []RepoContextForEnv) bool {
+	for _, r := range repos {
+		if r.DefaultBranch != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	var b strings.Builder
 
@@ -64,14 +73,31 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("## Repositories\n\n")
 		b.WriteString("The following code repositories are available in this workspace.\n")
 		b.WriteString("Use `multica repo checkout <url>` to check out a repository into your working directory.\n\n")
-		b.WriteString("| URL | Description |\n")
-		b.WriteString("|-----|-------------|\n")
-		for _, repo := range ctx.Repos {
-			desc := repo.Description
-			if desc == "" {
-				desc = "—"
+		// Include Default Branch column only if any repo has one configured.
+		if reposHaveConfiguredBranch(ctx.Repos) {
+			b.WriteString("| URL | Description | PR Target Branch |\n")
+			b.WriteString("|-----|-------------|------------------|\n")
+			for _, repo := range ctx.Repos {
+				desc := repo.Description
+				if desc == "" {
+					desc = "—"
+				}
+				branch := repo.DefaultBranch
+				if branch == "" {
+					branch = "auto-detect"
+				}
+				fmt.Fprintf(&b, "| %s | %s | `%s` |\n", repo.URL, desc, branch)
 			}
-			fmt.Fprintf(&b, "| %s | %s |\n", repo.URL, desc)
+		} else {
+			b.WriteString("| URL | Description |\n")
+			b.WriteString("|-----|-------------|\n")
+			for _, repo := range ctx.Repos {
+				desc := repo.Description
+				if desc == "" {
+					desc = "—"
+				}
+				fmt.Fprintf(&b, "| %s | %s |\n", repo.URL, desc)
+			}
 		}
 		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed.\n\n")
 	}
@@ -104,7 +130,14 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 			b.WriteString("   b. Implement the changes and commit\n")
 		}
 		b.WriteString("   c. Push the branch to the remote\n")
-		b.WriteString("   d. Create a pull request (decide the target branch based on the repo's conventions)\n")
+		// If any repo has a configured default branch, instruct the agent to use it.
+		if len(ctx.Repos) == 1 && ctx.Repos[0].DefaultBranch != "" {
+			fmt.Fprintf(&b, "   d. Create a pull request targeting the `%s` branch\n", ctx.Repos[0].DefaultBranch)
+		} else if reposHaveConfiguredBranch(ctx.Repos) {
+			b.WriteString("   d. Create a pull request targeting the configured PR target branch (see Repositories table above)\n")
+		} else {
+			b.WriteString("   d. Create a pull request (decide the target branch based on the repo's conventions)\n")
+		}
 		fmt.Fprintf(&b, "   e. Post the PR link as a comment: `multica issue comment add %s --content \"PR: <url>\"`\n", ctx.IssueID)
 		b.WriteString("5. If the task does not require code (e.g. research, documentation), post your findings as a comment\n")
 		fmt.Fprintf(&b, "6. Run `multica issue status %s in_review`\n", ctx.IssueID)

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -110,11 +110,12 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 		}
 
 		result, err := d.repoCache.CreateWorktree(repocache.WorktreeParams{
-			WorkspaceID: req.WorkspaceID,
-			RepoURL:     req.URL,
-			WorkDir:     req.WorkDir,
-			AgentName:   req.AgentName,
-			TaskID:      req.TaskID,
+			WorkspaceID:   req.WorkspaceID,
+			RepoURL:       req.URL,
+			WorkDir:       req.WorkDir,
+			AgentName:     req.AgentName,
+			TaskID:        req.TaskID,
+			DefaultBranch: d.repoCache.LookupDefaultBranch(req.WorkspaceID, req.URL),
 		})
 		if err != nil {
 			d.logger.Error("repo checkout failed", "url", req.URL, "error", err)

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -16,8 +16,9 @@ import (
 
 // RepoInfo describes a repository to cache.
 type RepoInfo struct {
-	URL         string
-	Description string
+	URL           string
+	Description   string
+	DefaultBranch string // user-configured merge target branch (empty = auto-detect)
 }
 
 // CachedRepo describes a cached bare clone ready for worktree creation.
@@ -29,14 +30,22 @@ type CachedRepo struct {
 
 // Cache manages bare git clones for workspace repositories.
 type Cache struct {
-	root   string // base directory for all caches (e.g. ~/multica_workspaces/.repos)
-	logger *slog.Logger
-	mu     sync.Mutex
+	root            string // base directory for all caches (e.g. ~/multica_workspaces/.repos)
+	logger          *slog.Logger
+	mu              sync.Mutex
+	defaultBranches map[string]string // key: "workspaceID:repoURL" → default branch
 }
 
 // New creates a new repo cache rooted at the given directory.
 func New(root string, logger *slog.Logger) *Cache {
-	return &Cache{root: root, logger: logger}
+	return &Cache{root: root, logger: logger, defaultBranches: make(map[string]string)}
+}
+
+// LookupDefaultBranch returns the user-configured default branch for a repo (empty if not set).
+func (c *Cache) LookupDefaultBranch(workspaceID, repoURL string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.defaultBranches[workspaceID+":"+repoURL]
 }
 
 // Sync ensures all repos for a workspace are cloned (or fetched if already cached).
@@ -55,6 +64,12 @@ func (c *Cache) Sync(workspaceID string, repos []RepoInfo) error {
 	for _, repo := range repos {
 		if repo.URL == "" {
 			continue
+		}
+		// Remember the configured default branch for this repo.
+		if repo.DefaultBranch != "" {
+			c.defaultBranches[workspaceID+":"+repo.URL] = repo.DefaultBranch
+		} else {
+			delete(c.defaultBranches, workspaceID+":"+repo.URL)
 		}
 		barePath := filepath.Join(wsDir, bareDirName(repo.URL))
 
@@ -153,11 +168,12 @@ func gitFetch(barePath string) error {
 
 // WorktreeParams holds inputs for creating a worktree from a cached bare clone.
 type WorktreeParams struct {
-	WorkspaceID string // workspace that owns the repo
-	RepoURL     string // remote URL to look up in the cache
-	WorkDir     string // parent directory for the worktree (e.g. task workdir)
-	AgentName   string // for branch naming
-	TaskID      string // for branch naming uniqueness
+	WorkspaceID   string // workspace that owns the repo
+	RepoURL       string // remote URL to look up in the cache
+	WorkDir       string // parent directory for the worktree (e.g. task workdir)
+	AgentName     string // for branch naming
+	TaskID        string // for branch naming uniqueness
+	DefaultBranch string // user-configured branch to base worktree on (empty = auto-detect)
 }
 
 // WorktreeResult describes a successfully created worktree.
@@ -179,8 +195,14 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 		c.logger.Warn("repo checkout: fetch failed (continuing with cached state)", "url", params.RepoURL, "error", err)
 	}
 
-	// Determine the default branch to base the worktree on.
-	baseRef := getRemoteDefaultBranch(barePath)
+	// Determine the base branch for the worktree.
+	// Use user-configured branch if set, otherwise auto-detect from remote.
+	var baseRef string
+	if params.DefaultBranch != "" {
+		baseRef = params.DefaultBranch
+	} else {
+		baseRef = getRemoteDefaultBranch(barePath)
+	}
 
 	// Build branch name: agent/{sanitized-name}/{short-task-id}
 	branchName := fmt.Sprintf("agent/%s/%s", sanitizeName(params.AgentName), shortID(params.TaskID))

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -16,8 +16,9 @@ type Runtime struct {
 
 // RepoData holds repository information from the workspace.
 type RepoData struct {
-	URL         string `json:"url"`
-	Description string `json:"description"`
+	URL           string `json:"url"`
+	Description   string `json:"description"`
+	DefaultBranch string `json:"default_branch,omitempty"`
 }
 
 // Task represents a claimed task from the server.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -88,8 +88,9 @@ func agentToResponse(a db.Agent) AgentResponse {
 // RepoData holds repository information included in claim responses so the
 // daemon can set up worktrees for each workspace repo.
 type RepoData struct {
-	URL         string `json:"url"`
-	Description string `json:"description"`
+	URL           string `json:"url"`
+	Description   string `json:"description"`
+	DefaultBranch string `json:"default_branch,omitempty"`
 }
 
 type AgentTaskResponse struct {


### PR DESCRIPTION
## Summary

- Add optional `default_branch` field to workspace repositories, allowing users to configure which branch agents target when creating PRs
- New **BranchPicker** combobox in Settings → Repositories with suggestions (main, develop, staging, master) and custom text input
- Agent instructions dynamically reference the configured branch in the workflow section
- Git worktree creation uses the configured branch as base ref when set

## Motivation

Teams using branching strategies (e.g. GitFlow) where PRs don't go to `main` need a way to configure the merge target per repo. Previously agents auto-detected via `origin/HEAD` → `origin/main` → `origin/master` fallback, which doesn't work for `develop`, `staging`, or custom branches.

## Changes

**Frontend (2 files):**
- `shared/types/workspace.ts` — Add `default_branch?: string` to `WorkspaceRepo`
- `settings/_components/repositories-tab.tsx` — Add `BranchPicker` combobox per repo

**Backend (7 files):**
- `handler/agent.go` — Add `DefaultBranch` to `RepoData` claim response
- `daemon/types.go` — Add `DefaultBranch` to daemon `RepoData`
- `daemon/daemon.go` — Pass `DefaultBranch` through conversion functions
- `daemon/execenv/execenv.go` — Add `DefaultBranch` to `RepoContextForEnv`
- `daemon/execenv/runtime_config.go` — Show configured branch in agent instructions table and workflow step
- `daemon/repocache/cache.go` — Store default branch mapping, use as base ref for worktree creation
- `daemon/health.go` — Look up configured branch in checkout handler

No migration needed — repos stored as JSONB, field is additive.

## Test plan

- [x] Go tests pass (`go test ./internal/daemon/execenv/ ./internal/daemon/repocache/`)
- [x] TypeScript typecheck passes
- [x] Add repo in Settings → Repositories, set "PR target branch" to "develop", save
- [x] Verify setting persists after page refresh
- [x] Verify agent instructions include configured branch in repos table and workflow step
- [x] Verify worktree is created from configured branch (not auto-detected default)