### PR TITLE
fix(cli): fix Windows login requiring two attempts

### DIFF
--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -79,7 +79,7 @@ func openBrowser(url string) error {
 		args = []string{url}
 	case "windows":
 		cmd = "cmd"
-		args = []string{"/c", "start", url}
+		args = []string{"/c", "start", "", url}
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}


### PR DESCRIPTION
## Summary

- Fix `multica setup` / `multica login` requiring two login attempts on Windows
- Root cause: `cmd /c start <url>` treats `&` in the login URL as a shell command separator, truncating the URL at `&cli_state=...` and causing OAuth state validation to fail silently
- Fix: add empty title arg (`""`) before the URL — standard Windows `start` workaround for URLs with special characters

Fixes MUL-755

## Test plan

- [ ] On Windows, run `multica setup` and verify browser opens with the full login URL (including `cli_state` parameter)
- [ ] Verify login succeeds on the first attempt without needing to retry
- [ ] Verify macOS and Linux login still work (unchanged code paths)