### PR TITLE
feat(desktop): drag-to-reorder tabs via dnd-kit

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,10 @@
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@multica/core": "workspace:*",
@@ -26,8 +30,8 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
-    "@multica/tsconfig": "workspace:*",
     "@electron-toolkit/tsconfig": "^2.0.0",
+    "@multica/tsconfig": "workspace:*",
     "@tailwindcss/vite": "^4",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/apps/desktop/src/renderer/src/components/tab-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/tab-bar.tsx
@@ -10,6 +10,24 @@ import {
   Plus,
   type LucideIcon,
 } from "lucide-react";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import {
+  restrictToHorizontalAxis,
+  restrictToParentElement,
+} from "@dnd-kit/modifiers";
+import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@multica/ui/lib/utils";
 import { useTabStore, resolveRouteIcon, type Tab } from "@/stores/tab-store";
 
@@ -23,11 +41,27 @@ const TAB_ICONS: Record<string, LucideIcon> = {
   Settings,
 };
 
-function TabItem({ tab, isActive, isOnly }: { tab: Tab; isActive: boolean; isOnly: boolean }) {
+function SortableTabItem({ tab, isActive, isOnly }: { tab: Tab; isActive: boolean; isOnly: boolean }) {
   const setActiveTab = useTabStore((s) => s.setActiveTab);
   const closeTab = useTabStore((s) => s.closeTab);
 
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: tab.id });
+
   const Icon = TAB_ICONS[tab.icon];
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    WebkitAppRegion: "no-drag",
+    zIndex: isDragging ? 10 : undefined,
+  } as React.CSSProperties;
 
   const handleClick = () => {
     if (isActive) return;
@@ -41,16 +75,25 @@ function TabItem({ tab, isActive, isOnly }: { tab: Tab; isActive: boolean; isOnl
     // No navigate() — store handles activeTabId switch
   };
 
+  // Stop pointer down on close so it doesn't start a drag on the parent button.
+  const stopDragOnClose = (e: React.PointerEvent) => {
+    e.stopPropagation();
+  };
+
   return (
     <button
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
       onClick={handleClick}
-      style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
       className={cn(
         "group flex h-7 w-40 items-center gap-1.5 rounded-md px-2 text-xs transition-colors",
         "select-none cursor-default",
         isActive
           ? "bg-sidebar-accent font-medium text-sidebar-accent-foreground"
           : "bg-sidebar-accent/50 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        isDragging && "opacity-60",
       )}
     >
       {Icon && <Icon className="size-3.5 shrink-0" />}
@@ -66,6 +109,7 @@ function TabItem({ tab, isActive, isOnly }: { tab: Tab; isActive: boolean; isOnl
       {!isOnly && (
         <span
           onClick={handleClose}
+          onPointerDown={stopDragOnClose}
           className="hidden size-3.5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors group-hover:flex hover:bg-muted-foreground/20 hover:text-foreground"
         >
           <X className="size-2.5" />
@@ -100,12 +144,44 @@ function NewTabButton() {
 export function TabBar() {
   const tabs = useTabStore((s) => s.tabs);
   const activeTabId = useTabStore((s) => s.activeTabId);
+  const moveTab = useTabStore((s) => s.moveTab);
+
+  // distance: 5 — pointer must move 5px to start a drag, otherwise it's a click.
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+  );
+
+  const tabIds = tabs.map((t) => t.id);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = tabs.findIndex((t) => t.id === active.id);
+    const to = tabs.findIndex((t) => t.id === over.id);
+    if (from !== -1 && to !== -1) moveTab(from, to);
+  };
 
   return (
     <div className="flex h-full items-center gap-0.5 px-2 justify-start">
-      {tabs.map((tab) => (
-        <TabItem key={tab.id} tab={tab} isActive={tab.id === activeTabId} isOnly={tabs.length === 1} />
-      ))}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+          {tabs.map((tab) => (
+            <SortableTabItem
+              key={tab.id}
+              tab={tab}
+              isActive={tab.id === activeTabId}
+              isOnly={tabs.length === 1}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
       <NewTabButton />
     </div>
   );

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { arrayMove } from "@dnd-kit/sortable";
+import { createPersistStorage, defaultStorage } from "@multica/core/platform";
 import type { DataRouter } from "react-router-dom";
 import { createTabRouter } from "../routes";
 
@@ -33,6 +35,8 @@ interface TabStore {
   updateTab: (tabId: string, patch: Partial<Pick<Tab, "path" | "title" | "icon">>) => void;
   /** Update a tab's history tracking. */
   updateTabHistory: (tabId: string, historyIndex: number, historyLength: number) => void;
+  /** Reorder tabs by moving one from fromIndex to toIndex. Preserves router/history. */
+  moveTab: (fromIndex: number, toIndex: number) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -150,10 +154,16 @@ export const useTabStore = create<TabStore>()(
       ),
     }));
   },
+
+  moveTab(fromIndex, toIndex) {
+    if (fromIndex === toIndex) return;
+    set((s) => ({ tabs: arrayMove(s.tabs, fromIndex, toIndex) }));
+  },
     }),
     {
       name: "multica_tabs",
       version: 1,
+      storage: createJSONStorage(() => createPersistStorage(defaultStorage)),
       partialize: (state) => ({
         tabs: state.tabs.map(
           ({ router, historyIndex, historyLength, ...rest }) => rest,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,18 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.3)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@39.8.7)
@@ -911,6 +923,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
 
   '@dnd-kit/sortable@10.0.0':
     resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
@@ -6589,6 +6607,13 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.3)
+      react: 19.2.3
       tslib: 2.8.1
 
   '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':


### PR DESCRIPTION
## Summary
- Adds horizontal drag-and-drop reordering for the desktop tab bar via `@dnd-kit/sortable`, with `restrictToHorizontalAxis` + `restrictToParentElement` so tabs only slide within the bar.
- Migrates `tab-store` into the standardized storage pipeline (`createPersistStorage(defaultStorage)`) — it was the last persist store still using vanilla zustand persist after #640. Storage key `multica_tabs` unchanged → existing user data preserved.
- New `moveTab(from, to)` action uses `arrayMove` so `Tab.router` references stay stable; navigation history of each tab survives reordering.

## Implementation Notes
- `PointerSensor` activation distance: 5px — disambiguates click (switch tab) from drag (reorder).
- `<X>` close button gets `onPointerDown stopPropagation` so clicking close never starts a drag.
- `NewTabButton` is rendered outside `SortableContext` so it can't be dragged or used as a drop target.
- `WebkitAppRegion: "no-drag"` on the tab button is preserved so Electron's title-bar drag region stays intact while still letting pointer events reach dnd-kit.

## Test plan
- [ ] Open ≥4 tabs, drag one across the bar — others slide horizontally to make room
- [ ] Tab follows cursor only on the X axis (no vertical drift) and cannot leave the tab bar
- [ ] Plain click (move <5px) still switches the active tab
- [ ] Click on `X` closes the tab and never triggers a drag
- [ ] Dragging the active tab does not change which tab is active
- [ ] Reorder, then `Cmd+R` reload — order is preserved
- [ ] Quit + relaunch Electron app — order still preserved
- [ ] DevTools → Application → Local Storage shows key `multica_tabs` (no `:wsId` suffix)
- [ ] Title-bar drag (clicking empty header area) still drags the window
- [ ] Double-click on empty header still maximizes the window
- [ ] `+` button still appends a fresh tab; cannot be dragged
- [ ] WS event opening a tab mid-drag does not crash or hijack the active drag
- [ ] `pnpm typecheck` ✅ (verified locally)
- [ ] `pnpm --filter @multica/desktop build` ✅ (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)