### PR TITLE
fix(agent): apply filterCustomArgs to hermes backend for parity

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -11,6 +11,14 @@ import (
 	"time"
 )
 
+// hermesBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. `acp` is the protocol
+// subcommand that drives the ACP JSON-RPC transport; overriding it
+// would break the daemon↔Hermes communication contract.
+var hermesBlockedArgs = map[string]blockedArgMode{
+	"acp": blockedStandalone,
+}
+
 // hermesBackend implements Backend by spawning `hermes acp` and communicating
 // via the ACP (Agent Communication Protocol) JSON-RPC 2.0 over stdin/stdout.
 // This is the same pattern as Codex but with the ACP protocol instead of
@@ -34,7 +42,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
-	hermesArgs := append([]string{"acp"}, opts.CustomArgs...)
+	hermesArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, hermesBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, hermesArgs...)
 	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", hermesArgs)
 	if opts.Cwd != "" {


### PR DESCRIPTION
## What does this PR do?

The Hermes backend appended `opts.CustomArgs` directly to argv without passing them through `filterCustomArgs`. Every other backend (claude, codex, opencode, openclaw, gemini) filters custom args through a per-backend blocked map so protocol-critical flags can't be overridden via the agent settings UI. This brings Hermes in line.

## Related Issue

Closes #1113

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`server/pkg/agent/hermes.go`**: Add `hermesBlockedArgs` map (blocking `acp`, the protocol subcommand) and route `opts.CustomArgs` through `filterCustomArgs` before appending to argv.

## How to Test

1. Create an agent with runtime type `hermes`.
2. Set `custom_args` to `["acp"]` — verify it is filtered out (logged as blocked).
3. Set `custom_args` to `["--model", "some-model"]` — verify it passes through.
4. Verify normal Hermes ACP session lifecycle works unchanged.

## Checklist

- [x] I have run tests locally and they pass

## AI Disclosure

**AI tool used:** Claude Code
**Prompt / approach:** Identified inconsistency by comparing all six backend Execute() implementations in `server/pkg/agent/`.