### PR TITLE
fix: handle mcpServer/elicitation/request with valid response

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -432,6 +432,10 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 		c.respond(id, map[string]any{"decision": "accept"})
 	case "item/fileChange/requestApproval", "applyPatchApproval":
 		c.respond(id, map[string]any{"decision": "accept"})
+	case "mcpServer/elicitation/request":
+		// Return a valid McpServerElicitationRequestResponse with accept action
+		// This fixes the deserialization error in Codex: "missing field `action`"
+		c.respond(id, map[string]any{"action": "accept", "content": nil, "_meta": nil})
 	default:
 		c.respond(id, map[string]any{})
 	}


### PR DESCRIPTION
## Summary

Fixes #783 - Daemon returns malformed response for mcpServer/elicitation/request

When Codex sends mcpServer/elicitation/request, Multica was falling through
the default handler and returning {}, which fails deserialization in Codex
with 'missing field action'.

This commit adds explicit handling for mcpServer/elicitation/request to return
a valid response with action set to 'accept'.