### PR TITLE
chore(desktop): rebuild CLI on every bundle-cli run

### DIFF
--- a/apps/desktop/scripts/bundle-cli.mjs
+++ b/apps/desktop/scripts/bundle-cli.mjs
@@ -1,26 +1,49 @@
 #!/usr/bin/env node
-// Copies the locally-built `multica` CLI into apps/desktop/resources/bin/
-// so electron-vite (dev) and electron-builder (prod) pick it up. Desktop's
-// cli-bootstrap prefers this bundled copy over the GitHub Releases download
-// path, which keeps dev iteration fast (edit Go → make build → restart
-// Desktop) and lets the released .app ship with a CLI out of the box.
+// Builds the `multica` CLI from server/cmd/multica and copies the binary
+// into apps/desktop/resources/bin/ so electron-vite (dev) and electron-
+// builder (prod) pick it up. Running this on every dev/build/package
+// invocation guarantees the bundled CLI always matches the current Go
+// source — no more stale binary surprises. Go's build cache makes the
+// no-op case (nothing changed) effectively free.
 //
-// Graceful: if server/bin/multica is missing, prints a warning and exits
-// with status 0 so the Desktop can still boot with auto-install fallback.
+// ldflags mirror `make build` so `multica --version` reports a meaningful
+// version / commit / date.
+//
+// Graceful: if `go` is not installed (e.g. frontend-only contributor), we
+// skip the build and fall through to auto-install at runtime. A genuine
+// Go compile error is fatal — you want that to block dev, not hide.
 
 import { access, chmod, copyFile, mkdir } from "node:fs/promises";
 import { constants } from "node:fs";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..", "..");
+const serverDir = join(repoRoot, "server");
 
 const binName = process.platform === "win32" ? "multica.exe" : "multica";
-const srcBinary = join(repoRoot, "server", "bin", binName);
+const srcBinary = join(serverDir, "bin", binName);
 const destDir = join(repoRoot, "apps", "desktop", "resources", "bin");
 const destBinary = join(destDir, binName);
+
+function sh(cmd) {
+  try {
+    return execSync(cmd, { encoding: "utf-8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function hasGo() {
+  try {
+    execSync("go version", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 async function exists(p) {
   try {
@@ -31,10 +54,39 @@ async function exists(p) {
   }
 }
 
+if (hasGo()) {
+  const version = sh("git describe --tags --always --dirty") || "dev";
+  const commit = sh("git rev-parse --short HEAD") || "unknown";
+  const date = new Date().toISOString().replace(/\.\d+Z$/, "Z");
+  const ldflags = `-X main.version=${version} -X main.commit=${commit} -X main.date=${date}`;
+
+  console.log(
+    `[bundle-cli] go build → ${srcBinary} (version=${version} commit=${commit})`,
+  );
+  execFileSync(
+    "go",
+    [
+      "build",
+      "-ldflags",
+      ldflags,
+      "-o",
+      join("bin", binName),
+      "./cmd/multica",
+    ],
+    { cwd: serverDir, stdio: "inherit" },
+  );
+} else {
+  console.warn(
+    "[bundle-cli] `go` not found in PATH — skipping CLI build. " +
+      "Desktop will use whatever is already in resources/bin/, or fall back " +
+      "to auto-installing the latest release at runtime.",
+  );
+}
+
 if (!(await exists(srcBinary))) {
   console.warn(
-    `[bundle-cli] ${srcBinary} not found — run 'make build' to bundle the CLI. ` +
-      `Desktop will fall back to auto-installing the latest release at runtime.`,
+    `[bundle-cli] ${srcBinary} not present — Desktop will fall back to ` +
+      `auto-installing the latest release at runtime.`,
   );
   process.exit(0);
 }
@@ -51,7 +103,7 @@ if (process.platform === "darwin") {
       stdio: "pipe",
     });
   } catch {
-    // Non-fatal. Unsigned binaries still run when the parent is trusted.
+    // Non-fatal. Unsigned binaries still run when the parent app is trusted.
   }
 }
 


### PR DESCRIPTION
## Summary

- `bundle-cli.mjs` now runs `go build` before copying, so every `pnpm dev:desktop` / `dev:remote` / `package` picks up the current Go source.
- ldflags match `make build` (version/commit/date), so `multica --version` stays meaningful.
- Go build cache makes no-op rebuilds ~a few hundred ms; compile errors are fatal so broken Go code blocks dev instead of silently falling back to a stale binary.
- Graceful fallback preserved: if `go` is not on PATH, we warn and skip the build, letting `cli-bootstrap` auto-install the latest release at runtime.

## Why

Previously bundle-cli only copied whatever was already in `server/bin/multica`. If you edited Go code and forgot to run `make build` first, Desktop would silently keep running the old binary — exactly the "stale CLI" caching issue we just hit.

## Test plan

- [x] `pnpm --filter @multica/desktop bundle-cli` — first run ~2s (Go cold build), subsequent no-op runs ~few hundred ms.
- [x] `multica version` from the bundled binary reports the current git describe output.
- [ ] `pnpm dev:desktop` boots Desktop with the freshly built CLI.
- [ ] `pnpm --filter @multica/desktop package` produces a .app with the bundled CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)