### PR TITLE
fix(codex): dispatch-level threadId filter for subagent notifications

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -615,6 +615,13 @@ func (c *codexClient) handleEvent(msg map[string]any) {
 }
 
 func (c *codexClient) handleRawNotification(method string, params map[string]any) {
+	// Ignore notifications from threads other than the one we are tracking.
+	// Codex multiplexes subagent threads (e.g. memory consolidation) on the
+	// same stdio pipe; only our thread should drive turn lifecycle and output.
+	if threadID, ok := params["threadId"].(string); ok && c.threadID != "" && threadID != c.threadID {
+		return
+	}
+
 	switch method {
 	case "turn/started":
 		c.turnStarted = true
@@ -677,12 +684,8 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 		}
 
 	case "thread/status/changed":
-		threadID, _ := params["threadId"].(string)
 		statusType := extractNestedString(params, "status", "type")
-		// Only react to status changes from the tracked thread; ignore
-		// subagent threads (e.g. memory consolidation) whose idle signal
-		// would otherwise prematurely terminate the main turn.
-		if statusType == "idle" && c.turnStarted && (threadID == "" || threadID == c.threadID) {
+		if statusType == "idle" && c.turnStarted {
 			if c.onTurnDone != nil {
 				c.onTurnDone(false)
 			}

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -677,8 +677,12 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 		}
 
 	case "thread/status/changed":
+		threadID, _ := params["threadId"].(string)
 		statusType := extractNestedString(params, "status", "type")
-		if statusType == "idle" && c.turnStarted {
+		// Only react to status changes from the tracked thread; ignore
+		// subagent threads (e.g. memory consolidation) whose idle signal
+		// would otherwise prematurely terminate the main turn.
+		if statusType == "idle" && c.turnStarted && (threadID == "" || threadID == c.threadID) {
 			if c.onTurnDone != nil {
 				c.onTurnDone(false)
 			}


### PR DESCRIPTION
## Summary

- Add a dispatch-level `threadId` guard at the top of `handleRawNotification` to ignore all notifications from non-tracked threads (e.g. memory consolidation subagent)
- Remove the now-redundant per-handler `threadId` check on `thread/status/changed`

## Context

Codex multiplexes subagent threads on the same stdio pipe. The previous fix (#1186, closed) only guarded `thread/status/changed`, but subagent notifications could still trigger `onTurnDone` or contaminate output via:

1. `turn/completed` from subagent turn
2. `item/completed` + `agentMessage` + `phase=final_answer` from subagent
3. `item/completed` + `agentMessage` text leaking into output builder
4. `turn/started` overwriting `c.turnID`

All v2 notifications carry a required top-level `threadId` field (confirmed via app-server-protocol schema). A single guard at the dispatch level protects all current and future handlers.

Fixes #1181