### PR TITLE
feat(daemon): add MiniMax agent support via API key injection and document all supported agents

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -125,6 +125,9 @@ The daemon auto-detects these AI CLIs on your PATH:
 |-----|---------|-------------|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `claude` | Anthropic's coding agent |
 | [Codex](https://github.com/openai/codex) | `codex` | OpenAI's coding agent |
+| [OpenCode](https://opencode.ai) | `opencode` | Open-source coding agent (multi-provider) |
+| [OpenClaw](https://openclaw.ai) | `openclaw` | MiniMax's coding agent |
+| [Hermes](https://hermes.ai) | `hermes` | MiniMax's Anthropic-compatible coding agent |
 
 You need at least one installed. The daemon registers each detected CLI as an available runtime.
 
@@ -156,9 +159,42 @@ Agent-specific overrides:
 | Variable | Description |
 |----------|-------------|
 | `MULTICA_CLAUDE_PATH` | Custom path to the `claude` binary |
-| `MULTICA_CLAUDE_MODEL` | Override the Claude model used |
+| `MULTICA_CLAUDE_MODEL` | Override the model used by Claude Code |
+| `MULTICA_CLAUDE_API_KEY` | API key injected as `ANTHROPIC_AUTH_TOKEN` (enables alternative providers, e.g. MiniMax) |
+| `MULTICA_CLAUDE_BASE_URL` | Base URL injected as `ANTHROPIC_BASE_URL` (e.g. `https://api.minimax.io/anthropic` for MiniMax) |
 | `MULTICA_CODEX_PATH` | Custom path to the `codex` binary |
-| `MULTICA_CODEX_MODEL` | Override the Codex model used |
+| `MULTICA_CODEX_MODEL` | Override the model used by Codex |
+| `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
+| `MULTICA_OPENCODE_MODEL` | Override the model used by OpenCode |
+| `MULTICA_OPENCLAW_PATH` | Custom path to the `openclaw` binary |
+| `MULTICA_OPENCLAW_MODEL` | Override the model used by OpenClaw |
+| `MULTICA_OPENCLAW_API_KEY` | MiniMax API key injected as `MINIMAX_API_KEY` for OpenClaw |
+| `MULTICA_HERMES_PATH` | Custom path to the `hermes` binary |
+| `MULTICA_HERMES_MODEL` | Override the model used by Hermes |
+| `MULTICA_HERMES_API_KEY` | MiniMax API key injected as `MINIMAX_API_KEY` for Hermes |
+
+#### Using MiniMax Models
+
+MiniMax's [MiniMax-M2.7](https://platform.minimax.io/docs/guides/text-ai-coding-tools) model can be used through any of the supported agents:
+
+**Via Claude Code** (Anthropic-compatible API):
+```bash
+export MULTICA_CLAUDE_API_KEY=your_minimax_api_key
+export MULTICA_CLAUDE_BASE_URL=https://api.minimax.io/anthropic
+multica daemon start
+```
+
+**Via OpenClaw** (MiniMax's native coding agent):
+```bash
+export MULTICA_OPENCLAW_API_KEY=your_minimax_api_key
+multica daemon start
+```
+
+**Via Hermes Agent** (MiniMax's Anthropic-compatible coding agent):
+```bash
+export MULTICA_HERMES_API_KEY=your_minimax_api_key
+multica daemon start
+```
 
 ### Self-Hosted Server
 

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -73,9 +73,20 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	agents := map[string]AgentEntry{}
 	claudePath := envOrDefault("MULTICA_CLAUDE_PATH", "claude")
 	if _, err := exec.LookPath(claudePath); err == nil {
+		claudeExtra := map[string]string{}
+		// Allow overriding the Anthropic API endpoint at the daemon level — useful
+		// for pointing Claude Code at a compatible provider (e.g. MiniMax's
+		// Anthropic-compatible API at https://api.minimax.io/anthropic).
+		if v := strings.TrimSpace(os.Getenv("MULTICA_CLAUDE_API_KEY")); v != "" {
+			claudeExtra["ANTHROPIC_AUTH_TOKEN"] = v
+		}
+		if v := strings.TrimSpace(os.Getenv("MULTICA_CLAUDE_BASE_URL")); v != "" {
+			claudeExtra["ANTHROPIC_BASE_URL"] = v
+		}
 		agents["claude"] = AgentEntry{
-			Path:  claudePath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_CLAUDE_MODEL")),
+			Path:     claudePath,
+			Model:    strings.TrimSpace(os.Getenv("MULTICA_CLAUDE_MODEL")),
+			ExtraEnv: claudeExtra,
 		}
 	}
 	codexPath := envOrDefault("MULTICA_CODEX_PATH", "codex")
@@ -94,16 +105,31 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 	openclawPath := envOrDefault("MULTICA_OPENCLAW_PATH", "openclaw")
 	if _, err := exec.LookPath(openclawPath); err == nil {
+		openclawExtra := map[string]string{}
+		// OpenClaw is MiniMax's coding agent CLI. Inject MINIMAX_API_KEY when
+		// MULTICA_OPENCLAW_API_KEY is set, so users can configure it at the
+		// daemon level without exporting it globally.
+		if v := strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_API_KEY")); v != "" {
+			openclawExtra["MINIMAX_API_KEY"] = v
+		}
 		agents["openclaw"] = AgentEntry{
-			Path:  openclawPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
+			Path:     openclawPath,
+			Model:    strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
+			ExtraEnv: openclawExtra,
 		}
 	}
 	hermesPath := envOrDefault("MULTICA_HERMES_PATH", "hermes")
 	if _, err := exec.LookPath(hermesPath); err == nil {
+		hermesExtra := map[string]string{}
+		// Hermes Agent is MiniMax's Anthropic-compatible coding agent CLI.
+		// Inject MINIMAX_API_KEY when MULTICA_HERMES_API_KEY is set.
+		if v := strings.TrimSpace(os.Getenv("MULTICA_HERMES_API_KEY")); v != "" {
+			hermesExtra["MINIMAX_API_KEY"] = v
+		}
 		agents["hermes"] = AgentEntry{
-			Path:  hermesPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+			Path:     hermesPath,
+			Model:    strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+			ExtraEnv: hermesExtra,
 		}
 	}
 	if len(agents) == 0 {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -954,6 +954,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	if env.CodexHome != "" {
 		agentEnv["CODEX_HOME"] = env.CodexHome
 	}
+	// Inject agent-specific extra env vars (e.g. API keys, base URLs configured
+	// via MULTICA_CLAUDE_API_KEY / MULTICA_OPENCLAW_API_KEY / etc.). These take
+	// priority over inherited env vars so daemon-level config wins.
+	for k, v := range entry.ExtraEnv {
+		agentEnv[k] = v
+	}
 	backend, err := agent.New(provider, agent.Config{
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 )
@@ -81,5 +82,106 @@ func TestIsWorkspaceNotFoundError(t *testing.T) {
 
 	if isWorkspaceNotFoundError(&requestError{StatusCode: http.StatusInternalServerError, Body: `{"error":"workspace not found"}`}) {
 		t.Fatal("did not expect 500 to be treated as workspace not found")
+	}
+}
+
+// TestLoadConfigClaudeExtraEnv verifies that MULTICA_CLAUDE_API_KEY and
+// MULTICA_CLAUDE_BASE_URL are populated into AgentEntry.ExtraEnv as the
+// correct Anthropic env var names.
+func TestLoadConfigClaudeExtraEnv(t *testing.T) {
+	// Create a temporary fake claude binary so exec.LookPath succeeds.
+	tmp := t.TempDir()
+	fakeClaude := tmp + "/claude"
+	if err := os.WriteFile(fakeClaude, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("create fake claude: %v", err)
+	}
+
+	t.Setenv("MULTICA_CLAUDE_PATH", fakeClaude)
+	t.Setenv("MULTICA_CLAUDE_API_KEY", "minimax-test-key")
+	t.Setenv("MULTICA_CLAUDE_BASE_URL", "https://api.minimax.io/anthropic")
+	// Ensure other agents are not found so we don't need more fake binaries.
+	for _, v := range []string{
+		"MULTICA_CODEX_PATH", "MULTICA_OPENCODE_PATH",
+		"MULTICA_OPENCLAW_PATH", "MULTICA_HERMES_PATH",
+	} {
+		t.Setenv(v, "/nonexistent/binary-"+v)
+	}
+
+	cfg, err := LoadConfig(Overrides{})
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+
+	claudeEntry, ok := cfg.Agents["claude"]
+	if !ok {
+		t.Fatal("expected claude entry in config")
+	}
+	if claudeEntry.ExtraEnv["ANTHROPIC_AUTH_TOKEN"] != "minimax-test-key" {
+		t.Errorf("ANTHROPIC_AUTH_TOKEN = %q, want %q", claudeEntry.ExtraEnv["ANTHROPIC_AUTH_TOKEN"], "minimax-test-key")
+	}
+	if claudeEntry.ExtraEnv["ANTHROPIC_BASE_URL"] != "https://api.minimax.io/anthropic" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q, want %q", claudeEntry.ExtraEnv["ANTHROPIC_BASE_URL"], "https://api.minimax.io/anthropic")
+	}
+}
+
+// TestLoadConfigOpenclawExtraEnv verifies that MULTICA_OPENCLAW_API_KEY is
+// mapped to MINIMAX_API_KEY in AgentEntry.ExtraEnv.
+func TestLoadConfigOpenclawExtraEnv(t *testing.T) {
+	tmp := t.TempDir()
+	fakeOpenclaw := tmp + "/openclaw"
+	if err := os.WriteFile(fakeOpenclaw, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("create fake openclaw: %v", err)
+	}
+
+	t.Setenv("MULTICA_OPENCLAW_PATH", fakeOpenclaw)
+	t.Setenv("MULTICA_OPENCLAW_API_KEY", "minimax-openclaw-key")
+	for _, v := range []string{
+		"MULTICA_CLAUDE_PATH", "MULTICA_CODEX_PATH",
+		"MULTICA_OPENCODE_PATH", "MULTICA_HERMES_PATH",
+	} {
+		t.Setenv(v, "/nonexistent/binary-"+v)
+	}
+
+	cfg, err := LoadConfig(Overrides{})
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+
+	entry, ok := cfg.Agents["openclaw"]
+	if !ok {
+		t.Fatal("expected openclaw entry in config")
+	}
+	if entry.ExtraEnv["MINIMAX_API_KEY"] != "minimax-openclaw-key" {
+		t.Errorf("MINIMAX_API_KEY = %q, want %q", entry.ExtraEnv["MINIMAX_API_KEY"], "minimax-openclaw-key")
+	}
+}
+
+// TestAgentEntryExtraEnvEmpty verifies that an agent entry without API key
+// env vars set has a nil or empty ExtraEnv — no spurious keys injected.
+func TestAgentEntryExtraEnvEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	fakeClaude := tmp + "/claude"
+	if err := os.WriteFile(fakeClaude, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("create fake claude: %v", err)
+	}
+
+	t.Setenv("MULTICA_CLAUDE_PATH", fakeClaude)
+	t.Setenv("MULTICA_CLAUDE_API_KEY", "")
+	t.Setenv("MULTICA_CLAUDE_BASE_URL", "")
+	for _, v := range []string{
+		"MULTICA_CODEX_PATH", "MULTICA_OPENCODE_PATH",
+		"MULTICA_OPENCLAW_PATH", "MULTICA_HERMES_PATH",
+	} {
+		t.Setenv(v, "/nonexistent/binary-"+v)
+	}
+
+	cfg, err := LoadConfig(Overrides{})
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+
+	entry := cfg.Agents["claude"]
+	if len(entry.ExtraEnv) != 0 {
+		t.Errorf("expected empty ExtraEnv, got %v", entry.ExtraEnv)
 	}
 }

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -2,8 +2,9 @@ package daemon
 
 // AgentEntry describes a single available agent CLI.
 type AgentEntry struct {
-	Path  string // path to CLI binary
-	Model string // model override (optional)
+	Path     string            // path to CLI binary
+	Model    string            // model override (optional)
+	ExtraEnv map[string]string // additional env vars injected into the agent process (e.g. API keys, base URLs)
 }
 
 // Runtime represents a registered daemon runtime.


### PR DESCRIPTION
## Summary

- Adds ExtraEnv field to AgentEntry so the daemon can inject provider-specific API keys at the daemon level
- Enables running Claude Code backed by MiniMax Anthropic-compatible API via MULTICA_CLAUDE_API_KEY / MULTICA_CLAUDE_BASE_URL
- Adds daemon-level API key injection for OpenClaw and Hermes Agent which support MiniMax-M2.7
- Updates CLI_AND_DAEMON.md to document all supported agents and adds a MiniMax usage guide

## Changes

- types.go: Add ExtraEnv to AgentEntry
- config.go: Read MULTICA_CLAUDE_API_KEY/BASE_URL, MULTICA_OPENCLAW_API_KEY, MULTICA_HERMES_API_KEY
- daemon.go: Merge entry.ExtraEnv into agentEnv in runTask
- CLI_AND_DAEMON.md: Add opencode/openclaw/hermes to supported agents table, MiniMax usage guide
- daemon_test.go: Add 3 new tests for ExtraEnv population

## Test plan

- [x] go test ./internal/daemon/ - all tests pass, 3 new tests added
- [x] go test ./pkg/agent/ - all agent backend tests pass

## References

MiniMax M2.7 for AI Coding Tools: https://platform.minimax.io/docs/guides/text-ai-coding-tools