### PR TITLE
fix(issue): default create status to todo instead of backlog

### DIFF
--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -252,6 +252,56 @@ func TestIssueCRUD(t *testing.T) {
 	}
 }
 
+// TestCreateIssueDefaultStatusIsTodo verifies that issues created without an
+// explicit status default to "todo" so the daemon picks them up immediately.
+// Before this fix the default was "backlog", which daemons ignore.
+func TestCreateIssueDefaultStatusIsTodo(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Issue with no explicit status",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+	if created.Status != "todo" {
+		t.Fatalf("CreateIssue: expected default status 'todo', got '%s'", created.Status)
+	}
+
+	// Cleanup
+	cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+	cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+	testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+}
+
+// TestCreateIssueExplicitBacklogPreserved verifies that explicitly requesting
+// "backlog" status is still respected — only the implicit default changed.
+func TestCreateIssueExplicitBacklogPreserved(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "Explicit backlog issue",
+		"status": "backlog",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+	if created.Status != "backlog" {
+		t.Fatalf("CreateIssue: expected explicit 'backlog' to be preserved, got '%s'", created.Status)
+	}
+
+	// Cleanup
+	cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+	cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+	testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+}
+
 func TestCommentCRUD(t *testing.T) {
 	// Create an issue first
 	w := httptest.NewRecorder()

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -762,7 +762,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 
 	status := req.Status
 	if status == "" {
-		status = "backlog"
+		status = "todo"
 	}
 	priority := req.Priority
 	if priority == "" {


### PR DESCRIPTION
## Problem

When creating an issue via the CLI (or API) without specifying a status, it defaults to `backlog`. The local daemon only polls for `todo` issues, so these issues are silently ignored — the daemon never picks them up and there is no error message to explain why.

This affects every user who runs `multica issue create` from the CLI without passing `--status todo`.

## Fix

Change the default status in `CreateIssue` from `"backlog"` to `"todo"` so newly created issues are immediately eligible for daemon pickup.

**File:** `server/internal/handler/issue.go`

```go
// Before
status = "backlog"

// After
status = "todo"
```

Callers that explicitly pass `status: "backlog"` are unaffected — the default only applies when no status is provided.

## Why not fix the daemon to also poll backlog?

`backlog` is intentionally a holding area — issues in backlog are not ready to work on yet. The fix belongs at the create side: if you're creating an issue and expect an agent to act on it, the right initial state is `todo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)