### PR TITLE
fix(cli): always use localhost for auth callback in browser login

### DIFF
--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -98,21 +98,12 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	serverURL := resolveServerURL(cmd)
 	appURL := resolveAppURL(cmd)
 
-	// Determine the callback host from the configured app URL.
-	// For self-hosted setups where the browser is on a different machine
-	// (e.g. Multica running on a LAN server), use the server's private IP
-	// so the browser can reach the CLI's local HTTP server.
-	// For production (public hostnames like multica.ai), keep localhost —
-	// the browser and CLI are on the same machine.
+	// The callback always targets localhost because the browser is opened on
+	// the same machine as the CLI (via openBrowser).  Even when the Multica
+	// server is on a remote LAN host, the browser-side redirect must reach
+	// the CLI's local HTTP server, not the remote server.
 	callbackHost := "localhost"
 	bindAddr := "127.0.0.1"
-	if parsed, err := url.Parse(appURL); err == nil {
-		h := parsed.Hostname()
-		if ip := net.ParseIP(h); ip != nil && ip.IsPrivate() {
-			callbackHost = h
-			bindAddr = "0.0.0.0"
-		}
-	}
 
 	// Start a local HTTP server on a random port to receive the callback.
 	listener, err := net.Listen("tcp", bindAddr+":0")


### PR DESCRIPTION
## Summary

- Fixes the self-hosted CLI login flow when the Multica server is on a remote LAN machine
- The CLI callback URL now always uses `localhost` instead of the server's private IP
- This ensures the browser redirect reaches the CLI's local HTTP server, not the remote server

## Problem

When self-hosting with the server on a different machine (e.g. `192.168.11.200`), `multica login` would construct a callback URL like `http://192.168.11.200:50423/callback`. The random port is only open on the CLI's local machine, so the browser redirect fails — the remote server has no listener on that port.

## Fix

The `openBrowser()` call always opens the browser on the same machine as the CLI. Therefore the callback must always target `localhost`, regardless of the app URL's hostname. Removed the private IP detection that was overriding the callback host.

Closes #1056

## Test plan

- [ ] Self-host Multica on a remote LAN server (e.g. `192.168.x.x`)
- [ ] Run `multica setup self-host --server-url http://<remote-ip>:30080 --app-url http://<remote-ip>:30080` on a local machine
- [ ] Run `multica login` — verify callback URL uses `localhost:<port>` 
- [ ] Confirm login completes successfully and token is saved
- [ ] Verify `multica login` still works with localhost-based setups (default case)