### PR TITLE
fix(views): add missing editor mocks in create-issue test

### DIFF
--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -60,6 +60,8 @@ vi.mock("@multica/core/api", () => ({
 }));
 
 vi.mock("../editor", () => ({
+  useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
+  FileDropOverlay: () => null,
   ContentEditor: forwardRef(({ defaultValue, onUpdate, placeholder }: any, ref: any) => {
     const valueRef = useRef(defaultValue || "");
     const [value, setValue] = useState(defaultValue || "");


### PR DESCRIPTION
## Summary
- The `create-issue.test.tsx` mock for `../editor` was missing `useFileDropZone` and `FileDropOverlay` exports, which were recently added to the component's imports
- Added stub mocks for both: `useFileDropZone` returns `{ isDragOver: false, dropZoneProps: {} }`, `FileDropOverlay` returns `null`

Fixes [MUL-641](mention://issue/8807b5ef-9d58-40ed-8678-abe7b60efb2f)

## Test plan
- [x] `pnpm --filter @multica/views exec npx vitest run modals/create-issue.test.tsx` passes locally