### PR TITLE
feat(hermes): support HERMES_PROFILE to target a specific Hermes profile

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -34,7 +34,11 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
-	cmd := exec.CommandContext(runCtx, execPath, "acp")
+	args := []string{"acp"}
+	if profile := b.cfg.Env["HERMES_PROFILE"]; profile != "" {
+		args = append([]string{"--profile", profile}, args...)
+	}
+	cmd := exec.CommandContext(runCtx, execPath, args...)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -38,6 +38,9 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		sessionID = fmt.Sprintf("multica-%d", time.Now().UnixNano())
 	}
 	args := []string{"agent", "--local", "--json", "--session-id", sessionID}
+	if agentID := b.cfg.Env["OPENCLAW_AGENT_ID"]; agentID != "" {
+		args = append(args, "--agent", agentID)
+	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}


### PR DESCRIPTION
## Summary

- Hermes supports multiple isolated profiles (each with its own model, gateway, and workspace config — e.g. `ara`, `prime`, `default`)
- Previously Multica always ran `hermes acp` with the default profile, making it impossible to use a specific Hermes profile per agent
- This PR adds support for a `HERMES_PROFILE` environment variable on the Multica agent, which gets passed as `--profile <name>` to the Hermes CLI

## How to use

1. Open your agent in Multica → **Environment** tab
2. Add `HERMES_PROFILE` = `ara` (or whichever Hermes profile name)
3. Tasks assigned to that Multica agent will now run via `hermes --profile ara acp`

## Implementation

Small change in `server/pkg/agent/hermes.go` — reads `HERMES_PROFILE` from the agent's env and prepends `--profile <name>` before the `acp` subcommand (since `--profile` is a global flag in Hermes):

```go
args := []string{"acp"}
if profile := b.cfg.Env["HERMES_PROFILE"]; profile != "" {
    args = append([]string{"--profile", profile}, args...)
}
```

Companion to #1079 which adds the same feature for OpenClaw (`OPENCLAW_AGENT_ID`).

## Test plan

- [ ] Set `HERMES_PROFILE=ara` on a Multica agent using the Hermes runtime
- [ ] Assign an issue to that agent — verify Hermes runs with the `ara` profile
- [ ] Leave `HERMES_PROFILE` unset — verify default Hermes profile is used as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)