### PR TITLE
fix(auth): fall back to token-mode WS for legacy localStorage users

### DIFF
--- a/apps/web/components/web-providers.tsx
+++ b/apps/web/components/web-providers.tsx
@@ -7,12 +7,25 @@ import {
   clearLoggedInCookie,
 } from "@/features/auth/auth-cookie";
 
+// Legacy token in localStorage → keep this session in token mode so users who
+// logged in before the cookie-auth migration stay authed. They migrate to
+// cookie mode on their next logout/login cycle (logout clears multica_token).
+function hasLegacyToken(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return Boolean(window.localStorage.getItem("multica_token"));
+  } catch {
+    return false;
+  }
+}
+
 export function WebProviders({ children }: { children: React.ReactNode }) {
+  const cookieAuth = !hasLegacyToken();
   return (
     <CoreProvider
       apiBaseUrl={process.env.NEXT_PUBLIC_API_URL}
       wsUrl={process.env.NEXT_PUBLIC_WS_URL}
-      cookieAuth
+      cookieAuth={cookieAuth}
       onLogin={setLoggedInCookie}
       onLogout={clearLoggedInCookie}
     >

--- a/apps/web/components/web-providers.tsx
+++ b/apps/web/components/web-providers.tsx
@@ -10,6 +10,9 @@ import {
 // Legacy token in localStorage → keep this session in token mode so users who
 // logged in before the cookie-auth migration stay authed. They migrate to
 // cookie mode on their next logout/login cycle (logout clears multica_token).
+// Sunset: once telemetry shows <1% of sessions still carry multica_token,
+// delete this branch and hard-code `cookieAuth` — the localStorage token is
+// XSS-exposed and is the exact thing the cookie migration exists to remove.
 function hasLegacyToken(): boolean {
   if (typeof window === "undefined") return false;
   try {


### PR DESCRIPTION
## Summary
- Users who logged in before the cookie-auth migration still have `multica_token` in localStorage but no `multica_auth` cookie. With `cookieAuth` hard-coded to `true` in `WebProviders`, their WebSocket upgrade hits `/ws?workspace_id=...` with neither token nor cookie and the server returns 401.
- Detect the legacy token at render time in `web-providers.tsx`; if present, run the whole session in token mode (Bearer HTTP + URL-param WS). Pure cookie-mode is used only when no legacy token exists.
- Legacy users migrate to cookie mode automatically on their next logout/login cycle, since `logout` already clears `multica_token` and fresh logins in cookie mode never re-populate it.

## Known tradeoff
This PR intentionally keeps the legacy `multica_token` flow alive for existing sessions, which means those users remain XSS-exposed — exactly the exposure the cookie migration (#819) was designed to eliminate. This is a deliberate, time-boxed compat shim, not a long-term solution. Sunset signal: once telemetry shows <1% of sessions still carry `multica_token`, the branch in `web-providers.tsx` should be deleted and `cookieAuth` hard-coded back to `true`.

## Follow-ups (out of scope for this PR)
- `packages/core/platform/auth-initializer.tsx` still unconditionally reads `multica_token` — pure cookie-mode users will be logged out on refresh. Needs a separate PR to make `AuthInitializer` cookie-aware.

## Test plan
- [ ] With `multica_token` present in localStorage (simulating a legacy user), open the app and confirm the WS connects via `?token=...&workspace_id=...` and HTTP requests carry the `Authorization: Bearer` header
- [ ] With `multica_token` removed and an `multica_auth` cookie set (fresh cookie-mode user), confirm the WS connects via `?workspace_id=...` only and the cookie is sent on upgrade
- [ ] Log out as a legacy user, log back in, confirm `multica_token` is no longer set and the next session runs in cookie mode
- [ ] Check browser console for any "Hydration failed" warnings in both legacy and cookie-mode states

🤖 Generated with [Claude Code](https://claude.com/claude-code)