### PR TITLE
fix(cli): use localhost for CLI callback when app URL is a public hostname

### DIFF
--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -99,13 +99,16 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	appURL := resolveAppURL(cmd)
 
 	// Determine the callback host from the configured app URL.
-	// For self-hosted setups where the browser is on a different machine,
-	// we need to use the server's reachable hostname instead of localhost.
+	// For self-hosted setups where the browser is on a different machine
+	// (e.g. Multica running on a LAN server), use the server's private IP
+	// so the browser can reach the CLI's local HTTP server.
+	// For production (public hostnames like multica.ai), keep localhost —
+	// the browser and CLI are on the same machine.
 	callbackHost := "localhost"
 	bindAddr := "127.0.0.1"
 	if parsed, err := url.Parse(appURL); err == nil {
 		h := parsed.Hostname()
-		if h != "" && h != "localhost" && h != "127.0.0.1" {
+		if ip := net.ParseIP(h); ip != nil && ip.IsPrivate() {
 			callbackHost = h
 			bindAddr = "0.0.0.0"
 		}


### PR DESCRIPTION
## Summary

- Fixes `multica login` failing to authorize when browser is already logged in (#974)
- The CLI was using the app URL hostname (e.g. `multica.ai`) as the callback host, producing `http://multica.ai:PORT/callback`
- This URL fails frontend validation (only localhost/private IPs allowed) and can't reach the CLI's local server anyway
- Now only RFC 1918 private IPs are used as callback host (for self-hosted LAN setups); public hostnames fall back to `localhost`

## Test plan

- [ ] Run `multica login` against production (`multica.ai`) — callback URL should use `localhost`
- [ ] Run `multica login` against a self-hosted server on a private IP (e.g. `http://192.168.1.100:3000`) — callback URL should use the private IP
- [ ] Verify that when already logged in, the browser shows the "Authorize CLI" screen instead of the email login form