### PR TITLE
feat(issues): persist comment collapse state

### DIFF
--- a/packages/core/issues/stores/comment-collapse-store.ts
+++ b/packages/core/issues/stores/comment-collapse-store.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
+import { defaultStorage } from "../../platform/storage";
+
+/**
+ * Tracks which comments are collapsed, keyed by issue ID.
+ * Only collapsed comment IDs are stored — expanded is the default state.
+ */
+interface CommentCollapseStore {
+  collapsedByIssue: Record<string, string[]>;
+  isCollapsed: (issueId: string, commentId: string) => boolean;
+  toggle: (issueId: string, commentId: string) => void;
+}
+
+export const useCommentCollapseStore = create<CommentCollapseStore>()(
+  persist(
+    (set, get) => ({
+      collapsedByIssue: {},
+      isCollapsed: (issueId, commentId) => {
+        const ids = get().collapsedByIssue[issueId];
+        return ids ? ids.includes(commentId) : false;
+      },
+      toggle: (issueId, commentId) =>
+        set((s) => {
+          const current = s.collapsedByIssue[issueId] ?? [];
+          const isCurrentlyCollapsed = current.includes(commentId);
+          if (isCurrentlyCollapsed) {
+            const next = current.filter((id) => id !== commentId);
+            if (next.length === 0) {
+              const { [issueId]: _, ...rest } = s.collapsedByIssue;
+              return { collapsedByIssue: rest };
+            }
+            return { collapsedByIssue: { ...s.collapsedByIssue, [issueId]: next } };
+          }
+          return { collapsedByIssue: { ...s.collapsedByIssue, [issueId]: [...current, commentId] } };
+        }),
+    }),
+    {
+      name: "multica_comment_collapse",
+      storage: createJSONStorage(() => createWorkspaceAwareStorage(defaultStorage)),
+    },
+  ),
+);
+
+registerForWorkspaceRehydration(() => useCommentCollapseStore.persist.rehydrate());

--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -7,6 +7,7 @@ export {
   useViewStoreApi,
 } from "./view-store-context";
 export { useIssuesScopeStore, type IssuesScope } from "./issues-scope-store";
+export { useCommentCollapseStore } from "./comment-collapse-store";
 export {
   myIssuesViewStore,
   type MyIssuesViewState,

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ChevronRight, Copy, Download, FileText, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@multica/ui/components/ui/card";
@@ -36,6 +36,7 @@ import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import { ReplyInput } from "./reply-input";
 import type { TimelineEntry, Attachment } from "@multica/core/types";
+import { useCommentCollapseStore } from "@multica/core/issues/stores";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -328,7 +329,10 @@ function CommentCard({
 }: CommentCardProps) {
   const { getActorName } = useActorName();
   const { uploadWithToast } = useFileUpload(api);
-  const [open, setOpen] = useState(true);
+  const isCollapsed = useCommentCollapseStore((s) => s.isCollapsed(issueId, entry.id));
+  const toggleCollapse = useCommentCollapseStore((s) => s.toggle);
+  const open = !isCollapsed;
+  const handleOpenChange = useCallback((_open: boolean) => toggleCollapse(issueId, entry.id), [toggleCollapse, issueId, entry.id]);
   const [editing, setEditing] = useState(false);
   const editEditorRef = useRef<ContentEditorRef>(null);
   const cancelledRef = useRef(false);
@@ -390,7 +394,7 @@ function CommentCard({
 
   return (
     <Card className={cn("!py-0 !gap-0 overflow-hidden transition-colors duration-700", isTemp && "opacity-60", isHighlighted && "ring-2 ring-brand/50 bg-brand/5")}>
-      <Collapsible open={open} onOpenChange={setOpen}>
+      <Collapsible open={open} onOpenChange={handleOpenChange}>
         {/* Header — always visible, acts as toggle */}
         <div className="px-4 py-3">
           <div className="flex items-center gap-2.5">

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -228,6 +228,14 @@ vi.mock("@multica/core/issues/stores", () => ({
     },
     { getState: () => ({ items: [], recordVisit: mockRecordVisit }) },
   ),
+  useCommentCollapseStore: (selector?: any) => {
+    const state = {
+      collapsedByIssue: {},
+      isCollapsed: () => false,
+      toggle: () => {},
+    };
+    return selector ? selector(state) : state;
+  },
 }));
 
 // Mock modals


### PR DESCRIPTION
## Summary
- Add `useCommentCollapseStore` — a workspace-scoped Zustand store that persists collapsed comment IDs to localStorage
- Replace transient `useState(true)` in `CommentCard` with the new store so collapse/expand state survives page reloads and navigation

Closes MUL-672

## Test plan
- [ ] Open an issue with multiple comment threads
- [ ] Collapse some comments, reload the page — they should remain collapsed
- [ ] Switch workspaces and verify collapse state is scoped per workspace
- [ ] Expand a previously collapsed comment, reload — it should stay expanded