### PR TITLE
fix(views): issue mentions missing status/title after page refresh

### DIFF
--- a/packages/views/editor/extensions/mention-view.tsx
+++ b/packages/views/editor/extensions/mention-view.tsx
@@ -21,7 +21,7 @@
 import { NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
 import { useQuery } from "@tanstack/react-query";
-import { issueListOptions } from "@multica/core/issues/queries";
+import { issueListOptions, issueDetailOptions } from "@multica/core/issues/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useNavigation } from "../../navigation";
 import { StatusIcon } from "../../issues/components/status-icon";
@@ -54,7 +54,14 @@ function IssueMention({
   const wsId = useWorkspaceId();
   const { data: issues = [] } = useQuery(issueListOptions(wsId));
   const { push, openInNewTab } = useNavigation();
-  const issue = issues.find((i) => i.id === issueId);
+  const listIssue = issues.find((i) => i.id === issueId);
+
+  const { data: detailIssue } = useQuery({
+    ...issueDetailOptions(wsId, issueId),
+    enabled: !listIssue,
+  });
+
+  const issue = listIssue ?? detailIssue;
 
   const issuePath = `/issues/${issueId}`;
   const tabTitle = issue ? `${issue.identifier}: ${issue.title}` : undefined;

--- a/packages/views/issues/components/issue-mention-card.tsx
+++ b/packages/views/issues/components/issue-mention-card.tsx
@@ -2,7 +2,7 @@
 
 import { AppLink } from "../../navigation";
 import { useQuery } from "@tanstack/react-query";
-import { issueListOptions } from "@multica/core/issues/queries";
+import { issueListOptions, issueDetailOptions } from "@multica/core/issues/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { StatusIcon } from "./status-icon";
 
@@ -15,7 +15,16 @@ interface IssueMentionCardProps {
 export function IssueMentionCard({ issueId, fallbackLabel }: IssueMentionCardProps) {
   const wsId = useWorkspaceId();
   const { data: issues = [] } = useQuery(issueListOptions(wsId));
-  const issue = issues.find((i) => i.id === issueId);
+  const listIssue = issues.find((i) => i.id === issueId);
+
+  // Fetch individual issue when not found in the list (e.g. done issues beyond
+  // the first page). Only fires when listIssue is undefined.
+  const { data: detailIssue } = useQuery({
+    ...issueDetailOptions(wsId, issueId),
+    enabled: !listIssue,
+  });
+
+  const issue = listIssue ?? detailIssue;
 
   if (!issue) {
     return (


### PR DESCRIPTION
## Summary
- Issue mentions in comments (e.g. `MUL-725`) lost their status icon and title after page refresh, showing only the identifier as fallback text
- Root cause: `IssueMentionCard` and `IssueMention` only looked up issues from `issueListOptions`, which returns open issues + first 50 done issues — older done issues were never found
- Added a fallback `issueDetailOptions` query (enabled only when the issue isn't in the list) to fetch the individual issue, so mentions always render with full data

Fixes MUL-779

## Test plan
- [ ] Create a comment mentioning a done issue that has >50 done issues after it
- [ ] Refresh the page — verify the mention renders with status icon + identifier + title
- [ ] Verify mentions for open issues still render immediately without extra fetch