### PR TITLE
fix(auth): preserve last workspace ID across re-login

### DIFF
--- a/apps/desktop/src/renderer/src/pages/login.tsx
+++ b/apps/desktop/src/renderer/src/pages/login.tsx
@@ -2,6 +2,8 @@ import { LoginPage } from "@multica/views/auth";
 import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
 
 export function DesktopLoginPage() {
+  const lastWorkspaceId = localStorage.getItem("multica_workspace_id");
+
   return (
     <div className="flex h-screen flex-col">
       {/* Traffic light inset */}
@@ -11,6 +13,7 @@ export function DesktopLoginPage() {
       />
       <LoginPage
         logo={<MulticaIcon bordered size="lg" />}
+        lastWorkspaceId={lastWorkspaceId}
         onSuccess={() => {
           // Auth store update triggers AppContent re-render → shows DesktopShell
         }}

--- a/packages/core/auth/store.ts
+++ b/packages/core/auth/store.ts
@@ -72,7 +72,6 @@ export function createAuthStore(options: AuthStoreOptions) {
 
     logout: () => {
       storage.removeItem("multica_token");
-      storage.removeItem("multica_workspace_id");
       api.setToken(null);
       api.setWorkspaceId(null);
       onLogout?.();


### PR DESCRIPTION
## Summary
- Stop clearing `multica_workspace_id` from storage on logout — the workspace ID is a user preference, not session-sensitive data
- Pass `lastWorkspaceId` in the desktop login page, which was missing

Fixes MUL-642: 重新登录后没有记住上次使用的 workspace

## Root cause
The `logout()` handler in `packages/core/auth/store.ts` was removing both `multica_token` and `multica_workspace_id` from storage. When the user logged back in, the login flow tried to read the stored workspace ID, got `null`, and defaulted to the first workspace in the list.

## Changes
- `packages/core/auth/store.ts` — removed `storage.removeItem("multica_workspace_id")` from `logout()`
- `apps/desktop/src/renderer/src/pages/login.tsx` — read stored workspace ID and pass as `lastWorkspaceId` prop (the web app already did this)

## Test plan
- [ ] Log in, switch to a non-default workspace
- [ ] Log out, then log back in — should return to the previously selected workspace
- [ ] Verify on both web and desktop
- [ ] Verify Google OAuth login also restores the workspace