### PR TITLE
fix(storage): clean up variable shadowing and dead code

### DIFF
--- a/server/internal/storage/local.go
+++ b/server/internal/storage/local.go
@@ -80,8 +80,8 @@ func (s *LocalStorage) DeleteKeys(ctx context.Context, keys []string) {
 }
 
 func (s *LocalStorage) Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error) {
-	filepath := filepath.Join(s.uploadDir, key)
-	if err := os.WriteFile(filepath, data, 0644); err != nil {
+	dest := filepath.Join(s.uploadDir, key)
+	if err := os.WriteFile(dest, data, 0644); err != nil {
 		return "", fmt.Errorf("local storage WriteFile: %w", err)
 	}
 

--- a/server/internal/storage/util.go
+++ b/server/internal/storage/util.go
@@ -1,8 +1,6 @@
 package storage
 
 import (
-	"net/http"
-	"path"
 	"strings"
 )
 
@@ -19,34 +17,6 @@ func sanitizeFilename(name string) string {
 		}
 	}
 	return b.String()
-}
-
-// detectContentType determines the content type for a file.
-// Uses http.DetectContentType as base, with overrides for common extensions.
-func detectContentType(data []byte, filename string) string {
-	contentType := http.DetectContentType(data)
-	ext := strings.ToLower(path.Ext(filename))
-	if ct := overrideContentType(ext); ct != "" {
-		return ct
-	}
-	return contentType
-}
-
-// overrideContentType returns content type overrides for extensions that http.DetectContentType gets wrong.
-func overrideContentType(ext string) string {
-	switch ext {
-	case ".svg":
-		return "image/svg+xml"
-	case ".css":
-		return "text/css"
-	case ".js", ".mjs":
-		return "application/javascript"
-	case ".json":
-		return "application/json"
-	case ".wasm":
-		return "application/wasm"
-	}
-	return ""
 }
 
 // isInlineContentType returns true for media types that browsers should


### PR DESCRIPTION
## Summary
Follow-up cleanup from PR #710 (local file storage fallback):

- Rename `filepath` local variable to `dest` in `LocalStorage.Upload` to avoid shadowing the `path/filepath` package import
- Remove unused `detectContentType` and `overrideContentType` functions from `util.go` — no longer needed after `ServeFile` switched to `http.ServeFile`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/storage/...` passes