### PR TITLE
fix(agents): make issue tasks easier to open from agent details

### DIFF
--- a/packages/views/agents/components/tabs/tasks-tab.tsx
+++ b/packages/views/agents/components/tabs/tasks-tab.tsx
@@ -8,6 +8,7 @@ import { api } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { issueListOptions } from "@multica/core/issues/queries";
 import { useQuery } from "@tanstack/react-query";
+import { AppLink } from "../../../navigation";
 import { taskStatusConfig } from "../../config";
 
 export function TasksTab({ agent }: { agent: Agent }) {
@@ -102,9 +103,12 @@ export function TasksTab({ agent }: { agent: Agent }) {
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     {issue && (
-                      <span className="shrink-0 text-xs font-mono text-muted-foreground">
+                      <AppLink
+                        href={`/issues/${issue.id}`}
+                        className="shrink-0 text-xs font-mono text-muted-foreground hover:text-foreground hover:underline"
+                      >
                         {issue.identifier}
-                      </span>
+                      </AppLink>
                     )}
                     <span className={`text-sm truncate ${isActive ? "font-medium" : ""}`}>
                       {issue?.title ?? `Issue ${task.issue_id.slice(0, 8)}...`}

--- a/packages/views/agents/components/tabs/tasks-tab.tsx
+++ b/packages/views/agents/components/tabs/tasks-tab.tsx
@@ -83,18 +83,16 @@ export function TasksTab({ agent }: { agent: Agent }) {
             const issue = issueMap.get(task.issue_id);
             const isActive = task.status === "running" || task.status === "dispatched";
             const isRunning = task.status === "running";
+            const rowClassName = `flex items-center gap-3 rounded-lg border px-4 py-3 transition-shadow hover:shadow-sm ${
+              isRunning
+                ? "border-success/40 bg-success/5"
+                : task.status === "dispatched"
+                  ? "border-info/40 bg-info/5"
+                  : ""
+            }`;
 
-            return (
-              <div
-                key={task.id}
-                className={`flex items-center gap-3 rounded-lg border px-4 py-3 ${
-                  isRunning
-                    ? "border-success/40 bg-success/5"
-                    : task.status === "dispatched"
-                      ? "border-info/40 bg-info/5"
-                      : ""
-                }`}
-              >
+            const content = (
+              <>
                 <Icon
                   className={`h-4 w-4 shrink-0 ${config.color} ${
                     isRunning ? "animate-spin" : ""
@@ -103,18 +101,15 @@ export function TasksTab({ agent }: { agent: Agent }) {
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     {issue && (
-                      <AppLink
-                        href={`/issues/${issue.id}`}
-                        className="shrink-0 text-xs font-mono text-muted-foreground hover:text-foreground hover:underline"
-                      >
+                      <span className="shrink-0 text-xs font-mono text-muted-foreground">
                         {issue.identifier}
-                      </AppLink>
+                      </span>
                     )}
                     <span className={`text-sm truncate ${isActive ? "font-medium" : ""}`}>
                       {issue?.title ?? `Issue ${task.issue_id.slice(0, 8)}...`}
                     </span>
                   </div>
-                  <div className="text-xs text-muted-foreground mt-0.5">
+                  <div className="mt-0.5 text-xs text-muted-foreground">
                     {isRunning && task.started_at
                       ? `Started ${new Date(task.started_at).toLocaleString()}`
                       : task.status === "dispatched" && task.dispatched_at
@@ -129,6 +124,24 @@ export function TasksTab({ agent }: { agent: Agent }) {
                 <span className={`shrink-0 text-xs font-medium ${config.color}`}>
                   {config.label}
                 </span>
+              </>
+            );
+
+            if (issue) {
+              return (
+                <AppLink
+                  key={task.id}
+                  href={`/issues/${issue.id}`}
+                  className={`${rowClassName} text-foreground no-underline hover:no-underline`}
+                >
+                  {content}
+                </AppLink>
+              );
+            }
+
+            return (
+              <div key={task.id} className={rowClassName}>
+                {content}
               </div>
             );
           })}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the agent Tasks tab so assigned issues are easier to open from the agent detail panel.

Previously, the Tasks tab showed the issue identifier and title, but getting to the actual issue required switching back to the Issues page and searching manually. This change makes the task row navigate directly to the related issue detail page when issue data is available.

This approach keeps the change low risk by reusing the existing cross-platform `AppLink` navigation pattern and preserving the current layout as much as possible. The only visual adjustment is a subtle hover shadow to make the interactive area easier to discover.

### Thinking path

From the project context, the Agents page is used to understand what an agent is currently working on. The friction here was not missing data, but the lack of a direct navigation path from a task entry to the underlying issue. The lowest-risk fix was to make the existing task row the navigation target instead of introducing new UI, new state, or deeper structural changes.

## Related Issue



## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/agents/components/tabs/tasks-tab.tsx`: make task rows link to `/issues/{issue.id}` when the related issue is available
- `packages/views/agents/components/tabs/tasks-tab.tsx`: keep the existing task row layout and text hierarchy with minimal visual change
- `packages/views/agents/components/tabs/tasks-tab.tsx`: add a subtle hover shadow so the clickable area is more discoverable
- `packages/views/agents/components/tabs/tasks-tab.tsx`: keep rows without resolved issue data as non-links to avoid invalid navigation

## How to Test

1. Open the Agents page.
2. Select an agent that already has one or more tasks and open the `Tasks` tab.
3. Hover a task row and confirm a subtle shadow appears.
4. Click the task row and confirm it navigates to the correct issue detail page.
5. Verify the task row still looks consistent with the existing panel UI.

## Risks

- This changes the clickable target from a small identifier link to the full task row when issue data is present.
- Rows without resolved issue data remain non-clickable by design, so behavior is slightly different between resolved and unresolved task entries.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** OpenAI Codex

**Prompt / approach:**
I used AI to implement issue #1129 by making the agent task entry navigate to the related issue while keeping the UI change as small as possible. I iterated on the interaction model from identifier-only linking to a full-row click target, then reduced the styling changes to preserve the original look and only keep a subtle hover shadow.

## Screenshots (optional)
### Before
<img width="1500" height="519" alt="image" src="https://github.com/user-attachments/assets/817778ce-3786-4771-8e30-2fdbf4b7e02d" />

### After
<img width="2286" height="349" alt="image" src="https://github.com/user-attachments/assets/af06a7ee-129d-434c-985d-3f30b3affa7e" />

