### PR TITLE
fix(handler): add .claude/skills/ candidate path for skills.sh import

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -646,6 +646,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 
 	// Skills can be at different paths depending on the repo structure:
 	//   skills/{name}/SKILL.md          (most common)
+	//   .claude/skills/{name}/SKILL.md  (Claude Code native discovery)
 	//   plugin/skills/{name}/SKILL.md   (e.g. microsoft repos)
 	//   {name}/SKILL.md                 (skill at repo root level)
 	defaultBranch := fetchGitHubDefaultBranch(httpClient, owner, repo)
@@ -654,6 +655,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 
 	candidatePaths := []string{
 		"skills/" + skillName,
+		".claude/skills/" + skillName,
 		"plugin/skills/" + skillName,
 		skillName,
 	}


### PR DESCRIPTION
## Summary
- Add `.claude/skills/{name}/SKILL.md` as a candidate path in the skills.sh importer
- This is the Claude Code native discovery convention and is already used by Multica's own daemon (`execenv/context.go`)
- Without this path, valid skills.sh URLs return a 502 when the repo uses the `.claude/skills/` layout

Fixes #777

## Test plan
- [ ] Import a skill from a repo that stores SKILL.md under `.claude/skills/{name}/`
- [ ] Verify existing imports (skills stored under `skills/`, `plugin/skills/`, root) still work