### PR TITLE
feat(search): show recent issues in cmd+k dialog

### DIFF
--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -1,5 +1,6 @@
 export { useIssueSelectionStore } from "./selection-store";
 export { useIssueDraftStore } from "./draft-store";
+export { useRecentIssuesStore, type RecentIssueEntry } from "./recent-issues-store";
 export {
   ViewStoreProvider,
   useViewStore,

--- a/packages/core/issues/stores/recent-issues-store.ts
+++ b/packages/core/issues/stores/recent-issues-store.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { IssueStatus } from "../../types";
+import {
+  createWorkspaceAwareStorage,
+  registerForWorkspaceRehydration,
+} from "../../platform/workspace-storage";
+import { defaultStorage } from "../../platform/storage";
+
+const MAX_RECENT_ISSUES = 20;
+
+export interface RecentIssueEntry {
+  id: string;
+  identifier: string;
+  title: string;
+  status: IssueStatus;
+  visitedAt: number;
+}
+
+interface RecentIssuesState {
+  items: RecentIssueEntry[];
+  recordVisit: (entry: Omit<RecentIssueEntry, "visitedAt">) => void;
+}
+
+export const useRecentIssuesStore = create<RecentIssuesState>()(
+  persist(
+    (set) => ({
+      items: [],
+      recordVisit: (entry) =>
+        set((state) => {
+          const filtered = state.items.filter((i) => i.id !== entry.id);
+          const updated: RecentIssueEntry = { ...entry, visitedAt: Date.now() };
+          return {
+            items: [updated, ...filtered].slice(0, MAX_RECENT_ISSUES),
+          };
+        }),
+    }),
+    {
+      name: "multica_recent_issues",
+      storage: createJSONStorage(() =>
+        createWorkspaceAwareStorage(defaultStorage),
+      ),
+      partialize: (state) => ({ items: state.items }),
+    },
+  ),
+);
+
+registerForWorkspaceRehydration(() =>
+  useRecentIssuesStore.persist.rehydrate(),
+);

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -210,6 +210,18 @@ vi.mock("@multica/core/issues/config", () => ({
   },
 }));
 
+// Mock recent issues store
+const mockRecordVisit = vi.fn();
+vi.mock("@multica/core/issues/stores", () => ({
+  useRecentIssuesStore: Object.assign(
+    (selector?: any) => {
+      const state = { items: [], recordVisit: mockRecordVisit };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ items: [], recordVisit: mockRecordVisit }) },
+  ),
+}));
+
 // Mock modals
 vi.mock("@multica/core/modals", () => ({
   useModalStore: Object.assign(

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -68,6 +68,7 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions } from "@multica/core/issues/queries";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import { useUpdateIssue, useDeleteIssue } from "@multica/core/issues/mutations";
+import { useRecentIssuesStore } from "@multica/core/issues/stores";
 import { useIssueTimeline } from "../hooks/use-issue-timeline";
 import { useIssueReactions } from "../hooks/use-issue-reactions";
 import { useIssueSubscribers } from "../hooks/use-issue-subscribers";
@@ -226,6 +227,19 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
       return cached?.description != null ? cached : undefined;
     },
   });
+
+  // Record recent visit
+  const recordVisit = useRecentIssuesStore((s) => s.recordVisit);
+  useEffect(() => {
+    if (issue) {
+      recordVisit({
+        id: issue.id,
+        identifier: issue.identifier,
+        title: issue.title,
+        status: issue.status,
+      });
+    }
+  }, [issue?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Custom hooks — encapsulate timeline, reactions, subscribers
   const {

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -131,6 +131,9 @@ const mockViewState = {
 
 vi.mock("@multica/core/issues/stores/view-store", () => ({
   initFilterWorkspaceSync: vi.fn(),
+  registerViewStoreForWorkspaceSync: vi.fn(),
+  viewStorePersistOptions: () => ({ name: "test", storage: undefined, partialize: (s: any) => s }),
+  viewStoreSlice: vi.fn(),
   useIssueViewStore: Object.assign(
     (selector?: any) => (selector ? selector(mockViewState) : mockViewState),
     { getState: () => mockViewState, setState: vi.fn() },
@@ -178,6 +181,16 @@ vi.mock("@multica/core/issues/stores/selection-store", () => ({
       return selector ? selector(state) : state;
     },
     { getState: () => ({ selectedIds: new Set(), toggle: vi.fn(), clear: vi.fn(), setAll: vi.fn() }) },
+  ),
+}));
+
+vi.mock("@multica/core/issues/stores/recent-issues-store", () => ({
+  useRecentIssuesStore: Object.assign(
+    (selector?: any) => {
+      const state = { items: [], recordVisit: vi.fn() };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ items: [], recordVisit: vi.fn() }) },
   ),
 }));
 

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -1,0 +1,59 @@
+import { act } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchCommand } from "./search-command";
+import { useSearchStore } from "./search-store";
+
+const { mockPush, mockSearchIssues } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockSearchIssues: vi.fn(),
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    searchIssues: mockSearchIssues,
+  },
+}));
+
+vi.mock("@multica/core/issues/stores", () => ({
+  useRecentIssuesStore: (selector?: (state: { items: [] }) => unknown) => {
+    const state = { items: [] as [] };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock("../navigation", () => ({
+  useNavigation: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe("SearchCommand", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockSearchIssues.mockReset().mockResolvedValue({ issues: [] });
+
+    act(() => {
+      useSearchStore.setState({ open: true });
+    });
+  });
+
+  it("closes on a single Escape press from the search input", async () => {
+    const user = userEvent.setup();
+
+    render(<SearchCommand />);
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.click(input);
+
+    expect(useSearchStore.getState().open).toBe(true);
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(useSearchStore.getState().open).toBe(false);
+    });
+    expect(screen.queryByPlaceholderText("Type a command or search...")).not.toBeInTheDocument();
+  });
+});

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -158,12 +158,6 @@ export function SearchCommand() {
         <CommandPrimitive
           shouldFilter={false}
           className="flex size-full flex-col overflow-hidden rounded-xl bg-popover text-popover-foreground"
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              e.preventDefault();
-              setOpen(false);
-            }
-          }}
         >
           {/* Search input */}
           <div className="flex items-center gap-3 border-b px-4 py-3">
@@ -172,6 +166,12 @@ export function SearchCommand() {
               placeholder="Type a command or search..."
               value={query}
               onValueChange={handleValueChange}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setOpen(false);
+                }
+              }}
               className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
             />
             <kbd className="hidden shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline">

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -82,6 +82,7 @@ export function SearchCommand() {
     if (!open) return;
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        e.preventDefault();
         e.stopPropagation();
         setOpen(false);
       }

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -77,6 +77,19 @@ export function SearchCommand() {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
+  // Close on single ESC — capture phase fires before base-ui Dialog's handlers
+  useEffect(() => {
+    if (!open) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleEsc, true);
+    return () => document.removeEventListener("keydown", handleEsc, true);
+  }, [open, setOpen]);
+
   // Cleanup debounce/abort on unmount
   useEffect(() => {
     return () => {
@@ -166,12 +179,6 @@ export function SearchCommand() {
               placeholder="Type a command or search..."
               value={query}
               onValueChange={handleValueChange}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  e.preventDefault();
-                  setOpen(false);
-                }
-              }}
               className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
             />
             <kbd className="hidden shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline">

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Loader2, MessageSquare, SearchIcon } from "lucide-react";
+import { Clock, Loader2, MessageSquare, SearchIcon } from "lucide-react";
 import { Command as CommandPrimitive } from "cmdk";
 import type { SearchIssueResult } from "@multica/core/types";
 import { api } from "@multica/core/api";
+import { useRecentIssuesStore } from "@multica/core/issues/stores";
 import { StatusIcon } from "../issues/components";
 import { STATUS_CONFIG } from "@multica/core/issues/config";
 import {
@@ -57,6 +58,7 @@ export function SearchCommand() {
   const { push } = useNavigation();
   const open = useSearchStore((s) => s.open);
   const setOpen = useSearchStore((s) => s.setOpen);
+  const recentIssues = useRecentIssuesStore((s) => s.items);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchIssueResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -228,7 +230,38 @@ export function SearchCommand() {
               </CommandPrimitive.Group>
             )}
 
-            {!isLoading && !query.trim() && (
+            {!isLoading && !query.trim() && recentIssues.length > 0 && (
+              <CommandPrimitive.Group className="p-2">
+                <div className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-muted-foreground">
+                  <Clock className="size-3" />
+                  <span>Recent</span>
+                </div>
+                {recentIssues.map((item) => (
+                  <CommandPrimitive.Item
+                    key={item.id}
+                    value={item.id}
+                    onSelect={handleSelect}
+                    className="flex cursor-default select-none items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-accent"
+                  >
+                    <StatusIcon
+                      status={item.status}
+                      className="size-4 shrink-0"
+                    />
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      {item.identifier}
+                    </span>
+                    <span className="truncate">{item.title}</span>
+                    <span
+                      className={`ml-auto text-xs shrink-0 ${STATUS_CONFIG[item.status]?.iconColor ?? ""}`}
+                    >
+                      {STATUS_CONFIG[item.status]?.label ?? ""}
+                    </span>
+                  </CommandPrimitive.Item>
+                ))}
+              </CommandPrimitive.Group>
+            )}
+
+            {!isLoading && !query.trim() && recentIssues.length === 0 && (
               <div className="flex flex-col items-center gap-2 py-10 text-sm text-muted-foreground">
                 <span>Type to search issues...</span>
                 <span className="text-xs">Press <kbd className="rounded bg-muted px-1.5 py-0.5 font-medium">⌘K</kbd> to open this anytime</span>

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -158,6 +158,12 @@ export function SearchCommand() {
         <CommandPrimitive
           shouldFilter={false}
           className="flex size-full flex-col overflow-hidden rounded-xl bg-popover text-popover-foreground"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              setOpen(false);
+            }
+          }}
         >
           {/* Search input */}
           <div className="flex items-center gap-3 border-b px-4 py-3">


### PR DESCRIPTION
## Summary
- When cmd+k opens, shows a list of recently visited issues (up to 20) instead of the empty "Type to search issues..." placeholder
- Visits are tracked via a new workspace-scoped persisted Zustand store (`useRecentIssuesStore`) in `packages/core/`
- Each time a user views an issue detail page, the visit is recorded with the issue's id, identifier, title, and status
- If no recent issues exist yet, the original placeholder text is shown as fallback

## Test plan
- [x] TypeScript typecheck passes
- [x] All affected unit tests pass (issue-detail, issues-page)
- [ ] Open cmd+k → should show "Type to search issues..." initially (no visits yet)
- [ ] Navigate to an issue detail page → open cmd+k → should show the issue under "Recent" section
- [ ] Visit multiple issues → cmd+k should show them in reverse chronological order
- [ ] Type a search query → recent list disappears, search results shown
- [ ] Clear search query → recent list reappears
- [ ] Switch workspaces → recent list should be independent per workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)