### PR TITLE
test(cli): cover API client context headers

### DIFF
--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -14,11 +14,8 @@ import (
 )
 
 // APIClient is a REST client for the Multica server API.
-// Used by ctrl subcommands (agent, runtime, status, etc.).
-//
-// TODO: Add Authorization header support. Agent routes (/api/agents/...)
-// require JWT auth via middleware.Auth, but this client currently sends
-// no auth token. CLI agent commands will fail with 401 until this is added.
+// Used by ctrl subcommands (agent, runtime, status, etc.). Requests
+// automatically include auth and execution context headers when configured.
 type APIClient struct {
 	BaseURL     string
 	WorkspaceID string

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -84,10 +84,16 @@ func TestPostJSON(t *testing.T) {
 		}
 	})
 
-	t.Run("workspace header", func(t *testing.T) {
+	t.Run("workspace and agent context headers", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if ws := r.Header.Get("X-Workspace-ID"); ws != "ws-abc" {
 				t.Errorf("expected X-Workspace-ID ws-abc, got %s", ws)
+			}
+			if agent := r.Header.Get("X-Agent-ID"); agent != "agent-123" {
+				t.Errorf("expected X-Agent-ID agent-123, got %s", agent)
+			}
+			if task := r.Header.Get("X-Task-ID"); task != "task-456" {
+				t.Errorf("expected X-Task-ID task-456, got %s", task)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(respBody{ID: "456"})
@@ -95,6 +101,8 @@ func TestPostJSON(t *testing.T) {
 		defer srv.Close()
 
 		client := NewAPIClient(srv.URL, "ws-abc", "test-token")
+		client.AgentID = "agent-123"
+		client.TaskID = "task-456"
 		var out respBody
 		err := client.PostJSON(context.Background(), "/test", reqBody{}, &out)
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

Removes a stale comment in the CLI API client and extends the existing client test to cover execution context headers.

`server/internal/cli/client.go` already sends the `Authorization` header via `setHeaders`, so the existing TODO claiming auth support was missing was no longer accurate. This PR keeps behavior unchanged and updates the test to verify that workspace, agent, and task context headers are forwarded as expected.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- removed the stale auth TODO from `server/internal/cli/client.go`
- updated `server/internal/cli/client_test.go` to extend the existing `PostJSON` test coverage for:
  - `X-Workspace-ID`
  - `X-Agent-ID`
  - `X-Task-ID`

## How to Test

1. Check out this branch
2. Run `cd server && go test ./internal/cli/...`
3. Confirm the test suite passes

## Checklist

- [x] I searched for [existing PRs](https://github.com/multica-ai/multica/pulls) to make sure this isn't a duplicate
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] `make check` passes (typecheck, unit tests, Go tests, E2E)
- [x] Changes follow existing code patterns and conventions
- [x] No unrelated changes included

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
I used Codex to inspect the CLI client call chain, confirm that the auth TODO was stale, and make a minimal change limited to the client comment plus a small extension to the existing test case.

## Screenshots (optional)
