### PR TITLE
feat(agents): distinguish chat tasks in agent task queue

### DIFF
--- a/apps/web/app/(dashboard)/agents/page.tsx
+++ b/apps/web/app/(dashboard)/agents/page.tsx
@@ -25,6 +25,7 @@ import {
   Settings,
   Camera,
   Archive,
+  MessageCircle,
 } from "lucide-react";
 import type {
   Agent,
@@ -644,7 +645,7 @@ function TasksTab({ agent }: { agent: Agent }) {
       <div>
         <h3 className="text-sm font-semibold">Task Queue</h3>
         <p className="text-xs text-muted-foreground mt-0.5">
-          Issues assigned to this agent and their execution status.
+          Tasks assigned to this agent and their execution status.
         </p>
       </div>
 
@@ -661,7 +662,8 @@ function TasksTab({ agent }: { agent: Agent }) {
           {sortedTasks.map((task) => {
             const config = taskStatusConfig[task.status] ?? taskStatusConfig.queued!;
             const Icon = config.icon;
-            const issue = issueMap.get(task.issue_id);
+            const isChat = !!task.chat_session_id;
+            const issue = isChat ? undefined : issueMap.get(task.issue_id);
             const isActive = task.status === "running" || task.status === "dispatched";
             const isRunning = task.status === "running";
 
@@ -683,13 +685,20 @@ function TasksTab({ agent }: { agent: Agent }) {
                 />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    {issue && (
+                    {isChat ? (
+                      <span className="inline-flex items-center gap-1 shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                        <MessageCircle className="h-3 w-3" />
+                        Chat
+                      </span>
+                    ) : issue ? (
                       <span className="shrink-0 text-xs font-mono text-muted-foreground">
                         {issue.identifier}
                       </span>
-                    )}
+                    ) : null}
                     <span className={`text-sm truncate ${isActive ? "font-medium" : ""}`}>
-                      {issue?.title ?? `Issue ${task.issue_id.slice(0, 8)}...`}
+                      {isChat
+                        ? "Chat session"
+                        : (issue?.title ?? `Issue ${task.issue_id.slice(0, 8)}...`)}
                     </span>
                   </div>
                   <div className="text-xs text-muted-foreground mt-0.5">

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -35,6 +35,7 @@ export interface AgentTask {
   result: unknown;
   error: string | null;
   created_at: string;
+  chat_session_id?: string;
 }
 
 export interface Agent {

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -123,6 +123,7 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
+		ChatSessionID:    uuidToString(t.ChatSessionID),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Backend `taskToResponse` now includes `chat_session_id` in the API response
- Added `chat_session_id` to the `AgentTask` TypeScript type
- Chat tasks in the agent Tasks tab show a "Chat" pill badge instead of an issue identifier

## Test plan
- [ ] Open agent detail → Tasks tab
- [ ] Verify issue-based tasks still show identifier + title as before
- [ ] Trigger a chat task → verify it shows a "Chat" badge with "Chat session" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)