### PR TITLE
fix(ws): include issue_id in task:dispatch event

### DIFF
--- a/packages/views/issues/components/agent-live-card.tsx
+++ b/packages/views/issues/components/agent-live-card.tsx
@@ -208,7 +208,9 @@ export function AgentLiveCard({ issueId }: AgentLiveCardProps) {
   // Pick up newly dispatched tasks
   useWSEvent(
     "task:dispatch",
-    useCallback(() => {
+    useCallback((payload: unknown) => {
+      const p = payload as { issue_id?: string };
+      if (p.issue_id && p.issue_id !== issueId) return;
       api.getActiveTasksForIssue(issueId).then(({ tasks }) => {
         setTaskStates((prev) => {
           const next = new Map(prev);

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -461,6 +461,8 @@ func (s *TaskService) broadcastTaskDispatch(ctx context.Context, task db.AgentTa
 	}
 	payload["task_id"] = util.UUIDToString(task.ID)
 	payload["runtime_id"] = util.UUIDToString(task.RuntimeID)
+	payload["issue_id"] = util.UUIDToString(task.IssueID)
+	payload["agent_id"] = util.UUIDToString(task.AgentID)
 
 	workspaceID := s.resolveTaskWorkspaceID(ctx, task)
 	if workspaceID == "" {


### PR DESCRIPTION
## Summary

- Add `issue_id` and `agent_id` to `broadcastTaskDispatch()` WebSocket payload, matching the pattern already used by `broadcastTaskEvent()` for all other task events
- Add `issue_id` filtering in the frontend `task:dispatch` handler in `agent-live-card.tsx`, matching the existing filtering in `task:message` and `task:completed/failed/cancelled` handlers

Fixes https://github.com/multica-ai/multica/issues/791 — agents @-mentioned in Issue A would briefly show activity in Issue B if the user had both open.

## Test plan

- [ ] Open two issues in separate tabs
- [ ] @-mention an agent in Issue A while viewing Issue B
- [ ] Verify the agent activity card only appears in Issue A's tab, not Issue B's