### PR TITLE
fix(daemon): pass MCP tools config when spawning Codex in app-server mode

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -155,19 +156,19 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		}
 
 		threadResult, err := c.request(runCtx, "thread/start", map[string]any{
-			"model":                    nilIfEmpty(opts.Model),
-			"modelProvider":            nil,
-			"profile":                  nil,
-			"cwd":                      opts.Cwd,
-			"approvalPolicy":           nil,
-			"sandbox":                  "workspace-write",
-			"config":                   threadConfig,
-			"baseInstructions":         nil,
-			"developerInstructions":    nilIfEmpty(opts.SystemPrompt),
-			"compactPrompt":            nil,
-			"includeApplyPatchTool":    nil,
-			"experimentalRawEvents":    false,
-			"persistExtendedHistory":   true,
+			"model":                  nilIfEmpty(opts.Model),
+			"modelProvider":          nil,
+			"profile":                nil,
+			"cwd":                    opts.Cwd,
+			"approvalPolicy":         nil,
+			"sandbox":                "workspace-write",
+			"config":                 threadConfig,
+			"baseInstructions":       nil,
+			"developerInstructions":  nilIfEmpty(opts.SystemPrompt),
+			"compactPrompt":          nil,
+			"includeApplyPatchTool":  nil,
+			"experimentalRawEvents":  false,
+			"persistExtendedHistory": true,
 		})
 		if err != nil {
 			finalStatus = "failed"
@@ -274,14 +275,14 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 // ── codexClient: JSON-RPC 2.0 transport ──
 
 type codexClient struct {
-	cfg       Config
-	stdin     interface{ Write([]byte) (int, error) }
-	mu        sync.Mutex
-	nextID    int
-	pending   map[int]*pendingRPC
-	threadID  string
-	turnID    string
-	onMessage func(Message)
+	cfg        Config
+	stdin      interface{ Write([]byte) (int, error) }
+	mu         sync.Mutex
+	nextID     int
+	pending    map[int]*pendingRPC
+	threadID   string
+	turnID     string
+	onMessage  func(Message)
 	onTurnDone func(aborted bool)
 
 	notificationProtocol string // "unknown", "legacy", "raw"
@@ -876,14 +877,18 @@ func bytesContainsStr(b []byte, s string) bool {
 // ── MCP config loader ──
 
 // loadCodexMCPServers reads MCP server definitions from the Codex config.toml.
-// It checks CODEX_HOME from the provided env map first, then falls back to
-// ~/.codex/config.toml. Returns nil if no MCP servers are configured.
+// It checks CODEX_HOME from the provided env map first. If CODEX_HOME is not
+// set, it falls back to ~/.codex/config.toml. Returns nil if no MCP servers are
+// configured.
 func loadCodexMCPServers(env map[string]string) map[string]any {
 	configPath := ""
 	if codexHome := env["CODEX_HOME"]; codexHome != "" {
 		configPath = filepath.Join(codexHome, "config.toml")
+		if !fileExists(configPath) {
+			return nil
+		}
 	}
-	if configPath == "" || !fileExists(configPath) {
+	if configPath == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return nil
@@ -917,7 +922,8 @@ func parseMCPServersFromTOML(content string) map[string]any {
 	var currentServer string // e.g. "vercel"
 	var currentSub string    // e.g. "env" for [mcp_servers.vercel.env]
 
-	for _, line := range lines {
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
 		trimmed := strings.TrimSpace(line)
 
 		// Skip empty lines and comments.
@@ -955,6 +961,26 @@ func parseMCPServersFromTOML(content string) map[string]any {
 			continue
 		}
 
+		// TOML arrays can span multiple lines. Coalesce a multi-line array before
+		// parsing so common Codex config such as args = ["--stdio", ...] works.
+		if strings.Contains(trimmed, "=") {
+			_, val, _ := strings.Cut(trimmed, "=")
+			if strings.HasPrefix(strings.TrimSpace(val), "[") && !tomlArrayComplete(val) {
+				var b strings.Builder
+				b.WriteString(trimmed)
+				for i+1 < len(lines) {
+					i++
+					next := strings.TrimSpace(lines[i])
+					b.WriteByte('\n')
+					b.WriteString(next)
+					if tomlArrayComplete(b.String()) {
+						break
+					}
+				}
+				trimmed = b.String()
+			}
+		}
+
 		key, value, ok := parseTOMLKeyValue(trimmed)
 		if !ok {
 			continue
@@ -988,25 +1014,22 @@ func parseTOMLKeyValue(line string) (string, any, bool) {
 		return "", nil, false
 	}
 	key := strings.TrimSpace(line[:idx])
-	val := strings.TrimSpace(line[idx+1:])
+	val := strings.TrimSpace(stripTOMLComment(line[idx+1:]))
 
 	// String value.
-	if strings.HasPrefix(val, "\"") && strings.HasSuffix(val, "\"") && len(val) >= 2 {
-		return key, val[1 : len(val)-1], true
+	if strings.HasPrefix(val, "\"") {
+		parsed, ok := parseTOMLString(val)
+		if !ok {
+			return "", nil, false
+		}
+		return key, parsed, true
 	}
 
 	// Array of strings.
-	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
-		inner := strings.TrimSpace(val[1 : len(val)-1])
-		if inner == "" {
-			return key, []any{}, true
-		}
-		var items []any
-		for _, item := range strings.Split(inner, ",") {
-			item = strings.TrimSpace(item)
-			if strings.HasPrefix(item, "\"") && strings.HasSuffix(item, "\"") && len(item) >= 2 {
-				items = append(items, item[1:len(item)-1])
-			}
+	if strings.HasPrefix(val, "[") {
+		items, ok := parseTOMLStringArray(val)
+		if !ok {
+			return "", nil, false
 		}
 		return key, items, true
 	}
@@ -1021,6 +1044,153 @@ func parseTOMLKeyValue(line string) (string, any, bool) {
 
 	// Pass through as string for other values.
 	return key, val, true
+}
+
+func parseTOMLString(val string) (string, bool) {
+	val = strings.TrimSpace(stripTOMLComment(val))
+	if !strings.HasPrefix(val, "\"") || !strings.HasSuffix(val, "\"") || len(val) < 2 {
+		return "", false
+	}
+	parsed, err := strconv.Unquote(val)
+	if err != nil {
+		return "", false
+	}
+	return parsed, true
+}
+
+func parseTOMLStringArray(val string) ([]any, bool) {
+	val = strings.TrimSpace(stripTOMLComment(val))
+	if !strings.HasPrefix(val, "[") || !strings.HasSuffix(val, "]") || !tomlArrayComplete(val) {
+		return nil, false
+	}
+	inner := strings.TrimSpace(val[1 : len(val)-1])
+	if inner == "" {
+		return []any{}, true
+	}
+
+	var items []any
+	for len(inner) > 0 {
+		inner = strings.TrimSpace(stripTOMLComment(inner))
+		if inner == "" {
+			break
+		}
+		if !strings.HasPrefix(inner, "\"") {
+			return nil, false
+		}
+
+		end := findTOMLStringEnd(inner)
+		if end < 0 {
+			return nil, false
+		}
+		item, ok := parseTOMLString(inner[:end+1])
+		if !ok {
+			return nil, false
+		}
+		items = append(items, item)
+
+		inner = strings.TrimSpace(inner[end+1:])
+		if inner == "" {
+			break
+		}
+		if !strings.HasPrefix(inner, ",") {
+			return nil, false
+		}
+		inner = strings.TrimSpace(inner[1:])
+	}
+
+	return items, true
+}
+
+func findTOMLStringEnd(s string) int {
+	escaped := false
+	for i := 1; i < len(s); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch s[i] {
+		case '\\':
+			escaped = true
+		case '"':
+			return i
+		}
+	}
+	return -1
+}
+
+func tomlArrayComplete(val string) bool {
+	inString := false
+	escaped := false
+	depth := 0
+	for i := 0; i < len(val); i++ {
+		ch := val[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inString = true
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func stripTOMLComment(val string) string {
+	inString := false
+	escaped := false
+	var b strings.Builder
+	b.Grow(len(val))
+
+	for i := 0; i < len(val); i++ {
+		ch := val[i]
+		if inString {
+			b.WriteByte(ch)
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inString = true
+			b.WriteByte(ch)
+		case '#':
+			for i+1 < len(val) && val[i+1] != '\n' && val[i+1] != '\r' {
+				i++
+			}
+		case '\n', '\r':
+			b.WriteByte(ch)
+		default:
+			b.WriteByte(ch)
+		}
+	}
+	return strings.TrimSpace(b.String())
 }
 
 // fileExists returns true if the path exists and is a regular file.

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -143,6 +143,17 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		c.notify("initialized")
 
 		// 2. Start thread
+		// Load MCP server configuration from the Codex config so that
+		// MCP tools are available in app-server mode. In interactive
+		// mode Codex reads config.toml itself, but app-server expects
+		// the client to pass it via the config parameter.
+		var threadConfig map[string]any
+		if mcpServers := loadCodexMCPServers(b.cfg.Env); len(mcpServers) > 0 {
+			threadConfig = map[string]any{
+				"mcp_servers": mcpServers,
+			}
+		}
+
 		threadResult, err := c.request(runCtx, "thread/start", map[string]any{
 			"model":                    nilIfEmpty(opts.Model),
 			"modelProvider":            nil,
@@ -150,7 +161,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 			"cwd":                      opts.Cwd,
 			"approvalPolicy":           nil,
 			"sandbox":                  "workspace-write",
-			"config":                   nil,
+			"config":                   threadConfig,
 			"baseInstructions":         nil,
 			"developerInstructions":    nilIfEmpty(opts.SystemPrompt),
 			"compactPrompt":            nil,
@@ -860,6 +871,162 @@ func parseCodexSessionFile(path string) *codexSessionUsage {
 // bytesContainsStr checks if b contains the string s (without allocating).
 func bytesContainsStr(b []byte, s string) bool {
 	return strings.Contains(string(b), s)
+}
+
+// ── MCP config loader ──
+
+// loadCodexMCPServers reads MCP server definitions from the Codex config.toml.
+// It checks CODEX_HOME from the provided env map first, then falls back to
+// ~/.codex/config.toml. Returns nil if no MCP servers are configured.
+func loadCodexMCPServers(env map[string]string) map[string]any {
+	configPath := ""
+	if codexHome := env["CODEX_HOME"]; codexHome != "" {
+		configPath = filepath.Join(codexHome, "config.toml")
+	}
+	if configPath == "" || !fileExists(configPath) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		configPath = filepath.Join(home, ".codex", "config.toml")
+	}
+	if !fileExists(configPath) {
+		return nil
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil
+	}
+
+	return parseMCPServersFromTOML(string(data))
+}
+
+// parseMCPServersFromTOML extracts [mcp_servers.*] sections from a TOML config.
+// It handles the subset of TOML used by Codex MCP configuration:
+//
+//	[mcp_servers.name]
+//	command = "..."
+//	args = ["arg1", "arg2"]
+//	[mcp_servers.name.env]
+//	KEY = "value"
+func parseMCPServersFromTOML(content string) map[string]any {
+	servers := make(map[string]any)
+	lines := strings.Split(content, "\n")
+
+	var currentServer string // e.g. "vercel"
+	var currentSub string    // e.g. "env" for [mcp_servers.vercel.env]
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Skip empty lines and comments.
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Section header.
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			header := trimmed[1 : len(trimmed)-1]
+			header = strings.TrimSpace(header)
+
+			if strings.HasPrefix(header, "mcp_servers.") {
+				parts := strings.SplitN(header[len("mcp_servers."):], ".", 2)
+				currentServer = parts[0]
+				if len(parts) > 1 {
+					currentSub = parts[1]
+				} else {
+					currentSub = ""
+				}
+				// Initialize server map if needed.
+				if _, ok := servers[currentServer]; !ok {
+					servers[currentServer] = map[string]any{}
+				}
+			} else {
+				// Different section — stop processing MCP.
+				currentServer = ""
+				currentSub = ""
+			}
+			continue
+		}
+
+		// Key-value pair inside an MCP server section.
+		if currentServer == "" {
+			continue
+		}
+
+		key, value, ok := parseTOMLKeyValue(trimmed)
+		if !ok {
+			continue
+		}
+
+		serverMap := servers[currentServer].(map[string]any)
+		if currentSub != "" {
+			// Nested section (e.g. [mcp_servers.name.env]).
+			sub, ok := serverMap[currentSub].(map[string]any)
+			if !ok {
+				sub = make(map[string]any)
+				serverMap[currentSub] = sub
+			}
+			sub[key] = value
+		} else {
+			serverMap[key] = value
+		}
+	}
+
+	if len(servers) == 0 {
+		return nil
+	}
+	return servers
+}
+
+// parseTOMLKeyValue parses a simple TOML key = value line.
+// Supports strings, arrays of strings, booleans, and integers.
+func parseTOMLKeyValue(line string) (string, any, bool) {
+	idx := strings.Index(line, "=")
+	if idx < 0 {
+		return "", nil, false
+	}
+	key := strings.TrimSpace(line[:idx])
+	val := strings.TrimSpace(line[idx+1:])
+
+	// String value.
+	if strings.HasPrefix(val, "\"") && strings.HasSuffix(val, "\"") && len(val) >= 2 {
+		return key, val[1 : len(val)-1], true
+	}
+
+	// Array of strings.
+	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+		inner := strings.TrimSpace(val[1 : len(val)-1])
+		if inner == "" {
+			return key, []any{}, true
+		}
+		var items []any
+		for _, item := range strings.Split(inner, ",") {
+			item = strings.TrimSpace(item)
+			if strings.HasPrefix(item, "\"") && strings.HasSuffix(item, "\"") && len(item) >= 2 {
+				items = append(items, item[1:len(item)-1])
+			}
+		}
+		return key, items, true
+	}
+
+	// Boolean.
+	if val == "true" {
+		return key, true, true
+	}
+	if val == "false" {
+		return key, false, true
+	}
+
+	// Pass through as string for other values.
+	return key, val, true
+}
+
+// fileExists returns true if the path exists and is a regular file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 // ── Helpers ──

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -531,7 +531,7 @@ command = "/usr/local/bin/vercel-mcp"
 args = ["--stdio"]
 
 [mcp_servers.vercel.env]
-VERCEL_TOKEN = "tok_123"
+VERCEL_TOKEN="tok_123"
 
 [mcp_servers.github]
 command = "gh-mcp"
@@ -609,6 +609,66 @@ args = ["hello"]
 	}
 	if srv["command"] != "/bin/echo" {
 		t.Fatalf("unexpected command: %v", srv["command"])
+	}
+}
+
+func TestParseMCPServersFromTOMLMultilineArrayAndEscapes(t *testing.T) {
+	t.Parallel()
+
+	config := `[mcp_servers.fs]
+command = "C:\\Program Files\\mcp\\server.exe"
+args = [
+  "--stdio",
+  "--label=contains \"quotes\"",
+  "--path=C:\\tmp"
+]
+`
+
+	servers := parseMCPServersFromTOML(config)
+	fs, ok := servers["fs"].(map[string]any)
+	if !ok {
+		t.Fatal("expected fs server")
+	}
+	if fs["command"] != `C:\Program Files\mcp\server.exe` {
+		t.Fatalf("unexpected command: %v", fs["command"])
+	}
+	args, ok := fs["args"].([]any)
+	if !ok {
+		t.Fatalf("expected args array, got %T", fs["args"])
+	}
+	expected := []any{"--stdio", `--label=contains "quotes"`, `--path=C:\tmp`}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i := range expected {
+		if args[i] != expected[i] {
+			t.Fatalf("arg %d: expected %q, got %q", i, expected[i], args[i])
+		}
+	}
+}
+
+func TestParseMCPServersFromTOMLRejectsNonStringArrayElements(t *testing.T) {
+	t.Parallel()
+
+	servers := parseMCPServersFromTOML(`[mcp_servers.bad]
+command = "mcp"
+args = ["--port", 3000]
+`)
+	bad, ok := servers["bad"].(map[string]any)
+	if !ok {
+		t.Fatal("expected bad server")
+	}
+	if _, ok := bad["args"]; ok {
+		t.Fatalf("expected invalid args array to be skipped, got %v", bad["args"])
+	}
+}
+
+func TestLoadCodexMCPServersDoesNotFallbackWhenEnvConfigMissing(t *testing.T) {
+	t.Parallel()
+
+	servers := loadCodexMCPServers(map[string]string{"CODEX_HOME": filepath.Join(t.TempDir(), "missing")})
+	if servers != nil {
+		t.Fatalf("expected nil for missing explicit CODEX_HOME config, got %v", servers)
 	}
 }
 

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 )
@@ -515,6 +517,98 @@ func TestNilIfEmpty(t *testing.T) {
 	}
 	if nilIfEmpty("hello") != "hello" {
 		t.Fatal("expected 'hello'")
+	}
+}
+
+func TestParseMCPServersFromTOML(t *testing.T) {
+	t.Parallel()
+
+	config := `
+model = "gpt-5.4"
+
+[mcp_servers.vercel]
+command = "/usr/local/bin/vercel-mcp"
+args = ["--stdio"]
+
+[mcp_servers.vercel.env]
+VERCEL_TOKEN = "tok_123"
+
+[mcp_servers.github]
+command = "gh-mcp"
+args = ["serve", "--port", "0"]
+
+[projects."/tmp/test"]
+trust_level = "trusted"
+`
+
+	servers := parseMCPServersFromTOML(config)
+	if servers == nil {
+		t.Fatal("expected non-nil servers")
+	}
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(servers))
+	}
+
+	vercel, ok := servers["vercel"].(map[string]any)
+	if !ok {
+		t.Fatal("expected vercel server")
+	}
+	if vercel["command"] != "/usr/local/bin/vercel-mcp" {
+		t.Fatalf("unexpected vercel command: %v", vercel["command"])
+	}
+	args, ok := vercel["args"].([]any)
+	if !ok || len(args) != 1 || args[0] != "--stdio" {
+		t.Fatalf("unexpected vercel args: %v", vercel["args"])
+	}
+	env, ok := vercel["env"].(map[string]any)
+	if !ok || env["VERCEL_TOKEN"] != "tok_123" {
+		t.Fatalf("unexpected vercel env: %v", vercel["env"])
+	}
+
+	github, ok := servers["github"].(map[string]any)
+	if !ok {
+		t.Fatal("expected github server")
+	}
+	if github["command"] != "gh-mcp" {
+		t.Fatalf("unexpected github command: %v", github["command"])
+	}
+	ghArgs, ok := github["args"].([]any)
+	if !ok || len(ghArgs) != 3 {
+		t.Fatalf("unexpected github args: %v", github["args"])
+	}
+}
+
+func TestParseMCPServersFromTOMLEmpty(t *testing.T) {
+	t.Parallel()
+
+	servers := parseMCPServersFromTOML(`model = "gpt-5.4"`)
+	if servers != nil {
+		t.Fatalf("expected nil for config without MCP servers, got %v", servers)
+	}
+}
+
+func TestLoadCodexMCPServersFromEnv(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	config := `[mcp_servers.test-server]
+command = "/bin/echo"
+args = ["hello"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	servers := loadCodexMCPServers(map[string]string{"CODEX_HOME": dir})
+	if servers == nil {
+		t.Fatal("expected non-nil servers")
+	}
+	srv, ok := servers["test-server"].(map[string]any)
+	if !ok {
+		t.Fatal("expected test-server")
+	}
+	if srv["command"] != "/bin/echo" {
+		t.Fatalf("unexpected command: %v", srv["command"])
 	}
 }
 


### PR DESCRIPTION
Fixes #674

## Summary

- Read MCP server configuration from Codex `config.toml` (respecting `CODEX_HOME` env var) and pass it through the `config` field in the `thread/start` JSON-RPC request
- In app-server mode, Codex does not auto-load MCP servers from config.toml — the client must pass them explicitly
- Added a minimal TOML parser scoped to `[mcp_servers.*]` sections (no new dependencies)
- Added tests for TOML parsing and MCP config loading

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All existing tests pass (115 tests in `pkg/agent/`)
- [x] 3 new tests for MCP config parsing and loading