### PR TITLE
fix: add orchestrator watcher

### DIFF
--- a/tools/multica_orchestrator_watcher.py
+++ b/tools/multica_orchestrator_watcher.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Poll Multica issue runs and write orchestrator inbox items on completion."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PROJECT_ID = "072b1862-109e-43c3-98d8-c18515961b93"
+DEFAULT_STATE_PATH = Path("/Volumes/itsmefelix SSD/appdata/multica/orchestrator-state/watcher_state.json")
+DEFAULT_INBOX_DIR = Path("/Volumes/itsmefelix SSD/appdata/multica/orchestrator-inbox")
+FALLBACK_MULTICA = "/opt/homebrew/bin/multica"
+
+TERMINAL_STATUSES = {"completed", "failed", "cancelled", "canceled"}
+ACTIVE_STATUSES = {"queued", "running", "dispatched", "started"}
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_multica() -> str:
+    return os.environ.get("MULTICA_BIN") or shutil.which("multica") or FALLBACK_MULTICA
+
+
+def run_json(command: list[str], *, timeout: int = 30) -> Any:
+    completed = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({completed.returncode}): {' '.join(command)}\n"
+            f"stdout={completed.stdout[-2000:]}\nstderr={completed.stderr[-2000:]}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Command did not return JSON: {' '.join(command)}\n{completed.stdout[-2000:]}") from exc
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"notified_runs": {}, "active_runs": {}, "last_checked_at": None}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {"notified_runs": {}, "active_runs": {}, "last_checked_at": None}
+    if not isinstance(payload, dict):
+        return {"notified_runs": {}, "active_runs": {}, "last_checked_at": None}
+    payload.setdefault("notified_runs", {})
+    payload.setdefault("active_runs", {})
+    payload.setdefault("last_checked_at", None)
+    return payload
+
+
+def write_state(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def slug(value: str) -> str:
+    lowered = value.strip().lower()
+    lowered = re.sub(r"[^a-z0-9._-]+", "-", lowered)
+    return lowered.strip("-") or "run"
+
+
+def issue_map(multica: str, project_id: str) -> dict[str, dict[str, Any]]:
+    issues = run_json([multica, "issue", "list", "--project", project_id, "--output", "json"])
+    result: dict[str, dict[str, Any]] = {}
+    if not isinstance(issues, list):
+        return result
+    for issue in issues:
+        if not isinstance(issue, dict):
+            continue
+        if issue.get("project_id") != project_id:
+            continue
+        issue_id = str(issue.get("id") or "")
+        if issue_id:
+            result[issue_id] = issue
+    return result
+
+
+def issue_runs(multica: str, issue_id: str) -> list[dict[str, Any]]:
+    runs = run_json([multica, "issue", "runs", issue_id, "--output", "json"])
+    if not isinstance(runs, list):
+        return []
+    return [run for run in runs if isinstance(run, dict)]
+
+
+def run_messages(multica: str, run_id: str) -> list[dict[str, Any]]:
+    messages = run_json([multica, "issue", "run-messages", run_id, "--output", "json"], timeout=45)
+    if not isinstance(messages, list):
+        return []
+    return [message for message in messages if isinstance(message, dict)]
+
+
+def has_result_output(run: dict[str, Any]) -> bool:
+    result = run.get("result")
+    return isinstance(result, dict) and isinstance(result.get("output"), str) and bool(result["output"].strip())
+
+
+def concise_result(run: dict[str, Any], messages: list[dict[str, Any]]) -> str:
+    result = run.get("result")
+    if has_result_output(run):
+        return result["output"].strip()
+    text_messages = [m.get("content") for m in messages if isinstance(m.get("content"), str) and m["content"].strip()]
+    if text_messages:
+        return str(text_messages[-1]).strip()
+    output_messages = [m.get("output") for m in messages if isinstance(m.get("output"), str) and m["output"].strip()]
+    if output_messages:
+        return str(output_messages[-1]).strip()
+    error = run.get("error")
+    if error:
+        return str(error)
+    return "No result text available."
+
+
+def write_inbox_item(
+    inbox_dir: Path,
+    *,
+    issue: dict[str, Any],
+    run: dict[str, Any],
+    messages: list[dict[str, Any]],
+) -> Path:
+    inbox_dir.mkdir(parents=True, exist_ok=True)
+    identifier = str(issue.get("identifier") or issue.get("number") or issue.get("id") or "issue")
+    title = str(issue.get("title") or "Untitled issue")
+    status = str(run.get("status") or "unknown")
+    run_id = str(run.get("id") or "unknown-run")
+    created = utc_now()
+    filename = f"{created.replace(':', '').replace('-', '')}-{slug(identifier)}-{slug(status)}-{slug(run_id[:8])}.md"
+    path = inbox_dir / filename
+    output = concise_result(run, messages)
+    result = run.get("result") if isinstance(run.get("result"), dict) else {}
+    workdir = str(result.get("work_dir") or "") if isinstance(result, dict) else ""
+    pr_url = str(result.get("pr_url") or "") if isinstance(result, dict) else ""
+
+    body = [
+        f"# Multica Run {status}: {identifier}",
+        "",
+        f"- Checked at: `{created}`",
+        f"- Issue: `{identifier}`",
+        f"- Issue ID: `{issue.get('id', '')}`",
+        f"- Title: {title}",
+        f"- Run ID: `{run_id}`",
+        f"- Run status: `{status}`",
+        f"- Agent ID: `{run.get('agent_id', '')}`",
+        f"- Runtime ID: `{run.get('runtime_id', '')}`",
+        f"- Started at: `{run.get('started_at') or ''}`",
+        f"- Completed at: `{run.get('completed_at') or ''}`",
+    ]
+    if workdir:
+        body.append(f"- Workdir: `{workdir}`")
+    if pr_url:
+        body.append(f"- PR: {pr_url}")
+    if run.get("error"):
+        body.append(f"- Error: `{run.get('error')}`")
+    body.extend(["", "## Result", "", output, ""])
+    path.write_text("\n".join(body), encoding="utf-8")
+    return path
+
+
+def notify(title: str, message: str) -> None:
+    escaped_title = title.replace('"', '\\"')
+    escaped_message = message.replace('"', '\\"')
+    subprocess.run(
+        [
+            "/usr/bin/osascript",
+            "-e",
+            f'display notification "{escaped_message}" with title "{escaped_title}"',
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def check_once(args: argparse.Namespace) -> int:
+    state = load_state(args.state_path)
+    notified = dict(state.get("notified_runs") or {})
+    active = dict(state.get("active_runs") or {})
+    issues = issue_map(args.multica, args.project_id)
+    events: list[Path] = []
+
+    for issue_id, issue in issues.items():
+        for run in issue_runs(args.multica, issue_id):
+            run_id = str(run.get("id") or "")
+            status = str(run.get("status") or "unknown")
+            if not run_id:
+                continue
+            if status in ACTIVE_STATUSES:
+                active[run_id] = {
+                    "issue_id": issue_id,
+                    "identifier": issue.get("identifier"),
+                    "title": issue.get("title"),
+                    "status": status,
+                    "seen_at": utc_now(),
+                }
+                continue
+            if status not in TERMINAL_STATUSES:
+                continue
+            if notified.get(run_id) == status:
+                active.pop(run_id, None)
+                continue
+            try:
+                messages = run_messages(args.multica, run_id)
+            except Exception as exc:
+                print(f"Warning: failed to fetch messages for run {run_id}: {exc}", file=sys.stderr)
+                if not has_result_output(run):
+                    continue
+                messages = []
+            path = write_inbox_item(args.inbox_dir, issue=issue, run=run, messages=messages)
+            events.append(path)
+            notified[run_id] = status
+            active.pop(run_id, None)
+            if not args.no_notify:
+                identifier = str(issue.get("identifier") or issue.get("number") or "issue")
+                notify("Multica run finished", f"{identifier} {status}; inbox item written")
+
+    state["notified_runs"] = notified
+    state["active_runs"] = active
+    state["last_checked_at"] = utc_now()
+    write_state(args.state_path, state)
+    for event in events:
+        print(event)
+    if not events:
+        print("No new completed Multica runs.")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-id", default=DEFAULT_PROJECT_ID)
+    parser.add_argument("--state-path", type=Path, default=DEFAULT_STATE_PATH)
+    parser.add_argument("--inbox-dir", type=Path, default=DEFAULT_INBOX_DIR)
+    parser.add_argument("--multica", "--cli-path", dest="multica", default=default_multica())
+    parser.add_argument("--no-notify", action="store_true")
+    parser.add_argument("--once", action="store_true", help="Run one polling pass and exit; this is the default behavior.")
+    args = parser.parse_args(argv)
+    try:
+        return check_once(args)
+    except Exception as exc:
+        args.inbox_dir.mkdir(parents=True, exist_ok=True)
+        error_path = args.inbox_dir / f"{utc_now().replace(':', '').replace('-', '')}-watcher-error.md"
+        error_path.write_text(f"# Multica Watcher Error\n\n`{utc_now()}`\n\n```\n{exc}\n```\n", encoding="utf-8")
+        print(f"Watcher error: {exc}", file=sys.stderr)
+        print(error_path)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/test_multica_orchestrator_watcher.py
+++ b/tools/test_multica_orchestrator_watcher.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("multica_orchestrator_watcher.py")
+SPEC = importlib.util.spec_from_file_location("multica_orchestrator_watcher", SCRIPT_PATH)
+watcher = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(watcher)
+
+
+PROJECT_ID = "072b1862-109e-43c3-98d8-c18515961b93"
+ISSUE_ID = "issue-1"
+RUN_ID = "run-1"
+
+
+def issue(project_id: str = PROJECT_ID) -> dict[str, object]:
+    return {
+        "id": ISSUE_ID,
+        "project_id": project_id,
+        "identifier": "FT-1",
+        "title": "Do the deterministic thing",
+    }
+
+
+def run(status: str, *, result: dict[str, object] | None = None) -> dict[str, object]:
+    return {
+        "id": RUN_ID,
+        "issue_id": ISSUE_ID,
+        "agent_id": "agent-1",
+        "runtime_id": "runtime-1",
+        "status": status,
+        "result": result if result is not None else {"output": "done"},
+        "started_at": "2026-04-12T00:00:00Z",
+        "completed_at": "2026-04-12T00:01:00Z" if status in watcher.TERMINAL_STATUSES else None,
+    }
+
+
+class FakeMultica:
+    def __init__(
+        self,
+        runs: list[dict[str, object]],
+        messages: list[dict[str, object]] | None = None,
+        messages_error: Exception | None = None,
+    ):
+        self.runs = runs
+        self.messages = messages or []
+        self.messages_error = messages_error
+        self.commands: list[list[str]] = []
+
+    def run_json(self, command: list[str], *, timeout: int = 30) -> object:
+        self.commands.append(command)
+        if command[:6] == ["/fake/multica", "issue", "list", "--project", PROJECT_ID, "--output"]:
+            return [issue()]
+        if command == ["/fake/multica", "issue", "runs", ISSUE_ID, "--output", "json"]:
+            return self.runs
+        if command == ["/fake/multica", "issue", "run-messages", RUN_ID, "--output", "json"]:
+            if self.messages_error is not None:
+                raise self.messages_error
+            return self.messages
+        raise AssertionError(f"unexpected command: {command}")
+
+
+def args_for(tmp: Path, *, no_notify: bool = True) -> argparse.Namespace:
+    return argparse.Namespace(
+        project_id=PROJECT_ID,
+        state_path=tmp / "state" / "watcher_state.json",
+        inbox_dir=tmp / "inbox",
+        multica="/fake/multica",
+        no_notify=no_notify,
+        once=True,
+    )
+
+
+def inbox_items(tmp: Path) -> list[Path]:
+    inbox = tmp / "inbox"
+    if not inbox.exists():
+        return []
+    return sorted(inbox.glob("*.md"))
+
+
+class WatcherTests(unittest.TestCase):
+    def test_first_terminal_run_creates_exactly_one_inbox_item(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            fake = FakeMultica([run("completed")])
+            with mock.patch.object(watcher, "run_json", fake.run_json), mock.patch.object(watcher, "notify"):
+                self.assertEqual(watcher.check_once(args_for(tmp)), 0)
+
+            items = inbox_items(tmp)
+            self.assertEqual(len(items), 1)
+            self.assertIn("Run status: `completed`", items[0].read_text(encoding="utf-8"))
+            self.assertIn("done", items[0].read_text(encoding="utf-8"))
+            state = json.loads((tmp / "state" / "watcher_state.json").read_text(encoding="utf-8"))
+            self.assertEqual(state["notified_runs"], {RUN_ID: "completed"})
+
+    def test_rerun_does_not_duplicate_notification_for_same_run_status(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            fake = FakeMultica([run("completed")])
+            with mock.patch.object(watcher, "run_json", fake.run_json), mock.patch.object(watcher, "notify"):
+                self.assertEqual(watcher.check_once(args_for(tmp)), 0)
+                self.assertEqual(watcher.check_once(args_for(tmp)), 0)
+
+            self.assertEqual(len(inbox_items(tmp)), 1)
+
+    def test_running_task_is_tracked_but_does_not_notify(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            fake = FakeMultica([run("running")])
+            with mock.patch.object(watcher, "run_json", fake.run_json), mock.patch.object(watcher, "notify") as notify:
+                self.assertEqual(watcher.check_once(args_for(tmp)), 0)
+
+            self.assertEqual(inbox_items(tmp), [])
+            notify.assert_not_called()
+            state = json.loads((tmp / "state" / "watcher_state.json").read_text(encoding="utf-8"))
+            self.assertEqual(state["active_runs"][RUN_ID]["status"], "running")
+
+    def test_terminal_statuses_notify(self) -> None:
+        for status in ["failed", "cancelled", "completed"]:
+            with self.subTest(status=status), tempfile.TemporaryDirectory() as td:
+                tmp = Path(td)
+                fake = FakeMultica([run(status)])
+                with mock.patch.object(watcher, "run_json", fake.run_json), mock.patch.object(watcher, "notify") as notify:
+                    self.assertEqual(watcher.check_once(args_for(tmp, no_notify=False)), 0)
+
+                self.assertEqual(len(inbox_items(tmp)), 1)
+                notify.assert_called_once()
+
+    def test_run_message_fallback_when_result_output_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            fake = FakeMultica(
+                [run("completed", result={})],
+                messages=[{"content": ""}, {"output": "fallback from message output"}],
+            )
+            with mock.patch.object(watcher, "run_json", fake.run_json), mock.patch.object(watcher, "notify"):
+                self.assertEqual(watcher.check_once(args_for(tmp)), 0)
+
+            items = inbox_items(tmp)
+            self.assertEqual(len(items), 1)
+            self.assertIn("fallback from message output", items[0].read_text(encoding="utf-8"))
+
+    def test_missing_result_output_and_run_messages_failure_does_not_notify(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            fake = FakeMultica([run("completed", result={})], messages_error=RuntimeError("message fetch failed"))
+            with mock.patch.object(watcher, "run_json", fake.run_json), mock.patch.object(
+                watcher, "notify", side_effect=AssertionError("notify should not be called")
+            ), mock.patch("sys.stderr") as stderr:
+                self.assertEqual(watcher.check_once(args_for(tmp, no_notify=False)), 0)
+
+            self.assertEqual(inbox_items(tmp), [])
+            state = json.loads((tmp / "state" / "watcher_state.json").read_text(encoding="utf-8"))
+            self.assertNotIn(RUN_ID, state["notified_runs"])
+            self.assertIn("failed to fetch messages", "".join(call.args[0] for call in stderr.write.call_args_list))
+
+    def test_result_output_and_run_messages_failure_still_notifies(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            fake = FakeMultica([run("completed")], messages_error=RuntimeError("message fetch failed"))
+            with mock.patch.object(watcher, "run_json", fake.run_json), mock.patch.object(
+                watcher, "notify"
+            ) as notify, mock.patch("sys.stderr") as stderr:
+                self.assertEqual(watcher.check_once(args_for(tmp, no_notify=False)), 0)
+
+            items = inbox_items(tmp)
+            self.assertEqual(len(items), 1)
+            self.assertIn("done", items[0].read_text(encoding="utf-8"))
+            notify.assert_called_once()
+            self.assertIn("failed to fetch messages", "".join(call.args[0] for call in stderr.write.call_args_list))
+            state = json.loads((tmp / "state" / "watcher_state.json").read_text(encoding="utf-8"))
+            self.assertEqual(state["notified_runs"], {RUN_ID: "completed"})
+
+    def test_no_notify_avoids_osascript(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            fake = FakeMultica([run("completed")])
+            with mock.patch.object(watcher, "run_json", fake.run_json), mock.patch.object(
+                watcher, "notify", side_effect=AssertionError("notify should not be called")
+            ):
+                self.assertEqual(watcher.check_once(args_for(tmp, no_notify=True)), 0)
+
+            self.assertEqual(len(inbox_items(tmp)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a deterministic one-shot Multica orchestrator watcher for local run completion inbox items
- persist notified run/status state and active run tracking in a local state file
- keep run-message fetch failures retryable when result output is missing, while still allowing result-output notifications to proceed

## Scope
- Includes only `tools/multica_orchestrator_watcher.py` and `tools/test_multica_orchestrator_watcher.py`
- Does not include PR #758 daemon completion writeback changes
- Does not include Docker setup files, `LOCAL_SETUP_REPORT.md`, Felix Trainer files, or the `status_changed` metadata fix

## Validation
- `python3 -m unittest tools/test_multica_orchestrator_watcher.py`
- `python3 -m py_compile tools/multica_orchestrator_watcher.py tools/test_multica_orchestrator_watcher.py`
- `git diff --check`