### PR TITLE
fix(desktop): evaluate daemon spawn env lazily to pick up PATH fix

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -598,11 +598,12 @@ function profileArgs(active: ActiveProfile): string[] {
 
 // Env passed to every CLI child so the daemon process knows it was spawned
 // by the Desktop app. The server uses this to mark runtimes as managed and
-// hide CLI self-update UI.
-const DESKTOP_SPAWN_ENV = {
-  ...process.env,
-  MULTICA_LAUNCHED_BY: "desktop",
-};
+// hide CLI self-update UI. Computed lazily so it picks up the PATH fix
+// applied by fix-path in main/index.ts — as a top-level const it would
+// snapshot process.env at import time, before that block runs.
+function desktopSpawnEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, MULTICA_LAUNCHED_BY: "desktop" };
+}
 
 async function startDaemon(): Promise<{ success: boolean; error?: string }> {
   const bin = await resolveCliBinary();
@@ -624,7 +625,7 @@ async function startDaemon(): Promise<{ success: boolean; error?: string }> {
     execFile(
       bin,
       args,
-      { timeout: 20_000, env: DESKTOP_SPAWN_ENV },
+      { timeout: 20_000, env: desktopSpawnEnv() },
       (err) => {
         if (err) {
           currentState = "stopped";


### PR DESCRIPTION
## Summary
- `DESKTOP_SPAWN_ENV` in `daemon-manager.ts` was a top-level const that snapshotted `process.env` at module load time. ESM imports are hoisted and evaluated before `main/index.ts` runs `fix-path`, so the snapshot captured launchd's minimal PATH (missing `~/.local/bin`, Homebrew paths from `.zshrc`, etc.).
- The main process ended up with the corrected PATH, but every daemon child spawned via `execFile(bin, args, { env: DESKTOP_SPAWN_ENV })` inherited the stale one and failed with `no agent CLI found` on fresh GUI launches — even though the user's shell had `claude` on PATH.
- Convert `DESKTOP_SPAWN_ENV` into a `desktopSpawnEnv()` function so `process.env` is read at call time, after `fix-path` + fallback-prepend have already updated it.

## Repro (before fix)

Launching a packaged Multica.app from Finder on a fresh account with `claude` installed at `~/.local/bin/claude`:

- ``~/.multica/profiles/<profile>/daemon.log``:
  ```
  Error: no agent CLI found: install claude, codex, opencode, openclaw, hermes, or gemini and ensure it is on PATH
  ```
- Running the bundled CLI directly confirmed the daemon itself works when PATH is correct:
  ```
  TEST 1 (PATH without ~/.local/bin) → Error: no agent CLI found
  TEST 2 (PATH with ~/.local/bin)    → daemon started, agents=[claude] ✅
  ```
- Inspecting the packaged `app.asar` showed the `fix-path` block is present and runs, but `DESKTOP_SPAWN_ENV` was already frozen before it executed.

## Test plan
- [ ] Package an unsigned build: `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm --filter @multica/desktop package -- --mac dmg -p never`
- [ ] Quit any running Multica.app and kill any stray `multica daemon` processes
- [ ] Drag the new `.app` into `/Applications`, launch from Finder
- [ ] Confirm the daemon starts and `agents=[claude]` appears in `~/.multica/profiles/<profile>/daemon.log`
- [ ] Sanity check: `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)