### PR TITLE
fix(server): cancel active tasks when issue status changes to cancelled

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1122,6 +1122,13 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Cancel active tasks when the issue is cancelled by a user.
+	// This is distinct from agent-managed status transitions — cancellation
+	// is a user-initiated terminal action that should stop execution.
+	if statusChanged && issue.Status == "cancelled" {
+		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
+	}
+
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -1409,6 +1416,11 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			if h.shouldEnqueueAgentTask(r.Context(), issue) {
 				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
 			}
+		}
+
+		// Cancel active tasks when the issue is cancelled by a user.
+		if statusChanged && issue.Status == "cancelled" {
+			h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 		}
 
 		updated++


### PR DESCRIPTION
## Summary
- When a user changes an issue's status to `cancelled`, active agent tasks for that issue are now automatically cancelled
- Added cancellation check in both `UpdateIssue()` and `BatchUpdateIssues()` handlers
- The existing daemon polling mechanism picks up the cancellation within 5 seconds — no daemon changes needed

Closes #926

## Test plan
- [x] Go build passes
- [x] Handler tests pass
- [ ] Manual: assign an agent to an issue, wait for task to start, cancel the issue — task should stop within ~5s