### PR TITLE
revert: handle control_request messages in claude backend (#811)

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -71,13 +71,14 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		_ = cmd.Wait()
 		return nil, fmt.Errorf("write claude input: %w", err)
 	}
+	closeStdin()
+
 	b.cfg.Logger.Info("claude started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
 	go func() {
-		defer closeStdin()
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
@@ -132,10 +133,6 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 						Content: msg.Log.Message,
 					})
 				}
-			case "control_request":
-				// Auto-approve tool-use permission requests so that Claude
-				// can proceed in daemon / bypass-permissions mode.
-				b.handleControlRequest(msg, stdin)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Reverts #811 which caused a deadlock — agents hang after execution because stdin remained open inside the goroutine instead of being closed immediately after writing input.

- Closes stdin before the goroutine starts (restoring pre-#811 behavior)
- Removes `defer closeStdin()` from inside the goroutine
- Removes the `case "control_request"` handler

Closes MUL-718