### PR TITLE
fix(desktop): hardcode Windows & Linux artifact names to avoid scoped-package slash

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -33,11 +33,17 @@ linux:
   target:
     - AppImage
     - deb
-  artifactName: ${name}-${version}-${arch}.${ext}
+  # Hardcoded name — same rationale as mac: avoids the `@multica/desktop-*`
+  # subdirectory that `${name}` produces for scoped package names.
+  artifactName: multica-desktop-${version}-${arch}.${ext}
 win:
   target:
     - nsis
-  artifactName: ${name}-${version}-setup.${ext}
+  # Hardcoded name — `${name}` resolves to `@multica/desktop` which contains
+  # a slash, producing invalid filenames on Windows.
+  artifactName: multica-desktop-${version}-setup.${ext}
+nsis:
+  artifactName: multica-desktop-${version}-setup.${ext}
 publish:
   provider: github
   owner: multica-ai


### PR DESCRIPTION
## Problem

The package name `@multica/desktop` contains a slash. When electron-builder interpolates `${name}` in `artifactName`, it produces invalid filenames on Windows (e.g. `@multica/desktop-0.1.0-setup.exe`).

The `mac` and `dmg` sections already hardcode `multica-desktop-*` to work around this, but `win` and `linux` still used `${name}`.

## Changes

- **`win.artifactName`**: `multica-desktop-${version}-setup.${ext}`
- **`linux.artifactName`**: `multica-desktop-${version}-${arch}.${ext}`
- Added explicit **`nsis.artifactName`** for consistency with the win config

Part of MUL-938 (Windows Desktop release support).