### PR TITLE
fix(docs): use light theme for Star History chart in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow, worktr
 
 <a href="https://www.star-history.com/?repos=multica-ai%2Fmultica&type=date&legend=bottom-right">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=multica-ai/multica&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=multica-ai/multica&type=date&legend=top-left" />
     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=multica-ai/multica&type=date&legend=top-left" />
     <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=multica-ai/multica&type=date&legend=top-left" />
   </picture>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Turn coding agents into real teammates — assign tasks, track progress, compoun
 [![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
 
+<a href="https://trendshift.io/repositories/24695" target="_blank"><img src="https://trendshift.io/api/badge/repositories/24695" alt="multica-ai/multica | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
 [Website](https://multica.ai) · [Cloud](https://multica.ai/app) · [X](https://x.com/MulticaAI) · [Self-Hosting](SELF_HOSTING.md) · [Contributing](CONTRIBUTING.md)
 
 **English | [简体中文](README.zh-CN.md)**

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Turn coding agents into real teammates — assign tasks, track progress, compoun
 [![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
 
-<a href="https://trendshift.io/repositories/24695" target="_blank"><img src="https://trendshift.io/api/badge/repositories/24695" alt="multica-ai/multica | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-
 [Website](https://multica.ai) · [Cloud](https://multica.ai/app) · [X](https://x.com/MulticaAI) · [Self-Hosting](SELF_HOSTING.md) · [Contributing](CONTRIBUTING.md)
 
 **English | [简体中文](README.zh-CN.md)**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,6 +20,8 @@
 [![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
 
+<a href="https://trendshift.io/repositories/24695" target="_blank"><img src="https://trendshift.io/api/badge/repositories/24695" alt="multica-ai/multica | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+
 [官网](https://multica.ai) · [云服务](https://multica.ai/app) · [X](https://x.com/MulticaAI) · [自部署指南](SELF_HOSTING.md) · [参与贡献](CONTRIBUTING.md)
 
 **[English](README.md) | 简体中文**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,7 +177,7 @@ make start
 
 <a href="https://www.star-history.com/?repos=multica-ai%2Fmultica&type=date&legend=bottom-right">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=multica-ai/multica&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=multica-ai/multica&type=date&legend=top-left" />
     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=multica-ai/multica&type=date&legend=top-left" />
     <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=multica-ai/multica&type=date&legend=top-left" />
   </picture>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,8 +20,6 @@
 [![CI](https://github.com/multica-ai/multica/actions/workflows/ci.yml/badge.svg)](https://github.com/multica-ai/multica/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/multica-ai/multica?style=flat)](https://github.com/multica-ai/multica/stargazers)
 
-<a href="https://trendshift.io/repositories/24695" target="_blank"><img src="https://trendshift.io/api/badge/repositories/24695" alt="multica-ai/multica | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-
 [官网](https://multica.ai) · [云服务](https://multica.ai/app) · [X](https://x.com/MulticaAI) · [自部署指南](SELF_HOSTING.md) · [参与贡献](CONTRIBUTING.md)
 
 **[English](README.md) | 简体中文**


### PR DESCRIPTION
## Summary
- Remove `&theme=dark` from the Star History dark mode `<source>` in both READMEs
- Chart now always renders with a light background regardless of GitHub's color scheme

Fixes the dark background issue introduced in #989.