### PR TITLE
fix(web): proxy /uploads/* to backend in next.config rewrites

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -45,6 +45,10 @@ const nextConfig: NextConfig = {
         source: "/auth/:path*",
         destination: `${remoteApiUrl}/auth/:path*`,
       },
+      {
+        source: "/uploads/:path*",
+        destination: `${remoteApiUrl}/uploads/:path*`,
+      },
     ];
   },
 };


### PR DESCRIPTION
## What does this PR do?

Adds a missing Next.js rewrite rule so that `/uploads/*` requests from the web app are proxied to the backend.

On self-host deployments, `LocalStorage.URL()` returns relative paths like `/uploads/workspaces/<wsid>/<fileid>.png` (see `server/internal/storage/local.go:90`). The browser requests those through the Next.js app on `:3000`, but `apps/web/next.config.ts` only rewrote `/api/*`, `/ws`, and `/auth/*` to the backend — `/uploads/*` fell through and returned 404. As a result, profile avatars (user and agent) uploaded on self-host never rendered, even though the backend served the files correctly on `:8080`.

Cloud deployments are unaffected: `S3Storage` returns absolute S3/CDN URLs, so the browser fetches those directly and never hits the Next.js server for uploads. This rewrite is a no-op on cloud and only activates on self-host — no environment branching needed, consistent with the existing `/api`, `/ws`, `/auth` rules.

## Related Issue

Closes #

<!-- No pre-existing issue; happy to open one if preferred. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `apps/web/next.config.ts` — added `{ source: "/uploads/:path*", destination: "${remoteApiUrl}/uploads/:path*" }` to the `rewrites()` array.

## How to Test

Reproduction (before fix, on self-host):

1. `docker compose -f server/docker-compose.selfhost.yml up -d`
2. Log in, open profile, upload an avatar image.
3. Observe broken image in the UI. `curl -I http://localhost:3000/uploads/workspaces/<wsid>/<fileid>.png` → `404`, while `curl -I http://localhost:8080/uploads/workspaces/<wsid>/<fileid>.png` → `200`.

Verification (with fix):

1. Rebuild the frontend container:
   ```bash
   docker compose -f server/docker-compose.selfhost.yml build frontend
   docker compose -f server/docker-compose.selfhost.yml up -d frontend
   ```
2. `curl -I http://localhost:3000/uploads/workspaces/<wsid>/<fileid>.png` → `200 OK`.
3. Reload the app; uploaded user/agent avatars render immediately.

## Checklist

- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My commit messages follow Conventional Commits (`fix(web):`)
- [x] Changes follow existing code patterns and conventions (mirrors the `/api`, `/ws`, `/auth` rewrite entries directly above it)
- [x] No unrelated changes included
- [ ] `make check` passes — this change is a Next.js runtime config; not exercised by unit tests. Verified manually via the self-host reproduction above.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Investigated a bug report that profile images 404 on self-host. Traced the request path (browser → Next.js `:3000` → backend `:8080`), confirmed the backend + storage layer + file on disk were all healthy, and narrowed the failure to a missing rewrite in `apps/web/next.config.ts`. Also verified that the cloud path (`S3Storage`) returns absolute URLs and is therefore unaffected, so no environment branching was needed. Used Claude Code to explore the repo, review the fix against `CONTRIBUTING.md` / the PR template, and draft this PR body.