### PR TITLE
fix: forward CLAUDE_CODE_USE_BEDROCK to child Claude Code processes

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -484,8 +484,21 @@ func (d *Daemon) handlePing(ctx context.Context, rt Runtime, pingID string) {
 		return
 	}
 
+	// Forward critical environment variables that the agent's mergeEnv filter
+	// strips from os.Environ(). Without this, child Claude Code processes lose
+	// config like CLAUDE_CODE_USE_BEDROCK and report "not logged in".
+	pingEnv := map[string]string{}
+	for _, key := range []string{
+		"CLAUDE_CODE_USE_BEDROCK",
+		"ANTHROPIC_SMALL_FAST_MODEL",
+	} {
+		if v := os.Getenv(key); v != "" {
+			pingEnv[key] = v
+		}
+	}
 	backend, err := agent.New(rt.Provider, agent.Config{
 		ExecutablePath: entry.Path,
+		Env:            pingEnv,
 		Logger:         d.logger,
 	})
 	if err != nil {
@@ -940,6 +953,17 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		"MULTICA_AGENT_NAME":   agentName,
 		"MULTICA_AGENT_ID":     task.AgentID,
 		"MULTICA_TASK_ID":      task.ID,
+	}
+	// Forward CLAUDE_CODE_* env vars that the filter in claude.go strips from
+	// os.Environ(). Without this, child Claude Code processes lose critical
+	// config like CLAUDE_CODE_USE_BEDROCK.
+	for _, key := range []string{
+		"CLAUDE_CODE_USE_BEDROCK",
+		"ANTHROPIC_SMALL_FAST_MODEL",
+	} {
+		if v := os.Getenv(key); v != "" {
+			agentEnv[key] = v
+		}
 	}
 	// Ensure the multica CLI is on PATH inside the agent's environment.
 	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not


### PR DESCRIPTION
## Problem

When the daemon spawns Claude Code as a child process to execute tasks, Claude Code fails immediately with:

```
Not logged in - Please run /login
```

This happens even though the daemon process itself has `CLAUDE_CODE_USE_BEDROCK=1` in its environment and AWS Bedrock credentials are properly configured.

## Root Cause

`server/pkg/agent/claude.go` has an environment filter that strips all `CLAUDE_CODE_*` prefixed environment variables from the child process:

```go
func isFilteredChildEnvKey(key string) bool {
    return key == "CLAUDECODE" ||
        strings.HasPrefix(key, "CLAUDECODE_") ||
        strings.HasPrefix(key, "CLAUDE_CODE_")
}
```

`CLAUDE_CODE_USE_BEDROCK` matches the `CLAUDE_CODE_` prefix and gets stripped. Without this variable, the child Claude Code process falls back to the default Anthropic API auth flow, finds no API key, and reports "not logged in".

The same issue affects `ANTHROPIC_SMALL_FAST_MODEL`, which may route to a region where the IAM user lacks permissions on Bedrock.

## Fix

Explicitly forward `CLAUDE_CODE_USE_BEDROCK` and `ANTHROPIC_SMALL_FAST_MODEL` through the `Env` map in both `runTask` and `handlePing` code paths. Values in the `Env` map bypass the `isFilteredChildEnvKey` filter in `mergeEnv()`.

### Changes

- **`server/internal/daemon/daemon.go` — `handlePing`**: Added `pingEnv` map with `CLAUDE_CODE_USE_BEDROCK` and `ANTHROPIC_SMALL_FAST_MODEL`, passed as `Env` to `agent.New()`.
- **`server/internal/daemon/daemon.go` — `runTask`**: Added loop to forward the same variables into `agentEnv` after initialization.

## Impact

- Bedrock-based daemon deployments are now functional
- The ping health-check also properly inherits Bedrock configuration

## Alternative (longer-term)

Refine `isFilteredChildEnvKey` to only strip internal runtime state variables (`CLAUDECODE`, `CLAUDECODE_*`) while preserving user-facing `CLAUDE_CODE_*` configuration variables.