### PR TITLE
fix: pass model to Hermes ACP and add hermes to InjectRuntimeConfig

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -747,6 +747,74 @@ func TestInjectRuntimeConfigUnknownProvider(t *testing.T) {
 	}
 }
 
+func TestInjectRuntimeConfigHermes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID:     "test-issue-id",
+		AgentSkills: []SkillContextForEnv{{Name: "Coding", Content: "Write good code."}},
+	}
+
+	if err := InjectRuntimeConfig(dir, "hermes", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	// Hermes uses AGENTS.md.
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("failed to read AGENTS.md: %v", err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "Multica Agent Runtime") {
+		t.Error("AGENTS.md missing meta skill header")
+	}
+	if !strings.Contains(s, "Coding") {
+		t.Error("AGENTS.md missing skill name")
+	}
+	// Hermes has no native skill discovery path wired up, so AGENTS.md must
+	// point the agent at the .agent_context/skills/ fallback — NOT claim that
+	// skills are "discovered automatically".
+	if strings.Contains(s, "discovered automatically") {
+		t.Error("AGENTS.md for Hermes should not claim native skill discovery")
+	}
+	if !strings.Contains(s, ".agent_context/skills/") {
+		t.Error("AGENTS.md for Hermes should reference .agent_context/skills/ fallback path")
+	}
+
+	// CLAUDE.md should NOT exist.
+	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Error("expected CLAUDE.md to NOT exist for Hermes provider")
+	}
+}
+
+func TestWriteContextFilesHermesFallbackSkills(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID: "hermes-skill-test",
+		AgentSkills: []SkillContextForEnv{
+			{Name: "Go Conventions", Content: "Follow Go conventions."},
+		},
+	}
+
+	if err := writeContextFiles(dir, "hermes", ctx); err != nil {
+		t.Fatalf("writeContextFiles failed: %v", err)
+	}
+
+	// Skills should be in the fallback .agent_context/skills/ path since
+	// Hermes has no native skills discovery directory.
+	skillMd, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "go-conventions", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("failed to read .agent_context/skills/go-conventions/SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
+		t.Error("SKILL.md missing content")
+	}
+}
+
 func TestPrepareCodexHomeSeedsFromShared(t *testing.T) {
 	// Cannot use t.Parallel() with t.Setenv.
 

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -25,7 +25,7 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error 
 	switch provider {
 	case "claude":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi":
+	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)
@@ -152,8 +152,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi":
-			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, and Kimi discover skills natively from their respective paths — just list names.
+		case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi":
+			// Codex, Copilot, OpenCode, OpenClaw, Hermes, Pi, Cursor, and Kimi discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
 		case "gemini":
 			// Gemini reads GEMINI.md directly; point it at the fallback skills dir.

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -15,6 +15,7 @@ import (
 // For Copilot:  writes {workDir}/AGENTS.md  (skills discovered natively from .github/skills/)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .config/opencode/skills/)
 // For OpenClaw: writes {workDir}/AGENTS.md  (skills discovered natively from .openclaw/skills/)
+// For Hermes:   writes {workDir}/AGENTS.md  (skills fall back to .agent_context/skills/; AGENTS.md points there)
 // For Gemini:   writes {workDir}/GEMINI.md  (discovered natively by the Gemini CLI)
 // For Pi:       writes {workDir}/AGENTS.md  (skills discovered natively from ~/.pi/agent/skills/)
 // For Cursor:   writes {workDir}/AGENTS.md  (skills discovered natively from .cursor/skills/)
@@ -152,11 +153,12 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi":
-			// Codex, Copilot, OpenCode, OpenClaw, Hermes, Pi, Cursor, and Kimi discover skills natively from their respective paths — just list names.
+		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi":
+			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, and Kimi discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "gemini":
-			// Gemini reads GEMINI.md directly; point it at the fallback skills dir.
+		case "gemini", "hermes":
+			// Gemini reads GEMINI.md directly; Hermes has no native skills discovery path
+			// wired up in resolveSkillsDir, so both fall back to .agent_context/skills/.
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")
 		default:
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -180,10 +180,14 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			sessionID = opts.ResumeSessionID
 			_ = result
 		} else {
-			result, err := c.request(runCtx, "session/new", map[string]any{
+			sessionParams := map[string]any{
 				"cwd":        cwd,
 				"mcpServers": []any{},
-			})
+			}
+			if opts.Model != "" {
+				sessionParams["model"] = opts.Model
+			}
+			result, err := c.request(runCtx, "session/new", sessionParams)
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("hermes session/new failed: %v", err)

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -180,14 +180,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			sessionID = opts.ResumeSessionID
 			_ = result
 		} else {
-			sessionParams := map[string]any{
-				"cwd":        cwd,
-				"mcpServers": []any{},
-			}
-			if opts.Model != "" {
-				sessionParams["model"] = opts.Model
-			}
-			result, err := c.request(runCtx, "session/new", sessionParams)
+			result, err := c.request(runCtx, "session/new", buildHermesSessionParams(cwd, opts.Model))
 			if err != nil {
 				finalStatus = "failed"
 				finalError = fmt.Sprintf("hermes session/new failed: %v", err)
@@ -977,6 +970,20 @@ func extractACPSessionID(result json.RawMessage) string {
 		return ""
 	}
 	return r.SessionID
+}
+
+// buildHermesSessionParams constructs the params map for the ACP `session/new`
+// request. The `model` field is only included when non-empty so Hermes falls
+// back to its default only when no explicit model was configured.
+func buildHermesSessionParams(cwd, model string) map[string]any {
+	params := map[string]any{
+		"cwd":        cwd,
+		"mcpServers": []any{},
+	}
+	if model != "" {
+		params["model"] = model
+	}
+	return params
 }
 
 // hermesToolNameFromTitle extracts a tool name from the ACP tool call title.

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -48,6 +48,30 @@ func TestExtractACPSessionIDInvalidJSON(t *testing.T) {
 	}
 }
 
+// ── buildHermesSessionParams ──
+
+func TestBuildHermesSessionParamsIncludesModel(t *testing.T) {
+	t.Parallel()
+	params := buildHermesSessionParams("/tmp/work", "gpt-4o")
+	if params["cwd"] != "/tmp/work" {
+		t.Errorf("cwd: got %v, want /tmp/work", params["cwd"])
+	}
+	if _, ok := params["mcpServers"]; !ok {
+		t.Error("mcpServers missing")
+	}
+	if got, ok := params["model"].(string); !ok || got != "gpt-4o" {
+		t.Errorf("model: got %v, want gpt-4o", params["model"])
+	}
+}
+
+func TestBuildHermesSessionParamsOmitsEmptyModel(t *testing.T) {
+	t.Parallel()
+	params := buildHermesSessionParams("/tmp/work", "")
+	if _, present := params["model"]; present {
+		t.Error("expected model key to be omitted when model is empty")
+	}
+}
+
 // ── hermesToolNameFromTitle ──
 
 func TestHermesToolNameFromTitle(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two bugs causing Hermes agent to fail with local LLM providers (#1195):

### 1. Model not passed to Hermes ACP `session/new`

`server/pkg/agent/hermes.go` was not including `opts.Model` in the `session/new` ACP request. This meant Hermes always used its default model name, which local LLM providers don't recognize, causing an `Internal error`.

**Fix**: `buildHermesSessionParams` now includes `model` in the `session/new` params when `opts.Model` is set, matching the behavior of Claude / OpenCode runtimes.

### 2. Hermes missing from runtime config / AGENTS.md injection

`server/internal/daemon/execenv/runtime_config.go` didn't include `"hermes"` when writing `AGENTS.md`, so Hermes never received Multica runtime instructions.

**Fix**:
- Add `"hermes"` to the `AGENTS.md` writing case so Hermes receives runtime instructions.
- For skill discovery, Hermes does **not** have a native skills directory in `resolveSkillsDir`, so it is grouped with `gemini` in the **fallback** branch of `buildMetaSkillContent`. The generated `AGENTS.md` correctly points Hermes to `.agent_context/skills/` (where skills actually land), instead of falsely claiming "discovered automatically".

## Testing

New regression tests:
- `TestBuildHermesSessionParamsIncludesModel` / `TestBuildHermesSessionParamsOmitsEmptyModel` — lock in that `session/new` carries `model` when set, and omits it when empty.
- `TestInjectRuntimeConfigHermes` — verifies `AGENTS.md` is written for Hermes and does not advertise non-existent native skill discovery.
- `TestWriteContextFilesHermesFallbackSkills` — verifies skills are written to `.agent_context/skills/` for Hermes.

`go test ./pkg/agent ./internal/daemon/execenv` passes.

Closes #1195
