### PR TITLE
fix(openclaw): handle JSON results with durationMs but no payloads

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -168,7 +168,7 @@ func tryParseOpenclawResult(raw string) (openclawResult, bool) {
 		if raw[i] != '{' {
 			continue
 		}
-		if err := json.Unmarshal([]byte(raw[i:]), &result); err == nil && result.Payloads != nil {
+		if err := json.Unmarshal([]byte(raw[i:]), &result); err == nil && (result.Payloads != nil || result.Meta.DurationMs > 0) {
 			return result, true
 		}
 	}


### PR DESCRIPTION
## Summary

Some OpenClaw JSON outputs contain `durationMs` but lack `payloads` field. The original condition rejected these results, causing the agent to return "openclaw returned no parseable output" instead of the actual execution result.

## Fix

Accept results that have either `payloads` OR `durationMs > 0`.

```go
// Before
if err := json.Unmarshal([]byte(raw[i:]), &result); err == nil && result.Payloads != nil {

// After
if err := json.Unmarshal([]byte(raw[i:]), &result); err == nil && (result.Payloads != nil || result.Meta.DurationMs > 0) {
```

## Related

- Issue #830
- PR #836 (upstream fix for line-by-line scanning)