### PR TITLE
fix(comment): set trigger_comment_id to actual reply, not thread root

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -409,12 +409,9 @@ func (h *Handler) enqueueMentionedAgentTasks(ctx context.Context, issue db.Issue
 		if err != nil || hasPending {
 			continue
 		}
-		// Resolve thread root for reply threading.
-		replyTo := comment.ID
-		if comment.ParentID.Valid {
-			replyTo = comment.ParentID
-		}
-		if _, err := h.TaskService.EnqueueTaskForMention(ctx, issue, agentUUID, replyTo); err != nil {
+		// Always use the current comment as the trigger so the agent reads the
+		// actual reply that mentioned it, not the thread root.
+		if _, err := h.TaskService.EnqueueTaskForMention(ctx, issue, agentUUID, comment.ID); err != nil {
 			slog.Warn("enqueue mention agent task failed", "issue_id", uuidToString(issue.ID), "agent_id", m.ID, "error", err)
 		}
 	}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -561,6 +561,13 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 	if err != nil {
 		return
 	}
+	// Resolve thread root: if parentID points to a reply (has its own parent),
+	// use that parent instead so the comment lands in the top-level thread.
+	if parentID.Valid {
+		if parent, err := s.Queries.GetComment(ctx, parentID); err == nil && parent.ParentID.Valid {
+			parentID = parent.ParentID
+		}
+	}
 	// Expand bare issue identifiers (e.g. MUL-117) into mention links.
 	content = mention.ExpandIssueIdentifiers(ctx, s.Queries, issue.WorkspaceID, content)
 	comment, err := s.Queries.CreateComment(ctx, db.CreateCommentParams{


### PR DESCRIPTION
## Summary
- When a user replies in a thread and @mentions an agent, `enqueueMentionedAgentTasks` was setting `trigger_comment_id` to the parent (thread root) instead of the actual reply comment
- The mentioned agent would read the wrong comment and miss the user's instructions
- Fixed by always passing `comment.ID` to `EnqueueTaskForMention`

Fixes MUL-708

## Test plan
- [ ] Reply to an agent's comment with @mention of another agent → verify the triggered agent's task has `trigger_comment_id` pointing to the reply, not the parent
- [ ] Top-level comment with @mention still works correctly (no parent, `comment.ID` used as before)
- [ ] Inherited mentions (reply without explicit @mention) still trigger correctly