### PR TITLE
feat(views): add "Go to end" button for long issue conversations

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -347,6 +347,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const [propertiesOpen, setPropertiesOpen] = useState(true);
   const [detailsOpen, setDetailsOpen] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [showGoToEnd, setShowGoToEnd] = useState(false);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const didHighlightRef = useRef<string | null>(null);
   const [parentPickerOpen, setParentPickerOpen] = useState(false);
@@ -898,7 +899,15 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
           </div>
 
         {/* Content — scrollable */}
-        <div ref={scrollContainerRef} className="relative flex-1 overflow-y-auto">
+        <div
+          ref={scrollContainerRef}
+          className="relative flex-1 overflow-y-auto"
+          onScroll={() => {
+            const el = scrollContainerRef.current;
+            if (!el) return;
+            setShowGoToEnd(el.scrollHeight - el.scrollTop - el.clientHeight > 200);
+          }}
+        >
         <div className="mx-auto w-full max-w-4xl px-8 py-8">
           <TitleEditor
             key={`title-${id}`}
@@ -1329,6 +1338,23 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
             </div>
           </div>
         </div>
+
+          {showGoToEnd && (
+            <div className="sticky bottom-4 z-10 flex justify-center pointer-events-none">
+              <button
+                onClick={() => {
+                  const el = scrollContainerRef.current;
+                  if (el) {
+                    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+                  }
+                }}
+                className="pointer-events-auto flex items-center gap-1 rounded-full bg-background border shadow-md px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ArrowDown className="h-3 w-3" />
+                Go to end
+              </button>
+            </div>
+          )}
         </div>
       </div>
       </ResizablePanel>


### PR DESCRIPTION
## What does this PR do?

Add a floating "Go to end" button on the issue detail page for long conversation threads.

When an issue has many comments, users must manually scroll all the way down to see the latest messages and leave new comments. This adds a small floating button that appears when the scroll position is far from the bottom (>200px), allowing one-click smooth scroll to the end.

The implementation follows the same scroll-detection pattern already used in `agent-live-card.tsx` for the "Latest" button.

## Related Issue

Closes #594

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/issues/components/issue-detail.tsx`: Added `ArrowDown` icon import, `showGoToEnd` state, `onScroll` handler on the main scroll container, and a sticky floating "Go to end" button that appears when scrolled away from bottom.

## How to Test

1. Open any issue with 10+ comments (or create one and add multiple comments)
2. Scroll up so the latest comments are out of view
3. Observe the "Go to end" button appears at the bottom center
4. Click the button — page smoothly scrolls to the latest comment
5. Once at the bottom, the button disappears

## Checklist

- [x] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:**
Explored the existing scroll-to-bottom pattern in `agent-live-card.tsx` and applied the same approach to the issue detail page's main scroll container.


## Screenshots (optional)
<img width="1902" height="952" alt="image" src="https://github.com/user-attachments/assets/af081c13-e622-411f-80ee-e07a48ec49fb" />
