### PR TITLE
fix(daemon): use runtime's owner_id for agent migration on upgrade

### DIFF
--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -125,38 +125,6 @@ func gcRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bus) {
 	}
 }
 
-// gcRuntimes deletes offline runtimes that have exceeded the TTL and have
-// no active (non-archived) agents. Before deleting, it cleans up any
-// archived agents so the FK constraint (ON DELETE RESTRICT) doesn't block.
-func gcRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bus) {
-	deleted, err := queries.DeleteStaleOfflineRuntimes(ctx, offlineRuntimeTTLSeconds)
-	if err != nil {
-		slog.Warn("runtime GC: failed to delete stale offline runtimes", "error", err)
-		return
-	}
-	if len(deleted) == 0 {
-		return
-	}
-
-	gcWorkspaces := make(map[string]bool)
-	for _, row := range deleted {
-		gcWorkspaces[util.UUIDToString(row.WorkspaceID)] = true
-	}
-
-	slog.Info("runtime GC: deleted stale offline runtimes", "count", len(deleted), "workspaces", len(gcWorkspaces))
-
-	for wsID := range gcWorkspaces {
-		bus.Publish(events.Event{
-			Type:        protocol.EventDaemonRegister,
-			WorkspaceID: wsID,
-			ActorType:   "system",
-			Payload: map[string]any{
-				"action": "runtime_gc",
-			},
-		})
-	}
-}
-
 // sweepStaleTasks fails tasks stuck in dispatched/running for too long,
 // even when the runtime is still online. This handles cases where:
 // - The agent process hangs and the daemon is still heartbeating

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -91,6 +91,43 @@ func sweepStaleRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bu
 			},
 		})
 	}
+
+	// GC: delete offline runtimes that have been stale beyond the TTL and
+	// have no active agents. This cleans up orphaned runtimes left behind
+	// by profile switches or uninstalled daemons.
+	gcRuntimes(ctx, queries, bus)
+}
+
+// gcRuntimes deletes offline runtimes that have exceeded the TTL and have
+// no active (non-archived) agents. Before deleting, it cleans up any
+// archived agents so the FK constraint (ON DELETE RESTRICT) doesn't block.
+func gcRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bus) {
+	deleted, err := queries.DeleteStaleOfflineRuntimes(ctx, offlineRuntimeTTLSeconds)
+	if err != nil {
+		slog.Warn("runtime GC: failed to delete stale offline runtimes", "error", err)
+		return
+	}
+	if len(deleted) == 0 {
+		return
+	}
+
+	gcWorkspaces := make(map[string]bool)
+	for _, row := range deleted {
+		gcWorkspaces[util.UUIDToString(row.WorkspaceID)] = true
+	}
+
+	slog.Info("runtime GC: deleted stale offline runtimes", "count", len(deleted), "workspaces", len(gcWorkspaces))
+
+	for wsID := range gcWorkspaces {
+		bus.Publish(events.Event{
+			Type:        protocol.EventDaemonRegister,
+			WorkspaceID: wsID,
+			ActorType:   "system",
+			Payload: map[string]any{
+				"action": "runtime_gc",
+			},
+		})
+	}
 }
 
 // gcRuntimes deletes offline runtimes that have exceeded the TTL and have

--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -91,11 +91,6 @@ func sweepStaleRuntimes(ctx context.Context, queries *db.Queries, bus *events.Bu
 			},
 		})
 	}
-
-	// GC: delete offline runtimes that have been stale beyond the TTL and
-	// have no active agents. This cleans up orphaned runtimes left behind
-	// by profile switches or uninstalled daemons.
-	gcRuntimes(ctx, queries, bus)
 }
 
 // gcRuntimes deletes offline runtimes that have exceeded the TTL and have

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -219,15 +219,17 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Migrate agents from old offline runtimes on the same machine to the
-		// newly registered runtime. Scoped by daemon_id prefix so that only
-		// old profile-suffixed runtimes (e.g. "hostname-staging") from this
-		// machine are affected — runtimes from other machines are untouched.
-		if ownerID.Valid {
+		// newly registered runtime. Uses the runtime's owner_id (preserved via
+		// COALESCE on upsert) so migration works with both PAT and daemon tokens.
+		// Scoped by daemon_id prefix so that only old profile-suffixed runtimes
+		// (e.g. "hostname-staging") from this machine are affected.
+		effectiveOwnerID := registered.OwnerID
+		if effectiveOwnerID.Valid {
 			migrated, err := h.Queries.MigrateAgentsToRuntime(r.Context(), db.MigrateAgentsToRuntimeParams{
 				NewRuntimeID:   registered.ID,
 				WorkspaceID:    parseUUID(req.WorkspaceID),
 				Provider:       provider,
-				OwnerID:        ownerID,
+				OwnerID:        effectiveOwnerID,
 				DaemonIDPrefix: strToText(req.DaemonID),
 			})
 			if err != nil {


### PR DESCRIPTION
## Summary
- Agent migration during `DaemonRegister` was gated on `ownerID.Valid`, which is only true for PAT/JWT auth. Daemon tokens (the common case for background daemon restarts/upgrades) had `ownerID` as zero — **migration was completely skipped**.
- Fix: use `registered.OwnerID` (preserved via COALESCE on upsert) instead of the caller's `ownerID`. This ensures migration runs for daemon token registrations too.

This is why upgrading from old daemon (daemon_id `hostname-staging`) to new daemon (daemon_id `hostname`) left agents stuck on the old offline runtime — the migration query existed but was never executed.

Closes MUL-695

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./internal/handler/ ./cmd/server/` passes
- [x] `make build` succeeds
- [ ] Manual: upgrade daemon from old version → verify agents auto-migrate to new runtime