### PR TITLE
fix(landing): replace AI-Native Task Management with landing page messaging

### DIFF
--- a/apps/web/app/(landing)/about/page.tsx
+++ b/apps/web/app/(landing)/about/page.tsx
@@ -4,11 +4,11 @@ import { AboutPageClient } from "@/features/landing/components/about-page-client
 export const metadata: Metadata = {
   title: "About",
   description:
-    "Learn about Multica — multiplexed information and computing agent. An open-source AI-native task management platform.",
+    "Learn about Multica — multiplexed information and computing agent. An open-source project management platform for human + agent teams.",
   openGraph: {
     title: "About Multica",
     description:
-      "The story behind Multica and why we're building AI-native task management.",
+      "The story behind Multica and why we're building project management for human + agent teams.",
     url: "/about",
   },
   alternates: {

--- a/apps/web/app/(landing)/homepage/page.tsx
+++ b/apps/web/app/(landing)/homepage/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
   description:
     "Multica — open-source platform that turns coding agents into real teammates. Assign tasks, track progress, compound skills.",
   openGraph: {
-    title: "Multica — AI-Native Task Management",
+    title: "Multica — Project Management for Human + Agent Teams",
     description:
       "Manage your human + agent workforce in one place.",
     url: "/homepage",

--- a/apps/web/app/(landing)/layout.tsx
+++ b/apps/web/app/(landing)/layout.tsx
@@ -30,7 +30,7 @@ const jsonLd = {
       applicationCategory: "ProjectManagement",
       operatingSystem: "Web",
       description:
-        "AI-native task management platform that turns coding agents into real teammates.",
+        "Open-source project management platform that turns coding agents into real teammates.",
       offers: {
         "@type": "Offer",
         price: "0",

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -3,12 +3,12 @@ import { MulticaLanding } from "@/features/landing/components/multica-landing";
 
 export const metadata: Metadata = {
   title: {
-    absolute: "Multica — AI-Native Task Management",
+    absolute: "Multica — Project Management for Human + Agent Teams",
   },
   description:
     "Open-source platform that turns coding agents into real teammates. Assign tasks, track progress, compound skills.",
   openGraph: {
-    title: "Multica — AI-Native Task Management",
+    title: "Multica — Project Management for Human + Agent Teams",
     description:
       "Manage your human + agent workforce in one place.",
     url: "/",

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -22,7 +22,7 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.multica.ai"),
   title: {
-    default: "Multica — AI-Native Task Management",
+    default: "Multica — Project Management for Human + Agent Teams",
     template: "%s | Multica",
   },
   description:


### PR DESCRIPTION
## Summary
- Replaced all occurrences of "AI-Native Task Management" across page titles, OpenGraph metadata, JSON-LD structured data, and about page descriptions
- New messaging uses "Project Management for Human + Agent Teams" — aligned with the landing page hero subheading ("manage your human + agent workforce in one place") and footer tagline ("Project management for human + agent teams")
- Updated 5 files: root layout, landing page, homepage, landing layout (JSON-LD), and about page

## Test plan
- [ ] Verify landing page `<title>` shows new text
- [ ] Check OpenGraph metadata via social share preview tools
- [ ] Confirm about page meta description updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)