### PR TITLE
fix(core): redirect to login when auth token expires during session

### DIFF
--- a/packages/core/platform/core-provider.tsx
+++ b/packages/core/platform/core-provider.tsx
@@ -34,6 +34,10 @@ function initCore(
     onUnauthorized: () => {
       storage.removeItem("multica_token");
       storage.removeItem("multica_workspace_id");
+      // Clear auth state so DashboardGuard redirects to login.
+      // `authStore` is always initialized before any API call can fire.
+      authStore?.setState({ user: null });
+      onLogout?.();
     },
   });
   setApiInstance(api);

--- a/packages/core/query-client.ts
+++ b/packages/core/query-client.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
+import { ApiError } from "./api/client";
 
 export function createQueryClient(): QueryClient {
   return new QueryClient({
@@ -8,7 +9,11 @@ export function createQueryClient(): QueryClient {
         gcTime: 10 * 60 * 1000, // 10 minutes
         refetchOnWindowFocus: false,
         refetchOnReconnect: true,
-        retry: 1,
+        retry: (failureCount, error) => {
+          // Don't retry auth failures — the user needs to re-login.
+          if (error instanceof ApiError && error.status === 401) return false;
+          return failureCount < 1;
+        },
       },
       mutations: {
         retry: false,


### PR DESCRIPTION
## Summary

Improves auth error handling: when a 401 response is received (e.g. expired token/cookie), the app now properly redirects to the login page instead of silently showing empty data.

**Note:** This is a defense-in-depth improvement, not the root cause fix for [#951](https://github.com/multica-ai/multica/issues/951) (that issue involves 200 responses, not 401s — root cause still under investigation).

**Changes:**
- `CoreProvider.onUnauthorized` now clears auth store state (`user: null`) and calls `onLogout`, triggering `DashboardGuard` to redirect to login
- `QueryClient` no longer retries 401 errors (retrying after auth expiry is pointless)

## Test plan
- [x] Verify typecheck passes (`pnpm typecheck` ✅)
- [x] Verify unit tests pass (`pnpm test` — 97 tests ✅)
- [ ] Manual test: log in, let session expire (or manually clear auth cookie), interact with Issues page — should redirect to login instead of showing empty state