### PR TITLE
feat(cli): add Windows installation support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,14 +17,22 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
 
 archives:
   - id: default
     formats:
       - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:

--- a/CLI_INSTALL.md
+++ b/CLI_INSTALL.md
@@ -27,7 +27,9 @@ multica version
 
 ## Step 2: Install the Multica CLI
 
-### Option A: Homebrew (preferred)
+> **Windows users:** Skip to [Option C: Windows (PowerShell)](#option-c-windows-powershell) below.
+
+### Option A: Homebrew (preferred — macOS/Linux)
 
 Check if Homebrew is available:
 
@@ -49,7 +51,7 @@ multica version
 
 If the version prints successfully, skip to **Step 3**.
 
-### Option B: Download from GitHub Releases (no Homebrew)
+### Option B: Download from GitHub Releases (macOS/Linux, no Homebrew)
 
 If Homebrew is not available, download the binary directly.
 
@@ -84,6 +86,27 @@ multica version
 - Check that `/usr/local/bin` is in `$PATH`.
 - On Linux, you may need `chmod +x /usr/local/bin/multica`.
 - If `sudo` is not available, install to a user-writable directory: `mv /tmp/multica ~/.local/bin/multica` and ensure `~/.local/bin` is in `$PATH`.
+
+### Option C: Windows (PowerShell)
+
+Run in PowerShell (no admin required):
+
+```powershell
+irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
+```
+
+This downloads the latest Windows binary from GitHub Releases, installs it to `%USERPROFILE%\.multica\bin\`, and adds it to your user PATH.
+
+Verify:
+
+```powershell
+multica version
+```
+
+**If this fails:**
+- Restart your terminal so the updated PATH takes effect.
+- If you use Scoop, the installer will use it automatically: `scoop bucket add multica https://github.com/multica-ai/scoop-bucket.git && scoop install multica`
+- If your execution policy blocks the script: `Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned` then re-run.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/ins
 
 Installs the Multica CLI on macOS and Linux. Works with Homebrew or downloads the binary directly.
 
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
+```
+
 After installation:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,6 +56,12 @@ curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/ins
 
 安装 Multica CLI，支持 macOS 和 Linux。有 Homebrew 用 Homebrew，没有则直接下载二进制。
 
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
+```
+
 安装完成后：
 
 ```bash

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -32,16 +32,11 @@ function Test-CommandExists {
 
 function Get-LatestVersion {
     try {
-        $response = Invoke-WebRequest -Uri "$RepoWebUrl/releases/latest" -MaximumRedirection 0 -ErrorAction SilentlyContinue 2>$null
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/multica-ai/multica/releases/latest" -ErrorAction Stop
+        return $release.tag_name
     } catch {
-        $response = $_.Exception.Response
+        return $null
     }
-    if ($response -and $response.Headers -and $response.Headers.Location) {
-        $location = $response.Headers.Location
-        if ($location -is [array]) { $location = $location[0] }
-        return ($location -split "tag/" | Select-Object -Last 1).Trim()
-    }
-    return $null
 }
 
 # ---------------------------------------------------------------------------
@@ -50,7 +45,10 @@ function Get-LatestVersion {
 function Install-CliBinary {
     Write-Info "Installing Multica CLI from GitHub Releases..."
 
-    $arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { Write-Fail "Multica requires a 64-bit Windows installation." }
+    if (-not [Environment]::Is64BitOperatingSystem) {
+        Write-Fail "Multica requires a 64-bit Windows installation."
+    }
+    $arch = "amd64"
 
     $latest = Get-LatestVersion
     if (-not $latest) {
@@ -69,6 +67,27 @@ function Install-CliBinary {
     } catch {
         Remove-Item $tmpDir -Recurse -Force
         Write-Fail "Failed to download CLI binary: $_"
+    }
+
+    # Verify SHA256 checksum
+    $checksumUrl = "https://github.com/multica-ai/multica/releases/download/$latest/checksums.txt"
+    try {
+        $checksums = Invoke-WebRequest -Uri $checksumUrl -UseBasicParsing -ErrorAction Stop
+        $zipFile = Join-Path $tmpDir "multica.zip"
+        $actualHash = (Get-FileHash -Path $zipFile -Algorithm SHA256).Hash.ToLower()
+        $expectedLine = ($checksums.Content -split "`n") | Where-Object { $_ -match "multica_windows_$arch\.zip" } | Select-Object -First 1
+        if ($expectedLine) {
+            $expectedHash = ($expectedLine -split "\s+")[0].ToLower()
+            if ($actualHash -ne $expectedHash) {
+                Remove-Item $tmpDir -Recurse -Force
+                Write-Fail "Checksum verification failed. Expected: $expectedHash, Got: $actualHash"
+            }
+            Write-Ok "Checksum verified"
+        } else {
+            Write-Warn "Could not find checksum entry for windows_$arch — skipping verification."
+        }
+    } catch {
+        Write-Warn "Could not download checksums.txt — skipping verification."
     }
 
     Expand-Archive -Path (Join-Path $tmpDir "multica.zip") -DestinationPath $tmpDir -Force
@@ -127,9 +146,18 @@ function Install-Cli {
         $latestVer = Get-LatestVersion
 
         $currentCmp = $currentVer -replace '^v',''
-        $latestCmp = $latestVer -replace '^v',''
+        $latestCmp = if ($latestVer) { $latestVer -replace '^v','' } else { $null }
 
-        if (-not $latestVer -or $currentCmp -eq $latestCmp) {
+        $isUpToDate = -not $latestCmp
+        if (-not $isUpToDate) {
+            try {
+                $isUpToDate = [System.Version]$currentCmp -ge [System.Version]$latestCmp
+            } catch {
+                $isUpToDate = $currentCmp -eq $latestCmp
+            }
+        }
+
+        if ($isUpToDate) {
             Write-Ok "Multica CLI is up to date ($currentVer)"
             return
         }
@@ -185,6 +213,7 @@ function Install-Server {
 
     if (Test-Path (Join-Path $InstallDir ".git")) {
         Write-Info "Updating existing installation at $InstallDir..."
+        Write-Warn "Any local changes in $InstallDir will be overwritten."
         Push-Location $InstallDir
         git fetch origin main --depth 1 2>$null
         git reset --hard origin/main 2>$null

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,374 @@
+# Multica installer for Windows — one command to get started.
+#
+# Install CLI (default): connects to multica.ai
+#   irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
+#
+# Self-host: starts a local Multica server + installs CLI + configures
+#   $env:MULTICA_MODE="local"; irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex
+#
+
+$ErrorActionPreference = "Stop"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+$RepoUrl       = "https://github.com/multica-ai/multica.git"
+$RepoWebUrl    = "https://github.com/multica-ai/multica"
+$DefaultInstallDir = Join-Path $env:USERPROFILE ".multica\server"
+$InstallDir    = if ($env:MULTICA_INSTALL_DIR) { $env:MULTICA_INSTALL_DIR } else { $DefaultInstallDir }
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Write-Info  { param([string]$Msg) Write-Host "==> $Msg" -ForegroundColor Cyan }
+function Write-Ok    { param([string]$Msg) Write-Host "[OK] $Msg" -ForegroundColor Green }
+function Write-Warn  { param([string]$Msg) Write-Warning $Msg }
+function Write-Fail  { param([string]$Msg) Write-Host "[ERROR] $Msg" -ForegroundColor Red; exit 1 }
+
+function Test-CommandExists {
+    param([string]$Name)
+    $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-LatestVersion {
+    try {
+        $response = Invoke-WebRequest -Uri "$RepoWebUrl/releases/latest" -MaximumRedirection 0 -ErrorAction SilentlyContinue 2>$null
+    } catch {
+        $response = $_.Exception.Response
+    }
+    if ($response -and $response.Headers -and $response.Headers.Location) {
+        $location = $response.Headers.Location
+        if ($location -is [array]) { $location = $location[0] }
+        return ($location -split "tag/" | Select-Object -Last 1).Trim()
+    }
+    return $null
+}
+
+# ---------------------------------------------------------------------------
+# CLI Installation
+# ---------------------------------------------------------------------------
+function Install-CliBinary {
+    Write-Info "Installing Multica CLI from GitHub Releases..."
+
+    $arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { Write-Fail "Multica requires a 64-bit Windows installation." }
+
+    $latest = Get-LatestVersion
+    if (-not $latest) {
+        Write-Fail "Could not determine latest release. Check your network connection."
+    }
+
+    $url = "https://github.com/multica-ai/multica/releases/download/$latest/multica_windows_$arch.zip"
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "multica-install"
+
+    if (Test-Path $tmpDir) { Remove-Item $tmpDir -Recurse -Force }
+    New-Item -ItemType Directory -Path $tmpDir | Out-Null
+
+    Write-Info "Downloading $url ..."
+    try {
+        Invoke-WebRequest -Uri $url -OutFile (Join-Path $tmpDir "multica.zip") -UseBasicParsing
+    } catch {
+        Remove-Item $tmpDir -Recurse -Force
+        Write-Fail "Failed to download CLI binary: $_"
+    }
+
+    Expand-Archive -Path (Join-Path $tmpDir "multica.zip") -DestinationPath $tmpDir -Force
+
+    $binDir = Join-Path $env:USERPROFILE ".multica\bin"
+    if (-not (Test-Path $binDir)) {
+        New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+    }
+
+    $exeSrc = Join-Path $tmpDir "multica.exe"
+    if (-not (Test-Path $exeSrc)) {
+        $exeSrc = Get-ChildItem -Path $tmpDir -Filter "multica.exe" -Recurse | Select-Object -First 1 -ExpandProperty FullName
+    }
+    if (-not $exeSrc -or -not (Test-Path $exeSrc)) {
+        Remove-Item $tmpDir -Recurse -Force
+        Write-Fail "multica.exe not found in downloaded archive."
+    }
+
+    Copy-Item $exeSrc (Join-Path $binDir "multica.exe") -Force
+    Remove-Item $tmpDir -Recurse -Force
+
+    Add-ToUserPath $binDir
+    Write-Ok "Multica CLI installed to $binDir\multica.exe"
+}
+
+function Add-ToUserPath {
+    param([string]$Dir)
+    $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($currentPath -and $currentPath.Split(";") -contains $Dir) {
+        return
+    }
+    $newPath = if ($currentPath) { "$currentPath;$Dir" } else { $Dir }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    # Also update current session
+    if ($env:Path -notlike "*$Dir*") {
+        $env:Path = "$Dir;$env:Path"
+    }
+    Write-Info "Added $Dir to user PATH (restart your terminal for other sessions to pick it up)."
+}
+
+function Install-CliScoop {
+    Write-Info "Installing Multica CLI via Scoop..."
+    try {
+        scoop bucket add multica https://github.com/multica-ai/scoop-bucket.git 2>$null
+        scoop install multica
+        Write-Ok "Multica CLI installed via Scoop"
+    } catch {
+        Write-Warn "Scoop install failed, falling back to direct download."
+        Install-CliBinary
+    }
+}
+
+function Install-Cli {
+    if (Test-CommandExists "multica") {
+        $currentVer = (multica version 2>$null) -replace '.*?(v[\d.]+).*','$1'
+        $latestVer = Get-LatestVersion
+
+        $currentCmp = $currentVer -replace '^v',''
+        $latestCmp = $latestVer -replace '^v',''
+
+        if (-not $latestVer -or $currentCmp -eq $latestCmp) {
+            Write-Ok "Multica CLI is up to date ($currentVer)"
+            return
+        }
+
+        Write-Info "Multica CLI $currentVer installed, latest is $latestVer - upgrading..."
+        Install-CliBinary
+
+        $newVer = (multica version 2>$null) -replace '.*?(v[\d.]+).*','$1'
+        Write-Ok "Multica CLI upgraded ($currentVer -> $newVer)"
+        return
+    }
+
+    if (Test-CommandExists "scoop") {
+        Install-CliScoop
+    } else {
+        Install-CliBinary
+    }
+
+    if (-not (Test-CommandExists "multica")) {
+        Write-Fail "CLI installed but 'multica' not found on PATH. Restart your terminal and try again."
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Docker check
+# ---------------------------------------------------------------------------
+function Test-Docker {
+    if (-not (Test-CommandExists "docker")) {
+        Write-Fail @"
+Docker is not installed. Multica self-hosting requires Docker and Docker Compose.
+
+Install Docker Desktop for Windows:
+  https://docs.docker.com/desktop/install/windows-install/
+
+After installing Docker, re-run this script with `$env:MULTICA_MODE="local"`.
+"@
+    }
+
+    try {
+        docker info 2>$null | Out-Null
+    } catch {
+        Write-Fail "Docker is installed but not running. Please start Docker Desktop and re-run this script."
+    }
+
+    Write-Ok "Docker is available"
+}
+
+# ---------------------------------------------------------------------------
+# Server setup (self-host / local)
+# ---------------------------------------------------------------------------
+function Install-Server {
+    Write-Info "Setting up Multica server..."
+
+    if (Test-Path (Join-Path $InstallDir ".git")) {
+        Write-Info "Updating existing installation at $InstallDir..."
+        Push-Location $InstallDir
+        git fetch origin main --depth 1 2>$null
+        git reset --hard origin/main 2>$null
+        Pop-Location
+    } else {
+        Write-Info "Cloning Multica repository..."
+        if (-not (Test-CommandExists "git")) {
+            Write-Fail "Git is not installed. Please install git and re-run."
+        }
+        if (Test-Path $InstallDir) {
+            Write-Warn "Removing incomplete installation at $InstallDir..."
+            Remove-Item $InstallDir -Recurse -Force
+        }
+        $parentDir = Split-Path $InstallDir -Parent
+        if (-not (Test-Path $parentDir)) {
+            New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+        }
+        git clone --depth 1 $RepoUrl $InstallDir
+    }
+
+    Write-Ok "Repository ready at $InstallDir"
+
+    Push-Location $InstallDir
+
+    if (-not (Test-Path ".env")) {
+        Write-Info "Creating .env with random JWT_SECRET..."
+        Copy-Item ".env.example" ".env"
+        $jwt = -join ((1..32) | ForEach-Object { "{0:x2}" -f (Get-Random -Maximum 256) })
+        (Get-Content ".env") -replace '^JWT_SECRET=.*', "JWT_SECRET=$jwt" | Set-Content ".env"
+        Write-Ok "Generated .env with random JWT_SECRET"
+    } else {
+        Write-Ok "Using existing .env"
+    }
+
+    Write-Info "Starting Multica services (this may take a few minutes on first run)..."
+    docker compose -f docker-compose.selfhost.yml up -d --build
+
+    Write-Info "Waiting for backend to be ready..."
+    $ready = $false
+    for ($i = 1; $i -le 45; $i++) {
+        try {
+            $null = Invoke-WebRequest -Uri "http://localhost:8080/health" -UseBasicParsing -TimeoutSec 2
+            $ready = $true
+            break
+        } catch {
+            Start-Sleep -Seconds 2
+        }
+    }
+
+    if ($ready) {
+        Write-Ok "Multica server is running"
+    } else {
+        Write-Warn "Server is still starting. Check logs with:"
+        Write-Host "  cd $InstallDir; docker compose -f docker-compose.selfhost.yml logs"
+    }
+
+    Pop-Location
+}
+
+# ---------------------------------------------------------------------------
+# Configure CLI
+# ---------------------------------------------------------------------------
+function Set-ConfigLocal {
+    Write-Info "Configuring CLI for local server..."
+    try {
+        multica config local 2>$null
+    } catch {
+        multica config set app_url http://localhost:3000 2>$null
+        multica config set server_url http://localhost:8080 2>$null
+    }
+    Write-Ok "CLI configured for localhost (backend :8080, frontend :3000)"
+}
+
+function Set-ConfigCloud {
+    Write-Info "Configuring CLI for Multica Cloud..."
+    multica config set server_url https://api.multica.ai 2>$null
+    multica config set app_url https://multica.ai 2>$null
+    Write-Ok "CLI configured for multica.ai"
+}
+
+# ---------------------------------------------------------------------------
+# Main: Default mode (cloud)
+# ---------------------------------------------------------------------------
+function Start-DefaultInstall {
+    Write-Host ""
+    Write-Host "  Multica - Installer" -ForegroundColor White
+    Write-Host "  Installing the CLI to connect to multica.ai" -ForegroundColor Cyan
+    Write-Host ""
+
+    Install-Cli
+    Set-ConfigCloud
+
+    Write-Host ""
+    Write-Host "  ============================================" -ForegroundColor Green
+    Write-Host "  [OK] Multica CLI is installed!" -ForegroundColor Green
+    Write-Host "  ============================================" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "  Next steps:"
+    Write-Host ""
+    Write-Host "     multica login          " -NoNewline; Write-Host "# Authenticate with multica.ai" -ForegroundColor DarkGray
+    Write-Host "     multica daemon start   " -NoNewline; Write-Host "# Start the agent daemon" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "  Or do it all in one command:"
+    Write-Host ""
+    Write-Host "     multica setup" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  Self-hosting? Re-run with:"
+    Write-Host '     $env:MULTICA_MODE="local"; irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex'
+    Write-Host ""
+}
+
+# ---------------------------------------------------------------------------
+# Main: Local mode (self-host)
+# ---------------------------------------------------------------------------
+function Start-LocalInstall {
+    Write-Host ""
+    Write-Host "  Multica - Self-Host Installer" -ForegroundColor White
+    Write-Host "  Setting up a local Multica server + CLI"
+    Write-Host ""
+
+    Test-Docker
+    Install-Server
+    Install-Cli
+    Set-ConfigLocal
+
+    Write-Host ""
+    Write-Host "  ============================================" -ForegroundColor Green
+    Write-Host "  [OK] Multica is installed and running!" -ForegroundColor Green
+    Write-Host "  ============================================" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "  Frontend:  http://localhost:3000"
+    Write-Host "  Backend:   http://localhost:8080"
+    Write-Host "  Server at: $InstallDir"
+    Write-Host ""
+    Write-Host "  Next steps:"
+    Write-Host "  1. Open http://localhost:3000 in your browser"
+    Write-Host "  2. Log in with any email + verification code: 888888"
+    Write-Host "  3. Then run:"
+    Write-Host ""
+    Write-Host "     multica login          " -NoNewline; Write-Host "# Authenticate (opens browser)" -ForegroundColor DarkGray
+    Write-Host "     multica daemon start   " -NoNewline; Write-Host "# Start the agent daemon" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "  To stop all services:"
+    Write-Host '     $env:MULTICA_MODE="stop"; irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex'
+    Write-Host ""
+}
+
+# ---------------------------------------------------------------------------
+# Stop: shut down a self-hosted installation
+# ---------------------------------------------------------------------------
+function Start-Stop {
+    Write-Host ""
+    Write-Info "Stopping Multica services..."
+
+    if (Test-Path $InstallDir) {
+        Push-Location $InstallDir
+        if (Test-Path "docker-compose.selfhost.yml") {
+            docker compose -f docker-compose.selfhost.yml down
+            Write-Ok "Docker services stopped"
+        } else {
+            Write-Warn "No docker-compose.selfhost.yml found at $InstallDir"
+        }
+        Pop-Location
+    } else {
+        Write-Warn "No Multica installation found at $InstallDir"
+    }
+
+    if (Test-CommandExists "multica") {
+        try {
+            multica daemon stop 2>$null
+            Write-Ok "Daemon stopped"
+        } catch {}
+    }
+
+    Write-Host ""
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+$mode = if ($env:MULTICA_MODE) { $env:MULTICA_MODE.ToLower() } else { "default" }
+
+switch ($mode) {
+    "local" { Start-LocalInstall }
+    "stop"  { Start-Stop }
+    default { Start-DefaultInstall }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,7 +43,10 @@ detect_os() {
   case "$(uname -s)" in
     Darwin) OS="darwin" ;;
     Linux)  OS="linux" ;;
-    *)      fail "Unsupported operating system: $(uname -s). Multica supports macOS and Linux." ;;
+    MINGW*|MSYS*|CYGWIN*)
+            fail "This script does not support Windows. Use the PowerShell installer instead:
+  irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex" ;;
+    *)      fail "Unsupported operating system: $(uname -s). Multica supports macOS, Linux, and Windows." ;;
   esac
 
   ARCH="$(uname -m)"


### PR DESCRIPTION
## Summary
- Add `scripts/install.ps1` PowerShell installer for Windows (downloads binary from GitHub Releases, installs to `%USERPROFILE%\.multica\bin\`, adds to user PATH, optional Scoop support)
- Add Windows (`windows/amd64`) to `.goreleaser.yml` builds with `.zip` archive format
- Update `install.sh` to redirect Windows users to the PowerShell script instead of hard-failing
- Update `CLI_INSTALL.md`, `README.md`, and `README.zh-CN.md` with Windows install instructions

Closes MUL-689

## Test plan
- [ ] Verify GoReleaser builds Windows binary: `goreleaser check` passes
- [ ] Run `install.ps1` on a Windows machine — binary downloads and `multica version` works
- [ ] Run `install.ps1` on a machine with Scoop — falls through to Scoop install path
- [ ] Verify `install.sh` on Git Bash/MSYS prints the PowerShell redirect message
- [ ] Verify PATH persistence across terminal restarts on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)