### PR TITLE
fix(daemon): forward CLAUDE_CODE_USE_BEDROCK to child Claude Code processes

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -484,8 +484,21 @@ func (d *Daemon) handlePing(ctx context.Context, rt Runtime, pingID string) {
 		return
 	}
 
+	// Forward CLAUDE_CODE_* env vars that the filter in claude.go strips from
+	// os.Environ(). Without this, child Claude Code processes lose critical
+	// config like CLAUDE_CODE_USE_BEDROCK.
+	pingEnv := map[string]string{}
+	for _, key := range []string{
+		"CLAUDE_CODE_USE_BEDROCK",
+		"ANTHROPIC_SMALL_FAST_MODEL",
+	} {
+		if v := os.Getenv(key); v != "" {
+			pingEnv[key] = v
+		}
+	}
 	backend, err := agent.New(rt.Provider, agent.Config{
 		ExecutablePath: entry.Path,
+		Env:            pingEnv,
 		Logger:         d.logger,
 	})
 	if err != nil {
@@ -940,6 +953,17 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		"MULTICA_AGENT_NAME":   agentName,
 		"MULTICA_AGENT_ID":     task.AgentID,
 		"MULTICA_TASK_ID":      task.ID,
+	}
+	// Forward CLAUDE_CODE_* env vars that the filter in claude.go strips from
+	// os.Environ(). Without this, child Claude Code processes lose critical
+	// config like CLAUDE_CODE_USE_BEDROCK.
+	for _, key := range []string{
+		"CLAUDE_CODE_USE_BEDROCK",
+		"ANTHROPIC_SMALL_FAST_MODEL",
+	} {
+		if v := os.Getenv(key); v != "" {
+			agentEnv[key] = v
+		}
 	}
 	// Ensure the multica CLI is on PATH inside the agent's environment.
 	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not


### PR DESCRIPTION
## Bug

When the daemon spawns Claude Code as a child process to execute tasks, Claude Code fails immediately with:

```
Not logged in - Please run /login
```

This happens even though the daemon process itself has `CLAUDE_CODE_USE_BEDROCK=1` in its environment and Bedrock credentials are properly configured.

## Root Cause

`server/pkg/agent/claude.go` has an environment filter that strips all `CLAUDE_CODE_*` prefixed environment variables from child processes:

```go
func isFilteredChildEnvKey(key string) bool {
    return key == "CLAUDECODE" ||
        strings.HasPrefix(key, "CLAUDECODE_") ||
        strings.HasPrefix(key, "CLAUDE_CODE_")
}
```

`CLAUDE_CODE_USE_BEDROCK` matches the `CLAUDE_CODE_*` prefix and gets stripped. Without it, the child Claude Code process falls back to Anthropic API key auth, finds no key, and reports "Not logged in".

## Fix

Explicitly forward critical `CLAUDE_CODE_*` env vars through the `extra` map in `mergeEnv()`, which bypasses the filter. Applied to both `runTask()` and `handlePing()` code paths in `server/internal/daemon/daemon.go`.

The following vars are forwarded:
- `CLAUDE_CODE_USE_BEDROCK` — required for Bedrock auth
- `ANTHROPIC_SMALL_FAST_MODEL` — needed alongside Bedrock to override the small fast model (Haiku) to a permitted inference profile ARN

## Testing

1. Deploy daemon with `CLAUDE_CODE_USE_BEDROCK=1` set
2. Submit a task that routes to a Claude Code runtime
3. Verify the task completes successfully instead of failing with "Not logged in"
