### PR TITLE
feat(daemon): add minimum Claude Code version check

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -235,6 +235,10 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 			d.logger.Warn("skip registering runtime", "name", name, "error", err)
 			continue
 		}
+		if err := agent.CheckMinVersion(name, version); err != nil {
+			d.logger.Warn("skip registering runtime: version too old", "name", name, "version", version, "error", err)
+			continue
+		}
 		displayName := strings.ToUpper(name[:1]) + name[1:]
 		if d.cfg.DeviceName != "" {
 			displayName = fmt.Sprintf("%s (%s)", displayName, d.cfg.DeviceName)

--- a/server/pkg/agent/version.go
+++ b/server/pkg/agent/version.go
@@ -10,6 +10,7 @@ import (
 // Versions below these will be rejected during daemon registration.
 var MinVersions = map[string]string{
 	"claude": "2.0.0",
+	"codex":  "0.100.0", // app-server --listen stdio:// added in 0.100.0
 }
 
 // semver holds a parsed semantic version (major.minor.patch).

--- a/server/pkg/agent/version.go
+++ b/server/pkg/agent/version.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// MinVersions defines the minimum required CLI version for each agent type.
+// Versions below these will be rejected during daemon registration.
+var MinVersions = map[string]string{
+	"claude": "2.0.0",
+}
+
+// semver holds a parsed semantic version (major.minor.patch).
+type semver struct {
+	Major, Minor, Patch int
+}
+
+// versionRe matches version strings like "2.1.100", "v2.0.0", or
+// "2.1.100 (Claude Code)" — it extracts the first three numeric components.
+var versionRe = regexp.MustCompile(`v?(\d+)\.(\d+)\.(\d+)`)
+
+// parseSemver extracts a semver from a version string.
+func parseSemver(raw string) (semver, error) {
+	m := versionRe.FindStringSubmatch(raw)
+	if m == nil {
+		return semver{}, fmt.Errorf("cannot parse version %q", raw)
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	patch, _ := strconv.Atoi(m[3])
+	return semver{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// lessThan returns true if v < other.
+func (v semver) lessThan(other semver) bool {
+	if v.Major != other.Major {
+		return v.Major < other.Major
+	}
+	if v.Minor != other.Minor {
+		return v.Minor < other.Minor
+	}
+	return v.Patch < other.Patch
+}
+
+// CheckMinVersion validates that detectedVersion meets the minimum for agentType.
+// Returns nil if the version is acceptable or no minimum is defined.
+func CheckMinVersion(agentType, detectedVersion string) error {
+	minRaw, ok := MinVersions[agentType]
+	if !ok {
+		return nil
+	}
+	min, err := parseSemver(minRaw)
+	if err != nil {
+		return fmt.Errorf("invalid minimum version %q for %s: %w", minRaw, agentType, err)
+	}
+	detected, err := parseSemver(detectedVersion)
+	if err != nil {
+		return fmt.Errorf("cannot parse detected %s version %q: %w", agentType, detectedVersion, err)
+	}
+	if detected.lessThan(min) {
+		return fmt.Errorf("%s version %s is below minimum required %s — please upgrade", agentType, detectedVersion, minRaw)
+	}
+	return nil
+}

--- a/server/pkg/agent/version_test.go
+++ b/server/pkg/agent/version_test.go
@@ -13,6 +13,7 @@ func TestParseSemver(t *testing.T) {
 		{"2.0.0", semver{2, 0, 0}, false},
 		{"v2.1.100", semver{2, 1, 100}, false},
 		{"2.1.100 (Claude Code)", semver{2, 1, 100}, false},
+		{"codex-cli 0.118.0", semver{0, 118, 0}, false},
 		{"1.0.20", semver{1, 0, 20}, false},
 		{"invalid", semver{}, true},
 		{"", semver{}, true},
@@ -63,7 +64,10 @@ func TestCheckMinVersion(t *testing.T) {
 		{"claude", "1.0.128", true},
 		{"claude", "1.9.99", true},
 		{"claude", "invalid", true},
-		{"codex", "0.0.1", false}, // no minimum defined for codex
+		{"codex", "codex-cli 0.118.0", false},
+		{"codex", "codex-cli 0.100.0", false},
+		{"codex", "codex-cli 0.99.0", true},
+		{"codex", "codex-cli 0.50.0", true},
 		{"unknown", "1.0.0", false},
 	}
 	for _, tt := range tests {

--- a/server/pkg/agent/version_test.go
+++ b/server/pkg/agent/version_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    semver
+		wantErr bool
+	}{
+		{"2.0.0", semver{2, 0, 0}, false},
+		{"v2.1.100", semver{2, 1, 100}, false},
+		{"2.1.100 (Claude Code)", semver{2, 1, 100}, false},
+		{"1.0.20", semver{1, 0, 20}, false},
+		{"invalid", semver{}, true},
+		{"", semver{}, true},
+	}
+	for _, tt := range tests {
+		got, err := parseSemver(tt.input)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("parseSemver(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseSemver(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSemverLessThan(t *testing.T) {
+	tests := []struct {
+		a, b semver
+		want bool
+	}{
+		{semver{1, 0, 0}, semver{2, 0, 0}, true},
+		{semver{2, 0, 0}, semver{1, 0, 0}, false},
+		{semver{2, 0, 0}, semver{2, 1, 0}, true},
+		{semver{2, 1, 0}, semver{2, 0, 0}, false},
+		{semver{2, 1, 12}, semver{2, 1, 13}, true},
+		{semver{2, 1, 13}, semver{2, 1, 12}, false},
+		{semver{2, 0, 0}, semver{2, 0, 0}, false},
+	}
+	for _, tt := range tests {
+		got := tt.a.lessThan(tt.b)
+		if got != tt.want {
+			t.Errorf("%v.lessThan(%v) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCheckMinVersion(t *testing.T) {
+	tests := []struct {
+		agentType string
+		version   string
+		wantErr   bool
+	}{
+		{"claude", "2.0.0", false},
+		{"claude", "2.1.100", false},
+		{"claude", "2.1.100 (Claude Code)", false},
+		{"claude", "v2.0.0", false},
+		{"claude", "1.0.128", true},
+		{"claude", "1.9.99", true},
+		{"claude", "invalid", true},
+		{"codex", "0.0.1", false}, // no minimum defined for codex
+		{"unknown", "1.0.0", false},
+	}
+	for _, tt := range tests {
+		err := CheckMinVersion(tt.agentType, tt.version)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("CheckMinVersion(%q, %q) error = %v, wantErr %v", tt.agentType, tt.version, err, tt.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds version parsing and comparison utilities to `server/pkg/agent/`
- Daemon now validates detected Claude Code CLI version >= 2.0.0 before registering a runtime
- Versions below minimum are skipped with a warning log, preventing silent failures where old CLI versions don't support required flags (`--output-format stream-json`, `--permission-mode bypassPermissions`)

## Context
Users reported agents stuck on "waiting for events" with no logs (GitHub #569). Root cause was Claude Code versions too old to support the CLI flags the daemon passes. This adds a proactive check during registration.

## Test plan
- [x] Unit tests for semver parsing, comparison, and `CheckMinVersion`
- [x] Go build passes
- [ ] CI