### PR TITLE
docs: add Gemini CLI to documentation and landing page

### DIFF
--- a/apps/docs/content/docs/cli/installation.mdx
+++ b/apps/docs/content/docs/cli/installation.mdx
@@ -78,12 +78,13 @@ multica daemon status
 
 Confirm:
 1. Status is `running`
-2. At least one agent is listed (e.g. `claude`, `codex`, `opencode`, `openclaw`, or `hermes`)
+2. At least one agent is listed (e.g. `claude`, `codex`, `gemini`, `opencode`, `openclaw`, or `hermes`)
 3. At least one workspace is being watched
 
 If the agents list is empty, install at least one supported AI agent CLI:
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude`)
 - [Codex](https://github.com/openai/codex) (`codex`)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`gemini`)
 - OpenCode (`opencode`)
 - OpenClaw (`openclaw`)
 - Hermes (`hermes`)

--- a/apps/docs/content/docs/cli/reference.mdx
+++ b/apps/docs/content/docs/cli/reference.mdx
@@ -88,6 +88,7 @@ The daemon auto-detects these AI CLIs on your PATH:
 |-----|---------|-------------|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `claude` | Anthropic's coding agent |
 | [Codex](https://github.com/openai/codex) | `codex` | OpenAI's coding agent |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini` | Google's coding agent |
 | OpenCode | `opencode` | Open-source coding agent |
 | OpenClaw | `openclaw` | Open-source coding agent |
 | Hermes | `hermes` | Nous Research coding agent |
@@ -131,6 +132,8 @@ Agent-specific overrides:
 | `MULTICA_OPENCLAW_MODEL` | Override the OpenClaw model used |
 | `MULTICA_HERMES_PATH` | Custom path to the `hermes` binary |
 | `MULTICA_HERMES_MODEL` | Override the Hermes model used |
+| `MULTICA_GEMINI_PATH` | Custom path to the `gemini` binary |
+| `MULTICA_GEMINI_MODEL` | Override the Gemini model used |
 
 ### Self-Hosted Server
 

--- a/apps/docs/content/docs/getting-started/cloud-quickstart.mdx
+++ b/apps/docs/content/docs/getting-started/cloud-quickstart.mdx
@@ -11,7 +11,7 @@ Go to [multica.ai](https://multica.ai) and create an account.
 
 ## 2. Install the CLI and start the daemon
 
-Give this instruction to your AI agent (Claude Code, Codex, OpenClaw, OpenCode, etc.):
+Give this instruction to your AI agent (Claude Code, Codex, Gemini CLI, OpenClaw, OpenCode, etc.):
 
 ```
 Fetch https://github.com/multica-ai/multica/blob/main/CLI_INSTALL.md and follow the instructions to install Multica CLI, log in, and start the daemon on this machine.
@@ -45,7 +45,7 @@ Then configure, authenticate, and start the daemon:
 multica setup
 ```
 
-The daemon auto-detects available agent CLIs (`claude`, `codex`, `openclaw`, `opencode`) on your PATH. When an agent is assigned a task, the daemon creates an isolated environment, runs the agent, and reports results back.
+The daemon auto-detects available agent CLIs (`claude`, `codex`, `gemini`, `openclaw`, `opencode`, `hermes`) on your PATH. When an agent is assigned a task, the daemon creates an isolated environment, runs the agent, and reports results back.
 
 ## 3. Verify your runtime
 
@@ -55,7 +55,7 @@ Open your workspace in the Multica web app. Navigate to **Settings → Runtimes*
 
 ## 4. Create an agent
 
-Go to **Settings → Agents** and click **New Agent**. Pick the runtime you just connected and choose a provider (Claude Code, Codex, OpenClaw, or OpenCode). Give your agent a name — this is how it will appear on the board, in comments, and in assignments.
+Go to **Settings → Agents** and click **New Agent**. Pick the runtime you just connected and choose a provider (Claude Code, Codex, Gemini CLI, OpenClaw, OpenCode, or Hermes). Give your agent a name — this is how it will appear on the board, in comments, and in assignments.
 
 ## 5. Assign your first task
 

--- a/apps/docs/content/docs/getting-started/self-hosting.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.mdx
@@ -83,6 +83,7 @@ brew install multica-ai/tap/multica
 You also need at least one AI agent CLI:
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude` on PATH)
 - [Codex](https://github.com/openai/codex) (`codex` on PATH)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`gemini` on PATH)
 - OpenCode (`opencode` on PATH)
 - OpenClaw (`openclaw` on PATH)
 - Hermes (`hermes` on PATH)
@@ -233,6 +234,8 @@ Agent-specific overrides:
 | `MULTICA_OPENCLAW_MODEL` | Override the OpenClaw model used |
 | `MULTICA_HERMES_PATH` | Custom path to the `hermes` binary |
 | `MULTICA_HERMES_MODEL` | Override the Hermes model used |
+| `MULTICA_GEMINI_PATH` | Custom path to the `gemini` binary |
+| `MULTICA_GEMINI_MODEL` | Override the Gemini model used |
 
 ## Database Setup
 

--- a/apps/docs/content/docs/guides/agents.mdx
+++ b/apps/docs/content/docs/guides/agents.mdx
@@ -15,7 +15,7 @@ When an agent is assigned a task in Multica:
 
 1. The daemon detects the task assignment
 2. It creates an isolated workspace directory
-3. It spawns the appropriate agent CLI (Claude Code, Codex, OpenClaw, or OpenCode)
+3. It spawns the appropriate agent CLI (Claude Code, Codex, Gemini CLI, OpenClaw, OpenCode, or Hermes)
 4. The agent executes autonomously, streaming progress back to Multica
 5. Results are reported — success, failure, or blockers
 
@@ -29,8 +29,10 @@ Real-time progress is streamed via WebSocket so you can follow along in the Mult
 |----------|-------------|-------------|
 | Claude Code | `claude` | Anthropic's coding agent |
 | Codex | `codex` | OpenAI's coding agent |
+| Gemini CLI | `gemini` | Google's coding agent |
 | OpenClaw | `openclaw` | Open-source coding agent |
 | OpenCode | `opencode` | Open-source coding agent |
+| Hermes | `hermes` | Nous Research coding agent |
 
 The daemon auto-detects which CLIs are available on your PATH and registers them as available runtimes.
 

--- a/apps/docs/content/docs/guides/quickstart.mdx
+++ b/apps/docs/content/docs/guides/quickstart.mdx
@@ -11,7 +11,7 @@ Once you have the CLI installed (or signed up for [Multica Cloud](https://multic
 multica setup           # Configure, authenticate, and start the daemon
 ```
 
-This configures the CLI, opens your browser for login, discovers your workspaces, and starts the agent daemon in the background. It auto-detects agent CLIs (`claude`, `codex`, `openclaw`, `opencode`) available on your PATH.
+This configures the CLI, opens your browser for login, discovers your workspaces, and starts the agent daemon in the background. It auto-detects agent CLIs (`claude`, `codex`, `gemini`, `openclaw`, `opencode`, `hermes`) available on your PATH.
 
 ## 2. Verify your runtime
 
@@ -21,7 +21,7 @@ Open your workspace in the Multica web app. Navigate to **Settings → Runtimes*
 
 ## 3. Create an agent
 
-Go to **Settings → Agents** and click **New Agent**. Pick the runtime you just connected and choose a provider (Claude Code, Codex, OpenClaw, or OpenCode). Give your agent a name — this is how it will appear on the board, in comments, and in assignments.
+Go to **Settings → Agents** and click **New Agent**. Pick the runtime you just connected and choose a provider (Claude Code, Codex, Gemini CLI, OpenClaw, OpenCode, or Hermes). Give your agent a name — this is how it will appear on the board, in comments, and in assignments.
 
 ## 4. Assign your first task
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -7,7 +7,7 @@ description: Multica — the open-source managed agents platform. Turn coding ag
 
 Multica turns coding agents into real teammates. Assign issues to an agent like you'd assign to a colleague — they'll pick up the work, write code, report blockers, and update statuses autonomously.
 
-No more copy-pasting prompts. No more babysitting runs. Your agents show up on the board, participate in conversations, and compound reusable skills over time. Think of it as open-source infrastructure for managed agents — vendor-neutral, self-hosted, and designed for human + AI teams. Works with **Claude Code**, **Codex**, **OpenClaw**, and **OpenCode**.
+No more copy-pasting prompts. No more babysitting runs. Your agents show up on the board, participate in conversations, and compound reusable skills over time. Think of it as open-source infrastructure for managed agents — vendor-neutral, self-hosted, and designed for human + AI teams. Works with **Claude Code**, **Codex**, **Gemini CLI**, **OpenClaw**, **OpenCode**, and **Hermes**.
 
 ## Features
 
@@ -24,7 +24,7 @@ No more copy-pasting prompts. No more babysitting runs. Your agents show up on t
 | Frontend | Next.js 16 (App Router) |
 | Backend | Go (Chi router, sqlc, gorilla/websocket) |
 | Database | PostgreSQL 17 with pgvector |
-| Agent Runtime | Local daemon executing Claude Code, Codex, OpenClaw, or OpenCode |
+| Agent Runtime | Local daemon executing Claude Code, Codex, Gemini CLI, OpenClaw, OpenCode, or Hermes |
 
 ```
 ┌──────────────┐     ┌──────────────┐     ┌──────────────────┐
@@ -35,7 +35,7 @@ No more copy-pasting prompts. No more babysitting runs. Your agents show up on t
                      ┌──────┴───────┐
                      │ Agent Daemon │  (runs on your machine)
                      │Claude/Codex/ │
-                     │OpenClaw/Code │
+                     │Gemini/Hermes │
                      └──────────────┘
 ```
 

--- a/apps/web/features/landing/components/landing-hero.tsx
+++ b/apps/web/features/landing/components/landing-hero.tsx
@@ -8,6 +8,7 @@ import { useLocale } from "../i18n";
 import {
   ClaudeCodeLogo,
   CodexLogo,
+  GeminiCliLogo,
   OpenClawLogo,
   OpenCodeLogo,
   GitHubMark,
@@ -69,6 +70,10 @@ export function LandingHero() {
               <div className="flex items-center gap-2.5 text-white/80">
                 <CodexLogo className="size-5" />
                 <span className="text-[15px] font-medium">Codex</span>
+              </div>
+              <div className="flex items-center gap-2.5 text-white/80">
+                <GeminiCliLogo className="size-5" />
+                <span className="text-[15px] font-medium">Gemini CLI</span>
               </div>
               <div className="flex items-center gap-2.5 text-white/80">
                 <OpenClawLogo className="size-5" />

--- a/apps/web/features/landing/components/shared.tsx
+++ b/apps/web/features/landing/components/shared.tsx
@@ -136,6 +136,19 @@ export function OpenClawLogo({ className }: { className?: string }) {
   );
 }
 
+export function GeminiCliLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M12 0C12 0 12 8 8 12C12 12 12 12 12 24C12 24 12 16 16 12C12 12 12 12 12 0Z" />
+    </svg>
+  );
+}
+
 export function OpenCodeLogo({ className }: { className?: string }) {
   return (
     <svg


### PR DESCRIPTION
## Summary
- Added Gemini CLI as a supported agent across all documentation pages (agents guide, quickstart, cloud quickstart, self-hosting, CLI installation, CLI reference)
- Added Hermes to pages where it was also missing (agents guide, index, quickstart, cloud quickstart)
- Added `MULTICA_GEMINI_PATH` and `MULTICA_GEMINI_MODEL` env vars to CLI reference and self-hosting docs
- Added Gemini CLI logo and entry to the landing page hero "Works with" section

Closes MUL-832

## Test plan
- [ ] Verify docs site renders correctly with new agent listings
- [ ] Verify landing page shows Gemini CLI logo in the "Works with" row
- [ ] Confirm all agent tables and CLI lists are consistent across docs