### PR TITLE
feat(github): add deployment type to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,17 @@ description: Report a bug — something that's broken, crashes, or behaves incor
 title: "[Bug]: "
 labels: ["bug"]
 body:
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment type
+      description: Are you using the hosted version or a self-hosted instance?
+      options:
+        - multica.ai (hosted)
+        - Self-hosted
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,17 @@ description: Suggest a new feature or improvement.
 title: "[Feature]: "
 labels: ["enhancement"]
 body:
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment type
+      description: Are you using the hosted version or a self-hosted instance?
+      options:
+        - multica.ai (hosted)
+        - Self-hosted
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
## Summary
- Adds a required "Deployment type" dropdown (multica.ai hosted / Self-hosted) to both bug report and feature request issue templates
- Helps triage by immediately knowing whether an issue affects the hosted platform or a self-hosted instance

## Test plan
- [ ] Open a new bug report on GitHub and verify the deployment type dropdown appears as the first field
- [ ] Open a new feature request and verify the same dropdown appears
- [ ] Confirm both options (multica.ai hosted, Self-hosted) are selectable