### PR TITLE
feat(search): implement full-text search for issues

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -7,6 +7,7 @@ import { useNavigationStore } from "@/features/navigation";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { useAuthStore } from "@/features/auth";
 import { useWorkspaceStore } from "@/features/workspace";
+import { SearchCommand } from "@/features/search";
 import { AppSidebar } from "./_components/app-sidebar";
 
 export default function DashboardLayout({
@@ -52,6 +53,7 @@ export default function DashboardLayout({
           </div>
         )}
       </SidebarInset>
+      <SearchCommand />
     </SidebarProvider>
   );
 }

--- a/apps/web/features/search/components/search-command.tsx
+++ b/apps/web/features/search/components/search-command.tsx
@@ -62,7 +62,7 @@ export function SearchCommand() {
       const controller = new AbortController();
       abortRef.current = controller;
       try {
-        const res = await api.searchIssues({ q: q.trim(), limit: 20 });
+        const res = await api.searchIssues({ q: q.trim(), limit: 20, signal: controller.signal });
         if (!controller.signal.aborted) {
           setResults(res.issues);
           setIsLoading(false);

--- a/apps/web/features/search/components/search-command.tsx
+++ b/apps/web/features/search/components/search-command.tsx
@@ -2,20 +2,19 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Loader2, MessageSquare } from "lucide-react";
+import { Loader2, MessageSquare, SearchIcon } from "lucide-react";
+import { Command as CommandPrimitive } from "cmdk";
 import type { SearchIssueResult } from "@/shared/types";
 import { api } from "@/shared/api";
 import { StatusIcon } from "@/features/issues";
 import { STATUS_CONFIG } from "@/features/issues/config";
 import {
-  CommandDialog,
-  Command,
-  CommandInput,
-  CommandList,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-} from "@/components/ui/command";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
 
 export function SearchCommand() {
   const router = useRouter();
@@ -62,7 +61,12 @@ export function SearchCommand() {
       const controller = new AbortController();
       abortRef.current = controller;
       try {
-        const res = await api.searchIssues({ q: q.trim(), limit: 20, include_closed: true, signal: controller.signal });
+        const res = await api.searchIssues({
+          q: q.trim(),
+          limit: 20,
+          include_closed: true,
+          signal: controller.signal,
+        });
         if (!controller.signal.aborted) {
           setResults(res.issues);
           setIsLoading(false);
@@ -92,39 +96,63 @@ export function SearchCommand() {
   );
 
   return (
-    <CommandDialog
-      open={open}
-      onOpenChange={setOpen}
-      title="Search Issues"
-      description="Search issues by title or description"
-    >
-      <Command shouldFilter={false}>
-        <CommandInput
-          placeholder="Search issues..."
-          value={query}
-          onValueChange={handleValueChange}
-        />
-        <CommandList>
-          {isLoading && (
-            <div className="flex items-center justify-center py-6">
-              <Loader2 className="size-4 animate-spin text-muted-foreground" />
-            </div>
-          )}
-          {!isLoading && query.trim() && results.length === 0 && (
-            <CommandEmpty>No issues found.</CommandEmpty>
-          )}
-          {!isLoading && results.length > 0 && (
-            <CommandGroup heading="Issues">
-              {results.map((issue) => (
-                <CommandItem
-                  key={issue.id}
-                  value={issue.id}
-                  onSelect={handleSelect}
-                  className="gap-3"
-                >
-                  <div className="flex flex-col gap-0.5 min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <StatusIcon status={issue.status} className="size-4 shrink-0" />
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>Search Issues</DialogTitle>
+        <DialogDescription>
+          Search issues by title, description, or comments
+        </DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className="top-[20%] translate-y-0 overflow-hidden rounded-xl! p-0 sm:max-w-xl!"
+        showCloseButton={false}
+      >
+        <CommandPrimitive
+          shouldFilter={false}
+          className="flex size-full flex-col overflow-hidden rounded-xl bg-popover text-popover-foreground"
+        >
+          {/* Search input */}
+          <div className="flex items-center gap-3 border-b px-4 py-3">
+            <SearchIcon className="size-5 shrink-0 text-muted-foreground" />
+            <CommandPrimitive.Input
+              placeholder="Type a command or search..."
+              value={query}
+              onValueChange={handleValueChange}
+              className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            />
+            <kbd className="hidden shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline">
+              ESC
+            </kbd>
+          </div>
+
+          {/* Results list */}
+          <CommandPrimitive.List className="max-h-[min(400px,50vh)] overflow-y-auto overflow-x-hidden">
+            {isLoading && (
+              <div className="flex items-center justify-center py-10">
+                <Loader2 className="size-5 animate-spin text-muted-foreground" />
+              </div>
+            )}
+
+            {!isLoading && query.trim() && results.length === 0 && (
+              <CommandPrimitive.Empty className="py-10 text-center text-sm text-muted-foreground">
+                No issues found.
+              </CommandPrimitive.Empty>
+            )}
+
+            {!isLoading && results.length > 0 && (
+              <CommandPrimitive.Group className="p-2">
+                {results.map((issue) => (
+                  <CommandPrimitive.Item
+                    key={issue.id}
+                    value={issue.id}
+                    onSelect={handleSelect}
+                    className="flex cursor-default select-none flex-col gap-1 rounded-lg px-3 py-2.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-accent"
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <StatusIcon
+                        status={issue.status}
+                        className="size-4 shrink-0"
+                      />
                       <span className="text-xs text-muted-foreground shrink-0">
                         {issue.identifier}
                       </span>
@@ -135,26 +163,28 @@ export function SearchCommand() {
                         {STATUS_CONFIG[issue.status].label}
                       </span>
                     </div>
-                    {issue.match_source === "comment" && issue.matched_snippet && (
-                      <div className="flex items-start gap-1.5 pl-6">
-                        <MessageSquare className="size-3 shrink-0 text-muted-foreground mt-0.5" />
-                        <span className="text-xs text-muted-foreground truncate">
-                          {issue.matched_snippet}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          )}
-          {!isLoading && !query.trim() && (
-            <div className="py-6 text-center text-sm text-muted-foreground">
-              Type to search issues...
-            </div>
-          )}
-        </CommandList>
-      </Command>
-    </CommandDialog>
+                    {issue.match_source === "comment" &&
+                      issue.matched_snippet && (
+                        <div className="flex items-start gap-2 pl-[26px]">
+                          <MessageSquare className="size-3 shrink-0 text-muted-foreground mt-0.5" />
+                          <span className="text-xs text-muted-foreground truncate">
+                            {issue.matched_snippet}
+                          </span>
+                        </div>
+                      )}
+                  </CommandPrimitive.Item>
+                ))}
+              </CommandPrimitive.Group>
+            )}
+
+            {!isLoading && !query.trim() && (
+              <div className="py-10 text-center text-sm text-muted-foreground">
+                Type to search issues...
+              </div>
+            )}
+          </CommandPrimitive.List>
+        </CommandPrimitive>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/features/search/components/search-command.tsx
+++ b/apps/web/features/search/components/search-command.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import type { Issue } from "@/shared/types";
+import { api } from "@/shared/api";
+import { StatusIcon } from "@/features/issues";
+import { STATUS_CONFIG } from "@/features/issues/config";
+import {
+  CommandDialog,
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+
+export function SearchCommand() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Issue[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Global Cmd+K / Ctrl+K shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Reset state when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setResults([]);
+      setIsLoading(false);
+    }
+  }, [open]);
+
+  const search = useCallback((q: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (abortRef.current) abortRef.current.abort();
+
+    if (!q.trim()) {
+      setResults([]);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    debounceRef.current = setTimeout(async () => {
+      const controller = new AbortController();
+      abortRef.current = controller;
+      try {
+        const res = await api.searchIssues({ q: q.trim(), limit: 20 });
+        if (!controller.signal.aborted) {
+          setResults(res.issues);
+          setIsLoading(false);
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }, 300);
+  }, []);
+
+  const handleValueChange = useCallback(
+    (value: string) => {
+      setQuery(value);
+      search(value);
+    },
+    [search],
+  );
+
+  const handleSelect = useCallback(
+    (issueId: string) => {
+      setOpen(false);
+      router.push(`/issues/${issueId}`);
+    },
+    [router],
+  );
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Search Issues"
+      description="Search issues by title or description"
+    >
+      <Command shouldFilter={false}>
+        <CommandInput
+          placeholder="Search issues..."
+          value={query}
+          onValueChange={handleValueChange}
+        />
+        <CommandList>
+          {isLoading && (
+            <div className="flex items-center justify-center py-6">
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            </div>
+          )}
+          {!isLoading && query.trim() && results.length === 0 && (
+            <CommandEmpty>No issues found.</CommandEmpty>
+          )}
+          {!isLoading && results.length > 0 && (
+            <CommandGroup heading="Issues">
+              {results.map((issue) => (
+                <CommandItem
+                  key={issue.id}
+                  value={issue.id}
+                  onSelect={handleSelect}
+                  className="gap-3"
+                >
+                  <StatusIcon status={issue.status} className="size-4 shrink-0" />
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {issue.identifier}
+                  </span>
+                  <span className="truncate">{issue.title}</span>
+                  <span
+                    className={`ml-auto text-xs shrink-0 ${STATUS_CONFIG[issue.status].iconColor}`}
+                  >
+                    {STATUS_CONFIG[issue.status].label}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+          {!isLoading && !query.trim() && (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              Type to search issues...
+            </div>
+          )}
+        </CommandList>
+      </Command>
+    </CommandDialog>
+  );
+}

--- a/apps/web/features/search/components/search-command.tsx
+++ b/apps/web/features/search/components/search-command.tsx
@@ -62,7 +62,7 @@ export function SearchCommand() {
       const controller = new AbortController();
       abortRef.current = controller;
       try {
-        const res = await api.searchIssues({ q: q.trim(), limit: 20, signal: controller.signal });
+        const res = await api.searchIssues({ q: q.trim(), limit: 20, include_closed: true, signal: controller.signal });
         if (!controller.signal.aborted) {
           setResults(res.issues);
           setIsLoading(false);

--- a/apps/web/features/search/components/search-command.tsx
+++ b/apps/web/features/search/components/search-command.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Loader2 } from "lucide-react";
-import type { Issue } from "@/shared/types";
+import { Loader2, MessageSquare } from "lucide-react";
+import type { SearchIssueResult } from "@/shared/types";
 import { api } from "@/shared/api";
 import { StatusIcon } from "@/features/issues";
 import { STATUS_CONFIG } from "@/features/issues/config";
@@ -21,7 +21,7 @@ export function SearchCommand() {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<Issue[]>([]);
+  const [results, setResults] = useState<SearchIssueResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -122,16 +122,28 @@ export function SearchCommand() {
                   onSelect={handleSelect}
                   className="gap-3"
                 >
-                  <StatusIcon status={issue.status} className="size-4 shrink-0" />
-                  <span className="text-xs text-muted-foreground shrink-0">
-                    {issue.identifier}
-                  </span>
-                  <span className="truncate">{issue.title}</span>
-                  <span
-                    className={`ml-auto text-xs shrink-0 ${STATUS_CONFIG[issue.status].iconColor}`}
-                  >
-                    {STATUS_CONFIG[issue.status].label}
-                  </span>
+                  <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <StatusIcon status={issue.status} className="size-4 shrink-0" />
+                      <span className="text-xs text-muted-foreground shrink-0">
+                        {issue.identifier}
+                      </span>
+                      <span className="truncate">{issue.title}</span>
+                      <span
+                        className={`ml-auto text-xs shrink-0 ${STATUS_CONFIG[issue.status].iconColor}`}
+                      >
+                        {STATUS_CONFIG[issue.status].label}
+                      </span>
+                    </div>
+                    {issue.match_source === "comment" && issue.matched_snippet && (
+                      <div className="flex items-start gap-1.5 pl-6">
+                        <MessageSquare className="size-3 shrink-0 text-muted-foreground mt-0.5" />
+                        <span className="text-xs text-muted-foreground truncate">
+                          {issue.matched_snippet}
+                        </span>
+                      </div>
+                    )}
+                  </div>
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/apps/web/features/search/index.ts
+++ b/apps/web/features/search/index.ts
@@ -1,0 +1,1 @@
+export { SearchCommand } from "./components/search-command";

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -176,11 +176,12 @@ export class ApiClient {
     return this.fetch(`/api/issues?${search}`);
   }
 
-  async searchIssues(params: { q: string; limit?: number; offset?: number }): Promise<ListIssuesResponse> {
+  async searchIssues(params: { q: string; limit?: number; offset?: number; include_closed?: boolean; signal?: AbortSignal }): Promise<ListIssuesResponse> {
     const search = new URLSearchParams({ q: params.q });
-    if (params.limit) search.set("limit", String(params.limit));
-    if (params.offset) search.set("offset", String(params.offset));
-    return this.fetch(`/api/issues/search?${search}`);
+    if (params.limit !== undefined) search.set("limit", String(params.limit));
+    if (params.offset !== undefined) search.set("offset", String(params.offset));
+    if (params.include_closed) search.set("include_closed", "true");
+    return this.fetch(`/api/issues/search?${search}`, params.signal ? { signal: params.signal } : undefined);
   }
 
   async getIssue(id: string): Promise<Issue> {

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -176,6 +176,13 @@ export class ApiClient {
     return this.fetch(`/api/issues?${search}`);
   }
 
+  async searchIssues(params: { q: string; limit?: number; offset?: number }): Promise<ListIssuesResponse> {
+    const search = new URLSearchParams({ q: params.q });
+    if (params.limit) search.set("limit", String(params.limit));
+    if (params.offset) search.set("offset", String(params.offset));
+    return this.fetch(`/api/issues/search?${search}`);
+  }
+
   async getIssue(id: string): Promise<Issue> {
     return this.fetch(`/api/issues/${id}`);
   }

--- a/apps/web/shared/api/client.ts
+++ b/apps/web/shared/api/client.ts
@@ -3,6 +3,7 @@ import type {
   CreateIssueRequest,
   UpdateIssueRequest,
   ListIssuesResponse,
+  SearchIssuesResponse,
   UpdateMeRequest,
   CreateMemberRequest,
   UpdateMemberRequest,
@@ -176,7 +177,7 @@ export class ApiClient {
     return this.fetch(`/api/issues?${search}`);
   }
 
-  async searchIssues(params: { q: string; limit?: number; offset?: number; include_closed?: boolean; signal?: AbortSignal }): Promise<ListIssuesResponse> {
+  async searchIssues(params: { q: string; limit?: number; offset?: number; include_closed?: boolean; signal?: AbortSignal }): Promise<SearchIssuesResponse> {
     const search = new URLSearchParams({ q: params.q });
     if (params.limit !== undefined) search.set("limit", String(params.limit));
     if (params.offset !== undefined) search.set("offset", String(params.offset));

--- a/apps/web/shared/types/api.ts
+++ b/apps/web/shared/types/api.ts
@@ -43,6 +43,16 @@ export interface ListIssuesResponse {
   doneTotal?: number;
 }
 
+export interface SearchIssueResult extends Issue {
+  match_source: "title" | "description" | "comment";
+  matched_snippet?: string;
+}
+
+export interface SearchIssuesResponse {
+  issues: SearchIssueResult[];
+  total: number;
+}
+
 export interface UpdateMeRequest {
   name?: string;
   avatar_url?: string;

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -189,6 +189,7 @@ func init() {
 
 	// issue search
 	issueSearchCmd.Flags().Int("limit", 20, "Maximum number of results to return")
+	issueSearchCmd.Flags().Bool("include-closed", false, "Include done and cancelled issues")
 	issueSearchCmd.Flags().String("output", "table", "Output format: table or json")
 }
 
@@ -811,6 +812,9 @@ func runIssueSearch(cmd *cobra.Command, args []string) error {
 	params.Set("q", args[0])
 	if v, _ := cmd.Flags().GetInt("limit"); v > 0 {
 		params.Set("limit", fmt.Sprintf("%d", v))
+	}
+	if v, _ := cmd.Flags().GetBool("include-closed"); v {
+		params.Set("include_closed", "true")
 	}
 
 	path := "/api/issues/search?" + params.Encode()

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -103,6 +103,13 @@ var issueRunMessagesCmd = &cobra.Command{
 	RunE:  runIssueRunMessages,
 }
 
+var issueSearchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search issues by title or description",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runIssueSearch,
+}
+
 var validIssueStatuses = []string{
 	"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled",
 }
@@ -117,6 +124,7 @@ func init() {
 	issueCmd.AddCommand(issueCommentCmd)
 	issueCmd.AddCommand(issueRunsCmd)
 	issueCmd.AddCommand(issueRunMessagesCmd)
+	issueCmd.AddCommand(issueSearchCmd)
 
 	issueCommentCmd.AddCommand(issueCommentListCmd)
 	issueCommentCmd.AddCommand(issueCommentAddCmd)
@@ -178,6 +186,10 @@ func init() {
 	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID (reply to a specific comment)")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
+
+	// issue search
+	issueSearchCmd.Flags().Int("limit", 20, "Maximum number of results to return")
+	issueSearchCmd.Flags().String("output", "table", "Output format: table or json")
 }
 
 // ---------------------------------------------------------------------------
@@ -776,6 +788,58 @@ func runIssueRunMessages(cmd *cobra.Command, args []string) error {
 			strVal(m, "type"),
 			strVal(m, "tool"),
 			content,
+		})
+	}
+	cli.PrintTable(os.Stdout, headers, rows)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Search command
+// ---------------------------------------------------------------------------
+
+func runIssueSearch(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	params := url.Values{}
+	params.Set("q", args[0])
+	if v, _ := cmd.Flags().GetInt("limit"); v > 0 {
+		params.Set("limit", fmt.Sprintf("%d", v))
+	}
+
+	path := "/api/issues/search?" + params.Encode()
+
+	var result map[string]any
+	if err := client.GetJSON(ctx, path, &result); err != nil {
+		return fmt.Errorf("search issues: %w", err)
+	}
+
+	issuesRaw, _ := result["issues"].([]any)
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+
+	headers := []string{"ID", "IDENTIFIER", "TITLE", "STATUS", "PRIORITY"}
+	rows := make([][]string, 0, len(issuesRaw))
+	for _, raw := range issuesRaw {
+		issue, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		rows = append(rows, []string{
+			truncateID(strVal(issue, "id")),
+			strVal(issue, "identifier"),
+			strVal(issue, "title"),
+			strVal(issue, "status"),
+			strVal(issue, "priority"),
 		})
 	}
 	cli.PrintTable(os.Stdout, headers, rows)

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -831,19 +831,27 @@ func runIssueSearch(cmd *cobra.Command, args []string) error {
 		return cli.PrintJSON(os.Stdout, result)
 	}
 
-	headers := []string{"ID", "IDENTIFIER", "TITLE", "STATUS", "PRIORITY"}
+	headers := []string{"ID", "IDENTIFIER", "TITLE", "STATUS", "MATCH"}
 	rows := make([][]string, 0, len(issuesRaw))
 	for _, raw := range issuesRaw {
 		issue, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
+		matchInfo := strVal(issue, "match_source")
+		if snippet := strVal(issue, "matched_snippet"); snippet != "" {
+			if utf8.RuneCountInString(snippet) > 50 {
+				runes := []rune(snippet)
+				snippet = string(runes[:47]) + "..."
+			}
+			matchInfo += ": " + snippet
+		}
 		rows = append(rows, []string{
 			truncateID(strVal(issue, "id")),
 			strVal(issue, "identifier"),
 			strVal(issue, "title"),
 			strVal(issue, "status"),
-			strVal(issue, "priority"),
+			matchInfo,
 		})
 	}
 	cli.PrintTable(os.Stdout, headers, rows)

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -157,6 +157,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 
 			// Issues
 			r.Route("/api/issues", func(r chi.Router) {
+				r.Get("/search", h.SearchIssues)
 				r.Get("/", h.ListIssues)
 				r.Post("/", h.CreateIssue)
 				r.Post("/batch-update", h.BatchUpdateIssues)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -62,6 +63,14 @@ func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
 	}
 }
 
+// escapeLike escapes LIKE special characters (%, _, \) in user input.
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
 func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	workspaceID := resolveWorkspaceID(r)
@@ -88,14 +97,17 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	wsUUID := parseUUID(workspaceID)
-	queryText := strToText(q)
+	includeClosed := r.URL.Query().Get("include_closed") == "true"
 
-	issues, err := h.Queries.SearchIssues(ctx, db.SearchIssuesParams{
-		WorkspaceID:  wsUUID,
-		Query:        queryText,
-		SearchLimit:  int32(limit),
-		SearchOffset: int32(offset),
+	wsUUID := parseUUID(workspaceID)
+	queryText := strToText(escapeLike(q))
+
+	rows, err := h.Queries.SearchIssues(ctx, db.SearchIssuesParams{
+		WorkspaceID:   wsUUID,
+		Query:         queryText,
+		SearchLimit:   int32(limit),
+		SearchOffset:  int32(offset),
+		IncludeClosed: includeClosed,
 	})
 	if err != nil {
 		slog.Warn("search issues failed", "error", err, "workspace_id", workspaceID, "query", q)
@@ -103,20 +115,15 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	total, err := h.Queries.SearchIssuesCount(ctx, db.SearchIssuesCountParams{
-		WorkspaceID: wsUUID,
-		Query:       queryText,
-	})
-	if err != nil {
-		slog.Warn("search issues count failed", "error", err, "workspace_id", workspaceID, "query", q)
-		writeError(w, http.StatusInternalServerError, "failed to search issues")
-		return
+	var total int64
+	if len(rows) > 0 {
+		total = rows[0].TotalCount
 	}
 
 	prefix := h.getIssuePrefix(ctx, wsUUID)
-	resp := make([]IssueResponse, len(issues))
-	for i, issue := range issues {
-		resp[i] = issueToResponse(issue, prefix)
+	resp := make([]IssueResponse, len(rows))
+	for i, row := range rows {
+		resp[i] = issueToResponse(searchRowToIssue(row), prefix)
 	}
 
 	w.Header().Set("X-Total-Count", strconv.FormatInt(total, 10))
@@ -124,6 +131,29 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 		"issues": resp,
 		"total":  total,
 	})
+}
+
+func searchRowToIssue(row db.SearchIssuesRow) db.Issue {
+	return db.Issue{
+		ID:                 row.ID,
+		WorkspaceID:        row.WorkspaceID,
+		Title:              row.Title,
+		Description:        row.Description,
+		Status:             row.Status,
+		Priority:           row.Priority,
+		AssigneeType:       row.AssigneeType,
+		AssigneeID:         row.AssigneeID,
+		CreatorType:        row.CreatorType,
+		CreatorID:          row.CreatorID,
+		ParentIssueID:      row.ParentIssueID,
+		AcceptanceCriteria: row.AcceptanceCriteria,
+		ContextRefs:        row.ContextRefs,
+		Position:           row.Position,
+		DueDate:            row.DueDate,
+		CreatedAt:          row.CreatedAt,
+		UpdatedAt:          row.UpdatedAt,
+		Number:             row.Number,
+	}
 }
 
 func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -62,6 +62,70 @@ func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
 	}
 }
 
+func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	workspaceID := resolveWorkspaceID(r)
+
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		writeError(w, http.StatusBadRequest, "q parameter is required")
+		return
+	}
+
+	limit := 20
+	offset := 0
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	if o := r.URL.Query().Get("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil && v >= 0 {
+			offset = v
+		}
+	}
+
+	wsUUID := parseUUID(workspaceID)
+	queryText := strToText(q)
+
+	issues, err := h.Queries.SearchIssues(ctx, db.SearchIssuesParams{
+		WorkspaceID:  wsUUID,
+		Query:        queryText,
+		SearchLimit:  int32(limit),
+		SearchOffset: int32(offset),
+	})
+	if err != nil {
+		slog.Warn("search issues failed", "error", err, "workspace_id", workspaceID, "query", q)
+		writeError(w, http.StatusInternalServerError, "failed to search issues")
+		return
+	}
+
+	total, err := h.Queries.SearchIssuesCount(ctx, db.SearchIssuesCountParams{
+		WorkspaceID: wsUUID,
+		Query:       queryText,
+	})
+	if err != nil {
+		slog.Warn("search issues count failed", "error", err, "workspace_id", workspaceID, "query", q)
+		writeError(w, http.StatusInternalServerError, "failed to search issues")
+		return
+	}
+
+	prefix := h.getIssuePrefix(ctx, wsUUID)
+	resp := make([]IssueResponse, len(issues))
+	for i, issue := range issues {
+		resp[i] = issueToResponse(issue, prefix)
+	}
+
+	w.Header().Set("X-Total-Count", strconv.FormatInt(total, 10))
+	writeJSON(w, http.StatusOK, map[string]any{
+		"issues": resp,
+		"total":  total,
+	})
+}
+
 func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -63,6 +63,42 @@ func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
 	}
 }
 
+// SearchIssueResponse extends IssueResponse with search metadata.
+type SearchIssueResponse struct {
+	IssueResponse
+	MatchSource    string  `json:"match_source"`
+	MatchedSnippet *string `json:"matched_snippet,omitempty"`
+}
+
+// extractSnippet extracts a snippet of text around the first occurrence of query.
+// Returns up to ~120 chars centered on the match.
+func extractSnippet(content, query string) string {
+	lower := strings.ToLower(content)
+	idx := strings.Index(lower, strings.ToLower(query))
+	if idx < 0 {
+		if len(content) > 120 {
+			return content[:120] + "..."
+		}
+		return content
+	}
+	start := idx - 40
+	if start < 0 {
+		start = 0
+	}
+	end := idx + len(query) + 80
+	if end > len(content) {
+		end = len(content)
+	}
+	snippet := content[start:end]
+	if start > 0 {
+		snippet = "..." + snippet
+	}
+	if end < len(content) {
+		snippet = snippet + "..."
+	}
+	return snippet
+}
+
 // escapeLike escapes LIKE special characters (%, _, \) in user input.
 func escapeLike(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
@@ -121,9 +157,19 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	prefix := h.getIssuePrefix(ctx, wsUUID)
-	resp := make([]IssueResponse, len(rows))
+	resp := make([]SearchIssueResponse, len(rows))
 	for i, row := range rows {
-		resp[i] = issueToResponse(searchRowToIssue(row), prefix)
+		sir := SearchIssueResponse{
+			IssueResponse: issueToResponse(searchRowToIssue(row), prefix),
+			MatchSource:   row.MatchSource,
+		}
+		if row.MatchSource == "comment" {
+			if content, ok := row.MatchedCommentContent.(string); ok && content != "" {
+				snippet := extractSnippet(content, q)
+				sir.MatchedSnippet = &snippet
+			}
+		}
+		resp[i] = sir
 	}
 
 	w.Header().Set("X-Total-Count", strconv.FormatInt(total, 10))

--- a/server/migrations/032_issue_search_index.down.sql
+++ b/server/migrations/032_issue_search_index.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_issue_description_bigm;
+DROP INDEX IF EXISTS idx_issue_title_bigm;
+DROP EXTENSION IF EXISTS pg_bigm;

--- a/server/migrations/032_issue_search_index.up.sql
+++ b/server/migrations/032_issue_search_index.up.sql
@@ -1,0 +1,8 @@
+-- Enable pg_bigm extension for bigram-based full-text search (CJK-friendly).
+CREATE EXTENSION IF NOT EXISTS pg_bigm;
+
+-- GIN index on issue title for LIKE '%keyword%' queries.
+CREATE INDEX idx_issue_title_bigm ON issue USING gin (title gin_bigm_ops);
+
+-- GIN index on issue description (nullable, use COALESCE).
+CREATE INDEX idx_issue_description_bigm ON issue USING gin (COALESCE(description, '') gin_bigm_ops);

--- a/server/migrations/033_comment_search_index.down.sql
+++ b/server/migrations/033_comment_search_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_comment_content_bigm;

--- a/server/migrations/033_comment_search_index.up.sql
+++ b/server/migrations/033_comment_search_index.up.sql
@@ -1,0 +1,2 @@
+-- GIN index on comment content for LIKE '%keyword%' queries (pg_bigm).
+CREATE INDEX idx_comment_content_bigm ON comment USING gin (content gin_bigm_ops);

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -381,29 +381,54 @@ func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) 
 }
 
 const searchIssues = `-- name: SearchIssues :many
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, COUNT(*) OVER() AS total_count FROM issue
 WHERE workspace_id = $1
   AND (
     title LIKE '%' || $2 || '%'
     OR COALESCE(description, '') LIKE '%' || $2 || '%'
   )
+  AND ($3::boolean OR status NOT IN ('done', 'cancelled'))
 ORDER BY
   CASE WHEN title LIKE '%' || $2 || '%' THEN 0 ELSE 1 END,
   updated_at DESC
-LIMIT $4 OFFSET $3
+LIMIT $5 OFFSET $4
 `
 
 type SearchIssuesParams struct {
-	WorkspaceID  pgtype.UUID `json:"workspace_id"`
-	Query        pgtype.Text `json:"query"`
-	SearchOffset int32       `json:"search_offset"`
-	SearchLimit  int32       `json:"search_limit"`
+	WorkspaceID   pgtype.UUID `json:"workspace_id"`
+	Query         pgtype.Text `json:"query"`
+	IncludeClosed bool        `json:"include_closed"`
+	SearchOffset  int32       `json:"search_offset"`
+	SearchLimit   int32       `json:"search_limit"`
 }
 
-func (q *Queries) SearchIssues(ctx context.Context, arg SearchIssuesParams) ([]Issue, error) {
+type SearchIssuesRow struct {
+	ID                 pgtype.UUID        `json:"id"`
+	WorkspaceID        pgtype.UUID        `json:"workspace_id"`
+	Title              string             `json:"title"`
+	Description        pgtype.Text        `json:"description"`
+	Status             string             `json:"status"`
+	Priority           string             `json:"priority"`
+	AssigneeType       pgtype.Text        `json:"assignee_type"`
+	AssigneeID         pgtype.UUID        `json:"assignee_id"`
+	CreatorType        string             `json:"creator_type"`
+	CreatorID          pgtype.UUID        `json:"creator_id"`
+	ParentIssueID      pgtype.UUID        `json:"parent_issue_id"`
+	AcceptanceCriteria []byte             `json:"acceptance_criteria"`
+	ContextRefs        []byte             `json:"context_refs"`
+	Position           float64            `json:"position"`
+	DueDate            pgtype.Timestamptz `json:"due_date"`
+	CreatedAt          pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
+	Number             int32              `json:"number"`
+	TotalCount         int64              `json:"total_count"`
+}
+
+func (q *Queries) SearchIssues(ctx context.Context, arg SearchIssuesParams) ([]SearchIssuesRow, error) {
 	rows, err := q.db.Query(ctx, searchIssues,
 		arg.WorkspaceID,
 		arg.Query,
+		arg.IncludeClosed,
 		arg.SearchOffset,
 		arg.SearchLimit,
 	)
@@ -411,9 +436,9 @@ func (q *Queries) SearchIssues(ctx context.Context, arg SearchIssuesParams) ([]I
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Issue{}
+	items := []SearchIssuesRow{}
 	for rows.Next() {
-		var i Issue
+		var i SearchIssuesRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.WorkspaceID,
@@ -433,6 +458,7 @@ func (q *Queries) SearchIssues(ctx context.Context, arg SearchIssuesParams) ([]I
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.Number,
+			&i.TotalCount,
 		); err != nil {
 			return nil, err
 		}
@@ -442,27 +468,6 @@ func (q *Queries) SearchIssues(ctx context.Context, arg SearchIssuesParams) ([]I
 		return nil, err
 	}
 	return items, nil
-}
-
-const searchIssuesCount = `-- name: SearchIssuesCount :one
-SELECT COUNT(*) FROM issue
-WHERE workspace_id = $1
-  AND (
-    title LIKE '%' || $2 || '%'
-    OR COALESCE(description, '') LIKE '%' || $2 || '%'
-  )
-`
-
-type SearchIssuesCountParams struct {
-	WorkspaceID pgtype.UUID `json:"workspace_id"`
-	Query       pgtype.Text `json:"query"`
-}
-
-func (q *Queries) SearchIssuesCount(ctx context.Context, arg SearchIssuesCountParams) (int64, error) {
-	row := q.db.QueryRow(ctx, searchIssuesCount, arg.WorkspaceID, arg.Query)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
 }
 
 const updateIssue = `-- name: UpdateIssue :one

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -380,6 +380,91 @@ func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) 
 	return items, nil
 }
 
+const searchIssues = `-- name: SearchIssues :many
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number FROM issue
+WHERE workspace_id = $1
+  AND (
+    title LIKE '%' || $2 || '%'
+    OR COALESCE(description, '') LIKE '%' || $2 || '%'
+  )
+ORDER BY
+  CASE WHEN title LIKE '%' || $2 || '%' THEN 0 ELSE 1 END,
+  updated_at DESC
+LIMIT $4 OFFSET $3
+`
+
+type SearchIssuesParams struct {
+	WorkspaceID  pgtype.UUID `json:"workspace_id"`
+	Query        pgtype.Text `json:"query"`
+	SearchOffset int32       `json:"search_offset"`
+	SearchLimit  int32       `json:"search_limit"`
+}
+
+func (q *Queries) SearchIssues(ctx context.Context, arg SearchIssuesParams) ([]Issue, error) {
+	rows, err := q.db.Query(ctx, searchIssues,
+		arg.WorkspaceID,
+		arg.Query,
+		arg.SearchOffset,
+		arg.SearchLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Issue{}
+	for rows.Next() {
+		var i Issue
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.Title,
+			&i.Description,
+			&i.Status,
+			&i.Priority,
+			&i.AssigneeType,
+			&i.AssigneeID,
+			&i.CreatorType,
+			&i.CreatorID,
+			&i.ParentIssueID,
+			&i.AcceptanceCriteria,
+			&i.ContextRefs,
+			&i.Position,
+			&i.DueDate,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Number,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const searchIssuesCount = `-- name: SearchIssuesCount :one
+SELECT COUNT(*) FROM issue
+WHERE workspace_id = $1
+  AND (
+    title LIKE '%' || $2 || '%'
+    OR COALESCE(description, '') LIKE '%' || $2 || '%'
+  )
+`
+
+type SearchIssuesCountParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	Query       pgtype.Text `json:"query"`
+}
+
+func (q *Queries) SearchIssuesCount(ctx context.Context, arg SearchIssuesCountParams) (int64, error) {
+	row := q.db.QueryRow(ctx, searchIssuesCount, arg.WorkspaceID, arg.Query)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const updateIssue = `-- name: UpdateIssue :one
 UPDATE issue SET
     title = COALESCE($2, title),

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -381,53 +381,80 @@ func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) 
 }
 
 const searchIssues = `-- name: SearchIssues :many
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, COUNT(*) OVER() AS total_count FROM issue
-WHERE workspace_id = $1
+SELECT i.id, i.workspace_id, i.title, i.description, i.status, i.priority, i.assignee_type, i.assignee_id, i.creator_type, i.creator_id, i.parent_issue_id, i.acceptance_criteria, i.context_refs, i.position, i.due_date, i.created_at, i.updated_at, i.number,
+  COUNT(*) OVER() AS total_count,
+  CASE
+    WHEN i.title LIKE '%' || $1 || '%' THEN 'title'
+    WHEN COALESCE(i.description, '') LIKE '%' || $1 || '%' THEN 'description'
+    ELSE 'comment'
+  END AS match_source,
+  CASE
+    WHEN i.title LIKE '%' || $1 || '%' THEN ''
+    WHEN COALESCE(i.description, '') LIKE '%' || $1 || '%' THEN ''
+    ELSE COALESCE(
+      (SELECT c.content FROM comment c
+       WHERE c.issue_id = i.id AND c.content LIKE '%' || $1 || '%'
+       ORDER BY c.created_at DESC LIMIT 1),
+      ''
+    )
+  END AS matched_comment_content
+FROM issue i
+WHERE i.workspace_id = $2
   AND (
-    title LIKE '%' || $2 || '%'
-    OR COALESCE(description, '') LIKE '%' || $2 || '%'
+    i.title LIKE '%' || $1 || '%'
+    OR COALESCE(i.description, '') LIKE '%' || $1 || '%'
+    OR EXISTS (
+      SELECT 1 FROM comment c
+      WHERE c.issue_id = i.id AND c.content LIKE '%' || $1 || '%'
+    )
   )
-  AND ($3::boolean OR status NOT IN ('done', 'cancelled'))
+  AND ($3::boolean OR i.status NOT IN ('done', 'cancelled'))
 ORDER BY
-  CASE WHEN title LIKE '%' || $2 || '%' THEN 0 ELSE 1 END,
-  updated_at DESC
+  CASE
+    WHEN i.title LIKE '%' || $1 || '%' THEN 0
+    WHEN COALESCE(i.description, '') LIKE '%' || $1 || '%' THEN 1
+    ELSE 2
+  END,
+  i.updated_at DESC
 LIMIT $5 OFFSET $4
 `
 
 type SearchIssuesParams struct {
-	WorkspaceID   pgtype.UUID `json:"workspace_id"`
 	Query         pgtype.Text `json:"query"`
+	WorkspaceID   pgtype.UUID `json:"workspace_id"`
 	IncludeClosed bool        `json:"include_closed"`
 	SearchOffset  int32       `json:"search_offset"`
 	SearchLimit   int32       `json:"search_limit"`
 }
 
 type SearchIssuesRow struct {
-	ID                 pgtype.UUID        `json:"id"`
-	WorkspaceID        pgtype.UUID        `json:"workspace_id"`
-	Title              string             `json:"title"`
-	Description        pgtype.Text        `json:"description"`
-	Status             string             `json:"status"`
-	Priority           string             `json:"priority"`
-	AssigneeType       pgtype.Text        `json:"assignee_type"`
-	AssigneeID         pgtype.UUID        `json:"assignee_id"`
-	CreatorType        string             `json:"creator_type"`
-	CreatorID          pgtype.UUID        `json:"creator_id"`
-	ParentIssueID      pgtype.UUID        `json:"parent_issue_id"`
-	AcceptanceCriteria []byte             `json:"acceptance_criteria"`
-	ContextRefs        []byte             `json:"context_refs"`
-	Position           float64            `json:"position"`
-	DueDate            pgtype.Timestamptz `json:"due_date"`
-	CreatedAt          pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
-	Number             int32              `json:"number"`
-	TotalCount         int64              `json:"total_count"`
+	ID                    pgtype.UUID        `json:"id"`
+	WorkspaceID           pgtype.UUID        `json:"workspace_id"`
+	Title                 string             `json:"title"`
+	Description           pgtype.Text        `json:"description"`
+	Status                string             `json:"status"`
+	Priority              string             `json:"priority"`
+	AssigneeType          pgtype.Text        `json:"assignee_type"`
+	AssigneeID            pgtype.UUID        `json:"assignee_id"`
+	CreatorType           string             `json:"creator_type"`
+	CreatorID             pgtype.UUID        `json:"creator_id"`
+	ParentIssueID         pgtype.UUID        `json:"parent_issue_id"`
+	AcceptanceCriteria    []byte             `json:"acceptance_criteria"`
+	ContextRefs           []byte             `json:"context_refs"`
+	Position              float64            `json:"position"`
+	DueDate               pgtype.Timestamptz `json:"due_date"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
+	Number                int32              `json:"number"`
+	TotalCount            int64              `json:"total_count"`
+	MatchSource           string             `json:"match_source"`
+	MatchedCommentContent interface{}        `json:"matched_comment_content"`
 }
 
 func (q *Queries) SearchIssues(ctx context.Context, arg SearchIssuesParams) ([]SearchIssuesRow, error) {
 	rows, err := q.db.Query(ctx, searchIssues,
-		arg.WorkspaceID,
 		arg.Query,
+		arg.WorkspaceID,
 		arg.IncludeClosed,
 		arg.SearchOffset,
 		arg.SearchLimit,
@@ -459,6 +486,8 @@ func (q *Queries) SearchIssues(ctx context.Context, arg SearchIssuesParams) ([]S
 			&i.UpdatedAt,
 			&i.Number,
 			&i.TotalCount,
+			&i.MatchSource,
+			&i.MatchedCommentContent,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -74,21 +74,14 @@ WHERE parent_issue_id = $1
 ORDER BY position ASC, created_at DESC;
 
 -- name: SearchIssues :many
-SELECT * FROM issue
+SELECT *, COUNT(*) OVER() AS total_count FROM issue
 WHERE workspace_id = @workspace_id
   AND (
     title LIKE '%' || @query || '%'
     OR COALESCE(description, '') LIKE '%' || @query || '%'
   )
+  AND (@include_closed::boolean OR status NOT IN ('done', 'cancelled'))
 ORDER BY
   CASE WHEN title LIKE '%' || @query || '%' THEN 0 ELSE 1 END,
   updated_at DESC
 LIMIT @search_limit OFFSET @search_offset;
-
--- name: SearchIssuesCount :one
-SELECT COUNT(*) FROM issue
-WHERE workspace_id = @workspace_id
-  AND (
-    title LIKE '%' || @query || '%'
-    OR COALESCE(description, '') LIKE '%' || @query || '%'
-  );

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -72,3 +72,23 @@ WHERE workspace_id = $1
 SELECT * FROM issue
 WHERE parent_issue_id = $1
 ORDER BY position ASC, created_at DESC;
+
+-- name: SearchIssues :many
+SELECT * FROM issue
+WHERE workspace_id = @workspace_id
+  AND (
+    title LIKE '%' || @query || '%'
+    OR COALESCE(description, '') LIKE '%' || @query || '%'
+  )
+ORDER BY
+  CASE WHEN title LIKE '%' || @query || '%' THEN 0 ELSE 1 END,
+  updated_at DESC
+LIMIT @search_limit OFFSET @search_offset;
+
+-- name: SearchIssuesCount :one
+SELECT COUNT(*) FROM issue
+WHERE workspace_id = @workspace_id
+  AND (
+    title LIKE '%' || @query || '%'
+    OR COALESCE(description, '') LIKE '%' || @query || '%'
+  );

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -74,14 +74,39 @@ WHERE parent_issue_id = $1
 ORDER BY position ASC, created_at DESC;
 
 -- name: SearchIssues :many
-SELECT *, COUNT(*) OVER() AS total_count FROM issue
-WHERE workspace_id = @workspace_id
+SELECT i.*,
+  COUNT(*) OVER() AS total_count,
+  CASE
+    WHEN i.title LIKE '%' || @query || '%' THEN 'title'
+    WHEN COALESCE(i.description, '') LIKE '%' || @query || '%' THEN 'description'
+    ELSE 'comment'
+  END AS match_source,
+  CASE
+    WHEN i.title LIKE '%' || @query || '%' THEN ''
+    WHEN COALESCE(i.description, '') LIKE '%' || @query || '%' THEN ''
+    ELSE COALESCE(
+      (SELECT c.content FROM comment c
+       WHERE c.issue_id = i.id AND c.content LIKE '%' || @query || '%'
+       ORDER BY c.created_at DESC LIMIT 1),
+      ''
+    )
+  END AS matched_comment_content
+FROM issue i
+WHERE i.workspace_id = @workspace_id
   AND (
-    title LIKE '%' || @query || '%'
-    OR COALESCE(description, '') LIKE '%' || @query || '%'
+    i.title LIKE '%' || @query || '%'
+    OR COALESCE(i.description, '') LIKE '%' || @query || '%'
+    OR EXISTS (
+      SELECT 1 FROM comment c
+      WHERE c.issue_id = i.id AND c.content LIKE '%' || @query || '%'
+    )
   )
-  AND (@include_closed::boolean OR status NOT IN ('done', 'cancelled'))
+  AND (@include_closed::boolean OR i.status NOT IN ('done', 'cancelled'))
 ORDER BY
-  CASE WHEN title LIKE '%' || @query || '%' THEN 0 ELSE 1 END,
-  updated_at DESC
+  CASE
+    WHEN i.title LIKE '%' || @query || '%' THEN 0
+    WHEN COALESCE(i.description, '') LIKE '%' || @query || '%' THEN 1
+    ELSE 2
+  END,
+  i.updated_at DESC
 LIMIT @search_limit OFFSET @search_offset;


### PR DESCRIPTION
## Summary

- Add pg_bigm-based full-text search for issue titles and descriptions (CJK-friendly bigram indexing)
- New `GET /api/issues/search?q=keyword&limit=20&offset=0` API endpoint with pagination
- New `multica issue search <query>` CLI subcommand with table/json output
- New Cmd+K (Ctrl+K) global search dialog in the web app using cmdk

Closes MUL-398

## Changes

| Layer | Files |
|-------|-------|
| DB | `migrations/032_issue_search_index.{up,down}.sql` — pg_bigm extension + GIN indexes |
| sqlc | `pkg/db/queries/issue.sql` — SearchIssues + SearchIssuesCount queries |
| Server | `internal/handler/issue.go` — SearchIssues handler; `cmd/server/router.go` — route registration |
| CLI | `cmd/multica/cmd_issue.go` — issueSearchCmd cobra command |
| Web | `features/search/` — SearchCommand component; `shared/api/client.ts` — searchIssues method; dashboard layout integration |

## Test plan

- [ ] Run `make migrate-up` — verify pg_bigm extension creates successfully
- [ ] Create several issues with CJK and English titles, search via API and confirm results
- [ ] Test `multica issue search "keyword"` CLI output in both table and json modes
- [ ] Open web app, press Cmd+K, type a query — verify debounced search, result display, and navigation on select
- [ ] Verify empty state and loading state in search dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)