### PR TITLE
fix(auth): honor ?next= redirect through Google OAuth flow

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -37,6 +37,15 @@ function LoginPageContent() {
     router.push(ws ? nextUrl : "/onboarding");
   };
 
+  // Build Google OAuth state: encode platform + next URL so the callback
+  // can redirect to the right place after login.
+  const googleState = [
+    platform === "desktop" ? "platform:desktop" : "",
+    nextUrl !== "/issues" ? `next:${nextUrl}` : "",
+  ]
+    .filter(Boolean)
+    .join(",") || undefined;
+
   return (
     <LoginPage
       onSuccess={handleSuccess}
@@ -45,7 +54,7 @@ function LoginPageContent() {
           ? {
               clientId: googleClientId,
               redirectUri: `${window.location.origin}/auth/callback`,
-              state: platform === "desktop" ? "platform:desktop" : undefined,
+              state: googleState,
             }
           : undefined
       }

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -39,8 +39,11 @@ function CallbackContent() {
       return;
     }
 
-    const state = searchParams.get("state");
-    const isDesktop = state === "platform:desktop";
+    const state = searchParams.get("state") || "";
+    const stateParts = state.split(",");
+    const isDesktop = stateParts.includes("platform:desktop");
+    const nextPart = stateParts.find((p) => p.startsWith("next:"));
+    const nextUrl = nextPart ? nextPart.slice(5) : null; // strip "next:" prefix
 
     const redirectUri = `${window.location.origin}/auth/callback`;
 
@@ -63,7 +66,9 @@ function CallbackContent() {
           qc.setQueryData(workspaceKeys.list(), wsList);
           const lastWsId = localStorage.getItem("multica_workspace_id");
           const ws = await hydrateWorkspace(wsList, lastWsId);
-          router.push(ws ? "/issues" : "/onboarding");
+          // Honor the ?next= redirect if present (e.g. /invite/{id})
+          const defaultDest = ws ? "/issues" : "/onboarding";
+          router.push(nextUrl || defaultDest);
         })
         .catch((err) => {
           setError(err instanceof Error ? err.message : "Login failed");


### PR DESCRIPTION
## Summary

- Fix: after Google OAuth login, the callback page now redirects to the `?next=` destination (e.g. `/invite/{id}`) instead of always going to `/issues`
- The login page encodes `next` into the OAuth `state` param (e.g. `state=next:/invite/xxx`)
- The callback page parses the `state` to extract and redirect to the correct URL

This fixes the bug where unauthenticated users clicking an invite email link would end up in their own workspace after Google login instead of the invitation page.

## Test plan

- [ ] Click invite email link while not logged in → Google login → verify redirect to `/invite/{id}`
- [ ] Click invite email link while logged in → verify direct access to `/invite/{id}`
- [ ] Normal Google login (no `?next=`) → verify redirect to `/issues` as before
- [ ] Desktop Google login flow → verify `platform:desktop` state still works