### PR TITLE
feat(agent): log full command line at debug level when spawning agents

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -37,6 +37,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	args := buildClaudeArgs(opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -42,6 +42,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 	codexArgs := append([]string{"app-server", "--listen", "stdio://"}, filterCustomArgs(opts.CustomArgs, codexBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, codexArgs...)
+	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", codexArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -35,6 +35,7 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	args := buildGeminiArgs(prompt, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -36,6 +36,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 	hermesArgs := append([]string{"acp"}, opts.CustomArgs...)
 	cmd := exec.CommandContext(runCtx, execPath, hermesArgs...)
+	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", hermesArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -60,6 +60,7 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	args = append(args, "--message", prompt)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -55,6 +55,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	args = append(args, prompt)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd


### PR DESCRIPTION
## Summary
- Add debug-level log in all 6 agent backends (claude, codex, opencode, openclaw, gemini, hermes) that prints the executable path and full argument list when spawning
- Helps diagnose custom args, model overrides, and CLI flag issues without needing to attach to the process

## Example log output
```
DBG agent command exec=/opt/homebrew/bin/claude args="[-p --output-format stream-json ... --model claude-sonnet-4-20250514]"
```

## Test plan
- [x] `go build ./...` passes
- [ ] Trigger a task, verify `agent command` debug line appears in daemon log