### PR TITLE
fix(db): relax pending task unique index to per-(issue, agent)

### DIFF
--- a/server/migrations/037_fix_pending_task_unique_index.down.sql
+++ b/server/migrations/037_fix_pending_task_unique_index.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_one_pending_task_per_issue_agent;
+
+CREATE UNIQUE INDEX idx_one_pending_task_per_issue
+    ON agent_task_queue (issue_id)
+    WHERE status IN ('queued', 'dispatched');

--- a/server/migrations/037_fix_pending_task_unique_index.up.sql
+++ b/server/migrations/037_fix_pending_task_unique_index.up.sql
@@ -1,0 +1,8 @@
+-- Fix: the old index only allowed one pending task per issue across ALL agents.
+-- This caused different agents' pending tasks to block each other.
+-- Change to per-(issue, agent) so each agent can independently have one pending task.
+DROP INDEX IF EXISTS idx_one_pending_task_per_issue;
+
+CREATE UNIQUE INDEX idx_one_pending_task_per_issue_agent
+    ON agent_task_queue (issue_id, agent_id)
+    WHERE status IN ('queued', 'dispatched');


### PR DESCRIPTION
## Summary

- Migration 022 created a unique index `idx_one_pending_task_per_issue` on `agent_task_queue(issue_id)` that only allows **one** pending (queued/dispatched) task per issue, regardless of agent
- The code-level dedup (`HasPendingTaskForIssueAndAgent`) checks per `(issue_id, agent_id)`, creating a mismatch: the code thinks it's OK to enqueue for Agent B, but the DB rejects the INSERT because Agent A already has a pending task on the same issue
- New migration 037 drops the old index and creates `idx_one_pending_task_per_issue_agent` on `(issue_id, agent_id)`, so each agent can independently have one pending task per issue

Fixes MUL-495

## Test plan

- [ ] Run `make migrate-up` — migration 037 applies cleanly
- [ ] Create a task for Agent A on an issue (leave it queued)
- [ ] Create a task for Agent B on the same issue — should succeed now (previously would fail with unique constraint violation)
- [ ] Verify that creating a second task for the *same* agent on the same issue is still rejected by the index

🤖 Generated with [Claude Code](https://claude.com/claude-code)