### PR TITLE
fix(handler): add cycle detection to BatchUpdateIssues

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1310,6 +1310,23 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 				}); err != nil {
 					continue
 				}
+				// Cycle detection: walk up from the new parent to ensure we don't reach this issue.
+				cycleDetected := false
+				cursor := newParentID
+				for depth := 0; depth < 10; depth++ {
+					ancestor, err := h.Queries.GetIssue(r.Context(), cursor)
+					if err != nil || !ancestor.ParentIssueID.Valid {
+						break
+					}
+					if uuidToString(ancestor.ParentIssueID) == issueID {
+						cycleDetected = true
+						break
+					}
+					cursor = ancestor.ParentIssueID
+				}
+				if cycleDetected {
+					continue
+				}
 				params.ParentIssueID = newParentID
 			} else {
 				params.ParentIssueID = pgtype.UUID{Valid: false}


### PR DESCRIPTION
## Summary

- `BatchUpdateIssues` was missing cycle detection when setting `parent_issue_id`, allowing circular parent relationships (e.g. A→B→A) via the batch API
- Added the same depth-limited ancestor walk (up to 10 levels) that `UpdateIssue` already has — issues that would create a cycle are skipped in the batch

Follow-up from PR #779 review ([MUL-645](https://github.com/multica-ai/multica/issues/645)).

## Test plan

- [ ] Batch update with `parent_issue_id` that would create a cycle (A parent→B, then batch-set B parent→A) — should skip the update
- [ ] Batch update with valid `parent_issue_id` — should still work correctly
- [ ] Single `UpdateIssue` cycle detection unchanged