### PR TITLE
fix(web): stabilize login and dashboard redirects

### DIFF
--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -12,6 +12,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       searchSlot={<SearchTrigger />}
       extra={<><SearchCommand /><ChatWindow /><ChatFab /></>}
       onboardingPath="/onboarding"
+      loginPath="/login"
     >
       {children}
     </DashboardLayout>

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,11 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-export function proxy(request: NextRequest) {
-  const loggedIn = request.cookies.has("multica_logged_in");
-  if (loggedIn) {
-    return NextResponse.redirect(new URL("/issues", request.url));
-  }
+export function proxy(_request: NextRequest) {
   return NextResponse.next();
 }
 

--- a/packages/views/layout/dashboard-layout.tsx
+++ b/packages/views/layout/dashboard-layout.tsx
@@ -14,6 +14,8 @@ interface DashboardLayoutProps {
   searchSlot?: ReactNode;
   /** Loading indicator */
   loadingIndicator?: ReactNode;
+  /** Path to redirect when user is not authenticated */
+  loginPath?: string;
   /** Path to redirect when user has no workspace */
   onboardingPath?: string;
 }
@@ -23,11 +25,12 @@ export function DashboardLayout({
   extra,
   searchSlot,
   loadingIndicator,
+  loginPath,
   onboardingPath,
 }: DashboardLayoutProps) {
   return (
     <DashboardGuard
-      loginPath="/"
+      loginPath={loginPath}
       onboardingPath={onboardingPath}
       loadingFallback={
         <div className="flex h-svh items-center justify-center">

--- a/packages/views/layout/use-dashboard-guard.ts
+++ b/packages/views/layout/use-dashboard-guard.ts
@@ -7,7 +7,7 @@ import { useWorkspaceStore } from "@multica/core/workspace";
 import { useNavigation } from "../navigation";
 
 export function useDashboardGuard(loginPath = "/", onboardingPath?: string) {
-  const { pathname, push } = useNavigation();
+  const { pathname, replace } = useNavigation();
   const user = useAuthStore((s) => s.user);
   const isLoading = useAuthStore((s) => s.isLoading);
   const workspace = useWorkspaceStore((s) => s.workspace);
@@ -15,13 +15,13 @@ export function useDashboardGuard(loginPath = "/", onboardingPath?: string) {
   useEffect(() => {
     if (isLoading) return;
     if (!user) {
-      push(loginPath);
+      replace(loginPath);
       return;
     }
     if (!workspace && onboardingPath) {
-      push(onboardingPath);
+      replace(onboardingPath);
     }
-  }, [user, isLoading, workspace, push, loginPath, onboardingPath]);
+  }, [user, isLoading, workspace, replace, loginPath, onboardingPath]);
 
   useEffect(() => {
     useNavigationStore.getState().onPathChange(pathname);


### PR DESCRIPTION
## What does this PR do?

Stabilizes the web login and dashboard redirect flow by removing an eager cookie-based root redirect and keeping auth/workspace gating inside the shared dashboard guard.

The result is a more predictable transition from login to dashboard pages, with cleaner history behavior for auth and onboarding redirects.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor / code improvement (no behavior change)

## Changes Made

- `apps/web/proxy.ts`
  - remove the root `/` -> `/issues` redirect based only on `multica_logged_in`
- `apps/web/app/(dashboard)/layout.tsx`
  - pass an explicit `loginPath` into the shared dashboard layout
- `packages/views/layout/dashboard-layout.tsx`
  - accept `loginPath` as a prop instead of hard-coding `/`
- `packages/views/layout/use-dashboard-guard.ts`
  - use `replace()` instead of `push()` for auth/onboarding redirects
  - keep redirect decisions in the shared guard path

## How to Test

1. Open the web app while logged out and confirm dashboard routes redirect cleanly to `/login`
2. Log in and confirm the app reaches the expected dashboard route without bouncing through a stale root redirect
3. Verify onboarding/no-workspace redirects still work and do not leave broken back-stack entries

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My commit messages follow Conventional Commits (`feat(scope):`, `fix(scope):`, etc.)
- [x] Manual auth/dashboard redirect verification completed
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
Traced the broken login-to-dashboard flow through the edge proxy and shared dashboard guard, then reduced the fix to the smallest routing changes that restore a single redirect source of truth.
