### PR TITLE
feat(core): storage standardization + workspace isolation

### DIFF
--- a/packages/core/auth/store.ts
+++ b/packages/core/auth/store.ts
@@ -72,6 +72,7 @@ export function createAuthStore(options: AuthStoreOptions) {
 
     logout: () => {
       storage.removeItem("multica_token");
+      storage.removeItem("multica_workspace_id");
       api.setToken(null);
       api.setWorkspaceId(null);
       onLogout?.();

--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { StorageAdapter } from "../types";
+import { getCurrentWorkspaceId, registerForWorkspaceRehydration } from "../platform/workspace-storage";
 
 const AGENT_STORAGE_KEY = "multica:chat:selectedAgentId";
 const SESSION_STORAGE_KEY = "multica:chat:activeSessionId";
@@ -39,12 +40,17 @@ export interface ChatStoreOptions {
 export function createChatStore(options: ChatStoreOptions) {
   const { storage } = options;
 
-  return create<ChatState>((set) => ({
+  const wsKey = (base: string) => {
+    const wsId = getCurrentWorkspaceId();
+    return wsId ? `${base}:${wsId}` : base;
+  };
+
+  const store = create<ChatState>((set) => ({
     isOpen: false,
     isFullscreen: false,
-    activeSessionId: storage.getItem(SESSION_STORAGE_KEY),
+    activeSessionId: storage.getItem(wsKey(SESSION_STORAGE_KEY)),
     pendingTaskId: null,
-    selectedAgentId: storage.getItem(AGENT_STORAGE_KEY),
+    selectedAgentId: storage.getItem(wsKey(AGENT_STORAGE_KEY)),
     showHistory: false,
     timelineItems: [],
     setOpen: (open) =>
@@ -57,15 +63,15 @@ export function createChatStore(options: ChatStoreOptions) {
     toggleFullscreen: () => set((s) => ({ isFullscreen: !s.isFullscreen })),
     setActiveSession: (id) => {
       if (id) {
-        storage.setItem(SESSION_STORAGE_KEY, id);
+        storage.setItem(wsKey(SESSION_STORAGE_KEY), id);
       } else {
-        storage.removeItem(SESSION_STORAGE_KEY);
+        storage.removeItem(wsKey(SESSION_STORAGE_KEY));
       }
       set({ activeSessionId: id });
     },
     setPendingTask: (taskId) => set({ pendingTaskId: taskId, timelineItems: [] }),
     setSelectedAgentId: (id) => {
-      storage.setItem(AGENT_STORAGE_KEY, id);
+      storage.setItem(wsKey(AGENT_STORAGE_KEY), id);
       set({ selectedAgentId: id });
     },
     setShowHistory: (show) => set({ showHistory: show }),
@@ -80,4 +86,14 @@ export function createChatStore(options: ChatStoreOptions) {
       }),
     clearTimeline: () => set({ timelineItems: [] }),
   }));
+
+  registerForWorkspaceRehydration(() => {
+    store.setState({
+      activeSessionId: storage.getItem(wsKey(SESSION_STORAGE_KEY)),
+      selectedAgentId: storage.getItem(wsKey(AGENT_STORAGE_KEY)),
+      timelineItems: [],
+    });
+  });
+
+  return store;
 }

--- a/packages/core/issues/stores/draft-store.ts
+++ b/packages/core/issues/stores/draft-store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import type { IssueStatus, IssuePriority, IssueAssigneeType } from "../../types";
-import { createWorkspaceAwareStorage } from "../../platform/workspace-storage";
+import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
 
 interface IssueDraft {
@@ -49,3 +49,5 @@ export const useIssueDraftStore = create<IssueDraftStore>()(
     },
   ),
 );
+
+registerForWorkspaceRehydration(() => useIssueDraftStore.persist.rehydrate());

--- a/packages/core/issues/stores/draft-store.ts
+++ b/packages/core/issues/stores/draft-store.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 import type { IssueStatus, IssuePriority, IssueAssigneeType } from "../../types";
+import { createWorkspaceAwareStorage } from "../../platform/workspace-storage";
+import { defaultStorage } from "../../platform/storage";
 
 interface IssueDraft {
   title: string;
@@ -41,6 +43,9 @@ export const useIssueDraftStore = create<IssueDraftStore>()(
         return !!(draft.title || draft.description);
       },
     }),
-    { name: "multica_issue_draft" },
+    {
+      name: "multica_issue_draft",
+      storage: createJSONStorage(() => createWorkspaceAwareStorage(defaultStorage)),
+    },
   ),
 );

--- a/packages/core/issues/stores/issues-scope-store.ts
+++ b/packages/core/issues/stores/issues-scope-store.ts
@@ -2,7 +2,7 @@
 
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import { createWorkspaceAwareStorage } from "../../platform/workspace-storage";
+import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
 
 export type IssuesScope = "all" | "members" | "agents";
@@ -24,3 +24,5 @@ export const useIssuesScopeStore = create<IssuesScopeState>()(
     },
   ),
 );
+
+registerForWorkspaceRehydration(() => useIssuesScopeStore.persist.rehydrate());

--- a/packages/core/issues/stores/issues-scope-store.ts
+++ b/packages/core/issues/stores/issues-scope-store.ts
@@ -1,7 +1,9 @@
 "use client";
 
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { createWorkspaceAwareStorage } from "../../platform/workspace-storage";
+import { defaultStorage } from "../../platform/storage";
 
 export type IssuesScope = "all" | "members" | "agents";
 
@@ -16,6 +18,9 @@ export const useIssuesScopeStore = create<IssuesScopeState>()(
       scope: "all",
       setScope: (scope) => set({ scope }),
     }),
-    { name: "multica_issues_scope" },
+    {
+      name: "multica_issues_scope",
+      storage: createJSONStorage(() => createWorkspaceAwareStorage(defaultStorage)),
+    },
   ),
 );

--- a/packages/core/issues/stores/my-issues-view-store.ts
+++ b/packages/core/issues/stores/my-issues-view-store.ts
@@ -7,6 +7,7 @@ import {
   viewStoreSlice,
   viewStorePersistOptions,
 } from "./view-store";
+import { registerForWorkspaceRehydration } from "../../platform/workspace-storage";
 
 export type MyIssuesScope = "assigned" | "created" | "agents";
 
@@ -17,7 +18,7 @@ export interface MyIssuesViewState extends IssueViewState {
 
 const basePersist = viewStorePersistOptions("multica_my_issues_view");
 
-export const myIssuesViewStore: StoreApi<MyIssuesViewState> = createStore<MyIssuesViewState>()(
+const _myIssuesViewStore = createStore<MyIssuesViewState>()(
   persist(
     (set) => ({
       ...viewStoreSlice(set as unknown as StoreApi<IssueViewState>["setState"]),
@@ -34,3 +35,7 @@ export const myIssuesViewStore: StoreApi<MyIssuesViewState> = createStore<MyIssu
     },
   ),
 );
+
+export const myIssuesViewStore: StoreApi<MyIssuesViewState> = _myIssuesViewStore;
+
+registerForWorkspaceRehydration(() => _myIssuesViewStore.persist.rehydrate());

--- a/packages/core/issues/stores/my-issues-view-store.ts
+++ b/packages/core/issues/stores/my-issues-view-store.ts
@@ -26,6 +26,7 @@ export const myIssuesViewStore: StoreApi<MyIssuesViewState> = createStore<MyIssu
     }),
     {
       name: basePersist.name,
+      storage: basePersist.storage,
       partialize: (state: MyIssuesViewState) => ({
         ...basePersist.partialize(state),
         scope: state.scope,

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -5,7 +5,7 @@ import { createStore, type StoreApi } from "zustand/vanilla";
 import { createJSONStorage, persist } from "zustand/middleware";
 import type { IssueStatus, IssuePriority } from "../../types";
 import { ALL_STATUSES } from "../config";
-import { createWorkspaceAwareStorage } from "../../platform/workspace-storage";
+import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
 
 export type ViewMode = "board" | "list";
@@ -183,15 +183,19 @@ export const viewStorePersistOptions = (name: string) => ({
 
 /** Factory: creates a vanilla StoreApi for use with React Context. */
 export function createIssueViewStore(persistKey: string): StoreApi<IssueViewState> {
-  return createStore<IssueViewState>()(
+  const store = createStore<IssueViewState>()(
     persist(viewStoreSlice, viewStorePersistOptions(persistKey))
   );
+  registerForWorkspaceRehydration(() => store.persist.rehydrate());
+  return store;
 }
 
 /** Global singleton for the /issues page. */
 export const useIssueViewStore = create<IssueViewState>()(
   persist(viewStoreSlice, viewStorePersistOptions("multica_issues_view"))
 );
+
+registerForWorkspaceRehydration(() => useIssueViewStore.persist.rehydrate());
 
 // Clear filters on all registered view stores when workspace switches.
 const _syncedStores = new Set<StoreApi<IssueViewState>>();

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -2,9 +2,11 @@
 
 import { create } from "zustand";
 import { createStore, type StoreApi } from "zustand/vanilla";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 import type { IssueStatus, IssuePriority } from "../../types";
 import { ALL_STATUSES } from "../config";
+import { createWorkspaceAwareStorage } from "../../platform/workspace-storage";
+import { defaultStorage } from "../../platform/storage";
 
 export type ViewMode = "board" | "list";
 export type SortField = "position" | "priority" | "due_date" | "created_at" | "title";
@@ -164,6 +166,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
 
 export const viewStorePersistOptions = (name: string) => ({
   name,
+  storage: createJSONStorage(() => createWorkspaceAwareStorage(defaultStorage)),
   partialize: (state: IssueViewState) => ({
     viewMode: state.viewMode,
     statusFilters: state.statusFilters,

--- a/packages/core/navigation/store.ts
+++ b/packages/core/navigation/store.ts
@@ -1,7 +1,9 @@
 "use client";
 
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { createPersistStorage } from "../platform/persist-storage";
+import { defaultStorage } from "../platform/storage";
 
 const EXCLUDED_PREFIXES = ["/login", "/pair/"];
 
@@ -23,6 +25,7 @@ export const useNavigationStore = create<NavigationState>()(
     }),
     {
       name: "multica_navigation",
+      storage: createJSONStorage(() => createPersistStorage(defaultStorage)),
       partialize: (state) => ({ lastPath: state.lastPath }),
     }
   )

--- a/packages/core/platform/index.ts
+++ b/packages/core/platform/index.ts
@@ -3,4 +3,5 @@ export type { CoreProviderProps } from "./types";
 export { AuthInitializer } from "./auth-initializer";
 export { defaultStorage } from "./storage";
 export { createPersistStorage } from "./persist-storage";
-export { createWorkspaceAwareStorage, setCurrentWorkspaceId, getCurrentWorkspaceId } from "./workspace-storage";
+export { createWorkspaceAwareStorage, setCurrentWorkspaceId, getCurrentWorkspaceId, registerForWorkspaceRehydration, rehydrateAllWorkspaceStores } from "./workspace-storage";
+export { clearWorkspaceStorage } from "./storage-cleanup";

--- a/packages/core/platform/index.ts
+++ b/packages/core/platform/index.ts
@@ -2,3 +2,4 @@ export { CoreProvider } from "./core-provider";
 export type { CoreProviderProps } from "./types";
 export { AuthInitializer } from "./auth-initializer";
 export { defaultStorage } from "./storage";
+export { createPersistStorage } from "./persist-storage";

--- a/packages/core/platform/index.ts
+++ b/packages/core/platform/index.ts
@@ -3,3 +3,4 @@ export type { CoreProviderProps } from "./types";
 export { AuthInitializer } from "./auth-initializer";
 export { defaultStorage } from "./storage";
 export { createPersistStorage } from "./persist-storage";
+export { createWorkspaceAwareStorage, setCurrentWorkspaceId, getCurrentWorkspaceId } from "./workspace-storage";

--- a/packages/core/platform/persist-storage.test.ts
+++ b/packages/core/platform/persist-storage.test.ts
@@ -12,7 +12,7 @@ function mockAdapter(): StorageAdapter {
 }
 
 describe("createPersistStorage", () => {
-  it("delegates to StorageAdapter without namespace", () => {
+  it("delegates to StorageAdapter", () => {
     const adapter = mockAdapter();
     const storage = createPersistStorage(adapter);
 
@@ -27,33 +27,19 @@ describe("createPersistStorage", () => {
     expect(result).toEqual(JSON.stringify("value"));
   });
 
-  it("namespaces keys when wsId is provided", () => {
-    const adapter = mockAdapter();
-    const storage = createPersistStorage(adapter, "ws_123");
-
-    storage.setItem("draft", JSON.stringify({ title: "test" }));
-    expect(adapter.setItem).toHaveBeenCalledWith(
-      "draft:ws_123",
-      JSON.stringify({ title: "test" }),
-    );
-
-    storage.getItem("draft");
-    expect(adapter.getItem).toHaveBeenCalledWith("draft:ws_123");
-  });
-
-  it("removeItem namespaces correctly", () => {
-    const adapter = mockAdapter();
-    const storage = createPersistStorage(adapter, "ws_abc");
-
-    storage.removeItem("draft");
-    expect(adapter.removeItem).toHaveBeenCalledWith("draft:ws_abc");
-  });
-
   it("returns null for missing keys", () => {
     const adapter = mockAdapter();
     const storage = createPersistStorage(adapter);
 
     const result = storage.getItem("nonexistent");
     expect(result).toBeNull();
+  });
+
+  it("removeItem delegates correctly", () => {
+    const adapter = mockAdapter();
+    const storage = createPersistStorage(adapter);
+
+    storage.removeItem("key");
+    expect(adapter.removeItem).toHaveBeenCalledWith("key");
   });
 });

--- a/packages/core/platform/persist-storage.test.ts
+++ b/packages/core/platform/persist-storage.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { createPersistStorage } from "./persist-storage";
+import type { StorageAdapter } from "../types/storage";
+
+function mockAdapter(): StorageAdapter {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((k) => store.get(k) ?? null),
+    setItem: vi.fn((k, v) => store.set(k, v)),
+    removeItem: vi.fn((k) => store.delete(k)),
+  };
+}
+
+describe("createPersistStorage", () => {
+  it("delegates to StorageAdapter without namespace", () => {
+    const adapter = mockAdapter();
+    const storage = createPersistStorage(adapter);
+
+    storage.setItem("key", JSON.stringify("value"));
+    expect(adapter.setItem).toHaveBeenCalledWith(
+      "key",
+      JSON.stringify("value"),
+    );
+
+    const result = storage.getItem("key");
+    expect(adapter.getItem).toHaveBeenCalledWith("key");
+    expect(result).toEqual(JSON.stringify("value"));
+  });
+
+  it("namespaces keys when wsId is provided", () => {
+    const adapter = mockAdapter();
+    const storage = createPersistStorage(adapter, "ws_123");
+
+    storage.setItem("draft", JSON.stringify({ title: "test" }));
+    expect(adapter.setItem).toHaveBeenCalledWith(
+      "draft:ws_123",
+      JSON.stringify({ title: "test" }),
+    );
+
+    storage.getItem("draft");
+    expect(adapter.getItem).toHaveBeenCalledWith("draft:ws_123");
+  });
+
+  it("removeItem namespaces correctly", () => {
+    const adapter = mockAdapter();
+    const storage = createPersistStorage(adapter, "ws_abc");
+
+    storage.removeItem("draft");
+    expect(adapter.removeItem).toHaveBeenCalledWith("draft:ws_abc");
+  });
+
+  it("returns null for missing keys", () => {
+    const adapter = mockAdapter();
+    const storage = createPersistStorage(adapter);
+
+    const result = storage.getItem("nonexistent");
+    expect(result).toBeNull();
+  });
+});

--- a/packages/core/platform/persist-storage.ts
+++ b/packages/core/platform/persist-storage.ts
@@ -1,14 +1,14 @@
 import type { StateStorage } from "zustand/middleware";
 import type { StorageAdapter } from "../types/storage";
 
-export function createPersistStorage(
-  adapter: StorageAdapter,
-  wsId?: string,
-): StateStorage {
-  const resolve = (key: string) => (wsId ? `${key}:${wsId}` : key);
+/**
+ * Bridge between Zustand persist middleware and our StorageAdapter DI system.
+ * For workspace-scoped stores, use createWorkspaceAwareStorage instead.
+ */
+export function createPersistStorage(adapter: StorageAdapter): StateStorage {
   return {
-    getItem: (key) => adapter.getItem(resolve(key)),
-    setItem: (key, value) => adapter.setItem(resolve(key), value),
-    removeItem: (key) => adapter.removeItem(resolve(key)),
+    getItem: (key) => adapter.getItem(key),
+    setItem: (key, value) => adapter.setItem(key, value),
+    removeItem: (key) => adapter.removeItem(key),
   };
 }

--- a/packages/core/platform/persist-storage.ts
+++ b/packages/core/platform/persist-storage.ts
@@ -1,0 +1,14 @@
+import type { StateStorage } from "zustand/middleware";
+import type { StorageAdapter } from "../types/storage";
+
+export function createPersistStorage(
+  adapter: StorageAdapter,
+  wsId?: string,
+): StateStorage {
+  const resolve = (key: string) => (wsId ? `${key}:${wsId}` : key);
+  return {
+    getItem: (key) => adapter.getItem(resolve(key)),
+    setItem: (key, value) => adapter.setItem(resolve(key), value),
+    removeItem: (key) => adapter.removeItem(resolve(key)),
+  };
+}

--- a/packages/core/platform/storage-cleanup.test.ts
+++ b/packages/core/platform/storage-cleanup.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { clearWorkspaceStorage } from "./storage-cleanup";
+
+describe("clearWorkspaceStorage", () => {
+  it("removes all workspace-scoped keys for given wsId", () => {
+    const adapter = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+
+    clearWorkspaceStorage(adapter, "ws_123");
+
+    expect(adapter.removeItem).toHaveBeenCalledWith("multica_issue_draft:ws_123");
+    expect(adapter.removeItem).toHaveBeenCalledWith("multica_issues_view:ws_123");
+    expect(adapter.removeItem).toHaveBeenCalledWith("multica_issues_scope:ws_123");
+    expect(adapter.removeItem).toHaveBeenCalledWith("multica_my_issues_view:ws_123");
+    expect(adapter.removeItem).toHaveBeenCalledWith("multica:chat:selectedAgentId:ws_123");
+    expect(adapter.removeItem).toHaveBeenCalledWith("multica:chat:activeSessionId:ws_123");
+    expect(adapter.removeItem).toHaveBeenCalledTimes(6);
+  });
+});

--- a/packages/core/platform/storage-cleanup.ts
+++ b/packages/core/platform/storage-cleanup.ts
@@ -1,0 +1,27 @@
+import type { StorageAdapter } from "../types/storage";
+
+/**
+ * Keys that are namespaced per workspace (stored as `${key}:${wsId}`).
+ *
+ * IMPORTANT: When adding a new workspace-scoped persist store or storage key,
+ * add its key here so that workspace deletion and logout properly clean it up.
+ * Also ensure the store uses `createWorkspaceAwareStorage` for its persist config.
+ */
+const WORKSPACE_SCOPED_KEYS = [
+  "multica_issue_draft",
+  "multica_issues_view",
+  "multica_issues_scope",
+  "multica_my_issues_view",
+  "multica:chat:selectedAgentId",
+  "multica:chat:activeSessionId",
+];
+
+/** Remove all workspace-scoped storage entries for the given workspace. */
+export function clearWorkspaceStorage(
+  adapter: StorageAdapter,
+  wsId: string,
+) {
+  for (const key of WORKSPACE_SCOPED_KEYS) {
+    adapter.removeItem(`${key}:${wsId}`);
+  }
+}

--- a/packages/core/platform/workspace-storage.test.ts
+++ b/packages/core/platform/workspace-storage.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createWorkspaceAwareStorage, setCurrentWorkspaceId } from "./workspace-storage";
+import type { StorageAdapter } from "../types/storage";
+
+function mockAdapter(): StorageAdapter {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((k) => store.get(k) ?? null),
+    setItem: vi.fn((k, v) => store.set(k, v)),
+    removeItem: vi.fn((k) => store.delete(k)),
+  };
+}
+
+afterEach(() => {
+  setCurrentWorkspaceId(null);
+});
+
+describe("workspace-aware storage", () => {
+  it("uses plain key when no workspace is set", () => {
+    const adapter = mockAdapter();
+    setCurrentWorkspaceId(null);
+    const storage = createWorkspaceAwareStorage(adapter);
+
+    storage.setItem("draft", "data");
+    expect(adapter.setItem).toHaveBeenCalledWith("draft", "data");
+  });
+
+  it("namespaces key when workspace is set", () => {
+    const adapter = mockAdapter();
+    setCurrentWorkspaceId("ws_abc");
+    const storage = createWorkspaceAwareStorage(adapter);
+
+    storage.setItem("draft", "data");
+    expect(adapter.setItem).toHaveBeenCalledWith("draft:ws_abc", "data");
+
+    storage.getItem("draft");
+    expect(adapter.getItem).toHaveBeenCalledWith("draft:ws_abc");
+  });
+
+  it("follows workspace changes dynamically", () => {
+    const adapter = mockAdapter();
+    const storage = createWorkspaceAwareStorage(adapter);
+
+    setCurrentWorkspaceId("ws_1");
+    storage.setItem("draft", "v1");
+    expect(adapter.setItem).toHaveBeenCalledWith("draft:ws_1", "v1");
+
+    setCurrentWorkspaceId("ws_2");
+    storage.setItem("draft", "v2");
+    expect(adapter.setItem).toHaveBeenCalledWith("draft:ws_2", "v2");
+  });
+
+  it("removeItem uses current workspace", () => {
+    const adapter = mockAdapter();
+    setCurrentWorkspaceId("ws_x");
+    const storage = createWorkspaceAwareStorage(adapter);
+
+    storage.removeItem("draft");
+    expect(adapter.removeItem).toHaveBeenCalledWith("draft:ws_x");
+  });
+});

--- a/packages/core/platform/workspace-storage.ts
+++ b/packages/core/platform/workspace-storage.ts
@@ -2,9 +2,22 @@ import type { StateStorage } from "zustand/middleware";
 import type { StorageAdapter } from "../types/storage";
 
 let _currentWsId: string | null = null;
+const _rehydrateFns: Array<() => void> = [];
 
 export function setCurrentWorkspaceId(wsId: string | null) {
   _currentWsId = wsId;
+}
+
+/** Register a persist store's rehydrate function to be called on workspace switch. */
+export function registerForWorkspaceRehydration(fn: () => void) {
+  _rehydrateFns.push(fn);
+}
+
+/** Rehydrate all registered workspace-scoped persist stores from the new namespace. */
+export function rehydrateAllWorkspaceStores() {
+  for (const fn of _rehydrateFns) {
+    fn();
+  }
 }
 
 export function getCurrentWorkspaceId(): string | null {

--- a/packages/core/platform/workspace-storage.ts
+++ b/packages/core/platform/workspace-storage.ts
@@ -1,0 +1,27 @@
+import type { StateStorage } from "zustand/middleware";
+import type { StorageAdapter } from "../types/storage";
+
+let _currentWsId: string | null = null;
+
+export function setCurrentWorkspaceId(wsId: string | null) {
+  _currentWsId = wsId;
+}
+
+export function getCurrentWorkspaceId(): string | null {
+  return _currentWsId;
+}
+
+/**
+ * Storage that automatically namespaces keys with the current workspace ID.
+ * Reads _currentWsId at call time, so it follows workspace switches dynamically.
+ */
+export function createWorkspaceAwareStorage(adapter: StorageAdapter): StateStorage {
+  const resolve = (key: string) =>
+    _currentWsId ? `${key}:${_currentWsId}` : key;
+
+  return {
+    getItem: (key) => adapter.getItem(resolve(key)),
+    setItem: (key, value) => adapter.setItem(resolve(key), value),
+    removeItem: (key) => adapter.removeItem(resolve(key)),
+  };
+}

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -7,6 +7,8 @@ import type { StoreApi, UseBoundStore } from "zustand";
 import type { AuthState } from "../auth/store";
 import type { WorkspaceStore } from "../workspace/store";
 import { createLogger } from "../logger";
+import { clearWorkspaceStorage } from "../platform/storage-cleanup";
+import { defaultStorage } from "../platform/storage";
 import { issueKeys } from "../issues/queries";
 import { projectKeys } from "../projects/queries";
 import { runtimeKeys } from "../runtimes/queries";
@@ -238,6 +240,7 @@ export function useRealtimeSync(
 
     const unsubWsDeleted = ws.on("workspace:deleted", (p) => {
       const { workspace_id } = p as WorkspaceDeletedPayload;
+      clearWorkspaceStorage(defaultStorage, workspace_id);
       const currentWs = workspaceStore.getState().workspace;
       if (currentWs?.id === workspace_id) {
         logger.warn("current workspace deleted, switching");
@@ -250,6 +253,8 @@ export function useRealtimeSync(
       const { user_id } = p as MemberRemovedPayload;
       const myUserId = authStore.getState().user?.id;
       if (user_id === myUserId) {
+        const wsId = workspaceStore.getState().workspace?.id;
+        if (wsId) clearWorkspaceStorage(defaultStorage, wsId);
         logger.warn("removed from workspace, switching");
         onToast?.("You were removed from this workspace", "info");
         workspaceStore.getState().refreshWorkspaces();

--- a/packages/core/workspace/store.ts
+++ b/packages/core/workspace/store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import type { Workspace, StorageAdapter } from "../types";
 import type { ApiClient } from "../api/client";
 import { createLogger } from "../logger";
-import { setCurrentWorkspaceId } from "../platform/workspace-storage";
+import { setCurrentWorkspaceId, rehydrateAllWorkspaceStores } from "../platform/workspace-storage";
 
 const logger = createLogger("workspace-store");
 
@@ -59,6 +59,7 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
       if (!nextWorkspace) {
         api.setWorkspaceId(null);
         setCurrentWorkspaceId(null);
+        rehydrateAllWorkspaceStores();
         storage?.removeItem("multica_workspace_id");
         set({ workspace: null });
         return null;
@@ -66,6 +67,7 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
 
       api.setWorkspaceId(nextWorkspace.id);
       setCurrentWorkspaceId(nextWorkspace.id);
+      rehydrateAllWorkspaceStores();
       storage?.setItem("multica_workspace_id", nextWorkspace.id);
       set({ workspace: nextWorkspace });
       logger.debug("hydrate workspace", nextWorkspace.name, nextWorkspace.id);
@@ -142,6 +144,7 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
     clearWorkspace: () => {
       api.setWorkspaceId(null);
       setCurrentWorkspaceId(null);
+      rehydrateAllWorkspaceStores();
       set({ workspace: null, workspaces: [] });
     },
   }));

--- a/packages/core/workspace/store.ts
+++ b/packages/core/workspace/store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { Workspace, StorageAdapter } from "../types";
 import type { ApiClient } from "../api/client";
 import { createLogger } from "../logger";
+import { setCurrentWorkspaceId } from "../platform/workspace-storage";
 
 const logger = createLogger("workspace-store");
 
@@ -57,12 +58,14 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
 
       if (!nextWorkspace) {
         api.setWorkspaceId(null);
+        setCurrentWorkspaceId(null);
         storage?.removeItem("multica_workspace_id");
         set({ workspace: null });
         return null;
       }
 
       api.setWorkspaceId(nextWorkspace.id);
+      setCurrentWorkspaceId(nextWorkspace.id);
       storage?.setItem("multica_workspace_id", nextWorkspace.id);
       set({ workspace: nextWorkspace });
       logger.debug("hydrate workspace", nextWorkspace.name, nextWorkspace.id);
@@ -138,6 +141,7 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
 
     clearWorkspace: () => {
       api.setWorkspaceId(null);
+      setCurrentWorkspaceId(null);
       set({ workspace: null, workspaces: [] });
     },
   }));

--- a/packages/views/editor/content-editor.css
+++ b/packages/views/editor/content-editor.css
@@ -458,23 +458,3 @@
 .rich-text-editor .image-toolbar button:hover {
   background: color-mix(in srgb, white 15%, transparent);
 }
-
-/* Drag-and-drop overlay */
-.editor-drop-overlay {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 2px dashed color-mix(in srgb, var(--brand) 40%, transparent);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--brand) 3%, transparent);
-  z-index: 10;
-  pointer-events: none;
-}
-
-.editor-drop-overlay p {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: color-mix(in srgb, var(--brand) 60%, transparent);
-}

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -55,6 +55,8 @@ interface ContentEditorProps {
   onSubmit?: () => void;
   onBlur?: () => void;
   onUploadFile?: (file: File) => Promise<UploadResult | null>;
+  /** When false, suppresses the internal drag-over overlay so the parent can render its own. Default true. */
+  showDropOverlay?: boolean;
 }
 
 interface ContentEditorRef {
@@ -80,6 +82,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       onSubmit,
       onBlur,
       onUploadFile,
+      showDropOverlay = true,
     },
     ref,
   ) {
@@ -180,6 +183,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
 
     // Always clear drag overlay on any drop/dragend anywhere in the document
     useEffect(() => {
+      if (!showDropOverlay) return;
       const clear = () => setDragOver(false);
       document.addEventListener("drop", clear);
       document.addEventListener("dragend", clear);
@@ -187,7 +191,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         document.removeEventListener("drop", clear);
         document.removeEventListener("dragend", clear);
       };
-    }, []);
+    }, [showDropOverlay]);
 
     // Readonly content update: when defaultValue changes and editor is readonly,
     // re-set the content (e.g. after editing a comment, the readonly view updates)
@@ -222,39 +226,47 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
 
     return (
       <div
-        className={cn("relative min-h-full", dragOver && "editor-drag-over")}
-        onDragEnter={(e) => {
-          e.preventDefault();
-          if (editable && e.dataTransfer.types.includes("Files"))
-            setDragOver(true);
-        }}
-        onDragOver={(e) => {
-          e.preventDefault();
-        }}
-        onDragLeave={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget as Node))
-            setDragOver(false);
-        }}
-        onDrop={(e) => {
-          const alreadyHandled = e.nativeEvent.defaultPrevented;
-          e.preventDefault();
-          setDragOver(false);
-          // Only upload if ProseMirror didn't already handle the drop.
-          // When drop lands on the editor area, ProseMirror's handleDrop
-          // processes it and calls preventDefault on the native event.
-          // This fallback only fires when the overlay intercepted the drop.
-          if (alreadyHandled) return;
-          const files = e.dataTransfer?.files;
-          if (files?.length && editor && onUploadFileRef.current) {
-            const endPos = editor.state.doc.content.size;
-            for (const file of Array.from(files)) {
-              uploadAndInsertFile(editor, file, onUploadFileRef.current, endPos);
+        className={cn(
+          "relative min-h-full",
+          showDropOverlay && dragOver && "editor-drag-over",
+        )}
+        {...(showDropOverlay
+          ? {
+              onDragEnter: (e: React.DragEvent) => {
+                e.preventDefault();
+                if (editable && e.dataTransfer.types.includes("Files"))
+                  setDragOver(true);
+              },
+              onDragOver: (e: React.DragEvent) => {
+                e.preventDefault();
+              },
+              onDragLeave: (e: React.DragEvent) => {
+                if (!e.currentTarget.contains(e.relatedTarget as Node))
+                  setDragOver(false);
+              },
+              onDrop: (e: React.DragEvent) => {
+                const alreadyHandled = e.nativeEvent.defaultPrevented;
+                e.preventDefault();
+                setDragOver(false);
+                if (alreadyHandled) return;
+                const files = e.dataTransfer?.files;
+                if (files?.length && editor && onUploadFileRef.current) {
+                  const endPos = editor.state.doc.content.size;
+                  for (const file of Array.from(files)) {
+                    uploadAndInsertFile(
+                      editor,
+                      file,
+                      onUploadFileRef.current,
+                      endPos,
+                    );
+                  }
+                }
+              },
             }
-          }
-        }}
+          : {})}
       >
         <EditorContent editor={editor} />
-        {dragOver && (
+        {showDropOverlay && dragOver && (
           <div className="editor-drop-overlay">
             <p>Drop files to upload</p>
           </div>

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -30,7 +30,6 @@ import {
   useEffect,
   useImperativeHandle,
   useRef,
-  useState,
 } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import { cn } from "@multica/ui/lib/utils";
@@ -55,8 +54,6 @@ interface ContentEditorProps {
   onSubmit?: () => void;
   onBlur?: () => void;
   onUploadFile?: (file: File) => Promise<UploadResult | null>;
-  /** When false, suppresses the internal drag-over overlay so the parent can render its own. Default true. */
-  showDropOverlay?: boolean;
 }
 
 interface ContentEditorRef {
@@ -82,11 +79,9 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       onSubmit,
       onBlur,
       onUploadFile,
-      showDropOverlay = true,
     },
     ref,
   ) {
-    const [dragOver, setDragOver] = useState(false);
     const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
     const onUpdateRef = useRef(onUpdate);
     const onSubmitRef = useRef(onSubmit);
@@ -181,18 +176,6 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       };
     }, []);
 
-    // Always clear drag overlay on any drop/dragend anywhere in the document
-    useEffect(() => {
-      if (!showDropOverlay) return;
-      const clear = () => setDragOver(false);
-      document.addEventListener("drop", clear);
-      document.addEventListener("dragend", clear);
-      return () => {
-        document.removeEventListener("drop", clear);
-        document.removeEventListener("dragend", clear);
-      };
-    }, [showDropOverlay]);
-
     // Readonly content update: when defaultValue changes and editor is readonly,
     // re-set the content (e.g. after editing a comment, the readonly view updates)
     useEffect(() => {
@@ -225,52 +208,8 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     if (!editor) return null;
 
     return (
-      <div
-        className={cn(
-          "relative min-h-full",
-          showDropOverlay && dragOver && "editor-drag-over",
-        )}
-        {...(showDropOverlay
-          ? {
-              onDragEnter: (e: React.DragEvent) => {
-                e.preventDefault();
-                if (editable && e.dataTransfer.types.includes("Files"))
-                  setDragOver(true);
-              },
-              onDragOver: (e: React.DragEvent) => {
-                e.preventDefault();
-              },
-              onDragLeave: (e: React.DragEvent) => {
-                if (!e.currentTarget.contains(e.relatedTarget as Node))
-                  setDragOver(false);
-              },
-              onDrop: (e: React.DragEvent) => {
-                const alreadyHandled = e.nativeEvent.defaultPrevented;
-                e.preventDefault();
-                setDragOver(false);
-                if (alreadyHandled) return;
-                const files = e.dataTransfer?.files;
-                if (files?.length && editor && onUploadFileRef.current) {
-                  const endPos = editor.state.doc.content.size;
-                  for (const file of Array.from(files)) {
-                    uploadAndInsertFile(
-                      editor,
-                      file,
-                      onUploadFileRef.current,
-                      endPos,
-                    );
-                  }
-                }
-              },
-            }
-          : {})}
-      >
+      <div className="relative min-h-full">
         <EditorContent editor={editor} />
-        {showDropOverlay && dragOver && (
-          <div className="editor-drop-overlay">
-            <p>Drop files to upload</p>
-          </div>
-        )}
       </div>
     );
   },

--- a/packages/views/editor/file-drop-overlay.tsx
+++ b/packages/views/editor/file-drop-overlay.tsx
@@ -1,0 +1,7 @@
+function FileDropOverlay() {
+  return (
+    <div className="absolute inset-0 z-10 rounded-[inherit] border border-dashed border-brand/20 bg-brand/[0.02] pointer-events-none" />
+  );
+}
+
+export { FileDropOverlay };

--- a/packages/views/editor/index.ts
+++ b/packages/views/editor/index.ts
@@ -10,3 +10,5 @@ export {
 } from "./title-editor";
 export { copyMarkdown } from "./utils/clipboard";
 export { ReadonlyContent } from "./readonly-content";
+export { useFileDropZone } from "./use-file-drop-zone";
+export { FileDropOverlay } from "./file-drop-overlay";

--- a/packages/views/editor/use-file-drop-zone.ts
+++ b/packages/views/editor/use-file-drop-zone.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useCallback, useRef, type DragEvent } from "react";
+
+interface UseFileDropZoneOptions {
+  onDrop: (files: File[]) => void;
+  enabled?: boolean;
+}
+
+function useFileDropZone({ onDrop, enabled = true }: UseFileDropZoneOptions) {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const onDropRef = useRef(onDrop);
+  onDropRef.current = onDrop;
+
+  // Clear on any document-level drop or dragend (e.g. user drops outside the zone)
+  useEffect(() => {
+    if (!enabled) return;
+    const clear = () => setIsDragOver(false);
+    document.addEventListener("drop", clear);
+    document.addEventListener("dragend", clear);
+    return () => {
+      document.removeEventListener("drop", clear);
+      document.removeEventListener("dragend", clear);
+    };
+  }, [enabled]);
+
+  const handleDragEnter = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      if (enabled && e.dataTransfer.types.includes("Files")) {
+        setIsDragOver(true);
+      }
+    },
+    [enabled],
+  );
+
+  const handleDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const handleDragLeave = useCallback((e: DragEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsDragOver(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: DragEvent) => {
+      const alreadyHandled = e.nativeEvent.defaultPrevented;
+      e.preventDefault();
+      setIsDragOver(false);
+      if (alreadyHandled || !enabled) return;
+      const files = e.dataTransfer?.files;
+      if (files?.length) {
+        onDropRef.current(Array.from(files));
+      }
+    },
+    [enabled],
+  );
+
+  const dropZoneProps = {
+    onDragEnter: handleDragEnter,
+    onDragOver: handleDragOver,
+    onDragLeave: handleDragLeave,
+    onDrop: handleDrop,
+  };
+
+  return { isDragOver: enabled && isDragOver, dropZoneProps };
+}
+
+export { useFileDropZone };

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -31,6 +31,8 @@ import { cn } from "@multica/ui/lib/utils";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { timeAgo } from "@multica/core/utils";
 import { ContentEditor, type ContentEditorRef, copyMarkdown, ReadonlyContent } from "../../editor";
+import { useFileDropZone } from "../../editor/use-file-drop-zone";
+import { FileDropOverlay } from "../../editor/file-drop-overlay";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
@@ -115,6 +117,10 @@ function CommentRow({
   const editEditorRef = useRef<ContentEditorRef>(null);
   const cancelledRef = useRef(false);
   const { uploadWithToast } = useFileUpload(api);
+  const { isDragOver, dropZoneProps } = useFileDropZone({
+    onDrop: (files) => files.forEach((f) => editEditorRef.current?.uploadFile(f)),
+    enabled: editing,
+  });
 
   const isOwn = entry.actor_type === "member" && entry.actor_id === currentUserId;
   const isTemp = entry.id.startsWith("temp-");
@@ -221,7 +227,8 @@ function CommentRow({
 
       {editing ? (
         <div
-          className="mt-1.5 pl-8"
+          {...dropZoneProps}
+          className="relative mt-1.5 pl-8"
           onKeyDown={(e) => { if (e.key === "Escape") cancelEdit(); }}
         >
           <div className="max-h-48 overflow-y-auto text-sm leading-relaxed">
@@ -231,6 +238,7 @@ function CommentRow({
               placeholder="Edit comment..."
               onSubmit={saveEdit}
               onUploadFile={(file) => uploadWithToast(file, { issueId })}
+              showDropOverlay={false}
               debounceMs={100}
             />
           </div>
@@ -244,6 +252,7 @@ function CommentRow({
               <Button size="sm" variant="outline" onClick={saveEdit}>Save</Button>
             </div>
           </div>
+          {isDragOver && <FileDropOverlay />}
         </div>
       ) : (
         <>
@@ -287,6 +296,10 @@ function CommentCard({
   const [editing, setEditing] = useState(false);
   const editEditorRef = useRef<ContentEditorRef>(null);
   const cancelledRef = useRef(false);
+  const { isDragOver: parentDragOver, dropZoneProps: parentDropZoneProps } = useFileDropZone({
+    onDrop: (files) => files.forEach((f) => editEditorRef.current?.uploadFile(f)),
+    enabled: editing,
+  });
 
   const isOwn = entry.actor_type === "member" && entry.actor_id === currentUserId;
   const isTemp = entry.id.startsWith("temp-");
@@ -431,7 +444,8 @@ function CommentCard({
           <div className="px-4 pb-3">
             {editing ? (
               <div
-                className="pl-10"
+                {...parentDropZoneProps}
+                className="relative pl-10"
                 onKeyDown={(e) => { if (e.key === "Escape") cancelEdit(); }}
               >
                 <div className="max-h-48 overflow-y-auto text-sm leading-relaxed">
@@ -441,6 +455,7 @@ function CommentCard({
                     placeholder="Edit comment..."
                     onSubmit={saveEdit}
                     onUploadFile={(file) => uploadWithToast(file, { issueId })}
+                    showDropOverlay={false}
                     debounceMs={100}
                   />
                 </div>
@@ -454,6 +469,7 @@ function CommentCard({
                     <Button size="sm" variant="outline" onClick={saveEdit}>Save</Button>
                   </div>
                 </div>
+                {parentDragOver && <FileDropOverlay />}
               </div>
             ) : (
               <>

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -30,9 +30,7 @@ import { QuickEmojiPicker } from "@multica/ui/components/common/quick-emoji-pick
 import { cn } from "@multica/ui/lib/utils";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { timeAgo } from "@multica/core/utils";
-import { ContentEditor, type ContentEditorRef, copyMarkdown, ReadonlyContent } from "../../editor";
-import { useFileDropZone } from "../../editor/use-file-drop-zone";
-import { FileDropOverlay } from "../../editor/file-drop-overlay";
+import { ContentEditor, type ContentEditorRef, copyMarkdown, ReadonlyContent, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
@@ -238,7 +236,6 @@ function CommentRow({
               placeholder="Edit comment..."
               onSubmit={saveEdit}
               onUploadFile={(file) => uploadWithToast(file, { issueId })}
-              showDropOverlay={false}
               debounceMs={100}
             />
           </div>
@@ -455,7 +452,6 @@ function CommentCard({
                     placeholder="Edit comment..."
                     onSubmit={saveEdit}
                     onUploadFile={(file) => uploadWithToast(file, { issueId })}
-                    showDropOverlay={false}
                     debounceMs={100}
                   />
                 </div>

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -3,7 +3,10 @@
 import { useRef, useState } from "react";
 import { ArrowUp, Loader2 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
+import { cn } from "@multica/ui/lib/utils";
 import { ContentEditor, type ContentEditorRef } from "../../editor";
+import { useFileDropZone } from "../../editor/use-file-drop-zone";
+import { FileDropOverlay } from "../../editor/file-drop-overlay";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
@@ -19,6 +22,9 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   const [submitting, setSubmitting] = useState(false);
   const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
   const { uploadWithToast } = useFileUpload(api);
+  const { isDragOver, dropZoneProps } = useFileDropZone({
+    onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
+  });
 
   const handleUpload = async (file: File) => {
     const result = await uploadWithToast(file, { issueId });
@@ -43,7 +49,13 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   };
 
   return (
-    <div className="relative flex max-h-56 flex-col rounded-lg bg-card pb-8 ring-1 ring-border">
+    <div
+      {...dropZoneProps}
+      className={cn(
+        "relative flex max-h-56 flex-col rounded-lg bg-card pb-8 ring-1 ring-border",
+        isDragOver && "ring-brand/30",
+      )}
+    >
       <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
         <ContentEditor
           ref={editorRef}
@@ -51,6 +63,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           onUpdate={(md) => setIsEmpty(!md.trim())}
           onSubmit={handleSubmit}
           onUploadFile={handleUpload}
+          showDropOverlay={false}
           debounceMs={100}
         />
       </div>
@@ -71,6 +84,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           )}
         </Button>
       </div>
+      {isDragOver && <FileDropOverlay />}
     </div>
   );
 }

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -3,10 +3,7 @@
 import { useRef, useState } from "react";
 import { ArrowUp, Loader2 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
-import { cn } from "@multica/ui/lib/utils";
-import { ContentEditor, type ContentEditorRef } from "../../editor";
-import { useFileDropZone } from "../../editor/use-file-drop-zone";
-import { FileDropOverlay } from "../../editor/file-drop-overlay";
+import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
@@ -51,10 +48,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   return (
     <div
       {...dropZoneProps}
-      className={cn(
-        "relative flex max-h-56 flex-col rounded-lg bg-card pb-8 ring-1 ring-border",
-        isDragOver && "ring-brand/30",
-      )}
+      className="relative flex max-h-56 flex-col rounded-lg bg-card pb-8 ring-1 ring-border"
     >
       <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
         <ContentEditor
@@ -63,7 +57,6 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           onUpdate={(md) => setIsEmpty(!md.trim())}
           onSubmit={handleSubmit}
           onUploadFile={handleUpload}
-          showDropOverlay={false}
           debounceMs={100}
         />
       </div>

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -85,6 +85,8 @@ vi.mock("../../navigation", () => ({
 
 // Mock editor components (Tiptap requires real DOM)
 vi.mock("../../editor", () => ({
+  useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
+  FileDropOverlay: () => null,
   ReadonlyContent: ({ content }: { content: string }) => (
     <div data-testid="readonly-content">{content}</div>
   ),

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -42,6 +42,8 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@multica/ui/components/ui/resizable";
 import { ContentEditor, type ContentEditorRef } from "../../editor";
+import { useFileDropZone } from "../../editor/use-file-drop-zone";
+import { FileDropOverlay } from "../../editor/file-drop-overlay";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { TitleEditor } from "../../editor";
 import {
@@ -297,6 +299,9 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   );
 
   const descEditorRef = useRef<ContentEditorRef>(null);
+  const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
+    onDrop: (files) => files.forEach((f) => descEditorRef.current?.uploadFile(f)),
+  });
   // Description uploads don't pass issueId — the URL lives in the markdown.
   // This avoids stale attachment records when users delete images from the editor.
   const handleDescriptionUpload = useCallback(
@@ -702,35 +707,38 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
             </AppLink>
           )}
 
-          <ContentEditor
-            ref={descEditorRef}
-            key={id}
-            defaultValue={issue.description || ""}
-            placeholder="Add description..."
-            onUpdate={(md) => handleUpdateField({ description: md || undefined })}
-            onUploadFile={handleDescriptionUpload}
-            debounceMs={1500}
-            className="mt-5"
-          />
-
-          <div className="flex items-center gap-1 mt-3">
-            {reactionsLoading ? (
-              <div className="flex items-center gap-1">
-                <Skeleton className="h-7 w-14 rounded-full" />
-                <Skeleton className="h-7 w-14 rounded-full" />
-              </div>
-            ) : (
-              <ReactionBar
-                reactions={issueReactions}
-                currentUserId={user?.id}
-                onToggle={handleToggleIssueReaction}
-                getActorName={getActorName}
-              />
-            )}
-            <FileUploadButton
-              size="sm"
-              onSelect={(file) => descEditorRef.current?.uploadFile(file)}
+          <div {...descDropZoneProps} className="relative mt-5 rounded-lg">
+            <ContentEditor
+              ref={descEditorRef}
+              key={id}
+              defaultValue={issue.description || ""}
+              placeholder="Add description..."
+              onUpdate={(md) => handleUpdateField({ description: md || undefined })}
+              onUploadFile={handleDescriptionUpload}
+              showDropOverlay={false}
+              debounceMs={1500}
             />
+
+            <div className="flex items-center gap-1 mt-3">
+              {reactionsLoading ? (
+                <div className="flex items-center gap-1">
+                  <Skeleton className="h-7 w-14 rounded-full" />
+                  <Skeleton className="h-7 w-14 rounded-full" />
+                </div>
+              ) : (
+                <ReactionBar
+                  reactions={issueReactions}
+                  currentUserId={user?.id}
+                  onToggle={handleToggleIssueReaction}
+                  getActorName={getActorName}
+                />
+              )}
+              <FileUploadButton
+                size="sm"
+                onSelect={(file) => descEditorRef.current?.uploadFile(file)}
+              />
+            </div>
+            {descDragOver && <FileDropOverlay />}
           </div>
 
           {/* Sub-issues — Linear-style */}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -41,11 +41,8 @@ import {
   DropdownMenuSubContent,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@multica/ui/components/ui/resizable";
-import { ContentEditor, type ContentEditorRef } from "../../editor";
-import { useFileDropZone } from "../../editor/use-file-drop-zone";
-import { FileDropOverlay } from "../../editor/file-drop-overlay";
+import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
-import { TitleEditor } from "../../editor";
 import {
   Tooltip,
   TooltipTrigger,
@@ -715,7 +712,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
               placeholder="Add description..."
               onUpdate={(md) => handleUpdateField({ description: md || undefined })}
               onUploadFile={handleDescriptionUpload}
-              showDropOverlay={false}
               debounceMs={1500}
             />
 

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState, useEffect } from "react";
 import { ArrowUp, Loader2 } from "lucide-react";
 import { ContentEditor, type ContentEditorRef } from "../../editor";
+import { useFileDropZone } from "../../editor/use-file-drop-zone";
+import { FileDropOverlay } from "../../editor/file-drop-overlay";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
@@ -41,6 +43,9 @@ function ReplyInput({
   const [submitting, setSubmitting] = useState(false);
   const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
   const { uploadWithToast } = useFileUpload(api);
+  const { isDragOver, dropZoneProps } = useFileDropZone({
+    onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
+  });
 
   useEffect(() => {
     const el = measureRef.current;
@@ -86,6 +91,7 @@ function ReplyInput({
         className="mt-0.5 shrink-0"
       />
       <div
+        {...dropZoneProps}
         className={cn(
           "relative min-w-0 flex-1 flex flex-col",
           size === "sm" ? "max-h-40" : "max-h-56",
@@ -100,6 +106,7 @@ function ReplyInput({
               onUpdate={(md) => setIsEmpty(!md.trim())}
               onSubmit={handleSubmit}
               onUploadFile={handleUpload}
+              showDropOverlay={false}
               debounceMs={100}
             />
           </div>
@@ -122,6 +129,7 @@ function ReplyInput({
             )}
           </button>
         </div>
+        {isDragOver && <FileDropOverlay />}
       </div>
     </div>
   );

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -2,9 +2,7 @@
 
 import { useRef, useState, useEffect } from "react";
 import { ArrowUp, Loader2 } from "lucide-react";
-import { ContentEditor, type ContentEditorRef } from "../../editor";
-import { useFileDropZone } from "../../editor/use-file-drop-zone";
-import { FileDropOverlay } from "../../editor/file-drop-overlay";
+import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
@@ -106,7 +104,6 @@ function ReplyInput({
               onUpdate={(md) => setIsEmpty(!md.trim())}
               onSubmit={handleSubmit}
               onUploadFile={handleUpload}
-              showDropOverlay={false}
               debounceMs={100}
             />
           </div>

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -47,7 +47,7 @@ import {
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceStore } from "@multica/core/workspace";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { inboxKeys, deduplicateInboxItems } from "@multica/core/inbox/queries";
 import { api } from "@multica/core/api";
 import { useModalStore } from "@multica/core/modals";
@@ -107,7 +107,9 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   );
   const hasRuntimeUpdates = useMyRuntimesNeedUpdate(wsId);
 
+  const queryClient = useQueryClient();
   const logout = () => {
+    queryClient.clear();
     authLogout();
     useWorkspaceStore.getState().clearWorkspace();
   };

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -14,6 +14,8 @@ import {
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import { ContentEditor, type ContentEditorRef } from "../editor";
+import { useFileDropZone } from "../editor/use-file-drop-zone";
+import { FileDropOverlay } from "../editor/file-drop-overlay";
 import { TitleEditor } from "../editor";
 import { StatusIcon, StatusPicker, PriorityPicker, AssigneePicker, DueDatePicker } from "../issues/components";
 import { ProjectPicker } from "../projects/components/project-picker";
@@ -62,6 +64,9 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
 
   const [title, setTitle] = useState(draft.title);
   const descEditorRef = useRef<ContentEditorRef>(null);
+  const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
+    onDrop: (files) => files.forEach((f) => descEditorRef.current?.uploadFile(f)),
+  });
   const [status, setStatus] = useState<IssueStatus>((data?.status as IssueStatus) || draft.status);
   const [priority, setPriority] = useState<IssuePriority>(draft.priority);
   const [submitting, setSubmitting] = useState(false);
@@ -215,15 +220,17 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         </div>
 
         {/* Description — takes remaining space */}
-        <div className="flex-1 min-h-0 overflow-y-auto px-5">
+        <div {...descDropZoneProps} className="relative flex-1 min-h-0 overflow-y-auto px-5">
           <ContentEditor
             ref={descEditorRef}
             defaultValue={draft.description}
             placeholder="Add description..."
             onUpdate={(md) => setDraft({ description: md })}
             onUploadFile={handleUpload}
+            showDropOverlay={false}
             debounceMs={500}
           />
+          {descDragOver && <FileDropOverlay />}
         </div>
 
         {/* Property toolbar */}

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -13,10 +13,7 @@ import {
 } from "@multica/ui/components/ui/dialog";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
-import { ContentEditor, type ContentEditorRef } from "../editor";
-import { useFileDropZone } from "../editor/use-file-drop-zone";
-import { FileDropOverlay } from "../editor/file-drop-overlay";
-import { TitleEditor } from "../editor";
+import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../editor";
 import { StatusIcon, StatusPicker, PriorityPicker, AssigneePicker, DueDatePicker } from "../issues/components";
 import { ProjectPicker } from "../projects/components/project-picker";
 import { useWorkspaceStore } from "@multica/core/workspace";
@@ -227,7 +224,6 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
             placeholder="Add description..."
             onUpdate={(md) => setDraft({ description: md })}
             onUploadFile={handleUpload}
-            showDropOverlay={false}
             debounceMs={500}
           />
           {descDragOver && <FileDropOverlay />}


### PR DESCRIPTION
## Summary

- **Storage standardization**: All Zustand persist stores now go through `StorageAdapter` DI instead of hardcoded `localStorage`, restoring the `packages/core/` zero-localStorage constraint
- **Workspace isolation**: Workspace-scoped stores (draft, view, scope, chat) auto-namespace keys as `${key}:${wsId}`, preventing cross-workspace data leakage
- **Logout security (P0)**: Logout now clears `multica_workspace_id` and `queryClient.clear()` — previously only token was removed, leaving stale data accessible to the next user
- **Lifecycle cleanup**: Workspace delete and member removal events clear scoped storage keys
- **Drag-drop overlay**: Lifted drop target from inside editor to outer container, fixing the "empty editor = tiny drop target" problem

## Key changes

**New utilities** (`packages/core/platform/`):
- `createPersistStorage` — static bridge for user-scoped stores (navigation)
- `createWorkspaceAwareStorage` — dynamic `${key}:${wsId}` namespace for workspace-scoped stores
- `registerForWorkspaceRehydration` — stores auto-rehydrate when workspace switches
- `clearWorkspaceStorage` — cleanup on workspace delete / member removal

**Migrated stores**: navigation, draft, view, issues-scope, my-issues-view, chat

## Test plan

- [x] `pnpm typecheck` — 5/5 packages pass
- [x] `pnpm test` — 82/82 tests pass (core: 8, views: 67, web: 6, desktop: 1)
- [ ] Manual: switch workspace → verify draft/filters/chat reset to new workspace's data
- [ ] Manual: logout → login as different user → verify no stale data visible
- [ ] Manual: drag file onto empty comment input → verify overlay covers outer container

🤖 Generated with [Claude Code](https://claude.com/claude-code)