### PR TITLE
feat(sweeper): make dispatch timeout configurable via env var

### DIFF
--- a/server/cmd/server/runtime_sweeper.go
+++ b/server/cmd/server/runtime_sweeper.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"log/slog"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -21,14 +23,27 @@ const (
 	// offlineRuntimeTTLSeconds deletes offline runtimes with no active agents
 	// after this duration. 7 days gives users plenty of time to restart daemons.
 	offlineRuntimeTTLSeconds = 7 * 24 * 3600.0
-	// dispatchTimeoutSeconds fails tasks stuck in 'dispatched' beyond this.
-	// The dispatched→running transition should be near-instant, so 5 minutes
-	// means something went wrong (e.g. StartTask API call failed silently).
-	dispatchTimeoutSeconds = 300.0
 	// runningTimeoutSeconds fails tasks stuck in 'running' beyond this.
 	// The default agent timeout is 2h, so 2.5h gives a generous buffer.
 	runningTimeoutSeconds = 9000.0
 )
+
+// dispatchTimeoutSeconds is read from MULTICA_DISPATCH_TIMEOUT_SECS at startup
+// (default 300s). Fails tasks stuck in 'dispatched' beyond this — the
+// dispatched→running transition should be near-instant so 5 minutes means
+// something went wrong (e.g. StartTask API call failed silently).
+var dispatchTimeoutSeconds = getEnvFloat("MULTICA_DISPATCH_TIMEOUT_SECS", 300.0)
+
+// getEnvFloat reads a float64 from an environment variable, returning
+// defaultVal if the variable is unset, empty, or not a valid positive number.
+func getEnvFloat(key string, defaultVal float64) float64 {
+	if s := os.Getenv(key); s != "" {
+		if v, err := strconv.ParseFloat(s, 64); err == nil && v > 0 {
+			return v
+		}
+	}
+	return defaultVal
+}
 
 // runRuntimeSweeper periodically marks runtimes as offline if their
 // last_seen_at exceeds the stale threshold, and fails orphaned tasks.

--- a/server/cmd/server/runtime_sweeper_test.go
+++ b/server/cmd/server/runtime_sweeper_test.go
@@ -485,3 +485,31 @@ func unhex(c byte) byte {
 	}
 	return 0
 }
+
+func TestGetEnvFloat_UsesDefault(t *testing.T) {
+	t.Setenv("MULTICA_TEST_FLOAT_UNSET", "")
+	if got := getEnvFloat("MULTICA_TEST_FLOAT_UNSET", 300.0); got != 300.0 {
+		t.Fatalf("expected default 300.0, got %f", got)
+	}
+}
+
+func TestGetEnvFloat_ReadsEnvVar(t *testing.T) {
+	t.Setenv("MULTICA_TEST_FLOAT_SET", "60.5")
+	if got := getEnvFloat("MULTICA_TEST_FLOAT_SET", 300.0); got != 60.5 {
+		t.Fatalf("expected 60.5, got %f", got)
+	}
+}
+
+func TestGetEnvFloat_RejectsInvalidValue(t *testing.T) {
+	t.Setenv("MULTICA_TEST_FLOAT_INVALID", "not-a-number")
+	if got := getEnvFloat("MULTICA_TEST_FLOAT_INVALID", 300.0); got != 300.0 {
+		t.Fatalf("expected default 300.0 for invalid value, got %f", got)
+	}
+}
+
+func TestGetEnvFloat_RejectsNonPositive(t *testing.T) {
+	t.Setenv("MULTICA_TEST_FLOAT_ZERO", "0")
+	if got := getEnvFloat("MULTICA_TEST_FLOAT_ZERO", 300.0); got != 300.0 {
+		t.Fatalf("expected default 300.0 for zero value, got %f", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Converts `dispatchTimeoutSeconds` from a compile-time constant to a package-level `var` backed by `getEnvFloat`
- Reads `MULTICA_DISPATCH_TIMEOUT_SECS` from the environment at startup (default 300s)
- Adds `getEnvFloat` helper: returns the default value if the env var is unset, empty, unparseable, or non-positive
- Adds 4 unit tests for `getEnvFloat` covering all fallback paths

## Motivation

The dispatch timeout was previously hardcoded at 300s (5 min). Operators running high-latency runtimes or needing to debug dispatched-task state needed a recompile to change it. The env var lets them tune it at deploy time.

## Test plan

- [ ] `TestGetEnvFloat_UsesDefault` — unset env var returns default
- [ ] `TestGetEnvFloat_ReadsEnvVar` — valid positive float is used
- [ ] `TestGetEnvFloat_RejectsInvalidValue` — non-numeric string falls back to default
- [ ] `TestGetEnvFloat_RejectsNonPositive` — zero or negative value falls back to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)