### PR TITLE
fix(agent): close Claude stdin after final stream-json result

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -52,14 +52,21 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cancel()
 		return nil, fmt.Errorf("claude stdin pipe: %w", err)
 	}
+	closeStdin := func() {
+		if stdin != nil {
+			_ = stdin.Close()
+			stdin = nil
+		}
+	}
 	cmd.Stderr = newLogWriter(b.cfg.Logger, "[claude:stderr] ")
 
 	if err := cmd.Start(); err != nil {
+		closeStdin()
 		cancel()
 		return nil, fmt.Errorf("start claude: %w", err)
 	}
 	if err := writeClaudeInput(stdin, prompt); err != nil {
-		_ = stdin.Close()
+		closeStdin()
 		cancel()
 		_ = cmd.Wait()
 		return nil, fmt.Errorf("write claude input: %w", err)
@@ -70,7 +77,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	resCh := make(chan Result, 1)
 
 	go func() {
-		defer stdin.Close()
+		defer closeStdin()
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
@@ -107,6 +114,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				}
 				trySend(msgCh, Message{Type: MessageStatus, Status: "running"})
 			case "result":
+				closeStdin()
 				sessionID = msg.SessionID
 				if msg.ResultText != "" {
 					output.Reset()


### PR DESCRIPTION
## What does this PR do?

Fixes a Claude runtime ping/task lifecycle bug where the Claude child process can emit its terminal `result` event but remain alive because stdin is still open.

This PR closes Claude stdin as soon as the final `result` event is received in `server/pkg/agent/claude.go`, allowing the Claude CLI process to exit promptly instead of hanging until timeout.

## Related Issue

Closes #467

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/claude.go`
  - add a small `closeStdin()` helper to avoid double-close
  - close stdin on startup/write failure paths
  - close stdin immediately when the Claude stream emits the terminal `result` event

## How to Test

1. Start a self-hosted Multica daemon with a Claude runtime
2. Open `/runtimes` and click **Test Connection** on the Claude runtime
3. Confirm the ping completes successfully instead of failing with `claude timed out after 1m0s`

Additional targeted verification:
1. Run `cd server && go test ./pkg/agent`
2. Confirm no regressions in Claude backend behavior

## Checklist

- [x] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
I reproduced the Claude runtime ping timeout on a self-hosted Multica instance, traced the Claude child-process lifecycle, and found that the CLI was emitting a final `result` event while stdin remained open. I then implemented the smallest possible fix: close stdin immediately on the terminal `result` event so the process can exit cleanly.
