### PR TITLE
fix(auth): retain stored token on non-401 errors in initialize

### DIFF
--- a/packages/core/auth/store.test.ts
+++ b/packages/core/auth/store.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "../api/client";
+import { ApiError } from "../api/client";
+import type { StorageAdapter, User } from "../types";
+import { createAuthStore } from "./store";
+
+const fakeUser: User = {
+  id: "u1",
+  name: "Alice",
+  email: "alice@example.com",
+  avatar_url: null,
+} as User;
+
+function makeStorage(initial: Record<string, string> = {}): StorageAdapter & {
+  snapshot: () => Record<string, string>;
+} {
+  const data = { ...initial };
+  return {
+    getItem: (k) => data[k] ?? null,
+    setItem: (k, v) => {
+      data[k] = v;
+    },
+    removeItem: (k) => {
+      delete data[k];
+    },
+    snapshot: () => ({ ...data }),
+  };
+}
+
+function makeApi(getMe: () => Promise<User>): ApiClient {
+  return {
+    setToken: vi.fn(),
+    getMe,
+    // Only the methods touched by store.initialize are needed. Cast to
+    // ApiClient for type compatibility — the store treats it opaquely.
+  } as unknown as ApiClient;
+}
+
+describe("authStore.initialize — token mode", () => {
+  it("keeps the stored token when getMe fails with a non-401 ApiError (e.g. 500)", async () => {
+    const storage = makeStorage({ multica_token: "t" });
+    const api = makeApi(() =>
+      Promise.reject(new ApiError("server error", 500, "Internal Server Error")),
+    );
+    const store = createAuthStore({ api, storage });
+
+    await store.getState().initialize();
+
+    expect(store.getState().user).toBeNull();
+    expect(store.getState().isLoading).toBe(false);
+    expect(storage.snapshot().multica_token).toBe("t");
+  });
+
+  it("keeps the stored token on a network failure (non-ApiError throw)", async () => {
+    const storage = makeStorage({ multica_token: "t" });
+    const api = makeApi(() => Promise.reject(new TypeError("fetch failed")));
+    const store = createAuthStore({ api, storage });
+
+    await store.getState().initialize();
+
+    expect(store.getState().user).toBeNull();
+    expect(storage.snapshot().multica_token).toBe("t");
+  });
+
+  it("on 401, leaves storage cleanup to ApiClient.onUnauthorized and resets state", async () => {
+    // Simulate the real path: ApiClient fires onUnauthorized on 401, which
+    // removes the token from storage. The store's catch block must not
+    // duplicate or short-circuit this — it should only reset in-memory
+    // auth state.
+    const storage = makeStorage({ multica_token: "t" });
+    const api = makeApi(() => {
+      storage.removeItem("multica_token"); // stand-in for onUnauthorized
+      return Promise.reject(new ApiError("unauthorized", 401, "Unauthorized"));
+    });
+    const store = createAuthStore({ api, storage });
+
+    await store.getState().initialize();
+
+    expect(store.getState().user).toBeNull();
+    expect(storage.snapshot().multica_token).toBeUndefined();
+  });
+
+  it("populates user when getMe succeeds", async () => {
+    const storage = makeStorage({ multica_token: "t" });
+    const api = makeApi(() => Promise.resolve(fakeUser));
+    const store = createAuthStore({ api, storage });
+
+    await store.getState().initialize();
+
+    expect(store.getState().user).toEqual(fakeUser);
+    expect(storage.snapshot().multica_token).toBe("t");
+  });
+});

--- a/packages/core/auth/store.ts
+++ b/packages/core/auth/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import type { User, StorageAdapter } from "../types";
-import type { ApiClient } from "../api/client";
+import { ApiError, type ApiClient } from "../api/client";
 import { setCurrentWorkspace } from "../platform/workspace-storage";
 
 export interface AuthStoreOptions {
@@ -57,10 +57,17 @@ export function createAuthStore(options: AuthStoreOptions) {
       try {
         const user = await api.getMe();
         set({ user, isLoading: false });
-      } catch {
-        api.setToken(null);
-        setCurrentWorkspace(null, null);
-        storage.removeItem("multica_token");
+      } catch (err) {
+        // Only clear the stored token on a genuine auth failure (401). For
+        // transient errors — network blips, backend rolling restarts, 5xx,
+        // aborted fetches — keep the token so the next initialize() (next
+        // page load or focus-refresh) can retry. The 401 path's token
+        // cleanup is handled upstream by ApiClient.handleUnauthorized via
+        // the onUnauthorized callback; we only need to reset the in-memory
+        // user + workspace state here.
+        if (err instanceof ApiError && err.status === 401) {
+          setCurrentWorkspace(null, null);
+        }
         set({ user: null, isLoading: false });
       }
     },


### PR DESCRIPTION
## Summary

`AuthStore.initialize()` treated any error from `api.getMe()` as an auth failure and cleared the stored token — including non-auth errors like network blips, backend rolling restarts, 5xx responses, or fetch aborts. This forced spurious re-logins. Now only a real 401 clears workspace context; every other error leaves the token in place so the next `initialize()` (next page load / focus-refresh) can retry.

## Why

Symptom observed in local dev: switching git branches triggers a wave of Vite HMR reloads. If `/api/me` is in flight during the reload or hits a transient error, the old catch block nukes the token and kicks the user back to login. Same class of bug hits production too, just rarer — any backend rolling restart or flaky network briefly makes `getMe` fail, and the old code would force a logout instead of letting the user retry.

## Change

`packages/core/auth/store.ts`:
- Narrow the catch to check `err instanceof ApiError && err.status === 401` before clearing workspace state.
- Do not remove the stored token or reset the in-memory api token on non-401 errors — the 401 path is already handled upstream by `ApiClient.handleUnauthorized` → `options.onUnauthorized` (wired in `core-provider.tsx` to call `storage.removeItem(\"multica_token\")`).
- Always reset in-memory `user: null, isLoading: false`.

Adds `packages/core/auth/store.test.ts` covering the 401, 500, network-failure, and happy paths.

## Production impact

Low risk, net positive:

- **Token valid, backend up** → unchanged (success path).
- **Token expired / invalid** → backend 401 → upstream `onUnauthorized` clears token → UI shows logged-out. Same behavior as before.
- **Backend temporarily down / 5xx** → *before:* forced logout. *after:* `user: null, isLoading: false`, token retained; next refresh succeeds and the user is back in.
- **Network blip / aborted fetch** → same as above, no more spurious logouts.
- **Cookie-auth mode (web)** → untouched; that branch already avoided clearing anything on error.

One edge case: if the backend is buggy and returns 500 for a token that \*should\* be rejected, the token now lingers. The user's experience is the same (every subsequent call fails), but they're not forced to re-login. Acceptable — the backend is the broken party.

## Test plan

- [x] `pnpm --filter @multica/core test` — 9 files, 28 tests pass (includes 4 new tests in `auth/store.test.ts`)
- [x] `pnpm typecheck` — passes
- [ ] Manual: log in on desktop, switch branches to cause HMR reload, verify session persists