### PR TITLE
fix(storage): support custom S3 endpoints for self-hosted deployments (MinIO)

### DIFF
--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -70,7 +70,7 @@ func NewS3StorageFromEnv() *S3Storage {
 		})
 	}
 
-	slog.Info("S3 storage initialized", "bucket", bucket, "region", region, "cdn_domain", cdnDomain)
+	slog.Info("S3 storage initialized", "bucket", bucket, "region", region, "cdn_domain", cdnDomain, "endpoint_url", endpointURL)
 	return &S3Storage{
 		client:      s3.NewFromConfig(cfg, s3Opts...),
 		bucket:      bucket,
@@ -106,6 +106,13 @@ func sanitizeFilename(name string) string {
 // KeyFromURL extracts the S3 object key from a CDN or bucket URL.
 // e.g. "https://multica-static.copilothub.ai/abc123.png" → "abc123.png"
 func (s *S3Storage) KeyFromURL(rawURL string) string {
+	if s.endpointURL != "" {
+		prefix := strings.TrimRight(s.endpointURL, "/") + "/" + s.bucket + "/"
+		if strings.HasPrefix(rawURL, prefix) {
+			return strings.TrimPrefix(rawURL, prefix)
+		}
+	}
+
 	// Strip the "https://domain/" prefix.
 	for _, prefix := range []string{
 		"https://" + s.cdnDomain + "/",

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -16,9 +16,10 @@ import (
 )
 
 type S3Storage struct {
-	client    *s3.Client
-	bucket    string
-	cdnDomain string // if set, returned URLs use this instead of bucket name
+	client      *s3.Client
+	bucket      string
+	cdnDomain   string // if set, returned URLs use this instead of bucket name
+	endpointURL string // if set, use path-style URLs (e.g. MinIO)
 }
 
 // NewS3StorageFromEnv creates an S3Storage from environment variables.
@@ -60,12 +61,31 @@ func NewS3StorageFromEnv() *S3Storage {
 
 	cdnDomain := os.Getenv("CLOUDFRONT_DOMAIN")
 
+	endpointURL := os.Getenv("AWS_ENDPOINT_URL")
+	s3Opts := []func(*s3.Options){}
+	if endpointURL != "" {
+		s3Opts = append(s3Opts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(endpointURL)
+			o.UsePathStyle = true
+		})
+	}
+
 	slog.Info("S3 storage initialized", "bucket", bucket, "region", region, "cdn_domain", cdnDomain)
 	return &S3Storage{
-		client:    s3.NewFromConfig(cfg),
-		bucket:    bucket,
-		cdnDomain: cdnDomain,
+		client:      s3.NewFromConfig(cfg, s3Opts...),
+		bucket:      bucket,
+		cdnDomain:   cdnDomain,
+		endpointURL: endpointURL,
 	}
+}
+
+// storageClass returns the appropriate S3 storage class.
+// Custom endpoints (e.g. MinIO) only support STANDARD; real AWS defaults to INTELLIGENT_TIERING.
+func (s *S3Storage) storageClass() types.StorageClass {
+	if s.endpointURL != "" {
+		return types.StorageClassStandard
+	}
+	return types.StorageClassIntelligentTiering
 }
 
 // sanitizeFilename removes characters that could cause header injection in Content-Disposition.
@@ -146,12 +166,16 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 		ContentType:        aws.String(contentType),
 		ContentDisposition: aws.String(fmt.Sprintf(`%s; filename="%s"`, disposition, safe)),
 		CacheControl:       aws.String("max-age=432000,public"),
-		StorageClass:       types.StorageClassIntelligentTiering,
+		StorageClass:       s.storageClass(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("s3 PutObject: %w", err)
 	}
 
+	if s.endpointURL != "" {
+		link := fmt.Sprintf("%s/%s/%s", strings.TrimRight(s.endpointURL, "/"), s.bucket, key)
+		return link, nil
+	}
 	domain := s.bucket
 	if s.cdnDomain != "" {
 		domain = s.cdnDomain

--- a/server/internal/storage/s3_test.go
+++ b/server/internal/storage/s3_test.go
@@ -1,0 +1,29 @@
+package storage
+
+import "testing"
+
+func TestS3StorageKeyFromURL_CustomEndpointPreservesNestedKey(t *testing.T) {
+	s := &S3Storage{
+		bucket:      "test-bucket",
+		endpointURL: "http://localhost:9000",
+	}
+
+	rawURL := "http://localhost:9000/test-bucket/uploads/abc/file.png"
+
+	if got := s.KeyFromURL(rawURL); got != "uploads/abc/file.png" {
+		t.Fatalf("KeyFromURL(%q) = %q, want %q", rawURL, got, "uploads/abc/file.png")
+	}
+}
+
+func TestS3StorageKeyFromURL_CustomEndpointWithTrailingSlash(t *testing.T) {
+	s := &S3Storage{
+		bucket:      "test-bucket",
+		endpointURL: "http://localhost:9000/",
+	}
+
+	rawURL := "http://localhost:9000/test-bucket/uploads/abc/file.png"
+
+	if got := s.KeyFromURL(rawURL); got != "uploads/abc/file.png" {
+		t.Fatalf("KeyFromURL(%q) = %q, want %q", rawURL, got, "uploads/abc/file.png")
+	}
+}


### PR DESCRIPTION
## Problem

Self-hosted deployments using MinIO or other S3-compatible stores couldn't upload files. Three issues:

1. The S3 client had no way to point to a custom endpoint — uploads always went to real AWS, resulting in a `500` error
2. Virtual-hosted style URLs (e.g. `https://bucket/key`) don't work with MinIO — path-style is required
3. `INTELLIGENT_TIERING` storage class is unsupported by MinIO, causing `PutObject` to fail

## Solution

When `AWS_ENDPOINT_URL` is set:
- Configure the S3 client to use the custom endpoint with path-style addressing
- Return path-style URLs (`endpoint/bucket/key`) for attachments
- Fall back to `STANDARD` storage class (only affects custom endpoints — real AWS still uses `INTELLIGENT_TIERING`)

## Self-hosting setup

Add to `.env`:
```
S3_BUCKET=multica
S3_REGION=us-east-1
AWS_ACCESS_KEY_ID=<key>
AWS_SECRET_ACCESS_KEY=<secret>
AWS_ENDPOINT_URL=http://localhost:9000
```

Works with any S3-compatible store (MinIO, Garage, Tigris, etc.).

## Changes

- `server/internal/storage/s3.go` — custom endpoint support + storage class fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)