### PR TITLE
fix(autopilot): stop echoing raw err.Error() in TriggerAutopilot response

### DIFF
--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -676,7 +677,8 @@ func (h *Handler) TriggerAutopilot(w http.ResponseWriter, r *http.Request) {
 
 	run, err := h.AutopilotService.DispatchAutopilot(r.Context(), autopilot, pgtype.UUID{}, "manual", nil)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to trigger autopilot: "+err.Error())
+		slog.Warn("failed to trigger autopilot", "autopilot_id", id, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to trigger autopilot")
 		return
 	}
 


### PR DESCRIPTION
## What does this PR do?

`TriggerAutopilot` was the only handler in `autopilot.go` that appended `err.Error()` to the user-visible HTTP response. Downstream errors from `DispatchAutopilot` can contain pgx details, constraint names, and task-service internals. Every other handler in the file returns a fixed string and keeps the cause server-side.

Log the error with `slog.Warn` for operator visibility and return a fixed message to the caller.

## Related Issue

Closes #1118

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`server/internal/handler/autopilot.go`**: Add `"log/slog"` import; replace `"failed to trigger autopilot: "+err.Error()` with `slog.Warn(...)` + fixed response string.

## How to Test

1. Trigger a condition where `DispatchAutopilot` fails (e.g. archived agent assigned to autopilot).
2. Call `POST /api/autopilots/{id}/trigger`.
3. Before: response body contains raw Go error. After: response says `"failed to trigger autopilot"`, detail is in server logs only.

## Checklist

- [x] I have run tests locally and they pass

## AI Disclosure

**AI tool used:** Claude Code
**Prompt / approach:** Compared error-handling patterns across all handlers in autopilot.go; this was the only one leaking err.Error().