### PR TITLE
fix(daemon): sync workspaces from API before failing on empty runtime list

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -86,6 +86,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return err
 	}
 
+	// If no runtimes yet (empty watched list), run one sync cycle to discover
+	// workspaces from the API before giving up. workspaceSyncLoop normally
+	// handles this, but the runtime check below would fail before it runs.
+	if len(d.allRuntimeIDs()) == 0 {
+		d.syncWorkspacesFromAPI(ctx)
+		// syncWorkspacesFromAPI writes to config; reload and register.
+		if err := d.loadWatchedWorkspaces(ctx); err != nil {
+			return err
+		}
+	}
+
 	runtimeIDs := d.allRuntimeIDs()
 	if len(runtimeIDs) == 0 {
 		return fmt.Errorf("no runtimes registered")


### PR DESCRIPTION
## Summary
- When CLI config has no watched workspaces (e.g. fresh desktop app install), the daemon fails with "no runtimes registered" before `workspaceSyncLoop` can discover workspaces
- Fix: run one sync cycle inline to fetch workspaces from the API, then retry registration before giving up

## Context
Desktop app spawns daemon with a fresh profile that has no pre-configured workspaces. The daemon authenticates successfully but exits immediately because the runtime check runs before the async workspace sync loop.

## Test plan
- [x] Desktop app daemon starts successfully with empty watched workspace list
- [x] Daemon discovers workspaces from API and registers runtimes