### PR TITLE
fix(views): trim search input in assignee and filter pickers

### DIFF
--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -173,7 +173,7 @@ function ActorSubContent({
   const wsId = useWorkspaceId();
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
-  const query = search.toLowerCase();
+  const query = search.trim().toLowerCase();
   const filteredMembers = members.filter((m) =>
     m.name.toLowerCase().includes(query),
   );
@@ -306,7 +306,7 @@ function ProjectSubContent({
   const [search, setSearch] = useState("");
   const wsId = useWorkspaceId();
   const { data: projects = [] } = useQuery(projectListOptions(wsId));
-  const query = search.toLowerCase();
+  const query = search.trim().toLowerCase();
   const filtered = projects.filter((p) =>
     p.title.toLowerCase().includes(query),
   );

--- a/packages/views/issues/components/pickers/assignee-picker.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.tsx
@@ -67,7 +67,7 @@ export function AssigneePicker({
 
   const getFreq = (type: string, id: string) => freqMap.get(`${type}:${id}`) ?? 0;
 
-  const query = filter.toLowerCase();
+  const query = filter.trim().toLowerCase();
   const filteredMembers = members
     .filter((m) => m.name.toLowerCase().includes(query))
     .sort((a, b) => getFreq("member", b.user_id) - getFreq("member", a.user_id));


### PR DESCRIPTION
## Summary
- Assign 搜索框输入带前导空格时（如 ` john`），`.includes()` 匹配失败导致搜不到结果
- 在 `assignee-picker.tsx`、`issues-header.tsx` 的 ActorSubContent 和 ProjectSubContent 三处搜索逻辑中，对 query 添加 `.trim()` 处理

## 方案
修改很简单：在 `.toLowerCase()` 之前加 `.trim()`，只影响搜索匹配逻辑，不改变输入框显示内容。

涉及文件：
- `packages/views/issues/components/pickers/assignee-picker.tsx` — issue 详情页的 assignee 选择器
- `packages/views/issues/components/issues-header.tsx` — issue 列表的 assignee/creator/project 筛选器

## Test plan
- [ ] 在 assignee picker 中输入 ` name`（带前导空格），确认能正常搜索到结果
- [ ] 在 issues header 的 assignee/creator 筛选中输入带空格的搜索词，确认正常
- [ ] 在 project 筛选中同样测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)