### PR TITLE
fix(selfhost): clear hardcoded NEXT_PUBLIC_API_URL/WS_URL defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,8 +55,10 @@ ALLOWED_ORIGINS=
 # Frontend
 FRONTEND_PORT=3000
 FRONTEND_ORIGIN=http://localhost:3000
-NEXT_PUBLIC_API_URL=http://localhost:8080
-NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
+# Leave empty — auto-derived from page origin in browser, set by Makefile for local dev.
+# Only set explicitly if frontend and backend are on different domains.
+NEXT_PUBLIC_API_URL=
+NEXT_PUBLIC_WS_URL=
 
 # Remote API (optional) — set to proxy local frontend to a remote backend
 # Leave empty to use local backend (localhost:8080)


### PR DESCRIPTION
## Summary
- Clear hardcoded `NEXT_PUBLIC_API_URL=http://localhost:8080` and `NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws` defaults from `.env.example`
- When empty, the frontend auto-derives URLs from the page origin (via `deriveWsUrl()` and relative API paths through Next.js rewrites)
- `make dev` still works — the Makefile sets these to `localhost:$PORT` automatically

This is the remaining fix for #1055 after the Caddy revert (#1062).

## Test plan
- [ ] Docker selfhost: `cp .env.example .env && docker compose -f docker-compose.selfhost.yml up -d` — verify frontend loads and API/WS work at `http://localhost:3000`
- [ ] Docker selfhost with custom port: set `PORT=8083` in `.env`, rebuild — verify frontend still works (no hardcoded 8080)
- [ ] Local dev: `make dev` — verify frontend connects to backend correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)