### PR TITLE
fix(chat): avoid nested button in session history item

### DIFF
--- a/packages/views/chat/components/chat-session-history.tsx
+++ b/packages/views/chat/components/chat-session-history.tsx
@@ -164,10 +164,18 @@ function SessionItem({
   const timeAgo = formatTimeAgo(session.updated_at);
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
       className={cn(
-        "group flex w-full items-start gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent/50",
+        "group flex w-full items-start gap-3 px-4 py-2.5 text-left transition-colors hover:bg-accent/50 cursor-pointer focus:outline-none focus-visible:bg-accent/40",
         isActive && "bg-accent/30",
       )}
     >
@@ -216,7 +224,7 @@ function SessionItem({
           <TooltipContent side="bottom">Archive</TooltipContent>
         </Tooltip>
       )}
-    </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
Outer SessionItem was a <button> containing an archive <button>, causing hydration errors. Switch the outer to a role="button" div while preserving keyboard (Enter/Space) activation.

## What does this PR do?

### Problem

  `ChatSessionHistory` rendered each session row as a `<button>` that also contained an archive action rendered via `TooltipTrigger` +
  `Button`. Because both the outer row and the inner archive control resolved to native `<button>` elements, React threw a hydration
  error in Next.js:

  > In HTML, `<button>` cannot be a descendant of `<button>`. This will cause a hydration error.
  >
  > `<button>` cannot contain a nested `<button>`.

  The nested buttons were also invalid HTML and made the archive control's click/keyboard semantics ambiguous.

  ### Fix

  Change the outer `SessionItem` wrapper from `<button>` to a `<div role="button">`:

  - Keeps the whole row clickable via `onClick`.
  - Preserves keyboard activation by handling `Enter` / `Space` in `onKeyDown` (with `preventDefault` to suppress page scroll on Space).
  - Adds `tabIndex={0}`, `cursor-pointer`, and `focus-visible` styles so focus behavior matches the previous native button.
  - Leaves the inner archive `Button` as the only real `<button>` in the subtree, so clicks on it (with existing `stopPropagation`)
  continue to work without triggering row selection.

  No behavioral change for users; only the DOM structure is corrected.



## Related Issue

Closes #875

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

See diffs, only one file has been changed.

## How to Test

1. Just click the `Chat history` button

## Checklist

- [x] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure

**AI tool used:**  Claude Code
