### PR TITLE
fix(desktop): allow dev and production instances to coexist

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -94,6 +94,18 @@ function createWindow(): void {
   }
 }
 
+// --- Dev / production isolation -------------------------------------------
+// Give dev mode a separate app name and userData path so it gets its own
+// single-instance lock file and doesn't conflict with the packaged production
+// app. Must run BEFORE requestSingleInstanceLock() because the lock location
+// is derived from the userData path. (Same approach VS Code uses for
+// Stable / Insiders coexistence.)
+
+if (is.dev) {
+  app.setName("Multica Dev");
+  app.setPath("userData", join(app.getPath("appData"), "Multica Dev"));
+}
+
 // --- Protocol registration -----------------------------------------------
 
 if (process.defaultApp) {
@@ -125,7 +137,9 @@ if (!gotTheLock) {
   });
 
   app.whenReady().then(() => {
-    electronApp.setAppUserModelId("ai.multica.desktop");
+    electronApp.setAppUserModelId(
+      is.dev ? "ai.multica.desktop.dev" : "ai.multica.desktop",
+    );
 
     app.on("browser-window-created", (_, window) => {
       optimizer.watchWindowShortcuts(window);


### PR DESCRIPTION
## Problem

`pnpm dev:desktop` fails to start when the production Multica desktop app is already running — the dev instance immediately quits because `requestSingleInstanceLock()` returns `false` (both share the same lock identity).

## Solution

Before calling `requestSingleInstanceLock()`, give dev mode a separate identity:

- **App name**: `Multica Dev` (→ separate userData at `~/Library/Application Support/Multica Dev/`)
- **AppUserModelId**: `ai.multica.desktop.dev` (Windows taskbar isolation)

This means dev and production each get their own lock file and can run simultaneously, while **single-instance lock still works within each mode** (you can't accidentally open two dev windows).

This follows the same pattern [VS Code uses for Stable / Insiders coexistence](https://github.com/microsoft/vscode/issues/97626).