### PR TITLE
fix(server): restrict issue subscriber management

### DIFF
--- a/server/internal/handler/subscriber.go
+++ b/server/internal/handler/subscriber.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -26,6 +27,69 @@ func subscriberToResponse(s db.IssueSubscriber) SubscriberResponse {
 		Reason:    s.Reason,
 		CreatedAt: timestampToString(s.CreatedAt),
 	}
+}
+
+type issueSubscriberRequest struct {
+	UserID   *string `json:"user_id"`
+	UserType *string `json:"user_type"`
+}
+
+func (h *Handler) resolveIssueSubscriberTarget(w http.ResponseWriter, r *http.Request, workspaceID string) (string, string, bool) {
+	callerID, ok := requireUserID(w, r)
+	if !ok {
+		return "", "", false
+	}
+
+	targetUserID := callerID
+	targetUserType := "member"
+
+	var req issueSubscriberRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return "", "", false
+		}
+	}
+
+	if req.UserID != nil && *req.UserID != "" {
+		targetUserID = *req.UserID
+	}
+	if req.UserType != nil && *req.UserType != "" {
+		targetUserType = *req.UserType
+	}
+
+	switch targetUserType {
+	case "member":
+		if targetUserID != callerID {
+			if _, ok := h.requireWorkspaceRole(w, r, workspaceID, "issue not found", "owner", "admin"); !ok {
+				return "", "", false
+			}
+		}
+		if _, err := h.getWorkspaceMember(r.Context(), targetUserID, workspaceID); err != nil {
+			writeError(w, http.StatusNotFound, "subscriber target not found")
+			return "", "", false
+		}
+	case "agent":
+		if req.UserID == nil || *req.UserID == "" {
+			writeError(w, http.StatusBadRequest, "user_id is required for agent subscribers")
+			return "", "", false
+		}
+		if _, ok := h.requireWorkspaceRole(w, r, workspaceID, "issue not found", "owner", "admin"); !ok {
+			return "", "", false
+		}
+		if _, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
+			ID:          parseUUID(targetUserID),
+			WorkspaceID: parseUUID(workspaceID),
+		}); err != nil {
+			writeError(w, http.StatusNotFound, "subscriber target not found")
+			return "", "", false
+		}
+	default:
+		writeError(w, http.StatusBadRequest, "invalid user_type")
+		return "", "", false
+	}
+
+	return targetUserType, targetUserID, true
 }
 
 // ListIssueSubscribers returns all subscribers for an issue.
@@ -59,21 +123,10 @@ func (h *Handler) SubscribeToIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Default to current user as member; allow specifying another user/agent
-	targetUserID := requestUserID(r)
-	targetUserType := "member"
-	var req struct {
-		UserID   *string `json:"user_id"`
-		UserType *string `json:"user_type"`
-	}
-	if r.Body != nil {
-		json.NewDecoder(r.Body).Decode(&req)
-	}
-	if req.UserID != nil && *req.UserID != "" {
-		targetUserID = *req.UserID
-	}
-	if req.UserType != nil && *req.UserType != "" {
-		targetUserType = *req.UserType
+	workspaceID := uuidToString(issue.WorkspaceID)
+	targetUserType, targetUserID, ok := h.resolveIssueSubscriberTarget(w, r, workspaceID)
+	if !ok {
+		return
 	}
 
 	err := h.Queries.AddIssueSubscriber(r.Context(), db.AddIssueSubscriberParams{
@@ -87,7 +140,6 @@ func (h *Handler) SubscribeToIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workspaceID := uuidToString(issue.WorkspaceID)
 	callerID := requestUserID(r)
 	subActorType, subActorID := h.resolveActor(r, callerID, workspaceID)
 	h.publish(protocol.EventSubscriberAdded, workspaceID, subActorType, subActorID, map[string]any{
@@ -109,20 +161,10 @@ func (h *Handler) UnsubscribeFromIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	targetUserID := requestUserID(r)
-	targetUserType := "member"
-	var req struct {
-		UserID   *string `json:"user_id"`
-		UserType *string `json:"user_type"`
-	}
-	if r.Body != nil {
-		json.NewDecoder(r.Body).Decode(&req)
-	}
-	if req.UserID != nil && *req.UserID != "" {
-		targetUserID = *req.UserID
-	}
-	if req.UserType != nil && *req.UserType != "" {
-		targetUserType = *req.UserType
+	workspaceID := uuidToString(issue.WorkspaceID)
+	targetUserType, targetUserID, ok := h.resolveIssueSubscriberTarget(w, r, workspaceID)
+	if !ok {
+		return
 	}
 
 	err := h.Queries.RemoveIssueSubscriber(r.Context(), db.RemoveIssueSubscriberParams{
@@ -135,7 +177,6 @@ func (h *Handler) UnsubscribeFromIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workspaceID := uuidToString(issue.WorkspaceID)
 	callerID := requestUserID(r)
 	unsubActorType, unsubActorID := h.resolveActor(r, callerID, workspaceID)
 	h.publish(protocol.EventSubscriberRemoved, workspaceID, unsubActorType, unsubActorID, map[string]any{

--- a/server/internal/handler/subscriber_test.go
+++ b/server/internal/handler/subscriber_test.go
@@ -3,12 +3,107 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
+
+func newRequestForUser(userID, method, path string, body any) *http.Request {
+	req := newRequest(method, path, body)
+	req.Header.Set("X-User-ID", userID)
+	return req
+}
+
+func createWorkspaceMember(t *testing.T, workspaceID, role, label string) string {
+	t.Helper()
+
+	slugPart := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-"))
+	email := fmt.Sprintf("%s-%s@multica.ai", slugPart, label)
+	name := fmt.Sprintf("Subscriber %s", label)
+
+	var userID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO "user" (name, email)
+		VALUES ($1, $2)
+		RETURNING id
+	`, name, email).Scan(&userID); err != nil {
+		t.Fatalf("createWorkspaceMember user: %v", err)
+	}
+
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, $3)
+	`, workspaceID, userID, role); err != nil {
+		t.Fatalf("createWorkspaceMember member: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+
+	return userID
+}
+
+func createExternalMember(t *testing.T, label string) string {
+	t.Helper()
+
+	slugPart := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-"))
+	email := fmt.Sprintf("%s-%s@multica.ai", slugPart, label)
+	workspaceSlug := fmt.Sprintf("%s-%s", slugPart, label)
+
+	var userID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO "user" (name, email)
+		VALUES ($1, $2)
+		RETURNING id
+	`, "External Subscriber", email).Scan(&userID); err != nil {
+		t.Fatalf("createExternalMember user: %v", err)
+	}
+
+	var workspaceID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`, "External Subscriber Workspace", workspaceSlug, "External subscriber test workspace", "EXT").Scan(&workspaceID); err != nil {
+		t.Fatalf("createExternalMember workspace: %v", err)
+	}
+
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'member')
+	`, workspaceID, userID); err != nil {
+		t.Fatalf("createExternalMember member: %v", err)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, workspaceID)
+		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+
+	return userID
+}
+
+func getWorkspaceAgentID(t *testing.T, workspaceID string) string {
+	t.Helper()
+
+	var agentID string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT id
+		FROM agent
+		WHERE workspace_id = $1
+		ORDER BY created_at ASC
+		LIMIT 1
+	`, workspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("getWorkspaceAgentID: %v", err)
+	}
+
+	return agentID
+}
 
 func TestSubscriberAPI(t *testing.T) {
 	ctx := context.Background()
@@ -203,6 +298,144 @@ func TestSubscriberAPI(t *testing.T) {
 		json.NewDecoder(w.Body).Decode(&subscribers)
 		if len(subscribers) != 0 {
 			t.Fatalf("ListIssueSubscribers: expected 0 subscribers after unsubscribe, got %d", len(subscribers))
+		}
+	})
+
+	t.Run("SubscribeOtherMemberRequiresAdmin", func(t *testing.T) {
+		issueID := createIssue(t)
+		defer deleteIssue(t, issueID)
+
+		callerID := createWorkspaceMember(t, testWorkspaceID, "member", "caller-member")
+		targetUserID := createWorkspaceMember(t, testWorkspaceID, "member", "target-member")
+
+		w := httptest.NewRecorder()
+		req := newRequestForUser(callerID, "POST", "/api/issues/"+issueID+"/subscribe", map[string]any{
+			"user_id":   targetUserID,
+			"user_type": "member",
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.SubscribeToIssue(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("SubscribeToIssue: expected 403 for non-admin managing another member, got %d: %s", w.Code, w.Body.String())
+		}
+
+		subscribed, err := testHandler.Queries.IsIssueSubscriber(ctx, db.IsIssueSubscriberParams{
+			IssueID:  parseUUID(issueID),
+			UserType: "member",
+			UserID:   parseUUID(targetUserID),
+		})
+		if err != nil {
+			t.Fatalf("IsIssueSubscriber: %v", err)
+		}
+		if subscribed {
+			t.Fatal("expected target member to remain unsubscribed")
+		}
+	})
+
+	t.Run("SubscribeOtherMemberAllowedForOwner", func(t *testing.T) {
+		issueID := createIssue(t)
+		defer deleteIssue(t, issueID)
+
+		targetUserID := createWorkspaceMember(t, testWorkspaceID, "member", "owner-target-member")
+
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", map[string]any{
+			"user_id":   targetUserID,
+			"user_type": "member",
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.SubscribeToIssue(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("SubscribeToIssue: expected 200 for owner managing same-workspace member, got %d: %s", w.Code, w.Body.String())
+		}
+
+		subscribed, err := testHandler.Queries.IsIssueSubscriber(ctx, db.IsIssueSubscriberParams{
+			IssueID:  parseUUID(issueID),
+			UserType: "member",
+			UserID:   parseUUID(targetUserID),
+		})
+		if err != nil {
+			t.Fatalf("IsIssueSubscriber: %v", err)
+		}
+		if !subscribed {
+			t.Fatal("expected owner-managed member subscription to be stored")
+		}
+	})
+
+	t.Run("SubscribeForeignMemberRejected", func(t *testing.T) {
+		issueID := createIssue(t)
+		defer deleteIssue(t, issueID)
+
+		foreignUserID := createExternalMember(t, "foreign-member")
+
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", map[string]any{
+			"user_id":   foreignUserID,
+			"user_type": "member",
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.SubscribeToIssue(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("SubscribeToIssue: expected 404 for foreign member target, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("SubscribeAgentRequiresAdmin", func(t *testing.T) {
+		issueID := createIssue(t)
+		defer deleteIssue(t, issueID)
+
+		callerID := createWorkspaceMember(t, testWorkspaceID, "member", "agent-caller")
+		agentID := getWorkspaceAgentID(t, testWorkspaceID)
+
+		w := httptest.NewRecorder()
+		req := newRequestForUser(callerID, "POST", "/api/issues/"+issueID+"/subscribe", map[string]any{
+			"user_id":   agentID,
+			"user_type": "agent",
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.SubscribeToIssue(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("SubscribeToIssue: expected 403 for non-admin managing an agent subscriber, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("UnsubscribeOtherMemberRequiresAdmin", func(t *testing.T) {
+		issueID := createIssue(t)
+		defer deleteIssue(t, issueID)
+
+		callerID := createWorkspaceMember(t, testWorkspaceID, "member", "unsubscribe-caller")
+		targetUserID := createWorkspaceMember(t, testWorkspaceID, "member", "unsubscribe-target")
+
+		if err := testHandler.Queries.AddIssueSubscriber(ctx, db.AddIssueSubscriberParams{
+			IssueID:  parseUUID(issueID),
+			UserType: "member",
+			UserID:   parseUUID(targetUserID),
+			Reason:   "manual",
+		}); err != nil {
+			t.Fatalf("AddIssueSubscriber: %v", err)
+		}
+
+		w := httptest.NewRecorder()
+		req := newRequestForUser(callerID, "POST", "/api/issues/"+issueID+"/unsubscribe", map[string]any{
+			"user_id":   targetUserID,
+			"user_type": "member",
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.UnsubscribeFromIssue(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("UnsubscribeFromIssue: expected 403 for non-admin managing another member, got %d: %s", w.Code, w.Body.String())
+		}
+
+		subscribed, err := testHandler.Queries.IsIssueSubscriber(ctx, db.IsIssueSubscriberParams{
+			IssueID:  parseUUID(issueID),
+			UserType: "member",
+			UserID:   parseUUID(targetUserID),
+		})
+		if err != nil {
+			t.Fatalf("IsIssueSubscriber: %v", err)
+		}
+		if !subscribed {
+			t.Fatal("expected target member subscription to remain present")
 		}
 	})
 }


### PR DESCRIPTION
  ## What

  Restrict issue subscriber management so users can only manage their own member subscription by default. Managing another member's subscription or adding/removing agent subscribers now requires owner/admin
  access, and subscriber targets are validated against the workspace.

  ## Why

  This closes a permission gap where subscriber management could target other users or agents without the right workspace-level authorization. It also prevents subscriptions for members or agents that do not
  belong to the issue's workspace.

  Closes: MED-1 

  ## Summary

  - Restricts subscribe/unsubscribe operations for other members to workspace owners/admins
  - Requires owner/admin access for agent subscriber management
  - Validates that target members and agents belong to the issue workspace
  - Adds coverage for allowed and rejected subscriber-management cases

  ## Implementation

  - Added `resolveIssueSubscriberTarget` in `server/internal/handler/subscriber.go` to parse the request body, default to the caller, enforce role checks, and validate subscriber targets
  - Updated subscribe/unsubscribe handlers to use the shared target-resolution path before mutating issue subscribers
  - Added handler tests for:
    - non-admin trying to manage another member
    - owner managing another member
    - rejecting foreign-workspace members
    - non-admin trying to manage agent subscribers
    - non-admin trying to unsubscribe another member

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation
  - [ ] CI / infrastructure
  - [ ] Other (describe below)

  ## How to Test

  1. Create an issue in a workspace.
  2. Subscribe/unsubscribe yourself as a member and confirm it still works.
  3. As a non-admin member, try subscribing or unsubscribing another member and confirm the API returns `403`.
  4. As an owner/admin, subscribe another member in the same workspace and confirm it succeeds.
  5. Try subscribing a member from another workspace and confirm the API returns `404`.
  6. As a non-admin member, try subscribing an agent and confirm the API returns `403`.
