### PR TITLE
feat: auto-fill project when creating issue via C shortcut

### DIFF
--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -127,12 +127,15 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
         if (isEditable) return;
         if (useModalStore.getState().modal) return;
         e.preventDefault();
-        useModalStore.getState().open("create-issue");
+        // Auto-fill project when on a project detail page
+        const projectMatch = pathname.match(/^\/projects\/([^/]+)$/);
+        const data = projectMatch ? { project_id: projectMatch[1] } : undefined;
+        useModalStore.getState().open("create-issue", data);
       }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [pathname]);
 
   return (
       <Sidebar variant="inset">


### PR DESCRIPTION
## Summary
- When pressing "C" to create a new issue from a project detail page (`/projects/<id>`), the project is now automatically set in the create-issue modal
- Extracts project ID from the current URL pathname and passes it as `project_id` data to the modal
- Added `pathname` to the effect dependency array so the handler always uses the current route

## Test plan
- [ ] Navigate to a project detail page, press "C", verify the project picker in the create-issue modal is pre-filled with the current project
- [ ] Navigate to the issues list (not inside a project), press "C", verify the project picker is empty (no regression)
- [ ] Create an issue from the project page via "C", verify the created issue has the correct project linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)