### PR TITLE
fix(views): navigate to issue in same tab instead of opening new tab

### DIFF
--- a/packages/views/editor/extensions/mention-view.tsx
+++ b/packages/views/editor/extensions/mention-view.tsx
@@ -53,7 +53,7 @@ function IssueMention({
 }) {
   const wsId = useWorkspaceId();
   const { data: issues = [] } = useQuery(issueListOptions(wsId));
-  const { openInNewTab } = useNavigation();
+  const { push, openInNewTab } = useNavigation();
   const issue = issues.find((i) => i.id === issueId);
 
   const issuePath = `/issues/${issueId}`;
@@ -61,11 +61,13 @@ function IssueMention({
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (openInNewTab) {
-      openInNewTab(issuePath, tabTitle);
-    } else {
-      window.open(issuePath, "_blank", "noopener,noreferrer");
+    if (e.metaKey || e.ctrlKey || e.shiftKey) {
+      if (openInNewTab) {
+        openInNewTab(issuePath, tabTitle);
+      }
+      return;
     }
+    push(issuePath);
   };
 
   const cardClass =

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -86,7 +86,7 @@ function urlTransform(url: string): string {
 // ---------------------------------------------------------------------------
 
 function IssueMentionLink({ issueId, label }: { issueId: string; label?: string }) {
-  const { openInNewTab } = useNavigation();
+  const { push, openInNewTab } = useNavigation();
   const path = `/issues/${issueId}`;
   return (
     <span
@@ -94,11 +94,13 @@ function IssueMentionLink({ issueId, label }: { issueId: string; label?: string 
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
-        if (openInNewTab) {
-          openInNewTab(path, label);
-        } else {
-          window.open(path, "_blank", "noopener,noreferrer");
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
+          if (openInNewTab) {
+            openInNewTab(path, label);
+          }
+          return;
         }
+        push(path);
       }}
     >
       <IssueMentionCard issueId={issueId} fallbackLabel={label} />


### PR DESCRIPTION
## Summary
- Issue mention links (in editor and readonly content) now navigate in the same tab using `push()` instead of always opening a new tab
- Cmd/Ctrl+Click still opens in a new tab on desktop (matching `AppLink` behavior)

Closes MUL-583