### PR TITLE
fix: Docker self-host build failures

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -16,6 +16,9 @@ COPY packages/eslint-config/package.json packages/eslint-config/
 
 RUN pnpm install --frozen-lockfile
 
+# Ensure node_modules dirs exist for packages that may have no dependencies
+RUN mkdir -p /app/packages/tsconfig/node_modules /app/packages/eslint-config/node_modules
+
 # --- Build ---
 FROM node:22-alpine AS builder
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "dotenv": "^16.4.7",
     "embla-carousel-react": "^8.6.0",
     "emoji-mart": "^5.6.0",
     "input-otp": "^1.4.2",


### PR DESCRIPTION
## Summary
- Create empty `node_modules` dirs for `packages/tsconfig` and `packages/eslint-config` in Dockerfile.web deps stage — pnpm hoists all their deps so these dirs don't exist after install, causing the COPY to fail
- Add missing `dotenv` dependency to `apps/web/package.json` — `next.config.ts` imports it but it was undeclared

## Fixes
Closes #658

## Test plan
- [ ] `docker compose -f docker-compose.selfhost.yml up -d --build` completes successfully
- [ ] Frontend loads at http://localhost:3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)