### PR TITLE
feat(desktop): restart local daemon when bundled CLI version differs

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
     "preview": "electron-vite preview",
     "package": "pnpm run bundle-cli && electron-builder",
     "lint": "eslint .",
+    "test": "vitest run",
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
@@ -47,6 +48,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "tailwindcss": "^4",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -39,6 +39,7 @@ let getMainWindow: () => BrowserWindow | null = () => null;
 let operationInProgress = false;
 let cachedCliBinary: string | null | undefined = undefined;
 let cliResolvePromise: Promise<string | null> | null = null;
+let cachedCliBinaryVersion: string | null | undefined = undefined;
 let targetApiBaseUrl: string | null = null;
 let activeProfile: ActiveProfile | null = null;
 
@@ -132,6 +133,7 @@ interface HealthPayload {
   daemon_id?: string;
   device_name?: string;
   server_url?: string;
+  cli_version?: string;
   agents?: string[];
   workspaces?: unknown[];
 }
@@ -359,6 +361,72 @@ async function resolveCliBinary(): Promise<string | null> {
   } finally {
     cliResolvePromise = null;
   }
+}
+
+/**
+ * Reads the version of the currently resolved CLI binary by invoking
+ * `multica version --output json`. Cached for the process lifetime — the
+ * bundled binary doesn't change after `bundle-cli.mjs` runs at dev/build time.
+ * Returns null on any failure (unknown `go` at bundle time, broken binary,
+ * etc.) so callers can fail open.
+ */
+async function getCliBinaryVersion(): Promise<string | null> {
+  if (cachedCliBinaryVersion !== undefined) return cachedCliBinaryVersion;
+  const bin = await resolveCliBinary();
+  if (!bin) {
+    cachedCliBinaryVersion = null;
+    return null;
+  }
+  try {
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(
+        bin,
+        ["version", "--output", "json"],
+        { timeout: 5_000 },
+        (err, out) => {
+          if (err) reject(err);
+          else resolve(out);
+        },
+      );
+    });
+    const parsed = JSON.parse(stdout) as { version?: string };
+    cachedCliBinaryVersion = parsed.version ?? null;
+  } catch (err) {
+    console.warn("[daemon] failed to read CLI binary version:", err);
+    cachedCliBinaryVersion = null;
+  }
+  return cachedCliBinaryVersion;
+}
+
+/**
+ * If a daemon is already running on the active profile's port, compares its
+ * reported `cli_version` to the CLI binary we would use to spawn a new one.
+ * Restarts only when BOTH versions are known AND they differ — a restart
+ * kills in-flight agent tasks, so we fail safe on any uncertainty.
+ *
+ * Returns `"restarted" | "ok" | "not_running"`.
+ */
+async function ensureRunningDaemonVersionMatches(): Promise<
+  "restarted" | "ok" | "not_running"
+> {
+  const active = await ensureActiveProfile();
+  const running = await fetchHealthAtPort(active.port);
+  if (!running || running.status !== "running") return "not_running";
+
+  const bundled = await getCliBinaryVersion();
+  const runningVersion = running.cli_version;
+
+  // Unknown on either side → can't prove mismatch → leave the daemon alone.
+  // This covers: bundled binary missing/broken, and older daemons that
+  // predate the cli_version field in /health.
+  if (!bundled || !runningVersion) return "ok";
+  if (runningVersion === bundled) return "ok";
+
+  console.log(
+    `[daemon] CLI version mismatch (bundled=${bundled} running=${runningVersion}) — restarting daemon`,
+  );
+  await restartDaemon();
+  return "restarted";
 }
 
 /**
@@ -755,7 +823,12 @@ export function setupDaemonManager(
     const bin = await resolveCliBinary();
     if (!bin) return;
     const health = await fetchHealth();
-    if (health.state === "running") return;
+    if (health.state === "running") {
+      // Daemon is up but may be running an older CLI than the one we just
+      // bundled. Restart it so the new binary actually takes effect.
+      await ensureRunningDaemonVersionMatches();
+      return;
+    }
     await startDaemon();
   });
 

--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -18,6 +18,7 @@ import { join } from "path";
 import { homedir } from "os";
 import type { DaemonStatus, DaemonPrefs } from "../shared/daemon-types";
 import { ensureManagedCli, managedCliPath } from "./cli-bootstrap";
+import { decideVersionAction } from "./version-decision";
 
 const DEFAULT_HEALTH_PORT = 19514;
 const POLL_INTERVAL_MS = 5_000;
@@ -405,7 +406,9 @@ async function getCliBinaryVersion(): Promise<string | null> {
 
 /**
  * Compares the running daemon's `cli_version` against the CLI binary we
- * would use to spawn a new one, and restarts only when safe.
+ * would use to spawn a new one, and restarts only when safe. The decision
+ * logic itself is in `version-decision.ts` (pure, unit-tested); this
+ * wrapper handles the async plumbing and side effects.
  *
  * Restart is only fired when ALL of:
  *   - a daemon is actually running on the active profile's port
@@ -421,46 +424,34 @@ async function ensureRunningDaemonVersionMatches(): Promise<
 > {
   const active = await ensureActiveProfile();
   const running = await fetchHealthAtPort(active.port);
-  if (!running || running.status !== "running") {
-    pendingVersionRestart = false;
-    return "not_running";
-  }
-
   const bundled = await getCliBinaryVersion();
-  const runningVersion = running.cli_version;
+  const action = decideVersionAction(bundled, running);
 
-  // Unknown on either side → can't prove mismatch → leave the daemon alone.
-  // This covers: bundled binary missing/broken, and older daemons that
-  // predate the cli_version field in /health.
-  if (!bundled || !runningVersion) {
-    pendingVersionRestart = false;
-    return "ok";
-  }
-  if (runningVersion === bundled) {
-    pendingVersionRestart = false;
-    return "ok";
-  }
-
-  // Mismatch confirmed. If the daemon is currently running agent tasks,
-  // defer the restart so we don't kill them mid-execution. The poll loop
-  // will retry on each tick and fire the restart once the count drops to 0.
-  const activeTasks = running.active_task_count ?? 0;
-  if (activeTasks > 0) {
-    if (!pendingVersionRestart) {
-      console.log(
-        `[daemon] CLI version mismatch (bundled=${bundled} running=${runningVersion}); deferring restart until ${activeTasks} active task(s) finish`,
-      );
+  switch (action) {
+    case "not_running":
+      pendingVersionRestart = false;
+      return "not_running";
+    case "ok":
+      pendingVersionRestart = false;
+      return "ok";
+    case "defer": {
+      if (!pendingVersionRestart) {
+        const activeTasks = running?.active_task_count ?? 0;
+        console.log(
+          `[daemon] CLI version mismatch (bundled=${bundled} running=${running?.cli_version}); deferring restart until ${activeTasks} active task(s) finish`,
+        );
+      }
+      pendingVersionRestart = true;
+      return "deferred";
     }
-    pendingVersionRestart = true;
-    return "deferred";
+    case "restart":
+      console.log(
+        `[daemon] CLI version mismatch (bundled=${bundled} running=${running?.cli_version}) — restarting daemon`,
+      );
+      pendingVersionRestart = false;
+      await restartDaemon();
+      return "restarted";
   }
-
-  console.log(
-    `[daemon] CLI version mismatch (bundled=${bundled} running=${runningVersion}) — restarting daemon`,
-  );
-  pendingVersionRestart = false;
-  await restartDaemon();
-  return "restarted";
 }
 
 /**

--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -835,6 +835,9 @@ export function setupDaemonManager(
   ipcMain.handle("daemon:retry-install", async () => {
     cachedCliBinary = undefined;
     cliResolvePromise = null;
+    // A retry-install may land a new CLI at a different version; drop the
+    // cached version string so the next check re-reads the binary.
+    cachedCliBinaryVersion = undefined;
     await bootstrapCli();
   });
   ipcMain.handle("daemon:get-prefs", () => loadPrefs());

--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -40,6 +40,10 @@ let operationInProgress = false;
 let cachedCliBinary: string | null | undefined = undefined;
 let cliResolvePromise: Promise<string | null> | null = null;
 let cachedCliBinaryVersion: string | null | undefined = undefined;
+// Set when a CLI version mismatch was detected but the running daemon is
+// busy executing tasks. The poll loop retries the check on each tick and
+// fires the restart once active_task_count drops to 0.
+let pendingVersionRestart = false;
 let targetApiBaseUrl: string | null = null;
 let activeProfile: ActiveProfile | null = null;
 
@@ -134,6 +138,7 @@ interface HealthPayload {
   device_name?: string;
   server_url?: string;
   cli_version?: string;
+  active_task_count?: number;
   agents?: string[];
   workspaces?: unknown[];
 }
@@ -399,19 +404,27 @@ async function getCliBinaryVersion(): Promise<string | null> {
 }
 
 /**
- * If a daemon is already running on the active profile's port, compares its
- * reported `cli_version` to the CLI binary we would use to spawn a new one.
- * Restarts only when BOTH versions are known AND they differ — a restart
- * kills in-flight agent tasks, so we fail safe on any uncertainty.
+ * Compares the running daemon's `cli_version` against the CLI binary we
+ * would use to spawn a new one, and restarts only when safe.
  *
- * Returns `"restarted" | "ok" | "not_running"`.
+ * Restart is only fired when ALL of:
+ *   - a daemon is actually running on the active profile's port
+ *   - both sides report a version and the strings differ
+ *   - `active_task_count` is 0 (no in-flight agent work would be killed)
+ *
+ * On a confirmed mismatch while the daemon is busy, `pendingVersionRestart`
+ * is set; the poll loop retries this function on each 5s tick and will fire
+ * the restart as soon as the daemon drains.
  */
 async function ensureRunningDaemonVersionMatches(): Promise<
-  "restarted" | "ok" | "not_running"
+  "restarted" | "deferred" | "ok" | "not_running"
 > {
   const active = await ensureActiveProfile();
   const running = await fetchHealthAtPort(active.port);
-  if (!running || running.status !== "running") return "not_running";
+  if (!running || running.status !== "running") {
+    pendingVersionRestart = false;
+    return "not_running";
+  }
 
   const bundled = await getCliBinaryVersion();
   const runningVersion = running.cli_version;
@@ -419,12 +432,33 @@ async function ensureRunningDaemonVersionMatches(): Promise<
   // Unknown on either side → can't prove mismatch → leave the daemon alone.
   // This covers: bundled binary missing/broken, and older daemons that
   // predate the cli_version field in /health.
-  if (!bundled || !runningVersion) return "ok";
-  if (runningVersion === bundled) return "ok";
+  if (!bundled || !runningVersion) {
+    pendingVersionRestart = false;
+    return "ok";
+  }
+  if (runningVersion === bundled) {
+    pendingVersionRestart = false;
+    return "ok";
+  }
+
+  // Mismatch confirmed. If the daemon is currently running agent tasks,
+  // defer the restart so we don't kill them mid-execution. The poll loop
+  // will retry on each tick and fire the restart once the count drops to 0.
+  const activeTasks = running.active_task_count ?? 0;
+  if (activeTasks > 0) {
+    if (!pendingVersionRestart) {
+      console.log(
+        `[daemon] CLI version mismatch (bundled=${bundled} running=${runningVersion}); deferring restart until ${activeTasks} active task(s) finish`,
+      );
+    }
+    pendingVersionRestart = true;
+    return "deferred";
+  }
 
   console.log(
     `[daemon] CLI version mismatch (bundled=${bundled} running=${runningVersion}) — restarting daemon`,
   );
+  pendingVersionRestart = false;
   await restartDaemon();
   return "restarted";
 }
@@ -650,6 +684,10 @@ async function pollOnce(): Promise<void> {
   const status = await fetchHealth();
   currentState = status.state;
   sendStatus(status);
+  // Retry a deferred version-mismatch restart once the daemon drains.
+  if (pendingVersionRestart && status.state === "running") {
+    void ensureRunningDaemonVersionMatches();
+  }
 }
 
 function startPolling(): void {

--- a/apps/desktop/src/main/version-decision.test.ts
+++ b/apps/desktop/src/main/version-decision.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { decideVersionAction } from "./version-decision";
+
+describe("decideVersionAction", () => {
+  it("returns not_running when health payload is null", () => {
+    expect(decideVersionAction("v1.0.0", null)).toBe("not_running");
+  });
+
+  it("returns not_running when status is not 'running'", () => {
+    expect(
+      decideVersionAction("v1.0.0", { status: "stopped", cli_version: "v1.0.0" }),
+    ).toBe("not_running");
+  });
+
+  it("returns ok when bundled version is unknown (fail safe)", () => {
+    expect(
+      decideVersionAction(null, {
+        status: "running",
+        cli_version: "v1.0.0",
+        active_task_count: 0,
+      }),
+    ).toBe("ok");
+  });
+
+  it("returns ok when running daemon does not report cli_version (older daemon)", () => {
+    expect(
+      decideVersionAction("v1.0.0", {
+        status: "running",
+        active_task_count: 0,
+      }),
+    ).toBe("ok");
+  });
+
+  it("returns ok when versions match exactly", () => {
+    expect(
+      decideVersionAction("v1.2.3", {
+        status: "running",
+        cli_version: "v1.2.3",
+        active_task_count: 5,
+      }),
+    ).toBe("ok");
+  });
+
+  it("returns restart when versions differ and daemon is idle", () => {
+    expect(
+      decideVersionAction("v1.2.3", {
+        status: "running",
+        cli_version: "v1.2.2",
+        active_task_count: 0,
+      }),
+    ).toBe("restart");
+  });
+
+  it("treats missing active_task_count as 0 (old daemon that still reports cli_version)", () => {
+    expect(
+      decideVersionAction("v1.2.3", {
+        status: "running",
+        cli_version: "v1.2.2",
+      }),
+    ).toBe("restart");
+  });
+
+  it("returns defer when versions differ but daemon is busy", () => {
+    expect(
+      decideVersionAction("v1.2.3", {
+        status: "running",
+        cli_version: "v1.2.2",
+        active_task_count: 2,
+      }),
+    ).toBe("defer");
+  });
+
+  it("transitions defer → restart as tasks drain", () => {
+    // Same bundled version across three observations while the daemon ages.
+    const bundled = "v2.0.0";
+    const base = { status: "running", cli_version: "v1.9.0" } as const;
+
+    expect(
+      decideVersionAction(bundled, { ...base, active_task_count: 3 }),
+    ).toBe("defer");
+    expect(
+      decideVersionAction(bundled, { ...base, active_task_count: 1 }),
+    ).toBe("defer");
+    expect(
+      decideVersionAction(bundled, { ...base, active_task_count: 0 }),
+    ).toBe("restart");
+  });
+});

--- a/apps/desktop/src/main/version-decision.ts
+++ b/apps/desktop/src/main/version-decision.ts
@@ -1,0 +1,37 @@
+// Pure decision logic for the daemon version-check flow. Kept in its own
+// module so it can be unit-tested without mocking Electron, execFile, or
+// the HTTP health probe.
+
+export interface VersionCheckHealth {
+  status?: string;
+  cli_version?: string;
+  active_task_count?: number;
+}
+
+export type VersionAction = "restart" | "defer" | "ok" | "not_running";
+
+/**
+ * Decides what the daemon-manager should do given the currently-resolved
+ * bundled CLI version and the latest /health payload.
+ *
+ *   not_running: no daemon is up, nothing to do
+ *   ok:          versions match, OR either side is unknown (fail safe)
+ *   defer:       versions differ but the daemon is busy — wait for drain
+ *   restart:     versions differ and the daemon is idle — safe to restart
+ *
+ * Pure function: no I/O, no side effects, no module state.
+ */
+export function decideVersionAction(
+  bundled: string | null,
+  running: VersionCheckHealth | null,
+): VersionAction {
+  if (!running || running.status !== "running") return "not_running";
+
+  const runningVersion = running.cli_version;
+  if (!bundled || !runningVersion) return "ok";
+  if (runningVersion === bundled) return "ok";
+
+  const activeTasks = running.active_task_count ?? 0;
+  if (activeTasks > 0) return "defer";
+  return "restart";
+}

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
 
   apps/docs:
     dependencies:

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -39,6 +39,7 @@ type Daemon struct {
 	cancelFunc    context.CancelFunc // set by Run(); called by triggerRestart
 	restartBinary string             // non-empty after a successful update; path to the new binary
 	updating      atomic.Bool        // prevents concurrent update attempts
+	activeTasks   atomic.Int64       // number of tasks currently in handleTask; exposed via /health
 }
 
 // New creates a new Daemon instance.
@@ -649,8 +650,10 @@ func (d *Daemon) pollLoop(ctx context.Context) error {
 				}
 				d.logger.Info("task received", "task", shortID(task.ID), "target", taskTarget)
 				wg.Add(1)
+				d.activeTasks.Add(1)
 				go func(t Task) {
 					defer wg.Done()
+					defer d.activeTasks.Add(-1)
 					defer func() { <-sem }()
 					d.handleTask(ctx, t)
 				}(*task)

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -20,6 +20,7 @@ type HealthResponse struct {
 	DaemonID   string            `json:"daemon_id"`
 	DeviceName string            `json:"device_name"`
 	ServerURL  string            `json:"server_url"`
+	CLIVersion string            `json:"cli_version"`
 	Agents     []string          `json:"agents"`
 	Workspaces []healthWorkspace `json:"workspaces"`
 }
@@ -76,6 +77,7 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 			DaemonID:   d.cfg.DaemonID,
 			DeviceName: d.cfg.DeviceName,
 			ServerURL:  d.cfg.ServerBaseURL,
+			CLIVersion: d.cfg.CLIVersion,
 			Agents:     agents,
 			Workspaces: wsList,
 		}

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -51,11 +51,10 @@ type repoCheckoutRequest struct {
 	TaskID      string `json:"task_id"`
 }
 
-// serveHealth runs the health HTTP server on the given listener.
-// Blocks until ctx is cancelled.
-func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt time.Time) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+// healthHandler returns the /health HTTP handler. Extracted from serveHealth
+// so tests can exercise it without spinning up a listener.
+func (d *Daemon) healthHandler(startedAt time.Time) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		d.mu.Lock()
 		var wsList []healthWorkspace
 		for id, ws := range d.workspaces {
@@ -86,7 +85,14 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
-	})
+	}
+}
+
+// serveHealth runs the health HTTP server on the given listener.
+// Blocks until ctx is cancelled.
+func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt time.Time) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", d.healthHandler(startedAt))
 
 	mux.HandleFunc("/repo/checkout", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -14,15 +14,16 @@ import (
 
 // HealthResponse is returned by the daemon's local health endpoint.
 type HealthResponse struct {
-	Status     string            `json:"status"`
-	PID        int               `json:"pid"`
-	Uptime     string            `json:"uptime"`
-	DaemonID   string            `json:"daemon_id"`
-	DeviceName string            `json:"device_name"`
-	ServerURL  string            `json:"server_url"`
-	CLIVersion string            `json:"cli_version"`
-	Agents     []string          `json:"agents"`
-	Workspaces []healthWorkspace `json:"workspaces"`
+	Status          string            `json:"status"`
+	PID             int               `json:"pid"`
+	Uptime          string            `json:"uptime"`
+	DaemonID        string            `json:"daemon_id"`
+	DeviceName      string            `json:"device_name"`
+	ServerURL       string            `json:"server_url"`
+	CLIVersion      string            `json:"cli_version"`
+	ActiveTaskCount int64             `json:"active_task_count"`
+	Agents          []string          `json:"agents"`
+	Workspaces      []healthWorkspace `json:"workspaces"`
 }
 
 type healthWorkspace struct {
@@ -71,15 +72,16 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 		}
 
 		resp := HealthResponse{
-			Status:     "running",
-			PID:        os.Getpid(),
-			Uptime:     time.Since(startedAt).Truncate(time.Second).String(),
-			DaemonID:   d.cfg.DaemonID,
-			DeviceName: d.cfg.DeviceName,
-			ServerURL:  d.cfg.ServerBaseURL,
-			CLIVersion: d.cfg.CLIVersion,
-			Agents:     agents,
-			Workspaces: wsList,
+			Status:          "running",
+			PID:             os.Getpid(),
+			Uptime:          time.Since(startedAt).Truncate(time.Second).String(),
+			DaemonID:        d.cfg.DaemonID,
+			DeviceName:      d.cfg.DeviceName,
+			ServerURL:       d.cfg.ServerBaseURL,
+			CLIVersion:      d.cfg.CLIVersion,
+			ActiveTaskCount: d.activeTasks.Load(),
+			Agents:          agents,
+			Workspaces:      wsList,
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/server/internal/daemon/health_test.go
+++ b/server/internal/daemon/health_test.go
@@ -1,0 +1,84 @@
+package daemon
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHealthHandlerReportsCLIVersionAndActiveTaskCount(t *testing.T) {
+	t.Parallel()
+
+	d := &Daemon{
+		cfg: Config{
+			CLIVersion:    "v9.9.9",
+			DaemonID:      "daemon-test",
+			DeviceName:    "dev",
+			ServerBaseURL: "http://localhost:8080",
+		},
+		workspaces: map[string]*workspaceState{},
+		logger:     slog.Default(),
+	}
+	d.activeTasks.Store(3)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	d.healthHandler(time.Now()).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.CLIVersion != "v9.9.9" {
+		t.Errorf("cli_version: got %q, want %q", resp.CLIVersion, "v9.9.9")
+	}
+	if resp.ActiveTaskCount != 3 {
+		t.Errorf("active_task_count: got %d, want 3", resp.ActiveTaskCount)
+	}
+	if resp.Status != "running" {
+		t.Errorf("status: got %q, want %q", resp.Status, "running")
+	}
+}
+
+func TestHealthHandlerActiveTaskCountTracksCounter(t *testing.T) {
+	t.Parallel()
+
+	d := &Daemon{
+		cfg:        Config{CLIVersion: "v1.0.0"},
+		workspaces: map[string]*workspaceState{},
+		logger:     slog.Default(),
+	}
+	handler := d.healthHandler(time.Now())
+
+	// Simulate the pollLoop increment/decrement protocol.
+	d.activeTasks.Add(1)
+	d.activeTasks.Add(1)
+	assertActiveTaskCount(t, handler, 2)
+
+	d.activeTasks.Add(-1)
+	assertActiveTaskCount(t, handler, 1)
+
+	d.activeTasks.Add(-1)
+	assertActiveTaskCount(t, handler, 0)
+}
+
+func assertActiveTaskCount(t *testing.T, h http.HandlerFunc, want int64) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	var resp HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ActiveTaskCount != want {
+		t.Errorf("active_task_count: got %d, want %d", resp.ActiveTaskCount, want)
+	}
+}

--- a/server/internal/daemon/health_test.go
+++ b/server/internal/daemon/health_test.go
@@ -32,19 +32,35 @@ func TestHealthHandlerReportsCLIVersionAndActiveTaskCount(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
 
-	var resp HealthResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode response: %v", err)
+	// Decode into a raw map so the test locks in the exact wire-level JSON
+	// keys — the desktop TS client depends on snake_case (cli_version,
+	// active_task_count), so a silent struct-tag rename must fail here.
+	var raw map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw response: %v", err)
+	}
+	if got, want := raw["cli_version"], "v9.9.9"; got != want {
+		t.Errorf("cli_version key: got %v, want %q", got, want)
+	}
+	// JSON numbers decode to float64 through map[string]any.
+	if got, want := raw["active_task_count"], float64(3); got != want {
+		t.Errorf("active_task_count key: got %v, want %v", got, want)
+	}
+	if got, want := raw["status"], "running"; got != want {
+		t.Errorf("status key: got %v, want %q", got, want)
 	}
 
+	// Also round-trip into the typed struct as a separate check that the
+	// field values match, independent of key naming.
+	var resp HealthResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode typed response: %v", err)
+	}
 	if resp.CLIVersion != "v9.9.9" {
-		t.Errorf("cli_version: got %q, want %q", resp.CLIVersion, "v9.9.9")
+		t.Errorf("CLIVersion: got %q, want %q", resp.CLIVersion, "v9.9.9")
 	}
 	if resp.ActiveTaskCount != 3 {
-		t.Errorf("active_task_count: got %d, want 3", resp.ActiveTaskCount)
-	}
-	if resp.Status != "running" {
-		t.Errorf("status: got %q, want %q", resp.Status, "running")
+		t.Errorf("ActiveTaskCount: got %d, want 3", resp.ActiveTaskCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Desktop bundles a `multica` CLI at build time via `bundle-cli.mjs`. If a local daemon is left running from a previous session with an older binary, the newly bundled version never takes effect until the user manually restarts. This PR makes the desktop app detect that case and restart the daemon automatically — **but only when it's actually safe to do so**, because restarting kills in-flight agent tasks.

## How it works

**Daemon side (Go)**
- `/health` now exposes `cli_version` (from `cfg.CLIVersion`, already set from the ldflag at daemon startup) and `active_task_count` (from a new `Daemon.activeTasks atomic.Int64` bumped around the `handleTask` goroutine launch).
- The `/health` handler is extracted into `(d *Daemon) healthHandler(startedAt)` so it's directly testable via `httptest`.

**Desktop side (TypeScript)**
- `getCliBinaryVersion()` shells out to `multica version --output json` on the resolved CLI binary and caches the result for the process lifetime.
- `decideVersionAction(bundled, health)` is a pure function (new `version-decision.ts`) that returns `not_running | ok | defer | restart` based on bundled version, running version, and active task count.
- `ensureRunningDaemonVersionMatches()` is now a thin async wrapper around `decideVersionAction`, owning only the side effects (logging, `pendingVersionRestart` flag, `restartDaemon()` call).
- `pollOnce()` re-invokes `ensureRunningDaemonVersionMatches` on each 5s tick while `pendingVersionRestart` is set, so a deferred restart fires the moment the daemon drains.

## Safety matrix

| State | Action |
|---|---|
| No daemon running | no-op |
| Versions match | no-op |
| Bundled CLI version unknown (e.g. `go` missing at bundle time) | no-op |
| Running daemon predates `cli_version` field | no-op |
| Versions differ + `active_task_count == 0` | immediate restart |
| Versions differ + `active_task_count > 0` | **defer**: set flag, log once, poll every 5s; restart the moment count hits 0 |
| `prefs.autoStart` disabled | no-op (existing opt-out preserved) |

**Eventual consistency trade-off**: if the user keeps the daemon permanently busy, the CLI version stays out of date. This is a strictly better failure mode than silently killing hour-long agent runs.

## Tests

- **Go** (`server/internal/daemon/health_test.go`) — asserts `cli_version` + `active_task_count` are present in the `/health` response and that the counter correctly tracks `Add(1)` / `Add(-1)` mutations (the same protocol used by `pollLoop`).
- **TS** (`apps/desktop/src/main/version-decision.test.ts`) — 9 cases covering all four action branches: null/stopped health, unknown bundled version, unknown running version, matching versions, idle-mismatch, busy-mismatch, missing `active_task_count`, and a busy→idle drain transition.
- New vitest setup in `apps/desktop` (config + `test` script + catalog devDep) — this is the first main-process unit test, so the infra lands with the PR.

## Test plan

- [ ] `make check` passes
- [x] `pnpm --filter @multica/desktop typecheck`
- [x] `pnpm --filter @multica/desktop test` (9/9)
- [x] `go test ./internal/daemon/ -run TestHealth` (2/2)
- [ ] Manual: start desktop, let daemon come up, rebuild CLI with a version bump, restart desktop → daemon restarts on login with the new version
- [ ] Manual: start desktop with matching bundled/running versions → no restart, existing agent runs unaffected
- [ ] Manual: trigger a long-running agent task, then bump the CLI and restart desktop → log shows "deferring restart until N task(s) finish", daemon keeps running until drain, then auto-restarts
- [ ] Manual: point desktop at a daemon running an older build without `cli_version` in `/health` → no restart (fail-safe path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)