### PR TITLE
fix(daemon): correct Gemini backend status on timeout and cancellation

### DIFF
--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -86,18 +86,21 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			DurationMs: durationMs,
 		}
 
-		if readErr != nil {
+		// Check context errors first — timeout and cancellation kill the
+		// process, which can cause readErr/waitErr as side effects. The
+		// context error is the root cause and determines the correct status.
+		if runCtx.Err() == context.DeadlineExceeded {
+			result.Status = "timeout"
+			result.Error = fmt.Sprintf("gemini timed out after %s", timeout)
+		} else if runCtx.Err() == context.Canceled {
+			result.Status = "aborted"
+			result.Error = "execution cancelled"
+		} else if readErr != nil {
 			result.Status = "failed"
 			result.Error = fmt.Sprintf("read stdout: %s", readErr.Error())
 		} else if waitErr != nil {
-			// Distinguish context cancellation (timeout) from exit errors.
-			if runCtx.Err() == context.DeadlineExceeded {
-				result.Status = "timeout"
-				result.Error = fmt.Sprintf("gemini timed out after %s", timeout)
-			} else {
-				result.Status = "failed"
-				result.Error = waitErr.Error()
-			}
+			result.Status = "failed"
+			result.Error = waitErr.Error()
 		}
 
 		resCh <- result


### PR DESCRIPTION
Fixes #914

## Problem

The Gemini backend (`server/pkg/agent/gemini.go`) reports `"failed"` instead of `"timeout"` or `"aborted"` when a task is killed by timeout or user cancellation.

Root cause: `readErr` was checked before `runCtx.Err()`. When `exec.CommandContext` kills the process on timeout/cancel, the stdout pipe closes and `io.ReadAll` returns an error as a side-effect. The code reported this side-effect error as "failed" before ever reaching the context check.

## Fix

Check `runCtx.Err()` first (the root cause), then fall through to `readErr`/`waitErr` (side effects). This matches the pattern already used in `claude.go` and `hermes.go`.

Before:
```go
if readErr != nil {
    result.Status = "failed"         // ← timeout lands here (wrong)
} else if waitErr != nil {
    if runCtx.Err() == context.DeadlineExceeded {
        result.Status = "timeout"    // ← never reached
    }
}
```

After:
```go
if runCtx.Err() == context.DeadlineExceeded {
    result.Status = "timeout"        // ← root cause checked first
} else if runCtx.Err() == context.Canceled {
    result.Status = "aborted"        // ← user cancellation (was missing entirely)
} else if readErr != nil {
    result.Status = "failed"         // ← genuine read failures only
} else if waitErr != nil {
    result.Status = "failed"
}
```

Also adds `context.Canceled` → `"aborted"` handling which was completely missing (the original code only handled `DeadlineExceeded`).

## Testing

Existing `TestBuildGeminiArgs*` tests pass. The status logic change is in the goroutine's result path which requires a real process to unit test — the fix is a straightforward reorder matching the battle-tested claude.go pattern.