### PR TITLE
fix(pins): scope cache by user and fix sidebar pin action

### DIFF
--- a/packages/core/pins/mutations.ts
+++ b/packages/core/pins/mutations.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
+import { useAuthStore } from "../auth";
 import { pinKeys } from "./queries";
 import { useWorkspaceId } from "../hooks";
 import type { PinnedItem, PinnedItemType } from "../types";
@@ -7,16 +8,17 @@ import type { PinnedItem, PinnedItemType } from "../types";
 export function useCreatePin() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
+  const userId = useAuthStore((s) => s.user?.id ?? "");
   return useMutation({
     mutationFn: (data: { item_type: PinnedItemType; item_id: string }) =>
       api.createPin(data),
     onSuccess: (newPin) => {
-      qc.setQueryData<PinnedItem[]>(pinKeys.list(wsId), (old) =>
+      qc.setQueryData<PinnedItem[]>(pinKeys.list(wsId, userId), (old) =>
         old ? [...old, newPin] : [newPin],
       );
     },
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: pinKeys.list(wsId) });
+      qc.invalidateQueries({ queryKey: pinKeys.list(wsId, userId) });
     },
   });
 }
@@ -24,22 +26,23 @@ export function useCreatePin() {
 export function useDeletePin() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
+  const userId = useAuthStore((s) => s.user?.id ?? "");
   return useMutation({
     mutationFn: ({ itemType, itemId }: { itemType: PinnedItemType; itemId: string }) =>
       api.deletePin(itemType, itemId),
     onMutate: async ({ itemType, itemId }) => {
-      await qc.cancelQueries({ queryKey: pinKeys.list(wsId) });
-      const prev = qc.getQueryData<PinnedItem[]>(pinKeys.list(wsId));
-      qc.setQueryData<PinnedItem[]>(pinKeys.list(wsId), (old) =>
+      await qc.cancelQueries({ queryKey: pinKeys.list(wsId, userId) });
+      const prev = qc.getQueryData<PinnedItem[]>(pinKeys.list(wsId, userId));
+      qc.setQueryData<PinnedItem[]>(pinKeys.list(wsId, userId), (old) =>
         old ? old.filter((p) => !(p.item_type === itemType && p.item_id === itemId)) : old,
       );
       return { prev };
     },
     onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) qc.setQueryData(pinKeys.list(wsId), ctx.prev);
+      if (ctx?.prev) qc.setQueryData(pinKeys.list(wsId, userId), ctx.prev);
     },
     onSettled: () => {
-      qc.invalidateQueries({ queryKey: pinKeys.list(wsId) });
+      qc.invalidateQueries({ queryKey: pinKeys.list(wsId, userId) });
     },
   });
 }
@@ -47,19 +50,20 @@ export function useDeletePin() {
 export function useReorderPins() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
+  const userId = useAuthStore((s) => s.user?.id ?? "");
   return useMutation({
     mutationFn: (reorderedPins: PinnedItem[]) => {
       const items = reorderedPins.map((p, i) => ({ id: p.id, position: i + 1 }));
       return api.reorderPins({ items });
     },
     onMutate: async (reorderedPins) => {
-      await qc.cancelQueries({ queryKey: pinKeys.list(wsId) });
-      const prev = qc.getQueryData<PinnedItem[]>(pinKeys.list(wsId));
-      qc.setQueryData<PinnedItem[]>(pinKeys.list(wsId), reorderedPins);
+      await qc.cancelQueries({ queryKey: pinKeys.list(wsId, userId) });
+      const prev = qc.getQueryData<PinnedItem[]>(pinKeys.list(wsId, userId));
+      qc.setQueryData<PinnedItem[]>(pinKeys.list(wsId, userId), reorderedPins);
       return { prev };
     },
     onError: (_err, _vars, ctx) => {
-      if (ctx?.prev) qc.setQueryData(pinKeys.list(wsId), ctx.prev);
+      if (ctx?.prev) qc.setQueryData(pinKeys.list(wsId, userId), ctx.prev);
     },
   });
 }

--- a/packages/core/pins/queries.ts
+++ b/packages/core/pins/queries.ts
@@ -2,13 +2,13 @@ import { queryOptions } from "@tanstack/react-query";
 import { api } from "../api";
 
 export const pinKeys = {
-  all: (wsId: string) => ["pins", wsId] as const,
-  list: (wsId: string) => [...pinKeys.all(wsId), "list"] as const,
+  all: (wsId: string, userId: string) => ["pins", wsId, userId] as const,
+  list: (wsId: string, userId: string) => [...pinKeys.all(wsId, userId), "list"] as const,
 };
 
-export function pinListOptions(wsId: string) {
+export function pinListOptions(wsId: string, userId: string) {
   return queryOptions({
-    queryKey: pinKeys.list(wsId),
+    queryKey: pinKeys.list(wsId, userId),
     queryFn: () => api.listPins(),
   });
 }

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -102,7 +102,8 @@ export function useRealtimeSync(
       },
       pin: () => {
         const wsId = workspaceStore.getState().workspace?.id;
-        if (wsId) qc.invalidateQueries({ queryKey: pinKeys.all(wsId) });
+        const userId = authStore.getState().user?.id;
+        if (wsId && userId) qc.invalidateQueries({ queryKey: pinKeys.all(wsId, userId) });
       },
       daemon: () => {
         const wsId = workspaceStore.getState().workspace?.id;

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -194,6 +194,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const id = issueId;
   const router = useNavigation();
   const user = useAuthStore((s) => s.user);
+  const userId = useAuthStore((s) => s.user?.id);
   const workspace = useWorkspaceStore((s) => s.workspace);
 
   // Issue navigation — read from TQ list cache
@@ -250,7 +251,10 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const { data: usage } = useQuery(issueUsageOptions(id));
 
   // Pinned state
-  const { data: pinnedItems = [] } = useQuery(pinListOptions(wsId));
+  const { data: pinnedItems = [] } = useQuery({
+    ...pinListOptions(wsId, userId ?? ""),
+    enabled: !!userId,
+  });
   const isPinned = pinnedItems.some((p) => p.item_type === "issue" && p.item_id === id);
   const createPin = useCreatePin();
   const deletePin = useDeletePin();

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -43,6 +43,7 @@ import {
   SidebarFooter,
   SidebarMenu,
   SidebarMenuButton,
+  SidebarMenuAction,
   SidebarMenuItem,
   SidebarRail,
 } from "@multica/ui/components/ui/sidebar";
@@ -63,7 +64,7 @@ import { inboxKeys, deduplicateInboxItems } from "@multica/core/inbox/queries";
 import { api } from "@multica/core/api";
 import { useModalStore } from "@multica/core/modals";
 import { useMyRuntimesNeedUpdate } from "@multica/core/runtimes/hooks";
-import { pinKeys } from "@multica/core/pins/queries";
+import { pinListOptions } from "@multica/core/pins/queries";
 import { useDeletePin, useReorderPins } from "@multica/core/pins/mutations";
 import type { PinnedItem } from "@multica/core/types";
 
@@ -93,7 +94,6 @@ function DraftDot() {
 function SortablePinItem({ pin, pathname, onUnpin }: { pin: PinnedItem; pathname: string; onUnpin: () => void }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: pin.id });
   const wasDragged = useRef(false);
-  const { push } = useNavigation();
 
   useEffect(() => {
     if (isDragging) wasDragged.current = true;
@@ -114,12 +114,13 @@ function SortablePinItem({ pin, pathname, onUnpin }: { pin: PinnedItem; pathname
     >
       <SidebarMenuButton
         isActive={isActive}
-        onClick={() => {
+        render={<AppLink href={href} />}
+        onClick={(event) => {
           if (wasDragged.current) {
             wasDragged.current = false;
+            event.preventDefault();
             return;
           }
-          push(href);
         }}
         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
       >
@@ -129,17 +130,17 @@ function SortablePinItem({ pin, pathname, onUnpin }: { pin: PinnedItem; pathname
           <FolderKanban className="size-4 shrink-0" />
         )}
         <span className="truncate">{label}</span>
-        <button
-          className="ml-auto opacity-0 group-hover/pin:opacity-100 transition-opacity p-0.5 rounded hover:bg-accent shrink-0"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onUnpin();
-          }}
-        >
-          <PinOff className="size-3 text-muted-foreground" />
-        </button>
       </SidebarMenuButton>
+      <SidebarMenuAction
+        showOnHover
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onUnpin();
+        }}
+      >
+        <PinOff className="size-3 text-muted-foreground" />
+      </SidebarMenuAction>
     </SidebarMenuItem>
   );
 }
@@ -158,6 +159,7 @@ interface AppSidebarProps {
 export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }: AppSidebarProps = {}) {
   const { pathname, push } = useNavigation();
   const user = useAuthStore((s) => s.user);
+  const userId = useAuthStore((s) => s.user?.id);
   const authLogout = useAuthStore((s) => s.logout);
   const workspace = useWorkspaceStore((s) => s.workspace);
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -174,10 +176,9 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
     [inboxItems],
   );
   const hasRuntimeUpdates = useMyRuntimesNeedUpdate(wsId);
-  const { data: pinnedItems = [] } = useQuery<PinnedItem[]>({
-    queryKey: wsId ? pinKeys.list(wsId) : ["pins", "disabled"],
-    queryFn: () => api.listPins(),
-    enabled: !!wsId,
+  const { data: pinnedItems = [] } = useQuery({
+    ...pinListOptions(wsId ?? "", userId ?? ""),
+    enabled: !!wsId && !!userId,
   });
   const deletePin = useDeletePin();
   const reorderPins = useReorderPins();

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { cn } from "@multica/ui/lib/utils";
 import { toast } from "sonner";
 import type { Issue, IssueStatus, ProjectStatus, ProjectPriority } from "@multica/core/types";
+import { useAuthStore } from "@multica/core/auth";
 import { projectDetailOptions } from "@multica/core/projects/queries";
 import { useUpdateProject, useDeleteProject } from "@multica/core/projects/mutations";
 import { pinListOptions } from "@multica/core/pins";
@@ -178,6 +179,7 @@ function ProjectIssuesTab({ projectIssues }: { projectIssues: Issue[] }) {
 export function ProjectDetail({ projectId }: { projectId: string }) {
   const wsId = useWorkspaceId();
   const router = useNavigation();
+  const userId = useAuthStore((s) => s.user?.id);
   const workspaceName = useWorkspaceStore((s) => s.workspace?.name);
   const { data: project, isLoading } = useQuery(projectDetailOptions(wsId, projectId));
   const { data: allIssues = [] } = useQuery(issueListOptions(wsId));
@@ -186,7 +188,10 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
   const { getActorName } = useActorName();
   const updateProject = useUpdateProject();
   const deleteProject = useDeleteProject();
-  const { data: pinnedItems = [] } = useQuery(pinListOptions(wsId));
+  const { data: pinnedItems = [] } = useQuery({
+    ...pinListOptions(wsId, userId ?? ""),
+    enabled: !!userId,
+  });
   const isPinned = pinnedItems.some((p) => p.item_type === "project" && p.item_id === projectId);
   const createPin = useCreatePin();
   const deletePinMut = useDeletePin();


### PR DESCRIPTION
## Summary\n- scope pin query keys by both workspace and user to prevent cross-user cache bleed\n- update pin mutations and realtime invalidation to use user-scoped keys\n- fix sidebar pinned item action markup by using a dedicated sidebar action instead of a nested button\n\n## Validation\n- pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx\n- pnpm typecheck