### PR TITLE
feat(chat): overhaul chat UI — resize, animations, session history

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,26 +1,41 @@
 import { resolve } from "path";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+import { loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig({
-  main: {
-    plugins: [externalizeDepsPlugin()],
-  },
-  preload: {
-    plugins: [externalizeDepsPlugin()],
-  },
-  renderer: {
-    server: {
-      port: 5173,
-      strictPort: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const remoteApi = env.VITE_REMOTE_API;
+  const remoteWs = remoteApi?.replace(/^https/, "wss").replace(/^http/, "ws");
+
+  return {
+    main: {
+      plugins: [externalizeDepsPlugin()],
     },
-    plugins: [react(), tailwindcss()],
-    resolve: {
-      alias: {
-        "@": resolve("src/renderer/src"),
+    preload: {
+      plugins: [externalizeDepsPlugin()],
+    },
+    renderer: {
+      server: {
+        port: 5173,
+        strictPort: true,
+        ...(remoteApi && {
+          proxy: {
+            "/api": { target: remoteApi, changeOrigin: true },
+            "/auth": { target: remoteApi, changeOrigin: true },
+            "/uploads": { target: remoteApi, changeOrigin: true },
+            "/ws": { target: remoteWs, changeOrigin: true, ws: true },
+          },
+        }),
       },
-      dedupe: ["react", "react-dom"],
+      plugins: [react(), tailwindcss()],
+      resolve: {
+        alias: {
+          "@": resolve("src/renderer/src"),
+        },
+        dedupe: ["react", "react-dom"],
+      },
     },
-  },
+  };
 });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,7 @@
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
+    "dev:remote": "electron-vite dev --mode remote",
     "build": "electron-vite build",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -39,12 +39,14 @@ function AppContent() {
   return <DesktopShell />;
 }
 
+const remoteProxy = Boolean(import.meta.env.VITE_REMOTE_API);
+
 export default function App() {
   return (
     <ThemeProvider>
       <CoreProvider
-        apiBaseUrl={import.meta.env.VITE_API_URL || "http://localhost:8080"}
-        wsUrl={import.meta.env.VITE_WS_URL || "ws://localhost:8080/ws"}
+        apiBaseUrl={remoteProxy ? "" : (import.meta.env.VITE_API_URL || "http://localhost:8080")}
+        wsUrl={remoteProxy ? "ws://localhost:5173/ws" : (import.meta.env.VITE_WS_URL || "ws://localhost:8080/ws")}
       >
         <AppContent />
       </CoreProvider>

--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -85,17 +85,17 @@ export function DesktopShell() {
               >
                 <TabBar />
               </header>
-              {/* Content area with inset styling */}
-              <div className="flex flex-1 min-h-0 flex-col overflow-hidden mr-2 mb-2 ml-0.5 rounded-xl shadow-sm bg-background">
+              {/* Content area with inset styling — relative so ChatWindow/ChatFab are constrained here */}
+              <div className="relative flex flex-1 min-h-0 flex-col overflow-hidden mr-2 mb-2 ml-0.5 rounded-xl shadow-sm bg-background">
                 <TabContent />
+                <ChatWindow />
+                <ChatFab />
               </div>
             </div>
           </SidebarProvider>
         </div>
         <ModalRegistry />
         <SearchCommand />
-        <ChatWindow />
-        <ChatFab />
       </DashboardGuard>
     </DesktopNavigationProvider>
   );

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev:web": "turbo dev --filter=@multica/web",
     "dev:desktop": "turbo dev --filter=@multica/desktop",
+    "dev:desktop:remote": "pnpm --filter @multica/desktop dev:remote",
     "build": "turbo build",
     "typecheck": "turbo typecheck",
     "test": "turbo test",

--- a/packages/core/chat/index.ts
+++ b/packages/core/chat/index.ts
@@ -1,4 +1,4 @@
-export { createChatStore } from "./store";
+export { createChatStore, CHAT_MIN_W, CHAT_MIN_H, CHAT_DEFAULT_W, CHAT_DEFAULT_H } from "./store";
 export type { ChatStoreOptions, ChatState, ChatTimelineItem } from "./store";
 
 import type { createChatStore as CreateChatStoreFn } from "./store";

--- a/packages/core/chat/mutations.ts
+++ b/packages/core/chat/mutations.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { useWorkspaceId } from "../hooks";
 import { chatKeys } from "./queries";
+import type { ChatSession } from "../types";
 
 export function useCreateChatSession() {
   const qc = useQueryClient();
@@ -23,6 +24,29 @@ export function useArchiveChatSession() {
 
   return useMutation({
     mutationFn: (sessionId: string) => api.archiveChatSession(sessionId),
+    onMutate: async (sessionId) => {
+      await qc.cancelQueries({ queryKey: chatKeys.sessions(wsId) });
+      await qc.cancelQueries({ queryKey: chatKeys.allSessions(wsId) });
+
+      const prevSessions = qc.getQueryData<ChatSession[]>(chatKeys.sessions(wsId));
+      const prevAll = qc.getQueryData<ChatSession[]>(chatKeys.allSessions(wsId));
+
+      // Optimistic: remove from active, mark as archived in allSessions
+      qc.setQueryData<ChatSession[]>(chatKeys.sessions(wsId), (old) =>
+        old ? old.filter((s) => s.id !== sessionId) : old,
+      );
+      qc.setQueryData<ChatSession[]>(chatKeys.allSessions(wsId), (old) =>
+        old?.map((s) =>
+          s.id === sessionId ? { ...s, status: "archived" as const } : s,
+        ),
+      );
+
+      return { prevSessions, prevAll };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prevSessions) qc.setQueryData(chatKeys.sessions(wsId), ctx.prevSessions);
+      if (ctx?.prevAll) qc.setQueryData(chatKeys.allSessions(wsId), ctx.prevAll);
+    },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: chatKeys.sessions(wsId) });
       qc.invalidateQueries({ queryKey: chatKeys.allSessions(wsId) });

--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -4,6 +4,15 @@ import { getCurrentWorkspaceId, registerForWorkspaceRehydration } from "../platf
 
 const AGENT_STORAGE_KEY = "multica:chat:selectedAgentId";
 const SESSION_STORAGE_KEY = "multica:chat:activeSessionId";
+const DRAFT_KEY = "multica:chat:draft";
+const CHAT_WIDTH_KEY = "multica:chat:width";
+const CHAT_HEIGHT_KEY = "multica:chat:height";
+const CHAT_EXPANDED_KEY = "multica:chat:expanded";
+
+export const CHAT_MIN_W = 360;
+export const CHAT_MIN_H = 480;
+export const CHAT_DEFAULT_W = 420;
+export const CHAT_DEFAULT_H = 600;
 
 export interface ChatTimelineItem {
   seq: number;
@@ -16,21 +25,29 @@ export interface ChatTimelineItem {
 
 export interface ChatState {
   isOpen: boolean;
-  isFullscreen: boolean;
   activeSessionId: string | null;
   pendingTaskId: string | null;
   selectedAgentId: string | null;
   showHistory: boolean;
   timelineItems: ChatTimelineItem[];
+  inputDraft: string;
+  /** Raw user-chosen size — no clamp applied. UI layer clamps at render time. */
+  chatWidth: number;
+  chatHeight: number;
+  isExpanded: boolean;
   setOpen: (open: boolean) => void;
   toggle: () => void;
-  toggleFullscreen: () => void;
   setActiveSession: (id: string | null) => void;
   setPendingTask: (taskId: string | null) => void;
   setSelectedAgentId: (id: string) => void;
   setShowHistory: (show: boolean) => void;
   addTimelineItem: (item: ChatTimelineItem) => void;
   clearTimeline: () => void;
+  setInputDraft: (draft: string) => void;
+  clearInputDraft: () => void;
+  /** Persist raw size and auto-exit expanded mode. */
+  setChatSize: (width: number, height: number) => void;
+  setExpanded: (expanded: boolean) => void;
 }
 
 export interface ChatStoreOptions {
@@ -47,20 +64,17 @@ export function createChatStore(options: ChatStoreOptions) {
 
   const store = create<ChatState>((set) => ({
     isOpen: false,
-    isFullscreen: false,
     activeSessionId: storage.getItem(wsKey(SESSION_STORAGE_KEY)),
     pendingTaskId: null,
     selectedAgentId: storage.getItem(wsKey(AGENT_STORAGE_KEY)),
     showHistory: false,
     timelineItems: [],
-    setOpen: (open) =>
-      set({ isOpen: open, ...(open ? {} : { isFullscreen: false }) }),
-    toggle: () =>
-      set((s) => ({
-        isOpen: !s.isOpen,
-        ...(s.isOpen ? { isFullscreen: false } : {}),
-      })),
-    toggleFullscreen: () => set((s) => ({ isFullscreen: !s.isFullscreen })),
+    inputDraft: storage.getItem(wsKey(DRAFT_KEY)) ?? "",
+    chatWidth: Number(storage.getItem(CHAT_WIDTH_KEY)) || CHAT_DEFAULT_W,
+    chatHeight: Number(storage.getItem(CHAT_HEIGHT_KEY)) || CHAT_DEFAULT_H,
+    isExpanded: storage.getItem(wsKey(CHAT_EXPANDED_KEY)) === "true",
+    setOpen: (open) => set({ isOpen: open }),
+    toggle: () => set((s) => ({ isOpen: !s.isOpen })),
     setActiveSession: (id) => {
       if (id) {
         storage.setItem(wsKey(SESSION_STORAGE_KEY), id);
@@ -75,6 +89,18 @@ export function createChatStore(options: ChatStoreOptions) {
       set({ selectedAgentId: id });
     },
     setShowHistory: (show) => set({ showHistory: show }),
+    setInputDraft: (draft) => {
+      if (draft) {
+        storage.setItem(wsKey(DRAFT_KEY), draft);
+      } else {
+        storage.removeItem(wsKey(DRAFT_KEY));
+      }
+      set({ inputDraft: draft });
+    },
+    clearInputDraft: () => {
+      storage.removeItem(wsKey(DRAFT_KEY));
+      set({ inputDraft: "" });
+    },
     addTimelineItem: (item) =>
       set((s) => {
         if (s.timelineItems.some((t) => t.seq === item.seq)) return s;
@@ -85,12 +111,28 @@ export function createChatStore(options: ChatStoreOptions) {
         };
       }),
     clearTimeline: () => set({ timelineItems: [] }),
+    setChatSize: (w, h) => {
+      storage.setItem(CHAT_WIDTH_KEY, String(w));
+      storage.setItem(CHAT_HEIGHT_KEY, String(h));
+      // Dragging = user chose a manual size → exit expanded mode
+      storage.removeItem(wsKey(CHAT_EXPANDED_KEY));
+      set({ chatWidth: w, chatHeight: h, isExpanded: false });
+    },
+    setExpanded: (expanded) => {
+      if (expanded) {
+        storage.setItem(wsKey(CHAT_EXPANDED_KEY), "true");
+      } else {
+        storage.removeItem(wsKey(CHAT_EXPANDED_KEY));
+      }
+      set({ isExpanded: expanded });
+    },
   }));
 
   registerForWorkspaceRehydration(() => {
     store.setState({
       activeSessionId: storage.getItem(wsKey(SESSION_STORAGE_KEY)),
       selectedAgentId: storage.getItem(wsKey(AGENT_STORAGE_KEY)),
+      inputDraft: storage.getItem(wsKey(DRAFT_KEY)) ?? "",
       timelineItems: [],
     });
   });

--- a/packages/core/provider.tsx
+++ b/packages/core/provider.tsx
@@ -2,16 +2,14 @@
 
 import { useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createQueryClient } from "./query-client";
 import type { ReactNode } from "react";
 
-export function QueryProvider({ children, showDevtools = true }: { children: ReactNode; showDevtools?: boolean }) {
+export function QueryProvider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(createQueryClient);
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      {showDevtools && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   );
 }

--- a/packages/ui/components/common/submit-button.tsx
+++ b/packages/ui/components/common/submit-button.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { ArrowUp, Loader2, Square } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+
+interface SubmitButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  running?: boolean;
+  onStop?: () => void;
+}
+
+function SubmitButton({ onClick, disabled, loading, running, onStop }: SubmitButtonProps) {
+  if (running) {
+    return (
+      <Button size="icon-sm" onClick={onStop}>
+        <Square className="fill-current" />
+      </Button>
+    );
+  }
+
+  return (
+    <Button size="icon-sm" disabled={disabled || loading} onClick={onClick}>
+      {loading ? (
+        <Loader2 className="animate-spin" />
+      ) : (
+        <ArrowUp />
+      )}
+    </Button>
+  );
+}
+
+export { SubmitButton, type SubmitButtonProps };

--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -18,7 +18,7 @@ export function ChatFab() {
     <Tooltip>
       <TooltipTrigger
         onClick={toggle}
-        className="fixed bottom-4 right-4 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full ring-1 ring-foreground/10 bg-card text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"
+        className="absolute bottom-2 right-2 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full ring-1 ring-foreground/10 bg-card text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"
       >
         <MessageCircle className="size-5" />
       </TooltipTrigger>

--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -15,7 +15,7 @@ export function ChatFab() {
   if (isOpen) return null;
 
   return (
-    <Tooltip delay={300}>
+    <Tooltip>
       <TooltipTrigger
         onClick={toggle}
         className="fixed bottom-4 right-4 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full border bg-background text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"

--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { Send } from "lucide-react";
+import { MessageCircle } from "lucide-react";
 import { useChatStore } from "@multica/core/chat";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@multica/ui/components/ui/tooltip";
 
 export function ChatFab() {
   const isOpen = useChatStore((s) => s.isOpen);
@@ -10,12 +15,14 @@ export function ChatFab() {
   if (isOpen) return null;
 
   return (
-    <button
-      onClick={toggle}
-      className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border bg-background px-4 py-2 text-sm font-medium text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
-    >
-      <Send className="size-3.5" />
-      Ask Multica
-    </button>
+    <Tooltip delay={300}>
+      <TooltipTrigger
+        onClick={toggle}
+        className="fixed bottom-4 right-4 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full border bg-background text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"
+      >
+        <MessageCircle className="size-5" />
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={10}>Ask Multica</TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/views/chat/components/chat-fab.tsx
+++ b/packages/views/chat/components/chat-fab.tsx
@@ -18,7 +18,7 @@ export function ChatFab() {
     <Tooltip>
       <TooltipTrigger
         onClick={toggle}
-        className="fixed bottom-4 right-4 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full border bg-background text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"
+        className="fixed bottom-4 right-4 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full ring-1 ring-foreground/10 bg-card text-muted-foreground shadow-sm transition-transform hover:scale-110 hover:text-accent-foreground active:scale-95"
       >
         <MessageCircle className="size-5" />
       </TooltipTrigger>

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
-import { ArrowUp, Square } from "lucide-react";
+import { useRef, useState } from "react";
+import { ContentEditor, type ContentEditorRef } from "../../editor";
+import { SubmitButton } from "@multica/ui/components/common/submit-button";
 
 interface ChatInputProps {
   onSend: (content: string) => void;
@@ -11,70 +12,36 @@ interface ChatInputProps {
 }
 
 export function ChatInput({ onSend, onStop, isRunning, disabled }: ChatInputProps) {
-  const [value, setValue] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editorRef = useRef<ContentEditorRef>(null);
+  const [isEmpty, setIsEmpty] = useState(true);
 
-  const handleSend = useCallback(() => {
-    const trimmed = value.trim();
-    if (!trimmed || isRunning || disabled) return;
-    onSend(trimmed);
-    setValue("");
-    if (textareaRef.current) {
-      textareaRef.current.style.height = "auto";
-    }
-    textareaRef.current?.focus();
-  }, [value, isRunning, disabled, onSend]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        handleSend();
-      }
-    },
-    [handleSend],
-  );
-
-  const handleInput = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = Math.min(el.scrollHeight, 120) + "px";
-  }, []);
+  const handleSend = () => {
+    const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
+    if (!content || isRunning || disabled) return;
+    onSend(content);
+    editorRef.current?.clearContent();
+    setIsEmpty(true);
+  };
 
   return (
-    <div className="border-t bg-muted/30 p-3">
-      <div className="rounded-lg border bg-background">
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => {
-            setValue(e.target.value);
-            handleInput();
-          }}
-          onKeyDown={handleKeyDown}
-          placeholder={disabled ? "This session is archived" : "Ask Multica..."}
-          disabled={isRunning || disabled}
-          className="block w-full resize-none bg-transparent px-3 pt-3 pb-2 text-sm placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
-          rows={1}
-        />
-        <div className="flex items-center justify-end px-2 pb-2">
-          {isRunning ? (
-            <button
-              onClick={onStop}
-              className="flex size-7 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-80"
-            >
-              <Square className="size-3 fill-current" />
-            </button>
-          ) : (
-            <button
-              onClick={handleSend}
-              disabled={!value.trim() || disabled}
-              className="flex size-7 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-80 disabled:opacity-30"
-            >
-              <ArrowUp className="size-4" />
-            </button>
-          )}
+    <div className="p-2 pt-0">
+      <div className="relative flex min-h-16 max-h-40 flex-col rounded-lg bg-card pb-8 ring-1 ring-border">
+        <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
+          <ContentEditor
+            ref={editorRef}
+            placeholder={disabled ? "This session is archived" : "Ask Multica..."}
+            onUpdate={(md) => setIsEmpty(!md.trim())}
+            onSubmit={handleSend}
+            debounceMs={100}
+          />
+        </div>
+        <div className="absolute bottom-1 right-1.5 flex items-center gap-1">
+          <SubmitButton
+            onClick={handleSend}
+            disabled={isEmpty || !!disabled}
+            running={isRunning}
+            onStop={onStop}
+          />
         </div>
       </div>
     </div>

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { ContentEditor, type ContentEditorRef } from "../../editor";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
+import { useChatStore } from "@multica/core/chat";
 
 interface ChatInputProps {
   onSend: (content: string) => void;
@@ -13,13 +14,17 @@ interface ChatInputProps {
 
 export function ChatInput({ onSend, onStop, isRunning, disabled }: ChatInputProps) {
   const editorRef = useRef<ContentEditorRef>(null);
-  const [isEmpty, setIsEmpty] = useState(true);
+  const inputDraft = useChatStore((s) => s.inputDraft);
+  const setInputDraft = useChatStore((s) => s.setInputDraft);
+  const clearInputDraft = useChatStore((s) => s.clearInputDraft);
+  const [isEmpty, setIsEmpty] = useState(!inputDraft.trim());
 
   const handleSend = () => {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
     if (!content || isRunning || disabled) return;
     onSend(content);
     editorRef.current?.clearContent();
+    clearInputDraft();
     setIsEmpty(true);
   };
 
@@ -29,8 +34,12 @@ export function ChatInput({ onSend, onStop, isRunning, disabled }: ChatInputProp
         <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
           <ContentEditor
             ref={editorRef}
+            defaultValue={inputDraft}
             placeholder={disabled ? "This session is archived" : "Ask Multica..."}
-            onUpdate={(md) => setIsEmpty(!md.trim())}
+            onUpdate={(md) => {
+              setIsEmpty(!md.trim());
+              setInputDraft(md);
+            }}
             onSubmit={handleSend}
             debounceMs={100}
           />

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -25,7 +25,7 @@ export function ChatInput({ onSend, onStop, isRunning, disabled }: ChatInputProp
 
   return (
     <div className="p-2 pt-0">
-      <div className="relative flex min-h-16 max-h-40 flex-col rounded-lg bg-card pb-8 ring-1 ring-border">
+      <div className="relative flex min-h-16 max-h-40 flex-col rounded-lg bg-card pb-8 border-1 border-border transition-colors focus-within:border-brand">
         <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
           <ContentEditor
             ref={editorRef}

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -1,47 +1,48 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { cn } from "@multica/ui/lib/utils";
-import { Avatar, AvatarFallback, AvatarImage } from "@multica/ui/components/ui/avatar";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@multica/ui/components/ui/collapsible";
-import { Bot, Loader2, ChevronRight, ChevronDown, Brain, AlertCircle } from "lucide-react";
+import { Loader2, ChevronRight, ChevronDown, Brain, AlertCircle } from "lucide-react";
+import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
+import { useAutoScroll } from "@multica/ui/hooks/use-auto-scroll";
 import { api } from "@multica/core/api";
 import { Markdown } from "@multica/views/common/markdown";
-import type { ChatMessage, Agent, TaskMessagePayload } from "@multica/core/types";
+import type { ChatMessage, TaskMessagePayload } from "@multica/core/types";
 import type { ChatTimelineItem } from "@multica/core/chat";
 
 // ─── Public component ────────────────────────────────────────────────────
 
 interface ChatMessageListProps {
   messages: ChatMessage[];
-  agent: Agent | null;
   timelineItems: ChatTimelineItem[];
   isWaiting: boolean;
 }
 
 export function ChatMessageList({
   messages,
-  agent,
   timelineItems,
   isWaiting,
 }: ChatMessageListProps) {
-  const bottomRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, timelineItems]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const fadeStyle = useScrollFade(scrollRef);
+  useAutoScroll(scrollRef);
 
   const hasTimeline = timelineItems.length > 0;
 
   return (
-    <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+    <div
+      ref={scrollRef}
+      style={fadeStyle}
+      className="flex-1 overflow-y-auto px-4 py-3 space-y-4"
+    >
       {messages.map((msg) => (
-        <MessageBubble key={msg.id} message={msg} agent={agent} />
+        <MessageBubble key={msg.id} message={msg} />
       ))}
       {/* Live streaming timeline */}
       {hasTimeline && (
@@ -52,20 +53,13 @@ export function ChatMessageList({
       {isWaiting && !hasTimeline && (
         <Loader2 className="size-4 animate-spin text-muted-foreground" />
       )}
-      <div ref={bottomRef} />
     </div>
   );
 }
 
 // ─── Message bubbles ─────────────────────────────────────────────────────
 
-function MessageBubble({
-  message,
-  agent,
-}: {
-  message: ChatMessage;
-  agent: Agent | null;
-}) {
+function MessageBubble({ message }: { message: ChatMessage }) {
   if (message.role === "user") {
     return (
       <div className="flex justify-end">
@@ -76,15 +70,13 @@ function MessageBubble({
     );
   }
 
-  return <AssistantMessage message={message} agent={agent} />;
+  return <AssistantMessage message={message} />;
 }
 
 function AssistantMessage({
   message,
-  agent,
 }: {
   message: ChatMessage;
-  agent: Agent | null;
 }) {
   const taskId = message.task_id;
 
@@ -345,13 +337,3 @@ function ErrorRow({ item }: { item: ChatTimelineItem }) {
 
 // ─── Shared ──────────────────────────────────────────────────────────────
 
-function AgentAvatar({ agent }: { agent: Agent | null }) {
-  return (
-    <Avatar className="size-6 shrink-0 mt-0.5">
-      {agent?.avatar_url && <AvatarImage src={agent.avatar_url} />}
-      <AvatarFallback className="bg-purple-100 text-purple-700">
-        <Bot className="size-3" />
-      </AvatarFallback>
-    </Avatar>
-  );
-}

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -45,20 +45,12 @@ export function ChatMessageList({
       ))}
       {/* Live streaming timeline */}
       {hasTimeline && (
-        <div className="flex items-start gap-3">
-          <AgentAvatar agent={agent} />
-          <div className="min-w-0 flex-1 space-y-1.5">
-            <TimelineView items={timelineItems} />
-          </div>
+        <div className="w-full space-y-1.5">
+          <TimelineView items={timelineItems} />
         </div>
       )}
       {isWaiting && !hasTimeline && (
-        <div className="flex items-start gap-3">
-          <AgentAvatar agent={agent} />
-          <div className="flex items-center pt-1">
-            <Loader2 className="size-4 animate-spin text-muted-foreground" />
-          </div>
-        </div>
+        <Loader2 className="size-4 animate-spin text-muted-foreground" />
       )}
       <div ref={bottomRef} />
     </div>
@@ -77,7 +69,7 @@ function MessageBubble({
   if (message.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="rounded-2xl bg-primary px-3.5 py-2 text-sm text-primary-foreground max-w-[85%] whitespace-pre-wrap break-words">
+        <div className="rounded-2xl bg-muted px-3.5 py-2 text-sm max-w-[80%] whitespace-pre-wrap break-words">
           {message.content}
         </div>
       </div>
@@ -116,17 +108,14 @@ function AssistantMessage({
   );
 
   return (
-    <div className="flex items-start gap-3">
-      <AgentAvatar agent={agent} />
-      <div className="min-w-0 flex-1 space-y-1.5">
-        {timeline.length > 0 ? (
-          <TimelineView items={timeline} />
-        ) : (
-          <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none">
-            <Markdown>{message.content}</Markdown>
-          </div>
-        )}
-      </div>
+    <div className="w-full space-y-1.5">
+      {timeline.length > 0 ? (
+        <TimelineView items={timeline} />
+      ) : (
+        <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none">
+          <Markdown>{message.content}</Markdown>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/views/chat/components/chat-resize-handles.tsx
+++ b/packages/views/chat/components/chat-resize-handles.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import React from "react";
+
+type DragDir = "left" | "top" | "corner";
+
+interface ChatResizeHandlesProps {
+  onDragStart: (e: React.PointerEvent, dir: DragDir) => void;
+}
+
+export function ChatResizeHandles({ onDragStart }: ChatResizeHandlesProps) {
+  return (
+    <>
+      {/* Left edge — expands width when dragged left */}
+      <div
+        aria-hidden
+        onPointerDown={(e) => onDragStart(e, "left")}
+        className="absolute left-0 top-4 bottom-0 w-1 z-10 cursor-col-resize"
+      />
+      {/* Top edge — expands height when dragged up */}
+      <div
+        aria-hidden
+        onPointerDown={(e) => onDragStart(e, "top")}
+        className="absolute top-0 left-4 right-0 h-1 z-10 cursor-row-resize"
+      />
+      {/* Top-left corner — expands both width and height */}
+      <div
+        aria-hidden
+        onPointerDown={(e) => onDragStart(e, "corner")}
+        className="absolute top-0 left-0 size-4 z-20 cursor-nw-resize"
+      />
+    </>
+  );
+}

--- a/packages/views/chat/components/chat-session-history.tsx
+++ b/packages/views/chat/components/chat-session-history.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, MessageSquare, Archive, Trash2 } from "lucide-react";
+import { ArrowLeft, MessageSquare, Archive, Bot, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@multica/ui/lib/utils";
 import { Button } from "@multica/ui/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Avatar, AvatarFallback, AvatarImage } from "@multica/ui/components/ui/avatar";
-import { Bot } from "lucide-react";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { agentListOptions } from "@multica/core/workspace/queries";
 import { allChatSessionsOptions } from "@multica/core/chat/queries";
@@ -36,10 +37,12 @@ export function ChatSessionHistory() {
 
   const handleArchive = (e: React.MouseEvent, sessionId: string) => {
     e.stopPropagation();
-    archiveSession.mutate(sessionId);
     if (activeSessionId === sessionId) {
       setActiveSession(null);
     }
+    archiveSession.mutate(sessionId, {
+      onError: () => toast.error("Failed to archive session"),
+    });
   };
 
   const activeSessions = sessions.filter((s) => s.status === "active");
@@ -82,6 +85,7 @@ export function ChatSessionHistory() {
                 sessions={activeSessions}
                 agentMap={agentMap}
                 activeSessionId={activeSessionId}
+                archivingId={archiveSession.isPending ? (archiveSession.variables as string) : null}
                 onSelect={handleSelectSession}
                 onArchive={handleArchive}
               />
@@ -92,6 +96,7 @@ export function ChatSessionHistory() {
                 sessions={archivedSessions}
                 agentMap={agentMap}
                 activeSessionId={activeSessionId}
+                archivingId={null}
                 onSelect={handleSelectSession}
               />
             )}
@@ -107,6 +112,7 @@ function SessionGroup({
   sessions,
   agentMap,
   activeSessionId,
+  archivingId,
   onSelect,
   onArchive,
 }: {
@@ -114,6 +120,7 @@ function SessionGroup({
   sessions: ChatSession[];
   agentMap: Map<string, Agent>;
   activeSessionId: string | null;
+  archivingId: string | null;
   onSelect: (session: ChatSession) => void;
   onArchive?: (e: React.MouseEvent, sessionId: string) => void;
 }) {
@@ -130,6 +137,7 @@ function SessionGroup({
           session={session}
           agent={agentMap.get(session.agent_id) ?? null}
           isActive={session.id === activeSessionId}
+          isArchiving={session.id === archivingId}
           onSelect={() => onSelect(session)}
           onArchive={onArchive ? (e) => onArchive(e, session.id) : undefined}
         />
@@ -142,12 +150,14 @@ function SessionItem({
   session,
   agent,
   isActive,
+  isArchiving,
   onSelect,
   onArchive,
 }: {
   session: ChatSession;
   agent: Agent | null;
   isActive: boolean;
+  isArchiving: boolean;
   onSelect: () => void;
   onArchive?: (e: React.MouseEvent) => void;
 }) {
@@ -156,9 +166,10 @@ function SessionItem({
   return (
     <button
       onClick={onSelect}
-      className={`group flex w-full items-start gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 ${
-        isActive ? "bg-accent/30" : ""
-      }`}
+      className={cn(
+        "group flex w-full items-start gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent/50",
+        isActive && "bg-accent/30",
+      )}
     >
       <Avatar className="size-6 shrink-0 mt-0.5">
         {agent?.avatar_url && <AvatarImage src={agent.avatar_url} />}
@@ -185,15 +196,25 @@ function SessionItem({
         </div>
       </div>
       {onArchive && (
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="invisible group-hover:visible text-muted-foreground hover:text-destructive shrink-0 mt-0.5"
-          onClick={onArchive}
-          title="Archive"
-        >
-          <Trash2 />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className={cn(
+                  "shrink-0 mt-0.5 text-muted-foreground",
+                  !isArchiving && "invisible group-hover:visible",
+                )}
+                onClick={onArchive}
+                disabled={isArchiving}
+              />
+            }
+          >
+            {isArchiving ? <Loader2 className="animate-spin" /> : <Archive />}
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Archive</TooltipContent>
+        </Tooltip>
       )}
     </button>
   );

--- a/packages/views/chat/components/chat-session-history.tsx
+++ b/packages/views/chat/components/chat-session-history.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, MessageSquare, Archive, Trash2 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Avatar, AvatarFallback, AvatarImage } from "@multica/ui/components/ui/avatar";
 import { Bot } from "lucide-react";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -48,14 +49,21 @@ export function ChatSessionHistory() {
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center gap-2 border-b px-4 py-2.5">
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="text-muted-foreground"
-          onClick={() => setShowHistory(false)}
-        >
-          <ArrowLeft />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground"
+                onClick={() => setShowHistory(false)}
+              />
+            }
+          >
+            <ArrowLeft />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Back</TooltipContent>
+        </Tooltip>
         <span className="text-sm font-medium">Chat History</span>
       </div>
 

--- a/packages/views/chat/components/chat-session-history.tsx
+++ b/packages/views/chat/components/chat-session-history.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, MessageSquare, Archive, Trash2 } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@multica/ui/components/ui/avatar";
 import { Bot } from "lucide-react";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -47,12 +48,14 @@ export function ChatSessionHistory() {
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center gap-2 border-b px-4 py-2.5">
-        <button
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="text-muted-foreground"
           onClick={() => setShowHistory(false)}
-          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
         >
-          <ArrowLeft className="size-3.5" />
-        </button>
+          <ArrowLeft />
+        </Button>
         <span className="text-sm font-medium">Chat History</span>
       </div>
 
@@ -151,7 +154,7 @@ function SessionItem({
     >
       <Avatar className="size-6 shrink-0 mt-0.5">
         {agent?.avatar_url && <AvatarImage src={agent.avatar_url} />}
-        <AvatarFallback className="bg-purple-100 text-purple-700 text-[10px]">
+        <AvatarFallback className="bg-purple-100 text-purple-700">
           <Bot className="size-3" />
         </AvatarFallback>
       </Avatar>
@@ -174,13 +177,15 @@ function SessionItem({
         </div>
       </div>
       {onArchive && (
-        <button
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="invisible group-hover:visible text-muted-foreground hover:text-destructive shrink-0 mt-0.5"
           onClick={onArchive}
           title="Archive"
-          className="invisible group-hover:visible flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-destructive shrink-0 mt-0.5"
         >
-          <Trash2 className="size-3" />
-        </button>
+          <Trash2 />
+        </Button>
       )}
     </button>
   );

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -232,7 +232,7 @@ export function ChatWindow() {
 
   const isVisible = isOpen && boundsReady;
 
-  const containerClass = "absolute bottom-4 right-4 z-50 flex flex-col rounded-xl ring-1 ring-foreground/10 bg-sidebar shadow-2xl overflow-hidden";
+  const containerClass = "absolute bottom-2 right-2 z-50 flex flex-col rounded-xl ring-1 ring-foreground/10 bg-sidebar shadow-2xl overflow-hidden";
   const containerStyle: React.CSSProperties = {
     width: `${renderWidth}px`,
     height: `${renderHeight}px`,

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Minus, Maximize2, Minimize2, Send, ChevronDown, Bot, Plus, History } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@multica/ui/components/ui/avatar";
@@ -8,7 +8,10 @@ import { Button } from "@multica/ui/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -27,19 +30,19 @@ import { useChatStore } from "@multica/core/chat";
 import { ChatMessageList } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
 import { ChatSessionHistory } from "./chat-session-history";
+import { ChatResizeHandles } from "./chat-resize-handles";
+import { useChatResize } from "./use-chat-resize";
 import { useWS } from "@multica/core/realtime";
 import type { TaskMessagePayload, ChatDonePayload, Agent, ChatMessage } from "@multica/core/types";
 
 export function ChatWindow() {
   const wsId = useWorkspaceId();
   const isOpen = useChatStore((s) => s.isOpen);
-  const isFullscreen = useChatStore((s) => s.isFullscreen);
   const activeSessionId = useChatStore((s) => s.activeSessionId);
   const pendingTaskId = useChatStore((s) => s.pendingTaskId);
   const timelineItems = useChatStore((s) => s.timelineItems);
   const selectedAgentId = useChatStore((s) => s.selectedAgentId);
   const setOpen = useChatStore((s) => s.setOpen);
-  const toggleFullscreen = useChatStore((s) => s.toggleFullscreen);
   const showHistory = useChatStore((s) => s.showHistory);
   const setActiveSession = useChatStore((s) => s.setActiveSession);
   const setPendingTask = useChatStore((s) => s.setPendingTask);
@@ -47,7 +50,6 @@ export function ChatWindow() {
   const clearTimeline = useChatStore((s) => s.clearTimeline);
   const setSelectedAgentId = useChatStore((s) => s.setSelectedAgentId);
   const setShowHistory = useChatStore((s) => s.setShowHistory);
-
   const user = useAuthStore((s) => s.user);
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
   const { data: members = [] } = useQuery(memberListOptions(wsId));
@@ -222,22 +224,36 @@ export function ChatWindow() {
     [setSelectedAgentId, setActiveSession],
   );
 
-  if (!isOpen) return null;
+  const windowRef = useRef<HTMLDivElement>(null);
+  const { renderWidth, renderHeight, isAtMax, boundsReady, isDragging, toggleExpand, startDrag } = useChatResize(windowRef);
 
   const hasMessages = messages.length > 0 || timelineItems.length > 0;
 
-  const containerClass = isFullscreen
-    ? "fixed top-4 right-4 bottom-4 z-50 flex flex-col w-[50%] rounded-xl ring-1 ring-foreground/10 bg-sidebar shadow-2xl overflow-hidden"
-    : "fixed bottom-4 right-4 z-50 flex flex-col w-[420px] h-[600px] rounded-xl ring-1 ring-foreground/10 bg-sidebar shadow-2xl overflow-hidden";
+  const isVisible = isOpen && boundsReady;
+
+  const containerClass = "absolute bottom-4 right-4 z-50 flex flex-col rounded-xl ring-1 ring-foreground/10 bg-sidebar shadow-2xl overflow-hidden";
+  const containerStyle: React.CSSProperties = {
+    width: `${renderWidth}px`,
+    height: `${renderHeight}px`,
+    opacity: isVisible ? 1 : 0,
+    transform: isVisible ? "scale(1)" : "scale(0.95)",
+    transformOrigin: "bottom right",
+    pointerEvents: isOpen ? "auto" : "none",
+    transition: isDragging
+      ? "none"
+      : "width 200ms ease-out, height 200ms ease-out, opacity 150ms ease-out, transform 150ms ease-out",
+  };
 
   return (
-    <div className={containerClass}>
+    <div ref={windowRef} className={containerClass} style={containerStyle}>
+      <ChatResizeHandles onDragStart={startDrag} />
       {/* Header */}
       {!showHistory && (
         <div className="flex items-center justify-between border-b px-4 py-2.5">
           <AgentSelector
             agents={availableAgents}
             activeAgent={activeAgent}
+            userId={user?.id}
             onSelect={handleSelectAgent}
           />
           <div className="flex items-center gap-0.5">
@@ -267,10 +283,10 @@ export function ChatWindow() {
               variant="ghost"
               size="icon-sm"
               className="text-muted-foreground"
-              onClick={toggleFullscreen}
-              title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+              onClick={toggleExpand}
+              title={isAtMax ? "Restore" : "Expand"}
             >
-              {isFullscreen ? <Minimize2 /> : <Maximize2 />}
+              {isAtMax ? <Minimize2 /> : <Maximize2 />}
             </Button>
             <Button
               variant="ghost"
@@ -293,7 +309,6 @@ export function ChatWindow() {
           {hasMessages ? (
             <ChatMessageList
               messages={messages}
-              agent={activeAgent}
               timelineItems={timelineItems}
               isWaiting={!!pendingTaskId}
             />
@@ -317,10 +332,12 @@ export function ChatWindow() {
 function AgentSelector({
   agents,
   activeAgent,
+  userId,
   onSelect,
 }: {
   agents: Agent[];
   activeAgent: Agent | null;
+  userId: string | undefined;
   onSelect: (agent: Agent) => void;
 }) {
   if (!activeAgent) {
@@ -336,6 +353,9 @@ function AgentSelector({
     );
   }
 
+  const myAgents = agents.filter((a) => a.owner_id === userId);
+  const othersAgents = agents.filter((a) => a.owner_id !== userId);
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="flex items-center gap-2 rounded-md px-1.5 py-1 -ml-1.5 transition-colors hover:bg-accent aria-expanded:bg-accent">
@@ -344,16 +364,37 @@ function AgentSelector({
         <ChevronDown className="size-3 text-muted-foreground" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="max-h-60 w-auto max-w-56">
-        {agents.map((agent) => (
-          <DropdownMenuItem
-            key={agent.id}
-            onClick={() => onSelect(agent)}
-            className="flex min-w-0 items-center gap-2"
-          >
-            <AgentAvatarSmall agent={agent} />
-            <span className="truncate">{agent.name}</span>
-          </DropdownMenuItem>
-        ))}
+        {myAgents.length > 0 && (
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>My Agents</DropdownMenuLabel>
+            {myAgents.map((agent) => (
+              <DropdownMenuItem
+                key={agent.id}
+                onClick={() => onSelect(agent)}
+                className="flex min-w-0 items-center gap-2"
+              >
+                <AgentAvatarSmall agent={agent} />
+                <span className="truncate">{agent.name}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+        )}
+        {myAgents.length > 0 && othersAgents.length > 0 && <DropdownMenuSeparator />}
+        {othersAgents.length > 0 && (
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Others</DropdownMenuLabel>
+            {othersAgents.map((agent) => (
+              <DropdownMenuItem
+                key={agent.id}
+                onClick={() => onSelect(agent)}
+                className="flex min-w-0 items-center gap-2"
+              >
+                <AgentAvatarSmall agent={agent} />
+                <span className="truncate">{agent.name}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Minus, Maximize2, Minimize2, Send, ChevronDown, Bot, Plus, History } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@multica/ui/components/ui/avatar";
 import { Button } from "@multica/ui/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -257,46 +258,72 @@ export function ChatWindow() {
             onSelect={handleSelectAgent}
           />
           <div className="flex items-center gap-0.5">
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground"
-              onClick={() => setShowHistory(true)}
-              title="Chat history"
-            >
-              <History />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground"
-              onClick={() => {
-                setActiveSession(null);
-                clearTimeline();
-                setPendingTask(null);
-              }}
-              title="New chat"
-            >
-              <Plus />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground"
-              onClick={toggleExpand}
-              title={isAtMax ? "Restore" : "Expand"}
-            >
-              {isAtMax ? <Minimize2 /> : <Maximize2 />}
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground"
-              onClick={() => setOpen(false)}
-              title="Minimize"
-            >
-              <Minus />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="text-muted-foreground"
+                    onClick={() => setShowHistory(true)}
+                  />
+                }
+              >
+                <History />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Chat history</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="text-muted-foreground"
+                    onClick={() => {
+                      setActiveSession(null);
+                      clearTimeline();
+                      setPendingTask(null);
+                    }}
+                  />
+                }
+              >
+                <Plus />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">New chat</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="text-muted-foreground"
+                    onClick={toggleExpand}
+                  />
+                }
+              >
+                {isAtMax ? <Minimize2 /> : <Maximize2 />}
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {isAtMax ? "Restore" : "Expand"}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="text-muted-foreground"
+                    onClick={() => setOpen(false)}
+                  />
+                }
+              >
+                <Minus />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Minimize</TooltipContent>
+            </Tooltip>
           </div>
         </div>
       )}

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Minus, Maximize2, Minimize2, Send, ChevronDown, Bot, Plus, History } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@multica/ui/components/ui/avatar";
+import { Button } from "@multica/ui/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -226,8 +227,8 @@ export function ChatWindow() {
   const hasMessages = messages.length > 0 || timelineItems.length > 0;
 
   const containerClass = isFullscreen
-    ? "fixed inset-y-0 right-0 z-50 flex flex-col w-[50%] border-l bg-background shadow-2xl"
-    : "fixed bottom-4 right-4 z-50 flex flex-col w-[420px] h-[600px] rounded-xl border bg-background shadow-2xl overflow-hidden";
+    ? "fixed top-4 right-4 bottom-4 z-50 flex flex-col w-[50%] rounded-xl ring-1 ring-foreground/10 bg-sidebar shadow-2xl overflow-hidden"
+    : "fixed bottom-4 right-4 z-50 flex flex-col w-[420px] h-[600px] rounded-xl ring-1 ring-foreground/10 bg-sidebar shadow-2xl overflow-hidden";
 
   return (
     <div className={containerClass}>
@@ -240,38 +241,46 @@ export function ChatWindow() {
             onSelect={handleSelectAgent}
           />
           <div className="flex items-center gap-0.5">
-            <button
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground"
               onClick={() => setShowHistory(true)}
               title="Chat history"
-              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             >
-              <History className="size-3.5" />
-            </button>
-            <button
+              <History />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground"
               onClick={() => {
                 setActiveSession(null);
                 clearTimeline();
                 setPendingTask(null);
               }}
               title="New chat"
-              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             >
-              <Plus className="size-3.5" />
-            </button>
-            <button
+              <Plus />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground"
               onClick={toggleFullscreen}
               title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             >
-              {isFullscreen ? <Minimize2 className="size-3.5" /> : <Maximize2 className="size-3.5" />}
-            </button>
-            <button
+              {isFullscreen ? <Minimize2 /> : <Maximize2 />}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground"
               onClick={() => setOpen(false)}
               title="Minimize"
-              className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             >
-              <Minus className="size-3.5" />
-            </button>
+              <Minus />
+            </Button>
           </div>
         </div>
       )}
@@ -329,20 +338,20 @@ function AgentSelector({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="flex items-center gap-2 rounded-md px-1.5 py-1 -ml-1.5 transition-colors hover:bg-accent">
+      <DropdownMenuTrigger className="flex items-center gap-2 rounded-md px-1.5 py-1 -ml-1.5 transition-colors hover:bg-accent aria-expanded:bg-accent">
         <AgentAvatarSmall agent={activeAgent} />
         <span className="text-sm font-medium">{activeAgent.name}</span>
         <ChevronDown className="size-3 text-muted-foreground" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
+      <DropdownMenuContent align="start" className="max-h-60 w-auto max-w-56">
         {agents.map((agent) => (
           <DropdownMenuItem
             key={agent.id}
             onClick={() => onSelect(agent)}
-            className="flex items-center gap-2"
+            className="flex min-w-0 items-center gap-2"
           >
             <AgentAvatarSmall agent={agent} />
-            <span>{agent.name}</span>
+            <span className="truncate">{agent.name}</span>
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>
@@ -354,7 +363,7 @@ function AgentAvatarSmall({ agent }: { agent: Agent }) {
   return (
     <Avatar className="size-5">
       {agent.avatar_url && <AvatarImage src={agent.avatar_url} />}
-      <AvatarFallback className="bg-purple-100 text-purple-700 text-[10px]">
+      <AvatarFallback className="bg-purple-100 text-purple-700">
         <Bot className="size-3" />
       </AvatarFallback>
     </Avatar>

--- a/packages/views/chat/components/use-chat-resize.ts
+++ b/packages/views/chat/components/use-chat-resize.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import React, { useRef, useCallback, useState, useEffect } from "react";
+import { CHAT_MIN_W, CHAT_MIN_H, useChatStore } from "@multica/core/chat";
+
+type DragDir = "left" | "top" | "corner";
+
+const MAX_RATIO = 0.9;
+const FALLBACK_MAX_W = 800;
+const FALLBACK_MAX_H = 700;
+
+function clamp(v: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, v));
+}
+
+export function useChatResize(
+  windowRef: React.RefObject<HTMLDivElement | null>,
+) {
+  const chatWidth = useChatStore((s) => s.chatWidth);
+  const chatHeight = useChatStore((s) => s.chatHeight);
+  const isExpanded = useChatStore((s) => s.isExpanded);
+  const setChatSize = useChatStore((s) => s.setChatSize);
+  const setExpanded = useChatStore((s) => s.setExpanded);
+
+  // ── Container bounds via ResizeObserver ────────────────────────────────
+  const boundsRef = useRef({ maxW: FALLBACK_MAX_W, maxH: FALLBACK_MAX_H });
+  const [boundsReady, setBoundsReady] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [, setRevision] = useState(0);
+
+  useEffect(() => {
+    const el = windowRef.current;
+    const parent = el?.parentElement;
+    if (!parent) return;
+
+    const update = () => {
+      boundsRef.current = {
+        maxW: Math.floor(parent.clientWidth * MAX_RATIO),
+        maxH: Math.floor(parent.clientHeight * MAX_RATIO),
+      };
+      setBoundsReady(true);
+      setRevision((r) => r + 1);
+    };
+
+    // Measure immediately (parent is already in DOM at this point)
+    update();
+
+    const ro = new ResizeObserver(update);
+    ro.observe(parent);
+    return () => ro.disconnect();
+  }, [windowRef]);
+
+  // ── Derive rendered size ──────────────────────────────────────────────
+  const { maxW, maxH } = boundsRef.current;
+
+  const renderWidth = isExpanded ? maxW : clamp(chatWidth, CHAT_MIN_W, maxW);
+  const renderHeight = isExpanded ? maxH : clamp(chatHeight, CHAT_MIN_H, maxH);
+
+  // ── Expand / Restore ──────────────────────────────────────────────────
+  const isAtMax = renderWidth >= maxW && renderHeight >= maxH;
+
+  const toggleExpand = useCallback(() => {
+    if (isExpanded || isAtMax) {
+      setChatSize(CHAT_MIN_W, CHAT_MIN_H);
+    } else {
+      setExpanded(true);
+    }
+  }, [isExpanded, isAtMax, setChatSize, setExpanded]);
+
+  // ── Drag ──────────────────────────────────────────────────────────────
+  const dragRef = useRef<{
+    startX: number;
+    startY: number;
+    startW: number;
+    startH: number;
+    dir: DragDir;
+  } | null>(null);
+
+  const startDrag = useCallback(
+    (e: React.PointerEvent, dir: DragDir) => {
+      e.preventDefault();
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+
+      dragRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        startW: renderWidth,
+        startH: renderHeight,
+        dir,
+      };
+      setIsDragging(true);
+
+      const onPointerMove = (ev: PointerEvent) => {
+        const d = dragRef.current;
+        if (!d) return;
+
+        const { maxW: mw, maxH: mh } = boundsRef.current;
+
+        const rawW =
+          dir === "left" || dir === "corner"
+            ? d.startW - (ev.clientX - d.startX)
+            : d.startW;
+        const rawH =
+          dir === "top" || dir === "corner"
+            ? d.startH - (ev.clientY - d.startY)
+            : d.startH;
+
+        setChatSize(clamp(rawW, CHAT_MIN_W, mw), clamp(rawH, CHAT_MIN_H, mh));
+      };
+
+      const onPointerUp = () => {
+        dragRef.current = null;
+        setIsDragging(false);
+        document.removeEventListener("pointermove", onPointerMove);
+        document.removeEventListener("pointerup", onPointerUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+
+      document.addEventListener("pointermove", onPointerMove);
+      document.addEventListener("pointerup", onPointerUp);
+
+      const cursorMap: Record<DragDir, string> = {
+        left: "col-resize",
+        top: "row-resize",
+        corner: "nw-resize",
+      };
+      document.body.style.cursor = cursorMap[dir];
+      document.body.style.userSelect = "none";
+    },
+    [renderWidth, renderHeight, setChatSize],
+  );
+
+  return { renderWidth, renderHeight, isAtMax, boundsReady, isDragging, toggleExpand, startDrag };
+}

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -66,14 +66,14 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           onSelect={(file) => editorRef.current?.uploadFile(file)}
         />
         <Button
-          size="icon-xs"
+          size="icon-sm"
           disabled={isEmpty || submitting}
           onClick={handleSubmit}
         >
           {submitting ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Loader2 className="animate-spin" />
           ) : (
-            <ArrowUp className="h-3.5 w-3.5" />
+            <ArrowUp />
           )}
         </Button>
       </div>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -505,7 +505,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                       }
                     }}
                   >
-                    {isPinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
+                    {isPinned ? <PinOff /> : <Pin />}
                   </Button>
                 }
               />

--- a/packages/views/layout/dashboard-layout.tsx
+++ b/packages/views/layout/dashboard-layout.tsx
@@ -8,7 +8,7 @@ import { DashboardGuard } from "./dashboard-guard";
 
 interface DashboardLayoutProps {
   children: ReactNode;
-  /** Sibling of SidebarInset (e.g. SearchCommand, ChatWindow) */
+  /** Rendered inside SidebarInset (e.g. ChatWindow, ChatFab — absolute-positioned overlays) */
   extra?: ReactNode;
   /** Rendered inside sidebar header as a search trigger */
   searchSlot?: ReactNode;
@@ -33,14 +33,14 @@ export function DashboardLayout({
     >
       <SidebarProvider className="h-svh">
         <AppSidebar searchSlot={searchSlot} />
-        <SidebarInset className="overflow-hidden">
+        <SidebarInset className="relative overflow-hidden">
           <div className="flex h-10 shrink-0 items-center border-b px-2 md:hidden">
             <SidebarTrigger />
           </div>
           {children}
           <ModalRegistry />
+          {extra}
         </SidebarInset>
-        {extra}
       </SidebarProvider>
     </DashboardGuard>
   );


### PR DESCRIPTION
## Summary
- **Resizable chat window** — drag handles (left/top/corner) with pointer capture, ResizeObserver for dynamic container tracking, size persisted to storage
- **Expand/Restore toggle** — expands to 90% of container, restores to minimum; button state driven by visual size (`isAtMax`), not internal flag
- **Open/close animation** — scale + opacity transition from bottom-right (FAB position), with `isDragging` gate to disable transition during drag
- **Session history improvements** — optimistic archive with rollback, Archive icon (was Trash2), spinner during mutation, toast on error, Tooltip consistency
- **Chat input** — migrated to ContentEditor + SubmitButton, draft persistence across sessions
- **Layout** — chat window moved from `fixed` to `absolute` inside content area (`relative` container), consistent `bottom-2 right-2` offset with FAB
- **Store refactor** — raw user intent only (no clamp), `isExpanded` boolean, input draft, workspace-scoped persistence

## Test plan
- [ ] Open/close chat: smooth scale+opacity animation from bottom-right
- [ ] Drag resize: instant (no transition lag), respects min/max bounds
- [ ] Click Expand: smooth transition to 90% of container
- [ ] Click Restore: smooth transition to minimum size
- [ ] Resize browser/Electron window: chat auto-adjusts (ResizeObserver)
- [ ] Toggle sidebar: chat respects new container bounds
- [ ] Archive session: optimistic removal, spinner, toast on error
- [ ] Input draft: persists across close/reopen and page reload
- [ ] Desktop + Web: both layouts work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)