### PR TITLE
fix: update X link to correct handle @MulticaAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Turn coding agents into real teammates — assign tasks, track progress, compoun
 [![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
 
-[Website](https://multica.ai) · [Cloud](https://multica.ai/app) · [X](https://x.com/multica_hq) · [Self-Hosting](SELF_HOSTING.md) · [Contributing](CONTRIBUTING.md)
+[Website](https://multica.ai) · [Cloud](https://multica.ai/app) · [X](https://x.com/MulticaAI) · [Self-Hosting](SELF_HOSTING.md) · [Contributing](CONTRIBUTING.md)
 
 **English | [简体中文](README.zh-CN.md)**
 


### PR DESCRIPTION
## Summary

- The X (Twitter) link in the README points to `https://x.com/multica_hq`, which returns a 404
- Updated to `https://x.com/MulticaAI`, the correct and active handle

## Change

```diff
- [X](https://x.com/multica_hq)
+ [X](https://x.com/MulticaAI)
```

One-line change, no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)