### PR TITLE
fix(web): clear stale auth state on login boundaries

### DIFF
--- a/apps/web/app/(auth)/login/page.test.tsx
+++ b/apps/web/app/(auth)/login/page.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { clearStoredSession } from "@/platform/auth-session";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
@@ -42,6 +43,10 @@ vi.mock("@/platform/api", () => ({
     setToken: vi.fn(),
     getMe: vi.fn(),
   },
+}));
+
+vi.mock("@/platform/auth-session", () => ({
+  clearStoredSession: vi.fn(),
 }));
 
 import LoginPage from "./page";
@@ -119,6 +124,14 @@ describe("LoginPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+  });
+
+  it("clears the logged-in cookie when no cached token exists", async () => {
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(clearStoredSession).toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/platform/auth";
 import { setLoggedInCookie } from "@/features/auth/auth-cookie";
 import { useWorkspaceStore } from "@/platform/workspace";
 import { api } from "@/platform/api";
+import { clearStoredSession } from "@/platform/auth-session";
 import {
   Card,
   CardHeader,
@@ -68,6 +69,13 @@ function LoginPageContent() {
   const [submitting, setSubmitting] = useState(false);
   const [cooldown, setCooldown] = useState(0);
   const [existingUser, setExistingUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem("multica_token");
+    if (!token) {
+      clearStoredSession();
+    }
+  }, []);
 
   // Check for existing session when CLI callback is present.
   useEffect(() => {

--- a/apps/web/app/(dashboard)/_components/app-sidebar.tsx
+++ b/apps/web/app/(dashboard)/_components/app-sidebar.tsx
@@ -48,6 +48,7 @@ import {
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { useAuthStore } from "@/platform/auth";
 import { useWorkspaceStore } from "@/platform/workspace";
+import { clearStoredSession } from "@/platform/auth-session";
 import { useQuery } from "@tanstack/react-query";
 import { inboxKeys, deduplicateInboxItems } from "@multica/core/inbox/queries";
 import { api } from "@/platform/api";
@@ -100,6 +101,7 @@ export function AppSidebar() {
   const hasRuntimeUpdates = useMyRuntimesNeedUpdate();
 
   const logout = () => {
+    clearStoredSession();
     router.push("/");
     authLogout();
     useWorkspaceStore.getState().clearWorkspace();

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -7,6 +7,7 @@ import { useNavigationStore } from "@multica/core/navigation";
 import { SidebarProvider, SidebarInset } from "@multica/ui/components/ui/sidebar";
 import { useAuthStore } from "@/platform/auth";
 import { useWorkspaceStore } from "@/platform/workspace";
+import { clearStoredSession } from "@/platform/auth-session";
 import { WorkspaceIdProvider } from "@multica/core/hooks";
 import { ModalRegistry } from "@multica/views/modals/registry";
 import { SearchCommand } from "@/features/search";
@@ -26,6 +27,7 @@ export default function DashboardLayout({
 
   useEffect(() => {
     if (!isLoading && !user) {
+      clearStoredSession();
       router.push("/");
     }
   }, [user, isLoading, router]);

--- a/apps/web/platform/api.ts
+++ b/apps/web/platform/api.ts
@@ -1,6 +1,10 @@
 import { ApiClient } from "@multica/core/api/client";
 import { setApiInstance } from "@multica/core/api";
 import { createLogger } from "@multica/core/logger";
+import {
+  clearStoredSession,
+  getUnauthorizedRedirectPath,
+} from "./auth-session";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
@@ -8,10 +12,10 @@ export const api = new ApiClient(API_BASE_URL, {
   logger: createLogger("api"),
   onUnauthorized: () => {
     if (typeof window !== "undefined") {
-      localStorage.removeItem("multica_token");
-      localStorage.removeItem("multica_workspace_id");
-      if (window.location.pathname !== "/") {
-        window.location.href = "/";
+      clearStoredSession();
+      const redirectPath = getUnauthorizedRedirectPath(window.location.pathname);
+      if (redirectPath) {
+        window.location.href = redirectPath;
       }
     }
   },

--- a/apps/web/platform/auth-session.test.ts
+++ b/apps/web/platform/auth-session.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearStoredSession,
+  getUnauthorizedRedirectPath,
+} from "./auth-session";
+
+describe("auth-session", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.cookie = "multica_logged_in=; path=/; max-age=0";
+  });
+
+  it("clears stored auth state", () => {
+    localStorage.setItem("multica_token", "token");
+    localStorage.setItem("multica_workspace_id", "workspace");
+    document.cookie = "multica_logged_in=1; path=/";
+
+    clearStoredSession();
+
+    expect(localStorage.getItem("multica_token")).toBeNull();
+    expect(localStorage.getItem("multica_workspace_id")).toBeNull();
+    expect(document.cookie).toBe("");
+  });
+
+  it("keeps login routes in place on unauthorized responses", () => {
+    expect(getUnauthorizedRedirectPath("/")).toBeNull();
+    expect(getUnauthorizedRedirectPath("/login")).toBeNull();
+    expect(getUnauthorizedRedirectPath("/auth/callback")).toBeNull();
+  });
+
+  it("redirects protected routes back to the landing page", () => {
+    expect(getUnauthorizedRedirectPath("/issues")).toBe("/");
+    expect(getUnauthorizedRedirectPath("/settings")).toBe("/");
+  });
+});

--- a/apps/web/platform/auth-session.ts
+++ b/apps/web/platform/auth-session.ts
@@ -1,0 +1,17 @@
+import { clearLoggedInCookie } from "@/features/auth/auth-cookie";
+
+export function clearStoredSession() {
+  if (typeof window === "undefined") return;
+
+  localStorage.removeItem("multica_token");
+  localStorage.removeItem("multica_workspace_id");
+  clearLoggedInCookie();
+}
+
+export function getUnauthorizedRedirectPath(pathname: string): string | null {
+  if (pathname === "/" || pathname === "/login" || pathname.startsWith("/auth/")) {
+    return null;
+  }
+
+  return "/";
+}


### PR DESCRIPTION
## Summary
- centralize browser auth-session cleanup so stale cookies/local storage do not trap users after logout or expired auth
- clear stale session state when the login page is opened without a cached token
- add focused unit coverage for the new session helpers and login boundary cleanup

## Verification
- 
 RUN  v4.1.0 /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/apps/web


 Test Files  2 passed (2)
      Tests  10 passed (10)
   Start at  06:57:18
   Duration  1.32s (transform 95ms, setup 144ms, import 276ms, tests 354ms, environment 1.05s)
- ==> Using env file: .env.worktree
==> Checking PostgreSQL...
==> Ensuring shared PostgreSQL container is running on localhost:5432...
==> Waiting for PostgreSQL to be ready...
==> Ensuring database 'multica_multica_340' exists...
✓ PostgreSQL ready (local Docker). Database: multica_multica_340

==> [1/5] TypeScript typecheck...

> multica@0.2.0 typecheck /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica
> turbo typecheck


   • Packages in scope: @multica/core, @multica/tsconfig, @multica/ui, @multica/views, @multica/web
   • Running typecheck in 5 packages
   • Remote caching disabled, using shared worktree cache

@multica/web:typecheck: cache hit, replaying logs 7bc17dcb5b4bfd9a
@multica/web:typecheck: 
@multica/web:typecheck: > @multica/web@0.2.0 typecheck /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/apps/web
@multica/web:typecheck: > tsc --noEmit
@multica/web:typecheck: 

 Tasks:    1 successful, 1 total
Cached:    1 cached, 1 total
  Time:    45ms >>> FULL TURBO


==> [2/5] TypeScript unit tests...

> multica@0.2.0 test /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica
> turbo test


   • Packages in scope: @multica/core, @multica/tsconfig, @multica/ui, @multica/views, @multica/web
   • Running test in 5 packages
   • Remote caching disabled, using shared worktree cache

@multica/web:test: cache hit, replaying logs 40c7336462e62e2d
@multica/web:test: 
@multica/web:test: > @multica/web@0.2.0 test /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/apps/web
@multica/web:test: > vitest run
@multica/web:test: 
@multica/web:test: 
@multica/web:test:  RUN  v4.1.0 /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/apps/web
@multica/web:test: 
@multica/web:test: (node:77999) Warning: `--localstorage-file` was provided without a valid path
@multica/web:test: (Use `node --trace-warnings ...` to show where the warning was created)
@multica/web:test: (node:78001) Warning: `--localstorage-file` was provided without a valid path
@multica/web:test: (Use `node --trace-warnings ...` to show where the warning was created)
@multica/web:test: (node:78000) Warning: `--localstorage-file` was provided without a valid path
@multica/web:test: (Use `node --trace-warnings ...` to show where the warning was created)
@multica/web:test: (node:77998) Warning: `--localstorage-file` was provided without a valid path
@multica/web:test: (Use `node --trace-warnings ...` to show where the warning was created)
@multica/web:test:  ✓ platform/auth-session.test.ts (3 tests) 8ms
@multica/web:test:  ✓ app/(auth)/login/page.test.tsx (7 tests) 355ms
@multica/web:test:  ✓ app/(dashboard)/issues/[id]/page.test.tsx (6 tests) 492ms
@multica/web:test:  ✓ app/(dashboard)/issues/page.test.tsx (7 tests) 276ms
@multica/web:test: 
@multica/web:test:  Test Files  4 passed (4)
@multica/web:test:       Tests  23 passed (23)
@multica/web:test:    Start at  06:38:33
@multica/web:test:    Duration  3.16s (transform 600ms, setup 262ms, import 4.46s, tests 1.13s, environment 1.91s)
@multica/web:test: 

 Tasks:    1 successful, 1 total
Cached:    1 cached, 1 total
  Time:    44ms >>> FULL TURBO


==> [3/5] Go tests...
==> Running database migrations...
  skip  001_init (already applied)
  skip  002_agent_config (already applied)
  skip  003_task_context (already applied)
  skip  004_agent_runtime_loop (already applied)
  skip  005_daemon_pairing (already applied)
  skip  006_workspace_context (already applied)
  skip  007_drop_issue_repository (already applied)
  skip  008_structured_skills (already applied)
  skip  009_verification_code (already applied)
  skip  010_verification_code_attempts (already applied)
  skip  011_personal_access_tokens (already applied)
  skip  012_inbox_actor (already applied)
  skip  013_runtime_usage (already applied)
  skip  014_workspace_repos (already applied)
  skip  015_issue_subscriber (already applied)
  skip  016_backfill_subscribers (already applied)
  skip  017_comment_parent_id (already applied)
  skip  018_comment_parent_cascade (already applied)
  skip  019_inbox_details (already applied)
  skip  020_issue_number (already applied)
  skip  020_task_session (already applied)
  skip  021_agent_instructions (already applied)
  skip  022_task_lifecycle_guards (already applied)
  skip  023_agent_concurrency_default (already applied)
  skip  024_backfill_empty_issue_prefix (already applied)
  skip  025_comment_workspace_id (already applied)
  skip  026_comment_reactions (already applied)
  skip  026_task_messages (already applied)
  skip  027_issue_reactions (already applied)
  skip  028_task_trigger_comment (already applied)
  skip  029_attachment (already applied)
  skip  029_daemon_token (already applied)
  skip  029_drop_daemon_pairing (already applied)
  skip  030_agent_default_private (already applied)
  skip  031_agent_archive (already applied)
  skip  032_drop_agent_triggers (already applied)
  skip  032_issue_search_index (already applied)
  skip  032_runtime_owner (already applied)
  skip  032_task_usage (already applied)
  skip  033_chat (already applied)
  skip  033_comment_search_index (already applied)
  skip  034_projects (already applied)
  skip  035_project_priority (already applied)
Done.
?   	github.com/multica-ai/multica/server/cmd/migrate	[no test files]
ok  	github.com/multica-ai/multica/server/cmd/multica	(cached)
ok  	github.com/multica-ai/multica/server/cmd/server	(cached)
?   	github.com/multica-ai/multica/server/internal/auth	[no test files]
ok  	github.com/multica-ai/multica/server/internal/cli	(cached)
ok  	github.com/multica-ai/multica/server/internal/daemon	(cached)
ok  	github.com/multica-ai/multica/server/internal/daemon/execenv	(cached)
ok  	github.com/multica-ai/multica/server/internal/daemon/repocache	(cached)
ok  	github.com/multica-ai/multica/server/internal/daemon/usage	(cached)
ok  	github.com/multica-ai/multica/server/internal/events	(cached)
ok  	github.com/multica-ai/multica/server/internal/handler	(cached)
?   	github.com/multica-ai/multica/server/internal/logger	[no test files]
ok  	github.com/multica-ai/multica/server/internal/mention	(cached)
ok  	github.com/multica-ai/multica/server/internal/middleware	(cached)
ok  	github.com/multica-ai/multica/server/internal/realtime	(cached)
?   	github.com/multica-ai/multica/server/internal/service	[no test files]
?   	github.com/multica-ai/multica/server/internal/storage	[no test files]
?   	github.com/multica-ai/multica/server/internal/util	[no test files]
ok  	github.com/multica-ai/multica/server/pkg/agent	(cached)
?   	github.com/multica-ai/multica/server/pkg/db/generated	[no test files]
?   	github.com/multica-ai/multica/server/pkg/protocol	[no test files]
ok  	github.com/multica-ai/multica/server/pkg/redact	(cached)

==> [4/5] Starting services for E2E...
    Backend already running on :18420
    Frontend already running on :13340

==> [5/5] E2E tests (Playwright)...

Running 15 tests using 5 workers

  ✘   3 [chromium] › e2e/auth.spec.ts:5:3 › Authentication › login page renders correctly (5.6s)
  ✘   5 [chromium] › e2e/issues.spec.ts:17:3 › Issues › issues page loads with board view (6.1s)
  ✘   7 [chromium] › e2e/issues.spec.ts:26:3 › Issues › can switch between board and list view (88ms)
  ✘   8 [chromium] › e2e/issues.spec.ts:38:3 › Issues › can create a new issue (82ms)
  ✘   9 [chromium] › e2e/issues.spec.ts:51:3 › Issues › can navigate to issue detail page (81ms)
  ✘  10 [chromium] › e2e/issues.spec.ts:74:3 › Issues › can cancel issue creation (81ms)
  ✘   6 [chromium] › e2e/auth.spec.ts:16:3 › Authentication › login and redirect to /issues (5.5s)
  ✘  11 [chromium] › e2e/auth.spec.ts:23:3 › Authentication › unauthenticated user is redirected to /login (10.4s)
  ✘   4 [chromium] › e2e/navigation.spec.ts:9:3 › Navigation › sidebar navigation works (30.0s)
  ✘   2 [chromium] › e2e/settings.spec.ts:5:3 › Settings › updating workspace name reflects in sidebar immediately (30.0s)
  ✘   1 [chromium] › e2e/comments.spec.ts:18:3 › Comments › can add a comment on an issue (30.1s)
  ✘  14 [chromium] › e2e/comments.spec.ts:44:3 › Comments › comment submit button is disabled when empty (88ms)
  ✘  13 [chromium] › e2e/navigation.spec.ts:26:3 › Navigation › settings page loads via workspace menu (79ms)
  ✘  15 [chromium] › e2e/navigation.spec.ts:36:3 › Navigation › agents page shows agent list (83ms)
  ✘  12 [chromium] › e2e/auth.spec.ts:34:3 › Authentication › logout redirects to /login (30.0s)


  1) [chromium] › e2e/auth.spec.ts:5:3 › Authentication › login page renders correctly ─────────────

    Error: [2mexpect([22m[31mlocator[39m[2m).[22mtoContainText[2m([22m[32mexpected[39m[2m)[22m failed

    Locator: locator('h1')
    Expected substring: [32m"Multica"[39m
    Timeout: 5000ms
    Error: element(s) not found

    Call log:
    [2m  - Expect "toContainText" with timeout 5000ms[22m
    [2m  - waiting for locator('h1')[22m


       6 |     await page.goto("/login");
       7 |
    >  8 |     await expect(page.locator("h1")).toContainText("Multica");
         |                                      ^
       9 |     await expect(page.locator('input[placeholder="Email"]')).toBeVisible();
      10 |     await expect(page.locator('input[placeholder="Name"]')).toBeVisible();
      11 |     await expect(page.locator('button[type="submit"]')).toContainText(
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/auth.spec.ts:8:38

    Error Context: test-results/auth-Authentication-login-page-renders-correctly-chromium/error-context.md

  2) [chromium] › e2e/auth.spec.ts:16:3 › Authentication › login and redirect to /issues ───────────

    Error: [2mexpect([22m[31mlocator[39m[2m).[22mtoBeVisible[2m([22m[2m)[22m failed

    Locator: locator('text=All Issues')
    Expected: visible
    Timeout: 5000ms
    Error: element(s) not found

    Call log:
    [2m  - Expect "toBeVisible" with timeout 5000ms[22m
    [2m  - waiting for locator('text=All Issues')[22m


      18 |
      19 |     await expect(page).toHaveURL(/\/issues/);
    > 20 |     await expect(page.locator("text=All Issues")).toBeVisible();
         |                                                   ^
      21 |   });
      22 |
      23 |   test("unauthenticated user is redirected to /login", async ({ page }) => {
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/auth.spec.ts:20:51

    Error Context: test-results/auth-Authentication-login-and-redirect-to-issues-chromium/error-context.md

  3) [chromium] › e2e/auth.spec.ts:23:3 › Authentication › unauthenticated user is redirected to /login 

    TimeoutError: page.waitForURL: Timeout 10000ms exceeded.
    =========================== logs ===========================
    waiting for navigation to "**/login" until "load"
      navigated to "http://localhost:13340/"
    ============================================================

      29 |
      30 |     await page.goto("/issues");
    > 31 |     await page.waitForURL("**/login", { timeout: 10000 });
         |                ^
      32 |   });
      33 |
      34 |   test("logout redirects to /login", async ({ page }) => {
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/auth.spec.ts:31:16

    Error Context: test-results/auth-Authentication-unauth-fb630-user-is-redirected-to-login-chromium/error-context.md

  4) [chromium] › e2e/auth.spec.ts:34:3 › Authentication › logout redirects to /login ──────────────

    [31mTest timeout of 30000ms exceeded.[39m

    Error: locator.click: Test timeout of 30000ms exceeded.
    Call log:
    [2m  - waiting for locator('aside button').first()[22m


       at helpers.ts:40

      38 | export async function openWorkspaceMenu(page: Page) {
      39 |   // Click the workspace switcher button (has ChevronDown icon)
    > 40 |   await page.locator("aside button").first().click();
         |                                              ^
      41 |   // Wait for dropdown to appear
      42 |   await page.locator('[class*="popover"]').waitFor({ state: "visible" });
      43 | }
        at openWorkspaceMenu (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/helpers.ts:40:46)
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/auth.spec.ts:38:11

    Error Context: test-results/auth-Authentication-logout-redirects-to-login-chromium/error-context.md

  5) [chromium] › e2e/comments.spec.ts:18:3 › Comments › can add a comment on an issue ─────────────

    [31mTest timeout of 30000ms exceeded.[39m

    Error: locator.fill: Test timeout of 30000ms exceeded.
    Call log:
    [2m  - waiting for locator('input[placeholder="Leave a comment..."]')[22m


      31 |       'input[placeholder="Leave a comment..."]',
      32 |     );
    > 33 |     await commentInput.fill(commentText);
         |                        ^
      34 |
      35 |     // Submit the comment
      36 |     await page.locator('form button[type="submit"]').last().click();
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/comments.spec.ts:33:24

    Error Context: test-results/comments-Comments-can-add-a-comment-on-an-issue-chromium/error-context.md

  6) [chromium] › e2e/comments.spec.ts:44:3 › Comments › comment submit button is disabled when empty 

    Error: No verification code found for e2e@multica.ai

       at fixtures.ts:46

      44 |       );
      45 |       if (result.rows.length === 0) {
    > 46 |         throw new Error(`No verification code found for ${email}`);
         |               ^
      47 |       }
      48 |       const code = result.rows[0].code;
      49 |
        at TestApiClient.login (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/fixtures.ts:46:15)
        at createTestApi (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/helpers.ts:33:3)
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/comments.spec.ts:9:11

    TypeError: Cannot read properties of undefined (reading 'cleanup')

      13 |
      14 |   test.afterEach(async () => {
    > 15 |     await api.cleanup();
         |               ^
      16 |   });
      17 |
      18 |   test("can add a comment on an issue", async ({ page }) => {
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/comments.spec.ts:15:15

  7) [chromium] › e2e/issues.spec.ts:17:3 › Issues › issues page loads with board view ─────────────

    Error: [2mexpect([22m[31mlocator[39m[2m).[22mtoBeVisible[2m([22m[2m)[22m failed

    Locator: locator('text=All Issues')
    Expected: visible
    Timeout: 5000ms
    Error: element(s) not found

    Call log:
    [2m  - Expect "toBeVisible" with timeout 5000ms[22m
    [2m  - waiting for locator('text=All Issues')[22m


      16 |
      17 |   test("issues page loads with board view", async ({ page }) => {
    > 18 |     await expect(page.locator("text=All Issues")).toBeVisible();
         |                                                   ^
      19 |
      20 |     // Board columns should be visible
      21 |     await expect(page.locator("text=Backlog")).toBeVisible();
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:18:51

    Error Context: test-results/issues-Issues-issues-page-loads-with-board-view-chromium/error-context.md

  8) [chromium] › e2e/issues.spec.ts:26:3 › Issues › can switch between board and list view ────────

    Error: No verification code found for e2e@multica.ai

       at fixtures.ts:46

      44 |       );
      45 |       if (result.rows.length === 0) {
    > 46 |         throw new Error(`No verification code found for ${email}`);
         |               ^
      47 |       }
      48 |       const code = result.rows[0].code;
      49 |
        at TestApiClient.login (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/fixtures.ts:46:15)
        at createTestApi (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/helpers.ts:33:3)
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:9:11

    TypeError: Cannot read properties of undefined (reading 'cleanup')

      12 |
      13 |   test.afterEach(async () => {
    > 14 |     await api.cleanup();
         |               ^
      15 |   });
      16 |
      17 |   test("issues page loads with board view", async ({ page }) => {
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:14:15

  9) [chromium] › e2e/issues.spec.ts:38:3 › Issues › can create a new issue ────────────────────────

    Error: No verification code found for e2e@multica.ai

       at fixtures.ts:46

      44 |       );
      45 |       if (result.rows.length === 0) {
    > 46 |         throw new Error(`No verification code found for ${email}`);
         |               ^
      47 |       }
      48 |       const code = result.rows[0].code;
      49 |
        at TestApiClient.login (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/fixtures.ts:46:15)
        at createTestApi (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/helpers.ts:33:3)
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:9:11

    TypeError: Cannot read properties of undefined (reading 'cleanup')

      12 |
      13 |   test.afterEach(async () => {
    > 14 |     await api.cleanup();
         |               ^
      15 |   });
      16 |
      17 |   test("issues page loads with board view", async ({ page }) => {
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:14:15

  10) [chromium] › e2e/issues.spec.ts:51:3 › Issues › can navigate to issue detail page ────────────

    Error: No verification code found for e2e@multica.ai

       at fixtures.ts:46

      44 |       );
      45 |       if (result.rows.length === 0) {
    > 46 |         throw new Error(`No verification code found for ${email}`);
         |               ^
      47 |       }
      48 |       const code = result.rows[0].code;
      49 |
        at TestApiClient.login (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/fixtures.ts:46:15)
        at createTestApi (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/helpers.ts:33:3)
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:9:11

    TypeError: Cannot read properties of undefined (reading 'cleanup')

      12 |
      13 |   test.afterEach(async () => {
    > 14 |     await api.cleanup();
         |               ^
      15 |   });
      16 |
      17 |   test("issues page loads with board view", async ({ page }) => {
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:14:15

  11) [chromium] › e2e/issues.spec.ts:74:3 › Issues › can cancel issue creation ────────────────────

    Error: No verification code found for e2e@multica.ai

       at fixtures.ts:46

      44 |       );
      45 |       if (result.rows.length === 0) {
    > 46 |         throw new Error(`No verification code found for ${email}`);
         |               ^
      47 |       }
      48 |       const code = result.rows[0].code;
      49 |
        at TestApiClient.login (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/fixtures.ts:46:15)
        at createTestApi (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/helpers.ts:33:3)
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:9:11

    TypeError: Cannot read properties of undefined (reading 'cleanup')

      12 |
      13 |   test.afterEach(async () => {
    > 14 |     await api.cleanup();
         |               ^
      15 |   });
      16 |
      17 |   test("issues page loads with board view", async ({ page }) => {
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/issues.spec.ts:14:15

  12) [chromium] › e2e/navigation.spec.ts:9:3 › Navigation › sidebar navigation works ──────────────

    [31mTest timeout of 30000ms exceeded.[39m

    Error: locator.click: Test timeout of 30000ms exceeded.
    Call log:
    [2m  - waiting for locator('nav a').filter({ hasText: 'Inbox' })[22m


       9 |   test("sidebar navigation works", async ({ page }) => {
      10 |     // Click Inbox
    > 11 |     await page.locator("nav a", { hasText: "Inbox" }).click();
         |                                                       ^
      12 |     await page.waitForURL("**/inbox");
      13 |     await expect(page).toHaveURL(/\/inbox/);
      14 |
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/navigation.spec.ts:11:55

    Error Context: test-results/navigation-Navigation-sidebar-navigation-works-chromium/error-context.md

  13) [chromium] › e2e/navigation.spec.ts:26:3 › Navigation › settings page loads via workspace menu 

    Error: No verification code found for e2e@multica.ai

       at fixtures.ts:46

      44 |       );
      45 |       if (result.rows.length === 0) {
    > 46 |         throw new Error(`No verification code found for ${email}`);
         |               ^
      47 |       }
      48 |       const code = result.rows[0].code;
      49 |
        at TestApiClient.login (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/fixtures.ts:46:15)
        at loginAsDefault (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/helpers.ts:15:3)
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/navigation.spec.ts:6:5

  14) [chromium] › e2e/navigation.spec.ts:36:3 › Navigation › agents page shows agent list ─────────

    Error: No verification code found for e2e@multica.ai

       at fixtures.ts:46

      44 |       );
      45 |       if (result.rows.length === 0) {
    > 46 |         throw new Error(`No verification code found for ${email}`);
         |               ^
      47 |       }
      48 |       const code = result.rows[0].code;
      49 |
        at TestApiClient.login (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/fixtures.ts:46:15)
        at loginAsDefault (/Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/helpers.ts:15:3)
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/navigation.spec.ts:6:5

  15) [chromium] › e2e/settings.spec.ts:5:3 › Settings › updating workspace name reflects in sidebar immediately 

    [31mTest timeout of 30000ms exceeded.[39m

    Error: locator.innerText: Test timeout of 30000ms exceeded.
    Call log:
    [2m  - waiting for locator('aside button').first()[22m


      10 |     // Read the current workspace name from the sidebar
      11 |     const sidebarName = page.locator("aside button").first();
    > 12 |     const originalName = await sidebarName.innerText();
         |                                            ^
      13 |
      14 |     // Navigate to settings
      15 |     await openWorkspaceMenu(page);
        at /Users/jack/multica_workspaces_local-multica/a15722ff-d053-4176-a269-bdad7e616965/80c4d719/workdir/multica/e2e/settings.spec.ts:12:44

    Error Context: test-results/settings-Settings-updating-67bb0-ects-in-sidebar-immediately-chromium/error-context.md

  15 failed
    [chromium] › e2e/auth.spec.ts:5:3 › Authentication › login page renders correctly ──────────────
    [chromium] › e2e/auth.spec.ts:16:3 › Authentication › login and redirect to /issues ────────────
    [chromium] › e2e/auth.spec.ts:23:3 › Authentication › unauthenticated user is redirected to /login 
    [chromium] › e2e/auth.spec.ts:34:3 › Authentication › logout redirects to /login ───────────────
    [chromium] › e2e/comments.spec.ts:18:3 › Comments › can add a comment on an issue ──────────────
    [chromium] › e2e/comments.spec.ts:44:3 › Comments › comment submit button is disabled when empty 
    [chromium] › e2e/issues.spec.ts:17:3 › Issues › issues page loads with board view ──────────────
    [chromium] › e2e/issues.spec.ts:26:3 › Issues › can switch between board and list view ─────────
    [chromium] › e2e/issues.spec.ts:38:3 › Issues › can create a new issue ─────────────────────────
    [chromium] › e2e/issues.spec.ts:51:3 › Issues › can navigate to issue detail page ──────────────
    [chromium] › e2e/issues.spec.ts:74:3 › Issues › can cancel issue creation ──────────────────────
    [chromium] › e2e/navigation.spec.ts:9:3 › Navigation › sidebar navigation works ────────────────
    [chromium] › e2e/navigation.spec.ts:26:3 › Navigation › settings page loads via workspace menu ─
    [chromium] › e2e/navigation.spec.ts:36:3 › Navigation › agents page shows agent list ───────────
    [chromium] › e2e/settings.spec.ts:5:3 › Settings › updating workspace name reflects in sidebar immediately 


✗ Checks FAILED. *(typecheck, unit tests, and Go tests passed; existing E2E suite failed for pre-existing baseline issues in auth/workspace fixtures and outdated login-page expectations)*