### PR TITLE
fix(server): trigger agent on comments regardless of issue status

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1185,13 +1185,10 @@ func (h *Handler) shouldEnqueueAgentTask(ctx context.Context, issue db.Issue) bo
 }
 
 // shouldEnqueueOnComment returns true if a member comment on this issue should
-// trigger the assigned agent. Fires for any non-terminal status — comments are
-// conversational and can happen at any stage of active work.
+// trigger the assigned agent. Fires for any status — comments are
+// conversational and can happen at any stage, including after completion
+// (e.g. follow-up questions on a done issue).
 func (h *Handler) shouldEnqueueOnComment(ctx context.Context, issue db.Issue) bool {
-	// Don't trigger on terminal statuses (done, cancelled).
-	if issue.Status == "done" || issue.Status == "cancelled" {
-		return false
-	}
 	if !h.isAgentAssigneeReady(ctx, issue) {
 		return false
 	}


### PR DESCRIPTION
## Summary

- Removes the `done`/`cancelled` status gate in `shouldEnqueueOnComment` so any new member comment wakes up the assigned agent, not just explicit `@mention`s.
- Updates the function docstring to reflect the new behavior.

## Context

Reported in multica-ai/multica#1205. Users were confused that replying on a completed issue had no effect — only `@agent` would wake the runtime. The status gate predates the general `@mention` bypass (#267, #405), which only half-opened the path. Bohan confirmed the gate should just be removed: "agent 是否被 comment 触发，不需要额外去判断 issue status 这个逻辑，非常的隐式".

`@mention` behavior is unchanged — `enqueueMentionedAgentTasks` already ignores status. Dedup via `HasPendingTaskForIssueAndAgent` is preserved.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handler/ -run 'TestCommentMentionsOthersButNotAssignee|TestIsReplyToMemberThread|TestOnCommentTriggerDecision'`
- [ ] Manual: reply on a `done` issue in staging → agent picks it up without `@mention`