### PR TITLE
docs: add switching to Multica Cloud section

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -123,6 +123,24 @@ make selfhost-stop
 multica daemon stop
 ```
 
+## Switching to Multica Cloud
+
+If you've been self-hosting and want to switch your CLI to [Multica Cloud](https://multica.ai):
+
+```bash
+multica config set server_url https://api.multica.ai
+multica config set app_url https://multica.ai
+multica login
+```
+
+Or re-run the install script without `--local` — it will reconfigure the CLI automatically:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash
+```
+
+> Your local Docker services are unaffected. Stop them separately if you no longer need them.
+
 ## Rebuilding After Updates
 
 ```bash

--- a/apps/docs/content/docs/getting-started/self-hosting.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.mdx
@@ -118,6 +118,26 @@ make selfhost-stop
 multica daemon stop
 ```
 
+## Switching to Multica Cloud
+
+If you've been self-hosting and want to switch your CLI to [Multica Cloud](https://multica.ai):
+
+```bash
+multica config set server_url https://api.multica.ai
+multica config set app_url https://multica.ai
+multica login
+```
+
+Or re-run the install script without `--local` — it will reconfigure the CLI automatically:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash
+```
+
+<Callout>
+Your local Docker services are unaffected. Stop them separately if you no longer need them.
+</Callout>
+
 ## Rebuilding After Updates
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a "Switching to Multica Cloud" section to both `SELF_HOSTING.md` and `self-hosting.mdx`
- Documents how self-host users can reconfigure their CLI to connect to multica.ai instead of localhost

## Changes

Both docs now include a section (after "Stopping Services") explaining two options:
1. `multica config set server_url / app_url` + `multica login`
2. Re-run the install script without `--local`

## Test plan

- [ ] Verify SELF_HOSTING.md renders correctly on GitHub
- [ ] Verify self-hosting.mdx renders correctly on docs site