### PR TITLE
feat(cli): support --version and -v flags

### DIFF
--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -22,6 +23,9 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.Version = fmt.Sprintf("%s (commit: %s, built: %s)\ngo: %s, os/arch: %s/%s", version, commit, date, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	rootCmd.SetVersionTemplate("multica {{.Version}}\n")
+
 	rootCmd.PersistentFlags().String("server-url", "", "Multica server URL (env: MULTICA_SERVER_URL)")
 	rootCmd.PersistentFlags().String("workspace-id", "", "Workspace ID (env: MULTICA_WORKSPACE_ID)")
 	rootCmd.PersistentFlags().String("profile", "", "Configuration profile name (e.g. dev) — isolates config, daemon state, and workspaces")


### PR DESCRIPTION
## Summary
- Adds `--version` / `-v` flag support to the root `multica` command using Cobra's built-in version feature
- `multica --version` and `multica -v` now produce the same output as `multica version`

## Test plan
- [x] `multica --version` prints version info
- [x] `multica -v` prints version info  
- [x] `multica version` continues to work as before
- [x] Go tests pass (`go test ./cmd/multica/`)

Closes MUL-743