### PR TITLE
feat: notify parent issue subscribers on sub-issue changes

### DIFF
--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -87,7 +87,7 @@ func notifySubscribers(
 	details []byte,
 ) {
 	notified := notifyIssueSubscribers(ctx, queries, bus,
-		issueID, issueStatus, workspaceID, e, exclude,
+		issueID, issueID, issueStatus, workspaceID, e, exclude,
 		notifType, severity, title, body, details)
 
 	// Also notify parent issue subscribers if this is a sub-issue.
@@ -110,19 +110,25 @@ func notifySubscribers(
 		parentExclude[id] = true
 	}
 
+	// Query subscribers from the parent issue, but the inbox item still
+	// points to the sub-issue so the user navigates to the actual change.
 	parentID := util.UUIDToString(issue.ParentIssueID)
 	notifyIssueSubscribers(ctx, queries, bus,
-		parentID, issueStatus, workspaceID, e, parentExclude,
+		parentID, issueID, issueStatus, workspaceID, e, parentExclude,
 		notifType, severity, title, body, details)
 }
 
-// notifyIssueSubscribers sends inbox notifications to subscribers of a single
-// issue and returns the set of member IDs that were notified.
+// notifyIssueSubscribers sends inbox notifications to subscribers of
+// subscriberIssueID, but creates inbox items pointing to targetIssueID.
+// This allows querying subscribers from a parent issue while the notification
+// links to the sub-issue where the change actually occurred.
+// Returns the set of member IDs that were notified.
 func notifyIssueSubscribers(
 	ctx context.Context,
 	queries *db.Queries,
 	bus *events.Bus,
-	issueID string,
+	subscriberIssueID string,
+	targetIssueID string,
 	issueStatus string,
 	workspaceID string,
 	e events.Event,
@@ -135,10 +141,10 @@ func notifyIssueSubscribers(
 ) map[string]bool {
 	notified := map[string]bool{}
 
-	subs, err := queries.ListIssueSubscribers(ctx, parseUUID(issueID))
+	subs, err := queries.ListIssueSubscribers(ctx, parseUUID(subscriberIssueID))
 	if err != nil {
 		slog.Error("failed to list subscribers for notification",
-			"issue_id", issueID, "error", err)
+			"issue_id", subscriberIssueID, "error", err)
 		return notified
 	}
 
@@ -166,7 +172,7 @@ func notifyIssueSubscribers(
 			RecipientID:   sub.UserID,
 			Type:          notifType,
 			Severity:      severity,
-			IssueID:       parseUUID(issueID),
+			IssueID:       parseUUID(targetIssueID),
 			Title:         title,
 			Body:          util.StrToText(body),
 			ActorType:     util.StrToText(e.ActorType),

--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -69,6 +69,8 @@ func parseMentions(content string) []mention {
 // notifySubscribers queries the subscriber table for an issue, excludes the
 // actor and any extra IDs, and creates inbox items for each remaining member
 // subscriber. Publishes an inbox:new event for each notification.
+// If the issue has a parent, parent issue subscribers are also notified
+// (deduplicated against direct subscribers).
 func notifySubscribers(
 	ctx context.Context,
 	queries *db.Queries,
@@ -84,11 +86,60 @@ func notifySubscribers(
 	body string,
 	details []byte,
 ) {
+	notified := notifyIssueSubscribers(ctx, queries, bus,
+		issueID, issueStatus, workspaceID, e, exclude,
+		notifType, severity, title, body, details)
+
+	// Also notify parent issue subscribers if this is a sub-issue.
+	issue, err := queries.GetIssue(ctx, parseUUID(issueID))
+	if err != nil {
+		slog.Error("failed to get issue for parent notification",
+			"issue_id", issueID, "error", err)
+		return
+	}
+	if !issue.ParentIssueID.Valid {
+		return
+	}
+
+	// Merge already-notified IDs into exclude set for parent subscribers.
+	parentExclude := make(map[string]bool, len(exclude)+len(notified))
+	for id := range exclude {
+		parentExclude[id] = true
+	}
+	for id := range notified {
+		parentExclude[id] = true
+	}
+
+	parentID := util.UUIDToString(issue.ParentIssueID)
+	notifyIssueSubscribers(ctx, queries, bus,
+		parentID, issueStatus, workspaceID, e, parentExclude,
+		notifType, severity, title, body, details)
+}
+
+// notifyIssueSubscribers sends inbox notifications to subscribers of a single
+// issue and returns the set of member IDs that were notified.
+func notifyIssueSubscribers(
+	ctx context.Context,
+	queries *db.Queries,
+	bus *events.Bus,
+	issueID string,
+	issueStatus string,
+	workspaceID string,
+	e events.Event,
+	exclude map[string]bool,
+	notifType string,
+	severity string,
+	title string,
+	body string,
+	details []byte,
+) map[string]bool {
+	notified := map[string]bool{}
+
 	subs, err := queries.ListIssueSubscribers(ctx, parseUUID(issueID))
 	if err != nil {
 		slog.Error("failed to list subscribers for notification",
 			"issue_id", issueID, "error", err)
-		return
+		return notified
 	}
 
 	for _, sub := range subs {
@@ -128,6 +179,7 @@ func notifySubscribers(
 			continue
 		}
 
+		notified[subID] = true
 		resp := inboxItemToResponse(item)
 		resp["issue_status"] = issueStatus
 		bus.Publish(events.Event{
@@ -138,6 +190,8 @@ func notifySubscribers(
 			Payload:     map[string]any{"item": resp},
 		})
 	}
+
+	return notified
 }
 
 // notifyDirect creates an inbox item for a specific recipient. Skips if the


### PR DESCRIPTION
## Summary
- When a sub-issue changes (status, assignee, priority, comment, task failure, etc.), parent issue subscribers now also receive inbox notifications
- Deduplicates against direct subscribers so users who subscribe to both parent and sub-issue only get one notification
- Inbox item `issue_id` still points to the sub-issue, so clicking the notification navigates directly to the actual change

## Implementation
Refactored `notifySubscribers()` into two layers:
- `notifyIssueSubscribers()` — sends notifications to a single issue's subscribers, returns the set of notified member IDs
- `notifySubscribers()` — calls `notifyIssueSubscribers()` for the direct issue, then if the issue has a `parent_issue_id`, also notifies parent subscribers (excluding already-notified members)

## Test plan
- [ ] Create a parent issue, subscribe to it
- [ ] Create a sub-issue under it
- [ ] Change sub-issue status → verify parent subscriber receives inbox notification
- [ ] Add comment to sub-issue → verify parent subscriber receives inbox notification
- [ ] Subscribe to both parent and sub-issue → verify only one notification per event (no duplicates)

Closes MUL-584

🤖 Generated with [Claude Code](https://claude.com/claude-code)