### PR TITLE
fix(server): fix ListRuntimeUsage to filter by date range instead of row count

### DIFF
--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -135,16 +135,17 @@ func (h *Handler) GetRuntimeUsage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	limit := int32(90)
-	if l := r.URL.Query().Get("days"); l != "" {
-		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 365 {
-			limit = int32(parsed)
+	days := 90
+	if d := r.URL.Query().Get("days"); d != "" {
+		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 && parsed <= 365 {
+			days = parsed
 		}
 	}
+	since := pgtype.Date{Time: time.Now().AddDate(0, 0, -days), Valid: true}
 
 	rows, err := h.Queries.ListRuntimeUsage(r.Context(), db.ListRuntimeUsageParams{
 		RuntimeID: parseUUID(runtimeID),
-		Limit:     limit,
+		Since:     since,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list usage")

--- a/server/pkg/db/generated/runtime_usage.sql.go
+++ b/server/pkg/db/generated/runtime_usage.sql.go
@@ -95,17 +95,17 @@ func (q *Queries) GetRuntimeUsageSummary(ctx context.Context, runtimeID pgtype.U
 const listRuntimeUsage = `-- name: ListRuntimeUsage :many
 SELECT id, runtime_id, date, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at, updated_at FROM runtime_usage
 WHERE runtime_id = $1
+  AND date >= $2
 ORDER BY date DESC
-LIMIT $2
 `
 
 type ListRuntimeUsageParams struct {
 	RuntimeID pgtype.UUID `json:"runtime_id"`
-	Limit     int32       `json:"limit"`
+	Since     pgtype.Date `json:"since"`
 }
 
 func (q *Queries) ListRuntimeUsage(ctx context.Context, arg ListRuntimeUsageParams) ([]RuntimeUsage, error) {
-	rows, err := q.db.Query(ctx, listRuntimeUsage, arg.RuntimeID, arg.Limit)
+	rows, err := q.db.Query(ctx, listRuntimeUsage, arg.RuntimeID, arg.Since)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/runtime_usage.sql
+++ b/server/pkg/db/queries/runtime_usage.sql
@@ -12,8 +12,8 @@ DO UPDATE SET
 -- name: ListRuntimeUsage :many
 SELECT * FROM runtime_usage
 WHERE runtime_id = $1
-ORDER BY date DESC
-LIMIT $2;
+  AND date >= $2
+ORDER BY date DESC;
 
 -- name: GetRuntimeUsageSummary :many
 SELECT provider, model,


### PR DESCRIPTION
Fixes #731

## Root cause

`GetRuntimeUsage` accepted a `?days=N` query parameter intended to return
N days of history, but the underlying `ListRuntimeUsage` SQL query used
it as a raw `LIMIT` on rows.

When a runtime uses multiple models (e.g. `claude-opus` and
`claude-sonnet`), each day produces multiple rows — so `LIMIT 90` would
silently return only ~30 days of data instead of 90.

## Fix

Replace `LIMIT $2` with `AND date >= $2` in the SQL query. The parameter
type changes from a row count (`int32`) to a date cutoff (`pgtype.Date`)
computed as `time.Now().AddDate(0, 0, -days)` in the handler.

Three files updated consistently:
- `server/pkg/db/queries/runtime_usage.sql` — SQL source
- `server/pkg/db/generated/runtime_usage.sql.go` — generated Go code
- `server/internal/handler/runtime.go` — handler