### PR TITLE
fix(daemon): explicitly prompt agent to mark issue in_progress on assignment

### DIFF
--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -18,7 +18,8 @@ func BuildPrompt(task Task) string {
 	var b strings.Builder
 	b.WriteString("You are running as a local coding agent for a Multica workspace.\n\n")
 	fmt.Fprintf(&b, "Your assigned issue ID is: %s\n\n", task.IssueID)
-	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
+	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task.\n", task.IssueID)
+	fmt.Fprintf(&b, "Then run `multica issue status %s in_progress` to mark it started before doing any work.\n", task.IssueID)
 	return b.String()
 }
 


### PR DESCRIPTION
## Problem

Closes #985.

Assignment-triggered tasks had a single-line prompt:

> Start by running `multica issue get {id} --output json` to understand your task, then complete it.

The trailing **"then complete it"** acts as a short-circuit — models jump straight to doing the work and skip the `multica issue status in_progress` step that's defined in the CLAUDE.md workflow. The issue status stays stuck at "Todo" even while the agent is actively running.

## Fix

Split into two explicit instructions in the initial prompt:

```
Start by running `multica issue get {id} --output json` to understand your task.
Then run `multica issue status {id} in_progress` to mark it started before doing any work.
```

This makes the status update impossible to miss without any dependency on the agent reading the full CLAUDE.md workflow.

## Scope

Only `BuildPrompt` (assignment-triggered) is changed. `buildCommentPrompt` is intentionally left alone — comment-triggered tasks should not change issue status unless explicitly asked (per the existing workflow design).

## Test plan

- [ ] Assign an agent to a new issue — issue status should move to `in_progress` when the agent starts
- [ ] Comment on an issue with an agent assigned — issue status should NOT change automatically