### PR TITLE
feat(daemon): add periodic GC for workspace isolation directories

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -141,6 +141,8 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 		r.Post("/tasks/{taskId}/usage", h.ReportTaskUsage)
 		r.Post("/tasks/{taskId}/messages", h.ReportTaskMessages)
 		r.Get("/tasks/{taskId}/messages", h.ListTaskMessages)
+
+		r.Get("/issues/{issueId}/gc-check", h.GetIssueGCCheck)
 	})
 
 	// Protected API routes

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -198,6 +198,21 @@ func (c *Client) ListWorkspaces(ctx context.Context) ([]WorkspaceInfo, error) {
 	return workspaces, nil
 }
 
+// IssueGCStatus holds the minimal issue info returned by the GC check endpoint.
+type IssueGCStatus struct {
+	Status    string    `json:"status"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// GetIssueGCCheck returns the status and updated_at of an issue for GC decisions.
+func (c *Client) GetIssueGCCheck(ctx context.Context, issueID string) (*IssueGCStatus, error) {
+	var resp IssueGCStatus
+	if err := c.getJSON(ctx, fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 func (c *Client) Deregister(ctx context.Context, runtimeIDs []string) error {
 	return c.postJSON(ctx, "/api/daemon/deregister", map[string]any{
 		"runtime_ids": runtimeIDs,

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -20,6 +20,9 @@ const (
 	DefaultWorkspaceSyncInterval = 30 * time.Second
 	DefaultHealthPort            = 19514
 	DefaultMaxConcurrentTasks    = 20
+	DefaultGCInterval            = 1 * time.Hour
+	DefaultGCTTL                 = 5 * 24 * time.Hour // 5 days
+	DefaultGCOrphanTTL           = 30 * 24 * time.Hour // 30 days
 )
 
 // Config holds all daemon configuration.
@@ -35,6 +38,10 @@ type Config struct {
 	KeepEnvAfterTask   bool                  // preserve env after task for debugging
 	HealthPort         int                   // local HTTP port for health checks (default: 19514)
 	MaxConcurrentTasks int                   // max tasks running in parallel (default: 20)
+	GCEnabled          bool                  // enable periodic workspace garbage collection (default: true)
+	GCInterval         time.Duration         // how often the GC loop runs (default: 1h)
+	GCTTL              time.Duration         // clean dirs whose issue is done/canceled and updated_at < now()-TTL (default: 5d)
+	GCOrphanTTL        time.Duration         // clean orphan dirs (no meta or unknown issue) older than this (default: 30d)
 	PollInterval       time.Duration
 	HeartbeatInterval  time.Duration
 	AgentTimeout       time.Duration
@@ -203,6 +210,24 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	// Keep env after task: env > default (false)
 	keepEnv := os.Getenv("MULTICA_KEEP_ENV_AFTER_TASK") == "true" || os.Getenv("MULTICA_KEEP_ENV_AFTER_TASK") == "1"
 
+	// GC config: env > defaults
+	gcEnabled := true
+	if v := os.Getenv("MULTICA_GC_ENABLED"); v == "false" || v == "0" {
+		gcEnabled = false
+	}
+	gcInterval, err := durationFromEnv("MULTICA_GC_INTERVAL", DefaultGCInterval)
+	if err != nil {
+		return Config{}, err
+	}
+	gcTTL, err := durationFromEnv("MULTICA_GC_TTL", DefaultGCTTL)
+	if err != nil {
+		return Config{}, err
+	}
+	gcOrphanTTL, err := durationFromEnv("MULTICA_GC_ORPHAN_TTL", DefaultGCOrphanTTL)
+	if err != nil {
+		return Config{}, err
+	}
+
 	return Config{
 		ServerBaseURL:      serverBaseURL,
 		DaemonID:           daemonID,
@@ -212,6 +237,10 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		Agents:             agents,
 		WorkspacesRoot:     workspacesRoot,
 		KeepEnvAfterTask:   keepEnv,
+		GCEnabled:          gcEnabled,
+		GCInterval:         gcInterval,
+		GCTTL:              gcTTL,
+		GCOrphanTTL:        gcOrphanTTL,
 		HealthPort:         healthPort,
 		MaxConcurrentTasks: maxConcurrentTasks,
 		PollInterval:       pollInterval,

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -102,6 +102,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	go d.heartbeatLoop(ctx)
 	go d.usageScanLoop(ctx)
+	go d.gcLoop(ctx)
 	go d.serveHealth(ctx, healthLn, time.Now())
 	return d.pollLoop(ctx)
 }
@@ -927,6 +928,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	// NOTE: No cleanup — workdir is preserved for reuse by future tasks on
 	// the same (agent, issue) pair. The work_dir path is stored in DB on
 	// task completion and passed back via PriorWorkDir on the next claim.
+
+	// Write GC metadata so the periodic GC loop can look up the issue later.
+	if err := env.WriteGCMeta(task.IssueID, task.WorkspaceID); err != nil {
+		taskLog.Warn("write gc meta failed (non-fatal)", "error", err)
+	}
 
 	prompt := BuildPrompt(task)
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -871,6 +871,15 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 			}
 		}
 	}
+
+	// Write GC metadata after the task finishes so the periodic GC loop
+	// can look up the issue later. Written last so that a mid-task crash
+	// leaves the directory as an orphan (cleaned up by GCOrphanTTL).
+	if result.EnvRoot != "" {
+		if err := execenv.WriteGCMeta(result.EnvRoot, task.IssueID, task.WorkspaceID); err != nil {
+			taskLog.Warn("write gc meta failed (non-fatal)", "error", err)
+		}
+	}
 }
 
 func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLog *slog.Logger) (TaskResult, error) {
@@ -928,11 +937,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	// NOTE: No cleanup — workdir is preserved for reuse by future tasks on
 	// the same (agent, issue) pair. The work_dir path is stored in DB on
 	// task completion and passed back via PriorWorkDir on the next claim.
-
-	// Write GC metadata so the periodic GC loop can look up the issue later.
-	if err := env.WriteGCMeta(task.IssueID, task.WorkspaceID); err != nil {
-		taskLog.Warn("write gc meta failed (non-fatal)", "error", err)
-	}
 
 	prompt := BuildPrompt(task)
 
@@ -1157,6 +1161,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 			Comment:   result.Output,
 			SessionID: result.SessionID,
 			WorkDir:   env.WorkDir,
+			EnvRoot:   env.RootDir,
 			Usage:     usageEntries,
 		}, nil
 	case "timeout":
@@ -1166,7 +1171,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		if errMsg == "" {
 			errMsg = fmt.Sprintf("%s execution %s", provider, result.Status)
 		}
-		return TaskResult{Status: "blocked", Comment: errMsg, Usage: usageEntries}, nil
+		return TaskResult{Status: "blocked", Comment: errMsg, EnvRoot: env.RootDir, Usage: usageEntries}, nil
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -168,9 +168,9 @@ type GCMeta struct {
 
 const gcMetaFile = ".gc_meta.json"
 
-// WriteGCMeta writes GC metadata into the environment root directory.
-func (env *Environment) WriteGCMeta(issueID, workspaceID string) error {
-	if env == nil {
+// WriteGCMeta writes GC metadata into the given directory.
+func WriteGCMeta(envRoot, issueID, workspaceID string) error {
+	if envRoot == "" {
 		return nil
 	}
 	meta := GCMeta{
@@ -182,7 +182,7 @@ func (env *Environment) WriteGCMeta(issueID, workspaceID string) error {
 	if err != nil {
 		return fmt.Errorf("marshal gc meta: %w", err)
 	}
-	return os.WriteFile(filepath.Join(env.RootDir, gcMetaFile), data, 0o644)
+	return os.WriteFile(filepath.Join(envRoot, gcMetaFile), data, 0o644)
 }
 
 // ReadGCMeta reads GC metadata from a task directory root.

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -4,10 +4,12 @@
 package execenv
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // RepoContextForEnv describes a workspace repo available for checkout.
@@ -154,6 +156,46 @@ func Reuse(workDir, provider string, task TaskContextForEnv, logger *slog.Logger
 
 	logger.Info("execenv: reusing env", "workdir", workDir)
 	return env
+}
+
+// GCMeta is persisted to .gc_meta.json inside the env root so the GC loop
+// can determine which issue this directory belongs to.
+type GCMeta struct {
+	IssueID     string    `json:"issue_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+const gcMetaFile = ".gc_meta.json"
+
+// WriteGCMeta writes GC metadata into the environment root directory.
+func (env *Environment) WriteGCMeta(issueID, workspaceID string) error {
+	if env == nil {
+		return nil
+	}
+	meta := GCMeta{
+		IssueID:     issueID,
+		WorkspaceID: workspaceID,
+		CompletedAt: time.Now().UTC(),
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshal gc meta: %w", err)
+	}
+	return os.WriteFile(filepath.Join(env.RootDir, gcMetaFile), data, 0o644)
+}
+
+// ReadGCMeta reads GC metadata from a task directory root.
+func ReadGCMeta(envRoot string) (*GCMeta, error) {
+	data, err := os.ReadFile(filepath.Join(envRoot, gcMetaFile))
+	if err != nil {
+		return nil, err
+	}
+	var meta GCMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
 }
 
 // Cleanup tears down the execution environment.

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -920,3 +920,46 @@ func TestEnsureSymlinkRepairsBrokenLink(t *testing.T) {
 		t.Errorf("content = %q, want %q", data, "real")
 	}
 }
+
+func TestWriteReadGCMeta(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	issueID := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	wsID := "ws-test-001"
+
+	if err := WriteGCMeta(dir, issueID, wsID); err != nil {
+		t.Fatalf("WriteGCMeta: %v", err)
+	}
+
+	meta, err := ReadGCMeta(dir)
+	if err != nil {
+		t.Fatalf("ReadGCMeta: %v", err)
+	}
+
+	if meta.IssueID != issueID {
+		t.Errorf("IssueID = %q, want %q", meta.IssueID, issueID)
+	}
+	if meta.WorkspaceID != wsID {
+		t.Errorf("WorkspaceID = %q, want %q", meta.WorkspaceID, wsID)
+	}
+	if meta.CompletedAt.IsZero() {
+		t.Error("CompletedAt should not be zero")
+	}
+}
+
+func TestWriteGCMeta_EmptyRoot(t *testing.T) {
+	t.Parallel()
+	if err := WriteGCMeta("", "issue", "ws"); err != nil {
+		t.Fatalf("expected nil for empty root, got %v", err)
+	}
+}
+
+func TestReadGCMeta_NoFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := ReadGCMeta(dir)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -204,17 +204,21 @@ func (d *Daemon) pruneRepoWorktrees(workspacesRoot string) {
 			if !isBareRepo(barePath) {
 				continue
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
-			cmd := exec.CommandContext(ctx, "git", "-C", barePath, "worktree", "prune")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				d.logger.Warn("gc: worktree prune failed",
-					"repo", barePath,
-					"output", strings.TrimSpace(string(out)),
-					"error", err,
-				)
-			}
-			cancel()
+			d.pruneWorktree(barePath)
 		}
+	}
+}
+
+func (d *Daemon) pruneWorktree(barePath string) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", barePath, "worktree", "prune")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		d.logger.Warn("gc: worktree prune failed",
+			"repo", barePath,
+			"output", strings.TrimSpace(string(out)),
+			"error", err,
+		)
 	}
 }
 

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -1,0 +1,213 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+)
+
+// gcLoop periodically scans local workspace directories and removes those
+// whose issue is done/canceled and hasn't been updated within the configured TTL.
+func (d *Daemon) gcLoop(ctx context.Context) {
+	if !d.cfg.GCEnabled {
+		d.logger.Info("gc: disabled")
+		return
+	}
+	d.logger.Info("gc: started", "interval", d.cfg.GCInterval, "ttl", d.cfg.GCTTL, "orphan_ttl", d.cfg.GCOrphanTTL)
+
+	// Run once at startup after a short delay (let the daemon finish initializing).
+	if err := sleepWithContext(ctx, 30*time.Second); err != nil {
+		return
+	}
+	d.runGC(ctx)
+
+	ticker := time.NewTicker(d.cfg.GCInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.runGC(ctx)
+		}
+	}
+}
+
+// runGC performs a single GC scan across all workspace directories.
+func (d *Daemon) runGC(ctx context.Context) {
+	root := d.cfg.WorkspacesRoot
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		d.logger.Warn("gc: read workspaces root failed", "error", err)
+		return
+	}
+
+	var cleaned, skipped, orphaned int
+	for _, wsEntry := range entries {
+		if !wsEntry.IsDir() || wsEntry.Name() == ".repos" {
+			continue
+		}
+		wsDir := filepath.Join(root, wsEntry.Name())
+		c, s, o := d.gcWorkspace(ctx, wsDir)
+		cleaned += c
+		skipped += s
+		orphaned += o
+	}
+
+	// Prune stale worktree references from all bare repo caches.
+	d.pruneRepoWorktrees(root)
+
+	if cleaned > 0 || orphaned > 0 {
+		d.logger.Info("gc: cycle complete", "cleaned", cleaned, "orphaned", orphaned, "skipped", skipped)
+	}
+}
+
+// gcWorkspace scans task directories inside a single workspace directory.
+func (d *Daemon) gcWorkspace(ctx context.Context, wsDir string) (cleaned, skipped, orphaned int) {
+	taskEntries, err := os.ReadDir(wsDir)
+	if err != nil {
+		d.logger.Warn("gc: read workspace dir failed", "dir", wsDir, "error", err)
+		return
+	}
+
+	for _, entry := range taskEntries {
+		if ctx.Err() != nil {
+			return
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		taskDir := filepath.Join(wsDir, entry.Name())
+		action := d.shouldCleanTaskDir(ctx, taskDir)
+		switch action {
+		case gcActionClean:
+			d.cleanTaskDir(taskDir)
+			cleaned++
+		case gcActionOrphan:
+			d.cleanTaskDir(taskDir)
+			orphaned++
+		default:
+			skipped++
+		}
+	}
+	return
+}
+
+type gcAction int
+
+const (
+	gcActionSkip   gcAction = iota
+	gcActionClean           // issue is done/canceled and stale
+	gcActionOrphan          // no meta or unknown issue and dir is old
+)
+
+// shouldCleanTaskDir decides whether a task directory should be removed.
+func (d *Daemon) shouldCleanTaskDir(ctx context.Context, taskDir string) gcAction {
+	meta, err := execenv.ReadGCMeta(taskDir)
+	if err != nil {
+		// No .gc_meta.json — check mtime for orphan cleanup.
+		info, statErr := os.Stat(taskDir)
+		if statErr != nil {
+			return gcActionSkip
+		}
+		if time.Since(info.ModTime()) > d.cfg.GCOrphanTTL {
+			d.logger.Info("gc: orphan directory (no meta)", "dir", taskDir, "age", time.Since(info.ModTime()).Round(time.Hour))
+			return gcActionOrphan
+		}
+		return gcActionSkip
+	}
+
+	status, err := d.client.GetIssueGCCheck(ctx, meta.IssueID)
+	if err != nil {
+		var reqErr *requestError
+		if errors.As(err, &reqErr) && reqErr.StatusCode == http.StatusNotFound {
+			// Issue deleted — check mtime for orphan cleanup.
+			info, statErr := os.Stat(taskDir)
+			if statErr != nil {
+				return gcActionSkip
+			}
+			if time.Since(info.ModTime()) > d.cfg.GCOrphanTTL {
+				d.logger.Info("gc: orphan directory (issue deleted)", "dir", taskDir, "issue", meta.IssueID)
+				return gcActionOrphan
+			}
+		}
+		// API error (network, auth, etc.) — skip and retry next cycle.
+		return gcActionSkip
+	}
+
+	if (status.Status == "done" || status.Status == "canceled") &&
+		time.Since(status.UpdatedAt) > d.cfg.GCTTL {
+		d.logger.Info("gc: eligible for cleanup",
+			"dir", filepath.Base(taskDir),
+			"issue", meta.IssueID,
+			"status", status.Status,
+			"updated_at", status.UpdatedAt.Format(time.RFC3339),
+		)
+		return gcActionClean
+	}
+
+	return gcActionSkip
+}
+
+// cleanTaskDir removes a task directory and logs the result.
+func (d *Daemon) cleanTaskDir(taskDir string) {
+	if err := os.RemoveAll(taskDir); err != nil {
+		d.logger.Warn("gc: remove task dir failed", "dir", taskDir, "error", err)
+	} else {
+		d.logger.Info("gc: removed", "dir", taskDir)
+	}
+}
+
+// pruneRepoWorktrees runs `git worktree prune` on all bare repos in the cache.
+func (d *Daemon) pruneRepoWorktrees(workspacesRoot string) {
+	reposRoot := filepath.Join(workspacesRoot, ".repos")
+	wsEntries, err := os.ReadDir(reposRoot)
+	if err != nil {
+		return
+	}
+
+	for _, wsEntry := range wsEntries {
+		if !wsEntry.IsDir() {
+			continue
+		}
+		wsRepoDir := filepath.Join(reposRoot, wsEntry.Name())
+		repoEntries, err := os.ReadDir(wsRepoDir)
+		if err != nil {
+			continue
+		}
+		for _, repoEntry := range repoEntries {
+			if !repoEntry.IsDir() {
+				continue
+			}
+			barePath := filepath.Join(wsRepoDir, repoEntry.Name())
+			if !isBareRepo(barePath) {
+				continue
+			}
+			cmd := exec.Command("git", "-C", barePath, "worktree", "prune")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				d.logger.Warn("gc: worktree prune failed",
+					"repo", barePath,
+					"output", strings.TrimSpace(string(out)),
+					"error", err,
+				)
+			}
+		}
+	}
+}
+
+// isBareRepo checks if a path looks like a bare git repository.
+func isBareRepo(path string) bool {
+	_, err := os.Stat(filepath.Join(path, "HEAD"))
+	return err == nil
+}

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -101,6 +101,14 @@ func (d *Daemon) gcWorkspace(ctx context.Context, wsDir string) (cleaned, skippe
 			skipped++
 		}
 	}
+
+	// Remove the workspace directory itself if it's now empty.
+	if cleaned+orphaned > 0 {
+		remaining, _ := os.ReadDir(wsDir)
+		if len(remaining) == 0 {
+			os.Remove(wsDir)
+		}
+	}
 	return
 }
 
@@ -169,6 +177,8 @@ func (d *Daemon) cleanTaskDir(taskDir string) {
 	}
 }
 
+const gitCmdTimeout = 30 * time.Second
+
 // pruneRepoWorktrees runs `git worktree prune` on all bare repos in the cache.
 func (d *Daemon) pruneRepoWorktrees(workspacesRoot string) {
 	reposRoot := filepath.Join(workspacesRoot, ".repos")
@@ -194,7 +204,8 @@ func (d *Daemon) pruneRepoWorktrees(workspacesRoot string) {
 			if !isBareRepo(barePath) {
 				continue
 			}
-			cmd := exec.Command("git", "-C", barePath, "worktree", "prune")
+			ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
+			cmd := exec.CommandContext(ctx, "git", "-C", barePath, "worktree", "prune")
 			if out, err := cmd.CombinedOutput(); err != nil {
 				d.logger.Warn("gc: worktree prune failed",
 					"repo", barePath,
@@ -202,12 +213,18 @@ func (d *Daemon) pruneRepoWorktrees(workspacesRoot string) {
 					"error", err,
 				)
 			}
+			cancel()
 		}
 	}
 }
 
 // isBareRepo checks if a path looks like a bare git repository.
 func isBareRepo(path string) bool {
-	_, err := os.Stat(filepath.Join(path, "HEAD"))
-	return err == nil
+	if _, err := os.Stat(filepath.Join(path, "HEAD")); err != nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "objects")); err != nil {
+		return false
+	}
+	return true
 }

--- a/server/internal/daemon/gc_test.go
+++ b/server/internal/daemon/gc_test.go
@@ -1,0 +1,300 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+)
+
+// newTestDaemon creates a minimal Daemon for GC testing with a mock HTTP server.
+func newTestDaemon(t *testing.T, handler http.Handler) *Daemon {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	root := t.TempDir()
+	cfg := Config{
+		WorkspacesRoot: root,
+		GCEnabled:      true,
+		GCInterval:     1 * time.Hour,
+		GCTTL:          5 * 24 * time.Hour,
+		GCOrphanTTL:    30 * 24 * time.Hour,
+	}
+	d := New(cfg, slog.Default())
+	d.client = NewClient(srv.URL)
+	d.client.SetToken("test-token")
+	return d
+}
+
+// createTaskDir creates a task directory with optional GC metadata.
+func createTaskDir(t *testing.T, root, wsID, dirName string, meta *execenv.GCMeta) string {
+	t.Helper()
+	taskDir := filepath.Join(root, wsID, dirName)
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if meta != nil {
+		data, _ := json.Marshal(meta)
+		if err := os.WriteFile(filepath.Join(taskDir, ".gc_meta.json"), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return taskDir
+}
+
+func TestShouldCleanTaskDir_DoneIssueOverTTL(t *testing.T) {
+	t.Parallel()
+	issueID := "11111111-1111-1111-1111-111111111111"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":     "done",
+			"updated_at": time.Now().Add(-10 * 24 * time.Hour), // 10 days ago
+		})
+	})
+
+	d := newTestDaemon(t, mux)
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task1", &execenv.GCMeta{
+		IssueID:     issueID,
+		WorkspaceID: "ws1",
+		CompletedAt: time.Now().Add(-10 * 24 * time.Hour),
+	})
+
+	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	if action != gcActionClean {
+		t.Fatalf("expected gcActionClean, got %d", action)
+	}
+}
+
+func TestShouldCleanTaskDir_CanceledIssueOverTTL(t *testing.T) {
+	t.Parallel()
+	issueID := "22222222-2222-2222-2222-222222222222"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":     "canceled",
+			"updated_at": time.Now().Add(-6 * 24 * time.Hour),
+		})
+	})
+
+	d := newTestDaemon(t, mux)
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task2", &execenv.GCMeta{
+		IssueID:     issueID,
+		WorkspaceID: "ws1",
+		CompletedAt: time.Now(),
+	})
+
+	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	if action != gcActionClean {
+		t.Fatalf("expected gcActionClean, got %d", action)
+	}
+}
+
+func TestShouldCleanTaskDir_OpenIssueSkipped(t *testing.T) {
+	t.Parallel()
+	issueID := "33333333-3333-3333-3333-333333333333"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":     "in_progress",
+			"updated_at": time.Now().Add(-30 * 24 * time.Hour),
+		})
+	})
+
+	d := newTestDaemon(t, mux)
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task3", &execenv.GCMeta{
+		IssueID:     issueID,
+		WorkspaceID: "ws1",
+		CompletedAt: time.Now(),
+	})
+
+	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	if action != gcActionSkip {
+		t.Fatalf("expected gcActionSkip for open issue, got %d", action)
+	}
+}
+
+func TestShouldCleanTaskDir_DoneButRecentSkipped(t *testing.T) {
+	t.Parallel()
+	issueID := "44444444-4444-4444-4444-444444444444"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":     "done",
+			"updated_at": time.Now().Add(-1 * 24 * time.Hour), // 1 day ago, within TTL
+		})
+	})
+
+	d := newTestDaemon(t, mux)
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task4", &execenv.GCMeta{
+		IssueID:     issueID,
+		WorkspaceID: "ws1",
+		CompletedAt: time.Now(),
+	})
+
+	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	if action != gcActionSkip {
+		t.Fatalf("expected gcActionSkip for recently-done issue, got %d", action)
+	}
+}
+
+func TestShouldCleanTaskDir_NoMetaRecentSkipped(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t, http.NewServeMux())
+	// No meta, fresh directory — should skip.
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task5", nil)
+
+	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	if action != gcActionSkip {
+		t.Fatalf("expected gcActionSkip for recent orphan, got %d", action)
+	}
+}
+
+func TestShouldCleanTaskDir_NoMetaOldOrphan(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t, http.NewServeMux())
+	d.cfg.GCOrphanTTL = 0 // treat all orphans as expired
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task6", nil)
+
+	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	if action != gcActionOrphan {
+		t.Fatalf("expected gcActionOrphan, got %d", action)
+	}
+}
+
+func TestShouldCleanTaskDir_APIErrorSkipped(t *testing.T) {
+	t.Parallel()
+	issueID := "55555555-5555-5555-5555-555555555555"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	d := newTestDaemon(t, mux)
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task7", &execenv.GCMeta{
+		IssueID:     issueID,
+		WorkspaceID: "ws1",
+		CompletedAt: time.Now(),
+	})
+
+	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	if action != gcActionSkip {
+		t.Fatalf("expected gcActionSkip on API error, got %d", action)
+	}
+}
+
+func TestShouldCleanTaskDir_Issue404OldOrphan(t *testing.T) {
+	t.Parallel()
+	issueID := "66666666-6666-6666-6666-666666666666"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"issue not found"}`))
+	})
+
+	d := newTestDaemon(t, mux)
+	d.cfg.GCOrphanTTL = 0 // treat orphans as immediately eligible
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "task8", &execenv.GCMeta{
+		IssueID:     issueID,
+		WorkspaceID: "ws1",
+		CompletedAt: time.Now(),
+	})
+
+	action := d.shouldCleanTaskDir(context.Background(), taskDir)
+	if action != gcActionOrphan {
+		t.Fatalf("expected gcActionOrphan for deleted issue, got %d", action)
+	}
+}
+
+func TestCleanTaskDir_RemovesDirectory(t *testing.T) {
+	t.Parallel()
+	d := newTestDaemon(t, http.NewServeMux())
+	taskDir := createTaskDir(t, d.cfg.WorkspacesRoot, "ws1", "doomed", nil)
+
+	if _, err := os.Stat(taskDir); err != nil {
+		t.Fatal("task dir should exist before cleanup")
+	}
+
+	d.cleanTaskDir(taskDir)
+
+	if _, err := os.Stat(taskDir); !os.IsNotExist(err) {
+		t.Fatal("task dir should be removed after cleanup")
+	}
+}
+
+func TestGcWorkspace_CleansEmptyWorkspaceDir(t *testing.T) {
+	t.Parallel()
+	issueID := "77777777-7777-7777-7777-777777777777"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/api/daemon/issues/%s/gc-check", issueID), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":     "done",
+			"updated_at": time.Now().Add(-10 * 24 * time.Hour),
+		})
+	})
+
+	d := newTestDaemon(t, mux)
+	wsDir := filepath.Join(d.cfg.WorkspacesRoot, "ws-empty")
+	createTaskDir(t, d.cfg.WorkspacesRoot, "ws-empty", "only-task", &execenv.GCMeta{
+		IssueID:     issueID,
+		WorkspaceID: "ws-empty",
+		CompletedAt: time.Now(),
+	})
+
+	d.gcWorkspace(context.Background(), wsDir)
+
+	if _, err := os.Stat(wsDir); !os.IsNotExist(err) {
+		t.Fatal("empty workspace dir should be removed after all tasks cleaned")
+	}
+}
+
+func TestIsBareRepo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid bare repo", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "HEAD"), []byte("ref: refs/heads/main"), 0o644)
+		os.MkdirAll(filepath.Join(dir, "objects"), 0o755)
+		if !isBareRepo(dir) {
+			t.Fatal("expected isBareRepo=true for dir with HEAD + objects/")
+		}
+	})
+
+	t.Run("HEAD only", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "HEAD"), []byte("ref: refs/heads/main"), 0o644)
+		if isBareRepo(dir) {
+			t.Fatal("expected isBareRepo=false for dir with only HEAD")
+		}
+	})
+
+	t.Run("empty dir", func(t *testing.T) {
+		dir := t.TempDir()
+		if isBareRepo(dir) {
+			t.Fatal("expected isBareRepo=false for empty dir")
+		}
+	})
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -76,5 +76,6 @@ type TaskResult struct {
 	EnvType    string           `json:"env_type,omitempty"`
 	SessionID  string           `json:"session_id,omitempty"` // Claude session ID for future resumption
 	WorkDir    string           `json:"work_dir,omitempty"`   // working directory used during execution
+	EnvRoot    string           `json:"-"`                    // env root dir for writing GC metadata (not sent to server)
 	Usage      []TaskUsageEntry `json:"usage,omitempty"`      // per-model token usage
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -842,3 +842,17 @@ func (h *Handler) GetIssueUsage(w http.ResponseWriter, r *http.Request) {
 		"task_count":               row.TaskCount,
 	})
 }
+
+// GetIssueGCCheck returns minimal issue info needed by the daemon GC loop.
+func (h *Handler) GetIssueGCCheck(w http.ResponseWriter, r *http.Request) {
+	issueID := chi.URLParam(r, "issueId")
+	issue, err := h.Queries.GetIssue(r.Context(), parseUUID(issueID))
+	if err != nil {
+		writeError(w, http.StatusNotFound, "issue not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":     issue.Status,
+		"updated_at": issue.UpdatedAt.Time,
+	})
+}


### PR DESCRIPTION
## Summary
- Add a background GC loop to the daemon that periodically scans local workspace directories and removes those whose issue is `done`/`canceled` and hasn't been updated in 5 days (configurable via `MULTICA_GC_TTL`)
- Write `.gc_meta.json` (issue_id, workspace_id) at task completion so GC can look up issue status via `GET /api/daemon/issues/{id}/gc-check`
- Prune stale git worktree references from bare repo caches each GC cycle
- Orphan directories (no metadata or deleted issues) cleaned after 30 days (`MULTICA_GC_ORPHAN_TTL`)
- New env vars: `MULTICA_GC_ENABLED` (default true), `MULTICA_GC_INTERVAL` (default 1h), `MULTICA_GC_TTL` (default 5d), `MULTICA_GC_ORPHAN_TTL` (default 30d)

## Test plan
- [x] Unit tests for all `shouldCleanTaskDir` scenarios (done+TTL, canceled+TTL, open skip, recent skip, orphan, API error skip, 404 orphan)
- [x] `WriteGCMeta`/`ReadGCMeta` round-trip serialization tests
- [x] `isBareRepo` validation tests
- [x] Empty workspace directory cleanup test
- [x] All existing Go tests pass (`go test ./...`)

Closes MUL-547

🤖 Generated with [Claude Code](https://claude.com/claude-code)