### PR TITLE
Improve discoverability of project delete and agent archive actions

### DIFF
--- a/packages/views/agents/components/agent-detail.test.tsx
+++ b/packages/views/agents/components/agent-detail.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Agent, RuntimeDevice } from "@multica/core/types";
+
+vi.mock("../../common/actor-avatar", () => ({
+  ActorAvatar: ({ actorId }: { actorId: string }) => <span data-testid="agent-avatar">{actorId}</span>,
+}));
+
+vi.mock("./tabs/instructions-tab", () => ({
+  InstructionsTab: () => <div data-testid="instructions-tab">Instructions</div>,
+}));
+
+vi.mock("./tabs/skills-tab", () => ({
+  SkillsTab: () => <div data-testid="skills-tab">Skills</div>,
+}));
+
+vi.mock("./tabs/tasks-tab", () => ({
+  TasksTab: () => <div data-testid="tasks-tab">Tasks</div>,
+}));
+
+vi.mock("./tabs/settings-tab", () => ({
+  SettingsTab: () => <div data-testid="settings-tab">Settings</div>,
+}));
+
+vi.mock("@multica/ui/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open?: boolean; children: React.ReactNode }) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { AgentDetail } from "./agent-detail";
+
+const baseAgent: Agent = {
+  id: "agent-1",
+  workspace_id: "ws-1",
+  runtime_id: "runtime-1",
+  name: "Build Agent",
+  description: "",
+  instructions: "",
+  avatar_url: null,
+  runtime_mode: "cloud",
+  runtime_config: {},
+  visibility: "workspace",
+  status: "idle",
+  max_concurrent_tasks: 1,
+  owner_id: null,
+  skills: [],
+  created_at: "2026-04-13T00:00:00Z",
+  updated_at: "2026-04-13T00:00:00Z",
+  archived_at: null,
+  archived_by: null,
+};
+
+const runtimeDevices: RuntimeDevice[] = [
+  {
+    id: "runtime-1",
+    workspace_id: "ws-1",
+    daemon_id: null,
+    name: "Cloud Runtime",
+    runtime_mode: "cloud",
+    provider: "openai",
+    status: "online",
+    device_info: "",
+    metadata: {},
+    owner_id: null,
+    last_seen_at: null,
+    created_at: "2026-04-13T00:00:00Z",
+    updated_at: "2026-04-13T00:00:00Z",
+  },
+];
+
+describe("AgentDetail", () => {
+  it("shows an explicit archive action and confirms before archiving", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onArchive = vi.fn().mockResolvedValue(undefined);
+    const onRestore = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AgentDetail
+        agent={baseAgent}
+        runtimes={runtimeDevices}
+        onUpdate={onUpdate}
+        onArchive={onArchive}
+        onRestore={onRestore}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Archive Agent" }));
+    expect(screen.getByText("Archive agent?")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+    expect(onArchive).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("shows restore action for archived agents", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onArchive = vi.fn().mockResolvedValue(undefined);
+    const onRestore = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AgentDetail
+        agent={{ ...baseAgent, archived_at: "2026-04-13T00:00:00Z" }}
+        runtimes={runtimeDevices}
+        onUpdate={onUpdate}
+        onArchive={onArchive}
+        onRestore={onRestore}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Archive Agent" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Restore" }));
+    expect(onRestore).toHaveBeenCalledWith("agent-1");
+  });
+});

--- a/packages/views/agents/components/agent-detail.tsx
+++ b/packages/views/agents/components/agent-detail.tsx
@@ -9,7 +9,6 @@ import {
   ListTodo,
   Trash2,
   AlertCircle,
-  MoreHorizontal,
   Settings,
 } from "lucide-react";
 import type { Agent, RuntimeDevice } from "@multica/core/types";
@@ -21,12 +20,6 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@multica/ui/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from "@multica/ui/components/ui/dropdown-menu";
 import { Button } from "@multica/ui/components/ui/button";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { statusConfig } from "../config";
@@ -107,24 +100,15 @@ export function AgentDetail({
           </div>
         </div>
         {!isArchived && (
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button variant="ghost" size="icon-sm" />
-              }
-            >
-              <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-auto">
-              <DropdownMenuItem
-                className="text-destructive"
-                onClick={() => setConfirmArchive(true)}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-                Archive Agent
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={() => setConfirmArchive(true)}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            Archive Agent
+          </Button>
         )}
       </div>
 

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { Plus, FolderKanban, ChevronRight, Maximize2, Minimize2, X as XIcon, UserMinus, Check } from "lucide-react";
+import { Plus, FolderKanban, ChevronRight, Maximize2, Minimize2, X as XIcon, UserMinus, Check, MoreHorizontal, Trash2 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { projectListOptions } from "@multica/core/projects/queries";
-import { useCreateProject, useUpdateProject } from "@multica/core/projects/mutations";
+import { useCreateProject, useUpdateProject, useDeleteProject } from "@multica/core/projects/mutations";
 import { PROJECT_STATUS_CONFIG, PROJECT_STATUS_ORDER, PROJECT_PRIORITY_CONFIG, PROJECT_PRIORITY_ORDER } from "@multica/core/projects/config";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspaceStore } from "@multica/core/workspace";
@@ -25,6 +25,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@multica/ui/components/ui/dropdown-menu";
 import {
@@ -33,6 +34,16 @@ import {
   PopoverContent,
 } from "@multica/ui/components/ui/popover";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@multica/ui/components/ui/alert-dialog";
 import { ContentEditor, type ContentEditorRef } from "../../editor";
 import { TitleEditor } from "../../editor";
 import { EmojiPicker } from "@multica/ui/components/common/emoji-picker";
@@ -51,15 +62,18 @@ function formatRelativeDate(date: string): string {
 
 function ProjectRow({ project }: { project: Project }) {
   const wsId = useWorkspaceId();
+  const router = useNavigation();
   const statusCfg = PROJECT_STATUS_CONFIG[project.status];
   const priorityCfg = PROJECT_PRIORITY_CONFIG[project.priority];
   const updateProject = useUpdateProject();
+  const deleteProject = useDeleteProject();
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const { getActorName } = useActorName();
 
   const [leadOpen, setLeadOpen] = useState(false);
   const [leadFilter, setLeadFilter] = useState("");
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const leadQuery = leadFilter.toLowerCase();
   const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery));
   const filteredAgents = agents.filter((a) => !a.archived_at && a.name.toLowerCase().includes(leadQuery));
@@ -70,6 +84,18 @@ function ProjectRow({ project }: { project: Project }) {
     },
     [project.id, updateProject],
   );
+
+  const handleDelete = useCallback(() => {
+    deleteProject.mutate(project.id, {
+      onSuccess: () => {
+        toast.success("Project deleted");
+        setDeleteDialogOpen(false);
+      },
+      onError: () => {
+        toast.error("Failed to delete project");
+      },
+    });
+  }, [deleteProject, project.id]);
 
   return (
     <div className="group/row flex h-11 items-center gap-2 px-5 text-sm transition-colors hover:bg-accent/40">
@@ -223,6 +249,44 @@ function ProjectRow({ project }: { project: Project }) {
       <span className="w-20 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
         {formatRelativeDate(project.created_at)}
       </span>
+
+      {/* Actions */}
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button variant="ghost" size="icon-xs" className="shrink-0" aria-label={`Actions for ${project.title}`}>
+              <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuItem onClick={() => router.push(`/projects/${project.id}`)}>
+            Open project
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onClick={() => setDeleteDialogOpen(true)}>
+            <Trash2 className="h-3.5 w-3.5" />
+            Delete project
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete project</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will delete the project. Issues will not be deleted but will be unlinked.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-white hover:bg-destructive/90">
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -581,6 +645,7 @@ export function ProjectsPage() {
               <span className="w-24 text-center shrink-0">Progress</span>
               <span className="w-10 text-center shrink-0">Lead</span>
               <span className="w-20 text-right shrink-0">Created</span>
+              <span className="w-6 shrink-0" />
             </div>
             {/* Rows */}
             {projects.map((project) => (


### PR DESCRIPTION
## Summary
- **Agent archive action** – now exposed as a direct button in the agent detail header (instead of being hidden inside a menu)  
- **Project delete action** – added a row actions menu in the projects list, including a direct **Delete project** entry with a confirmation dialog  
- **Regression tests** – added for agent archive/restore action visibility and the confirmation flow  

## Why  
Issue #849 reported that users struggle to find delete actions for projects and agents. This change keeps the existing backend behavior unchanged, but makes destructive actions clearly visible where users expect them.

## Testing  
```bash
pnpm --filter @multica/views test -- agent-detail.test.tsx
pnpm --filter @multica/views exec eslint agents/components/agent-detail.tsx agents/components/agent-detail.test.tsx projects/components/projects-page.tsx
pnpm --filter @multica/views typecheck
```

Closes #849