### PR TITLE
feat: add date filter to issues list

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -39,8 +39,12 @@ export const CARD_PROPERTY_OPTIONS: { key: keyof CardProperties; label: string }
   { key: "dueDate", label: "Due date" },
 ];
 
+/** Date filter value: "today" = current date, "all" = no date filter, or ISO date string (e.g. "2026-04-16") */
+export type DateFilterValue = "today" | "all" | string;
+
 export interface IssueViewState {
   viewMode: ViewMode;
+  dateFilter: DateFilterValue;
   statusFilters: IssueStatus[];
   priorityFilters: IssuePriority[];
   assigneeFilters: ActorFilterValue[];
@@ -53,6 +57,7 @@ export interface IssueViewState {
   cardProperties: CardProperties;
   listCollapsedStatuses: IssueStatus[];
   setViewMode: (mode: ViewMode) => void;
+  setDateFilter: (value: DateFilterValue) => void;
   toggleStatusFilter: (status: IssueStatus) => void;
   togglePriorityFilter: (priority: IssuePriority) => void;
   toggleAssigneeFilter: (value: ActorFilterValue) => void;
@@ -71,6 +76,7 @@ export interface IssueViewState {
 
 export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): IssueViewState => ({
   viewMode: "board",
+  dateFilter: "today",
   statusFilters: [],
   priorityFilters: [],
   assigneeFilters: [],
@@ -89,6 +95,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
   listCollapsedStatuses: [],
 
   setViewMode: (mode) => set({ viewMode: mode }),
+  setDateFilter: (value) => set({ dateFilter: value }),
   toggleStatusFilter: (status) =>
     set((state) => ({
       statusFilters: state.statusFilters.includes(status)
@@ -155,6 +162,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
     }),
   clearFilters: () =>
     set({
+      dateFilter: "today",
       statusFilters: [],
       priorityFilters: [],
       assigneeFilters: [],
@@ -185,6 +193,7 @@ export const viewStorePersistOptions = (name: string) => ({
   storage: createJSONStorage(() => createWorkspaceAwareStorage(defaultStorage)),
   partialize: (state: IssueViewState) => ({
     viewMode: state.viewMode,
+    dateFilter: state.dateFilter,
     statusFilters: state.statusFilters,
     priorityFilters: state.priorityFilters,
     assigneeFilters: state.assigneeFilters,

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import {
   ArrowDown,
   ArrowUp,
+  CalendarDays,
   Check,
   ChevronDown,
   CircleDot,
@@ -38,6 +39,7 @@ import {
   PopoverContent,
 } from "@multica/ui/components/ui/popover";
 import { Switch } from "@multica/ui/components/ui/switch";
+import { Calendar } from "@multica/ui/components/ui/calendar";
 import {
   ALL_STATUSES,
   STATUS_CONFIG,
@@ -54,6 +56,7 @@ import {
   SORT_OPTIONS,
   CARD_PROPERTY_OPTIONS,
   type ActorFilterValue,
+  type DateFilterValue,
 } from "@multica/core/issues/stores/view-store";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
 import {
@@ -86,6 +89,7 @@ function HoverCheck({ checked }: { checked: boolean }) {
 // ---------------------------------------------------------------------------
 
 function getActiveFilterCount(state: {
+  dateFilter: DateFilterValue;
   statusFilters: string[];
   priorityFilters: string[];
   assigneeFilters: ActorFilterValue[];
@@ -95,6 +99,7 @@ function getActiveFilterCount(state: {
   includeNoProject: boolean;
 }) {
   let count = 0;
+  if (state.dateFilter !== "today") count++;
   if (state.statusFilters.length > 0) count++;
   if (state.priorityFilters.length > 0) count++;
   if (state.assigneeFilters.length > 0 || state.includeNoAssignee) count++;
@@ -377,6 +382,21 @@ function ProjectSubContent({
 }
 
 // ---------------------------------------------------------------------------
+// Date filter label helper
+// ---------------------------------------------------------------------------
+
+function formatDateLabel(value: DateFilterValue): string {
+  if (value === "today") return "Today";
+  if (value === "all") return "All";
+  // Format ISO date string nicely
+  const d = new Date(value + "T00:00:00");
+  const now = new Date();
+  const isToday = value === `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  if (isToday) return "Today";
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+// ---------------------------------------------------------------------------
 // IssuesHeader
 // ---------------------------------------------------------------------------
 
@@ -385,6 +405,7 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
   const setScope = useIssuesScopeStore((s) => s.setScope);
 
   const viewMode = useViewStore((s) => s.viewMode);
+  const dateFilter = useViewStore((s) => s.dateFilter);
   const statusFilters = useViewStore((s) => s.statusFilters);
   const priorityFilters = useViewStore((s) => s.priorityFilters);
   const assigneeFilters = useViewStore((s) => s.assigneeFilters);
@@ -401,6 +422,7 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
 
   const hasActiveFilters =
     getActiveFilterCount({
+      dateFilter,
       statusFilters,
       priorityFilters,
       assigneeFilters,
@@ -415,7 +437,7 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
 
   return (
     <div className="flex h-12 shrink-0 items-center justify-between px-4">
-      {/* Left: scope buttons */}
+      {/* Left: scope buttons + date filter */}
       <div className="flex items-center gap-1">
         {SCOPES.map((s) => (
           <Tooltip key={s.value}>
@@ -438,6 +460,91 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
             <TooltipContent side="bottom">{s.description}</TooltipContent>
           </Tooltip>
         ))}
+
+        <div className="mx-1.5 h-4 w-px bg-border" />
+
+        {/* Date filter */}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="outline"
+                size="sm"
+                className={
+                  dateFilter === "today"
+                    ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                    : "text-muted-foreground"
+                }
+                onClick={() => act.setDateFilter("today")}
+              >
+                Today
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom">Show today&apos;s issues</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="outline"
+                size="sm"
+                className={
+                  dateFilter === "all"
+                    ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                    : "text-muted-foreground"
+                }
+                onClick={() => act.setDateFilter("all")}
+              >
+                All
+              </Button>
+            }
+          />
+          <TooltipContent side="bottom">Show all issues</TooltipContent>
+        </Tooltip>
+        <Popover>
+          <Tooltip>
+            <PopoverTrigger
+              render={
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className={
+                        dateFilter !== "today" && dateFilter !== "all"
+                          ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                          : "text-muted-foreground"
+                      }
+                    >
+                      <CalendarDays className="size-3.5 mr-1" />
+                      {dateFilter !== "today" && dateFilter !== "all"
+                        ? formatDateLabel(dateFilter)
+                        : "Pick date"}
+                    </Button>
+                  }
+                />
+              }
+            />
+            <TooltipContent side="bottom">Pick a specific date</TooltipContent>
+          </Tooltip>
+          <PopoverContent align="start" className="w-auto p-0">
+            <Calendar
+              mode="single"
+              selected={
+                dateFilter !== "today" && dateFilter !== "all"
+                  ? new Date(dateFilter + "T00:00:00")
+                  : undefined
+              }
+              onSelect={(day) => {
+                if (day) {
+                  const iso = `${day.getFullYear()}-${String(day.getMonth() + 1).padStart(2, "0")}-${String(day.getDate()).padStart(2, "0")}`;
+                  act.setDateFilter(iso);
+                }
+              }}
+            />
+          </PopoverContent>
+        </Popover>
       </div>
 
       {/* Right: filter + display + view toggle */}

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -30,6 +30,7 @@ export function IssuesPage() {
   const workspace = useWorkspaceStore((s) => s.workspace);
   const scope = useIssuesScopeStore((s) => s.scope);
   const viewMode = useIssueViewStore((s) => s.viewMode);
+  const dateFilter = useIssueViewStore((s) => s.dateFilter);
   const statusFilters = useIssueViewStore((s) => s.statusFilters);
   const priorityFilters = useIssueViewStore((s) => s.priorityFilters);
   const assigneeFilters = useIssueViewStore((s) => s.assigneeFilters);
@@ -56,8 +57,8 @@ export function IssuesPage() {
   }, [allIssues, scope]);
 
   const issues = useMemo(
-    () => filterIssues(scopedIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject }),
-    [scopedIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject],
+    () => filterIssues(scopedIssues, { dateFilter, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject }),
+    [scopedIssues, dateFilter, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject],
   );
 
   // Fetch sub-issue progress from the backend so counts are accurate

--- a/packages/views/issues/utils/filter.test.ts
+++ b/packages/views/issues/utils/filter.test.ts
@@ -3,6 +3,7 @@ import type { Issue } from "@multica/core/types";
 import { filterIssues, type IssueFilters } from "./filter";
 
 const NO_FILTER: IssueFilters = {
+  dateFilter: "all",
   statusFilters: [],
   priorityFilters: [],
   assigneeFilters: [],

--- a/packages/views/issues/utils/filter.ts
+++ b/packages/views/issues/utils/filter.ts
@@ -1,7 +1,8 @@
 import type { Issue, IssueStatus, IssuePriority } from "@multica/core/types";
-import type { ActorFilterValue } from "@multica/core/issues/stores/view-store";
+import type { ActorFilterValue, DateFilterValue } from "@multica/core/issues/stores/view-store";
 
 export interface IssueFilters {
+  dateFilter: DateFilterValue;
   statusFilters: IssueStatus[];
   priorityFilters: IssuePriority[];
   assigneeFilters: ActorFilterValue[];
@@ -9,6 +10,18 @@ export interface IssueFilters {
   creatorFilters: ActorFilterValue[];
   projectFilters: string[];
   includeNoProject: boolean;
+}
+
+/**
+ * Resolve a DateFilterValue to a date string (YYYY-MM-DD) or null (= no filter).
+ */
+function resolveDateFilter(value: DateFilterValue): string | null {
+  if (value === "all") return null;
+  if (value === "today") {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  }
+  return value; // specific ISO date string
 }
 
 /**
@@ -21,11 +34,17 @@ export interface IssueFilters {
  * - When both → show matching assignees + unassigned
  */
 export function filterIssues(issues: Issue[], filters: IssueFilters): Issue[] {
-  const { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject } = filters;
+  const { dateFilter, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject } = filters;
   const hasAssigneeFilter = assigneeFilters.length > 0 || includeNoAssignee;
   const hasProjectFilter = projectFilters.length > 0 || includeNoProject;
+  const dateStr = resolveDateFilter(dateFilter);
 
   return issues.filter((issue) => {
+    // Date filter: compare against created_at date portion
+    if (dateStr && issue.created_at) {
+      const issueDate = issue.created_at.slice(0, 10); // "YYYY-MM-DD"
+      if (issueDate !== dateStr) return false;
+    }
     if (statusFilters.length > 0 && !statusFilters.includes(issue.status))
       return false;
 

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -78,6 +78,7 @@ export function MyIssuesPage() {
   const issues = useMemo(
     () =>
       filterIssues(myIssues, {
+        dateFilter: "all",
         statusFilters,
         priorityFilters,
         assigneeFilters: [],

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -104,7 +104,7 @@ function ProjectIssuesContent({ projectIssues }: { projectIssues: Issue[] }) {
   const creatorFilters = useViewStore((s) => s.creatorFilters);
 
   const issues = useMemo(
-    () => filterIssues(projectIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters: [], includeNoProject: false }),
+    () => filterIssues(projectIssues, { dateFilter: "all", statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters: [], includeNoProject: false }),
     [projectIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters],
   );
   const doneColumnCount = useMemo(


### PR DESCRIPTION
## Summary

Add a date filter control (Today / All / date picker) to the issues header bar, enabling users to quickly narrow down issues by creation date.

## Changes

- **View store** (`view-store.ts`): Add `dateFilter` state (`DateFilterValue` type: `"today" | "all" | string`), `setDateFilter` action, persist to storage, reset on `clearFilters()`
- **Filter logic** (`filter.ts`): Add `dateFilter` to `IssueFilters` interface, `resolveDateFilter()` helper, date comparison in `filterIssues()`
- **Issues header** (`issues-header.tsx`): Today/All toggle buttons + Calendar date picker popover, active filter count includes date filter
- **Issues page** (`issues-page.tsx`): Wire `dateFilter` from store to `filterIssues`
- **My Issues page** (`my-issues-page.tsx`): Same wiring with `dateFilter: "all"` default
- **Project detail** (`project-detail.tsx`): Same wiring with `dateFilter: "all"` default
- **Tests** (`filter.test.ts`): Updated `NO_FILTER` constant

## Behavior

- Default: **Today** — shows only issues created today
- **All**: no date filter, shows everything
- **Date picker**: filter by any specific date
- State persisted per workspace via Zustand + localStorage