### PR TITLE
fix(desktop): stop macOS traffic lights from hijacking titlebar & modals

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -113,6 +113,14 @@ if (!gotTheLock) {
       return shell.openExternal(url);
     });
 
+    // IPC: toggle immersive mode — hides the macOS traffic lights so full-screen
+    // modals (create-workspace, onboarding) can place UI in the top-left corner
+    // without fighting the native window controls' hit-test.
+    ipcMain.handle("window:setImmersive", (_event, immersive: boolean) => {
+      if (process.platform !== "darwin") return;
+      mainWindow?.setWindowButtonVisibility(!immersive);
+    });
+
     createWindow();
 
     setupAutoUpdater(() => mainWindow);

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -5,6 +5,8 @@ interface DesktopAPI {
   onAuthToken: (callback: (token: string) => void) => () => void;
   /** Open a URL in the default browser. */
   openExternal: (url: string) => Promise<void>;
+  /** Hide macOS traffic lights for full-screen modals; restore when false. */
+  setImmersiveMode: (immersive: boolean) => Promise<void>;
 }
 
 interface UpdaterAPI {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -13,6 +13,9 @@ const desktopAPI = {
   },
   /** Open a URL in the default browser */
   openExternal: (url: string) => ipcRenderer.invoke("shell:openExternal", url),
+  /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
+  setImmersiveMode: (immersive: boolean) =>
+    ipcRenderer.invoke("window:setImmersive", immersive),
 };
 
 const updaterAPI = {

--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -1,9 +1,13 @@
 import { useEffect } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@multica/ui/lib/utils";
 import { useTabHistory } from "@/hooks/use-tab-history";
 import { useActiveTitleSync } from "@/hooks/use-tab-sync";
 import { useTabStore, resolveRouteIcon } from "@/stores/tab-store";
-import { SidebarProvider } from "@multica/ui/components/ui/sidebar";
+import {
+  SidebarProvider,
+  useSidebar,
+} from "@multica/ui/components/ui/sidebar";
 import { ModalRegistry } from "@multica/views/modals/registry";
 import { AppSidebar, DashboardGuard } from "@multica/views/layout";
 import { SearchCommand, SearchTrigger } from "@multica/views/search";
@@ -28,6 +32,7 @@ function SidebarTopBar() {
         <button
           onClick={goBack}
           disabled={!canGoBack}
+          aria-label="Go back"
           className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-30 disabled:pointer-events-none"
         >
           <ChevronLeft className="size-4" />
@@ -35,12 +40,30 @@ function SidebarTopBar() {
         <button
           onClick={goForward}
           disabled={!canGoForward}
+          aria-label="Go forward"
           className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-30 disabled:pointer-events-none"
         >
           <ChevronRight className="size-4" />
         </button>
       </div>
     </div>
+  );
+}
+
+// The main area's top bar doubles as a window drag region. When the sidebar
+// is collapsed, we pad the left side so tabs don't land under the macOS
+// traffic lights (which live at roughly x=16..68 and always hit-test above HTML).
+function MainTopBar() {
+  const { state } = useSidebar();
+  const sidebarCollapsed = state === "collapsed";
+
+  return (
+    <header
+      className={cn("h-12 shrink-0", sidebarCollapsed && "pl-20")}
+      style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+    >
+      <TabBar />
+    </header>
   );
 }
 
@@ -78,13 +101,7 @@ export function DesktopShell() {
             <AppSidebar topSlot={<SidebarTopBar />} searchSlot={<SearchTrigger />} />
             {/* Right side: header + content container */}
             <div className="flex flex-1 min-w-0 flex-col">
-              {/* Tab bar + drag region */}
-              <header
-                className="h-12 shrink-0"
-                style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-              >
-                <TabBar />
-              </header>
+              <MainTopBar />
               {/* Content area with inset styling — relative so ChatWindow/ChatFab are constrained here */}
               <div className="relative flex flex-1 min-h-0 flex-col overflow-hidden mr-2 mb-2 ml-0.5 rounded-xl shadow-sm bg-background">
                 <TabContent />

--- a/packages/views/modals/create-workspace.tsx
+++ b/packages/views/modals/create-workspace.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { useNavigation } from "../navigation";
+import { useImmersiveMode } from "../platform";
 import { toast } from "sonner";
 import { ArrowLeft } from "lucide-react";
 import { Input } from "@multica/ui/components/ui/input";
@@ -24,6 +25,11 @@ import {
 } from "../workspace/slug";
 
 export function CreateWorkspaceModal({ onClose }: { onClose: () => void }) {
+  // This modal is full-screen, so it covers the app titlebar. On macOS desktop
+  // we hide the traffic lights for its lifetime so the Back button in the top-
+  // left corner isn't stolen by the native controls' hit-test. No-op elsewhere.
+  useImmersiveMode();
+
   const router = useNavigation();
   const createWorkspace = useCreateWorkspace();
   const [name, setName] = useState("");
@@ -87,10 +93,20 @@ export function CreateWorkspaceModal({ onClose }: { onClose: () => void }) {
         showCloseButton={false}
         className="inset-0 flex h-full w-full max-w-none sm:max-w-none translate-0 flex-col items-center justify-center rounded-none bg-background ring-0 shadow-none"
       >
+        {/* Top drag region — restores window-drag ability that the full-screen
+            modal would otherwise swallow. Transparent; web browsers ignore the
+            -webkit-app-region property, so this is safe cross-platform. */}
+        <div
+          aria-hidden
+          className="absolute inset-x-0 top-0 h-10"
+          style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+        />
+
         <Button
           variant="ghost"
           size="sm"
-          className="absolute top-6 left-6 text-muted-foreground"
+          className="absolute top-12 left-12 text-muted-foreground"
+          style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
           onClick={onClose}
         >
           <ArrowLeft className="h-4 w-4" />

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -32,7 +32,8 @@
     "./search": "./search/index.ts",
     "./chat": "./chat/index.ts",
     "./settings": "./settings/index.ts",
-    "./onboarding": "./onboarding/index.ts"
+    "./onboarding": "./onboarding/index.ts",
+    "./platform": "./platform/index.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/packages/views/platform/index.ts
+++ b/packages/views/platform/index.ts
@@ -1,0 +1,1 @@
+export { useImmersiveMode } from "./use-immersive-mode";

--- a/packages/views/platform/use-immersive-mode.ts
+++ b/packages/views/platform/use-immersive-mode.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+type ImmersiveCapableAPI = {
+  setImmersiveMode?: (immersive: boolean) => Promise<void> | void;
+};
+
+function getDesktopAPI(): ImmersiveCapableAPI | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { desktopAPI?: ImmersiveCapableAPI }).desktopAPI;
+}
+
+/**
+ * Enter "immersive" mode for the lifetime of the component that calls it.
+ *
+ * On macOS desktop this hides the traffic-light window controls so full-screen
+ * modals (create-workspace, onboarding, etc.) can place UI in the top-left
+ * corner without fighting the native controls' hit-test. On web or non-macOS
+ * desktop this is a no-op.
+ */
+export function useImmersiveMode(): void {
+  useEffect(() => {
+    const api = getDesktopAPI();
+    api?.setImmersiveMode?.(true);
+    return () => {
+      api?.setImmersiveMode?.(false);
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- **Sidebar-collapse fix**: main area's top bar now pads `pl-20` when the sidebar is collapsed, so the TabBar no longer sits under the macOS traffic-light hit-test region (which always wins over HTML clicks).
- **Immersive mode for full-screen modals**: new `window:setImmersive` IPC channel calls `BrowserWindow.setWindowButtonVisibility`, exposed via the existing `desktopAPI` preload bridge. A `useImmersiveMode()` hook in `@multica/views/platform` toggles it for a component's lifetime; no-op on web and non-macOS.
- **CreateWorkspaceModal**: calls `useImmersiveMode()` so traffic lights disappear while open, adds a transparent `h-10` top drag strip to restore window-drag (which the full-screen modal would otherwise swallow), and moves the Back button to `top-12 left-12` with an explicit `no-drag` region so clicks always reach it.

## Test plan

- [ ] Desktop dev: expand/collapse sidebar — traffic lights stay visible and clickable; no TabBar tiles hide under them
- [ ] Desktop dev: TabBar click, reorder, new-tab, back/forward all still work
- [ ] Open "Create workspace" modal: traffic lights disappear, Back button in top-left is clickable, dragging the top 40px moves the window, closing restores traffic lights
- [ ] Web build: modal renders normally; Back button still in top-left; no functional regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)