### PR TITLE
fix(chat): reading-width container + refresh placeholder on agent switch

### DIFF
--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -30,7 +30,15 @@ export function ChatInput({
 }: ChatInputProps) {
   const editorRef = useRef<ContentEditorRef>(null);
   const activeSessionId = useChatStore((s) => s.activeSessionId);
-  const draftKey = activeSessionId ?? DRAFT_NEW_SESSION;
+  const selectedAgentId = useChatStore((s) => s.selectedAgentId);
+  // Scope the new-chat draft by agent:
+  //   1. Switching agents while composing a brand-new chat gives each
+  //      agent its own draft (no cross-agent leakage).
+  //   2. Tiptap's Placeholder extension is only applied at mount; this
+  //      key changes on agent switch so the editor remounts and the
+  //      `Tell {agent} what to do…` placeholder refreshes.
+  const draftKey =
+    activeSessionId ?? `${DRAFT_NEW_SESSION}:${selectedAgentId ?? ""}`;
   // Select a primitive — empty-string fallback keeps referential stability.
   const inputDraft = useChatStore((s) => s.inputDrafts[draftKey] ?? "");
   const setInputDraft = useChatStore((s) => s.setInputDraft);
@@ -65,8 +73,8 @@ export function ChatInput({
       : "Tell me what to do…";
 
   return (
-    <div className="p-2 pt-0">
-      <div className="relative flex min-h-16 max-h-40 flex-col rounded-lg bg-card pb-9 border-1 border-border transition-colors focus-within:border-brand">
+    <div className="px-5 pb-3 pt-0">
+      <div className="relative mx-auto flex min-h-16 max-h-40 w-full max-w-4xl flex-col rounded-lg bg-card pb-9 border-1 border-border transition-colors focus-within:border-brand">
         <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
           <ContentEditor
             // Remount the editor when the active session changes so its

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -75,6 +75,33 @@ export function ChatMessageList({
   );
 }
 
+/**
+ * Placeholder shown while `chat_message` for a session is being fetched
+ * (initial refresh, or switching to an un-cached session). Shape roughly
+ * mirrors an assistant → user → assistant exchange so the window doesn't
+ * shift under the user when real messages arrive.
+ */
+export function ChatMessageSkeleton() {
+  return (
+    <div className="flex-1 overflow-hidden">
+      <div className="mx-auto w-full max-w-4xl px-5 py-4 space-y-5">
+        <div className="space-y-2">
+          <div className="h-3.5 w-3/4 rounded bg-muted animate-pulse" />
+          <div className="h-3.5 w-1/2 rounded bg-muted animate-pulse" />
+        </div>
+        <div className="flex justify-end">
+          <div className="h-8 w-48 rounded-2xl bg-muted animate-pulse" />
+        </div>
+        <div className="space-y-2">
+          <div className="h-3.5 w-2/3 rounded bg-muted animate-pulse" />
+          <div className="h-3.5 w-5/6 rounded bg-muted animate-pulse" />
+          <div className="h-3.5 w-1/3 rounded bg-muted animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function toTimelineItem(m: TaskMessagePayload): ChatTimelineItem {
   return {
     seq: m.seq,

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -53,22 +53,24 @@ export function ChatMessageList({
   const hasLive = showLiveTimeline && liveTimeline.length > 0;
 
   return (
-    <div
-      ref={scrollRef}
-      style={fadeStyle}
-      className="flex-1 overflow-y-auto px-4 py-3 space-y-4"
-    >
-      {messages.map((msg) => (
-        <MessageBubble key={msg.id} message={msg} />
-      ))}
-      {hasLive && (
-        <div className="w-full space-y-1.5">
-          <TimelineView items={liveTimeline} />
-        </div>
-      )}
-      {isWaiting && !hasLive && !pendingAlreadyPersisted && (
-        <Loader2 className="size-4 animate-spin text-muted-foreground" />
-      )}
+    <div ref={scrollRef} style={fadeStyle} className="flex-1 overflow-y-auto">
+      {/* Inner container matches issue / project detail width convention
+       *  (max-w-4xl + mx-auto) so switching between chat and content
+       *  views doesn't jolt the reading width. px-5 is a touch tighter
+       *  than issue-detail's px-8 because the chat window can be narrow. */}
+      <div className="mx-auto w-full max-w-4xl px-5 py-4 space-y-4">
+        {messages.map((msg) => (
+          <MessageBubble key={msg.id} message={msg} />
+        ))}
+        {hasLive && (
+          <div className="w-full space-y-1.5">
+            <TimelineView items={liveTimeline} />
+          </div>
+        )}
+        {isWaiting && !hasLive && !pendingAlreadyPersisted && (
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -29,7 +29,7 @@ import {
 } from "@multica/core/chat/queries";
 import { useCreateChatSession, useMarkChatSessionRead } from "@multica/core/chat/mutations";
 import { useChatStore } from "@multica/core/chat";
-import { ChatMessageList } from "./chat-message-list";
+import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
 import { ChatResizeHandles } from "./chat-resize-handles";
 import { useChatResize } from "./use-chat-resize";
@@ -52,11 +52,15 @@ export function ChatWindow() {
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: sessions = [] } = useQuery(chatSessionsOptions(wsId));
   const { data: allSessions = [] } = useQuery(allChatSessionsOptions(wsId));
-  const { data: rawMessages } = useQuery(
+  const { data: rawMessages, isLoading: messagesLoading } = useQuery(
     chatMessagesOptions(activeSessionId ?? ""),
   );
   // When no active session, always show empty — don't use stale cache
   const messages = activeSessionId ? rawMessages ?? [] : [];
+  // Skeleton only shows for an un-cached session fetch. Cached switches
+  // return data synchronously — no flash. `enabled: false` (new chat)
+  // keeps isLoading false so the starter prompts aren't hidden.
+  const showSkeleton = !!activeSessionId && messagesLoading;
 
   // Server-authoritative pending task. Survives refresh / reopen / session
   // switch because it's keyed on sessionId in the Query cache; WS events
@@ -374,8 +378,10 @@ export function ChatWindow() {
         </div>
       </div>
 
-      {/* Messages or Empty State */}
-      {hasMessages ? (
+      {/* Messages / skeleton / empty state */}
+      {showSkeleton ? (
+        <ChatMessageSkeleton />
+      ) : hasMessages ? (
         <ChatMessageList
           messages={messages}
           pendingTaskId={pendingTaskId}


### PR DESCRIPTION
## Summary

Two targeted fixes on top of the recent chat redesign:

**Reading-width container.** Wrap `ChatMessageList` and `ChatInput` with `mx-auto w-full max-w-4xl px-5` so wide chat windows don't sprawl. Matches the width convention already used by issue-detail and project-detail (they use `max-w-4xl px-8`; chat uses `px-5` because its window can be as narrow as 360px).

**Placeholder refreshes on agent switch.** When a user is composing a brand-new chat and switches agents, the input placeholder used to stay stale (`Tell Coder what to do…` → still shows "Coder" after switching to Writer). Tiptap's Placeholder extension only applies at mount, and `draftKey` was `DRAFT_NEW_SESSION` for every new chat — same key, no remount. Now `draftKey` = `${DRAFT_NEW_SESSION}:${selectedAgentId}` in the new-chat state, so switching agents remounts the editor. Side benefit: each agent keeps its own unsent new-chat draft.

## Test plan

- [ ] Open chat from a fresh state → empty state shows
- [ ] Start composing in the new-chat input with Coder selected
- [ ] Switch agent to Writer → placeholder flips to `Tell Writer what to do…`
- [ ] Switch back to Coder → draft you started with Coder is still there (per-agent drafts)
- [ ] Drag chat window wide (> 900px) → messages and input stay centred at `max-w-4xl`
- [ ] Drag chat window narrow (~ 400px) → content fills; left/right padding is 20px
- [ ] No regressions in existing session switch / draft behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)