### PR TITLE
ci: add pnpm lint step to frontend CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint
+        run: pnpm lint
+
       - name: Build, type check, and test
         run: pnpm build && pnpm typecheck && pnpm test
 

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -88,55 +88,70 @@ vi.mock("../../navigation", () => ({
 }));
 
 // Mock editor components (Tiptap requires real DOM)
+const MockContentEditor = forwardRef(function MockContentEditor(
+  { defaultValue, onUpdate, placeholder }: any,
+  ref: any,
+) {
+  const valueRef = useRef(defaultValue || "");
+  const [value, setValue] = useState(defaultValue || "");
+  useImperativeHandle(ref, () => ({
+    getMarkdown: () => valueRef.current,
+    clearContent: () => {
+      valueRef.current = "";
+      setValue("");
+    },
+    focus: () => {},
+    uploadFile: () => {},
+  }));
+  return (
+    <textarea
+      value={value}
+      onChange={(e) => {
+        valueRef.current = e.target.value;
+        setValue(e.target.value);
+        onUpdate?.(e.target.value);
+      }}
+      placeholder={placeholder}
+      data-testid="rich-text-editor"
+    />
+  );
+});
+MockContentEditor.displayName = "MockContentEditor";
+
+const MockTitleEditor = forwardRef(function MockTitleEditor(
+  { defaultValue, placeholder, onBlur, onChange }: any,
+  ref: any,
+) {
+  const valueRef = useRef(defaultValue || "");
+  const [value, setValue] = useState(defaultValue || "");
+  useImperativeHandle(ref, () => ({
+    getText: () => valueRef.current,
+    focus: () => {},
+  }));
+  return (
+    <input
+      value={value}
+      onChange={(e) => {
+        valueRef.current = e.target.value;
+        setValue(e.target.value);
+        onChange?.(e.target.value);
+      }}
+      onBlur={() => onBlur?.(valueRef.current)}
+      placeholder={placeholder}
+      data-testid="title-editor"
+    />
+  );
+});
+MockTitleEditor.displayName = "MockTitleEditor";
+
 vi.mock("../../editor", () => ({
   useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
   FileDropOverlay: () => null,
   ReadonlyContent: ({ content }: { content: string }) => (
     <div data-testid="readonly-content">{content}</div>
   ),
-  ContentEditor: forwardRef(({ defaultValue, onUpdate, placeholder }: any, ref: any) => {
-    const valueRef = useRef(defaultValue || "");
-    const [value, setValue] = useState(defaultValue || "");
-    useImperativeHandle(ref, () => ({
-      getMarkdown: () => valueRef.current,
-      clearContent: () => { valueRef.current = ""; setValue(""); },
-      focus: () => {},
-      uploadFile: () => {},
-    }));
-    return (
-      <textarea
-        value={value}
-        onChange={(e) => {
-          valueRef.current = e.target.value;
-          setValue(e.target.value);
-          onUpdate?.(e.target.value);
-        }}
-        placeholder={placeholder}
-        data-testid="rich-text-editor"
-      />
-    );
-  }),
-  TitleEditor: forwardRef(({ defaultValue, placeholder, onBlur, onChange }: any, ref: any) => {
-    const valueRef = useRef(defaultValue || "");
-    const [value, setValue] = useState(defaultValue || "");
-    useImperativeHandle(ref, () => ({
-      getText: () => valueRef.current,
-      focus: () => {},
-    }));
-    return (
-      <input
-        value={value}
-        onChange={(e) => {
-          valueRef.current = e.target.value;
-          setValue(e.target.value);
-          onChange?.(e.target.value);
-        }}
-        onBlur={() => onBlur?.(valueRef.current)}
-        placeholder={placeholder}
-        data-testid="title-editor"
-      />
-    );
-  }),
+  ContentEditor: MockContentEditor,
+  TitleEditor: MockTitleEditor,
 }));
 
 // Mock common components

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -228,7 +228,7 @@ export function SearchCommand() {
       setOpen(false);
       push(href);
     },
-    [push],
+    [push, setOpen],
   );
 
   return (


### PR DESCRIPTION
`pnpm lint` (turbo lint) was never run in CI, so lint errors could land
on `main` without any gate. This adds a dedicated Lint step that runs
before the existing build/typecheck/test step.

All five frontend packages already define a `lint` script, and `turbo.json`
already has the `lint` task configured — this just wires it into CI.