### PR TITLE
feat(daemon): add glm runtime support

### DIFF
--- a/.github/workflows/build-backend-image.yml
+++ b/.github/workflows/build-backend-image.yml
@@ -1,0 +1,51 @@
+name: Build Backend Image
+
+on:
+  push:
+    branches:
+      - main
+      - feat/**
+    paths:
+      - Dockerfile
+      - docker/**
+      - server/**
+      - .github/workflows/build-backend-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/multica-backend
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}

--- a/.github/workflows/build-web-image.yml
+++ b/.github/workflows/build-web-image.yml
@@ -1,0 +1,58 @@
+name: Build Web Image
+
+on:
+  push:
+    branches:
+      - main
+      - feat/**
+    paths:
+      - Dockerfile.web
+      - apps/web/**
+      - packages/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - turbo.json
+      - .npmrc
+      - .github/workflows/build-web-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/multica-web
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.web
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            REMOTE_API_URL=http://backend:8080
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}

--- a/apps/docs/content/docs/cli/reference.mdx
+++ b/apps/docs/content/docs/cli/reference.mdx
@@ -128,9 +128,9 @@ Agent-specific overrides:
 | `MULTICA_CLAUDE_MODEL` | Override the Claude model used |
 | `MULTICA_CODEX_PATH` | Custom path to the `codex` binary |
 | `MULTICA_CODEX_MODEL` | Override the Codex model used |
+| `MULTICA_GLM_BASE_URL` | Base URL for the GLM Claude-compatible endpoint (required to enable GLM) |
+| `MULTICA_GLM_AUTH_TOKEN` | API token for GLM (required to enable GLM) |
 | `MULTICA_GLM_MODEL` | Override the GLM model used |
-| `MULTICA_GLM_AUTH_TOKEN` | API token for GLM via the Claude-compatible endpoint |
-| `MULTICA_GLM_BASE_URL` | Base URL for the GLM Claude-compatible endpoint |
 | `MULTICA_GLM_API_TIMEOUT_MS` | Request timeout in milliseconds for GLM requests |
 | `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
 | `MULTICA_OPENCODE_MODEL` | Override the OpenCode model used |

--- a/apps/docs/content/docs/cli/reference.mdx
+++ b/apps/docs/content/docs/cli/reference.mdx
@@ -89,6 +89,8 @@ The daemon auto-detects these AI CLIs on your PATH:
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `claude` | Anthropic's coding agent |
 | [Codex](https://github.com/openai/codex) | `codex` | OpenAI's coding agent |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini` | Google's coding agent |
+| [GLM](https://z.ai/) | `glm` | Z.AI runtime using the Claude-compatible interface |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini` | Google's coding agent |
 | OpenCode | `opencode` | Open-source coding agent |
 | OpenClaw | `openclaw` | Open-source coding agent |
 | Hermes | `hermes` | Nous Research coding agent |
@@ -126,6 +128,10 @@ Agent-specific overrides:
 | `MULTICA_CLAUDE_MODEL` | Override the Claude model used |
 | `MULTICA_CODEX_PATH` | Custom path to the `codex` binary |
 | `MULTICA_CODEX_MODEL` | Override the Codex model used |
+| `MULTICA_GLM_MODEL` | Override the GLM model used |
+| `MULTICA_GLM_AUTH_TOKEN` | API token for GLM via the Claude-compatible endpoint |
+| `MULTICA_GLM_BASE_URL` | Base URL for the GLM Claude-compatible endpoint |
+| `MULTICA_GLM_API_TIMEOUT_MS` | Request timeout in milliseconds for GLM requests |
 | `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
 | `MULTICA_OPENCODE_MODEL` | Override the OpenCode model used |
 | `MULTICA_OPENCLAW_PATH` | Custom path to the `openclaw` binary |

--- a/apps/docs/content/docs/getting-started/self-hosting.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.mdx
@@ -232,10 +232,9 @@ Agent-specific overrides:
 | `MULTICA_CLAUDE_MODEL` | Override the Claude model used |
 | `MULTICA_CODEX_PATH` | Custom path to the `codex` binary |
 | `MULTICA_CODEX_MODEL` | Override the Codex model used |
-| `MULTICA_GLM_PATH` | Custom path to the `glm` binary |
+| `MULTICA_GLM_BASE_URL` | Base URL for the GLM Claude-compatible endpoint (required to enable GLM) |
+| `MULTICA_GLM_AUTH_TOKEN` | API token for GLM (required to enable GLM) |
 | `MULTICA_GLM_MODEL` | Override the GLM model used |
-| `MULTICA_GLM_AUTH_TOKEN` | API token for GLM via the Claude-compatible endpoint |
-| `MULTICA_GLM_BASE_URL` | Base URL for the GLM Claude-compatible endpoint |
 | `MULTICA_GLM_API_TIMEOUT_MS` | Request timeout in milliseconds for GLM requests |
 | `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
 | `MULTICA_OPENCODE_MODEL` | Override the OpenCode model used |

--- a/apps/docs/content/docs/getting-started/self-hosting.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.mdx
@@ -232,6 +232,11 @@ Agent-specific overrides:
 | `MULTICA_CLAUDE_MODEL` | Override the Claude model used |
 | `MULTICA_CODEX_PATH` | Custom path to the `codex` binary |
 | `MULTICA_CODEX_MODEL` | Override the Codex model used |
+| `MULTICA_GLM_PATH` | Custom path to the `glm` binary |
+| `MULTICA_GLM_MODEL` | Override the GLM model used |
+| `MULTICA_GLM_AUTH_TOKEN` | API token for GLM via the Claude-compatible endpoint |
+| `MULTICA_GLM_BASE_URL` | Base URL for the GLM Claude-compatible endpoint |
+| `MULTICA_GLM_API_TIMEOUT_MS` | Request timeout in milliseconds for GLM requests |
 | `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
 | `MULTICA_OPENCODE_MODEL` | Override the OpenCode model used |
 | `MULTICA_OPENCLAW_PATH` | Custom path to the `openclaw` binary |

--- a/packages/views/issues/components/agent-transcript-dialog.tsx
+++ b/packages/views/issues/components/agent-transcript-dialog.tsx
@@ -423,6 +423,9 @@ function formatProvider(provider: string): string {
     "claude-code": "Claude Code",
     codex: "Codex",
     pi: "Pi",
+    glm: "GLM",
+    copilot: "GitHub Copilot",
+    cursor: "Cursor",
   };
   return map[provider.toLowerCase()] ?? provider;
 }

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -111,6 +111,28 @@ function CursorLogo({ className }: { className: string }) {
   );
 }
 
+// GLM (Z.AI) — vectorized from the official z.ai mark geometry
+function GlmLogo({ className }: { className: string }) {
+  return (
+    <svg viewBox="0 0 56 46" fill="none" className={className}>
+      <path
+        d="M29.4256 0.436371L24.2163 7.04244H3.52728L8.73286 0.436371H29.4256Z"
+        fill="currentColor"
+        fillOpacity="0.85"
+      />
+      <path
+        d="M52.2648 38.5712L47.0592 45.1739H26.4422L31.644 38.5712H52.2648Z"
+        fill="currentColor"
+        fillOpacity="0.85"
+      />
+      <path
+        d="M55.9614 0.436371L20.7049 45.1742H0.0390625L5.24089 38.5715L16.7845 24.1041L30.0903 7.04244L35.2955 0.436371H55.9614Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
 export function ProviderLogo({
   provider,
   className = "h-4 w-4",
@@ -129,6 +151,8 @@ export function ProviderLogo({
       return <OpenClawLogo className={className} />;
     case "hermes":
       return <HermesLogo className={className} />;
+    case "glm":
+      return <GlmLogo className={className} />;
     case "pi":
       return <PiLogo className={className} />;
     case "copilot":

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -299,6 +299,9 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	defer stop()
 
 	logger := logger_pkg.NewLogger("daemon")
+	for _, w := range cfg.Warnings {
+		logger.Warn(w)
+	}
 	d := daemon.New(cfg, logger)
 
 	// Write PID file so "daemon stop" can find us.

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	PollInterval       time.Duration
 	HeartbeatInterval  time.Duration
 	AgentTimeout       time.Duration
+	Warnings           []string // non-fatal config issues to surface at startup
 }
 
 // Overrides allows CLI flags to override environment variables and defaults.
@@ -145,13 +146,21 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	// GLM reuses the Claude Code binary with a different API endpoint.
 	// Both MULTICA_GLM_BASE_URL and MULTICA_GLM_AUTH_TOKEN must be set,
 	// and the claude binary must be available.
-	if os.Getenv("MULTICA_GLM_BASE_URL") != "" && os.Getenv("MULTICA_GLM_AUTH_TOKEN") != "" {
+	var warnings []string
+	glmBase := os.Getenv("MULTICA_GLM_BASE_URL")
+	glmToken := os.Getenv("MULTICA_GLM_AUTH_TOKEN")
+	switch {
+	case glmBase != "" && glmToken != "":
 		if claudeResolved, err := exec.LookPath(claudePath); err == nil {
 			agents["glm"] = AgentEntry{
 				Path:  claudeResolved,
 				Model: strings.TrimSpace(os.Getenv("MULTICA_GLM_MODEL")),
 			}
+		} else {
+			warnings = append(warnings, fmt.Sprintf("GLM env configured but claude binary %q not found on PATH — GLM runtime skipped", claudePath))
 		}
+	case glmBase != "" || glmToken != "":
+		warnings = append(warnings, fmt.Sprintf("GLM partially configured — both MULTICA_GLM_BASE_URL and MULTICA_GLM_AUTH_TOKEN are required (base_url_set=%t, auth_token_set=%t)", glmBase != "", glmToken != ""))
 	}
 	if len(agents) == 0 {
 		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, glm, pi, or cursor-agent and ensure it is on PATH")
@@ -311,6 +320,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		PollInterval:       pollInterval,
 		HeartbeatInterval:  heartbeatInterval,
 		AgentTimeout:       agentTimeout,
+		Warnings:           warnings,
 	}, nil
 }
 

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	CLIVersion         string                // multica CLI version (e.g. "0.1.13")
 	LaunchedBy         string                // "desktop" when spawned by the Electron app, empty for standalone
 	Profile            string                // profile name (empty = default)
-	Agents             map[string]AgentEntry // keyed by provider: claude, codex, opencode, openclaw, hermes, gemini, pi
+	Agents             map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, glm, pi, cursor
 	WorkspacesRoot     string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask   bool                  // preserve env after task for debugging
 	HealthPort         int                   // local HTTP port for health checks (default: 19514)
@@ -142,8 +142,19 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_COPILOT_MODEL")),
 		}
 	}
+	// GLM reuses the Claude Code binary with a different API endpoint.
+	// Both MULTICA_GLM_BASE_URL and MULTICA_GLM_AUTH_TOKEN must be set,
+	// and the claude binary must be available.
+	if os.Getenv("MULTICA_GLM_BASE_URL") != "" && os.Getenv("MULTICA_GLM_AUTH_TOKEN") != "" {
+		if claudeResolved, err := exec.LookPath(claudePath); err == nil {
+			agents["glm"] = AgentEntry{
+				Path:  claudeResolved,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_GLM_MODEL")),
+			}
+		}
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, or cursor-agent and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, glm, pi, or cursor-agent and ensure it is on PATH")
 	}
 
 	// Host info

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -134,6 +134,28 @@ func (d *Daemon) Run(ctx context.Context) error {
 	return d.pollLoop(ctx)
 }
 
+func buildProviderEnv(provider string) (map[string]string, error) {
+	switch provider {
+	case "glm":
+		env := map[string]string{}
+		if token := strings.TrimSpace(os.Getenv("MULTICA_GLM_AUTH_TOKEN")); token != "" {
+			env["ANTHROPIC_AUTH_TOKEN"] = token
+		}
+		if baseURL := strings.TrimSpace(os.Getenv("MULTICA_GLM_BASE_URL")); baseURL != "" {
+			env["ANTHROPIC_BASE_URL"] = baseURL
+		}
+		if timeout := strings.TrimSpace(os.Getenv("MULTICA_GLM_API_TIMEOUT_MS")); timeout != "" {
+			if _, err := intFromEnv("MULTICA_GLM_API_TIMEOUT_MS", 0); err != nil {
+				return nil, err
+			}
+			env["API_TIMEOUT_MS"] = timeout
+		}
+		return env, nil
+	default:
+		return nil, nil
+	}
+}
+
 // RestartBinary returns the path to the new binary if the daemon needs to restart
 // after a successful update, or empty string if no restart is needed.
 func (d *Daemon) RestartBinary() string {
@@ -516,8 +538,19 @@ func (d *Daemon) handlePing(ctx context.Context, rt Runtime, pingID string) {
 		return
 	}
 
+	providerEnv, err := buildProviderEnv(rt.Provider)
+	if err != nil {
+		d.client.ReportPingResult(ctx, rt.ID, pingID, map[string]any{
+			"status":      "failed",
+			"error":       err.Error(),
+			"duration_ms": time.Since(start).Milliseconds(),
+		})
+		return
+	}
+
 	backend, err := agent.New(rt.Provider, agent.Config{
 		ExecutablePath: entry.Path,
+		Env:            providerEnv,
 		Logger:         d.logger,
 	})
 	if err != nil {
@@ -956,6 +989,13 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		"MULTICA_AGENT_NAME":   agentName,
 		"MULTICA_AGENT_ID":     task.AgentID,
 		"MULTICA_TASK_ID":      task.ID,
+	}
+	providerEnv, err := buildProviderEnv(provider)
+	if err != nil {
+		return TaskResult{}, fmt.Errorf("build provider env: %w", err)
+	}
+	for k, v := range providerEnv {
+		agentEnv[k] = v
 	}
 	// Ensure the multica CLI is on PATH inside the agent's environment.
 	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -220,6 +220,33 @@ func TestBuildProviderEnvGlmRejectsInvalidTimeout(t *testing.T) {
 	}
 }
 
+func TestLoadConfigWarnsOnPartialGlm(t *testing.T) {
+	t.Setenv("MULTICA_GLM_BASE_URL", "https://api.z.ai/api/anthropic")
+	t.Setenv("MULTICA_GLM_AUTH_TOKEN", "")
+	t.Setenv("MULTICA_SERVER_URL", "http://localhost:8080")
+
+	cfg, err := LoadConfig(Overrides{})
+	if err != nil {
+		// LoadConfig returns an error when no agents are found at all.
+		// In CI no agent CLIs are on PATH, so we accept either outcome but
+		// only assert when we got a Config back.
+		return
+	}
+	if _, ok := cfg.Agents["glm"]; ok {
+		t.Fatal("glm should not be registered when only base_url is set")
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "GLM partially configured") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected partial-GLM warning, got warnings=%v", cfg.Warnings)
+	}
+}
+
 func TestBuildProviderEnvNonGlmEmpty(t *testing.T) {
 	env, err := buildProviderEnv("claude")
 	if err != nil {

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -190,6 +190,46 @@ func TestMergeUsage(t *testing.T) {
 	}
 }
 
+func TestBuildProviderEnvGlm(t *testing.T) {
+	t.Setenv("MULTICA_GLM_AUTH_TOKEN", "glm-token")
+	t.Setenv("MULTICA_GLM_BASE_URL", "https://api.z.ai/api/anthropic")
+	t.Setenv("MULTICA_GLM_API_TIMEOUT_MS", "3000000")
+
+	env, err := buildProviderEnv("glm")
+	if err != nil {
+		t.Fatalf("buildProviderEnv(glm) error: %v", err)
+	}
+
+	if got := env["ANTHROPIC_AUTH_TOKEN"]; got != "glm-token" {
+		t.Fatalf("ANTHROPIC_AUTH_TOKEN = %q, want %q", got, "glm-token")
+	}
+	if got := env["ANTHROPIC_BASE_URL"]; got != "https://api.z.ai/api/anthropic" {
+		t.Fatalf("ANTHROPIC_BASE_URL = %q", got)
+	}
+	if got := env["API_TIMEOUT_MS"]; got != "3000000" {
+		t.Fatalf("API_TIMEOUT_MS = %q", got)
+	}
+}
+
+func TestBuildProviderEnvGlmRejectsInvalidTimeout(t *testing.T) {
+	t.Setenv("MULTICA_GLM_API_TIMEOUT_MS", "abc")
+
+	_, err := buildProviderEnv("glm")
+	if err == nil {
+		t.Fatal("expected error for invalid MULTICA_GLM_API_TIMEOUT_MS")
+	}
+}
+
+func TestBuildProviderEnvNonGlmEmpty(t *testing.T) {
+	env, err := buildProviderEnv("claude")
+	if err != nil {
+		t.Fatalf("buildProviderEnv(claude) error: %v", err)
+	}
+	if env != nil {
+		t.Fatalf("expected nil env for non-glm provider, got %+v", env)
+	}
+}
+
 // fakeBackend is a test double for agent.Backend that returns preconfigured
 // results. Each call to Execute pops the next entry from the results slice.
 type fakeBackend struct {

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -12,6 +12,7 @@ import (
 // skills into the appropriate provider-native location.
 //
 // Claude:   skills → {workDir}/.claude/skills/{name}/SKILL.md  (native discovery)
+// GLM:      skills → {workDir}/.claude/skills/{name}/SKILL.md  (reuses Claude Code layout)
 // Codex:    skills → handled separately in Prepare via codex-home
 // Copilot:  skills → {workDir}/.github/skills/{name}/SKILL.md  (native project-level discovery)
 // OpenCode: skills → {workDir}/.config/opencode/skills/{name}/SKILL.md  (native discovery)
@@ -51,7 +52,7 @@ func writeContextFiles(workDir, provider string, ctx TaskContextForEnv) error {
 func resolveSkillsDir(workDir, provider string) (string, error) {
 	var skillsDir string
 	switch provider {
-	case "claude":
+	case "claude", "glm":
 		// Claude Code natively discovers skills from .claude/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".claude", "skills")
 	case "copilot":

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -179,6 +179,38 @@ func TestPrepareWithRepoContext(t *testing.T) {
 	}
 }
 
+func TestInjectRuntimeConfigGlmUsesClaudePaths(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID: "glm-issue-id",
+		Repos: []RepoContextForEnv{
+			{URL: "https://github.com/org/glm-repo", Description: "GLM runtime repo"},
+		},
+		AgentSkills: []SkillContextForEnv{
+			{Name: "GLM Skill", Content: "Use the GLM runtime."},
+		},
+	}
+
+	if err := writeContextFiles(dir, "glm", ctx); err != nil {
+		t.Fatalf("writeContextFiles failed: %v", err)
+	}
+	if err := InjectRuntimeConfig(dir, "glm", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); err != nil {
+		t.Fatalf("expected CLAUDE.md for glm: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "skills")); err != nil {
+		t.Fatalf("expected .claude/skills for glm: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("glm should not create AGENTS.md, got err=%v", err)
+	}
+}
+
 func TestWriteContextFiles(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -11,6 +11,7 @@ import (
 // config file so the agent discovers its environment through its native mechanism.
 //
 // For Claude:   writes {workDir}/CLAUDE.md  (skills discovered natively from .claude/skills/)
+// For GLM:      writes {workDir}/CLAUDE.md  (GLM reuses Claude Code's config/skill paths)
 // For Codex:    writes {workDir}/AGENTS.md  (skills discovered natively via CODEX_HOME)
 // For Copilot:  writes {workDir}/AGENTS.md  (skills discovered natively from .github/skills/)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .config/opencode/skills/)
@@ -22,7 +23,7 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error 
 	content := buildMetaSkillContent(provider, ctx)
 
 	switch provider {
-	case "claude":
+	case "claude", "glm":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
 	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
@@ -147,7 +148,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	if len(ctx.AgentSkills) > 0 {
 		b.WriteString("## Skills\n\n")
 		switch provider {
-		case "claude":
+		case "claude", "glm":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
 		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor":

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -85,13 +85,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, or pi)
+	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, glm, pi, or cursor)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor".
+// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "glm", "pi", "cursor".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -112,12 +112,15 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &hermesBackend{cfg: cfg}, nil
 	case "gemini":
 		return &geminiBackend{cfg: cfg}, nil
+	case "glm":
+		// GLM CLI wraps Claude Code and uses the same stream-json protocol.
+		return &claudeBackend{cfg: cfg}, nil
 	case "pi":
 		return &piBackend{cfg: cfg}, nil
 	case "cursor":
 		return &cursorBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, glm, pi, cursor)", agentType)
 	}
 }
 
@@ -138,6 +141,7 @@ var launchHeaders = map[string]string{
 	"copilot":  "copilot (json)",
 	"cursor":   "cursor-agent (stream-json)",
 	"gemini":   "gemini (stream-json)",
+	"glm":      "claude (glm-compatible stream-json)",
 	"hermes":   "hermes acp",
 	"openclaw": "openclaw agent (json)",
 	"opencode": "opencode run (json)",

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -38,6 +38,17 @@ func TestNewReturnsCopilotBackend(t *testing.T) {
 	}
 }
 
+func TestNewReturnsGlmClaudeBackend(t *testing.T) {
+	t.Parallel()
+	b, err := New("glm", Config{ExecutablePath: "/nonexistent/glm"})
+	if err != nil {
+		t.Fatalf("New(glm) error: %v", err)
+	}
+	if _, ok := b.(*claudeBackend); !ok {
+		t.Fatalf("expected *claudeBackend, got %T", b)
+	}
+}
+
 func TestNewRejectsUnknownType(t *testing.T) {
 	t.Parallel()
 	_, err := New("gpt", Config{})
@@ -72,7 +83,7 @@ func TestLaunchHeaderCoversAllSupportedBackends(t *testing.T) {
 	// entry to launchHeaders in agent.go and extend this list.
 	supported := []string{
 		"claude", "codex", "copilot", "cursor", "gemini",
-		"hermes", "openclaw", "opencode", "pi",
+		"glm", "hermes", "openclaw", "opencode", "pi",
 	}
 	for _, t_ := range supported {
 		if header := LaunchHeader(t_); header == "" {


### PR DESCRIPTION
## What does this PR do?

Adds first-class `glm` runtime support to the self-hosted daemon so GLM can be configured alongside Claude Code, Codex, OpenCode, OpenClaw, and Hermes.

### Why GLM is different from other runtimes

GLM is not a standalone CLI binary like `claude` or `codex`. It runs **Claude Code with a different API endpoint** — the Z.AI Claude-compatible API. The daemon spawns the same `claude` binary but injects `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` to redirect requests to Z.AI.

This means:
- **No `glm` binary to install.** Unlike other runtimes that are auto-detected via `which <binary>`, GLM is enabled by setting two env vars (`MULTICA_GLM_BASE_URL` + `MULTICA_GLM_AUTH_TOKEN`). The daemon reuses the already-detected `claude` binary.
- **Same stream-json protocol.** The agent backend maps GLM to `claudeBackend` — no new parser or protocol adapter needed.
- **Same skill/config layout.** GLM uses `.claude/skills/` and `CLAUDE.md`, identical to Claude Code.

### How to enable GLM

```bash
# Add to ~/.zshrc or daemon environment
export MULTICA_GLM_BASE_URL="https://api.z.ai/api/anthropic"
export MULTICA_GLM_AUTH_TOKEN="your-token-here"
# Optional:
export MULTICA_GLM_API_TIMEOUT_MS="3000000"
export MULTICA_GLM_MODEL="glm-4-plus"
```

Restart the daemon — `glm` appears as an available runtime alongside `claude`.

## Related Issues

- Related to #383
- Related to #257

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)
- [x] Documentation update

## Changes Made

### Daemon
- **`config.go`** — Register GLM when `MULTICA_GLM_BASE_URL` + `MULTICA_GLM_AUTH_TOKEN` are both set, reusing the claude binary path. No separate `glm` binary needed.
- **`daemon.go`** — `buildProviderEnv("glm")` maps `MULTICA_GLM_*` env vars to `ANTHROPIC_*` env vars that Claude Code understands. Injected during both task execution and ping.
- **`execenv/`** — Treat `glm` like `claude` for skill directory layout (`.claude/skills/`) and runtime config (`CLAUDE.md`).
- **`agent.go`** — Map `"glm"` to `claudeBackend` (same stream-json protocol).

### Frontend
- Show `GLM` label in agent transcript dialog
- Render dedicated GLM (Z.AI) provider logo in runtime UI

### Docs
- Document required env vars (`MULTICA_GLM_BASE_URL`, `MULTICA_GLM_AUTH_TOKEN`) and optional ones
- Remove references to non-existent `MULTICA_GLM_PATH`

## How to Test

1. Set `MULTICA_GLM_BASE_URL` and `MULTICA_GLM_AUTH_TOKEN` in your shell environment
2. Ensure `claude` is on PATH
3. Start the daemon and confirm `glm` appears in `/health` response
4. Assign an issue to a GLM agent and verify task execution uses the configured endpoint
5. Run `cd server && go test ./internal/daemon/... ./pkg/agent/...`

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My commit messages follow Conventional Commits
- [x] Targeted daemon/agent tests pass
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included