### PR TITLE
fix(docker): pass NEXT_PUBLIC_GOOGLE_CLIENT_ID as build arg for self-hosting

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -36,7 +36,9 @@ RUN pnpm install --frozen-lockfile --offline
 
 # Set build-time env: tells Next.js rewrites to proxy API calls to the backend service
 ARG REMOTE_API_URL=http://backend:8080
+ARG NEXT_PUBLIC_GOOGLE_CLIENT_ID
 ENV REMOTE_API_URL=$REMOTE_API_URL
+ENV NEXT_PUBLIC_GOOGLE_CLIENT_ID=$NEXT_PUBLIC_GOOGLE_CLIENT_ID
 ENV STANDALONE=true
 
 # Build the web app (standalone output for minimal runtime)

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -61,6 +61,7 @@ services:
       dockerfile: Dockerfile.web
       args:
         REMOTE_API_URL: http://backend:8080
+        NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${NEXT_PUBLIC_GOOGLE_CLIENT_ID:-}
     depends_on:
       - backend
     ports:


### PR DESCRIPTION
## Summary
- Pass `NEXT_PUBLIC_GOOGLE_CLIENT_ID` as a Docker build argument so the Google OAuth button renders in self-hosted deployments
- `NEXT_PUBLIC_*` env vars must be available at Next.js **build time** to be inlined into the client bundle — without this, the variable is `undefined` at runtime and the login page never shows the Google button

## Changes
- `Dockerfile.web`: Add `ARG` and `ENV` for `NEXT_PUBLIC_GOOGLE_CLIENT_ID` in the builder stage
- `docker-compose.selfhost.yml`: Forward the variable from `.env` as a build arg

## Test plan
- [x] Set `NEXT_PUBLIC_GOOGLE_CLIENT_ID` in `.env`
- [x] Run `docker compose -f docker-compose.selfhost.yml up -d --build`
- [x] Verify Google OAuth button appears on the login page
- [x] Verify Google OAuth login flow completes successfully