### PR TITLE
feat(dx): simplify local dev and self-hosting setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Dependencies
+node_modules
+.pnpm-store
+
+# Build outputs
+.next
+dist
+server/bin
+server/tmp
+
+# Git
+.git
+.gitignore
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test
+e2e/test-results
+coverage
+
+# Docs
+docs/
+
+# Desktop app (not needed for web self-hosting)
+apps/desktop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,10 @@ The architecture relies on a strict split between server state and client state.
 ## Commands
 
 ```bash
-# One-click setup & run
+# One-command dev (auto-setup + start everything)
+make dev              # Auto-creates env, installs deps, starts DB, migrates, launches app
+
+# Explicit setup & run (if you prefer separate steps)
 make setup            # First-time: ensure shared DB, create app DB, migrate
 make start            # Start backend + frontend together
 make stop             # Stop app processes for the current checkout
@@ -73,7 +76,7 @@ pnpm lint             # ESLint
 pnpm test             # TS tests (Vitest, all packages + apps via turbo)
 
 # Backend (Go)
-make dev              # Run Go server (port 8080)
+make server           # Run Go server only (port 8080)
 make daemon           # Run local daemon
 make build            # Build server + CLI binaries to server/bin/
 make cli ARGS="..."   # Run multica CLI (e.g. make cli ARGS="config")
@@ -112,6 +115,8 @@ CI runs on Node 22 and Go 1.26.1 with a `pgvector/pgvector:pg17` PostgreSQL serv
 ### Worktree Support
 
 All checkouts share one PostgreSQL container. Isolation is at the database level — each worktree gets its own DB name and unique ports via `.env.worktree`. Main checkouts use `.env`.
+
+`make dev` auto-detects worktrees and handles everything. For explicit control:
 
 ```bash
 make worktree-env       # Generate .env.worktree with unique DB/ports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,59 +94,52 @@ FORCE=1 make worktree-env
 
 ## First-Time Setup
 
-### Main Checkout
+### Quick Start (recommended)
 
-From the main checkout:
+From any checkout (main or worktree):
+
+```bash
+make dev
+```
+
+This single command:
+
+- auto-detects whether you're in a main checkout or a worktree
+- creates the appropriate env file (`.env` or `.env.worktree`) if it doesn't exist
+- checks that prerequisites (Node.js, pnpm, Go, Docker) are installed
+- installs JavaScript dependencies
+- ensures the shared PostgreSQL container is running
+- creates the application database if it does not exist
+- runs all migrations
+- starts both backend and frontend
+
+### Explicit Setup (advanced)
+
+If you prefer separate control over setup and startup:
+
+#### Main Checkout
 
 ```bash
 cp .env.example .env
 make setup-main
-```
-
-What `make setup-main` does:
-
-- installs JavaScript dependencies with `pnpm install`
-- ensures the shared PostgreSQL container is running
-- creates the application database if it does not exist
-- runs all migrations against that database
-
-Start the app:
-
-```bash
 make start-main
 ```
 
-Stop the app processes:
+Stop:
 
 ```bash
 make stop-main
 ```
 
-This does not stop PostgreSQL.
-
-### Worktree
-
-From the worktree directory:
+#### Worktree
 
 ```bash
 make worktree-env
 make setup-worktree
-```
-
-What `make setup-worktree` does:
-
-- uses `.env.worktree`
-- ensures the shared PostgreSQL container is running
-- creates the worktree database if it does not exist
-- runs migrations against the worktree database
-
-Start the worktree app:
-
-```bash
 make start-worktree
 ```
 
-Stop the worktree app processes:
+Stop:
 
 ```bash
 make stop-worktree
@@ -171,17 +164,15 @@ Use a worktree when you want isolated data and separate app ports.
 ```bash
 git worktree add ../multica-feature -b feat/my-change main
 cd ../multica-feature
-make worktree-env
-make setup-worktree
-make start-worktree
+make dev
 ```
 
 After that, day-to-day commands are:
 
 ```bash
-make start-worktree
-make stop-worktree
-make check-worktree
+make dev              # start (re-runs setup if needed, idempotent)
+make stop-worktree    # stop
+make check-worktree   # verify
 ```
 
 ## Running Main and Worktree at the Same Time
@@ -424,9 +415,7 @@ Warning:
 ### Stable Main Environment
 
 ```bash
-cp .env.example .env
-make setup-main
-make start-main
+make dev
 ```
 
 ### Feature Worktree
@@ -434,9 +423,7 @@ make start-main
 ```bash
 git worktree add ../multica-feature -b feat/my-change main
 cd ../multica-feature
-make worktree-env
-make setup-worktree
-make start-worktree
+make dev
 ```
 
 ### Return to a Previously Configured Worktree

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ COPY --from=builder /src/server/bin/server .
 COPY --from=builder /src/server/bin/multica .
 COPY --from=builder /src/server/bin/migrate .
 COPY server/migrations/ ./migrations/
+COPY docker/entrypoint.sh .
+RUN chmod +x entrypoint.sh
 
 EXPOSE 8080
 
-ENTRYPOINT ["./server"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,70 @@
+# --- Dependencies ---
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+
+WORKDIR /app
+
+# Copy workspace config and all package.json files for dependency resolution
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json ./
+COPY apps/web/package.json apps/web/
+COPY packages/core/package.json packages/core/
+COPY packages/ui/package.json packages/ui/
+COPY packages/views/package.json packages/views/
+COPY packages/tsconfig/package.json packages/tsconfig/
+COPY packages/eslint-config/package.json packages/eslint-config/
+
+RUN pnpm install --frozen-lockfile
+
+# --- Build ---
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
+COPY --from=deps /app/packages/ui/node_modules ./packages/ui/node_modules
+COPY --from=deps /app/packages/views/node_modules ./packages/views/node_modules
+COPY --from=deps /app/packages/tsconfig/node_modules ./packages/tsconfig/node_modules
+COPY --from=deps /app/packages/eslint-config/node_modules ./packages/eslint-config/node_modules
+
+# Copy source
+COPY package.json turbo.json pnpm-workspace.yaml ./
+COPY apps/web/ apps/web/
+COPY packages/ packages/
+
+# Set build-time env: tells Next.js rewrites to proxy API calls to the backend service
+ARG REMOTE_API_URL=http://backend:8080
+ENV REMOTE_API_URL=$REMOTE_API_URL
+ENV STANDALONE=true
+
+# Build the web app (standalone output for minimal runtime)
+RUN pnpm --filter @multica/web build
+
+# --- Runtime ---
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy standalone output (includes traced node_modules)
+COPY --from=builder /app/apps/web/.next/standalone ./
+# Copy static files (not included in standalone)
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+# Copy public assets
+COPY --from=builder /app/apps/web/public ./apps/web/public
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+CMD ["node", "apps/web/server.js"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down
+.PHONY: dev server daemon cli multica build test migrate-up migrate-down sqlc seed clean setup start stop check worktree-env setup-main start-main stop-main check-main setup-worktree start-worktree stop-worktree check-worktree db-up db-down
 
 MAIN_ENV_FILE ?= .env
 WORKTREE_ENV_FILE ?= .env.worktree
@@ -122,8 +122,12 @@ check-worktree:
 
 # ---------- Individual commands ----------
 
-# Go server
+# One-command dev: auto-setup env/deps/db/migrations, then start all services
 dev:
+	@bash scripts/dev.sh
+
+# Go server only
+server:
 	$(REQUIRE_ENV)
 	@bash scripts/ensure-postgres.sh "$(ENV_FILE)"
 	cd server && go run ./cmd/server

--- a/README.md
+++ b/README.md
@@ -58,15 +58,12 @@ The fastest way to get started — no setup required: **[multica.ai](https://mul
 ```bash
 git clone https://github.com/multica-ai/multica.git
 cd multica
-cp .env.example .env
-# Edit .env — at minimum, change JWT_SECRET
-
-docker compose up -d                              # Start PostgreSQL
-cd server && go run ./cmd/migrate up && cd ..     # Run migrations
-make start                                         # Start the app
+make dev    # auto-creates .env, installs deps, starts DB + migrations, launches app
 ```
 
-See the [Self-Hosting Guide](SELF_HOSTING.md) for full instructions.
+That's it — `make dev` handles environment setup, dependency installation, database creation, migrations, and starts both the backend and frontend. Edit `.env` afterward to customize settings (e.g. `JWT_SECRET`).
+
+For explicit control over each step, see the [Self-Hosting Guide](SELF_HOSTING.md).
 
 ## CLI
 
@@ -152,10 +149,9 @@ For contributors working on the Multica codebase, see the [Contributing Guide](C
 **Prerequisites:** [Node.js](https://nodejs.org/) v20+, [pnpm](https://pnpm.io/) v10.28+, [Go](https://go.dev/) v1.26+, [Docker](https://www.docker.com/)
 
 ```bash
-pnpm install
-cp .env.example .env
-make setup
-make start
+make dev
 ```
+
+`make dev` auto-detects your environment (main checkout or worktree), creates the env file, installs dependencies, sets up the database, runs migrations, and starts all services.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow, worktree support, testing, and troubleshooting.

--- a/README.md
+++ b/README.md
@@ -55,15 +55,19 @@ The fastest way to get started — no setup required: **[multica.ai](https://mul
 
 ### Self-Host with Docker
 
+**Prerequisites:** Docker and Docker Compose.
+
 ```bash
 git clone https://github.com/multica-ai/multica.git
 cd multica
-make dev    # auto-creates .env, installs deps, starts DB + migrations, launches app
+cp .env.example .env
+# Edit .env — change JWT_SECRET at minimum
+docker compose -f docker-compose.selfhost.yml up -d
 ```
 
-That's it — `make dev` handles environment setup, dependency installation, database creation, migrations, and starts both the backend and frontend. Edit `.env` afterward to customize settings (e.g. `JWT_SECRET`).
+This builds and starts PostgreSQL, the backend (with auto-migration), and the frontend. Open http://localhost:3000 when ready.
 
-For explicit control over each step, see the [Self-Hosting Guide](SELF_HOSTING.md).
+See the [Self-Hosting Guide](SELF_HOSTING.md) for full configuration, reverse proxy setup, and CLI/daemon instructions.
 
 ## CLI
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -14,14 +14,9 @@ Multica has three components:
 
 Additionally, each user who wants to run AI agents locally installs the **`multica` CLI** and runs the **agent daemon** on their own machine.
 
-## Prerequisites
-
-- Docker and Docker Compose (recommended), or:
-  - Go 1.26+ (to build from source)
-  - Node.js 20+ and pnpm 10.28+ (to build the frontend)
-  - PostgreSQL 17 with the pgvector extension
-
 ## Quick Start (Docker Compose)
+
+**Prerequisites:** Docker and Docker Compose.
 
 ```bash
 git clone https://github.com/multica-ai/multica.git
@@ -29,32 +24,33 @@ cd multica
 cp .env.example .env
 ```
 
-Edit `.env` with your production values (see [Configuration](#configuration) below), then:
+Edit `.env` — at minimum, change `JWT_SECRET`:
 
 ```bash
-# Start PostgreSQL
-docker compose up -d
-
-# Build the backend
-make build
-
-# Run database migrations
-DATABASE_URL="your-database-url" ./server/bin/migrate up
-
-# Start the backend server
-DATABASE_URL="your-database-url" PORT=8080 ./server/bin/server
+JWT_SECRET=$(openssl rand -hex 32)
 ```
 
-For the frontend:
+Then start everything:
 
 ```bash
-pnpm install
-pnpm build
-
-# Start the frontend (production mode)
-cd apps/web
-REMOTE_API_URL=http://localhost:8080 pnpm start
+docker compose -f docker-compose.selfhost.yml up -d
 ```
+
+That's it. This builds and starts PostgreSQL, the backend (with auto-migration), and the frontend:
+
+- **Frontend:** http://localhost:3000
+- **Backend API:** http://localhost:8080
+
+The backend automatically runs database migrations on startup — no manual migration step needed.
+
+### Rebuilding After Updates
+
+```bash
+git pull
+docker compose -f docker-compose.selfhost.yml up -d --build
+```
+
+Migrations run automatically on each backend startup.
 
 ## Configuration
 
@@ -122,25 +118,23 @@ These are configured on each user's machine, not on the server:
 
 Multica requires PostgreSQL 17 with the pgvector extension.
 
-### Using the Included Docker Compose
+### Using Docker Compose (Recommended)
 
-```bash
-docker compose up -d postgres
-```
-
-This starts a `pgvector/pgvector:pg17` container on port 5432 with default credentials (`multica`/`multica`).
+The `docker-compose.selfhost.yml` includes PostgreSQL. No separate setup needed.
 
 ### Using Your Own PostgreSQL
 
-Ensure the pgvector extension is available:
+If you prefer to use an existing PostgreSQL instance, ensure the pgvector extension is available:
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS vector;
 ```
 
-### Running Migrations
+Set `DATABASE_URL` in your `.env` and remove the `postgres` service from the compose file.
 
-Migrations must be run before starting the server:
+### Running Migrations Manually
+
+The Docker Compose setup runs migrations automatically. If you need to run them manually:
 
 ```bash
 # Using the built binary
@@ -148,6 +142,36 @@ Migrations must be run before starting the server:
 
 # Or from source
 cd server && go run ./cmd/migrate up
+```
+
+## Manual Setup (Without Docker Compose)
+
+If you prefer to build and run services manually:
+
+**Prerequisites:** Go 1.26+, Node.js 20+, pnpm 10.28+, PostgreSQL 17 with pgvector.
+
+```bash
+# Start your PostgreSQL (or use: docker compose up -d postgres)
+
+# Build the backend
+make build
+
+# Run database migrations
+DATABASE_URL="your-database-url" ./server/bin/migrate up
+
+# Start the backend server
+DATABASE_URL="your-database-url" PORT=8080 JWT_SECRET="your-secret" ./server/bin/server
+```
+
+For the frontend:
+
+```bash
+pnpm install
+pnpm build
+
+# Start the frontend (production mode)
+cd apps/web
+REMOTE_API_URL=http://localhost:8080 pnpm start
 ```
 
 ## Reverse Proxy
@@ -221,7 +245,7 @@ When using separate domains for frontend and backend, set these environment vari
 FRONTEND_ORIGIN=https://app.example.com
 CORS_ALLOWED_ORIGINS=https://app.example.com
 
-# Frontend
+# Frontend (set before building the frontend image)
 REMOTE_API_URL=https://api.example.com
 NEXT_PUBLIC_API_URL=https://api.example.com
 NEXT_PUBLIC_WS_URL=wss://api.example.com/ws
@@ -279,8 +303,9 @@ The daemon auto-detects installed agent CLIs and registers itself with the serve
 
 ## Upgrading
 
-1. Pull the latest code or image
-2. Run migrations: `./server/bin/migrate up`
-3. Restart the backend and frontend
+```bash
+git pull
+docker compose -f docker-compose.selfhost.yml up -d --build
+```
 
-Migrations are forward-only and safe to run on a live database. They are idempotent — running them multiple times has no effect.
+Migrations run automatically on backend startup. They are idempotent — running them multiple times has no effect.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -22,6 +22,7 @@ const allowedDevOrigins = process.env.CORS_ALLOWED_ORIGINS
   : undefined;
 
 const nextConfig: NextConfig = {
+  ...(process.env.STANDALONE === "true" ? { output: "standalone" as const } : {}),
   transpilePackages: ["@multica/core", "@multica/ui", "@multica/views"],
   ...(allowedDevOrigins && allowedDevOrigins.length > 0
     ? { allowedDevOrigins }

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -1,0 +1,72 @@
+# Self-hosting Docker Compose — starts PostgreSQL, backend, and frontend.
+#
+# Usage:
+#   cp .env.example .env
+#   # Edit .env — change JWT_SECRET at minimum
+#   docker compose -f docker-compose.selfhost.yml up -d
+#
+# Frontend: http://localhost:3000
+# Backend:  http://localhost:8080 (also used by CLI/daemon)
+
+name: multica
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-multica}
+      POSTGRES_USER: ${POSTGRES_USER:-multica}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-multica}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-multica} -d ${POSTGRES_DB:-multica}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "${PORT:-8080}:8080"
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-multica}:${POSTGRES_PASSWORD:-multica}@postgres:5432/${POSTGRES_DB:-multica}?sslmode=disable
+      PORT: "8080"
+      JWT_SECRET: ${JWT_SECRET:-change-me-in-production}
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-http://localhost:3000}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-noreply@multica.ai}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-http://localhost:3000/auth/callback}
+      S3_BUCKET: ${S3_BUCKET:-}
+      S3_REGION: ${S3_REGION:-us-west-2}
+      CLOUDFRONT_DOMAIN: ${CLOUDFRONT_DOMAIN:-}
+      CLOUDFRONT_KEY_PAIR_ID: ${CLOUDFRONT_KEY_PAIR_ID:-}
+      CLOUDFRONT_PRIVATE_KEY: ${CLOUDFRONT_PRIVATE_KEY:-}
+      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
+      MULTICA_APP_URL: ${MULTICA_APP_URL:-http://localhost:3000}
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+      args:
+        REMOTE_API_URL: http://backend:8080
+    depends_on:
+      - backend
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+    environment:
+      HOSTNAME: "0.0.0.0"
+
+volumes:
+  pgdata:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+./migrate up
+
+echo "Starting server..."
+exec ./server

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---------- Check prerequisites ----------
+missing=()
+command -v node >/dev/null 2>&1 || missing+=("node")
+command -v pnpm >/dev/null 2>&1 || missing+=("pnpm")
+command -v go >/dev/null 2>&1 || missing+=("go")
+command -v docker >/dev/null 2>&1 || missing+=("docker")
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "✗ Missing prerequisites: ${missing[*]}"
+  echo "  Please install: Node.js v20+, pnpm v10.28+, Go v1.26+, Docker"
+  exit 1
+fi
+
+# ---------- Environment file ----------
+if [ -f .git ]; then
+  # Inside a git worktree (.git is a file, not a directory)
+  ENV_FILE=".env.worktree"
+  if [ ! -f "$ENV_FILE" ]; then
+    echo "==> Worktree detected. Generating $ENV_FILE..."
+    bash scripts/init-worktree-env.sh "$ENV_FILE"
+  fi
+else
+  ENV_FILE=".env"
+  if [ ! -f "$ENV_FILE" ]; then
+    echo "==> Creating $ENV_FILE from .env.example..."
+    cp .env.example "$ENV_FILE"
+  fi
+fi
+
+echo "==> Using $ENV_FILE"
+
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+# ---------- Install dependencies ----------
+if [ ! -d node_modules ]; then
+  echo "==> Installing dependencies..."
+  pnpm install
+fi
+
+# ---------- Database ----------
+bash scripts/ensure-postgres.sh "$ENV_FILE"
+
+echo "==> Running migrations..."
+(cd server && go run ./cmd/migrate up)
+
+# ---------- Start services ----------
+echo ""
+echo "✓ Ready. Starting services..."
+echo "  Backend:  http://localhost:${PORT:-8080}"
+echo "  Frontend: http://localhost:${FRONTEND_PORT:-3000}"
+echo ""
+
+trap 'kill 0' EXIT
+(cd server && go run ./cmd/server) &
+pnpm dev:web &
+wait

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -20,6 +20,14 @@ import (
 func main() {
 	logger.Init()
 
+	// Warn about missing configuration
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Warn("JWT_SECRET is not set — using insecure default. Set JWT_SECRET for production use.")
+	}
+	if os.Getenv("RESEND_API_KEY") == "" {
+		slog.Warn("RESEND_API_KEY is not set — email verification codes will be printed to the log instead of emailed.")
+	}
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"


### PR DESCRIPTION
## Summary

Two improvements to simplify local deployment:

### 1. Developer experience: `make dev` (commit 1)
- Added `scripts/dev.sh` — auto-detects environment, creates env file, installs deps, starts DB + migrations, launches all services
- One command from fresh clone to running app: `make dev`

### 2. Self-hosting: Docker Compose full stack (commit 2)
- Added `docker-compose.selfhost.yml` with PostgreSQL + backend + frontend
- Backend auto-runs migrations on startup via `docker/entrypoint.sh`
- Frontend uses Next.js standalone output for minimal Docker image (`Dockerfile.web`)
- One command to deploy: `docker compose -f docker-compose.selfhost.yml up -d`

**Before (self-hosting):**
```bash
cp .env.example .env
docker compose up -d
make build
./server/bin/migrate up
./server/bin/server &
pnpm install && pnpm build
cd apps/web && pnpm start
```

**After (self-hosting):**
```bash
cp .env.example .env
docker compose -f docker-compose.selfhost.yml up -d
```

## Files changed

| File | Purpose |
|------|---------|
| `scripts/dev.sh` | One-command dev setup script |
| `Makefile` | New `dev` target, old `dev` → `server` |
| `docker-compose.selfhost.yml` | Full stack Docker Compose for self-hosting |
| `Dockerfile` | Added entrypoint for auto-migration |
| `Dockerfile.web` | Multi-stage Next.js frontend build |
| `docker/entrypoint.sh` | Runs migrations then starts server |
| `.dockerignore` | Exclude unnecessary files from Docker builds |
| `apps/web/next.config.ts` | Conditional standalone output for Docker |
| `SELF_HOSTING.md` | Rewritten with Docker Compose first |
| `README.md` | Updated getting started sections |
| `CONTRIBUTING.md` | Updated with `make dev` workflow |
| `CLAUDE.md` | Updated command reference |

## Test plan

- [ ] `make dev` in fresh clone — auto-setup and start
- [ ] `make dev` in worktree — auto-detect and use .env.worktree
- [ ] `docker compose -f docker-compose.selfhost.yml up -d` — builds and starts all 3 services
- [ ] Backend auto-migrates on startup
- [ ] Frontend proxies API calls to backend via Next.js rewrites
- [ ] Ctrl+C `make dev` cleans up child processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)