### PR TITLE
fix(daemon): embed triggering comment content in agent prompt

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -66,6 +66,53 @@ func TestBuildPromptNoIssueDetails(t *testing.T) {
 	}
 }
 
+func TestBuildPromptCommentTriggered(t *testing.T) {
+	t.Parallel()
+
+	issueID := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	commentID := "c1c2c3c4-d5d6-7890-abcd-ef1234567890"
+	commentContent := "请把报告翻译成英文"
+
+	prompt := BuildPrompt(Task{
+		IssueID:               issueID,
+		TriggerCommentID:      commentID,
+		TriggerCommentContent: commentContent,
+		Agent:                 &AgentData{Name: "Test"},
+	})
+
+	// Prompt should contain the comment content directly.
+	for _, want := range []string{
+		issueID,
+		commentContent,
+		"comment that triggered this task",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q", want)
+		}
+	}
+
+	// Should still contain CLI hint for fetching issue context.
+	if !strings.Contains(prompt, "multica issue get") {
+		t.Fatal("prompt missing CLI hint for issue context")
+	}
+}
+
+func TestBuildPromptCommentTriggeredNoContent(t *testing.T) {
+	t.Parallel()
+
+	// When TriggerCommentID is set but content is empty (e.g. fetch failed),
+	// it should still use the comment prompt path.
+	prompt := BuildPrompt(Task{
+		IssueID:          "test-id",
+		TriggerCommentID: "comment-id",
+		Agent:            &AgentData{Name: "Test"},
+	})
+
+	if !strings.Contains(prompt, "multica issue get") {
+		t.Fatal("prompt missing CLI hint")
+	}
+}
+
 func TestIsWorkspaceNotFoundError(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -12,9 +12,27 @@ func BuildPrompt(task Task) string {
 	if task.ChatSessionID != "" {
 		return buildChatPrompt(task)
 	}
+	if task.TriggerCommentID != "" {
+		return buildCommentPrompt(task)
+	}
 	var b strings.Builder
 	b.WriteString("You are running as a local coding agent for a Multica workspace.\n\n")
 	fmt.Fprintf(&b, "Your assigned issue ID is: %s\n\n", task.IssueID)
+	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
+	return b.String()
+}
+
+// buildCommentPrompt constructs a prompt for comment-triggered tasks.
+// The triggering comment content is embedded directly so the agent cannot
+// miss it, even when stale output files exist in a reused workdir.
+func buildCommentPrompt(task Task) string {
+	var b strings.Builder
+	b.WriteString("You are running as a local coding agent for a Multica workspace.\n\n")
+	fmt.Fprintf(&b, "Your assigned issue ID is: %s\n\n", task.IssueID)
+	if task.TriggerCommentContent != "" {
+		b.WriteString("A user left a comment that triggered this task. Here is their message:\n\n")
+		fmt.Fprintf(&b, "> %s\n\n", task.TriggerCommentContent)
+	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
 	return b.String()
 }

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -32,9 +32,10 @@ type Task struct {
 	Repos          []RepoData `json:"repos,omitempty"`
 	PriorSessionID   string     `json:"prior_session_id,omitempty"`    // Claude session ID from a previous task on this issue
 	PriorWorkDir     string     `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on this issue
-	TriggerCommentID string     `json:"trigger_comment_id,omitempty"` // comment that triggered this task
-	ChatSessionID    string     `json:"chat_session_id,omitempty"`    // non-empty for chat tasks
-	ChatMessage      string     `json:"chat_message,omitempty"`       // user message content for chat tasks
+	TriggerCommentID      string     `json:"trigger_comment_id,omitempty"`      // comment that triggered this task
+	TriggerCommentContent string     `json:"trigger_comment_content,omitempty"` // content of the triggering comment
+	ChatSessionID         string     `json:"chat_session_id,omitempty"`         // non-empty for chat tasks
+	ChatMessage           string     `json:"chat_message,omitempty"`            // user message content for chat tasks
 }
 
 // AgentData holds agent details returned by the claim endpoint.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -90,9 +90,10 @@ type AgentTaskResponse struct {
 	CreatedAt      string         `json:"created_at"`
 	PriorSessionID   string         `json:"prior_session_id,omitempty"`    // session ID from a previous task on same issue
 	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
-	TriggerCommentID *string        `json:"trigger_comment_id,omitempty"` // comment that triggered this task
-	ChatSessionID    string         `json:"chat_session_id,omitempty"`    // non-empty for chat tasks
-	ChatMessage      string         `json:"chat_message,omitempty"`       // user message for chat tasks
+	TriggerCommentID      *string        `json:"trigger_comment_id,omitempty"`      // comment that triggered this task
+	TriggerCommentContent string         `json:"trigger_comment_content,omitempty"` // content of the triggering comment
+	ChatSessionID         string         `json:"chat_session_id,omitempty"`         // non-empty for chat tasks
+	ChatMessage           string         `json:"chat_message,omitempty"`            // user message for chat tasks
 }
 
 // TaskAgentData holds agent info included in claim responses so the daemon

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -382,6 +382,15 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// Fetch the triggering comment content so the daemon can embed it
+		// directly in the agent prompt (prevents the agent from ignoring comments
+		// when stale output files exist in a reused workdir).
+		if task.TriggerCommentID.Valid {
+			if comment, err := h.Queries.GetComment(r.Context(), task.TriggerCommentID); err == nil {
+				resp.TriggerCommentContent = comment.Content
+			}
+		}
+
 		// Look up the prior session for this (agent, issue) pair so the daemon
 		// can resume the Claude Code conversation context.
 		if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{


### PR DESCRIPTION
## Summary

- Fetches the triggering comment's content in `ClaimTaskByRuntime` and passes it through to the daemon
- Adds a dedicated `buildCommentPrompt()` that embeds the comment content directly in the agent's initial prompt
- Agent can no longer miss the triggering comment, even when stale output files exist in a reused workdir

Closes #805

## Changes

| File | Change |
|------|--------|
| `handler/agent.go` | Added `TriggerCommentContent` field to `AgentTaskResponse` |
| `handler/daemon.go` | Fetch comment content via `GetComment()` when `TriggerCommentID` is set |
| `daemon/types.go` | Added `TriggerCommentContent` field to `Task` struct |
| `daemon/prompt.go` | New `buildCommentPrompt()` for comment-triggered tasks |
| `daemon/daemon_test.go` | Tests for comment-triggered prompt generation |

## Test plan

- [x] All existing `TestBuildPrompt*` tests pass
- [x] New `TestBuildPromptCommentTriggered` verifies comment content appears in prompt
- [x] New `TestBuildPromptCommentTriggeredNoContent` verifies graceful handling when content is empty
- [x] `go vet` passes cleanly