### PR TITLE
feat(server): trigger agent when issue moves out of backlog

### DIFF
--- a/packages/views/issues/components/backlog-agent-hint-dialog.tsx
+++ b/packages/views/issues/components/backlog-agent-hint-dialog.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Archive, ArrowRight, Bot } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from "@multica/ui/components/ui/alert-dialog";
+
+interface BacklogAgentHintDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDismissPermanently: () => void;
+  onMoveToTodo: () => void;
+}
+
+export function BacklogAgentHintDialog({
+  open,
+  onOpenChange,
+  onDismissPermanently,
+  onMoveToTodo,
+}: BacklogAgentHintDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="w-[calc(100vw-2rem)] !max-w-[460px] gap-0 overflow-hidden rounded-lg p-0">
+        <div className="px-5 pb-4 pt-5">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
+              <Bot className="size-4" />
+            </div>
+            <div className="min-w-0">
+              <AlertDialogTitle className="text-base font-semibold">
+                Agent is paused in Backlog
+              </AlertDialogTitle>
+              <AlertDialogDescription className="mt-1 text-sm leading-5 text-muted-foreground">
+                This issue is parked, so the assigned agent will wait. Move it
+                to Todo when you want the agent to start.
+              </AlertDialogDescription>
+            </div>
+          </div>
+
+          <div className="mt-4 flex items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2 text-xs">
+            <span className="inline-flex min-w-0 items-center gap-1.5 text-muted-foreground">
+              <Archive className="size-3.5 shrink-0" />
+              <span className="truncate">Backlog</span>
+            </span>
+            <ArrowRight className="size-3.5 shrink-0 text-muted-foreground/70" />
+            <span className="min-w-0 truncate font-medium">
+              Todo starts the agent
+            </span>
+          </div>
+        </div>
+
+        <div className="border-t bg-muted/30 px-5 py-3">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <AlertDialogCancel
+              variant="ghost"
+              className="w-full justify-center text-muted-foreground sm:w-auto"
+              onClick={onDismissPermanently}
+            >
+              Don&apos;t show again
+            </AlertDialogCancel>
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <AlertDialogCancel className="w-full sm:w-auto">
+                Keep in Backlog
+              </AlertDialogCancel>
+              <AlertDialogAction className="w-full sm:w-auto" onClick={onMoveToTodo}>
+                Move to Todo
+              </AlertDialogAction>
+            </div>
+          </div>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/views/issues/components/backlog-agent-hint-dialog.tsx
+++ b/packages/views/issues/components/backlog-agent-hint-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Archive, ArrowRight, Bot } from "lucide-react";
 import {
   AlertDialog,
@@ -23,6 +24,8 @@ export function BacklogAgentHintDialog({
   onDismissPermanently,
   onMoveToTodo,
 }: BacklogAgentHintDialogProps) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent className="w-[calc(100vw-2rem)] !max-w-[460px] gap-0 overflow-hidden rounded-lg p-0">
@@ -55,19 +58,27 @@ export function BacklogAgentHintDialog({
         </div>
 
         <div className="border-t bg-muted/30 px-5 py-3">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <AlertDialogCancel
-              variant="ghost"
-              className="w-full justify-center text-muted-foreground sm:w-auto"
-              onClick={onDismissPermanently}
-            >
-              Don&apos;t show again
-            </AlertDialogCancel>
+          <div className="flex flex-col gap-3 sm:gap-2">
+            <label className="flex items-center gap-2 cursor-pointer text-sm text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={dontShowAgain}
+                onChange={(e) => setDontShowAgain(e.target.checked)}
+                className="size-4 rounded border-border accent-primary cursor-pointer"
+              />
+              Don&apos;t show this again
+            </label>
             <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-              <AlertDialogCancel className="w-full sm:w-auto">
+              <AlertDialogCancel
+                className="w-full sm:w-auto"
+                onClick={() => { if (dontShowAgain) onDismissPermanently(); }}
+              >
                 Keep in Backlog
               </AlertDialogCancel>
-              <AlertDialogAction className="w-full sm:w-auto" onClick={onMoveToTodo}>
+              <AlertDialogAction
+                className="w-full sm:w-auto"
+                onClick={() => { if (dontShowAgain) onDismissPermanently(); onMoveToTodo(); }}
+              >
                 Move to Todo
               </AlertDialogAction>
             </div>

--- a/packages/views/issues/components/backlog-agent-hint-dialog.tsx
+++ b/packages/views/issues/components/backlog-agent-hint-dialog.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Archive, ArrowRight, Bot } from "lucide-react";
+import { Archive, ArrowRight, Bot, CheckCircle2 } from "lucide-react";
 import {
   AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
   AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogTitle,
 } from "@multica/ui/components/ui/alert-dialog";
+import { Button } from "@multica/ui/components/ui/button";
+import { Checkbox } from "@multica/ui/components/ui/checkbox";
 
 interface BacklogAgentHintDialogProps {
   open: boolean;
@@ -24,67 +22,103 @@ export function BacklogAgentHintDialog({
   onDismissPermanently,
   onMoveToTodo,
 }: BacklogAgentHintDialogProps) {
-  const [dontShowAgain, setDontShowAgain] = useState(false);
-
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent className="w-[calc(100vw-2rem)] !max-w-[460px] gap-0 overflow-hidden rounded-lg p-0">
-        <div className="px-5 pb-4 pt-5">
-          <div className="flex items-start gap-3">
-            <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
-              <Bot className="size-4" />
-            </div>
-            <div className="min-w-0">
-              <AlertDialogTitle className="text-base font-semibold">
-                Agent is paused in Backlog
-              </AlertDialogTitle>
-              <AlertDialogDescription className="mt-1 text-sm leading-5 text-muted-foreground">
-                This issue is parked, so the assigned agent will wait. Move it
-                to Todo when you want the agent to start.
-              </AlertDialogDescription>
-            </div>
-          </div>
-
-          <div className="mt-4 flex items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2 text-xs">
-            <span className="inline-flex min-w-0 items-center gap-1.5 text-muted-foreground">
-              <Archive className="size-3.5 shrink-0" />
-              <span className="truncate">Backlog</span>
-            </span>
-            <ArrowRight className="size-3.5 shrink-0 text-muted-foreground/70" />
-            <span className="min-w-0 truncate font-medium">
-              Todo starts the agent
-            </span>
-          </div>
-        </div>
-
-        <div className="border-t bg-muted/30 px-5 py-3">
-          <div className="flex flex-col gap-3 sm:gap-2">
-            <label className="flex items-center gap-2 cursor-pointer text-sm text-muted-foreground">
-              <input
-                type="checkbox"
-                checked={dontShowAgain}
-                onChange={(e) => setDontShowAgain(e.target.checked)}
-                className="size-4 rounded border-border accent-primary cursor-pointer"
-              />
-              Don&apos;t show this again
-            </label>
-            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-              <AlertDialogCancel
-                className="w-full sm:w-auto"
-                onClick={() => { if (dontShowAgain) onDismissPermanently(); }}
-              >
-                Keep in Backlog
-              </AlertDialogCancel>
-              <AlertDialogAction
-                className="w-full sm:w-auto"
-                onClick={() => { if (dontShowAgain) onDismissPermanently(); onMoveToTodo(); }}
-              >
-                Move to Todo
-              </AlertDialogAction>
-            </div>
-          </div>
-        </div>
+      <AlertDialogContent className="w-[calc(100vw-2rem)] !max-w-[480px] gap-0 overflow-hidden rounded-lg p-0">
+        <BacklogAgentHintContent
+          onKeepInBacklog={() => onOpenChange(false)}
+          onDismissPermanently={onDismissPermanently}
+          onMoveToTodo={onMoveToTodo}
+        />
       </AlertDialogContent>
     </AlertDialog>
+  );
+}
+
+interface BacklogAgentHintContentProps {
+  onKeepInBacklog: () => void;
+  onDismissPermanently: () => void;
+  onMoveToTodo: () => void;
+}
+
+export function BacklogAgentHintContent({
+  onKeepInBacklog,
+  onDismissPermanently,
+  onMoveToTodo,
+}: BacklogAgentHintContentProps) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  const handleKeepInBacklog = () => {
+    if (dontShowAgain) onDismissPermanently();
+    onKeepInBacklog();
+  };
+
+  const handleMoveToTodo = () => {
+    if (dontShowAgain) onDismissPermanently();
+    onMoveToTodo();
+  };
+
+  return (
+    <>
+      <div className="px-5 pb-4 pt-5">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
+            <Bot className="size-4" />
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-base font-semibold">
+              Agent is paused in Backlog
+            </h2>
+            <p className="mt-1 text-sm leading-5 text-muted-foreground">
+              This issue is parked, so the assigned agent will wait. Move it to
+              Todo when you want the agent to start.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-2 rounded-lg border bg-muted/35 p-3 text-sm">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Archive className="size-4 shrink-0" />
+            <span className="font-medium text-foreground">Backlog</span>
+            <span className="text-muted-foreground">keeps the agent paused</span>
+          </div>
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <ArrowRight className="size-4 shrink-0" />
+            <span className="font-medium text-foreground">Todo</span>
+            <span className="text-muted-foreground">starts the agent</span>
+            <CheckCircle2 className="ml-auto size-4 shrink-0 text-primary" />
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t bg-muted/25 px-5 py-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <label className="flex min-w-0 cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+            <Checkbox
+              checked={dontShowAgain}
+              onCheckedChange={(next) => setDontShowAgain(next === true)}
+            />
+            <span className="truncate">Don&apos;t show this again</span>
+          </label>
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full sm:w-auto"
+              onClick={handleKeepInBacklog}
+            >
+              Keep in Backlog
+            </Button>
+            <Button
+              type="button"
+              className="w-full sm:w-auto"
+              onClick={handleMoveToTodo}
+            >
+              Move to Todo
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
   );
 }

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -64,6 +64,7 @@ import { ProjectPicker } from "../../projects/components/project-picker";
 import { CommentCard } from "./comment-card";
 import { CommentInput } from "./comment-input";
 import { AgentLiveCard, TaskRunHistory } from "./agent-live-card";
+import { BacklogAgentHintDialog } from "./backlog-agent-hint-dialog";
 import { useQuery } from "@tanstack/react-query";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceStore } from "@multica/core/workspace";
@@ -873,33 +874,20 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
               </AlertDialogContent>
             </AlertDialog>
 
-            {/* Backlog agent hint dialog */}
-            <AlertDialog open={backlogHintOpen} onOpenChange={setBacklogHintOpen}>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Agent won&apos;t start in Backlog</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Issues in Backlog are parked — the agent won&apos;t start until the issue is moved to an active status like Todo.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel
-                    onClick={() => localStorage.setItem("multica:backlog-agent-hint-dismissed", "true")}
-                  >
-                    Don&apos;t show again
-                  </AlertDialogCancel>
-                  <AlertDialogCancel>Keep in Backlog</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() => updateIssueMutation.mutate(
-                      { id, status: "todo" },
-                      { onError: () => toast.error("Failed to update status") },
-                    )}
-                  >
-                    Move to Todo
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+            <BacklogAgentHintDialog
+              open={backlogHintOpen}
+              onOpenChange={setBacklogHintOpen}
+              onDismissPermanently={() => {
+                localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
+              }}
+              onMoveToTodo={() => {
+                updateIssueMutation.mutate(
+                  { id, status: "todo" },
+                  { onError: () => toast.error("Failed to update status") },
+                );
+                setBacklogHintOpen(false);
+              }}
+            />
 
             {/* Set parent issue picker */}
             <IssuePickerDialog

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -344,6 +344,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const [sidebarOpen, setSidebarOpen] = useState(defaultSidebarOpen);
   const [deleting, setDeleting] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [backlogHintOpen, setBacklogHintOpen] = useState(false);
   const [propertiesOpen, setPropertiesOpen] = useState(true);
   const [detailsOpen, setDetailsOpen] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -452,21 +453,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
         issue.status === "backlog" &&
         localStorage.getItem("multica:backlog-agent-hint-dismissed") !== "true"
       ) {
-        toast("Agent won't start in Backlog", {
-          description: "Move the issue to Todo to trigger execution.",
-          action: {
-            label: "Move to Todo",
-            onClick: () => updateIssueMutation.mutate(
-              { id, status: "todo" },
-              { onError: () => toast.error("Failed to update status") },
-            ),
-          },
-          cancel: {
-            label: "Don't show again",
-            onClick: () => localStorage.setItem("multica:backlog-agent-hint-dismissed", "true"),
-          },
-          duration: 8000,
-        });
+        setBacklogHintOpen(true);
       }
     },
     [issue, id, updateIssueMutation],
@@ -881,6 +868,34 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                     className="bg-destructive text-white hover:bg-destructive/90"
                   >
                     {deleting ? "Deleting..." : "Delete"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+
+            {/* Backlog agent hint dialog */}
+            <AlertDialog open={backlogHintOpen} onOpenChange={setBacklogHintOpen}>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Agent won&apos;t start in Backlog</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Issues in Backlog are parked — the agent won&apos;t start until the issue is moved to an active status like Todo.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel
+                    onClick={() => localStorage.setItem("multica:backlog-agent-hint-dismissed", "true")}
+                  >
+                    Don&apos;t show again
+                  </AlertDialogCancel>
+                  <AlertDialogCancel>Keep in Backlog</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => updateIssueMutation.mutate(
+                      { id, status: "todo" },
+                      { onError: () => toast.error("Failed to update status") },
+                    )}
+                  >
+                    Move to Todo
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -444,6 +444,25 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
         { id, ...updates },
         { onError: () => toast.error("Failed to update issue") },
       );
+      // Hint: assigning an agent to a backlog issue won't trigger execution
+      // until the issue is moved to an active status.
+      if (
+        updates.assignee_type === "agent" &&
+        updates.assignee_id &&
+        issue.status === "backlog"
+      ) {
+        toast("Agent won't start in Backlog", {
+          description: "Move the issue to Todo to trigger execution.",
+          action: {
+            label: "Move to Todo",
+            onClick: () => updateIssueMutation.mutate(
+              { id, status: "todo" },
+              { onError: () => toast.error("Failed to update status") },
+            ),
+          },
+          duration: 6000,
+        });
+      }
     },
     [issue, id, updateIssueMutation],
   );

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -449,7 +449,8 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
       if (
         updates.assignee_type === "agent" &&
         updates.assignee_id &&
-        issue.status === "backlog"
+        issue.status === "backlog" &&
+        localStorage.getItem("multica:backlog-agent-hint-dismissed") !== "true"
       ) {
         toast("Agent won't start in Backlog", {
           description: "Move the issue to Todo to trigger execution.",
@@ -460,7 +461,11 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
               { onError: () => toast.error("Failed to update status") },
             ),
           },
-          duration: 6000,
+          cancel: {
+            label: "Don't show again",
+            onClick: () => localStorage.setItem("multica:backlog-agent-hint-dismissed", "true"),
+          },
+          duration: 8000,
         });
       }
     },

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@multica/core/issues/stores/draft-store", () => ({
 
 vi.mock("@multica/core/issues/mutations", () => ({
   useCreateIssue: () => ({ mutateAsync: mockCreateIssue }),
+  useUpdateIssue: () => ({ mutate: vi.fn() }),
 }));
 
 vi.mock("@multica/core/hooks/use-file-upload", () => ({

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -11,20 +11,11 @@ import {
   DialogContent,
   DialogTitle,
 } from "@multica/ui/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@multica/ui/components/ui/alert-dialog";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../editor";
 import { StatusIcon, StatusPicker, PriorityPicker, AssigneePicker, DueDatePicker } from "../issues/components";
+import { BacklogAgentHintDialog } from "../issues/components/backlog-agent-hint-dialog";
 import { ProjectPicker } from "../projects/components/project-picker";
 import { useWorkspaceStore } from "@multica/core/workspace";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
@@ -308,45 +299,28 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         </div>
       </DialogContent>
 
-      {/* Backlog agent hint dialog */}
-      <AlertDialog open={!!backlogHintIssueId} onOpenChange={(v) => { if (!v) { setBacklogHintIssueId(null); onClose(); } }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Agent won&apos;t start in Backlog</AlertDialogTitle>
-            <AlertDialogDescription>
-              Issues in Backlog are parked — the agent won&apos;t start until the issue is moved to an active status like Todo.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel
-              onClick={() => {
-                localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
-                setBacklogHintIssueId(null);
-                onClose();
-              }}
-            >
-              Don&apos;t show again
-            </AlertDialogCancel>
-            <AlertDialogCancel onClick={() => { setBacklogHintIssueId(null); onClose(); }}>
-              Keep in Backlog
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (backlogHintIssueId) {
-                  updateIssueMutation.mutate(
-                    { id: backlogHintIssueId, status: "todo" },
-                    { onError: () => toast.error("Failed to update status") },
-                  );
-                }
-                setBacklogHintIssueId(null);
-                onClose();
-              }}
-            >
-              Move to Todo
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <BacklogAgentHintDialog
+        open={!!backlogHintIssueId}
+        onOpenChange={(v) => {
+          if (!v) {
+            setBacklogHintIssueId(null);
+            onClose();
+          }
+        }}
+        onDismissPermanently={() => {
+          localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
+        }}
+        onMoveToTodo={() => {
+          if (backlogHintIssueId) {
+            updateIssueMutation.mutate(
+              { id: backlogHintIssueId, status: "todo" },
+              { onError: () => toast.error("Failed to update status") },
+            );
+          }
+          setBacklogHintIssueId(null);
+          onClose();
+        }}
+      />
     </Dialog>
   );
 }

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -11,6 +11,16 @@ import {
   DialogContent,
   DialogTitle,
 } from "@multica/ui/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@multica/ui/components/ui/alert-dialog";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../editor";
@@ -74,6 +84,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
     (data?.project_id as string) || undefined,
   );
   const [isExpanded, setIsExpanded] = useState(false);
+  const [backlogHintIssueId, setBacklogHintIssueId] = useState<string | null>(null);
 
   // File upload — collect attachment IDs so we can link them after issue creation.
   const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
@@ -115,7 +126,15 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         project_id: projectId,
       });
       clearDraft();
-      onClose();
+      // Show backlog hint dialog instead of closing immediately.
+      if (
+        status === "backlog" && assigneeType === "agent" && assigneeId &&
+        localStorage.getItem("multica:backlog-agent-hint-dismissed") !== "true"
+      ) {
+        setBacklogHintIssueId(issue.id);
+      } else {
+        onClose();
+      }
       toast.custom((t) => (
         <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-4 w-[360px]">
           <div className="flex items-center gap-2 mb-2">
@@ -140,27 +159,6 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
           </button>
         </div>
       ), { duration: 5000 });
-      // Hint when creating a backlog issue with an agent assignee.
-      if (
-        status === "backlog" && assigneeType === "agent" && assigneeId &&
-        localStorage.getItem("multica:backlog-agent-hint-dismissed") !== "true"
-      ) {
-        toast("Agent won't start in Backlog", {
-          description: "Move the issue to Todo to trigger execution.",
-          action: {
-            label: "Move to Todo",
-            onClick: () => updateIssueMutation.mutate(
-              { id: issue.id, status: "todo" },
-              { onError: () => toast.error("Failed to update status") },
-            ),
-          },
-          cancel: {
-            label: "Don't show again",
-            onClick: () => localStorage.setItem("multica:backlog-agent-hint-dismissed", "true"),
-          },
-          duration: 8000,
-        });
-      }
     } catch {
       toast.error("Failed to create issue");
     } finally {
@@ -309,6 +307,46 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
           </Button>
         </div>
       </DialogContent>
+
+      {/* Backlog agent hint dialog */}
+      <AlertDialog open={!!backlogHintIssueId} onOpenChange={(v) => { if (!v) { setBacklogHintIssueId(null); onClose(); } }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Agent won&apos;t start in Backlog</AlertDialogTitle>
+            <AlertDialogDescription>
+              Issues in Backlog are parked — the agent won&apos;t start until the issue is moved to an active status like Todo.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              onClick={() => {
+                localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
+                setBacklogHintIssueId(null);
+                onClose();
+              }}
+            >
+              Don&apos;t show again
+            </AlertDialogCancel>
+            <AlertDialogCancel onClick={() => { setBacklogHintIssueId(null); onClose(); }}>
+              Keep in Backlog
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (backlogHintIssueId) {
+                  updateIssueMutation.mutate(
+                    { id: backlogHintIssueId, status: "todo" },
+                    { onError: () => toast.error("Failed to update status") },
+                  );
+                }
+                setBacklogHintIssueId(null);
+                onClose();
+              }}
+            >
+              Move to Todo
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   );
 }

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -141,7 +141,10 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         </div>
       ), { duration: 5000 });
       // Hint when creating a backlog issue with an agent assignee.
-      if (status === "backlog" && assigneeType === "agent" && assigneeId) {
+      if (
+        status === "backlog" && assigneeType === "agent" && assigneeId &&
+        localStorage.getItem("multica:backlog-agent-hint-dismissed") !== "true"
+      ) {
         toast("Agent won't start in Backlog", {
           description: "Move the issue to Todo to trigger execution.",
           action: {
@@ -151,7 +154,11 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
               { onError: () => toast.error("Failed to update status") },
             ),
           },
-          duration: 6000,
+          cancel: {
+            label: "Don't show again",
+            onClick: () => localStorage.setItem("multica:backlog-agent-hint-dismissed", "true"),
+          },
+          duration: 8000,
         });
       }
     } catch {

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -15,7 +15,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/
 import { Button } from "@multica/ui/components/ui/button";
 import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../editor";
 import { StatusIcon, StatusPicker, PriorityPicker, AssigneePicker, DueDatePicker } from "../issues/components";
-import { BacklogAgentHintDialog } from "../issues/components/backlog-agent-hint-dialog";
+import { BacklogAgentHintContent } from "../issues/components/backlog-agent-hint-dialog";
 import { ProjectPicker } from "../projects/components/project-picker";
 import { useWorkspaceStore } from "@multica/core/workspace";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
@@ -117,39 +117,42 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         project_id: projectId,
       });
       clearDraft();
-      // Show backlog hint dialog instead of closing immediately.
-      if (
+      const shouldShowBacklogHint =
         status === "backlog" && assigneeType === "agent" && assigneeId &&
-        localStorage.getItem("multica:backlog-agent-hint-dismissed") !== "true"
-      ) {
+        localStorage.getItem("multica:backlog-agent-hint-dismissed") !== "true";
+
+      if (shouldShowBacklogHint) {
         setBacklogHintIssueId(issue.id);
       } else {
         onClose();
       }
-      toast.custom((t) => (
-        <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-4 w-[360px]">
-          <div className="flex items-center gap-2 mb-2">
-            <div className="flex items-center justify-center size-5 rounded-full bg-emerald-500/15 text-emerald-500">
-              <Check className="size-3" />
+
+      if (!shouldShowBacklogHint) {
+        toast.custom((t) => (
+          <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg p-4 w-[360px]">
+            <div className="flex items-center gap-2 mb-2">
+              <div className="flex items-center justify-center size-5 rounded-full bg-emerald-500/15 text-emerald-500">
+                <Check className="size-3" />
+              </div>
+              <span className="text-sm font-medium">Issue created</span>
             </div>
-            <span className="text-sm font-medium">Issue created</span>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground ml-7">
+              <StatusIcon status={issue.status} className="size-3.5 shrink-0" />
+              <span className="truncate">{issue.identifier} – {issue.title}</span>
+            </div>
+            <button
+              type="button"
+              className="ml-7 mt-2 text-sm text-primary hover:underline cursor-pointer"
+              onClick={() => {
+                router.push(`/issues/${issue.id}`);
+                toast.dismiss(t);
+              }}
+            >
+              View issue
+            </button>
           </div>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground ml-7">
-            <StatusIcon status={issue.status} className="size-3.5 shrink-0" />
-            <span className="truncate">{issue.identifier} – {issue.title}</span>
-          </div>
-          <button
-            type="button"
-            className="ml-7 mt-2 text-sm text-primary hover:underline cursor-pointer"
-            onClick={() => {
-              router.push(`/issues/${issue.id}`);
-              toast.dismiss(t);
-            }}
-          >
-            View issue
-          </button>
-        </div>
-      ), { duration: 5000 });
+        ), { duration: 5000 });
+      }
     } catch {
       toast.error("Failed to create issue");
     } finally {
@@ -158,171 +161,180 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   };
 
   return (
-    <>
-    <Dialog open={!backlogHintIssueId} onOpenChange={(v) => { if (!v) onClose(); }}>
-      <DialogContent
-        finalFocus={false}
-        showCloseButton={false}
-        className={cn(
-          "p-0 gap-0 flex flex-col overflow-hidden",
-          "!top-1/2 !left-1/2 !-translate-x-1/2",
-          "!transition-all !duration-300 !ease-out",
-          isExpanded
-            ? "!max-w-4xl !w-full !h-5/6 !-translate-y-1/2"
-            : "!max-w-2xl !w-full !h-96 !-translate-y-1/2",
-        )}
-      >
-        <DialogTitle className="sr-only">New Issue</DialogTitle>
-
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 pt-3 pb-2 shrink-0">
-          <div className="flex items-center gap-1.5 text-xs">
-            <span className="text-muted-foreground">{workspaceName}</span>
-            <ChevronRight className="size-3 text-muted-foreground/50" />
-            {typeof data?.parent_issue_identifier === "string" && (
-              <>
-                <span className="text-muted-foreground">{data.parent_issue_identifier}</span>
-                <ChevronRight className="size-3 text-muted-foreground/50" />
-              </>
-            )}
-            <span className="font-medium">{data?.parent_issue_id ? "New sub-issue" : "New issue"}</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    onClick={() => setIsExpanded(!isExpanded)}
-                    className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
-                  >
-                    {isExpanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
-                  </button>
-                }
-              />
-              <TooltipContent side="bottom">{isExpanded ? "Collapse" : "Expand"}</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    onClick={onClose}
-                    className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
-                  >
-                    <XIcon className="size-4" />
-                  </button>
-                }
-              />
-              <TooltipContent side="bottom">Close</TooltipContent>
-            </Tooltip>
-          </div>
-        </div>
-
-        {/* Title */}
-        <div className="px-5 pb-2 shrink-0">
-          <TitleEditor
-            autoFocus
-            defaultValue={draft.title}
-            placeholder="Issue title"
-            className="text-lg font-semibold"
-            onChange={(v) => updateTitle(v)}
-            onSubmit={handleSubmit}
-          />
-        </div>
-
-        {/* Description — takes remaining space */}
-        <div {...descDropZoneProps} className="relative flex-1 min-h-0 overflow-y-auto px-5">
-          <ContentEditor
-            ref={descEditorRef}
-            defaultValue={draft.description}
-            placeholder="Add description..."
-            onUpdate={(md) => setDraft({ description: md })}
-            onUploadFile={handleUpload}
-            debounceMs={500}
-          />
-          {descDragOver && <FileDropOverlay />}
-        </div>
-
-        {/* Property toolbar */}
-        <div className="flex items-center gap-1.5 px-4 py-2 shrink-0 flex-wrap">
-          {/* Status */}
-          <StatusPicker
-            status={status}
-            onUpdate={(u) => { if (u.status) updateStatus(u.status); }}
-            triggerRender={<PillButton />}
-            align="start"
-          />
-
-          {/* Priority */}
-          <PriorityPicker
-            priority={priority}
-            onUpdate={(u) => { if (u.priority) updatePriority(u.priority); }}
-            triggerRender={<PillButton />}
-            align="start"
-          />
-
-          {/* Assignee */}
-          <AssigneePicker
-            assigneeType={assigneeType ?? null}
-            assigneeId={assigneeId ?? null}
-            onUpdate={(u) => updateAssignee(
-              u.assignee_type ?? undefined,
-              u.assignee_id ?? undefined,
-            )}
-            triggerRender={<PillButton />}
-            align="start"
-          />
-
-          {/* Due date */}
-          <DueDatePicker
-            dueDate={dueDate}
-            onUpdate={(u) => updateDueDate(u.due_date ?? null)}
-            triggerRender={<PillButton />}
-            align="start"
-          />
-
-          {/* Project */}
-          <ProjectPicker
-            projectId={projectId ?? null}
-            onUpdate={(u) => setProjectId(u.project_id ?? undefined)}
-            triggerRender={<PillButton />}
-            align="start"
-          />
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-between px-4 py-3 border-t shrink-0">
-          <FileUploadButton
-            onSelect={(file) => descEditorRef.current?.uploadFile(file)}
-          />
-          <Button size="sm" onClick={handleSubmit} disabled={!title.trim() || submitting}>
-            {submitting ? "Creating..." : "Create Issue"}
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
-
-    <BacklogAgentHintDialog
-      open={!!backlogHintIssueId}
+    <Dialog
+      open
       onOpenChange={(v) => {
         if (!v) {
           setBacklogHintIssueId(null);
           onClose();
         }
       }}
-      onDismissPermanently={() => {
-        localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
-      }}
-      onMoveToTodo={() => {
-        if (backlogHintIssueId) {
-          updateIssueMutation.mutate(
-            { id: backlogHintIssueId, status: "todo" },
-            { onError: () => toast.error("Failed to update status") },
-          );
-        }
-        setBacklogHintIssueId(null);
-        onClose();
-      }}
-    />
-    </>
+    >
+      <DialogContent
+        finalFocus={false}
+        showCloseButton={false}
+        className={cn(
+          "p-0 gap-0 flex flex-col overflow-hidden",
+          "!top-1/2 !left-1/2 !-translate-x-1/2",
+          backlogHintIssueId
+            ? "!max-w-[480px] !w-[calc(100vw-2rem)] !h-auto !-translate-y-1/2 !transition-none !duration-0"
+            : "!transition-all !duration-300 !ease-out",
+          !backlogHintIssueId && isExpanded
+            ? "!max-w-4xl !w-full !h-5/6 !-translate-y-1/2"
+            : !backlogHintIssueId
+              ? "!max-w-2xl !w-full !h-96 !-translate-y-1/2"
+              : "",
+        )}
+      >
+        {backlogHintIssueId ? (
+          <BacklogAgentHintContent
+            onKeepInBacklog={() => {
+              setBacklogHintIssueId(null);
+              onClose();
+            }}
+            onDismissPermanently={() => {
+              localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
+            }}
+            onMoveToTodo={() => {
+              updateIssueMutation.mutate(
+                { id: backlogHintIssueId, status: "todo" },
+                { onError: () => toast.error("Failed to update status") },
+              );
+              setBacklogHintIssueId(null);
+              onClose();
+            }}
+          />
+        ) : (
+          <>
+            <DialogTitle className="sr-only">New Issue</DialogTitle>
+
+            {/* Header */}
+            <div className="flex items-center justify-between px-5 pt-3 pb-2 shrink-0">
+              <div className="flex items-center gap-1.5 text-xs">
+                <span className="text-muted-foreground">{workspaceName}</span>
+                <ChevronRight className="size-3 text-muted-foreground/50" />
+                {typeof data?.parent_issue_identifier === "string" && (
+                  <>
+                    <span className="text-muted-foreground">{data.parent_issue_identifier}</span>
+                    <ChevronRight className="size-3 text-muted-foreground/50" />
+                  </>
+                )}
+                <span className="font-medium">{data?.parent_issue_id ? "New sub-issue" : "New issue"}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        onClick={() => setIsExpanded(!isExpanded)}
+                        className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
+                      >
+                        {isExpanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+                      </button>
+                    }
+                  />
+                  <TooltipContent side="bottom">{isExpanded ? "Collapse" : "Expand"}</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        onClick={onClose}
+                        className="rounded-sm p-1.5 opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
+                      >
+                        <XIcon className="size-4" />
+                      </button>
+                    }
+                  />
+                  <TooltipContent side="bottom">Close</TooltipContent>
+                </Tooltip>
+              </div>
+            </div>
+
+            {/* Title */}
+            <div className="px-5 pb-2 shrink-0">
+              <TitleEditor
+                autoFocus
+                defaultValue={draft.title}
+                placeholder="Issue title"
+                className="text-lg font-semibold"
+                onChange={(v) => updateTitle(v)}
+                onSubmit={handleSubmit}
+              />
+            </div>
+
+            {/* Description — takes remaining space */}
+            <div {...descDropZoneProps} className="relative flex-1 min-h-0 overflow-y-auto px-5">
+              <ContentEditor
+                ref={descEditorRef}
+                defaultValue={draft.description}
+                placeholder="Add description..."
+                onUpdate={(md) => setDraft({ description: md })}
+                onUploadFile={handleUpload}
+                debounceMs={500}
+              />
+              {descDragOver && <FileDropOverlay />}
+            </div>
+
+            {/* Property toolbar */}
+            <div className="flex items-center gap-1.5 px-4 py-2 shrink-0 flex-wrap">
+              {/* Status */}
+              <StatusPicker
+                status={status}
+                onUpdate={(u) => { if (u.status) updateStatus(u.status); }}
+                triggerRender={<PillButton />}
+                align="start"
+              />
+
+              {/* Priority */}
+              <PriorityPicker
+                priority={priority}
+                onUpdate={(u) => { if (u.priority) updatePriority(u.priority); }}
+                triggerRender={<PillButton />}
+                align="start"
+              />
+
+              {/* Assignee */}
+              <AssigneePicker
+                assigneeType={assigneeType ?? null}
+                assigneeId={assigneeId ?? null}
+                onUpdate={(u) => updateAssignee(
+                  u.assignee_type ?? undefined,
+                  u.assignee_id ?? undefined,
+                )}
+                triggerRender={<PillButton />}
+                align="start"
+              />
+
+              {/* Due date */}
+              <DueDatePicker
+                dueDate={dueDate}
+                onUpdate={(u) => updateDueDate(u.due_date ?? null)}
+                triggerRender={<PillButton />}
+                align="start"
+              />
+
+              {/* Project */}
+              <ProjectPicker
+                projectId={projectId ?? null}
+                onUpdate={(u) => setProjectId(u.project_id ?? undefined)}
+                triggerRender={<PillButton />}
+                align="start"
+              />
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-between px-4 py-3 border-t shrink-0">
+              <FileUploadButton
+                onSelect={(file) => descEditorRef.current?.uploadFile(file)}
+              />
+              <Button size="sm" onClick={handleSubmit} disabled={!title.trim() || submitting}>
+                {submitting ? "Creating..." : "Create Issue"}
+              </Button>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -158,7 +158,8 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   };
 
   return (
-    <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
+    <>
+    <Dialog open={!backlogHintIssueId} onOpenChange={(v) => { if (!v) onClose(); }}>
       <DialogContent
         finalFocus={false}
         showCloseButton={false}
@@ -298,29 +299,30 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
           </Button>
         </div>
       </DialogContent>
+    </Dialog>
 
-      <BacklogAgentHintDialog
-        open={!!backlogHintIssueId}
-        onOpenChange={(v) => {
-          if (!v) {
-            setBacklogHintIssueId(null);
-            onClose();
-          }
-        }}
-        onDismissPermanently={() => {
-          localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
-        }}
-        onMoveToTodo={() => {
-          if (backlogHintIssueId) {
-            updateIssueMutation.mutate(
-              { id: backlogHintIssueId, status: "todo" },
-              { onError: () => toast.error("Failed to update status") },
-            );
-          }
+    <BacklogAgentHintDialog
+      open={!!backlogHintIssueId}
+      onOpenChange={(v) => {
+        if (!v) {
           setBacklogHintIssueId(null);
           onClose();
-        }}
-      />
-    </Dialog>
+        }
+      }}
+      onDismissPermanently={() => {
+        localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
+      }}
+      onMoveToTodo={() => {
+        if (backlogHintIssueId) {
+          updateIssueMutation.mutate(
+            { id: backlogHintIssueId, status: "todo" },
+            { onError: () => toast.error("Failed to update status") },
+          );
+        }
+        setBacklogHintIssueId(null);
+        onClose();
+      }}
+    />
+    </>
   );
 }

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -18,7 +18,7 @@ import { StatusIcon, StatusPicker, PriorityPicker, AssigneePicker, DueDatePicker
 import { ProjectPicker } from "../projects/components/project-picker";
 import { useWorkspaceStore } from "@multica/core/workspace";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
-import { useCreateIssue } from "@multica/core/issues/mutations";
+import { useCreateIssue, useUpdateIssue } from "@multica/core/issues/mutations";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
@@ -97,6 +97,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   const updateDueDate = (v: string | null) => { setDueDate(v); setDraft({ dueDate: v }); };
 
   const createIssueMutation = useCreateIssue();
+  const updateIssueMutation = useUpdateIssue();
   const handleSubmit = async () => {
     if (!title.trim() || submitting) return;
     setSubmitting(true);
@@ -139,6 +140,20 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
           </button>
         </div>
       ), { duration: 5000 });
+      // Hint when creating a backlog issue with an agent assignee.
+      if (status === "backlog" && assigneeType === "agent" && assigneeId) {
+        toast("Agent won't start in Backlog", {
+          description: "Move the issue to Todo to trigger execution.",
+          action: {
+            label: "Move to Todo",
+            onClick: () => updateIssueMutation.mutate(
+              { id: issue.id, status: "todo" },
+              { onError: () => toast.error("Failed to update status") },
+            ),
+          },
+          duration: 6000,
+        });
+      }
     } catch {
       toast.error("Failed to create issue");
     } finally {

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -975,12 +975,11 @@ func TestResolveActor(t *testing.T) {
 	}
 }
 
-// TestBacklogToTodoTriggersAgent verifies that moving an agent-assigned issue
-// from "backlog" to "todo" enqueues an agent task.
-func TestBacklogToTodoTriggersAgent(t *testing.T) {
+// TestBacklogNoTriggerOnCreate verifies that creating a backlog issue with an
+// agent assignee does NOT enqueue a task — backlog is a parking lot.
+func TestBacklogNoTriggerOnCreate(t *testing.T) {
 	ctx := context.Background()
 
-	// Look up the test agent.
 	var agentID string
 	err := testPool.QueryRow(ctx,
 		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
@@ -990,7 +989,55 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 		t.Fatalf("failed to find test agent: %v", err)
 	}
 
-	// Create a backlog issue assigned to the agent.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "Backlog no-trigger test",
+		"status":        "backlog",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	var taskCount int
+	err = testPool.QueryRow(ctx,
+		`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1`,
+		created.ID,
+	).Scan(&taskCount)
+	if err != nil {
+		t.Fatalf("failed to count tasks: %v", err)
+	}
+	if taskCount != 0 {
+		t.Fatalf("expected no tasks for backlog issue on creation, got %d", taskCount)
+	}
+
+	// Cleanup
+	cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+	cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+	testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+}
+
+// TestBacklogToTodoTriggersAgent verifies that moving an agent-assigned issue
+// from "backlog" to "todo" enqueues exactly one agent task (none on creation,
+// one on status transition).
+func TestBacklogToTodoTriggersAgent(t *testing.T) {
+	ctx := context.Background()
+
+	var agentID string
+	err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	// Create a backlog issue assigned to the agent — should NOT trigger.
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
 		"title":         "Backlog trigger test",
@@ -1006,10 +1053,7 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 	var created IssueResponse
 	json.NewDecoder(w.Body).Decode(&created)
 
-	// Clean up any tasks created by the initial assignment.
-	testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
-
-	// Move the issue from backlog to todo.
+	// Move the issue from backlog to todo — should trigger.
 	w = httptest.NewRecorder()
 	req = newRequest("PUT", "/api/issues/"+created.ID, map[string]any{
 		"status": "todo",
@@ -1020,7 +1064,7 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 		t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Verify a task was enqueued.
+	// Verify exactly one task was enqueued (from the status transition, not creation).
 	var taskCount int
 	err = testPool.QueryRow(ctx,
 		`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'`,
@@ -1029,8 +1073,8 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to count tasks: %v", err)
 	}
-	if taskCount == 0 {
-		t.Fatal("expected agent task to be enqueued when moving from backlog to todo")
+	if taskCount != 1 {
+		t.Fatalf("expected exactly 1 task after backlog->todo transition, got %d", taskCount)
 	}
 
 	// Cleanup

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -975,6 +975,71 @@ func TestResolveActor(t *testing.T) {
 	}
 }
 
+// TestBacklogToTodoTriggersAgent verifies that moving an agent-assigned issue
+// from "backlog" to "todo" enqueues an agent task.
+func TestBacklogToTodoTriggersAgent(t *testing.T) {
+	ctx := context.Background()
+
+	// Look up the test agent.
+	var agentID string
+	err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	// Create a backlog issue assigned to the agent.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "Backlog trigger test",
+		"status":        "backlog",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	// Clean up any tasks created by the initial assignment.
+	testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+
+	// Move the issue from backlog to todo.
+	w = httptest.NewRecorder()
+	req = newRequest("PUT", "/api/issues/"+created.ID, map[string]any{
+		"status": "todo",
+	})
+	req = withURLParam(req, "id", created.ID)
+	testHandler.UpdateIssue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify a task was enqueued.
+	var taskCount int
+	err = testPool.QueryRow(ctx,
+		`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'`,
+		created.ID, agentID,
+	).Scan(&taskCount)
+	if err != nil {
+		t.Fatalf("failed to count tasks: %v", err)
+	}
+	if taskCount == 0 {
+		t.Fatal("expected agent task to be enqueued when moving from backlog to todo")
+	}
+
+	// Cleanup
+	testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+	cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+	cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+	testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+}
+
 func TestDaemonRegisterMissingWorkspaceReturns404(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/daemon/register", bytes.NewBufferString(`{

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -917,7 +917,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	slog.Info("issue created", append(logger.RequestAttrs(r), "issue_id", uuidToString(issue.ID), "title", issue.Title, "status", issue.Status, "workspace_id", workspaceID)...)
 	h.publish(protocol.EventIssueCreated, workspaceID, creatorType, actualCreatorID, map[string]any{"issue": resp})
 
-	// Only ready issues in todo are enqueued for agents.
+	// Enqueue agent task when an agent-assigned issue is created.
 	if issue.AssigneeType.Valid && issue.AssigneeID.Valid {
 		if h.shouldEnqueueAgentTask(r.Context(), issue) {
 			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
@@ -1112,11 +1112,20 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		"creator_id":          uuidToString(prevIssue.CreatorID),
 	})
 
-	// Reconcile task queue when assignee changes (not on status changes —
-	// agents manage issue status themselves via the CLI).
+	// Reconcile task queue when assignee changes.
 	if assigneeChanged {
 		h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
 
+		if h.shouldEnqueueAgentTask(r.Context(), issue) {
+			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
+		}
+	}
+
+	// Trigger the assigned agent when a member moves an issue out of backlog.
+	// Backlog acts as a parking lot — moving to an active status signals the
+	// issue is ready for work.
+	if statusChanged && !assigneeChanged && actorType == "member" &&
+		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 		if h.shouldEnqueueAgentTask(r.Context(), issue) {
 			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
 		}
@@ -1413,6 +1422,14 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 
 		if assigneeChanged {
 			h.TaskService.CancelTasksForIssue(r.Context(), issue.ID)
+			if h.shouldEnqueueAgentTask(r.Context(), issue) {
+				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
+			}
+		}
+
+		// Trigger agent when moving out of backlog (batch).
+		if statusChanged && !assigneeChanged && actorType == "member" &&
+			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 			if h.shouldEnqueueAgentTask(r.Context(), issue) {
 				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
 			}

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1126,7 +1126,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	// issue is ready for work.
 	if statusChanged && !assigneeChanged && actorType == "member" &&
 		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
-		if h.shouldEnqueueAgentTask(r.Context(), issue) {
+		if h.isAgentAssigneeReady(r.Context(), issue) {
 			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
 		}
 	}
@@ -1172,12 +1172,15 @@ func (h *Handler) canAssignAgent(ctx context.Context, r *http.Request, agentID, 
 	return false, "cannot assign to private agent"
 }
 
-// shouldEnqueueAgentTask returns true when an issue assignment should trigger
-// the assigned agent. No status gate — assignment is an explicit human action,
-// so it should trigger regardless of issue status (e.g. assigning an agent to
-// a done issue to fix a discovered problem).
-// All trigger types (on_assign, on_comment, on_mention) are always enabled.
+// shouldEnqueueAgentTask returns true when an issue creation or assignment
+// should trigger the assigned agent. Backlog issues are skipped — backlog
+// acts as a parking lot where issues can be pre-assigned without immediately
+// triggering execution. Moving out of backlog is handled separately in
+// UpdateIssue.
 func (h *Handler) shouldEnqueueAgentTask(ctx context.Context, issue db.Issue) bool {
+	if issue.Status == "backlog" {
+		return false
+	}
 	return h.isAgentAssigneeReady(ctx, issue)
 }
 
@@ -1430,7 +1433,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		// Trigger agent when moving out of backlog (batch).
 		if statusChanged && !assigneeChanged && actorType == "member" &&
 			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
-			if h.shouldEnqueueAgentTask(r.Context(), issue) {
+			if h.isAgentAssigneeReady(r.Context(), issue) {
 				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
 			}
 		}


### PR DESCRIPTION
## Summary
- When a member moves an agent-assigned issue from "backlog" to an active status (todo, in_progress, etc.), the assigned agent is now triggered automatically
- Backlog acts as a parking lot — issues can be assigned to agents without immediately triggering execution, then activated by moving to an active status
- Applies to both single and batch issue updates
- Fixes stale comments that incorrectly stated only "todo" issues trigger agents

Closes MUL-813

## Test plan
- [ ] Added `TestBacklogToTodoTriggersAgent` integration test
- [ ] Verify moving a backlog issue to "todo" with an agent assigned enqueues an agent task
- [ ] Verify moving a backlog issue to "done" or "cancelled" does NOT trigger the agent
- [ ] Verify agent-initiated status changes do NOT re-trigger (only member actions)
- [ ] Verify batch status updates from backlog also trigger agents