### PR TITLE
fix(workspace): auto-retry slug conflicts and show editable URL field

### DIFF
--- a/packages/views/onboarding/step-workspace.tsx
+++ b/packages/views/onboarding/step-workspace.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { toast } from "sonner";
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import { useCreateWorkspace } from "@multica/core/workspace/mutations";
+
+const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 function nameToSlug(name: string): string {
   return (
@@ -20,13 +22,34 @@ function nameToSlug(name: string): string {
 export function StepWorkspace({ onNext }: { onNext: () => void }) {
   const createWorkspace = useCreateWorkspace();
   const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  // Track whether the user has manually edited the slug field.
+  const slugTouched = useRef(false);
 
-  const canSubmit = name.trim().length > 0;
+  const slugError =
+    slug.length > 0 && !SLUG_REGEX.test(slug)
+      ? "Only lowercase letters, numbers, and hyphens"
+      : null;
+
+  const canSubmit =
+    name.trim().length > 0 && slug.trim().length > 0 && !slugError;
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (!slugTouched.current) {
+      setSlug(nameToSlug(value));
+    }
+  };
+
+  const handleSlugChange = (value: string) => {
+    slugTouched.current = true;
+    setSlug(value);
+  };
 
   const handleCreate = () => {
     if (!canSubmit) return;
     createWorkspace.mutate(
-      { name: name.trim(), slug: nameToSlug(name.trim()) },
+      { name: name.trim(), slug: slug.trim() },
       {
         onSuccess: () => onNext(),
         onError: () => toast.error("Failed to create workspace"),
@@ -53,10 +76,29 @@ export function StepWorkspace({ onNext }: { onNext: () => void }) {
               autoFocus
               type="text"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => handleNameChange(e.target.value)}
               placeholder="My Team"
               onKeyDown={(e) => e.key === "Enter" && handleCreate()}
             />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Workspace URL</Label>
+            <div className="flex items-center gap-0 rounded-md border bg-background focus-within:ring-2 focus-within:ring-ring">
+              <span className="pl-3 text-sm text-muted-foreground select-none">
+                multica.ai/
+              </span>
+              <Input
+                type="text"
+                value={slug}
+                onChange={(e) => handleSlugChange(e.target.value)}
+                placeholder="my-team"
+                className="border-0 shadow-none focus-visible:ring-0"
+                onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              />
+            </div>
+            {slugError && (
+              <p className="text-xs text-destructive">{slugError}</p>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -161,19 +162,31 @@ func (h *Handler) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	qtx := h.Queries.WithTx(tx)
-	ws, err := qtx.CreateWorkspace(r.Context(), db.CreateWorkspaceParams{
-		Name:        req.Name,
-		Slug:        req.Slug,
-		Description: ptrToText(req.Description),
-		Context:     ptrToText(req.Context),
-		IssuePrefix: issuePrefix,
-	})
-	if err != nil {
-		if isUniqueViolation(err) {
-			writeError(w, http.StatusConflict, "workspace slug already exists")
+
+	// Try the requested slug first, then append -2, -3, … on conflict.
+	const maxSlugAttempts = 10
+	var ws db.Workspace
+	slug := req.Slug
+	for attempt := 1; attempt <= maxSlugAttempts; attempt++ {
+		ws, err = qtx.CreateWorkspace(r.Context(), db.CreateWorkspaceParams{
+			Name:        req.Name,
+			Slug:        slug,
+			Description: ptrToText(req.Description),
+			Context:     ptrToText(req.Context),
+			IssuePrefix: issuePrefix,
+		})
+		if err == nil {
+			break
+		}
+		if !isUniqueViolation(err) {
+			writeError(w, http.StatusInternalServerError, "failed to create workspace: "+err.Error())
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "failed to create workspace: "+err.Error())
+		// Slug taken — try next suffix.
+		slug = fmt.Sprintf("%s-%d", req.Slug, attempt+1)
+	}
+	if err != nil {
+		writeError(w, http.StatusConflict, "workspace slug already exists")
 		return
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fixes workspace creation failing with a 409 error when two users pick the same workspace name. The server now auto-appends numeric suffixes (`-2`, `-3`, …) on slug conflicts instead of rejecting outright. The onboarding wizard also restores an editable Workspace URL field (`multica.ai/<slug>`) so users can see and customize their slug.

This was a regression from #852 which removed the old `CreateWorkspaceModal` (with visible slug field) and `ensureUserWorkspace` (which appended user ID suffixes for uniqueness).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/internal/handler/workspace.go`: `CreateWorkspace` retries with `-2`, `-3`, … suffixes (up to 10 attempts) on slug unique-violation instead of returning 409
- `packages/views/onboarding/step-workspace.tsx`: Added editable Workspace URL field below Workspace Name, auto-generated from name but manually customizable, with format validation

## How to Test

1. Create a workspace with name "My Team" (slug: `my-team`)
2. Log in as a different user and create another workspace named "My Team"
3. Verify the second workspace is created successfully with slug `my-team-2`
4. Verify the slug field is visible and editable in the onboarding wizard

## Checklist

- [x] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure

**AI tool used:** Claude Code (via Conductor)

**Prompt / approach:** Investigated git history to find the regression commit (#852 onboarding wizard), then restored the editable slug field and added server-side retry logic.