### PR TITLE
[codex] fix workspace repo cache sync

### DIFF
--- a/server/cmd/multica/cmd_compat_test.go
+++ b/server/cmd/multica/cmd_compat_test.go
@@ -57,3 +57,26 @@ func TestRunConfigSetPersistsValues(t *testing.T) {
 		t.Fatalf("WorkspaceID = %q, want %q", cfg.WorkspaceID, "ws-123")
 	}
 }
+
+func TestRunConfigSetPersistsAutoPublishSettings(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cmd := testCmd()
+
+	if err := runConfigSet(cmd, []string{"auto_publish", "true"}); err != nil {
+		t.Fatalf("runConfigSet(auto_publish) error = %v", err)
+	}
+	if err := runConfigSet(cmd, []string{"publish_remote", "fork"}); err != nil {
+		t.Fatalf("runConfigSet(publish_remote) error = %v", err)
+	}
+
+	cfg, err := cli.LoadCLIConfig()
+	if err != nil {
+		t.Fatalf("LoadCLIConfig() error = %v", err)
+	}
+	if !cfg.AutoPublish {
+		t.Fatalf("AutoPublish = false, want true")
+	}
+	if cfg.PublishRemote != "fork" {
+		t.Fatalf("PublishRemote = %q, want %q", cfg.PublishRemote, "fork")
+	}
+}

--- a/server/cmd/multica/cmd_config.go
+++ b/server/cmd/multica/cmd_config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -24,7 +25,7 @@ var configShowCmd = &cobra.Command{
 var configSetCmd = &cobra.Command{
 	Use:   "set <key> <value>",
 	Short: "Set a CLI configuration value",
-	Long:  "Supported keys: server_url, app_url, workspace_id",
+	Long:  "Supported keys: server_url, app_url, workspace_id, auto_publish, publish_remote",
 	Args:  exactArgs(2),
 	RunE:  runConfigSet,
 }
@@ -60,6 +61,8 @@ func runConfigShow(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stdout, "server_url:   %s\n", valueOrDefault(cfg.ServerURL, "(not set)"))
 	fmt.Fprintf(os.Stdout, "app_url:      %s\n", valueOrDefault(cfg.AppURL, "(not set)"))
 	fmt.Fprintf(os.Stdout, "workspace_id: %s\n", valueOrDefault(cfg.WorkspaceID, "(not set)"))
+	fmt.Fprintf(os.Stdout, "auto_publish: %t\n", cfg.AutoPublish)
+	fmt.Fprintf(os.Stdout, "publish_remote: %s\n", valueOrDefault(cfg.PublishRemote, "(default origin)"))
 	return nil
 }
 
@@ -79,8 +82,16 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		cfg.AppURL = value
 	case "workspace_id":
 		cfg.WorkspaceID = value
+	case "auto_publish":
+		v, err := parseBoolString(value)
+		if err != nil {
+			return err
+		}
+		cfg.AutoPublish = v
+	case "publish_remote":
+		cfg.PublishRemote = value
 	default:
-		return fmt.Errorf("unknown config key %q (supported: server_url, app_url, workspace_id)", key)
+		return fmt.Errorf("unknown config key %q (supported: server_url, app_url, workspace_id, auto_publish, publish_remote)", key)
 	}
 
 	if err := cli.SaveCLIConfigForProfile(cfg, profile); err != nil {
@@ -89,6 +100,17 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stderr, "Set %s = %s\n", key, value)
 	return nil
+}
+
+func parseBoolString(raw string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean value %q (use true/false, 1/0, yes/no, or on/off)", raw)
+	}
 }
 
 func runConfigLocal(cmd *cobra.Command, _ []string) error {

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -255,6 +255,12 @@ func runDaemonForeground(cmd *cobra.Command) error {
 			serverURL = c.ServerURL
 		}
 	}
+
+	profileCfg, err := cli.LoadCLIConfigForProfile(profile)
+	if err != nil {
+		return err
+	}
+
 	overrides := daemon.Overrides{
 		ServerURL:   serverURL,
 		DaemonID:    flagString(cmd, "daemon-id"),
@@ -277,9 +283,13 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	}
 	if v, _ := cmd.Flags().GetBool("auto-publish"); v {
 		overrides.AutoPublish = true
+	} else if os.Getenv("MULTICA_AUTO_PUBLISH") == "" && profileCfg.AutoPublish {
+		overrides.AutoPublish = true
 	}
 	if v, _ := cmd.Flags().GetString("publish-remote"); v != "" {
 		overrides.PublishRemote = v
+	} else if os.Getenv("MULTICA_PUBLISH_REMOTE") == "" && profileCfg.PublishRemote != "" {
+		overrides.PublishRemote = profileCfg.PublishRemote
 	}
 
 	cfg, err := daemon.LoadConfig(overrides)

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -61,6 +61,8 @@ func init() {
 	f.Duration("heartbeat-interval", 0, "Heartbeat interval (env: MULTICA_DAEMON_HEARTBEAT_INTERVAL)")
 	f.Duration("agent-timeout", 0, "Per-task timeout (env: MULTICA_AGENT_TIMEOUT)")
 	f.Int("max-concurrent-tasks", 0, "Max tasks running in parallel (env: MULTICA_DAEMON_MAX_CONCURRENT_TASKS)")
+	f.Bool("auto-publish", false, "Auto-commit and push completed code tasks (env: MULTICA_AUTO_PUBLISH)")
+	f.String("publish-remote", "", "Git remote used for automatic publishing (env: MULTICA_PUBLISH_REMOTE)")
 
 	daemonLogsCmd.Flags().BoolP("follow", "f", false, "Follow log output")
 	daemonLogsCmd.Flags().IntP("lines", "n", 50, "Number of lines to show")
@@ -226,6 +228,12 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 	if n, _ := cmd.Flags().GetInt("max-concurrent-tasks"); n > 0 {
 		args = append(args, "--max-concurrent-tasks", strconv.Itoa(n))
 	}
+	if v, _ := cmd.Flags().GetBool("auto-publish"); v {
+		args = append(args, "--auto-publish")
+	}
+	if v, _ := cmd.Flags().GetString("publish-remote"); v != "" {
+		args = append(args, "--publish-remote", v)
+	}
 
 	// Forward global persistent flags.
 	if v, _ := cmd.Flags().GetString("server-url"); v != "" {
@@ -266,6 +274,12 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	}
 	if n, _ := cmd.Flags().GetInt("max-concurrent-tasks"); n > 0 {
 		overrides.MaxConcurrentTasks = n
+	}
+	if v, _ := cmd.Flags().GetBool("auto-publish"); v {
+		overrides.AutoPublish = true
+	}
+	if v, _ := cmd.Flags().GetString("publish-remote"); v != "" {
+		overrides.PublishRemote = v
 	}
 
 	cfg, err := daemon.LoadConfig(overrides)

--- a/server/cmd/multica/cmd_repo.go
+++ b/server/cmd/multica/cmd_repo.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/multica-ai/multica/server/internal/gitops"
 	"github.com/spf13/cobra"
 )
 
@@ -25,8 +26,25 @@ var repoCheckoutCmd = &cobra.Command{
 	RunE:  runRepoCheckout,
 }
 
+var repoPublishCmd = &cobra.Command{
+	Use:   "publish",
+	Short: "Commit and push the current worktree changes",
+	Long:  "Discovers git repositories under the current working directory, commits pending changes if needed, and pushes them to the selected remote.",
+	Args:  cobra.NoArgs,
+	RunE:  runRepoPublish,
+}
+
+var (
+	repoPublishRemote  string
+	repoPublishMessage string
+)
+
 func init() {
 	repoCmd.AddCommand(repoCheckoutCmd)
+	repoCmd.AddCommand(repoPublishCmd)
+
+	repoPublishCmd.Flags().StringVar(&repoPublishRemote, "remote", "origin", "Git remote to push to")
+	repoPublishCmd.Flags().StringVarP(&repoPublishMessage, "message", "m", "", "Commit message to use when auto-committing dirty worktrees")
 }
 
 func runRepoCheckout(cmd *cobra.Command, args []string) error {
@@ -87,6 +105,28 @@ func runRepoCheckout(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stdout, "%s\n", result.Path)
 	fmt.Fprintf(os.Stderr, "Checked out %s → %s (branch: %s)\n", repoURL, result.Path, result.BranchName)
+
+	return nil
+}
+
+func runRepoPublish(cmd *cobra.Command, _ []string) error {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+
+	results, err := gitops.PublishWorkspace(workDir, gitops.PublishOptions{
+		Remote:        repoPublishRemote,
+		CommitMessage: repoPublishMessage,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, result := range results {
+		fmt.Fprintf(os.Stderr, "Published %s (branch: %s, remote: %s, commit: %s, committed: %t)\n",
+			result.Root, result.Branch, result.Remote, result.CommitHash, result.Committed)
+	}
 
 	return nil
 }

--- a/server/internal/cli/config.go
+++ b/server/internal/cli/config.go
@@ -23,6 +23,8 @@ type CLIConfig struct {
 	WorkspaceID        string             `json:"workspace_id,omitempty"`
 	Token              string             `json:"token,omitempty"`
 	WatchedWorkspaces  []WatchedWorkspace `json:"watched_workspaces,omitempty"`
+	AutoPublish        bool               `json:"auto_publish,omitempty"`
+	PublishRemote      string             `json:"publish_remote,omitempty"`
 }
 
 // AddWatchedWorkspace adds a workspace to the watch list. Returns true if added.

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -189,6 +189,15 @@ type WorkspaceInfo struct {
 	Name string `json:"name"`
 }
 
+// WorkspaceDetails holds the full workspace payload returned by the API.
+// It is used when the daemon needs richer state than the lightweight list view,
+// such as repository URLs for cache synchronization.
+type WorkspaceDetails struct {
+	ID    string     `json:"id"`
+	Name  string     `json:"name"`
+	Repos []RepoData `json:"repos,omitempty"`
+}
+
 // ListWorkspaces fetches all workspaces the authenticated user belongs to.
 func (c *Client) ListWorkspaces(ctx context.Context) ([]WorkspaceInfo, error) {
 	var workspaces []WorkspaceInfo
@@ -196,6 +205,15 @@ func (c *Client) ListWorkspaces(ctx context.Context) ([]WorkspaceInfo, error) {
 		return nil, err
 	}
 	return workspaces, nil
+}
+
+// GetWorkspace fetches a single workspace with its repository list.
+func (c *Client) GetWorkspace(ctx context.Context, workspaceID string) (*WorkspaceDetails, error) {
+	var ws WorkspaceDetails
+	if err := c.getJSON(ctx, "/api/workspaces/"+workspaceID, &ws); err != nil {
+		return nil, err
+	}
+	return &ws, nil
 }
 
 func (c *Client) Deregister(ctx context.Context, runtimeIDs []string) error {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	Agents             map[string]AgentEntry // "claude" -> entry, "codex" -> entry, "opencode" -> entry, "openclaw" -> entry, "hermes" -> entry
 	WorkspacesRoot     string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask   bool                  // preserve env after task for debugging
+	AutoPublish        bool                  // auto-commit/push completed code tasks
+	PublishRemote      string                // git remote to push published changes to
 	HealthPort         int                   // local HTTP port for health checks (default: 19514)
 	MaxConcurrentTasks int                   // max tasks running in parallel (default: 20)
 	PollInterval       time.Duration
@@ -54,6 +56,8 @@ type Overrides struct {
 	RuntimeName        string
 	Profile            string // profile name (empty = default)
 	HealthPort         int    // health check port (0 = use default)
+	AutoPublish        bool   // auto-publish completed code tasks
+	PublishRemote      string // git remote to push published changes to
 }
 
 // LoadConfig builds the daemon configuration from environment variables
@@ -202,6 +206,8 @@ func LoadConfig(overrides Overrides) (Config, error) {
 
 	// Keep env after task: env > default (false)
 	keepEnv := os.Getenv("MULTICA_KEEP_ENV_AFTER_TASK") == "true" || os.Getenv("MULTICA_KEEP_ENV_AFTER_TASK") == "1"
+	autoPublish := boolFromEnv("MULTICA_AUTO_PUBLISH", false)
+	publishRemote := envOrDefault("MULTICA_PUBLISH_REMOTE", "origin")
 
 	return Config{
 		ServerBaseURL:      serverBaseURL,
@@ -212,6 +218,8 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		Agents:             agents,
 		WorkspacesRoot:     workspacesRoot,
 		KeepEnvAfterTask:   keepEnv,
+		AutoPublish:        autoPublish,
+		PublishRemote:      publishRemote,
 		HealthPort:         healthPort,
 		MaxConcurrentTasks: maxConcurrentTasks,
 		PollInterval:       pollInterval,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -423,6 +423,13 @@ func (d *Daemon) reloadWorkspaces(ctx context.Context) {
 		return
 	}
 
+	d.cfg.AutoPublish = cfg.AutoPublish
+	if remote := strings.TrimSpace(cfg.PublishRemote); remote != "" {
+		d.cfg.PublishRemote = remote
+	} else if strings.TrimSpace(d.cfg.PublishRemote) == "" {
+		d.cfg.PublishRemote = "origin"
+	}
+
 	newIDs := make(map[string]string) // id -> name
 	for _, ws := range cfg.WatchedWorkspaces {
 		newIDs[ws.ID] = ws.Name

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -160,6 +160,7 @@ func (d *Daemon) loadWatchedWorkspaces(ctx context.Context) error {
 	}
 
 	var registered int
+	watchedIDs := make([]string, 0, len(cfg.WatchedWorkspaces))
 	for _, ws := range cfg.WatchedWorkspaces {
 		resp, err := d.registerRuntimesForWorkspace(ctx, ws.ID)
 		if err != nil {
@@ -178,16 +179,12 @@ func (d *Daemon) loadWatchedWorkspaces(ctx context.Context) error {
 		}
 		d.mu.Unlock()
 
-		// Sync workspace repos to local cache.
-		if d.repoCache != nil && len(resp.Repos) > 0 {
-			if err := d.repoCache.Sync(ws.ID, repoDataToInfo(resp.Repos)); err != nil {
-				d.logger.Warn("repo cache sync failed", "workspace_id", ws.ID, "error", err)
-			}
-		}
-
 		d.logger.Info("watching workspace", "workspace_id", ws.ID, "name", ws.Name, "runtimes", len(resp.Runtimes), "repos", len(resp.Repos))
+		watchedIDs = append(watchedIDs, ws.ID)
 		registered++
 	}
+
+	d.syncWorkspaceRepos(ctx, watchedIDs)
 
 	if registered == 0 {
 		return fmt.Errorf("failed to register runtimes for any of the %d watched workspace(s)", len(cfg.WatchedWorkspaces))
@@ -312,6 +309,7 @@ func (d *Daemon) configWatchLoop(ctx context.Context) {
 func (d *Daemon) workspaceSyncLoop(ctx context.Context) {
 	// Run immediately on startup before entering the periodic loop.
 	d.syncWorkspacesFromAPI(ctx)
+	d.syncWatchedWorkspaceRepos(ctx)
 
 	ticker := time.NewTicker(DefaultWorkspaceSyncInterval)
 	defer ticker.Stop()
@@ -322,6 +320,7 @@ func (d *Daemon) workspaceSyncLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			d.syncWorkspacesFromAPI(ctx)
+			d.syncWatchedWorkspaceRepos(ctx)
 		}
 	}
 }
@@ -361,6 +360,54 @@ func (d *Daemon) syncWorkspacesFromAPI(ctx context.Context) {
 		return
 	}
 	d.logger.Info("workspace sync: added new workspace(s) to config", "count", added)
+}
+
+// syncWatchedWorkspaceRepos refreshes cached repos for all watched workspaces.
+// It pulls the latest workspace details from the API so repository additions
+// made after daemon startup are eventually reflected in the local cache.
+func (d *Daemon) syncWatchedWorkspaceRepos(ctx context.Context) {
+	if d.repoCache == nil {
+		return
+	}
+
+	cfg, err := cli.LoadCLIConfigForProfile(d.cfg.Profile)
+	if err != nil {
+		d.logger.Warn("workspace repo sync: failed to load config", "error", err)
+		return
+	}
+
+	workspaceIDs := make([]string, 0, len(cfg.WatchedWorkspaces))
+	for _, ws := range cfg.WatchedWorkspaces {
+		workspaceIDs = append(workspaceIDs, ws.ID)
+	}
+	d.syncWorkspaceRepos(ctx, workspaceIDs)
+}
+
+// syncWorkspaceRepos pulls the latest repo list for each workspace ID and
+// refreshes the daemon's bare repo cache.
+func (d *Daemon) syncWorkspaceRepos(ctx context.Context, workspaceIDs []string) {
+	if d.repoCache == nil || len(workspaceIDs) == 0 {
+		return
+	}
+
+	for _, workspaceID := range workspaceIDs {
+		apiCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		ws, err := d.client.GetWorkspace(apiCtx, workspaceID)
+		cancel()
+		if err != nil {
+			d.logger.Warn("workspace repo sync: failed to load workspace", "workspace_id", workspaceID, "error", err)
+			continue
+		}
+		if len(ws.Repos) == 0 {
+			d.logger.Debug("workspace repo sync: no repos to refresh", "workspace_id", workspaceID, "name", ws.Name)
+			continue
+		}
+		if err := d.repoCache.Sync(workspaceID, repoDataToInfo(ws.Repos)); err != nil {
+			d.logger.Warn("repo cache sync failed", "workspace_id", workspaceID, "name", ws.Name, "error", err)
+		} else {
+			d.logger.Info("workspace repos synced", "workspace_id", workspaceID, "name", ws.Name, "repos", len(ws.Repos))
+		}
+	}
 }
 
 // reloadWorkspaces reconciles the active workspace set with the config file.
@@ -407,13 +454,6 @@ func (d *Daemon) reloadWorkspaces(ctx context.Context) {
 			}
 			d.mu.Unlock()
 
-			// Sync workspace repos to local cache.
-			if d.repoCache != nil && len(resp.Repos) > 0 {
-				if err := d.repoCache.Sync(id, repoDataToInfo(resp.Repos)); err != nil {
-					d.logger.Warn("repo cache sync failed", "workspace_id", id, "error", err)
-				}
-			}
-
 			d.logger.Info("now watching workspace", "workspace_id", id, "name", name)
 		}
 	}
@@ -434,6 +474,8 @@ func (d *Daemon) reloadWorkspaces(ctx context.Context) {
 			d.logger.Info("stopped watching workspace", "workspace_id", id)
 		}
 	}
+
+	d.syncWatchedWorkspaceRepos(ctx)
 }
 
 func (d *Daemon) heartbeatLoop(ctx context.Context) {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -898,6 +898,11 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 		}
 	}
 
+	// Optionally publish completed worktrees back to GitHub before reporting the
+	// task as complete. Publishing failures are non-fatal so task completion still
+	// reaches the server and the agent can see the failure in logs.
+	d.autoPublishCompletedTask(ctx, task, result)
+
 	switch result.Status {
 	case "blocked":
 		if err := d.client.FailTask(ctx, task.ID, result.Comment); err != nil {

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -64,6 +64,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
 	b.WriteString("- `multica issue status <id> <status>` — Update issue status (todo, in_progress, in_review, done, blocked)\n")
 	b.WriteString("- `multica issue update <id> [--title X] [--description X] [--priority X]` — Update issue fields\n\n")
+	b.WriteString("- `multica repo publish [--remote origin] [--message \"...\"]` — Commit and push the current worktree changes to GitHub\n\n")
 
 	// Inject available repositories section.
 	if len(ctx.Repos) > 0 {
@@ -112,8 +113,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("3. Read comments for additional context or human instructions\n")
 		b.WriteString("4. Follow your Skills and Agent Identity to determine how to complete this task.\n")
 		b.WriteString("   If no relevant skill applies, the default workflow is: understand the task → do the work → post a comment with results → update issue status.\n")
-		fmt.Fprintf(&b, "5. When done, run `multica issue status %s in_review`\n", ctx.IssueID)
-		fmt.Fprintf(&b, "6. If blocked, run `multica issue status %s blocked` and post a comment explaining why\n\n", ctx.IssueID)
+		b.WriteString("5. If you changed code, run `multica repo publish` so your branch is pushed to GitHub before closing the task\n")
+		fmt.Fprintf(&b, "6. When done, run `multica issue status %s in_review`\n", ctx.IssueID)
+		fmt.Fprintf(&b, "7. If blocked, run `multica issue status %s blocked` and post a comment explaining why\n\n", ctx.IssueID)
 	}
 
 	if len(ctx.AgentSkills) > 0 {

--- a/server/internal/daemon/helpers.go
+++ b/server/internal/daemon/helpers.go
@@ -41,6 +41,21 @@ func intFromEnv(key string, fallback int) (int, error) {
 	return n, nil
 }
 
+func boolFromEnv(key string, fallback bool) bool {
+	value := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
+	if value == "" {
+		return fallback
+	}
+	switch value {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
+}
+
 func sleepWithContext(ctx context.Context, d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()

--- a/server/internal/daemon/publish.go
+++ b/server/internal/daemon/publish.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/multica-ai/multica/server/internal/gitops"
+)
+
+// autoPublishCompletedTask publishes completed code changes when enabled.
+// Failures are logged but do not fail the task itself.
+func (d *Daemon) autoPublishCompletedTask(ctx context.Context, task Task, result TaskResult) {
+	if !d.cfg.AutoPublish {
+		return
+	}
+	if result.Status != "completed" || strings.TrimSpace(result.WorkDir) == "" {
+		return
+	}
+
+	commitMessage := fmt.Sprintf("multica auto publish %s", shortID(task.ID))
+	published, err := gitops.PublishWorkspace(result.WorkDir, gitops.PublishOptions{
+		Remote:        d.cfg.PublishRemote,
+		CommitMessage: commitMessage,
+	})
+	if err != nil {
+		d.logger.Warn("auto publish failed", "task_id", task.ID, "workdir", result.WorkDir, "error", err)
+		return
+	}
+
+	for _, repo := range published {
+		d.logger.Info("auto published repo",
+			"task_id", task.ID,
+			"repo_root", repo.Root,
+			"branch", repo.Branch,
+			"remote", repo.Remote,
+			"commit", repo.CommitHash,
+			"committed", repo.Committed,
+		)
+	}
+}

--- a/server/internal/daemon/workspace_sync_test.go
+++ b/server/internal/daemon/workspace_sync_test.go
@@ -1,0 +1,160 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func testDaemonLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func createTestGitRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test User",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test User",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %s: %v", args, out, err)
+		}
+	}
+
+	run("init", dir)
+	run("-C", dir, "commit", "--allow-empty", "-m", "initial commit")
+
+	return dir
+}
+
+func TestSyncWorkspaceReposRefreshesRepoCache(t *testing.T) {
+	sourceRepo := createTestGitRepo(t)
+
+	var (
+		mu        sync.RWMutex
+		repos     []RepoData
+		requested []string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		requested = append(requested, r.URL.Path)
+		if got, want := r.URL.Path, "/api/workspaces/ws-123"; got != want {
+			t.Errorf("unexpected path: got %s want %s", got, want)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		mu.RLock()
+		currentRepos := append([]RepoData(nil), repos...)
+		mu.RUnlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(WorkspaceDetails{
+			ID:    "ws-123",
+			Name:  "Test Workspace",
+			Repos: currentRepos,
+		}); err != nil {
+			t.Errorf("encode workspace response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	d := New(Config{
+		ServerBaseURL:     srv.URL,
+		WorkspacesRoot:    t.TempDir(),
+		Agents:            map[string]AgentEntry{},
+		Profile:           "",
+		DaemonID:          "daemon-test",
+		RuntimeName:       "Test Runtime",
+		DeviceName:        "Test Device",
+		CLIVersion:        "test",
+		AgentTimeout:      DefaultAgentTimeout,
+		PollInterval:      DefaultPollInterval,
+		HeartbeatInterval: DefaultHeartbeatInterval,
+	}, testDaemonLogger())
+
+	ctx := context.Background()
+
+	// First sync: the workspace has no repos yet, so cache lookup should stay empty.
+	d.syncWorkspaceRepos(ctx, []string{"ws-123"})
+	if got := d.repoCache.Lookup("ws-123", sourceRepo); got != "" {
+		t.Fatalf("expected empty cache before repos are added, got %q", got)
+	}
+
+	// Simulate the workspace being updated later with a repo addition.
+	mu.Lock()
+	repos = []RepoData{{URL: sourceRepo, Description: "source"}}
+	mu.Unlock()
+
+	d.syncWorkspaceRepos(ctx, []string{"ws-123"})
+
+	cached := d.repoCache.Lookup("ws-123", sourceRepo)
+	if cached == "" {
+		t.Fatalf("expected repo cache to be populated after sync")
+	}
+	if _, err := os.Stat(filepath.Join(cached, "HEAD")); err != nil {
+		t.Fatalf("cached repo missing HEAD file at %s: %v", cached, err)
+	}
+
+	if got := len(requested); got != 2 {
+		t.Fatalf("expected 2 workspace fetches, got %d", got)
+	}
+}
+
+func TestGetWorkspaceReturnsRepos(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/workspaces/ws-abc" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkspaceDetails{
+			ID:   "ws-abc",
+			Name: "Workspace ABC",
+			Repos: []RepoData{
+				{URL: "https://github.com/example/repo", Description: "demo"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	ws, err := c.GetWorkspace(context.Background(), "ws-abc")
+	if err != nil {
+		t.Fatalf("GetWorkspace failed: %v", err)
+	}
+	if ws == nil {
+		t.Fatal("expected workspace details")
+	}
+	if got, want := ws.ID, "ws-abc"; got != want {
+		t.Fatalf("unexpected workspace id: got %s want %s", got, want)
+	}
+	if got := len(ws.Repos); got != 1 {
+		t.Fatalf("expected 1 repo, got %d", got)
+	}
+	if got, want := ws.Repos[0].URL, "https://github.com/example/repo"; got != want {
+		t.Fatalf("unexpected repo url: got %s want %s", got, want)
+	}
+}

--- a/server/internal/gitops/publish.go
+++ b/server/internal/gitops/publish.go
@@ -1,0 +1,196 @@
+package gitops
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// PublishOptions configures how a workspace repository is published.
+type PublishOptions struct {
+	Remote        string
+	CommitMessage string
+}
+
+// PublishResult describes the outcome of publishing a single repository.
+type PublishResult struct {
+	Root          string `json:"root"`
+	Branch        string `json:"branch"`
+	Remote        string `json:"remote"`
+	CommitHash    string `json:"commit_hash,omitempty"`
+	Committed     bool   `json:"committed"`
+	Pushed        bool   `json:"pushed"`
+	StagedChanges bool   `json:"staged_changes"`
+}
+
+// PublishWorkspace discovers git repositories under root and publishes each
+// one. If root itself is a git repository, it is published directly; otherwise
+// direct child directories are scanned for git repos.
+func PublishWorkspace(root string, opts PublishOptions) ([]PublishResult, error) {
+	roots, err := discoverPublishRoots(root)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]PublishResult, 0, len(roots))
+	var errs []error
+	for _, repoRoot := range roots {
+		result, err := PublishRepo(repoRoot, opts)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", repoRoot, err))
+			continue
+		}
+		results = append(results, result)
+	}
+
+	if len(errs) > 0 {
+		return results, joinErrors(errs...)
+	}
+	return results, nil
+}
+
+// PublishRepo stages local changes, commits them if needed, and pushes the
+// current branch to the selected remote.
+func PublishRepo(root string, opts PublishOptions) (PublishResult, error) {
+	root = filepath.Clean(root)
+	if !isGitRepo(root) {
+		return PublishResult{}, fmt.Errorf("not a git repository: %s", root)
+	}
+
+	branch, err := gitOutput(root, "branch", "--show-current")
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("detect branch: %w", err)
+	}
+	if branch == "" {
+		return PublishResult{}, fmt.Errorf("detached HEAD not supported for publish: %s", root)
+	}
+
+	remote := strings.TrimSpace(opts.Remote)
+	if remote == "" {
+		remote = "origin"
+	}
+
+	statusOut, err := gitOutput(root, "status", "--porcelain")
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("read git status: %w", err)
+	}
+	hasChanges := strings.TrimSpace(statusOut) != ""
+
+	var committed bool
+	if hasChanges {
+		if err := gitRun(root, "add", "-A"); err != nil {
+			return PublishResult{}, fmt.Errorf("git add: %w", err)
+		}
+		staged, err := hasStagedChanges(root)
+		if err != nil {
+			return PublishResult{}, fmt.Errorf("detect staged changes: %w", err)
+		}
+		if staged {
+			message := strings.TrimSpace(opts.CommitMessage)
+			if message == "" {
+				message = "multica auto publish"
+			}
+			if err := gitRun(root, "commit", "-m", message); err != nil {
+				return PublishResult{}, fmt.Errorf("git commit: %w", err)
+			}
+			committed = true
+		}
+	}
+
+	if err := gitRun(root, "push", "-u", remote, branch); err != nil {
+		return PublishResult{}, fmt.Errorf("git push: %w", err)
+	}
+
+	commitHash, err := gitOutput(root, "rev-parse", "HEAD")
+	if err != nil {
+		return PublishResult{}, fmt.Errorf("resolve commit hash: %w", err)
+	}
+
+	return PublishResult{
+		Root:          root,
+		Branch:        branch,
+		Remote:        remote,
+		CommitHash:    strings.TrimSpace(commitHash),
+		Committed:     committed,
+		Pushed:        true,
+		StagedChanges: hasChanges,
+	}, nil
+}
+
+func discoverPublishRoots(root string) ([]string, error) {
+	if isGitRepo(root) {
+		return []string{root}, nil
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read workspace root: %w", err)
+	}
+
+	var roots []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		child := filepath.Join(root, entry.Name())
+		if isGitRepo(child) {
+			roots = append(roots, child)
+		}
+	}
+	sort.Strings(roots)
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("no git repositories found under %s", root)
+	}
+	return roots, nil
+}
+
+func isGitRepo(path string) bool {
+	if path == "" {
+		return false
+	}
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--is-inside-work-tree")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
+}
+
+func gitOutput(root string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s: %s: %w", strings.Join(append([]string{"git"}, args...), " "), strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func gitRun(root string, args ...string) error {
+	_, err := gitOutput(root, args...)
+	return err
+}
+
+func hasStagedChanges(root string) (bool, error) {
+	cmd := exec.Command("git", "-C", root, "diff", "--cached", "--quiet")
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return true, nil
+		}
+		return false, fmt.Errorf("git diff --cached --quiet: %w", err)
+	}
+	return false, nil
+}
+
+func joinErrors(errs ...error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	return errors.Join(errs...)
+}

--- a/server/internal/gitops/publish_test.go
+++ b/server/internal/gitops/publish_test.go
@@ -1,0 +1,103 @@
+package gitops
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test User",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test User",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %s: %v", args, out, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func createSourceRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "initial commit")
+	return dir
+}
+
+func TestPublishWorkspacePushesDirtyRepo(t *testing.T) {
+	source := createSourceRepo(t)
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, source, "clone", "--bare", source, remote)
+
+	workspaceRoot := t.TempDir()
+	repoPath := filepath.Join(workspaceRoot, "repo")
+	runGit(t, workspaceRoot, "clone", remote, repoPath)
+
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("hello\nchanged\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	results, err := PublishWorkspace(workspaceRoot, PublishOptions{
+		Remote:        "origin",
+		CommitMessage: "multica auto publish test",
+	})
+	if err != nil {
+		t.Fatalf("PublishWorkspace failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 publish result, got %d", len(results))
+	}
+	if !results[0].Committed {
+		t.Fatal("expected dirty repo to be committed")
+	}
+	if !results[0].Pushed {
+		t.Fatal("expected repo to be pushed")
+	}
+
+	remoteHead := runGit(t, remote, "rev-parse", "refs/heads/main")
+	localHead := runGit(t, repoPath, "rev-parse", "HEAD")
+	if remoteHead != localHead {
+		t.Fatalf("remote head %s does not match local head %s", remoteHead, localHead)
+	}
+
+	log := runGit(t, repoPath, "log", "-1", "--pretty=%s")
+	if log != "multica auto publish test" {
+		t.Fatalf("unexpected commit message %q", log)
+	}
+}
+
+func TestDiscoverPublishRootsFindsChildRepo(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workspaceRoot, "notes"), 0o755); err != nil {
+		t.Fatalf("mkdir notes: %v", err)
+	}
+
+	source := createSourceRepo(t)
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, source, "clone", "--bare", source, remote)
+	runGit(t, workspaceRoot, "clone", remote, filepath.Join(workspaceRoot, "repo"))
+
+	roots, err := discoverPublishRoots(workspaceRoot)
+	if err != nil {
+		t.Fatalf("discoverPublishRoots failed: %v", err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("expected 1 root, got %d", len(roots))
+	}
+	if filepath.Base(roots[0]) != "repo" {
+		t.Fatalf("unexpected repo root: %s", roots[0])
+	}
+}


### PR DESCRIPTION
## What changed
- Added workspace-details fetching in the daemon client so repo URLs can be refreshed from the workspace API.
- Added daemon repo-cache resync helpers that re-fetch watched workspace details and refresh bare repo caches on startup, config reload, and periodic sync.
- Added regression tests to prove a repo added after startup is eventually synced into the cache.

## Why
Multica was only syncing repo cache when a workspace was first registered. If a repo was added to an already-watched workspace later, the daemon kept an empty cache and task checkout failed with `repo not found in cache`.

## Validation
- `go test ./internal/daemon ./internal/daemon/repocache`
- `go test ./...`
