### PR TITLE
fix(views): show user-scoped done count on My Issues page

### DIFF
--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -103,6 +103,7 @@ export function BoardView({
   hiddenStatuses,
   onMoveIssue,
   childProgressMap = EMPTY_PROGRESS_MAP,
+  doneTotal: doneTotalOverride,
 }: {
   issues: Issue[];
   allIssues: Issue[];
@@ -114,10 +115,13 @@ export function BoardView({
     newPosition?: number
   ) => void;
   childProgressMap?: Map<string, ChildProgress>;
+  /** Override the done-column count (e.g. with a client-filtered total). */
+  doneTotal?: number;
 }) {
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
-  const { loadMore, hasMore, isLoading: loadingMore, doneTotal } = useLoadMoreDoneIssues();
+  const { loadMore, hasMore, isLoading: loadingMore, doneTotal: hookDoneTotal } = useLoadMoreDoneIssues();
+  const displayDoneTotal = doneTotalOverride ?? hookDoneTotal;
 
   // --- Drag state ---
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
@@ -281,7 +285,7 @@ export function BoardView({
             issueIds={columns[status] ?? []}
             issueMap={issueMapRef.current}
             childProgressMap={childProgressMap}
-            totalCount={status === "done" ? doneTotal : undefined}
+            totalCount={status === "done" ? displayDoneTotal : undefined}
             footer={
               status === "done" && hasMore ? (
                 <InfiniteScrollSentinel onVisible={loadMore} loading={loadingMore} />

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -22,10 +22,13 @@ export function ListView({
   issues,
   visibleStatuses,
   childProgressMap = EMPTY_PROGRESS_MAP,
+  doneTotal: doneTotalOverride,
 }: {
   issues: Issue[];
   visibleStatuses: IssueStatus[];
   childProgressMap?: Map<string, ChildProgress>;
+  /** Override the done-group count (e.g. with a client-filtered total). */
+  doneTotal?: number;
 }) {
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
@@ -38,7 +41,8 @@ export function ListView({
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
   const select = useIssueSelectionStore((s) => s.select);
   const deselect = useIssueSelectionStore((s) => s.deselect);
-  const { loadMore, hasMore, isLoading: loadingMore, doneTotal } = useLoadMoreDoneIssues();
+  const { loadMore, hasMore, isLoading: loadingMore, doneTotal: hookDoneTotal } = useLoadMoreDoneIssues();
+  const displayDoneTotal = doneTotalOverride ?? hookDoneTotal;
 
   const issuesByStatus = useMemo(() => {
     const map = new Map<IssueStatus, Issue[]>();
@@ -108,7 +112,7 @@ export function ListView({
                     {cfg.label}
                   </span>
                   <span className="text-xs text-muted-foreground">
-                    {status === "done" ? doneTotal : statusIssues.length}
+                    {status === "done" ? displayDoneTotal : statusIssues.length}
                   </span>
                 </Accordion.Trigger>
                 <div className="pr-2">

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -86,6 +86,12 @@ export function MyIssuesPage() {
     }
   }, [scope, assignedToMe, myAgentIssues, createdByMe]);
 
+  // Done count scoped to the current user (not the workspace-wide total)
+  const myDoneTotal = useMemo(
+    () => myIssues.filter((i) => i.status === "done").length,
+    [myIssues],
+  );
+
   // Apply status/priority filters from view store
   const issues = useMemo(
     () =>
@@ -204,9 +210,10 @@ export function MyIssuesPage() {
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
+                doneTotal={myDoneTotal}
               />
             ) : (
-              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} />
+              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} doneTotal={myDoneTotal} />
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- The Done column on "My Issues" displayed the workspace-wide total (269) instead of the current user's done issue count
- Added optional `doneTotal` prop to `BoardView` and `ListView` so the parent page can override the displayed count
- `MyIssuesPage` now computes done count from the client-filtered issue list and passes it to both view components

## Test plan
- [ ] Open My Issues → Assigned tab, verify Done column count reflects only issues assigned to you
- [ ] Switch to Created / My Agents tabs, verify Done count updates to match each scope
- [ ] Open workspace Issues page, verify Done count still shows workspace-wide total (unchanged behavior)
- [ ] Toggle between board and list view on My Issues, verify count is consistent
- [ ] `pnpm typecheck` and `pnpm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)