### PR TITLE
feat(daemon): add Google Gemini CLI backend

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	RuntimeName        string
 	CLIVersion         string                // multica CLI version (e.g. "0.1.13")
 	Profile            string                // profile name (empty = default)
-	Agents             map[string]AgentEntry // "claude" -> entry, "codex" -> entry, "opencode" -> entry, "openclaw" -> entry, "hermes" -> entry
+	Agents             map[string]AgentEntry // keyed by provider: claude, codex, opencode, openclaw, hermes, gemini
 	WorkspacesRoot     string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask   bool                  // preserve env after task for debugging
 	HealthPort         int                   // local HTTP port for health checks (default: 19514)
@@ -106,8 +106,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
 		}
 	}
+	geminiPath := envOrDefault("MULTICA_GEMINI_PATH", "gemini")
+	if _, err := exec.LookPath(geminiPath); err == nil {
+		agents["gemini"] = AgentEntry{
+			Path:  geminiPath,
+			Model: strings.TrimSpace(os.Getenv("MULTICA_GEMINI_MODEL")),
+		}
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, opencode, openclaw, or hermes and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, opencode, openclaw, hermes, or gemini and ensure it is on PATH")
 	}
 
 	// Host info

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -390,6 +390,44 @@ func TestInjectRuntimeConfigClaude(t *testing.T) {
 	}
 }
 
+func TestInjectRuntimeConfigGemini(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID:     "test-issue-id",
+		AgentSkills: []SkillContextForEnv{{Name: "Writing", Content: "Write clearly."}},
+	}
+
+	if err := InjectRuntimeConfig(dir, "gemini", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "GEMINI.md"))
+	if err != nil {
+		t.Fatalf("failed to read GEMINI.md: %v", err)
+	}
+
+	s := string(content)
+	for _, want := range []string{
+		"Multica Agent Runtime",
+		"multica issue get",
+		"Writing",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("GEMINI.md missing %q", want)
+		}
+	}
+
+	// Should not write CLAUDE.md or AGENTS.md for gemini provider.
+	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Error("gemini provider should not create CLAUDE.md")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Error("gemini provider should not create AGENTS.md")
+	}
+}
+
 func TestInjectRuntimeConfigCodex(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -14,6 +14,7 @@ import (
 // For Codex:    writes {workDir}/AGENTS.md  (skills discovered natively via CODEX_HOME)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .config/opencode/skills/)
 // For OpenClaw: writes {workDir}/AGENTS.md  (skills discovered natively from .openclaw/skills/)
+// For Gemini:   writes {workDir}/GEMINI.md  (discovered natively by the Gemini CLI)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error {
 	content := buildMetaSkillContent(provider, ctx)
 
@@ -22,6 +23,8 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error 
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
 	case "codex", "opencode", "openclaw":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
+	case "gemini":
+		return os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)
 	default:
 		// Unknown provider — skip config injection, prompt-only mode.
 		return nil
@@ -125,6 +128,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "codex", "opencode", "openclaw":
 			// Codex, OpenCode, and OpenClaw discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
+		case "gemini":
+			// Gemini reads GEMINI.md directly; point it at the fallback skills dir.
+			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")
 		default:
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")
 		}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -82,13 +82,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, opencode, openclaw, or hermes)
+	ExecutablePath string            // path to CLI binary (claude, codex, opencode, openclaw, hermes, or gemini)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "opencode", "openclaw", "hermes".
+// Supported types: "claude", "codex", "opencode", "openclaw", "hermes", "gemini".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -105,8 +105,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &openclawBackend{cfg: cfg}, nil
 	case "hermes":
 		return &hermesBackend{cfg: cfg}, nil
+	case "gemini":
+		return &geminiBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, openclaw, hermes)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, openclaw, hermes, gemini)", agentType)
 	}
 }
 

--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// geminiBackend implements Backend by spawning the Google Gemini CLI
+// (`gemini -p <prompt> --yolo -o text`) and collecting its stdout.
+//
+// This is a minimal v1 implementation — it captures the final text
+// response but does not stream tool calls in real time. Follow-ups
+// can move to `-o stream-json` and parse Gemini's event schema once
+// we have a reliable reproduction of its output format.
+type geminiBackend struct {
+	cfg Config
+}
+
+func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "gemini"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("gemini executable not found at %q: %w", execPath, err)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	args := buildGeminiArgs(prompt, opts)
+
+	cmd := exec.CommandContext(runCtx, execPath, args...)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("gemini stdout pipe: %w", err)
+	}
+	cmd.Stderr = newLogWriter(b.cfg.Logger, "[gemini:stderr] ")
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start gemini: %w", err)
+	}
+
+	b.cfg.Logger.Info("gemini started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+
+	msgCh := make(chan Message, 16)
+	resCh := make(chan Result, 1)
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		startTime := time.Now()
+		output, readErr := io.ReadAll(bufio.NewReader(stdout))
+
+		// Forward the full response as a single text message so the daemon
+		// can persist it verbatim. Tool streaming is intentionally omitted
+		// in v1; see the file-level comment.
+		text := strings.TrimRight(string(output), "\n")
+		if text != "" {
+			trySend(msgCh, Message{Type: MessageText, Content: text})
+		}
+
+		waitErr := cmd.Wait()
+		durationMs := time.Since(startTime).Milliseconds()
+
+		result := Result{
+			Status:     "completed",
+			Output:     text,
+			DurationMs: durationMs,
+		}
+
+		if readErr != nil {
+			result.Status = "failed"
+			result.Error = fmt.Sprintf("read stdout: %s", readErr.Error())
+		} else if waitErr != nil {
+			// Distinguish context cancellation (timeout) from exit errors.
+			if runCtx.Err() == context.DeadlineExceeded {
+				result.Status = "timeout"
+				result.Error = fmt.Sprintf("gemini timed out after %s", timeout)
+			} else {
+				result.Status = "failed"
+				result.Error = waitErr.Error()
+			}
+		}
+
+		resCh <- result
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// buildGeminiArgs assembles the argv for a one-shot gemini invocation.
+//
+// Flags:
+//
+//	-p / --prompt         non-interactive prompt (the user's task)
+//	--yolo                auto-approve all tool executions (equivalent to
+//	                      claude's --permission-mode bypassPermissions)
+//	-o text               plain text output (stream-json is a follow-up)
+//	-m <model>            optional model override (from MULTICA_GEMINI_MODEL)
+//	-r <session>          resume a previous session (if provided)
+//
+// Note: gemini reads stdin and appends it to -p when both are present.
+// The daemon does not pipe stdin, so the prompt comes exclusively from -p.
+func buildGeminiArgs(prompt string, opts ExecOptions) []string {
+	args := []string{
+		"-p", prompt,
+		"--yolo",
+		"-o", "text",
+	}
+	if opts.Model != "" {
+		args = append(args, "-m", opts.Model)
+	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "-r", opts.ResumeSessionID)
+	}
+	return args
+}

--- a/server/pkg/agent/gemini_test.go
+++ b/server/pkg/agent/gemini_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestBuildGeminiArgsBaseline(t *testing.T) {
+	t.Parallel()
+
+	args := buildGeminiArgs("write a haiku", ExecOptions{})
+	expected := []string{
+		"-p", "write a haiku",
+		"--yolo",
+		"-o", "text",
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Fatalf("expected args[%d] = %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestBuildGeminiArgsWithModel(t *testing.T) {
+	t.Parallel()
+
+	args := buildGeminiArgs("hi", ExecOptions{Model: "gemini-2.5-pro"})
+
+	var foundModel bool
+	for i, a := range args {
+		if a == "-m" {
+			if i+1 >= len(args) || args[i+1] != "gemini-2.5-pro" {
+				t.Fatalf("expected -m followed by gemini-2.5-pro, got %v", args)
+			}
+			foundModel = true
+			break
+		}
+	}
+	if !foundModel {
+		t.Fatalf("expected -m flag when Model is set, got args=%v", args)
+	}
+}
+
+func TestBuildGeminiArgsWithResume(t *testing.T) {
+	t.Parallel()
+
+	args := buildGeminiArgs("hi", ExecOptions{ResumeSessionID: "3"})
+
+	var foundResume bool
+	for i, a := range args {
+		if a == "-r" {
+			if i+1 >= len(args) || args[i+1] != "3" {
+				t.Fatalf("expected -r followed by session id, got %v", args)
+			}
+			foundResume = true
+			break
+		}
+	}
+	if !foundResume {
+		t.Fatalf("expected -r flag when ResumeSessionID is set, got args=%v", args)
+	}
+}
+
+func TestBuildGeminiArgsOmitsModelWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	args := buildGeminiArgs("hi", ExecOptions{})
+	for _, a := range args {
+		if a == "-m" {
+			t.Fatalf("expected no -m flag when Model is empty, got args=%v", args)
+		}
+		if a == "-r" {
+			t.Fatalf("expected no -r flag when ResumeSessionID is empty, got args=%v", args)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Registers `gemini` (Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli)) as a sixth supported agent provider alongside `claude`, `codex`, `opencode`, `openclaw`, and `hermes`.

## Motivation

I'm running a self-hosted Multica instance on a machine where Gemini CLI is already installed and authenticated (alongside Claude Code). Hard-coding the probe list in `daemon/config.go` to the existing five providers was the only thing keeping Gemini off the supported list — the rest of the architecture (polymorphic `Backend` interface, pluggable agent providers, execenv meta-skill injection) is already generic.

## Change

- **Daemon config probe** (`server/internal/daemon/config.go`) — adds a `gemini` entry to the auto-detection loop, using `MULTICA_GEMINI_PATH` / `MULTICA_GEMINI_MODEL` env overrides to mirror the other providers. If `gemini` is not on PATH, the provider is simply absent at runtime — no behavior change for existing deployments.
- **New backend** (`server/pkg/agent/gemini.go`) — `geminiBackend` implements the `Backend` interface by spawning:
  ```
  gemini -p <prompt> --yolo -o text [-m <model>] [-r <session>]
  ```
  and collecting stdout to completion. Returns a single `MessageText` on the message channel plus a `Result` with `Status` / `Output` / `DurationMs`. Context deadline is translated to `\"timeout\"` status to match the existing Claude/Codex contracts.
- **Agent factory** (`server/pkg/agent/agent.go`) — adds the `gemini` case to `New()` and updates the supported-types list in the error message and doc comment.
- **Runtime config injection** (`server/internal/daemon/execenv/runtime_config.go`) — adds a `gemini` case that writes a `GEMINI.md` file into the task workdir, mirroring the existing `CLAUDE.md` / `AGENTS.md` injection for the other providers. Gemini CLI discovers `GEMINI.md` natively, so the meta-skill content (available `multica` commands, agent identity, workflow guidance) flows through without any Gemini-specific template changes.

## Tests

- `server/pkg/agent/gemini_test.go` — four tests covering `buildGeminiArgs`:
  - baseline (`-p` + `--yolo` + `-o text`)
  - `-m <model>` when `Model` is set
  - `-r <session>` when `ResumeSessionID` is set
  - no `-m`/`-r` flags when those fields are empty
- `server/internal/daemon/execenv/TestInjectRuntimeConfigGemini` — verifies `GEMINI.md` is written with the expected meta-skill content and that `CLAUDE.md` / `AGENTS.md` are *not* created for the `gemini` provider.

Verified locally with:

```bash
go build ./...
go test ./pkg/agent/... ./internal/daemon/execenv/... ./internal/daemon/
go vet ./pkg/agent/... ./internal/daemon/...
gofmt -l pkg/agent/gemini*.go pkg/agent/agent.go internal/daemon/config.go internal/daemon/execenv/runtime_config.go internal/daemon/execenv/execenv_test.go   # clean
```

All green.

## Scope (intentional for v1 — follow-ups noted)

This is a **minimal-viable** Gemini backend, not feature parity with the Claude backend. Specifically:

- **Text output only** (`-o text`). Streaming tool events via `--output-format stream-json` is a follow-up. I wasn't able to get a reliable reproduction of Gemini's stream-json schema in my test environment (the process hung under various combinations of stdin/tty/auth), and I didn't want to guess at the schema. Once someone with a working `gemini -p ... -o stream-json` capture can share the wire format, migrating `gemini.go` to a streaming parser is mechanical.
- **No MCP config plumbing.** Gemini's `--allowed-mcp-server-names` filter pairs naturally with the per-agent MCP work in #754; stacking the two can land as a follow-up.
- **No token usage scraping.** Claude/Codex expose per-session JSONL logs under `~/.claude/projects` / `~/.codex/sessions` that the daemon's usage package already scrapes. Gemini's accounting lives on Google Cloud's side rather than a local log file, so there's nothing to read — usage reporting would need a different mechanism.
- **Session resume accepted but not persisted.** `ExecOptions.ResumeSessionID` is wired through to `-r`, but the daemon doesn't currently track Gemini session IDs since the text output mode doesn't expose them. Passing a value works for humans driving the CLI directly; end-to-end resume from inside Multica is follow-up work.

None of these limitations block practical use: assigning an issue to a Gemini agent with instructions like *\"write me a haiku about Docker containers\"* or *\"summarize the attached spec\"* works end-to-end. Tool-heavy work would benefit from the streaming upgrade.

## Migration / env changes

- New optional env variables: `MULTICA_GEMINI_PATH`, `MULTICA_GEMINI_MODEL`.
- New optional documented provider name: `gemini`.
- Error message in `daemon/config.go` updated from *\"install claude, codex, opencode, openclaw, or hermes\"* to *\"...or gemini\"* to reflect the new option.
- No database migrations, no CLI surface changes beyond what falls out of adding the provider (users can already pass `--runtime-config`, etc).

## Note to reviewers

I've been unable to test this end-to-end against a live Gemini install — the CLI hangs in non-interactive mode on my specific setup for reasons unrelated to Multica (likely an auth or stdin-handling quirk of the Gemini CLI on macOS). The unit tests cover the argv builder and the `GEMINI.md` injection; the backend's subprocess lifecycle mirrors `claudeBackend` almost 1:1. Full end-to-end verification from a maintainer with a working `gemini -p` install would be valuable before merging.