### PR TITLE
fix(web): add /uploads/* rewrite for self-hosted deployments

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -45,6 +45,10 @@ const nextConfig: NextConfig = {
         source: "/auth/:path*",
         destination: `${remoteApiUrl}/auth/:path*`,
       },
+      {
+        source: "/uploads/:path*",
+        destination: `${remoteApiUrl}/uploads/:path*`,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary
- Add `/uploads/:path*` rewrite rule in `next.config.ts` to proxy upload requests to the backend
- Fixes #1004: uploaded files (profile pictures, etc.) return 404 on self-hosted deployments where the frontend is the sole entrypoint

Cherry-picked from #1005 (only the uploads rewrite, without the unrelated WebSocket ping/pong changes).

## Test plan
- [ ] Deploy locally with `S3_BUCKET` / `CLOUDFRONT_DOMAIN` unset
- [ ] Upload a workspace profile picture
- [ ] Verify the image loads correctly (no 404)