### PR TITLE
fix(selfhost): remove hardcoded port defaults and prevent HTTP→HTTPS redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,9 +57,9 @@ ALLOWED_ORIGINS=
 # Frontend
 FRONTEND_PORT=3000
 FRONTEND_ORIGIN=http://localhost:3000
-NEXT_PUBLIC_API_URL=http://localhost:8080
-NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
+NEXT_PUBLIC_API_URL=
+NEXT_PUBLIC_WS_URL=
 
 # Remote API (optional) — set to proxy local frontend to a remote backend
 # Leave empty to use local backend (localhost:8080)
-REMOTE_API_URL=http://localhost:8080
+REMOTE_API_URL=

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-{$TASK_DOMAIN} {
+{$CADDY_SITE_ADDRESS} {
     @next_static path /_next/static/*
     header @next_static Cache-Control "public, max-age=31536000, immutable, no-transform"
 

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -5,7 +5,7 @@
 #   # Edit .env — change JWT_SECRET at minimum
 #   docker compose -f docker-compose.selfhost.yml up -d
 #
-# Frontend: https://$TASK_DOMAIN (via Caddy reverse proxy)
+# Frontend: http://$TASK_DOMAIN (via Caddy reverse proxy)
 # Backend:  internal on backend:8080 (health exposed at /health through Caddy)
 
 name: multica
@@ -41,7 +41,7 @@ services:
       APP_ENV: ${APP_ENV:-}
       PORT: "8080"
       JWT_SECRET: ${JWT_SECRET:-change-me-in-production}
-      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-https://${TASK_DOMAIN:-localhost}}
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-http://${TASK_DOMAIN:-localhost}}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-noreply@multica.ai}
@@ -83,7 +83,7 @@ services:
       - "80:80"
       - "443:443"
     environment:
-      TASK_DOMAIN: ${TASK_DOMAIN:-localhost}
+      CADDY_SITE_ADDRESS: ${CADDY_SITE_ADDRESS:-http://${TASK_DOMAIN:-localhost}}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data


### PR DESCRIPTION
## Summary
- Remove hardcoded `http://localhost:8080` defaults from `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_WS_URL`, and `REMOTE_API_URL` in `.env.example` — the frontend falls back to relative paths through Caddy's reverse proxy, so custom ports work without rebuilding
- Replace `TASK_DOMAIN` with `CADDY_SITE_ADDRESS` (defaulting to `http://{TASK_DOMAIN}`) in Caddyfile/docker-compose to prevent Caddy from auto-redirecting HTTP→HTTPS on localhost
- Fix `FRONTEND_ORIGIN` default from `https://` to `http://` to match

Closes https://github.com/multica-ai/multica/issues/1055

## Test plan
- [ ] `cp .env.example .env && docker compose -f docker-compose.selfhost.yml up -d` — verify `http://localhost` works without HTTPS redirect
- [ ] Custom ports: set `PORT=8083`, `FRONTEND_PORT=3003` in `.env`, rebuild — verify frontend communicates with backend correctly
- [ ] Production domain: set `CADDY_SITE_ADDRESS=app.example.com` — verify Caddy provisions HTTPS automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)