### PR TITLE
fix(email): HTML-escape workspace/inviter names in invitation email

### DIFF
--- a/server/internal/service/email.go
+++ b/server/internal/service/email.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"html"
 	"os"
 	"strings"
 
@@ -68,10 +69,13 @@ func (s *EmailService) SendInvitationEmail(to, inviterName, workspaceName, invit
 		return nil
 	}
 
+	safeWorkspace := html.EscapeString(workspaceName)
+	safeInviter := html.EscapeString(inviterName)
+
 	params := &resend.SendEmailRequest{
 		From:    s.fromEmail,
 		To:      []string{to},
-		Subject: fmt.Sprintf("%s invited you to %s on Multica", inviterName, workspaceName),
+		Subject: fmt.Sprintf("%s invited you to %s on Multica", safeInviter, safeWorkspace),
 		Html: fmt.Sprintf(
 			`<div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
 				<h2>You're invited to join %s</h2>
@@ -80,7 +84,7 @@ func (s *EmailService) SendInvitationEmail(to, inviterName, workspaceName, invit
 					<a href="%s" style="display: inline-block; padding: 12px 24px; background: #000; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 500;">Accept invitation</a>
 				</p>
 				<p style="color: #666; font-size: 14px;">You'll need to log in to accept or decline the invitation.</p>
-			</div>`, workspaceName, inviterName, workspaceName, inviteURL),
+			</div>`, safeWorkspace, safeInviter, safeWorkspace, inviteURL),
 	}
 
 	_, err := s.client.Emails.Send(params)

--- a/server/internal/service/email.go
+++ b/server/internal/service/email.go
@@ -75,7 +75,7 @@ func (s *EmailService) SendInvitationEmail(to, inviterName, workspaceName, invit
 	params := &resend.SendEmailRequest{
 		From:    s.fromEmail,
 		To:      []string{to},
-		Subject: fmt.Sprintf("%s invited you to %s on Multica", safeInviter, safeWorkspace),
+		Subject: fmt.Sprintf("%s invited you to %s on Multica", inviterName, workspaceName),
 		Html: fmt.Sprintf(
 			`<div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
 				<h2>You're invited to join %s</h2>


### PR DESCRIPTION
## What does this PR do?

`SendInvitationEmail` interpolated `workspaceName` and `inviterName` into the HTML body via `fmt.Sprintf` without escaping. A workspace owner who sets a name containing HTML tags can break the email structure and inject attacker-controlled links that appear as part of the official Multica invitation.

Wraps both values with `html.EscapeString` before interpolation.

## Related Issue

Closes #1117

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`server/internal/service/email.go`**: Add `"html"` import; escape `workspaceName` and `inviterName` before use in both Subject and Html fields.

## How to Test

1. Create a workspace named `Acme</h2><script>alert(1)</script>`.
2. Invite an external email address.
3. Verify the received email shows the name as literal text, not parsed HTML.
4. Verify normal workspace names render correctly.

## Checklist

- [x] I have run tests locally and they pass

## AI Disclosure

**AI tool used:** Claude Code
**Prompt / approach:** Traced user-controlled values into fmt.Sprintf HTML template; confirmed no html.EscapeString call in the path.