### PR TITLE
fix: clarify local vs workspace skills to reduce user confusion

### DIFF
--- a/apps/docs/content/docs/guides/agents.mdx
+++ b/apps/docs/content/docs/guides/agents.mdx
@@ -36,14 +36,19 @@ The daemon auto-detects which CLIs are available on your PATH and registers them
 
 ## Reusable Skills
 
-Every solution an agent creates can become a reusable skill for the whole team. Skills compound your team's capabilities over time:
+Multica supports two layers of skills:
+
+- **Local skills** — Skills already installed in your local runtime (e.g., `.claude/skills/`, `.config/opencode/skills/`) are automatically discovered and used by agents. You do **not** need to upload them to Multica.
+- **Workspace skills** — Skills created or imported in the Multica Skills page are shared across the workspace. They are automatically injected into agent runs as supplementary context, so every team member's agents benefit from them.
+
+Workspace skills are designed for team-wide sharing and collaboration — codify your team's best practices once, and every agent can leverage them:
 
 - Deployments
 - Migrations
 - Code reviews
 - Common patterns
 
-Skills are shared across the workspace, so any agent (or human) can leverage them.
+Your skill library compounds over time. Local skills give individual agents their capabilities; workspace skills align the entire team.
 
 ## Multi-Workspace Support
 

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -65,7 +65,7 @@ export function SkillsTab({
         <div>
           <h3 className="text-sm font-semibold">Skills</h3>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Reusable skills assigned to this agent. Manage skills on the Skills page.
+            Workspace skills assigned to this agent. Local runtime skills are always available automatically.
           </p>
         </div>
         <Button
@@ -84,7 +84,7 @@ export function SkillsTab({
           <FileText className="h-8 w-8 text-muted-foreground/40" />
           <p className="mt-3 text-sm text-muted-foreground">No skills assigned</p>
           <p className="mt-1 text-xs text-muted-foreground">
-            Add skills from the workspace to this agent.
+            Add workspace skills to share team knowledge with this agent. Local skills are already used automatically.
           </p>
           {availableSkills.length > 0 && (
             <Button

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, FileText, Trash2 } from "lucide-react";
+import { Plus, FileText, Trash2, Info } from "lucide-react";
 import type { Agent } from "@multica/core/types";
 import {
   Dialog,
@@ -65,7 +65,7 @@ export function SkillsTab({
         <div>
           <h3 className="text-sm font-semibold">Skills</h3>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Workspace skills assigned to this agent. Local runtime skills are always available automatically.
+            Workspace skills assigned to this agent.
           </p>
         </div>
         <Button
@@ -77,6 +77,13 @@ export function SkillsTab({
           <Plus className="h-3 w-3" />
           Add Skill
         </Button>
+      </div>
+
+      <div className="flex items-start gap-2 rounded-md border border-info/20 bg-info/5 px-3 py-2.5">
+        <Info className="h-3.5 w-3.5 shrink-0 text-info mt-0.5" />
+        <p className="text-xs text-muted-foreground">
+          Local runtime skills (from your CLI&apos;s skills directory) are always available automatically — no need to add them here.
+        </p>
       </div>
 
       {agent.skills.length === 0 ? (

--- a/packages/views/onboarding/step-complete.tsx
+++ b/packages/views/onboarding/step-complete.tsx
@@ -59,6 +59,8 @@ function getOnboardingIssues(): OnboardingIssueDef[] {
       description: [
         "Skills are reusable instructions that make agents better at recurring tasks — deployments, code reviews, migrations, etc.",
         "",
+        "**Note:** Skills already installed in your local runtime (e.g., `.claude/skills/`) are automatically available to agents — no need to re-upload them. Workspace skills here are for sharing knowledge across your team.",
+        "",
         "**Steps:**",
         "1. Go to **Skills** in the sidebar",
         "2. Click **New Skill**",

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -96,9 +96,9 @@ function CreateSkillDialog({
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Add Skill</DialogTitle>
+          <DialogTitle>Add Workspace Skill</DialogTitle>
           <DialogDescription>
-            Create a new skill or import from ClawHub / Skills.sh.
+            Create a new skill or import from ClawHub / Skills.sh. Workspace skills are shared with your team and automatically injected into agent runs.
           </DialogDescription>
         </DialogHeader>
 
@@ -744,9 +744,9 @@ export default function SkillsPage() {
           {skills.length === 0 ? (
             <div className="flex flex-col items-center justify-center px-4 py-12">
               <Sparkles className="h-8 w-8 text-muted-foreground/40" />
-              <p className="mt-3 text-sm text-muted-foreground">No skills yet</p>
-              <p className="mt-1 text-xs text-muted-foreground text-center">
-                Skills define reusable instructions for agents.
+              <p className="mt-3 text-sm text-muted-foreground">No workspace skills yet</p>
+              <p className="mt-1 text-xs text-muted-foreground text-center max-w-[280px]">
+                Workspace skills are shared across your team and injected into agent runs. Skills already installed in your local runtime are used automatically.
               </p>
               <Button
                 onClick={() => setShowCreate(true)}
@@ -788,6 +788,9 @@ export default function SkillsPage() {
             <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
               <Sparkles className="h-10 w-10 text-muted-foreground/30" />
               <p className="mt-3 text-sm">Select a skill to view details</p>
+              <p className="mt-1 text-xs text-center max-w-[260px]">
+                Workspace skills supplement your local skills and are shared across the team.
+              </p>
               <Button
                 onClick={() => setShowCreate(true)}
                 size="xs"


### PR DESCRIPTION
## Summary
- Updated UI copy across skills page, agent skills tab, onboarding, and docs to clearly distinguish **local skills** (auto-discovered from runtime, e.g. `.claude/skills/`) from **workspace skills** (shared across the team via Multica)
- Users were confused that they needed to re-upload locally installed skills — this makes it explicit that local skills already work automatically
- Workspace skills are positioned as a team collaboration feature, not a requirement for agent functionality

Closes #972

## Test plan
- [x] Visit Skills page with no workspace skills — verify empty state explains both local and workspace skills
- [x] Open Create Skill dialog — verify description mentions workspace sharing
- [x] Check Agent → Skills tab — verify help text mentions local skills auto-discovery
- [ ] Review onboarding task text for skill creation
- [x] Review docs at /docs/guides/agents for updated skills section