### PR TITLE
fix(security): add Content-Security-Policy response header

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -78,6 +78,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 	r.Use(chimw.RequestID)
 	r.Use(middleware.RequestLogger)
 	r.Use(chimw.Recoverer)
+	r.Use(middleware.ContentSecurityPolicy)
 	origins := allowedOrigins()
 
 	// Share allowed origins with WebSocket origin checker.

--- a/server/internal/middleware/csp.go
+++ b/server/internal/middleware/csp.go
@@ -1,0 +1,20 @@
+package middleware
+
+import "net/http"
+
+const cspHeader = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' https: data:; " +
+	"connect-src 'self' wss:; " +
+	"frame-ancestors 'none'; " +
+	"object-src 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'"
+
+func ContentSecurityPolicy(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", cspHeader)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/internal/middleware/csp_test.go
+++ b/server/internal/middleware/csp_test.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestContentSecurityPolicy(t *testing.T) {
+	handler := ContentSecurityPolicy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("Content-Security-Policy header is missing")
+	}
+
+	required := []string{
+		"script-src 'self'",
+		"object-src 'none'",
+		"frame-ancestors 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+	}
+	for _, directive := range required {
+		if !strings.Contains(csp, directive) {
+			t.Errorf("CSP missing directive %q; got: %s", directive, csp)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds CSP middleware (`server/internal/middleware/csp.go`) to the global middleware chain
- Directives: `script-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'`
- Includes httptest assertion for all required directives

Split from #817 — the WebSocket auth portion was superseded by #819.

Relates to MUL-568 (parent: MUL-566 security audit).

## Test plan

- [x] `TestContentSecurityPolicy` — asserts all required CSP directives are present
- [x] All Go `internal/` tests pass (12 packages)
- [ ] Manual: verify CSP header appears on API responses in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)