### PR TITLE
fix(server): cross-workspace attachment injection & query filtering

### DIFF
--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -80,7 +80,11 @@ func (h *Handler) groupAttachments(r *http.Request, commentIDs []pgtype.UUID) ma
 	if len(commentIDs) == 0 {
 		return nil
 	}
-	attachments, err := h.Queries.ListAttachmentsByCommentIDs(r.Context(), commentIDs)
+	workspaceID := resolveWorkspaceID(r)
+	attachments, err := h.Queries.ListAttachmentsByCommentIDs(r.Context(), db.ListAttachmentsByCommentIDsParams{
+		Column1:     commentIDs,
+		WorkspaceID: parseUUID(workspaceID),
+	})
 	if err != nil {
 		slog.Error("failed to load attachments for comments", "error", err)
 		return nil
@@ -180,12 +184,25 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 			SizeBytes:    int64(len(data)),
 		}
 
-		// Optional issue_id / comment_id from form fields
+		// Optional issue_id / comment_id from form fields — validate ownership.
 		if issueID := r.FormValue("issue_id"); issueID != "" {
-			params.IssueID = parseUUID(issueID)
+			issue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+				ID:          parseUUID(issueID),
+				WorkspaceID: parseUUID(workspaceID),
+			})
+			if err != nil {
+				writeError(w, http.StatusForbidden, "invalid issue_id")
+				return
+			}
+			params.IssueID = issue.ID
 		}
 		if commentID := r.FormValue("comment_id"); commentID != "" {
-			params.CommentID = parseUUID(commentID)
+			comment, err := h.Queries.GetComment(r.Context(), parseUUID(commentID))
+			if err != nil || uuidToString(comment.WorkspaceID) != workspaceID {
+				writeError(w, http.StatusForbidden, "invalid comment_id")
+				return
+			}
+			params.CommentID = comment.ID
 		}
 
 		att, err := h.Queries.CreateAttachment(r.Context(), params)

--- a/server/pkg/db/generated/attachment.sql.go
+++ b/server/pkg/db/generated/attachment.sql.go
@@ -237,12 +237,17 @@ func (q *Queries) ListAttachmentsByComment(ctx context.Context, arg ListAttachme
 
 const listAttachmentsByCommentIDs = `-- name: ListAttachmentsByCommentIDs :many
 SELECT id, workspace_id, issue_id, comment_id, uploader_type, uploader_id, filename, url, content_type, size_bytes, created_at FROM attachment
-WHERE comment_id = ANY($1::uuid[])
+WHERE comment_id = ANY($1::uuid[]) AND workspace_id = $2
 ORDER BY created_at ASC
 `
 
-func (q *Queries) ListAttachmentsByCommentIDs(ctx context.Context, dollar_1 []pgtype.UUID) ([]Attachment, error) {
-	rows, err := q.db.Query(ctx, listAttachmentsByCommentIDs, dollar_1)
+type ListAttachmentsByCommentIDsParams struct {
+	Column1     []pgtype.UUID `json:"column_1"`
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+}
+
+func (q *Queries) ListAttachmentsByCommentIDs(ctx context.Context, arg ListAttachmentsByCommentIDsParams) ([]Attachment, error) {
+	rows, err := q.db.Query(ctx, listAttachmentsByCommentIDs, arg.Column1, arg.WorkspaceID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/attachment.sql
+++ b/server/pkg/db/queries/attachment.sql
@@ -19,7 +19,7 @@ WHERE id = $1 AND workspace_id = $2;
 
 -- name: ListAttachmentsByCommentIDs :many
 SELECT * FROM attachment
-WHERE comment_id = ANY($1::uuid[])
+WHERE comment_id = ANY($1::uuid[]) AND workspace_id = $2
 ORDER BY created_at ASC;
 
 -- name: ListAttachmentURLsByIssueOrComments :many


### PR DESCRIPTION
## Summary
- **CRIT-3 fix**: `UploadFile` handler now validates that `issue_id` and `comment_id` form fields belong to the caller's workspace before creating attachment records, preventing cross-workspace attachment injection
- **MED-3 fix**: `ListAttachmentsByCommentIDs` SQL query now includes `workspace_id` filter, preventing cross-workspace attachment data leakage

## Changes
- `server/internal/handler/file.go`: Added workspace ownership validation for `issue_id` (via `GetIssueInWorkspace`) and `comment_id` (via `GetComment` + workspace check) before creating attachment records
- `server/pkg/db/queries/attachment.sql`: Added `AND workspace_id = $2` to `ListAttachmentsByCommentIDs` query
- `server/pkg/db/generated/attachment.sql.go`: Regenerated sqlc code with new query signature

## Test plan
- [ ] Verify uploading attachments with valid issue_id/comment_id in own workspace works
- [ ] Verify uploading with another workspace's issue_id returns 403
- [ ] Verify uploading with another workspace's comment_id returns 403
- [ ] Verify comment attachment loading still works correctly with workspace filter
- [ ] Run `make test` — Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)