### PR TITLE
fix(web): correct project kanban issue counts

### DIFF
--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -22,6 +22,7 @@ import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { createIssueViewStore } from "@multica/core/issues/stores/view-store";
 import { ViewStoreProvider, useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { filterIssues } from "../../issues/utils/filter";
+import { getProjectIssueMetrics } from "./project-issue-metrics";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { AppLink, useNavigation } from "../../navigation";
 import { TitleEditor, ContentEditor, type ContentEditorRef } from "../../editor";
@@ -101,6 +102,10 @@ function ProjectIssuesContent({ projectIssues }: { projectIssues: Issue[] }) {
     () => filterIssues(projectIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters }),
     [projectIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters],
   );
+  const doneColumnCount = useMemo(
+    () => projectIssues.filter((issue) => issue.status === "done").length,
+    [projectIssues],
+  );
 
   const childProgressMap = useMemo(() => {
     const map = new Map<string, { done: number; total: number }>();
@@ -167,9 +172,15 @@ function ProjectIssuesContent({ projectIssues }: { projectIssues: Issue[] }) {
           hiddenStatuses={hiddenStatuses}
           onMoveIssue={handleMoveIssue}
           childProgressMap={childProgressMap}
+          doneTotal={doneColumnCount}
         />
       ) : (
-        <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} />
+        <ListView
+          issues={issues}
+          visibleStatuses={visibleStatuses}
+          childProgressMap={childProgressMap}
+          doneTotal={doneColumnCount}
+        />
       )}
     </div>
   );
@@ -251,6 +262,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
     return <div className="flex items-center justify-center h-full text-muted-foreground">Project not found</div>;
   }
 
+  const issueMetrics = getProjectIssueMetrics(project, projectIssues);
   const statusCfg = PROJECT_STATUS_CONFIG[project.status];
   const priorityCfg = PROJECT_PRIORITY_CONFIG[project.priority];
 
@@ -548,10 +560,8 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
               </div>
 
               {/* Progress */}
-              {projectIssues.length > 0 && (() => {
-                const doneCount = projectIssues.filter((i) => i.status === "done" || i.status === "cancelled").length;
-                const totalCount = projectIssues.length;
-                const pct = Math.round((doneCount / totalCount) * 100);
+              {issueMetrics.totalCount > 0 && (() => {
+                const pct = Math.round((issueMetrics.completedCount / issueMetrics.totalCount) * 100);
                 return (
                   <div>
                     <div className="text-xs font-medium mb-2 flex items-center gap-1">
@@ -565,7 +575,9 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
                           style={{ width: `${pct}%` }}
                         />
                       </div>
-                      <span className="text-xs text-muted-foreground tabular-nums shrink-0">{doneCount}/{totalCount}</span>
+                      <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+                        {issueMetrics.completedCount}/{issueMetrics.totalCount}
+                      </span>
                     </div>
                   </div>
                 );

--- a/packages/views/projects/components/project-issue-metrics.test.ts
+++ b/packages/views/projects/components/project-issue-metrics.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "@multica/core/types";
+import { getProjectIssueMetrics } from "./project-issue-metrics";
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    id: "issue-1",
+    workspace_id: "ws-1",
+    number: 1,
+    identifier: "MUL-1",
+    title: "Test issue",
+    description: null,
+    status: "todo",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "member-1",
+    parent_issue_id: null,
+    project_id: "project-1",
+    position: 0,
+    due_date: null,
+    created_at: "2026-04-10T00:00:00Z",
+    updated_at: "2026-04-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("getProjectIssueMetrics", () => {
+  it("uses project totals for progress and project-local done issues for the kanban done count", () => {
+    const metrics = getProjectIssueMetrics(
+      { issue_count: 9, done_count: 5 },
+      [
+        makeIssue({ id: "issue-1", status: "done" }),
+        makeIssue({ id: "issue-2", status: "done" }),
+        makeIssue({ id: "issue-3", status: "cancelled" }),
+        makeIssue({ id: "issue-4", status: "todo" }),
+      ],
+    );
+
+    expect(metrics).toEqual({
+      totalCount: 9,
+      completedCount: 5,
+      doneColumnCount: 2,
+    });
+  });
+});

--- a/packages/views/projects/components/project-issue-metrics.ts
+++ b/packages/views/projects/components/project-issue-metrics.ts
@@ -1,0 +1,12 @@
+import type { Issue, Project } from "@multica/core/types";
+
+export function getProjectIssueMetrics(
+  project: Pick<Project, "issue_count" | "done_count">,
+  projectIssues: Issue[],
+) {
+  return {
+    totalCount: project.issue_count,
+    completedCount: project.done_count,
+    doneColumnCount: projectIssues.filter((issue) => issue.status === "done").length,
+  };
+}

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -45,6 +46,14 @@ func projectToResponse(p db.Project) ProjectResponse {
 		CreatedAt:   timestampToString(p.CreatedAt),
 		UpdatedAt:   timestampToString(p.UpdatedAt),
 	}
+}
+
+func (h *Handler) loadProjectIssueStats(ctx context.Context, projectID pgtype.UUID) (int64, int64) {
+	stats, err := h.Queries.GetProjectIssueStats(ctx, []pgtype.UUID{projectID})
+	if err != nil || len(stats) == 0 {
+		return 0, 0
+	}
+	return stats[0].TotalCount, stats[0].DoneCount
 }
 
 type CreateProjectRequest struct {
@@ -123,7 +132,9 @@ func (h *Handler) GetProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "project not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, projectToResponse(project))
+	resp := projectToResponse(project)
+	resp.IssueCount, resp.DoneCount = h.loadProjectIssueStats(r.Context(), project.ID)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
@@ -459,8 +470,8 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 	defer rows.Close()
 
 	type projectSearchRow struct {
-		project    db.Project
-		totalCount int64
+		project     db.Project
+		totalCount  int64
 		matchSource string
 	}
 


### PR DESCRIPTION
## Summary
- pass a project-local done total into the shared board/list views so project kanban counts no longer fall back to the workspace-wide done count
- return issue stats from the project detail API so the sidebar progress uses authoritative project totals
- add a focused regression test for the project issue metrics split between progress and kanban counts

## Testing
- Not run (repo guidance says to only run verification when explicitly requested)
