### PR TITLE
fix(makefile): binary build missing for migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 build:
 	cd server && go build -o bin/server ./cmd/server
 	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/multica ./cmd/multica
+	cd server && go build -o bin/migrate ./cmd/migrate
 
 test:
 	$(REQUIRE_ENV)


### PR DESCRIPTION
## Description

When using a self-deployment solution, the absence of the `migrate` build in the `Makefile` will result in the following error:

```diff
➜  multica git:(fix-mirgate-bin-not-exist) ✗ DATABASE_URL="postgres://multica:multica@localhost:5432/multica?sslmode=disable" ./server/bin/migrate up
- zsh: no such file or directory: ./server/bin/migrate
➜  multica git:(fix-mirgate-bin-not-exist) ✗
```

This Pull Request supplements the build action of the `migrate` program during the `make build` process.