### PR TITLE
fix(agents): invalidate runtimes cache on daemon events

### DIFF
--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -9,6 +9,7 @@ import type { WorkspaceStore } from "../workspace/store";
 import { createLogger } from "../logger";
 import { issueKeys } from "../issues/queries";
 import { projectKeys } from "../projects/queries";
+import { runtimeKeys } from "../runtimes/queries";
 import {
   onIssueCreated,
   onIssueUpdated,
@@ -54,7 +55,8 @@ export interface RealtimeSyncStores {
  *
  * Per-issue events (comments, activity, reactions, subscribers) are handled
  * both here (invalidation fallback) and by per-page useWSEvent hooks (granular
- * updates). Daemon events are handled by individual components only.
+ * updates). Daemon register events invalidate runtimes globally; heartbeats
+ * are skipped to avoid excessive refetches.
  *
  * @param ws - WebSocket client instance (null when not yet connected)
  * @param stores - Platform-created Zustand store instances for auth and workspace
@@ -95,6 +97,10 @@ export function useRealtimeSync(
         const wsId = workspaceStore.getState().workspace?.id;
         if (wsId) qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
       },
+      daemon: () => {
+        const wsId = workspaceStore.getState().workspace?.id;
+        if (wsId) qc.invalidateQueries({ queryKey: runtimeKeys.all(wsId) });
+      },
     };
 
     const timers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -118,6 +124,7 @@ export function useRealtimeSync(
       "reaction:added", "reaction:removed",
       "issue_reaction:added", "issue_reaction:removed",
       "subscriber:added", "subscriber:removed",
+      "daemon:heartbeat",
     ]);
 
     const unsubAny = ws.onAny((msg) => {
@@ -300,6 +307,7 @@ export function useRealtimeSync(
           qc.invalidateQueries({ queryKey: workspaceKeys.members(wsId) });
           qc.invalidateQueries({ queryKey: workspaceKeys.skills(wsId) });
           qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
+          qc.invalidateQueries({ queryKey: runtimeKeys.all(wsId) });
         }
         qc.invalidateQueries({ queryKey: workspaceKeys.list() });
       } catch (e) {

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -30,7 +30,7 @@ export function AgentsPage() {
   const [selectedId, setSelectedId] = useState<string>("");
   const [showArchived, setShowArchived] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
-  const { data: runtimes = [] } = useQuery(runtimeListOptions(wsId));
+  const { data: runtimes = [], isLoading: runtimesLoading } = useQuery(runtimeListOptions(wsId));
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "multica_agents_layout",
   });
@@ -224,6 +224,7 @@ export function AgentsPage() {
       {showCreate && (
         <CreateAgentDialog
           runtimes={runtimes}
+          runtimesLoading={runtimesLoading}
           onClose={() => setShowCreate(false)}
           onCreate={handleCreate}
         />

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   Globe,
   Lock,
+  Loader2,
 } from "lucide-react";
 import type {
   AgentVisibility,
@@ -33,10 +34,12 @@ import { toast } from "sonner";
 
 export function CreateAgentDialog({
   runtimes,
+  runtimesLoading,
   onClose,
   onCreate,
 }: {
   runtimes: RuntimeDevice[];
+  runtimesLoading?: boolean;
   onClose: () => void;
   onCreate: (data: CreateAgentRequest) => Promise<void>;
 }) {
@@ -147,10 +150,12 @@ export function CreateAgentDialog({
             <Label className="text-xs text-muted-foreground">Runtime</Label>
             <Popover open={runtimeOpen} onOpenChange={setRuntimeOpen}>
               <PopoverTrigger
-                disabled={runtimes.length === 0}
+                disabled={runtimes.length === 0 && !runtimesLoading}
                 className="flex w-full items-center gap-3 rounded-lg border border-border bg-background px-3 py-2.5 mt-1.5 text-left text-sm transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
               >
-                {selectedRuntime?.runtime_mode === "cloud" ? (
+                {runtimesLoading ? (
+                  <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+                ) : selectedRuntime?.runtime_mode === "cloud" ? (
                   <Cloud className="h-4 w-4 shrink-0 text-muted-foreground" />
                 ) : (
                   <Monitor className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -158,7 +163,7 @@ export function CreateAgentDialog({
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="truncate font-medium">
-                      {selectedRuntime?.name ?? "No runtime available"}
+                      {runtimesLoading ? "Loading runtimes..." : (selectedRuntime?.name ?? "No runtime available")}
                     </span>
                     {selectedRuntime?.runtime_mode === "cloud" && (
                       <span className="shrink-0 rounded bg-info/10 px-1.5 py-0.5 text-xs font-medium text-info">


### PR DESCRIPTION
## Summary

Fixes https://github.com/multica-ai/multica/issues/615

- The Agents page never received runtime cache updates when daemons registered/deregistered. The centralized `useRealtimeSync` had no `daemon` entry in its refresh map, so `daemon:register` events were silently dropped — only the Runtimes page (which had its own `useWSEvent` handler) stayed fresh.
- Added `daemon` to the global refresh map so all pages (Agents, Settings, etc.) get updated runtimes when a daemon registers.
- Skipped `daemon:heartbeat` in the generic handler to avoid refetching every 15 seconds.
- Added runtimes invalidation on WS reconnect (was missing alongside agents, members, skills, projects).
- Added a loading indicator in the Create Agent dialog so users see "Loading runtimes..." instead of the misleading "No runtime available" while the query is in flight.

## Test plan

- [ ] Register a local runtime, then open the Agents page — Create Agent dialog should show the runtime
- [ ] Open the Agents page first, then register a runtime — the Create Agent dialog should update automatically
- [ ] Open the Create Agent dialog while runtimes are loading — should show spinner and "Loading runtimes..."
- [ ] Verify the Runtimes page still works as before (has its own `useWSEvent` handler which still fires)