### PR TITLE
feat: add cursor-agent provider

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -21,7 +21,7 @@ const (
 	DefaultHealthPort            = 19514
 	DefaultMaxConcurrentTasks    = 20
 	DefaultGCInterval            = 1 * time.Hour
-	DefaultGCTTL                 = 5 * 24 * time.Hour // 5 days
+	DefaultGCTTL                 = 5 * 24 * time.Hour  // 5 days
 	DefaultGCOrphanTTL           = 30 * 24 * time.Hour // 30 days
 )
 
@@ -33,7 +33,7 @@ type Config struct {
 	RuntimeName        string
 	CLIVersion         string                // multica CLI version (e.g. "0.1.13")
 	Profile            string                // profile name (empty = default)
-	Agents             map[string]AgentEntry // keyed by provider: claude, codex, opencode, openclaw, hermes, gemini
+	Agents             map[string]AgentEntry // keyed by provider: claude, codex, cursor, opencode, openclaw, hermes, gemini
 	WorkspacesRoot     string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask   bool                  // preserve env after task for debugging
 	HealthPort         int                   // local HTTP port for health checks (default: 19514)
@@ -92,6 +92,13 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_CODEX_MODEL")),
 		}
 	}
+	cursorPath := envOrDefault("MULTICA_CURSOR_PATH", "cursor-agent")
+	if _, err := exec.LookPath(cursorPath); err == nil {
+		agents["cursor"] = AgentEntry{
+			Path:  cursorPath,
+			Model: strings.TrimSpace(os.Getenv("MULTICA_CURSOR_MODEL")),
+		}
+	}
 	opencodePath := envOrDefault("MULTICA_OPENCODE_PATH", "opencode")
 	if _, err := exec.LookPath(opencodePath); err == nil {
 		agents["opencode"] = AgentEntry{
@@ -121,7 +128,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		}
 	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, opencode, openclaw, hermes, or gemini and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, cursor-agent, opencode, openclaw, hermes, or gemini and ensure it is on PATH")
 	}
 
 	// Host info

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -874,6 +875,19 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 			if failErr := d.client.FailTask(ctx, task.ID, fmt.Sprintf("complete task failed: %s", err.Error())); failErr != nil {
 				taskLog.Error("fail task fallback also failed", "error", failErr)
 			}
+		}
+	}
+
+	// For providers that don't self-manage issue status (e.g. cursor-agent
+	// runs in print mode and may not successfully call the multica CLI),
+	// auto-transition the issue to in_review after successful completion.
+	// This is a safety net — providers that already set the status are
+	// unaffected since setting in_review on an already-in_review issue is a no-op.
+	if result.Status == "completed" && task.IssueID != "" {
+		if out, err := exec.CommandContext(ctx, "multica", "issue", "status", task.IssueID, "in_review").CombinedOutput(); err != nil {
+			taskLog.Warn("auto-transition issue to in_review failed (non-fatal)", "error", err, "output", string(out))
+		} else {
+			taskLog.Info("auto-transitioned issue to in_review", "issue_id", task.IssueID)
 		}
 	}
 

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -21,7 +21,7 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error 
 	switch provider {
 	case "claude":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "opencode", "openclaw":
+	case "codex", "cursor", "opencode", "openclaw":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)
@@ -139,7 +139,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "opencode", "openclaw":
+		case "codex", "cursor", "opencode", "openclaw":
 			// Codex, OpenCode, and OpenClaw discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
 		case "gemini":

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -82,13 +82,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, opencode, openclaw, hermes, or gemini)
+	ExecutablePath string            // path to CLI binary (claude, codex, cursor-agent, opencode, openclaw, hermes, or gemini)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "opencode", "openclaw", "hermes", "gemini".
+// Supported types: "claude", "codex", "cursor", "opencode", "openclaw", "hermes", "gemini".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -99,6 +99,8 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &claudeBackend{cfg: cfg}, nil
 	case "codex":
 		return &codexBackend{cfg: cfg}, nil
+	case "cursor":
+		return &cursorBackend{cfg: cfg}, nil
 	case "opencode":
 		return &opencodeBackend{cfg: cfg}, nil
 	case "openclaw":
@@ -108,7 +110,7 @@ func New(agentType string, cfg Config) (Backend, error) {
 	case "gemini":
 		return &geminiBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, openclaw, hermes, gemini)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, cursor, opencode, openclaw, hermes, gemini)", agentType)
 	}
 }
 

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// cursorBackend implements Backend by spawning `cursor-agent` as a one-shot
+// subprocess and streaming its stdout lines back to the caller.
+type cursorBackend struct {
+	cfg Config
+}
+
+func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "cursor-agent"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("cursor-agent executable not found at %q: %w", execPath, err)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	taskPrompt := prompt
+	if opts.SystemPrompt != "" {
+		taskPrompt = opts.SystemPrompt + "\n\n---\n\n" + prompt
+	}
+
+	args := []string{"--print", "--force", "--trust", "--sandbox", "disabled", taskPrompt}
+
+	cmd := exec.CommandContext(runCtx, execPath, args...)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("cursor-agent stdout pipe: %w", err)
+	}
+	cmd.Stderr = newLogWriter(b.cfg.Logger, "[cursor:stderr] ")
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start cursor-agent: %w", err)
+	}
+
+	b.cfg.Logger.Info("cursor-agent started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		startTime := time.Now()
+
+		var output strings.Builder
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			trySend(msgCh, Message{Type: MessageText, Content: line})
+			if output.Len() > 0 {
+				output.WriteByte('\n')
+			}
+			output.WriteString(line)
+		}
+
+		readErr := scanner.Err()
+		waitErr := cmd.Wait()
+		duration := time.Since(startTime)
+
+		result := Result{
+			Status:     "completed",
+			Output:     output.String(),
+			DurationMs: duration.Milliseconds(),
+		}
+
+		if runCtx.Err() == context.DeadlineExceeded {
+			result.Status = "timeout"
+			result.Error = fmt.Sprintf("cursor-agent timed out after %s", timeout)
+		} else if runCtx.Err() == context.Canceled {
+			result.Status = "aborted"
+			result.Error = "execution cancelled"
+		} else if readErr != nil {
+			result.Status = "failed"
+			result.Error = fmt.Sprintf("read stdout: %v", readErr)
+		} else if waitErr != nil {
+			result.Status = "failed"
+			result.Error = fmt.Sprintf("cursor-agent exited with error: %v", waitErr)
+		}
+
+		b.cfg.Logger.Info("cursor-agent finished", "pid", cmd.Process.Pid, "status", result.Status, "duration", duration.Round(time.Millisecond).String())
+
+		resCh <- result
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}


### PR DESCRIPTION
## Summary

Adds `cursor` as a native agent provider, enabling Multica to auto-detect and dispatch tasks to [cursor-agent](https://github.com/anysphere/cursor-agent) — Cursor's headless CLI for autonomous coding.

## What it does

- **`pkg/agent/cursor.go`** — New `cursorBackend` implementing `Backend.Execute()`. Spawns cursor-agent as a one-shot subprocess (`--print --force --trust --sandbox disabled <prompt>`), streams stdout, logs stderr, defaults to 20min timeout.
- **`pkg/agent/agent.go`** — Registers `"cursor"` in `New()` switch.
- **`internal/daemon/config.go`** — Auto-detects `cursor-agent` on PATH. Env overrides: `MULTICA_CURSOR_PATH`, `MULTICA_CURSOR_MODEL`.
- **`internal/daemon/execenv/runtime_config.go`** — Adds `"cursor"` to AGENTS.md injection and skill metadata groupings (same case as codex/opencode/openclaw).

## How it works

cursor-agent runs in print-and-exit mode (no JSON-RPC, no long-running server). The implementation mirrors the simpler providers (openclaw) rather than the Codex JSON-RPC pattern. The daemon:

1. Auto-detects `cursor-agent` on PATH at startup
2. Registers a `Cursor` runtime (visible in `multica runtime list`)
3. When an issue is assigned to a Cursor agent, spawns the subprocess with the issue description as a positional prompt argument
4. Streams output back to Multica and transitions status on completion

## CLI interface notes

Two details discovered during testing that future maintainers should know:

- `--sandbox` requires a value (`enabled` or `disabled`), not a bare flag
- The task prompt is a **positional argument** (last arg after all flags), not a `--prompt` flag

## Testing

Tested on macOS (Apple Silicon) with:
- cursor-agent v2026.04.08
- Multica self-host (Docker)
- Verified: daemon auto-detect → runtime registration → issue assignment → cursor-agent execution → status transition to in_review