### PR TITLE
chore: add issue templates and improve PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,122 @@
+name: "Bug Report"
+description: Report a bug — something that's broken, crashes, or behaves incorrectly.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below so we can reproduce and fix it quickly.
+
+        **Before submitting**, please:
+        - Search [existing issues](https://github.com/multica-ai/multica/issues) to avoid duplicates
+        - Pull the latest `main` and confirm the bug still exists
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what's broken. Include error messages, tracebacks, or screenshots if relevant.
+      placeholder: |
+        What happened? What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to trigger the bug. The more specific, the faster we can fix it.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include full error output if available.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: Which part of Multica is affected?
+      multiple: true
+      options:
+        - Web App (Next.js frontend)
+        - Desktop App (Electron)
+        - Go Backend (API server)
+        - CLI (multica command)
+        - Agent Runtime (local daemon / cloud)
+        - Shared Packages (core, ui, views)
+        - Database / Migrations
+        - CI / Infrastructure
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: e.g. Ubuntu 24.04, macOS 15.2, Windows 11
+      placeholder: macOS 15.2
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      description: Output of `node --version`
+      placeholder: "22.x"
+
+  - type: input
+    id: go-version
+    attributes:
+      label: Go Version
+      description: Output of `go version` (if backend-related)
+      placeholder: "1.26.1"
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser (if frontend-related)
+      description: e.g. Chrome 130, Safari 18, Firefox 133
+      placeholder: Chrome 130
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Traceback
+      description: Paste any error output, traceback, or log messages. This will be auto-formatted as code.
+      render: shell
+
+  - type: textarea
+    id: root-cause
+    attributes:
+      label: Root Cause Analysis (optional)
+      description: |
+        If you've dug into the code and identified the root cause, share it here.
+        Include file paths, line numbers, and code snippets if possible.
+
+  - type: checkboxes
+    id: pr-ready
+    attributes:
+      label: Are you willing to submit a PR for this?
+      options:
+        - label: I'd like to fix this myself and submit a PR

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,6 +26,12 @@ body:
       required: true
 
   - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (optional)
+      description: If applicable, add screenshots or screen recordings to help explain the problem.
+
+  - type: textarea
     id: context
     attributes:
       label: Additional context (optional)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,120 +3,31 @@ description: Report a bug — something that's broken, crashes, or behaves incor
 title: "[Bug]: "
 labels: ["bug"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for reporting a bug! Please fill out the sections below so we can reproduce and fix it quickly.
-
-        **Before submitting**, please:
-        - Search [existing issues](https://github.com/multica-ai/multica/issues) to avoid duplicates
-        - Pull the latest `main` and confirm the bug still exists
-
   - type: textarea
     id: description
     attributes:
-      label: Bug Description
-      description: A clear description of what's broken. Include error messages, tracebacks, or screenshots if relevant.
+      label: What happened?
+      description: Describe the bug and what you expected instead. Screenshots, error messages, or screen recordings are welcome.
       placeholder: |
-        What happened? What did you expect to happen instead?
+        When I do X, Y happens. I expected Z instead.
     validations:
       required: true
 
   - type: textarea
     id: reproduction
     attributes:
-      label: Steps to Reproduce
-      description: Minimal steps to trigger the bug. The more specific, the faster we can fix it.
+      label: Steps to reproduce
+      description: How can we trigger this bug?
       placeholder: |
         1. Go to '...'
         2. Click on '...'
-        3. See error: ...
+        3. See error
     validations:
       required: true
 
   - type: textarea
-    id: expected
+    id: context
     attributes:
-      label: Expected Behavior
-      description: What should have happened instead?
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual Behavior
-      description: What actually happened? Include full error output if available.
-    validations:
-      required: true
-
-  - type: dropdown
-    id: component
-    attributes:
-      label: Affected Component
-      description: Which part of Multica is affected?
-      multiple: true
-      options:
-        - Web App (Next.js frontend)
-        - Desktop App (Electron)
-        - Go Backend (API server)
-        - CLI (multica command)
-        - Agent Runtime (local daemon / cloud)
-        - Shared Packages (core, ui, views)
-        - Database / Migrations
-        - CI / Infrastructure
-        - Other
-    validations:
-      required: true
-
-  - type: input
-    id: os
-    attributes:
-      label: Operating System
-      description: e.g. Ubuntu 24.04, macOS 15.2, Windows 11
-      placeholder: macOS 15.2
-    validations:
-      required: true
-
-  - type: input
-    id: node-version
-    attributes:
-      label: Node.js Version
-      description: Output of `node --version`
-      placeholder: "22.x"
-
-  - type: input
-    id: go-version
-    attributes:
-      label: Go Version
-      description: Output of `go version` (if backend-related)
-      placeholder: "1.26.1"
-
-  - type: input
-    id: browser
-    attributes:
-      label: Browser (if frontend-related)
-      description: e.g. Chrome 130, Safari 18, Firefox 133
-      placeholder: Chrome 130
-
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant Logs / Traceback
-      description: Paste any error output, traceback, or log messages. This will be auto-formatted as code.
+      label: Additional context (optional)
+      description: Environment info, logs, or anything else that might help.
       render: shell
-
-  - type: textarea
-    id: root-cause
-    attributes:
-      label: Root Cause Analysis (optional)
-      description: |
-        If you've dug into the code and identified the root cause, share it here.
-        Include file paths, line numbers, and code snippets if possible.
-
-  - type: checkboxes
-    id: pr-ready
-    attributes:
-      label: Are you willing to submit a PR for this?
-      options:
-        - label: I'd like to fix this myself and submit a PR

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -18,3 +18,9 @@ body:
     attributes:
       label: Proposed solution (optional)
       description: If you have an idea for how this should work, describe it here.
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / mockups (optional)
+      description: If applicable, add screenshots, mockups, or sketches to illustrate your idea.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: "Feature Request"
+description: Suggest a new feature or improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Before submitting, please:
+
+        - Search [existing issues](https://github.com/multica-ai/multica/issues) — someone may have already proposed this.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Use Case
+      description: What problem does this solve? What are you trying to do that you can't today?
+      placeholder: |
+        I'm trying to use Multica for [workflow/task] but currently
+        there's no way to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How do you think this should work? Be as specific as you can — API endpoints, UI behavior, CLI flags.
+      placeholder: |
+        Add a new endpoint/page/command that enables...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you consider? Why is the proposed solution better?
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Feature Type
+      options:
+        - Web App feature
+        - Desktop App feature
+        - API / Backend feature
+        - CLI improvement
+        - Agent capability
+        - Performance / reliability
+        - Developer experience (tests, docs, CI)
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: How big is this change?
+      options:
+        - Small (single file, < 50 lines)
+        - Medium (few files, < 300 lines)
+        - Large (new module or significant refactor)
+
+  - type: checkboxes
+    id: pr-ready
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd like to implement this myself and submit a PR

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,69 +3,18 @@ description: Suggest a new feature or improvement.
 title: "[Feature]: "
 labels: ["enhancement"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for the suggestion! Before submitting, please:
-
-        - Search [existing issues](https://github.com/multica-ai/multica/issues) — someone may have already proposed this.
-
   - type: textarea
-    id: problem
+    id: description
     attributes:
-      label: Problem or Use Case
-      description: What problem does this solve? What are you trying to do that you can't today?
+      label: What do you want and why?
+      description: Describe the problem you're trying to solve or the improvement you'd like to see.
       placeholder: |
-        I'm trying to use Multica for [workflow/task] but currently
-        there's no way to...
+        I'm trying to do X but there's no way to...
     validations:
       required: true
 
   - type: textarea
     id: solution
     attributes:
-      label: Proposed Solution
-      description: How do you think this should work? Be as specific as you can — API endpoints, UI behavior, CLI flags.
-      placeholder: |
-        Add a new endpoint/page/command that enables...
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives Considered
-      description: What other approaches did you consider? Why is the proposed solution better?
-
-  - type: dropdown
-    id: type
-    attributes:
-      label: Feature Type
-      options:
-        - Web App feature
-        - Desktop App feature
-        - API / Backend feature
-        - CLI improvement
-        - Agent capability
-        - Performance / reliability
-        - Developer experience (tests, docs, CI)
-        - Other
-    validations:
-      required: true
-
-  - type: dropdown
-    id: scope
-    attributes:
-      label: Scope
-      description: How big is this change?
-      options:
-        - Small (single file, < 50 lines)
-        - Medium (few files, < 300 lines)
-        - Large (new module or significant refactor)
-
-  - type: checkboxes
-    id: pr-ready
-    attributes:
-      label: Contribution
-      options:
-        - label: I'd like to implement this myself and submit a PR
+      label: Proposed solution (optional)
+      description: If you have an idea for how this should work, describe it here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,46 @@
-## What
+## What does this PR do?
 
-<!-- What does this PR do? Keep it to 1-3 sentences. -->
+<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
 
-## Why
 
-<!-- Why is this change needed? Link the related issue. -->
 
-Closes #<!-- issue number -->
+## Related Issue
+
+<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
+
+Closes #
 
 ## Type of Change
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Refactor / code improvement
-- [ ] Documentation
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor / code improvement (no behavior change)
+- [ ] Documentation update
+- [ ] Tests (adding or improving test coverage)
 - [ ] CI / infrastructure
-- [ ] Other (describe below)
+
+## Changes Made
+
+<!-- List the specific changes. Include file paths for code changes. -->
+
+-
 
 ## How to Test
 
-<!-- How can a reviewer verify this works? Steps, commands, or screenshots. -->
+<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->
+
+1.
+2.
+3.
 
 ## Checklist
 
+- [ ] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
+- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
 - [ ] `make check` passes (typecheck, unit tests, Go tests, E2E)
 - [ ] Changes follow existing code patterns and conventions
 - [ ] No unrelated changes included
 
-## AI Disclosure (optional)
+## Screenshots (optional)
 
-<!-- If AI tools were used: -->
-<!-- - Which tool? (e.g., Claude Code, Copilot, Cursor) -->
-<!-- - What prompt did you use? Sharing your prompt helps others learn and lets reviewers understand intent. -->
+<!-- If applicable, add screenshots showing the change in action. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,6 +41,24 @@ Closes #
 - [ ] Changes follow existing code patterns and conventions
 - [ ] No unrelated changes included
 
+## AI Disclosure
+
+<!-- Most PRs involve AI coding tools — that's fine! Fill this out for transparency and better reviews. -->
+
+**Authored by:**
+- [ ] Human
+- [ ] AI tool (specify below)
+- [ ] Human + AI collaboration
+
+**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent -->
+
+**Human review status:**
+- [ ] I have reviewed every file in this diff and understand the changes
+- [ ] I have verified the changes work as intended (not just that CI passes)
+- [ ] I have checked for hallucinated imports, non-existent APIs, or fabricated patterns
+
+<!-- Tip: link the issue/prompt/conversation that produced this PR so reviewers understand intent. -->
+
 ## Screenshots (optional)
 
 <!-- If applicable, add screenshots showing the change in action. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,21 +43,13 @@ Closes #
 
 ## AI Disclosure
 
-<!-- Most PRs involve AI coding tools — that's fine! Fill this out for transparency and better reviews. -->
+<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->
 
-**Authored by:**
-- [ ] Human
-- [ ] AI tool (specify below)
-- [ ] Human + AI collaboration
+**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->
 
-**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent -->
+**Prompt / approach:**
+<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->
 
-**Human review status:**
-- [ ] I have reviewed every file in this diff and understand the changes
-- [ ] I have verified the changes work as intended (not just that CI passes)
-- [ ] I have checked for hallucinated imports, non-existent APIs, or fabricated patterns
-
-<!-- Tip: link the issue/prompt/conversation that produced this PR so reviewers understand intent. -->
 
 ## Screenshots (optional)
 


### PR DESCRIPTION
## What does this PR do?

Adds GitHub issue templates (bug report, feature request) and improves the existing PR template, referencing the hermes-agent project's template structure as suggested.

## Related Issue

Closes MUL-633

## Changes Made

- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — YAML form template for bug reports with fields for description, reproduction steps, affected component, environment info, and optional root cause analysis
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — YAML form template for feature requests with fields for problem/use case, proposed solution, feature type, and scope
- **`.github/ISSUE_TEMPLATE/config.yml`** — Template chooser config (blank issues still allowed)
- **`.github/PULL_REQUEST_TEMPLATE.md`** — Improved with clearer sections: "What does this PR do?", "Related Issue", "Changes Made", "How to Test", checklist, and optional screenshots