### PR TITLE
feat(cli): enhance version command with JSON output and build info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
       - -s -w
       - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/Makefile
+++ b/Makefile
@@ -190,10 +190,11 @@ multica:
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+DATE    ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 
 build:
 	cd server && go build -o bin/server ./cmd/server
-	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)" -o bin/multica ./cmd/multica
+	cd server && go build -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o bin/multica ./cmd/multica
 	cd server && go build -o bin/migrate ./cmd/migrate
 
 test:

--- a/server/cmd/multica/cmd_update.go
+++ b/server/cmd/multica/cmd_update.go
@@ -17,7 +17,7 @@ var updateCmd = &cobra.Command{
 }
 
 func runUpdate(_ *cobra.Command, _ []string) error {
-	fmt.Fprintf(os.Stderr, "Current version: %s (commit: %s)\n", version, commit)
+	fmt.Fprintf(os.Stderr, "Current version: %s (commit: %s, built: %s)\n", version, commit, date)
 
 	// Check latest version from GitHub.
 	latest, err := cli.FetchLatestRelease()

--- a/server/cmd/multica/cmd_version.go
+++ b/server/cmd/multica/cmd_version.go
@@ -1,15 +1,42 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	versionCmd.Flags().String("output", "text", "Output format: text or json")
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
-	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Printf("multica %s (commit: %s)\n", version, commit)
-	},
+	RunE:  runVersion,
+}
+
+func runVersion(cmd *cobra.Command, _ []string) error {
+	output, _ := cmd.Flags().GetString("output")
+
+	if output == "json" {
+		info := map[string]string{
+			"version":   version,
+			"commit":    commit,
+			"date":      date,
+			"go":        runtime.Version(),
+			"os":        runtime.GOOS,
+			"arch":      runtime.GOARCH,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(info)
+	}
+
+	fmt.Printf("multica %s (commit: %s, built: %s)\n", version, commit, date)
+	fmt.Printf("go: %s, os/arch: %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	return nil
 }

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -10,6 +10,7 @@ import (
 var (
 	version = "dev"
 	commit  = "unknown"
+	date    = "unknown"
 )
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
## Summary
- Enhanced `multica version` with `--output json` support for structured output
- Added build date, Go version, and OS/arch info to version output
- Updated Makefile and `.goreleaser.yml` to inject build date via ldflags
- Updated `multica update` to display build date consistently

## Test plan
- [x] `multica version` shows version, commit, date, Go version, OS/arch
- [x] `multica version --output json` outputs structured JSON
- [x] `go vet` passes
- [x] Code compiles cleanly

Closes MUL-630