### PR TITLE
fix(server): validate workspace membership for subscriptions and uploads

### DIFF
--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -171,6 +171,11 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 
 	// If workspace context is available, create an attachment record.
 	if workspaceID != "" {
+		if _, err := h.getWorkspaceMember(r.Context(), userID, workspaceID); err != nil {
+			writeError(w, http.StatusForbidden, "not a member of this workspace")
+			return
+		}
+
 		uploaderType, uploaderID := h.resolveActor(r, userID, workspaceID)
 
 		params := db.CreateAttachmentParams{

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type mockStorage struct{}
+
+func (m *mockStorage) Upload(_ context.Context, key string, _ []byte, _ string, _ string) (string, error) {
+	return fmt.Sprintf("https://cdn.example.com/%s", key), nil
+}
+
+func (m *mockStorage) Delete(_ context.Context, _ string)        {}
+func (m *mockStorage) DeleteKeys(_ context.Context, _ []string)  {}
+func (m *mockStorage) KeyFromURL(rawURL string) string            { return rawURL }
+
+func TestUploadFileForeignWorkspace(t *testing.T) {
+	origStorage := testHandler.Storage
+	testHandler.Storage = &mockStorage{}
+	defer func() { testHandler.Storage = origStorage }()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	part.Write([]byte("hello world"))
+	writer.Close()
+
+	foreignWorkspaceID := "00000000-0000-0000-0000-000000000099"
+	req := httptest.NewRequest("POST", "/api/upload-file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("X-User-ID", testUserID)
+	req.Header.Set("X-Workspace-ID", foreignWorkspaceID)
+
+	w := httptest.NewRecorder()
+	testHandler.UploadFile(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("UploadFile with foreign workspace: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -246,6 +246,22 @@ func (h *Handler) requireWorkspaceRole(w http.ResponseWriter, r *http.Request, w
 	return member, true
 }
 
+// isWorkspaceEntity checks whether a user_id belongs to the given workspace,
+// as either a member or an agent depending on userType.
+func (h *Handler) isWorkspaceEntity(ctx context.Context, userType, userID, workspaceID string) bool {
+	switch userType {
+	case "agent":
+		_, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+			ID:          parseUUID(userID),
+			WorkspaceID: parseUUID(workspaceID),
+		})
+		return err == nil
+	default:
+		_, err := h.getWorkspaceMember(ctx, userID, workspaceID)
+		return err == nil
+	}
+}
+
 func (h *Handler) loadIssueForUser(w http.ResponseWriter, r *http.Request, issueID string) (db.Issue, bool) {
 	if _, ok := requireUserID(w, r); !ok {
 		return db.Issue{}, false

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -250,6 +250,9 @@ func (h *Handler) requireWorkspaceRole(w http.ResponseWriter, r *http.Request, w
 // as either a member or an agent depending on userType.
 func (h *Handler) isWorkspaceEntity(ctx context.Context, userType, userID, workspaceID string) bool {
 	switch userType {
+	case "member":
+		_, err := h.getWorkspaceMember(ctx, userID, workspaceID)
+		return err == nil
 	case "agent":
 		_, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
 			ID:          parseUUID(userID),
@@ -257,8 +260,7 @@ func (h *Handler) isWorkspaceEntity(ctx context.Context, userType, userID, works
 		})
 		return err == nil
 	default:
-		_, err := h.getWorkspaceMember(ctx, userID, workspaceID)
-		return err == nil
+		return false
 	}
 }
 

--- a/server/internal/handler/subscriber.go
+++ b/server/internal/handler/subscriber.go
@@ -76,6 +76,12 @@ func (h *Handler) SubscribeToIssue(w http.ResponseWriter, r *http.Request) {
 		targetUserType = *req.UserType
 	}
 
+	workspaceID := uuidToString(issue.WorkspaceID)
+	if !h.isWorkspaceEntity(r.Context(), targetUserType, targetUserID, workspaceID) {
+		writeError(w, http.StatusForbidden, "target user is not a member of this workspace")
+		return
+	}
+
 	err := h.Queries.AddIssueSubscriber(r.Context(), db.AddIssueSubscriberParams{
 		IssueID:  issue.ID,
 		UserType: targetUserType,
@@ -87,7 +93,6 @@ func (h *Handler) SubscribeToIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workspaceID := uuidToString(issue.WorkspaceID)
 	callerID := requestUserID(r)
 	subActorType, subActorID := h.resolveActor(r, callerID, workspaceID)
 	h.publish(protocol.EventSubscriberAdded, workspaceID, subActorType, subActorID, map[string]any{
@@ -125,6 +130,12 @@ func (h *Handler) UnsubscribeFromIssue(w http.ResponseWriter, r *http.Request) {
 		targetUserType = *req.UserType
 	}
 
+	workspaceID := uuidToString(issue.WorkspaceID)
+	if !h.isWorkspaceEntity(r.Context(), targetUserType, targetUserID, workspaceID) {
+		writeError(w, http.StatusForbidden, "target user is not a member of this workspace")
+		return
+	}
+
 	err := h.Queries.RemoveIssueSubscriber(r.Context(), db.RemoveIssueSubscriberParams{
 		IssueID:  issue.ID,
 		UserType: targetUserType,
@@ -135,7 +146,6 @@ func (h *Handler) UnsubscribeFromIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	workspaceID := uuidToString(issue.WorkspaceID)
 	callerID := requestUserID(r)
 	unsubActorType, unsubActorID := h.resolveActor(r, callerID, workspaceID)
 	h.publish(protocol.EventSubscriberRemoved, workspaceID, unsubActorType, unsubActorID, map[string]any{

--- a/server/internal/handler/subscriber_test.go
+++ b/server/internal/handler/subscriber_test.go
@@ -174,6 +174,52 @@ func TestSubscriberAPI(t *testing.T) {
 		}
 	})
 
+	t.Run("SubscribeCrossWorkspaceUser", func(t *testing.T) {
+		issueID := createIssue(t)
+		defer deleteIssue(t, issueID)
+
+		foreignUserID := "00000000-0000-0000-0000-000000000099"
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues/"+issueID+"/subscribe", map[string]any{
+			"user_id":   foreignUserID,
+			"user_type": "member",
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.SubscribeToIssue(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("SubscribeToIssue with cross-workspace user: expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+
+		subscribed, err := testHandler.Queries.IsIssueSubscriber(ctx, db.IsIssueSubscriberParams{
+			IssueID:  parseUUID(issueID),
+			UserType: "member",
+			UserID:   parseUUID(foreignUserID),
+		})
+		if err != nil {
+			t.Fatalf("IsIssueSubscriber: %v", err)
+		}
+		if subscribed {
+			t.Fatal("cross-workspace user should NOT be subscribed in DB")
+		}
+	})
+
+	t.Run("UnsubscribeCrossWorkspaceUser", func(t *testing.T) {
+		issueID := createIssue(t)
+		defer deleteIssue(t, issueID)
+
+		foreignUserID := "00000000-0000-0000-0000-000000000099"
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues/"+issueID+"/unsubscribe", map[string]any{
+			"user_id":   foreignUserID,
+			"user_type": "member",
+		})
+		req = withURLParam(req, "id", issueID)
+		testHandler.UnsubscribeFromIssue(w, req)
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("UnsubscribeFromIssue with cross-workspace user: expected 403, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
 	t.Run("ListAfterUnsubscribe", func(t *testing.T) {
 		issueID := createIssue(t)
 		defer deleteIssue(t, issueID)


### PR DESCRIPTION
## Summary

Fixes two medium-severity findings from the security audit (MED-1, MED-2):

- **MED-1 — Cross-workspace subscription injection**: `SubscribeToIssue` and `UnsubscribeFromIssue` now validate that the target `user_id` belongs to the issue's workspace (as member or agent) before allowing the operation. Previously, any workspace member could subscribe arbitrary external user IDs.
- **MED-2 — File upload missing workspace member check**: `UploadFile` now verifies the caller is a member of the workspace specified in the request before creating attachment records. The route sits outside `RequireWorkspaceMember` middleware (to support avatar uploads without workspace context), so the check is done inline when `workspaceID` is present.

Resolves [MUL-581](mention://issue/0b53e168-43fd-43aa-842d-de07a18b1c4a)

## Changes

- `handler.go`: Added `isWorkspaceEntity()` helper that validates a user ID belongs to a workspace (dispatches to member lookup or agent-in-workspace lookup based on `userType`)
- `subscriber.go`: Both `SubscribeToIssue` and `UnsubscribeFromIssue` call `isWorkspaceEntity` before proceeding
- `file.go`: `UploadFile` calls `getWorkspaceMember` at the start of the workspace-scoped branch

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/handler/` passes
- [ ] Manual test: subscribe with a cross-workspace user_id → expect 403
- [ ] Manual test: upload file with a foreign workspace_id → expect 403
- [ ] Manual test: normal subscribe/unsubscribe/upload flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)