### PR TITLE
fix(desktop): restrict shell.openExternal to http/https schemes

### DIFF
--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isSafeExternalHttpUrl } from "./external-url";
+
+describe("isSafeExternalHttpUrl", () => {
+  it("allows http and https URLs", () => {
+    expect(isSafeExternalHttpUrl("https://multica.ai")).toBe(true);
+    expect(isSafeExternalHttpUrl("http://localhost:3000/auth")).toBe(true);
+  });
+
+  it("rejects invalid and non-http schemes", () => {
+    expect(isSafeExternalHttpUrl("not a url")).toBe(false);
+    expect(isSafeExternalHttpUrl("file:///etc/passwd")).toBe(false);
+    expect(isSafeExternalHttpUrl("vscode://file/test")).toBe(false);
+    expect(isSafeExternalHttpUrl("mailto:test@example.com")).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -1,0 +1,10 @@
+export function isSafeExternalHttpUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  return parsed.protocol === "https:" || parsed.protocol === "http:";
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -131,8 +131,25 @@ if (!gotTheLock) {
       optimizer.watchWindowShortcuts(window);
     });
 
-    // IPC: open URL in default browser (used by renderer for Google login)
+    // IPC: open URL in default browser (used by renderer for Google login).
+    // Restrict to http/https so the renderer can't dispatch arbitrary OS
+    // protocol handlers (file://, smb://, ms-msdt:, vscode://, ...) which
+    // become a concern under this app's intentional webSecurity: false +
+    // sandbox: false configuration.
     ipcMain.handle("shell:openExternal", (_event, url: string) => {
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        console.warn("[security] blocked openExternal: invalid URL");
+        return;
+      }
+      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+        console.warn(
+          `[security] blocked openExternal: scheme=${parsed.protocol}`,
+        );
+        return;
+      }
       return shell.openExternal(url);
     });
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 import fixPath from "fix-path";
 import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
+import { isSafeExternalHttpUrl } from "./external-url";
 
 // macOS/Linux GUI launches inherit a minimal PATH from launchd that omits
 // the user's shell config (~/.zshrc, Homebrew, nvm, ~/.local/bin, etc.).
@@ -83,6 +84,10 @@ function createWindow(): void {
   });
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
+    if (!isSafeExternalHttpUrl(details.url)) {
+      console.warn("[security] blocked window.open external URL");
+      return { action: "deny" };
+    }
     shell.openExternal(details.url);
     return { action: "deny" };
   });
@@ -137,17 +142,8 @@ if (!gotTheLock) {
     // become a concern under this app's intentional webSecurity: false +
     // sandbox: false configuration.
     ipcMain.handle("shell:openExternal", (_event, url: string) => {
-      let parsed: URL;
-      try {
-        parsed = new URL(url);
-      } catch {
-        console.warn("[security] blocked openExternal: invalid URL");
-        return;
-      }
-      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-        console.warn(
-          `[security] blocked openExternal: scheme=${parsed.protocol}`,
-        );
+      if (!isSafeExternalHttpUrl(url)) {
+        console.warn("[security] blocked openExternal: invalid external URL");
         return;
       }
       return shell.openExternal(url);


### PR DESCRIPTION
## What does this PR do?

The `shell:openExternal` IPC handler passed any renderer-supplied URL to `shell.openExternal` without validating the scheme. Under this app's intentional `webSecurity: false` + `sandbox: false` configuration (#648), this lets any unsafe content reaching the renderer dispatch arbitrary OS protocol handlers (`file://`, `smb://`, Windows `ms-msdt:`, etc.).

This adds a scheme allowlist (http/https only), matching the Electron security checklist guidance.

## Related Issue

Closes #1115

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`apps/desktop/src/main/index.ts`**: Parse the URL and reject anything outside `https:` / `http:` with a console warning.

## How to Test

1. In desktop app devtools: `window.electron.ipcRenderer.invoke("shell:openExternal", "https://multica.ai")` → opens normally.
2. `window.electron.ipcRenderer.invoke("shell:openExternal", "file:///etc/passwd")` → blocked, warning in console.
3. Google login OAuth redirect flow still works (uses `https:` URLs).

## Checklist

- [x] I have considered and documented any risks above

## AI Disclosure

**AI tool used:** Claude Code
**Prompt / approach:** Reviewed desktop app main process against Electron security checklist; identified unvalidated openExternal as the primary IPC concern given the existing webSecurity/sandbox configuration.