### PR TITLE
feat(agent): support custom environment variables for router/proxy mode

### DIFF
--- a/apps/web/test/helpers.tsx
+++ b/apps/web/test/helpers.tsx
@@ -54,6 +54,7 @@ export const mockAgents: Agent[] = [
     status: "idle",
     runtime_mode: "cloud",
     runtime_config: {},
+    custom_env: {},
     visibility: "workspace",
     max_concurrent_tasks: 3,
     owner_id: null,

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -47,6 +47,7 @@ export interface Agent {
   avatar_url: string | null;
   runtime_mode: AgentRuntimeMode;
   runtime_config: Record<string, unknown>;
+  custom_env: Record<string, string>;
   visibility: AgentVisibility;
   status: AgentStatus;
   max_concurrent_tasks: number;
@@ -65,6 +66,7 @@ export interface CreateAgentRequest {
   avatar_url?: string;
   runtime_id: string;
   runtime_config?: Record<string, unknown>;
+  custom_env?: Record<string, string>;
   visibility?: AgentVisibility;
   max_concurrent_tasks?: number;
 }
@@ -76,6 +78,7 @@ export interface UpdateAgentRequest {
   avatar_url?: string;
   runtime_id?: string;
   runtime_config?: Record<string, unknown>;
+  custom_env?: Record<string, string>;
   visibility?: AgentVisibility;
   status?: AgentStatus;
   max_concurrent_tasks?: number;

--- a/packages/views/agents/components/tabs/settings-tab.tsx
+++ b/packages/views/agents/components/tabs/settings-tab.tsx
@@ -29,7 +29,10 @@ import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { ActorAvatar } from "../../../common/actor-avatar";
 
+let nextEnvId = 0;
+
 interface EnvEntry {
+  id: number;
   key: string;
   value: string;
   visible: boolean;
@@ -37,6 +40,7 @@ interface EnvEntry {
 
 function envMapToEntries(env: Record<string, string>): EnvEntry[] {
   return Object.entries(env).map(([key, value]) => ({
+    id: nextEnvId++,
     key,
     value,
     visible: false,
@@ -137,7 +141,7 @@ export function SettingsTab({
   };
 
   const addEnvEntry = () => {
-    setEnvEntries([...envEntries, { key: "", value: "", visible: true }]);
+    setEnvEntries([...envEntries, { id: nextEnvId++, key: "", value: "", visible: true }]);
   };
 
   const removeEnvEntry = (index: number) => {
@@ -355,7 +359,7 @@ export function SettingsTab({
         {envEntries.length > 0 && (
           <div className="mt-2 space-y-2">
             {envEntries.map((entry, index) => (
-              <div key={index} className="flex items-center gap-2">
+              <div key={entry.id} className="flex items-center gap-2">
                 <Input
                   value={entry.key}
                   onChange={(e) => updateEnvEntry(index, "key", e.target.value)}

--- a/packages/views/agents/components/tabs/settings-tab.tsx
+++ b/packages/views/agents/components/tabs/settings-tab.tsx
@@ -10,6 +10,10 @@ import {
   Lock,
   Camera,
   ChevronDown,
+  Plus,
+  Trash2,
+  Eye,
+  EyeOff,
 } from "lucide-react";
 import type { Agent, AgentVisibility, RuntimeDevice } from "@multica/core/types";
 import {
@@ -24,6 +28,31 @@ import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { ActorAvatar } from "../../../common/actor-avatar";
+
+interface EnvEntry {
+  key: string;
+  value: string;
+  visible: boolean;
+}
+
+function envMapToEntries(env: Record<string, string>): EnvEntry[] {
+  return Object.entries(env).map(([key, value]) => ({
+    key,
+    value,
+    visible: false,
+  }));
+}
+
+function entriesToEnvMap(entries: EnvEntry[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const entry of entries) {
+    const key = entry.key.trim();
+    if (key) {
+      map[key] = entry.value;
+    }
+  }
+  return map;
+}
 
 export function SettingsTab({
   agent,
@@ -41,6 +70,9 @@ export function SettingsTab({
   const [selectedRuntimeId, setSelectedRuntimeId] = useState(agent.runtime_id);
   const [runtimeOpen, setRuntimeOpen] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [envEntries, setEnvEntries] = useState<EnvEntry[]>(
+    envMapToEntries(agent.custom_env ?? {})
+  );
   const { upload, uploading } = useFileUpload(api);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -60,18 +92,32 @@ export function SettingsTab({
     }
   };
 
+  const currentEnvMap = entriesToEnvMap(envEntries);
+  const originalEnvMap = agent.custom_env ?? {};
+  const envDirty =
+    JSON.stringify(currentEnvMap) !== JSON.stringify(originalEnvMap);
+
   const dirty =
     name !== agent.name ||
     description !== (agent.description ?? "") ||
     visibility !== agent.visibility ||
     maxTasks !== agent.max_concurrent_tasks ||
-    selectedRuntimeId !== agent.runtime_id;
+    selectedRuntimeId !== agent.runtime_id ||
+    envDirty;
 
   const handleSave = async () => {
     if (!name.trim()) {
       toast.error("Name is required");
       return;
     }
+    // Validate env var keys
+    const keys = envEntries.filter((e) => e.key.trim()).map((e) => e.key.trim());
+    const uniqueKeys = new Set(keys);
+    if (uniqueKeys.size < keys.length) {
+      toast.error("Duplicate environment variable keys");
+      return;
+    }
+
     setSaving(true);
     try {
       await onSave({
@@ -80,6 +126,7 @@ export function SettingsTab({
         visibility,
         max_concurrent_tasks: maxTasks,
         runtime_id: selectedRuntimeId,
+        custom_env: currentEnvMap,
       });
       toast.success("Settings saved");
     } catch {
@@ -87,6 +134,34 @@ export function SettingsTab({
     } finally {
       setSaving(false);
     }
+  };
+
+  const addEnvEntry = () => {
+    setEnvEntries([...envEntries, { key: "", value: "", visible: true }]);
+  };
+
+  const removeEnvEntry = (index: number) => {
+    setEnvEntries(envEntries.filter((_, i) => i !== index));
+  };
+
+  const updateEnvEntry = (
+    index: number,
+    field: "key" | "value",
+    val: string
+  ) => {
+    setEnvEntries(
+      envEntries.map((entry, i) =>
+        i === index ? { ...entry, [field]: val } : entry
+      )
+    );
+  };
+
+  const toggleEnvVisibility = (index: number) => {
+    setEnvEntries(
+      envEntries.map((entry, i) =>
+        i === index ? { ...entry, visible: !entry.visible } : entry
+      )
+    );
   };
 
   return (
@@ -255,6 +330,71 @@ export function SettingsTab({
             ))}
           </PopoverContent>
         </Popover>
+      </div>
+
+      {/* Environment Variables */}
+      <div>
+        <div className="flex items-center justify-between">
+          <div>
+            <Label className="text-xs text-muted-foreground">Environment Variables</Label>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Injected into the agent process at launch (e.g. ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL)
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addEnvEntry}
+            className="h-7 gap-1 text-xs"
+          >
+            <Plus className="h-3 w-3" />
+            Add
+          </Button>
+        </div>
+        {envEntries.length > 0 && (
+          <div className="mt-2 space-y-2">
+            {envEntries.map((entry, index) => (
+              <div key={index} className="flex items-center gap-2">
+                <Input
+                  value={entry.key}
+                  onChange={(e) => updateEnvEntry(index, "key", e.target.value)}
+                  placeholder="KEY"
+                  className="w-[40%] font-mono text-xs"
+                />
+                <div className="relative flex-1">
+                  <Input
+                    type={entry.visible ? "text" : "password"}
+                    value={entry.value}
+                    onChange={(e) =>
+                      updateEnvEntry(index, "value", e.target.value)
+                    }
+                    placeholder="value"
+                    className="pr-8 font-mono text-xs"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => toggleEnvVisibility(index)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  >
+                    {entry.visible ? (
+                      <EyeOff className="h-3.5 w-3.5" />
+                    ) : (
+                      <Eye className="h-3.5 w-3.5" />
+                    )}
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeEnvEntry(index)}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <Button onClick={handleSave} disabled={!dirty || saving} size="sm">

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -972,8 +972,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	// Inject user-configured custom environment variables (e.g. ANTHROPIC_API_KEY,
 	// ANTHROPIC_BASE_URL for router/proxy mode, or CLAUDE_CODE_USE_BEDROCK for
 	// Bedrock). These are set per-agent via the agent settings UI.
+	// Critical internal variables are blocklisted to prevent accidental or
+	// malicious override of daemon-set values.
 	if task.Agent != nil {
 		for k, v := range task.Agent.CustomEnv {
+			if isBlockedEnvKey(k) {
+				d.logger.Warn("custom_env: blocked key skipped", "key", k)
+				continue
+			}
 			agentEnv[k] = v
 		}
 	}
@@ -1292,4 +1298,19 @@ func convertSkillsForEnv(skills []SkillData) []execenv.SkillContextForEnv {
 		}
 	}
 	return result
+}
+
+// isBlockedEnvKey returns true if the key must not be overridden by user-
+// configured custom_env. This prevents accidental or malicious override of
+// daemon-internal variables and critical system paths.
+func isBlockedEnvKey(key string) bool {
+	upper := strings.ToUpper(key)
+	if strings.HasPrefix(upper, "MULTICA_") {
+		return true
+	}
+	switch upper {
+	case "HOME", "PATH", "USER", "SHELL", "TERM", "CODEX_HOME":
+		return true
+	}
+	return false
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -969,6 +969,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	if env.CodexHome != "" {
 		agentEnv["CODEX_HOME"] = env.CodexHome
 	}
+	// Inject user-configured custom environment variables (e.g. ANTHROPIC_API_KEY,
+	// ANTHROPIC_BASE_URL for router/proxy mode, or CLAUDE_CODE_USE_BEDROCK for
+	// Bedrock). These are set per-agent via the agent settings UI.
+	if task.Agent != nil {
+		for k, v := range task.Agent.CustomEnv {
+			agentEnv[k] = v
+		}
+	}
 	backend, err := agent.New(provider, agent.Config{
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -40,10 +40,11 @@ type Task struct {
 
 // AgentData holds agent details returned by the claim endpoint.
 type AgentData struct {
-	ID           string      `json:"id"`
-	Name         string      `json:"name"`
-	Instructions string      `json:"instructions"`
-	Skills       []SkillData `json:"skills"`
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Instructions string            `json:"instructions"`
+	Skills       []SkillData       `json:"skills"`
+	CustomEnv    map[string]string `json:"custom_env,omitempty"`
 }
 
 // SkillData represents a structured skill for task execution.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -46,7 +46,9 @@ func agentToResponse(a db.Agent) AgentResponse {
 
 	var customEnv map[string]string
 	if a.CustomEnv != nil {
-		json.Unmarshal(a.CustomEnv, &customEnv)
+		if err := json.Unmarshal(a.CustomEnv, &customEnv); err != nil {
+			slog.Warn("failed to unmarshal agent custom_env", "agent_id", uuidToString(a.ID), "error", err)
+		}
 	}
 	if customEnv == nil {
 		customEnv = map[string]string{}

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -14,24 +14,25 @@ import (
 )
 
 type AgentResponse struct {
-	ID                 string          `json:"id"`
-	WorkspaceID        string          `json:"workspace_id"`
-	RuntimeID          string          `json:"runtime_id"`
-	Name               string          `json:"name"`
-	Description        string          `json:"description"`
-	Instructions       string          `json:"instructions"`
-	AvatarURL          *string         `json:"avatar_url"`
-	RuntimeMode        string          `json:"runtime_mode"`
-	RuntimeConfig      any             `json:"runtime_config"`
-	Visibility         string          `json:"visibility"`
-	Status             string          `json:"status"`
-	MaxConcurrentTasks int32           `json:"max_concurrent_tasks"`
-	OwnerID            *string         `json:"owner_id"`
-	Skills             []SkillResponse `json:"skills"`
-	CreatedAt          string          `json:"created_at"`
-	UpdatedAt          string          `json:"updated_at"`
-	ArchivedAt         *string         `json:"archived_at"`
-	ArchivedBy         *string         `json:"archived_by"`
+	ID                 string            `json:"id"`
+	WorkspaceID        string            `json:"workspace_id"`
+	RuntimeID          string            `json:"runtime_id"`
+	Name               string            `json:"name"`
+	Description        string            `json:"description"`
+	Instructions       string            `json:"instructions"`
+	AvatarURL          *string           `json:"avatar_url"`
+	RuntimeMode        string            `json:"runtime_mode"`
+	RuntimeConfig      any               `json:"runtime_config"`
+	CustomEnv          map[string]string `json:"custom_env"`
+	Visibility         string            `json:"visibility"`
+	Status             string            `json:"status"`
+	MaxConcurrentTasks int32             `json:"max_concurrent_tasks"`
+	OwnerID            *string           `json:"owner_id"`
+	Skills             []SkillResponse   `json:"skills"`
+	CreatedAt          string            `json:"created_at"`
+	UpdatedAt          string            `json:"updated_at"`
+	ArchivedAt         *string           `json:"archived_at"`
+	ArchivedBy         *string           `json:"archived_by"`
 }
 
 func agentToResponse(a db.Agent) AgentResponse {
@@ -41,6 +42,14 @@ func agentToResponse(a db.Agent) AgentResponse {
 	}
 	if rc == nil {
 		rc = map[string]any{}
+	}
+
+	var customEnv map[string]string
+	if a.CustomEnv != nil {
+		json.Unmarshal(a.CustomEnv, &customEnv)
+	}
+	if customEnv == nil {
+		customEnv = map[string]string{}
 	}
 
 	return AgentResponse{
@@ -53,6 +62,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		AvatarURL:          textToPtr(a.AvatarUrl),
 		RuntimeMode:        a.RuntimeMode,
 		RuntimeConfig:      rc,
+		CustomEnv:          customEnv,
 		Visibility:         a.Visibility,
 		Status:             a.Status,
 		MaxConcurrentTasks: a.MaxConcurrentTasks,
@@ -103,6 +113,7 @@ type TaskAgentData struct {
 	Name         string                   `json:"name"`
 	Instructions string                   `json:"instructions"`
 	Skills       []service.AgentSkillData `json:"skills,omitempty"`
+	CustomEnv    map[string]string        `json:"custom_env,omitempty"`
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
@@ -196,14 +207,15 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 }
 
 type CreateAgentRequest struct {
-	Name               string  `json:"name"`
-	Description        string  `json:"description"`
-	Instructions       string  `json:"instructions"`
-	AvatarURL          *string `json:"avatar_url"`
-	RuntimeID          string  `json:"runtime_id"`
-	RuntimeConfig      any     `json:"runtime_config"`
-	Visibility         string  `json:"visibility"`
-	MaxConcurrentTasks int32   `json:"max_concurrent_tasks"`
+	Name               string            `json:"name"`
+	Description        string            `json:"description"`
+	Instructions       string            `json:"instructions"`
+	AvatarURL          *string           `json:"avatar_url"`
+	RuntimeID          string            `json:"runtime_id"`
+	RuntimeConfig      any               `json:"runtime_config"`
+	CustomEnv          map[string]string `json:"custom_env"`
+	Visibility         string            `json:"visibility"`
+	MaxConcurrentTasks int32             `json:"max_concurrent_tasks"`
 }
 
 func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
@@ -249,6 +261,11 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		rc = []byte("{}")
 	}
 
+	ce, _ := json.Marshal(req.CustomEnv)
+	if req.CustomEnv == nil {
+		ce = []byte("{}")
+	}
+
 	agent, err := h.Queries.CreateAgent(r.Context(), db.CreateAgentParams{
 		WorkspaceID:        parseUUID(workspaceID),
 		Name:               req.Name,
@@ -261,6 +278,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		Visibility:         req.Visibility,
 		MaxConcurrentTasks: req.MaxConcurrentTasks,
 		OwnerID:            parseUUID(ownerID),
+		CustomEnv:          ce,
 	})
 	if err != nil {
 		slog.Warn("create agent failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID)...)
@@ -283,15 +301,16 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 
 
 type UpdateAgentRequest struct {
-	Name               *string `json:"name"`
-	Description        *string `json:"description"`
-	Instructions       *string `json:"instructions"`
-	AvatarURL          *string `json:"avatar_url"`
-	RuntimeID          *string `json:"runtime_id"`
-	RuntimeConfig      any     `json:"runtime_config"`
-	Visibility         *string `json:"visibility"`
-	Status             *string `json:"status"`
-	MaxConcurrentTasks *int32  `json:"max_concurrent_tasks"`
+	Name               *string            `json:"name"`
+	Description        *string            `json:"description"`
+	Instructions       *string            `json:"instructions"`
+	AvatarURL          *string            `json:"avatar_url"`
+	RuntimeID          *string            `json:"runtime_id"`
+	RuntimeConfig      any                `json:"runtime_config"`
+	CustomEnv          *map[string]string `json:"custom_env"`
+	Visibility         *string            `json:"visibility"`
+	Status             *string            `json:"status"`
+	MaxConcurrentTasks *int32             `json:"max_concurrent_tasks"`
 }
 
 // canManageAgent checks whether the current user can update or archive an agent.
@@ -346,6 +365,10 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	if req.RuntimeConfig != nil {
 		rc, _ := json.Marshal(req.RuntimeConfig)
 		params.RuntimeConfig = rc
+	}
+	if req.CustomEnv != nil {
+		ce, _ := json.Marshal(*req.CustomEnv)
+		params.CustomEnv = ce
 	}
 	if req.RuntimeID != nil {
 		runtime, err := h.Queries.GetAgentRuntimeForWorkspace(r.Context(), db.GetAgentRuntimeForWorkspaceParams{

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -364,7 +364,9 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		skills := h.TaskService.LoadAgentSkills(r.Context(), task.AgentID)
 		var customEnv map[string]string
 		if agent.CustomEnv != nil {
-			json.Unmarshal(agent.CustomEnv, &customEnv)
+			if err := json.Unmarshal(agent.CustomEnv, &customEnv); err != nil {
+				slog.Warn("failed to unmarshal agent custom_env", "agent_id", uuidToString(agent.ID), "error", err)
+			}
 		}
 		resp.Agent = &TaskAgentData{
 			ID:           uuidToString(agent.ID),

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -358,15 +358,20 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build response with fresh agent data (name + skills).
+	// Build response with fresh agent data (name + skills + custom_env).
 	resp := taskToResponse(*task)
 	if agent, err := h.Queries.GetAgent(r.Context(), task.AgentID); err == nil {
 		skills := h.TaskService.LoadAgentSkills(r.Context(), task.AgentID)
+		var customEnv map[string]string
+		if agent.CustomEnv != nil {
+			json.Unmarshal(agent.CustomEnv, &customEnv)
+		}
 		resp.Agent = &TaskAgentData{
 			ID:           uuidToString(agent.ID),
 			Name:         agent.Name,
 			Instructions: agent.Instructions,
 			Skills:       skills,
+			CustomEnv:    customEnv,
 		}
 	}
 

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -145,7 +145,7 @@ func (h *Handler) GetRuntimeUsage(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := h.Queries.ListRuntimeUsage(r.Context(), db.ListRuntimeUsageParams{
 		RuntimeID: parseUUID(runtimeID),
-		Since:     since,
+		Date:      since,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list usage")

--- a/server/migrations/040_agent_custom_env.down.sql
+++ b/server/migrations/040_agent_custom_env.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent DROP COLUMN custom_env;

--- a/server/migrations/040_agent_custom_env.up.sql
+++ b/server/migrations/040_agent_custom_env.up.sql
@@ -1,0 +1,5 @@
+-- Add custom_env column to agent table for user-configurable environment
+-- variables that get injected into the agent subprocess at launch time.
+-- Supports router/proxy (ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL),
+-- Bedrock (CLAUDE_CODE_USE_BEDROCK + AWS creds), and Vertex AI modes.
+ALTER TABLE agent ADD COLUMN custom_env JSONB NOT NULL DEFAULT '{}';

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -14,7 +14,7 @@ import (
 const archiveAgent = `-- name: ArchiveAgent :one
 UPDATE agent SET archived_at = now(), archived_by = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env
 `
 
 type ArchiveAgentParams struct {
@@ -43,6 +43,7 @@ func (q *Queries) ArchiveAgent(ctx context.Context, arg ArchiveAgentParams) (Age
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.CustomEnv,
 	)
 	return i, err
 }
@@ -213,9 +214,9 @@ const createAgent = `-- name: CreateAgent :one
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
-    instructions
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by
+    instructions, custom_env
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env
 `
 
 type CreateAgentParams struct {
@@ -230,6 +231,7 @@ type CreateAgentParams struct {
 	MaxConcurrentTasks int32       `json:"max_concurrent_tasks"`
 	OwnerID            pgtype.UUID `json:"owner_id"`
 	Instructions       string      `json:"instructions"`
+	CustomEnv          []byte      `json:"custom_env"`
 }
 
 func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent, error) {
@@ -245,6 +247,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		arg.MaxConcurrentTasks,
 		arg.OwnerID,
 		arg.Instructions,
+		arg.CustomEnv,
 	)
 	var i Agent
 	err := row.Scan(
@@ -265,6 +268,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.CustomEnv,
 	)
 	return i, err
 }
@@ -394,7 +398,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env FROM agent
 WHERE id = $1
 `
 
@@ -419,12 +423,13 @@ func (q *Queries) GetAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.CustomEnv,
 	)
 	return i, err
 }
 
 const getAgentInWorkspace = `-- name: GetAgentInWorkspace :one
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env FROM agent
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -454,6 +459,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.CustomEnv,
 	)
 	return i, err
 }
@@ -651,7 +657,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env FROM agent
 WHERE workspace_id = $1 AND archived_at IS NULL
 ORDER BY created_at ASC
 `
@@ -683,6 +689,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 			&i.Instructions,
 			&i.ArchivedAt,
 			&i.ArchivedBy,
+			&i.CustomEnv,
 		); err != nil {
 			return nil, err
 		}
@@ -695,7 +702,7 @@ func (q *Queries) ListAgents(ctx context.Context, workspaceID pgtype.UUID) ([]Ag
 }
 
 const listAllAgents = `-- name: ListAllAgents :many
-SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by FROM agent
+SELECT id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env FROM agent
 WHERE workspace_id = $1
 ORDER BY created_at ASC
 `
@@ -727,6 +734,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 			&i.Instructions,
 			&i.ArchivedAt,
 			&i.ArchivedBy,
+			&i.CustomEnv,
 		); err != nil {
 			return nil, err
 		}
@@ -829,7 +837,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env
 `
 
 func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, error) {
@@ -853,6 +861,7 @@ func (q *Queries) RestoreAgent(ctx context.Context, id pgtype.UUID) (Agent, erro
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.CustomEnv,
 	)
 	return i, err
 }
@@ -901,9 +910,10 @@ UPDATE agent SET
     status = COALESCE($9, status),
     max_concurrent_tasks = COALESCE($10, max_concurrent_tasks),
     instructions = COALESCE($11, instructions),
+    custom_env = COALESCE($12, custom_env),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env
 `
 
 type UpdateAgentParams struct {
@@ -918,6 +928,7 @@ type UpdateAgentParams struct {
 	Status             pgtype.Text `json:"status"`
 	MaxConcurrentTasks pgtype.Int4 `json:"max_concurrent_tasks"`
 	Instructions       pgtype.Text `json:"instructions"`
+	CustomEnv          []byte      `json:"custom_env"`
 }
 
 func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent, error) {
@@ -933,6 +944,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.Status,
 		arg.MaxConcurrentTasks,
 		arg.Instructions,
+		arg.CustomEnv,
 	)
 	var i Agent
 	err := row.Scan(
@@ -953,6 +965,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.CustomEnv,
 	)
 	return i, err
 }
@@ -960,7 +973,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 const updateAgentStatus = `-- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env
 `
 
 type UpdateAgentStatusParams struct {
@@ -989,6 +1002,7 @@ func (q *Queries) UpdateAgentStatus(ctx context.Context, arg UpdateAgentStatusPa
 		&i.Instructions,
 		&i.ArchivedAt,
 		&i.ArchivedBy,
+		&i.CustomEnv,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -37,6 +37,7 @@ type Agent struct {
 	Instructions       string             `json:"instructions"`
 	ArchivedAt         pgtype.Timestamptz `json:"archived_at"`
 	ArchivedBy         pgtype.UUID        `json:"archived_by"`
+	CustomEnv          []byte             `json:"custom_env"`
 }
 
 type AgentRuntime struct {

--- a/server/pkg/db/generated/runtime_usage.sql.go
+++ b/server/pkg/db/generated/runtime_usage.sql.go
@@ -101,11 +101,11 @@ ORDER BY date DESC
 
 type ListRuntimeUsageParams struct {
 	RuntimeID pgtype.UUID `json:"runtime_id"`
-	Since     pgtype.Date `json:"since"`
+	Date      pgtype.Date `json:"date"`
 }
 
 func (q *Queries) ListRuntimeUsage(ctx context.Context, arg ListRuntimeUsageParams) ([]RuntimeUsage, error) {
-	rows, err := q.db.Query(ctx, listRuntimeUsage, arg.RuntimeID, arg.Since)
+	rows, err := q.db.Query(ctx, listRuntimeUsage, arg.RuntimeID, arg.Date)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -20,8 +20,8 @@ WHERE id = $1 AND workspace_id = $2;
 INSERT INTO agent (
     workspace_id, name, description, avatar_url, runtime_mode,
     runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id,
-    instructions
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    instructions, custom_env
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 RETURNING *;
 
 -- name: UpdateAgent :one
@@ -36,6 +36,7 @@ UPDATE agent SET
     status = COALESCE(sqlc.narg('status'), status),
     max_concurrent_tasks = COALESCE(sqlc.narg('max_concurrent_tasks'), max_concurrent_tasks),
     instructions = COALESCE(sqlc.narg('instructions'), instructions),
+    custom_env = COALESCE(sqlc.narg('custom_env'), custom_env),
     updated_at = now()
 WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## Summary

- Add per-agent `custom_env` (JSONB) field that gets injected into agent subprocess environment at launch time
- Full-stack: DB migration → backend API → daemon injection → frontend settings UI
- Enables router/proxy mode (ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL), Bedrock, and Vertex AI without code changes

## Changes

**Backend:**
- Migration `040_agent_custom_env`: adds `custom_env JSONB NOT NULL DEFAULT '{}'` to agent table
- Agent CRUD API: `custom_env` (map[string]string) in create/update/response
- Claim endpoint: includes `custom_env` in `TaskAgentData` so daemon receives it
- Daemon `runTask()`: merges `task.Agent.CustomEnv` into subprocess env vars

**Frontend:**
- Agent settings tab: key-value environment variable editor with add/remove, visibility toggle for sensitive values, duplicate key validation

**Also fixes:** sqlc regeneration renamed `ListRuntimeUsageParams.Since` → `.Date` (unrelated pre-existing issue)

## Test Plan

- [x] Create agent with custom_env via API
- [x] Edit custom_env in agent settings UI (add/remove/toggle visibility)
- [x] Verify env vars are injected into agent subprocess (check with `env` in agent)
- [ ] Verify router mode works with ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL
- [ ] Verify Bedrock mode works with CLAUDE_CODE_USE_BEDROCK

Closes #816 | Related: #807, #809