### PR TITLE
fix(views): fix Y-axis tick ordering on Daily Token Usage chart

### DIFF
--- a/packages/views/runtimes/components/charts/daily-token-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-token-chart.tsx
@@ -38,6 +38,7 @@ export function DailyTokenChart({ data }: { data: DailyTokenData[] }) {
             interval="preserveStartEnd"
           />
           <YAxis
+            type="number"
             tickLine={false}
             axisLine={false}
             tickMargin={8}


### PR DESCRIPTION
## Summary
- Fixed the Daily Token Usage chart Y-axis displaying tick labels in wrong order (0 → 60M → 20M → 80M → 40M instead of ascending 0 → 20M → 40M → 60M → 80M)
- Added explicit `type="number"` to the `YAxis` component in the stacked area chart to ensure Recharts sorts ticks numerically

Fixes [MUL-450](mention://issue/d140fd21-4bdc-47db-a496-bd897df26373)

## Test plan
- [ ] Open the Runtimes usage page and verify the Daily Token Usage chart Y-axis labels are in ascending order

🤖 Generated with [Claude Code](https://claude.com/claude-code)