### PR TITLE
fix(daemon): differentiate comment-triggered prompt from assignment prompt

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -50,6 +50,34 @@ func TestBuildPromptContainsIssueID(t *testing.T) {
 	}
 }
 
+func TestBuildPromptCommentTriggered(t *testing.T) {
+	t.Parallel()
+
+	issueID := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	commentID := "c0mment-1d00-0000-0000-000000000000"
+	prompt := BuildPrompt(Task{
+		IssueID:          issueID,
+		TriggerCommentID: commentID,
+		Agent:            &AgentData{Name: "Test"},
+	})
+
+	// Comment-triggered prompt must mention the comment and instruct to read it.
+	for _, want := range []string{
+		commentID,
+		"comment",
+		"multica issue comment list",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("comment-triggered prompt missing %q\nprompt: %s", want, prompt)
+		}
+	}
+
+	// Should NOT contain the generic assignment phrasing.
+	if strings.Contains(prompt, "Start by running `multica issue get") {
+		t.Fatal("comment-triggered prompt should not use the assignment-style phrasing")
+	}
+}
+
 func TestBuildPromptNoIssueDetails(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -12,10 +12,24 @@ func BuildPrompt(task Task) string {
 	if task.ChatSessionID != "" {
 		return buildChatPrompt(task)
 	}
+	if task.TriggerCommentID != "" {
+		return buildCommentPrompt(task)
+	}
 	var b strings.Builder
 	b.WriteString("You are running as a local coding agent for a Multica workspace.\n\n")
 	fmt.Fprintf(&b, "Your assigned issue ID is: %s\n\n", task.IssueID)
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
+	return b.String()
+}
+
+// buildCommentPrompt constructs a prompt for comment-triggered tasks.
+// In resumed sessions the agent already has prior context and may conclude the
+// issue is "already done". This prompt must clearly signal there is a new
+// comment to act on — the detailed workflow lives in CLAUDE.md / AGENTS.md.
+func buildCommentPrompt(task Task) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Respond to comment %s on issue %s.\n\n", task.TriggerCommentID, task.IssueID)
+	fmt.Fprintf(&b, "Run `multica issue comment list %s --output json`, find the comment, act on its request, and reply.\n", task.IssueID)
 	return b.String()
 }
 


### PR DESCRIPTION
## What

Add a dedicated `buildCommentPrompt()` in the daemon so comment-triggered tasks produce a distinct prompt from assignment-triggered tasks.

## Why

`BuildPrompt()` produced the same generic prompt for both assignment and comment triggers: "understand your task, then complete it". In resumed sessions where the agent had prior context, it would check the issue status, see `in_review`, and exit — ignoring the triggering comment entirely (e.g. user asks "add before/after screenshots to the PR", agent replies "no further action needed").

## Type of Change

- [X] Bug fix

## How to Test

  1. Assign an agent to an issue — it completes the task, updates the issue status to `in review` and creates a PR (assignment-triggered prompt)
  2. Post a comment on the same issue requesting additional work (e.g. "add screenshots to the PR")
  3. The agent should now receive: Respond to comment <id> on issue <id>. Run multica issue comment list... instead of the generic assignment prompt
  4. Verify the agent reads and acts on the comment instead of declaring the issue already done

  Unit test:
  `cd server && go test ./internal/daemon/ -run TestBuildPromptCommentTriggered -v`

## Checklist

  - make check passes (typecheck, unit tests, Go tests, E2E)
  - Changes follow existing code patterns and conventions
  - No unrelated changes included

## AI Disclosure (optional)

Fixed by Claude Code (Opus 4.6) and verified with Codex (GPT-5.4)
