### PR TITLE
fix(web): Sync status update to recent issues store

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -154,10 +154,11 @@ export function useUpdateIssue() {
         );
       }
       // Sync status update to recent issues store
+      const prevRecentItems = useRecentIssuesStore.getState().items;
       if (data.status) {
         useRecentIssuesStore.getState().updateIssueStatus(id, data.status);
       }
-      return { prevList, prevDetail, prevChildren, parentId, id };
+      return { prevList, prevDetail, prevChildren, parentId, id, prevRecentItems };
     },
     onError: (_err, _vars, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
@@ -168,6 +169,9 @@ export function useUpdateIssue() {
           issueKeys.children(wsId, ctx.parentId),
           ctx.prevChildren,
         );
+      }
+      if (ctx?.prevRecentItems) {
+        useRecentIssuesStore.setState({ items: ctx.prevRecentItems });
       }
     },
     onSettled: (_data, _err, vars, ctx) => {
@@ -204,11 +208,15 @@ export function useDeleteIssue() {
       });
       qc.removeQueries({ queryKey: issueKeys.detail(wsId, id) });
       // Mark as deleted in recent issues store
+      const prevRecentItems = useRecentIssuesStore.getState().items;
       useRecentIssuesStore.getState().markAsDeleted(id);
-      return { prevList, parentIssueId: deleted?.parent_issue_id };
+      return { prevList, parentIssueId: deleted?.parent_issue_id, prevRecentItems };
     },
     onError: (_err, _id, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
+      if (ctx?.prevRecentItems) {
+        useRecentIssuesStore.setState({ items: ctx.prevRecentItems });
+      }
     },
     onSettled: (_data, _err, _id, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
@@ -245,14 +253,18 @@ export function useBatchUpdateIssues() {
           : old,
       );
       // Sync status update to recent issues store
+      const prevRecentItems = useRecentIssuesStore.getState().items;
       if (updates.status) {
         const { updateIssueStatus } = useRecentIssuesStore.getState();
         ids.forEach((id) => updateIssueStatus(id, updates.status!));
       }
-      return { prevList };
+      return { prevList, prevRecentItems };
     },
     onError: (_err, _vars, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
+      if (ctx?.prevRecentItems) {
+        useRecentIssuesStore.setState({ items: ctx.prevRecentItems });
+      }
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
@@ -287,12 +299,16 @@ export function useBatchDeleteIssues() {
         };
       });
       // Mark as deleted in recent issues store
+      const prevRecentItems = useRecentIssuesStore.getState().items;
       const { markAsDeleted } = useRecentIssuesStore.getState();
       ids.forEach((id) => markAsDeleted(id));
-      return { prevList, parentIssueIds };
+      return { prevList, parentIssueIds, prevRecentItems };
     },
     onError: (_err, _ids, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
+      if (ctx?.prevRecentItems) {
+        useRecentIssuesStore.setState({ items: ctx.prevRecentItems });
+      }
     },
     onSettled: (_data, _err, _ids, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { issueKeys, CLOSED_PAGE_SIZE, type MyIssuesFilter } from "./queries";
 import { useWorkspaceId } from "../hooks";
+import { useRecentIssuesStore } from "./stores";
 import type { Issue, IssueReaction } from "../types";
 import type {
   CreateIssueRequest,
@@ -152,6 +153,10 @@ export function useUpdateIssue() {
             old?.map((c) => (c.id === id ? { ...c, ...data } : c)),
         );
       }
+      // Sync status update to recent issues store
+      if (data.status) {
+        useRecentIssuesStore.getState().updateIssueStatus(id, data.status);
+      }
       return { prevList, prevDetail, prevChildren, parentId, id };
     },
     onError: (_err, _vars, ctx) => {
@@ -237,6 +242,11 @@ export function useBatchUpdateIssues() {
             }
           : old,
       );
+      // Sync status update to recent issues store
+      if (updates.status) {
+        const { updateIssueStatus } = useRecentIssuesStore.getState();
+        ids.forEach((id) => updateIssueStatus(id, updates.status!));
+      }
       return { prevList };
     },
     onError: (_err, _vars, ctx) => {

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -203,6 +203,8 @@ export function useDeleteIssue() {
         };
       });
       qc.removeQueries({ queryKey: issueKeys.detail(wsId, id) });
+      // Mark as deleted in recent issues store
+      useRecentIssuesStore.getState().markAsDeleted(id);
       return { prevList, parentIssueId: deleted?.parent_issue_id };
     },
     onError: (_err, _id, ctx) => {
@@ -284,6 +286,9 @@ export function useBatchDeleteIssues() {
           doneTotal: (old.doneTotal ?? 0) - doneDeleted,
         };
       });
+      // Mark as deleted in recent issues store
+      const { markAsDeleted } = useRecentIssuesStore.getState();
+      ids.forEach((id) => markAsDeleted(id));
       return { prevList, parentIssueIds };
     },
     onError: (_err, _ids, ctx) => {

--- a/packages/core/issues/stores/recent-issues-store.ts
+++ b/packages/core/issues/stores/recent-issues-store.ts
@@ -17,12 +17,14 @@ export interface RecentIssueEntry {
   title: string;
   status: IssueStatus;
   visitedAt: number;
+  isDeleted?: boolean;
 }
 
 interface RecentIssuesState {
   items: RecentIssueEntry[];
-  recordVisit: (entry: Omit<RecentIssueEntry, "visitedAt">) => void;
+  recordVisit: (entry: Omit<RecentIssueEntry, "visitedAt" | "isDeleted">) => void;
   updateIssueStatus: (id: string, status: IssueStatus) => void;
+  markAsDeleted: (id: string) => void;
 }
 
 export const useRecentIssuesStore = create<RecentIssuesState>()(
@@ -41,6 +43,12 @@ export const useRecentIssuesStore = create<RecentIssuesState>()(
         set((state) => ({
           items: state.items.map((item) =>
             item.id === id ? { ...item, status } : item,
+          ),
+        })),
+      markAsDeleted: (id) =>
+        set((state) => ({
+          items: state.items.map((item) =>
+            item.id === id ? { ...item, isDeleted: true } : item,
           ),
         })),
     }),

--- a/packages/core/issues/stores/recent-issues-store.ts
+++ b/packages/core/issues/stores/recent-issues-store.ts
@@ -22,6 +22,7 @@ export interface RecentIssueEntry {
 interface RecentIssuesState {
   items: RecentIssueEntry[];
   recordVisit: (entry: Omit<RecentIssueEntry, "visitedAt">) => void;
+  updateIssueStatus: (id: string, status: IssueStatus) => void;
 }
 
 export const useRecentIssuesStore = create<RecentIssuesState>()(
@@ -36,6 +37,12 @@ export const useRecentIssuesStore = create<RecentIssuesState>()(
             items: [updated, ...filtered].slice(0, MAX_RECENT_ISSUES),
           };
         }),
+      updateIssueStatus: (id, status) =>
+        set((state) => ({
+          items: state.items.map((item) =>
+            item.id === id ? { ...item, status } : item,
+          ),
+        })),
     }),
     {
       name: "multica_recent_issues",

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { issueKeys } from "./queries";
+import { useRecentIssuesStore } from "./stores";
 import type { Issue } from "../types";
 import type { ListIssuesResponse } from "../types";
 
@@ -70,6 +71,10 @@ export function onIssueUpdated(
     if (issue.status !== undefined || issue.parent_issue_id !== undefined) {
       qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
     }
+  }
+  // Sync status update to recent issues store
+  if (issue.status) {
+    useRecentIssuesStore.getState().updateIssueStatus(issue.id, issue.status);
   }
 }
 

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -107,4 +107,6 @@ export function onIssueDeleted(
     qc.invalidateQueries({ queryKey: issueKeys.children(wsId, deleted.parent_issue_id) });
     qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
   }
+  // Mark as deleted in recent issues store
+  useRecentIssuesStore.getState().markAsDeleted(issueId);
 }

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -404,7 +404,9 @@ export function SearchCommand() {
                     <span className="text-xs text-muted-foreground shrink-0">
                       {item.identifier}
                     </span>
-                    <span className="truncate">{item.title}</span>
+                    <span className={`truncate ${item.isDeleted ? "line-through text-muted-foreground" : ""}`}>
+                      {item.title}
+                    </span>
                     <span
                       className={`ml-auto text-xs shrink-0 ${STATUS_CONFIG[item.status]?.iconColor ?? ""}`}
                     >


### PR DESCRIPTION
                                                                                                                                                                                                                                               
##  What does this PR do?                 
                                                                                                                                                                                                                                                            
  Fixes a bug where issue status updates were not being synchronized to the recent issues store, causing stale status to be displayed in the "Search" dropdown.
                                                                                                                                                                                                                                                            
  When a user updates an issue status (single or batch update), the change is now immediately reflected in the recent issues list.                                                                                         
                                                                                                                                                                                                                                                            
 ## Related Issue                                                                                                                                                                                                                                             
                                        
  Closes #                                                                                                                                                                                                                                                  
                              
 ## Type of Change                                                                                                                                                                                                                                            
                                 
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                            
## Changes Made                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                            
 - `packages/core/issues/stores/recent-issues-store.ts` - Add `updateIssueStatus` action to update status for a specific issue ID; Add `isDeleted` field and `markAsDeleted` actions                                                                  
  - `packages/core/issues/mutations.ts` - Sync status updates to recent issues store in `useUpdateIssue` and `useBatchUpdateIssues` mutations; Mark deleted issues in recent issues store for `useDeleteIssue` and `useBatchDeleteIssues`
  - `packages/core/issues/ws-updaters.ts` - Sync status updates from WebSocket events to recent issues store; Mark deleted issues when receiving WebSocket delete events                                                                                      
  - `packages/views/search/search-command.tsx` - Apply strikethrough styling to deleted issues in the recent issues list                                                                                                                                                  
                                                                                                                                                                                                                                                            
## How to Test                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                            
  1. Open any issue and change its status (e.g., from "Todo" to "In Progress") or Delete it                                                                                                                                                                              
  2. Open the "Search" in the sidebar
  3. Verify the issue status is updated immediately                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                            
 ## Checklist                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                            
- [x] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included                                                                                                                                                                                                                
                                                                                                                                                                                                                                                            
  ## AI Disclosure                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                            
  AI tool used: Claude Code                                                                                                                                                                                                                                                                                                                                                                                              
                                 
  ---                       