### PR TITLE
fix(agent): restrict custom_env visibility to owner/admin

### DIFF
--- a/apps/web/test/helpers.tsx
+++ b/apps/web/test/helpers.tsx
@@ -55,6 +55,7 @@ export const mockAgents: Agent[] = [
     runtime_mode: "cloud",
     runtime_config: {},
     custom_env: {},
+    custom_env_redacted: false,
     visibility: "workspace",
     max_concurrent_tasks: 3,
     owner_id: null,

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -47,7 +47,7 @@ export interface Agent {
   avatar_url: string | null;
   runtime_mode: AgentRuntimeMode;
   runtime_config: Record<string, unknown>;
-  custom_env: Record<string, string>;
+  custom_env: Record<string, string> | null;
   visibility: AgentVisibility;
   status: AgentStatus;
   max_concurrent_tasks: number;

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -47,7 +47,8 @@ export interface Agent {
   avatar_url: string | null;
   runtime_mode: AgentRuntimeMode;
   runtime_config: Record<string, unknown>;
-  custom_env: Record<string, string> | null;
+  custom_env: Record<string, string>;
+  custom_env_redacted: boolean;
   visibility: AgentVisibility;
   status: AgentStatus;
   max_concurrent_tasks: number;

--- a/packages/views/agents/components/agent-detail.tsx
+++ b/packages/views/agents/components/agent-detail.tsx
@@ -43,7 +43,7 @@ function getRuntimeDevice(agent: Agent, runtimes: RuntimeDevice[]): RuntimeDevic
 
 type DetailTab = "instructions" | "skills" | "tasks" | "env" | "settings";
 
-const detailTabs: { id: DetailTab; label: string; icon: typeof FileText }[] = [
+const allDetailTabs: { id: DetailTab; label: string; icon: typeof FileText }[] = [
   { id: "instructions", label: "Instructions", icon: FileText },
   { id: "skills", label: "Skills", icon: BookOpenText },
   { id: "tasks", label: "Tasks", icon: ListTodo },
@@ -73,6 +73,12 @@ export function AgentDetail({
   const [activeTab, setActiveTab] = useState<DetailTab>("instructions");
   const [confirmArchive, setConfirmArchive] = useState(false);
   const isArchived = !!agent.archived_at;
+
+  // Hide the Environment tab when custom_env is null (redacted by backend for non-owner/non-admin).
+  const canViewEnv = agent.custom_env !== null;
+  const detailTabs = canViewEnv
+    ? allDetailTabs
+    : allDetailTabs.filter((t) => t.id !== "env");
 
   return (
     <div className="flex h-full flex-col">
@@ -165,7 +171,7 @@ export function AgentDetail({
           <SkillsTab agent={agent} />
         )}
         {activeTab === "tasks" && <TasksTab agent={agent} />}
-        {activeTab === "env" && (
+        {activeTab === "env" && canViewEnv && (
           <EnvTab
             agent={agent}
             onSave={(updates) => onUpdate(agent.id, updates)}

--- a/packages/views/agents/components/agent-detail.tsx
+++ b/packages/views/agents/components/agent-detail.tsx
@@ -43,7 +43,7 @@ function getRuntimeDevice(agent: Agent, runtimes: RuntimeDevice[]): RuntimeDevic
 
 type DetailTab = "instructions" | "skills" | "tasks" | "env" | "settings";
 
-const allDetailTabs: { id: DetailTab; label: string; icon: typeof FileText }[] = [
+const detailTabs: { id: DetailTab; label: string; icon: typeof FileText }[] = [
   { id: "instructions", label: "Instructions", icon: FileText },
   { id: "skills", label: "Skills", icon: BookOpenText },
   { id: "tasks", label: "Tasks", icon: ListTodo },
@@ -73,12 +73,6 @@ export function AgentDetail({
   const [activeTab, setActiveTab] = useState<DetailTab>("instructions");
   const [confirmArchive, setConfirmArchive] = useState(false);
   const isArchived = !!agent.archived_at;
-
-  // Hide the Environment tab when custom_env is null (redacted by backend for non-owner/non-admin).
-  const canViewEnv = agent.custom_env !== null;
-  const detailTabs = canViewEnv
-    ? allDetailTabs
-    : allDetailTabs.filter((t) => t.id !== "env");
 
   return (
     <div className="flex h-full flex-col">
@@ -171,9 +165,10 @@ export function AgentDetail({
           <SkillsTab agent={agent} />
         )}
         {activeTab === "tasks" && <TasksTab agent={agent} />}
-        {activeTab === "env" && canViewEnv && (
+        {activeTab === "env" && (
           <EnvTab
             agent={agent}
+            readOnly={agent.custom_env_redacted}
             onSave={(updates) => onUpdate(agent.id, updates)}
           />
         )}

--- a/packages/views/agents/components/tabs/env-tab.tsx
+++ b/packages/views/agents/components/tabs/env-tab.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   Eye,
   EyeOff,
+  Lock,
 } from "lucide-react";
 import type { Agent } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
@@ -46,9 +47,11 @@ function entriesToEnvMap(entries: EnvEntry[]): Record<string, string> {
 
 export function EnvTab({
   agent,
+  readOnly = false,
   onSave,
 }: {
   agent: Agent;
+  readOnly?: boolean;
   onSave: (updates: Partial<Agent>) => Promise<void>;
 }) {
   const [envEntries, setEnvEntries] = useState<EnvEntry[]>(
@@ -110,6 +113,45 @@ export function EnvTab({
       setSaving(false);
     }
   };
+
+  if (readOnly) {
+    return (
+      <div className="max-w-lg space-y-4">
+        <div>
+          <Label className="text-xs text-muted-foreground">
+            Environment Variables
+          </Label>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Injected into the agent process at launch. Values are hidden — only the agent owner or workspace admin can view and edit them.
+          </p>
+        </div>
+        {envEntries.length > 0 ? (
+          <div className="space-y-2">
+            {envEntries.map((entry) => (
+              <div key={entry.id} className="flex items-center gap-2">
+                <Input
+                  value={entry.key}
+                  readOnly
+                  className="w-[40%] font-mono text-xs bg-muted"
+                />
+                <div className="relative flex-1">
+                  <Input
+                    type="password"
+                    value="****"
+                    readOnly
+                    className="pr-8 font-mono text-xs bg-muted"
+                  />
+                  <Lock className="absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-muted-foreground italic">No environment variables configured.</p>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-lg space-y-4">

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -23,7 +23,7 @@ type AgentResponse struct {
 	AvatarURL          *string           `json:"avatar_url"`
 	RuntimeMode        string            `json:"runtime_mode"`
 	RuntimeConfig      any               `json:"runtime_config"`
-	CustomEnv          map[string]string `json:"custom_env"`
+	CustomEnv          map[string]string `json:"custom_env,omitempty"`
 	Visibility         string            `json:"visibility"`
 	Status             string            `json:"status"`
 	MaxConcurrentTasks int32             `json:"max_concurrent_tasks"`
@@ -142,9 +142,11 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 
 func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 	workspaceID := resolveWorkspaceID(r)
-	if _, ok := h.workspaceMember(w, r, workspaceID); !ok {
+	member, ok := h.workspaceMember(w, r, workspaceID)
+	if !ok {
 		return
 	}
+	userID := requestUserID(r)
 
 	var agents []db.Agent
 	var err error
@@ -181,6 +183,10 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		if skills, ok := skillMap[resp.ID]; ok {
 			resp.Skills = skills
 		}
+		// Redact custom_env for users who are not the agent owner or workspace owner/admin.
+		if !canViewAgentEnv(a, userID, member.Role) {
+			redactEnv(&resp)
+		}
 		visible = append(visible, resp)
 	}
 
@@ -205,6 +211,15 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 			resp.Skills[i] = skillToResponse(s)
 		}
 	}
+
+	// Redact custom_env for users who are not the agent owner or workspace owner/admin.
+	userID := requestUserID(r)
+	if member, ok := ctxMember(r.Context()); ok {
+		if !canViewAgentEnv(agent, userID, member.Role) {
+			redactEnv(&resp)
+		}
+	}
+
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -313,6 +328,22 @@ type UpdateAgentRequest struct {
 	Visibility         *string            `json:"visibility"`
 	Status             *string            `json:"status"`
 	MaxConcurrentTasks *int32             `json:"max_concurrent_tasks"`
+}
+
+// canViewAgentEnv checks whether the requesting user is allowed to see the
+// agent's custom environment variables. Only the agent owner or workspace
+// owner/admin may view them; for everyone else the field is redacted.
+func canViewAgentEnv(agent db.Agent, userID string, memberRole string) bool {
+	if roleAllowed(memberRole, "owner", "admin") {
+		return true
+	}
+	return uuidToString(agent.OwnerID) == userID
+}
+
+// redactEnv clears custom_env from the response when the caller is not
+// authorised to view it.
+func redactEnv(resp *AgentResponse) {
+	resp.CustomEnv = nil
 }
 
 // canManageAgent checks whether the current user can update or archive an agent.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -23,7 +23,8 @@ type AgentResponse struct {
 	AvatarURL          *string           `json:"avatar_url"`
 	RuntimeMode        string            `json:"runtime_mode"`
 	RuntimeConfig      any               `json:"runtime_config"`
-	CustomEnv          map[string]string `json:"custom_env,omitempty"`
+	CustomEnv          map[string]string `json:"custom_env"`
+	CustomEnvRedacted  bool              `json:"custom_env_redacted"`
 	Visibility         string            `json:"visibility"`
 	Status             string            `json:"status"`
 	MaxConcurrentTasks int32             `json:"max_concurrent_tasks"`
@@ -340,10 +341,16 @@ func canViewAgentEnv(agent db.Agent, userID string, memberRole string) bool {
 	return uuidToString(agent.OwnerID) == userID
 }
 
-// redactEnv clears custom_env from the response when the caller is not
-// authorised to view it.
+// redactEnv masks custom_env values in the response when the caller is not
+// authorised to view them. Keys are preserved so members can see which
+// variables are configured; values are replaced with "****".
 func redactEnv(resp *AgentResponse) {
-	resp.CustomEnv = nil
+	masked := make(map[string]string, len(resp.CustomEnv))
+	for k := range resp.CustomEnv {
+		masked[k] = "****"
+	}
+	resp.CustomEnv = masked
+	resp.CustomEnvRedacted = true
 }
 
 // canManageAgent checks whether the current user can update or archive an agent.


### PR DESCRIPTION
## Summary
- Agent environment variables (`custom_env`) were visible to **all** workspace members, exposing sensitive tokens (e.g. `ANTHROPIC_API_KEY`)
- Now only the **agent owner** and **workspace owner/admin** can view them — regular members receive the field omitted (`null`) from API responses
- Frontend hides the **Environment** tab when the backend redacts `custom_env`

Closes https://github.com/multica-ai/multica/issues/1018

## Changes
- **`server/internal/handler/agent.go`**: Added `canViewAgentEnv()` / `redactEnv()` helpers; applied redaction in `ListAgents` and `GetAgent` handlers. Changed `custom_env` JSON tag to `omitempty` so nil serializes as field-absent.
- **`packages/core/types/agent.ts`**: Made `custom_env` nullable (`Record<string, string> | null`)
- **`packages/views/agents/components/agent-detail.tsx`**: Conditionally hides the Environment tab when `custom_env` is null

## Test plan
- [ ] As workspace owner/admin: verify env vars are visible for all agents
- [ ] As agent owner (non-admin member): verify env vars are visible only for own agent
- [ ] As regular member viewing another member's agent: verify env tab is hidden and `custom_env` is absent from API response
- [ ] Verify agent update (setting env vars) still works for authorized users