### PR TITLE
fix(auth): add user-facing task messages endpoint for cookie auth

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -447,7 +447,7 @@ export class ApiClient {
   }
 
   async listTaskMessages(taskId: string): Promise<TaskMessagePayload[]> {
-    return this.fetch(`/api/daemon/tasks/${taskId}/messages`);
+    return this.fetch(`/api/tasks/${taskId}/messages`);
   }
 
   async listTasksByIssue(issueId: string): Promise<AgentTask[]> {

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -221,6 +221,9 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 				})
 			})
 
+			// Task messages (user-facing, not daemon auth)
+			r.Get("/api/tasks/{taskId}/messages", h.ListTaskMessagesByUser)
+
 			// Projects
 			r.Route("/api/projects", func(r chi.Router) {
 				r.Get("/search", h.SearchProjects)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -833,6 +833,70 @@ func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// ListTaskMessagesByUser returns task messages for a task.
+// Used by the frontend under regular user auth (not daemon auth).
+// Verifies the task belongs to the caller's workspace.
+func (h *Handler) ListTaskMessagesByUser(w http.ResponseWriter, r *http.Request) {
+	taskID := chi.URLParam(r, "taskId")
+
+	task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	if err != nil {
+		writeError(w, http.StatusNotFound, "task not found")
+		return
+	}
+
+	// Verify the task belongs to the caller's workspace.
+	wsID := h.resolveTaskWorkspaceID(r, task)
+	if wsID == "" || wsID != middleware.WorkspaceIDFromContext(r.Context()) {
+		writeError(w, http.StatusNotFound, "task not found")
+		return
+	}
+
+	var (
+		messages []db.TaskMessage
+		queryErr error
+	)
+	if sinceStr := r.URL.Query().Get("since"); sinceStr != "" {
+		sinceSeq, parseErr := strconv.Atoi(sinceStr)
+		if parseErr != nil {
+			writeError(w, http.StatusBadRequest, "invalid since parameter")
+			return
+		}
+		messages, queryErr = h.Queries.ListTaskMessagesSince(r.Context(), db.ListTaskMessagesSinceParams{
+			TaskID: parseUUID(taskID),
+			Seq:    int32(sinceSeq),
+		})
+	} else {
+		messages, queryErr = h.Queries.ListTaskMessages(r.Context(), parseUUID(taskID))
+	}
+	if queryErr != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list task messages")
+		return
+	}
+
+	issueID := uuidToString(task.IssueID)
+
+	resp := make([]protocol.TaskMessagePayload, len(messages))
+	for i, m := range messages {
+		var input map[string]any
+		if m.Input != nil {
+			json.Unmarshal(m.Input, &input)
+		}
+		resp[i] = protocol.TaskMessagePayload{
+			TaskID:  taskID,
+			IssueID: issueID,
+			Seq:     int(m.Seq),
+			Type:    m.Type,
+			Tool:    m.Tool.String,
+			Content: m.Content.String,
+			Input:   input,
+			Output:  m.Output.String,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // GetIssueUsage returns aggregated token usage for all tasks belonging to an issue.
 func (h *Handler) GetIssueUsage(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "id")


### PR DESCRIPTION
## Summary

- Adds `GET /api/tasks/{taskId}/messages` under regular user auth (not daemon auth) for frontend to fetch task run messages
- Updates frontend `listTaskMessages()` to use the new endpoint instead of `/api/daemon/tasks/{id}/messages`
- The daemon endpoint remains unchanged for backward compatibility with actual daemons

## Root cause

After the cookie auth migration (#819), the frontend in cookie mode no longer sends an `Authorization` header. The daemon endpoint `/api/daemon/tasks/{id}/messages` uses `DaemonAuth` middleware which only reads headers (not cookies), returning 401. This 401 triggers `handleUnauthorized()` which clears the workspace context, cascading into 400 "workspace_id is required" errors on all subsequent requests.

## Test plan

- [x] Go build passes
- [x] Go tests pass (handler, middleware, server)
- [x] TypeScript typecheck passes
- [x] Frontend tests pass (79/79)
- [ ] Manual: log in as new user (cookie mode), view issue with agent task run — should load messages without errors

Closes #833