### PR TITLE
fix(desktop): strip Origin header from WebSocket requests

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -44,6 +44,16 @@ function createWindow(): void {
     },
   });
 
+  // Strip Origin header from WebSocket upgrade requests so the server's
+  // origin whitelist doesn't reject connections from localhost dev origins.
+  mainWindow.webContents.session.webRequest.onBeforeSendHeaders(
+    { urls: ["wss://*/*", "ws://*/*"] },
+    (details, callback) => {
+      delete details.requestHeaders["Origin"];
+      callback({ requestHeaders: details.requestHeaders });
+    },
+  );
+
   mainWindow.on("ready-to-show", () => {
     mainWindow?.show();
   });


### PR DESCRIPTION
## Summary
- Strip Origin header from WebSocket upgrade requests in Electron main process
- Fixes 403 rejection from server's WS origin whitelist (added in #819) which doesn't include `localhost:5173`
- Desktop app doesn't need Origin-based security since it runs in Electron with `webSecurity: false`

## Test plan
- [x] Desktop app WS connection stays open (no more rapid connect/disconnect loop)
- [x] Real-time updates work in desktop app