### PR TITLE
MUL-4914: fix(daemon): expand isBlockedEnvKey with code-injection vectors

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1386,11 +1386,18 @@ var blockedEnvKeys = map[string]struct{}{
 	"DYLD_INSERT_LIBRARIES": {}, "DYLD_LIBRARY_PATH": {},
 	"NODE_OPTIONS": {}, "NODE_PATH": {},
 	"PYTHONPATH": {}, "PYTHONSTARTUP": {},
+	"RUBYOPT": {}, "PERL5OPT": {},
+	"JAVA_TOOL_OPTIONS": {}, "_JAVA_OPTIONS": {},
+
+	// Shell init-time code execution
+	"BASH_ENV": {}, "ENV": {}, "ZDOTDIR": {},
 
 	// Proxy / TLS hijacking
 	"HTTP_PROXY": {}, "HTTPS_PROXY": {}, "ALL_PROXY": {}, "NO_PROXY": {},
 	"SSL_CERT_FILE": {}, "SSL_CERT_DIR": {},
+	"CURL_CA_BUNDLE": {}, "REQUESTS_CA_BUNDLE": {},
 	"NODE_TLS_REJECT_UNAUTHORIZED": {},
+	"NODE_EXTRA_CA_CERTS": {},
 
 	// Git-driven command execution
 	"GIT_SSH_COMMAND": {}, "GIT_TERMINAL_PROMPT": {},

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1374,17 +1374,40 @@ func convertSkillsForEnv(skills []SkillData) []execenv.SkillContextForEnv {
 	return result
 }
 
+// blockedEnvKeys covers daemon-managed internals plus well-known code-injection
+// and TLS/proxy-hijack vectors that would otherwise let a custom_env value
+// gain execution or traffic interception on the daemon host.
+var blockedEnvKeys = map[string]struct{}{
+	// Daemon-managed core
+	"HOME": {}, "PATH": {}, "USER": {}, "SHELL": {}, "TERM": {}, "CODEX_HOME": {},
+
+	// Code-injection via dynamic loader / interpreters
+	"LD_PRELOAD": {}, "LD_LIBRARY_PATH": {},
+	"DYLD_INSERT_LIBRARIES": {}, "DYLD_LIBRARY_PATH": {},
+	"NODE_OPTIONS": {}, "NODE_PATH": {},
+	"PYTHONPATH": {}, "PYTHONSTARTUP": {},
+
+	// Proxy / TLS hijacking
+	"HTTP_PROXY": {}, "HTTPS_PROXY": {}, "ALL_PROXY": {}, "NO_PROXY": {},
+	"SSL_CERT_FILE": {}, "SSL_CERT_DIR": {},
+	"NODE_TLS_REJECT_UNAUTHORIZED": {},
+
+	// Git-driven command execution
+	"GIT_SSH_COMMAND": {}, "GIT_TERMINAL_PROMPT": {},
+	"GIT_EXEC_PATH": {}, "GIT_TEMPLATE_DIR": {},
+
+	// Editor-as-shell
+	"EDITOR": {}, "VISUAL": {},
+}
+
 // isBlockedEnvKey returns true if the key must not be overridden by user-
 // configured custom_env. This prevents accidental or malicious override of
-// daemon-internal variables and critical system paths.
+// daemon-internal variables, critical system paths, and known RCE vectors.
 func isBlockedEnvKey(key string) bool {
 	upper := strings.ToUpper(key)
 	if strings.HasPrefix(upper, "MULTICA_") {
 		return true
 	}
-	switch upper {
-	case "HOME", "PATH", "USER", "SHELL", "TERM", "CODEX_HOME":
-		return true
-	}
-	return false
+	_, ok := blockedEnvKeys[upper]
+	return ok
 }


### PR DESCRIPTION
## What does this PR do?

`isBlockedEnvKey` only rejected 6 specific keys plus the `MULTICA_` prefix. Well-known variables that lead to code execution (`LD_PRELOAD`, `NODE_OPTIONS`, `PYTHONPATH`) or traffic interception (`HTTP_PROXY`, `SSL_CERT_FILE`) on agent CLI child processes were not blocked, meaning any agent owner could achieve RCE on the daemon host via `custom_env`.

This expands the blocklist to cover dynamic-loader injection, interpreter-level injection, proxy/TLS hijacking, git-driven command execution, and editor-as-shell vectors. Legitimate keys like `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_USE_BEDROCK` are unaffected.

## Related Issue

Closes #1114

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`server/internal/daemon/daemon.go`**: Replace the `switch` statement with a `map[string]struct{}` covering ~25 dangerous keys across 5 categories. Move to package-level var for easier future additions.

## How to Test

1. Set `custom_env` on an agent to `{"LD_PRELOAD": "/evil.so"}` → verify it is blocked and a warning is logged.
2. Set `custom_env` to `{"NODE_OPTIONS": "--require /evil.js"}` → blocked.
3. Set `custom_env` to `{"HTTP_PROXY": "http://attacker:8080"}` → blocked.
4. Set `custom_env` to `{"ANTHROPIC_API_KEY": "sk-..."}` → passes through (legitimate use case).
5. Verify existing agents with legitimate `custom_env` are unaffected.

## Checklist

- [x] I have run tests locally and they pass
- [x] I have considered and documented any risks above

## AI Disclosure

**AI tool used:** Claude Code
**Prompt / approach:** Audited isBlockedEnvKey against known code-injection environment variables for Node.js, Python, Go, and OS-level dynamic linkers.