### PR TITLE
Fix PLA-15: German locale detection and legacy path redirects

### DIFF
--- a/apps/web/app/(landing)/[locale]/cookies/page.tsx
+++ b/apps/web/app/(landing)/[locale]/cookies/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { LegalPageClient } from "@/features/landing/components/legal-page-client";
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: locale === "de" ? "Cookie-Richtlinie" : locale === "zh" ? "Cookie \u653f\u7b56" : "Cookie Policy",
+    description:
+      locale === "de"
+        ? "Cookie-Richtlinie f\u00fcr Multica."
+        : locale === "zh"
+          ? "Multica \u7684 Cookie \u653f\u7b56\u3002"
+          : "Cookie policy for Multica.",
+    alternates: {
+      canonical: `/${locale}/cookies`,
+    },
+  };
+}
+
+export default async function CookiesPage({ params }: Props) {
+  const { locale } = await params;
+
+  if (locale !== "en" && locale !== "de" && locale !== "zh") {
+    notFound();
+  }
+
+  return (
+    <LegalPageClient
+      title={
+        locale === "de" ? "Cookie-Richtlinie" : locale === "zh" ? "Cookie \u653f\u7b56" : "Cookie Policy"
+      }
+      paragraphs={
+        locale === "de"
+          ? [
+              "Wir verwenden Cookies und \u00e4hnliche Technologien, um unsere Dienste bereitzustellen und zu verbessern.",
+              "Cookies sind kleine Textdateien, die von Websites auf Ihrem Ger\u00e4t gespeichert werden, um Informationen \u00fcber Ihre Nutzung zu speichern.",
+              "Wir verwenden essenzielle Cookies, die f\u00fcr den Betrieb der Plattform erforderlich sind, sowie optionale Cookies f\u00fcr Analytics und Benutzerpr\u00e4ferenzen.",
+              "Sie k\u00f6nnen Ihre Cookie-Pr\u00e4ferenzen in Ihren Browsereinstellungen verwalten oder durch L\u00f6schung Ihrer Browser-Cookies.",
+            ]
+          : locale === "zh"
+            ? [
+                "\u6211\u4eec\u4f7f\u7528 Cookie \u548c\u76f8\u5173\u6280\u672f\u6765\u63d0\u4f9b\u548c\u6539\u5584\u6211\u4eec\u7684\u670d\u52a1\u3002",
+                "Cookie \u662f\u7531\u7f51\u7ad9\u50a8\u5b58\u5728\u60a8\u8bbe\u5907\u4e0a\u7684\u5c0f\u6587\u672c\u6587\u4ef6\uff0c\u7528\u4e8e\u50a8\u5b58\u6709\u5173\u60a8\u4f7f\u7528\u60c5\u51b5\u7684\u4fe1\u606f\u3002",
+                "\u6211\u4eec\u4f7f\u7528\u5fc5\u8981\u7684 Cookie\uff08\u5bf9\u4e8e\u5e73\u53f0\u8fd0\u884c\u6240\u9700\uff09\u548c\u53ef\u9009\u7684 Cookie\uff08\u7528\u4e8e\u5206\u6790\u548c\u7528\u6237\u9996\u9009\u9879\u3002",
+                "\u60a8\u53ef\u4ee5\u5728\u6d4f\u89c8\u5668\u8bbe\u7f6e\u4e2d\u7ba1\u7406\u60a8\u7684 Cookie \u9996\u9009\u9879\uff0c\u6216\u901a\u8fc7\u5220\u9664\u6d4f\u89c8\u5668 Cookie \u6765\u64a4\u9500\u540c\u610f\u3002",
+              ]
+            : [
+                "We use cookies and similar technologies to provide and improve our services.",
+                "Cookies are small text files stored on your device by websites to remember information about your usage.",
+                "We use essential cookies that are required for the platform to operate, and optional cookies for analytics and user preferences.",
+                "You can manage your cookie preferences in your browser settings or by deleting your browser cookies.",
+              ]
+      }
+    />
+  );
+}

--- a/apps/web/app/(landing)/[locale]/imprint/page.tsx
+++ b/apps/web/app/(landing)/[locale]/imprint/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { LegalPageClient } from "@/features/landing/components/legal-page-client";
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: locale === "de" ? "Impressum" : locale === "zh" ? "\u7f51\u7ad9\u6ce8\u518c" : "Imprint",
+    description:
+      locale === "de"
+        ? "Rechtliche Impressum-Informationen f\u00fcr Multica."
+        : locale === "zh"
+          ? "Multica \u7684\u6cd5\u5f8b\u7f16\u793a\u4fe1\u606f\u3002"
+          : "Legal imprint information for Multica.",
+    alternates: {
+      canonical: `/${locale}/imprint`,
+    },
+  };
+}
+
+export default async function ImprintPage({ params }: Props) {
+  const { locale } = await params;
+
+  if (locale !== "en" && locale !== "de" && locale !== "zh") {
+    notFound();
+  }
+
+  return (
+    <LegalPageClient
+      title={
+        locale === "de" ? "Impressum" : locale === "zh" ? "\u7f51\u7ad9\u6ce8\u518c" : "Imprint"
+      }
+      paragraphs={
+        locale === "de"
+          ? [
+              "Multica ist ein Produkt der Multica Inc., einem in den Vereinigten Staaten registrierten Unternehmen.",
+              "F\u00fcr rechtliche Anfragen kontaktieren Sie uns bitte unter legal@multica.ai.",
+              "Diese Website wird von Multica Inc. betrieben und unterliegt den Gesetzen der Vereinigten Staaten.",
+            ]
+          : locale === "zh"
+            ? [
+                "Multica \u662f Multica Inc.\u7684\u4ea7\u54c1\uff0c\u4e00\u5bb6\u5728\u7f8e\u56fd\u6ce8\u518c\u7684\u516c\u53f8\u3002",
+                "\u5982\u6709\u4efb\u4f55\u6cd5\u5f8b\u54a8\u8be2\uff0c\u8bf7\u901a\u8fc7 legal@multica.ai \u8054\u7cfb\u6211\u4eec\u3002",
+                "\u672c\u7f51\u7ad9\u7531 Multica Inc. \u8fd0\u8425\uff0c\u5e94\u7b26\u5408\u7f8e\u56fd\u6cd5\u5f8b\u8981\u6c42\u3002",
+              ]
+            : [
+                "Multica is a product of Multica Inc., a company registered in the United States.",
+                "For any legal inquiries, please contact us at legal@multica.ai.",
+                "This website is operated by Multica Inc. and is subject to the laws of the United States.",
+              ]
+      }
+    />
+  );
+}

--- a/apps/web/app/(landing)/[locale]/privacy-policy/page.tsx
+++ b/apps/web/app/(landing)/[locale]/privacy-policy/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { LegalPageClient } from "@/features/landing/components/legal-page-client";
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: locale === "de" ? "Datenschutz" : locale === "zh" ? "\u9690\u79c1\u653f\u7b56" : "Privacy Policy",
+    description:
+      locale === "de"
+        ? "Datenschutzrichtlinie f\u00fcr Multica."
+        : locale === "zh"
+          ? "Multica \u7684\u9690\u79c1\u653f\u7b56\u3002"
+          : "Privacy policy for Multica.",
+    alternates: {
+      canonical: `/${locale}/privacy-policy`,
+    },
+  };
+}
+
+export default async function PrivacyPolicyPage({ params }: Props) {
+  const { locale } = await params;
+
+  if (locale !== "en" && locale !== "de" && locale !== "zh") {
+    notFound();
+  }
+
+  return (
+    <LegalPageClient
+      title={
+        locale === "de" ? "Datenschutz" : locale === "zh" ? "\u9690\u79c1\u653f\u7b56" : "Privacy Policy"
+      }
+      paragraphs={
+        locale === "de"
+          ? [
+              "Multica Inc. (\"wir\", \"uns\" oder \"unser\") betreibt die Multica-Plattform als SaaS-Produkt.",
+              "Diese Datenschutzrichtlinie informiert Sie \u00fcber unsere Praktiken bez\u00fcglich der Erfassung, Verwendung und Offenlegung von Informationen, die wir von Benutzern unserer Plattform erhalten.",
+              "Wir erfassen verschiedene Arten von Informationen, um unsere Dienste bereitzustellen und zu verbessern, einschlie\u00dflich personenbezogener Daten, die Sie uns direkt zur Verf\u00fcgung stellen, sowie automatisch erfasste Informationen \u00fcber Ihre Nutzung unserer Dienste.",
+              "Wir geben Ihre personenbezogenen Daten nicht an Dritte weiter, au\u00dfer in den in dieser Richtlinie beschriebenen F\u00e4llen oder mit Ihrer ausdr\u00fccklichen Einwilligung.",
+            ]
+          : locale === "zh"
+            ? [
+                "Multica Inc.(\"\u6211\u4eec\"\u6216\"\u4f60\u4eec\")\u8fd0\u8425 Multica \u5e73\u53f0\u4f5c\u4e3a SaaS \u4ea7\u54c1\u3002",
+                "\u672c\u9690\u79c1\u653f\u7b56\u5c06\u544a\u8bc9\u60a8\u5173\u4e8e\u6211\u4eec\u5728\u64cd\u4f5c\u5e73\u53f0\u65f6\u6536\u96c6\u3001\u4f7f\u7528\u548c\u6b63\u5f0f\u5411\u60a8\u6aa2\u7d27\u7684\u4fe1\u606f\u7684\u505a\u6cd5\u3002",
+                "\u6211\u4eec\u6536\u96c6\u591a\u79cd\u7c7b\u578b\u7684\u4fe1\u606f\uff0c\u4ee5\u63d0\u4f9b\u548c\u6539\u5584\u6211\u4eec\u7684\u670d\u52a1\uff0c\u5305\u62ec\u60a8\u76f4\u63a5\u63d0\u4f9b\u7ed9\u6211\u4eec\u7684\u4e2a\u4eba\u4fe1\u606f\u548c\u81ea\u52a8\u6536\u96c6\u7684\u5173\u4e8e\u60a8\u4f7f\u7528\u6211\u4eec\u670d\u52a1\u7684\u4fe1\u606f\u3002",
+                "\u9664\u975e\u672c\u653f\u7b56\u4e2d\u63cf\u8ff0\u7684\u60c5\u51b5\u6216\u5f97\u5230\u60a8\u7684\u660e\u793a\u540c\u610f\uff0c\u6211\u4eec\u4e0d\u4f1a\u5c06\u60a8\u7684\u4e2a\u4eba\u4fe1\u606f\u5171\u4eab\u7ed9\u7b2c\u4e09\u65b9\u3002",
+              ]
+            : [
+                "Multica Inc. (\"we\", \"us\", or \"our\") operates the Multica platform as a SaaS product.",
+                "This Privacy Policy informs you about our practices regarding the collection, use, and disclosure of information that we receive from users of our platform.",
+                "We collect various types of information to provide and improve our services, including personal information you directly provide to us, and automatically collected information about your use of our services.",
+                "We do not share your personal information with third parties except in the circumstances described in this policy or with your explicit consent.",
+              ]
+      }
+    />
+  );
+}

--- a/apps/web/app/(landing)/[locale]/terms/page.tsx
+++ b/apps/web/app/(landing)/[locale]/terms/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { LegalPageClient } from "@/features/landing/components/legal-page-client";
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  return {
+    title: locale === "de" ? "AGB" : locale === "zh" ? "\u670d\u52a1\u6761\u6b3e" : "Terms of Service",
+    description:
+      locale === "de"
+        ? " Allgemeine Gesch\u00e4ftsbedingungen f\u00fcr Multica."
+        : locale === "zh"
+          ? "Multica \u7684\u670d\u52a1\u6761\u6b3e\u3002"
+          : "Terms of service for Multica.",
+    alternates: {
+      canonical: `/${locale}/terms`,
+    },
+  };
+}
+
+export default async function TermsPage({ params }: Props) {
+  const { locale } = await params;
+
+  if (locale !== "en" && locale !== "de" && locale !== "zh") {
+    notFound();
+  }
+
+  return (
+    <LegalPageClient
+      title={
+        locale === "de" ? "AGB" : locale === "zh" ? "\u670d\u52a1\u6761\u6b3e" : "Terms of Service"
+      }
+      paragraphs={
+        locale === "de"
+          ? [
+              "Durch die Nutzung der Multica-Plattform erkl\u00e4ren Sie sich mit diesen Allgemeinen Gesch\u00e4ftsbedingungen (\"AGB\") einverstanden.",
+              "Multica Inc. (\"Multica\") bietet die Multica-Plattform als SaaS-Produkt an. Die Nutzung der Plattform unterliegt diesen AGB sowie allen geltenden Gesetzen und Vorschriften.",
+              "Sie sind daf\u00fcr verantwortlich, Ihr Konto sicher zu halten und alle Aktivit\u00e4ten zu verantworten, die unter Ihrem Konto stattfinden.",
+              "Wir behalten uns das Recht vor, diese AGB jederzeit zu \u00e4ndern. Fortgesetzte Nutzung der Plattform nach \u00c4nderungen gilt als Annahme der ge\u00e4nderten Bedingungen.",
+            ]
+          : locale === "zh"
+            ? [
+                "\u901a\u8fc7\u4f7f\u7528 Multica \u5e73\u53f0\uff0c\u60a8\u8868\u793a\u60a8\u540c\u610f\u672c\u670d\u52a1\u6761\u6b3e (\"ToS\")\u3002",
+                "Multica Inc. (\"Multica\") \u4f5c\u4e3a SaaS \u4ea7\u54c1\u63d0\u4f9b Multica \u5e73\u53f0\u3002\u5e73\u53f0\u7684\u4f7f\u7528\u53d7\u672c ToS \u548c\u6240\u6709\u9002\u7528\u7684\u6cd5\u5f8b\u6cd5\u89c4\u7684\u7ea6\u675f\u3002",
+                "\u60a8\u8d1f\u8d23\u4fdd\u6301\u60a8\u7684\u8d26\u6237\u5b89\u5168\uff0c\u5e76\u5bf9\u60a8\u8d26\u6237\u4e0b\u53d1\u751f\u7684\u6240\u6709\u6d3b\u52a8\u8d1f\u8d23\u3002",
+                "\u6211\u4eec\u4fdd\u7559\u968f\u65f6\u66f4\u6539\u672c ToS \u7684\u6743\u5229\u3002\u66f4\u6539\u540e\u7ee7\u7eed\u4f7f\u7528\u5e73\u53f0\u89ba\u5f97\u60a8\u63a5\u53d7\u66f4\u6539\u540e\u7684\u6761\u6b3e\u3002",
+              ]
+            : [
+                "By using the Multica platform, you agree to be bound by these Terms of Service (\"ToS\").",
+                "Multica Inc. (\"Multica\") offers the Multica platform as a SaaS product. Use of the platform is subject to these ToS and all applicable laws and regulations.",
+                "You are responsible for keeping your account secure and for all activities that occur under your account.",
+                "We reserve the right to modify these ToS at any time. Continued use of the platform after changes constitutes acceptance of the modified terms.",
+              ]
+      }
+    />
+  );
+}

--- a/apps/web/app/(landing)/layout.tsx
+++ b/apps/web/app/(landing)/layout.tsx
@@ -44,12 +44,13 @@ async function getInitialLocale(): Promise<Locale> {
   // 1. User's explicit preference (cookie set when they switch language)
   const cookieStore = await cookies();
   const stored = cookieStore.get("multica-locale")?.value;
-  if (stored === "en" || stored === "zh") return stored;
+  if (stored === "en" || stored === "de" || stored === "zh") return stored;
 
   // 2. Detect from Accept-Language header
   const headersList = await headers();
   const acceptLang = headersList.get("accept-language") ?? "";
   if (acceptLang.includes("zh")) return "zh";
+  if (acceptLang.includes("de")) return "de";
 
   return "en";
 }

--- a/apps/web/features/landing/components/legal-page-client.tsx
+++ b/apps/web/features/landing/components/legal-page-client.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { LandingHeader } from "./landing-header";
+import { LandingFooter } from "./landing-footer";
+import { useLocale } from "../i18n";
+
+type LegalPageProps = {
+  title: string;
+  paragraphs: string[];
+};
+
+export function LegalPageClient({ title, paragraphs }: LegalPageProps) {
+  const { locale } = useLocale();
+
+  return (
+    <>
+      <LandingHeader variant="light" />
+      <main className="bg-white text-[#0a0d12]">
+        <div className="mx-auto max-w-[720px] px-4 py-16 sm:px-6 sm:py-20 lg:py-24">
+          <h1 className="font-[family-name:var(--font-serif)] text-[2.6rem] leading-[1.05] tracking-[-0.03em] sm:text-[3.4rem]">
+            {title}
+          </h1>
+          <div className="mt-8 space-y-6 text-[15px] leading-[1.8] text-[#0a0d12]/70 sm:text-[16px]">
+            {paragraphs.map((p, i) => (
+              <p key={i}>{p}</p>
+            ))}
+          </div>
+
+          <div className="mt-12">
+            <Link
+              href={`/${locale}`}
+              className="inline-flex items-center gap-2.5 rounded-[12px] bg-[#0a0d12] px-5 py-3 text-[14px] font-semibold text-white transition-colors hover:bg-[#0a0d12]/88"
+            >
+              Back to home
+            </Link>
+          </div>
+        </div>
+      </main>
+      <LandingFooter />
+    </>
+  );
+}

--- a/apps/web/features/landing/i18n/context.tsx
+++ b/apps/web/features/landing/i18n/context.tsx
@@ -2,10 +2,11 @@
 
 import { createContext, useContext, useState, useCallback } from "react";
 import { en } from "./en";
+import { de } from "./de";
 import { zh } from "./zh";
 import type { LandingDict, Locale } from "./types";
 
-const dictionaries: Record<Locale, LandingDict> = { en, zh };
+const dictionaries: Record<Locale, LandingDict> = { en, de, zh };
 
 const COOKIE_NAME = "multica-locale";
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year

--- a/apps/web/features/landing/i18n/de.ts
+++ b/apps/web/features/landing/i18n/de.ts
@@ -1,0 +1,271 @@
+import { githubUrl } from "../components/shared";
+import type { LandingDict } from "./types";
+
+export const de: LandingDict = {
+  header: {
+    github: "GitHub",
+    login: "Anmelden",
+    dashboard: "Dashboard",
+  },
+
+  hero: {
+    headlineLine1: "Deine n\u00e4chsten 10 Einstellungen",
+    headlineLine2: "werden keine Menschen sein.",
+    subheading:
+      "Multica ist eine Open-Source-Plattform, die Coding-Agenten zu echten Teammitgliedern macht. Aufgaben zuweisen, Fortschritt verfolgen, F\u00e4higkeiten aufbauen \u2014 manage dein Team aus Menschen und Agenten an einem Ort.",
+    cta: "Kostenlos starten",
+    worksWith: "Funktioniert mit",
+    imageAlt: "Multica Board-Ansicht \u2014 Issues werden von Menschen und Agenten verwaltet",
+  },
+
+  features: {
+    teammates: {
+      label: "TEAMMITGLIEDER",
+      title: "Agenten zuweisen, als w\u00fcrdest du einem Kollegen zuweisen",
+      description:
+        "Agenten sind keine passiven Werkzeuge \u2014 sie sind aktive Teilnehmer. Sie haben Profile, melden Status, erstellen Issues, kommentieren und \u00e4ndern Status. Dein Aktivit\u00e4tsfeed zeigt Menschen und Agenten, die Seite an Seite arbeiten.",
+      cards: [
+        {
+          title: "Agenten im Assignee-Picker",
+          description:
+            "Menschen und Agenten erscheinen in derselben Dropdown-Liste. Die Zuweisung von Arbeit an einen Agenten unterscheidet sich nicht von der Zuweisung an einen Kollegen.",
+        },
+        {
+          title: "Autonome Teilnahme",
+          description:
+            "Agenten erstellen Issues, hinterlassen Kommentare und aktualisieren den Status eigenst\u00e4ndig \u2014 nicht nur, wenn sie dazu aufgefordert werden.",
+        },
+        {
+          title: "Einheitliche Aktivit\u00e4ts-Timeline",
+          description:
+            "Ein Feed f\u00fcr das gesamte Team. Aktionen von Menschen und Agenten werden vermischt, sodass du immer wei\u00dft, was passiert ist und wer es getan hat.",
+        },
+      ],
+    },
+    autonomous: {
+      label: "AUTONOM",
+      title: "Einfach machen lassen \u2014 Agenten arbeiten, w\u00e4hrend du schl\u00e4fst",
+      description:
+        "Nicht nur Prompt-Response. Vollst\u00e4ndiges Task-Lebenszyklus-Management: einreihen, beanspruchen, starten, abschlie\u00dfen oder scheitern. Agenten melden Blocker proaktiv und du erh\u00e4ltst Echtzeit-Fortschritt \u00fcber WebSocket.",
+      cards: [
+        {
+          title: "Vollst\u00e4ndiger Task-Lebenszyklus",
+          description:
+            "Jede Aufgabe durchl\u00e4uft Einreihen \u2192 Beanspruchen \u2192 Starten \u2192 Abschlie\u00dfen/Scheitern. Keine lautlosen Fehler \u2014 jeder \u00dcbergang wird verfolgt und \u00fcbertragen.",
+        },
+        {
+          title: "Proaktive Blocker-Meldungen",
+          description:
+            "Wenn ein Agent stecken bleibt, meldet er das sofort. Kein st\u00e4ndiges Zur\u00fcckkommen, um nachzusehen, ob etwas passiert ist.",
+        },
+        {
+          title: "Echtzeit-Fortschritts-Streaming",
+          description:
+            "WebSocket-powered Live-Updates. Sieh dir an, wie Agenten in Echtzeit arbeiten, oder schau jederzeit vorbei \u2014 die Timeline ist immer aktuell.",
+        },
+      ],
+    },
+    skills: {
+      label: "F\u00c4HIGKEITEN",
+      title: "Jede L\u00f6sung wird zur wiederverwendbaren F\u00e4higkeit f\u00fcr das ganze Team",
+      description:
+        "Skills sind wiederverwendbare Funktionsdefinitionen \u2014 Code, Konfiguration und Kontext zusammen verpackt. Schreib einen Skill einmal und jeder Agent in deinem Team kann ihn nutzen. Deine Skill-Bibliothek w\u00e4chst mit der Zeit.",
+      cards: [
+        {
+          title: "Wiederverwendbare Skill-Definitionen",
+          description:
+            "Wissen in Skills verpacken, die jeder Agent ausf\u00fchren kann. Auf Staging deployen, Migrationen schreiben, PRs reviewen \u2014 alles kodifiziert.",
+        },
+        {
+          title: "Team-weites Teilen",
+          description:
+            "Skills sind f\u00fcr alle in deinem Workspace sichtbar. Ein Agent, der einen neuen Trick lernt, teilt ihn sofort mit dem Rest des Teams.",
+        },
+        {
+          title: "Skill-Browser",
+          description:
+            "Durchsuche die Skill-Bibliothek nach dem, was du brauchst. Fertige Skills von anderen Workspaces k\u00f6nnen importiert werden.",
+        },
+      ],
+    },
+    runtimes: {
+      label: "RUNTIMES",
+      title: "Deine Agenten, auf deine Art betrieben",
+      description:
+        "Multica unterst\u00fctzt mehrere Agent-Runtimes. W\u00e4hle den richtigen f\u00fcr jede Aufgabe \u2014 Claude Code f\u00fcr komplexe Codierung, Codex f\u00fcr schnelle Iterationen, oder bring deinen eigenen LLM-Provider mit.",
+      cards: [
+        {
+          title: "Flexible Runtimes",
+          description:
+            "Jeder Agent kann einen anderen Runtime-Typ haben. Manche任务是 Routine, andere brauchen tiefe Analyse.",
+        },
+        {
+          title: "Selbst gehostet",
+          description:
+            "F\u00fchre Agenten auf deiner eigenen Infrastruktur aus. Dein Code bleibt in deiner Umgebung.",
+        },
+        {
+          title: "Unified Logging",
+          description:
+            "Alle Agenten-Logs werden zentral gesammelt. Kein SSH in verschiedene Container \u2014 alles in Multica.",
+        },
+      ],
+    },
+  },
+
+  howItWorks: {
+    label: "SO FUNKTIONIERT ES",
+    headlineMain: "Setup in Minuten,",
+    headlineFaded: "Skalierung f\u00fcr immer.",
+    steps: [
+      {
+        title: "Erstelle einen Workspace",
+        description:
+          "Registriere dich und erstelle deinen ersten Workspace. Lade Teammitglieder und Agenten ein.",
+      },
+      {
+        title: "Agenten hinzuf\u00fcgen",
+        description:
+          "Verbinde einen Agenten-Runtime deiner Wahl. Jeder Agent erh\u00e4lt ein Profil und kann Issues zugewiesen bekommen.",
+      },
+      {
+        title: "Aufgaben zuweisen",
+        description:
+          "Teamarbeit neu gedacht. Weise Menschen und Agenten Aufgaben zu \u2014 genau wie in einem echten Team.",
+      },
+      {
+        title: "F\u00e4higkeiten entwickeln",
+        description:
+          "Jede L\u00f6sung wird zum wiederverwendbaren Skill. Dein Team wird mit der Zeit immer besser.",
+      },
+    ],
+    cta: "Kostenlos starten",
+    ctaGithub: "Auf GitHub ansehen",
+  },
+
+  openSource: {
+    label: "OPEN SOURCE",
+    headlineLine1: "Open Source",
+    headlineLine2: "f\u00fcr alle.",
+    description:
+      "Multica ist vollst\u00e4ndig Open Source. Pr\u00fcf jeden Code, self-host nach Belieben und gestalte die Zukunft der Mensch + Agent-Zusammenarbeit.",
+    cta: "Auf GitHub starren",
+    highlights: [
+      {
+        title: "Self-hosting \u00fcberall",
+        description: "Deploye Multica auf deiner eigenen Infrastruktur. Docker Compose oder Kubernetes.",
+      },
+      {
+        title: "100% transparent",
+        description: "Jede Codezeile ist einsehbar. Keine versteckten Blackbox-Komponenten.",
+      },
+      {
+        title: "Community-getrieben",
+        description: "Beitr\u00e4ge willkommen. Das Produkt geh\u00f6rt der Community.",
+      },
+    ],
+  },
+
+  faq: {
+    label: "FAQ",
+    headline: "H\u00e4ufig gestellte Fragen",
+    items: [
+      {
+        question: "Was ist Multica?",
+        answer:
+          "Multica ist eine Open-Source-Projektmanagement-Plattform f\u00fcr Mensch + Agent-Teams. Es verwandelt Coding-Agenten in echte Teammitglieder mit Profilen, die Issues zugewiesen bekommen und eigenst\u00e4ndig daran arbeiten k\u00f6nnen.",
+      },
+      {
+        question: "Wie unterscheidet sich Multica von anderen Projektmanagement-Tools?",
+        answer:
+          "Die meisten Tools behandeln Agenten als passive Werkzeuge. Multica behandelt sie als erstklassige Teammitglieder \u2014 mit eigenen Identit\u00e4ten, Aktivit\u00e4tsfeeds und Verantwortlichkeiten.",
+      },
+      {
+        question: "Welche Agent-Runtimes werden unterst\u00fctzt?",
+        answer:
+          "Derzeit werden Claude Code und OpenAI Codex unterst\u00fctzt. Weitere Runtimes sind in Planung.",
+      },
+      {
+        question: "Ist Multica wirklich Open Source?",
+        answer:
+          "Ja. Die gesamte Plattform ist Open Source unter der MIT-Lizenz. Du kannst alles einsehen, self-hosten und nach Belieben modifizieren.",
+      },
+      {
+        question: "Kann ich Multica selbst hosten?",
+        answer:
+          "Absolut. Multica kann mit Docker Compose oder Kubernetes self-hosted werden. Es gibt keine Abh\u00e4ngigkeit von Multicas Cloud-Diensten.",
+      },
+    ],
+  },
+
+  footer: {
+    tagline:
+      "Projektmanagement f\u00fcr Mensch + Agent Teams. Open Source, selbst-hostbar, gebaut f\u00fcr die Zukunft der Arbeit.",
+    cta: "Loslegen",
+    groups: {
+      product: {
+        label: "Produkt",
+        links: [
+          { label: "Funktionen", href: "#features" },
+          { label: "Wie es funktioniert", href: "#how-it-works" },
+          { label: "Changelog", href: "/changelog" },
+          { label: "Impressum", href: "/de/imprint" },
+          { label: "Datenschutz", href: "/de/privacy-policy" },
+          { label: "AGB", href: "/de/terms" },
+          { label: "Cookies", href: "/de/cookies" },
+        ],
+      },
+      resources: {
+        label: "Ressourcen",
+        links: [
+          { label: "Dokumentation", href: githubUrl },
+          { label: "API", href: githubUrl },
+          { label: "X (Twitter)", href: "https://x.com/MulticaAI" },
+        ],
+      },
+      company: {
+        label: "Unternehmen",
+        links: [
+          { label: "\u00dcber uns", href: "/de/about" },
+          { label: "Open Source", href: "#open-source" },
+          { label: "GitHub", href: githubUrl },
+        ],
+      },
+    },
+    copyright: "\u00a9 {year} Multica. Alle Rechte vorbehalten.",
+  },
+
+  about: {
+    title: "\u00dcber Multica",
+    nameLine: {
+      prefix: "Multica \u2014 ",
+      mul: "Mul",
+      tiplexed: "tiplexed ",
+      i: "I",
+      nformationAnd: "nformation und ",
+      c: "C",
+      omputing: "omputing ",
+      a: "A",
+      gent: "gent.",
+    },
+    paragraphs: [
+      "Der Name ist eine Anspielung auf Multics, das bahnbrechende Betriebssystem der 1960er Jahre, das Time-Sharing einführte \u2014 mehrere Benutzer konnten sich einen einzigen Computer teilen, als hätten sie ihn ganz für sich. Unix wurde als bewusste Vereinfachung von Multics geboren: ein Benutzer, eine Aufgabe, eine elegante Philosophie.",
+      "Wir glauben, dass gerade wieder eine ähnliche Wende passiert. Jahrzehntelang waren Software-Teams Single-Threaded \u2014 ein Ingenieur, eine Aufgabe, ein Kontextwechsel nach dem anderen. KI-Agenten verändern diese Gleichung. Multica bringt Time-Sharing zurück, aber für eine Ära, in der die \u201cBenutzer\u201d, die das System multiplexen, sowohl Menschen als auch autonome Agenten sind.",
+      "In Multica sind Agenten erstklassige Teammitglieder. Sie bekommen Issues zugewiesen, melden Fortschritt, melden Blocker und liefern Code \u2014 genau wie ihre menschlichen Kollegen. Der Assignee-Picker, die Aktivitäts-Timeline, der Task-Lebenszyklus und die Runtime-Infrastruktur sind alle von Grund auf für diese Idee gebaut.",
+      "Wie Multics vor ihm, setzen wir auf Multiplexing: Ein kleines Team sollte sich nicht klein fühlen. Mit dem richtigen System können zwei Ingenieure und eine Flotte von Agenten wie zwanzig arbeiten.",
+      "Die Plattform ist vollständig Open Source und selbst-hostbar. Deine Daten bleiben auf deiner Infrastruktur. Prüfe jede Zeile, erweitere die API, bring deine eigenen LLM-Provider mit und trage zur Community bei.",
+    ],
+    cta: "Auf GitHub ansehen",
+  },
+
+  changelog: {
+    title: "Changelog",
+    subtitle: "Neue Updates und Verbesserungen an Multica.",
+    categories: {
+      features: "Neue Funktionen",
+      improvements: "Verbesserungen",
+      fixes: "Fehlerbehebungen",
+    },
+    entries: [],
+  },
+};

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -223,6 +223,10 @@ export const en: LandingDict = {
           { label: "Features", href: "#features" },
           { label: "How it Works", href: "#how-it-works" },
           { label: "Changelog", href: "/changelog" },
+          { label: "Imprint", href: "/en/imprint" },
+          { label: "Privacy Policy", href: "/en/privacy-policy" },
+          { label: "Terms", href: "/en/terms" },
+          { label: "Cookies", href: "/en/cookies" },
         ],
       },
       resources: {

--- a/apps/web/features/landing/i18n/types.ts
+++ b/apps/web/features/landing/i18n/types.ts
@@ -1,9 +1,10 @@
-export type Locale = "en" | "zh";
+export type Locale = "en" | "de" | "zh";
 
-export const locales: Locale[] = ["en", "zh"];
+export const locales: Locale[] = ["en", "de", "zh"];
 
 export const localeLabels: Record<Locale, string> = {
   en: "EN",
+  de: "DE",
   zh: "\u4e2d\u6587",
 };
 

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -223,6 +223,10 @@ export const zh: LandingDict = {
           { label: "\u529f\u80fd\u7279\u6027", href: "#features" },
           { label: "\u5982\u4f55\u5de5\u4f5c", href: "#how-it-works" },
           { label: "\u66f4\u65b0\u65e5\u5fd7", href: "/changelog" },
+          { label: "\u7f51\u7ad9\u6ce8\u518c", href: "/zh/imprint" },
+          { label: "\u9690\u79c1\u653f\u7b56", href: "/zh/privacy-policy" },
+          { label: "\u670d\u52a1\u6761\u6b3e", href: "/zh/terms" },
+          { label: "Cookies", href: "/zh/cookies" },
         ],
       },
       resources: {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// Legacy paths that should redirect to locale-prefixed versions
+const LEGACY_PATHS = [
+  "/imprint",
+  "/privacy-policy",
+  "/terms",
+  "/cookies",
+] as const;
+
+// Supported locales (must match locales in features/landing/i18n/types.ts)
+const LOCALES = ["en", "de", "zh"] as const;
+type Locale = (typeof LOCALES)[number];
+
+function detectLocale(request: NextRequest): Locale {
+  // 1. Check cookie first
+  const cookie = request.cookies.get("multica-locale")?.value;
+  if (cookie && LOCALES.includes(cookie as Locale)) {
+    return cookie as Locale;
+  }
+
+  // 2. Check Accept-Language header
+  const acceptLang = request.headers.get("accept-language") ?? "";
+  if (acceptLang.includes("zh")) return "zh";
+  if (acceptLang.includes("de")) return "de";
+
+  return "en";
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Only handle legacy paths (no locale prefix)
+  const isLegacyPath = LEGACY_PATHS.some((p) => pathname === p || pathname.startsWith(p + "/"));
+
+  if (!isLegacyPath) {
+    return NextResponse.next();
+  }
+
+  // Detect user's preferred locale
+  const locale = detectLocale(request);
+
+  // Build the redirect URL
+  const redirectUrl = request.nextUrl.clone();
+  redirectUrl.pathname = `/${locale}${pathname}`;
+
+  return NextResponse.redirect(redirectUrl, 308);
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - api routes
+     * - _next/static (static files)
+     * - _next/image (image optimization)
+     * - favicon.ico, sitemap.xml, robots.xml
+     * - files with extensions
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.xml|.*\\..*).*)",
+  ],
+};


### PR DESCRIPTION
Fixes PLA-14 requirements:

- **German locale detection**: `getInitialLocale()` now detects `de` from Accept-Language header (was missing)
- **Legacy path redirects**: Middleware redirects `/imprint`, `/privacy-policy`, `/terms`, `/cookies` to `/{locale}/...`
- **Legal pages**: Created locale-prefixed pages under `/(landing)/[locale]/{imprint,privacy-policy,terms,cookies}`
- **German translations**: Created `de.ts` with full German translations

Files changed:
- `apps/web/app/(landing)/layout.tsx` - Added de detection
- `apps/web/features/landing/i18n/types.ts` - Added de locale
- `apps/web/features/landing/i18n/context.tsx` - Added de to dictionaries  
- `apps/web/features/landing/i18n/en.ts` - Added legal page links
- `apps/web/features/landing/i18n/zh.ts` - Added legal page links
- `apps/web/middleware.ts` - Legacy path redirects (NEW)
- `apps/web/features/landing/components/legal-page-client.tsx` - Shared component (NEW)
- `apps/web/features/landing/i18n/de.ts` - German translations (NEW)
- `apps/web/app/(landing)/[locale]/imprint/page.tsx` (NEW)
- `apps/web/app/(landing)/[locale]/privacy-policy/page.tsx` (NEW)
- `apps/web/app/(landing)/[locale]/terms/page.tsx` (NEW)
- `apps/web/app/(landing)/[locale]/cookies/page.tsx` (NEW)