### PR TITLE
fix(my-issues): use server-side filtering instead of client-side

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -182,6 +182,8 @@ export class ApiClient {
     if (params?.status) search.set("status", params.status);
     if (params?.priority) search.set("priority", params.priority);
     if (params?.assignee_id) search.set("assignee_id", params.assignee_id);
+    if (params?.assignee_ids?.length) search.set("assignee_ids", params.assignee_ids.join(","));
+    if (params?.creator_id) search.set("creator_id", params.creator_id);
     if (params?.open_only) search.set("open_only", "true");
     return this.fetch(`/api/issues?${search}`);
   }

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
-import { issueKeys, CLOSED_PAGE_SIZE } from "./queries";
+import { issueKeys, CLOSED_PAGE_SIZE, type MyIssuesFilter } from "./queries";
 import { useWorkspaceId } from "../hooks";
 import type { Issue, IssueReaction } from "../types";
 import type {
@@ -66,6 +66,50 @@ export function useLoadMoreDoneIssues() {
       setIsLoading(false);
     }
   }, [qc, wsId, doneLoaded, hasMore, isLoading]);
+
+  return { loadMore, hasMore, isLoading, doneTotal };
+}
+
+/**
+ * Paginate done issues for a My Issues scope (server-filtered).
+ */
+export function useLoadMoreMyDoneIssues(scope: string, filter: MyIssuesFilter) {
+  const qc = useQueryClient();
+  const wsId = useWorkspaceId();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const queryKey = issueKeys.myList(wsId, scope, filter);
+  const cache = qc.getQueryData<ListIssuesResponse>(queryKey);
+  const doneLoaded = cache
+    ? cache.issues.filter((i) => i.status === "done").length
+    : 0;
+  const doneTotal = cache?.doneTotal ?? 0;
+  const hasMore = doneLoaded < doneTotal;
+
+  const loadMore = useCallback(async () => {
+    if (isLoading || !hasMore) return;
+    setIsLoading(true);
+    try {
+      const res = await api.listIssues({
+        status: "done",
+        limit: CLOSED_PAGE_SIZE,
+        offset: doneLoaded,
+        ...filter,
+      });
+      qc.setQueryData<ListIssuesResponse>(queryKey, (old) => {
+        if (!old) return old;
+        const existingIds = new Set(old.issues.map((i) => i.id));
+        const newIssues = res.issues.filter((i) => !existingIds.has(i.id));
+        return {
+          ...old,
+          issues: [...old.issues, ...newIssues],
+          doneTotal: res.total,
+        };
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [qc, queryKey, doneLoaded, hasMore, isLoading, filter]);
 
   return { loadMore, hasMore, isLoading, doneTotal };
 }

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -31,54 +31,14 @@ export type ToggleIssueReactionVars = {
 // Done issue pagination
 // ---------------------------------------------------------------------------
 
-export function useLoadMoreDoneIssues() {
+export function useLoadMoreDoneIssues(myIssues?: { scope: string; filter: MyIssuesFilter }) {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   const [isLoading, setIsLoading] = useState(false);
 
-  const cache = qc.getQueryData<ListIssuesResponse>(issueKeys.list(wsId));
-  const doneLoaded = cache
-    ? cache.issues.filter((i) => i.status === "done").length
-    : 0;
-  const doneTotal = cache?.doneTotal ?? 0;
-  const hasMore = doneLoaded < doneTotal;
-
-  const loadMore = useCallback(async () => {
-    if (isLoading || !hasMore) return;
-    setIsLoading(true);
-    try {
-      const res = await api.listIssues({
-        status: "done",
-        limit: CLOSED_PAGE_SIZE,
-        offset: doneLoaded,
-      });
-      qc.setQueryData<ListIssuesResponse>(issueKeys.list(wsId), (old) => {
-        if (!old) return old;
-        const existingIds = new Set(old.issues.map((i) => i.id));
-        const newIssues = res.issues.filter((i) => !existingIds.has(i.id));
-        return {
-          ...old,
-          issues: [...old.issues, ...newIssues],
-          doneTotal: res.total,
-        };
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  }, [qc, wsId, doneLoaded, hasMore, isLoading]);
-
-  return { loadMore, hasMore, isLoading, doneTotal };
-}
-
-/**
- * Paginate done issues for a My Issues scope (server-filtered).
- */
-export function useLoadMoreMyDoneIssues(scope: string, filter: MyIssuesFilter) {
-  const qc = useQueryClient();
-  const wsId = useWorkspaceId();
-  const [isLoading, setIsLoading] = useState(false);
-
-  const queryKey = issueKeys.myList(wsId, scope, filter);
+  const queryKey = myIssues
+    ? issueKeys.myList(wsId, myIssues.scope, myIssues.filter)
+    : issueKeys.list(wsId);
   const cache = qc.getQueryData<ListIssuesResponse>(queryKey);
   const doneLoaded = cache
     ? cache.issues.filter((i) => i.status === "done").length
@@ -94,7 +54,7 @@ export function useLoadMoreMyDoneIssues(scope: string, filter: MyIssuesFilter) {
         status: "done",
         limit: CLOSED_PAGE_SIZE,
         offset: doneLoaded,
-        ...filter,
+        ...myIssues?.filter,
       });
       qc.setQueryData<ListIssuesResponse>(queryKey, (old) => {
         if (!old) return old;
@@ -109,7 +69,7 @@ export function useLoadMoreMyDoneIssues(scope: string, filter: MyIssuesFilter) {
     } finally {
       setIsLoading(false);
     }
-  }, [qc, queryKey, doneLoaded, hasMore, isLoading, filter]);
+  }, [qc, queryKey, doneLoaded, hasMore, isLoading, myIssues?.filter]);
 
   return { loadMore, hasMore, isLoading, doneTotal };
 }

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -1,9 +1,15 @@
 import { queryOptions } from "@tanstack/react-query";
 import { api } from "../api";
+import type { ListIssuesParams } from "../types";
 
 export const issueKeys = {
   all: (wsId: string) => ["issues", wsId] as const,
   list: (wsId: string) => [...issueKeys.all(wsId), "list"] as const,
+  /** All "my issues" queries — use for bulk invalidation. */
+  myAll: (wsId: string) => [...issueKeys.all(wsId), "my"] as const,
+  /** Per-scope "my issues" list with filter identity baked into the key. */
+  myList: (wsId: string, scope: string, filter: MyIssuesFilter) =>
+    [...issueKeys.myAll(wsId), scope, filter] as const,
   detail: (wsId: string, id: string) =>
     [...issueKeys.all(wsId), "detail", id] as const,
   children: (wsId: string, id: string) =>
@@ -14,6 +20,8 @@ export const issueKeys = {
     ["issues", "subscribers", issueId] as const,
   usage: (issueId: string) => ["issues", "usage", issueId] as const,
 };
+
+export type MyIssuesFilter = Pick<ListIssuesParams, "assignee_id" | "assignee_ids" | "creator_id">;
 
 export const CLOSED_PAGE_SIZE = 50;
 
@@ -32,6 +40,37 @@ export function issueListOptions(wsId: string) {
       const [openRes, closedRes] = await Promise.all([
         api.listIssues({ open_only: true }),
         api.listIssues({ status: "done", limit: CLOSED_PAGE_SIZE, offset: 0 }),
+      ]);
+      return {
+        issues: [...openRes.issues, ...closedRes.issues],
+        total: openRes.total + closedRes.total,
+        doneTotal: closedRes.total,
+      };
+    },
+    select: (data) => data.issues,
+  });
+}
+
+/**
+ * Server-filtered issue list for the My Issues page.
+ * Each scope gets its own cache entry so switching tabs is instant after first load.
+ */
+export function myIssueListOptions(
+  wsId: string,
+  scope: string,
+  filter: MyIssuesFilter,
+) {
+  return queryOptions({
+    queryKey: issueKeys.myList(wsId, scope, filter),
+    queryFn: async () => {
+      const [openRes, closedRes] = await Promise.all([
+        api.listIssues({ open_only: true, ...filter }),
+        api.listIssues({
+          status: "done",
+          limit: CLOSED_PAGE_SIZE,
+          offset: 0,
+          ...filter,
+        }),
       ]);
       return {
         issues: [...openRes.issues, ...closedRes.issues],

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -17,6 +17,7 @@ export function onIssueCreated(
       doneTotal: (old.doneTotal ?? 0) + (issue.status === "done" ? 1 : 0),
     };
   });
+  qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   if (issue.parent_issue_id) {
     qc.invalidateQueries({ queryKey: issueKeys.children(wsId, issue.parent_issue_id) });
   }
@@ -57,6 +58,7 @@ export function onIssueUpdated(
       doneTotal: (old.doneTotal ?? 0) + doneDelta,
     };
   });
+  qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issue.id), (old) =>
     old ? { ...old, ...issue } : old,
   );
@@ -86,6 +88,7 @@ export function onIssueDeleted(
       doneTotal: (old.doneTotal ?? 0) - (del?.status === "done" ? 1 : 0),
     };
   });
+  qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.removeQueries({ queryKey: issueKeys.detail(wsId, issueId) });
   qc.removeQueries({ queryKey: issueKeys.timeline(issueId) });
   qc.removeQueries({ queryKey: issueKeys.reactions(issueId) });

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -35,6 +35,8 @@ export interface ListIssuesParams {
   status?: IssueStatus;
   priority?: IssuePriority;
   assignee_id?: string;
+  assignee_ids?: string[];
+  creator_id?: string;
   open_only?: boolean;
 }
 

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -18,7 +18,7 @@ import { arrayMove } from "@dnd-kit/sortable";
 import { Eye, MoreHorizontal } from "lucide-react";
 import type { Issue, IssueStatus } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
-import { useLoadMoreDoneIssues, useLoadMoreMyDoneIssues } from "@multica/core/issues/mutations";
+import { useLoadMoreDoneIssues } from "@multica/core/issues/mutations";
 import type { MyIssuesFilter } from "@multica/core/issues/queries";
 import {
   DropdownMenu,
@@ -126,10 +126,9 @@ export function BoardView({
 }) {
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
-  const wsHook = useLoadMoreDoneIssues();
-  const myHook = useLoadMoreMyDoneIssues(myIssuesScope ?? "", myIssuesFilter ?? {});
+  const myIssuesOpts = myIssuesScope ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} } : undefined;
   const { loadMore, hasMore, isLoading: loadingMore, doneTotal: hookDoneTotal } =
-    myIssuesScope ? myHook : wsHook;
+    useLoadMoreDoneIssues(myIssuesOpts);
   const displayDoneTotal = doneTotalOverride ?? hookDoneTotal;
 
   // --- Drag state ---

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -18,7 +18,8 @@ import { arrayMove } from "@dnd-kit/sortable";
 import { Eye, MoreHorizontal } from "lucide-react";
 import type { Issue, IssueStatus } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
-import { useLoadMoreDoneIssues } from "@multica/core/issues/mutations";
+import { useLoadMoreDoneIssues, useLoadMoreMyDoneIssues } from "@multica/core/issues/mutations";
+import type { MyIssuesFilter } from "@multica/core/issues/queries";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -104,6 +105,8 @@ export function BoardView({
   onMoveIssue,
   childProgressMap = EMPTY_PROGRESS_MAP,
   doneTotal: doneTotalOverride,
+  myIssuesScope,
+  myIssuesFilter,
 }: {
   issues: Issue[];
   allIssues: Issue[];
@@ -115,12 +118,18 @@ export function BoardView({
     newPosition?: number
   ) => void;
   childProgressMap?: Map<string, ChildProgress>;
-  /** Override the done-column count (e.g. with a client-filtered total). */
+  /** Override the done-column count (e.g. with a server-filtered total). */
   doneTotal?: number;
+  /** When set, use the My Issues load-more hook instead of the workspace one. */
+  myIssuesScope?: string;
+  myIssuesFilter?: MyIssuesFilter;
 }) {
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
-  const { loadMore, hasMore, isLoading: loadingMore, doneTotal: hookDoneTotal } = useLoadMoreDoneIssues();
+  const wsHook = useLoadMoreDoneIssues();
+  const myHook = useLoadMoreMyDoneIssues(myIssuesScope ?? "", myIssuesFilter ?? {});
+  const { loadMore, hasMore, isLoading: loadingMore, doneTotal: hookDoneTotal } =
+    myIssuesScope ? myHook : wsHook;
   const displayDoneTotal = doneTotalOverride ?? hookDoneTotal;
 
   // --- Drag state ---

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -6,7 +6,8 @@ import { Accordion } from "@base-ui/react/accordion";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import type { Issue, IssueStatus } from "@multica/core/types";
-import { useLoadMoreDoneIssues } from "@multica/core/issues/mutations";
+import { useLoadMoreDoneIssues, useLoadMoreMyDoneIssues } from "@multica/core/issues/mutations";
+import type { MyIssuesFilter } from "@multica/core/issues/queries";
 import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { useModalStore } from "@multica/core/modals";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
@@ -23,12 +24,17 @@ export function ListView({
   visibleStatuses,
   childProgressMap = EMPTY_PROGRESS_MAP,
   doneTotal: doneTotalOverride,
+  myIssuesScope,
+  myIssuesFilter,
 }: {
   issues: Issue[];
   visibleStatuses: IssueStatus[];
   childProgressMap?: Map<string, ChildProgress>;
-  /** Override the done-group count (e.g. with a client-filtered total). */
+  /** Override the done-group count (e.g. with a server-filtered total). */
   doneTotal?: number;
+  /** When set, use the My Issues load-more hook instead of the workspace one. */
+  myIssuesScope?: string;
+  myIssuesFilter?: MyIssuesFilter;
 }) {
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
@@ -41,7 +47,10 @@ export function ListView({
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
   const select = useIssueSelectionStore((s) => s.select);
   const deselect = useIssueSelectionStore((s) => s.deselect);
-  const { loadMore, hasMore, isLoading: loadingMore, doneTotal: hookDoneTotal } = useLoadMoreDoneIssues();
+  const wsHook = useLoadMoreDoneIssues();
+  const myHook = useLoadMoreMyDoneIssues(myIssuesScope ?? "", myIssuesFilter ?? {});
+  const { loadMore, hasMore, isLoading: loadingMore, doneTotal: hookDoneTotal } =
+    myIssuesScope ? myHook : wsHook;
   const displayDoneTotal = doneTotalOverride ?? hookDoneTotal;
 
   const issuesByStatus = useMemo(() => {

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -6,7 +6,7 @@ import { Accordion } from "@base-ui/react/accordion";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import type { Issue, IssueStatus } from "@multica/core/types";
-import { useLoadMoreDoneIssues, useLoadMoreMyDoneIssues } from "@multica/core/issues/mutations";
+import { useLoadMoreDoneIssues } from "@multica/core/issues/mutations";
 import type { MyIssuesFilter } from "@multica/core/issues/queries";
 import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { useModalStore } from "@multica/core/modals";
@@ -47,10 +47,9 @@ export function ListView({
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
   const select = useIssueSelectionStore((s) => s.select);
   const deselect = useIssueSelectionStore((s) => s.deselect);
-  const wsHook = useLoadMoreDoneIssues();
-  const myHook = useLoadMoreMyDoneIssues(myIssuesScope ?? "", myIssuesFilter ?? {});
+  const myIssuesOpts = myIssuesScope ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} } : undefined;
   const { loadMore, hasMore, isLoading: loadingMore, doneTotal: hookDoneTotal } =
-    myIssuesScope ? myHook : wsHook;
+    useLoadMoreDoneIssues(myIssuesOpts);
   const displayDoneTotal = doneTotalOverride ?? hookDoneTotal;
 
   const issuesByStatus = useMemo(() => {

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -20,8 +20,8 @@ import { ListView } from "../../issues/components/list-view";
 import { BatchActionToolbar } from "../../issues/components/batch-action-toolbar";
 import { registerViewStoreForWorkspaceSync } from "@multica/core/issues/stores/view-store";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { issueListOptions } from "@multica/core/issues/queries";
-import { useUpdateIssue } from "@multica/core/issues/mutations";
+import { myIssueListOptions, type MyIssuesFilter } from "@multica/core/issues/queries";
+import { useUpdateIssue, useLoadMoreMyDoneIssues } from "@multica/core/issues/mutations";
 import { myIssuesViewStore } from "@multica/core/issues/stores/my-issues-view-store";
 import { MyIssuesHeader } from "./my-issues-header";
 
@@ -30,7 +30,6 @@ export function MyIssuesPage() {
   const workspace = useWorkspaceStore((s) => s.workspace);
   const wsId = useWorkspaceId();
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
-  const { data: allIssues = [], isLoading: loading } = useQuery(issueListOptions(wsId));
 
   const viewMode = useStore(myIssuesViewStore, (s) => s.viewMode);
   const statusFilters = useStore(myIssuesViewStore, (s) => s.statusFilters);
@@ -45,52 +44,34 @@ export function MyIssuesPage() {
     useIssueSelectionStore.getState().clear();
   }, [viewMode, scope]);
 
+  // Build server-side filter based on scope
   const myAgentIds = useMemo(() => {
-    if (!user) return new Set<string>();
-    return new Set(
-      agents.filter((a) => a.owner_id === user.id).map((a) => a.id),
-    );
+    if (!user) return [] as string[];
+    return agents
+      .filter((a) => a.owner_id === user.id)
+      .map((a) => a.id)
+      .sort();
   }, [agents, user]);
 
-  // Per-scope issue lists
-  const assignedToMe = useMemo(() => {
-    if (!user) return [];
-    return allIssues.filter(
-      (i) => i.assignee_type === "member" && i.assignee_id === user.id,
-    );
-  }, [allIssues, user]);
-
-  const myAgentIssues = useMemo(() => {
-    if (!user) return [];
-    return allIssues.filter(
-      (i) =>
-        i.assignee_type === "agent" &&
-        i.assignee_id &&
-        myAgentIds.has(i.assignee_id),
-    );
-  }, [allIssues, user, myAgentIds]);
-
-  const createdByMe = useMemo(() => {
-    if (!user) return [];
-    return allIssues.filter(
-      (i) => i.creator_type === "member" && i.creator_id === user.id,
-    );
-  }, [allIssues, user]);
-
-  const myIssues = useMemo(() => {
+  const filter: MyIssuesFilter = useMemo(() => {
+    if (!user) return {};
     switch (scope) {
-      case "assigned": return assignedToMe;
-      case "agents": return myAgentIssues;
-      case "created": return createdByMe;
-      default: return assignedToMe;
+      case "assigned":
+        return { assignee_id: user.id };
+      case "created":
+        return { creator_id: user.id };
+      case "agents":
+        return { assignee_ids: myAgentIds };
+      default:
+        return { assignee_id: user.id };
     }
-  }, [scope, assignedToMe, myAgentIssues, createdByMe]);
+  }, [scope, user, myAgentIds]);
 
-  // Done count scoped to the current user (not the workspace-wide total)
-  const myDoneTotal = useMemo(
-    () => myIssues.filter((i) => i.status === "done").length,
-    [myIssues],
+  const { data: myIssues = [], isLoading: loading } = useQuery(
+    myIssueListOptions(wsId, scope, filter),
   );
+
+  const { doneTotal } = useLoadMoreMyDoneIssues(scope, filter);
 
   // Apply status/priority filters from view store
   const issues = useMemo(
@@ -107,7 +88,7 @@ export function MyIssuesPage() {
 
   const childProgressMap = useMemo(() => {
     const map = new Map<string, { done: number; total: number }>();
-    for (const issue of allIssues) {
+    for (const issue of myIssues) {
       if (!issue.parent_issue_id) continue;
       const entry = map.get(issue.parent_issue_id);
       const isDone = issue.status === "done" || issue.status === "cancelled";
@@ -119,7 +100,7 @@ export function MyIssuesPage() {
       }
     }
     return map;
-  }, [allIssues]);
+  }, [myIssues]);
 
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0)
@@ -210,10 +191,19 @@ export function MyIssuesPage() {
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
-                doneTotal={myDoneTotal}
+                doneTotal={doneTotal}
+                myIssuesScope={scope}
+                myIssuesFilter={filter}
               />
             ) : (
-              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} doneTotal={myDoneTotal} />
+              <ListView
+                issues={issues}
+                visibleStatuses={visibleStatuses}
+                childProgressMap={childProgressMap}
+                doneTotal={doneTotal}
+                myIssuesScope={scope}
+                myIssuesFilter={filter}
+              />
             )}
           </div>
         )}

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -21,7 +21,7 @@ import { BatchActionToolbar } from "../../issues/components/batch-action-toolbar
 import { registerViewStoreForWorkspaceSync } from "@multica/core/issues/stores/view-store";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { myIssueListOptions, type MyIssuesFilter } from "@multica/core/issues/queries";
-import { useUpdateIssue, useLoadMoreMyDoneIssues } from "@multica/core/issues/mutations";
+import { useUpdateIssue, useLoadMoreDoneIssues } from "@multica/core/issues/mutations";
 import { myIssuesViewStore } from "@multica/core/issues/stores/my-issues-view-store";
 import { MyIssuesHeader } from "./my-issues-header";
 
@@ -71,7 +71,7 @@ export function MyIssuesPage() {
     myIssueListOptions(wsId, scope, filter),
   );
 
-  const { doneTotal } = useLoadMoreMyDoneIssues(scope, filter);
+  const { doneTotal } = useLoadMoreDoneIssues({ scope, filter });
 
   // Apply status/priority filters from view store
   const issues = useMemo(

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -568,6 +568,18 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	if a := r.URL.Query().Get("assignee_id"); a != "" {
 		assigneeFilter = parseUUID(a)
 	}
+	var assigneeIdsFilter []pgtype.UUID
+	if ids := r.URL.Query().Get("assignee_ids"); ids != "" {
+		for _, raw := range strings.Split(ids, ",") {
+			if s := strings.TrimSpace(raw); s != "" {
+				assigneeIdsFilter = append(assigneeIdsFilter, parseUUID(s))
+			}
+		}
+	}
+	var creatorFilter pgtype.UUID
+	if c := r.URL.Query().Get("creator_id"); c != "" {
+		creatorFilter = parseUUID(c)
+	}
 
 	// open_only=true returns all non-done/cancelled issues (no limit).
 	if r.URL.Query().Get("open_only") == "true" {
@@ -575,6 +587,8 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 			WorkspaceID: wsUUID,
 			Priority:    priorityFilter,
 			AssigneeID:  assigneeFilter,
+			AssigneeIds: assigneeIdsFilter,
+			CreatorID:   creatorFilter,
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -619,6 +633,8 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		Status:      statusFilter,
 		Priority:    priorityFilter,
 		AssigneeID:  assigneeFilter,
+		AssigneeIds: assigneeIdsFilter,
+		CreatorID:   creatorFilter,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -631,6 +647,8 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		Status:      statusFilter,
 		Priority:    priorityFilter,
 		AssigneeID:  assigneeFilter,
+		AssigneeIds: assigneeIdsFilter,
+		CreatorID:   creatorFilter,
 	})
 	if err != nil {
 		total = int64(len(issues))

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -17,13 +17,17 @@ WHERE workspace_id = $1
   AND ($2::text IS NULL OR status = $2)
   AND ($3::text IS NULL OR priority = $3)
   AND ($4::uuid IS NULL OR assignee_id = $4)
+  AND ($5::uuid[] IS NULL OR assignee_id = ANY($5::uuid[]))
+  AND ($6::uuid IS NULL OR creator_id = $6)
 `
 
 type CountIssuesParams struct {
-	WorkspaceID pgtype.UUID `json:"workspace_id"`
-	Status      pgtype.Text `json:"status"`
-	Priority    pgtype.Text `json:"priority"`
-	AssigneeID  pgtype.UUID `json:"assignee_id"`
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+	Status      pgtype.Text   `json:"status"`
+	Priority    pgtype.Text   `json:"priority"`
+	AssigneeID  pgtype.UUID   `json:"assignee_id"`
+	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
+	CreatorID   pgtype.UUID   `json:"creator_id"`
 }
 
 func (q *Queries) CountIssues(ctx context.Context, arg CountIssuesParams) (int64, error) {
@@ -32,6 +36,8 @@ func (q *Queries) CountIssues(ctx context.Context, arg CountIssuesParams) (int64
 		arg.Status,
 		arg.Priority,
 		arg.AssigneeID,
+		arg.AssigneeIds,
+		arg.CreatorID,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -277,17 +283,21 @@ WHERE workspace_id = $1
   AND ($4::text IS NULL OR status = $4)
   AND ($5::text IS NULL OR priority = $5)
   AND ($6::uuid IS NULL OR assignee_id = $6)
+  AND ($7::uuid[] IS NULL OR assignee_id = ANY($7::uuid[]))
+  AND ($8::uuid IS NULL OR creator_id = $8)
 ORDER BY position ASC, created_at DESC
 LIMIT $2 OFFSET $3
 `
 
 type ListIssuesParams struct {
-	WorkspaceID pgtype.UUID `json:"workspace_id"`
-	Limit       int32       `json:"limit"`
-	Offset      int32       `json:"offset"`
-	Status      pgtype.Text `json:"status"`
-	Priority    pgtype.Text `json:"priority"`
-	AssigneeID  pgtype.UUID `json:"assignee_id"`
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+	Limit       int32         `json:"limit"`
+	Offset      int32         `json:"offset"`
+	Status      pgtype.Text   `json:"status"`
+	Priority    pgtype.Text   `json:"priority"`
+	AssigneeID  pgtype.UUID   `json:"assignee_id"`
+	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
+	CreatorID   pgtype.UUID   `json:"creator_id"`
 }
 
 type ListIssuesRow struct {
@@ -317,6 +327,8 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 		arg.Status,
 		arg.Priority,
 		arg.AssigneeID,
+		arg.AssigneeIds,
+		arg.CreatorID,
 	)
 	if err != nil {
 		return nil, err
@@ -362,13 +374,17 @@ WHERE workspace_id = $1
   AND status NOT IN ('done', 'cancelled')
   AND ($2::text IS NULL OR priority = $2)
   AND ($3::uuid IS NULL OR assignee_id = $3)
+  AND ($4::uuid[] IS NULL OR assignee_id = ANY($4::uuid[]))
+  AND ($5::uuid IS NULL OR creator_id = $5)
 ORDER BY position ASC, created_at DESC
 `
 
 type ListOpenIssuesParams struct {
-	WorkspaceID pgtype.UUID `json:"workspace_id"`
-	Priority    pgtype.Text `json:"priority"`
-	AssigneeID  pgtype.UUID `json:"assignee_id"`
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+	Priority    pgtype.Text   `json:"priority"`
+	AssigneeID  pgtype.UUID   `json:"assignee_id"`
+	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
+	CreatorID   pgtype.UUID   `json:"creator_id"`
 }
 
 type ListOpenIssuesRow struct {
@@ -391,7 +407,13 @@ type ListOpenIssuesRow struct {
 }
 
 func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) ([]ListOpenIssuesRow, error) {
-	rows, err := q.db.Query(ctx, listOpenIssues, arg.WorkspaceID, arg.Priority, arg.AssigneeID)
+	rows, err := q.db.Query(ctx, listOpenIssues,
+		arg.WorkspaceID,
+		arg.Priority,
+		arg.AssigneeID,
+		arg.AssigneeIds,
+		arg.CreatorID,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -7,6 +7,8 @@ WHERE workspace_id = $1
   AND (sqlc.narg('status')::text IS NULL OR status = sqlc.narg('status'))
   AND (sqlc.narg('priority')::text IS NULL OR priority = sqlc.narg('priority'))
   AND (sqlc.narg('assignee_id')::uuid IS NULL OR assignee_id = sqlc.narg('assignee_id'))
+  AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
+  AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'))
 ORDER BY position ASC, created_at DESC
 LIMIT $2 OFFSET $3;
 
@@ -66,6 +68,8 @@ WHERE workspace_id = $1
   AND status NOT IN ('done', 'cancelled')
   AND (sqlc.narg('priority')::text IS NULL OR priority = sqlc.narg('priority'))
   AND (sqlc.narg('assignee_id')::uuid IS NULL OR assignee_id = sqlc.narg('assignee_id'))
+  AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
+  AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'))
 ORDER BY position ASC, created_at DESC;
 
 -- name: CountIssues :one
@@ -73,7 +77,9 @@ SELECT count(*) FROM issue
 WHERE workspace_id = $1
   AND (sqlc.narg('status')::text IS NULL OR status = sqlc.narg('status'))
   AND (sqlc.narg('priority')::text IS NULL OR priority = sqlc.narg('priority'))
-  AND (sqlc.narg('assignee_id')::uuid IS NULL OR assignee_id = sqlc.narg('assignee_id'));
+  AND (sqlc.narg('assignee_id')::uuid IS NULL OR assignee_id = sqlc.narg('assignee_id'))
+  AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
+  AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'));
 
 -- name: ListChildIssues :many
 SELECT * FROM issue


### PR DESCRIPTION
## Summary
- My Issues was fetching ALL workspace issues and filtering client-side, causing the Done column to show wrong count (269 = workspace total) and only 2-3 done issues from the first page of 50
- Backend: added `creator_id` and `assignee_ids` (comma-separated uuid array) filter params to `ListIssues`, `ListOpenIssues`, and `CountIssues` SQL queries + Go handler
- Frontend: new `myIssueListOptions` with per-scope server-filtered queries — **Assigned** → `assignee_id`, **Created** → `creator_id`, **My Agents** → `assignee_ids`
- Separate query cache (`issueKeys.myList`) so My Issues and workspace Issues don't interfere
- WS events invalidate My Issues cache via `issueKeys.myAll`

## Deployment
Requires **backend + frontend** deploy together (new query params).

## Test plan
- [ ] Open My Issues → Assigned tab, verify Done count is correct and all your done issues load
- [ ] Switch to Created tab, verify only issues you created appear
- [ ] Switch to My Agents tab, verify only issues assigned to your agents appear
- [ ] Verify workspace Issues page still works unchanged
- [ ] Network tab: confirm API calls include `assignee_id`, `creator_id`, or `assignee_ids` params
- [ ] `pnpm typecheck`, `pnpm test`, `make test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)