### PR TITLE
fix(daemon): include dispatched agent identity in CLAUDE.md

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -894,9 +894,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	}
 
 	agentName := "agent"
+	var agentID string
 	var skills []SkillData
 	var instructions string
 	if task.Agent != nil {
+		agentID = task.Agent.ID
 		agentName = task.Agent.Name
 		skills = task.Agent.Skills
 		instructions = task.Agent.Instructions
@@ -908,6 +910,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	taskCtx := execenv.TaskContextForEnv{
 		IssueID:           task.IssueID,
 		TriggerCommentID:  task.TriggerCommentID,
+		AgentID:           agentID,
 		AgentName:         agentName,
 		AgentInstructions: instructions,
 		AgentSkills:       convertSkillsForEnv(skills),

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -32,6 +32,7 @@ type PrepareParams struct {
 type TaskContextForEnv struct {
 	IssueID           string
 	TriggerCommentID  string // comment that triggered this task (empty for on_assign)
+	AgentID           string // unique ID of the dispatched agent
 	AgentName         string
 	AgentInstructions string // agent identity/persona instructions, injected into CLAUDE.md
 	AgentSkills       []SkillContextForEnv

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -36,8 +36,22 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("# Multica Agent Runtime\n\n")
 	b.WriteString("You are a coding agent in the Multica platform. Use the `multica` CLI to interact with the platform.\n\n")
 
-	// Inject agent identity instructions before workflow commands.
-	if ctx.AgentInstructions != "" {
+	// Always emit agent identity so the agent knows who it is, even when
+	// dispatched via @mention on an issue assigned to a different agent.
+	if ctx.AgentName != "" || ctx.AgentID != "" {
+		b.WriteString("## Agent Identity\n\n")
+		if ctx.AgentName != "" {
+			fmt.Fprintf(&b, "**You are: %s**", ctx.AgentName)
+			if ctx.AgentID != "" {
+				fmt.Fprintf(&b, " (ID: `%s`)", ctx.AgentID)
+			}
+			b.WriteString("\n\n")
+		}
+		if ctx.AgentInstructions != "" {
+			b.WriteString(ctx.AgentInstructions)
+			b.WriteString("\n\n")
+		}
+	} else if ctx.AgentInstructions != "" {
 		b.WriteString("## Agent Identity\n\n")
 		b.WriteString(ctx.AgentInstructions)
 		b.WriteString("\n\n")


### PR DESCRIPTION
## Summary
- When an agent is triggered via @mention on an issue assigned to a different agent, the generated CLAUDE.md had no explicit agent identity (name/ID). The agent would read the issue, see the assignee was a different agent, and skip the task thinking it wasn't addressed to it.
- Added `AgentID` to `TaskContextForEnv` and now always emit `**You are: <name>** (ID: <id>)` in the Agent Identity section of CLAUDE.md, so every dispatched agent knows exactly who it is.

Closes MUL-709

## Test plan
- [x] All existing `execenv` tests pass
- [x] All `daemon` package tests pass
- [x] `go build ./...` compiles cleanly