### PR TITLE
fix(agent): correct gemini task status on timeout and cancellation

### DIFF
--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -86,18 +86,22 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			DurationMs: durationMs,
 		}
 
-		if readErr != nil {
+		// Check context-level errors first: killing the process on timeout or
+		// cancellation closes the stdout pipe, which may produce a non-nil
+		// readErr as a side effect. Checking runCtx.Err() first ensures we
+		// always report the root cause rather than the downstream symptom.
+		if runCtx.Err() == context.DeadlineExceeded {
+			result.Status = "timeout"
+			result.Error = fmt.Sprintf("gemini timed out after %s", timeout)
+		} else if runCtx.Err() == context.Canceled {
+			result.Status = "aborted"
+			result.Error = "execution cancelled"
+		} else if readErr != nil {
 			result.Status = "failed"
 			result.Error = fmt.Sprintf("read stdout: %s", readErr.Error())
 		} else if waitErr != nil {
-			// Distinguish context cancellation (timeout) from exit errors.
-			if runCtx.Err() == context.DeadlineExceeded {
-				result.Status = "timeout"
-				result.Error = fmt.Sprintf("gemini timed out after %s", timeout)
-			} else {
-				result.Status = "failed"
-				result.Error = waitErr.Error()
-			}
+			result.Status = "failed"
+			result.Error = waitErr.Error()
 		}
 
 		resCh <- result


### PR DESCRIPTION
Fixes #914

## Summary

- When `exec.CommandContext` kills the Gemini process on timeout, closing the stdout pipe can make `io.ReadAll` return a non-nil error. The old code checked `readErr != nil` first, so the task status was reported as `"failed"` with `"read stdout: ..."` rather than `"timeout"`.
- When the parent context was cancelled (user stops a task), `context.Canceled` was not handled, so the status fell through to `"failed"` instead of `"aborted"`.

The fix mirrors the ordering already used in `claude.go` and `hermes.go`: check `runCtx.Err()` before `readErr` / `waitErr`, because context errors are the root cause and any pipe/wait errors are downstream side effects.

```
ctx.DeadlineExceeded → "timeout"
ctx.Canceled         → "aborted"
readErr != nil       → "failed"  (genuine I/O problem)
waitErr != nil       → "failed"  (non-zero exit)
```

## Test plan

- [ ] Assign a task to a Gemini runtime with a very short timeout (e.g. 1 second via `opts.Timeout`) and verify the final status is `"timeout"`.
- [ ] Cancel a running Gemini task and verify the final status is `"aborted"`.
- [ ] Let a Gemini task complete normally and verify the final status is `"completed"`.
- [ ] Existing `TestBuildGeminiArgs*` unit tests continue to pass (`go test ./pkg/agent/...`).