### PR TITLE
fix(runtimes): persist ping and daemon update status across navigation

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiClient } from "./client";
+
+describe("ApiClient request IDs", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("falls back when crypto.randomUUID is unavailable", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "user-1" }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("crypto", {});
+
+    const client = new ApiClient("http://example.com");
+    await client.getMe();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+
+    expect(headers["X-Request-ID"]).toMatch(/^[a-z0-9]{8}$/);
+  });
+});

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -63,6 +63,16 @@ export interface LoginResponse {
   user: User;
 }
 
+export class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
 export class ApiClient {
   private baseUrl: string;
   private token: string | null = null;
@@ -107,8 +117,17 @@ export class ApiClient {
     return fallback;
   }
 
+  private createRequestId(): string {
+    const randomUUID = globalThis.crypto?.randomUUID;
+    if (typeof randomUUID === "function") {
+      return randomUUID.call(globalThis.crypto).slice(0, 8);
+    }
+
+    return `${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`.slice(0, 8);
+  }
+
   private async fetch<T>(path: string, init?: RequestInit): Promise<T> {
-    const rid = crypto.randomUUID().slice(0, 8);
+    const rid = this.createRequestId();
     const start = Date.now();
     const method = init?.method ?? "GET";
 
@@ -132,7 +151,7 @@ export class ApiClient {
       const message = await this.parseErrorMessage(res, `API error: ${res.status} ${res.statusText}`);
       const logLevel = res.status === 404 ? "warn" : "error";
       this.logger[logLevel](`← ${res.status} ${path}`, { rid, duration: `${Date.now() - start}ms`, error: message });
-      throw new Error(message);
+      throw new ApiError(message, res.status);
     }
 
     this.logger.info(`← ${res.status} ${path}`, { rid, duration: `${Date.now() - start}ms` });
@@ -610,7 +629,7 @@ export class ApiClient {
     if (opts?.issueId) formData.append("issue_id", opts.issueId);
     if (opts?.commentId) formData.append("comment_id", opts.commentId);
 
-    const rid = crypto.randomUUID().slice(0, 8);
+    const rid = this.createRequestId();
     const start = Date.now();
     this.logger.info("→ POST /api/upload-file", { rid });
 
@@ -625,7 +644,7 @@ export class ApiClient {
       if (res.status === 401) this.handleUnauthorized();
       const message = await this.parseErrorMessage(res, `Upload failed: ${res.status}`);
       this.logger.error(`← ${res.status} /api/upload-file`, { rid, duration: `${Date.now() - start}ms`, error: message });
-      throw new Error(message);
+      throw new ApiError(message, res.status);
     }
 
     this.logger.info(`← ${res.status} /api/upload-file`, { rid, duration: `${Date.now() - start}ms` });

--- a/packages/core/api/index.ts
+++ b/packages/core/api/index.ts
@@ -1,4 +1,4 @@
-export { ApiClient } from "./client";
+export { ApiClient, ApiError } from "./client";
 export type { ApiClientOptions } from "./client";
 export { WSClient } from "./ws-client";
 

--- a/packages/core/platform/storage-cleanup.test.ts
+++ b/packages/core/platform/storage-cleanup.test.ts
@@ -15,8 +15,9 @@ describe("clearWorkspaceStorage", () => {
     expect(adapter.removeItem).toHaveBeenCalledWith("multica_issues_view:ws_123");
     expect(adapter.removeItem).toHaveBeenCalledWith("multica_issues_scope:ws_123");
     expect(adapter.removeItem).toHaveBeenCalledWith("multica_my_issues_view:ws_123");
+    expect(adapter.removeItem).toHaveBeenCalledWith("multica_runtime_ping:ws_123");
     expect(adapter.removeItem).toHaveBeenCalledWith("multica:chat:selectedAgentId:ws_123");
     expect(adapter.removeItem).toHaveBeenCalledWith("multica:chat:activeSessionId:ws_123");
-    expect(adapter.removeItem).toHaveBeenCalledTimes(6);
+    expect(adapter.removeItem).toHaveBeenCalledTimes(7);
   });
 });

--- a/packages/core/platform/storage-cleanup.ts
+++ b/packages/core/platform/storage-cleanup.ts
@@ -12,6 +12,7 @@ const WORKSPACE_SCOPED_KEYS = [
   "multica_issues_view",
   "multica_issues_scope",
   "multica_my_issues_view",
+  "multica_runtime_ping",
   "multica:chat:selectedAgentId",
   "multica:chat:activeSessionId",
 ];

--- a/packages/core/runtimes/index.ts
+++ b/packages/core/runtimes/index.ts
@@ -1,3 +1,4 @@
 export * from "./queries";
 export * from "./mutations";
 export * from "./hooks";
+export * from "./store";

--- a/packages/core/runtimes/store.test.ts
+++ b/packages/core/runtimes/store.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { StorageAdapter } from "../types";
+import { setCurrentWorkspaceId } from "../platform/workspace-storage";
+import {
+  PING_RECOVERY_WINDOW_MS,
+  PING_TERMINAL_TTL_MS,
+  UPDATE_COMPLETED_TTL_MS,
+  UPDATE_RECOVERY_WINDOW_MS,
+  createDaemonUpdateStore,
+  createRuntimePingStore,
+} from "./store";
+
+function createMemoryStorage(): StorageAdapter {
+  const data = new Map<string, string>();
+
+  return {
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => {
+      data.set(key, value);
+    },
+    removeItem: (key) => {
+      data.delete(key);
+    },
+  };
+}
+
+describe("runtime ping store", () => {
+  beforeEach(() => {
+    setCurrentWorkspaceId(null);
+  });
+
+  it("writes, updates, clears, and cleans up ping entries", () => {
+    const store = createRuntimePingStore(createMemoryStorage());
+
+    store.getState().setEntry({
+      runtimeId: "runtime-1",
+      requestId: "ping-1",
+      status: "running",
+      startedAt: 1_000,
+    });
+
+    expect(store.getState().entries["runtime-1"]).toMatchObject({
+      requestId: "ping-1",
+      status: "running",
+    });
+
+    store.getState().updateEntry("runtime-1", {
+      status: "completed",
+      output: "pong",
+      finishedAt: 2_000,
+      durationMs: 120,
+    });
+
+    expect(store.getState().entries["runtime-1"]).toMatchObject({
+      status: "completed",
+      output: "pong",
+      durationMs: 120,
+      finishedAt: 2_000,
+    });
+
+    store.getState().cleanupExpired(2_000 + PING_TERMINAL_TTL_MS + 1);
+    expect(store.getState().entries["runtime-1"]).toBeUndefined();
+
+    store.getState().setEntry({
+      runtimeId: "runtime-2",
+      requestId: "ping-2",
+      status: "running",
+      startedAt: 0,
+    });
+    store.getState().cleanupExpired(PING_RECOVERY_WINDOW_MS + 1);
+
+    expect(store.getState().entries["runtime-2"]).toMatchObject({
+      status: "timeout",
+      finishedAt: PING_RECOVERY_WINDOW_MS + 1,
+    });
+
+    store.getState().clearEntry("runtime-2");
+    expect(store.getState().entries["runtime-2"]).toBeUndefined();
+  });
+
+  it("isolates persisted ping entries by workspace", async () => {
+    const storage = createMemoryStorage();
+
+    setCurrentWorkspaceId("ws-a");
+    const store = createRuntimePingStore(storage);
+    store.getState().setEntry({
+      runtimeId: "runtime-a",
+      requestId: "ping-a",
+      status: "completed",
+      startedAt: 100,
+      finishedAt: 200,
+      output: "pong",
+    });
+
+    setCurrentWorkspaceId("ws-b");
+    await store.persist.rehydrate();
+    expect(store.getState().entries).toEqual({});
+
+    store.getState().setEntry({
+      runtimeId: "runtime-b",
+      requestId: "ping-b",
+      status: "failed",
+      startedAt: 300,
+      finishedAt: 400,
+      error: "boom",
+    });
+
+    setCurrentWorkspaceId("ws-a");
+    await store.persist.rehydrate();
+    expect(store.getState().entries["runtime-a"]).toMatchObject({
+      requestId: "ping-a",
+      output: "pong",
+    });
+    expect(store.getState().entries["runtime-b"]).toBeUndefined();
+  });
+});
+
+describe("daemon update store", () => {
+  it("shares update entries by daemon ID and preserves identifiers", () => {
+    const store = createDaemonUpdateStore(createMemoryStorage());
+
+    store.getState().setEntry({
+      daemonId: "daemon-1",
+      runtimeId: "runtime-a",
+      requestId: "update-1",
+      targetVersion: "v1.2.3",
+      status: "running",
+      startedAt: 1_000,
+    });
+
+    expect(store.getState().entries["daemon-1"]).toMatchObject({
+      daemonId: "daemon-1",
+      runtimeId: "runtime-a",
+      requestId: "update-1",
+      targetVersion: "v1.2.3",
+      status: "running",
+    });
+
+    store.getState().setEntry({
+      daemonId: "daemon-2",
+      runtimeId: "runtime-c",
+      requestId: "update-2",
+      targetVersion: "v2.0.0",
+      status: "failed",
+      startedAt: 2_000,
+      finishedAt: 3_000,
+      error: "failed",
+    });
+
+    expect(store.getState().entries["daemon-1"]?.runtimeId).toBe("runtime-a");
+    expect(store.getState().entries["daemon-2"]?.requestId).toBe("update-2");
+  });
+
+  it("applies update cleanup rules by status", () => {
+    const store = createDaemonUpdateStore(createMemoryStorage());
+
+    store.getState().setEntry({
+      daemonId: "daemon-complete",
+      runtimeId: "runtime-a",
+      requestId: "update-complete",
+      targetVersion: "v1.2.3",
+      status: "completed",
+      startedAt: 0,
+      finishedAt: 10,
+      output: "done",
+    });
+    store.getState().setEntry({
+      daemonId: "daemon-failed",
+      runtimeId: "runtime-b",
+      requestId: "update-failed",
+      targetVersion: "v1.2.3",
+      status: "failed",
+      startedAt: 0,
+      finishedAt: 10,
+      error: "nope",
+    });
+    store.getState().setEntry({
+      daemonId: "daemon-stale",
+      runtimeId: "runtime-c",
+      requestId: "update-stale",
+      targetVersion: "v1.2.3",
+      status: "interrupted",
+      startedAt: 0,
+      error: "network lost",
+    });
+
+    store.getState().cleanupExpired(UPDATE_RECOVERY_WINDOW_MS + 1);
+    expect(store.getState().entries["daemon-stale"]).toMatchObject({
+      status: "timeout",
+      finishedAt: UPDATE_RECOVERY_WINDOW_MS + 1,
+    });
+    expect(store.getState().entries["daemon-failed"]?.status).toBe("failed");
+
+    store.getState().cleanupExpired(UPDATE_COMPLETED_TTL_MS + 11);
+    expect(store.getState().entries["daemon-complete"]).toBeUndefined();
+    expect(store.getState().entries["daemon-failed"]?.status).toBe("failed");
+  });
+});

--- a/packages/core/runtimes/store.ts
+++ b/packages/core/runtimes/store.ts
@@ -1,0 +1,269 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { RuntimePingStatus, RuntimeUpdateStatus, StorageAdapter } from "../types";
+import {
+  createPersistStorage,
+  createWorkspaceAwareStorage,
+  defaultStorage,
+  registerForWorkspaceRehydration,
+} from "../platform";
+
+export const RUNTIME_PING_STORAGE_KEY = "multica_runtime_ping";
+export const DAEMON_UPDATE_STORAGE_KEY = "multica_daemon_update";
+
+export const PING_RECOVERY_WINDOW_MS = 90 * 1000;
+export const PING_TERMINAL_TTL_MS = 10 * 60 * 1000;
+export const UPDATE_RECOVERY_WINDOW_MS = 180 * 1000;
+export const UPDATE_COMPLETED_TTL_MS = 30 * 60 * 1000;
+
+export interface RuntimePingEntry {
+  runtimeId: string;
+  requestId: string;
+  status: RuntimePingStatus;
+  startedAt: number;
+  finishedAt?: number;
+  output?: string;
+  error?: string;
+  durationMs?: number | null;
+}
+
+export interface DaemonUpdateEntry {
+  daemonId: string;
+  runtimeId: string;
+  requestId: string;
+  targetVersion: string;
+  status: RuntimeUpdateStatus;
+  startedAt: number;
+  finishedAt?: number;
+  output?: string;
+  error?: string;
+}
+
+interface RuntimePingStoreState {
+  entries: Record<string, RuntimePingEntry>;
+  setEntry: (entry: RuntimePingEntry) => void;
+  updateEntry: (runtimeId: string, patch: Partial<RuntimePingEntry>) => void;
+  clearEntry: (runtimeId: string) => void;
+  cleanupExpired: (now?: number) => void;
+}
+
+interface DaemonUpdateStoreState {
+  entries: Record<string, DaemonUpdateEntry>;
+  setEntry: (entry: DaemonUpdateEntry) => void;
+  updateEntry: (daemonId: string, patch: Partial<DaemonUpdateEntry>) => void;
+  clearEntry: (daemonId: string) => void;
+  cleanupExpired: (now?: number) => void;
+}
+
+function isPingTerminal(status: RuntimePingStatus): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "timeout" ||
+    status === "interrupted"
+  );
+}
+
+function normalizePingEntry(
+  entry: RuntimePingEntry,
+  now: number,
+): RuntimePingEntry | null {
+  if (
+    (entry.status === "pending" || entry.status === "running") &&
+    now - entry.startedAt > PING_RECOVERY_WINDOW_MS
+  ) {
+    return {
+      ...entry,
+      status: "timeout",
+      error: entry.error ?? "Test status recovery timed out",
+      finishedAt: entry.finishedAt ?? now,
+    };
+  }
+
+  const terminalAt = entry.finishedAt ?? entry.startedAt;
+  if (isPingTerminal(entry.status) && now - terminalAt > PING_TERMINAL_TTL_MS) {
+    return null;
+  }
+
+  return entry;
+}
+
+function normalizeUpdateEntry(
+  entry: DaemonUpdateEntry,
+  now: number,
+): DaemonUpdateEntry | null {
+  if (
+    (entry.status === "pending" ||
+      entry.status === "running" ||
+      entry.status === "interrupted") &&
+    now - entry.startedAt > UPDATE_RECOVERY_WINDOW_MS
+  ) {
+    return {
+      ...entry,
+      status: "timeout",
+      error: entry.error ?? "Update status recovery timed out",
+      finishedAt: entry.finishedAt ?? now,
+    };
+  }
+
+  if (entry.status === "completed") {
+    const terminalAt = entry.finishedAt ?? entry.startedAt;
+    if (now - terminalAt > UPDATE_COMPLETED_TTL_MS) {
+      return null;
+    }
+  }
+
+  return entry;
+}
+
+function rehydrateAndCleanup<T extends { cleanupExpired: () => void }>(store: {
+  persist: { rehydrate: () => void | Promise<void> };
+  getState: () => T;
+}) {
+  return () => {
+    void Promise.resolve(store.persist.rehydrate()).then(() => {
+      store.getState().cleanupExpired();
+    });
+  };
+}
+
+export function createRuntimePingStore(storageAdapter: StorageAdapter) {
+  return create<RuntimePingStoreState>()(
+    persist(
+      (set) => ({
+        entries: {},
+        setEntry: (entry) =>
+          set((state) => ({
+            entries: {
+              ...state.entries,
+              [entry.runtimeId]: entry,
+            },
+          })),
+        updateEntry: (runtimeId, patch) =>
+          set((state) => {
+            const existing = state.entries[runtimeId];
+            if (!existing) return state;
+
+            return {
+              entries: {
+                ...state.entries,
+                [runtimeId]: {
+                  ...existing,
+                  ...patch,
+                },
+              },
+            };
+          }),
+        clearEntry: (runtimeId) =>
+          set((state) => {
+            const entries = { ...state.entries };
+            delete entries[runtimeId];
+            return { entries };
+          }),
+        cleanupExpired: (now = Date.now()) =>
+          set((state) => {
+            const entries: Record<string, RuntimePingEntry> = {};
+
+            for (const [runtimeId, entry] of Object.entries(state.entries)) {
+              const normalized = normalizePingEntry(entry, now);
+              if (normalized) {
+                entries[runtimeId] = normalized;
+              }
+            }
+
+            return { entries };
+          }),
+      }),
+      {
+        name: RUNTIME_PING_STORAGE_KEY,
+        storage: createJSONStorage(() =>
+          createWorkspaceAwareStorage(storageAdapter),
+        ),
+        partialize: (state) => ({ entries: state.entries }),
+        merge: (persistedState, currentState) => ({
+          ...currentState,
+          entries:
+            (persistedState as Partial<RuntimePingStoreState> | undefined)?.entries ??
+            {},
+        }),
+      },
+    ),
+  );
+}
+
+export function createDaemonUpdateStore(storageAdapter: StorageAdapter) {
+  return create<DaemonUpdateStoreState>()(
+    persist(
+      (set) => ({
+        entries: {},
+        setEntry: (entry) =>
+          set((state) => ({
+            entries: {
+              ...state.entries,
+              [entry.daemonId]: entry,
+            },
+          })),
+        updateEntry: (daemonId, patch) =>
+          set((state) => {
+            const existing = state.entries[daemonId];
+            if (!existing) return state;
+
+            return {
+              entries: {
+                ...state.entries,
+                [daemonId]: {
+                  ...existing,
+                  ...patch,
+                },
+              },
+            };
+          }),
+        clearEntry: (daemonId) =>
+          set((state) => {
+            const entries = { ...state.entries };
+            delete entries[daemonId];
+            return { entries };
+          }),
+        cleanupExpired: (now = Date.now()) =>
+          set((state) => {
+            const entries: Record<string, DaemonUpdateEntry> = {};
+
+            for (const [daemonId, entry] of Object.entries(state.entries)) {
+              const normalized = normalizeUpdateEntry(entry, now);
+              if (normalized) {
+                entries[daemonId] = normalized;
+              }
+            }
+
+            return { entries };
+          }),
+      }),
+      {
+        name: DAEMON_UPDATE_STORAGE_KEY,
+        storage: createJSONStorage(() => createPersistStorage(storageAdapter)),
+        partialize: (state) => ({ entries: state.entries }),
+        merge: (persistedState, currentState) => ({
+          ...currentState,
+          entries:
+            (persistedState as Partial<DaemonUpdateStoreState> | undefined)
+              ?.entries ?? {},
+        }),
+      },
+    ),
+  );
+}
+
+export const useRuntimePingStore = createRuntimePingStore(defaultStorage);
+export const useDaemonUpdateStore = createDaemonUpdateStore(defaultStorage);
+
+registerForWorkspaceRehydration(rehydrateAndCleanup(useRuntimePingStore));
+void Promise.resolve(useRuntimePingStore.persist.rehydrate()).then(() => {
+  useRuntimePingStore.getState().cleanupExpired();
+});
+void Promise.resolve(useDaemonUpdateStore.persist.rehydrate()).then(() => {
+  useDaemonUpdateStore.getState().cleanupExpired();
+});
+
+export function resolveUpdateScopeId(daemonId: string | null, runtimeId: string) {
+  return daemonId || runtimeId;
+}

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -125,7 +125,13 @@ export interface SetAgentSkillsRequest {
   skill_ids: string[];
 }
 
-export type RuntimePingStatus = "pending" | "running" | "completed" | "failed" | "timeout";
+export type RuntimePingStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "timeout"
+  | "interrupted";
 
 export interface RuntimePing {
   id: string;
@@ -167,7 +173,8 @@ export type RuntimeUpdateStatus =
   | "running"
   | "completed"
   | "failed"
-  | "timeout";
+  | "timeout"
+  | "interrupted";
 
 export interface RuntimeUpdate {
   id: string;

--- a/packages/views/runtimes/components/ping-section.tsx
+++ b/packages/views/runtimes/components/ping-section.tsx
@@ -1,8 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Loader2, CheckCircle2, XCircle, Zap } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
-import { api } from "@multica/core/api";
+import { ApiError, api } from "@multica/core/api";
 import type { RuntimePingStatus } from "@multica/core/types";
+import {
+  PING_RECOVERY_WINDOW_MS,
+  useRuntimePingStore,
+} from "@multica/core/runtimes";
 
 const pingStatusConfig: Record<
   RuntimePingStatus,
@@ -13,27 +17,158 @@ const pingStatusConfig: Record<
   completed: { label: "Connected", icon: CheckCircle2, color: "text-success" },
   failed: { label: "Failed", icon: XCircle, color: "text-destructive" },
   timeout: { label: "Timeout", icon: XCircle, color: "text-warning" },
+  interrupted: { label: "Connection check interrupted", icon: XCircle, color: "text-warning" },
 };
 
 export function PingSection({ runtimeId }: { runtimeId: string }) {
-  const [status, setStatus] = useState<RuntimePingStatus | null>(null);
+  const entry = useRuntimePingStore((s) => s.entries[runtimeId]);
+  const setEntry = useRuntimePingStore((s) => s.setEntry);
+  const updateEntry = useRuntimePingStore((s) => s.updateEntry);
+  const clearEntry = useRuntimePingStore((s) => s.clearEntry);
+  const cleanupExpired = useRuntimePingStore((s) => s.cleanupExpired);
+
+  const [status, setStatus] = useState<RuntimePingStatus | null>(entry?.status ?? null);
   const [output, setOutput] = useState("");
   const [error, setError] = useState("");
   const [durationMs, setDurationMs] = useState<number | null>(null);
   const [testing, setTesting] = useState(false);
+  const [notice, setNotice] = useState("");
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const activeRequestIdRef = useRef<string | null>(null);
+  const pollFailuresRef = useRef(0);
 
   const cleanup = useCallback(() => {
     if (pollRef.current) {
       clearInterval(pollRef.current);
       pollRef.current = null;
     }
+    activeRequestIdRef.current = null;
   }, []);
 
   useEffect(() => cleanup, [cleanup]);
 
+  useEffect(() => {
+    cleanupExpired();
+  }, [cleanupExpired]);
+
+  useEffect(() => {
+    setStatus(entry?.status ?? null);
+    setOutput(entry?.output ?? "");
+    setError(entry?.error ?? "");
+    setDurationMs(entry?.durationMs ?? null);
+    setTesting(entry?.status === "pending" || entry?.status === "running");
+  }, [entry]);
+
+  const finishWithEntry = useCallback(
+    (
+      nextStatus: Extract<
+        RuntimePingStatus,
+        "completed" | "failed" | "timeout" | "interrupted"
+      >,
+      patch: {
+        output?: string;
+        error?: string;
+        durationMs?: number | null;
+      } = {},
+    ) => {
+      updateEntry(runtimeId, {
+        status: nextStatus,
+        finishedAt: Date.now(),
+        output: patch.output,
+        error: patch.error,
+        durationMs: patch.durationMs ?? null,
+      });
+      setTesting(false);
+      cleanup();
+    },
+    [cleanup, runtimeId, updateEntry],
+  );
+
+  const startPolling = useCallback(
+    (requestId: string) => {
+      if (activeRequestIdRef.current === requestId) {
+        return;
+      }
+
+      cleanup();
+      activeRequestIdRef.current = requestId;
+      pollFailuresRef.current = 0;
+      setTesting(true);
+
+      const pollOnce = async () => {
+        try {
+          const result = await api.getPingResult(runtimeId, requestId);
+          pollFailuresRef.current = 0;
+          updateEntry(runtimeId, {
+            status: result.status as RuntimePingStatus,
+          });
+
+          if (result.status === "completed") {
+            finishWithEntry("completed", {
+              output: result.output ?? "",
+              durationMs: result.duration_ms ?? null,
+            });
+            return;
+          }
+
+          if (result.status === "failed" || result.status === "timeout") {
+            finishWithEntry(result.status as "failed" | "timeout", {
+              error: result.error ?? "Unknown error",
+              durationMs: result.duration_ms ?? null,
+            });
+          }
+        } catch (e) {
+          if (e instanceof ApiError && e.status === 404) {
+            clearEntry(runtimeId);
+            setNotice("Previous test status expired");
+            setTesting(false);
+            cleanup();
+            return;
+          }
+
+          pollFailuresRef.current += 1;
+          if (pollFailuresRef.current >= 5) {
+            finishWithEntry("interrupted", {
+              error: "Connection check was interrupted. Please try again.",
+            });
+          }
+        }
+      };
+
+      void pollOnce();
+      pollRef.current = setInterval(() => {
+        void pollOnce();
+      }, 2000);
+    },
+    [cleanup, clearEntry, finishWithEntry, runtimeId, updateEntry],
+  );
+
+  useEffect(() => {
+    if (!entry) return;
+    if (!entry.requestId) return;
+
+    const isRecoverable =
+      (entry.status === "pending" || entry.status === "running") &&
+      Date.now() - entry.startedAt <= PING_RECOVERY_WINDOW_MS;
+
+    if (isRecoverable) {
+      startPolling(entry.requestId);
+      return;
+    }
+
+    if (
+      (entry.status === "pending" || entry.status === "running") &&
+      Date.now() - entry.startedAt > PING_RECOVERY_WINDOW_MS
+    ) {
+      finishWithEntry("timeout", {
+        error: "Connection check expired before it could be restored.",
+      });
+    }
+  }, [entry, finishWithEntry, startPolling]);
+
   const handleTest = async () => {
     cleanup();
+    setNotice("");
     setTesting(true);
     setStatus("pending");
     setOutput("");
@@ -42,27 +177,12 @@ export function PingSection({ runtimeId }: { runtimeId: string }) {
 
     try {
       const ping = await api.pingRuntime(runtimeId);
-
-      pollRef.current = setInterval(async () => {
-        try {
-          const result = await api.getPingResult(runtimeId, ping.id);
-          setStatus(result.status as RuntimePingStatus);
-
-          if (result.status === "completed") {
-            setOutput(result.output ?? "");
-            setDurationMs(result.duration_ms ?? null);
-            setTesting(false);
-            cleanup();
-          } else if (result.status === "failed" || result.status === "timeout") {
-            setError(result.error ?? "Unknown error");
-            setDurationMs(result.duration_ms ?? null);
-            setTesting(false);
-            cleanup();
-          }
-        } catch {
-          // ignore poll errors
-        }
-      }, 2000);
+      setEntry({
+        runtimeId,
+        requestId: ping.id,
+        status: "pending",
+        startedAt: Date.now(),
+      });
     } catch {
       setStatus("failed");
       setError("Failed to initiate test");
@@ -104,13 +224,15 @@ export function PingSection({ runtimeId }: { runtimeId: string }) {
         )}
       </div>
 
+      {notice && <p className="text-xs text-muted-foreground">{notice}</p>}
+
       {status === "completed" && output && (
         <div className="rounded-lg border bg-success/5 px-3 py-2">
           <pre className="text-xs font-mono whitespace-pre-wrap">{output}</pre>
         </div>
       )}
 
-      {(status === "failed" || status === "timeout") && error && (
+      {(status === "failed" || status === "timeout" || status === "interrupted") && error && (
         <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
           <p className="text-xs text-destructive">{error}</p>
         </div>

--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -144,6 +144,7 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
             </h3>
             <UpdateSection
               runtimeId={runtime.id}
+              daemonId={runtime.daemon_id}
               currentVersion={cliVersion}
               isOnline={runtime.status === "online"}
             />

--- a/packages/views/runtimes/components/runtime-sections.test.tsx
+++ b/packages/views/runtimes/components/runtime-sections.test.tsx
@@ -1,0 +1,369 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiError, api } from "@multica/core/api";
+import {
+  useDaemonUpdateStore,
+  useRuntimePingStore,
+} from "@multica/core/runtimes";
+import { setCurrentWorkspaceId } from "@multica/core/platform";
+import { PingSection } from "./ping-section";
+import { UpdateSection } from "./update-section";
+
+vi.mock("@multica/core/api", () => {
+  class MockApiError extends Error {
+    status: number;
+
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  }
+
+  return {
+    ApiError: MockApiError,
+    api: {
+      pingRuntime: vi.fn(),
+      getPingResult: vi.fn(),
+      initiateUpdate: vi.fn(),
+      getUpdateResult: vi.fn(),
+    },
+  };
+});
+
+function renderWithClient(node: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>,
+  );
+}
+
+describe("PingSection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-04-12T10:00:00Z"));
+    localStorage.clear();
+    setCurrentWorkspaceId("ws-1");
+    useRuntimePingStore.persist.clearStorage();
+    useRuntimePingStore.setState({ entries: {} });
+    vi.mocked(api.pingRuntime).mockReset();
+    vi.mocked(api.getPingResult).mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("restores a started ping after remount", async () => {
+    vi.mocked(api.pingRuntime).mockResolvedValue({
+      id: "ping-1",
+      runtime_id: "runtime-1",
+      status: "pending",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    vi.mocked(api.getPingResult)
+      .mockResolvedValueOnce({
+        id: "ping-1",
+        runtime_id: "runtime-1",
+        status: "running",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce({
+        id: "ping-1",
+        runtime_id: "runtime-1",
+        status: "completed",
+        output: "pong",
+        duration_ms: 120,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      });
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTimeAsync });
+    const firstRender = renderWithClient(<PingSection runtimeId="runtime-1" />);
+
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(useRuntimePingStore.getState().entries["runtime-1"]?.requestId).toBe(
+      "ping-1",
+    );
+
+    firstRender.unmount();
+    renderWithClient(<PingSection runtimeId="runtime-1" />);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+    });
+    expect(screen.getByText("pong")).toBeInTheDocument();
+  });
+
+  it("clears expired ping state when the server returns 404", async () => {
+    useRuntimePingStore.getState().setEntry({
+      runtimeId: "runtime-404",
+      requestId: "ping-404",
+      status: "running",
+      startedAt: Date.now(),
+    });
+    vi.mocked(api.getPingResult).mockRejectedValue(
+      new ApiError("ping not found", 404),
+    );
+
+    renderWithClient(<PingSection runtimeId="runtime-404" />);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await waitFor(() => {
+      expect(screen.getByText("Previous test status expired")).toBeInTheDocument();
+    });
+    expect(useRuntimePingStore.getState().entries["runtime-404"]).toBeUndefined();
+  });
+
+  it("marks ping polling as interrupted after repeated non-404 failures", async () => {
+    useRuntimePingStore.getState().setEntry({
+      runtimeId: "runtime-fail",
+      requestId: "ping-fail",
+      status: "running",
+      startedAt: Date.now(),
+    });
+    vi.mocked(api.getPingResult).mockRejectedValue(new Error("network"));
+
+    renderWithClient(<PingSection runtimeId="runtime-fail" />);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await waitFor(() => {
+      expect(useRuntimePingStore.getState().entries["runtime-fail"]?.status).toBe(
+        "interrupted",
+      );
+    });
+  });
+});
+
+describe("UpdateSection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-04-12T10:00:00Z"));
+    localStorage.clear();
+    useDaemonUpdateStore.persist.clearStorage();
+    useDaemonUpdateStore.setState({ entries: {} });
+    vi.mocked(api.initiateUpdate).mockReset();
+    vi.mocked(api.getUpdateResult).mockReset();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ tag_name: "v1.2.0" }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("shows shared update state for another runtime on the same daemon", async () => {
+    useDaemonUpdateStore.getState().setEntry({
+      daemonId: "daemon-1",
+      runtimeId: "runtime-a",
+      requestId: "update-1",
+      targetVersion: "v1.2.0",
+      status: "running",
+      startedAt: Date.now(),
+    });
+    vi.mocked(api.getUpdateResult).mockResolvedValue({
+      id: "update-1",
+      runtime_id: "runtime-a",
+      status: "running",
+      target_version: "v1.2.0",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    renderWithClient(
+      <UpdateSection
+        runtimeId="runtime-b"
+        daemonId="daemon-1"
+        currentVersion="v1.0.0"
+        isOnline
+      />,
+    );
+
+    expect(await screen.findByText("Updating...")).toBeInTheDocument();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(api.getUpdateResult).toHaveBeenCalledWith("runtime-a", "update-1");
+  });
+
+  it("handles 409 conflicts with a transient notice instead of a failure state", async () => {
+    vi.mocked(api.initiateUpdate).mockRejectedValue(
+      new ApiError("already running", 409),
+    );
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTimeAsync });
+    renderWithClient(
+      <UpdateSection
+        runtimeId="runtime-a"
+        daemonId="daemon-1"
+        currentVersion="v1.0.0"
+        isOnline
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: /update/i }));
+
+    expect(
+      screen.getByText("An update is already in progress, please wait"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Update failed")).not.toBeInTheDocument();
+    expect(useDaemonUpdateStore.getState().entries["daemon-1"]).toBeUndefined();
+  });
+
+  it("clears completed shared state once the current version catches up", async () => {
+    useDaemonUpdateStore.getState().setEntry({
+      daemonId: "daemon-1",
+      runtimeId: "runtime-a",
+      requestId: "update-1",
+      targetVersion: "v1.2.0",
+      status: "completed",
+      startedAt: Date.now() - 5_000,
+      finishedAt: Date.now() - 1_000,
+      output: "Updated to v1.2.0",
+    });
+
+    renderWithClient(
+      <UpdateSection
+        runtimeId="runtime-b"
+        daemonId="daemon-1"
+        currentVersion="v1.2.0"
+        isOnline
+      />,
+    );
+
+    await waitFor(() => {
+      expect(useDaemonUpdateStore.getState().entries["daemon-1"]).toBeUndefined();
+    });
+  });
+
+  it("keeps failed update state until the next attempt replaces it", async () => {
+    useDaemonUpdateStore.getState().setEntry({
+      daemonId: "daemon-1",
+      runtimeId: "runtime-a",
+      requestId: "update-1",
+      targetVersion: "v1.2.0",
+      status: "failed",
+      startedAt: Date.now() - 5_000,
+      finishedAt: Date.now() - 1_000,
+      error: "boom",
+    });
+    vi.mocked(api.initiateUpdate).mockResolvedValue({
+      id: "update-2",
+      runtime_id: "runtime-b",
+      status: "pending",
+      target_version: "v1.2.0",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTimeAsync });
+    renderWithClient(
+      <UpdateSection
+        runtimeId="runtime-b"
+        daemonId="daemon-1"
+        currentVersion="v1.0.0"
+        isOnline
+      />,
+    );
+
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(useDaemonUpdateStore.getState().entries["daemon-1"]).toMatchObject({
+      requestId: "update-2",
+      runtimeId: "runtime-b",
+      status: "pending",
+    });
+  });
+
+  it("allows dismissing shared update errors without starting a new attempt", async () => {
+    useDaemonUpdateStore.getState().setEntry({
+      daemonId: "daemon-1",
+      runtimeId: "runtime-a",
+      requestId: "update-1",
+      targetVersion: "v1.2.0",
+      status: "failed",
+      startedAt: Date.now() - 5_000,
+      finishedAt: Date.now() - 1_000,
+      error: "boom",
+    });
+
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTimeAsync });
+    renderWithClient(
+      <UpdateSection
+        runtimeId="runtime-b"
+        daemonId="daemon-1"
+        currentVersion="v1.0.0"
+        isOnline
+      />,
+    );
+
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    await waitFor(() => {
+      expect(useDaemonUpdateStore.getState().entries["daemon-1"]).toBeUndefined();
+    });
+    expect(screen.queryByText("boom")).not.toBeInTheDocument();
+    expect(api.initiateUpdate).not.toHaveBeenCalled();
+  });
+
+  it("keeps interrupted state through refresh and resumes polling within the recovery window", async () => {
+    useDaemonUpdateStore.getState().setEntry({
+      daemonId: "daemon-1",
+      runtimeId: "runtime-a",
+      requestId: "update-1",
+      targetVersion: "v1.2.0",
+      status: "interrupted",
+      startedAt: Date.now() - 60_000,
+      error: "connection lost",
+    });
+    vi.mocked(api.getUpdateResult).mockResolvedValue({
+      id: "update-1",
+      runtime_id: "runtime-a",
+      status: "running",
+      target_version: "v1.2.0",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    renderWithClient(
+      <UpdateSection
+        runtimeId="runtime-b"
+        daemonId="daemon-1"
+        currentVersion="v1.0.0"
+        isOnline
+      />,
+    );
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(api.getUpdateResult).toHaveBeenCalledWith("runtime-a", "update-1");
+    await waitFor(() => {
+      expect(useDaemonUpdateStore.getState().entries["daemon-1"]?.status).toBe(
+        "running",
+      );
+    });
+  });
+});

--- a/packages/views/runtimes/components/update-section.tsx
+++ b/packages/views/runtimes/components/update-section.tsx
@@ -7,8 +7,13 @@ import {
   Check,
 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
-import { api } from "@multica/core/api";
+import { ApiError, api } from "@multica/core/api";
 import type { RuntimeUpdateStatus } from "@multica/core/types";
+import {
+  UPDATE_RECOVERY_WINDOW_MS,
+  resolveUpdateScopeId,
+  useDaemonUpdateStore,
+} from "@multica/core/runtimes";
 
 const GITHUB_RELEASES_URL =
   "https://api.github.com/repos/multica-ai/multica/releases/latest";
@@ -72,43 +77,196 @@ const statusConfig: Record<
   },
   failed: { label: "Update failed", icon: XCircle, color: "text-destructive" },
   timeout: { label: "Timeout", icon: XCircle, color: "text-warning" },
+  interrupted: { label: "Update interrupted", icon: XCircle, color: "text-warning" },
 };
 
 interface UpdateSectionProps {
   runtimeId: string;
+  daemonId: string | null;
   currentVersion: string | null;
   isOnline: boolean;
 }
 
 export function UpdateSection({
   runtimeId,
+  daemonId,
   currentVersion,
   isOnline,
 }: UpdateSectionProps) {
+  const scopeId = resolveUpdateScopeId(daemonId, runtimeId);
+  const entry = useDaemonUpdateStore((s) => s.entries[scopeId]);
+  const setEntry = useDaemonUpdateStore((s) => s.setEntry);
+  const updateEntry = useDaemonUpdateStore((s) => s.updateEntry);
+  const clearEntry = useDaemonUpdateStore((s) => s.clearEntry);
+  const cleanupExpired = useDaemonUpdateStore((s) => s.cleanupExpired);
+
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
-  const [status, setStatus] = useState<RuntimeUpdateStatus | null>(null);
-  const [error, setError] = useState("");
-  const [output, setOutput] = useState("");
+  const [status, setStatus] = useState<RuntimeUpdateStatus | null>(entry?.status ?? null);
+  const [error, setError] = useState(entry?.error ?? "");
+  const [output, setOutput] = useState(entry?.output ?? "");
   const [updating, setUpdating] = useState(false);
+  const [notice, setNotice] = useState("");
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const activeRequestIdRef = useRef<string | null>(null);
+  const pollFailuresRef = useRef(0);
 
   const cleanup = useCallback(() => {
     if (pollRef.current) {
       clearInterval(pollRef.current);
       pollRef.current = null;
     }
+    activeRequestIdRef.current = null;
   }, []);
 
   useEffect(() => cleanup, [cleanup]);
+  useEffect(() => {
+    cleanupExpired();
+  }, [cleanupExpired]);
+
+  useEffect(() => {
+    setStatus(entry?.status ?? null);
+    setError(entry?.error ?? "");
+    setOutput(entry?.output ?? "");
+    setUpdating(entry?.status === "pending" || entry?.status === "running");
+  }, [entry]);
 
   // Fetch latest version on mount.
   useEffect(() => {
     fetchLatestVersion().then(setLatestVersion);
   }, []);
 
+  const finishWithEntry = useCallback(
+    (
+      nextStatus: Extract<
+        RuntimeUpdateStatus,
+        "completed" | "failed" | "timeout" | "interrupted"
+      >,
+      patch: { output?: string; error?: string } = {},
+    ) => {
+      updateEntry(scopeId, {
+        status: nextStatus,
+        finishedAt: Date.now(),
+        output: patch.output,
+        error: patch.error,
+      });
+      setUpdating(false);
+      cleanup();
+    },
+    [cleanup, scopeId, updateEntry],
+  );
+
+  const handleDismiss = useCallback(() => {
+    cleanup();
+    setNotice("");
+    clearEntry(scopeId);
+  }, [cleanup, clearEntry, scopeId]);
+
+  const startPolling = useCallback(
+    (requestRuntimeId: string, requestId: string) => {
+      if (activeRequestIdRef.current === requestId) {
+        return;
+      }
+
+      cleanup();
+      activeRequestIdRef.current = requestId;
+      pollFailuresRef.current = 0;
+      setUpdating(true);
+
+      const pollOnce = async () => {
+        try {
+          const result = await api.getUpdateResult(requestRuntimeId, requestId);
+          pollFailuresRef.current = 0;
+          updateEntry(scopeId, {
+            status: result.status as RuntimeUpdateStatus,
+          });
+
+          if (result.status === "completed") {
+            finishWithEntry("completed", {
+              output: result.output ?? "",
+            });
+            return;
+          }
+
+          if (result.status === "failed" || result.status === "timeout") {
+            finishWithEntry(result.status as "failed" | "timeout", {
+              error: result.error ?? "Unknown error",
+            });
+          }
+        } catch (e) {
+          if (e instanceof ApiError && e.status === 404) {
+            clearEntry(scopeId);
+            setNotice("Previous update status expired");
+            setUpdating(false);
+            cleanup();
+            return;
+          }
+
+          pollFailuresRef.current += 1;
+          if (pollFailuresRef.current >= 5) {
+            finishWithEntry("interrupted", {
+              error: "Update polling was interrupted. Please check again.",
+            });
+          }
+        }
+      };
+
+      void pollOnce();
+      pollRef.current = setInterval(() => {
+        void pollOnce();
+      }, 2000);
+    },
+    [cleanup, clearEntry, finishWithEntry, scopeId, updateEntry],
+  );
+
+  useEffect(() => {
+    if (!entry) return;
+    if (!entry.requestId) return;
+
+    const shouldClearCompleted =
+      entry.status === "completed" &&
+      currentVersion != null &&
+      !isNewer(entry.targetVersion, currentVersion);
+
+    if (shouldClearCompleted) {
+      clearEntry(scopeId);
+      return;
+    }
+
+    if (
+      entry.status === "completed" ||
+      entry.status === "failed" ||
+      entry.status === "timeout"
+    ) {
+      return;
+    }
+
+    const recoverable =
+      (entry.status === "pending" ||
+        entry.status === "running" ||
+        entry.status === "interrupted") &&
+      Date.now() - entry.startedAt <= UPDATE_RECOVERY_WINDOW_MS;
+
+    if (recoverable) {
+      startPolling(entry.runtimeId, entry.requestId);
+      return;
+    }
+
+    if (
+      (entry.status === "pending" ||
+        entry.status === "running" ||
+        entry.status === "interrupted") &&
+      Date.now() - entry.startedAt > UPDATE_RECOVERY_WINDOW_MS
+    ) {
+      finishWithEntry("timeout", {
+        error: "Update status expired before it could be restored.",
+      });
+    }
+  }, [clearEntry, currentVersion, entry, finishWithEntry, scopeId, startPolling]);
+
   const handleUpdate = async () => {
     if (!latestVersion) return;
     cleanup();
+    setNotice("");
     setUpdating(true);
     setStatus("pending");
     setError("");
@@ -116,32 +274,22 @@ export function UpdateSection({
 
     try {
       const update = await api.initiateUpdate(runtimeId, latestVersion);
+      setEntry({
+        daemonId: scopeId,
+        runtimeId,
+        requestId: update.id,
+        targetVersion: latestVersion,
+        status: "pending",
+        startedAt: Date.now(),
+      });
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        setStatus(null);
+        setUpdating(false);
+        setNotice("An update is already in progress, please wait");
+        return;
+      }
 
-      pollRef.current = setInterval(async () => {
-        try {
-          const result = await api.getUpdateResult(runtimeId, update.id);
-          setStatus(result.status as RuntimeUpdateStatus);
-
-          if (result.status === "completed") {
-            setOutput(result.output ?? "");
-            setUpdating(false);
-            cleanup();
-            // Auto-clear status after a few seconds so the UI
-            // refreshes to show the new version from the re-fetched runtime data.
-            setTimeout(() => setStatus(null), 5000);
-          } else if (
-            result.status === "failed" ||
-            result.status === "timeout"
-          ) {
-            setError(result.error ?? "Unknown error");
-            setUpdating(false);
-            cleanup();
-          }
-        } catch {
-          // ignore poll errors
-        }
-      }, 2000);
-    } catch {
       setStatus("failed");
       setError("Failed to initiate update");
       setUpdating(false);
@@ -204,25 +352,33 @@ export function UpdateSection({
         )}
       </div>
 
+      {notice && <p className="text-xs text-muted-foreground">{notice}</p>}
+
       {status === "completed" && output && (
         <div className="rounded-lg border bg-success/5 px-3 py-2">
           <p className="text-xs text-success">{output}</p>
         </div>
       )}
 
-      {(status === "failed" || status === "timeout") && error && (
+      {(status === "failed" || status === "timeout" || status === "interrupted") && error && (
         <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
           <p className="text-xs text-destructive">{error}</p>
-          {status === "failed" && (
+          <div className="mt-1 flex items-center gap-2">
             <Button
               variant="ghost"
               size="xs"
-              className="mt-1"
               onClick={handleUpdate}
             >
               Retry
             </Button>
-          )}
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={handleDismiss}
+            >
+              Dismiss
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/packages/views/test/setup.ts
+++ b/packages/views/test/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
 
 // jsdom doesn't provide ResizeObserver; stub it so components that rely on it
 // (e.g. input-otp) can render in tests.
@@ -13,4 +14,35 @@ if (typeof globalThis.ResizeObserver === "undefined") {
 // jsdom doesn't implement elementFromPoint; input-otp uses it internally.
 if (typeof document.elementFromPoint !== "function") {
   document.elementFromPoint = () => null;
+}
+
+if (
+  typeof globalThis.localStorage === "undefined" ||
+  typeof globalThis.localStorage.getItem !== "function" ||
+  typeof globalThis.localStorage.clear !== "function"
+) {
+  const store: Record<string, string> = {};
+  const localStorageMock = {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+      }
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+
+  Object.defineProperty(globalThis, "localStorage", {
+    value: localStorageMock,
+    writable: true,
+  });
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -306,7 +306,8 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify the caller owns this runtime's workspace.
-	if _, ok := h.requireDaemonRuntimeAccess(w, r, req.RuntimeID); !ok {
+	rt, ok := h.requireDaemonRuntimeAccess(w, r, req.RuntimeID)
+	if !ok {
 		return
 	}
 
@@ -325,8 +326,9 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 		resp["pending_ping"] = map[string]string{"id": pending.ID}
 	}
 
-	// Check for pending update requests for this runtime.
-	if pending := h.UpdateStore.PopPending(req.RuntimeID); pending != nil {
+	// Check for pending update requests for this daemon scope.
+	scopeID := updateScopeID(req.RuntimeID, textToPtr(rt.DaemonID))
+	if pending := h.UpdateStore.PopPending(scopeID); pending != nil {
 		resp["pending_update"] = map[string]string{
 			"id":             pending.ID,
 			"target_version": pending.TargetVersion,

--- a/server/internal/handler/runtime_update.go
+++ b/server/internal/handler/runtime_update.go
@@ -27,6 +27,7 @@ const (
 type UpdateRequest struct {
 	ID            string       `json:"id"`
 	RuntimeID     string       `json:"runtime_id"`
+	DaemonScope   string       `json:"-"`
 	Status        UpdateStatus `json:"status"`
 	TargetVersion string       `json:"target_version"`
 	Output        string       `json:"output,omitempty"`
@@ -47,7 +48,14 @@ func NewUpdateStore() *UpdateStore {
 	}
 }
 
-func (s *UpdateStore) Create(runtimeID, targetVersion string) (*UpdateRequest, error) {
+func updateScopeID(runtimeID string, daemonID *string) string {
+	if daemonID != nil && *daemonID != "" {
+		return *daemonID
+	}
+	return runtimeID
+}
+
+func (s *UpdateStore) Create(runtimeID string, daemonID *string, targetVersion string) (*UpdateRequest, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -58,9 +66,11 @@ func (s *UpdateStore) Create(runtimeID, targetVersion string) (*UpdateRequest, e
 		}
 	}
 
-	// Reject if there is already a pending or running update for this runtime.
+	scopeID := updateScopeID(runtimeID, daemonID)
+
+	// Reject if there is already a pending or running update for this daemon scope.
 	for _, req := range s.requests {
-		if req.RuntimeID == runtimeID && (req.Status == UpdatePending || req.Status == UpdateRunning) {
+		if req.DaemonScope == scopeID && (req.Status == UpdatePending || req.Status == UpdateRunning) {
 			return nil, errUpdateInProgress
 		}
 	}
@@ -68,6 +78,7 @@ func (s *UpdateStore) Create(runtimeID, targetVersion string) (*UpdateRequest, e
 	req := &UpdateRequest{
 		ID:            randomID(),
 		RuntimeID:     runtimeID,
+		DaemonScope:   scopeID,
 		Status:        UpdatePending,
 		TargetVersion: targetVersion,
 		CreatedAt:     time.Now(),
@@ -77,7 +88,7 @@ func (s *UpdateStore) Create(runtimeID, targetVersion string) (*UpdateRequest, e
 	return req, nil
 }
 
-var errUpdateInProgress = &updateError{msg: "an update is already in progress for this runtime"}
+var errUpdateInProgress = &updateError{msg: "an update is already in progress for this daemon"}
 
 type updateError struct{ msg string }
 
@@ -100,13 +111,13 @@ func (s *UpdateStore) Get(id string) *UpdateRequest {
 	return req
 }
 
-// PopPending returns and marks as running the pending update for a runtime.
-func (s *UpdateStore) PopPending(runtimeID string) *UpdateRequest {
+// PopPending returns and marks as running the pending update for a daemon scope.
+func (s *UpdateStore) PopPending(scopeID string) *UpdateRequest {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	for _, req := range s.requests {
-		if req.RuntimeID == runtimeID && req.Status == UpdatePending {
+		if req.DaemonScope == scopeID && req.Status == UpdatePending {
 			req.Status = UpdateRunning
 			req.UpdatedAt = time.Now()
 			return req
@@ -167,7 +178,8 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	update, err := h.UpdateStore.Create(runtimeID, req.TargetVersion)
+	daemonID := textToPtr(rt.DaemonID)
+	update, err := h.UpdateStore.Create(runtimeID, daemonID, req.TargetVersion)
 	if err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return

--- a/server/internal/handler/runtime_update_test.go
+++ b/server/internal/handler/runtime_update_test.go
@@ -1,0 +1,50 @@
+package handler
+
+import "testing"
+
+func TestUpdateStoreScopesByDaemon(t *testing.T) {
+	store := NewUpdateStore()
+
+	daemon1 := "daemon-1"
+	daemon2 := "daemon-2"
+
+	if _, err := store.Create("runtime-a", &daemon1, "v1.2.3"); err != nil {
+		t.Fatalf("create first update: %v", err)
+	}
+
+	if _, err := store.Create("runtime-b", &daemon1, "v1.2.3"); err == nil {
+		t.Fatal("expected conflict for same daemon")
+	}
+
+	if _, err := store.Create("runtime-c", &daemon2, "v1.2.3"); err != nil {
+		t.Fatalf("create second daemon update: %v", err)
+	}
+
+	pending := store.PopPending("daemon-1")
+	if pending == nil {
+		t.Fatal("expected pending update for daemon-1")
+	}
+	if pending.RuntimeID != "runtime-a" {
+		t.Fatalf("expected runtime-a, got %s", pending.RuntimeID)
+	}
+
+	if got := store.PopPending("daemon-1"); got != nil {
+		t.Fatal("expected daemon-1 update to already be claimed")
+	}
+
+	if got := store.PopPending("daemon-2"); got == nil || got.RuntimeID != "runtime-c" {
+		t.Fatalf("expected daemon-2 pending update for runtime-c, got %#v", got)
+	}
+}
+
+func TestUpdateStoreFallsBackToRuntimeScope(t *testing.T) {
+	store := NewUpdateStore()
+
+	if _, err := store.Create("runtime-a", nil, "v1.2.3"); err != nil {
+		t.Fatalf("create first update: %v", err)
+	}
+
+	if _, err := store.Create("runtime-b", nil, "v1.2.3"); err != nil {
+		t.Fatalf("expected distinct runtime fallback scopes, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

Fix runtime operation state being lost on navigation or refresh.

- Persist runtime-scoped ping state so `Test Connection` can recover after remount/reload
- Persist daemon-scoped update state so runtimes on the same daemon share the same visible update progress
- Resume polling from persisted request IDs within bounded recovery windows
- Treat `409 Conflict` update responses as a transient “already running” notice instead of a generic failure
- Add a dismiss action for persisted update errors so failed/timed-out daemon-scoped update state does not become a dead-end UI

## Why

Closes #780

Both runtime operations stored request IDs only in component state. After unmount or refresh, the frontend lost the ID and could no longer restore the state, while the backend only supports looking up ping/update status by request ID.

This change keeps the fix frontend-focused and aligned with the existing architecture:
- no DB persistence
- no migration
- no new latest-operation API

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Other (describe below)

## How to Test

- [ ] Start `Test Connection` on a runtime, navigate away, then return — the ping state should be restored
- [ ] Start `Test Connection`, refresh the page, and confirm the latest ping state/result is still shown
- [ ] Confirm a ping started on runtime A does not affect runtime B
- [ ] Start a CLI update on runtime A, then open runtime B on the same daemon — both pages should show the same update state
- [ ] Let the update complete and confirm the shared update state clears once a same-daemon runtime reports the target CLI version
- [ ] Trigger a `409 Conflict` update case and confirm the page shows `An update is already in progress, please wait`
- [ ] Trigger a failed or timed-out update and confirm the error can be dismissed without starting a new update

## Verification

Passed locally:
- [x] `npx pnpm typecheck`
- [x] `npx pnpm test`
- [x] `cd server && go run ./cmd/migrate up`
- [x] `cd server && go test ./...`

Manual validation:
- [x] Verified runtime-scoped ping persistence on remote deployment
- [x] Verified daemon-scoped update sharing on remote deployment
- [x] Verified shared update state clears after version catches up
- [x] Verified real `409` UI path shows `An update is already in progress, please wait`
- [x] Verified persisted update errors can be dismissed

Playwright:
- [ ] `npx pnpm exec playwright test`
  - Current local E2E baseline is failing outside this change as well (auth / navigation / issue flows), so full `make check` is not green in this environment

## Notes

- Ping state remains runtime-scoped
- Update state is daemon-scoped so sibling runtimes on the same daemon stay consistent
- Failed/timed-out update state is intentionally retained until the user retries or dismisses it
- No unrelated files are included in this PR

## Checklist

- [ ] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure (optional)

- Tool: Codex
- Prompt: implement runtime ping/update status persistence across navigation and refresh, with runtime-scoped ping state, daemon-scoped update state, 409 handling, interrupted recovery, and dismissible persisted update errors
