### PR TITLE
fix(desktop): prevent false onboarding trigger on OTP login

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import { UpdateNotification } from "./components/update-notification";
 function AppContent() {
   const user = useAuthStore((s) => s.user);
   const isLoading = useAuthStore((s) => s.isLoading);
+  const workspaceHydrated = useWorkspaceStore((s) => s.workspaceHydrated);
   // Deep-link login runs loginWithToken → syncToken → listWorkspaces →
   // hydrateWorkspace sequentially. loginWithToken sets user+isLoading=false
   // as soon as getMe resolves, which would cause DesktopShell to mount
@@ -72,6 +73,20 @@ function AppContent() {
   }
 
   if (!user) return <DesktopLoginPage />;
+
+  // Wait for workspace hydration before mounting DesktopShell so that
+  // OnboardingGate gets a definitive hasWorkspace value on first render.
+  // Without this, OTP login sets `user` (triggering this branch) before
+  // listWorkspaces + hydrateWorkspace complete, causing OnboardingGate
+  // to freeze with hasWorkspace=false even when the user has a workspace.
+  if (!workspaceHydrated) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <MulticaIcon className="size-6 animate-pulse" />
+      </div>
+    );
+  }
+
   return <DesktopShell />;
 }
 

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -43,9 +43,11 @@ export function AuthInitializer({
       Promise.all([api.getMe(), api.listWorkspaces()])
         .then(([user, wsList]) => {
           onLogin?.();
-          useAuthStore.setState({ user, isLoading: false });
+          // Hydrate workspace BEFORE flipping isLoading — AppContent gates
+          // on isLoading, so workspace must be ready when it re-renders.
           qc.setQueryData(workspaceKeys.list(), wsList);
           useWorkspaceStore.getState().hydrateWorkspace(wsList, wsId);
+          useAuthStore.setState({ user, isLoading: false });
         })
         .catch((err) => {
           logger.error("cookie auth init failed", err);
@@ -68,10 +70,11 @@ export function AuthInitializer({
     Promise.all([api.getMe(), api.listWorkspaces()])
       .then(([user, wsList]) => {
         onLogin?.();
-        useAuthStore.setState({ user, isLoading: false });
-        // Seed React Query cache so components don't need a second fetch
+        // Hydrate workspace BEFORE flipping isLoading — AppContent gates
+        // on isLoading, so workspace must be ready when it re-renders.
         qc.setQueryData(workspaceKeys.list(), wsList);
         useWorkspaceStore.getState().hydrateWorkspace(wsList, wsId);
+        useAuthStore.setState({ user, isLoading: false });
       })
       .catch((err) => {
         logger.error("auth init failed", err);

--- a/packages/core/workspace/store.ts
+++ b/packages/core/workspace/store.ts
@@ -12,6 +12,8 @@ interface WorkspaceStoreOptions {
 
 interface WorkspaceState {
   workspace: Workspace | null;
+  /** True once `hydrateWorkspace` has run (even if no workspace was found). */
+  workspaceHydrated: boolean;
 }
 
 interface WorkspaceActions {
@@ -39,6 +41,7 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
     // Only the currently selected workspace (UI state).
     // The workspace list is server state and lives in React Query.
     workspace: null,
+    workspaceHydrated: false,
 
     hydrateWorkspace: (wsList, preferredWorkspaceId) => {
       const nextWorkspace =
@@ -53,7 +56,7 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
         setCurrentWorkspaceId(null);
         rehydrateAllWorkspaceStores();
         storage?.removeItem("multica_workspace_id");
-        set({ workspace: null });
+        set({ workspace: null, workspaceHydrated: true });
         return null;
       }
 
@@ -61,7 +64,7 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
       setCurrentWorkspaceId(nextWorkspace.id);
       rehydrateAllWorkspaceStores();
       storage?.setItem("multica_workspace_id", nextWorkspace.id);
-      set({ workspace: nextWorkspace });
+      set({ workspace: nextWorkspace, workspaceHydrated: true });
       logger.debug("hydrate workspace", nextWorkspace.name, nextWorkspace.id);
 
       return nextWorkspace;
@@ -86,7 +89,7 @@ export function createWorkspaceStore(api: ApiClient, options?: WorkspaceStoreOpt
       api.setWorkspaceId(null);
       setCurrentWorkspaceId(null);
       rehydrateAllWorkspaceStores();
-      set({ workspace: null });
+      set({ workspace: null, workspaceHydrated: false });
     },
   }));
 }


### PR DESCRIPTION
## Summary
- Fixes a race condition where Desktop app shows onboarding wizard for users who already have workspaces
- Root cause: `verifyCode` (email/OTP login) sets `user` in auth store before `listWorkspaces` + `hydrateWorkspace` complete, causing `OnboardingGate` to freeze `hasWorkspace=false`
- Adds `workspaceHydrated` flag to workspace store so `AppContent` can wait for definitive workspace state before rendering `DesktopShell`
- Reorders `AuthInitializer` to hydrate workspace before flipping `isLoading`

Resolves MUL-888

## Test plan
- [ ] Email/OTP login on desktop with existing workspace — should go straight to main app, no onboarding flash
- [ ] Email/OTP login on desktop with no workspace — should show onboarding wizard
- [ ] Deep-link (Google) login — should still work correctly (protected by `bootstrapping` flag)
- [ ] Session restore on app restart — should load workspace without showing onboarding
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (all 97 tests including login-page tests)