### PR TITLE
fix(desktop): strip leading '--' so --publish reaches electron-builder

### DIFF
--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -40,6 +40,18 @@ function sh(cmd) {
 }
 
 /**
+ * Strip the leading `--` that npm/pnpm insert to separate their own
+ * flags from the ones meant for the underlying script.  Without this,
+ * `pnpm package -- --mac --arm64 --publish always` forwards the bare
+ * `--` into electron-builder's argv, which terminates option parsing
+ * and turns `--publish always` into ignored positional arguments.
+ */
+export function stripLeadingSeparator(argv) {
+  if (argv.length > 0 && argv[0] === "--") return argv.slice(1);
+  return argv;
+}
+
+/**
  * Pure transformation from the `git describe --tags --always --dirty`
  * output to the value we feed into electron-builder's extraMetadata.version.
  *
@@ -102,7 +114,7 @@ function main() {
   }
 
   // Step 4: assemble electron-builder args.
-  const passthrough = process.argv.slice(2);
+  const passthrough = stripLeadingSeparator(process.argv.slice(2));
   const builderArgs = [];
   if (version) builderArgs.push(`-c.extraMetadata.version=${version}`);
 

--- a/apps/desktop/scripts/package.test.mjs
+++ b/apps/desktop/scripts/package.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeGitVersion } from "./package.mjs";
+import { normalizeGitVersion, stripLeadingSeparator } from "./package.mjs";
 
 describe("normalizeGitVersion", () => {
   it("returns null for empty / nullish input", () => {
@@ -35,5 +35,27 @@ describe("normalizeGitVersion", () => {
     // when there are no tags in the history at all.
     expect(normalizeGitVersion("f1415e96")).toBe("0.0.0-f1415e96");
     expect(normalizeGitVersion("abc1234")).toBe("0.0.0-abc1234");
+  });
+});
+
+describe("stripLeadingSeparator", () => {
+  it("removes the leading -- inserted by npm/pnpm", () => {
+    expect(stripLeadingSeparator(["--", "--mac", "--arm64", "--publish", "always"])).toEqual([
+      "--mac", "--arm64", "--publish", "always",
+    ]);
+  });
+
+  it("leaves args untouched when there is no leading --", () => {
+    expect(stripLeadingSeparator(["--mac", "--arm64"])).toEqual(["--mac", "--arm64"]);
+  });
+
+  it("does not strip a -- that appears mid-argv", () => {
+    expect(stripLeadingSeparator(["--mac", "--", "--arm64"])).toEqual([
+      "--mac", "--", "--arm64",
+    ]);
+  });
+
+  it("handles an empty array", () => {
+    expect(stripLeadingSeparator([])).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

When running `pnpm package -- --mac --arm64 --publish always`, the `--` separator that pnpm inserts was forwarded verbatim into electron-builder's argv. This terminated option parsing, causing `--publish always` to be treated as positional arguments. As a result, every artifact had `isPublish: false` and nothing was uploaded to the GitHub Release.

## Fix

Added `stripLeadingSeparator()` in `apps/desktop/scripts/package.mjs` to strip the leading `--` before passing args through to electron-builder. Includes unit tests covering the new helper.

## Testing

All 10 tests pass (6 existing + 4 new).