### PR TITLE
feat(issues): add 'Add sub-issues' button

### DIFF
--- a/apps/web/features/issues/components/issue-detail.tsx
+++ b/apps/web/features/issues/components/issue-detail.tsx
@@ -878,6 +878,23 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
             );
           })()}
 
+          {/* Add sub-issues button — shown when no sub-issues exist */}
+          {childIssues.length === 0 && (
+            <button
+              type="button"
+              className="mt-6 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() =>
+                useModalStore.getState().open("create-issue", {
+                  parent_issue_id: issue.id,
+                  parent_issue_identifier: issue.identifier,
+                })
+              }
+            >
+              <Plus className="h-3.5 w-3.5" />
+              <span>Add sub-issues</span>
+            </button>
+          )}
+
           <div className="my-8 border-t" />
 
           {/* Activity / Comments */}


### PR DESCRIPTION
## Summary
- Adds a Linear-style "+ Add sub-issues" button in the issue detail view when an issue has no child issues yet
- The button opens the create-issue modal with `parent_issue_id` pre-filled
- When sub-issues already exist, the existing collapsible section with its "+" icon button continues to be shown

Closes MUL-400

## Test plan
- [ ] Open an issue with no sub-issues — verify the "+ Add sub-issues" button appears below the description
- [ ] Click the button — verify the create-issue modal opens with the parent issue pre-filled
- [ ] Create a sub-issue — verify the button is replaced by the collapsible sub-issues section
- [ ] Open an issue that already has sub-issues — verify the button does not appear (existing section shown instead)