### PR TITLE
fix(auth): AuthInitializer not supporting cookie auth mode

### DIFF
--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -17,15 +17,39 @@ export function AuthInitializer({
   onLogin,
   onLogout,
   storage = defaultStorage,
+  cookieAuth,
 }: {
   children: ReactNode;
   onLogin?: () => void;
   onLogout?: () => void;
   storage?: StorageAdapter;
+  cookieAuth?: boolean;
 }) {
   const qc = useQueryClient();
 
   useEffect(() => {
+    const api = getApi();
+    const wsId = storage.getItem("multica_workspace_id");
+
+    if (cookieAuth) {
+      // Cookie mode: the HttpOnly cookie is sent automatically by the browser.
+      // Call the API to check if the session is still valid.
+      Promise.all([api.getMe(), api.listWorkspaces()])
+        .then(([user, wsList]) => {
+          onLogin?.();
+          useAuthStore.setState({ user, isLoading: false });
+          qc.setQueryData(workspaceKeys.list(), wsList);
+          useWorkspaceStore.getState().hydrateWorkspace(wsList, wsId);
+        })
+        .catch((err) => {
+          logger.error("cookie auth init failed", err);
+          onLogout?.();
+          useAuthStore.setState({ user: null, isLoading: false });
+        });
+      return;
+    }
+
+    // Token mode: read from localStorage (Electron / legacy).
     const token = storage.getItem("multica_token");
     if (!token) {
       onLogout?.();
@@ -33,9 +57,7 @@ export function AuthInitializer({
       return;
     }
 
-    const api = getApi();
     api.setToken(token);
-    const wsId = storage.getItem("multica_workspace_id");
 
     Promise.all([api.getMe(), api.listWorkspaces()])
       .then(([user, wsList]) => {

--- a/packages/core/platform/core-provider.tsx
+++ b/packages/core/platform/core-provider.tsx
@@ -74,7 +74,7 @@ export function CoreProvider({
 
   return (
     <QueryProvider>
-      <AuthInitializer onLogin={onLogin} onLogout={onLogout} storage={storage}>
+      <AuthInitializer onLogin={onLogin} onLogout={onLogout} storage={storage} cookieAuth={cookieAuth}>
         <WSProvider
           wsUrl={wsUrl}
           authStore={authStore}


### PR DESCRIPTION
## Summary

- `AuthInitializer` was never updated for the HttpOnly cookie migration (#819). It only checked `localStorage` for `multica_token` — in cookie auth mode there is no localStorage token, so every page load/reload immediately set `user: null` and redirected to login.
- Added a `cookieAuth` prop to `AuthInitializer` and a code path that calls `api.getMe()` (the HttpOnly cookie is sent automatically by the browser) to restore the session.

## Root cause

`AuthInitializer` (packages/core/platform/auth-initializer.tsx) had a guard at the top:

```ts
const token = storage.getItem("multica_token");
if (!token) {
  onLogout?.();
  useAuthStore.setState({ isLoading: false });
  return; // ← always hit in cookie auth mode
}
```

In cookie auth mode there is no localStorage token, so this early return fires on every load, clearing the user and triggering the dashboard guard's login redirect.

Fixes MUL-705, fixes #864

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (79/79)
- [ ] Deploy and verify: login → reload page → session persists
- [ ] Verify self-hosted Docker setup retains session across container restarts
- [ ] Verify Electron/desktop (token mode) still works unchanged