### PR TITLE
fix(daemon): make meta-skill workflow defer to agent Skills instead of hardcoding

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -105,29 +105,15 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("5. If the comment requests code changes or further work, do the work first, then reply with your results\n")
 		b.WriteString("6. Do NOT change the issue status unless the comment explicitly asks for it\n\n")
 	} else {
-		// Assignment-triggered: full workflow
+		// Assignment-triggered: defer to agent Skills for workflow specifics.
 		b.WriteString("You are responsible for managing the issue status throughout your work.\n\n")
 		fmt.Fprintf(&b, "1. Run `multica issue get %s --output json` to understand your task\n", ctx.IssueID)
 		fmt.Fprintf(&b, "2. Run `multica issue status %s in_progress`\n", ctx.IssueID)
 		b.WriteString("3. Read comments for additional context or human instructions\n")
-		b.WriteString("4. If the task requires code changes:\n")
-		if len(ctx.Repos) > 0 {
-			b.WriteString("   a. Run `multica repo checkout <url>` to check out the appropriate repository\n")
-			b.WriteString("   b. `cd` into the checked-out directory\n")
-			b.WriteString("   c. Implement the changes and commit\n")
-			b.WriteString("   d. Push the branch to the remote\n")
-			b.WriteString("   e. Create a pull request (decide the target branch based on the repo's conventions)\n")
-			fmt.Fprintf(&b, "   f. Post the PR link as a comment: `multica issue comment add %s --content \"PR: <url>\"`\n", ctx.IssueID)
-		} else {
-			b.WriteString("   a. Create a new branch\n")
-			b.WriteString("   b. Implement the changes and commit\n")
-			b.WriteString("   c. Push the branch to the remote\n")
-			b.WriteString("   d. Create a pull request (decide the target branch based on the repo's conventions)\n")
-			fmt.Fprintf(&b, "   e. Post the PR link as a comment: `multica issue comment add %s --content \"PR: <url>\"`\n", ctx.IssueID)
-		}
-		b.WriteString("5. If the task does not require code (e.g. research, documentation), post your findings as a comment\n")
-		fmt.Fprintf(&b, "6. Run `multica issue status %s in_review`\n", ctx.IssueID)
-		fmt.Fprintf(&b, "7. If blocked, run `multica issue status %s blocked` and post a comment explaining why\n\n", ctx.IssueID)
+		b.WriteString("4. Follow your Skills and Agent Identity to determine how to complete this task.\n")
+		b.WriteString("   If no relevant skill applies, the default workflow is: understand the task → do the work → post a comment with results → update issue status.\n")
+		fmt.Fprintf(&b, "5. When done, run `multica issue status %s in_review`\n", ctx.IssueID)
+		fmt.Fprintf(&b, "6. If blocked, run `multica issue status %s blocked` and post a comment explaining why\n\n", ctx.IssueID)
 	}
 
 	if len(ctx.AgentSkills) > 0 {


### PR DESCRIPTION
## Summary
- Replaces the hardcoded workflow in `buildMetaSkillContent()` with a minimal version that defers to agent Skills
- Keeps platform capability documentation (CLI commands) intact
- Allows role-specific agents (Architect, Tester, etc.) to follow their own skill-defined workflows

Fixes #669