### PR TITLE
feat(daemon): per-agent MCP support via runtime_config.mcp_servers

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -881,10 +882,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	agentName := "agent"
 	var skills []SkillData
 	var instructions string
+	var mcpServers json.RawMessage
 	if task.Agent != nil {
 		agentName = task.Agent.Name
 		skills = task.Agent.Skills
 		instructions = task.Agent.Instructions
+		mcpServers = task.Agent.MCPServers
 	}
 
 	// Prepare isolated execution environment.
@@ -898,6 +901,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		AgentSkills:       convertSkillsForEnv(skills),
 		Repos:             convertReposForEnv(task.Repos),
 		ChatSessionID:     task.ChatSessionID,
+		MCPServers:        mcpServers,
 	}
 
 	// Try to reuse the workdir from a previous task on the same (agent, issue) pair.
@@ -981,6 +985,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		Model:           entry.Model,
 		Timeout:         d.cfg.AgentTimeout,
 		ResumeSessionID: task.PriorSessionID,
+		MCPConfigPath:   env.MCPConfigPath,
 	})
 	if err != nil {
 		return TaskResult{}, err

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -1,6 +1,8 @@
 package execenv
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -108,6 +110,56 @@ func writeSkillFiles(skillsDir string, skills []SkillContextForEnv) error {
 	}
 
 	return nil
+}
+
+// writeMCPConfig writes a Claude-compatible .mcp.json file into workDir when
+// the agent has mcp_servers configured in its runtime_config. It returns the
+// absolute path to the written file, or an empty string when no file was
+// written (empty servers, unsupported provider, or invalid JSON shape).
+//
+// The raw value must be a JSON object whose keys are server names, matching
+// Claude Code's native mcpServers map:
+//
+//	{
+//	  "fs": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]},
+//	  "fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}
+//	}
+//
+// It is written to disk wrapped as {"mcpServers": <raw>}.
+//
+// Currently only claude consumes .mcp.json; other providers are no-ops.
+func writeMCPConfig(workDir, provider string, servers json.RawMessage) (string, error) {
+	if provider != "claude" {
+		return "", nil
+	}
+	trimmed := bytes.TrimSpace(servers)
+	if len(trimmed) == 0 || string(trimmed) == "null" || string(trimmed) == "{}" {
+		return "", nil
+	}
+	// Validate that the raw value is a JSON object.
+	var check map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &check); err != nil {
+		return "", fmt.Errorf("mcp_servers must be a JSON object: %w", err)
+	}
+	if len(check) == 0 {
+		return "", nil
+	}
+
+	wrapper := struct {
+		MCPServers json.RawMessage `json:"mcpServers"`
+	}{MCPServers: trimmed}
+
+	data, err := json.MarshalIndent(wrapper, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal mcp config: %w", err)
+	}
+	data = append(data, '\n')
+
+	path := filepath.Join(workDir, ".mcp.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", path, err)
+	}
+	return path, nil
 }
 
 // renderIssueContext builds the markdown content for issue_context.md.

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -4,6 +4,7 @@
 package execenv
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -18,11 +19,11 @@ type RepoContextForEnv struct {
 
 // PrepareParams holds all inputs needed to set up an execution environment.
 type PrepareParams struct {
-	WorkspacesRoot string           // base path for all envs (e.g., ~/multica_workspaces)
-	WorkspaceID    string           // workspace UUID — tasks are grouped under this
-	TaskID         string           // task UUID — used for directory name
-	AgentName      string           // for git branch naming only
-	Provider       string           // agent provider ("claude", "codex") — determines skill injection paths
+	WorkspacesRoot string            // base path for all envs (e.g., ~/multica_workspaces)
+	WorkspaceID    string            // workspace UUID — tasks are grouped under this
+	TaskID         string            // task UUID — used for directory name
+	AgentName      string            // for git branch naming only
+	Provider       string            // agent provider ("claude", "codex") — determines skill injection paths
 	Task           TaskContextForEnv // context data for writing files
 }
 
@@ -35,6 +36,11 @@ type TaskContextForEnv struct {
 	AgentSkills       []SkillContextForEnv
 	Repos             []RepoContextForEnv // workspace repos available for checkout
 	ChatSessionID     string              // non-empty for chat tasks
+	// MCPServers, if non-empty, is written as {"mcpServers": <raw>} to
+	// {workdir}/.mcp.json and picked up by claude via --mcp-config. The raw
+	// value must be a JSON object whose keys are server names — the same
+	// shape as Claude Code's native mcpServers map.
+	MCPServers json.RawMessage
 }
 
 // SkillContextForEnv represents a skill to be written into the execution environment.
@@ -58,6 +64,10 @@ type Environment struct {
 	WorkDir string
 	// CodexHome is the path to the per-task CODEX_HOME directory (set only for codex provider).
 	CodexHome string
+	// MCPConfigPath is the absolute path to the .mcp.json file written into
+	// the workdir, or empty if no MCP servers were configured for the agent.
+	// The caller passes this as --mcp-config to claude.
+	MCPConfigPath string
 
 	logger *slog.Logger // for cleanup logging
 }
@@ -104,6 +114,14 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		return nil, fmt.Errorf("execenv: write context files: %w", err)
 	}
 
+	// Write .mcp.json for providers that consume it (claude). This is only
+	// written when the agent has mcp_servers configured in its runtime_config.
+	if mcpPath, err := writeMCPConfig(workDir, params.Provider, params.Task.MCPServers); err != nil {
+		return nil, fmt.Errorf("execenv: write mcp config: %w", err)
+	} else if mcpPath != "" {
+		env.MCPConfigPath = mcpPath
+	}
+
 	// For Codex, set up a per-task CODEX_HOME seeded from ~/.codex/ with skills.
 	if params.Provider == "codex" {
 		codexHome := filepath.Join(envRoot, "codex-home")
@@ -138,6 +156,14 @@ func Reuse(workDir, provider string, task TaskContextForEnv, logger *slog.Logger
 	// Refresh context files (issue_context.md, skills).
 	if err := writeContextFiles(workDir, provider, task); err != nil {
 		logger.Warn("execenv: refresh context files failed", "error", err)
+	}
+
+	// Refresh .mcp.json so server changes to the agent's runtime_config
+	// take effect on the next task.
+	if mcpPath, err := writeMCPConfig(workDir, provider, task.MCPServers); err != nil {
+		logger.Warn("execenv: refresh mcp config failed", "error", err)
+	} else {
+		env.MCPConfigPath = mcpPath
 	}
 
 	logger.Info("execenv: reusing env", "workdir", workDir)

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1,6 +1,7 @@
 package execenv
 
 import (
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -736,5 +737,94 @@ func TestEnsureSymlinkRepairsBrokenLink(t *testing.T) {
 	data, _ := os.ReadFile(dst)
 	if string(data) != "real" {
 		t.Errorf("content = %q, want %q", data, "real")
+	}
+}
+
+func TestWriteMCPConfigClaude(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	servers := json.RawMessage(`{"fs":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/tmp"]}}`)
+
+	path, err := writeMCPConfig(workDir, "claude", servers)
+	if err != nil {
+		t.Fatalf("writeMCPConfig: %v", err)
+	}
+	if path != filepath.Join(workDir, ".mcp.json") {
+		t.Errorf("path = %q, want %q", path, filepath.Join(workDir, ".mcp.json"))
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read mcp.json: %v", err)
+	}
+
+	var parsed struct {
+		MCPServers map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal mcp.json: %v", err)
+	}
+	if _, ok := parsed.MCPServers["fs"]; !ok {
+		t.Errorf("expected mcpServers.fs in %s, got %s", path, data)
+	}
+}
+
+func TestWriteMCPConfigNonClaudeProvider(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	servers := json.RawMessage(`{"fs":{"command":"npx"}}`)
+
+	path, err := writeMCPConfig(workDir, "codex", servers)
+	if err != nil {
+		t.Fatalf("writeMCPConfig: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path for non-claude provider, got %q", path)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".mcp.json")); !os.IsNotExist(err) {
+		t.Errorf("expected .mcp.json not to exist for non-claude provider")
+	}
+}
+
+func TestWriteMCPConfigEmptyServers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		servers json.RawMessage
+	}{
+		{"nil", nil},
+		{"empty", json.RawMessage(``)},
+		{"null", json.RawMessage(`null`)},
+		{"emptyObject", json.RawMessage(`{}`)},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			workDir := t.TempDir()
+			path, err := writeMCPConfig(workDir, "claude", tc.servers)
+			if err != nil {
+				t.Fatalf("writeMCPConfig: %v", err)
+			}
+			if path != "" {
+				t.Errorf("expected empty path for %s, got %q", tc.name, path)
+			}
+		})
+	}
+}
+
+func TestWriteMCPConfigRejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	_, err := writeMCPConfig(workDir, "claude", json.RawMessage(`not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "mcp_servers must be a JSON object") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -1,5 +1,7 @@
 package daemon
 
+import "encoding/json"
+
 // AgentEntry describes a single available agent CLI.
 type AgentEntry struct {
 	Path  string // path to CLI binary
@@ -23,14 +25,14 @@ type RepoData struct {
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID             string     `json:"id"`
-	AgentID        string     `json:"agent_id"`
-	RuntimeID      string     `json:"runtime_id"`
-	IssueID        string     `json:"issue_id"`
-	WorkspaceID    string     `json:"workspace_id"`
-	Agent          *AgentData `json:"agent,omitempty"`
-	Repos          []RepoData `json:"repos,omitempty"`
-	PriorSessionID   string     `json:"prior_session_id,omitempty"`    // Claude session ID from a previous task on this issue
+	ID               string     `json:"id"`
+	AgentID          string     `json:"agent_id"`
+	RuntimeID        string     `json:"runtime_id"`
+	IssueID          string     `json:"issue_id"`
+	WorkspaceID      string     `json:"workspace_id"`
+	Agent            *AgentData `json:"agent,omitempty"`
+	Repos            []RepoData `json:"repos,omitempty"`
+	PriorSessionID   string     `json:"prior_session_id,omitempty"`   // Claude session ID from a previous task on this issue
 	PriorWorkDir     string     `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on this issue
 	TriggerCommentID string     `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 	ChatSessionID    string     `json:"chat_session_id,omitempty"`    // non-empty for chat tasks
@@ -43,6 +45,11 @@ type AgentData struct {
 	Name         string      `json:"name"`
 	Instructions string      `json:"instructions"`
 	Skills       []SkillData `json:"skills"`
+	// MCPServers is the raw mcp_servers JSON object extracted from the
+	// agent's runtime_config. The daemon writes it into {workdir}/.mcp.json
+	// and passes the path to the CLI via --mcp-config (claude) so the agent
+	// gets exactly the MCP servers configured for it.
+	MCPServers json.RawMessage `json:"mcp_servers,omitempty"`
 }
 
 // SkillData represents a structured skill for task execution.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -73,22 +73,22 @@ type RepoData struct {
 }
 
 type AgentTaskResponse struct {
-	ID             string         `json:"id"`
-	AgentID        string         `json:"agent_id"`
-	RuntimeID      string         `json:"runtime_id"`
-	IssueID        string         `json:"issue_id"`
-	WorkspaceID    string         `json:"workspace_id"`
-	Status         string         `json:"status"`
-	Priority       int32          `json:"priority"`
-	DispatchedAt   *string        `json:"dispatched_at"`
-	StartedAt      *string        `json:"started_at"`
-	CompletedAt    *string        `json:"completed_at"`
-	Result         any            `json:"result"`
-	Error          *string        `json:"error"`
-	Agent          *TaskAgentData `json:"agent,omitempty"`
-	Repos          []RepoData     `json:"repos,omitempty"`
-	CreatedAt      string         `json:"created_at"`
-	PriorSessionID   string         `json:"prior_session_id,omitempty"`    // session ID from a previous task on same issue
+	ID               string         `json:"id"`
+	AgentID          string         `json:"agent_id"`
+	RuntimeID        string         `json:"runtime_id"`
+	IssueID          string         `json:"issue_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Status           string         `json:"status"`
+	Priority         int32          `json:"priority"`
+	DispatchedAt     *string        `json:"dispatched_at"`
+	StartedAt        *string        `json:"started_at"`
+	CompletedAt      *string        `json:"completed_at"`
+	Result           any            `json:"result"`
+	Error            *string        `json:"error"`
+	Agent            *TaskAgentData `json:"agent,omitempty"`
+	Repos            []RepoData     `json:"repos,omitempty"`
+	CreatedAt        string         `json:"created_at"`
+	PriorSessionID   string         `json:"prior_session_id,omitempty"`   // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
 	TriggerCommentID *string        `json:"trigger_comment_id,omitempty"` // comment that triggered this task
 	ChatSessionID    string         `json:"chat_session_id,omitempty"`    // non-empty for chat tasks
@@ -102,6 +102,29 @@ type TaskAgentData struct {
 	Name         string                   `json:"name"`
 	Instructions string                   `json:"instructions"`
 	Skills       []service.AgentSkillData `json:"skills,omitempty"`
+	// MCPServers is the raw mcp_servers object extracted from the agent's
+	// runtime_config. The daemon writes it into .mcp.json inside the task
+	// workdir so the agent CLI (currently claude) can load exactly those
+	// servers via --mcp-config.
+	MCPServers json.RawMessage `json:"mcp_servers,omitempty"`
+}
+
+// extractMCPServers pulls the "mcp_servers" key out of an agent's runtime_config
+// JSONB column. It returns nil when the column is empty, not an object, or
+// missing the key — in all of those cases no .mcp.json is written downstream.
+func extractMCPServers(runtimeConfig []byte) json.RawMessage {
+	if len(runtimeConfig) == 0 {
+		return nil
+	}
+	var cfg map[string]json.RawMessage
+	if err := json.Unmarshal(runtimeConfig, &cfg); err != nil {
+		return nil
+	}
+	raw, ok := cfg["mcp_servers"]
+	if !ok {
+		return nil
+	}
+	return raw
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
@@ -110,16 +133,16 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		json.Unmarshal(t.Result, &result)
 	}
 	return AgentTaskResponse{
-		ID:           uuidToString(t.ID),
-		AgentID:      uuidToString(t.AgentID),
-		RuntimeID:    uuidToString(t.RuntimeID),
-		IssueID:      uuidToString(t.IssueID),
-		Status:       t.Status,
-		Priority:     t.Priority,
-		DispatchedAt: timestampToPtr(t.DispatchedAt),
-		StartedAt:    timestampToPtr(t.StartedAt),
-		CompletedAt:  timestampToPtr(t.CompletedAt),
-		Result:       result,
+		ID:               uuidToString(t.ID),
+		AgentID:          uuidToString(t.AgentID),
+		RuntimeID:        uuidToString(t.RuntimeID),
+		IssueID:          uuidToString(t.IssueID),
+		Status:           t.Status,
+		Priority:         t.Priority,
+		DispatchedAt:     timestampToPtr(t.DispatchedAt),
+		StartedAt:        timestampToPtr(t.StartedAt),
+		CompletedAt:      timestampToPtr(t.CompletedAt),
+		Result:           result,
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
@@ -278,8 +301,6 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": resp})
 	writeJSON(w, http.StatusCreated, resp)
 }
-
-
 
 type UpdateAgentRequest struct {
 	Name               *string `json:"name"`

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractMCPServersReturnsNilForEmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	if got := extractMCPServers(nil); got != nil {
+		t.Errorf("expected nil for nil config, got %s", got)
+	}
+	if got := extractMCPServers([]byte{}); got != nil {
+		t.Errorf("expected nil for empty config, got %s", got)
+	}
+}
+
+func TestExtractMCPServersReturnsNilForInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	if got := extractMCPServers([]byte("not json")); got != nil {
+		t.Errorf("expected nil for invalid JSON, got %s", got)
+	}
+}
+
+func TestExtractMCPServersReturnsNilWhenKeyMissing(t *testing.T) {
+	t.Parallel()
+
+	cfg := []byte(`{"other_field":"value"}`)
+	if got := extractMCPServers(cfg); got != nil {
+		t.Errorf("expected nil when mcp_servers key missing, got %s", got)
+	}
+}
+
+func TestExtractMCPServersReturnsRawJSON(t *testing.T) {
+	t.Parallel()
+
+	cfg := []byte(`{"mcp_servers":{"fs":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/tmp"]}}}`)
+	got := extractMCPServers(cfg)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// The extracted value should be a JSON object with key "fs".
+	var servers map[string]json.RawMessage
+	if err := json.Unmarshal(got, &servers); err != nil {
+		t.Fatalf("unmarshal extracted: %v", err)
+	}
+	if _, ok := servers["fs"]; !ok {
+		t.Errorf("expected fs key in extracted servers, got %s", got)
+	}
+
+	// Make sure we preserved the raw bytes without re-marshalling.
+	if !bytes.Contains(got, []byte(`"command":"npx"`)) {
+		t.Errorf("expected raw bytes to contain command, got %s", got)
+	}
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -367,6 +367,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			Name:         agent.Name,
 			Instructions: agent.Instructions,
 			Skills:       skills,
+			MCPServers:   extractMCPServers(agent.RuntimeConfig),
 		}
 	}
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -26,6 +26,7 @@ type ExecOptions struct {
 	MaxTurns        int
 	Timeout         time.Duration
 	ResumeSessionID string // if non-empty, resume a previous agent session
+	MCPConfigPath   string // if non-empty, path to an .mcp.json file passed via --mcp-config (claude only)
 }
 
 // Session represents a running agent execution.

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -340,6 +340,11 @@ func buildClaudeArgs(opts ExecOptions) []string {
 		"--strict-mcp-config",
 		"--permission-mode", "bypassPermissions",
 	}
+	// --strict-mcp-config alone means "no MCP servers"; pair it with --mcp-config
+	// to load exactly the servers configured for this agent in runtime_config.
+	if opts.MCPConfigPath != "" {
+		args = append(args, "--mcp-config", opts.MCPConfigPath)
+	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -217,6 +217,49 @@ func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeArgsAppendsMCPConfigPath(t *testing.T) {
+	t.Parallel()
+
+	args := buildClaudeArgs(ExecOptions{MCPConfigPath: "/tmp/task-42/.mcp.json"})
+
+	var found bool
+	for i, a := range args {
+		if a == "--mcp-config" {
+			if i+1 >= len(args) || args[i+1] != "/tmp/task-42/.mcp.json" {
+				t.Fatalf("expected --mcp-config followed by path, got args=%v", args)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected --mcp-config flag when MCPConfigPath is set, got args=%v", args)
+	}
+
+	// --strict-mcp-config must still be present.
+	var strict bool
+	for _, a := range args {
+		if a == "--strict-mcp-config" {
+			strict = true
+			break
+		}
+	}
+	if !strict {
+		t.Fatalf("expected --strict-mcp-config to remain set, got args=%v", args)
+	}
+}
+
+func TestBuildClaudeArgsOmitsMCPConfigWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	args := buildClaudeArgs(ExecOptions{})
+	for _, a := range args {
+		if a == "--mcp-config" {
+			t.Fatalf("expected no --mcp-config flag when MCPConfigPath is empty, got args=%v", args)
+		}
+	}
+}
+
 func TestBuildClaudeInputEncodesUserMessage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

The daemon spawns Claude with `--strict-mcp-config` but never pairs it with `--mcp-config`. In Claude Code semantics, `--strict-mcp-config` means *"use only MCP servers from the `--mcp-config` flag, ignoring user/project/local settings"* — so without a file, **zero MCP servers are available to any agent**.

I discovered this while testing a self-hosted Multica instance: assigning an issue to an agent with instructions like *"use the filesystem MCP to list /tmp"* consistently failed because the agent's tool set never contained `mcp__fs__*`. The agent correctly reported the tool was missing and marked the issue blocked — it wasn't a prompt/instructions problem, it was platform-level MCP isolation.

The existing `agents.runtime_config` JSONB column is already in the schema but unused by the daemon, making this a clean place to add per-agent MCP configuration.

## Change

An agent's `runtime_config` JSONB may now contain an `mcp_servers` object in the same shape as Claude Code's native `mcpServers` map:

```json
{
  "mcp_servers": {
    "fs":    {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]},
    "fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}
  }
}
```

End-to-end flow:

1. **Server** — `ClaimTaskByRuntime` extracts `mcp_servers` from `agent.runtime_config` and returns it as `TaskAgentData.MCPServers` (`json.RawMessage`). Extraction helper (`extractMCPServers`) is defensive: nil / invalid JSON / missing key → nil, never an error.
2. **Daemon** — `AgentData.MCPServers` mirrors the field and flows into `execenv.TaskContextForEnv.MCPServers`.
3. **Execenv** — `writeMCPConfig` writes `{workdir}/.mcp.json` wrapped as `{"mcpServers": <raw>}` and records the path on `Environment.MCPConfigPath`. Only writes for `provider == "claude"` — a no-op for every other backend. Empty / null / `{}` / non-object all short-circuit to "no file written."
4. **Daemon** — passes `env.MCPConfigPath` as `ExecOptions.MCPConfigPath` to the claude backend.
5. **Agent** — `buildClaudeArgs` appends `--mcp-config <path>` when set. Pairs cleanly with the existing `--strict-mcp-config` so claude loads exactly the agent's servers and nothing else.

`Reuse` also refreshes `.mcp.json` so edits to `runtime_config` take effect on the next task without a workdir wipe.

## Tests

New unit coverage:

- `TestExtractMCPServersReturnsNilForEmptyConfig` / `InvalidJSON` / `WhenKeyMissing` / `ReturnsRawJSON` — handler-side extraction.
- `TestWriteMCPConfigClaude` / `NonClaudeProvider` / `EmptyServers` / `RejectsInvalidJSON` — execenv-side writing.
- `TestBuildClaudeArgsAppendsMCPConfigPath` — verifies `--mcp-config` is appended *and* `--strict-mcp-config` is preserved.
- `TestBuildClaudeArgsOmitsMCPConfigWhenEmpty` — verifies no flag when unset (existing `TestBuildClaudeArgsIncludesStrictMCPConfig` still guards the baseline).

Verified locally with:

```bash
go build ./...
go test ./pkg/agent/... ./internal/daemon/execenv/... ./internal/handler/...
go vet ./...
```

All green. Full `make check` not run (I don't have a local DB set up for the migration step); CI will cover it.

## Scope

Claude-only for this PR — other backends (`codex`, `opencode`, `openclaw`, `hermes`, and the new-in-flight `gemini`) ignore `MCPConfigPath`. Adding MCP support to any of them in a follow-up is purely additive: `writeMCPConfig` already guards on provider, and each backend's arg builder can pick up the field when it lands.

## Backwards compatibility

Existing agents with empty `runtime_config` (or `runtime_config` without an `mcp_servers` key) behave identically to today — no `.mcp.json` is written, no `--mcp-config` is passed, Claude runs with `--strict-mcp-config` alone (effectively zero MCPs). No migration required.

## UI/UX follow-up

The `runtime_config` field is already exposed through the agent create/update handlers and CLI (`--runtime-config`), so this PR unblocks configuration without any frontend work. A nicer settings UI that presents the MCP servers as a structured list could come later.