### PR TITLE
perf(db): add missing index for GetLastTaskSession

### DIFF
--- a/server/migrations/041_task_queue_composite_indexes.down.sql
+++ b/server/migrations/041_task_queue_composite_indexes.down.sql
@@ -1,2 +1,1 @@
 DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_session_lookup;
-DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_queue_issue_active;

--- a/server/migrations/041_task_queue_composite_indexes.down.sql
+++ b/server/migrations/041_task_queue_composite_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_session_lookup;
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_queue_issue_active;

--- a/server/migrations/041_task_queue_composite_indexes.up.sql
+++ b/server/migrations/041_task_queue_composite_indexes.up.sql
@@ -1,0 +1,15 @@
+-- GetLastTaskSession queries by (agent_id, issue_id) with status = 'completed',
+-- ordered by completed_at DESC. The existing (agent_id, status) index forces a
+-- full scan of all tasks for the agent to find matching issue rows.
+-- This partial index covers the lookup exactly and stays compact.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_session_lookup
+    ON agent_task_queue (agent_id, issue_id, completed_at DESC)
+    WHERE status = 'completed' AND session_id IS NOT NULL;
+
+-- HasActiveTaskForIssue checks status IN ('queued', 'dispatched', 'running').
+-- The partial index from migration 037 only covers queued/dispatched; the general
+-- issue_id index (migration 035) covers all statuses but can't filter on status.
+-- This partial index lets the hot-path comment trigger check skip completed/failed rows.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_queue_issue_active
+    ON agent_task_queue (issue_id)
+    WHERE status IN ('queued', 'dispatched', 'running');

--- a/server/migrations/041_task_queue_composite_indexes.up.sql
+++ b/server/migrations/041_task_queue_composite_indexes.up.sql
@@ -5,11 +5,3 @@
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_session_lookup
     ON agent_task_queue (agent_id, issue_id, completed_at DESC)
     WHERE status = 'completed' AND session_id IS NOT NULL;
-
--- HasActiveTaskForIssue checks status IN ('queued', 'dispatched', 'running').
--- The partial index from migration 037 only covers queued/dispatched; the general
--- issue_id index (migration 035) covers all statuses but can't filter on status.
--- This partial index lets the hot-path comment trigger check skip completed/failed rows.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_queue_issue_active
-    ON agent_task_queue (issue_id)
-    WHERE status IN ('queued', 'dispatched', 'running');


### PR DESCRIPTION
## Summary

`GetLastTaskSession` has no efficient index for its lookup pattern:

```sql
SELECT session_id, work_dir FROM agent_task_queue
WHERE agent_id = $1 AND issue_id = $2 AND status = 'completed' AND session_id IS NOT NULL
ORDER BY completed_at DESC
LIMIT 1;
```

The existing `idx_agent_task_queue_agent (agent_id, status)` finds all completed tasks for the agent but then must scan across all of them to filter by `issue_id`. As completed task history grows per agent, this becomes a full scan of the agent's entire task history.

This adds a compact partial index that covers the lookup exactly:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_session_lookup
    ON agent_task_queue (agent_id, issue_id, completed_at DESC)
    WHERE status = 'completed' AND session_id IS NOT NULL;
```

Uses `CONCURRENTLY` and `IF NOT EXISTS` — safe to apply on live instances without table locks.

## Test plan

- [ ] `make migrate-up` applies cleanly
- [ ] `make migrate-down` rolls back cleanly