### PR TITLE
feat: add Trendshift badge to README and landing page footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Turn coding agents into real teammates — assign tasks, track progress, compoun
 [![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
+[![multica-ai/multica | Trendshift](https://trendshift.io/api/badge/repositories/24695)](https://trendshift.io/repositories/24695)
 
 [Website](https://multica.ai) · [Cloud](https://multica.ai/app) · [X](https://x.com/multica_hq) · [Self-Hosting](SELF_HOSTING.md) · [Contributing](CONTRIBUTING.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,6 +20,7 @@
 [![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
+[![multica-ai/multica | Trendshift](https://trendshift.io/api/badge/repositories/24695)](https://trendshift.io/repositories/24695)
 
 [官网](https://multica.ai) · [云服务](https://multica.ai/app) · [X](https://x.com/multica_hq) · [自部署指南](SELF_HOSTING.md) · [参与贡献](CONTRIBUTING.md)
 

--- a/apps/web/features/landing/components/landing-footer.tsx
+++ b/apps/web/features/landing/components/landing-footer.tsx
@@ -83,14 +83,28 @@ export function LandingFooter() {
           </div>
         </div>
 
-        {/* Bottom: copyright + language switcher */}
+        {/* Bottom: copyright + badge + language switcher */}
         <div className="flex items-center justify-between py-6">
-          <p className="text-[13px] text-white/36">
-            {t.footer.copyright.replace(
-              "{year}",
-              String(new Date().getFullYear()),
-            )}
-          </p>
+          <div className="flex items-center gap-4">
+            <p className="text-[13px] text-white/36">
+              {t.footer.copyright.replace(
+                "{year}",
+                String(new Date().getFullYear()),
+              )}
+            </p>
+            <Link
+              href="https://trendshift.io/repositories/24695"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="https://trendshift.io/api/badge/repositories/24695"
+                alt="multica-ai/multica | Trendshift"
+                className="h-[28px] w-auto"
+              />
+            </Link>
+          </div>
           <div className="flex items-center">
             {locales.map((l, i) => (
               <button


### PR DESCRIPTION
## Summary
- Added Trendshift badge to `README.md` and `README.zh-CN.md` alongside existing CI/License/Stars badges
- Added Trendshift badge to the landing page footer (bottom section, next to copyright text)

## Test plan
- [ ] Verify badge renders correctly on GitHub README
- [ ] Verify badge renders correctly on landing page footer
- [ ] Check badge links to `https://trendshift.io/repositories/24695`

🤖 Generated with [Claude Code](https://claude.com/claude-code)