### PR TITLE
fix(editor): add dirty check and allow clearing description

### DIFF
--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -112,6 +112,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     const onBlurRef = useRef(onBlur);
     const onUploadFileRef = useRef(onUploadFile);
     const prevContentRef = useRef(defaultValue);
+    const lastEmittedRef = useRef<string | null>(null);
 
     // Keep refs in sync without recreating editor
     onUpdateRef.current = onUpdate;
@@ -127,6 +128,9 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       // Explicit for clarity — the real perf win is useEditorState in BubbleMenu.
       shouldRerenderOnTransaction: false,
       editable,
+      onCreate: ({ editor: ed }) => {
+        lastEmittedRef.current = stripBlobUrls(ed.getMarkdown());
+      },
       content: defaultValue ? preprocessMarkdown(defaultValue) : "",
       contentType: defaultValue ? "markdown" : undefined,
       extensions: createEditorExtensions({
@@ -141,7 +145,10 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         if (!onUpdateRef.current) return;
         if (debounceRef.current) clearTimeout(debounceRef.current);
         debounceRef.current = setTimeout(() => {
-          onUpdateRef.current?.(stripBlobUrls(ed.getMarkdown()));
+          const md = stripBlobUrls(ed.getMarkdown());
+          if (md === lastEmittedRef.current) return;
+          lastEmittedRef.current = md;
+          onUpdateRef.current?.(md);
         }, debounceMs);
       },
       onBlur: () => {

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useRef, useState, useImperativeHandle } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, TimelineEntry } from "@multica/core/types";
 import { WorkspaceIdProvider } from "@multica/core/hooks";
@@ -473,5 +473,23 @@ describe("IssueDetail (shared)", () => {
     });
 
     expect(screen.getByText("I can help with this")).toBeInTheDocument();
+  });
+
+  it("sends empty description when editor is cleared", async () => {
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Add JWT auth to the backend")).toBeInTheDocument();
+    });
+
+    const editor = screen.getByPlaceholderText("Add description...");
+    fireEvent.change(editor, { target: { value: "" } });
+
+    await waitFor(() => {
+      expect(mockApiObj.updateIssue).toHaveBeenCalledWith(
+        "issue-1",
+        expect.objectContaining({ description: "" }),
+      );
+    });
   });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1032,7 +1032,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
               key={id}
               defaultValue={issue.description || ""}
               placeholder="Add description..."
-              onUpdate={(md) => handleUpdateField({ description: md || undefined })}
+              onUpdate={(md) => handleUpdateField({ description: md })}
               onUploadFile={handleDescriptionUpload}
               debounceMs={1500}
             />


### PR DESCRIPTION
## Summary

- **Dirty check**: Added `onCreate` baseline capture + `getMarkdown()` comparison in debounced `onUpdate` — mutations only fire when content actually changes, preventing phantom saves on focus/normalization
- **Empty description**: Changed `md || undefined` to `md` so clearing all text sends `description: ""` to the API instead of omitting the field entirely

## Details

See `docs/plans/2026-04-16-editor-save-fixes.md` for full design analysis including alternatives considered and composability verification.

## Test plan

- [x] New test: verifies `updateIssue` is called with `description: ""` when editor cleared
- [x] `pnpm typecheck` passes (6/6)
- [x] `pnpm test` passes (98/98)
- [ ] Manual: open issue with description → focus editor without editing → verify no network request
- [ ] Manual: clear description entirely → reload → verify description is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)