### PR TITLE
fix(install): check port availability before starting services

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -30,6 +30,21 @@ function Test-CommandExists {
     $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Test-PortFree {
+    param([int]$Port)
+    $listener = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+    return ($null -eq $listener)
+}
+
+function Find-FreePort {
+    param([int]$StartPort)
+    $max = $StartPort + 100
+    for ($p = $StartPort; $p -lt $max; $p++) {
+        if (Test-PortFree $p) { return $p }
+    }
+    return $null
+}
+
 function Get-LatestVersion {
     try {
         $release = Invoke-RestMethod -Uri "https://api.github.com/repos/multica-ai/multica/releases/latest" -ErrorAction Stop
@@ -248,6 +263,56 @@ function Install-Server {
         Write-Ok "Using existing .env"
     }
 
+    # --- Port availability check -------------------------------------------
+    $envContent = Get-Content ".env" -Raw
+    $backendPort  = if ($envContent -match '(?m)^PORT=(\d+)')          { [int]$Matches[1] } else { 8080 }
+    $frontendPort = if ($envContent -match '(?m)^FRONTEND_PORT=(\d+)') { [int]$Matches[1] } else { 3000 }
+    $pgPort       = if ($envContent -match '(?m)^POSTGRES_PORT=(\d+)') { [int]$Matches[1] } else { 5432 }
+
+    $portsChanged = $false
+
+    $portMap = @(
+        @{ Name = "backend";  Var = "backendPort";  Port = $backendPort }
+        @{ Name = "frontend"; Var = "frontendPort"; Port = $frontendPort }
+        @{ Name = "postgres"; Var = "pgPort";       Port = $pgPort }
+    )
+
+    foreach ($entry in $portMap) {
+        if (-not (Test-PortFree $entry.Port)) {
+            $newPort = Find-FreePort ($entry.Port + 1)
+            if (-not $newPort) {
+                Write-Fail "No free port found near $($entry.Port). Free the port or set a custom one in $InstallDir\.env"
+            }
+            Write-Warn "Port $($entry.Port) is already in use - switching to $newPort"
+            $oldPort = $entry.Port
+
+            switch ($entry.Name) {
+                "backend" {
+                    $backendPort = $newPort
+                    $envContent = $envContent -replace "(?m)^PORT=.*", "PORT=$newPort"
+                    $envContent = $envContent -replace "http://localhost:$oldPort", "http://localhost:$newPort"
+                    $envContent = $envContent -replace "ws://localhost:$oldPort", "ws://localhost:$newPort"
+                }
+                "frontend" {
+                    $frontendPort = $newPort
+                    $envContent = $envContent -replace "(?m)^FRONTEND_PORT=.*", "FRONTEND_PORT=$newPort"
+                    $envContent = $envContent -replace "(?m)^FRONTEND_ORIGIN=.*", "FRONTEND_ORIGIN=http://localhost:$newPort"
+                }
+                "postgres" {
+                    $pgPort = $newPort
+                    $envContent = $envContent -replace "(?m)^POSTGRES_PORT=.*", "POSTGRES_PORT=$newPort"
+                }
+            }
+            $portsChanged = $true
+        }
+    }
+
+    if ($portsChanged) {
+        Set-Content ".env" $envContent -NoNewline
+        Write-Ok "Ports adjusted in .env to avoid conflicts"
+    }
+    # -----------------------------------------------------------------------
+
     Write-Info "Starting Multica services (this may take a few minutes on first run)..."
     docker compose -f docker-compose.selfhost.yml up -d --build
 
@@ -255,7 +320,7 @@ function Install-Server {
     $ready = $false
     for ($i = 1; $i -le 45; $i++) {
         try {
-            $null = Invoke-WebRequest -Uri "http://localhost:8080/health" -UseBasicParsing -TimeoutSec 2
+            $null = Invoke-WebRequest -Uri "http://localhost:$backendPort/health" -UseBasicParsing -TimeoutSec 2
             $ready = $true
             break
         } catch {
@@ -278,13 +343,20 @@ function Install-Server {
 # ---------------------------------------------------------------------------
 function Set-ConfigLocal {
     Write-Info "Configuring CLI for local server..."
+    $envPath = Join-Path $InstallDir ".env"
+    $bp = 8080; $fp = 3000
+    if (Test-Path $envPath) {
+        $c = Get-Content $envPath -Raw
+        if ($c -match '(?m)^PORT=(\d+)')          { $bp = $Matches[1] }
+        if ($c -match '(?m)^FRONTEND_PORT=(\d+)') { $fp = $Matches[1] }
+    }
     try {
         multica config local 2>$null
     } catch {
-        multica config set app_url http://localhost:3000 2>$null
-        multica config set server_url http://localhost:8080 2>$null
+        multica config set app_url "http://localhost:$fp" 2>$null
+        multica config set server_url "http://localhost:$bp" 2>$null
     }
-    Write-Ok "CLI configured for localhost (backend :8080, frontend :3000)"
+    Write-Ok "CLI configured for localhost (backend :$bp, frontend :$fp)"
 }
 
 function Set-ConfigCloud {
@@ -339,17 +411,26 @@ function Start-LocalInstall {
     Install-Cli
     Set-ConfigLocal
 
+    # Read actual ports from .env for display
+    $bp = 8080; $fp = 3000
+    $envPath = Join-Path $InstallDir ".env"
+    if (Test-Path $envPath) {
+        $c = Get-Content $envPath -Raw
+        if ($c -match '(?m)^PORT=(\d+)')          { $bp = $Matches[1] }
+        if ($c -match '(?m)^FRONTEND_PORT=(\d+)') { $fp = $Matches[1] }
+    }
+
     Write-Host ""
     Write-Host "  ============================================" -ForegroundColor Green
     Write-Host "  [OK] Multica is installed and running!" -ForegroundColor Green
     Write-Host "  ============================================" -ForegroundColor Green
     Write-Host ""
-    Write-Host "  Frontend:  http://localhost:3000"
-    Write-Host "  Backend:   http://localhost:8080"
+    Write-Host "  Frontend:  http://localhost:$fp"
+    Write-Host "  Backend:   http://localhost:$bp"
     Write-Host "  Server at: $InstallDir"
     Write-Host ""
     Write-Host "  Next steps:"
-    Write-Host "  1. Open http://localhost:3000 in your browser"
+    Write-Host "  1. Open http://localhost:$fp in your browser"
     Write-Host "  2. Log in with any email + verification code: 888888"
     Write-Host "  3. Then run:"
     Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,6 +39,34 @@ fail()  { printf "${BOLD}${RED}✗ %s${RESET}\n" "$*" >&2; exit 1; }
 
 command_exists() { command -v "$1" >/dev/null 2>&1; }
 
+# Check whether a TCP port is available to bind.
+# Works on both macOS (lsof) and Linux (ss).
+port_is_free() {
+  local port="$1"
+  if command_exists ss; then
+    ! ss -tlnH "sport = :$port" 2>/dev/null | grep -q .
+  elif command_exists lsof; then
+    ! lsof -iTCP:"$port" -sTCP:LISTEN -P -n >/dev/null 2>&1
+  else
+    # Can't check — assume free and let Docker fail with a clear message
+    return 0
+  fi
+}
+
+# Find the next free port starting from a given value.
+find_free_port() {
+  local port="$1"
+  local max=$((port + 100))
+  while [ "$port" -lt "$max" ]; do
+    if port_is_free "$port"; then
+      echo "$port"
+      return 0
+    fi
+    port=$((port + 1))
+  done
+  return 1
+}
+
 detect_os() {
   case "$(uname -s)" in
     Darwin) OS="darwin" ;;
@@ -257,6 +285,66 @@ setup_server() {
     ok "Using existing .env"
   fi
 
+  # --- Port availability check -------------------------------------------
+  # Read desired ports from .env (fall back to defaults)
+  local backend_port frontend_port pg_port
+  backend_port=$(grep -E '^PORT=' .env 2>/dev/null | head -1 | cut -d= -f2 || echo "8080")
+  frontend_port=$(grep -E '^FRONTEND_PORT=' .env 2>/dev/null | head -1 | cut -d= -f2 || echo "3000")
+  pg_port=$(grep -E '^POSTGRES_PORT=' .env 2>/dev/null | head -1 | cut -d= -f2 || echo "5432")
+  backend_port="${backend_port:-8080}"
+  frontend_port="${frontend_port:-3000}"
+  pg_port="${pg_port:-5432}"
+
+  local ports_changed=false
+
+  for var_name in backend_port frontend_port pg_port; do
+    eval "local port=\$$var_name"
+    if ! port_is_free "$port"; then
+      local new_port
+      new_port=$(find_free_port "$((port + 1))") || fail "No free port found near $port. Free the port or set a custom one in $INSTALL_DIR/.env"
+      warn "Port $port is already in use — switching to $new_port"
+
+      case "$var_name" in
+        backend_port)
+          eval "$var_name=$new_port"
+          if [ "$OS" = "darwin" ]; then
+            sed -i '' "s/^PORT=.*/PORT=$new_port/" .env
+            sed -i '' "s|http://localhost:$port|http://localhost:$new_port|g" .env
+            sed -i '' "s|ws://localhost:$port|ws://localhost:$new_port|g" .env
+          else
+            sed -i "s/^PORT=.*/PORT=$new_port/" .env
+            sed -i "s|http://localhost:$port|http://localhost:$new_port|g" .env
+            sed -i "s|ws://localhost:$port|ws://localhost:$new_port|g" .env
+          fi
+          ;;
+        frontend_port)
+          eval "$var_name=$new_port"
+          if [ "$OS" = "darwin" ]; then
+            sed -i '' "s/^FRONTEND_PORT=.*/FRONTEND_PORT=$new_port/" .env
+            sed -i '' "s|^FRONTEND_ORIGIN=.*|FRONTEND_ORIGIN=http://localhost:$new_port|" .env
+          else
+            sed -i "s/^FRONTEND_PORT=.*/FRONTEND_PORT=$new_port/" .env
+            sed -i "s|^FRONTEND_ORIGIN=.*|FRONTEND_ORIGIN=http://localhost:$new_port|" .env
+          fi
+          ;;
+        pg_port)
+          eval "$var_name=$new_port"
+          if [ "$OS" = "darwin" ]; then
+            sed -i '' "s/^POSTGRES_PORT=.*/POSTGRES_PORT=$new_port/" .env
+          else
+            sed -i "s/^POSTGRES_PORT=.*/POSTGRES_PORT=$new_port/" .env
+          fi
+          ;;
+      esac
+      ports_changed=true
+    fi
+  done
+
+  if [ "$ports_changed" = true ]; then
+    ok "Ports adjusted in .env to avoid conflicts"
+  fi
+  # -----------------------------------------------------------------------
+
   # Start Docker Compose
   info "Starting Multica services (this may take a few minutes on first run)..."
   docker compose -f docker-compose.selfhost.yml up -d --build
@@ -265,7 +353,7 @@ setup_server() {
   info "Waiting for backend to be ready..."
   local ready=false
   for i in $(seq 1 45); do
-    if curl -sf http://localhost:8080/health >/dev/null 2>&1; then
+    if curl -sf "http://localhost:${backend_port}/health" >/dev/null 2>&1; then
       ready=true
       break
     fi
@@ -286,12 +374,17 @@ setup_server() {
 # ---------------------------------------------------------------------------
 configure_local() {
   info "Configuring CLI for local server..."
+  local bp fp
+  bp=$(grep -E '^PORT=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2 || echo "8080")
+  fp=$(grep -E '^FRONTEND_PORT=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2 || echo "3000")
+  bp="${bp:-8080}"
+  fp="${fp:-3000}"
+
   multica config local 2>/dev/null || {
-    # Fallback if config local doesn't exist in installed version
-    multica config set app_url http://localhost:3000 2>/dev/null || true
-    multica config set server_url http://localhost:8080 2>/dev/null || true
+    multica config set app_url "http://localhost:$fp" 2>/dev/null || true
+    multica config set server_url "http://localhost:$bp" 2>/dev/null || true
   }
-  ok "CLI configured for localhost (backend :8080, frontend :3000)"
+  ok "CLI configured for localhost (backend :$bp, frontend :$fp)"
 }
 
 # ---------------------------------------------------------------------------
@@ -351,17 +444,24 @@ run_local() {
   install_cli
   configure_local
 
+  # Read actual ports from .env for display
+  local bp fp
+  bp=$(grep -E '^PORT=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2 || echo "8080")
+  fp=$(grep -E '^FRONTEND_PORT=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2 || echo "3000")
+  bp="${bp:-8080}"
+  fp="${fp:-3000}"
+
   printf "\n"
   printf "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
   printf "${BOLD}${GREEN}  ✓ Multica is installed and running!${RESET}\n"
   printf "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
   printf "\n"
-  printf "  ${BOLD}Frontend:${RESET}  http://localhost:3000\n"
-  printf "  ${BOLD}Backend:${RESET}   http://localhost:8080\n"
+  printf "  ${BOLD}Frontend:${RESET}  http://localhost:%s\n" "$fp"
+  printf "  ${BOLD}Backend:${RESET}   http://localhost:%s\n" "$bp"
   printf "  ${BOLD}Server at:${RESET} %s\n" "$INSTALL_DIR"
   printf "\n"
   printf "  ${BOLD}Next steps:${RESET}\n"
-  printf "  1. Open ${CYAN}http://localhost:3000${RESET} in your browser\n"
+  printf "  1. Open ${CYAN}http://localhost:%s${RESET} in your browser\n" "$fp"
   printf "  2. Log in with any email + verification code: ${BOLD}888888${RESET}\n"
   printf "  3. Then run:\n"
   printf "\n"


### PR DESCRIPTION
## What does this PR do?

The self-host installer (`install.sh` and `install.ps1`) fails when default ports (8080, 3000, or 5432) are already in use on the host. Docker cannot bind the port and the install hangs or errors out.

This PR adds port availability detection before starting services. When a port conflict is found, the installer auto-selects the next free port and updates `.env` + all dependent URLs accordingly.

## Related Issue

Closes #883

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `scripts/install.sh`:
  - Added `port_is_free()` helper — cross-platform port check (`ss` on Linux, `lsof` on macOS)
  - Added `find_free_port()` helper — scans from given port up to +100
  - Added port conflict detection block in `setup_server()` before `docker compose up`
  - Updated `configure_local()` to read actual ports from `.env`
  - Updated `run_local()` to display actual ports in final output
  - Health check now polls the correct (possibly reassigned) backend port

- `scripts/install.ps1`:
  - Added `Test-PortFree` function using `Get-NetTCPConnection`
  - Added `Find-FreePort` function — same scan logic as bash version
  - Added port conflict detection block in `Install-Server` before `docker compose up`
  - Updated `Set-ConfigLocal` to read actual ports from `.env`
  - Updated `Start-LocalInstall` to display actual ports in final output
  - Health check now polls the correct backend port

## How to Test

1. Start a process on port 8080: `python3 -m http.server 8080`
2. Run the installer: `bash scripts/install.sh --local`
3. Verify the installer warns about the port conflict and switches to 8081
4. Verify `.env` has `PORT=8081` and updated `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_WS_URL`
5. Verify the final output shows the correct ports
6. Stop the blocking process, re-run installer to confirm no regression on default ports

## Checklist

- [x] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure

**AI tool used:** Claude Code (Claude Opus 4.6)

**Prompt / approach:** Reproduced the port conflict error during a `--local` install, asked Claude Code to create the issue and propose a fix. The approach was informed by the existing dynamic port allocation in `scripts/init-worktree-env.sh` which uses hash-based offsets for worktree isolation.