### PR TITLE
fix(openclaw): handle pretty-printed multi-line JSON output

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -254,8 +254,25 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 
 	// If we got no events at all, fall back to raw output.
 	if !gotEvents {
+		// OpenClaw may output pretty-printed (multi-line) JSON. No single line
+		// would parse, so try parsing the accumulated output as a whole.
+		// Log lines may precede the JSON, so find the first '{' at line start.
 		trimmed := strings.TrimSpace(strings.Join(rawLines, "\n"))
 		if trimmed != "" {
+			if result, ok := tryParseOpenclawResult(trimmed); ok {
+				return b.buildOpenclawEventResult(result, ch, &output)
+			}
+			// Log lines may precede the JSON blob. Find the first line that
+			// starts with '{' and try parsing from there.
+			for i, line := range rawLines {
+				if len(line) > 0 && line[0] == '{' {
+					candidate := strings.TrimSpace(strings.Join(rawLines[i:], "\n"))
+					if result, ok := tryParseOpenclawResult(candidate); ok {
+						return b.buildOpenclawEventResult(result, ch, &output)
+					}
+					break
+				}
+			}
 			return openclawEventResult{status: "completed", output: trimmed}
 		}
 		return openclawEventResult{status: "failed", errMsg: "openclaw returned no parseable output"}

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -819,6 +819,75 @@ func TestOpenclawUsageFinalResultAlternativeFields(t *testing.T) {
 	close(ch)
 }
 
+func TestOpenclawProcessOutputMultilineJSON(t *testing.T) {
+	t.Parallel()
+
+	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	result := openclawResult{
+		Payloads: []openclawPayload{{Text: "Pretty printed response"}},
+		Meta: openclawMeta{
+			DurationMs: 4764,
+			AgentMeta: map[string]any{
+				"sessionId": "test-session",
+				"usage": map[string]any{
+					"input":  float64(100),
+					"output": float64(34),
+				},
+			},
+		},
+	}
+	// Marshal with indentation to simulate openclaw's pretty-printed output.
+	data, _ := json.MarshalIndent(result, "", "  ")
+
+	res := b.processOutput(strings.NewReader(string(data)), ch)
+
+	if res.status != "completed" {
+		t.Errorf("status: got %q, want %q", res.status, "completed")
+	}
+	if res.output != "Pretty printed response" {
+		t.Errorf("output: got %q, want %q", res.output, "Pretty printed response")
+	}
+	if res.sessionID != "test-session" {
+		t.Errorf("sessionID: got %q, want %q", res.sessionID, "test-session")
+	}
+
+	close(ch)
+	var msgs []Message
+	for m := range ch {
+		msgs = append(msgs, m)
+	}
+	if len(msgs) != 1 || msgs[0].Content != "Pretty printed response" {
+		t.Errorf("expected 1 text message with content, got %d msgs", len(msgs))
+	}
+}
+
+func TestOpenclawProcessOutputMultilineJSONWithLeadingLogs(t *testing.T) {
+	t.Parallel()
+
+	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	result := openclawResult{
+		Payloads: []openclawPayload{{Text: "Answer after logs"}},
+		Meta:     openclawMeta{DurationMs: 100},
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	input := "some startup log\nanother log line\n" + string(data)
+
+	res := b.processOutput(strings.NewReader(input), ch)
+
+	if res.status != "completed" {
+		t.Errorf("status: got %q, want %q", res.status, "completed")
+	}
+	if res.output != "Answer after logs" {
+		t.Errorf("output: got %q, want %q", res.output, "Answer after logs")
+	}
+
+	close(ch)
+}
+
 // ── openclawInt64 tests ──
 
 func TestOpenclawInt64Float(t *testing.T) {


### PR DESCRIPTION
## Summary
- OpenClaw's `--json` flag outputs pretty-printed (multi-line) JSON to stderr
- The line-by-line scanner in `processOutput` couldn't parse any single line as valid JSON, so the entire raw JSON was returned as the chat message content
- After exhausting line-by-line parsing, the accumulated output is now tried as a whole JSON object before falling back to raw text

Closes MUL-725

## Test plan
- [x] Added `TestOpenclawProcessOutputMultilineJSON` — verifies text extraction from pretty-printed JSON
- [x] Added `TestOpenclawProcessOutputMultilineJSONWithLeadingLogs` — verifies parsing when log lines precede multi-line JSON
- [x] All existing openclaw tests pass (14 total)