### PR TITLE
fix(issues): include done issues in parent/sub-issue picker

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -229,6 +229,7 @@ function IssuePickerDialog({
           const res = await api.searchIssues({
             q: q.trim(),
             limit: 20,
+            include_closed: true,
             signal: controller.signal,
           });
           if (!controller.signal.aborted) {


### PR DESCRIPTION
## Summary
- Fixed the issue picker dialog not showing done/cancelled issues by adding `include_closed: true` to the search API call

## Context
The `IssuePickerDialog` (used by "Set parent issue..." and "Add sub-issue..." in the More menu) calls `api.searchIssues()` without `include_closed: true`, so any issue with status `done` or `cancelled` was invisible in search results.

## Test plan
- [ ] Open an issue, click More > "Set parent issue..."
- [ ] Search for an issue that has status "done" — it should now appear in results
- [ ] Same for "Add sub-issue..."

Relates to MUL-737