### PR TITLE
feat: add Hindsight long-term memory for agents

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
 	"github.com/multica-ai/multica/server/internal/daemon/usage"
+	"github.com/multica-ai/multica/server/internal/hindsight"
 	"github.com/multica-ai/multica/server/pkg/agent"
 )
 
@@ -26,10 +27,11 @@ type workspaceState struct {
 
 // Daemon is the local agent runtime that polls for and executes tasks.
 type Daemon struct {
-	cfg       Config
-	client    *Client
-	repoCache *repocache.Cache
-	logger    *slog.Logger
+	cfg          Config
+	client       *Client
+	repoCache    *repocache.Cache
+	hindsightCfg *hindsight.Config // nil when memory is disabled
+	logger       *slog.Logger
 
 	mu           sync.Mutex
 	workspaces   map[string]*workspaceState
@@ -44,10 +46,15 @@ type Daemon struct {
 // New creates a new Daemon instance.
 func New(cfg Config, logger *slog.Logger) *Daemon {
 	cacheRoot := filepath.Join(cfg.WorkspacesRoot, ".repos")
+	hsCfg := hindsight.ConfigFromEnv()
+	if hsCfg != nil {
+		logger.Info("hindsight memory enabled", "url", hsCfg.APIURL, "bank", hsCfg.BankID)
+	}
 	return &Daemon{
 		cfg:          cfg,
 		client:       NewClient(cfg.ServerBaseURL),
 		repoCache:    repocache.New(cacheRoot, logger),
+		hindsightCfg: hsCfg,
 		logger:       logger,
 		workspaces:   make(map[string]*workspaceState),
 		runtimeIndex: make(map[string]Runtime),
@@ -920,8 +927,16 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		}
 	}
 
+	// Recall relevant memories from Hindsight (no-op when memory is disabled).
+	recallQuery := task.ChatMessage
+	if recallQuery == "" {
+		recallQuery = "workspace context recent tasks"
+	}
+	memories := hindsight.Recall(ctx, d.hindsightCfg, recallQuery, d.logger)
+	memoriesBlock := hindsight.FormatMemoriesBlock(memories)
+
 	// Inject runtime-specific config (meta skill) so the agent discovers .agent_context/.
-	if err := execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx); err != nil {
+	if err := execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx, memoriesBlock); err != nil {
 		d.logger.Warn("execenv: inject runtime config failed (non-fatal)", "error", err)
 	}
 	// NOTE: No cleanup — workdir is preserved for reuse by future tasks on
@@ -1145,6 +1160,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	case "completed":
 		if result.Output == "" {
 			return TaskResult{}, fmt.Errorf("%s returned empty output", provider)
+		}
+		// Retain the task outcome to Hindsight memory (fire-and-forget).
+		if d.hindsightCfg != nil {
+			content := hindsight.BuildRetainContent(task.WorkspaceID, task.IssueID, agentName, "completed", result.Output)
+			go hindsight.Retain(context.Background(), d.hindsightCfg, content, d.logger)
 		}
 		return TaskResult{
 			Status:    "completed",

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -144,7 +144,7 @@ func TestPrepareWithRepoContext(t *testing.T) {
 	defer env.Cleanup(true)
 
 	// Inject runtime config (done separately in daemon, replicate here).
-	if err := InjectRuntimeConfig(env.WorkDir, "claude", taskCtx); err != nil {
+	if err := InjectRuntimeConfig(env.WorkDir, "claude", taskCtx, ""); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 
@@ -366,7 +366,7 @@ func TestInjectRuntimeConfigClaude(t *testing.T) {
 		},
 	}
 
-	if err := InjectRuntimeConfig(dir, "claude", ctx); err != nil {
+	if err := InjectRuntimeConfig(dir, "claude", ctx, ""); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 
@@ -399,7 +399,7 @@ func TestInjectRuntimeConfigCodex(t *testing.T) {
 		AgentSkills: []SkillContextForEnv{{Name: "Coding", Content: "Write good code."}},
 	}
 
-	if err := InjectRuntimeConfig(dir, "codex", ctx); err != nil {
+	if err := InjectRuntimeConfig(dir, "codex", ctx, ""); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 
@@ -423,7 +423,7 @@ func TestInjectRuntimeConfigNoSkills(t *testing.T) {
 
 	ctx := TaskContextForEnv{IssueID: "test-issue-id"}
 
-	if err := InjectRuntimeConfig(dir, "claude", ctx); err != nil {
+	if err := InjectRuntimeConfig(dir, "claude", ctx, ""); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 
@@ -500,7 +500,7 @@ func TestInjectRuntimeConfigOpencode(t *testing.T) {
 		AgentSkills: []SkillContextForEnv{{Name: "Coding", Content: "Write good code."}},
 	}
 
-	if err := InjectRuntimeConfig(dir, "opencode", ctx); err != nil {
+	if err := InjectRuntimeConfig(dir, "opencode", ctx, ""); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 
@@ -550,7 +550,7 @@ func TestPrepareWithRepoContextOpencode(t *testing.T) {
 	}
 	defer env.Cleanup(true)
 
-	if err := InjectRuntimeConfig(env.WorkDir, "opencode", taskCtx); err != nil {
+	if err := InjectRuntimeConfig(env.WorkDir, "opencode", taskCtx, ""); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 
@@ -588,7 +588,7 @@ func TestInjectRuntimeConfigUnknownProvider(t *testing.T) {
 	dir := t.TempDir()
 
 	// Unknown provider should be a no-op.
-	if err := InjectRuntimeConfig(dir, "unknown", TaskContextForEnv{}); err != nil {
+	if err := InjectRuntimeConfig(dir, "unknown", TaskContextForEnv{}, ""); err != nil {
 		t.Fatalf("expected no error for unknown provider, got: %v", err)
 	}
 

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -14,8 +14,11 @@ import (
 // For Codex:    writes {workDir}/AGENTS.md  (skills discovered natively via CODEX_HOME)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .config/opencode/skills/)
 // For OpenClaw: writes {workDir}/AGENTS.md  (skills discovered natively from .openclaw/skills/)
-func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error {
-	content := buildMetaSkillContent(provider, ctx)
+//
+// memories is an optional pre-formatted <hindsight_memories> block (or "") that is
+// prepended to the config file content when non-empty.
+func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv, memories string) error {
+	content := buildMetaSkillContent(provider, ctx, memories)
 
 	switch provider {
 	case "claude":
@@ -30,8 +33,14 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error 
 
 // buildMetaSkillContent generates the meta skill markdown that teaches the agent
 // about the Multica runtime environment and available CLI tools.
-func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
+// memories is a pre-formatted <hindsight_memories> block prepended when non-empty.
+func buildMetaSkillContent(provider string, ctx TaskContextForEnv, memories string) string {
 	var b strings.Builder
+
+	if memories != "" {
+		b.WriteString(memories)
+		b.WriteString("\n\n")
+	}
 
 	b.WriteString("# Multica Agent Runtime\n\n")
 	b.WriteString("You are a coding agent in the Multica platform. Use the `multica` CLI to interact with the platform.\n\n")

--- a/server/internal/hindsight/hindsight.go
+++ b/server/internal/hindsight/hindsight.go
@@ -1,0 +1,200 @@
+// Package hindsight provides long-term memory for Multica agents via the Hindsight API.
+//
+// When MULTICA_HINDSIGHT_URL is set, the daemon recalls relevant memories before
+// each task and retains the task outcome after completion. Memory is silently
+// disabled when the env var is absent — existing behaviour is unchanged.
+package hindsight
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// Config holds the Hindsight connection settings read from environment variables.
+//
+//	MULTICA_HINDSIGHT_URL     – base URL of the Hindsight API (required to enable memory)
+//	MULTICA_HINDSIGHT_API_KEY – Bearer token for Hindsight Cloud (optional for self-hosted)
+//	MULTICA_HINDSIGHT_BANK_ID – memory bank to use (default: "multica")
+type Config struct {
+	APIURL string
+	APIKey string
+	BankID string
+}
+
+// ConfigFromEnv reads MULTICA_HINDSIGHT_* env vars and returns a Config.
+// Returns nil when MULTICA_HINDSIGHT_URL is not set (memory is disabled).
+func ConfigFromEnv() *Config {
+	apiURL := strings.TrimRight(strings.TrimSpace(os.Getenv("MULTICA_HINDSIGHT_URL")), "/")
+	if apiURL == "" {
+		return nil
+	}
+	bankID := strings.TrimSpace(os.Getenv("MULTICA_HINDSIGHT_BANK_ID"))
+	if bankID == "" {
+		bankID = "multica"
+	}
+	return &Config{
+		APIURL: apiURL,
+		APIKey: strings.TrimSpace(os.Getenv("MULTICA_HINDSIGHT_API_KEY")),
+		BankID: bankID,
+	}
+}
+
+// recallRequest is the body sent to POST /v1/default/banks/{bank_id}/memories/recall.
+type recallRequest struct {
+	Query     string `json:"query"`
+	Budget    string `json:"budget"`
+	MaxTokens int    `json:"max_tokens"`
+}
+
+// recallResult is a single item in the recall response.
+type recallResult struct {
+	Text string `json:"text"`
+}
+
+// recallResponse is the JSON body returned by the recall endpoint.
+type recallResponse struct {
+	Results []recallResult `json:"results"`
+}
+
+// Recall retrieves memories relevant to query from the Hindsight bank.
+// Returns a formatted numbered list string, or "" when there are no results
+// or when cfg is nil. Errors are logged but never propagated — a recall
+// failure must never block task execution.
+func Recall(ctx context.Context, cfg *Config, query string, logger *slog.Logger) string {
+	if cfg == nil || query == "" {
+		return ""
+	}
+
+	reqBody, _ := json.Marshal(recallRequest{
+		Query:     query,
+		Budget:    "mid",
+		MaxTokens: 4096,
+	})
+
+	url := fmt.Sprintf("%s/v1/default/banks/%s/memories/recall", cfg.APIURL, cfg.BankID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		logger.Debug("hindsight: recall request build failed", "error", err)
+		return ""
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if cfg.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		logger.Debug("hindsight: recall request failed", "error", err)
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Debug("hindsight: recall returned non-200", "status", resp.StatusCode)
+		return ""
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.Debug("hindsight: recall read body failed", "error", err)
+		return ""
+	}
+
+	var result recallResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		logger.Debug("hindsight: recall unmarshal failed", "error", err)
+		return ""
+	}
+
+	if len(result.Results) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for i, r := range result.Results {
+		fmt.Fprintf(&b, "%d. %s\n", i+1, strings.TrimSpace(r.Text))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// retainRequest is the body sent to POST /v1/default/banks/{bank_id}/memories.
+type retainRequest struct {
+	Items []retainItem `json:"items"`
+	Async bool         `json:"async"`
+}
+
+// retainItem is a single memory item to store.
+type retainItem struct {
+	Content string `json:"content"`
+}
+
+// Retain stores content in the Hindsight bank asynchronously (fire-and-forget).
+// It is designed to be called as a goroutine after task completion.
+// Errors are logged but never propagated.
+func Retain(ctx context.Context, cfg *Config, content string, logger *slog.Logger) {
+	if cfg == nil || strings.TrimSpace(content) == "" {
+		return
+	}
+
+	reqBody, _ := json.Marshal(retainRequest{
+		Items: []retainItem{{Content: content}},
+		Async: true,
+	})
+
+	url := fmt.Sprintf("%s/v1/default/banks/%s/memories", cfg.APIURL, cfg.BankID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		logger.Debug("hindsight: retain request build failed", "error", err)
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if cfg.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		logger.Debug("hindsight: retain request failed", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+		logger.Debug("hindsight: retain returned non-2xx", "status", resp.StatusCode)
+	}
+}
+
+// FormatMemoriesBlock wraps a numbered memory list in a <hindsight_memories> XML block.
+// Returns "" when memories is empty.
+func FormatMemoriesBlock(memories string) string {
+	if memories == "" {
+		return ""
+	}
+	return "<hindsight_memories>\nRelevant memories from past tasks:\n" + memories + "\n</hindsight_memories>"
+}
+
+// BuildRetainContent formats a task outcome into a string suitable for retention.
+func BuildRetainContent(workspaceID, issueID, agentName, result, comment string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Workspace: %s\n", workspaceID)
+	fmt.Fprintf(&b, "Issue: %s\n", issueID)
+	if agentName != "" {
+		fmt.Fprintf(&b, "Agent: %s\n", agentName)
+	}
+	fmt.Fprintf(&b, "Status: %s\n", result)
+	if comment != "" {
+		b.WriteString("\nOutcome:\n")
+		b.WriteString(comment)
+	}
+	return b.String()
+}

--- a/server/internal/hindsight/hindsight_test.go
+++ b/server/internal/hindsight/hindsight_test.go
@@ -1,0 +1,224 @@
+package hindsight_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/hindsight"
+)
+
+var noopLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+// --- ConfigFromEnv ---
+
+func TestConfigFromEnv_DisabledWhenNoURL(t *testing.T) {
+	t.Setenv("MULTICA_HINDSIGHT_URL", "")
+	if cfg := hindsight.ConfigFromEnv(); cfg != nil {
+		t.Errorf("expected nil config when URL is unset, got %+v", cfg)
+	}
+}
+
+func TestConfigFromEnv_DefaultBankID(t *testing.T) {
+	t.Setenv("MULTICA_HINDSIGHT_URL", "http://localhost:8888")
+	t.Setenv("MULTICA_HINDSIGHT_BANK_ID", "")
+	cfg := hindsight.ConfigFromEnv()
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.BankID != "multica" {
+		t.Errorf("expected default bank ID 'multica', got %q", cfg.BankID)
+	}
+}
+
+func TestConfigFromEnv_CustomBankID(t *testing.T) {
+	t.Setenv("MULTICA_HINDSIGHT_URL", "http://localhost:8888")
+	t.Setenv("MULTICA_HINDSIGHT_BANK_ID", "my-workspace")
+	cfg := hindsight.ConfigFromEnv()
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if cfg.BankID != "my-workspace" {
+		t.Errorf("expected bank ID 'my-workspace', got %q", cfg.BankID)
+	}
+}
+
+func TestConfigFromEnv_TrailingSlashStripped(t *testing.T) {
+	t.Setenv("MULTICA_HINDSIGHT_URL", "http://localhost:8888/")
+	cfg := hindsight.ConfigFromEnv()
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if strings.HasSuffix(cfg.APIURL, "/") {
+		t.Errorf("expected trailing slash stripped, got %q", cfg.APIURL)
+	}
+}
+
+// --- Recall ---
+
+func TestRecall_ReturnsFormattedList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/memories/recall") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"results": []map[string]any{
+				{"id": "1", "text": "Workspace uses trunk-based development"},
+				{"id": "2", "text": "Tests require a running PostgreSQL instance"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := &hindsight.Config{APIURL: srv.URL, BankID: "test"}
+	result := hindsight.Recall(context.Background(), cfg, "workspace context", noopLogger)
+	if !strings.Contains(result, "trunk-based development") {
+		t.Errorf("expected recall result to contain memory text, got %q", result)
+	}
+	if !strings.Contains(result, "1.") {
+		t.Errorf("expected numbered list format, got %q", result)
+	}
+}
+
+func TestRecall_EmptyResultsReturnsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+	}))
+	defer srv.Close()
+
+	cfg := &hindsight.Config{APIURL: srv.URL, BankID: "test"}
+	result := hindsight.Recall(context.Background(), cfg, "anything", noopLogger)
+	if result != "" {
+		t.Errorf("expected empty string for empty results, got %q", result)
+	}
+}
+
+func TestRecall_NilConfigReturnsEmpty(t *testing.T) {
+	result := hindsight.Recall(context.Background(), nil, "query", noopLogger)
+	if result != "" {
+		t.Errorf("expected empty string for nil config, got %q", result)
+	}
+}
+
+func TestRecall_EmptyQueryReturnsEmpty(t *testing.T) {
+	cfg := &hindsight.Config{APIURL: "http://localhost:8888", BankID: "test"}
+	result := hindsight.Recall(context.Background(), cfg, "", noopLogger)
+	if result != "" {
+		t.Errorf("expected empty string for empty query, got %q", result)
+	}
+}
+
+func TestRecall_ServerErrorReturnsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := &hindsight.Config{APIURL: srv.URL, BankID: "test"}
+	result := hindsight.Recall(context.Background(), cfg, "query", noopLogger)
+	if result != "" {
+		t.Errorf("expected empty string on server error, got %q", result)
+	}
+}
+
+func TestRecall_SendsAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+	}))
+	defer srv.Close()
+
+	cfg := &hindsight.Config{APIURL: srv.URL, BankID: "test", APIKey: "hsk_secret"}
+	hindsight.Recall(context.Background(), cfg, "query", noopLogger)
+	if gotAuth != "Bearer hsk_secret" {
+		t.Errorf("expected Bearer token, got %q", gotAuth)
+	}
+}
+
+// --- Retain ---
+
+func TestRetain_PostsToCorrectEndpoint(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	cfg := &hindsight.Config{APIURL: srv.URL, BankID: "test"}
+	hindsight.Retain(context.Background(), cfg, "task completed successfully", noopLogger)
+
+	if !strings.HasSuffix(gotPath, "/memories") {
+		t.Errorf("expected path to end with /memories, got %s", gotPath)
+	}
+	items, _ := gotBody["items"].([]any)
+	if len(items) != 1 {
+		t.Errorf("expected 1 item in retain request, got %d", len(items))
+	}
+}
+
+func TestRetain_NilConfigIsNoop(t *testing.T) {
+	// Should not panic or make any network calls.
+	hindsight.Retain(context.Background(), nil, "content", noopLogger)
+}
+
+func TestRetain_EmptyContentIsNoop(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := &hindsight.Config{APIURL: srv.URL, BankID: "test"}
+	hindsight.Retain(context.Background(), cfg, "   ", noopLogger)
+	if called {
+		t.Error("expected no HTTP call for empty content")
+	}
+}
+
+// --- FormatMemoriesBlock ---
+
+func TestFormatMemoriesBlock_EmptyReturnsEmpty(t *testing.T) {
+	if block := hindsight.FormatMemoriesBlock(""); block != "" {
+		t.Errorf("expected empty string, got %q", block)
+	}
+}
+
+func TestFormatMemoriesBlock_WrapsContent(t *testing.T) {
+	block := hindsight.FormatMemoriesBlock("1. Some memory")
+	if !strings.Contains(block, "<hindsight_memories>") {
+		t.Errorf("missing opening tag in %q", block)
+	}
+	if !strings.Contains(block, "</hindsight_memories>") {
+		t.Errorf("missing closing tag in %q", block)
+	}
+	if !strings.Contains(block, "Some memory") {
+		t.Errorf("missing memory content in %q", block)
+	}
+}
+
+// --- BuildRetainContent ---
+
+func TestBuildRetainContent_IncludesAllFields(t *testing.T) {
+	content := hindsight.BuildRetainContent("ws-123", "issue-456", "bot", "completed", "Fixed the bug. PR: https://...")
+	for _, want := range []string{"ws-123", "issue-456", "bot", "completed", "Fixed the bug"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %q in retain content, got:\n%s", want, content)
+		}
+	}
+}


### PR DESCRIPTION
## What this does

Gives Multica agents **persistent memory across tasks** via [Hindsight](https://hindsight.vectorize.io) — an open-source long-term memory system for AI agents.

Without memory, every task starts cold. The agent fixing a bug today has no recollection of the fix it made last week, the team's conventions, or which approaches have worked before. This PR changes that.

## How it works

**Before each task** — the daemon recalls relevant memories from the Hindsight bank using the task context as the query. Results are injected as a `<hindsight_memories>` block at the top of `CLAUDE.md` / `AGENTS.md`, so the agent reads past context through its native mechanism with no prompt changes.

**After each task completes** — the task outcome (workspace, issue, agent, status, final comment) is retained to Hindsight asynchronously (fire-and-forget goroutine, never delays execution).

Over time the bank accumulates workspace knowledge: what got fixed, how, what patterns emerged, what the team prefers — making each agent measurably better on its Nth task than on its first.

## Changes

### New: `server/internal/hindsight/` (stdlib only, zero new deps)

- `ConfigFromEnv()` — reads `MULTICA_HINDSIGHT_*` env vars; returns `nil` when `MULTICA_HINDSIGHT_URL` is unset (memory fully disabled, no behaviour change)
- `Recall()` — queries `/v1/default/banks/{id}/memories/recall`, returns numbered fact list or `""` on any error
- `Retain()` — posts to `/v1/default/banks/{id}/memories` with `async:true`; designed for goroutine use
- `FormatMemoriesBlock()` / `BuildRetainContent()` — formatting helpers
- **16 unit tests** using `httptest.Server`

### Modified: `runtime_config.go`

`InjectRuntimeConfig` accepts an optional `memories string`; when non-empty it's prepended to the generated `CLAUDE.md` / `AGENTS.md` content.

### Modified: `daemon.go`

- `Daemon` holds `*hindsight.Config` (nil = disabled)
- `New()` initialises from env, logs when memory is active
- `runTask()`: recall → inject → execute → retain (async)

## Configuration

```bash
export MULTICA_HINDSIGHT_URL=http://localhost:8888   # self-hosted
# or
export MULTICA_HINDSIGHT_URL=https://api.hindsight.vectorize.io  # Cloud
export MULTICA_HINDSIGHT_API_KEY=hsk_...             # Cloud only
export MULTICA_HINDSIGHT_BANK_ID=my-workspace        # default: "multica"

multica daemon start
```

Memory is **opt-in**: if `MULTICA_HINDSIGHT_URL` is not set, all code paths are no-ops and existing behaviour is unchanged.

## Self-hosting Hindsight

```bash
pip install hindsight-all
export HINDSIGHT_API_LLM_API_KEY=your-openai-key
hindsight-api   # starts on http://localhost:8888
```

Or use [Hindsight Cloud](https://hindsight.vectorize.io) (free tier available).

## Test

```bash
cd server
go test ./internal/hindsight/... -v        # 16 new tests
go test ./internal/daemon/execenv/... -v   # existing tests, updated signatures
go build ./...
```