### PR TITLE
fix(docker): chown runtime files to nextjs user in web image

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -54,11 +54,11 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # Copy standalone output (includes traced node_modules)
-COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
 # Copy static files (not included in standalone)
-COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 # Copy public assets
-COPY --from=builder /app/apps/web/public ./apps/web/public
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
 
 USER nextjs
 


### PR DESCRIPTION
## Summary
- Add `--chown=nextjs:nodejs` to the three runtime `COPY` steps in `Dockerfile.web` (standalone, static, public) so files are owned by the non-root user that actually runs the server.

## Why
Booting the stack with `docker compose -f docker-compose.selfhost.yml up` crashed the `frontend` container on the first request:

```
Error: EACCES: permission denied, scandir '/app/apps/web/public/images'
```

Root cause: `apps/web/public/` is mode `750` locally (no "other" read/exec). Without `--chown`, the `COPY --from=builder` steps preserved those perms with root as owner, so `USER nextjs` (UID 1001) fell under "other" and couldn't traverse `public/images`. This is the standard Next.js standalone pattern — just wasn't applied here.

## Test plan
- [x] `docker compose -f docker-compose.selfhost.yml up -d --build frontend` — containers come up clean
- [x] `curl -sS -o /dev/null -w "%{http_code}" http://localhost:3000/` → `200`
- [x] Frontend logs no longer show `EACCES` on `public/images`