### PR TITLE
fix(server): allow members to create agents

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -263,7 +263,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 			// Agents
 			r.Route("/api/agents", func(r chi.Router) {
 				r.Get("/", h.ListAgents)
-				r.With(middleware.RequireWorkspaceRole(queries, "owner", "admin")).Post("/", h.CreateAgent)
+				r.Post("/", h.CreateAgent)
 				r.Route("/{id}", func(r chi.Router) {
 					r.Get("/", h.GetAgent)
 					r.Put("/", h.UpdateAgent)


### PR DESCRIPTION
## Summary

- Remove the `RequireWorkspaceRole(queries, "owner", "admin")` middleware from the `POST /api/agents` endpoint so that workspace members (not just owners/admins) can create agents.

Fixes [MUL-819](mention://issue/eabb72a4-8cea-42f1-b1a7-626ef5c3613d)

## Test plan

- [ ] Log in as a workspace member and verify that creating an agent succeeds (previously returned 403)
- [ ] Verify owners and admins can still create agents
- [ ] Verify unauthenticated and non-member users still cannot create agents