### PR TITLE
feat(desktop): tab persistence + last-tab close button fix

### DIFF
--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -23,7 +23,7 @@ const TAB_ICONS: Record<string, LucideIcon> = {
   Settings,
 };
 
-function TabItem({ tab, isActive }: { tab: Tab; isActive: boolean }) {
+function TabItem({ tab, isActive, isOnly }: { tab: Tab; isActive: boolean; isOnly: boolean }) {
   const setActiveTab = useTabStore((s) => s.setActiveTab);
   const closeTab = useTabStore((s) => s.closeTab);
 
@@ -62,12 +62,14 @@ function TabItem({ tab, isActive }: { tab: Tab; isActive: boolean }) {
       >
         {tab.title}
       </span>
-      <span
-        onClick={handleClose}
-        className="hidden size-3.5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors group-hover:flex hover:bg-muted-foreground/20 hover:text-foreground"
-      >
-        <X className="size-2.5" />
-      </span>
+      {!isOnly && (
+        <span
+          onClick={handleClose}
+          className="hidden size-3.5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors group-hover:flex hover:bg-muted-foreground/20 hover:text-foreground"
+        >
+          <X className="size-2.5" />
+        </span>
+      )}
     </button>
   );
 }
@@ -103,7 +105,7 @@ export function TabBar() {
       style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
     >
       {tabs.map((tab) => (
-        <TabItem key={tab.id} tab={tab} isActive={tab.id === activeTabId} />
+        <TabItem key={tab.id} tab={tab} isActive={tab.id === activeTabId} isOnly={tabs.length === 1} />
       ))}
       <NewTabButton />
     </div>

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import type { DataRouter } from "react-router-dom";
 import { createTabRouter } from "../routes";
 
@@ -81,7 +82,9 @@ function makeTab(path: string, title: string, icon: string): Tab {
 
 const initialTab = makeTab(DEFAULT_PATH, "Issues", resolveRouteIcon(DEFAULT_PATH));
 
-export const useTabStore = create<TabStore>((set, get) => ({
+export const useTabStore = create<TabStore>()(
+  persist(
+    (set, get) => ({
   tabs: [initialTab],
   activeTabId: initialTab.id,
 
@@ -147,4 +150,36 @@ export const useTabStore = create<TabStore>((set, get) => ({
       ),
     }));
   },
-}));
+    }),
+    {
+      name: "multica_tabs",
+      version: 1,
+      partialize: (state) => ({
+        tabs: state.tabs.map(
+          ({ router, historyIndex, historyLength, ...rest }) => rest,
+        ),
+        activeTabId: state.activeTabId,
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as
+          | Pick<TabStore, "tabs" | "activeTabId">
+          | undefined;
+        if (!persisted?.tabs?.length) return currentState;
+
+        const tabs: Tab[] = persisted.tabs.map((tab) => ({
+          ...tab,
+          router: createTabRouter(tab.path),
+          historyIndex: 0,
+          historyLength: 1,
+        }));
+
+        // Validate activeTabId — fall back to first tab if stale
+        const activeTabId = tabs.some((t) => t.id === persisted.activeTabId)
+          ? persisted.activeTabId
+          : tabs[0].id;
+
+        return { ...currentState, tabs, activeTabId };
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- **Tab state persistence** — open tabs, active tab, and their paths are saved to localStorage via Zustand `persist` middleware. On restart, memory routers are rebuilt from saved paths. History stacks start fresh (same as browser "restore tabs").
- **Hide close button on last tab** — the X button no longer shows on hover when only one tab remains, since closing it just replaces with a default tab.

## Test plan
- [ ] Open multiple tabs → close app → reopen → tabs should be restored
- [ ] Navigate to a sub-page in a tab → restart → tab should show the sub-page
- [ ] Clear localStorage → restart → should fall back to single Issues tab
- [ ] Back/forward should start fresh after restart (no persisted history)
- [ ] Last remaining tab should not show close button on hover
- [ ] With 2+ tabs, close buttons should appear normally on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)