### PR TITLE
fix(cli): show identifier (e.g. ABC-42) instead of truncated UUID in issue list

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -267,7 +267,7 @@ func runIssueList(cmd *cobra.Command, _ []string) error {
 			dueDate = dueDate[:10]
 		}
 		rows = append(rows, []string{
-			truncateID(strVal(issue, "id")),
+			issueDisplayID(issue),
 			strVal(issue, "title"),
 			strVal(issue, "status"),
 			strVal(issue, "priority"),
@@ -302,7 +302,7 @@ func runIssueGet(cmd *cobra.Command, args []string) error {
 		}
 		headers := []string{"ID", "TITLE", "STATUS", "PRIORITY", "ASSIGNEE", "DUE DATE", "DESCRIPTION"}
 		rows := [][]string{{
-			truncateID(strVal(issue, "id")),
+			issueDisplayID(issue),
 			strVal(issue, "title"),
 			strVal(issue, "status"),
 			strVal(issue, "priority"),
@@ -387,7 +387,7 @@ func runIssueCreate(cmd *cobra.Command, _ []string) error {
 	if output == "table" {
 		headers := []string{"ID", "TITLE", "STATUS", "PRIORITY"}
 		rows := [][]string{{
-			truncateID(strVal(result, "id")),
+			issueDisplayID(result),
 			strVal(result, "title"),
 			strVal(result, "status"),
 			strVal(result, "priority"),
@@ -456,7 +456,7 @@ func runIssueUpdate(cmd *cobra.Command, args []string) error {
 	if output == "table" {
 		headers := []string{"ID", "TITLE", "STATUS", "PRIORITY"}
 		rows := [][]string{{
-			truncateID(strVal(result, "id")),
+			issueDisplayID(result),
 			strVal(result, "title"),
 			strVal(result, "status"),
 			strVal(result, "priority"),
@@ -864,7 +864,7 @@ func runIssueSearch(cmd *cobra.Command, args []string) error {
 			matchInfo += ": " + snippet
 		}
 		rows = append(rows, []string{
-			truncateID(strVal(issue, "id")),
+			issueDisplayID(issue),
 			strVal(issue, "identifier"),
 			strVal(issue, "title"),
 			strVal(issue, "status"),
@@ -963,4 +963,15 @@ func truncateID(id string) string {
 		return string(runes[:8])
 	}
 	return id
+}
+
+// issueDisplayID returns the human-readable identifier (e.g. "PRA-42") for an
+// issue map, falling back to a truncated UUID if the identifier is absent.
+// The identifier format is accepted by all issue commands, so it can be copied
+// directly from list output into commands like `multica issue status PRA-42 todo`.
+func issueDisplayID(issue map[string]any) string {
+	if id := strVal(issue, "identifier"); id != "" {
+		return id
+	}
+	return truncateID(strVal(issue, "id"))
 }

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -848,7 +848,7 @@ func runIssueSearch(cmd *cobra.Command, args []string) error {
 		return cli.PrintJSON(os.Stdout, result)
 	}
 
-	headers := []string{"ID", "IDENTIFIER", "TITLE", "STATUS", "MATCH"}
+	headers := []string{"ID", "TITLE", "STATUS", "MATCH"}
 	rows := make([][]string, 0, len(issuesRaw))
 	for _, raw := range issuesRaw {
 		issue, ok := raw.(map[string]any)
@@ -865,7 +865,6 @@ func runIssueSearch(cmd *cobra.Command, args []string) error {
 		}
 		rows = append(rows, []string{
 			issueDisplayID(issue),
-			strVal(issue, "identifier"),
 			strVal(issue, "title"),
 			strVal(issue, "status"),
 			matchInfo,

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -137,6 +137,71 @@ func TestResolveAssignee(t *testing.T) {
 	})
 }
 
+func TestIssueDisplayID(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue map[string]any
+		want  string
+	}{
+		{
+			name:  "returns identifier when present",
+			issue: map[string]any{"identifier": "PRA-42", "id": "5847db82-bf0a-404f-b987-5cfc2d402ebd"},
+			want:  "PRA-42",
+		},
+		{
+			name:  "falls back to truncated UUID when identifier is absent",
+			issue: map[string]any{"id": "5847db82-bf0a-404f-b987-5cfc2d402ebd"},
+			want:  "5847db82",
+		},
+		{
+			name:  "falls back to truncated UUID when identifier is empty string",
+			issue: map[string]any{"identifier": "", "id": "5847db82-bf0a-404f-b987-5cfc2d402ebd"},
+			want:  "5847db82",
+		},
+		{
+			name:  "empty map returns empty string",
+			issue: map[string]any{},
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := issueDisplayID(tt.issue)
+			if got != tt.want {
+				t.Errorf("issueDisplayID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssueListUsesIdentifierAsID(t *testing.T) {
+	issues := []map[string]any{
+		{"identifier": "MUL-1", "id": "aaaaaaaa-0000-0000-0000-000000000001", "title": "First", "status": "todo", "priority": "high"},
+		{"identifier": "MUL-2", "id": "bbbbbbbb-0000-0000-0000-000000000002", "title": "Second", "status": "backlog", "priority": "none"},
+		{"id": "cccccccc-0000-0000-0000-000000000003", "title": "No identifier", "status": "done", "priority": "low"},
+	}
+
+	rows := make([][]string, 0, len(issues))
+	for _, issue := range issues {
+		rows = append(rows, []string{
+			issueDisplayID(issue),
+			strVal(issue, "title"),
+			strVal(issue, "status"),
+		})
+	}
+
+	// Verify identifiers are used where available, truncated UUID otherwise
+	if rows[0][0] != "MUL-1" {
+		t.Errorf("row 0 ID = %q, want MUL-1", rows[0][0])
+	}
+	if rows[1][0] != "MUL-2" {
+		t.Errorf("row 1 ID = %q, want MUL-2", rows[1][0])
+	}
+	if rows[2][0] != "cccccccc" {
+		t.Errorf("row 2 ID = %q, want cccccccc (truncated UUID fallback)", rows[2][0])
+	}
+}
+
 func TestValidIssueStatuses(t *testing.T) {
 	expected := map[string]bool{
 		"backlog":     true,


### PR DESCRIPTION
## Problem

\`issue list\`, \`issue get\`, \`issue create\`, and \`issue update\` display the first 8 characters of the UUID in the ID column, e.g.:

\`\`\`
ID         TITLE               STATUS
5847db82   Add login page      in_progress
\`\`\`

If a user copies \`5847db82\` and runs \`multica issue status 5847db82 todo\`, they get a 404. The server tries to:
1. Parse it as an identifier (\`PREFIX-NUMBER\`) — fails, no dash
2. Parse it as a full UUID — fails, only 8 chars

The truncation is display-only, but there's no hint that it can't be used as an argument.

## Fix

Replace \`truncateID(strVal(issue, \"id\"))\` with a new \`issueDisplayID\` helper that returns the \`identifier\` field (e.g. \`ABC-42\`) when available, falling back to the truncated UUID for any older response that lacks it.

\`\`\`
ID      TITLE               STATUS
ABC-42  Add login page      in_progress
\`\`\`

The identifier format is already accepted by \`resolveIssueByIdentifier\` on the server, so users can copy directly from list output into any write command.

**Files changed:** \`server/cmd/multica/cmd_issue.go\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)