### PR TITLE
fix(auth): graceful email degradation for self-hosting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ MULTICA_CODEX_WORKDIR=
 MULTICA_CODEX_TIMEOUT=20m
 
 # Email (Resend)
+# For local/dev use, leave RESEND_API_KEY empty — codes print to stdout, and master code 888888 works.
+# For production, set your Resend API key and change RESEND_FROM_EMAIL to a domain verified in your Resend account.
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=noreply@multica.ai
 

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -242,12 +242,8 @@ func (h *Handler) SendCode(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.EmailService.SendVerificationCode(email, code); err != nil {
 		slog.Error("failed to send verification code", "email", email, "error", err)
-		if os.Getenv("APP_ENV") != "production" {
-			slog.Warn("non-production: proceeding despite email send failure (use master code 888888 to verify)")
-		} else {
-			writeError(w, http.StatusInternalServerError, "failed to send verification code")
-			return
-		}
+		writeError(w, http.StatusInternalServerError, "failed to send verification code")
+		return
 	}
 
 	// Best-effort cleanup of expired codes

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -241,8 +241,13 @@ func (h *Handler) SendCode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.EmailService.SendVerificationCode(email, code); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to send verification code")
-		return
+		slog.Error("failed to send verification code", "email", email, "error", err)
+		if os.Getenv("APP_ENV") != "production" {
+			slog.Warn("non-production: proceeding despite email send failure (use master code 888888 to verify)")
+		} else {
+			writeError(w, http.StatusInternalServerError, "failed to send verification code")
+			return
+		}
 	}
 
 	// Best-effort cleanup of expired codes


### PR DESCRIPTION
## Summary

- In non-production environments, if sending the verification code email fails, log the error and still return success — this lets self-hosters log in with the master code `888888` even when Resend isn't fully configured
- In production, email failures still return 500 (unchanged)
- Added error logging (`slog.Error`) so the actual Resend error appears in backend logs
- Updated `.env.example` with guidance about `RESEND_FROM_EMAIL` for self-hosters

Closes #723

## Test plan

- [ ] Self-host with `RESEND_API_KEY` set but `RESEND_FROM_EMAIL` left as default → verify login works with master code `888888`
- [ ] Self-host without `RESEND_API_KEY` → verify login still works (codes print to stdout)
- [ ] Set `APP_ENV=production` with invalid Resend config → verify 500 is still returned
- [ ] `go build ./...` compiles cleanly