### PR TITLE
fix(make): run migrations before starting server in 'make start'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ start:
 	@echo "Backend: http://localhost:$(PORT)"
 	@echo "Frontend: http://localhost:$(FRONTEND_PORT)"
 	@bash scripts/ensure-postgres.sh "$(ENV_FILE)"
+	@echo "Running migrations..."
+	cd server && go run ./cmd/migrate up
 	@echo "Starting backend and frontend..."
 	@trap 'kill 0' EXIT; \
 		(cd server && go run ./cmd/server) & \


### PR DESCRIPTION
## Summary

- `make start` was starting the Go server without running pending migrations first
- This caused silent API failures (e.g. `column "custom_env" does not exist`) after pulling latest changes that include new migrations
- `make setup` and `make test` already run migrations — this makes `make start` consistent with them

## Root cause

After pulling latest `main`, a user who runs `make start` directly (without `make setup`) would get a server running against a stale schema. Any query touching new columns would fail with a postgres error, returning empty results to the UI with no visible error.

## Fix

Added `cd server && go run ./cmd/migrate up` to the `start` target, before the server process starts.

## Test plan

- [ ] Run `make start` after pulling a branch with a new migration — verify migrations apply before server starts
- [ ] Confirm existing `make start` behaviour is unchanged when no new migrations are pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)