### PR TITLE
fix(editor): avoid accessing editor.view during initial render in link preview

### DIFF
--- a/packages/views/editor/link-preview.tsx
+++ b/packages/views/editor/link-preview.tsx
@@ -156,9 +156,10 @@ function EditorLinkPreview({ editor }: { editor: Editor }) {
 
   const close = useCallback(() => setVisible(false), []);
 
+  // Avoid accessing editor.view during initial render — it may not be mounted yet.
   const virtualRef = useRef({
     getBoundingClientRect: () => new DOMRect(),
-    contextElement: editor.view?.dom,
+    contextElement: undefined as Element | undefined,
   });
 
   const { refs, floatingStyles, isPositioned, update } = useFloating({


### PR DESCRIPTION
## Summary
- Fix crash: `The editor view is not available. Cannot access view['dom']` in `EditorLinkPreview`
- Root cause: `useRef` initializer accessed `editor.view?.dom` during component mount, before Tiptap's editor view is ready (Tiptap uses a Proxy that throws on premature access)
- Fix: initialize `contextElement` as `undefined`, it gets set correctly in the `selectionUpdate` callback where the view is guaranteed to exist

## Context
Introduced in 6a451c1c (`fix(editor): rewrite bubble menu and link preview with useFloating`)

## Test plan
- [x] Navigate to an issue with links in description — no crash
- [x] Hover/click links — link preview still works correctly
- [x] Typecheck passes