### PR TITLE
feat(cli): add --content-stdin flag to issue comment add

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -185,7 +186,8 @@ func init() {
 	issueRunMessagesCmd.Flags().Int("since", 0, "Only return messages after this sequence number")
 
 	// issue comment add
-	issueCommentAddCmd.Flags().String("content", "", "Comment content (required)")
+	issueCommentAddCmd.Flags().String("content", "", "Comment content (required unless --content-stdin)")
+	issueCommentAddCmd.Flags().Bool("content-stdin", false, "Read comment content from stdin (avoids shell escaping issues)")
 	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID (reply to a specific comment)")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
@@ -637,8 +639,15 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 
 func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	content, _ := cmd.Flags().GetString("content")
+	if useStdin, _ := cmd.Flags().GetBool("content-stdin"); useStdin {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+		content = strings.TrimRight(string(data), "\n")
+	}
 	if content == "" {
-		return fmt.Errorf("--content is required")
+		return fmt.Errorf("--content or --content-stdin is required")
 	}
 
 	client, err := newAPIClient(cmd)

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -639,13 +639,23 @@ func runIssueCommentList(cmd *cobra.Command, args []string) error {
 
 func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	content, _ := cmd.Flags().GetString("content")
-	if useStdin, _ := cmd.Flags().GetBool("content-stdin"); useStdin {
+	useStdin, _ := cmd.Flags().GetBool("content-stdin")
+
+	if content != "" && useStdin {
+		return fmt.Errorf("--content and --content-stdin are mutually exclusive")
+	}
+
+	if useStdin {
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("read stdin: %w", err)
 		}
-		content = strings.TrimRight(string(data), "\n")
+		content = strings.TrimSuffix(string(data), "\n")
+		if content == "" {
+			return fmt.Errorf("stdin content is empty")
+		}
 	}
+
 	if content == "" {
 		return fmt.Errorf("--content or --content-stdin is required")
 	}

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -61,6 +61,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica issue create --title \"...\" [--description \"...\"] [--priority X] [--assignee X] [--parent <issue-id>] [--status X]` — Create a new issue\n")
 	b.WriteString("- `multica issue assign <id> --to <name>` — Assign an issue to a member or agent by name (use --unassign to remove assignee)\n")
 	b.WriteString("- `multica issue comment add <issue-id> --content \"...\" [--parent <comment-id>]` — Post a comment (use --parent to reply to a specific comment)\n")
+	b.WriteString("  - For content with special characters (backticks, quotes), pipe via stdin: `cat <<'COMMENT' | multica issue comment add <issue-id> --content-stdin`\n")
 	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
 	b.WriteString("- `multica issue status <id> <status>` — Update issue status (todo, in_progress, in_review, done, blocked)\n")
 	b.WriteString("- `multica issue update <id> [--title X] [--description X] [--priority X]` — Update issue fields\n\n")


### PR DESCRIPTION
## Summary

- Adds `--content-stdin` flag to `multica issue comment add` so agents can pipe comment content through stdin, avoiding shell escaping issues with backticks, quotes, and other special characters in markdown
- Updates runtime config docs to mention the stdin option for agents

**Note:** The local storage changes originally in this PR have been removed — upstream merged #710 which covers the same functionality.

## Test plan

- [ ] `go build ./...` passes
- [ ] `echo "hello **world** with \`backticks\`" | multica issue comment add <id> --content-stdin` — verify comment is created with correct content
- [ ] `multica issue comment add <id> --content "normal content"` — verify existing --content flag still works
- [ ] Running with neither --content nor --content-stdin returns an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)