### PR TITLE
fix(issues): update UI immediately when parent/sub-issue changes

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -168,9 +168,18 @@ export function useUpdateIssue() {
     onSettled: (_data, _err, vars, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.detail(wsId, vars.id) });
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
+      // Invalidate old parent's children cache
       if (ctx?.parentId) {
         qc.invalidateQueries({
           queryKey: issueKeys.children(wsId, ctx.parentId),
+        });
+        qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+      }
+      // Invalidate new parent's children cache when parent_issue_id changed
+      const newParentId = vars.parent_issue_id;
+      if (newParentId && newParentId !== ctx?.parentId) {
+        qc.invalidateQueries({
+          queryKey: issueKeys.children(wsId, newParentId),
         });
         qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
       }

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -29,16 +29,19 @@ export function onIssueUpdated(
   wsId: string,
   issue: Partial<Issue> & { id: string },
 ) {
-  // Look up the parent before mutating list state, so we can also keep the
-  // parent's children cache in sync (powers the sub-issues list shown on
-  // the parent issue page).
+  // Look up the OLD parent before mutating list state, so we can keep
+  // the parent's children cache in sync (powers the sub-issues list
+  // shown on the parent issue page).
   const listData = qc.getQueryData<ListIssuesResponse>(issueKeys.list(wsId));
   const detailData = qc.getQueryData<Issue>(issueKeys.detail(wsId, issue.id));
-  const parentId =
-    issue.parent_issue_id ??
+  const oldParentId =
     detailData?.parent_issue_id ??
     listData?.issues.find((i) => i.id === issue.id)?.parent_issue_id ??
     null;
+  // The NEW parent comes from the WS payload when parent_issue_id changed
+  const newParentId = issue.parent_issue_id ?? null;
+  const parentChanged =
+    issue.parent_issue_id !== undefined && newParentId !== oldParentId;
 
   qc.setQueryData<ListIssuesResponse>(issueKeys.list(wsId), (old) => {
     if (!old) return old;
@@ -63,10 +66,22 @@ export function onIssueUpdated(
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issue.id), (old) =>
     old ? { ...old, ...issue } : old,
   );
-  if (parentId) {
-    qc.setQueryData<Issue[]>(issueKeys.children(wsId, parentId), (old) =>
-      old?.map((c) => (c.id === issue.id ? { ...c, ...issue } : c)),
-    );
+
+  // Invalidate old parent's children (issue was removed from it)
+  if (oldParentId) {
+    if (parentChanged) {
+      qc.invalidateQueries({ queryKey: issueKeys.children(wsId, oldParentId) });
+    } else {
+      qc.setQueryData<Issue[]>(issueKeys.children(wsId, oldParentId), (old) =>
+        old?.map((c) => (c.id === issue.id ? { ...c, ...issue } : c)),
+      );
+    }
+  }
+  // Invalidate new parent's children (issue was added to it)
+  if (newParentId && parentChanged) {
+    qc.invalidateQueries({ queryKey: issueKeys.children(wsId, newParentId) });
+  }
+  if (oldParentId || newParentId) {
     if (issue.status !== undefined || issue.parent_issue_id !== undefined) {
       qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
     }


### PR DESCRIPTION
## Summary
- Fixed cache invalidation when `parent_issue_id` changes — both the mutation (`useUpdateIssue`) and WebSocket handler (`onIssueUpdated`) only invalidated the OLD parent's children query, not the NEW parent's
- After this fix, setting a parent or adding a sub-issue updates the UI immediately without requiring a page refresh

## Changes
- **`packages/core/issues/mutations.ts`**: `onSettled` now also invalidates the new parent's children cache when `parent_issue_id` differs from the old parent
- **`packages/core/issues/ws-updaters.ts`**: `onIssueUpdated` now tracks old vs new parent separately — invalidates both when parent changes (covers CLI/agent updates via WebSocket)

## Test plan
- [ ] Open issue A, click More > "Set parent issue...", select issue B → issue A immediately shows "Sub-issue of B" breadcrumb, issue B immediately shows A in sub-issues
- [ ] Open issue A, click More > "Add sub-issue...", select issue C → issue C immediately appears in A's sub-issues list
- [ ] Have an agent update parent via CLI (`multica issue update <id> --parent <parent-id>`) → UI updates in real-time via WebSocket

Relates to MUL-737