### PR TITLE
fix(handler): fix batch operations and error handling bugs

### DIFF
--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -412,7 +412,12 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch user info from Google.
-	userInfoReq, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://www.googleapis.com/oauth2/v2/userinfo", nil)
+	userInfoReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://www.googleapis.com/oauth2/v2/userinfo", nil)
+	if err != nil {
+		slog.Error("failed to create userinfo request", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
 	userInfoReq.Header.Set("Authorization", "Bearer "+gToken.AccessToken)
 
 	userInfoResp, err := http.DefaultClient.Do(userInfoReq)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1252,6 +1252,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			AssigneeID:    prevIssue.AssigneeID,
 			DueDate:       prevIssue.DueDate,
 			ParentIssueID: prevIssue.ParentIssueID,
+			ProjectID:     prevIssue.ProjectID,
 		}
 
 		if req.Updates.Title != nil {
@@ -1292,6 +1293,33 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 				params.DueDate = pgtype.Timestamptz{Time: t, Valid: true}
 			} else {
 				params.DueDate = pgtype.Timestamptz{Valid: false}
+			}
+		}
+
+		if _, ok := rawUpdates["parent_issue_id"]; ok {
+			if req.Updates.ParentIssueID != nil {
+				newParentID := parseUUID(*req.Updates.ParentIssueID)
+				// Cannot set self as parent.
+				if uuidToString(newParentID) == issueID {
+					continue
+				}
+				// Validate parent exists in the same workspace.
+				if _, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+					ID:          newParentID,
+					WorkspaceID: prevIssue.WorkspaceID,
+				}); err != nil {
+					continue
+				}
+				params.ParentIssueID = newParentID
+			} else {
+				params.ParentIssueID = pgtype.UUID{Valid: false}
+			}
+		}
+		if _, ok := rawUpdates["project_id"]; ok {
+			if req.Updates.ProjectID != nil {
+				params.ProjectID = parseUUID(*req.Updates.ProjectID)
+			} else {
+				params.ProjectID = pgtype.UUID{Valid: false}
 			}
 		}
 
@@ -1372,10 +1400,15 @@ func (h *Handler) BatchDeleteIssues(w http.ResponseWriter, r *http.Request) {
 
 		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 
-		if err := h.Queries.DeleteIssue(r.Context(), parseUUID(issueID)); err != nil {
+		// Collect attachment URLs before CASCADE delete to clean up S3 objects.
+		attachmentURLs, _ := h.Queries.ListAttachmentURLsByIssueOrComments(r.Context(), issue.ID)
+
+		if err := h.Queries.DeleteIssue(r.Context(), issue.ID); err != nil {
 			slog.Warn("batch delete issue failed", "issue_id", issueID, "error", err)
 			continue
 		}
+
+		h.deleteS3Objects(r.Context(), attachmentURLs)
 
 		actorType, actorID := h.resolveActor(r, userID, workspaceID)
 		h.publish(protocol.EventIssueDeleted, workspaceID, actorType, actorID, map[string]any{"issue_id": issueID})


### PR DESCRIPTION
## Summary

This PR fixes three bugs in the Go server handler layer:

1. **BatchDeleteIssues S3 resource leak** — The single `DeleteIssue` handler correctly collects attachment URLs and deletes associated S3 objects before removing the database record, but `BatchDeleteIssues` did not perform this cleanup. This caused orphaned S3 storage files every time issues were batch-deleted.

2. **BatchUpdateIssues missing field handling** — `BatchUpdateIssues` was missing `ProjectID` in the initial params struct (causing it to be zeroed on every batch update), and did not handle `parent_issue_id` or `project_id` from the request body's `rawUpdates`. This meant batch updates could silently clear these fields. Added:
   - `ProjectID` initialization from `prevIssue.ProjectID`
   - `parent_issue_id` handling with self-reference prevention and workspace validation
   - `project_id` handling for set/clear operations

3. **GoogleLogin ignored `NewRequestWithContext` error** — The error return from `http.NewRequestWithContext` was discarded with `_`, which could mask context cancellation or memory allocation failures.

## Changes

- `server/internal/handler/issue.go`: Added S3 cleanup in `BatchDeleteIssues`; added `ProjectID` init and `parent_issue_id`/`project_id` handling in `BatchUpdateIssues`
- `server/internal/handler/auth.go`: Added proper error handling for `http.NewRequestWithContext` in `GoogleLogin`

## Test plan

- [ ] Verify batch-deleted issues clean up their S3 attachments (no orphaned files)
- [ ] Verify batch update with `parent_issue_id` and `project_id` fields correctly updates these fields
- [ ] Verify batch update without these fields preserves existing values (no data loss)
- [ ] Verify self-parent prevention in batch operations
- [ ] Verify Google login still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)