### PR TITLE
fix(inbox): read workspace ID from request context

### DIFF
--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -90,7 +90,7 @@ func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	workspaceID := r.Header.Get("X-Workspace-ID")
+	workspaceID := ctxWorkspaceID(r.Context())
 
 	items, err := h.Queries.ListInboxItems(r.Context(), db.ListInboxItemsParams{
 		WorkspaceID:   parseUUID(workspaceID),
@@ -170,7 +170,7 @@ func (h *Handler) CountUnreadInbox(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	workspaceID := r.Header.Get("X-Workspace-ID")
+	workspaceID := ctxWorkspaceID(r.Context())
 
 	count, err := h.Queries.CountUnreadInbox(r.Context(), db.CountUnreadInboxParams{
 		WorkspaceID:   parseUUID(workspaceID),
@@ -190,7 +190,7 @@ func (h *Handler) MarkAllInboxRead(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	workspaceID := r.Header.Get("X-Workspace-ID")
+	workspaceID := ctxWorkspaceID(r.Context())
 
 	count, err := h.Queries.MarkAllInboxRead(r.Context(), db.MarkAllInboxReadParams{
 		WorkspaceID: parseUUID(workspaceID),
@@ -215,7 +215,7 @@ func (h *Handler) ArchiveAllInbox(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	workspaceID := r.Header.Get("X-Workspace-ID")
+	workspaceID := ctxWorkspaceID(r.Context())
 
 	count, err := h.Queries.ArchiveAllInbox(r.Context(), db.ArchiveAllInboxParams{
 		WorkspaceID: parseUUID(workspaceID),
@@ -240,7 +240,7 @@ func (h *Handler) ArchiveAllReadInbox(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	workspaceID := r.Header.Get("X-Workspace-ID")
+	workspaceID := ctxWorkspaceID(r.Context())
 
 	count, err := h.Queries.ArchiveAllReadInbox(r.Context(), db.ArchiveAllReadInboxParams{
 		WorkspaceID: parseUUID(workspaceID),
@@ -265,7 +265,7 @@ func (h *Handler) ArchiveCompletedInbox(w http.ResponseWriter, r *http.Request) 
 	if !ok {
 		return
 	}
-	workspaceID := r.Header.Get("X-Workspace-ID")
+	workspaceID := ctxWorkspaceID(r.Context())
 
 	count, err := h.Queries.ArchiveCompletedInbox(r.Context(), db.ArchiveCompletedInboxParams{
 		WorkspaceID: parseUUID(workspaceID),


### PR DESCRIPTION
## Summary

After #1138 (slug-first workspace URL refactor), the frontend sends `X-Workspace-Slug` only. The `RequireWorkspaceMember` middleware resolves it to a UUID and stores the value in the request context.

Six inbox handlers still called `r.Header.Get("X-Workspace-ID")` directly, which is now always empty. Every query ran with `workspace_id = NULL`, so the inbox list returned zero rows and all batch mutations silently updated zero rows.

This is the last handler file that was not already on `ctxWorkspaceID` / `resolveWorkspaceID` — grep across `server/internal/handler/` confirms no other handler reads the header directly.

## Changes

`server/internal/handler/inbox.go` — replace six `r.Header.Get("X-Workspace-ID")` calls with `ctxWorkspaceID(r.Context())`:

- `ListInbox`
- `CountUnreadInbox`
- `MarkAllInboxRead`
- `ArchiveAllInbox`
- `ArchiveAllReadInbox`
- `ArchiveCompletedInbox`

The two per-item handlers (`MarkInboxRead`, `ArchiveInboxItem`) do not need workspace ID — they look up by inbox item ID and fetch the workspace from the returned row.

No frontend changes required.

## Test plan

- [x] `go build ./...` passes
- [x] `make test` passes (handler / middleware / realtime / cli packages)
- [ ] Manually verify Inbox loads notifications after restart
- [ ] Manually verify "Mark all read" / "Archive all" / "Archive all read" / "Archive completed" affect the correct workspace
- [ ] Manually verify sidebar unread count is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)