### PR TITLE
MUL: Support per-agent runtime model override

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -24,11 +24,13 @@ import (
 // server refresh.
 var ErrRepoNotConfigured = errors.New("repo is not configured for this workspace")
 
+var newAgentBackend = agent.New
+
 // workspaceState tracks registered runtimes for a single workspace.
 type workspaceState struct {
 	workspaceID     string
 	runtimeIDs      []string
-	reposVersion    string             // stored for future use: skip refresh when version unchanged
+	reposVersion    string // stored for future use: skip refresh when version unchanged
 	allowedRepoURLs map[string]struct{}
 	lastRepoSyncErr string
 	repoRefreshMu   sync.Mutex
@@ -1026,7 +1028,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 			agentEnv[k] = v
 		}
 	}
-	backend, err := agent.New(provider, agent.Config{
+	backend, err := newAgentBackend(provider, agent.Config{
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,
 		Logger:         d.logger,
@@ -1035,11 +1037,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)
 	}
 
+	effectiveModel := entry.Model
+	if task.Agent != nil {
+		effectiveModel = resolveTaskModel(entry.Model, task.Agent.RuntimeConfig)
+	}
 	reused := task.PriorWorkDir != "" && env.WorkDir == task.PriorWorkDir
 	taskLog.Info("starting agent",
 		"provider", provider,
 		"workdir", env.WorkDir,
-		"model", entry.Model,
+		"model", effectiveModel,
 		"reused", reused,
 	)
 	if task.PriorSessionID != "" {
@@ -1054,7 +1060,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	}
 	execOpts := agent.ExecOptions{
 		Cwd:             env.WorkDir,
-		Model:           entry.Model,
+		Model:           effectiveModel,
 		Timeout:         d.cfg.AgentTimeout,
 		ResumeSessionID: task.PriorSessionID,
 		CustomArgs:      customArgs,

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
 	"github.com/multica-ai/multica/server/pkg/agent"
@@ -190,6 +192,110 @@ func TestMergeUsage(t *testing.T) {
 	}
 }
 
+func TestResolveTaskModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		runtimeConfig   any
+		providerDefault string
+		want            string
+	}{
+		{
+			name:            "no runtime config uses provider default",
+			runtimeConfig:   nil,
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.4",
+		},
+		{
+			name: "absent model uses provider default and ignores extra keys",
+			runtimeConfig: map[string]any{
+				"temperature": 0.2,
+				"notes":       "preserved elsewhere",
+			},
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.4",
+		},
+		{
+			name: "string model overrides provider default",
+			runtimeConfig: map[string]any{
+				"model": "gpt-5.3-codex-spark",
+			},
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.3-codex-spark",
+		},
+		{
+			name: "whitespace around model is trimmed",
+			runtimeConfig: map[string]any{
+				"model": "  gpt-5.3-codex-spark  ",
+			},
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.3-codex-spark",
+		},
+		{
+			name: "empty model uses provider default",
+			runtimeConfig: map[string]any{
+				"model": "",
+			},
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.4",
+		},
+		{
+			name: "whitespace model uses provider default",
+			runtimeConfig: map[string]any{
+				"model": " \t\n ",
+			},
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.4",
+		},
+		{
+			name: "non-string model uses provider default",
+			runtimeConfig: map[string]any{
+				"model": 123,
+			},
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.4",
+		},
+		{
+			name:            "raw json runtime config model overrides provider default",
+			runtimeConfig:   json.RawMessage(`{"model":"gpt-5.3-codex-spark","keep":"value"}`),
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.3-codex-spark",
+		},
+		{
+			name:            "invalid json uses provider default",
+			runtimeConfig:   json.RawMessage(`{"model":`),
+			providerDefault: "gpt-5.4",
+			want:            "gpt-5.4",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveTaskModel(tt.providerDefault, tt.runtimeConfig); got != tt.want {
+				t.Fatalf("resolveTaskModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTaskModelDoesNotMutateRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	runtimeConfig := map[string]any{
+		"model": "gpt-5.3-codex-spark",
+		"keep":  "value",
+	}
+	if got := resolveTaskModel("gpt-5.4", runtimeConfig); got != "gpt-5.3-codex-spark" {
+		t.Fatalf("resolveTaskModel() = %q, want gpt-5.3-codex-spark", got)
+	}
+	if got := runtimeConfig["keep"]; got != "value" {
+		t.Fatalf("runtime config extra key changed: got %v", got)
+	}
+}
+
 // fakeBackend is a test double for agent.Backend that returns preconfigured
 // results. Each call to Execute pops the next entry from the results slice.
 type fakeBackend struct {
@@ -221,6 +327,76 @@ func newTestDaemon(t *testing.T) *Daemon {
 	return &Daemon{
 		client: NewClient(srv.URL),
 		logger: slog.Default(),
+	}
+}
+
+func TestRunTaskPassesResolvedModelToExecOptions(t *testing.T) {
+	oldNewAgentBackend := newAgentBackend
+	t.Cleanup(func() {
+		newAgentBackend = oldNewAgentBackend
+	})
+
+	tests := []struct {
+		name          string
+		runtimeConfig any
+		wantModel     string
+	}{
+		{
+			name:      "no runtime config passes provider default",
+			wantModel: "gpt-5.4",
+		},
+		{
+			name: "runtime config model override is passed",
+			runtimeConfig: map[string]any{
+				"model":       "gpt-5.3-codex-spark",
+				"temperature": 0.2,
+			},
+			wantModel: "gpt-5.3-codex-spark",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &fakeBackend{
+				results: []agent.Result{{
+					Status: "completed",
+					Output: "done",
+				}},
+			}
+			newAgentBackend = func(agentType string, cfg agent.Config) (agent.Backend, error) {
+				if agentType != "claude" {
+					t.Fatalf("agent type = %q, want claude", agentType)
+				}
+				return backend, nil
+			}
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			d := New(Config{
+				ServerBaseURL:  "http://example.test",
+				Agents:         map[string]AgentEntry{"claude": {Path: "claude", Model: "gpt-5.4"}},
+				WorkspacesRoot: t.TempDir(),
+				AgentTimeout:   time.Second,
+			}, logger)
+
+			_, err := d.runTask(context.Background(), Task{
+				ID:          "task-00000001",
+				AgentID:     "agent-1",
+				IssueID:     "issue-1",
+				WorkspaceID: "workspace-1",
+				Agent: &AgentData{
+					ID:            "agent-1",
+					Name:          "Test Agent",
+					Instructions:  "Test instructions",
+					RuntimeConfig: tt.runtimeConfig,
+				},
+			}, "claude", logger)
+			if err != nil {
+				t.Fatalf("runTask() error = %v", err)
+			}
+			if backend.calls[0].Model != tt.wantModel {
+				t.Fatalf("ExecOptions.Model = %q, want %q", backend.calls[0].Model, tt.wantModel)
+			}
+		})
 	}
 }
 

--- a/server/internal/daemon/model.go
+++ b/server/internal/daemon/model.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func resolveTaskModel(providerDefault string, runtimeConfig any) string {
+	if model := runtimeConfigModel(runtimeConfig); model != "" {
+		return model
+	}
+	return providerDefault
+}
+
+func runtimeConfigModel(runtimeConfig any) string {
+	switch rc := runtimeConfig.(type) {
+	case nil:
+		return ""
+	case map[string]any:
+		return modelFromMap(rc)
+	case map[string]string:
+		return strings.TrimSpace(rc["model"])
+	case json.RawMessage:
+		return runtimeConfigModelFromJSON(rc)
+	case []byte:
+		return runtimeConfigModelFromJSON(rc)
+	default:
+		return ""
+	}
+}
+
+func modelFromMap(runtimeConfig map[string]any) string {
+	model, ok := runtimeConfig["model"].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(model)
+}
+
+func runtimeConfigModelFromJSON(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var runtimeConfig map[string]any
+	if err := json.Unmarshal(raw, &runtimeConfig); err != nil {
+		return ""
+	}
+	return modelFromMap(runtimeConfig)
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -23,15 +23,15 @@ type RepoData struct {
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID             string     `json:"id"`
-	AgentID        string     `json:"agent_id"`
-	RuntimeID      string     `json:"runtime_id"`
-	IssueID        string     `json:"issue_id"`
-	WorkspaceID    string     `json:"workspace_id"`
-	Agent          *AgentData `json:"agent,omitempty"`
-	Repos          []RepoData `json:"repos,omitempty"`
-	PriorSessionID   string     `json:"prior_session_id,omitempty"`    // Claude session ID from a previous task on this issue
-	PriorWorkDir     string     `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on this issue
+	ID                    string     `json:"id"`
+	AgentID               string     `json:"agent_id"`
+	RuntimeID             string     `json:"runtime_id"`
+	IssueID               string     `json:"issue_id"`
+	WorkspaceID           string     `json:"workspace_id"`
+	Agent                 *AgentData `json:"agent,omitempty"`
+	Repos                 []RepoData `json:"repos,omitempty"`
+	PriorSessionID        string     `json:"prior_session_id,omitempty"`        // Claude session ID from a previous task on this issue
+	PriorWorkDir          string     `json:"prior_work_dir,omitempty"`          // work_dir from a previous task on this issue
 	TriggerCommentID      string     `json:"trigger_comment_id,omitempty"`      // comment that triggered this task
 	TriggerCommentContent string     `json:"trigger_comment_content,omitempty"` // content of the triggering comment
 	ChatSessionID         string     `json:"chat_session_id,omitempty"`         // non-empty for chat tasks
@@ -40,12 +40,13 @@ type Task struct {
 
 // AgentData holds agent details returned by the claim endpoint.
 type AgentData struct {
-	ID           string            `json:"id"`
-	Name         string            `json:"name"`
-	Instructions string            `json:"instructions"`
-	Skills       []SkillData       `json:"skills"`
-	CustomEnv    map[string]string `json:"custom_env,omitempty"`
-	CustomArgs   []string          `json:"custom_args,omitempty"`
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Instructions  string            `json:"instructions"`
+	RuntimeConfig any               `json:"runtime_config,omitempty"`
+	Skills        []SkillData       `json:"skills"`
+	CustomEnv     map[string]string `json:"custom_env,omitempty"`
+	CustomArgs    []string          `json:"custom_args,omitempty"`
 }
 
 // SkillData represents a structured skill for task execution.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -38,14 +38,6 @@ type AgentResponse struct {
 }
 
 func agentToResponse(a db.Agent) AgentResponse {
-	var rc any
-	if a.RuntimeConfig != nil {
-		json.Unmarshal(a.RuntimeConfig, &rc)
-	}
-	if rc == nil {
-		rc = map[string]any{}
-	}
-
 	var customEnv map[string]string
 	if a.CustomEnv != nil {
 		if err := json.Unmarshal(a.CustomEnv, &customEnv); err != nil {
@@ -75,7 +67,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		Instructions:       a.Instructions,
 		AvatarURL:          textToPtr(a.AvatarUrl),
 		RuntimeMode:        a.RuntimeMode,
-		RuntimeConfig:      rc,
+		RuntimeConfig:      runtimeConfigToResponse(a.RuntimeConfig),
 		CustomEnv:          customEnv,
 		CustomArgs:         customArgs,
 		Visibility:         a.Visibility,
@@ -90,6 +82,17 @@ func agentToResponse(a db.Agent) AgentResponse {
 	}
 }
 
+func runtimeConfigToResponse(raw []byte) any {
+	var rc any
+	if raw != nil {
+		json.Unmarshal(raw, &rc)
+	}
+	if rc == nil {
+		return map[string]any{}
+	}
+	return rc
+}
+
 // RepoData holds repository information included in claim responses so the
 // daemon can set up worktrees for each workspace repo.
 type RepoData struct {
@@ -98,23 +101,23 @@ type RepoData struct {
 }
 
 type AgentTaskResponse struct {
-	ID             string         `json:"id"`
-	AgentID        string         `json:"agent_id"`
-	RuntimeID      string         `json:"runtime_id"`
-	IssueID        string         `json:"issue_id"`
-	WorkspaceID    string         `json:"workspace_id"`
-	Status         string         `json:"status"`
-	Priority       int32          `json:"priority"`
-	DispatchedAt   *string        `json:"dispatched_at"`
-	StartedAt      *string        `json:"started_at"`
-	CompletedAt    *string        `json:"completed_at"`
-	Result         any            `json:"result"`
-	Error          *string        `json:"error"`
-	Agent          *TaskAgentData `json:"agent,omitempty"`
-	Repos          []RepoData     `json:"repos,omitempty"`
-	CreatedAt      string         `json:"created_at"`
-	PriorSessionID   string         `json:"prior_session_id,omitempty"`    // session ID from a previous task on same issue
-	PriorWorkDir     string         `json:"prior_work_dir,omitempty"`     // work_dir from a previous task on same issue
+	ID                    string         `json:"id"`
+	AgentID               string         `json:"agent_id"`
+	RuntimeID             string         `json:"runtime_id"`
+	IssueID               string         `json:"issue_id"`
+	WorkspaceID           string         `json:"workspace_id"`
+	Status                string         `json:"status"`
+	Priority              int32          `json:"priority"`
+	DispatchedAt          *string        `json:"dispatched_at"`
+	StartedAt             *string        `json:"started_at"`
+	CompletedAt           *string        `json:"completed_at"`
+	Result                any            `json:"result"`
+	Error                 *string        `json:"error"`
+	Agent                 *TaskAgentData `json:"agent,omitempty"`
+	Repos                 []RepoData     `json:"repos,omitempty"`
+	CreatedAt             string         `json:"created_at"`
+	PriorSessionID        string         `json:"prior_session_id,omitempty"`        // session ID from a previous task on same issue
+	PriorWorkDir          string         `json:"prior_work_dir,omitempty"`          // work_dir from a previous task on same issue
 	TriggerCommentID      *string        `json:"trigger_comment_id,omitempty"`      // comment that triggered this task
 	TriggerCommentContent string         `json:"trigger_comment_content,omitempty"` // content of the triggering comment
 	ChatSessionID         string         `json:"chat_session_id,omitempty"`         // non-empty for chat tasks
@@ -124,12 +127,13 @@ type AgentTaskResponse struct {
 // TaskAgentData holds agent info included in claim responses so the daemon
 // can set up the execution environment (branch naming, skill files, instructions).
 type TaskAgentData struct {
-	ID           string                   `json:"id"`
-	Name         string                   `json:"name"`
-	Instructions string                   `json:"instructions"`
-	Skills       []service.AgentSkillData `json:"skills,omitempty"`
-	CustomEnv    map[string]string        `json:"custom_env,omitempty"`
-	CustomArgs   []string                 `json:"custom_args,omitempty"`
+	ID            string                   `json:"id"`
+	Name          string                   `json:"name"`
+	Instructions  string                   `json:"instructions"`
+	RuntimeConfig any                      `json:"runtime_config,omitempty"`
+	Skills        []service.AgentSkillData `json:"skills,omitempty"`
+	CustomEnv     map[string]string        `json:"custom_env,omitempty"`
+	CustomArgs    []string                 `json:"custom_args,omitempty"`
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
@@ -138,16 +142,16 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		json.Unmarshal(t.Result, &result)
 	}
 	return AgentTaskResponse{
-		ID:           uuidToString(t.ID),
-		AgentID:      uuidToString(t.AgentID),
-		RuntimeID:    uuidToString(t.RuntimeID),
-		IssueID:      uuidToString(t.IssueID),
-		Status:       t.Status,
-		Priority:     t.Priority,
-		DispatchedAt: timestampToPtr(t.DispatchedAt),
-		StartedAt:    timestampToPtr(t.StartedAt),
-		CompletedAt:  timestampToPtr(t.CompletedAt),
-		Result:       result,
+		ID:               uuidToString(t.ID),
+		AgentID:          uuidToString(t.AgentID),
+		RuntimeID:        uuidToString(t.RuntimeID),
+		IssueID:          uuidToString(t.IssueID),
+		Status:           t.Status,
+		Priority:         t.Priority,
+		DispatchedAt:     timestampToPtr(t.DispatchedAt),
+		StartedAt:        timestampToPtr(t.StartedAt),
+		CompletedAt:      timestampToPtr(t.CompletedAt),
+		Result:           result,
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
@@ -335,8 +339,6 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": resp})
 	writeJSON(w, http.StatusCreated, resp)
 }
-
-
 
 type UpdateAgentRequest struct {
 	Name               *string            `json:"name"`

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -477,12 +477,13 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		resp.Agent = &TaskAgentData{
-			ID:           uuidToString(agent.ID),
-			Name:         agent.Name,
-			Instructions: agent.Instructions,
-			Skills:       skills,
-			CustomEnv:    customEnv,
-			CustomArgs:   customArgs,
+			ID:            uuidToString(agent.ID),
+			Name:          agent.Name,
+			Instructions:  agent.Instructions,
+			RuntimeConfig: runtimeConfigToResponse(agent.RuntimeConfig),
+			Skills:        skills,
+			CustomEnv:     customEnv,
+			CustomArgs:    customArgs,
 		}
 	}
 

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -201,6 +201,81 @@ func TestGetTaskStatus_WithDaemonToken_CrossWorkspace(t *testing.T) {
 	}
 }
 
+func TestClaimTaskByRuntimeIncludesAgentRuntimeConfig(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	var agentID, runtimeID string
+	err := testPool.QueryRow(context.Background(), `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID)
+	if err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE agent SET runtime_config = $1 WHERE id = $2
+	`, []byte(`{"model":"gpt-5.3-codex-spark","keep":"value"}`), agentID); err != nil {
+		t.Fatalf("setup: update runtime_config: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `UPDATE agent SET runtime_config = '{}'::jsonb WHERE id = $1`, agentID)
+	})
+
+	var issueID, taskID string
+	err = testPool.QueryRow(context.Background(), `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type)
+		VALUES ($1, 'daemon-claim-runtime-config-test', 'todo', 'medium', $2, 'member')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID)
+	if err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	err = testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id)
+		VALUES ($1, $2, 'queued', $3)
+		RETURNING id
+	`, agentID, issueID, runtimeID).Scan(&taskID)
+	if err != nil {
+		t.Fatalf("setup: create task: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "claim-runtime-config-test")
+	req = withURLParam(req, "runtimeId", runtimeID)
+
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp AgentTaskResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Agent == nil {
+		t.Fatalf("expected agent payload")
+	}
+	cfg, ok := resp.Agent.RuntimeConfig.(map[string]any)
+	if !ok {
+		t.Fatalf("runtime_config = %#v, want object", resp.Agent.RuntimeConfig)
+	}
+	if got := cfg["model"]; got != "gpt-5.3-codex-spark" {
+		t.Fatalf("runtime_config.model = %#v, want gpt-5.3-codex-spark", got)
+	}
+	if got := cfg["keep"]; got != "value" {
+		t.Fatalf("runtime_config.keep = %#v, want value", got)
+	}
+}
+
 func TestGetDaemonWorkspaceRepos_WithDaemonToken(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")


### PR DESCRIPTION
## Summary
- Add per-agent `runtime_config.model` resolution for local daemon task execution.
- Pass the resolved effective model into `agent.ExecOptions.Model`, falling back to the provider default for missing, empty, whitespace-only, non-string, or invalid JSON-shaped runtime config.
- Include `runtime_config` in claimed task agent payloads so real daemon task execution can see the configured model.
- Add focused daemon and handler coverage for model resolution and claim-payload propagation.

## Safety
- No live Multica agent configs were changed.
- No daemon restart was run.
- No Multica tasks were run.
- No production runtime routing was changed.
- No Trainer files were touched.

## Validation
```bash
cd server && go test ./internal/daemon/...
cd server && go test ./pkg/agent/...
cd server && go test ./internal/handler
cd .. && git diff --check
```

All passed locally.
