### PR TITLE
Add email/password login for self-hosted auth

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -160,6 +160,20 @@ export class ApiClient {
     });
   }
 
+  async loginWithPassword(email: string, password: string): Promise<LoginResponse> {
+    return this.fetch("/auth/password/login", {
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+    });
+  }
+
+  async setupPassword(email: string, code: string, password: string): Promise<LoginResponse> {
+    return this.fetch("/auth/password/setup", {
+      method: "POST",
+      body: JSON.stringify({ email, code, password }),
+    });
+  }
+
   async googleLogin(code: string, redirectUri: string): Promise<LoginResponse> {
     return this.fetch("/auth/google", {
       method: "POST",

--- a/packages/core/auth/store.ts
+++ b/packages/core/auth/store.ts
@@ -16,6 +16,8 @@ export interface AuthState {
   initialize: () => Promise<void>;
   sendCode: (email: string) => Promise<void>;
   verifyCode: (email: string, code: string) => Promise<User>;
+  loginWithPassword: (email: string, password: string) => Promise<User>;
+  setupPassword: (email: string, code: string, password: string) => Promise<User>;
   loginWithGoogle: (code: string, redirectUri: string) => Promise<User>;
   logout: () => void;
   setUser: (user: User) => void;
@@ -54,6 +56,24 @@ export function createAuthStore(options: AuthStoreOptions) {
 
     verifyCode: async (email: string, code: string) => {
       const { token, user } = await api.verifyCode(email, code);
+      storage.setItem("multica_token", token);
+      api.setToken(token);
+      onLogin?.();
+      set({ user });
+      return user;
+    },
+
+    loginWithPassword: async (email: string, password: string) => {
+      const { token, user } = await api.loginWithPassword(email, password);
+      storage.setItem("multica_token", token);
+      api.setToken(token);
+      onLogin?.();
+      set({ user });
+      return user;
+    },
+
+    setupPassword: async (email: string, code: string, password: string) => {
+      const { token, user } = await api.setupPassword(email, code, password);
       storage.setItem("multica_token", token);
       api.setToken(token);
       onLogin?.();

--- a/packages/views/auth/login-page.test.tsx
+++ b/packages/views/auth/login-page.test.tsx
@@ -8,9 +8,13 @@ import userEvent from "@testing-library/user-event";
 
 const mockSendCode = vi.hoisted(() => vi.fn());
 const mockVerifyCode = vi.hoisted(() => vi.fn());
+const mockLoginWithPassword = vi.hoisted(() => vi.fn());
+const mockSetupPassword = vi.hoisted(() => vi.fn());
 const mockHydrateWorkspace = vi.hoisted(() => vi.fn());
 const mockApiListWorkspaces = vi.hoisted(() => vi.fn());
 const mockApiVerifyCode = vi.hoisted(() => vi.fn());
+const mockApiLoginWithPassword = vi.hoisted(() => vi.fn());
+const mockApiSetupPassword = vi.hoisted(() => vi.fn());
 const mockApiSetToken = vi.hoisted(() => vi.fn());
 const mockApiGetMe = vi.hoisted(() => vi.fn());
 
@@ -18,13 +22,20 @@ vi.mock("@multica/core/auth", () => ({
   useAuthStore: Object.assign(
     // Zustand hook form — component may call useAuthStore(selector)
     (selector?: (s: unknown) => unknown) => {
-      const state = { sendCode: mockSendCode, verifyCode: mockVerifyCode };
+      const state = {
+        sendCode: mockSendCode,
+        verifyCode: mockVerifyCode,
+        loginWithPassword: mockLoginWithPassword,
+        setupPassword: mockSetupPassword,
+      };
       return selector ? selector(state) : state;
     },
     {
       getState: () => ({
         sendCode: mockSendCode,
         verifyCode: mockVerifyCode,
+        loginWithPassword: mockLoginWithPassword,
+        setupPassword: mockSetupPassword,
       }),
     },
   ),
@@ -48,6 +59,8 @@ vi.mock("@multica/core/api", () => ({
   api: {
     listWorkspaces: mockApiListWorkspaces,
     verifyCode: mockApiVerifyCode,
+    loginWithPassword: mockApiLoginWithPassword,
+    setupPassword: mockApiSetupPassword,
     setToken: mockApiSetToken,
     getMe: mockApiGetMe,
   },
@@ -209,6 +222,54 @@ describe("LoginPage", () => {
     });
   });
 
+  it("switches to password mode and signs in with email + password", async () => {
+    mockLoginWithPassword.mockResolvedValueOnce({
+      id: "u-1",
+      email: "test@example.com",
+      name: "Test User",
+    });
+    mockApiListWorkspaces.mockResolvedValueOnce([{ id: "ws-1" }]);
+
+    render(<LoginPage onSuccess={onSuccess} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /password/i }));
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(
+      screen.getByRole("button", { name: /sign in with password/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockLoginWithPassword).toHaveBeenCalledWith(
+        "test@example.com",
+        "Password123",
+      );
+      expect(mockHydrateWorkspace).toHaveBeenCalledWith(
+        [{ id: "ws-1" }],
+        undefined,
+      );
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it("shows password login errors", async () => {
+    mockLoginWithPassword.mockRejectedValueOnce(new Error("Invalid password"));
+    render(<LoginPage onSuccess={onSuccess} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /password/i }));
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(
+      screen.getByRole("button", { name: /sign in with password/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid password")).toBeInTheDocument();
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Code verification
   // -------------------------------------------------------------------------
@@ -296,6 +357,76 @@ describe("LoginPage", () => {
     // After transitioning to code step, cooldown is 10s
     const resendBtn = screen.getByRole("button", { name: /resend in/i });
     expect(resendBtn).toBeDisabled();
+  });
+
+  it("opens password setup from the code step and submits successfully", async () => {
+    mockSendCode.mockResolvedValueOnce(undefined);
+    mockSetupPassword.mockResolvedValueOnce({
+      id: "u-1",
+      email: "test@example.com",
+      name: "Test User",
+    });
+    mockApiListWorkspaces.mockResolvedValueOnce([{ id: "ws-1" }]);
+
+    render(<LoginPage onSuccess={onSuccess} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/check your email/i)).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /set a password instead/i }),
+    );
+    await user.type(screen.getByLabelText(/verification code/i), "123456");
+    await user.type(
+      screen.getByLabelText(/^password$/i),
+      "Password123",
+    );
+    await user.type(
+      screen.getByLabelText(/confirm password/i),
+      "Password123",
+    );
+    await user.click(screen.getByRole("button", { name: /set password/i }));
+
+    await waitFor(() => {
+      expect(mockSetupPassword).toHaveBeenCalledWith(
+        "test@example.com",
+        "123456",
+        "Password123",
+      );
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it("blocks password setup when confirmation does not match", async () => {
+    mockSendCode.mockResolvedValueOnce(undefined);
+    render(<LoginPage onSuccess={onSuccess} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/check your email/i)).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /set a password instead/i }),
+    );
+    await user.type(screen.getByLabelText(/verification code/i), "123456");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.type(
+      screen.getByLabelText(/confirm password/i),
+      "Mismatch123",
+    );
+    await user.click(screen.getByRole("button", { name: /set password/i }));
+
+    expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+    expect(mockSetupPassword).not.toHaveBeenCalled();
   });
 
   it("shows resend button with cooldown text after sending code", async () => {
@@ -512,6 +643,38 @@ describe("LoginPage", () => {
     expect(mockVerifyCode).not.toHaveBeenCalled();
     // onSuccess should NOT be called in CLI path — redirect handles it
     expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("CLI password login redirects to callback URL", async () => {
+    mockApiLoginWithPassword.mockResolvedValueOnce({ token: "pw-token" });
+    const onTokenObtained = vi.fn();
+
+    render(
+      <LoginPage
+        onSuccess={onSuccess}
+        onTokenObtained={onTokenObtained}
+        cliCallback={{ url: "http://localhost:9876/callback", state: "pw" }}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /password/i }));
+    await user.type(screen.getByLabelText(/email/i), "cli@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "Password123");
+    await user.click(
+      screen.getByRole("button", { name: /sign in with password/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockApiLoginWithPassword).toHaveBeenCalledWith(
+        "cli@example.com",
+        "Password123",
+      );
+      expect(window.location.href).toContain(
+        "http://localhost:9876/callback?token=pw-token&state=pw",
+      );
+      expect(onTokenObtained).toHaveBeenCalled();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/views/auth/login-page.tsx
+++ b/packages/views/auth/login-page.tsx
@@ -87,9 +87,12 @@ export function LoginPage({
   lastWorkspaceId,
   onTokenObtained,
 }: LoginPageProps) {
-  const [step, setStep] = useState<"email" | "code" | "cli_confirm">("email");
+  const [step, setStep] = useState<"email" | "code" | "set_password" | "cli_confirm">("email");
+  const [method, setMethod] = useState<"otp" | "password">("otp");
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [cooldown, setCooldown] = useState(0);
@@ -148,6 +151,43 @@ export function LoginPage({
     [email],
   );
 
+  const handlePasswordLogin = useCallback(
+    async (e?: React.FormEvent) => {
+      e?.preventDefault();
+      if (!email || !password) {
+        setError("Email and password are required");
+        return;
+      }
+      setLoading(true);
+      setError("");
+      try {
+        if (cliCallback) {
+          const { token } = await api.loginWithPassword(email, password);
+          localStorage.setItem("multica_token", token);
+          api.setToken(token);
+          onTokenObtained?.();
+          redirectToCliCallback(cliCallback.url, token, cliCallback.state);
+          return;
+        }
+
+        await useAuthStore.getState().loginWithPassword(email, password);
+        const wsList = await api.listWorkspaces();
+        useWorkspaceStore.getState().hydrateWorkspace(wsList, lastWorkspaceId);
+        onTokenObtained?.();
+        onSuccess();
+      } catch (err) {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to sign in with password",
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [cliCallback, email, lastWorkspaceId, onSuccess, onTokenObtained, password],
+  );
+
   const handleVerify = useCallback(
     async (value: string) => {
       if (value.length !== 6) return;
@@ -193,6 +233,55 @@ export function LoginPage({
       );
     }
   };
+
+  const handleSetupPassword = useCallback(
+    async (e?: React.FormEvent) => {
+      e?.preventDefault();
+      if (!email || !code || !password) {
+        setError("Email, code, and password are required");
+        return;
+      }
+      if (password !== confirmPassword) {
+        setError("Passwords do not match");
+        return;
+      }
+
+      setLoading(true);
+      setError("");
+      try {
+        if (cliCallback) {
+          const { token } = await api.setupPassword(email, code, password);
+          localStorage.setItem("multica_token", token);
+          api.setToken(token);
+          onTokenObtained?.();
+          redirectToCliCallback(cliCallback.url, token, cliCallback.state);
+          return;
+        }
+
+        await useAuthStore.getState().setupPassword(email, code, password);
+        const wsList = await api.listWorkspaces();
+        useWorkspaceStore.getState().hydrateWorkspace(wsList, lastWorkspaceId);
+        onTokenObtained?.();
+        onSuccess();
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to set password",
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [
+      cliCallback,
+      code,
+      confirmPassword,
+      email,
+      lastWorkspaceId,
+      onSuccess,
+      onTokenObtained,
+      password,
+    ],
+  );
 
   const handleCliAuthorize = () => {
     if (!cliCallback) return;
@@ -298,6 +387,17 @@ export function LoginPage({
             {error && (
               <p className="text-sm text-destructive">{error}</p>
             )}
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={() => {
+                setStep("set_password");
+                setError("");
+              }}
+            >
+              Set a password instead
+            </Button>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <button
                 type="button"
@@ -328,6 +428,90 @@ export function LoginPage({
     );
   }
 
+  if (step === "set_password") {
+    return (
+      <div className="flex min-h-svh items-center justify-center">
+        <Card className="w-full max-w-sm">
+          <CardHeader className="text-center">
+            {logo && <div className="mx-auto mb-4">{logo}</div>}
+            <CardTitle className="text-2xl">Set your password</CardTitle>
+            <CardDescription>
+              Use the email code to create a password for{" "}
+              <span className="font-medium text-foreground">{email}</span>
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form
+              id="set-password-form"
+              onSubmit={handleSetupPassword}
+              className="space-y-4"
+            >
+              <div className="space-y-2">
+                <Label htmlFor="setup-code">Verification code</Label>
+                <Input
+                  id="setup-code"
+                  inputMode="numeric"
+                  maxLength={6}
+                  placeholder="123456"
+                  value={code}
+                  onChange={(e) => setCode(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="setup-password">Password</Label>
+                <Input
+                  id="setup-password"
+                  type="password"
+                  placeholder="At least 8 characters"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="setup-password-confirm">Confirm password</Label>
+                <Input
+                  id="setup-password-confirm"
+                  type="password"
+                  placeholder="Repeat password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                />
+              </div>
+              {error && <p className="text-sm text-destructive">{error}</p>}
+            </form>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-3">
+            <Button
+              type="submit"
+              form="set-password-form"
+              className="w-full"
+              size="lg"
+              disabled={!code || !password || !confirmPassword || loading}
+            >
+              {loading ? "Saving password..." : "Set password"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full"
+              onClick={() => {
+                setStep("code");
+                setError("");
+                setPassword("");
+                setConfirmPassword("");
+              }}
+            >
+              Back
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    );
+  }
+
   // -------------------------------------------------------------------------
   // Email step
   // -------------------------------------------------------------------------
@@ -339,11 +523,39 @@ export function LoginPage({
           {logo && <div className="mx-auto mb-4">{logo}</div>}
           <CardTitle className="text-2xl">Sign in to Multica</CardTitle>
           <CardDescription>
-            Enter your email to get a login code
+            {method === "otp"
+              ? "Enter your email to get a login code"
+              : "Sign in with your email and password"}
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form id="login-form" onSubmit={handleSendCode} className="space-y-4">
+          <div className="mb-4 grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant={method === "otp" ? "default" : "outline"}
+              onClick={() => {
+                setMethod("otp");
+                setError("");
+              }}
+            >
+              Email code
+            </Button>
+            <Button
+              type="button"
+              variant={method === "password" ? "default" : "outline"}
+              onClick={() => {
+                setMethod("password");
+                setError("");
+              }}
+            >
+              Password
+            </Button>
+          </div>
+          <form
+            id="login-form"
+            onSubmit={method === "otp" ? handleSendCode : handlePasswordLogin}
+            className="space-y-4"
+          >
             <div className="space-y-2">
               <Label htmlFor="login-email">Email</Label>
               <Input
@@ -356,6 +568,19 @@ export function LoginPage({
                 required
               />
             </div>
+            {method === "password" && (
+              <div className="space-y-2">
+                <Label htmlFor="login-password">Password</Label>
+                <Input
+                  id="login-password"
+                  type="password"
+                  placeholder="Enter your password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+            )}
             {error && (
               <p className="text-sm text-destructive">{error}</p>
             )}
@@ -367,10 +592,29 @@ export function LoginPage({
             form="login-form"
             className="w-full"
             size="lg"
-            disabled={!email || loading}
+            disabled={!email || (method === "password" && !password) || loading}
           >
-            {loading ? "Sending code..." : "Continue"}
+            {loading
+              ? method === "otp"
+                ? "Sending code..."
+                : "Signing in..."
+              : method === "otp"
+                ? "Continue"
+                : "Sign in with password"}
           </Button>
+          {method === "password" && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full"
+              onClick={() => {
+                setMethod("otp");
+                setError("");
+              }}
+            >
+              Need to set a password? Use an email code
+            </Button>
+          )}
           {google && (
             <>
               <div className="relative w-full">

--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -306,6 +306,82 @@ func TestSendCodeAndVerify(t *testing.T) {
 	meResp.Body.Close()
 }
 
+func TestPasswordSetupAndLogin(t *testing.T) {
+	const email = "integration-password@multica.ai"
+	ctx := context.Background()
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM verification_code WHERE email = $1`, email)
+		var userID string
+		err := testPool.QueryRow(ctx, `SELECT id FROM "user" WHERE email = $1`, email).Scan(&userID)
+		if err == nil {
+			rows, queryErr := testPool.Query(ctx, `
+				SELECT w.id FROM workspace w JOIN member m ON m.workspace_id = w.id WHERE m.user_id = $1
+			`, userID)
+			if queryErr == nil {
+				defer rows.Close()
+				for rows.Next() {
+					var wsID string
+					if rows.Scan(&wsID) == nil {
+						testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, wsID)
+					}
+				}
+			}
+		}
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	body, _ := json.Marshal(map[string]string{"email": email})
+	resp, err := http.Post(testServer.URL+"/auth/send-code", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("send-code failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("send-code: expected 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	var code string
+	if err := testPool.QueryRow(ctx, `SELECT code FROM verification_code WHERE email = $1 ORDER BY created_at DESC LIMIT 1`, email).Scan(&code); err != nil {
+		t.Fatalf("query verification code: %v", err)
+	}
+
+	setupBody, _ := json.Marshal(map[string]string{
+		"email":    email,
+		"code":     code,
+		"password": "Password123",
+	})
+	resp, err = http.Post(testServer.URL+"/auth/password/setup", "application/json", bytes.NewReader(setupBody))
+	if err != nil {
+		t.Fatalf("password setup failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("password setup: expected 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	loginBody, _ := json.Marshal(map[string]string{
+		"email":    email,
+		"password": "Password123",
+	})
+	resp, err = http.Post(testServer.URL+"/auth/password/login", "application/json", bytes.NewReader(loginBody))
+	if err != nil {
+		t.Fatalf("password login failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("password login: expected 200, got %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	var loginResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		t.Fatalf("decode login response: %v", err)
+	}
+	if loginResp["token"] == "" {
+		t.Fatal("expected password login token")
+	}
+}
+
 func TestVerifyCodeCreatesWorkspaceForNewUser(t *testing.T) {
 	const email = "new-integration-verify@multica.ai"
 	ctx := context.Background()

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -90,6 +90,8 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 	// Auth (public)
 	r.Post("/auth/send-code", h.SendCode)
 	r.Post("/auth/verify-code", h.VerifyCode)
+	r.Post("/auth/password/login", h.LoginWithPassword)
+	r.Post("/auth/password/setup", h.SetupPassword)
 	r.Post("/auth/google", h.GoogleLogin)
 
 	// Daemon API routes (all require a valid token)

--- a/server/go.mod
+++ b/server/go.mod
@@ -11,11 +11,14 @@ require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/lmittmann/tint v1.1.3
+	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/resend/resend-go/v2 v2.28.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/crypto v0.40.0
 )
 
 require (
@@ -35,15 +38,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -85,8 +85,10 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/crypto v0.40.0 h1:r4x+VvoG5Fm+eJcxMaY8CQM7Lb0l1lsmjGBQ6s8BfKM=
+golang.org/x/crypto v0.40.0/go.mod h1:Qr1vMER5WyS2dfPHAlsOj01wgLbsyWtFn/aY+5+ZdxY=
+golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
+golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/logger"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type UserResponse struct {
@@ -55,6 +56,19 @@ type VerifyCodeRequest struct {
 	Email string `json:"email"`
 	Code  string `json:"code"`
 }
+
+type PasswordLoginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type SetupPasswordRequest struct {
+	Email    string `json:"email"`
+	Code     string `json:"code"`
+	Password string `json:"password"`
+}
+
+const minPasswordLength = 8
 
 func defaultWorkspaceName(user db.User) string {
 	name := strings.TrimSpace(user.Name)
@@ -183,6 +197,25 @@ func (h *Handler) issueJWT(user db.User) (string, error) {
 	return token.SignedString(auth.JWTSecret())
 }
 
+func (h *Handler) writeLoginResponse(w http.ResponseWriter, user db.User, expiry time.Duration) {
+	tokenString, err := h.issueJWT(user)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+
+	if h.CFSigner != nil {
+		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(expiry)) {
+			http.SetCookie(w, cookie)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, LoginResponse{
+		Token: tokenString,
+		User:  userToResponse(user),
+	})
+}
+
 func (h *Handler) findOrCreateUser(ctx context.Context, email string) (db.User, error) {
 	user, err := h.Queries.GetUserByEmail(ctx, email)
 	if err != nil {
@@ -194,14 +227,30 @@ func (h *Handler) findOrCreateUser(ctx context.Context, email string) (db.User, 
 			name = email[:at]
 		}
 		user, err = h.Queries.CreateUser(ctx, db.CreateUserParams{
-			Name:  name,
-			Email: email,
+			Name:         name,
+			Email:        email,
+			PasswordHash: pgtype.Text{},
 		})
 		if err != nil {
 			return db.User{}, err
 		}
 	}
 	return user, nil
+}
+
+func verifyStoredCode(submittedCode, actualCode string) bool {
+	isMasterCode := submittedCode == "888888" && os.Getenv("APP_ENV") != "production"
+	if isMasterCode {
+		return true
+	}
+	return subtle.ConstantTimeCompare([]byte(submittedCode), []byte(actualCode)) == 1
+}
+
+func validatePassword(password string) error {
+	if len(password) < minPasswordLength {
+		return fmt.Errorf("password must be at least %d characters", minPasswordLength)
+	}
+	return nil
 }
 
 func (h *Handler) SendCode(w http.ResponseWriter, r *http.Request) {
@@ -272,8 +321,7 @@ func (h *Handler) VerifyCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	isMasterCode := code == "888888" && os.Getenv("APP_ENV") != "production"
-	if !isMasterCode && subtle.ConstantTimeCompare([]byte(code), []byte(dbCode.Code)) != 1 {
+	if !verifyStoredCode(code, dbCode.Code) {
 		_ = h.Queries.IncrementVerificationCodeAttempts(r.Context(), dbCode.ID)
 		writeError(w, http.StatusBadRequest, "invalid or expired code")
 		return
@@ -295,25 +343,8 @@ func (h *Handler) VerifyCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenString, err := h.issueJWT(user)
-	if err != nil {
-		slog.Warn("login failed", append(logger.RequestAttrs(r), "error", err, "email", req.Email)...)
-		writeError(w, http.StatusInternalServerError, "failed to generate token")
-		return
-	}
-
-	// Set CloudFront signed cookies for CDN access.
-	if h.CFSigner != nil {
-		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(30 * 24 * time.Hour)) {
-			http.SetCookie(w, cookie)
-		}
-	}
-
 	slog.Info("user logged in", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email)...)
-	writeJSON(w, http.StatusOK, LoginResponse{
-		Token: tokenString,
-		User:  userToResponse(user),
-	})
+	h.writeLoginResponse(w, user, 30*24*time.Hour)
 }
 
 func (h *Handler) GetMe(w http.ResponseWriter, r *http.Request) {
@@ -472,24 +503,112 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenString, err := h.issueJWT(user)
-	if err != nil {
-		slog.Warn("google login failed", append(logger.RequestAttrs(r), "error", err, "email", email)...)
-		writeError(w, http.StatusInternalServerError, "failed to generate token")
+	slog.Info("user logged in via google", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email)...)
+	h.writeLoginResponse(w, user, 72*time.Hour)
+}
+
+func (h *Handler) LoginWithPassword(w http.ResponseWriter, r *http.Request) {
+	var req PasswordLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
-	if h.CFSigner != nil {
-		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(72 * time.Hour)) {
-			http.SetCookie(w, cookie)
-		}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	password := req.Password
+	if email == "" || password == "" {
+		writeError(w, http.StatusBadRequest, "email and password are required")
+		return
 	}
 
-	slog.Info("user logged in via google", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email)...)
-	writeJSON(w, http.StatusOK, LoginResponse{
-		Token: tokenString,
-		User:  userToResponse(user),
+	user, err := h.Queries.GetUserByEmail(r.Context(), email)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid email or password")
+		return
+	}
+
+	if !user.PasswordHash.Valid || user.PasswordHash.String == "" {
+		writeError(w, http.StatusBadRequest, "password login is not set up for this account")
+		return
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash.String), []byte(password)); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid password")
+		return
+	}
+
+	if err := h.ensureUserWorkspace(r.Context(), user); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to provision workspace")
+		return
+	}
+
+	slog.Info("user logged in with password", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email)...)
+	h.writeLoginResponse(w, user, 30*24*time.Hour)
+}
+
+func (h *Handler) SetupPassword(w http.ResponseWriter, r *http.Request) {
+	var req SetupPasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	code := strings.TrimSpace(req.Code)
+	if email == "" || code == "" || req.Password == "" {
+		writeError(w, http.StatusBadRequest, "email, code, and password are required")
+		return
+	}
+	if err := validatePassword(req.Password); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	dbCode, err := h.Queries.GetLatestVerificationCode(r.Context(), email)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid or expired code")
+		return
+	}
+
+	if !verifyStoredCode(code, dbCode.Code) {
+		_ = h.Queries.IncrementVerificationCodeAttempts(r.Context(), dbCode.ID)
+		writeError(w, http.StatusBadRequest, "invalid or expired code")
+		return
+	}
+
+	if err := h.Queries.MarkVerificationCodeUsed(r.Context(), dbCode.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to verify code")
+		return
+	}
+
+	user, err := h.findOrCreateUser(r.Context(), email)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create user")
+		return
+	}
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to store password")
+		return
+	}
+
+	user, err = h.Queries.SetUserPasswordHash(r.Context(), db.SetUserPasswordHashParams{
+		ID:           user.ID,
+		PasswordHash: pgtype.Text{String: string(passwordHash), Valid: true},
 	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to store password")
+		return
+	}
+
+	if err := h.ensureUserWorkspace(r.Context(), user); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to provision workspace")
+		return
+	}
+
+	slog.Info("user set password", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email)...)
+	h.writeLoginResponse(w, user, 30*24*time.Hour)
 }
 
 func (h *Handler) UpdateMe(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -609,6 +609,139 @@ func TestVerifyCodeCreatesWorkspace(t *testing.T) {
 	}
 }
 
+func TestSetupPasswordAndLogin(t *testing.T) {
+	const email = "password-auth-test@multica.ai"
+	ctx := context.Background()
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM verification_code WHERE email = $1`, email)
+		user, err := testHandler.Queries.GetUserByEmail(ctx, email)
+		if err == nil {
+			workspaces, listErr := testHandler.Queries.ListWorkspaces(ctx, user.ID)
+			if listErr == nil {
+				for _, workspace := range workspaces {
+					_ = testHandler.Queries.DeleteWorkspace(ctx, workspace.ID)
+				}
+			}
+		}
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SendCode: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	dbCode, err := testHandler.Queries.GetLatestVerificationCode(ctx, email)
+	if err != nil {
+		t.Fatalf("GetLatestVerificationCode: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	buf.Reset()
+	json.NewEncoder(&buf).Encode(map[string]string{
+		"email":    email,
+		"code":     dbCode.Code,
+		"password": "Password123",
+	})
+	req = httptest.NewRequest("POST", "/auth/password/setup", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SetupPassword(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SetupPassword: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	user, err := testHandler.Queries.GetUserByEmail(ctx, email)
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	if !user.PasswordHash.Valid || user.PasswordHash.String == "" {
+		t.Fatal("expected password hash to be stored")
+	}
+	if user.PasswordHash.String == "Password123" {
+		t.Fatal("password should not be stored in plain text")
+	}
+
+	w = httptest.NewRecorder()
+	buf.Reset()
+	json.NewEncoder(&buf).Encode(map[string]string{
+		"email":    email,
+		"password": "Password123",
+	})
+	req = httptest.NewRequest("POST", "/auth/password/login", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.LoginWithPassword(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("LoginWithPassword: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestLoginWithPasswordWrongPassword(t *testing.T) {
+	const email = "password-auth-wrong@multica.ai"
+	ctx := context.Background()
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM verification_code WHERE email = $1`, email)
+		user, err := testHandler.Queries.GetUserByEmail(ctx, email)
+		if err == nil {
+			workspaces, listErr := testHandler.Queries.ListWorkspaces(ctx, user.ID)
+			if listErr == nil {
+				for _, workspace := range workspaces {
+					_ = testHandler.Queries.DeleteWorkspace(ctx, workspace.ID)
+				}
+			}
+		}
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{"email": email})
+	req := httptest.NewRequest("POST", "/auth/send-code", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SendCode(w, req)
+
+	dbCode, err := testHandler.Queries.GetLatestVerificationCode(ctx, email)
+	if err != nil {
+		t.Fatalf("GetLatestVerificationCode: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	buf.Reset()
+	json.NewEncoder(&buf).Encode(map[string]string{
+		"email":    email,
+		"code":     dbCode.Code,
+		"password": "Password123",
+	})
+	req = httptest.NewRequest("POST", "/auth/password/setup", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.SetupPassword(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SetupPassword: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	buf.Reset()
+	json.NewEncoder(&buf).Encode(map[string]string{
+		"email":    email,
+		"password": "WrongPassword",
+	})
+	req = httptest.NewRequest("POST", "/auth/password/login", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	testHandler.LoginWithPassword(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("LoginWithPassword: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invalid password") {
+		t.Fatalf("expected invalid password error, got %s", w.Body.String())
+	}
+}
+
 func TestResolveActor(t *testing.T) {
 	ctx := context.Background()
 
@@ -656,11 +789,11 @@ func TestResolveActor(t *testing.T) {
 	})
 
 	tests := []struct {
-		name            string
-		agentIDHeader   string
-		taskIDHeader    string
-		wantActorType   string
-		wantIsAgent     bool
+		name          string
+		agentIDHeader string
+		taskIDHeader  string
+		wantActorType string
+		wantIsAgent   bool
 	}{
 		{
 			name:          "no headers returns member",

--- a/server/migrations/040_user_password_auth.down.sql
+++ b/server/migrations/040_user_password_auth.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user"
+DROP COLUMN password_hash;

--- a/server/migrations/040_user_password_auth.up.sql
+++ b/server/migrations/040_user_password_auth.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user"
+ADD COLUMN password_hash TEXT;

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -341,12 +341,13 @@ type TaskUsage struct {
 }
 
 type User struct {
-	ID        pgtype.UUID        `json:"id"`
-	Name      string             `json:"name"`
-	Email     string             `json:"email"`
-	AvatarUrl pgtype.Text        `json:"avatar_url"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	ID           pgtype.UUID        `json:"id"`
+	Name         string             `json:"name"`
+	Email        string             `json:"email"`
+	AvatarUrl    pgtype.Text        `json:"avatar_url"`
+	PasswordHash pgtype.Text        `json:"password_hash"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
 }
 
 type VerificationCode struct {

--- a/server/pkg/db/generated/user.sql.go
+++ b/server/pkg/db/generated/user.sql.go
@@ -12,25 +12,27 @@ import (
 )
 
 const createUser = `-- name: CreateUser :one
-INSERT INTO "user" (name, email, avatar_url)
-VALUES ($1, $2, $3)
-RETURNING id, name, email, avatar_url, created_at, updated_at
+INSERT INTO "user" (name, email, avatar_url, password_hash)
+VALUES ($1, $2, $3, $4)
+RETURNING id, name, email, avatar_url, password_hash, created_at, updated_at
 `
 
 type CreateUserParams struct {
-	Name      string      `json:"name"`
-	Email     string      `json:"email"`
-	AvatarUrl pgtype.Text `json:"avatar_url"`
+	Name         string      `json:"name"`
+	Email        string      `json:"email"`
+	AvatarUrl    pgtype.Text `json:"avatar_url"`
+	PasswordHash pgtype.Text `json:"password_hash"`
 }
 
 func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, error) {
-	row := q.db.QueryRow(ctx, createUser, arg.Name, arg.Email, arg.AvatarUrl)
+	row := q.db.QueryRow(ctx, createUser, arg.Name, arg.Email, arg.AvatarUrl, arg.PasswordHash)
 	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Name,
 		&i.Email,
 		&i.AvatarUrl,
+		&i.PasswordHash,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -38,7 +40,7 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 }
 
 const getUser = `-- name: GetUser :one
-SELECT id, name, email, avatar_url, created_at, updated_at FROM "user"
+SELECT id, name, email, avatar_url, password_hash, created_at, updated_at FROM "user"
 WHERE id = $1
 `
 
@@ -50,6 +52,7 @@ func (q *Queries) GetUser(ctx context.Context, id pgtype.UUID) (User, error) {
 		&i.Name,
 		&i.Email,
 		&i.AvatarUrl,
+		&i.PasswordHash,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -57,7 +60,7 @@ func (q *Queries) GetUser(ctx context.Context, id pgtype.UUID) (User, error) {
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, name, email, avatar_url, created_at, updated_at FROM "user"
+SELECT id, name, email, avatar_url, password_hash, created_at, updated_at FROM "user"
 WHERE email = $1
 `
 
@@ -69,6 +72,7 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.Name,
 		&i.Email,
 		&i.AvatarUrl,
+		&i.PasswordHash,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -81,7 +85,7 @@ UPDATE "user" SET
     avatar_url = COALESCE($3, avatar_url),
     updated_at = now()
 WHERE id = $1
-RETURNING id, name, email, avatar_url, created_at, updated_at
+RETURNING id, name, email, avatar_url, password_hash, created_at, updated_at
 `
 
 type UpdateUserParams struct {
@@ -98,6 +102,35 @@ func (q *Queries) UpdateUser(ctx context.Context, arg UpdateUserParams) (User, e
 		&i.Name,
 		&i.Email,
 		&i.AvatarUrl,
+		&i.PasswordHash,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const setUserPasswordHash = `-- name: SetUserPasswordHash :one
+UPDATE "user" SET
+    password_hash = $2,
+    updated_at = now()
+WHERE id = $1
+RETURNING id, name, email, avatar_url, password_hash, created_at, updated_at
+`
+
+type SetUserPasswordHashParams struct {
+	ID           pgtype.UUID `json:"id"`
+	PasswordHash pgtype.Text `json:"password_hash"`
+}
+
+func (q *Queries) SetUserPasswordHash(ctx context.Context, arg SetUserPasswordHashParams) (User, error) {
+	row := q.db.QueryRow(ctx, setUserPasswordHash, arg.ID, arg.PasswordHash)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Email,
+		&i.AvatarUrl,
+		&i.PasswordHash,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/pkg/db/queries/user.sql
+++ b/server/pkg/db/queries/user.sql
@@ -7,14 +7,21 @@ SELECT * FROM "user"
 WHERE email = $1;
 
 -- name: CreateUser :one
-INSERT INTO "user" (name, email, avatar_url)
-VALUES ($1, $2, $3)
+INSERT INTO "user" (name, email, avatar_url, password_hash)
+VALUES ($1, $2, $3, $4)
 RETURNING *;
 
 -- name: UpdateUser :one
 UPDATE "user" SET
     name = COALESCE($2, name),
     avatar_url = COALESCE($3, avatar_url),
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- name: SetUserPasswordHash :one
+UPDATE "user" SET
+    password_hash = $2,
     updated_at = now()
 WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## Summary
- add password setup and password login endpoints while keeping OTP and Google auth intact
- store password hashes with bcrypt and add migration/query updates for the new user field
- update the shared login UI and auth client/store to support password sign-in and initial password setup

## Testing
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go run ./cmd/migrate up
- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod-cache go test ./internal/handler ./cmd/server
- COREPACK_HOME=/tmp/corepack-cache pnpm exec vitest run --config vitest.config.ts auth/login-page.test.tsx
- COREPACK_HOME=/tmp/corepack-cache pnpm exec vitest run --config vitest.config.ts 'app/(auth)/login/page.test.tsx'