### PR TITLE
feat(cli): add --project filter to issue list

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -135,6 +135,7 @@ func init() {
 	issueListCmd.Flags().String("status", "", "Filter by status")
 	issueListCmd.Flags().String("priority", "", "Filter by priority")
 	issueListCmd.Flags().String("assignee", "", "Filter by assignee name")
+	issueListCmd.Flags().String("project", "", "Filter by project ID")
 	issueListCmd.Flags().Int("limit", 50, "Maximum number of issues to return")
 
 	// issue get
@@ -231,6 +232,9 @@ func runIssueList(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("resolve assignee: %w", resolveErr)
 		}
 		params.Set("assignee_id", aID)
+	}
+	if v, _ := cmd.Flags().GetString("project"); v != "" {
+		params.Set("project_id", v)
 	}
 
 	path := "/api/issues"

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -580,6 +580,10 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	if c := r.URL.Query().Get("creator_id"); c != "" {
 		creatorFilter = parseUUID(c)
 	}
+	var projectFilter pgtype.UUID
+	if p := r.URL.Query().Get("project_id"); p != "" {
+		projectFilter = parseUUID(p)
+	}
 
 	// open_only=true returns all non-done/cancelled issues (no limit).
 	if r.URL.Query().Get("open_only") == "true" {
@@ -589,6 +593,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 			AssigneeID:  assigneeFilter,
 			AssigneeIds: assigneeIdsFilter,
 			CreatorID:   creatorFilter,
+			ProjectID:   projectFilter,
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -635,6 +640,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		AssigneeID:  assigneeFilter,
 		AssigneeIds: assigneeIdsFilter,
 		CreatorID:   creatorFilter,
+		ProjectID:   projectFilter,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -649,6 +655,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		AssigneeID:  assigneeFilter,
 		AssigneeIds: assigneeIdsFilter,
 		CreatorID:   creatorFilter,
+		ProjectID:   projectFilter,
 	})
 	if err != nil {
 		total = int64(len(issues))

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -65,6 +65,7 @@ WHERE workspace_id = $1
   AND ($4::uuid IS NULL OR assignee_id = $4)
   AND ($5::uuid[] IS NULL OR assignee_id = ANY($5::uuid[]))
   AND ($6::uuid IS NULL OR creator_id = $6)
+  AND ($7::uuid IS NULL OR project_id = $7)
 `
 
 type CountIssuesParams struct {
@@ -74,6 +75,7 @@ type CountIssuesParams struct {
 	AssigneeID  pgtype.UUID   `json:"assignee_id"`
 	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
 	CreatorID   pgtype.UUID   `json:"creator_id"`
+	ProjectID   pgtype.UUID   `json:"project_id"`
 }
 
 func (q *Queries) CountIssues(ctx context.Context, arg CountIssuesParams) (int64, error) {
@@ -84,6 +86,7 @@ func (q *Queries) CountIssues(ctx context.Context, arg CountIssuesParams) (int64
 		arg.AssigneeID,
 		arg.AssigneeIds,
 		arg.CreatorID,
+		arg.ProjectID,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -331,6 +334,7 @@ WHERE workspace_id = $1
   AND ($6::uuid IS NULL OR assignee_id = $6)
   AND ($7::uuid[] IS NULL OR assignee_id = ANY($7::uuid[]))
   AND ($8::uuid IS NULL OR creator_id = $8)
+  AND ($9::uuid IS NULL OR project_id = $9)
 ORDER BY position ASC, created_at DESC
 LIMIT $2 OFFSET $3
 `
@@ -344,6 +348,7 @@ type ListIssuesParams struct {
 	AssigneeID  pgtype.UUID   `json:"assignee_id"`
 	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
 	CreatorID   pgtype.UUID   `json:"creator_id"`
+	ProjectID   pgtype.UUID   `json:"project_id"`
 }
 
 type ListIssuesRow struct {
@@ -375,6 +380,7 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 		arg.AssigneeID,
 		arg.AssigneeIds,
 		arg.CreatorID,
+		arg.ProjectID,
 	)
 	if err != nil {
 		return nil, err
@@ -422,6 +428,7 @@ WHERE workspace_id = $1
   AND ($3::uuid IS NULL OR assignee_id = $3)
   AND ($4::uuid[] IS NULL OR assignee_id = ANY($4::uuid[]))
   AND ($5::uuid IS NULL OR creator_id = $5)
+  AND ($6::uuid IS NULL OR project_id = $6)
 ORDER BY position ASC, created_at DESC
 `
 
@@ -431,6 +438,7 @@ type ListOpenIssuesParams struct {
 	AssigneeID  pgtype.UUID   `json:"assignee_id"`
 	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
 	CreatorID   pgtype.UUID   `json:"creator_id"`
+	ProjectID   pgtype.UUID   `json:"project_id"`
 }
 
 type ListOpenIssuesRow struct {
@@ -459,6 +467,7 @@ func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) 
 		arg.AssigneeID,
 		arg.AssigneeIds,
 		arg.CreatorID,
+		arg.ProjectID,
 	)
 	if err != nil {
 		return nil, err

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -9,6 +9,7 @@ WHERE workspace_id = $1
   AND (sqlc.narg('assignee_id')::uuid IS NULL OR assignee_id = sqlc.narg('assignee_id'))
   AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
   AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'))
+  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
 ORDER BY position ASC, created_at DESC
 LIMIT $2 OFFSET $3;
 
@@ -70,6 +71,7 @@ WHERE workspace_id = $1
   AND (sqlc.narg('assignee_id')::uuid IS NULL OR assignee_id = sqlc.narg('assignee_id'))
   AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
   AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'))
+  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
 ORDER BY position ASC, created_at DESC;
 
 -- name: CountIssues :one
@@ -79,7 +81,8 @@ WHERE workspace_id = $1
   AND (sqlc.narg('priority')::text IS NULL OR priority = sqlc.narg('priority'))
   AND (sqlc.narg('assignee_id')::uuid IS NULL OR assignee_id = sqlc.narg('assignee_id'))
   AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
-  AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'));
+  AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'))
+  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'));
 
 -- name: ListChildIssues :many
 SELECT * FROM issue


### PR DESCRIPTION
## Summary

Add `--project` flag to `multica issue list` so users can filter issues by project.

`--project` was added to `issue create` and `issue update` in #562, but `issue list` was missed. This makes the CLI inconsistent — you can assign issues to projects but cannot list them by project.

## Changes

**CLI** (`server/cmd/multica/cmd_issue.go`)
- Register `--project` flag on `issueListCmd`
- Pass `project_id` query parameter in `runIssueList`

**API handler** (`server/internal/handler/issue.go`)
- Parse `project_id` query parameter in `ListIssues`
- Pass to `ListIssuesParams`, `ListOpenIssuesParams`, and `CountIssuesParams`

**SQL** (`server/pkg/db/queries/issue.sql`)
- Add `project_id` filter to `ListIssues`, `ListOpenIssues`, and `CountIssues` queries using the same `sqlc.narg` pattern as existing filters

## Usage

```bash
multica issue list --project <project-id>
multica issue list --project <project-id> --status todo --output json
```

## Test plan

- [x] `go build ./cmd/multica/` — compiles
- [x] `go build ./cmd/server/` — compiles  
- [x] `go test ./cmd/multica/` — passes
- [x] Manual test: created a project, assigned an issue, confirmed `--project` returns only matching issues