### PR TITLE
docs: add v0.1.33 changelog (2026-04-14)

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -280,12 +280,11 @@ export const en: LandingDict = {
       {
         version: "0.1.33",
         date: "2026-04-14",
-        title: "Gemini CLI, Agent Env Vars & Desktop Auto-Update",
+        title: "Gemini CLI & Agent Env Vars",
         changes: [],
         features: [
           "Google Gemini CLI as a new agent runtime with live log streaming",
           "Custom environment variables for agents (router/proxy mode) with dedicated settings tab",
-          "Desktop app auto-update via GitHub Releases",
           "\"Set parent issue\" and \"Add sub-issue\" actions in issue context menu",
           "CLI `--parent` flag for issue update and `--content-stdin` for piping comment content",
           "Sub-issues inherit parent project automatically",

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -278,6 +278,33 @@ export const en: LandingDict = {
     },
     entries: [
       {
+        version: "0.1.33",
+        date: "2026-04-14",
+        title: "Gemini CLI, Agent Env Vars & Desktop Auto-Update",
+        changes: [],
+        features: [
+          "Google Gemini CLI as a new agent runtime with live log streaming",
+          "Custom environment variables for agents (router/proxy mode) with dedicated settings tab",
+          "Desktop app auto-update via GitHub Releases",
+          "\"Set parent issue\" and \"Add sub-issue\" actions in issue context menu",
+          "CLI `--parent` flag for issue update and `--content-stdin` for piping comment content",
+          "Sub-issues inherit parent project automatically",
+        ],
+        improvements: [
+          "Editor bubble menu and link preview rewritten for reliability",
+          "OpenClaw backend P0+P1 improvements (multi-line JSON, incremental parsing)",
+          "Self-hosted WebSocket URL auto-derived for LAN access",
+        ],
+        fixes: [
+          "S3 upload keys scoped by workspace (security)",
+          "Workspace membership validation for subscriptions and uploads (security)",
+          "Active tasks auto-cancelled when issue status changes to cancelled",
+          "Agent task stall when process hangs on stdout",
+          "Daemon trigger prompt now embeds the actual triggering comment content",
+          "Login and dashboard redirect stability improvements",
+        ],
+      },
+      {
         version: "0.1.28",
         date: "2026-04-13",
         title: "Windows Support, Auth & Onboarding",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -280,12 +280,11 @@ export const zh: LandingDict = {
       {
         version: "0.1.33",
         date: "2026-04-14",
-        title: "Gemini CLI、Agent 环境变量与桌面自动更新",
+        title: "Gemini CLI 与 Agent 环境变量",
         changes: [],
         features: [
           "Google Gemini CLI 作为新的 Agent 运行时，支持实时日志流",
           "Agent 自定义环境变量（router/proxy 模式），新增专用设置标签页",
-          "桌面应用通过 GitHub Releases 自动更新",
           "Issue 右键菜单新增「设置父 Issue」和「添加子 Issue」",
           "CLI `--parent` 更新父 Issue，`--content-stdin` 管道输入评论内容",
           "子 Issue 自动继承父级项目",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -278,6 +278,33 @@ export const zh: LandingDict = {
     },
     entries: [
       {
+        version: "0.1.33",
+        date: "2026-04-14",
+        title: "Gemini CLI、Agent 环境变量与桌面自动更新",
+        changes: [],
+        features: [
+          "Google Gemini CLI 作为新的 Agent 运行时，支持实时日志流",
+          "Agent 自定义环境变量（router/proxy 模式），新增专用设置标签页",
+          "桌面应用通过 GitHub Releases 自动更新",
+          "Issue 右键菜单新增「设置父 Issue」和「添加子 Issue」",
+          "CLI `--parent` 更新父 Issue，`--content-stdin` 管道输入评论内容",
+          "子 Issue 自动继承父级项目",
+        ],
+        improvements: [
+          "编辑器气泡菜单和链接预览重写",
+          "OpenClaw 后端 P0+P1 优化（多行 JSON、增量解析）",
+          "自部署 WebSocket URL 自动适配局域网访问",
+        ],
+        fixes: [
+          "S3 上传路径按工作区隔离（安全）",
+          "订阅和上传新增工作区成员身份校验（安全）",
+          "Issue 状态改为已取消时自动终止进行中的任务",
+          "Agent 进程 stdout 挂起导致任务卡住",
+          "Daemon 触发提示现在嵌入实际的触发评论内容",
+          "登录和仪表盘跳转稳定性改进",
+        ],
+      },
+      {
         version: "0.1.28",
         date: "2026-04-13",
         title: "Windows 支持、认证与引导",


### PR DESCRIPTION
## Summary
- Add v0.1.33 changelog covering all changes since v0.1.28
- Key: Gemini CLI runtime, agent custom env vars, desktop auto-update, parent/sub-issue management, security fixes
- Both en and zh updated