### PR TITLE
fix(desktop): read VITE_APP_URL for Google login external redirect

### DIFF
--- a/apps/desktop/src/renderer/src/pages/login.tsx
+++ b/apps/desktop/src/renderer/src/pages/login.tsx
@@ -1,7 +1,7 @@
 import { LoginPage } from "@multica/views/auth";
 import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
 
-const WEB_URL = import.meta.env.VITE_WEB_URL || "http://localhost:3000";
+const WEB_URL = import.meta.env.VITE_APP_URL || "http://localhost:3000";
 
 export function DesktopLoginPage() {
   const lastWorkspaceId = localStorage.getItem("multica_workspace_id");


### PR DESCRIPTION
## Summary
Production desktop build was opening `http://localhost:3000/login?platform=desktop` when users clicked "Sign in with Google". The cause: `apps/desktop/src/renderer/src/pages/login.tsx` read `import.meta.env.VITE_WEB_URL`, but that variable is defined nowhere in the committed env files. In production it resolved to `undefined` and fell back to `http://localhost:3000`.

Switch to `VITE_APP_URL`, which is:
- already set in `apps/desktop/.env.production` (`https://multica.ai`)
- already the variable `platform/navigation.tsx` uses for shareable links
- the only `VITE_*_URL` for the web app that appears in tracked code after this change

## Test plan
- [ ] Package a desktop build (`pnpm --filter @multica/desktop package`) and click "Sign in with Google" → default browser opens `https://multica.ai/login?platform=desktop`.
- [ ] Dev build (with `VITE_APP_URL` set in `apps/desktop/.env`) → opens the configured dev web URL.
- [ ] Dev build without `VITE_APP_URL` → falls back to `http://localhost:3000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)