### PR TITLE
fix(server): reduce JWT expiry to 72h and use UUIDv4 for attachment IDs

### DIFF
--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -70,7 +70,7 @@ func (h *Handler) issueJWT(user db.User) (string, error) {
 		"sub":   uuidToString(user.ID),
 		"email": user.Email,
 		"name":  user.Name,
-		"exp":   time.Now().Add(30 * 24 * time.Hour).Unix(),
+		"exp":   time.Now().Add(72 * time.Hour).Unix(),
 		"iat":   time.Now().Unix(),
 	})
 	return token.SignedString(auth.JWTSecret())

--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -153,8 +153,7 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generate a UUIDv7 to use as both the attachment ID and S3 key.
-	id, err := uuid.NewV7()
+	id, err := uuid.NewRandom()
 	if err != nil {
 		slog.Error("failed to generate uuid", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")


### PR DESCRIPTION
## Summary

Addresses security audit findings LOW-1, LOW-2, LOW-3 from [MUL-582](https://github.com/multica-ai/multica/issues/582):

- **LOW-1 (WebSocket CORS wildcard):** Already resolved — `checkOrigin` in `hub.go` validates against an origin allowlist loaded from env vars.
- **LOW-2 (JWT 30-day expiry):** Reduced JWT token lifetime from 30 days to 72 hours to limit the attack window for stolen tokens.
- **LOW-3 (UUIDv7 time enumeration):** Switched attachment ID generation from `uuid.NewV7()` (time-embedded) to `uuid.NewRandom()` (UUIDv4, fully random) to prevent timestamp-based search space reduction.

## Test plan

- [ ] Verify login still returns a valid JWT with ~72h expiry
- [ ] Verify file uploads still generate valid attachment IDs (now UUIDv4)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)