### PR TITLE
fix(search): make pg_bigm migration graceful for CI

### DIFF
--- a/server/migrations/032_issue_search_index.up.sql
+++ b/server/migrations/032_issue_search_index.up.sql
@@ -1,8 +1,20 @@
 -- Enable pg_bigm extension for bigram-based full-text search (CJK-friendly).
-CREATE EXTENSION IF NOT EXISTS pg_bigm;
+-- Skips gracefully if pg_bigm is not available (e.g. CI environments).
+DO $$
+BEGIN
+  CREATE EXTENSION IF NOT EXISTS pg_bigm;
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'pg_bigm not available, skipping bigram indexes';
+END
+$$;
 
--- GIN index on issue title for LIKE '%keyword%' queries.
-CREATE INDEX idx_issue_title_bigm ON issue USING gin (title gin_bigm_ops);
-
--- GIN index on issue description (nullable, use COALESCE).
-CREATE INDEX idx_issue_description_bigm ON issue USING gin (COALESCE(description, '') gin_bigm_ops);
+-- GIN indexes on issue title/description for LIKE '%keyword%' queries.
+-- Only created when pg_bigm is installed.
+DO $$
+BEGIN
+  CREATE INDEX idx_issue_title_bigm ON issue USING gin (title gin_bigm_ops);
+  CREATE INDEX idx_issue_description_bigm ON issue USING gin (COALESCE(description, '') gin_bigm_ops);
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'skipping bigram indexes (pg_bigm not installed)';
+END
+$$;

--- a/server/migrations/033_comment_search_index.up.sql
+++ b/server/migrations/033_comment_search_index.up.sql
@@ -1,2 +1,9 @@
 -- GIN index on comment content for LIKE '%keyword%' queries (pg_bigm).
-CREATE INDEX idx_comment_content_bigm ON comment USING gin (content gin_bigm_ops);
+-- Only created when pg_bigm is installed.
+DO $$
+BEGIN
+  CREATE INDEX idx_comment_content_bigm ON comment USING gin (content gin_bigm_ops);
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'skipping bigram index on comment (pg_bigm not installed)';
+END
+$$;


### PR DESCRIPTION
## Summary
- CI fails at migration 032 because `pgvector/pgvector:pg17` doesn't include the `pg_bigm` extension
- Wrap `CREATE EXTENSION` and `CREATE INDEX` in `DO $$ ... EXCEPTION` blocks so migrations skip gracefully when pg_bigm is unavailable
- Production (with pg_bigm installed) is unaffected — indexes are created as before

## Test plan
- [ ] CI backend job passes migrations and tests
- [ ] Local `make migrate-up` still creates pg_bigm indexes when the extension is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)