### PR TITLE
fix(server): handle cancel request for already-completed tasks gracefully

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -147,6 +147,13 @@ func (s *TaskService) CancelTasksForIssue(ctx context.Context, issueID pgtype.UU
 // so frontends can update immediately.
 func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.AgentTaskQueue, error) {
 	task, err := s.Queries.CancelAgentTask(ctx, taskID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		existing, err := s.Queries.GetAgentTask(ctx, taskID)
+		if err != nil {
+			return nil, fmt.Errorf("cancel task: %w", err)
+		}
+		return &existing, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("cancel task: %w", err)
 	}


### PR DESCRIPTION
## What does this PR do?
Fix a race condition where clicking "Stop" in the Chat window after a task has already completed returns a 400 error. The `CancelAgentTask` SQL query only matches active statuses (`queued`, `dispatched`, `running`), so completed tasks cause `ErrNoRows`. This change catches that case and returns the current task state with 200 instead of an error.


## Related Issue

Closes #954

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/service/task.go`: In `CancelTask`, check for `pgx.ErrNoRows` and return the existing task state instead of propagating the error.

-

## How to Test

1. Start a chat session and send a message to an agent
2. Wait for the task to complete
3. Before the UI updates, click "Stop" (or call `POST /api/tasks/{id}/cancel` on a completed task)
4. Verify the response is `200` with the current task state, not `400`


Alternatively via curl:
```bash
# Find a completed task ID
psql -c "SELECT id FROM agent_task_queue WHERE status = 'completed' LIMIT 1;"

# Cancel it — should return 200
curl -X POST http://localhost:8080/api/tasks/{taskId}/cancel \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-Workspace-ID: $WS_ID"

## Checklist

- [x] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:**
Found the bug via browser console error during local testing. Traced the call stack from `chat-window.tsx` through `ApiClient.cancelTaskById` to the `CancelAgentTask` SQL query to identify the root cause.

## Screenshots (optional)
