### PR TITLE
[codex] add a local filesystem storage backend for uploads

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -40,6 +40,10 @@ const nextConfig: NextConfig = {
         destination: `${remoteApiUrl}/ws`,
       },
       {
+        source: "/files/:path*",
+        destination: `${remoteApiUrl}/files/:path*`,
+      },
+      {
         source: "/auth/:path*",
         destination: `${remoteApiUrl}/auth/:path*`,
       },

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -49,9 +49,9 @@ func allowedOrigins() []string {
 func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Router {
 	queries := db.New(pool)
 	emailSvc := service.NewEmailService()
-	s3 := storage.NewS3StorageFromEnv()
+	fileStorage := storage.NewFromEnv()
 	cfSigner := auth.NewCloudFrontSignerFromEnv()
-	h := handler.New(queries, pool, hub, bus, emailSvc, s3, cfSigner)
+	h := handler.New(queries, pool, hub, bus, emailSvc, fileStorage, cfSigner)
 
 	r := chi.NewRouter()
 
@@ -72,6 +72,10 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"status":"ok"}`))
 	})
+
+	if localStorage, ok := fileStorage.(*storage.LocalStorage); ok {
+		r.Handle("/files/*", http.StripPrefix("/files/", localStorage.FileHandler()))
+	}
 
 	// WebSocket
 	mc := &membershipChecker{queries: queries}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -542,7 +542,7 @@ func (h *Handler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.deleteS3Objects(r.Context(), attachmentURLs)
+	h.deleteStoredObjects(r.Context(), attachmentURLs)
 	slog.Info("comment deleted", append(logger.RequestAttrs(r), "comment_id", commentId, "issue_id", uuidToString(comment.IssueID))...)
 	h.publish(protocol.EventCommentDeleted, workspaceID, actorType, actorID, map[string]any{
 		"comment_id": commentId,

--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/storage"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -50,7 +51,9 @@ func (h *Handler) attachmentToResponse(a db.Attachment) AttachmentResponse {
 		CreatedAt:    a.CreatedAt.Time.Format("2006-01-02T15:04:05Z07:00"),
 	}
 	if h.CFSigner != nil {
-		resp.DownloadURL = h.CFSigner.SignedURL(a.Url, time.Now().Add(30*time.Minute))
+		if _, ok := h.Storage.(*storage.S3Storage); ok {
+			resp.DownloadURL = h.CFSigner.SignedURL(a.Url, time.Now().Add(30*time.Minute))
+		}
 	}
 	if a.IssueID.Valid {
 		s := uuidToString(a.IssueID)
@@ -142,12 +145,12 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	key := id.String() + path.Ext(header.Filename)
 
-	link, err := h.Storage.Upload(r.Context(), key, data, contentType, header.Filename)
-	if err != nil {
+	if err := h.Storage.Upload(r.Context(), key, data, contentType, header.Filename); err != nil {
 		slog.Error("file upload failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "upload failed")
 		return
 	}
+	link := h.Storage.PublicURL(r, key)
 
 	// If workspace context is available, create an attachment record.
 	if workspaceID != "" {
@@ -288,7 +291,7 @@ func (h *Handler) DeleteAttachment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.deleteS3Object(r.Context(), att.Url)
+	h.deleteStoredObject(r.Context(), att.Url)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -328,16 +331,16 @@ func (h *Handler) linkAttachmentsByIDs(ctx context.Context, commentID, issueID p
 	}
 }
 
-// deleteS3Object removes a single file from S3 by its CDN URL.
-func (h *Handler) deleteS3Object(ctx context.Context, url string) {
+// deleteStoredObject removes a single file from the configured storage backend.
+func (h *Handler) deleteStoredObject(ctx context.Context, url string) {
 	if h.Storage == nil || url == "" {
 		return
 	}
 	h.Storage.Delete(ctx, h.Storage.KeyFromURL(url))
 }
 
-// deleteS3Objects removes multiple files from S3 by their CDN URLs.
-func (h *Handler) deleteS3Objects(ctx context.Context, urls []string) {
+// deleteStoredObjects removes multiple files from the configured storage backend.
+func (h *Handler) deleteStoredObjects(ctx context.Context, urls []string) {
 	if h.Storage == nil || len(urls) == 0 {
 		return
 	}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
-	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/middleware"
@@ -19,6 +18,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/internal/storage"
 	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 type txStarter interface {
@@ -41,11 +41,11 @@ type Handler struct {
 	EmailService *service.EmailService
 	PingStore    *PingStore
 	UpdateStore  *UpdateStore
-	Storage      *storage.S3Storage
+	Storage      storage.Storage
 	CFSigner     *auth.CloudFrontSigner
 }
 
-func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *events.Bus, emailService *service.EmailService, s3 *storage.S3Storage, cfSigner *auth.CloudFrontSigner) *Handler {
+func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *events.Bus, emailService *service.EmailService, fileStorage storage.Storage, cfSigner *auth.CloudFrontSigner) *Handler {
 	var executor dbExecutor
 	if candidate, ok := txStarter.(dbExecutor); ok {
 		executor = candidate
@@ -61,7 +61,7 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 		EmailService: emailService,
 		PingStore:    NewPingStore(),
 		UpdateStore:  NewUpdateStore(),
-		Storage:      s3,
+		Storage:      fileStorage,
 		CFSigner:     cfSigner,
 	}
 }
@@ -77,14 +77,14 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 }
 
 // Thin wrappers around util functions (preserve existing handler code unchanged).
-func parseUUID(s string) pgtype.UUID       { return util.ParseUUID(s) }
-func uuidToString(u pgtype.UUID) string    { return util.UUIDToString(u) }
-func textToPtr(t pgtype.Text) *string      { return util.TextToPtr(t) }
-func ptrToText(s *string) pgtype.Text      { return util.PtrToText(s) }
-func strToText(s string) pgtype.Text       { return util.StrToText(s) }
+func parseUUID(s string) pgtype.UUID                      { return util.ParseUUID(s) }
+func uuidToString(u pgtype.UUID) string                   { return util.UUIDToString(u) }
+func textToPtr(t pgtype.Text) *string                     { return util.TextToPtr(t) }
+func ptrToText(s *string) pgtype.Text                     { return util.PtrToText(s) }
+func strToText(s string) pgtype.Text                      { return util.StrToText(s) }
 func timestampToString(t pgtype.Timestamptz) string { return util.TimestampToString(t) }
 func timestampToPtr(t pgtype.Timestamptz) *string   { return util.TimestampToPtr(t) }
-func uuidToPtr(u pgtype.UUID) *string      { return util.UUIDToPtr(u) }
+func uuidToPtr(u pgtype.UUID) *string                     { return util.UUIDToPtr(u) }
 
 // publish sends a domain event through the event bus.
 func (h *Handler) publish(eventType, workspaceID, actorType, actorID string, payload any) {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -660,7 +660,7 @@ func (h *Handler) DeleteIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.deleteS3Objects(r.Context(), attachmentURLs)
+	h.deleteStoredObjects(r.Context(), attachmentURLs)
 	userID := requestUserID(r)
 	actorType, actorID := h.resolveActor(r, userID, uuidToString(issue.WorkspaceID))
 	h.publish(protocol.EventIssueDeleted, uuidToString(issue.WorkspaceID), actorType, actorID, map[string]any{"issue_id": id})

--- a/server/internal/storage/local.go
+++ b/server/internal/storage/local.go
@@ -1,0 +1,168 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const defaultUploadDir = "./uploads"
+
+type LocalStorage struct {
+	dir string
+}
+
+func NewLocalStorageFromEnv() *LocalStorage {
+	dir := strings.TrimSpace(os.Getenv("UPLOAD_DIR"))
+	if dir == "" {
+		dir = defaultUploadDir
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err == nil {
+		dir = absDir
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Error("failed to initialize local upload dir", "dir", dir, "error", err)
+		return nil
+	}
+
+	slog.Info("local storage initialized", "dir", dir)
+	return &LocalStorage{dir: dir}
+}
+
+func (s *LocalStorage) Dir() string {
+	return s.dir
+}
+
+func (s *LocalStorage) FileHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		filePath, err := s.pathForKey(r.URL.Path)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		info, err := os.Stat(filePath)
+		if err != nil || info.IsDir() {
+			http.NotFound(w, r)
+			return
+		}
+
+		http.ServeFile(w, r, filePath)
+	})
+}
+
+func (s *LocalStorage) Upload(_ context.Context, key string, data []byte, _ string, _ string) error {
+	filePath, err := s.pathForKey(key)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		return fmt.Errorf("create local upload dir: %w", err)
+	}
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+		return fmt.Errorf("write local upload file: %w", err)
+	}
+	return nil
+}
+
+func (s *LocalStorage) PublicURL(r *http.Request, key string) string {
+	return requestBaseURL(r) + path.Join("/files", key)
+}
+
+func (s *LocalStorage) KeyFromURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err == nil && parsed.Path != "" {
+		return strings.TrimPrefix(parsed.Path, "/files/")
+	}
+	return strings.TrimPrefix(rawURL, "/files/")
+}
+
+func (s *LocalStorage) Delete(_ context.Context, key string) {
+	filePath, err := s.pathForKey(key)
+	if err != nil {
+		slog.Error("local delete rejected invalid key", "key", key, "error", err)
+		return
+	}
+	if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+		slog.Error("local file delete failed", "key", key, "error", err)
+	}
+}
+
+func (s *LocalStorage) DeleteKeys(ctx context.Context, keys []string) {
+	for _, key := range keys {
+		s.Delete(ctx, key)
+	}
+}
+
+func (s *LocalStorage) pathForKey(key string) (string, error) {
+	for _, segment := range strings.Split(strings.TrimPrefix(key, "/"), "/") {
+		if segment == ".." {
+			return "", fmt.Errorf("invalid key path")
+		}
+	}
+
+	cleanKey := strings.TrimPrefix(path.Clean("/"+key), "/")
+	if cleanKey == "" || cleanKey == "." {
+		return "", fmt.Errorf("empty key")
+	}
+
+	fullPath := filepath.Join(s.dir, filepath.FromSlash(cleanKey))
+	relPath, err := filepath.Rel(s.dir, fullPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve path: %w", err)
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("invalid key path")
+	}
+	return fullPath, nil
+}
+
+func requestBaseURL(r *http.Request) string {
+	scheme := forwardedScheme(r)
+	host := forwardedHost(r)
+	return scheme + "://" + host
+}
+
+func forwardedScheme(r *http.Request) string {
+	if forwarded := r.Header.Get("Forwarded"); forwarded != "" {
+		parts := strings.Split(strings.Split(forwarded, ",")[0], ";")
+		for _, part := range parts {
+			kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+			if len(kv) == 2 && strings.EqualFold(kv[0], "proto") && kv[1] != "" {
+				return strings.Trim(kv[1], "\"")
+			}
+		}
+	}
+	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		return proto
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+func forwardedHost(r *http.Request) string {
+	if forwarded := r.Header.Get("Forwarded"); forwarded != "" {
+		parts := strings.Split(strings.Split(forwarded, ",")[0], ";")
+		for _, part := range parts {
+			kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+			if len(kv) == 2 && strings.EqualFold(kv[0], "host") && kv[1] != "" {
+				return strings.Trim(kv[1], "\"")
+			}
+		}
+	}
+	if host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); host != "" {
+		return host
+	}
+	return r.Host
+}

--- a/server/internal/storage/local_test.go
+++ b/server/internal/storage/local_test.go
@@ -1,0 +1,100 @@
+package storage
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalStorageUploadAndDelete(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storage := &LocalStorage{dir: dir}
+	key := "screenshots/test.png"
+	data := []byte("hello")
+
+	if err := storage.Upload(context.Background(), key, data, "image/png", "test.png"); err != nil {
+		t.Fatalf("Upload() error = %v", err)
+	}
+
+	filePath := filepath.Join(dir, "screenshots", "test.png")
+	got, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("stored data = %q, want %q", string(got), string(data))
+	}
+
+	storage.Delete(context.Background(), key)
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Fatalf("expected file to be deleted, stat err = %v", err)
+	}
+}
+
+func TestLocalStoragePublicURLUsesForwardedHeaders(t *testing.T) {
+	t.Parallel()
+
+	storage := &LocalStorage{dir: t.TempDir()}
+	req := httptest.NewRequest("POST", "http://127.0.0.1:8080/api/upload-file", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "multica.example.com")
+
+	got := storage.PublicURL(req, "images/demo.png")
+	want := "https://multica.example.com/files/images/demo.png"
+	if got != want {
+		t.Fatalf("PublicURL() = %q, want %q", got, want)
+	}
+}
+
+func TestLocalStorageRejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	storage := &LocalStorage{dir: t.TempDir()}
+	if _, err := storage.pathForKey("../secrets.txt"); err == nil {
+		t.Fatal("expected path traversal to be rejected")
+	}
+}
+
+func TestLocalStorageKeyFromURL(t *testing.T) {
+	t.Parallel()
+
+	storage := &LocalStorage{dir: t.TempDir()}
+	got := storage.KeyFromURL("https://multica.example.com/files/images/demo.png")
+	if got != "images/demo.png" {
+		t.Fatalf("KeyFromURL() = %q, want %q", got, "images/demo.png")
+	}
+}
+
+func TestLocalStorageFileHandlerServesFilesWithoutDirectoryListing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	storage := &LocalStorage{dir: dir}
+	if err := os.WriteFile(filepath.Join(dir, "demo.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	handler := storage.FileHandler()
+
+	fileReq := httptest.NewRequest(http.MethodGet, "/demo.txt", nil)
+	fileRes := httptest.NewRecorder()
+	handler.ServeHTTP(fileRes, fileReq)
+	if fileRes.Code != http.StatusOK {
+		t.Fatalf("file response status = %d, want %d", fileRes.Code, http.StatusOK)
+	}
+	if fileRes.Body.String() != "hello" {
+		t.Fatalf("file response body = %q, want %q", fileRes.Body.String(), "hello")
+	}
+
+	dirReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	dirRes := httptest.NewRecorder()
+	handler.ServeHTTP(dirRes, dirReq)
+	if dirRes.Code != http.StatusNotFound {
+		t.Fatalf("directory response status = %d, want %d", dirRes.Code, http.StatusNotFound)
+	}
+}

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 
@@ -31,7 +32,7 @@ type S3Storage struct {
 func NewS3StorageFromEnv() *S3Storage {
 	bucket := os.Getenv("S3_BUCKET")
 	if bucket == "" {
-		slog.Info("S3_BUCKET not set, file upload disabled")
+		slog.Info("S3_BUCKET not set, skipping S3 storage")
 		return nil
 	}
 
@@ -66,6 +67,13 @@ func NewS3StorageFromEnv() *S3Storage {
 		bucket:    bucket,
 		cdnDomain: cdnDomain,
 	}
+}
+
+func NewFromEnv() Storage {
+	if strings.TrimSpace(os.Getenv("S3_BUCKET")) != "" {
+		return NewS3StorageFromEnv()
+	}
+	return NewLocalStorageFromEnv()
 }
 
 // sanitizeFilename removes characters that could cause header injection in Content-Disposition.
@@ -123,7 +131,7 @@ func (s *S3Storage) DeleteKeys(ctx context.Context, keys []string) {
 	}
 }
 
-func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error) {
+func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, contentType string, filename string) error {
 	safe := sanitizeFilename(filename)
 	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:             aws.String(s.bucket),
@@ -135,13 +143,15 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 		StorageClass:       types.StorageClassIntelligentTiering,
 	})
 	if err != nil {
-		return "", fmt.Errorf("s3 PutObject: %w", err)
+		return fmt.Errorf("s3 PutObject: %w", err)
 	}
+	return nil
+}
 
+func (s *S3Storage) PublicURL(_ *http.Request, key string) string {
 	domain := s.bucket
 	if s.cdnDomain != "" {
 		domain = s.cdnDomain
 	}
-	link := fmt.Sprintf("https://%s/%s", domain, key)
-	return link, nil
+	return fmt.Sprintf("https://%s/%s", domain, key)
 }

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -1,0 +1,15 @@
+package storage
+
+import (
+	"context"
+	"net/http"
+)
+
+// Storage provides a backend-agnostic interface for file uploads.
+type Storage interface {
+	Upload(ctx context.Context, key string, data []byte, contentType string, filename string) error
+	PublicURL(r *http.Request, key string) string
+	KeyFromURL(rawURL string) string
+	Delete(ctx context.Context, key string)
+	DeleteKeys(ctx context.Context, keys []string)
+}


### PR DESCRIPTION
## Summary
- add a storage abstraction for attachment uploads so the server can use S3 or local disk
- introduce a local filesystem backend with safe path handling, file deletion, and direct `/files/*` serving
- wire the web app to proxy `/files/*` requests so locally stored attachment links work through the Next.js frontend

## Why
Issue #505 requests a self-host-friendly upload backend. Before this change, uploads only worked when S3 was configured, and the server otherwise returned `file upload not configured`.

## Impact
- self-hosted environments can upload attachments without provisioning S3
- S3-backed deployments keep the existing behavior, including signed download URLs when CloudFront signing is enabled
- local uploads use stable URLs and avoid directory listing exposure

## Validation
- `pnpm build`
- `cd server && PATH=/tmp/go1.26.2/bin:$PATH /tmp/go1.26.2/bin/go test ./internal/storage ./internal/handler ./cmd/server`

Closes #505.
