### PR TITLE
fix(agent): surface codex turn errors instead of reporting empty output

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -200,9 +200,15 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		// Wait for turn completion or context cancellation
 		select {
 		case aborted := <-turnDone:
-			if aborted {
+			switch {
+			case aborted:
 				finalStatus = "aborted"
 				finalError = "turn was aborted"
+			default:
+				if errMsg := c.getTurnError(); errMsg != "" {
+					finalStatus = "failed"
+					finalError = errMsg
+				}
 			}
 		case <-runCtx.Done():
 			if runCtx.Err() == context.DeadlineExceeded {
@@ -287,6 +293,26 @@ type codexClient struct {
 
 	usageMu sync.Mutex
 	usage   TokenUsage // accumulated from turn events
+
+	turnErrorMu sync.Mutex
+	turnError   string // captured from turn/completed status=failed or terminal error notifications
+}
+
+func (c *codexClient) setTurnError(msg string) {
+	if msg == "" {
+		return
+	}
+	c.turnErrorMu.Lock()
+	defer c.turnErrorMu.Unlock()
+	if c.turnError == "" {
+		c.turnError = msg
+	}
+}
+
+func (c *codexClient) getTurnError() string {
+	c.turnErrorMu.Lock()
+	defer c.turnErrorMu.Unlock()
+	return c.turnError
 }
 
 type pendingRPC struct {
@@ -567,6 +593,16 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 		aborted := status == "cancelled" || status == "canceled" ||
 			status == "aborted" || status == "interrupted"
 
+		// Capture the error message from failed turns so callers can surface
+		// a real reason instead of falling back to "empty output".
+		if status == "failed" {
+			errMsg := extractNestedString(params, "turn", "error", "message")
+			if errMsg == "" {
+				errMsg = "codex turn failed"
+			}
+			c.setTurnError(errMsg)
+		}
+
 		if c.completedTurnIDs == nil {
 			c.completedTurnIDs = map[string]bool{}
 		}
@@ -584,6 +620,22 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 
 		if c.onTurnDone != nil {
 			c.onTurnDone(aborted)
+		}
+
+	case "error":
+		// Top-level protocol error. Retrying notifications (willRetry=true) are
+		// transient reconnect attempts; only capture terminal errors so we
+		// don't stomp on a real failure later with a retry placeholder.
+		willRetry, _ := params["willRetry"].(bool)
+		errMsg := extractNestedString(params, "error", "message")
+		if errMsg == "" {
+			errMsg = extractNestedString(params, "message")
+		}
+		if errMsg != "" {
+			c.cfg.Logger.Warn("codex error notification", "message", errMsg, "will_retry", willRetry)
+			if !willRetry {
+				c.setTurnError(errMsg)
+			}
 		}
 
 	case "thread/status/changed":

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -349,6 +349,80 @@ func TestCodexRawTurnCompletedAborted(t *testing.T) {
 	}
 }
 
+func TestCodexRawTurnCompletedFailedCapturesError(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+
+	var wasAborted bool
+	c.onTurnDone = func(aborted bool) {
+		wasAborted = aborted
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"turn":{"id":"turn-f","status":"failed","error":{"message":"unexpected status 401 Unauthorized"}}}}`)
+
+	if wasAborted {
+		t.Fatal("failed is distinct from aborted")
+	}
+	if got := c.getTurnError(); got != "unexpected status 401 Unauthorized" {
+		t.Fatalf("expected error captured from turn.error.message, got %q", got)
+	}
+}
+
+func TestCodexRawTurnCompletedFailedWithoutMessageFallsBack(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	c.onTurnDone = func(aborted bool) {}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"turn":{"id":"turn-f","status":"failed"}}}`)
+
+	if got := c.getTurnError(); got != "codex turn failed" {
+		t.Fatalf("expected fallback message, got %q", got)
+	}
+}
+
+func TestCodexRawErrorNotificationTerminal(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"error","params":{"error":{"message":"boom"},"willRetry":false}}`)
+
+	if got := c.getTurnError(); got != "boom" {
+		t.Fatalf("expected terminal error captured, got %q", got)
+	}
+}
+
+func TestCodexRawErrorNotificationRetryingIgnored(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"error","params":{"error":{"message":"reconnecting"},"willRetry":true}}`)
+
+	if got := c.getTurnError(); got != "" {
+		t.Fatalf("retrying error should not be captured, got %q", got)
+	}
+}
+
+func TestCodexSetTurnErrorFirstWins(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+
+	c.setTurnError("first")
+	c.setTurnError("second")
+
+	if got := c.getTurnError(); got != "first" {
+		t.Fatalf("expected first-wins semantics, got %q", got)
+	}
+}
+
 func TestCodexRawItemCommandExecution(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

When codex's `turn/completed` notification carries `status=\"failed\"` with a `turn.error.message`, or codex emits a terminal top-level `error` notification, the daemon currently ignores both and reports the generic `codex returned empty output`, swallowing the real cause (auth failure, sandbox denial, API error, etc.).

This PR teaches the codex backend to capture those error messages on `codexClient` and propagate them through `Result.Error` with `finalStatus=\"failed\"`, so the daemon's default branch surfaces the real reason.

Context: https://github.com/multica-ai/multica/issues/1130 — a user reported a silent `codex returned empty output` and no obvious way to debug it. Reproduced locally with codex `0.118.0` against multica's JSON-RPC sequence (intentionally bad auth): codex emits
```json
{\"method\":\"turn/completed\",\"params\":{\"turn\":{\"status\":\"failed\",
  \"error\":{\"message\":\"unexpected status 401 Unauthorized …\"}}}}
```
but the daemon still logs `status=completed … codex returned empty output`. That matches the reporter's log shape exactly.

### Changes

- `server/pkg/agent/codex.go`:
  - `codexClient` gains a mutex-guarded `turnError` field + `setTurnError` / `getTurnError` helpers (first-wins semantics, so a later retry placeholder can't stomp a real error).
  - `handleRawNotification`:
    - `turn/completed` with `status==\"failed\"`: extract `turn.error.message` (fallback: `\"codex turn failed\"`) into `turnError`. Still signals `onTurnDone(aborted=false)` — failed is distinct from aborted/cancelled.
    - New `case \"error\":` — log every error notification at WARN, and only capture into `turnError` when `willRetry=false` so transient reconnect notifications don't pollute the real failure.
  - Lifecycle goroutine now consults `getTurnError()` after `<-turnDone`; if non-empty (and we didn't already mark aborted/timeout/cancel), sets `finalStatus=\"failed\"` / `finalError=<msg>`. The daemon's default branch then reports the real error instead of the empty-output fallback.

### What this doesn't change

- The legacy `codex/event` protocol path (`handleEvent`) is unchanged — the reported issue and the reproduction are both on the raw v2 protocol, and the legacy path doesn't currently ship error info.
- The `\"%s returned empty output\"` message in daemon.go stays as a last-resort fallback for the (unlikely) case where codex genuinely reports `status=completed` with empty items and no error.

## Test plan

- [x] `go test ./server/pkg/agent/... -run TestCodex -count=1` — passes, incl. new cases:
  - `TestCodexRawTurnCompletedFailedCapturesError`
  - `TestCodexRawTurnCompletedFailedWithoutMessageFallsBack`
  - `TestCodexRawErrorNotificationTerminal`
  - `TestCodexRawErrorNotificationRetryingIgnored`
  - `TestCodexSetTurnErrorFirstWins`
- [x] `go test ./server/pkg/agent/... ./server/internal/daemon/... -count=1` — full agent + daemon suites green
- [x] `go build ./...`, `go vet ./server/pkg/agent/... ./server/internal/daemon/...` — clean
- [ ] Manual repro: re-run the failing codex task from #1130 with this change — daemon log should now contain the real codex error instead of `codex returned empty output`.