### PR TITLE
fix(cli): ensure cloud URLs when not using local mode

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -242,6 +242,16 @@ configure_local() {
 }
 
 # ---------------------------------------------------------------------------
+# Configure CLI for Multica Cloud
+# ---------------------------------------------------------------------------
+configure_cloud() {
+  info "Configuring CLI for Multica Cloud..."
+  multica config set server_url https://api.multica.ai 2>/dev/null || true
+  multica config set app_url https://multica.ai 2>/dev/null || true
+  ok "CLI configured for multica.ai"
+}
+
+# ---------------------------------------------------------------------------
 # Main: Default mode (cloud — install CLI to connect to multica.ai)
 # ---------------------------------------------------------------------------
 run_default() {
@@ -252,6 +262,7 @@ run_default() {
 
   detect_os
   install_cli
+  configure_cloud
 
   printf "\n"
   printf "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"

--- a/server/cmd/multica/cmd_setup.go
+++ b/server/cmd/multica/cmd_setup.go
@@ -55,6 +55,13 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "  server_url: %s\n", cfg.ServerURL)
 	} else if !forceLocal {
 		fmt.Fprintln(os.Stderr, "No local server detected — using Multica Cloud (https://multica.ai).")
+
+		cfg, _ := cli.LoadCLIConfigForProfile(profile)
+		cfg.AppURL = "https://multica.ai"
+		cfg.ServerURL = "https://api.multica.ai"
+		if err := cli.SaveCLIConfigForProfile(cfg, profile); err != nil {
+			return fmt.Errorf("save config: %w", err)
+		}
 	}
 
 	// Authenticate.


### PR DESCRIPTION
## Summary

- After `curl | bash` (cloud mode) or `multica setup` without a local server, the CLI config could retain stale `localhost` URLs from a previous local setup, causing `multica login` to connect to localhost instead of `multica.ai`
- Fixes by explicitly writing cloud URLs (`https://api.multica.ai` / `https://multica.ai`) in both the install script's cloud path and `multica setup`'s cloud fallback

## Changes

**`scripts/install.sh`**: Added `configure_cloud()` function called in `run_default()` — sets `server_url` and `app_url` to cloud defaults after CLI install

**`server/cmd/multica/cmd_setup.go`**: When `probeLocalServer` finds no local server, now explicitly writes cloud URLs to config (previously only printed a message but left config unchanged)

## Test plan

- [ ] Run `multica config local` then `curl ... | bash` (default mode), verify `multica config show` points to `multica.ai`
- [ ] Run `multica setup` without a local server running, verify config shows cloud URLs
- [ ] Run `curl ... | bash -s -- --local` still correctly configures localhost