### PR TITLE
fix(server): skip auto-comment when agent already posted during task

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -277,7 +277,7 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		agentCommented, _ := s.Queries.HasAgentCommentedSince(ctx, db.HasAgentCommentedSinceParams{
 			IssueID:  task.IssueID,
 			AuthorID: task.AgentID,
-			Since:    task.CreatedAt,
+			Since:    task.StartedAt,
 		})
 		if !agentCommented {
 			var payload protocol.TaskCompletedPayload

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -268,15 +268,23 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 
 	slog.Info("task completed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
 
-	// Post agent output as a comment, but only for issue tasks with assignment triggers.
+	// Post agent output as a comment, but only for assignment-triggered issue tasks
+	// where the agent did NOT already post a comment during execution.
 	// Comment-triggered tasks: the agent replies via CLI with --parent, so
 	// posting here would create a duplicate.
 	// Chat tasks: no comment posting needed.
 	if task.IssueID.Valid && !task.TriggerCommentID.Valid {
-		var payload protocol.TaskCompletedPayload
-		if err := json.Unmarshal(result, &payload); err == nil {
-			if payload.Output != "" {
-				s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(payload.Output), "comment", task.TriggerCommentID)
+		agentCommented, _ := s.Queries.HasAgentCommentedSince(ctx, db.HasAgentCommentedSinceParams{
+			IssueID:  task.IssueID,
+			AuthorID: task.AgentID,
+			Since:    task.CreatedAt,
+		})
+		if !agentCommented {
+			var payload protocol.TaskCompletedPayload
+			if err := json.Unmarshal(result, &payload); err == nil {
+				if payload.Output != "" {
+					s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(payload.Output), "comment", task.TriggerCommentID)
+				}
 			}
 		}
 	}

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -130,6 +130,29 @@ func (q *Queries) GetCommentInWorkspace(ctx context.Context, arg GetCommentInWor
 	return i, err
 }
 
+const hasAgentCommentedSince = `-- name: HasAgentCommentedSince :one
+SELECT EXISTS (
+    SELECT 1 FROM comment
+    WHERE issue_id = $1
+      AND author_type = 'agent'
+      AND author_id = $2
+      AND created_at >= $3
+) AS commented
+`
+
+type HasAgentCommentedSinceParams struct {
+	IssueID  pgtype.UUID        `json:"issue_id"`
+	AuthorID pgtype.UUID        `json:"author_id"`
+	Since    pgtype.Timestamptz `json:"since"`
+}
+
+func (q *Queries) HasAgentCommentedSince(ctx context.Context, arg HasAgentCommentedSinceParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasAgentCommentedSince, arg.IssueID, arg.AuthorID, arg.Since)
+	var commented bool
+	err := row.Scan(&commented)
+	return commented, err
+}
+
 const listComments = `-- name: ListComments :many
 SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
 WHERE issue_id = $1 AND workspace_id = $2

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -44,5 +44,14 @@ UPDATE comment SET
 WHERE id = $1
 RETURNING *;
 
+-- name: HasAgentCommentedSince :one
+SELECT EXISTS (
+    SELECT 1 FROM comment
+    WHERE issue_id = @issue_id
+      AND author_type = 'agent'
+      AND author_id = @author_id
+      AND created_at >= @since
+) AS commented;
+
 -- name: DeleteComment :exec
 DELETE FROM comment WHERE id = $1;


### PR DESCRIPTION
## Summary
- Added `HasAgentCommentedSince` SQL query to check if an agent already posted a comment on an issue since a given timestamp
- Modified `CompleteTask()` to skip the automatic output comment when the agent already posted comments during the task execution
- Preserves the fallback: if the agent didn't post any comments via CLI, the server still auto-posts the terminal output

## Context
Fixes duplicate comments in assignment-triggered tasks (MUL-609). When an agent used `multica issue comment add` during execution AND produced terminal output, `CompleteTask()` would auto-post the output as a second comment. Now it checks first.

## Changes
- `server/pkg/db/queries/comment.sql` — new `HasAgentCommentedSince` query
- `server/pkg/db/generated/comment.sql.go` — sqlc-generated code
- `server/internal/service/task.go` — skip auto-comment if agent already commented since task start

## Test plan
- [ ] Assignment-triggered task where agent posts via CLI → only CLI comment appears (no duplicate)
- [ ] Assignment-triggered task where agent does NOT post via CLI → server auto-posts output (fallback works)
- [ ] Comment-triggered tasks unaffected (still skipped by `!task.TriggerCommentID.Valid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)