### PR TITLE
fix(daemon): inject NO_PROXY for server host and fix mergeEnv override precedence

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1011,6 +1012,21 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	// without polluting the system ~/.codex/skills/.
 	if env.CodexHome != "" {
 		agentEnv["CODEX_HOME"] = env.CodexHome
+	}
+	// Ensure the multica CLI bypasses any local HTTP proxy (e.g. Clash, Charles)
+	// when calling the Multica API. Agents inherit the host's HTTPS_PROXY setting
+	// which is often a localhost proxy; inside sandboxed runtimes (Codex) that
+	// blocks localhost, causing every multica CLI call to fail. We inject NO_PROXY
+	// covering the server hostname so the CLI always connects directly.
+	if u, err := url.Parse(d.cfg.ServerBaseURL); err == nil && u.Hostname() != "" {
+		noProxy := u.Hostname()
+		if existing := os.Getenv("NO_PROXY"); existing != "" {
+			noProxy = existing + "," + noProxy
+		} else if existing := os.Getenv("no_proxy"); existing != "" {
+			noProxy = existing + "," + noProxy
+		}
+		agentEnv["NO_PROXY"] = noProxy
+		agentEnv["no_proxy"] = noProxy
 	}
 	// Inject user-configured custom environment variables (e.g. ANTHROPIC_API_KEY,
 	// ANTHROPIC_BASE_URL for router/proxy mode, or CLAUDE_CODE_USE_BEDROCK for

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -420,6 +420,10 @@ func mergeEnv(base []string, extra map[string]string) []string {
 		if isFilteredChildEnvKey(key) {
 			continue
 		}
+		// Skip keys that are explicitly set in extra — extra takes precedence.
+		if _, overridden := extra[key]; overridden {
+			continue
+		}
 		env = append(env, entry)
 	}
 	for k, v := range extra {


### PR DESCRIPTION
## Problem

Two related bugs that together caused **all `multica` CLI calls to silently fail** inside agent sandboxes (Codex) on machines with a local HTTP proxy (e.g. Clash, Charles — common on Chinese networks):

### Bug 1: `mergeEnv` didn't let `extra` override `base`

`extra` vars were appended *after* `os.Environ()` entries. However `execve` resolves duplicate env keys by **first occurrence**, so any daemon-injected value (e.g. `MULTICA_SERVER_URL`) was silently ignored whenever the same key already existed in the user's shell environment. The intent was clearly that `extra` should win; the implementation had the order wrong.

### Bug 2: Agent subprocesses inherit `HTTPS_PROXY` pointing at localhost

When agents (Codex, Claude) spawn `multica` CLI subprocesses, the CLI inherits `HTTPS_PROXY` from the host shell. If that proxy is a localhost address (`127.0.0.1:7890` is the default Clash port), Codex's sandbox blocks the loopback connection:

```
Error: get issue: Get "https://…/api/issues/…": proxyconnect tcp: dial tcp 127.0.0.1:7890: connect: operation not permitted
```

Tasks appear to complete (`status=completed`) but no comments or status changes are actually posted because every `multica` API call fails on the first attempt. Codex retries via "elevated" execution but that runs in the same environment, so it also fails.

## Fix

**`server/pkg/agent/claude.go` — fix `mergeEnv` override precedence**

Skip base entries whose keys appear in `extra`, so daemon-injected values always win over inherited shell variables.

**`server/internal/daemon/daemon.go` — inject `NO_PROXY` for the server hostname**

When building the agent environment, parse `ServerBaseURL` and add its hostname to `NO_PROXY` (and `no_proxy`). This ensures the `multica` CLI always connects directly to the configured server, regardless of any proxy the user has configured on their machine. Existing `NO_PROXY` values from the host are preserved.

## Impact

- Fixes external users (e.g. users behind Clash/V2Ray/etc.) whose codex agents were silently doing nothing
- The `mergeEnv` fix is a correctness fix that affects all agent providers (Claude, Codex, Gemini, OpenCode, OpenClaw)
- No behaviour change for users without a local proxy