### PR TITLE
fix(daemon): symlink Codex sessions to shared home

### DIFF
--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -8,6 +8,13 @@ import (
 	"path/filepath"
 )
 
+// Directories to symlink from the shared ~/.codex/ into the per-task CODEX_HOME.
+// The shared directory is created if it doesn't exist, ensuring Codex session
+// logs are always written to the global home where users can find them.
+var codexSymlinkedDirs = []string{
+	"sessions",
+}
+
 // Files to symlink from the shared ~/.codex/ into the per-task CODEX_HOME.
 // Symlinks share state (e.g. auth tokens) so changes propagate automatically.
 var codexSymlinkedFiles = []string{
@@ -30,6 +37,15 @@ func prepareCodexHome(codexHome string, logger *slog.Logger) error {
 
 	if err := os.MkdirAll(codexHome, 0o755); err != nil {
 		return fmt.Errorf("create codex-home dir: %w", err)
+	}
+
+	// Symlink shared directories (sessions) so logs stay in the global home.
+	for _, name := range codexSymlinkedDirs {
+		src := filepath.Join(sharedHome, name)
+		dst := filepath.Join(codexHome, name)
+		if err := ensureDirSymlink(src, dst); err != nil {
+			logger.Warn("execenv: codex-home dir symlink failed", "dir", name, "error", err)
+		}
 	}
 
 	// Symlink shared files (auth).
@@ -67,6 +83,31 @@ func resolveSharedCodexHome() string {
 		return filepath.Join("/tmp", ".codex") // last resort fallback
 	}
 	return filepath.Join(home, ".codex")
+}
+
+// ensureDirSymlink creates a symlink dst → src for a directory.
+// Unlike ensureSymlink, it creates the source directory if it doesn't exist,
+// so Codex can write to it immediately.
+func ensureDirSymlink(src, dst string) error {
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		return fmt.Errorf("create shared dir %s: %w", src, err)
+	}
+
+	// Check if dst already exists.
+	if fi, err := os.Lstat(dst); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(dst)
+			if err == nil && target == src {
+				return nil // already correct
+			}
+			os.Remove(dst)
+		} else {
+			// Regular file/dir exists — don't overwrite.
+			return nil
+		}
+	}
+
+	return os.Symlink(src, dst)
 }
 
 // ensureSymlink creates a symlink dst → src. If src doesn't exist, it's a no-op.

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -617,9 +617,23 @@ func TestPrepareCodexHomeSeedsFromShared(t *testing.T) {
 		t.Fatalf("prepareCodexHome failed: %v", err)
 	}
 
+	// sessions should be a symlink to the shared sessions dir.
+	sessionsPath := filepath.Join(codexHome, "sessions")
+	fi, err := os.Lstat(sessionsPath)
+	if err != nil {
+		t.Fatalf("sessions not found: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("sessions should be a symlink")
+	}
+	sessTarget, _ := os.Readlink(sessionsPath)
+	if sessTarget != filepath.Join(sharedHome, "sessions") {
+		t.Errorf("sessions symlink target = %q, want %q", sessTarget, filepath.Join(sharedHome, "sessions"))
+	}
+
 	// auth.json should be a symlink.
 	authPath := filepath.Join(codexHome, "auth.json")
-	fi, err := os.Lstat(authPath)
+	fi, err = os.Lstat(authPath)
 	if err != nil {
 		t.Fatalf("auth.json not found: %v", err)
 	}
@@ -675,17 +689,26 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 		t.Fatalf("prepareCodexHome failed: %v", err)
 	}
 
-	// Directory should exist but be empty (no auth.json, no config.json, etc.).
+	// Directory should only contain the sessions symlink (no auth.json, no config.json, etc.).
 	entries, err := os.ReadDir(codexHome)
 	if err != nil {
 		t.Fatalf("failed to read codex-home: %v", err)
 	}
-	if len(entries) != 0 {
+	if len(entries) != 1 {
 		names := make([]string, len(entries))
 		for i, e := range entries {
 			names[i] = e.Name()
 		}
-		t.Errorf("expected empty codex-home, got: %v", names)
+		t.Errorf("expected only sessions symlink in codex-home, got: %v", names)
+	}
+	// sessions should be a symlink to the shared sessions dir.
+	sessionsPath := filepath.Join(codexHome, "sessions")
+	fi, err := os.Lstat(sessionsPath)
+	if err != nil {
+		t.Fatalf("sessions not found: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("sessions should be a symlink")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Symlink the `sessions` directory from per-task `CODEX_HOME` to the shared `~/.codex/sessions/`, so Codex session logs are written to the global location where users can find them
- Skills remain isolated per task (copied, not symlinked)
- Added `ensureDirSymlink` helper that creates the target directory if needed before symlinking

## Context
Users reported that Codex sessions triggered by Multica were invisible in `~/.codex/sessions/` because each task used an isolated `CODEX_HOME`. This made it impossible to debug Codex executions without manually searching per-task directories.

Fixes MUL-481.

## Test plan
- [x] Existing `TestPrepareCodexHomeSeedsFromShared` updated to verify sessions symlink
- [x] Existing `TestPrepareCodexHomeSkipsMissingFiles` updated to expect sessions symlink
- [x] All `execenv` and `agent` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)