### PR TITLE
fix(server): add missing WorkspaceID to agent comment creation

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -554,12 +554,13 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 	// Expand bare issue identifiers (e.g. MUL-117) into mention links.
 	content = mention.ExpandIssueIdentifiers(ctx, s.Queries, issue.WorkspaceID, content)
 	comment, err := s.Queries.CreateComment(ctx, db.CreateCommentParams{
-		IssueID:    issueID,
-		AuthorType: "agent",
-		AuthorID:   agentID,
-		Content:    content,
-		Type:       commentType,
-		ParentID:   parentID,
+		IssueID:     issueID,
+		WorkspaceID: issue.WorkspaceID,
+		AuthorType:  "agent",
+		AuthorID:    agentID,
+		Content:     content,
+		Type:        commentType,
+		ParentID:    parentID,
 	})
 	if err != nil {
 		return


### PR DESCRIPTION
## Summary
- `createAgentComment` in `server/internal/service/task.go` omitted `WorkspaceID` when calling `CreateComment`
- The `comment.workspace_id` column has a `NOT NULL` constraint (added in migration `025_comment_workspace_id`)
- This caused all agent comments (progress updates, completion messages) to silently fail — the error was swallowed at line 564
- The handler path in `comment.go:225-232` already sets `WorkspaceID: issue.WorkspaceID` correctly; this fix matches that pattern
- The `issue` is already fetched on the preceding line (550) for mention expansion, so `issue.WorkspaceID` is available