### PR TITLE
fix(desktop): augment PATH when spawning daemon on macOS

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -599,10 +599,34 @@ function profileArgs(active: ActiveProfile): string[] {
 // Env passed to every CLI child so the daemon process knows it was spawned
 // by the Desktop app. The server uses this to mark runtimes as managed and
 // hide CLI self-update UI.
-const DESKTOP_SPAWN_ENV = {
-  ...process.env,
-  MULTICA_LAUNCHED_BY: "desktop",
-};
+//
+// On macOS, apps launched from the Dock inherit a stripped-down PATH that
+// omits Homebrew and other user-installed tool directories. We augment it
+// here so the daemon can find agent CLIs (claude, codex, openclaw, etc.)
+// that the user installed via brew or other package managers.
+function buildDesktopSpawnEnv(): NodeJS.ProcessEnv {
+  const base = process.env["PATH"] ?? "";
+  const extras =
+    process.platform === "darwin"
+      ? [
+          join(homedir(), ".local", "bin"),
+          "/opt/homebrew/bin",
+          "/opt/homebrew/sbin",
+          "/usr/local/bin",
+          "/usr/local/sbin",
+        ]
+      : [join(homedir(), ".local", "bin")];
+  const parts = base.split(process.platform === "win32" ? ";" : ":");
+  for (const extra of extras) {
+    if (!parts.includes(extra)) parts.push(extra);
+  }
+  return {
+    ...process.env,
+    PATH: parts.join(process.platform === "win32" ? ";" : ":"),
+    MULTICA_LAUNCHED_BY: "desktop",
+  };
+}
+const DESKTOP_SPAWN_ENV = buildDesktopSpawnEnv();
 
 async function startDaemon(): Promise<{ success: boolean; error?: string }> {
   const bin = await resolveCliBinary();


### PR DESCRIPTION
## Problem

On macOS, apps launched from the Dock inherit a stripped `PATH` that omits user-installed directories like `/opt/homebrew/bin` and `~/.local/bin`. The desktop app restarts the daemon automatically when its bundled CLI version differs from the running one (added in #1041). The new daemon process inherits this stripped `PATH` and immediately exits with:

```
Error: no agent CLI found: install claude, codex, opencode, openclaw, hermes, or gemini and ensure it is on PATH
```

This leaves the sidebar stuck on **"Starting…"** forever with no visible error.

## Fix

Build an augmented `PATH` in `DESKTOP_SPAWN_ENV` that appends the common macOS tool directories (`~/.local/bin`, `/opt/homebrew/bin`, `/opt/homebrew/sbin`, `/usr/local/bin`, `/usr/local/sbin`) before spawning any CLI child process. Existing entries are preserved and duplicates are skipped.

## Test plan

- [ ] Launch Multica from the Dock (not terminal) with agent CLIs installed in `/opt/homebrew/bin` or `~/.local/bin`
- [ ] Trigger a daemon restart (change bundled CLI version or restart app)
- [ ] Confirm daemon comes up as "running" with all agents listed
- [ ] Confirm sidebar no longer gets stuck on "Starting…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)