### PR TITLE
docs: add v0.1.28 changelog (2026-04-13)

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -278,6 +278,29 @@ export const en: LandingDict = {
     },
     entries: [
       {
+        version: "0.1.28",
+        date: "2026-04-13",
+        title: "Windows Support, Auth & Onboarding",
+        changes: [],
+        features: [
+          "Windows support — CLI install, daemon, and GoReleaser build targets",
+          "Full-screen onboarding wizard for new workspaces",
+          "Auth token migrated to HttpOnly Cookie with WebSocket Origin whitelist",
+          "Resizable Master Agent chat window with improved session history UX",
+          "Keyboard navigation in assignee picker",
+          "Token usage log scanning for OpenCode, OpenClaw, and Hermes runtimes",
+          "Daemon periodic GC for workspace isolation directories",
+        ],
+        fixes: [
+          "WebSocket first-message authentication (MUL-580)",
+          "Content-Security-Policy response header added",
+          "Daemon session resume fallback for failed sessions",
+          "OpenClaw result parsing rewritten to handle incremental output",
+          "Codex sandbox network access for Multica CLI",
+          "Default issue creation status changed to \"todo\" instead of \"backlog\"",
+        ],
+      },
+      {
         version: "0.1.27",
         date: "2026-04-12",
         title: "One-Click Setup, Self-Hosting & Stability",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -278,6 +278,29 @@ export const zh: LandingDict = {
     },
     entries: [
       {
+        version: "0.1.28",
+        date: "2026-04-13",
+        title: "Windows 支持、认证与引导",
+        changes: [],
+        features: [
+          "Windows 支持——CLI 安装、Daemon 运行和 GoReleaser 构建",
+          "新工作区全屏引导向导",
+          "认证 Token 迁移至 HttpOnly Cookie，WebSocket 新增 Origin 白名单",
+          "Master Agent 聊天窗口可调整大小，会话历史体验优化",
+          "指派人选择器支持键盘导航",
+          "OpenCode、OpenClaw 和 Hermes 运行时 Token 用量日志扫描",
+          "Daemon 定期 GC 工作区隔离目录",
+        ],
+        fixes: [
+          "WebSocket 首条消息认证（MUL-580）",
+          "新增 Content-Security-Policy 响应头",
+          "Daemon 会话恢复失败时的回退处理",
+          "OpenClaw 结果解析改为增量处理",
+          "Codex 沙箱网络访问以连接 Multica CLI",
+          "Issue 创建默认状态改为「todo」而非「backlog」",
+        ],
+      },
+      {
         version: "0.1.27",
         date: "2026-04-12",
         title: "一键安装、自部署与稳定性",


### PR DESCRIPTION
## Summary
- Add v0.1.28 changelog: Windows support, HttpOnly Cookie auth, onboarding wizard, resizable chat, WebSocket auth fix, CSP header
- Concise format — 7 features, 6 fixes, no trivial items
- Both en and zh updated