### PR TITLE
fix(views): sort timeline after WebSocket append

### DIFF
--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -70,7 +70,9 @@ export function useIssueTimeline(issueId: string, userId?: string) {
           (old) => {
             if (!old) return old;
             if (old.some((e) => e.id === comment.id)) return old;
-            return [...old, commentToTimelineEntry(comment)];
+            return [...old, commentToTimelineEntry(comment)].sort(
+              (a, b) => a.created_at.localeCompare(b.created_at),
+            );
           },
         );
       },
@@ -144,7 +146,9 @@ export function useIssueTimeline(issueId: string, userId?: string) {
           (old) => {
             if (!old) return old;
             if (old.some((e) => e.id === entry.id)) return old;
-            return [...old, entry];
+            return [...old, entry].sort(
+              (a, b) => a.created_at.localeCompare(b.created_at),
+            );
           },
         );
       },


### PR DESCRIPTION
## Summary
- WebSocket event handlers for `comment:created` and `activity:created` appended new entries to the timeline array without sorting by timestamp
- When events arrived out of order (e.g. agent replying rapidly, network latency), comments displayed out of chronological order
- Added `.sort()` by `created_at` after each append to maintain correct ordering

Closes #1032

## Test plan
- [ ] Open an issue, have an agent reply rapidly — verify comments stay in chronological order
- [ ] Refresh the page — verify order matches (confirms backend was already correct)
- [ ] Add a human comment while agent is replying — verify interleaved ordering is correct