### PR TITLE
feat(agent): add native Ollama backend with tool-use loop

### DIFF
--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -73,6 +73,16 @@ function HermesLogo({ className }: { className: string }) {
   );
 }
 
+// Ollama — official llama silhouette, monochrome, sourced from
+// github.com/ollama/ollama brand assets (logo.svg, simplified path).
+function OllamaLogo({ className }: { className: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M7.755 0c-.704.014-1.396.293-1.94.84-.96.962-1.244 2.376-.92 3.673-.747.59-1.318 1.43-1.61 2.413-.291.984-.281 2.025.013 2.99-.83.83-1.298 1.96-1.298 3.135 0 1.077.394 2.114 1.105 2.917-.214.787-.211 1.62.011 2.405-.222.785-.225 1.62-.011 2.407-.711.802-1.105 1.84-1.105 2.916 0 .073.002.145.005.218H22.99c.003-.073.005-.145.005-.218 0-1.076-.394-2.114-1.105-2.916.222-.787.219-1.62-.011-2.407.222-.786.225-1.618.011-2.405.711-.803 1.105-1.84 1.105-2.917 0-1.175-.468-2.305-1.298-3.135.294-.965.304-2.006.013-2.99-.292-.984-.863-1.823-1.61-2.413.324-1.297.04-2.711-.92-3.673-1.087-1.092-2.795-1.122-3.91-.114-.997-.585-2.215-.59-3.218-.012-1.003-.578-2.221-.573-3.218.012C9.71.297 8.86-.012 8 0a2.92 2.92 0 0 0-.245 0Z" />
+    </svg>
+  );
+}
+
 export function ProviderLogo({
   provider,
   className = "h-4 w-4",
@@ -91,6 +101,8 @@ export function ProviderLogo({
       return <OpenClawLogo className={className} />;
     case "hermes":
       return <HermesLogo className={className} />;
+    case "ollama":
+      return <OllamaLogo className={className} />;
     default:
       return <Monitor className={className} />;
   }

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -1,13 +1,17 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
 )
 
 const (
@@ -21,8 +25,9 @@ const (
 	DefaultHealthPort            = 19514
 	DefaultMaxConcurrentTasks    = 20
 	DefaultGCInterval            = 1 * time.Hour
-	DefaultGCTTL                 = 5 * 24 * time.Hour // 5 days
+	DefaultGCTTL                 = 5 * 24 * time.Hour  // 5 days
 	DefaultGCOrphanTTL           = 30 * 24 * time.Hour // 30 days
+	ollamaProbeTimeout           = 2 * time.Second
 )
 
 // Config holds all daemon configuration.
@@ -34,7 +39,7 @@ type Config struct {
 	CLIVersion         string                // multica CLI version (e.g. "0.1.13")
 	LaunchedBy         string                // "desktop" when spawned by the Electron app, empty for standalone
 	Profile            string                // profile name (empty = default)
-	Agents             map[string]AgentEntry // keyed by provider: claude, codex, opencode, openclaw, hermes, gemini
+	Agents             map[string]AgentEntry // keyed by provider: claude, codex, opencode, openclaw, hermes, gemini, ollama
 	WorkspacesRoot     string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask   bool                  // preserve env after task for debugging
 	HealthPort         int                   // local HTTP port for health checks (default: 19514)
@@ -121,8 +126,42 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_GEMINI_MODEL")),
 		}
 	}
+
+	// Ollama is HTTP-based, not a CLI — probe the /api/tags endpoint
+	// rather than looking for a binary on PATH. The resolved base URL is
+	// stored in AgentEntry.Path and read back by the ollama backend.
+	ollamaHost := strings.TrimRight(envOrDefault("MULTICA_OLLAMA_HOST", agent.DefaultOllamaHost), "/")
+	ollamaModel := strings.TrimSpace(os.Getenv("MULTICA_OLLAMA_MODEL"))
+	if ollamaModel != "" && probeOllamaReachable(ollamaHost) {
+		agents["ollama"] = AgentEntry{
+			Path:  ollamaHost,
+			Model: ollamaModel,
+		}
+		// Best-effort capability check — warn if the model doesn't
+		// advertise tool support. Don't block registration: the user
+		// may intentionally want a chat-only model, and an /api/show
+		// failure shouldn't stop the daemon from starting. Scope the
+		// cancel to the narrowest block so it matches the pattern in
+		// probeOllamaReachable rather than hanging around for the rest
+		// of LoadConfig.
+		capCtx, capCancel := context.WithTimeout(context.Background(), ollamaProbeTimeout)
+		supports, capErr := agent.OllamaModelSupportsTools(capCtx, ollamaHost, ollamaModel)
+		capCancel()
+		if capErr == nil && !supports {
+			fmt.Fprintf(os.Stderr,
+				"WARNING: Ollama model %q does not declare 'tools' capability. "+
+					"Issue-assignment tasks will degrade to text-only responses. "+
+					"Use a tool-capable model (e.g. gemma4:latest, qwen2.5-coder:1.5b, llama3.1).\n",
+				ollamaModel)
+		}
+	}
+
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, opencode, openclaw, hermes, or gemini and ensure it is on PATH")
+		return Config{}, fmt.Errorf(
+			"no agent runtime available: install claude/codex/opencode/openclaw/hermes/gemini on PATH, " +
+				"or set MULTICA_OLLAMA_MODEL with a reachable Ollama server " +
+				"(MULTICA_OLLAMA_HOST, default " + agent.DefaultOllamaHost + ")",
+		)
 	}
 
 	// Host info
@@ -278,4 +317,25 @@ func NormalizeServerBaseURL(raw string) (string, error) {
 	u.RawQuery = ""
 	u.Fragment = ""
 	return strings.TrimRight(u.String(), "/"), nil
+}
+
+// probeOllamaReachable returns true if an Ollama server responds 2xx to
+// GET {baseURL}/api/tags within ollamaProbeTimeout. The call is cheap
+// (lists local model tags) and exists on every Ollama version.
+func probeOllamaReachable(baseURL string) bool {
+	if baseURL == "" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), ollamaProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/tags", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -250,7 +250,7 @@ func (d *Daemon) providerToRuntimeMap() map[string]string {
 func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, error) {
 	var runtimes []map[string]string
 	for name, entry := range d.cfg.Agents {
-		version, err := agent.DetectVersion(ctx, entry.Path)
+		version, err := agent.DetectVersion(ctx, name, entry.Path)
 		if err != nil {
 			d.logger.Warn("skip registering runtime", "name", name, "error", err)
 			continue

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -15,13 +15,16 @@ import (
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .config/opencode/skills/)
 // For OpenClaw: writes {workDir}/AGENTS.md  (skills discovered natively from .openclaw/skills/)
 // For Gemini:   writes {workDir}/GEMINI.md  (discovered natively by the Gemini CLI)
+// For Ollama:   writes {workDir}/AGENTS.md  (Ollama has no native config file convention;
+//                                            kept for parity so a human inspecting the
+//                                            workdir sees the same context)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error {
 	content := buildMetaSkillContent(provider, ctx)
 
 	switch provider {
 	case "claude":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "opencode", "openclaw":
+	case "codex", "opencode", "openclaw", "ollama":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -82,13 +82,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, opencode, openclaw, hermes, or gemini)
+	ExecutablePath string            // path to CLI binary (claude, codex, opencode, openclaw, hermes, gemini), or base URL for HTTP-based providers (ollama)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "opencode", "openclaw", "hermes", "gemini".
+// Supported types: "claude", "codex", "opencode", "openclaw", "hermes", "gemini", "ollama".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -107,12 +107,22 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &hermesBackend{cfg: cfg}, nil
 	case "gemini":
 		return &geminiBackend{cfg: cfg}, nil
+	case "ollama":
+		return &ollamaBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, openclaw, hermes, gemini)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, openclaw, hermes, gemini, ollama)", agentType)
 	}
 }
 
-// DetectVersion runs the agent CLI with --version and returns the output.
-func DetectVersion(ctx context.Context, executablePath string) (string, error) {
+// DetectVersion returns the version string for the given agent.
+//
+// For CLI-based providers (claude, codex, opencode, openclaw, hermes, gemini)
+// this runs `<executablePath> --version`. For HTTP-based providers (ollama)
+// the executablePath is the base URL and version is fetched via the
+// provider's HTTP API.
+func DetectVersion(ctx context.Context, agentType, executablePath string) (string, error) {
+	if agentType == "ollama" {
+		return detectOllamaVersion(ctx, executablePath)
+	}
 	return detectCLIVersion(ctx, executablePath)
 }

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -46,7 +46,7 @@ func TestNewDefaultsLogger(t *testing.T) {
 
 func TestDetectVersionFailsForMissingBinary(t *testing.T) {
 	t.Parallel()
-	_, err := DetectVersion(context.Background(), "/nonexistent/binary")
+	_, err := DetectVersion(context.Background(), "claude", "/nonexistent/binary")
 	if err == nil {
 		t.Fatal("expected error for missing binary")
 	}

--- a/server/pkg/agent/ollama.go
+++ b/server/pkg/agent/ollama.go
@@ -1,0 +1,609 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ollamaBackend implements Backend by driving a local Ollama server
+// (https://ollama.com) via its `/api/chat` endpoint. The backend runs a
+// tool-use loop: it offers a single `shell` function to the model, executes
+// any commands the model invokes against the task's working directory, and
+// feeds the output back as a tool-result message until the model returns a
+// final answer (or MaxTurns is reached).
+//
+// Models with tool support (gemma3+, qwen2.5+, llama3.1+, etc.) can use
+// this to drive the `multica` CLI — read issue context, post comments,
+// update status, etc. — exactly the way Claude/Codex/Gemini do via their
+// native shells. Models without tool support degrade gracefully: they
+// return text-only responses, which still works for chat-mode tasks.
+//
+// The shell tool runs commands in the daemon's prepared working directory
+// (`opts.Cwd`) with the env vars the daemon already merged (`cfg.Env`,
+// which includes the multica binary on PATH). This is yolo-equivalent —
+// no command filter — matching what Claude's `bypassPermissions` and
+// Gemini's `--yolo` already do.
+//
+// Configuration:
+//
+//	cfg.ExecutablePath  — Ollama base URL (default "http://localhost:11434").
+//	                      The daemon's config probe writes this from
+//	                      MULTICA_OLLAMA_HOST.
+//	cfg.Env             — env vars merged into each shell tool invocation.
+//	opts.Model          — Ollama model name (e.g. "gemma4:latest"). Required.
+//	opts.MaxTurns       — max tool-loop iterations (default 25).
+//	opts.Timeout        — overall request deadline (default 20 min).
+//	opts.SystemPrompt   — sent as a system message before the user prompt.
+//	opts.ResumeSessionID — ignored (Ollama is stateless).
+type ollamaBackend struct {
+	cfg Config
+}
+
+// DefaultOllamaHost is the canonical base URL for an unconfigured local
+// Ollama server. Exported so the daemon config probe can share it
+// without duplicating the literal.
+const DefaultOllamaHost = "http://localhost:11434"
+
+const (
+	defaultOllamaTimeout  = 20 * time.Minute
+	defaultOllamaMaxTurns = 25
+	// shellExecTimeoutDefault caps a single shell tool invocation so a
+	// hung command can't block the whole task. The agent timeout
+	// (opts.Timeout) is the outer ceiling; this is the per-call limit.
+	// Override with MULTICA_OLLAMA_SHELL_TIMEOUT (duration, e.g. "10m").
+	shellExecTimeoutDefault = 5 * time.Minute
+	// maxToolOutputDefault caps the bytes of a single tool-result
+	// message fed back to the model. Models can re-run with `| head` or
+	// `| tail` if they need more. Override with
+	// MULTICA_OLLAMA_MAX_OUTPUT_BYTES (positive int).
+	maxToolOutputDefault = 16 * 1024
+)
+
+// shellExecTimeout returns the per-command shell timeout, honoring
+// MULTICA_OLLAMA_SHELL_TIMEOUT if set and parseable. Read at Execute
+// time (not init) so tests can override freely.
+func shellExecTimeout() time.Duration {
+	if v := strings.TrimSpace(os.Getenv("MULTICA_OLLAMA_SHELL_TIMEOUT")); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return shellExecTimeoutDefault
+}
+
+// maxToolOutput returns the byte cap on a single tool-result message,
+// honoring MULTICA_OLLAMA_MAX_OUTPUT_BYTES if set and positive.
+func maxToolOutput() int {
+	if v := strings.TrimSpace(os.Getenv("MULTICA_OLLAMA_MAX_OUTPUT_BYTES")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return maxToolOutputDefault
+}
+
+// ── Wire types ─────────────────────────────────────────────────────────────
+
+// ollamaChatRequest is the body of POST /api/chat.
+type ollamaChatRequest struct {
+	Model    string              `json:"model"`
+	Messages []ollamaChatMessage `json:"messages"`
+	Stream   bool                `json:"stream"`
+	Tools    []ollamaTool        `json:"tools,omitempty"`
+}
+
+// ollamaChatMessage is one message in a /api/chat conversation. Both
+// inbound (response) and outbound (request) messages use this shape.
+//
+// On the request side: Role is "system", "user", "assistant", or "tool".
+// Tool-result messages set Role="tool", Content to the command output,
+// and ToolCallID to the id of the call being answered (some models
+// strictly correlate; gemma is lenient, qwen2.5/llama3.1 are not).
+//
+// On the response side: a model returning tool_calls leaves Content empty
+// and populates ToolCalls with one or more requested invocations.
+type ollamaChatMessage struct {
+	Role       string           `json:"role"`
+	Content    string           `json:"content"`
+	ToolCalls  []ollamaToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+// ollamaTool defines a function the model may invoke. Ollama follows the
+// OpenAI function-calling schema (type=function, parameters as JSON Schema).
+type ollamaTool struct {
+	Type     string             `json:"type"`
+	Function ollamaToolFunction `json:"function"`
+}
+
+type ollamaToolFunction struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+
+// ollamaToolCall is one invocation requested by the model. The Function
+// arguments arrive as a JSON object (not a JSON-encoded string like OpenAI),
+// so we keep them as RawMessage and decode per-tool.
+type ollamaToolCall struct {
+	ID       string             `json:"id,omitempty"`
+	Function ollamaToolCallFunc `json:"function"`
+}
+
+type ollamaToolCallFunc struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// ollamaChatResponse is the body of a non-streaming POST /api/chat
+// response. (The streaming NDJSON format is one chunk per line; we use
+// stream:false here because tool_calls and final content arrive together
+// in the last chunk anyway, so reassembly buys us nothing.)
+type ollamaChatResponse struct {
+	Model           string            `json:"model"`
+	Message         ollamaChatMessage `json:"message"`
+	Done            bool              `json:"done"`
+	DoneReason      string            `json:"done_reason,omitempty"`
+	PromptEvalCount int64             `json:"prompt_eval_count,omitempty"`
+	EvalCount       int64             `json:"eval_count,omitempty"`
+}
+
+// ── Tool catalog ───────────────────────────────────────────────────────────
+
+// shellToolDef is the only tool exposed to the model. The single
+// `command` string is passed to `bash -lc` in the task's working
+// directory. The model is expected to use this to invoke the `multica`
+// CLI (already on PATH) plus standard Unix utilities.
+var shellToolDef = ollamaTool{
+	Type: "function",
+	Function: ollamaToolFunction{
+		Name:        "shell",
+		Description: "Execute a shell command in the current working directory and return its combined stdout+stderr. Use this to run the `multica` CLI (e.g. `multica issue get <id> --output json`) and any other Unix command needed to complete the task.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "The shell command to execute. Will be run via `bash -c` in your current working directory.",
+				},
+			},
+			"required": []string{"command"},
+		},
+	},
+}
+
+// ── Backend implementation ─────────────────────────────────────────────────
+
+func (b *ollamaBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	baseURL := strings.TrimRight(b.cfg.ExecutablePath, "/")
+	if baseURL == "" {
+		baseURL = DefaultOllamaHost
+	}
+	if opts.Model == "" {
+		return nil, fmt.Errorf("ollama: model is required (set MULTICA_OLLAMA_MODEL on the daemon)")
+	}
+	if opts.ResumeSessionID != "" {
+		b.cfg.Logger.Debug("ollama: ignoring ResumeSessionID (provider is stateless)", "session_id", opts.ResumeSessionID)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = defaultOllamaTimeout
+	}
+	maxTurns := opts.MaxTurns
+	if maxTurns <= 0 {
+		maxTurns = defaultOllamaMaxTurns
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	// Capacity matches claude.go and gemini.go (256). A 25-turn loop with
+	// 2 events per tool call plus text fits comfortably; oversize is fine
+	// because trySend drops on full anyway.
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		startTime := time.Now()
+		client := &http.Client{}
+
+		messages := buildInitialMessages(prompt, opts)
+
+		var (
+			finalText      strings.Builder
+			usage          TokenUsage
+			gotFinalAnswer bool // model produced a turn with no tool_calls
+		)
+
+		b.cfg.Logger.Info("ollama started", "url", baseURL+"/api/chat", "model", opts.Model, "cwd", opts.Cwd, "max_turns", maxTurns)
+
+		for turn := 0; turn < maxTurns; turn++ {
+			resp, err := postOllamaChat(runCtx, client, baseURL, opts.Model, messages)
+			if err != nil {
+				resCh <- failedResult(err, finalText.String(), startTime, runCtx, timeout, opts.Model, usage)
+				return
+			}
+
+			// Track token counts across turns.
+			usage.InputTokens += resp.PromptEvalCount
+			usage.OutputTokens += resp.EvalCount
+
+			assistantMsg := resp.Message
+
+			// Guard against an empty response from Ollama — e.g. the
+			// server returns {"done":true} with no message payload, or
+			// the model OOMed mid-generation and emitted
+			// {role:"assistant", content:"", tool_calls:[]} (common for
+			// small quantized models under memory pressure). Without
+			// this check, the loop would exit with gotFinalAnswer=true
+			// and the task would be reported "completed" with empty
+			// output. Role is always "assistant" on responses and tells
+			// us nothing useful — only content/tool_calls matter.
+			if assistantMsg.Content == "" && len(assistantMsg.ToolCalls) == 0 {
+				resCh <- failedResult(
+					fmt.Errorf("ollama: response carried no message content and no tool_calls (turn %d, done=%v)", turn+1, resp.Done),
+					finalText.String(), startTime, runCtx, timeout, opts.Model, usage,
+				)
+				return
+			}
+
+			// If the model returned text content, accumulate and stream it.
+			if assistantMsg.Content != "" {
+				finalText.WriteString(assistantMsg.Content)
+				trySend(msgCh, Message{Type: MessageText, Content: assistantMsg.Content})
+			}
+
+			// No tool calls → final answer, exit the loop.
+			if len(assistantMsg.ToolCalls) == 0 {
+				gotFinalAnswer = true
+				break
+			}
+
+			// Append the assistant turn (with tool_calls) to history so the
+			// model sees its own request when we return tool results.
+			messages = append(messages, assistantMsg)
+
+			// Execute each tool call and append a tool-result message.
+			for _, call := range assistantMsg.ToolCalls {
+				toolResult := b.dispatchTool(runCtx, call, opts.Cwd)
+				trySend(msgCh, Message{
+					Type:   MessageToolUse,
+					Tool:   call.Function.Name,
+					CallID: call.ID,
+					Input:  decodeToolArgs(call.Function.Arguments),
+				})
+				trySend(msgCh, Message{
+					Type:   MessageToolResult,
+					Tool:   call.Function.Name,
+					CallID: call.ID,
+					Output: toolResult,
+				})
+				messages = append(messages, ollamaChatMessage{
+					Role:       "tool",
+					Content:    toolResult,
+					ToolCallID: call.ID,
+				})
+			}
+		}
+
+		durationMs := time.Since(startTime).Milliseconds()
+		text := finalText.String()
+		result := Result{
+			Status:     "completed",
+			Output:     text,
+			DurationMs: durationMs,
+		}
+		if usage.InputTokens > 0 || usage.OutputTokens > 0 {
+			result.Usage = map[string]TokenUsage{opts.Model: usage}
+		}
+		// Context status takes precedence over a clean loop exit. If the
+		// parent timed out or cancelled between the last iteration and now,
+		// the loop may have broken because postOllamaChat returned a
+		// transport error and we exited via the failedResult path — but we
+		// also defend the success path so a race window doesn't report a
+		// half-finished task as "completed". Same hardening claude.go has.
+		switch {
+		case errors.Is(runCtx.Err(), context.DeadlineExceeded):
+			result.Status = "timeout"
+			result.Error = fmt.Sprintf("ollama timed out after %s", timeout)
+		case errors.Is(runCtx.Err(), context.Canceled):
+			result.Status = "aborted"
+			result.Error = "execution cancelled"
+		case !gotFinalAnswer:
+			// Loop exhausted MaxTurns without the model producing a
+			// non-tool-call response — treat as a failure so the user sees
+			// it rather than silently truncating mid-task.
+			result.Status = "failed"
+			result.Error = fmt.Sprintf("ollama: hit MaxTurns=%d without a final response", maxTurns)
+		}
+
+		b.cfg.Logger.Info("ollama finished",
+			"model", opts.Model,
+			"status", result.Status,
+			"duration", time.Since(startTime).Round(time.Millisecond).String(),
+		)
+		resCh <- result
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// postOllamaChat sends one /api/chat request and decodes the (non-streaming)
+// response. Tool-related streaming is intentionally avoided — Ollama emits
+// tool_calls only on the final chunk anyway, so single-shot is simpler and
+// equally responsive at task granularity.
+func postOllamaChat(ctx context.Context, client *http.Client, baseURL, model string, messages []ollamaChatMessage) (*ollamaChatResponse, error) {
+	body, err := json.Marshal(ollamaChatRequest{
+		Model:    model,
+		Messages: messages,
+		Stream:   false,
+		Tools:    []ollamaTool{shellToolDef},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ollama: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("ollama: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: unreachable at %s: %w", baseURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<10))
+		return nil, fmt.Errorf("ollama returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var out ollamaChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("ollama: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// dispatchTool routes a tool call to its handler and returns the output
+// the model should see. Unknown tool names get an explanatory error
+// string (returned to the model rather than failing the task — the model
+// can recover by trying a different approach).
+func (b *ollamaBackend) dispatchTool(ctx context.Context, call ollamaToolCall, cwd string) string {
+	switch call.Function.Name {
+	case "shell":
+		return b.execShell(ctx, call.Function.Arguments, cwd)
+	default:
+		b.cfg.Logger.Warn("ollama: model called unknown tool", "name", call.Function.Name)
+		return fmt.Sprintf("error: unknown tool %q (only 'shell' is available)", call.Function.Name)
+	}
+}
+
+// execShell runs a single shell command via `bash -lc` in cwd, with the
+// daemon-prepared environment, and returns the combined stdout+stderr
+// truncated to a sane size. Any error is folded into the returned string
+// so the model can react to it on the next turn.
+func (b *ollamaBackend) execShell(ctx context.Context, rawArgs json.RawMessage, cwd string) string {
+	var args struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(rawArgs, &args); err != nil {
+		return fmt.Sprintf("error: invalid arguments for shell tool: %s", err.Error())
+	}
+	cmdStr := strings.TrimSpace(args.Command)
+	if cmdStr == "" {
+		return "error: shell tool requires a non-empty 'command' argument"
+	}
+
+	timeout := shellExecTimeout()
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Use `bash -c` (NOT `bash -lc`): the daemon prepends the multica
+	// binary's directory to PATH via cfg.Env, but a login shell would
+	// re-source /etc/profile and overwrite that injection. Avoid the
+	// reset by skipping login mode — the agent doesn't need shell init
+	// files anyway.
+	cmd := exec.CommandContext(cmdCtx, "bash", "-c", cmdStr)
+	cmd.Dir = cwd
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	b.cfg.Logger.Info("ollama: shell exec", "cmd", truncate(cmdStr, 200), "cwd", cwd)
+
+	output, err := cmd.CombinedOutput()
+	out := string(output)
+	if err != nil {
+		var exitErr *exec.ExitError
+		switch {
+		case errors.As(err, &exitErr):
+			out += fmt.Sprintf("\n[exit code %d]", exitErr.ExitCode())
+		case errors.Is(cmdCtx.Err(), context.DeadlineExceeded):
+			out += fmt.Sprintf("\n[command timed out after %s]", timeout)
+		case errors.Is(cmdCtx.Err(), context.Canceled):
+			// Parent was cancelled (user aborted task or daemon
+			// shutting down). The outer loop will detect this on its
+			// next postOllamaChat call and bail with status="aborted".
+			out += "\n[command cancelled]"
+		default:
+			out += "\n[error: " + err.Error() + "]"
+		}
+	}
+	// Cap to keep token usage bounded; the model can re-run with `| head`
+	// or `| tail` if it needs more context.
+	cap := maxToolOutput()
+	if len(out) > cap {
+		out = out[:cap] + fmt.Sprintf("\n[truncated: %d more bytes]", len(out)-cap)
+	}
+	return out
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+// buildInitialMessages assembles the [system?, user] starting conversation.
+func buildInitialMessages(prompt string, opts ExecOptions) []ollamaChatMessage {
+	msgs := make([]ollamaChatMessage, 0, 2)
+	if opts.SystemPrompt != "" {
+		msgs = append(msgs, ollamaChatMessage{Role: "system", Content: opts.SystemPrompt})
+	}
+	msgs = append(msgs, ollamaChatMessage{Role: "user", Content: prompt})
+	return msgs
+}
+
+// decodeToolArgs converts a tool-call argument object into a generic map
+// for forwarding as a Message.Input. Returns nil if decode fails — the
+// streamed message is informational and shouldn't fail the task.
+func decodeToolArgs(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// failedResult produces a Result for an error that aborted the loop.
+//
+// Status is determined by the CONTEXT, not the side-effect error: a
+// timeout or user cancellation kills the in-flight HTTP request, which
+// surfaces as a generic transport error from the client. Reporting that
+// transport error as "failed" hides the real cause. This mirrors the
+// pattern claude.go and gemini.go use after upstream PR #920 fixed the
+// equivalent bug there.
+func failedResult(err error, accumulated string, start time.Time, ctx context.Context, timeout time.Duration, model string, usage TokenUsage) Result {
+	r := Result{
+		Output:     accumulated,
+		DurationMs: time.Since(start).Milliseconds(),
+	}
+	if usage.InputTokens > 0 || usage.OutputTokens > 0 {
+		r.Usage = map[string]TokenUsage{model: usage}
+	}
+	switch {
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		r.Status = "timeout"
+		r.Error = fmt.Sprintf("ollama timed out after %s", timeout)
+	case errors.Is(ctx.Err(), context.Canceled):
+		r.Status = "aborted"
+		r.Error = "execution cancelled"
+	default:
+		r.Status = "failed"
+		r.Error = err.Error()
+	}
+	return r
+}
+
+// OllamaModelCapabilities fetches the capabilities list Ollama
+// advertises for a given model via POST /api/show. Used by the daemon
+// config probe to warn operators when they've configured a model that
+// does NOT declare "tools" capability — those models will fall back to
+// text-only responses and appear broken for issue-assignment tasks.
+// Returns (caps, nil) on success; (nil, err) if the request fails.
+func OllamaModelCapabilities(ctx context.Context, baseURL, model string) ([]string, error) {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if baseURL == "" {
+		baseURL = DefaultOllamaHost
+	}
+	body, err := json.Marshal(map[string]string{"name": model})
+	if err != nil {
+		return nil, fmt.Errorf("ollama: marshal /api/show: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/show", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("ollama: build /api/show request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama: /api/show unreachable at %s: %w", baseURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+		return nil, fmt.Errorf("ollama: /api/show returned %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+	var out struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("ollama: decode /api/show: %w", err)
+	}
+	return out.Capabilities, nil
+}
+
+// OllamaModelSupportsTools returns true if the given model declares
+// "tools" in its /api/show capabilities list. False means the model
+// can still chat but won't follow tool_calls requests — in that case
+// Multica issue-assignment tasks will degrade to text-only and the
+// daemon should warn the operator.
+func OllamaModelSupportsTools(ctx context.Context, baseURL, model string) (bool, error) {
+	caps, err := OllamaModelCapabilities(ctx, baseURL, model)
+	if err != nil {
+		return false, err
+	}
+	for _, c := range caps {
+		if c == "tools" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// detectOllamaVersion fetches the running Ollama server's version via
+// GET {baseURL}/api/version. Used by agent.DetectVersion when the
+// provider is "ollama" — the daemon stores the base URL in entry.Path.
+func detectOllamaVersion(ctx context.Context, baseURL string) (string, error) {
+	if baseURL == "" {
+		baseURL = DefaultOllamaHost
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/version", nil)
+	if err != nil {
+		return "", fmt.Errorf("ollama: build version request: %w", err)
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("ollama: unreachable at %s: %w", baseURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("ollama: /api/version returned %d", resp.StatusCode)
+	}
+	var body struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("ollama: decode version: %w", err)
+	}
+	if body.Version == "" {
+		return "", fmt.Errorf("ollama: empty version in response")
+	}
+	return body.Version, nil
+}

--- a/server/pkg/agent/ollama_test.go
+++ b/server/pkg/agent/ollama_test.go
@@ -1,0 +1,712 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// drainSession reads all messages and the final result with a hard cap so
+// a hung test fails quickly instead of stalling the suite.
+func drainSession(t *testing.T, s *Session, perOp time.Duration) ([]Message, Result) {
+	t.Helper()
+	var msgs []Message
+	for {
+		select {
+		case m, ok := <-s.Messages:
+			if !ok {
+				select {
+				case r := <-s.Result:
+					return msgs, r
+				case <-time.After(perOp):
+					t.Fatalf("timed out waiting for Result after Messages closed")
+				}
+			}
+			msgs = append(msgs, m)
+		case <-time.After(perOp):
+			t.Fatalf("timed out waiting for Message or Result")
+		}
+	}
+}
+
+// chatHandler returns a handler that responds with a sequence of
+// ollamaChatResponse JSON bodies, one per call. After the sequence is
+// exhausted it returns the last entry repeatedly (avoids panics if the
+// model accidentally calls one extra time).
+func chatHandler(t *testing.T, responses []ollamaChatResponse, capturedReqs *[]ollamaChatRequest) http.HandlerFunc {
+	t.Helper()
+	var idx atomic.Int32
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		var got ollamaChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if capturedReqs != nil {
+			*capturedReqs = append(*capturedReqs, got)
+		}
+		i := int(idx.Load())
+		if i >= len(responses) {
+			i = len(responses) - 1
+		} else {
+			idx.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(responses[i])
+	}
+}
+
+// ── Single-turn (no tool call) ────────────────────────────────────────────
+
+func TestOllamaExecuteSingleTurnNoTools(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(chatHandler(t, []ollamaChatResponse{{
+		Model:           "qwen",
+		Message:         ollamaChatMessage{Role: "assistant", Content: "Hello world!"},
+		Done:            true,
+		PromptEvalCount: 12,
+		EvalCount:       34,
+	}}, nil))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, err := b.Execute(context.Background(), "say hello", ExecOptions{Model: "qwen"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	msgs, res := drainSession(t, sess, 5*time.Second)
+
+	if res.Status != "completed" {
+		t.Fatalf("expected completed, got %q (err=%q)", res.Status, res.Error)
+	}
+	if res.Output != "Hello world!" {
+		t.Errorf("expected output 'Hello world!', got %q", res.Output)
+	}
+	if got := countText(msgs); got != 1 {
+		t.Errorf("expected 1 text message, got %d", got)
+	}
+	if u, ok := res.Usage["qwen"]; !ok || u.InputTokens != 12 || u.OutputTokens != 34 {
+		t.Errorf("expected usage 12/34, got %+v", res.Usage)
+	}
+}
+
+// ── Tool loop: model calls shell once, then returns final answer ─────────
+
+func TestOllamaExecuteToolLoop(t *testing.T) {
+	t.Parallel()
+
+	var captured []ollamaChatRequest
+	// Use a deterministic command: print a fixed string.
+	cmdArg, _ := json.Marshal(map[string]string{"command": "echo OLLAMA_TOOL_OK"})
+	srv := httptest.NewServer(chatHandler(t, []ollamaChatResponse{
+		// Turn 1: model decides to call shell.
+		{
+			Model: "gemma",
+			Message: ollamaChatMessage{
+				Role: "assistant",
+				ToolCalls: []ollamaToolCall{{
+					ID: "call_1",
+					Function: ollamaToolCallFunc{
+						Name:      "shell",
+						Arguments: json.RawMessage(cmdArg),
+					},
+				}},
+			},
+			Done:            true,
+			PromptEvalCount: 5,
+			EvalCount:       3,
+		},
+		// Turn 2: model summarizes the tool output.
+		{
+			Model: "gemma",
+			Message: ollamaChatMessage{
+				Role:    "assistant",
+				Content: "Done. The command output was OLLAMA_TOOL_OK.",
+			},
+			Done:            true,
+			PromptEvalCount: 30,
+			EvalCount:       11,
+		},
+	}, &captured))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, err := b.Execute(context.Background(), "do the thing", ExecOptions{Model: "gemma"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	msgs, res := drainSession(t, sess, 30*time.Second)
+
+	if res.Status != "completed" {
+		t.Fatalf("expected completed, got %q (err=%q)", res.Status, res.Error)
+	}
+	if !strings.Contains(res.Output, "OLLAMA_TOOL_OK") {
+		t.Errorf("expected output to mention OLLAMA_TOOL_OK, got %q", res.Output)
+	}
+
+	// Verify we made 2 chat calls.
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 chat calls, got %d", len(captured))
+	}
+	// The second call must include the assistant tool_calls turn AND a
+	// tool result message — total 4 messages (user, assistant w/ calls,
+	// tool result, but no system because none was set).
+	if got := len(captured[1].Messages); got != 3 {
+		t.Errorf("expected 3 messages on turn 2 (user, assistant+tool_calls, tool result), got %d: %+v", got, captured[1].Messages)
+	}
+	// The shell tool must be advertised on every call.
+	for i, c := range captured {
+		if len(c.Tools) != 1 || c.Tools[0].Function.Name != "shell" {
+			t.Errorf("call %d: expected shell tool advertised, got %+v", i, c.Tools)
+		}
+	}
+
+	// Verify tool-use + tool-result were streamed.
+	var sawToolUse, sawToolResult bool
+	for _, m := range msgs {
+		if m.Type == MessageToolUse && m.Tool == "shell" {
+			sawToolUse = true
+		}
+		if m.Type == MessageToolResult && m.Tool == "shell" && strings.Contains(m.Output, "OLLAMA_TOOL_OK") {
+			sawToolResult = true
+		}
+	}
+	if !sawToolUse || !sawToolResult {
+		t.Errorf("expected both ToolUse and ToolResult messages with shell output, got %+v", msgs)
+	}
+
+	// Token usage should sum across both turns.
+	if u := res.Usage["gemma"]; u.InputTokens != 35 || u.OutputTokens != 14 {
+		t.Errorf("expected summed usage 35/14, got %+v", u)
+	}
+}
+
+// ── Tool loop: tool_call_id is propagated on the tool-result message ────
+
+func TestOllamaToolCallIDIsPropagated(t *testing.T) {
+	t.Parallel()
+
+	var captured []ollamaChatRequest
+	cmdArg, _ := json.Marshal(map[string]string{"command": "true"})
+	srv := httptest.NewServer(chatHandler(t, []ollamaChatResponse{
+		{Message: ollamaChatMessage{Role: "assistant", ToolCalls: []ollamaToolCall{{
+			ID: "call_abc123", Function: ollamaToolCallFunc{Name: "shell", Arguments: cmdArg},
+		}}}, Done: true},
+		{Message: ollamaChatMessage{Role: "assistant", Content: "done"}, Done: true},
+	}, &captured))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "x", ExecOptions{Model: "m"})
+	_, res := drainSession(t, sess, 10*time.Second)
+	if res.Status != "completed" {
+		t.Fatalf("expected completed, got %q", res.Status)
+	}
+
+	// Second turn must carry a tool-role message with tool_call_id
+	// set to the call ID from turn 1 — models like qwen2.5 require
+	// this to correlate results back to their call.
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 chat calls, got %d", len(captured))
+	}
+	var toolMsg *ollamaChatMessage
+	for i := range captured[1].Messages {
+		if captured[1].Messages[i].Role == "tool" {
+			toolMsg = &captured[1].Messages[i]
+			break
+		}
+	}
+	if toolMsg == nil {
+		t.Fatalf("turn 2 request had no tool role message: %+v", captured[1].Messages)
+	}
+	if toolMsg.ToolCallID != "call_abc123" {
+		t.Errorf("expected tool_call_id=call_abc123, got %q", toolMsg.ToolCallID)
+	}
+}
+
+// ── Tool loop: shell command exits non-zero — model still gets output ────
+
+func TestOllamaShellExitNonZeroIsForwardedToModel(t *testing.T) {
+	t.Parallel()
+
+	cmdArg, _ := json.Marshal(map[string]string{"command": "echo BEFORE; exit 7"})
+	srv := httptest.NewServer(chatHandler(t, []ollamaChatResponse{
+		{Message: ollamaChatMessage{Role: "assistant", ToolCalls: []ollamaToolCall{{
+			ID: "c1", Function: ollamaToolCallFunc{Name: "shell", Arguments: cmdArg},
+		}}}, Done: true},
+		{Message: ollamaChatMessage{Role: "assistant", Content: "Saw exit 7"}, Done: true},
+	}, nil))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "x", ExecOptions{Model: "m"})
+	msgs, res := drainSession(t, sess, 10*time.Second)
+
+	if res.Status != "completed" {
+		t.Fatalf("expected completed even with non-zero exit, got %q", res.Status)
+	}
+	var toolOut string
+	for _, m := range msgs {
+		if m.Type == MessageToolResult {
+			toolOut = m.Output
+		}
+	}
+	if !strings.Contains(toolOut, "BEFORE") || !strings.Contains(toolOut, "exit code 7") {
+		t.Errorf("expected tool output to include both 'BEFORE' and 'exit code 7', got %q", toolOut)
+	}
+}
+
+// ── Tool loop: unknown tool name returns error string, not crash ────────
+
+func TestOllamaUnknownToolReturnsErrorString(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(chatHandler(t, []ollamaChatResponse{
+		{Message: ollamaChatMessage{Role: "assistant", ToolCalls: []ollamaToolCall{{
+			ID: "c1", Function: ollamaToolCallFunc{Name: "delete_universe", Arguments: json.RawMessage(`{}`)},
+		}}}, Done: true},
+		{Message: ollamaChatMessage{Role: "assistant", Content: "ok"}, Done: true},
+	}, nil))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "x", ExecOptions{Model: "m"})
+	msgs, res := drainSession(t, sess, 10*time.Second)
+
+	if res.Status != "completed" {
+		t.Fatalf("expected completed, got %q", res.Status)
+	}
+	var saw bool
+	for _, m := range msgs {
+		if m.Type == MessageToolResult && strings.Contains(m.Output, "unknown tool") {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected ToolResult mentioning 'unknown tool', got %+v", msgs)
+	}
+}
+
+// ── MaxTurns enforcement: model loops forever, we cap it ─────────────────
+
+func TestOllamaMaxTurnsCap(t *testing.T) {
+	t.Parallel()
+
+	cmdArg, _ := json.Marshal(map[string]string{"command": "echo loop"})
+	loopResp := ollamaChatResponse{
+		Message: ollamaChatMessage{Role: "assistant", ToolCalls: []ollamaToolCall{{
+			ID: "c", Function: ollamaToolCallFunc{Name: "shell", Arguments: cmdArg},
+		}}},
+		Done: true,
+	}
+	// Always-loop server: every response is another tool call.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(loopResp)
+	}))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "x", ExecOptions{Model: "m", MaxTurns: 3})
+	_, res := drainSession(t, sess, 10*time.Second)
+
+	if res.Status != "failed" {
+		t.Fatalf("expected status failed when MaxTurns hit, got %q", res.Status)
+	}
+	if !strings.Contains(res.Error, "MaxTurns=3") {
+		t.Errorf("expected error mentioning MaxTurns=3, got %q", res.Error)
+	}
+}
+
+// ── Context cancellation / timeout (regression for Gemini PR #920 bug) ──
+
+// slowHandler returns an http.Handler that blocks until EITHER the
+// request context is cancelled (normal path) OR a fallback timer fires
+// (test safety net — Go's http.Client can leave the connection open on
+// context cancel and the server may not observe the disconnect
+// immediately). The fallback MUST be longer than any timeout/cancel the
+// caller sets, so the client's context error wins and we actually test
+// the intended path rather than the server-side give-up.
+func slowHandler(fallback time.Duration) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(fallback):
+		}
+	})
+}
+
+func TestOllamaCancelMidLoopReportsAborted(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(slowHandler(10 * time.Second))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, err := b.Execute(ctx, "x", ExecOptions{Model: "m"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, res := drainSession(t, sess, 15*time.Second)
+	if res.Status != "aborted" {
+		t.Fatalf("expected status 'aborted' on parent cancel, got %q (err=%q)", res.Status, res.Error)
+	}
+	if res.Error != "execution cancelled" {
+		t.Errorf("expected error 'execution cancelled', got %q", res.Error)
+	}
+}
+
+func TestOllamaTimeoutMidLoopReportsTimeout(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(slowHandler(10 * time.Second))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, err := b.Execute(context.Background(), "x", ExecOptions{Model: "m", Timeout: 200 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	_, res := drainSession(t, sess, 15*time.Second)
+	if res.Status != "timeout" {
+		t.Fatalf("expected status 'timeout' on context deadline, got %q (err=%q)", res.Status, res.Error)
+	}
+	if !strings.Contains(res.Error, "timed out after") {
+		t.Errorf("expected error mentioning 'timed out after', got %q", res.Error)
+	}
+}
+
+// ── Server error / unreachable / missing model — same as before ──────────
+
+func TestOllamaExecuteServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "model not found")
+	}))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "hi", ExecOptions{Model: "missing"})
+	_, res := drainSession(t, sess, 5*time.Second)
+	if res.Status != "failed" {
+		t.Fatalf("expected failed, got %q", res.Status)
+	}
+	if !strings.Contains(res.Error, "500") || !strings.Contains(res.Error, "model not found") {
+		t.Errorf("expected error mentioning 500 + 'model not found', got %q", res.Error)
+	}
+}
+
+func TestOllamaExecuteUnreachable(t *testing.T) {
+	t.Parallel()
+	b := &ollamaBackend{cfg: Config{ExecutablePath: "http://127.0.0.1:1", Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "hi", ExecOptions{Model: "qwen"})
+	_, res := drainSession(t, sess, 5*time.Second)
+	if res.Status != "failed" {
+		t.Fatalf("expected failed for unreachable host, got %q", res.Status)
+	}
+}
+
+func TestOllamaExecuteRequiresModel(t *testing.T) {
+	t.Parallel()
+	b := &ollamaBackend{cfg: Config{ExecutablePath: "http://localhost:11434", Logger: slog.Default()}}
+	_, err := b.Execute(context.Background(), "hi", ExecOptions{Model: ""})
+	if err == nil {
+		t.Fatal("expected error when Model is empty")
+	}
+}
+
+// ── System prompt is forwarded as a system role message ──────────────────
+
+func TestOllamaExecuteSendsSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	var captured []ollamaChatRequest
+	srv := httptest.NewServer(chatHandler(t, []ollamaChatResponse{{
+		Message: ollamaChatMessage{Role: "assistant", Content: "ok"}, Done: true,
+	}}, &captured))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "user prompt", ExecOptions{Model: "m", SystemPrompt: "you are helpful"})
+	_, res := drainSession(t, sess, 5*time.Second)
+	if res.Status != "completed" {
+		t.Fatalf("expected completed, got %q", res.Status)
+	}
+	if len(captured) != 1 || len(captured[0].Messages) != 2 {
+		t.Fatalf("expected 1 call with 2 messages, got %+v", captured)
+	}
+	if captured[0].Messages[0].Role != "system" || captured[0].Messages[0].Content != "you are helpful" {
+		t.Errorf("expected system message first, got %+v", captured[0].Messages[0])
+	}
+}
+
+// ── Version detection ────────────────────────────────────────────────────
+
+func TestDetectOllamaVersionHappy(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/version" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"version":"0.20.7"}`)
+	}))
+	t.Cleanup(srv.Close)
+	v, err := detectOllamaVersion(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("detectOllamaVersion: %v", err)
+	}
+	if v != "0.20.7" {
+		t.Errorf("expected 0.20.7, got %q", v)
+	}
+}
+
+func TestDetectOllamaVersionUnreachable(t *testing.T) {
+	t.Parallel()
+	_, err := detectOllamaVersion(context.Background(), "http://127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected error for unreachable host")
+	}
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+func TestBuildInitialMessagesNoSystemPrompt(t *testing.T) {
+	t.Parallel()
+	got := buildInitialMessages("hi", ExecOptions{})
+	if len(got) != 1 || got[0].Role != "user" || got[0].Content != "hi" {
+		t.Errorf("expected 1 user/hi message, got %+v", got)
+	}
+}
+
+func TestBuildInitialMessagesWithSystemPrompt(t *testing.T) {
+	t.Parallel()
+	got := buildInitialMessages("hi", ExecOptions{SystemPrompt: "be concise"})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got))
+	}
+	if got[0].Role != "system" || got[1].Role != "user" {
+		t.Errorf("expected system then user, got %+v", got)
+	}
+}
+
+func countText(msgs []Message) int {
+	n := 0
+	for _, m := range msgs {
+		if m.Type == MessageText {
+			n++
+		}
+	}
+	return n
+}
+
+// ── Malformed response ───────────────────────────────────────────────────
+
+func TestOllamaMalformedResponseFailsClearly(t *testing.T) {
+	t.Parallel()
+
+	// Ollama returns done=true with NO message content, role, or
+	// tool_calls. Without the guard this gets treated as "completed"
+	// with empty output.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ollamaChatResponse{Done: true})
+	}))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "x", ExecOptions{Model: "m"})
+	_, res := drainSession(t, sess, 5*time.Second)
+
+	if res.Status != "failed" {
+		t.Fatalf("expected status failed on empty response, got %q", res.Status)
+	}
+	if !strings.Contains(res.Error, "no message content") {
+		t.Errorf("expected error mentioning 'no message content', got %q", res.Error)
+	}
+}
+
+// Regression test for the OOM case: small quantized models under memory
+// pressure can return {role:"assistant", content:"", tool_calls:[]} with
+// done:true. The guard must NOT require Role to be empty — role is
+// always "assistant" on responses.
+func TestOllamaEmptyAssistantResponseFailsClearly(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ollamaChatResponse{
+			Message: ollamaChatMessage{Role: "assistant", Content: "", ToolCalls: nil},
+			Done:    true,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "x", ExecOptions{Model: "m"})
+	_, res := drainSession(t, sess, 5*time.Second)
+
+	if res.Status != "failed" {
+		t.Fatalf("expected status failed on assistant-with-no-output, got %q (output=%q)", res.Status, res.Output)
+	}
+	if !strings.Contains(res.Error, "no message content") {
+		t.Errorf("expected error mentioning 'no message content', got %q", res.Error)
+	}
+}
+
+// ── Env-configurable shell timeout + output cap ──────────────────────────
+
+func TestShellExecTimeoutHonorsEnvVar(t *testing.T) {
+	// Not t.Parallel — mutates env for the duration of this test.
+	t.Setenv("MULTICA_OLLAMA_SHELL_TIMEOUT", "750ms")
+	if got := shellExecTimeout(); got != 750*time.Millisecond {
+		t.Errorf("expected 750ms, got %s", got)
+	}
+}
+
+func TestShellExecTimeoutFallsBackOnInvalidEnv(t *testing.T) {
+	t.Setenv("MULTICA_OLLAMA_SHELL_TIMEOUT", "not-a-duration")
+	if got := shellExecTimeout(); got != shellExecTimeoutDefault {
+		t.Errorf("expected default %s on invalid env, got %s", shellExecTimeoutDefault, got)
+	}
+}
+
+func TestShellExecTimeoutFallsBackOnNegative(t *testing.T) {
+	t.Setenv("MULTICA_OLLAMA_SHELL_TIMEOUT", "-1s")
+	if got := shellExecTimeout(); got != shellExecTimeoutDefault {
+		t.Errorf("expected default %s on negative duration, got %s", shellExecTimeoutDefault, got)
+	}
+}
+
+func TestMaxToolOutputHonorsEnvVar(t *testing.T) {
+	t.Setenv("MULTICA_OLLAMA_MAX_OUTPUT_BYTES", "2048")
+	if got := maxToolOutput(); got != 2048 {
+		t.Errorf("expected 2048, got %d", got)
+	}
+}
+
+func TestMaxToolOutputFallsBackOnInvalidEnv(t *testing.T) {
+	t.Setenv("MULTICA_OLLAMA_MAX_OUTPUT_BYTES", "not-a-number")
+	if got := maxToolOutput(); got != maxToolOutputDefault {
+		t.Errorf("expected default %d on invalid env, got %d", maxToolOutputDefault, got)
+	}
+}
+
+func TestMaxToolOutputFallsBackOnNonPositive(t *testing.T) {
+	t.Setenv("MULTICA_OLLAMA_MAX_OUTPUT_BYTES", "0")
+	if got := maxToolOutput(); got != maxToolOutputDefault {
+		t.Errorf("expected default on zero, got %d", got)
+	}
+}
+
+func TestExecShellTruncatesLargeOutput(t *testing.T) {
+	t.Setenv("MULTICA_OLLAMA_MAX_OUTPUT_BYTES", "32")
+
+	// Script prints 200 bytes. With cap=32 the output should be
+	// truncated and tagged with the "[truncated: N more bytes]" suffix.
+	cmdArg, _ := json.Marshal(map[string]string{"command": "printf '%0.sX' $(seq 1 200)"})
+	srv := httptest.NewServer(chatHandler(t, []ollamaChatResponse{
+		{Message: ollamaChatMessage{Role: "assistant", ToolCalls: []ollamaToolCall{{
+			ID: "c", Function: ollamaToolCallFunc{Name: "shell", Arguments: cmdArg},
+		}}}, Done: true},
+		{Message: ollamaChatMessage{Role: "assistant", Content: "ok"}, Done: true},
+	}, nil))
+	t.Cleanup(srv.Close)
+
+	b := &ollamaBackend{cfg: Config{ExecutablePath: srv.URL, Logger: slog.Default()}}
+	sess, _ := b.Execute(context.Background(), "x", ExecOptions{Model: "m"})
+	msgs, _ := drainSession(t, sess, 10*time.Second)
+
+	var toolOut string
+	for _, m := range msgs {
+		if m.Type == MessageToolResult {
+			toolOut = m.Output
+		}
+	}
+	if !strings.Contains(toolOut, "truncated") {
+		t.Errorf("expected truncation marker in tool output, got %q", toolOut)
+	}
+	if len(toolOut) > 100 { // 32 + truncation suffix ~= 55 chars
+		t.Errorf("expected output capped near 32 bytes + suffix, got %d chars", len(toolOut))
+	}
+}
+
+// ── Model capability probe ──────────────────────────────────────────────
+
+func TestOllamaModelSupportsToolsTrue(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/show" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"capabilities":["completion","tools","thinking"]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ok, err := OllamaModelSupportsTools(context.Background(), srv.URL, "gemma4:latest")
+	if err != nil {
+		t.Fatalf("OllamaModelSupportsTools: %v", err)
+	}
+	if !ok {
+		t.Error("expected true for model with 'tools' capability")
+	}
+}
+
+func TestOllamaModelSupportsToolsFalse(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"capabilities":["completion"]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ok, err := OllamaModelSupportsTools(context.Background(), srv.URL, "llama2")
+	if err != nil {
+		t.Fatalf("OllamaModelSupportsTools: %v", err)
+	}
+	if ok {
+		t.Error("expected false for model without 'tools' capability")
+	}
+}
+
+func TestOllamaModelSupportsToolsUnreachable(t *testing.T) {
+	t.Parallel()
+	_, err := OllamaModelSupportsTools(context.Background(), "http://127.0.0.1:1", "gemma4:latest")
+	if err == nil {
+		t.Fatal("expected error for unreachable /api/show")
+	}
+}
+
+func TestOllamaModelSupportsToolsNotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "model not found")
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := OllamaModelSupportsTools(context.Background(), srv.URL, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected error mentioning 404, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## What

Adds a first-class `ollama` agent provider alongside claude/codex/opencode/openclaw/hermes/gemini. Models with `tools` capability (gemma3+, qwen2.5+, llama3.1+) drive the Multica CLI via a single shell tool; chat-only models still work for conversational tasks.

Closes #769.

## Why

Issue #769 closed with the env-var workaround (#846) — pointing `ANTHROPIC_BASE_URL` at Ollama. That works for users who've installed Claude Code, but Ollama-only users still need a supported CLI on their machine before anything works. This ships the real native path.

## End-to-end verified

- **LOC-3 (in-workdir)**: `gemma4:latest` ran a 6-tool-call sequence on a Multica issue — read context, wrote a file, updated status to `in_review`, posted a summary comment. 29s.
- **LOC-5 (out-of-sandbox)**: same model wrote `$HOME/Desktop/multica-ollama-test.txt` via absolute-path `printf`, verified with `ls -l`, posted output as comment. 4 calls / 20s.

## Configuration

```
MULTICA_OLLAMA_HOST              default http://localhost:11434
MULTICA_OLLAMA_MODEL             required; empty = provider skipped
MULTICA_OLLAMA_SHELL_TIMEOUT     default 5m; per-command cap
MULTICA_OLLAMA_MAX_OUTPUT_BYTES  default 16384; tool-result cap
```

Daemon probes `/api/tags` for reachability, `/api/version` for version, `/api/show` for tool capability (prints stderr WARNING if the configured model doesn't declare `"tools"`). All probes are best-effort and do not block daemon startup.

## Architecture

- `stream:false` when tools active — tool_calls arrive on the final chunk anyway; single-shot is simpler and equally responsive at task granularity.
- Single `shell` tool, executed via `bash -c` (NOT `-lc`; login shells re-source `/etc/profile` and wipe the PATH injection the daemon makes for the `multica` CLI). Matches Claude's `bypassPermissions` and Gemini's `--yolo`.
- `tool_call_id` threaded on tool-role messages so strict models (qwen2.5, llama3.1) can correlate results to calls.
- MaxTurns cap (default 25) prevents runaway tool loops.
- Context status (`DeadlineExceeded`/`Canceled`) takes precedence over side-effect errors when determining `Result.Status` — matches the pattern `claude.go` and `gemini.go` use after PR #920.

## v1 non-goals (deliberate, documented)

- Streaming during tool turns (chat-only non-tool turns still stream the final text as one event)
- Per-task model selection (single configured model wins)
- Session resume (Ollama is stateless; `ResumeSessionID` ignored with debug log)
- Dynamic `/api/tags` model discovery
- Granular tools (file_read/file_write/etc. — single shell covers the same ground via standard Unix utilities)

These match the limitations Gemini #755 shipped with.

## Test plan

- [x] `go test ./pkg/agent/... ./internal/daemon/...` — 22 new tests, all pass in 10s
- [x] `go vet ./...` clean
- [x] `gofmt -w` applied
- [x] `pnpm --filter @multica/views --filter @multica/core typecheck` clean
- [x] End-to-end smoke test: gemma4:latest on local Docker stack, 2 live tasks completed (in-workdir file write + out-of-sandbox Desktop write)
- [x] Daemon registers `ollama` runtime, reports online, appears in `/api/runtimes`
- [x] Regression tests for: context cancel mid-loop, timeout mid-loop, malformed response (both empty-everywhere and OOM-case `{role:assistant, content:"", tool_calls:[]}`), MaxTurns cap, shell exit code forwarding, unknown tool, `tool_call_id` wire propagation, env-var fallback on malformed values, `/api/show` capability probe (true/false/404/unreachable)

## Files changed

- `server/pkg/agent/ollama.go` — new (609 LOC)
- `server/pkg/agent/ollama_test.go` — new (712 LOC)
- `server/pkg/agent/agent.go` — register `case "ollama"`; `DetectVersion` now takes provider name to dispatch HTTP probe for HTTP-based backends
- `server/internal/daemon/config.go` — HTTP probe of `MULTICA_OLLAMA_HOST`; capability check with WARNING; references `agent.DefaultOllamaHost`
- `server/internal/daemon/execenv/runtime_config.go` — `ollama` added to the AGENTS.md case
- `server/internal/daemon/daemon.go` — one-line change to pass provider name into `DetectVersion`
- `packages/views/runtimes/components/provider-logo.tsx` — `OllamaLogo` SVG + switch case