### PR TITLE
feat(desktop): sync package version with CLI via git tag at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ build
 bin
 dist-electron
 *.tsbuildinfo
+# ...except electron-builder's source resources dir, which holds tracked
+# config files (entitlements, icons) — not build output.
+!apps/desktop/build/
+!apps/desktop/build/**
 
 # env
 .env*

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ dist-electron
 # env
 .env*
 !.env.example
+# Desktop production config is public (backend URL, etc.) — track it so
+# `pnpm package` produces a release-ready build without extra setup.
+!apps/desktop/.env.production
 
 # test coverage
 coverage

--- a/apps/desktop/.env.production
+++ b/apps/desktop/.env.production
@@ -1,0 +1,12 @@
+# Production environment for `pnpm package` / `pnpm build`.
+# electron-vite (Vite under the hood) reads this automatically in
+# production mode and inlines the values into the renderer bundle via
+# import.meta.env.VITE_*. These are public URLs, not secrets.
+
+# Backend API + websocket the desktop app talks to.
+VITE_API_URL=https://api.multica.ai
+VITE_WS_URL=wss://api.multica.ai/ws
+
+# Public web app URL — used to build shareable links like "Copy link to
+# issue" that users paste into Slack / messages. See platform/navigation.tsx.
+VITE_APP_URL=https://multica.ai

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Electron / V8 need JIT and unsigned executable memory under the
+       hardened runtime. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- Required so the app can spawn the bundled `multica` Go binary and
+       any other child processes (e.g. agent CLIs) without Gatekeeper
+       blocking exec. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+  <!-- Network client — the daemon talks to the backend + GitHub releases. -->
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -19,10 +19,16 @@ mac:
   target:
     - dmg
     - zip
-  artifactName: ${name}-${version}-${arch}.${ext}
-  notarize: false
+  # Hardcoded name avoids the `@multica/desktop-*` subdirectory that
+  # `${name}` produces for scoped package names.
+  artifactName: multica-desktop-${version}-${arch}.${ext}
+  # Notarize via notarytool. Requires APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD
+  # + APPLE_TEAM_ID env vars at package time. Non-mac contributors are
+  # unaffected because `pnpm package` already requires the Developer ID
+  # signing cert — notarization is a strict superset.
+  notarize: true
 dmg:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: multica-desktop-${version}-${arch}.${ext}
 linux:
   target:
     - AppImage

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,7 +11,7 @@
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
     "preview": "electron-vite preview",
-    "package": "pnpm run bundle-cli && electron-builder",
+    "package": "node scripts/package.mjs",
     "lint": "eslint .",
     "test": "vitest run",
     "postinstall": "electron-builder install-app-deps"

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Wrapper around `electron-builder` that keeps the Desktop version in
+// lockstep with the CLI. Both are derived from `git describe --tags
+// --always --dirty` — the same source GoReleaser reads for the CLI
+// binary via the `main.version` ldflag — so a single `vX.Y.Z` tag push
+// produces matching CLI and Desktop versions.
+//
+// Runs the existing bundle-cli.mjs first (so the Go binary is compiled
+// and copied into resources/bin/), then invokes electron-builder with
+// `-c.extraMetadata.version=<derived>` so the override applies at build
+// time without mutating the tracked package.json.
+//
+// Extra CLI args after `pnpm package --` are forwarded to electron-builder
+// unchanged (e.g. `--mac --arm64`).
+
+import { execFileSync, spawnSync, execSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const desktopRoot = resolve(here, "..");
+
+function sh(cmd) {
+  try {
+    return execSync(cmd, { encoding: "utf-8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+// Same derivation as bundle-cli.mjs / GoReleaser's {{.Version}}:
+//   - on a tag commit          → "0.1.36"
+//   - between tags             → "0.1.35-14-gf1415e96"  (semver prerelease)
+//   - dirty working tree       → "0.1.35-14-gf1415e96-dirty"
+//   - no tags in history       → "0.0.0-<shortcommit>"  (fallback)
+// Leading `v` is stripped to match semver / package.json format.
+function deriveVersion() {
+  const raw = sh("git describe --tags --always --dirty");
+  if (!raw) return null;
+  const stripped = raw.replace(/^v/, "");
+  if (!/^\d/.test(stripped)) {
+    // No reachable tag — `git describe` fell back to just the commit hash.
+    return `0.0.0-${stripped}`;
+  }
+  return stripped;
+}
+
+// Step 1: build + bundle the Go CLI via the existing script.
+execFileSync("node", [resolve(here, "bundle-cli.mjs")], {
+  stdio: "inherit",
+  cwd: desktopRoot,
+});
+
+// Step 2: derive the version that should be written into the app.
+const version = deriveVersion();
+if (version) {
+  console.log(`[package] Desktop version → ${version} (from git describe)`);
+} else {
+  console.warn(
+    "[package] could not derive version from git; falling back to package.json",
+  );
+}
+
+// Step 3: invoke electron-builder with the override (if we have one) plus
+// any passthrough args the caller appended (--mac, --arm64, etc.).
+const passthrough = process.argv.slice(2);
+const builderArgs = [];
+if (version) builderArgs.push(`-c.extraMetadata.version=${version}`);
+builderArgs.push(...passthrough);
+
+const result = spawnSync("electron-builder", builderArgs, {
+  stdio: "inherit",
+  cwd: desktopRoot,
+  shell: true,
+});
+
+process.exit(result.status ?? 1);

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -12,10 +12,13 @@
 //
 // Extra CLI args after `pnpm package --` are forwarded to electron-builder
 // unchanged (e.g. `--mac --arm64`).
+//
+// The `normalizeGitVersion` helper is exported so tests can cover the
+// version-derivation logic without shelling out.
 
 import { execFileSync, spawnSync, execSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(here, "..");
@@ -28,14 +31,19 @@ function sh(cmd) {
   }
 }
 
-// Same derivation as bundle-cli.mjs / GoReleaser's {{.Version}}:
-//   - on a tag commit          → "0.1.36"
-//   - between tags             → "0.1.35-14-gf1415e96"  (semver prerelease)
-//   - dirty working tree       → "0.1.35-14-gf1415e96-dirty"
-//   - no tags in history       → "0.0.0-<shortcommit>"  (fallback)
-// Leading `v` is stripped to match semver / package.json format.
-function deriveVersion() {
-  const raw = sh("git describe --tags --always --dirty");
+/**
+ * Pure transformation from the `git describe --tags --always --dirty`
+ * output to the value we feed into electron-builder's extraMetadata.version.
+ *
+ *   - empty input              → null   (caller should fall back)
+ *   - "v0.1.36"                → "0.1.36"
+ *   - "v0.1.35-14-gf1415e96"   → "0.1.35-14-gf1415e96"  (semver prerelease)
+ *   - "v0.1.35-…-dirty"        → same, dirty suffix preserved
+ *   - "f1415e96" (no tag)      → "0.0.0-f1415e96"        (fallback)
+ *
+ * Leading `v` is stripped so the result is valid semver for package.json.
+ */
+export function normalizeGitVersion(raw) {
   if (!raw) return null;
   const stripped = raw.replace(/^v/, "");
   if (!/^\d/.test(stripped)) {
@@ -45,33 +53,70 @@ function deriveVersion() {
   return stripped;
 }
 
-// Step 1: build + bundle the Go CLI via the existing script.
-execFileSync("node", [resolve(here, "bundle-cli.mjs")], {
-  stdio: "inherit",
-  cwd: desktopRoot,
-});
-
-// Step 2: derive the version that should be written into the app.
-const version = deriveVersion();
-if (version) {
-  console.log(`[package] Desktop version → ${version} (from git describe)`);
-} else {
-  console.warn(
-    "[package] could not derive version from git; falling back to package.json",
-  );
+function deriveVersion() {
+  return normalizeGitVersion(sh("git describe --tags --always --dirty"));
 }
 
-// Step 3: invoke electron-builder with the override (if we have one) plus
-// any passthrough args the caller appended (--mac, --arm64, etc.).
-const passthrough = process.argv.slice(2);
-const builderArgs = [];
-if (version) builderArgs.push(`-c.extraMetadata.version=${version}`);
-builderArgs.push(...passthrough);
+function main() {
+  // Step 1: build + bundle the Go CLI via the existing script.
+  execFileSync("node", [resolve(here, "bundle-cli.mjs")], {
+    stdio: "inherit",
+    cwd: desktopRoot,
+  });
 
-const result = spawnSync("electron-builder", builderArgs, {
-  stdio: "inherit",
-  cwd: desktopRoot,
-  shell: true,
-});
+  // Step 2: derive the version that should be written into the app.
+  const version = deriveVersion();
+  if (version) {
+    console.log(`[package] Desktop version → ${version} (from git describe)`);
+  } else {
+    console.warn(
+      "[package] could not derive version from git; falling back to package.json",
+    );
+  }
 
-process.exit(result.status ?? 1);
+  // Step 3: assemble electron-builder args.
+  const passthrough = process.argv.slice(2);
+  const builderArgs = [];
+  if (version) builderArgs.push(`-c.extraMetadata.version=${version}`);
+
+  // Step 4: gracefully degrade for local dev builds. electron-builder.yml
+  // sets `notarize: true` so real releases notarize in-build (keeping the
+  // stapled .app consistent with latest-mac.yml's SHA512). But a mac dev
+  // who just wants to smoke-test a local package doesn't have Apple
+  // credentials, and would otherwise hit a hard failure at the notarize
+  // step. Detect the missing env and flip notarize off for this run only.
+  if (!process.env.APPLE_TEAM_ID) {
+    console.warn(
+      "[package] APPLE_TEAM_ID not set — skipping notarization (local dev build). " +
+        "Set APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID for a release build.",
+    );
+    builderArgs.push("-c.mac.notarize=false");
+  }
+
+  builderArgs.push(...passthrough);
+
+  // Step 5: invoke electron-builder. pnpm puts node_modules/.bin on PATH
+  // for the script run, so spawnSync finds the binary without needing a
+  // shell wrapper (avoids any risk of argv interpolation).
+  const result = spawnSync("electron-builder", builderArgs, {
+    stdio: "inherit",
+    cwd: desktopRoot,
+  });
+
+  if (result.error) {
+    console.error(
+      "[package] failed to spawn electron-builder:",
+      result.error.message,
+    );
+    process.exit(1);
+  }
+  process.exit(result.status ?? 1);
+}
+
+// Only run when invoked as a CLI, not when imported by a test file.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/apps/desktop/scripts/package.test.mjs
+++ b/apps/desktop/scripts/package.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { normalizeGitVersion } from "./package.mjs";
+
+describe("normalizeGitVersion", () => {
+  it("returns null for empty / nullish input", () => {
+    expect(normalizeGitVersion("")).toBe(null);
+    expect(normalizeGitVersion(null)).toBe(null);
+    expect(normalizeGitVersion(undefined)).toBe(null);
+  });
+
+  it("strips the leading v on a clean tag", () => {
+    expect(normalizeGitVersion("v0.1.36")).toBe("0.1.36");
+    expect(normalizeGitVersion("v1.0.0")).toBe("1.0.0");
+  });
+
+  it("preserves the prerelease suffix between tags", () => {
+    expect(normalizeGitVersion("v0.1.35-14-gf1415e96")).toBe(
+      "0.1.35-14-gf1415e96",
+    );
+  });
+
+  it("preserves the dirty suffix on a modified worktree", () => {
+    expect(normalizeGitVersion("v0.1.35-14-gf1415e96-dirty")).toBe(
+      "0.1.35-14-gf1415e96-dirty",
+    );
+  });
+
+  it("handles v-prefixed prerelease tags", () => {
+    expect(normalizeGitVersion("v1.0.0-alpha")).toBe("1.0.0-alpha");
+    expect(normalizeGitVersion("v1.0.0-rc.2")).toBe("1.0.0-rc.2");
+  });
+
+  it("falls back to 0.0.0-<hash> when no tags are reachable", () => {
+    // `git describe --tags --always` returns just the short commit hash
+    // when there are no tags in the history at all.
+    expect(normalizeGitVersion("f1415e96")).toBe("0.0.0-f1415e96");
+    expect(normalizeGitVersion("abc1234")).toBe("0.0.0-abc1234");
+  });
+});

--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -7,6 +7,11 @@ import {
 import { useAuthStore } from "@multica/core/auth";
 import { useTabStore, resolveRouteIcon } from "@/stores/tab-store";
 
+// Public web app URL — injected at build time via .env.production. Falls
+// back to the production host for dev builds so "Copy link" yields a URL
+// that actually points somewhere a teammate can open.
+const APP_URL = import.meta.env.VITE_APP_URL || "https://multica.ai";
+
 /**
  * Root-level navigation provider for components outside the per-tab RouterProviders
  * (sidebar, search dialog, modals, etc.).
@@ -64,7 +69,7 @@ export function DesktopNavigationProvider({
         const tabId = store.openTab(path, title ?? path, icon);
         store.setActiveTab(tabId);
       },
-      getShareableUrl: (path: string) => `https://www.multica.ai${path}`,
+      getShareableUrl: (path: string) => `${APP_URL}${path}`,
     }),
     [pathname],
   );
@@ -107,7 +112,7 @@ export function TabNavigationProvider({
         const newTabId = store.openTab(path, title ?? path, icon);
         store.setActiveTab(newTabId);
       },
-      getShareableUrl: (path: string) => `https://www.multica.ai${path}`,
+      getShareableUrl: (path: string) => `${APP_URL}${path}`,
     }),
     [router, location],
   );

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.mjs"],
     environment: "node",
     passWithNoTests: true,
   },


### PR DESCRIPTION
## Summary

The Desktop app version was hardcoded to \`\"0.1.0\"\` in \`package.json\`, while the bundled \`multica\` CLI derives its version from \`git describe\` at build time. Result: yesterday's package produced \`desktop-0.1.0.dmg\` containing CLI \`v0.1.35-14-gf1415e96\` — two unrelated version numbers for the same release. This PR makes Desktop derive its version from the same source as the CLI (git tags → GoReleaser \`{{.Version}}\`), and fixes the packaging pipeline so it produces a notarized, release-ready artifact end-to-end.

## What changed

**Version sync (\`scripts/package.mjs\`)** — new wrapper around electron-builder. Runs \`bundle-cli.mjs\`, reads \`git describe --tags --always --dirty\`, strips the leading \`v\`, falls back to \`0.0.0-<shorthash>\` when no tags are reachable, and invokes electron-builder with \`-c.extraMetadata.version=<derived>\`. No mutation of the tracked \`package.json\`. Passthrough args (\`--mac --arm64\`, etc.) forward to electron-builder unchanged.

| git state | derived version |
|---|---|
| clean tag commit \`v0.1.36\` | \`0.1.36\` |
| 14 commits past \`v0.1.35\` | \`0.1.35-14-gf1415e96\` |
| same, dirty tree | \`0.1.35-14-gf1415e96-dirty\` |
| no tags reachable | \`0.0.0-f1415e96\` |
| \`v1.0.0-alpha\` / \`v1.0.0-rc.2\` | \`1.0.0-alpha\` / \`1.0.0-rc.2\` |

**Entitlements (\`build/entitlements.mac.plist\`)** — electron-builder.yml already referenced this file via \`entitlementsInherit\`, but it was missing from the tree, so \`pnpm package\` was failing at the codesign step with \`cannot read entitlement data\`. This PR ships it with the hardened-runtime capabilities the app actually needs: JIT + unsigned executable memory (V8), disable-library-validation + allow-dyld-env (to spawn the bundled Go CLI as a child process), and network client/server (for the daemon). Also adds a scoped exception in the root \`.gitignore\` so \`apps/desktop/build/\` survives the top-level \`build\` rule.

**Notarization (\`electron-builder.yml\`)** — flips \`mac.notarize\` from \`false\` to \`true\` so release builds notarize in-build via \`notarytool\` (reading APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID from env). electron-builder staples the notarization ticket onto the \`.app\` **before** zipping, so \`latest-mac.yml\`'s SHA512s match the published artifacts exactly — critical for \`electron-updater\`, since post-hoc re-stapling would invalidate the hashes and clients would reject the update as corrupt.

**Artifact names (\`electron-builder.yml\`)** — cleaned up \`mac.artifactName\` and \`dmg.artifactName\` to use a hardcoded \`multica-desktop-<version>-<arch>.<ext>\` pattern instead of \`\${name}-…\`. The \`\${name}\` placeholder was expanding to \`@multica/desktop\` (scoped package name), literally creating files at \`dist/@multica/desktop-*.dmg\` via the \`/\` path separator. New layout is flat: \`dist/multica-desktop-<ver>-arm64.dmg\`.

**Local-dev fallback (\`scripts/package.mjs\`)** — \`mac.notarize: true\` would otherwise hard-fail on macs without Apple credentials, even for non-publishing local smoke tests. The wrapper detects missing \`APPLE_TEAM_ID\` and passes \`-c.mac.notarize=false\` for that run only, with a warning. Release builds (which source \`macOS/.env\` via the \`release-desktop\` skill) are unaffected.

## Tests

New: \`apps/desktop/scripts/package.test.mjs\` covers all six branches of \`normalizeGitVersion\` — null/empty, clean tag, between-tags prerelease, dirty suffix, v-prefixed prereleases (\`v1.0.0-alpha\`, \`v1.0.0-rc.2\`), and the \`0.0.0-<hash>\` fallback. \`vitest.config.ts\` picks up \`scripts/**/*.test.mjs\` in addition to the existing \`src/**/*.test.ts\`.

Total: **15/15 passing** (9 existing \`version-decision\` tests from #1041 + 6 new).

## Commits

1. \`fix(desktop): ship entitlements.mac.plist so electron-builder can codesign\` — unblocks codesign + gitignore exception
2. \`feat(desktop): derive package version from git tag at build time\` — the wrapper script + package.json script pointer
3. \`feat(desktop): enable macOS notarization and clean artifact names\` — electron-builder.yml flips + artifact cleanup
4. \`fix(desktop): keep local package builds working after notarize: true\` — local-dev opt-out, spawn hardening, \`normalizeGitVersion\` unit tests

Split so the codesign fix, the version-sync feature, the notarization flip, and the follow-up polish can each be reviewed / reverted independently.

## Test plan

- [x] \`pnpm --filter @multica/desktop test\` (15/15)
- [x] \`pnpm --filter @multica/desktop typecheck\`
- [x] \`normalizeGitVersion\` smoke-tested against the live repo: \`v0.1.35-14-gf1415e96-dirty\` → \`0.1.35-14-gf1415e96-dirty\`
- [x] Earlier session: full \`pnpm package -- --mac --arm64\` successfully produced a signed + notarized + stapled DMG (manual notarization flow; this PR automates it)
- [ ] End-to-end after merge: \`pnpm package -- --mac --arm64\` on a clean tag checkout, confirm the DMG is named \`multica-desktop-<tag>-arm64.dmg\` and \`Info.plist\` reports the tag as \`CFBundleShortVersionString\`
- [ ] Local-dev regression: \`pnpm package -- --mac --arm64\` without Apple env vars set, confirm the wrapper logs the skip warning and produces a signed-but-unnotarized build instead of hard-failing
- [ ] Between-tags commit: confirm electron-builder accepts the prerelease-format semver

## Follow-up (not in this PR)

Hook Desktop packaging into \`.github/workflows/release.yml\` so a tag push produces CLI + Desktop atomically. The cleanest path is a self-hosted macOS runner on the Mac mini that already holds the cert and credentials — keeps Apple secrets off GitHub. Prereq for that is exactly what this PR makes work locally, and the \`release-desktop\` skill (separate, user-global) already exercises the same toolchain end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)