### PR TITLE
refactor(desktop): keep only create-workspace step in onboarding

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -12,7 +12,7 @@ import { ModalRegistry } from "@multica/views/modals/registry";
 import { AppSidebar, DashboardGuard } from "@multica/views/layout";
 import { SearchCommand, SearchTrigger } from "@multica/views/search";
 import { ChatFab, ChatWindow } from "@multica/views/chat";
-import { OnboardingWizard } from "@multica/views/onboarding";
+import { StepWorkspace } from "@multica/views/onboarding";
 import { useWorkspaceStore } from "@multica/core/workspace";
 import { DesktopNavigationProvider } from "@/platform/navigation";
 import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
@@ -96,8 +96,8 @@ export function DesktopShell() {
       <OnboardingGate
         hasWorkspace={!!workspace}
         onboarding={(onComplete) => (
-          <div className="h-screen overflow-auto">
-            <OnboardingWizard onComplete={onComplete} />
+          <div className="flex min-h-screen items-center justify-center overflow-auto bg-background px-6 py-12">
+            <StepWorkspace onNext={onComplete} />
           </div>
         )}
       >

--- a/apps/desktop/src/renderer/src/components/onboarding-gate.tsx
+++ b/apps/desktop/src/renderer/src/components/onboarding-gate.tsx
@@ -5,10 +5,10 @@ import { useState, type ReactNode } from "react";
  * without a workspace, otherwise renders `children`.
  *
  * The "needs onboarding" decision is frozen at first mount via the lazy
- * useState initializer — creating a workspace mid-wizard (step 0) must not
- * unmount the wizard, because steps 1-3 (runtime, agent, get started) still
- * need to run. Calling the `onComplete` passed to `onboarding` flips the
- * gate to `children`.
+ * useState initializer so the onboarding view controls its own exit: the
+ * onboarding component calls the `onComplete` callback when it's ready to
+ * hand off to `children`, instead of getting unmounted the moment the
+ * workspace store updates.
  *
  * Assumes `hasWorkspace` is definitive at first render: desktop only mounts
  * DesktopShell after AppContent's bootstrapping flag resolves, so the first

--- a/packages/views/onboarding/index.ts
+++ b/packages/views/onboarding/index.ts
@@ -1,2 +1,3 @@
 export { OnboardingWizard } from "./onboarding-wizard";
 export type { OnboardingWizardProps } from "./onboarding-wizard";
+export { StepWorkspace } from "./step-workspace";


### PR DESCRIPTION
## Summary
- Desktop fresh-account onboarding now renders only `StepWorkspace`; runtime/agent/get-started steps are skipped so users land in the app immediately after creating a workspace.
- Exports `StepWorkspace` from `@multica/views/onboarding` so the desktop shell can render it directly without the multi-step wizard chrome.
- Web onboarding (`apps/web/app/(auth)/onboarding/page.tsx`) still uses the full `OnboardingWizard` — no change.

## Test plan
- [ ] Launch desktop dev against a fresh account → only the "Welcome to Multica / Create Workspace" screen is shown.
- [ ] Create a workspace → onboarding dismisses and the main shell mounts without flashing runtime/agent steps.
- [ ] Web onboarding still walks through Workspace → Runtime → Agent → Get Started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)