### PR TITLE
feat(agent): add Hermes backend adapter via ACP protocol

### DIFF
--- a/packages/views/issues/components/agent-transcript-dialog.tsx
+++ b/packages/views/issues/components/agent-transcript-dialog.tsx
@@ -422,6 +422,7 @@ function formatProvider(provider: string): string {
     claude: "Claude Code",
     "claude-code": "Claude Code",
     codex: "Codex",
+    hermes: "Hermes",
   };
   return map[provider.toLowerCase()] ?? provider;
 }

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -89,6 +89,16 @@ function OpenClawLogo({ className }: { className: string }) {
   );
 }
 
+// Hermes (NousResearch) — caduceus-inspired mark (☤)
+function HermesLogo({ className }: { className: string }) {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" className={className}>
+      <path d="M7.5 0h1v2h-1zM7 3h2v1H7zM6.5 4.5h3v1h-3zM6 6h4v1H6zM5.5 7.5h5v1h-5zM6 9h4v1H6zM6.5 10.5h3v1h-3zM7 12h2v1H7zM7.5 13.5h1v2h-1z" />
+      <path d="M3 5.5a2.5 2.5 0 0 1 2.5-2.5v1A1.5 1.5 0 0 0 4 5.5 1.5 1.5 0 0 0 5.5 7v1A2.5 2.5 0 0 1 3 5.5zM10.5 3A2.5 2.5 0 0 1 13 5.5 2.5 2.5 0 0 1 10.5 8v-1A1.5 1.5 0 0 0 12 5.5 1.5 1.5 0 0 0 10.5 4z" />
+    </svg>
+  );
+}
+
 export function ProviderLogo({
   provider,
   className = "h-4 w-4",
@@ -105,6 +115,8 @@ export function ProviderLogo({
       return <OpenCodeLogo className={className} />;
     case "openclaw":
       return <OpenClawLogo className={className} />;
+    case "hermes":
+      return <HermesLogo className={className} />;
     default:
       return <Monitor className={className} />;
   }

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	RuntimeName        string
 	CLIVersion         string                // multica CLI version (e.g. "0.1.13")
 	Profile            string                // profile name (empty = default)
-	Agents             map[string]AgentEntry // "claude" -> entry, "codex" -> entry, "opencode" -> entry, "openclaw" -> entry
+	Agents             map[string]AgentEntry // "claude"|"codex"|"opencode"|"openclaw"|"hermes" -> entry
 	WorkspacesRoot     string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask   bool                  // preserve env after task for debugging
 	HealthPort         int                   // local HTTP port for health checks (default: 19514)
@@ -70,7 +70,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 
 	// Probe available agent CLIs
-	agents := map[string]AgentEntry{}
+	agents := map[string]AgentEntry{} // "claude"|"codex"|"opencode"|"openclaw"|"hermes" -> entry
 	claudePath := envOrDefault("MULTICA_CLAUDE_PATH", "claude")
 	if _, err := exec.LookPath(claudePath); err == nil {
 		agents["claude"] = AgentEntry{
@@ -99,8 +99,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
 		}
 	}
+	hermesPath := envOrDefault("MULTICA_HERMES_PATH", "hermes")
+	if _, err := exec.LookPath(hermesPath); err == nil {
+		agents["hermes"] = AgentEntry{
+			Path:  hermesPath,
+			Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+		}
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, opencode, or openclaw and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, opencode, openclaw, or hermes and ensure it is on PATH")
 	}
 
 	// Host info

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -14,6 +14,7 @@ import (
 // Claude:   skills → {workDir}/.claude/skills/{name}/SKILL.md  (native discovery)
 // Codex:    skills → handled separately in Prepare via codex-home
 // OpenCode: skills → {workDir}/.config/opencode/skills/{name}/SKILL.md  (native discovery)
+// Hermes:   skills → {workDir}/.hermes/skills/{name}/SKILL.md  (native discovery)
 // Default:  skills → {workDir}/.agent_context/skills/{name}/SKILL.md
 func writeContextFiles(workDir, provider string, ctx TaskContextForEnv) error {
 	contextDir := filepath.Join(workDir, ".agent_context")
@@ -54,6 +55,9 @@ func resolveSkillsDir(workDir, provider string) (string, error) {
 	case "opencode":
 		// OpenCode natively discovers skills from .config/opencode/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".config", "opencode", "skills")
+	case "hermes":
+		// Hermes natively discovers skills from .hermes/skills/ in the workdir.
+		skillsDir = filepath.Join(workDir, ".hermes", "skills")
 	default:
 		// Fallback: write to .agent_context/skills/ (referenced by meta config).
 		skillsDir = filepath.Join(workDir, ".agent_context", "skills")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -14,13 +14,14 @@ import (
 // For Codex:    writes {workDir}/AGENTS.md  (skills discovered natively via CODEX_HOME)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .config/opencode/skills/)
 // For OpenClaw: writes {workDir}/AGENTS.md  (skills discovered natively from .openclaw/skills/)
+// For Hermes:   writes {workDir}/AGENTS.md  (skills discovered natively from .hermes/skills/)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error {
 	content := buildMetaSkillContent(provider, ctx)
 
 	switch provider {
 	case "claude":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "opencode", "openclaw":
+	case "codex", "opencode", "openclaw", "hermes":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	default:
 		// Unknown provider — skip config injection, prompt-only mode.
@@ -136,7 +137,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "opencode", "openclaw":
+		case "codex", "opencode", "openclaw", "hermes":
 			// Codex, OpenCode, and OpenClaw discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
 		default:

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,5 +1,5 @@
 // Package agent provides a unified interface for executing prompts via
-// coding agents (Claude Code, Codex, OpenCode, OpenClaw). It mirrors the happy-cli AgentBackend
+// coding agents (Claude Code, Codex, OpenCode, OpenClaw, Hermes). It mirrors the happy-cli AgentBackend
 // pattern, translated to idiomatic Go.
 package agent
 
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 )
 
@@ -82,13 +83,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, opencode, or openclaw)
+	ExecutablePath string            // path to CLI binary (claude, codex, opencode, openclaw, or hermes)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "opencode", "openclaw".
+// Supported types: "claude", "codex", "opencode", "openclaw", "hermes".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -103,12 +104,27 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &opencodeBackend{cfg: cfg}, nil
 	case "openclaw":
 		return &openclawBackend{cfg: cfg}, nil
+	case "hermes":
+		return &hermesBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, openclaw)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, openclaw, hermes)", agentType)
 	}
 }
 
 // DetectVersion runs the agent CLI with --version and returns the output.
+// For CLIs with verbose version output (e.g. Hermes), only the short
+// version string is returned.
 func DetectVersion(ctx context.Context, executablePath string) (string, error) {
-	return detectCLIVersion(ctx, executablePath)
+	version, err := detectCLIVersion(ctx, executablePath)
+	if err != nil {
+		return "", err
+	}
+	// Hermes outputs verbose version info; extract just the short version.
+	// e.g. "Hermes Agent v0.6.0 (2026.3.30) Project: /Users/..." → "Hermes Agent v0.6.0"
+	if strings.HasPrefix(version, "Hermes Agent") {
+		if idx := strings.Index(version, ")"); idx != -1 {
+			return strings.TrimSpace(version[:idx+1]), nil
+		}
+	}
+	return version, nil
 }

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -1,0 +1,603 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// hermesBackend implements Backend by spawning `hermes acp` and communicating
+// via JSON-RPC 2.0 over stdin/stdout using the ACP (Agent Client Protocol).
+// The protocol flow mirrors the Codex backend: initialize → session/new →
+// session/prompt, with session/update notifications for streaming output.
+type hermesBackend struct {
+	cfg Config
+}
+
+func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "hermes"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("hermes executable not found at %q: %w", execPath, err)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	cmd := exec.CommandContext(runCtx, execPath, "acp")
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("hermes stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("hermes stdin pipe: %w", err)
+	}
+	cmd.Stderr = newLogWriter(b.cfg.Logger, "[hermes:stderr] ")
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start hermes: %w", err)
+	}
+
+	b.cfg.Logger.Info("hermes started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	var outputMu sync.Mutex
+	var output strings.Builder
+
+	c := &hermesClient{
+		cfg:     b.cfg,
+		stdin:   stdin,
+		pending: make(map[int]*pendingRPC),
+		onMessage: func(msg Message) {
+			if msg.Type == MessageText {
+				outputMu.Lock()
+				output.WriteString(msg.Content)
+				outputMu.Unlock()
+			}
+			trySend(msgCh, msg)
+		},
+	}
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			c.handleLine(line)
+		}
+		c.closeAllPending(fmt.Errorf("hermes process exited"))
+	}()
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+		defer func() {
+			stdin.Close()
+			_ = cmd.Wait()
+		}()
+
+		startTime := time.Now()
+		finalStatus := "completed"
+		var finalError string
+
+		// 1. Initialize handshake (ACP spec: protocolVersion is an integer, not a string).
+		_, err := c.request(runCtx, "initialize", map[string]any{
+			"protocolVersion": 1,
+			"clientInfo": map[string]any{
+				"name":    "multica-agent-sdk",
+				"title":   "Multica Agent SDK",
+				"version": "0.2.0",
+			},
+			"clientCapabilities": map[string]any{
+				"fs": map[string]any{
+					"readTextFile":  false,
+					"writeTextFile": false,
+				},
+				"terminal": false,
+			},
+		})
+		if err != nil {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("hermes initialize failed: %v", err)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		// 2. Create session
+		sessionResult, err := c.request(runCtx, "session/new", map[string]any{
+			"cwd":        opts.Cwd,
+			"mcpServers": []any{},
+		})
+		if err != nil {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("hermes session/new failed: %v", err)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		sessionID := extractHermesSessionID(sessionResult)
+		if sessionID == "" {
+			finalStatus = "failed"
+			finalError = "hermes session/new returned no session ID"
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+		c.sessionID = sessionID
+		b.cfg.Logger.Info("hermes session created", "session_id", sessionID)
+
+		// 3. Send prompt — use session/load if resuming, else session/prompt
+		promptParams := map[string]any{
+			"sessionId": sessionID,
+			"prompt": []map[string]any{
+				{"type": "text", "text": prompt},
+			},
+		}
+
+		if opts.ResumeSessionID != "" {
+			// For resume, use session/load first, then session/prompt.
+			_, loadErr := c.request(runCtx, "session/load", map[string]any{
+				"sessionId":   opts.ResumeSessionID,
+				"cwd":         opts.Cwd,
+				"mcpServers":  []any{},
+			})
+			if loadErr != nil {
+				b.cfg.Logger.Warn("hermes session/load failed, starting fresh", "error", loadErr)
+			}
+		}
+
+		promptResult, err := c.request(runCtx, "session/prompt", promptParams)
+		if err != nil {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("hermes session/prompt failed: %v", err)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		// session/prompt returns after execution completes with a stopReason.
+		// Check for cancellation vs normal completion.
+		stopReason := extractHermesStopReason(promptResult)
+		switch stopReason {
+		case "cancelled":
+			finalStatus = "aborted"
+			finalError = "turn was cancelled"
+		case "max_tokens", "max_turn_requests":
+			finalStatus = "completed"
+		default:
+			// "end_turn" or empty — normal completion.
+		}
+
+		duration := time.Since(startTime)
+		b.cfg.Logger.Info("hermes finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		// Close stdin and cancel to signal the ACP server to exit.
+		stdin.Close()
+		cancel()
+
+		// Wait for the reader goroutine to finish so all output is accumulated.
+		<-readerDone
+
+		outputMu.Lock()
+		finalOutput := output.String()
+		outputMu.Unlock()
+
+		// Build usage map from accumulated hermes usage.
+		var usage map[string]TokenUsage
+		c.usageMu.Lock()
+		u := c.usage
+		c.usageMu.Unlock()
+
+		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 || u.CacheWriteTokens > 0 {
+			model := opts.Model
+			if model == "" {
+				model = "unknown"
+			}
+			usage = map[string]TokenUsage{model: u}
+		}
+
+		resCh <- Result{
+			Status:     finalStatus,
+			Output:     finalOutput,
+			Error:      finalError,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  sessionID,
+			Usage:      usage,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// ── hermesClient: ACP JSON-RPC 2.0 transport ──
+
+type hermesClient struct {
+	cfg       Config
+	stdin     interface{ Write([]byte) (int, error) }
+	mu        sync.Mutex
+	nextID    int
+	pending   map[int]*pendingRPC
+	sessionID string
+	onMessage func(Message)
+
+	usageMu sync.Mutex
+	usage   TokenUsage
+}
+
+func (c *hermesClient) request(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	c.mu.Lock()
+	c.nextID++
+	id := c.nextID
+	pr := &pendingRPC{ch: make(chan rpcResult, 1), method: method}
+	c.pending[id] = pr
+	c.mu.Unlock()
+
+	msg := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, err
+	}
+	data = append(data, '\n')
+	if _, err := c.stdin.Write(data); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, fmt.Errorf("write %s: %w", method, err)
+	}
+
+	select {
+	case res := <-pr.ch:
+		return res.result, res.err
+	case <-ctx.Done():
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, ctx.Err()
+	}
+}
+
+func (c *hermesClient) respond(id int, result any) {
+	msg := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result":  result,
+	}
+	data, _ := json.Marshal(msg)
+	data = append(data, '\n')
+	_, _ = c.stdin.Write(data)
+}
+
+func (c *hermesClient) closeAllPending(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, pr := range c.pending {
+		pr.ch <- rpcResult{err: err}
+		delete(c.pending, id)
+	}
+}
+
+func (c *hermesClient) handleLine(line string) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return
+	}
+
+	// Check if it's a response to our request.
+	if _, hasID := raw["id"]; hasID {
+		if _, hasResult := raw["result"]; hasResult {
+			c.handleResponse(raw)
+			return
+		}
+		if _, hasError := raw["error"]; hasError {
+			c.handleResponse(raw)
+			return
+		}
+		// Server request (has id + method).
+		if _, hasMethod := raw["method"]; hasMethod {
+			c.handleServerRequest(raw)
+			return
+		}
+	}
+
+	// Notification (no id, has method).
+	if _, hasMethod := raw["method"]; hasMethod {
+		c.handleNotification(raw)
+	}
+}
+
+func (c *hermesClient) handleResponse(raw map[string]json.RawMessage) {
+	var id int
+	if err := json.Unmarshal(raw["id"], &id); err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	pr, ok := c.pending[id]
+	if ok {
+		delete(c.pending, id)
+	}
+	c.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	if errData, hasErr := raw["error"]; hasErr {
+		var rpcErr struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(errData, &rpcErr)
+		pr.ch <- rpcResult{err: fmt.Errorf("%s: %s (code=%d)", pr.method, rpcErr.Message, rpcErr.Code)}
+	} else {
+		pr.ch <- rpcResult{result: raw["result"]}
+	}
+}
+
+func (c *hermesClient) handleServerRequest(raw map[string]json.RawMessage) {
+	var id int
+	_ = json.Unmarshal(raw["id"], &id)
+
+	var method string
+	_ = json.Unmarshal(raw["method"], &method)
+
+	// Auto-approve all permission requests in daemon mode.
+	switch method {
+	case "session/request_permission":
+		c.respond(id, map[string]any{
+			"outcome": "allow_once",
+		})
+	default:
+		c.respond(id, map[string]any{})
+	}
+}
+
+func (c *hermesClient) handleNotification(raw map[string]json.RawMessage) {
+	var method string
+	_ = json.Unmarshal(raw["method"], &method)
+
+	var params map[string]any
+	if p, ok := raw["params"]; ok {
+		_ = json.Unmarshal(p, &params)
+	}
+
+	switch method {
+	case "session/update":
+		c.handleSessionUpdate(params)
+	}
+}
+
+// handleSessionUpdate processes ACP session/update notifications, which carry
+// the streaming output from the agent. Per the ACP spec, each notification
+// carries a single update in the "update" field with a "sessionUpdate" type:
+// agent_message_chunk, tool_call, tool_call_update, plan.
+func (c *hermesClient) handleSessionUpdate(params map[string]any) {
+	if params == nil {
+		return
+	}
+
+	// ACP spec: params.update (singular object with sessionUpdate field).
+	update, ok := params["update"].(map[string]any)
+	if !ok {
+		return
+	}
+	c.processSingleUpdate(update)
+}
+
+func (c *hermesClient) processSingleUpdate(update map[string]any) {
+	// ACP spec uses "sessionUpdate" to identify the update kind.
+	updateType, _ := update["sessionUpdate"].(string)
+	// Fallback: some implementations may use "type" instead.
+	if updateType == "" {
+		updateType, _ = update["type"].(string)
+	}
+
+	switch updateType {
+	case "agent_message_chunk":
+		c.handleContentUpdate(update)
+	case "tool_call":
+		c.handleToolCallUpdate(update)
+	case "tool_call_update":
+		c.handleToolCallUpdate(update)
+	case "plan":
+		// Plan updates don't map to messages; skip.
+	}
+}
+
+// handleContentUpdate processes text and thinking content chunks from
+// ACP session/update notifications. The ACP spec sends agent_message_chunk
+// with a "content" field containing a single content block:
+//   {"type": "text", "text": "..."}  or  {"type": "thinking", "text": "..."}
+func (c *hermesClient) handleContentUpdate(update map[string]any) {
+	content, _ := update["content"].(map[string]any)
+	if content == nil {
+		return
+	}
+
+	contentType, _ := content["type"].(string)
+	text, _ := content["text"].(string)
+
+	if text == "" || c.onMessage == nil {
+		return
+	}
+
+	switch contentType {
+	case "thinking":
+		c.onMessage(Message{Type: MessageThinking, Content: text})
+	case "text":
+		c.onMessage(Message{Type: MessageText, Content: text})
+	}
+}
+
+// handleToolCallUpdate processes tool call start and completion events from
+// ACP session/update notifications. ACP uses tool_call for start and
+// tool_call_update for progress/completion.
+func (c *hermesClient) handleToolCallUpdate(update map[string]any) {
+	callID, _ := update["toolCallId"].(string)
+	toolName, _ := update["title"].(string)
+	status, _ := update["status"].(string)
+
+	// For tool_call (start), status may be "pending" or empty.
+	// For tool_call_update, status is "in_progress" or "completed".
+	switch status {
+	case "pending", "":
+		// Tool call started.
+		var input map[string]any
+		if raw, ok := update["input"]; ok {
+			if m, ok := raw.(map[string]any); ok {
+				input = m
+			}
+		}
+		if c.onMessage != nil {
+			c.onMessage(Message{
+				Type:   MessageToolUse,
+				Tool:   toolName,
+				CallID: callID,
+				Input:  input,
+			})
+		}
+	case "in_progress":
+		// Tool is running; no message needed.
+	case "completed", "failed":
+		// Tool call completed. ACP puts results in "content" (array of content blocks).
+		var outputStr string
+		if raw, ok := update["content"]; ok {
+			outputStr = extractACPContentOutput(raw)
+		}
+		if c.onMessage != nil {
+			c.onMessage(Message{
+				Type:   MessageToolResult,
+				Tool:   toolName,
+				CallID: callID,
+				Output: outputStr,
+			})
+		}
+	}
+
+	// Extract token usage from tool call updates if present.
+	c.extractUsageFromUpdate(update)
+}
+
+// extractUsageFromUpdate tries to extract token usage from ACP session/update
+// notifications. Usage data may appear in the _meta field.
+func (c *hermesClient) extractUsageFromUpdate(update map[string]any) {
+	meta, ok := update["_meta"].(map[string]any)
+	if !ok {
+		return
+	}
+	usage, ok := meta["usage"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	c.usageMu.Lock()
+	defer c.usageMu.Unlock()
+	c.usage.InputTokens += hermesInt64(usage, "inputTokens", "input_tokens")
+	c.usage.OutputTokens += hermesInt64(usage, "outputTokens", "output_tokens")
+	c.usage.CacheReadTokens += hermesInt64(usage, "cacheReadTokens", "cache_read_tokens")
+	c.usage.CacheWriteTokens += hermesInt64(usage, "cacheWriteTokens", "cache_write_tokens")
+}
+
+// hermesInt64 safely extracts an int64 from a JSON-decoded map value.
+func hermesInt64(data map[string]any, keys ...string) int64 {
+	for _, key := range keys {
+		v, ok := data[key]
+		if !ok {
+			continue
+		}
+		switch n := v.(type) {
+		case float64:
+			if n != 0 {
+				return int64(n)
+			}
+		case int64:
+			if n != 0 {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+// extractHermesSessionID extracts the session ID from a session/new response.
+func extractHermesSessionID(result json.RawMessage) string {
+	var r struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(result, &r); err != nil {
+		return ""
+	}
+	return r.SessionID
+}
+
+// extractHermesStopReason extracts the stopReason from a session/prompt response.
+func extractHermesStopReason(result json.RawMessage) string {
+	var r struct {
+		StopReason string `json:"stopReason"`
+	}
+	if err := json.Unmarshal(result, &r); err != nil {
+		return ""
+	}
+	return r.StopReason
+}
+
+// extractACPContentOutput extracts text from an ACP tool_call_update content field.
+// ACP content is an array of content blocks, each with {type, content: {type, text}}.
+func extractACPContentOutput(raw any) string {
+	blocks, ok := raw.([]any)
+	if !ok {
+		return extractToolOutput(raw)
+	}
+
+	var parts []string
+	for _, b := range blocks {
+		block, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		// Each block may have a nested "content" object with "text".
+		if inner, ok := block["content"].(map[string]any); ok {
+			if text, ok := inner["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+		}
+		// Or the block itself may have "text" directly.
+		if text, ok := block["text"].(string); ok && text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1,0 +1,532 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+func newTestHermesClient(t *testing.T) (*hermesClient, *fakeStdin, *[]Message) {
+	t.Helper()
+	fs := &fakeStdin{}
+	var mu sync.Mutex
+	messages := &[]Message{}
+
+	c := &hermesClient{
+		cfg:     Config{Logger: slog.Default()},
+		stdin:   fs,
+		pending: make(map[int]*pendingRPC),
+		onMessage: func(msg Message) {
+			mu.Lock()
+			*messages = append(*messages, msg)
+			mu.Unlock()
+		},
+	}
+	return c, fs, messages
+}
+
+func TestNewReturnsHermesBackend(t *testing.T) {
+	t.Parallel()
+	b, err := New("hermes", Config{ExecutablePath: "/nonexistent/hermes"})
+	if err != nil {
+		t.Fatalf("New(hermes) error: %v", err)
+	}
+	if _, ok := b.(*hermesBackend); !ok {
+		t.Fatalf("expected *hermesBackend, got %T", b)
+	}
+}
+
+func TestHermesHandleResponseSuccess(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestHermesClient(t)
+
+	pr := &pendingRPC{ch: make(chan rpcResult, 1), method: "test"}
+	c.mu.Lock()
+	c.pending[1] = pr
+	c.mu.Unlock()
+
+	c.handleLine(`{"jsonrpc":"2.0","id":1,"result":{"sessionId":"ses_123"}}`)
+
+	res := <-pr.ch
+	if res.err != nil {
+		t.Fatalf("expected no error, got %v", res.err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(res.result, &parsed); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if parsed["sessionId"] != "ses_123" {
+		t.Fatalf("expected sessionId=ses_123, got %v", parsed["sessionId"])
+	}
+}
+
+func TestHermesHandleResponseError(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestHermesClient(t)
+
+	pr := &pendingRPC{ch: make(chan rpcResult, 1), method: "test"}
+	c.mu.Lock()
+	c.pending[1] = pr
+	c.mu.Unlock()
+
+	c.handleLine(`{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"bad request"}}`)
+
+	res := <-pr.ch
+	if res.err == nil {
+		t.Fatal("expected error")
+	}
+	if res.result != nil {
+		t.Fatalf("expected nil result, got %v", res.result)
+	}
+}
+
+func TestHermesHandleServerRequestPermissionAutoApproves(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestHermesClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","id":10,"method":"session/request_permission","params":{"options":[{"id":"allow_once","kind":"allow_once"}]}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["id"] != float64(10) {
+		t.Fatalf("expected id=10, got %v", resp["id"])
+	}
+	result := resp["result"].(map[string]any)
+	if result["outcome"] != "allow_once" {
+		t.Fatalf("expected outcome=allow_once, got %v", result["outcome"])
+	}
+}
+
+func TestHermesHandleServerRequestUnknown(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestHermesClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","id":11,"method":"unknown_method","params":{}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	result := resp["result"].(map[string]any)
+	if len(result) != 0 {
+		t.Fatalf("expected empty result, got %v", result)
+	}
+}
+
+func TestHermesSessionUpdateContentText(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	// ACP spec: agent_message_chunk with content object.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Hello from hermes"}}}}`)
+
+	if len(*messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(*messages))
+	}
+	if (*messages)[0].Type != MessageText {
+		t.Errorf("type: got %v, want MessageText", (*messages)[0].Type)
+	}
+	if (*messages)[0].Content != "Hello from hermes" {
+		t.Errorf("content: got %q, want %q", (*messages)[0].Content, "Hello from hermes")
+	}
+}
+
+func TestHermesSessionUpdateContentThinking(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	// ACP spec: thinking content block.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"thinking","text":"Let me think..."}}}}`)
+
+	if len(*messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(*messages))
+	}
+	if (*messages)[0].Type != MessageThinking {
+		t.Errorf("type: got %v, want MessageThinking", (*messages)[0].Type)
+	}
+	if (*messages)[0].Content != "Let me think..." {
+		t.Errorf("content: got %q", (*messages)[0].Content)
+	}
+}
+
+func TestHermesSessionUpdateToolCallStarted(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	// ACP spec: tool_call with toolCallId, title, status pending.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call","toolCallId":"call_1","title":"terminal","kind":"other","status":"pending"}}}`)
+
+	if len(*messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(*messages))
+	}
+	if (*messages)[0].Type != MessageToolUse {
+		t.Errorf("type: got %v, want MessageToolUse", (*messages)[0].Type)
+	}
+	if (*messages)[0].Tool != "terminal" {
+		t.Errorf("tool: got %q, want %q", (*messages)[0].Tool, "terminal")
+	}
+	if (*messages)[0].CallID != "call_1" {
+		t.Errorf("callID: got %q, want %q", (*messages)[0].CallID, "call_1")
+	}
+}
+
+func TestHermesSessionUpdateToolCallCompleted(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	// ACP spec: tool_call_update with status completed and content array.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call_update","toolCallId":"call_1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"file1.go\nfile2.go\n"}}]}}}`)
+
+	if len(*messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(*messages))
+	}
+	if (*messages)[0].Type != MessageToolResult {
+		t.Errorf("type: got %v, want MessageToolResult", (*messages)[0].Type)
+	}
+	if (*messages)[0].CallID != "call_1" {
+		t.Errorf("callID: got %q, want %q", (*messages)[0].CallID, "call_1")
+	}
+	if (*messages)[0].Output != "file1.go\nfile2.go\n" {
+		t.Errorf("output: got %q", (*messages)[0].Output)
+	}
+}
+
+func TestHermesSessionUpdateToolCallFailed(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call_update","toolCallId":"call_2","title":"read_file","status":"failed","content":[{"type":"content","content":{"type":"text","text":"file not found"}}]}}}`)
+
+	if len(*messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(*messages))
+	}
+	if (*messages)[0].Type != MessageToolResult {
+		t.Errorf("type: got %v, want MessageToolResult", (*messages)[0].Type)
+	}
+}
+
+func TestHermesSessionUpdateToolCallNoStatus(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	// tool_call without explicit status should be treated as started.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call","toolCallId":"call_3","title":"write_file","kind":"other"}}}`)
+
+	if len(*messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(*messages))
+	}
+	if (*messages)[0].Type != MessageToolUse {
+		t.Errorf("type: got %v, want MessageToolUse", (*messages)[0].Type)
+	}
+}
+
+func TestHermesSessionUpdateWithUsage(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestHermesClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call_update","toolCallId":"call_4","title":"terminal","status":"completed","content":[],"_meta":{"usage":{"inputTokens":100,"outputTokens":50,"cacheReadTokens":10,"cacheWriteTokens":5}}}}}`)
+
+	c.usageMu.Lock()
+	u := c.usage
+	c.usageMu.Unlock()
+
+	if u.InputTokens != 100 {
+		t.Errorf("InputTokens: got %d, want 100", u.InputTokens)
+	}
+	if u.OutputTokens != 50 {
+		t.Errorf("OutputTokens: got %d, want 50", u.OutputTokens)
+	}
+	if u.CacheReadTokens != 10 {
+		t.Errorf("CacheReadTokens: got %d, want 10", u.CacheReadTokens)
+	}
+	if u.CacheWriteTokens != 5 {
+		t.Errorf("CacheWriteTokens: got %d, want 5", u.CacheWriteTokens)
+	}
+}
+
+func TestHermesSessionUpdateSingularUpdate(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	// Test the singular "update" field path (which is the only ACP spec path).
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"singular update"}}}}`)
+
+	if len(*messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(*messages))
+	}
+	if (*messages)[0].Content != "singular update" {
+		t.Errorf("content: got %q, want %q", (*messages)[0].Content, "singular update")
+	}
+}
+
+func TestHermesSessionUpdateNilParams(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestHermesClient(t)
+
+	// Should not panic.
+	c.handleLine(`{"jsonrpc":"2.0","method":"session/update"}`)
+}
+
+func TestHermesHandleInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestHermesClient(t)
+	// Should not panic.
+	c.handleLine("not json at all")
+	c.handleLine("")
+	c.handleLine("{}")
+}
+
+func TestHermesCloseAllPending(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestHermesClient(t)
+
+	pr1 := &pendingRPC{ch: make(chan rpcResult, 1), method: "m1"}
+	pr2 := &pendingRPC{ch: make(chan rpcResult, 1), method: "m2"}
+	c.mu.Lock()
+	c.pending[1] = pr1
+	c.pending[2] = pr2
+	c.mu.Unlock()
+
+	c.closeAllPending(fmt.Errorf("test error"))
+
+	r1 := <-pr1.ch
+	if r1.err == nil {
+		t.Fatal("expected error for pending 1")
+	}
+	r2 := <-pr2.ch
+	if r2.err == nil {
+		t.Fatal("expected error for pending 2")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.pending) != 0 {
+		t.Fatalf("expected empty pending map, got %d", len(c.pending))
+	}
+}
+
+func TestExtractHermesSessionID(t *testing.T) {
+	t.Parallel()
+
+	data := json.RawMessage(`{"sessionId":"ses_hermes_123"}`)
+	got := extractHermesSessionID(data)
+	if got != "ses_hermes_123" {
+		t.Fatalf("expected ses_hermes_123, got %q", got)
+	}
+}
+
+func TestExtractHermesSessionIDMissing(t *testing.T) {
+	t.Parallel()
+
+	got := extractHermesSessionID(json.RawMessage(`{}`))
+	if got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+}
+
+func TestExtractHermesStopReason(t *testing.T) {
+	t.Parallel()
+
+	data := json.RawMessage(`{"stopReason":"end_turn"}`)
+	got := extractHermesStopReason(data)
+	if got != "end_turn" {
+		t.Fatalf("expected end_turn, got %q", got)
+	}
+}
+
+func TestExtractHermesStopReasonCancelled(t *testing.T) {
+	t.Parallel()
+
+	data := json.RawMessage(`{"stopReason":"cancelled"}`)
+	got := extractHermesStopReason(data)
+	if got != "cancelled" {
+		t.Fatalf("expected cancelled, got %q", got)
+	}
+}
+
+func TestExtractACPContentOutput(t *testing.T) {
+	t.Parallel()
+
+	// ACP content array with nested content objects.
+	input := []any{
+		map[string]any{
+			"type": "content",
+			"content": map[string]any{
+				"type": "text",
+				"text": "result line 1",
+			},
+		},
+		map[string]any{
+			"type": "content",
+			"content": map[string]any{
+				"type": "text",
+				"text": "result line 2",
+			},
+		},
+	}
+
+	got := extractACPContentOutput(input)
+	want := "result line 1\nresult line 2"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExtractACPContentOutputString(t *testing.T) {
+	t.Parallel()
+
+	// Fallback: plain string.
+	got := extractACPContentOutput("plain text")
+	if got != "plain text" {
+		t.Errorf("got %q, want %q", got, "plain text")
+	}
+}
+
+func TestHermesInt64(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data map[string]any
+		keys []string
+		want int64
+	}{
+		{
+			name: "float64 value",
+			data: map[string]any{"inputTokens": float64(100)},
+			keys: []string{"inputTokens"},
+			want: 100,
+		},
+		{
+			name: "int64 value",
+			data: map[string]any{"inputTokens": int64(200)},
+			keys: []string{"inputTokens"},
+			want: 200,
+		},
+		{
+			name: "zero float64 skipped",
+			data: map[string]any{"inputTokens": float64(0)},
+			keys: []string{"inputTokens", "input_tokens"},
+			want: 0,
+		},
+		{
+			name: "fallback key",
+			data: map[string]any{"input_tokens": float64(300)},
+			keys: []string{"inputTokens", "input_tokens"},
+			want: 300,
+		},
+		{
+			name: "missing key",
+			data: map[string]any{},
+			keys: []string{"inputTokens"},
+			want: 0,
+		},
+		{
+			name: "wrong type",
+			data: map[string]any{"inputTokens": "not a number"},
+			keys: []string{"inputTokens"},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hermesInt64(tt.data, tt.keys...); got != tt.want {
+				t.Errorf("hermesInt64() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// ── Full integration test with simulated ACP event stream ──
+
+func TestHermesSessionUpdateHappyPath(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	// Simulate: text -> tool call -> tool result -> text
+	updates := []string{
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Analyzing the issue..."}}}}`,
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call","toolCallId":"call_1","title":"terminal","kind":"other","status":"pending"}}}`,
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"tool_call_update","toolCallId":"call_1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"file.go\n"}}]}}}`,
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":" Done."}}}}`,
+	}
+
+	for _, line := range updates {
+		c.handleLine(line)
+	}
+
+	msgs := *messages
+	if len(msgs) != 4 {
+		t.Fatalf("expected 4 messages, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Type != MessageText || msgs[0].Content != "Analyzing the issue..." {
+		t.Errorf("msg[0]: got %+v", msgs[0])
+	}
+	if msgs[1].Type != MessageToolUse || msgs[1].Tool != "terminal" {
+		t.Errorf("msg[1]: got %+v, want tool-use(terminal)", msgs[1])
+	}
+	if msgs[2].Type != MessageToolResult || msgs[2].Output != "file.go\n" {
+		t.Errorf("msg[2]: got %+v, want tool-result", msgs[2])
+	}
+	if msgs[3].Type != MessageText || msgs[3].Content != " Done." {
+		t.Errorf("msg[3]: got %+v", msgs[3])
+	}
+}
+
+func TestHermesSessionUpdateThinkingAndText(t *testing.T) {
+	t.Parallel()
+
+	c, _, messages := newTestHermesClient(t)
+
+	// Simulate thinking followed by text output.
+	updates := []string{
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"thinking","text":"I need to check the files..."}}}}`,
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"I found the issue."}}}}`,
+	}
+
+	for _, line := range updates {
+		c.handleLine(line)
+	}
+
+	msgs := *messages
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Type != MessageThinking {
+		t.Errorf("msg[0]: got type %v, want MessageThinking", msgs[0].Type)
+	}
+	if msgs[1].Type != MessageText {
+		t.Errorf("msg[1]: got type %v, want MessageText", msgs[1].Type)
+	}
+}


### PR DESCRIPTION
## What
- Adds a Hermes (NousResearch) backend adapter that communicates via the ACP (Agent Client Protocol) over JSON-RPC 2.0/stdio, following the same patterns as the existing Claude, Codex, OpenCode, and OpenClaw adapters.

## Why
- Multica supports multiple coding agent runtimes. Hermes is a popular open-source agent that exposes an ACP server via `hermes acp`.
- Adding native support lets Multica users assign tasks to Hermes agents the same way they use Claude Code or Codex today.

## Type of Change
- [x] New feature

## How to Test
1. Install Hermes and the ACP extra: `pip install -e '.[acp]'`
2. Configure a provider: `hermes model`
3. Start the daemon: `make daemon` — Hermes appears in the Runtimes page with the caduceus logo
4. Create a Hermes agent and assign it a task — verify execution completes and the transcript shows agent messages, tool calls, and thinking
5. Optional: set `MULTICA_HERMES_MODEL=<model>` in `.env` to override the model

## Checklist
- [ ] `make check` passes (typecheck, unit tests, Go tests, E2E) - auth test failures are pre-existing and unrelated to this change
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure (optional)
- Factory.ai (Opus 4.6) was used to implement the adapter, following the patterns of existing adapters (claude.go, codex.go, opencode.go, openclaw.go)
- ACP protocol spec was referenced from agentclientprotocol.com