### PR TITLE
[codex] fix codex runtime preflight and version labeling

### DIFF
--- a/apps/web/features/runtimes/components/runtime-detail.tsx
+++ b/apps/web/features/runtimes/components/runtime-detail.tsx
@@ -4,21 +4,13 @@ import { RuntimeModeIcon, StatusBadge, InfoField } from "./shared";
 import { PingSection } from "./ping-section";
 import { UpdateSection } from "./update-section";
 import { UsageSection } from "./usage-section";
-
-function getCliVersion(metadata: Record<string, unknown>): string | null {
-  if (
-    metadata &&
-    typeof metadata.cli_version === "string" &&
-    metadata.cli_version
-  ) {
-    return metadata.cli_version;
-  }
-  return null;
-}
+import { getMulticaCliVersion, getRuntimeCliVersion } from "./runtime-metadata";
 
 export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
-  const cliVersion =
-    runtime.runtime_mode === "local" ? getCliVersion(runtime.metadata) : null;
+  const runtimeCliVersion =
+    runtime.runtime_mode === "local" ? getRuntimeCliVersion(runtime.metadata) : null;
+  const multicaCliVersion =
+    runtime.runtime_mode === "local" ? getMulticaCliVersion(runtime.metadata) : null;
 
   return (
     <div className="flex h-full flex-col">
@@ -60,15 +52,28 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
 
         {/* CLI Version & Update */}
         {runtime.runtime_mode === "local" && (
-          <div>
-            <h3 className="text-xs font-medium text-muted-foreground mb-3">
-              CLI Version
-            </h3>
-            <UpdateSection
-              runtimeId={runtime.id}
-              currentVersion={cliVersion}
-              isOnline={runtime.status === "online"}
-            />
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground mb-3">
+                Runtime CLI
+              </h3>
+              <InfoField
+                label={`${runtime.provider} version`}
+                value={runtimeCliVersion ?? "unknown"}
+                mono
+              />
+            </div>
+
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground mb-3">
+                Multica CLI
+              </h3>
+              <UpdateSection
+                runtimeId={runtime.id}
+                currentVersion={multicaCliVersion}
+                isOnline={runtime.status === "online"}
+              />
+            </div>
           </div>
         )}
 

--- a/apps/web/features/runtimes/components/runtime-metadata.test.ts
+++ b/apps/web/features/runtimes/components/runtime-metadata.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMetadataString,
+  getMulticaCliVersion,
+  getRuntimeCliVersion,
+} from "./runtime-metadata";
+
+describe("runtime metadata helpers", () => {
+  it("returns null for missing or invalid values", () => {
+    expect(getMetadataString({}, "version")).toBeNull();
+    expect(getMetadataString({ version: 123 }, "version")).toBeNull();
+    expect(getMetadataString({ version: "" }, "version")).toBeNull();
+  });
+
+  it("extracts runtime and multica CLI versions separately", () => {
+    const metadata = {
+      version: "codex-cli 0.118.0",
+      cli_version: "multica 0.1.19",
+    };
+
+    expect(getRuntimeCliVersion(metadata)).toBe("codex-cli 0.118.0");
+    expect(getMulticaCliVersion(metadata)).toBe("multica 0.1.19");
+  });
+});

--- a/apps/web/features/runtimes/components/runtime-metadata.ts
+++ b/apps/web/features/runtimes/components/runtime-metadata.ts
@@ -1,0 +1,19 @@
+export function getMetadataString(
+  metadata: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value ? value : null;
+}
+
+export function getRuntimeCliVersion(
+  metadata: Record<string, unknown>,
+): string | null {
+  return getMetadataString(metadata, "version");
+}
+
+export function getMulticaCliVersion(
+  metadata: Record<string, unknown>,
+): string | null {
+  return getMetadataString(metadata, "cli_version");
+}

--- a/apps/web/features/runtimes/components/update-section.tsx
+++ b/apps/web/features/runtimes/components/update-section.tsx
@@ -160,7 +160,7 @@ export function UpdateSection({
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2 flex-wrap">
-        <span className="text-xs text-muted-foreground">CLI Version:</span>
+        <span className="text-xs text-muted-foreground">Current version:</span>
         <span className="text-xs font-mono">
           {currentVersion ?? "unknown"}
         </span>

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -25,6 +25,9 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	if _, err := exec.LookPath(execPath); err != nil {
 		return nil, fmt.Errorf("codex executable not found at %q: %w", execPath, err)
 	}
+	if err := ensureCodexAppServer(ctx, execPath); err != nil {
+		return nil, err
+	}
 
 	timeout := opts.Timeout
 	if timeout == 0 {

--- a/server/pkg/agent/codex_preflight.go
+++ b/server/pkg/agent/codex_preflight.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+type codexPreflightResult struct {
+	err error
+}
+
+var codexAppServerPreflightCache sync.Map
+
+func ensureCodexAppServer(ctx context.Context, execPath string) error {
+	if cached, ok := codexAppServerPreflightCache.Load(execPath); ok {
+		return cached.(codexPreflightResult).err
+	}
+
+	versionCtx, cancelVersion := context.WithTimeout(ctx, 5*time.Second)
+	version, _ := detectCLIVersion(versionCtx, execPath)
+	cancelVersion()
+
+	checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(checkCtx, execPath, "app-server", "--help")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		codexAppServerPreflightCache.Store(execPath, codexPreflightResult{})
+		return nil
+	}
+
+	details := strings.TrimSpace(string(output))
+	if details == "" {
+		details = err.Error()
+	}
+
+	versionSuffix := ""
+	if version != "" {
+		versionSuffix = fmt.Sprintf(" (detected version: %s)", version)
+	}
+
+	preflightErr := fmt.Errorf(
+		"codex CLI does not support the `app-server` command%s: %s. Please upgrade codex-cli and restart the daemon",
+		versionSuffix,
+		details,
+	)
+	codexAppServerPreflightCache.Store(execPath, codexPreflightResult{err: preflightErr})
+	return preflightErr
+}

--- a/server/pkg/agent/codex_preflight_test.go
+++ b/server/pkg/agent/codex_preflight_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureCodexAppServerAcceptsSupportedCLI(t *testing.T) {
+	t.Parallel()
+
+	execPath := writeTestExecutable(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 0.119.0"
+  exit 0
+fi
+if [ "$1" = "app-server" ] && [ "$2" = "--help" ]; then
+  echo "Usage: codex app-server --listen stdio://"
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 1
+`)
+
+	if err := ensureCodexAppServer(context.Background(), execPath); err != nil {
+		t.Fatalf("ensureCodexAppServer() error = %v", err)
+	}
+}
+
+func TestEnsureCodexAppServerRejectsUnsupportedCLI(t *testing.T) {
+	t.Parallel()
+
+	execPath := writeTestExecutable(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 0.118.0"
+  exit 0
+fi
+echo "unknown command \"app-server\"" >&2
+exit 1
+`)
+
+	err := ensureCodexAppServer(context.Background(), execPath)
+	if err == nil {
+		t.Fatal("expected unsupported codex CLI to fail preflight")
+	}
+	if !strings.Contains(err.Error(), "detected version: codex-cli 0.118.0") {
+		t.Fatalf("expected version in error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "Please upgrade codex-cli and restart the daemon") {
+		t.Fatalf("expected upgrade hint in error, got %q", err.Error())
+	}
+}
+
+func TestEnsureCodexAppServerCachesResultPerExecutable(t *testing.T) {
+	countFile := filepath.Join(t.TempDir(), "count")
+	execPath := writeTestExecutable(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 0.119.0"
+  exit 0
+fi
+if [ "$1" = "app-server" ] && [ "$2" = "--help" ]; then
+  count=0
+  if [ -f "` + countFile + `" ]; then
+    count=$(cat "` + countFile + `")
+  fi
+  count=$((count+1))
+  echo "$count" > "` + countFile + `"
+  exit 0
+fi
+echo "unexpected args: $@" >&2
+exit 1
+`)
+
+	if err := ensureCodexAppServer(context.Background(), execPath); err != nil {
+		t.Fatalf("first ensureCodexAppServer() error = %v", err)
+	}
+	if err := ensureCodexAppServer(context.Background(), execPath); err != nil {
+		t.Fatalf("second ensureCodexAppServer() error = %v", err)
+	}
+
+	data, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "1" {
+		t.Fatalf("app-server preflight count = %q, want %q", strings.TrimSpace(string(data)), "1")
+	}
+}
+
+func writeTestExecutable(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex")
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write test executable: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
- fail fast when the installed Codex CLI does not support `codex app-server`
- cache the Codex app-server preflight result so the daemon does not repeat the same compatibility probe on every run
- separate the runtime provider version from the Multica CLI version in the runtime detail UI

## Why
Issue #490 comes from older Codex CLI builds exiting before the app-server handshake, which surfaces as a vague `codex initialize failed` error in Multica. The UI also showed `cli_version` as the runtime CLI version, which made it harder to understand what actually needed to be upgraded.

## Impact
- local Codex runtimes now fail with an actionable upgrade message instead of a generic initialization failure
- the runtime details panel now makes it clear which version belongs to Codex and which belongs to Multica CLI
- repeated ping and task runs avoid unnecessary preflight overhead after the first successful check

## Validation
- `pnpm --filter @multica/web test -- runtime-metadata.test.ts`
- `pnpm typecheck`
- `cd server && PATH=/tmp/go1.26.2/bin:$PATH /tmp/go1.26.2/bin/go test ./pkg/agent`

Closes #490.
