### PR TITLE
fix(desktop): disable web security for CORS and fix dev server port

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()],
   },
   renderer: {
+    server: {
+      port: 5173,
+      strictPort: true,
+    },
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -17,6 +17,7 @@ function createWindow(): void {
     webPreferences: {
       preload: join(__dirname, "../preload/index.js"),
       sandbox: false,
+      webSecurity: false,
     },
   });
 


### PR DESCRIPTION
## Summary
- Set `webSecurity: false` in BrowserWindow to bypass CORS when connecting to remote API (standard Electron practice)
- Fix renderer dev server to port 5173 with `strictPort: true` so localStorage persists across restarts (prevents losing login state on every restart)

## Test plan
- [ ] `pnpm dev:desktop` starts without CORS errors when connecting to remote API
- [ ] Restart desktop app and verify login state is preserved