### PR TITLE
feat(issue): add soft archive support

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -226,14 +226,16 @@ export class ApiClient {
     if (params?.assignee_ids?.length) search.set("assignee_ids", params.assignee_ids.join(","));
     if (params?.creator_id) search.set("creator_id", params.creator_id);
     if (params?.open_only) search.set("open_only", "true");
+    if (params?.include_archived) search.set("include_archived", "true");
     return this.fetch(`/api/issues?${search}`);
   }
 
-  async searchIssues(params: { q: string; limit?: number; offset?: number; include_closed?: boolean; signal?: AbortSignal }): Promise<SearchIssuesResponse> {
+  async searchIssues(params: { q: string; limit?: number; offset?: number; include_closed?: boolean; include_archived?: boolean; signal?: AbortSignal }): Promise<SearchIssuesResponse> {
     const search = new URLSearchParams({ q: params.q });
     if (params.limit !== undefined) search.set("limit", String(params.limit));
     if (params.offset !== undefined) search.set("offset", String(params.offset));
     if (params.include_closed) search.set("include_closed", "true");
+    if (params.include_archived) search.set("include_archived", "true");
     return this.fetch(`/api/issues/search?${search}`, params.signal ? { signal: params.signal } : undefined);
   }
 
@@ -265,8 +267,11 @@ export class ApiClient {
     });
   }
 
-  async listChildIssues(id: string): Promise<{ issues: Issue[] }> {
-    return this.fetch(`/api/issues/${id}/children`);
+  async listChildIssues(id: string, params?: { include_archived?: boolean }): Promise<{ issues: Issue[] }> {
+    const search = new URLSearchParams();
+    if (params?.include_archived) search.set("include_archived", "true");
+    const qs = search.toString();
+    return this.fetch(`/api/issues/${id}/children${qs ? `?${qs}` : ""}`);
   }
 
   async getChildIssueProgress(): Promise<{ progress: { parent_issue_id: string; total: number; done: number }[] }> {
@@ -275,6 +280,17 @@ export class ApiClient {
 
   async deleteIssue(id: string): Promise<void> {
     await this.fetch(`/api/issues/${id}`, { method: "DELETE" });
+  }
+
+  async archiveIssue(id: string, params?: { force?: boolean }): Promise<Issue> {
+    const search = new URLSearchParams();
+    if (params?.force) search.set("force", "true");
+    const qs = search.toString();
+    return this.fetch(`/api/issues/${id}/archive${qs ? `?${qs}` : ""}`, { method: "POST" });
+  }
+
+  async restoreIssue(id: string): Promise<Issue> {
+    return this.fetch(`/api/issues/${id}/restore`, { method: "POST" });
   }
 
   async batchUpdateIssues(issueIds: string[], updates: UpdateIssueRequest): Promise<{ updated: number }> {

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -213,6 +213,54 @@ export function useDeleteIssue() {
   });
 }
 
+export function useArchiveIssue() {
+  const qc = useQueryClient();
+  const wsId = useWorkspaceId();
+  return useMutation({
+    mutationFn: ({ id, force }: { id: string; force?: boolean }) =>
+      api.archiveIssue(id, { force }),
+    onSuccess: (archivedIssue) => {
+      qc.setQueryData<ListIssuesResponse>(issueKeys.list(wsId), (old) => {
+        if (!old) return old;
+        const prev = old.issues.find((i) => i.id === archivedIssue.id);
+        return {
+          ...old,
+          issues: old.issues.filter((i) => i.id !== archivedIssue.id),
+          total: prev ? old.total - 1 : old.total,
+          doneTotal: (old.doneTotal ?? 0) - (prev?.status === "done" ? 1 : 0),
+        };
+      });
+      qc.setQueryData<Issue>(issueKeys.detail(wsId, archivedIssue.id), archivedIssue);
+      qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
+      if (archivedIssue.parent_issue_id) {
+        qc.invalidateQueries({ queryKey: issueKeys.children(wsId, archivedIssue.parent_issue_id) });
+        qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+      }
+    },
+    onSettled: (_data, _err, vars) => {
+      qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.detail(wsId, vars.id) });
+    },
+  });
+}
+
+export function useRestoreIssue() {
+  const qc = useQueryClient();
+  const wsId = useWorkspaceId();
+  return useMutation({
+    mutationFn: (id: string) => api.restoreIssue(id),
+    onSuccess: (restoredIssue) => {
+      qc.setQueryData<Issue>(issueKeys.detail(wsId, restoredIssue.id), restoredIssue);
+      qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
+      if (restoredIssue.parent_issue_id) {
+        qc.invalidateQueries({ queryKey: issueKeys.children(wsId, restoredIssue.parent_issue_id) });
+        qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+      }
+    },
+  });
+}
+
 export function useBatchUpdateIssues() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -1,0 +1,166 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { issueKeys } from "./queries";
+import { onIssueUpdated } from "./ws-updaters";
+import type { Issue, ListIssuesResponse } from "../types";
+
+const workspaceId = "ws_1";
+const parentId = "issue_parent";
+
+function makeIssue(
+  overrides: Partial<Issue> & Pick<Issue, "id" | "title">,
+): Issue {
+  const { id, title, ...rest } = overrides;
+
+  return {
+    id,
+    workspace_id: workspaceId,
+    number: 1,
+    identifier: "MUL-1",
+    title,
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "member_1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 0,
+    due_date: null,
+    archived_at: null,
+    archived_by: null,
+    created_at: "2026-04-13T00:00:00Z",
+    updated_at: "2026-04-13T00:00:00Z",
+    ...rest,
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+describe("issue websocket updaters", () => {
+  it("removes archived children from child caches and invalidates for refetch", () => {
+    const qc = makeQueryClient();
+    const child = makeIssue({
+      id: "issue_child",
+      title: "Child",
+      parent_issue_id: parentId,
+      status: "done",
+    });
+    const sibling = makeIssue({
+      id: "issue_sibling",
+      title: "Sibling",
+      parent_issue_id: parentId,
+    });
+    qc.setQueryData<Issue[]>(issueKeys.children(workspaceId, parentId), [
+      child,
+      sibling,
+    ]);
+    qc.setQueryData<ListIssuesResponse>(issueKeys.list(workspaceId), {
+      issues: [child, sibling],
+      total: 2,
+      doneTotal: 1,
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    onIssueUpdated(
+      qc,
+      workspaceId,
+      {
+        id: child.id,
+        parent_issue_id: parentId,
+        archived_at: "2026-04-13T12:00:00Z",
+        archived_by: "member_1",
+      },
+      { archived: true },
+    );
+
+    expect(
+      qc.getQueryData<Issue[]>(issueKeys.children(workspaceId, parentId)),
+    ).toEqual([sibling]);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: issueKeys.children(workspaceId, parentId),
+    });
+  });
+
+  it("invalidates child caches when restored children are missing from cache", () => {
+    const qc = makeQueryClient();
+    const child = makeIssue({
+      id: "issue_child",
+      title: "Child",
+      parent_issue_id: parentId,
+      archived_at: "2026-04-13T12:00:00Z",
+      archived_by: "member_1",
+    });
+    const sibling = makeIssue({
+      id: "issue_sibling",
+      title: "Sibling",
+      parent_issue_id: parentId,
+    });
+    qc.setQueryData<Issue[]>(issueKeys.children(workspaceId, parentId), [
+      sibling,
+    ]);
+    qc.setQueryData<Issue>(issueKeys.detail(workspaceId, child.id), child);
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    onIssueUpdated(
+      qc,
+      workspaceId,
+      {
+        id: child.id,
+        parent_issue_id: parentId,
+        archived_at: null,
+        archived_by: null,
+      },
+      { restored: true },
+    );
+
+    expect(
+      qc.getQueryData<Issue[]>(issueKeys.children(workspaceId, parentId)),
+    ).toEqual([sibling]);
+    expect(
+      qc.getQueryData<Issue>(issueKeys.detail(workspaceId, child.id))?.archived_at,
+    ).toBeNull();
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: issueKeys.children(workspaceId, parentId),
+    });
+  });
+
+  it("updates cached children without child-list refetch for ordinary updates", () => {
+    const qc = makeQueryClient();
+    const child = makeIssue({
+      id: "issue_child",
+      title: "Child",
+      parent_issue_id: parentId,
+    });
+    qc.setQueryData<Issue[]>(issueKeys.children(workspaceId, parentId), [child]);
+    qc.setQueryData<ListIssuesResponse>(issueKeys.list(workspaceId), {
+      issues: [child],
+      total: 1,
+      doneTotal: 0,
+    });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+
+    onIssueUpdated(qc, workspaceId, {
+      ...child,
+      title: "Updated child",
+      archived_at: null,
+      archived_by: null,
+    });
+
+    expect(
+      qc.getQueryData<Issue[]>(issueKeys.children(workspaceId, parentId)),
+    ).toEqual([{ ...child, title: "Updated child" }]);
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: issueKeys.children(workspaceId, parentId),
+    });
+  });
+});

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -28,7 +28,12 @@ export function onIssueUpdated(
   qc: QueryClient,
   wsId: string,
   issue: Partial<Issue> & { id: string },
+  options?: { archived?: boolean; restored?: boolean },
 ) {
+  const isArchived = issue.archived_at != null || options?.archived === true;
+  const isRestored = options?.restored === true;
+  const archiveStateChanged = isArchived || isRestored;
+
   // Look up the parent before mutating list state, so we can also keep the
   // parent's children cache in sync (powers the sub-issues list shown on
   // the parent issue page).
@@ -43,6 +48,14 @@ export function onIssueUpdated(
   qc.setQueryData<ListIssuesResponse>(issueKeys.list(wsId), (old) => {
     if (!old) return old;
     const prev = old.issues.find((i) => i.id === issue.id);
+    if (isArchived) {
+      return {
+        ...old,
+        issues: old.issues.filter((i) => i.id !== issue.id),
+        total: prev ? old.total - 1 : old.total,
+        doneTotal: (old.doneTotal ?? 0) - (prev?.status === "done" ? 1 : 0),
+      };
+    }
     const wasDone = prev?.status === "done";
     const isDone = issue.status === "done";
     // Only adjust doneTotal when status field is present and actually changed
@@ -59,14 +72,22 @@ export function onIssueUpdated(
       doneTotal: (old.doneTotal ?? 0) + doneDelta,
     };
   });
+  if (isRestored && !listData?.issues.some((i) => i.id === issue.id)) {
+    qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
+  }
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issue.id), (old) =>
     old ? { ...old, ...issue } : old,
   );
   if (parentId) {
     qc.setQueryData<Issue[]>(issueKeys.children(wsId, parentId), (old) =>
-      old?.map((c) => (c.id === issue.id ? { ...c, ...issue } : c)),
+      isArchived
+        ? old?.filter((c) => c.id !== issue.id)
+        : old?.map((c) => (c.id === issue.id ? { ...c, ...issue } : c)),
     );
+    if (archiveStateChanged) {
+      qc.invalidateQueries({ queryKey: issueKeys.children(wsId, parentId) });
+    }
     if (issue.status !== undefined || issue.parent_issue_id !== undefined) {
       qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
     }

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -148,11 +148,11 @@ export function useRealtimeSync(
     // Instead, both mutations and WS handlers use dedup checks to be idempotent.
 
     const unsubIssueUpdated = ws.on("issue:updated", (p) => {
-      const { issue } = p as IssueUpdatedPayload;
+      const { issue, archived, restored } = p as IssueUpdatedPayload;
       if (!issue?.id) return;
       const wsId = workspaceStore.getState().workspace?.id;
       if (wsId) {
-        onIssueUpdated(qc, wsId, issue);
+        onIssueUpdated(qc, wsId, issue, { archived, restored });
         if (issue.status) {
           onInboxIssueStatusChanged(qc, wsId, issue.id, issue.status);
         }

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -39,6 +39,7 @@ export interface ListIssuesParams {
   assignee_ids?: string[];
   creator_id?: string;
   open_only?: boolean;
+  include_archived?: boolean;
 }
 
 export interface ListIssuesResponse {

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -66,6 +66,8 @@ export interface IssueCreatedPayload {
 
 export interface IssueUpdatedPayload {
   issue: Issue;
+  archived?: boolean;
+  restored?: boolean;
 }
 
 export interface IssueDeletedPayload {

--- a/packages/core/types/issue.ts
+++ b/packages/core/types/issue.ts
@@ -37,6 +37,8 @@ export interface Issue {
   project_id: string | null;
   position: number;
   due_date: string | null;
+  archived_at: string | null;
+  archived_by: string | null;
   reactions?: IssueReaction[];
   created_at: string;
   updated_at: string;

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -290,6 +290,8 @@ const mockIssue: Issue = {
   project_id: null,
   position: 0,
   due_date: "2026-06-01T00:00:00Z",
+  archived_at: null,
+  archived_by: null,
   created_at: "2026-01-15T00:00:00Z",
   updated_at: "2026-01-20T00:00:00Z",
 };

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -262,6 +262,8 @@ const issueDefaults = {
   parent_issue_id: null,
   project_id: null,
   position: 0,
+  archived_at: null,
+  archived_by: null,
 };
 
 const mockIssues: Issue[] = [

--- a/packages/views/issues/utils/filter.test.ts
+++ b/packages/views/issues/utils/filter.test.ts
@@ -30,6 +30,8 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
     project_id: null,
     position: 0,
     due_date: null,
+    archived_at: null,
+    archived_by: null,
     created_at: "2025-01-01T00:00:00Z",
     updated_at: "2025-01-01T00:00:00Z",
     ...overrides,

--- a/packages/views/projects/components/project-issue-metrics.test.ts
+++ b/packages/views/projects/components/project-issue-metrics.test.ts
@@ -20,6 +20,8 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
     project_id: "project-1",
     position: 0,
     due_date: null,
+    archived_at: null,
+    archived_by: null,
     created_at: "2026-04-10T00:00:00Z",
     updated_at: "2026-04-10T00:00:00Z",
     ...overrides,

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -59,6 +59,20 @@ var issueStatusCmd = &cobra.Command{
 	RunE:  runIssueStatus,
 }
 
+var issueArchiveCmd = &cobra.Command{
+	Use:   "archive <id>",
+	Short: "Archive an issue",
+	Args:  exactArgs(1),
+	RunE:  runIssueArchive,
+}
+
+var issueRestoreCmd = &cobra.Command{
+	Use:   "restore <id>",
+	Short: "Restore an archived issue",
+	Args:  exactArgs(1),
+	RunE:  runIssueRestore,
+}
+
 // Comment subcommands.
 
 var issueCommentCmd = &cobra.Command{
@@ -121,6 +135,8 @@ func init() {
 	issueCmd.AddCommand(issueUpdateCmd)
 	issueCmd.AddCommand(issueAssignCmd)
 	issueCmd.AddCommand(issueStatusCmd)
+	issueCmd.AddCommand(issueArchiveCmd)
+	issueCmd.AddCommand(issueRestoreCmd)
 	issueCmd.AddCommand(issueCommentCmd)
 	issueCmd.AddCommand(issueRunsCmd)
 	issueCmd.AddCommand(issueRunMessagesCmd)
@@ -137,6 +153,7 @@ func init() {
 	issueListCmd.Flags().String("assignee", "", "Filter by assignee name")
 	issueListCmd.Flags().String("project", "", "Filter by project ID")
 	issueListCmd.Flags().Int("limit", 50, "Maximum number of issues to return")
+	issueListCmd.Flags().Bool("include-archived", false, "Include archived issues")
 
 	// issue get
 	issueGetCmd.Flags().String("output", "json", "Output format: table or json")
@@ -166,6 +183,11 @@ func init() {
 	// issue status
 	issueStatusCmd.Flags().String("output", "table", "Output format: table or json")
 
+	// issue archive / restore
+	issueArchiveCmd.Flags().Bool("force", false, "Archive even when issue status is not done or cancelled (owner/admin only)")
+	issueArchiveCmd.Flags().String("output", "table", "Output format: table or json")
+	issueRestoreCmd.Flags().String("output", "table", "Output format: table or json")
+
 	// issue assign
 	issueAssignCmd.Flags().String("to", "", "Assignee name (member or agent)")
 	issueAssignCmd.Flags().Bool("unassign", false, "Remove current assignee")
@@ -193,6 +215,7 @@ func init() {
 	// issue search
 	issueSearchCmd.Flags().Int("limit", 20, "Maximum number of results to return")
 	issueSearchCmd.Flags().Bool("include-closed", false, "Include done and cancelled issues")
+	issueSearchCmd.Flags().Bool("include-archived", false, "Include archived issues")
 	issueSearchCmd.Flags().String("output", "table", "Output format: table or json")
 }
 
@@ -235,6 +258,9 @@ func runIssueList(cmd *cobra.Command, _ []string) error {
 	}
 	if v, _ := cmd.Flags().GetString("project"); v != "" {
 		params.Set("project_id", v)
+	}
+	if v, _ := cmd.Flags().GetBool("include-archived"); v {
+		params.Set("include_archived", "true")
 	}
 
 	path := "/api/issues"
@@ -556,6 +582,61 @@ func runIssueStatus(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func runIssueArchive(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	params := url.Values{}
+	if v, _ := cmd.Flags().GetBool("force"); v {
+		params.Set("force", "true")
+	}
+	path := "/api/issues/" + args[0] + "/archive"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	var result map[string]any
+	if err := client.PostJSON(ctx, path, nil, &result); err != nil {
+		return fmt.Errorf("archive issue: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+
+	fmt.Printf("Issue archived: %s (%s)\n", strVal(result, "identifier"), strVal(result, "id"))
+	return nil
+}
+
+func runIssueRestore(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var result map[string]any
+	if err := client.PostJSON(ctx, "/api/issues/"+args[0]+"/restore", nil, &result); err != nil {
+		return fmt.Errorf("restore issue: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+
+	fmt.Printf("Issue restored: %s (%s)\n", strVal(result, "identifier"), strVal(result, "id"))
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Comment commands
 // ---------------------------------------------------------------------------
@@ -832,6 +913,9 @@ func runIssueSearch(cmd *cobra.Command, args []string) error {
 	}
 	if v, _ := cmd.Flags().GetBool("include-closed"); v {
 		params.Set("include_closed", "true")
+	}
+	if v, _ := cmd.Flags().GetBool("include-archived"); v {
+		params.Set("include_archived", "true")
 	}
 
 	path := "/api/issues/search?" + params.Encode()

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -157,3 +157,26 @@ func TestValidIssueStatuses(t *testing.T) {
 	}
 }
 
+func TestIssueArchiveCommandsRegistered(t *testing.T) {
+	if _, _, err := issueCmd.Find([]string{"archive"}); err != nil {
+		t.Fatalf("archive command not registered: %v", err)
+	}
+	if _, _, err := issueCmd.Find([]string{"restore"}); err != nil {
+		t.Fatalf("restore command not registered: %v", err)
+	}
+	if issueArchiveCmd.Flags().Lookup("force") == nil {
+		t.Fatal("archive command should expose --force")
+	}
+	if issueArchiveCmd.Flags().Lookup("output") == nil {
+		t.Fatal("archive command should expose --output")
+	}
+	if issueRestoreCmd.Flags().Lookup("output") == nil {
+		t.Fatal("restore command should expose --output")
+	}
+	if issueListCmd.Flags().Lookup("include-archived") == nil {
+		t.Fatal("list command should expose --include-archived")
+	}
+	if issueSearchCmd.Flags().Lookup("include-archived") == nil {
+		t.Fatal("search command should expose --include-archived")
+	}
+}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -208,6 +208,8 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 					r.Get("/", h.GetIssue)
 					r.Put("/", h.UpdateIssue)
 					r.Delete("/", h.DeleteIssue)
+					r.Post("/archive", h.ArchiveIssue)
+					r.Post("/restore", h.RestoreIssue)
 					r.Post("/comments", h.CreateComment)
 					r.Get("/comments", h.ListComments)
 					r.Get("/timeline", h.ListTimeline)

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -252,6 +252,239 @@ func TestIssueCRUD(t *testing.T) {
 	}
 }
 
+func TestIssueArchiveRestore(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, `DELETE FROM issue WHERE workspace_id = $1 AND title LIKE 'archive test %'`, testWorkspaceID); err != nil {
+		t.Fatalf("cleanup archive test issues: %v", err)
+	}
+
+	var todoID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+		VALUES ($1, 'archive test todo issue', 'todo', 'none', 'member', $2, 90001, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&todoID)
+	if err != nil {
+		t.Fatalf("create todo issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue WHERE workspace_id = $1 AND title LIKE 'archive test %'`, testWorkspaceID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+todoID+"/archive", nil)
+	req = withURLParam(req, "id", todoID)
+	testHandler.ArchiveIssue(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("ArchiveIssue(todo): expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var doneID string
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+		VALUES ($1, 'archive test done issue', 'done', 'none', 'member', $2, 90002, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&doneID)
+	if err != nil {
+		t.Fatalf("create done issue: %v", err)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues/"+doneID+"/archive", nil)
+	req = withURLParam(req, "id", doneID)
+	testHandler.ArchiveIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ArchiveIssue(done): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var archived IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&archived); err != nil {
+		t.Fatalf("decode archived issue: %v", err)
+	}
+	if archived.ArchivedAt == nil || archived.ArchivedBy == nil {
+		t.Fatalf("ArchiveIssue(done): expected archive metadata, got archived_at=%v archived_by=%v", archived.ArchivedAt, archived.ArchivedBy)
+	}
+	if archived.Status != "done" {
+		t.Fatalf("ArchiveIssue(done): status = %q, want done", archived.Status)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues/"+doneID, nil)
+	req = withURLParam(req, "id", doneID)
+	testHandler.GetIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetIssue(archived): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues?workspace_id="+testWorkspaceID+"&status=done&limit=1000", nil)
+	testHandler.ListIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListIssues(default): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if issueListContainsID(t, w.Body.Bytes(), doneID) {
+		t.Fatal("ListIssues(default): archived issue should be hidden")
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues?workspace_id="+testWorkspaceID+"&status=done&include_archived=true&limit=1000", nil)
+	testHandler.ListIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListIssues(include_archived): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !issueListContainsID(t, w.Body.Bytes(), doneID) {
+		t.Fatal("ListIssues(include_archived): archived issue should be included")
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues/"+doneID+"/restore", nil)
+	req = withURLParam(req, "id", doneID)
+	testHandler.RestoreIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("RestoreIssue: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var restored IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&restored); err != nil {
+		t.Fatalf("decode restored issue: %v", err)
+	}
+	if restored.ArchivedAt != nil || restored.ArchivedBy != nil {
+		t.Fatalf("RestoreIssue: expected archive metadata cleared, got archived_at=%v archived_by=%v", restored.ArchivedAt, restored.ArchivedBy)
+	}
+	if restored.Status != "done" {
+		t.Fatalf("RestoreIssue: status = %q, want done", restored.Status)
+	}
+}
+
+func TestListChildIssuesHidesArchivedByDefault(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, `DELETE FROM issue WHERE workspace_id = $1 AND title LIKE 'archive child test %'`, testWorkspaceID); err != nil {
+		t.Fatalf("cleanup child archive test issues: %v", err)
+	}
+
+	var parentID, archivedChildID, visibleChildID string
+	err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, number, position)
+		VALUES ($1, 'archive child test parent issue', 'todo', 'none', 'member', $2, 90101, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&parentID)
+	if err != nil {
+		t.Fatalf("create parent issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue WHERE workspace_id = $1 AND title LIKE 'archive child test %'`, testWorkspaceID)
+	})
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, parent_issue_id, number, position)
+		VALUES ($1, 'archive child test archived child issue', 'done', 'none', 'member', $2, $3, 90102, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID, parentID).Scan(&archivedChildID)
+	if err != nil {
+		t.Fatalf("create archived child issue: %v", err)
+	}
+
+	err = testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, parent_issue_id, number, position)
+		VALUES ($1, 'archive child test visible child issue', 'todo', 'none', 'member', $2, $3, 90103, 1)
+		RETURNING id
+	`, testWorkspaceID, testUserID, parentID).Scan(&visibleChildID)
+	if err != nil {
+		t.Fatalf("create visible child issue: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+archivedChildID+"/archive", nil)
+	req = withURLParam(req, "id", archivedChildID)
+	testHandler.ArchiveIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ArchiveIssue(child): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues/"+parentID+"/children", nil)
+	req = withURLParam(req, "id", parentID)
+	testHandler.ListChildIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListChildIssues(default): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if issueListContainsID(t, w.Body.Bytes(), archivedChildID) {
+		t.Fatal("ListChildIssues(default): archived child should be hidden")
+	}
+	if !issueListContainsID(t, w.Body.Bytes(), visibleChildID) {
+		t.Fatal("ListChildIssues(default): visible child should still be included")
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues/"+parentID+"/children?include_archived=true", nil)
+	req = withURLParam(req, "id", parentID)
+	testHandler.ListChildIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListChildIssues(include_archived): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !issueListContainsID(t, w.Body.Bytes(), archivedChildID) {
+		t.Fatal("ListChildIssues(include_archived): archived child should be included")
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues/"+archivedChildID, nil)
+	req = withURLParam(req, "id", archivedChildID)
+	testHandler.GetIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetIssue(archived child): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/issues/child-progress", nil)
+	testHandler.ChildIssueProgress(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ChildIssueProgress: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	progress := childProgressByParentID(t, w.Body.Bytes())
+	entry, ok := progress[parentID]
+	if !ok {
+		t.Fatal("ChildIssueProgress: expected parent progress entry")
+	}
+	if entry.Total != 1 || entry.Done != 0 {
+		t.Fatalf("ChildIssueProgress: got total=%d done=%d, want total=1 done=0", entry.Total, entry.Done)
+	}
+}
+
+func issueListContainsID(t *testing.T, body []byte, id string) bool {
+	t.Helper()
+	var resp struct {
+		Issues []IssueResponse `json:"issues"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode issue list: %v", err)
+	}
+	for _, issue := range resp.Issues {
+		if issue.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+type childProgressEntry struct {
+	ParentIssueID string `json:"parent_issue_id"`
+	Total         int64  `json:"total"`
+	Done          int64  `json:"done"`
+}
+
+func childProgressByParentID(t *testing.T, body []byte) map[string]childProgressEntry {
+	t.Helper()
+	var resp struct {
+		Progress []childProgressEntry `json:"progress"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode child progress: %v", err)
+	}
+	progress := make(map[string]childProgressEntry, len(resp.Progress))
+	for _, entry := range resp.Progress {
+		progress[entry.ParentIssueID] = entry
+	}
+	return progress
+}
+
 // TestCreateIssueDefaultStatusIsTodo verifies that issues created without an
 // explicit status default to "todo" so the daemon picks them up immediately.
 // Before this fix the default was "backlog", which daemons ignore.

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -22,26 +22,28 @@ import (
 
 // IssueResponse is the JSON response for an issue.
 type IssueResponse struct {
-	ID                 string                  `json:"id"`
-	WorkspaceID        string                  `json:"workspace_id"`
-	Number             int32                   `json:"number"`
-	Identifier         string                  `json:"identifier"`
-	Title              string                  `json:"title"`
-	Description        *string                 `json:"description"`
-	Status             string                  `json:"status"`
-	Priority           string                  `json:"priority"`
-	AssigneeType       *string                 `json:"assignee_type"`
-	AssigneeID         *string                 `json:"assignee_id"`
-	CreatorType        string                  `json:"creator_type"`
-	CreatorID          string                  `json:"creator_id"`
-	ParentIssueID      *string                 `json:"parent_issue_id"`
-	ProjectID          *string                 `json:"project_id"`
-	Position           float64                 `json:"position"`
-	DueDate            *string                 `json:"due_date"`
-	CreatedAt          string                  `json:"created_at"`
-	UpdatedAt          string                  `json:"updated_at"`
-	Reactions          []IssueReactionResponse `json:"reactions,omitempty"`
-	Attachments        []AttachmentResponse    `json:"attachments,omitempty"`
+	ID            string                  `json:"id"`
+	WorkspaceID   string                  `json:"workspace_id"`
+	Number        int32                   `json:"number"`
+	Identifier    string                  `json:"identifier"`
+	Title         string                  `json:"title"`
+	Description   *string                 `json:"description"`
+	Status        string                  `json:"status"`
+	Priority      string                  `json:"priority"`
+	AssigneeType  *string                 `json:"assignee_type"`
+	AssigneeID    *string                 `json:"assignee_id"`
+	CreatorType   string                  `json:"creator_type"`
+	CreatorID     string                  `json:"creator_id"`
+	ParentIssueID *string                 `json:"parent_issue_id"`
+	ProjectID     *string                 `json:"project_id"`
+	Position      float64                 `json:"position"`
+	DueDate       *string                 `json:"due_date"`
+	ArchivedAt    *string                 `json:"archived_at"`
+	ArchivedBy    *string                 `json:"archived_by"`
+	CreatedAt     string                  `json:"created_at"`
+	UpdatedAt     string                  `json:"updated_at"`
+	Reactions     []IssueReactionResponse `json:"reactions,omitempty"`
+	Attachments   []AttachmentResponse    `json:"attachments,omitempty"`
 }
 
 func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
@@ -63,6 +65,8 @@ func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
 		ProjectID:     uuidToPtr(i.ProjectID),
 		Position:      i.Position,
 		DueDate:       timestampToPtr(i.DueDate),
+		ArchivedAt:    timestampToPtr(i.ArchivedAt),
+		ArchivedBy:    uuidToPtr(i.ArchivedBy),
 		CreatedAt:     timestampToString(i.CreatedAt),
 		UpdatedAt:     timestampToString(i.UpdatedAt),
 	}
@@ -87,6 +91,8 @@ func issueListRowToResponse(i db.ListIssuesRow, issuePrefix string) IssueRespons
 		ProjectID:     uuidToPtr(i.ProjectID),
 		Position:      i.Position,
 		DueDate:       timestampToPtr(i.DueDate),
+		ArchivedAt:    timestampToPtr(i.ArchivedAt),
+		ArchivedBy:    uuidToPtr(i.ArchivedBy),
 		CreatedAt:     timestampToString(i.CreatedAt),
 		UpdatedAt:     timestampToString(i.UpdatedAt),
 	}
@@ -110,6 +116,8 @@ func openIssueRowToResponse(i db.ListOpenIssuesRow, issuePrefix string) IssueRes
 		ProjectID:     uuidToPtr(i.ProjectID),
 		Position:      i.Position,
 		DueDate:       timestampToPtr(i.DueDate),
+		ArchivedAt:    timestampToPtr(i.ArchivedAt),
+		ArchivedBy:    uuidToPtr(i.ArchivedBy),
 		CreatedAt:     timestampToString(i.CreatedAt),
 		UpdatedAt:     timestampToString(i.UpdatedAt),
 	}
@@ -224,7 +232,7 @@ type searchResult struct {
 // buildSearchQuery builds a dynamic SQL query for issue search.
 // It uses LOWER(column) LIKE for case-insensitive matching compatible with pg_bigm 1.2 GIN indexes.
 // Search patterns are lowercased in Go to avoid redundant LOWER() on the pattern side in SQL.
-func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, includeClosed bool) (string, []any) {
+func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, includeClosed bool, includeArchived bool) (string, []any) {
 	// Lowercase in Go so SQL only needs LOWER() on the column side.
 	phrase = strings.ToLower(phrase)
 	for i, t := range terms {
@@ -242,7 +250,7 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 	}
 
 	escapedPhrase := escapeLike(phrase)
-	phraseParam := nextArg(escapedPhrase)               // $1
+	phraseParam := nextArg(escapedPhrase) // $1
 	phraseContains := "'%' || " + phraseParam + " || '%'"
 	phraseStartsWith := phraseParam + " || '%'"
 
@@ -292,6 +300,9 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 
 	if !includeClosed {
 		whereClause += " AND i.status NOT IN ('done', 'cancelled')"
+	}
+	if !includeArchived {
+		whereClause += " AND i.archived_at IS NULL"
 	}
 
 	// --- ORDER BY clause ---
@@ -422,6 +433,7 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 		i.assignee_type, i.assignee_id, i.creator_type, i.creator_id,
 		i.parent_issue_id, i.acceptance_criteria, i.context_refs, i.position,
 		i.due_date, i.created_at, i.updated_at, i.number, i.project_id,
+		i.archived_at, i.archived_by,
 		COUNT(*) OVER() AS total_count,
 		%s AS match_source,
 		%s AS matched_comment_content
@@ -469,12 +481,13 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	includeClosed := r.URL.Query().Get("include_closed") == "true"
+	includeArchived := r.URL.Query().Get("include_archived") == "true"
 
 	wsUUID := parseUUID(workspaceID)
 	terms := splitSearchTerms(q)
 	queryNum, hasNum := parseQueryNumber(q)
 
-	sqlQuery, args := buildSearchQuery(q, terms, queryNum, hasNum, includeClosed)
+	sqlQuery, args := buildSearchQuery(q, terms, queryNum, hasNum, includeClosed, includeArchived)
 	// Fill placeholder args: $2 = workspace_id, last two = limit, offset
 	args[1] = wsUUID
 	args[len(args)-2] = limit
@@ -511,6 +524,8 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 			&sr.issue.UpdatedAt,
 			&sr.issue.Number,
 			&sr.issue.ProjectID,
+			&sr.issue.ArchivedAt,
+			&sr.issue.ArchivedBy,
 			&sr.totalCount,
 			&sr.matchSource,
 			&sr.matchedCommentContent,
@@ -584,16 +599,18 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	if p := r.URL.Query().Get("project_id"); p != "" {
 		projectFilter = parseUUID(p)
 	}
+	includeArchived := r.URL.Query().Get("include_archived") == "true"
 
 	// open_only=true returns all non-done/cancelled issues (no limit).
 	if r.URL.Query().Get("open_only") == "true" {
 		issues, err := h.Queries.ListOpenIssues(ctx, db.ListOpenIssuesParams{
-			WorkspaceID: wsUUID,
-			Priority:    priorityFilter,
-			AssigneeID:  assigneeFilter,
-			AssigneeIds: assigneeIdsFilter,
-			CreatorID:   creatorFilter,
-			ProjectID:   projectFilter,
+			WorkspaceID:     wsUUID,
+			Priority:        priorityFilter,
+			AssigneeID:      assigneeFilter,
+			AssigneeIds:     assigneeIdsFilter,
+			CreatorID:       creatorFilter,
+			ProjectID:       projectFilter,
+			IncludeArchived: includeArchived,
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -632,15 +649,16 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	issues, err := h.Queries.ListIssues(ctx, db.ListIssuesParams{
-		WorkspaceID: wsUUID,
-		Limit:       int32(limit),
-		Offset:      int32(offset),
-		Status:      statusFilter,
-		Priority:    priorityFilter,
-		AssigneeID:  assigneeFilter,
-		AssigneeIds: assigneeIdsFilter,
-		CreatorID:   creatorFilter,
-		ProjectID:   projectFilter,
+		WorkspaceID:     wsUUID,
+		Limit:           int32(limit),
+		Offset:          int32(offset),
+		Status:          statusFilter,
+		Priority:        priorityFilter,
+		AssigneeID:      assigneeFilter,
+		AssigneeIds:     assigneeIdsFilter,
+		CreatorID:       creatorFilter,
+		ProjectID:       projectFilter,
+		IncludeArchived: includeArchived,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -649,13 +667,14 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 
 	// Get the true total count for pagination awareness.
 	total, err := h.Queries.CountIssues(ctx, db.CountIssuesParams{
-		WorkspaceID: wsUUID,
-		Status:      statusFilter,
-		Priority:    priorityFilter,
-		AssigneeID:  assigneeFilter,
-		AssigneeIds: assigneeIdsFilter,
-		CreatorID:   creatorFilter,
-		ProjectID:   projectFilter,
+		WorkspaceID:     wsUUID,
+		Status:          statusFilter,
+		Priority:        priorityFilter,
+		AssigneeID:      assigneeFilter,
+		AssigneeIds:     assigneeIdsFilter,
+		CreatorID:       creatorFilter,
+		ProjectID:       projectFilter,
+		IncludeArchived: includeArchived,
 	})
 	if err != nil {
 		total = int64(len(issues))
@@ -712,7 +731,11 @@ func (h *Handler) ListChildIssues(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	children, err := h.Queries.ListChildIssues(r.Context(), issue.ID)
+	includeArchived := r.URL.Query().Get("include_archived") == "true"
+	children, err := h.Queries.ListChildIssues(r.Context(), db.ListChildIssuesParams{
+		ParentIssueID:   issue.ID,
+		IncludeArchived: includeArchived,
+	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list child issues")
 		return
@@ -756,16 +779,16 @@ func (h *Handler) ChildIssueProgress(w http.ResponseWriter, r *http.Request) {
 }
 
 type CreateIssueRequest struct {
-	Title              string   `json:"title"`
-	Description        *string  `json:"description"`
-	Status             string   `json:"status"`
-	Priority           string   `json:"priority"`
-	AssigneeType       *string  `json:"assignee_type"`
-	AssigneeID         *string  `json:"assignee_id"`
-	ParentIssueID      *string  `json:"parent_issue_id"`
-	ProjectID          *string  `json:"project_id"`
-	DueDate            *string  `json:"due_date"`
-	AttachmentIDs      []string `json:"attachment_ids,omitempty"`
+	Title         string   `json:"title"`
+	Description   *string  `json:"description"`
+	Status        string   `json:"status"`
+	Priority      string   `json:"priority"`
+	AssigneeType  *string  `json:"assignee_type"`
+	AssigneeID    *string  `json:"assignee_id"`
+	ParentIssueID *string  `json:"parent_issue_id"`
+	ProjectID     *string  `json:"project_id"`
+	DueDate       *string  `json:"due_date"`
+	AttachmentIDs []string `json:"attachment_ids,omitempty"`
 }
 
 func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
@@ -866,20 +889,20 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	creatorType, actualCreatorID := h.resolveActor(r, creatorID, workspaceID)
 
 	issue, err := qtx.CreateIssue(r.Context(), db.CreateIssueParams{
-		WorkspaceID:        parseUUID(workspaceID),
-		Title:              req.Title,
-		Description:        ptrToText(req.Description),
-		Status:             status,
-		Priority:           priority,
-		AssigneeType:       assigneeType,
-		AssigneeID:         assigneeID,
-		CreatorType:        creatorType,
-		CreatorID:          parseUUID(actualCreatorID),
-		ParentIssueID:      parentIssueID,
-		Position:           0,
-		DueDate:            dueDate,
-		Number:             issueNumber,
-		ProjectID:          projectID,
+		WorkspaceID:   parseUUID(workspaceID),
+		Title:         req.Title,
+		Description:   ptrToText(req.Description),
+		Status:        status,
+		Priority:      priority,
+		AssigneeType:  assigneeType,
+		AssigneeID:    assigneeID,
+		CreatorType:   creatorType,
+		CreatorID:     parseUUID(actualCreatorID),
+		ParentIssueID: parentIssueID,
+		Position:      0,
+		DueDate:       dueDate,
+		Number:        issueNumber,
+		ProjectID:     projectID,
 	})
 	if err != nil {
 		slog.Warn("create issue failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID)...)
@@ -928,16 +951,16 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 }
 
 type UpdateIssueRequest struct {
-	Title              *string  `json:"title"`
-	Description        *string  `json:"description"`
-	Status             *string  `json:"status"`
-	Priority           *string  `json:"priority"`
-	AssigneeType       *string  `json:"assignee_type"`
-	AssigneeID         *string  `json:"assignee_id"`
-	Position           *float64 `json:"position"`
-	DueDate            *string  `json:"due_date"`
-	ParentIssueID      *string  `json:"parent_issue_id"`
-	ProjectID          *string  `json:"project_id"`
+	Title         *string  `json:"title"`
+	Description   *string  `json:"description"`
+	Status        *string  `json:"status"`
+	Priority      *string  `json:"priority"`
+	AssigneeType  *string  `json:"assignee_type"`
+	AssigneeID    *string  `json:"assignee_id"`
+	Position      *float64 `json:"position"`
+	DueDate       *string  `json:"due_date"`
+	ParentIssueID *string  `json:"parent_issue_id"`
+	ProjectID     *string  `json:"project_id"`
 }
 
 func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
@@ -1122,6 +1145,89 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) ArchiveIssue(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	issue, ok := h.loadIssueForUser(w, r, id)
+	if !ok {
+		return
+	}
+	if issue.ArchivedAt.Valid {
+		writeError(w, http.StatusConflict, "issue is already archived")
+		return
+	}
+
+	force := r.URL.Query().Get("force") == "true"
+	if force {
+		if _, ok := h.requireWorkspaceRole(w, r, uuidToString(issue.WorkspaceID), "issue not found", "owner", "admin"); !ok {
+			return
+		}
+	}
+	if issue.Status != "done" && issue.Status != "cancelled" && !force {
+		writeError(w, http.StatusConflict, "issue can only be archived when done or cancelled")
+		return
+	}
+
+	userID := requestUserID(r)
+	archived, err := h.Queries.ArchiveIssue(r.Context(), db.ArchiveIssueParams{
+		ID:         issue.ID,
+		ArchivedBy: parseUUID(userID),
+		Force:      force,
+	})
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusConflict, "issue could not be archived")
+			return
+		}
+		slog.Warn("archive issue failed", append(logger.RequestAttrs(r), "error", err, "issue_id", id, "workspace_id", uuidToString(issue.WorkspaceID))...)
+		writeError(w, http.StatusInternalServerError, "failed to archive issue")
+		return
+	}
+
+	prefix := h.getIssuePrefix(r.Context(), archived.WorkspaceID)
+	resp := issueToResponse(archived, prefix)
+	workspaceID := uuidToString(archived.WorkspaceID)
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	h.publish(protocol.EventIssueUpdated, workspaceID, actorType, actorID, map[string]any{
+		"issue":    resp,
+		"archived": true,
+	})
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) RestoreIssue(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	issue, ok := h.loadIssueForUser(w, r, id)
+	if !ok {
+		return
+	}
+	if !issue.ArchivedAt.Valid {
+		writeError(w, http.StatusConflict, "issue is not archived")
+		return
+	}
+
+	restored, err := h.Queries.RestoreIssue(r.Context(), issue.ID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusConflict, "issue is not archived")
+			return
+		}
+		slog.Warn("restore issue failed", append(logger.RequestAttrs(r), "error", err, "issue_id", id, "workspace_id", uuidToString(issue.WorkspaceID))...)
+		writeError(w, http.StatusInternalServerError, "failed to restore issue")
+		return
+	}
+
+	prefix := h.getIssuePrefix(r.Context(), restored.WorkspaceID)
+	resp := issueToResponse(restored, prefix)
+	workspaceID := uuidToString(restored.WorkspaceID)
+	userID := requestUserID(r)
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	h.publish(protocol.EventIssueUpdated, workspaceID, actorType, actorID, map[string]any{
+		"issue":    resp,
+		"restored": true,
+	})
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/server/internal/handler/search_test.go
+++ b/server/internal/handler/search_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestBuildSearchQuery_SingleTerm(t *testing.T) {
-	query, args := buildSearchQuery("Hello", []string{"Hello"}, 0, false, false)
+	query, args := buildSearchQuery("Hello", []string{"Hello"}, 0, false, false, false)
 
 	// Pattern should be lowercased in Go.
 	if args[0] != "hello" {
@@ -42,7 +42,7 @@ func TestBuildSearchQuery_SingleTerm(t *testing.T) {
 }
 
 func TestBuildSearchQuery_MultiTerm(t *testing.T) {
-	query, args := buildSearchQuery("Foo Bar", []string{"Foo", "Bar"}, 0, false, false)
+	query, args := buildSearchQuery("Foo Bar", []string{"Foo", "Bar"}, 0, false, false, false)
 
 	// Both phrase and terms should be lowercased.
 	if args[0] != "foo bar" {
@@ -63,7 +63,7 @@ func TestBuildSearchQuery_MultiTerm(t *testing.T) {
 }
 
 func TestBuildSearchQuery_WithNumber(t *testing.T) {
-	query, args := buildSearchQuery("MUL-42", []string{"MUL-42"}, 42, true, false)
+	query, args := buildSearchQuery("MUL-42", []string{"MUL-42"}, 42, true, false, false)
 
 	_ = args
 	// Number match should be in WHERE.
@@ -77,15 +77,23 @@ func TestBuildSearchQuery_WithNumber(t *testing.T) {
 }
 
 func TestBuildSearchQuery_IncludeClosed(t *testing.T) {
-	query, _ := buildSearchQuery("test", []string{"test"}, 0, false, true)
+	query, _ := buildSearchQuery("test", []string{"test"}, 0, false, true, false)
 
 	if strings.Contains(query, "NOT IN ('done', 'cancelled')") {
 		t.Error("query should not exclude done/cancelled when includeClosed=true")
 	}
 }
 
+func TestBuildSearchQuery_IncludeArchived(t *testing.T) {
+	query, _ := buildSearchQuery("test", []string{"test"}, 0, false, false, true)
+
+	if strings.Contains(query, "i.archived_at IS NULL") {
+		t.Error("query should not exclude archived issues when includeArchived=true")
+	}
+}
+
 func TestBuildSearchQuery_SpecialChars(t *testing.T) {
-	query, args := buildSearchQuery("100%", []string{"100%"}, 0, false, false)
+	query, args := buildSearchQuery("100%", []string{"100%"}, 0, false, false, false)
 
 	_ = query
 	// % should be escaped in the phrase arg.

--- a/server/migrations/001_init.up.sql
+++ b/server/migrations/001_init.up.sql
@@ -68,9 +68,7 @@ CREATE TABLE issue (
     position FLOAT NOT NULL DEFAULT 0,
     due_date TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    archived_at TIMESTAMPTZ,
-    archived_by UUID REFERENCES "user"(id)
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- Issue labels

--- a/server/migrations/001_init.up.sql
+++ b/server/migrations/001_init.up.sql
@@ -68,7 +68,9 @@ CREATE TABLE issue (
     position FLOAT NOT NULL DEFAULT 0,
     due_date TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    archived_at TIMESTAMPTZ,
+    archived_by UUID REFERENCES "user"(id)
 );
 
 -- Issue labels

--- a/server/migrations/040_issue_soft_archive.down.sql
+++ b/server/migrations/040_issue_soft_archive.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_issue_workspace_archived;
+
+ALTER TABLE issue
+    DROP COLUMN IF EXISTS archived_by,
+    DROP COLUMN IF EXISTS archived_at;

--- a/server/migrations/040_issue_soft_archive.up.sql
+++ b/server/migrations/040_issue_soft_archive.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE issue
+    ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS archived_by UUID REFERENCES "user"(id);
+
+CREATE INDEX IF NOT EXISTS idx_issue_workspace_archived
+    ON issue(workspace_id, archived_at);

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -11,6 +11,52 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const archiveIssue = `-- name: ArchiveIssue :one
+UPDATE issue SET
+    archived_at = now(),
+    archived_by = $2,
+    updated_at = now()
+WHERE id = $1
+  AND archived_at IS NULL
+  AND (status IN ('done', 'cancelled') OR $3::boolean)
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
+`
+
+type ArchiveIssueParams struct {
+	ID         pgtype.UUID `json:"id"`
+	ArchivedBy pgtype.UUID `json:"archived_by"`
+	Force      bool        `json:"force"`
+}
+
+func (q *Queries) ArchiveIssue(ctx context.Context, arg ArchiveIssueParams) (Issue, error) {
+	row := q.db.QueryRow(ctx, archiveIssue, arg.ID, arg.ArchivedBy, arg.Force)
+	var i Issue
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Title,
+		&i.Description,
+		&i.Status,
+		&i.Priority,
+		&i.AssigneeType,
+		&i.AssigneeID,
+		&i.CreatorType,
+		&i.CreatorID,
+		&i.ParentIssueID,
+		&i.AcceptanceCriteria,
+		&i.ContextRefs,
+		&i.Position,
+		&i.DueDate,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.Number,
+		&i.ProjectID,
+	)
+	return i, err
+}
+
 const childIssueProgress = `-- name: ChildIssueProgress :many
 SELECT parent_issue_id,
        COUNT(*)::bigint AS total,
@@ -18,6 +64,7 @@ SELECT parent_issue_id,
 FROM issue
 WHERE workspace_id = $1
   AND parent_issue_id IS NOT NULL
+  AND archived_at IS NULL
 GROUP BY parent_issue_id
 `
 
@@ -102,16 +149,18 @@ WHERE workspace_id = $1
   AND ($5::uuid[] IS NULL OR assignee_id = ANY($5::uuid[]))
   AND ($6::uuid IS NULL OR creator_id = $6)
   AND ($7::uuid IS NULL OR project_id = $7)
+  AND ($8::boolean OR archived_at IS NULL)
 `
 
 type CountIssuesParams struct {
-	WorkspaceID pgtype.UUID   `json:"workspace_id"`
-	Status      pgtype.Text   `json:"status"`
-	Priority    pgtype.Text   `json:"priority"`
-	AssigneeID  pgtype.UUID   `json:"assignee_id"`
-	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
-	CreatorID   pgtype.UUID   `json:"creator_id"`
-	ProjectID   pgtype.UUID   `json:"project_id"`
+	WorkspaceID     pgtype.UUID   `json:"workspace_id"`
+	Status          pgtype.Text   `json:"status"`
+	Priority        pgtype.Text   `json:"priority"`
+	AssigneeID      pgtype.UUID   `json:"assignee_id"`
+	AssigneeIds     []pgtype.UUID `json:"assignee_ids"`
+	CreatorID       pgtype.UUID   `json:"creator_id"`
+	ProjectID       pgtype.UUID   `json:"project_id"`
+	IncludeArchived bool          `json:"include_archived"`
 }
 
 func (q *Queries) CountIssues(ctx context.Context, arg CountIssuesParams) (int64, error) {
@@ -123,6 +172,7 @@ func (q *Queries) CountIssues(ctx context.Context, arg CountIssuesParams) (int64
 		arg.AssigneeIds,
 		arg.CreatorID,
 		arg.ProjectID,
+		arg.IncludeArchived,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -136,7 +186,7 @@ INSERT INTO issue (
     parent_issue_id, position, due_date, number, project_id
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
-) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id
+) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
 `
 
 type CreateIssueParams struct {
@@ -192,6 +242,8 @@ func (q *Queries) CreateIssue(ctx context.Context, arg CreateIssueParams) (Issue
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
 	)
@@ -208,7 +260,7 @@ func (q *Queries) DeleteIssue(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getIssue = `-- name: GetIssue :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id FROM issue
 WHERE id = $1
 `
 
@@ -233,6 +285,8 @@ func (q *Queries) GetIssue(ctx context.Context, id pgtype.UUID) (Issue, error) {
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
 	)
@@ -240,7 +294,7 @@ func (q *Queries) GetIssue(ctx context.Context, id pgtype.UUID) (Issue, error) {
 }
 
 const getIssueByNumber = `-- name: GetIssueByNumber :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id FROM issue
 WHERE workspace_id = $1 AND number = $2
 `
 
@@ -270,6 +324,8 @@ func (q *Queries) GetIssueByNumber(ctx context.Context, arg GetIssueByNumberPara
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
 	)
@@ -277,7 +333,7 @@ func (q *Queries) GetIssueByNumber(ctx context.Context, arg GetIssueByNumberPara
 }
 
 const getIssueInWorkspace = `-- name: GetIssueInWorkspace :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id FROM issue
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -307,6 +363,8 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
 	)
@@ -314,13 +372,19 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 }
 
 const listChildIssues = `-- name: ListChildIssues :many
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id FROM issue
 WHERE parent_issue_id = $1
+  AND ($2::boolean OR archived_at IS NULL)
 ORDER BY position ASC, created_at DESC
 `
 
-func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID) ([]Issue, error) {
-	rows, err := q.db.Query(ctx, listChildIssues, parentIssueID)
+type ListChildIssuesParams struct {
+	ParentIssueID   pgtype.UUID `json:"parent_issue_id"`
+	IncludeArchived bool        `json:"include_archived"`
+}
+
+func (q *Queries) ListChildIssues(ctx context.Context, arg ListChildIssuesParams) ([]Issue, error) {
+	rows, err := q.db.Query(ctx, listChildIssues, arg.ParentIssueID, arg.IncludeArchived)
 	if err != nil {
 		return nil, err
 	}
@@ -346,6 +410,8 @@ func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID
 			&i.DueDate,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.ArchivedAt,
+			&i.ArchivedBy,
 			&i.Number,
 			&i.ProjectID,
 		); err != nil {
@@ -362,7 +428,8 @@ func (q *Queries) ListChildIssues(ctx context.Context, parentIssueID pgtype.UUID
 const listIssues = `-- name: ListIssues :many
 SELECT id, workspace_id, title, status, priority,
        assignee_type, assignee_id, creator_type, creator_id,
-       parent_issue_id, position, due_date, created_at, updated_at, number, project_id
+       parent_issue_id, position, due_date, created_at, updated_at, number, project_id,
+       archived_at, archived_by
 FROM issue
 WHERE workspace_id = $1
   AND ($4::text IS NULL OR status = $4)
@@ -371,20 +438,22 @@ WHERE workspace_id = $1
   AND ($7::uuid[] IS NULL OR assignee_id = ANY($7::uuid[]))
   AND ($8::uuid IS NULL OR creator_id = $8)
   AND ($9::uuid IS NULL OR project_id = $9)
+  AND ($10::boolean OR archived_at IS NULL)
 ORDER BY position ASC, created_at DESC
 LIMIT $2 OFFSET $3
 `
 
 type ListIssuesParams struct {
-	WorkspaceID pgtype.UUID   `json:"workspace_id"`
-	Limit       int32         `json:"limit"`
-	Offset      int32         `json:"offset"`
-	Status      pgtype.Text   `json:"status"`
-	Priority    pgtype.Text   `json:"priority"`
-	AssigneeID  pgtype.UUID   `json:"assignee_id"`
-	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
-	CreatorID   pgtype.UUID   `json:"creator_id"`
-	ProjectID   pgtype.UUID   `json:"project_id"`
+	WorkspaceID     pgtype.UUID   `json:"workspace_id"`
+	Limit           int32         `json:"limit"`
+	Offset          int32         `json:"offset"`
+	Status          pgtype.Text   `json:"status"`
+	Priority        pgtype.Text   `json:"priority"`
+	AssigneeID      pgtype.UUID   `json:"assignee_id"`
+	AssigneeIds     []pgtype.UUID `json:"assignee_ids"`
+	CreatorID       pgtype.UUID   `json:"creator_id"`
+	ProjectID       pgtype.UUID   `json:"project_id"`
+	IncludeArchived bool          `json:"include_archived"`
 }
 
 type ListIssuesRow struct {
@@ -404,6 +473,8 @@ type ListIssuesRow struct {
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
 	Number        int32              `json:"number"`
 	ProjectID     pgtype.UUID        `json:"project_id"`
+	ArchivedAt    pgtype.Timestamptz `json:"archived_at"`
+	ArchivedBy    pgtype.UUID        `json:"archived_by"`
 }
 
 func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListIssuesRow, error) {
@@ -417,6 +488,7 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 		arg.AssigneeIds,
 		arg.CreatorID,
 		arg.ProjectID,
+		arg.IncludeArchived,
 	)
 	if err != nil {
 		return nil, err
@@ -442,6 +514,8 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 			&i.UpdatedAt,
 			&i.Number,
 			&i.ProjectID,
+			&i.ArchivedAt,
+			&i.ArchivedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -456,7 +530,8 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 const listOpenIssues = `-- name: ListOpenIssues :many
 SELECT id, workspace_id, title, status, priority,
        assignee_type, assignee_id, creator_type, creator_id,
-       parent_issue_id, position, due_date, created_at, updated_at, number, project_id
+       parent_issue_id, position, due_date, created_at, updated_at, number, project_id,
+       archived_at, archived_by
 FROM issue
 WHERE workspace_id = $1
   AND status NOT IN ('done', 'cancelled')
@@ -465,16 +540,18 @@ WHERE workspace_id = $1
   AND ($4::uuid[] IS NULL OR assignee_id = ANY($4::uuid[]))
   AND ($5::uuid IS NULL OR creator_id = $5)
   AND ($6::uuid IS NULL OR project_id = $6)
+  AND ($7::boolean OR archived_at IS NULL)
 ORDER BY position ASC, created_at DESC
 `
 
 type ListOpenIssuesParams struct {
-	WorkspaceID pgtype.UUID   `json:"workspace_id"`
-	Priority    pgtype.Text   `json:"priority"`
-	AssigneeID  pgtype.UUID   `json:"assignee_id"`
-	AssigneeIds []pgtype.UUID `json:"assignee_ids"`
-	CreatorID   pgtype.UUID   `json:"creator_id"`
-	ProjectID   pgtype.UUID   `json:"project_id"`
+	WorkspaceID     pgtype.UUID   `json:"workspace_id"`
+	Priority        pgtype.Text   `json:"priority"`
+	AssigneeID      pgtype.UUID   `json:"assignee_id"`
+	AssigneeIds     []pgtype.UUID `json:"assignee_ids"`
+	CreatorID       pgtype.UUID   `json:"creator_id"`
+	ProjectID       pgtype.UUID   `json:"project_id"`
+	IncludeArchived bool          `json:"include_archived"`
 }
 
 type ListOpenIssuesRow struct {
@@ -494,6 +571,8 @@ type ListOpenIssuesRow struct {
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
 	Number        int32              `json:"number"`
 	ProjectID     pgtype.UUID        `json:"project_id"`
+	ArchivedAt    pgtype.Timestamptz `json:"archived_at"`
+	ArchivedBy    pgtype.UUID        `json:"archived_by"`
 }
 
 func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) ([]ListOpenIssuesRow, error) {
@@ -504,6 +583,7 @@ func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) 
 		arg.AssigneeIds,
 		arg.CreatorID,
 		arg.ProjectID,
+		arg.IncludeArchived,
 	)
 	if err != nil {
 		return nil, err
@@ -529,6 +609,8 @@ func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) 
 			&i.UpdatedAt,
 			&i.Number,
 			&i.ProjectID,
+			&i.ArchivedAt,
+			&i.ArchivedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -538,6 +620,45 @@ func (q *Queries) ListOpenIssues(ctx context.Context, arg ListOpenIssuesParams) 
 		return nil, err
 	}
 	return items, nil
+}
+
+const restoreIssue = `-- name: RestoreIssue :one
+UPDATE issue SET
+    archived_at = NULL,
+    archived_by = NULL,
+    updated_at = now()
+WHERE id = $1
+  AND archived_at IS NOT NULL
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
+`
+
+func (q *Queries) RestoreIssue(ctx context.Context, id pgtype.UUID) (Issue, error) {
+	row := q.db.QueryRow(ctx, restoreIssue, id)
+	var i Issue
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Title,
+		&i.Description,
+		&i.Status,
+		&i.Priority,
+		&i.AssigneeType,
+		&i.AssigneeID,
+		&i.CreatorType,
+		&i.CreatorID,
+		&i.ParentIssueID,
+		&i.AcceptanceCriteria,
+		&i.ContextRefs,
+		&i.Position,
+		&i.DueDate,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
+		&i.Number,
+		&i.ProjectID,
+	)
+	return i, err
 }
 
 const updateIssue = `-- name: UpdateIssue :one
@@ -554,7 +675,7 @@ UPDATE issue SET
     project_id = $11,
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
 `
 
 type UpdateIssueParams struct {
@@ -604,6 +725,8 @@ func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
 	)
@@ -615,7 +738,7 @@ UPDATE issue SET
     status = $2,
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
 `
 
 type UpdateIssueStatusParams struct {
@@ -644,6 +767,8 @@ func (q *Queries) UpdateIssueStatus(ctx context.Context, arg UpdateIssueStatusPa
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
 	)

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -19,7 +19,7 @@ UPDATE issue SET
 WHERE id = $1
   AND archived_at IS NULL
   AND (status IN ('done', 'cancelled') OR $3::boolean)
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by
 `
 
 type ArchiveIssueParams struct {
@@ -49,10 +49,10 @@ func (q *Queries) ArchiveIssue(ctx context.Context, arg ArchiveIssueParams) (Iss
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 	)
 	return i, err
 }
@@ -186,7 +186,7 @@ INSERT INTO issue (
     parent_issue_id, position, due_date, number, project_id
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
-) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
+) RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by
 `
 
 type CreateIssueParams struct {
@@ -242,10 +242,10 @@ func (q *Queries) CreateIssue(ctx context.Context, arg CreateIssueParams) (Issue
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 	)
 	return i, err
 }
@@ -260,7 +260,7 @@ func (q *Queries) DeleteIssue(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getIssue = `-- name: GetIssue :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by FROM issue
 WHERE id = $1
 `
 
@@ -285,16 +285,16 @@ func (q *Queries) GetIssue(ctx context.Context, id pgtype.UUID) (Issue, error) {
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 	)
 	return i, err
 }
 
 const getIssueByNumber = `-- name: GetIssueByNumber :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by FROM issue
 WHERE workspace_id = $1 AND number = $2
 `
 
@@ -324,16 +324,16 @@ func (q *Queries) GetIssueByNumber(ctx context.Context, arg GetIssueByNumberPara
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 	)
 	return i, err
 }
 
 const getIssueInWorkspace = `-- name: GetIssueInWorkspace :one
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by FROM issue
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -363,16 +363,16 @@ func (q *Queries) GetIssueInWorkspace(ctx context.Context, arg GetIssueInWorkspa
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 	)
 	return i, err
 }
 
 const listChildIssues = `-- name: ListChildIssues :many
-SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id FROM issue
+SELECT id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by FROM issue
 WHERE parent_issue_id = $1
   AND ($2::boolean OR archived_at IS NULL)
 ORDER BY position ASC, created_at DESC
@@ -410,10 +410,10 @@ func (q *Queries) ListChildIssues(ctx context.Context, arg ListChildIssuesParams
 			&i.DueDate,
 			&i.CreatedAt,
 			&i.UpdatedAt,
-			&i.ArchivedAt,
-			&i.ArchivedBy,
 			&i.Number,
 			&i.ProjectID,
+			&i.ArchivedAt,
+			&i.ArchivedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -629,7 +629,7 @@ UPDATE issue SET
     updated_at = now()
 WHERE id = $1
   AND archived_at IS NOT NULL
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by
 `
 
 func (q *Queries) RestoreIssue(ctx context.Context, id pgtype.UUID) (Issue, error) {
@@ -653,10 +653,10 @@ func (q *Queries) RestoreIssue(ctx context.Context, id pgtype.UUID) (Issue, erro
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 	)
 	return i, err
 }
@@ -675,7 +675,7 @@ UPDATE issue SET
     project_id = $11,
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by
 `
 
 type UpdateIssueParams struct {
@@ -725,10 +725,10 @@ func (q *Queries) UpdateIssue(ctx context.Context, arg UpdateIssueParams) (Issue
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 	)
 	return i, err
 }
@@ -738,7 +738,7 @@ UPDATE issue SET
     status = $2,
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, archived_at, archived_by, number, project_id
+RETURNING id, workspace_id, title, description, status, priority, assignee_type, assignee_id, creator_type, creator_id, parent_issue_id, acceptance_criteria, context_refs, position, due_date, created_at, updated_at, number, project_id, archived_at, archived_by
 `
 
 type UpdateIssueStatusParams struct {
@@ -767,10 +767,10 @@ func (q *Queries) UpdateIssueStatus(ctx context.Context, arg UpdateIssueStatusPa
 		&i.DueDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
-		&i.ArchivedAt,
-		&i.ArchivedBy,
 		&i.Number,
 		&i.ProjectID,
+		&i.ArchivedAt,
+		&i.ArchivedBy,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -196,6 +196,8 @@ type Issue struct {
 	DueDate            pgtype.Timestamptz `json:"due_date"`
 	CreatedAt          pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
+	ArchivedAt         pgtype.Timestamptz `json:"archived_at"`
+	ArchivedBy         pgtype.UUID        `json:"archived_by"`
 	Number             int32              `json:"number"`
 	ProjectID          pgtype.UUID        `json:"project_id"`
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -196,10 +196,10 @@ type Issue struct {
 	DueDate            pgtype.Timestamptz `json:"due_date"`
 	CreatedAt          pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
-	ArchivedAt         pgtype.Timestamptz `json:"archived_at"`
-	ArchivedBy         pgtype.UUID        `json:"archived_by"`
 	Number             int32              `json:"number"`
 	ProjectID          pgtype.UUID        `json:"project_id"`
+	ArchivedAt         pgtype.Timestamptz `json:"archived_at"`
+	ArchivedBy         pgtype.UUID        `json:"archived_by"`
 }
 
 type IssueDependency struct {

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -1,7 +1,8 @@
 -- name: ListIssues :many
 SELECT id, workspace_id, title, status, priority,
        assignee_type, assignee_id, creator_type, creator_id,
-       parent_issue_id, position, due_date, created_at, updated_at, number, project_id
+       parent_issue_id, position, due_date, created_at, updated_at, number, project_id,
+       archived_at, archived_by
 FROM issue
 WHERE workspace_id = $1
   AND (sqlc.narg('status')::text IS NULL OR status = sqlc.narg('status'))
@@ -10,6 +11,7 @@ WHERE workspace_id = $1
   AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
   AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'))
   AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (sqlc.arg('include_archived')::boolean OR archived_at IS NULL)
 ORDER BY position ASC, created_at DESC
 LIMIT $2 OFFSET $3;
 
@@ -50,6 +52,25 @@ UPDATE issue SET
 WHERE id = $1
 RETURNING *;
 
+-- name: ArchiveIssue :one
+UPDATE issue SET
+    archived_at = now(),
+    archived_by = $2,
+    updated_at = now()
+WHERE id = $1
+  AND archived_at IS NULL
+  AND (status IN ('done', 'cancelled') OR sqlc.arg('force')::boolean)
+RETURNING *;
+
+-- name: RestoreIssue :one
+UPDATE issue SET
+    archived_at = NULL,
+    archived_by = NULL,
+    updated_at = now()
+WHERE id = $1
+  AND archived_at IS NOT NULL
+RETURNING *;
+
 -- name: UpdateIssueStatus :one
 UPDATE issue SET
     status = $2,
@@ -63,7 +84,8 @@ DELETE FROM issue WHERE id = $1;
 -- name: ListOpenIssues :many
 SELECT id, workspace_id, title, status, priority,
        assignee_type, assignee_id, creator_type, creator_id,
-       parent_issue_id, position, due_date, created_at, updated_at, number, project_id
+       parent_issue_id, position, due_date, created_at, updated_at, number, project_id,
+       archived_at, archived_by
 FROM issue
 WHERE workspace_id = $1
   AND status NOT IN ('done', 'cancelled')
@@ -72,6 +94,7 @@ WHERE workspace_id = $1
   AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
   AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'))
   AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (sqlc.arg('include_archived')::boolean OR archived_at IS NULL)
 ORDER BY position ASC, created_at DESC;
 
 -- name: CountIssues :one
@@ -82,11 +105,13 @@ WHERE workspace_id = $1
   AND (sqlc.narg('assignee_id')::uuid IS NULL OR assignee_id = sqlc.narg('assignee_id'))
   AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
   AND (sqlc.narg('creator_id')::uuid IS NULL OR creator_id = sqlc.narg('creator_id'))
-  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'));
+  AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (sqlc.arg('include_archived')::boolean OR archived_at IS NULL);
 
 -- name: ListChildIssues :many
 SELECT * FROM issue
 WHERE parent_issue_id = $1
+  AND (sqlc.arg('include_archived')::boolean OR archived_at IS NULL)
 ORDER BY position ASC, created_at DESC;
 
 -- name: CountCreatedIssueAssignees :many
@@ -110,6 +135,7 @@ SELECT parent_issue_id,
 FROM issue
 WHERE workspace_id = $1
   AND parent_issue_id IS NOT NULL
+  AND archived_at IS NULL
 GROUP BY parent_issue_id;
 
 -- SearchIssues: moved to handler (dynamic SQL for multi-word search support).


### PR DESCRIPTION
## Summary
- Add issue-level soft archive metadata, archive/restore handlers, CLI commands, and default list/search filtering.
- Keep direct issue get working for archived issues and preserve status semantics on restore.
- Include child-list filtering and realtime child-cache handling so archived children stay hidden unless explicitly included.

## Validation
- `corepack pnpm --filter @multica/core test -- ws-updaters.test.ts` passed: 6 files, 15 tests
- `corepack pnpm --filter @multica/core typecheck` passed
- `corepack pnpm --filter @multica/views typecheck` passed
- `git diff --check` passed
- `git diff --check origin/main..HEAD` passed

Earlier packaged validation also passed:
- `PATH="$(go env GOPATH)/bin:$PATH" make sqlc`
- `go test ./internal/handler -run "TestBuildSearchQuery|TestIssueArchiveRestore|TestListChildIssuesHidesArchivedByDefault"`
- `go test ./cmd/multica -run "TestIssueArchiveCommandsRegistered|TestValidIssueStatuses"`
- `go test ./internal/handler ./cmd/multica ./cmd/server ./internal/service`

Multica: MUL-17