### PR TITLE
feat: add 'C' keyboard shortcut for New Issue

### DIFF
--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { cn } from "@multica/ui/lib/utils";
 import { AppLink, useNavigation } from "../navigation";
 import {
@@ -112,6 +112,26 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
     useWorkspaceStore.getState().clearWorkspace();
   };
 
+  // Global "C" shortcut to open create-issue modal (like Linear)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "c" && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        const tag = (e.target as HTMLElement)?.tagName;
+        const isEditable =
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          (e.target as HTMLElement)?.isContentEditable;
+        if (isEditable) return;
+        if (useModalStore.getState().modal) return;
+        e.preventDefault();
+        useModalStore.getState().open("create-issue");
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
       <Sidebar variant="inset">
         {topSlot}
@@ -203,6 +223,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                   <DraftDot />
                 </span>
                 <span>New Issue</span>
+                <kbd className="ml-auto text-[10px] font-medium text-muted-foreground/60 tracking-widest">C</kbd>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -223,7 +223,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                   <DraftDot />
                 </span>
                 <span>New Issue</span>
-                <kbd className="ml-auto text-[10px] font-medium text-muted-foreground/60 tracking-widest">C</kbd>
+                <kbd className="pointer-events-none ml-auto inline-flex h-5 select-none items-center gap-0.5 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">C</kbd>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>


### PR DESCRIPTION
## Summary
- Adds a global `C` keyboard shortcut (matching Linear's convention) to open the create-issue modal
- Only triggers when not focused on an input/textarea/contenteditable element, and when no modal is already open
- Displays a `C` shortcut hint in the sidebar "New Issue" button

## Test plan
- [ ] Press `C` on any page → create-issue modal opens
- [ ] Press `C` while typing in an input/textarea/editor → nothing happens (continues typing)
- [ ] Press `C` while another modal is open → nothing happens
- [ ] Verify the `C` hint shows next to "New Issue" in the sidebar
- [ ] Test on both web and desktop apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)