### PR TITLE
feat(openclaw): fix stdout/stderr + add Gateway mode with per-task sessions

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -101,9 +101,14 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 	openclawPath := envOrDefault("MULTICA_OPENCLAW_PATH", "openclaw")
 	if _, err := exec.LookPath(openclawPath); err == nil {
+		openclawGateway := strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_GATEWAY")) == "1" ||
+			strings.EqualFold(strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_GATEWAY")), "true")
+		openclawSessionPrefix := envOrDefault("MULTICA_OPENCLAW_SESSION_PREFIX", "multica")
 		agents["openclaw"] = AgentEntry{
-			Path:  openclawPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
+			Path:          openclawPath,
+			Model:         strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
+			GatewayMode:   openclawGateway,
+			SessionPrefix: openclawSessionPrefix,
 		}
 	}
 	hermesPath := envOrDefault("MULTICA_HERMES_PATH", "hermes")

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -976,6 +976,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,
 		Logger:         d.logger,
+		GatewayMode:    entry.GatewayMode,
+		SessionPrefix:  entry.SessionPrefix,
 	})
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -2,8 +2,10 @@ package daemon
 
 // AgentEntry describes a single available agent CLI.
 type AgentEntry struct {
-	Path  string // path to CLI binary
-	Model string // model override (optional)
+	Path           string // path to CLI binary
+	Model          string // model override (optional)
+	GatewayMode    bool   // if true, route through OpenClaw Gateway instead of --local
+	SessionPrefix  string // session ID prefix for Gateway mode (default: "multica")
 }
 
 // Runtime represents a registered daemon runtime.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -85,6 +85,11 @@ type Config struct {
 	ExecutablePath string            // path to CLI binary (claude, codex, opencode, openclaw, hermes, or gemini)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
+	// OpenClaw-specific: route through the OpenClaw Gateway instead of --local.
+	// When true, tasks run with full Gateway context (memory, workspace, tools).
+	// Requires an OpenClaw Gateway to be running and configured.
+	GatewayMode   bool
+	SessionPrefix string // prefix for per-task session IDs (default: "multica")
 }
 
 // New creates a Backend for the given agent type.

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -7,13 +7,25 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
 
-// openclawBackend implements Backend by spawning `openclaw agent --message <prompt>
-// --output-format stream-json --yes` and reading streaming NDJSON events from
-// stdout — similar to the opencode backend.
+// openclawBackend implements Backend by spawning `openclaw agent --json
+// --session-id <id> --message <prompt>`.
+//
+// By default it runs in embedded mode (--local), which starts a blank agent
+// instance without any persistent context. When GatewayMode is enabled via
+// MULTICA_OPENCLAW_GATEWAY=1, the --local flag is omitted and the task is
+// routed through the OpenClaw Gateway, giving agents access to the full
+// workspace context (memory, skills, tools, identity).
+//
+// Session lifecycle:
+//   - Gateway mode: each task gets an isolated session derived from its workdir
+//     (multica-<task-id>). Comment-triggered follow-ups reuse PriorSessionID
+//     for continuity within the same issue thread.
+//   - Local mode: session IDs are random per-run (no persistence).
 type openclawBackend struct {
 	cfg Config
 }
@@ -35,9 +47,31 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 	sessionID := opts.ResumeSessionID
 	if sessionID == "" {
-		sessionID = fmt.Sprintf("multica-%d", time.Now().UnixNano())
+		if b.cfg.GatewayMode {
+			// Derive a stable per-task session ID from the task workdir so each
+			// Multica task gets its own isolated Gateway session. The workdir path
+			// is <workspacesRoot>/<task-id>/workdir — two levels up from workdir
+			// gives the short task ID.
+			prefix := b.cfg.SessionPrefix
+			if prefix == "" {
+				prefix = "multica"
+			}
+			if opts.Cwd != "" {
+				sessionID = prefix + "-" + filepath.Base(filepath.Dir(opts.Cwd))
+			} else {
+				sessionID = fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+			}
+		} else {
+			sessionID = fmt.Sprintf("multica-%d", time.Now().UnixNano())
+		}
 	}
-	args := []string{"agent", "--local", "--json", "--session-id", sessionID}
+
+	args := []string{"agent", "--json", "--session-id", sessionID}
+	if !b.cfg.GatewayMode {
+		// Embedded mode: run a blank local agent instance.
+		args = append([]string{"agent", "--local", "--json", "--session-id", sessionID}, args[3:]...)
+		args = []string{"agent", "--local", "--json", "--session-id", sessionID}
+	}
 	if opts.Timeout > 0 {
 		args = append(args, "--timeout", fmt.Sprintf("%d", int(opts.Timeout.Seconds())))
 	}
@@ -49,20 +83,20 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}
 	cmd.Env = buildEnv(b.cfg.Env)
 
-	// openclaw writes its --json output to stderr, not stdout.
-	stderr, err := cmd.StderrPipe()
+	// openclaw agent --json writes its result JSON to stdout.
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("openclaw stderr pipe: %w", err)
+		return nil, fmt.Errorf("openclaw stdout pipe: %w", err)
 	}
-	cmd.Stdout = newLogWriter(b.cfg.Logger, "[openclaw:stdout] ")
+	cmd.Stderr = newLogWriter(b.cfg.Logger, "[openclaw:stderr] ")
 
 	if err := cmd.Start(); err != nil {
 		cancel()
 		return nil, fmt.Errorf("start openclaw: %w", err)
 	}
 
-	b.cfg.Logger.Info("openclaw started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+	b.cfg.Logger.Info("openclaw started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model, "gateway", b.cfg.GatewayMode, "session", sessionID)
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
@@ -73,7 +107,7 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		defer close(resCh)
 
 		startTime := time.Now()
-		scanResult := b.processOutput(stderr, msgCh)
+		scanResult := b.processOutput(stdout, msgCh)
 
 		// Wait for process exit.
 		exitErr := cmd.Wait()
@@ -128,10 +162,9 @@ type openclawEventResult struct {
 	usage     TokenUsage
 }
 
-// processOutput reads the JSON output from openclaw --json stderr and returns
-// the parsed result. OpenClaw writes its JSON result to stderr, which may also
-// contain non-JSON log lines. We scan line-by-line so a final result line can
-// be recognized without waiting for the entire stderr stream to be buffered.
+// processOutput reads the JSON output from `openclaw agent --json` stdout and
+// returns the parsed result. It scans line-by-line so a final result line can
+// be recognized without waiting for the entire stream to buffer.
 func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclawEventResult {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
@@ -145,12 +178,12 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 		if result, ok := tryParseOpenclawResult(line); ok {
 			return b.buildOpenclawEventResult(result, ch)
 		}
-		b.cfg.Logger.Debug("[openclaw:stderr] " + line)
+		b.cfg.Logger.Debug("[openclaw:stdout] " + line)
 		rawLines = append(rawLines, line)
 	}
 
 	if err := scanner.Err(); err != nil {
-		return openclawEventResult{status: "failed", errMsg: fmt.Sprintf("read stderr: %v", err)}
+		return openclawEventResult{status: "failed", errMsg: fmt.Sprintf("read stdout: %v", err)}
 	}
 
 	trimmed := strings.TrimSpace(strings.Join(rawLines, "\n"))
@@ -162,7 +195,7 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 
 func tryParseOpenclawResult(raw string) (openclawResult, bool) {
 	// Try each '{' position until we find valid openclawResult JSON.
-	// Earlier '{' chars may appear in log/error lines (e.g. raw_params={...}).
+	// Earlier '{' chars may appear in log/info lines (e.g. raw_params={...}).
 	var result openclawResult
 	for i := 0; i < len(raw); i++ {
 		if raw[i] != '{' {

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -220,8 +220,8 @@ func TestOpenclawProcessOutputReadError(t *testing.T) {
 	if res.status != "failed" {
 		t.Errorf("status: got %q, want %q", res.status, "failed")
 	}
-	if !strings.Contains(res.errMsg, "read stderr") {
-		t.Errorf("errMsg: got %q, want it to contain 'read stderr'", res.errMsg)
+	if !strings.Contains(res.errMsg, "read stdout") {
+		t.Errorf("errMsg: got %q, want it to contain 'read stdout'", res.errMsg)
 	}
 
 	close(ch)
@@ -276,5 +276,31 @@ func TestOpenclawInt64Nil(t *testing.T) {
 	data := map[string]any{"count": "not a number"}
 	if got := openclawInt64(data, "count"); got != 0 {
 		t.Errorf("got %d, want 0", got)
+	}
+}
+
+// ── Gateway mode tests ──
+
+func TestOpenclawGatewayModeConfig(t *testing.T) {
+	t.Parallel()
+
+	// Verify GatewayMode and SessionPrefix fields are wired through Config.
+	b, err := New("openclaw", Config{
+		ExecutablePath: "/nonexistent/openclaw",
+		GatewayMode:    true,
+		SessionPrefix:  "myproject",
+	})
+	if err != nil {
+		t.Fatalf("New(openclaw) error: %v", err)
+	}
+	oc, ok := b.(*openclawBackend)
+	if !ok {
+		t.Fatalf("expected *openclawBackend, got %T", b)
+	}
+	if !oc.cfg.GatewayMode {
+		t.Error("GatewayMode not set on backend config")
+	}
+	if oc.cfg.SessionPrefix != "myproject" {
+		t.Errorf("SessionPrefix = %q, want %q", oc.cfg.SessionPrefix, "myproject")
 	}
 }


### PR DESCRIPTION
## Summary

Two changes to the OpenClaw backend:

### Bug Fix: stdout not stderr

`openclaw agent --json` writes its result JSON to **stdout**, not stderr. The current backend pipes stderr for reading and logs stdout — this causes the process to go zombie, waiting indefinitely on an empty stderr pipe. Swap to `StdoutPipe` and log stderr instead.

### Feature: Gateway Mode

Add optional Gateway routing for the OpenClaw provider via `MULTICA_OPENCLAW_GATEWAY=1`.

**Why:** OpenClaw has a Gateway architecture where a persistent agent process holds workspace context (memory, skills, tools, identity). By default, `--local` spawns a blank embedded instance with no context. Gateway mode omits `--local` so tasks route through the user's configured Gateway — giving agents access to their full workspace context.

**Session lifecycle:**
- Each task gets an isolated session ID derived from its workdir (`multica-<task-id>`), preventing context bleed between parallel issues
- Comment-triggered follow-ups reuse `PriorSessionID` for thread continuity within the same issue
- Sessions expire naturally when the task completes — no cleanup needed

**Configuration:**
```bash
# Enable Gateway mode
MULTICA_OPENCLAW_GATEWAY=1

# Optional: customize session ID prefix (default: multica)
MULTICA_OPENCLAW_SESSION_PREFIX=myproject
```

**Backward compatible:** Gateway mode is opt-in. Default behavior (`--local`) is unchanged.

## Files Changed

- `server/pkg/agent/openclaw.go` — fix stdout/stderr + gateway mode implementation
- `server/pkg/agent/openclaw_test.go` — fix test assertion, add gateway config test
- `server/pkg/agent/agent.go` — add `GatewayMode` and `SessionPrefix` to `Config`
- `server/internal/daemon/types.go` — add fields to `AgentEntry`
- `server/internal/daemon/config.go` — read env vars for gateway config
- `server/internal/daemon/daemon.go` — pass gateway config to `agent.New`

## Testing

```
go test ./server/pkg/agent/
ok  github.com/multica-ai/multica/server/pkg/agent  0.296s
```