### PR TITLE
fix(execenv): reuse codex CODEX_HOME across tasks on same issue

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -160,7 +160,7 @@ Each issue — not each task — owns a persistent workspace directory under `MU
 
 - **workdir** (`{root}/{task-short-id}/workdir`) is created on the first task and reused by subsequent tasks on the same `(agent, issue)` pair via `PriorWorkDir`. Repo checkouts and local edits survive across comments.
 - **Session** (Claude) is resumed via `PriorSessionID`, so the conversation context carries forward.
-- **`CODEX_HOME`** (Codex) lives at `{root}/{task-short-id}/codex-home` and is **reused as-is across tasks on the same issue**. The daemon does not re-run the seeding step on reuse — Codex's rollouts, per-session cache, and any user edits to `config.toml` are preserved. A fresh `CODEX_HOME` is only created when a brand-new issue starts or the prior workdir no longer exists.
+- **`CODEX_HOME`** (Codex) lives at `{root}/{task-short-id}/codex-home` alongside the workdir and is **reused across tasks on the same issue**. The daemon re-runs its seeding step on every reuse, but the step is idempotent: broken `auth.json` / `sessions` symlinks and a missing `config.toml` are repaired, while existing content — user edits to `config.toml`, Codex's rollouts, and the per-session cache — is left untouched. A fresh `CODEX_HOME` is created only when a brand-new issue starts.
 
 ### Configuration
 

--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -154,6 +154,14 @@ You need at least one installed. The daemon registers each detected CLI as an av
 4. Heartbeats are sent periodically (default: 15s) so the server knows the daemon is alive
 5. On shutdown, all runtimes are deregistered
 
+### Task Isolation
+
+Each issue — not each task — owns a persistent workspace directory under `MULTICA_WORKSPACES_ROOT`.
+
+- **workdir** (`{root}/{task-short-id}/workdir`) is created on the first task and reused by subsequent tasks on the same `(agent, issue)` pair via `PriorWorkDir`. Repo checkouts and local edits survive across comments.
+- **Session** (Claude) is resumed via `PriorSessionID`, so the conversation context carries forward.
+- **`CODEX_HOME`** (Codex) lives at `{root}/{task-short-id}/codex-home` and is **reused as-is across tasks on the same issue**. The daemon does not re-run the seeding step on reuse — Codex's rollouts, per-session cache, and any user edits to `config.toml` are preserved. A fresh `CODEX_HOME` is only created when a brand-new issue starts or the prior workdir no longer exists.
+
 ### Configuration
 
 Daemon behavior is configured via flags or environment variables:

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -143,13 +143,18 @@ func Reuse(workDir, provider string, task TaskContextForEnv, logger *slog.Logger
 		logger.Warn("execenv: refresh context files failed", "error", err)
 	}
 
-	// Restore CodexHome for Codex provider — the per-task codex-home directory
-	// lives alongside the workdir. Re-run prepareCodexHome to ensure config
-	// (especially network access) is up to date.
+	// Restore CodexHome for Codex provider — the codex-home directory lives
+	// alongside the workdir and is reused as-is across tasks on the same issue.
+	// Re-running prepareCodexHome here would churn Codex's accumulated state
+	// (rollouts, per-session cache) and make users feel the sandbox is being
+	// re-initialized on every new comment. If the directory is missing (older
+	// env, manual cleanup) we seed it fresh.
 	if provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, "codex-home")
-		if err := prepareCodexHome(codexHome, logger); err != nil {
-			logger.Warn("execenv: refresh codex-home failed", "error", err)
+		if _, err := os.Stat(codexHome); err == nil {
+			env.CodexHome = codexHome
+		} else if err := prepareCodexHome(codexHome, logger); err != nil {
+			logger.Warn("execenv: prepare codex-home on reuse failed", "error", err)
 		} else {
 			env.CodexHome = codexHome
 		}

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -144,17 +144,19 @@ func Reuse(workDir, provider string, task TaskContextForEnv, logger *slog.Logger
 	}
 
 	// Restore CodexHome for Codex provider — the codex-home directory lives
-	// alongside the workdir and is reused as-is across tasks on the same issue.
-	// Re-running prepareCodexHome here would churn Codex's accumulated state
-	// (rollouts, per-session cache) and make users feel the sandbox is being
-	// re-initialized on every new comment. If the directory is missing (older
-	// env, manual cleanup) we seed it fresh.
+	// alongside the workdir and is reused across tasks on the same issue.
+	// prepareCodexHome is deliberately idempotent: it only (re)creates broken
+	// or missing symlinks (auth.json, sessions), copies config files when the
+	// destination is absent, and leaves existing content — including user
+	// edits to config.toml and Codex's accumulated rollouts / per-session
+	// cache — untouched. Running it on every reuse therefore gives us a cheap
+	// self-heal path when something in the env has been corrupted, without
+	// churning the state that makes the per-issue reuse useful in the first
+	// place.
 	if provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, "codex-home")
-		if _, err := os.Stat(codexHome); err == nil {
-			env.CodexHome = codexHome
-		} else if err := prepareCodexHome(codexHome, logger); err != nil {
-			logger.Warn("execenv: prepare codex-home on reuse failed", "error", err)
+		if err := prepareCodexHome(codexHome, logger); err != nil {
+			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome
 		}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -932,6 +932,114 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 	}
 }
 
+func TestReusePreservesCodexHomeContents(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	workspacesRoot := t.TempDir()
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-codex-preserve",
+		TaskID:         "f6a7b8c9-d0e1-2345-fabc-678901234567",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "preserve-test"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	// Simulate Codex-internal state accumulated during the first task
+	// (e.g. rollouts, per-session cache that should survive into the next task).
+	sentinel := filepath.Join(env.CodexHome, "rollouts", "session.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sentinel), 0o755); err != nil {
+		t.Fatalf("mkdir sentinel dir: %v", err)
+	}
+	if err := os.WriteFile(sentinel, []byte("session-1-data"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	// Also modify config.toml — a user-supplied edit must survive reuse.
+	configPath := filepath.Join(env.CodexHome, "config.toml")
+	configBefore, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	customConfig := string(configBefore) + "\nmodel_reasoning_effort = \"high\"\n"
+	if err := os.WriteFile(configPath, []byte(customConfig), 0o644); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+
+	reused := Reuse(env.WorkDir, "codex", TaskContextForEnv{IssueID: "preserve-test"}, testLogger())
+	if reused == nil {
+		t.Fatal("Reuse returned nil")
+	}
+	if reused.CodexHome != env.CodexHome {
+		t.Errorf("CodexHome = %q, want %q", reused.CodexHome, env.CodexHome)
+	}
+
+	// Sentinel state from the previous task must still exist untouched.
+	data, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("sentinel gone after Reuse: %v", err)
+	}
+	if string(data) != "session-1-data" {
+		t.Errorf("sentinel content = %q, want %q", data, "session-1-data")
+	}
+
+	// User edits to config.toml must survive reuse (no re-prepare overwrite).
+	configAfter, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml after reuse: %v", err)
+	}
+	if string(configAfter) != customConfig {
+		t.Errorf("config.toml was modified by Reuse; got:\n%s", configAfter)
+	}
+}
+
+func TestReuseSeedsCodexHomeIfMissing(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	workspacesRoot := t.TempDir()
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-codex-missing",
+		TaskID:         "a7b8c9d0-e1f2-3456-abcd-789012345678",
+		AgentName:      "Codex Agent",
+		Provider:       "codex",
+		Task:           TaskContextForEnv{IssueID: "missing-test"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	// Simulate the codex-home being wiped (e.g. manual cleanup or older env
+	// that predates codex-home). Reuse should re-seed it cleanly.
+	if err := os.RemoveAll(env.CodexHome); err != nil {
+		t.Fatalf("remove codex-home: %v", err)
+	}
+
+	reused := Reuse(env.WorkDir, "codex", TaskContextForEnv{IssueID: "missing-test"}, testLogger())
+	if reused == nil {
+		t.Fatal("Reuse returned nil")
+	}
+	if reused.CodexHome == "" {
+		t.Fatal("expected CodexHome to be re-seeded")
+	}
+	if _, err := os.Stat(filepath.Join(reused.CodexHome, "config.toml")); err != nil {
+		t.Errorf("expected config.toml in re-seeded codex-home: %v", err)
+	}
+}
+
 func TestEnsureSymlinkRepairsBrokenLink(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -932,10 +932,15 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 	}
 }
 
-func TestReusePreservesCodexHomeContents(t *testing.T) {
+// TestReuseIsIdempotentForCodexHome locks in the contract that Reuse() does
+// not churn Codex state that accumulates across tasks on the same issue —
+// user-level edits to config.toml, rollouts, per-session cache — even though
+// prepareCodexHome runs on every reuse for self-healing.
+func TestReuseIsIdempotentForCodexHome(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	os.WriteFile(filepath.Join(sharedHome, "auth.json"), []byte(`{"token":"v1"}`), 0o644)
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	workspacesRoot := t.TempDir()
@@ -954,7 +959,7 @@ func TestReusePreservesCodexHomeContents(t *testing.T) {
 	defer env.Cleanup(true)
 
 	// Simulate Codex-internal state accumulated during the first task
-	// (e.g. rollouts, per-session cache that should survive into the next task).
+	// (rollouts / per-session cache) and a user edit to config.toml.
 	sentinel := filepath.Join(env.CodexHome, "rollouts", "session.jsonl")
 	if err := os.MkdirAll(filepath.Dir(sentinel), 0o755); err != nil {
 		t.Fatalf("mkdir sentinel dir: %v", err)
@@ -962,8 +967,6 @@ func TestReusePreservesCodexHomeContents(t *testing.T) {
 	if err := os.WriteFile(sentinel, []byte("session-1-data"), 0o644); err != nil {
 		t.Fatalf("write sentinel: %v", err)
 	}
-
-	// Also modify config.toml — a user-supplied edit must survive reuse.
 	configPath := filepath.Join(env.CodexHome, "config.toml")
 	configBefore, err := os.ReadFile(configPath)
 	if err != nil {
@@ -982,7 +985,6 @@ func TestReusePreservesCodexHomeContents(t *testing.T) {
 		t.Errorf("CodexHome = %q, want %q", reused.CodexHome, env.CodexHome)
 	}
 
-	// Sentinel state from the previous task must still exist untouched.
 	data, err := os.ReadFile(sentinel)
 	if err != nil {
 		t.Fatalf("sentinel gone after Reuse: %v", err)
@@ -991,7 +993,6 @@ func TestReusePreservesCodexHomeContents(t *testing.T) {
 		t.Errorf("sentinel content = %q, want %q", data, "session-1-data")
 	}
 
-	// User edits to config.toml must survive reuse (no re-prepare overwrite).
 	configAfter, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read config.toml after reuse: %v", err)
@@ -1001,42 +1002,91 @@ func TestReusePreservesCodexHomeContents(t *testing.T) {
 	}
 }
 
-func TestReuseSeedsCodexHomeIfMissing(t *testing.T) {
+// TestReuseHealsCorruptedCodexHome guards the self-heal contract: if an
+// existing codex-home is partially corrupt (missing sessions symlink, broken
+// auth.json link, missing config.toml) the next task claim must repair it
+// instead of silently failing.
+func TestReuseHealsCorruptedCodexHome(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 
 	sharedHome := t.TempDir()
+	os.WriteFile(filepath.Join(sharedHome, "auth.json"), []byte(`{"token":"secret"}`), 0o644)
 	t.Setenv("CODEX_HOME", sharedHome)
 
 	workspacesRoot := t.TempDir()
 
 	env, err := Prepare(PrepareParams{
 		WorkspacesRoot: workspacesRoot,
-		WorkspaceID:    "ws-codex-missing",
+		WorkspaceID:    "ws-codex-heal",
 		TaskID:         "a7b8c9d0-e1f2-3456-abcd-789012345678",
 		AgentName:      "Codex Agent",
 		Provider:       "codex",
-		Task:           TaskContextForEnv{IssueID: "missing-test"},
+		Task:           TaskContextForEnv{IssueID: "heal-test"},
 	}, testLogger())
 	if err != nil {
 		t.Fatalf("Prepare failed: %v", err)
 	}
 	defer env.Cleanup(true)
 
-	// Simulate the codex-home being wiped (e.g. manual cleanup or older env
-	// that predates codex-home). Reuse should re-seed it cleanly.
-	if err := os.RemoveAll(env.CodexHome); err != nil {
-		t.Fatalf("remove codex-home: %v", err)
+	// Simulate partial corruption of the persisted codex-home:
+	// - sessions symlink removed
+	// - auth.json repointed at a non-existent path (broken link)
+	// - config.toml deleted
+	sessionsPath := filepath.Join(env.CodexHome, "sessions")
+	if err := os.Remove(sessionsPath); err != nil {
+		t.Fatalf("remove sessions: %v", err)
+	}
+	authPath := filepath.Join(env.CodexHome, "auth.json")
+	if err := os.Remove(authPath); err != nil {
+		t.Fatalf("remove auth.json: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(sharedHome, "missing.json"), authPath); err != nil {
+		t.Fatalf("write broken auth.json symlink: %v", err)
+	}
+	configPath := filepath.Join(env.CodexHome, "config.toml")
+	if err := os.Remove(configPath); err != nil {
+		t.Fatalf("remove config.toml: %v", err)
 	}
 
-	reused := Reuse(env.WorkDir, "codex", TaskContextForEnv{IssueID: "missing-test"}, testLogger())
+	reused := Reuse(env.WorkDir, "codex", TaskContextForEnv{IssueID: "heal-test"}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
-	if reused.CodexHome == "" {
-		t.Fatal("expected CodexHome to be re-seeded")
+	if reused.CodexHome != env.CodexHome {
+		t.Errorf("CodexHome = %q, want %q", reused.CodexHome, env.CodexHome)
 	}
-	if _, err := os.Stat(filepath.Join(reused.CodexHome, "config.toml")); err != nil {
-		t.Errorf("expected config.toml in re-seeded codex-home: %v", err)
+
+	// sessions should be re-linked to the shared dir.
+	fi, err := os.Lstat(sessionsPath)
+	if err != nil {
+		t.Fatalf("sessions not restored: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error("sessions should be a symlink after heal")
+	}
+	if target, _ := os.Readlink(sessionsPath); target != filepath.Join(sharedHome, "sessions") {
+		t.Errorf("sessions target = %q, want %q", target, filepath.Join(sharedHome, "sessions"))
+	}
+
+	// auth.json should point at the real shared auth.json again.
+	if target, _ := os.Readlink(authPath); target != filepath.Join(sharedHome, "auth.json") {
+		t.Errorf("auth.json target = %q, want %q", target, filepath.Join(sharedHome, "auth.json"))
+	}
+	data, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("auth.json unreadable after heal: %v", err)
+	}
+	if string(data) != `{"token":"secret"}` {
+		t.Errorf("auth.json content = %q", data)
+	}
+
+	// config.toml should be recreated with network access enabled.
+	data, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config.toml not restored: %v", err)
+	}
+	if !strings.Contains(string(data), "network_access = true") {
+		t.Errorf("restored config.toml missing network_access = true; got:\n%s", data)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stop re-running `prepareCodexHome` inside `Reuse()` when the per-issue `codex-home` directory already exists. Reuse is now inert and preserves Codex's rollouts, per-session cache, and any user edits to `config.toml`.
- Still seed cleanly when the directory is missing (older envs or manual cleanup).
- Document task isolation boundaries — workdir, Claude session, and CODEX_HOME lifecycle — in `CLI_AND_DAEMON.md`.

Fixes the pain point from GitHub [#1136](https://github.com/multica-ai/multica/issues/1136) and Multica [MUL-913](mention://issue/f5fb74da-dce3-473d-9a68-14b6360eac21): a new comment on the same issue made Codex feel like it was re-initializing the sandbox every time, because `Reuse()` was re-seeding `CODEX_HOME` on each claim.

## Test plan

- [x] `go test ./server/internal/daemon/execenv/...`
- [x] New `TestReusePreservesCodexHomeContents` asserts sentinel files and config edits survive a `Reuse()`.
- [x] New `TestReuseSeedsCodexHomeIfMissing` asserts fallback seeding still works when `codex-home` is absent.
- [ ] Smoke test against a real Codex runtime on the same issue across two consecutive comments.