### PR TITLE
feat(release): add Windows build target to GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
@@ -25,6 +26,10 @@ archives:
   - id: default
     formats:
       - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -156,7 +156,7 @@ func runDaemonBackground(cmd *cobra.Command) error {
 	child := exec.Command(exePath, args...)
 	child.Stdout = logFile
 	child.Stderr = logFile
-	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	child.SysProcAttr = daemonSysProcAttr()
 
 	if err := child.Start(); err != nil {
 		logFile.Close()
@@ -306,7 +306,7 @@ func runDaemonForeground(cmd *cobra.Command) error {
 		}
 		child.Stdout = logFile
 		child.Stderr = logFile
-		child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		child.SysProcAttr = daemonSysProcAttr()
 
 		if err := child.Start(); err != nil {
 			logFile.Close()

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -8,10 +8,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -274,7 +272,7 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	}
 	cfg.CLIVersion = version
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, stop := daemonNotifyContext(context.Background())
 	defer stop()
 
 	logger := logger_pkg.NewLogger("daemon")
@@ -355,7 +353,7 @@ func runDaemonStop(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("find process %d: %w", int(pid), err)
 	}
 
-	if err := process.Signal(syscall.SIGTERM); err != nil {
+	if err := process.Signal(daemonStopSignal()); err != nil {
 		return fmt.Errorf("stop daemon (pid %d): %w", int(pid), err)
 	}
 

--- a/server/cmd/multica/sysproc_unix.go
+++ b/server/cmd/multica/sysproc_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/server/cmd/multica/sysproc_unix.go
+++ b/server/cmd/multica/sysproc_unix.go
@@ -2,8 +2,21 @@
 
 package main
 
-import "syscall"
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
 
 func daemonSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setsid: true}
+}
+
+func daemonNotifyContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
+}
+
+func daemonStopSignal() os.Signal {
+	return syscall.SIGTERM
 }

--- a/server/cmd/multica/sysproc_windows.go
+++ b/server/cmd/multica/sysproc_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{HideWindow: true}
+}

--- a/server/cmd/multica/sysproc_windows.go
+++ b/server/cmd/multica/sysproc_windows.go
@@ -2,8 +2,24 @@
 
 package main
 
-import "syscall"
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
 
 func daemonSysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{HideWindow: true}
+	return &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}
+
+func daemonNotifyContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, os.Interrupt)
+}
+
+func daemonStopSignal() os.Signal {
+	return os.Interrupt
 }


### PR DESCRIPTION
## Summary
- Add `windows` to GoReleaser `goos` list (amd64 + arm64)
- Add `format_overrides` so Windows archives use `.zip` instead of `.tar.gz`
- Extract `syscall.SysProcAttr` into build-tagged files (`sysproc_unix.go` / `sysproc_windows.go`) to fix cross-compilation — `Setsid` doesn't exist on Windows

## Artifacts produced
| OS | Arch | Format |
|---|---|---|
| darwin | amd64, arm64 | `.tar.gz` |
| linux | amd64, arm64 | `.tar.gz` |
| windows | amd64, arm64 | `.zip` |

## Test plan
- [x] `goreleaser check` — config valid
- [x] `goreleaser build --snapshot` — all 6 binaries compile
- [x] `goreleaser release --snapshot` — all 6 archives produced with correct formats

Closes MUL-688

🤖 Generated with [Claude Code](https://claude.com/claude-code)