### PR TITLE
fix(daemon): normalize repo URL and clarify reposVersion intent

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -28,7 +28,7 @@ var ErrRepoNotConfigured = errors.New("repo is not configured for this workspace
 type workspaceState struct {
 	workspaceID     string
 	runtimeIDs      []string
-	reposVersion    string
+	reposVersion    string             // stored for future use: skip refresh when version unchanged
 	allowedRepoURLs map[string]struct{}
 	lastRepoSyncErr string
 	repoRefreshMu   sync.Mutex
@@ -318,6 +318,8 @@ func (d *Daemon) ensureRepoReady(ctx context.Context, workspaceID, repoURL strin
 		return fmt.Errorf("repo cache not initialized")
 	}
 
+	repoURL = strings.TrimSpace(repoURL)
+
 	d.mu.Lock()
 	ws, ok := d.workspaces[workspaceID]
 	d.mu.Unlock()
@@ -406,7 +408,7 @@ func (d *Daemon) syncWorkspacesFromAPI(ctx context.Context) error {
 	var registered int
 	for id, name := range apiIDs {
 		if currentIDs[id] {
-			continue
+			continue // important: never replace existing workspaceState; ensureRepoReady holds ws.repoRefreshMu from the original pointer
 		}
 		resp, err := d.registerRuntimesForWorkspace(ctx, id)
 		if err != nil {

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -342,6 +342,29 @@ func TestEnsureRepoReadyFastPathDoesNotRefresh(t *testing.T) {
 	}
 }
 
+func TestEnsureRepoReadyTrimsURL(t *testing.T) {
+	t.Parallel()
+
+	sourceRepo := createDaemonTestRepo(t)
+	var refreshCalls atomic.Int32
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		refreshCalls.Add(1)
+		http.Error(w, "unexpected refresh", http.StatusInternalServerError)
+	})
+	if err := d.repoCache.Sync("ws-1", []repocache.RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("seed repo cache: %v", err)
+	}
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", nil, "v1", []RepoData{{URL: sourceRepo}})
+
+	// URL with trailing whitespace should still hit the fast path.
+	if err := d.ensureRepoReady(context.Background(), "ws-1", "  "+sourceRepo+"  "); err != nil {
+		t.Fatalf("ensureRepoReady with padded URL: %v", err)
+	}
+	if got := refreshCalls.Load(); got != 0 {
+		t.Fatalf("expected no refresh calls for trimmed URL, got %d", got)
+	}
+}
+
 func TestEnsureRepoReadyRefreshesOnMiss(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What does this PR do?

Follow-up nit fixes from the review of #1085. Three small improvements:

1. **URL normalization**: `TrimSpace` incoming `repoURL` in `ensureRepoReady` so URLs with whitespace still hit the fast path instead of triggering unnecessary server refreshes
2. **Comment clarification**: Added inline comment on `reposVersion` field explaining it's stored for future version-based skip optimization (currently unused in comparison logic)
3. **Concurrency safety comment**: Documented that `syncWorkspacesFromAPI` must not replace existing `workspaceState` pointers, since `ensureRepoReady` holds `ws.repoRefreshMu` from the original pointer

## Related Issue

Follow-up from #1085 review

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `server/internal/daemon/daemon.go`: Added `strings.TrimSpace(repoURL)` at `ensureRepoReady` entry, added comment on `reposVersion` field, added concurrency safety comment on workspace skip logic
- `server/internal/daemon/daemon_test.go`: Added `TestEnsureRepoReadyTrimsURL` test

## How to Test

```bash
cd server && go test ./internal/daemon/ -run TestEnsureRepoReady -v
```

## AI Disclosure

**AI tool used:** Claude Code