### PR TITLE
fix(security): enforce workspace access on GetIssueGCCheck

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1033,11 +1033,16 @@ func (h *Handler) GetIssueUsage(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetIssueGCCheck returns minimal issue info needed by the daemon GC loop.
+// Gated on workspace access so a daemon token scoped to workspace A cannot
+// read issue metadata from workspace B via UUID enumeration.
 func (h *Handler) GetIssueGCCheck(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "issueId")
 	issue, err := h.Queries.GetIssue(r.Context(), parseUUID(issueID))
 	if err != nil {
 		writeError(w, http.StatusNotFound, "issue not found")
+		return
+	}
+	if !h.requireDaemonWorkspaceAccess(w, r, uuidToString(issue.WorkspaceID)) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{


### PR DESCRIPTION
## What does this PR do?

The daemon GC check endpoint (`GetIssueGCCheck`) did not verify the caller's access to the issue's workspace. A daemon token scoped to workspace A could read issue status and `updated_at` for any issue UUID across the entire instance by calling `GET /api/daemon/issues/{id}/gc-check`.

Every other handler under `/api/daemon/*` gates on `requireDaemonWorkspaceAccess` or `requireDaemonTaskAccess`. This endpoint was the sole exception — likely missed when #684 introduced the workspace ownership helpers.

## Related Issue

Closes #1112

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`server/internal/handler/daemon.go`**: After fetching the issue, call `requireDaemonWorkspaceAccess(w, r, uuidToString(issue.WorkspaceID))` before returning data. Mirrors the pattern used by `StartTask`, `CompleteTask`, `FailTask`, `GetTaskStatus`, etc. in the same file.

## How to Test

1. Set up two workspaces (A and B) on a self-hosted instance with separate owners.
2. Create an issue in workspace B and note its UUID.
3. Pair a daemon to workspace A to obtain an `mdt_` token.
4. `GET /api/daemon/issues/{B-issue-UUID}/gc-check` with the workspace-A token.
5. Before this fix: `200 OK` with B's data. After: `404 not found`.
6. Verify GC still works normally for same-workspace issues.

## Checklist

- [x] I have run tests locally and they pass
- [x] I have considered and documented any risks above

## AI Disclosure

**AI tool used:** Claude Code
**Prompt / approach:** Security review of v0.1.22→v0.2.0 diff, confirmed against local v0.2.0 fork. Identified the missing access check by comparing all daemon handlers.