### PR TITLE
fix(desktop): reserve traffic-light space and surface trigger when sidebar is hidden

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-layout.tsx
@@ -6,6 +6,7 @@ import { useActiveTitleSync } from "@/hooks/use-tab-sync";
 import { useTabStore, resolveRouteIcon } from "@/stores/tab-store";
 import {
   SidebarProvider,
+  SidebarTrigger,
   useSidebar,
 } from "@multica/ui/components/ui/sidebar";
 import { ModalRegistry } from "@multica/views/modals/registry";
@@ -54,17 +55,28 @@ function SidebarTopBar() {
 }
 
 // The main area's top bar doubles as a window drag region. When the sidebar
-// is collapsed, we pad the left side so tabs don't land under the macOS
-// traffic lights (which live at roughly x=16..68 and always hit-test above HTML).
+// is not occupying main-flow width — either user-collapsed (offcanvas) or
+// auto-hidden in mobile mode (<768px, becomes a sheet drawer) — we pad the
+// left side so tabs don't land under the macOS traffic lights (which live at
+// roughly x=16..68 and always hit-test above HTML), and surface a trigger so
+// the sidebar can be brought back without keyboard shortcut.
 function MainTopBar() {
-  const { state } = useSidebar();
-  const sidebarCollapsed = state === "collapsed";
+  const { state, isMobile } = useSidebar();
+  const sidebarHidden = state === "collapsed" || isMobile;
 
   return (
     <header
-      className={cn("h-12 shrink-0", sidebarCollapsed && "pl-20")}
+      className={cn(
+        "h-12 shrink-0 flex items-center gap-2",
+        sidebarHidden && "pl-20",
+      )}
       style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
     >
+      {sidebarHidden && (
+        <SidebarTrigger
+          style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+        />
+      )}
       <TabBar />
     </header>
   );


### PR DESCRIPTION
## Summary

- Top bar's `pl-20` padding (which keeps tabs clear of macOS traffic lights) only triggered on `state === "collapsed"`. The shadcn sidebar also hides itself in **mobile mode** (`<768px` viewport) where `state` stays `"expanded"` and only `isMobile` flips — so dragging the window narrow caused tabs to slide under the traffic lights.
- In that same scenario there was no way to reopen the sidebar from the UI: the only trigger lives inside the sidebar itself, which goes off-canvas with it. Users had to know `Cmd+B`.
- Fix: treat collapsed-or-mobile as "sidebar not in main flow" → apply the padding, and render a `SidebarTrigger` in the header (with `WebkitAppRegion: no-drag` so the window drag region doesn't eat the click).

## Test plan

- [ ] Desktop: with sidebar expanded, top bar looks unchanged (no padding, no trigger button)
- [ ] Desktop: click sidebar collapse → tabs shift right past traffic lights, trigger appears in header, clicking it re-expands sidebar
- [ ] Desktop: drag window narrower than 768px → sidebar auto-hides, tabs no longer overlap traffic lights, trigger appears, clicking it opens the sheet drawer
- [ ] Desktop: trigger button is clickable (not blocked by window drag region)

🤖 Generated with [Claude Code](https://claude.com/claude-code)