### PR TITLE
feat(openclaw): add Gateway mode for full workspace context

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -101,8 +101,8 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 	openclawPath := envOrDefault("MULTICA_OPENCLAW_PATH", "openclaw")
 	if _, err := exec.LookPath(openclawPath); err == nil {
-		openclawGateway := strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_GATEWAY")) == "1" ||
-			strings.EqualFold(strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_GATEWAY")), "true")
+		v := strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_GATEWAY"))
+		openclawGateway := v == "1" || strings.EqualFold(v, "true")
 		agents["openclaw"] = AgentEntry{
 			Path:          openclawPath,
 			Model:         strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -101,9 +101,13 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 	openclawPath := envOrDefault("MULTICA_OPENCLAW_PATH", "openclaw")
 	if _, err := exec.LookPath(openclawPath); err == nil {
+		openclawGateway := strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_GATEWAY")) == "1" ||
+			strings.EqualFold(strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_GATEWAY")), "true")
 		agents["openclaw"] = AgentEntry{
-			Path:  openclawPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
+			Path:          openclawPath,
+			Model:         strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
+			GatewayMode:   openclawGateway,
+			SessionPrefix: envOrDefault("MULTICA_OPENCLAW_SESSION_PREFIX", "multica"),
 		}
 	}
 	hermesPath := envOrDefault("MULTICA_HERMES_PATH", "hermes")

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -898,6 +898,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,
 		Logger:         d.logger,
+		GatewayMode:    entry.GatewayMode,
+		SessionPrefix:  entry.SessionPrefix,
 	})
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -2,8 +2,10 @@ package daemon
 
 // AgentEntry describes a single available agent CLI.
 type AgentEntry struct {
-	Path  string // path to CLI binary
-	Model string // model override (optional)
+	Path          string // path to CLI binary
+	Model         string // model override (optional)
+	GatewayMode   bool   // omit --local to route through OpenClaw Gateway
+	SessionPrefix string // prefix for derived Gateway session IDs (default "multica")
 }
 
 // Runtime represents a registered daemon runtime.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -93,6 +93,7 @@ type Config struct {
 	GatewayMode bool
 
 	// SessionPrefix is prepended to derived Gateway session IDs (default "multica").
+	// Only used when GatewayMode is true; local mode always uses "multica-" prefix.
 	SessionPrefix string
 }
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -86,6 +86,14 @@ type Config struct {
 	ExecutablePath string            // path to CLI binary (claude, codex, opencode, openclaw, hermes, or gemini)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
+
+	// GatewayMode, when true, omits --local from openclaw invocations so tasks
+	// route through the OpenClaw Gateway instead of a blank local instance.
+	// Enabled via MULTICA_OPENCLAW_GATEWAY=1 in the daemon config.
+	GatewayMode bool
+
+	// SessionPrefix is prepended to derived Gateway session IDs (default "multica").
+	SessionPrefix string
 }
 
 // New creates a Backend for the given agent type.

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -53,8 +53,9 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	if sessionID == "" {
 		if b.cfg.GatewayMode {
 			// Derive a stable per-task session ID from the task workdir so each
-			// Multica task gets its own isolated Gateway session. The workdir path
-			// is <workspacesRoot>/<task-id>/workdir — two levels up gives the task ID.
+			// Multica task gets its own isolated Gateway session.
+			// Expected path shape: <workspacesRoot>/<task-id>/workdir
+			// filepath.Dir gives <workspacesRoot>/<task-id>, Base gives the task ID.
 			prefix := b.cfg.SessionPrefix
 			if prefix == "" {
 				prefix = "multica"

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -20,9 +21,15 @@ var openclawBlockedArgs = map[string]blockedArgMode{
 	"--message":    blockedWithValue,  // prompt is set by daemon
 }
 
-// openclawBackend implements Backend by spawning `openclaw agent --message <prompt>
-// --output-format stream-json --yes` and reading streaming NDJSON events from
-// stdout — similar to the opencode backend.
+// openclawBackend implements Backend by spawning `openclaw agent --local --json
+// --session-id <id> --message <prompt>` and reading streaming NDJSON events
+// from stderr — similar to the opencode backend.
+//
+// Gateway mode (MULTICA_OPENCLAW_GATEWAY=1) omits --local so the task routes
+// through the OpenClaw Gateway, giving agents access to workspace context
+// (memory, skills, tools, identity). Each task gets a stable per-task session
+// ID derived from its workdir path to prevent context bleed between issues.
+// Comment-triggered follow-ups reuse PriorSessionID for continuity.
 type openclawBackend struct {
 	cfg Config
 }
@@ -44,9 +51,31 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 
 	sessionID := opts.ResumeSessionID
 	if sessionID == "" {
-		sessionID = fmt.Sprintf("multica-%d", time.Now().UnixNano())
+		if b.cfg.GatewayMode {
+			// Derive a stable per-task session ID from the task workdir so each
+			// Multica task gets its own isolated Gateway session. The workdir path
+			// is <workspacesRoot>/<task-id>/workdir — two levels up gives the task ID.
+			prefix := b.cfg.SessionPrefix
+			if prefix == "" {
+				prefix = "multica"
+			}
+			if opts.Cwd != "" {
+				sessionID = prefix + "-" + filepath.Base(filepath.Dir(opts.Cwd))
+			} else {
+				sessionID = fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+			}
+		} else {
+			sessionID = fmt.Sprintf("multica-%d", time.Now().UnixNano())
+		}
 	}
-	args := []string{"agent", "--local", "--json", "--session-id", sessionID}
+
+	var args []string
+	if b.cfg.GatewayMode {
+		// Gateway mode: omit --local to route through the OpenClaw Gateway.
+		args = []string{"agent", "--json", "--session-id", sessionID}
+	} else {
+		args = []string{"agent", "--local", "--json", "--session-id", sessionID}
+	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}
@@ -79,7 +108,7 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		return nil, fmt.Errorf("start openclaw: %w", err)
 	}
 
-	b.cfg.Logger.Info("openclaw started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+	b.cfg.Logger.Info("openclaw started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model, "gateway", b.cfg.GatewayMode, "session", sessionID)
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)


### PR DESCRIPTION
## Summary

Adds an optional **Gateway mode** for the openclaw backend. When `MULTICA_OPENCLAW_GATEWAY=1` is set, the daemon omits `--local` from openclaw invocations so tasks route through the OpenClaw Gateway instead of a blank embedded instance. This gives agents access to persistent workspace context — memory, skills, tools, and identity.

This is the Gateway mode feature extracted from #924 as requested by @Bohan-J, without the stdout/stderr pipe change (upstream `--json` correctly uses stderr per #897).

## How it works

**Local mode (default, unchanged):**
```
openclaw agent --local --json --session-id multica-<nanos> --message <prompt>
```

**Gateway mode (`MULTICA_OPENCLAW_GATEWAY=1`):**
```
openclaw agent --json --session-id multica-<task-id> --message <prompt>
```

Session IDs in gateway mode are derived from the task's workdir path (`<workspacesRoot>/<task-id>/workdir`), giving each Multica task its own isolated Gateway session. Comment-triggered follow-ups reuse `PriorSessionID` for continuity within the same issue thread.

## Configuration

| Env var | Default | Description |
|---|---|---|
| `MULTICA_OPENCLAW_GATEWAY` | `0` | Set to `1` or `true` to enable gateway mode |
| `MULTICA_OPENCLAW_SESSION_PREFIX` | `multica` | Prefix for derived session IDs |

## Changes

- `pkg/agent`: add `GatewayMode` + `SessionPrefix` fields to `Config`
- `pkg/agent/openclaw`: derive stable session IDs in gateway mode; omit `--local`  
- `daemon/types`: add `GatewayMode` + `SessionPrefix` to `AgentEntry`
- `daemon/config`: read `MULTICA_OPENCLAW_GATEWAY` + `MULTICA_OPENCLAW_SESSION_PREFIX` env vars
- `daemon/daemon`: pass `GatewayMode` + `SessionPrefix` into `agent.Config`

All existing tests pass. Default behavior (local mode) is unchanged.