### PR TITLE
chore(desktop): remove dev:desktop:remote proxy mode

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,41 +1,26 @@
 import { resolve } from "path";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
-import { loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
-  const remoteApi = env.VITE_REMOTE_API;
-  const remoteWs = remoteApi?.replace(/^https/, "wss").replace(/^http/, "ws");
-
-  return {
-    main: {
-      plugins: [externalizeDepsPlugin()],
+export default defineConfig({
+  main: {
+    plugins: [externalizeDepsPlugin()],
+  },
+  preload: {
+    plugins: [externalizeDepsPlugin()],
+  },
+  renderer: {
+    server: {
+      port: 5173,
+      strictPort: true,
     },
-    preload: {
-      plugins: [externalizeDepsPlugin()],
-    },
-    renderer: {
-      server: {
-        port: 5173,
-        strictPort: true,
-        ...(remoteApi && {
-          proxy: {
-            "/api": { target: remoteApi, changeOrigin: true },
-            "/auth": { target: remoteApi, changeOrigin: true },
-            "/uploads": { target: remoteApi, changeOrigin: true },
-            "/ws": { target: remoteWs, changeOrigin: true, ws: true },
-          },
-        }),
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        "@": resolve("src/renderer/src"),
       },
-      plugins: [react(), tailwindcss()],
-      resolve: {
-        alias: {
-          "@": resolve("src/renderer/src"),
-        },
-        dedupe: ["react", "react-dom"],
-      },
+      dedupe: ["react", "react-dom"],
     },
-  };
+  },
 });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "bundle-cli": "node scripts/bundle-cli.mjs",
     "dev": "pnpm run bundle-cli && electron-vite dev",
-    "dev:remote": "pnpm run bundle-cli && electron-vite dev --mode remote",
     "build": "pnpm run bundle-cli && electron-vite build",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -120,15 +120,9 @@ function AppContent() {
   return <DesktopShell />;
 }
 
-const remoteProxy = Boolean(import.meta.env.VITE_REMOTE_API);
-// Backend the daemon should connect to. In remote-proxy mode the renderer
-// talks through a local Vite proxy, but the daemon needs the real upstream
-// URL — which is what VITE_REMOTE_API holds. Fall back to VITE_API_URL
-// (direct mode) and finally localhost:8080 (local dev default).
+// Backend the daemon should connect to — same URL the renderer talks to.
 const DAEMON_TARGET_API_URL =
-  import.meta.env.VITE_REMOTE_API ||
-  import.meta.env.VITE_API_URL ||
-  "http://localhost:8080";
+  import.meta.env.VITE_API_URL || "http://localhost:8080";
 
 // On logout, clear any cached PAT and stop the daemon so that a subsequent
 // login as a different user never inherits the previous user's credentials.
@@ -149,8 +143,8 @@ export default function App() {
   return (
     <ThemeProvider>
       <CoreProvider
-        apiBaseUrl={remoteProxy ? "" : (import.meta.env.VITE_API_URL || "http://localhost:8080")}
-        wsUrl={remoteProxy ? "ws://localhost:5173/ws" : (import.meta.env.VITE_WS_URL || "ws://localhost:8080/ws")}
+        apiBaseUrl={import.meta.env.VITE_API_URL || "http://localhost:8080"}
+        wsUrl={import.meta.env.VITE_WS_URL || "ws://localhost:8080/ws"}
         onLogout={handleDaemonLogout}
       >
         <AppContent />

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev:web": "turbo dev --filter=@multica/web",
     "dev:desktop": "turbo dev --filter=@multica/desktop",
-    "dev:desktop:remote": "pnpm --filter @multica/desktop dev:remote",
     "build": "turbo build",
     "typecheck": "turbo typecheck",
     "test": "turbo test",


### PR DESCRIPTION
## Summary

Removes the `VITE_REMOTE_API` Vite-proxy path introduced in be8b099c. The remote-backend proxy is no longer needed for any supported dev workflow — direct mode via `VITE_API_URL` covers everything.

- Drops `dev:desktop:remote` (root) and `dev:remote` (desktop) scripts
- Reverts `electron.vite.config.ts` to a flat config — no `loadEnv`, no per-route `/api` `/auth` `/uploads` `/ws` proxies
- Simplifies `App.tsx`: single `apiBaseUrl` / `wsUrl` branch; `DAEMON_TARGET_API_URL` now derives directly from `VITE_API_URL`

## Test plan

- [ ] `pnpm dev:desktop` still boots against local backend as before
- [ ] `pnpm dev:desktop` against a cloud `VITE_API_URL` (what the proxy mode used to enable) works by just setting `VITE_API_URL` + `VITE_WS_URL` directly — no proxy needed
- [ ] Typecheck (`pnpm typecheck`) passes
- [ ] Unit tests (`pnpm test`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)