### PR TITLE
fix: unify path handling — remove hardcoded Unix path separators

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -82,11 +83,11 @@ func daemonDirForProfile(profile string) string {
 }
 
 func daemonPIDPathForProfile(profile string) string {
-	return daemonDirForProfile(profile) + "/daemon.pid"
+	return filepath.Join(daemonDirForProfile(profile), "daemon.pid")
 }
 
 func daemonLogPathForProfile(profile string) string {
-	return daemonDirForProfile(profile) + "/daemon.log"
+	return filepath.Join(daemonDirForProfile(profile), "daemon.log")
 }
 
 // healthPortForProfile returns the health check port for the given profile.

--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -87,7 +87,7 @@ func resolveSharedCodexHome() string {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join("/tmp", ".codex") // last resort fallback
+		return filepath.Join(os.TempDir(), ".codex") // last resort fallback
 	}
 	return filepath.Join(home, ".codex")
 }


### PR DESCRIPTION
## Summary
- Replace string concatenation with `/` in `cmd_daemon.go` path helpers with `filepath.Join()` for cross-platform correctness
- Replace hardcoded `/tmp` in `codex_home.go` fallback with `os.TempDir()` so it works on Windows (`%TEMP%`) and other platforms
- Audited all Go files in `server/` — remaining `/` concatenations are URL paths (not filesystem), which correctly use forward slashes

Closes MUL-692

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/daemon/execenv/ ./cmd/multica/` passes
- [ ] Verify daemon start/stop still works with the updated PID/log paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)