### PR TITLE
feat(openclaw): support OPENCLAW_AGENT_ID to target a specific OpenClaw agent

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -38,6 +38,9 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		sessionID = fmt.Sprintf("multica-%d", time.Now().UnixNano())
 	}
 	args := []string{"agent", "--local", "--json", "--session-id", sessionID}
+	if agentID := b.cfg.Env["OPENCLAW_AGENT_ID"]; agentID != "" {
+		args = append(args, "--agent", agentID)
+	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}


### PR DESCRIPTION
## Summary

- OpenClaw supports multiple named agents, each with its own soul file, model config, and workspace (e.g. `lara`, `master`, `nova`)
- Previously Multica always ran the default OpenClaw agent — there was no way to target a specific one
- This PR adds support for an `OPENCLAW_AGENT_ID` environment variable on the Multica agent, which gets passed as `--agent <id>` to the OpenClaw CLI

## How to use

1. Open your agent in Multica → **Environment** tab
2. Add `OPENCLAW_AGENT_ID` = `lara` (or whichever OpenClaw agent name)
3. Tasks assigned to that Multica agent will now run via `openclaw agent --agent lara ...`

## Implementation

One check in `server/pkg/agent/openclaw.go` before building the args list:

```go
if agentID := b.cfg.Env["OPENCLAW_AGENT_ID"]; agentID != "" {
    args = append(args, "--agent", agentID)
}
```

The env var flows through the existing `Config.Env` map which is already populated from the agent's custom environment variables.

## Test plan

- [ ] Set `OPENCLAW_AGENT_ID=lara` on a Multica agent using the Openclaw runtime
- [ ] Assign an issue to that agent — verify OpenClaw runs as the `lara` agent (check soul file / model being used)
- [ ] Leave `OPENCLAW_AGENT_ID` unset on another agent — verify default OpenClaw agent is used as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)