### PR TITLE
fix(daemon): filter thread/status/changed by threadId to prevent subagent interference

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -677,8 +677,12 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 		}
 
 	case "thread/status/changed":
+		threadID, _ := params["threadId"].(string)
 		statusType := extractNestedString(params, "status", "type")
-		if statusType == "idle" && c.turnStarted {
+		// Only react to status changes from the tracked thread; ignore
+		// subagent threads (e.g. memory consolidation) whose idle signal
+		// would otherwise prematurely terminate the main turn.
+		if statusType == "idle" && c.turnStarted && (threadID == "" || threadID == c.threadID) {
 			if c.onTurnDone != nil {
 				c.onTurnDone(false)
 			}


### PR DESCRIPTION
## Summary

- Filter `thread/status/changed` notifications by `threadId` in the codex backend so only status changes from the **tracked thread** trigger turn completion
- Prevents memory consolidation subagent (or any other subagent thread) from prematurely terminating the main turn

## Problem

When Codex CLI has `memories = true` (default in recent versions), `codex app-server` spawns a memory consolidation subagent as a separate thread within the same stdio connection. When that subagent thread finishes and transitions to `idle`, the daemon mistakenly interprets the idle signal as the main turn completing — closing stdin and cancelling the context before the real turn produces any output → `"codex returned empty output"`.

Root cause: `handleRawNotification` for `thread/status/changed` did not check which thread the idle signal belonged to.

Fixes #1181

## Test plan

- [x] Verified on Windows 11 with codex-cli 0.121.0 and `memories = true`
- [x] Before fix: every codex task fails with `codex returned empty output` (5s duration, 0 tools)
- [x] After fix: codex tasks complete normally with output and tool calls
- [ ] Confirm no regression when `memories = false`
- [ ] Confirm no regression on Linux/macOS daemons