### PR TITLE
fix(cli): redirect to web onboarding when new user has no workspaces

### DIFF
--- a/server/cmd/multica/cmd_login.go
+++ b/server/cmd/multica/cmd_login.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/multica-ai/multica/server/internal/cli"
 )
+
+var nonSlugChar = regexp.MustCompile(`[^a-z0-9-]+`)
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
@@ -59,8 +63,14 @@ func autoWatchWorkspaces(cmd *cobra.Command) error {
 	}
 
 	if len(workspaces) == 0 {
-		fmt.Fprintln(os.Stderr, "\nNo workspaces found.")
-		return nil
+		fmt.Fprintln(os.Stderr, "\nNo workspaces found. Creating one for you...")
+		ws, err := createDefaultWorkspace(ctx, client)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not create workspace: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Create one at the web dashboard, then run 'multica login' again.")
+			return nil
+		}
+		workspaces = append(workspaces, ws)
 	}
 
 	profile := resolveProfile(cmd)
@@ -95,4 +105,58 @@ func autoWatchWorkspaces(cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+// nameToSlug converts a human name into a URL-safe slug.
+// E.g. "Alice Zhang" → "alice-zhang".
+func nameToSlug(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = nonSlugChar.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	// Collapse consecutive hyphens.
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	if s == "" {
+		s = "my-workspace"
+	}
+	return s
+}
+
+// createDefaultWorkspace creates a workspace for a new user who has none.
+func createDefaultWorkspace(ctx context.Context, client *cli.APIClient) (struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}, error) {
+	type wsInfo struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	var zero wsInfo
+
+	// Fetch the current user's name to derive workspace name/slug.
+	var me struct {
+		Name string `json:"name"`
+	}
+	if err := client.GetJSON(ctx, "/api/me", &me); err != nil {
+		return zero, fmt.Errorf("fetch user info: %w", err)
+	}
+
+	wsName := strings.TrimSpace(me.Name) + "'s Workspace"
+	slug := nameToSlug(me.Name)
+
+	var created struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	err := client.PostJSON(ctx, "/api/workspaces", map[string]string{
+		"name": wsName,
+		"slug": slug,
+	}, &created)
+	if err != nil {
+		return zero, fmt.Errorf("create workspace: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "✓ Created workspace %q (%s)\n", created.Name, created.ID)
+	return created, nil
 }

--- a/server/cmd/multica/cmd_login.go
+++ b/server/cmd/multica/cmd_login.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/multica-ai/multica/server/internal/cli"
 )
-
-var nonSlugChar = regexp.MustCompile(`[^a-z0-9-]+`)
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
@@ -63,14 +59,15 @@ func autoWatchWorkspaces(cmd *cobra.Command) error {
 	}
 
 	if len(workspaces) == 0 {
-		fmt.Fprintln(os.Stderr, "\nNo workspaces found. Creating one for you...")
-		ws, err := createDefaultWorkspace(ctx, client)
+		var err error
+		workspaces, err = waitForOnboarding(cmd, client)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Could not create workspace: %v\n", err)
-			fmt.Fprintln(os.Stderr, "Create one at the web dashboard, then run 'multica login' again.")
+			return err
+		}
+		if len(workspaces) == 0 {
+			fmt.Fprintln(os.Stderr, "\nNo workspaces found.")
 			return nil
 		}
-		workspaces = append(workspaces, ws)
 	}
 
 	profile := resolveProfile(cmd)
@@ -107,56 +104,45 @@ func autoWatchWorkspaces(cmd *cobra.Command) error {
 	return nil
 }
 
-// nameToSlug converts a human name into a URL-safe slug.
-// E.g. "Alice Zhang" → "alice-zhang".
-func nameToSlug(name string) string {
-	s := strings.ToLower(strings.TrimSpace(name))
-	s = nonSlugChar.ReplaceAllString(s, "-")
-	s = strings.Trim(s, "-")
-	// Collapse consecutive hyphens.
-	for strings.Contains(s, "--") {
-		s = strings.ReplaceAll(s, "--", "-")
-	}
-	if s == "" {
-		s = "my-workspace"
-	}
-	return s
-}
-
-// createDefaultWorkspace creates a workspace for a new user who has none.
-func createDefaultWorkspace(ctx context.Context, client *cli.APIClient) (struct {
+// waitForOnboarding opens the web onboarding page and polls until the user
+// creates a workspace, returning the new workspace list.
+func waitForOnboarding(cmd *cobra.Command, client *cli.APIClient) ([]struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }, error) {
-	type wsInfo struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	}
-	var zero wsInfo
+	appURL := resolveAppURL(cmd)
+	onboardingURL := appURL + "/onboarding"
 
-	// Fetch the current user's name to derive workspace name/slug.
-	var me struct {
-		Name string `json:"name"`
+	fmt.Fprintln(os.Stderr, "\nNo workspaces found. Opening onboarding in your browser...")
+	if err := openBrowser(onboardingURL); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not open browser automatically.\n")
 	}
-	if err := client.GetJSON(ctx, "/api/me", &me); err != nil {
-		return zero, fmt.Errorf("fetch user info: %w", err)
+	fmt.Fprintf(os.Stderr, "If the browser didn't open, visit:\n  %s\n", onboardingURL)
+	fmt.Fprintln(os.Stderr, "\nWaiting for workspace creation...")
+
+	// Poll until a workspace appears or timeout (5 minutes).
+	const pollInterval = 2 * time.Second
+	const pollTimeout = 5 * time.Minute
+	deadline := time.Now().Add(pollTimeout)
+
+	for time.Now().Before(deadline) {
+		time.Sleep(pollInterval)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		var workspaces []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		err := client.GetJSON(ctx, "/api/workspaces", &workspaces)
+		cancel()
+
+		if err != nil {
+			continue // transient error, keep polling
+		}
+		if len(workspaces) > 0 {
+			return workspaces, nil
+		}
 	}
 
-	wsName := strings.TrimSpace(me.Name) + "'s Workspace"
-	slug := nameToSlug(me.Name)
-
-	var created struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	}
-	err := client.PostJSON(ctx, "/api/workspaces", map[string]string{
-		"name": wsName,
-		"slug": slug,
-	}, &created)
-	if err != nil {
-		return zero, fmt.Errorf("create workspace: %w", err)
-	}
-
-	fmt.Fprintf(os.Stderr, "✓ Created workspace %q (%s)\n", created.Name, created.ID)
-	return created, nil
+	return nil, fmt.Errorf("timed out waiting for workspace creation")
 }

--- a/server/cmd/multica/cmd_login.go
+++ b/server/cmd/multica/cmd_login.go
@@ -4,12 +4,29 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/multica-ai/multica/server/internal/cli"
 )
+
+// tryResolveAppURL returns the app URL if configured, or "" if not available.
+// Unlike resolveAppURL, it never calls os.Exit.
+func tryResolveAppURL(cmd *cobra.Command) string {
+	for _, key := range []string{"MULTICA_APP_URL", "FRONTEND_ORIGIN"} {
+		if val := strings.TrimSpace(os.Getenv(key)); val != "" {
+			return strings.TrimRight(val, "/")
+		}
+	}
+	profile := resolveProfile(cmd)
+	cfg, err := cli.LoadCLIConfigForProfile(profile)
+	if err == nil && cfg.AppURL != "" {
+		return strings.TrimRight(cfg.AppURL, "/")
+	}
+	return ""
+}
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
@@ -110,7 +127,15 @@ func waitForOnboarding(cmd *cobra.Command, client *cli.APIClient) ([]struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }, error) {
-	appURL := resolveAppURL(cmd)
+	appURL := tryResolveAppURL(cmd)
+	if appURL == "" {
+		// No app URL available (e.g. token login without prior setup).
+		// Can't open the browser — tell the user to create a workspace manually.
+		fmt.Fprintln(os.Stderr, "\nNo workspaces found.")
+		fmt.Fprintln(os.Stderr, "Create a workspace in the web dashboard, then run 'multica login' again.")
+		return nil, nil
+	}
+
 	onboardingURL := appURL + "/onboarding"
 
 	fmt.Fprintln(os.Stderr, "\nNo workspaces found. Opening onboarding in your browser...")

--- a/server/cmd/multica/cmd_setup.go
+++ b/server/cmd/multica/cmd_setup.go
@@ -135,10 +135,15 @@ func runSetupCloud(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Start daemon in background.
-	fmt.Fprintln(os.Stderr, "\nStarting daemon...")
-	if err := runDaemonBackground(cmd); err != nil {
-		return fmt.Errorf("start daemon: %w", err)
+	// Start daemon only if we have workspaces to watch.
+	if hasWatchedWorkspaces(resolveProfile(cmd)) {
+		fmt.Fprintln(os.Stderr, "\nStarting daemon...")
+		if err := runDaemonBackground(cmd); err != nil {
+			return fmt.Errorf("start daemon: %w", err)
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "\nNo workspaces configured — skipping daemon start.")
+		fmt.Fprintln(os.Stderr, "Create a workspace at the web dashboard, then run 'multica login' and 'multica daemon start'.")
 	}
 
 	fmt.Fprintln(os.Stderr, "\n✓ Setup complete! Your machine is now connected to Multica.")
@@ -195,14 +200,28 @@ func runSetupSelfHost(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Start daemon in background.
-	fmt.Fprintln(os.Stderr, "\nStarting daemon...")
-	if err := runDaemonBackground(cmd); err != nil {
-		return fmt.Errorf("start daemon: %w", err)
+	// Start daemon only if we have workspaces to watch.
+	if hasWatchedWorkspaces(resolveProfile(cmd)) {
+		fmt.Fprintln(os.Stderr, "\nStarting daemon...")
+		if err := runDaemonBackground(cmd); err != nil {
+			return fmt.Errorf("start daemon: %w", err)
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "\nNo workspaces configured — skipping daemon start.")
+		fmt.Fprintln(os.Stderr, "Create a workspace at the web dashboard, then run 'multica login' and 'multica daemon start'.")
 	}
 
 	fmt.Fprintln(os.Stderr, "\n✓ Setup complete! Your machine is now connected to Multica.")
 	return nil
+}
+
+// hasWatchedWorkspaces returns true if the CLI config has at least one watched workspace.
+func hasWatchedWorkspaces(profile string) bool {
+	cfg, err := cli.LoadCLIConfigForProfile(profile)
+	if err != nil {
+		return false
+	}
+	return len(cfg.WatchedWorkspaces) > 0
 }
 
 // probeServer checks whether a Multica backend is reachable at the given URL.

--- a/server/cmd/multica/cmd_setup.go
+++ b/server/cmd/multica/cmd_setup.go
@@ -141,12 +141,12 @@ func runSetupCloud(cmd *cobra.Command, args []string) error {
 		if err := runDaemonBackground(cmd); err != nil {
 			return fmt.Errorf("start daemon: %w", err)
 		}
+		fmt.Fprintln(os.Stderr, "\n✓ Setup complete! Your machine is now connected to Multica.")
 	} else {
-		fmt.Fprintln(os.Stderr, "\nNo workspaces configured — skipping daemon start.")
+		fmt.Fprintln(os.Stderr, "\n⚠ Setup incomplete: no workspaces configured.")
 		fmt.Fprintln(os.Stderr, "Create a workspace at the web dashboard, then run 'multica login' and 'multica daemon start'.")
 	}
 
-	fmt.Fprintln(os.Stderr, "\n✓ Setup complete! Your machine is now connected to Multica.")
 	return nil
 }
 
@@ -206,12 +206,12 @@ func runSetupSelfHost(cmd *cobra.Command, args []string) error {
 		if err := runDaemonBackground(cmd); err != nil {
 			return fmt.Errorf("start daemon: %w", err)
 		}
+		fmt.Fprintln(os.Stderr, "\n✓ Setup complete! Your machine is now connected to Multica.")
 	} else {
-		fmt.Fprintln(os.Stderr, "\nNo workspaces configured — skipping daemon start.")
+		fmt.Fprintln(os.Stderr, "\n⚠ Setup incomplete: no workspaces configured.")
 		fmt.Fprintln(os.Stderr, "Create a workspace at the web dashboard, then run 'multica login' and 'multica daemon start'.")
 	}
 
-	fmt.Fprintln(os.Stderr, "\n✓ Setup complete! Your machine is now connected to Multica.")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- When `multica setup` or `multica login` finds no workspaces for a new user, the CLI now opens the web `/onboarding` wizard in the browser and polls until the user completes workspace creation.
- If app URL is not available (e.g. `multica login --token` on a fresh account), falls back to printing manual instructions instead of crashing.
- Setup commands show "⚠ Setup incomplete" (not "✓ Setup complete!") when onboarding was not finished, with clear next steps.

Fixes MUL-731.

## Test plan

- [ ] Run `multica setup` with a new account that has no workspaces — browser should open to `/onboarding`, CLI waits, then auto-watches after completion
- [ ] Run `multica login --token` with a fresh token (no AppURL configured) — should print manual instructions, not crash
- [ ] If user closes browser without completing onboarding, setup should show "⚠ Setup incomplete" (not success)
- [ ] Run `multica setup` with an existing account that has workspaces — behavior unchanged
- [ ] Verify `go test ./cmd/multica/` passes