### PR TITLE
fix(editor): fix bubble menu positioning on first selection

### DIFF
--- a/packages/views/editor/bubble-menu.tsx
+++ b/packages/views/editor/bubble-menu.tsx
@@ -359,6 +359,7 @@ function ListDropdown({ editor, onOpenChange, isBullet, isOrdered }: { editor: E
 function EditorBubbleMenu({ editor }: { editor: Editor }) {
   const [mode, setMode] = useState<"toolbar" | "link-edit">("toolbar");
   const [scrollTarget, setScrollTarget] = useState<HTMLElement | Window>(window);
+  const menuElRef = useRef<HTMLDivElement>(null);
 
   // Precise subscription to formatting state — only re-renders when these
   // values actually change, replacing direct editor.isActive() calls that
@@ -456,6 +457,7 @@ function EditorBubbleMenu({ editor }: { editor: Editor }) {
 
   return (
     <BubbleMenu
+      ref={menuElRef}
       editor={editor}
       shouldShow={shouldShowBubbleMenu}
       updateDelay={0}
@@ -471,6 +473,17 @@ function EditorBubbleMenu({ editor }: { editor: Editor }) {
         shift: { padding: 8 },
         hide: true,
         scrollTarget,
+        // Tiptap's React wrapper initialises the menu element with
+        // position:absolute, but computePosition (called right after
+        // show()) needs position:fixed so that getOffsetParent returns
+        // the viewport instead of a positioned ancestor. Without this,
+        // the first positioning computes coordinates relative to the
+        // wrong containing block and the menu flies off-screen.
+        onShow: () => {
+          if (menuElRef.current) {
+            menuElRef.current.style.position = "fixed";
+          }
+        },
       }}
     >
       {mode === "link-edit" ? (


### PR DESCRIPTION
## Summary
- Bubble menu was flying to the top-left corner (negative coordinates) on the first text selection, especially noticeable with short content like a single comma
- **Root cause**: Tiptap's React wrapper initialises the menu element with `position:absolute`. When `computePosition` runs with `strategy:"fixed"`, Floating UI's `getOffsetParent` checks the element's *current* position (`absolute`) and returns a positioned ancestor instead of the viewport. The resulting coordinates are relative to that ancestor, but then get applied as `position:fixed` (viewport-relative) — causing the mismatch
- **Fix**: Set `position:fixed` in the `onShow` callback, which fires right before `updatePosition()`, ensuring `computePosition` sees the correct offset parent

## Test plan
- [ ] Open an issue with only a comma `,` as content → select it → bubble menu should appear above the selection, not at top-left
- [ ] First text selection after page load should position correctly
- [ ] Subsequent selections still work correctly
- [ ] Bubble menu positioning after scroll still works
- [ ] Heading/list dropdowns within bubble menu still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)