### PR TITLE
fix(chat): reconnect to running task after navigating away

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -435,6 +435,10 @@ export class ApiClient {
     return this.fetch(`/api/daemon/tasks/${taskId}/messages`);
   }
 
+  async getActiveChatTask(sessionId: string): Promise<{ task_id: string; status: string } | null> {
+    return this.fetch(`/api/chat/sessions/${sessionId}/active-task`);
+  }
+
   async listTasksByIssue(issueId: string): Promise<AgentTask[]> {
     return this.fetch(`/api/issues/${issueId}/task-runs`);
   }

--- a/packages/views/chat/components/chat-session-history.tsx
+++ b/packages/views/chat/components/chat-session-history.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, MessageSquare, Archive, Trash2 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@multica/ui/components/ui/avatar";
 import { Bot } from "lucide-react";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { agentListOptions } from "@multica/core/workspace/queries";
-import { allChatSessionsOptions } from "@multica/core/chat/queries";
+import { allChatSessionsOptions, chatKeys } from "@multica/core/chat/queries";
 import { useArchiveChatSession } from "@multica/core/chat/mutations";
 import { useChatStore } from "@multica/core/chat";
 import type { ChatSession, Agent } from "@multica/core/types";
@@ -19,6 +19,7 @@ export function ChatSessionHistory() {
   const setPendingTask = useChatStore((s) => s.setPendingTask);
   const activeSessionId = useChatStore((s) => s.activeSessionId);
 
+  const qc = useQueryClient();
   const { data: sessions = [] } = useQuery(allChatSessionsOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const archiveSession = useArchiveChatSession();
@@ -26,6 +27,10 @@ export function ChatSessionHistory() {
   const agentMap = new Map(agents.map((a) => [a.id, a]));
 
   const handleSelectSession = (session: ChatSession) => {
+    // Invalidate cached messages so we fetch the latest from the server.
+    // Without this, stale cache (staleTime: Infinity) would hide messages
+    // that arrived after the cache was originally populated.
+    qc.invalidateQueries({ queryKey: chatKeys.messages(session.id) });
     setActiveSession(session.id);
     clearTimeline();
     setPendingTask(null);

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -100,21 +100,8 @@ export function ChatWindow() {
   const { subscribe } = useWS();
 
   useEffect(() => {
-    // Returns true if the event was for our pending task and was handled.
-    // Caller still decides whether to invalidate cache (chat:done / completed do; failed doesn't).
     const matchesPending = (taskId: string) =>
       !!pendingTaskRef.current && taskId === pendingTaskRef.current;
-
-    const finalizePending = (invalidateCache: boolean) => {
-      if (invalidateCache) {
-        const sid = useChatStore.getState().activeSessionId;
-        if (sid) {
-          qc.invalidateQueries({ queryKey: chatKeys.messages(sid) });
-        }
-      }
-      clearTimeline();
-      setPendingTask(null);
-    };
 
     const unsubMessage = subscribe("task:message", (payload) => {
       const p = payload as TaskMessagePayload;
@@ -129,22 +116,40 @@ export function ChatWindow() {
       });
     });
 
+    // chat:done carries the session ID in the payload, so we can always
+    // invalidate the correct session's cache — even if the user clicked
+    // "New Chat" (which clears activeSessionId/pendingTaskId) while the
+    // task was still running.
     const unsubDone = subscribe("chat:done", (payload) => {
       const p = payload as ChatDonePayload;
-      if (!matchesPending(p.task_id)) return;
-      finalizePending(true);
+      if (p.chat_session_id) {
+        qc.invalidateQueries({ queryKey: chatKeys.messages(p.chat_session_id) });
+      }
+      qc.invalidateQueries({ queryKey: chatKeys.sessions(wsId) });
+      qc.invalidateQueries({ queryKey: chatKeys.allSessions(wsId) });
+      if (matchesPending(p.task_id)) {
+        clearTimeline();
+        setPendingTask(null);
+      }
     });
 
+    // Fallback for non-chat tasks or if chat:done wasn't emitted.
     const unsubCompleted = subscribe("task:completed", (payload) => {
       const p = payload as { task_id: string };
       if (!matchesPending(p.task_id)) return;
-      finalizePending(true);
+      const sid = useChatStore.getState().activeSessionId;
+      if (sid) {
+        qc.invalidateQueries({ queryKey: chatKeys.messages(sid) });
+      }
+      clearTimeline();
+      setPendingTask(null);
     });
 
     const unsubFailed = subscribe("task:failed", (payload) => {
       const p = payload as { task_id: string };
       if (!matchesPending(p.task_id)) return;
-      finalizePending(false);
+      clearTimeline();
+      setPendingTask(null);
     });
 
     return () => {
@@ -153,7 +158,41 @@ export function ChatWindow() {
       unsubCompleted();
       unsubFailed();
     };
-  }, [subscribe, addTimelineItem, clearTimeline, setPendingTask, qc]);
+  }, [subscribe, addTimelineItem, clearTimeline, setPendingTask, qc, wsId]);
+
+  // Reconnect to a running task when switching to a session that has one.
+  // This handles the case where the user clicked "New Chat" while a task was
+  // still running, then returned to the session via history.
+  useEffect(() => {
+    if (!activeSessionId || pendingTaskRef.current) return;
+
+    let cancelled = false;
+
+    api.getActiveChatTask(activeSessionId).then((activeTask) => {
+      if (cancelled || !activeTask) return;
+
+      setPendingTask(activeTask.task_id);
+
+      // Backfill timeline with already-persisted task messages.
+      api.listTaskMessages(activeTask.task_id).then((msgs) => {
+        if (cancelled) return;
+        for (const msg of msgs) {
+          addTimelineItem({
+            seq: msg.seq,
+            type: msg.type,
+            tool: msg.tool,
+            content: msg.content,
+            input: msg.input,
+            output: msg.output,
+          });
+        }
+      });
+    }).catch(() => {
+      // No active task or fetch error — nothing to reconnect to.
+    });
+
+    return () => { cancelled = true; };
+  }, [activeSessionId, setPendingTask, addTimelineItem]);
 
   const handleSend = useCallback(
     async (content: string) => {

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -287,6 +287,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 					r.Delete("/", h.ArchiveChatSession)
 					r.Post("/messages", h.SendChatMessage)
 					r.Get("/messages", h.ListChatMessages)
+					r.Get("/active-task", h.GetActiveChatTask)
 				})
 			})
 

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -274,6 +274,45 @@ func (h *Handler) ListChatMessages(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
+// Active task for a chat session (used by the frontend to reconnect to a
+// running task after navigating away and back).
+// ---------------------------------------------------------------------------
+
+func (h *Handler) GetActiveChatTask(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := ctxWorkspaceID(r.Context())
+	sessionID := chi.URLParam(r, "sessionId")
+
+	session, err := h.Queries.GetChatSessionInWorkspace(r.Context(), db.GetChatSessionInWorkspaceParams{
+		ID:          parseUUID(sessionID),
+		WorkspaceID: parseUUID(workspaceID),
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "chat session not found")
+		return
+	}
+	if uuidToString(session.CreatorID) != userID {
+		writeError(w, http.StatusForbidden, "not your chat session")
+		return
+	}
+
+	task, err := h.Queries.GetActiveTaskByChatSession(r.Context(), parseUUID(sessionID))
+	if err != nil {
+		// No active task — return null.
+		writeJSON(w, http.StatusOK, nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"task_id": uuidToString(task.ID),
+		"status":  task.Status,
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Task cancellation (user-facing, with ownership check)
 // ---------------------------------------------------------------------------
 

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -393,6 +393,38 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 	return items, nil
 }
 
+const getActiveTaskByChatSession = `-- name: GetActiveTaskByChatSession :one
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id FROM agent_task_queue
+WHERE chat_session_id = $1 AND status IN ('queued', 'dispatched', 'running')
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+func (q *Queries) GetActiveTaskByChatSession(ctx context.Context, chatSessionID pgtype.UUID) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, getActiveTaskByChatSession, chatSessionID)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+	)
+	return i, err
+}
+
 const getAgent = `-- name: GetAgent :one
 SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by FROM agent
 WHERE id = $1

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -175,6 +175,12 @@ SELECT * FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('dispatched', 'running')
 ORDER BY created_at DESC;
 
+-- name: GetActiveTaskByChatSession :one
+SELECT * FROM agent_task_queue
+WHERE chat_session_id = $1 AND status IN ('queued', 'dispatched', 'running')
+ORDER BY created_at DESC
+LIMIT 1;
+
 -- name: ListTasksByIssue :many
 SELECT * FROM agent_task_queue
 WHERE issue_id = $1


### PR DESCRIPTION
When a user clicks "New Chat" while a chat task is still running, the frontend loses track of the task entirely. The cache for the original session is never invalidated (because pendingTaskId and activeSessionId are both cleared), and returning to the session via history shows stale data — only the user's message, with no agent responses or tool calls.

Three fixes:

1. Decouple chat:done WS handler from pendingTaskId — use the session ID from the event payload to always invalidate the correct cache, regardless of local UI state.

2. Add a reconnection effect: when switching to a session, query the new GET /api/chat/sessions/{id}/active-task endpoint. If a task is still running, set pendingTaskId to resume WS streaming and backfill the timeline with already-persisted task messages.

3. Invalidate message cache when restoring a session from history, so completed responses aren't hidden by stale staleTime:Infinity cache.

  ## What

  Fix chat sessions losing track of running tasks when the user clicks "New Chat", making agent responses and tool calls
   invisible when returning via history.

  ## Why

  Three cascading bugs caused this:
  1. "New Chat" clears `pendingTaskId`, so all subsequent WS events (`chat:done`, `task:completed`) are ignored by
  `matchesPending()`
  2. Even if events reached `finalizePending`, it reads `activeSessionId` from the store (now null), skipping cache
  invalidation
  3. Chat history restore doesn't invalidate the `staleTime: Infinity` message cache, so stale data is served

  Closes #<!-- issue number if applicable -->

  ## Type of Change

  - [x] Bug fix

  ## How to Test

  1. Open chat, send a message to an agent
  2. While the agent is executing, click **New Chat**
  3. Go to **Chat History**, click on the previous session
  4. **Before fix**: only user message visible, no agent responses/tool calls
  5. **After fix**: running task reconnects — live tool calls resume, and completed responses appear

  ## Checklist

  - [x] `pnpm typecheck` passes
  - [x] `pnpm test` passes (78/78)
  - [x] `go build ./...` passes
  - [x] Changes follow existing code patterns and conventions
  - [x] No unrelated changes included

  ## AI Disclosure

  - Claude Code (Opus 4.6) — investigated the bug, implemented the fix across frontend WS handlers, backend endpoint,
  and sqlc query
