### PR TITLE
Fix Claude stream-json startup hangs

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -33,24 +34,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
-	args := []string{
-		"--output-format", "stream-json",
-		"--verbose",
-		"--permission-mode", "bypassPermissions",
-	}
-	if opts.Model != "" {
-		args = append(args, "--model", opts.Model)
-	}
-	if opts.MaxTurns > 0 {
-		args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
-	}
-	if opts.SystemPrompt != "" {
-		args = append(args, "--append-system-prompt", opts.SystemPrompt)
-	}
-	if opts.ResumeSessionID != "" {
-		args = append(args, "--resume", opts.ResumeSessionID)
-	}
-	args = append(args, "-p", prompt)
+	args := buildClaudeArgs(opts)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	if opts.Cwd != "" {
@@ -74,6 +58,17 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cancel()
 		return nil, fmt.Errorf("start claude: %w", err)
 	}
+	if err := writeClaudeInput(stdin, prompt); err != nil {
+		_ = stdin.Close()
+		cancel()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("write claude input: %w", err)
+	}
+	if err := stdin.Close(); err != nil {
+		cancel()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("close claude stdin: %w", err)
+	}
 
 	b.cfg.Logger.Info("claude started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
 
@@ -84,7 +79,6 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
-		defer stdin.Close()
 
 		startTime := time.Now()
 		var output strings.Builder
@@ -135,8 +129,6 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 						Content: msg.Log.Message,
 					})
 				}
-			case "control_request":
-				b.handleControlRequest(msg, stdin)
 			}
 		}
 
@@ -339,12 +331,84 @@ func trySend(ch chan<- Message, msg Message) {
 	}
 }
 
+func buildClaudeArgs(opts ExecOptions) []string {
+	args := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--input-format", "stream-json",
+		"--verbose",
+		"--strict-mcp-config",
+		"--permission-mode", "bypassPermissions",
+	}
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+	if opts.MaxTurns > 0 {
+		args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
+	}
+	if opts.SystemPrompt != "" {
+		args = append(args, "--append-system-prompt", opts.SystemPrompt)
+	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--resume", opts.ResumeSessionID)
+	}
+	return args
+}
+
+func writeClaudeInput(w io.Writer, prompt string) error {
+	data, err := buildClaudeInput(prompt)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildClaudeInput(prompt string) ([]byte, error) {
+	payload := map[string]any{
+		"type": "user",
+		"message": map[string]any{
+			"role": "user",
+			"content": []map[string]string{
+				{
+					"type": "text",
+					"text": prompt,
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal claude input: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
 func buildEnv(extra map[string]string) []string {
-	env := os.Environ()
+	return mergeEnv(os.Environ(), extra)
+}
+
+func mergeEnv(base []string, extra map[string]string) []string {
+	env := make([]string, 0, len(base)+len(extra))
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if isFilteredChildEnvKey(key) {
+			continue
+		}
+		env = append(env, entry)
+	}
 	for k, v := range extra {
 		env = append(env, k+"="+v)
 	}
 	return env
+}
+
+func isFilteredChildEnvKey(key string) bool {
+	return key == "CLAUDECODE" ||
+		strings.HasPrefix(key, "CLAUDECODE_") ||
+		strings.HasPrefix(key, "CLAUDE_CODE_")
 }
 
 func detectCLIVersion(ctx context.Context, execPath string) (string, error) {

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -194,6 +194,101 @@ func TestTrySendDropsWhenFull(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
+	t.Parallel()
+
+	args := buildClaudeArgs(ExecOptions{})
+	expected := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--input-format", "stream-json",
+		"--verbose",
+		"--strict-mcp-config",
+		"--permission-mode", "bypassPermissions",
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Fatalf("expected args[%d] = %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestBuildClaudeInputEncodesUserMessage(t *testing.T) {
+	t.Parallel()
+
+	data, err := buildClaudeInput("say pong")
+	if err != nil {
+		t.Fatalf("buildClaudeInput: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatalf("expected newline-terminated payload, got %q", data)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(data), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["type"] != "user" {
+		t.Fatalf("expected type user, got %v", payload["type"])
+	}
+
+	message, ok := payload["message"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected message object, got %T", payload["message"])
+	}
+	if message["role"] != "user" {
+		t.Fatalf("expected role user, got %v", message["role"])
+	}
+
+	content, ok := message["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("expected one content block, got %v", message["content"])
+	}
+	block, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected content block object, got %T", content[0])
+	}
+	if block["type"] != "text" || block["text"] != "say pong" {
+		t.Fatalf("unexpected content block: %v", block)
+	}
+}
+
+func TestMergeEnvFiltersClaudeCodeVars(t *testing.T) {
+	t.Parallel()
+
+	env := mergeEnv([]string{
+		"PATH=/usr/bin",
+		"CLAUDECODE=1",
+		"CLAUDE_CODE_ENTRYPOINT=cli",
+		"CLAUDECODEX=keep-me",
+	}, map[string]string{"FOO": "bar"})
+
+	for _, entry := range env {
+		if entry == "CLAUDECODE=1" || entry == "CLAUDE_CODE_ENTRYPOINT=cli" {
+			t.Fatalf("expected CLAUDECODE vars to be filtered, got %v", env)
+		}
+	}
+
+	found := map[string]bool{}
+	for _, entry := range env {
+		found[entry] = true
+	}
+
+	if !found["PATH=/usr/bin"] {
+		t.Fatalf("expected PATH to be preserved, got %v", env)
+	}
+	if !found["CLAUDECODEX=keep-me"] {
+		t.Fatalf("expected unrelated env vars to be preserved, got %v", env)
+	}
+	if !found["FOO=bar"] {
+		t.Fatalf("expected extra env var to be appended, got %v", env)
+	}
+}
+
 func TestBuildEnvAppendsExtras(t *testing.T) {
 	t.Parallel()
 
@@ -217,7 +312,6 @@ func TestBuildEnvNilExtras(t *testing.T) {
 		t.Fatal("expected at least system env vars")
 	}
 }
-
 
 func mustMarshal(t *testing.T, v any) json.RawMessage {
 	t.Helper()


### PR DESCRIPTION
## Summary
- switch the Claude backend to the documented stream-json stdin protocol instead of passing the prompt as a CLI arg while keeping stdin open
- add `--strict-mcp-config` and filter inherited `CLAUDECODE` / `CLAUDE_CODE_*` env vars before spawning Claude child processes
- add focused tests for argument construction, stdin payload encoding, and env filtering

## Why
Claude Code can hang during Multica daemon startup when it is launched with `-p --output-format stream-json` while stdin stays open. In practice the child process waits for stdin EOF and never emits a result, which makes the daemon ping time out.

## Testing
- `docker run --rm -v /tmp/multica-codex:/src -w /src/server golang:1.26 go test ./pkg/agent`
