### PR TITLE
fix(views): prevent focus jump on modal close

### DIFF
--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -149,6 +149,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   return (
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
       <DialogContent
+        finalFocus={false}
         showCloseButton={false}
         className={cn(
           "p-0 gap-0 flex flex-col overflow-hidden",

--- a/packages/views/modals/create-workspace.tsx
+++ b/packages/views/modals/create-workspace.tsx
@@ -83,6 +83,7 @@ export function CreateWorkspaceModal({ onClose }: { onClose: () => void }) {
       }}
     >
       <DialogContent
+        finalFocus={false}
         showCloseButton={false}
         className="inset-0 flex h-full w-full max-w-none sm:max-w-none translate-0 flex-col items-center justify-center rounded-none bg-background ring-0 shadow-none"
       >


### PR DESCRIPTION
## Summary
- Add `finalFocus={false}` to `<DialogContent>` in `create-issue.tsx` and `create-workspace.tsx`
- Prevents Base UI from restoring focus to a random button when ESC closes a store-opened modal (no trigger element)
- Focus naturally falls to `document.body`, matching Linear's behavior

Fixes MUL-530

## Test plan
- [ ] Press C to open create issue modal → ESC → verify no button gets focus ring
- [ ] Click "New Issue" button → ESC → verify same
- [ ] Open create workspace modal → ESC → verify same

🤖 Generated with [Claude Code](https://claude.com/claude-code)