### PR TITLE
feat(desktop): brand dev build as Multica Canary with bundled icon

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
   },
   renderer: {
     server: {
-      port: 5173,
+      // Allow parallel worktrees to run `pnpm dev:desktop` side-by-side
+      // (e.g. Multica Canary alongside a primary checkout) by overriding
+      // the renderer port via env. Falls back to 5173 for the common case.
+      port: Number(process.env.DESKTOP_RENDERER_PORT) || 5173,
       strictPort: true,
     },
     plugins: [react(), tailwindcss()],

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,7 +5,8 @@
   "main": "./out/main/index.js",
   "scripts": {
     "bundle-cli": "node scripts/bundle-cli.mjs",
-    "dev": "pnpm run bundle-cli && electron-vite dev",
+    "brand-dev-electron": "node scripts/brand-dev-electron.mjs",
+    "dev": "pnpm run bundle-cli && pnpm run brand-dev-electron && electron-vite dev",
     "build": "pnpm run bundle-cli && electron-vite build",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",

--- a/apps/desktop/scripts/brand-dev-electron.mjs
+++ b/apps/desktop/scripts/brand-dev-electron.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Rebrand the bundled Electron.app's Info.plist so `pnpm dev:desktop`
+// shows "Multica Canary" in the menu bar, Cmd+Tab switcher, and
+// Activity Monitor. On macOS these titles come from CFBundleName at
+// launch time — `app.setName()` cannot override them at runtime, so
+// patching the plist in node_modules is the only working fix.
+//
+// Idempotent: runs on every dev launch and no-ops once the plist already
+// matches. The patch is isolated to this worktree's node_modules — we
+// unlink the file before rewriting so we never mutate a pnpm-store inode
+// shared with another project.
+
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+if (process.platform !== "darwin") process.exit(0);
+
+const DESIRED_NAME = "Multica Canary";
+
+const require = createRequire(import.meta.url);
+// `require('electron')` returns the path to the executable
+// (.../Electron.app/Contents/MacOS/Electron). Walk up to Contents/Info.plist.
+const electronBin = require("electron");
+const plistPath = resolve(electronBin, "../../Info.plist");
+
+function plistGet(key) {
+  try {
+    return execFileSync(
+      "/usr/libexec/PlistBuddy",
+      ["-c", `Print :${key}`, plistPath],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+  } catch {
+    return "";
+  }
+}
+
+function plistSet(key, value) {
+  try {
+    execFileSync("/usr/libexec/PlistBuddy", [
+      "-c",
+      `Set :${key} ${value}`,
+      plistPath,
+    ]);
+  } catch {
+    execFileSync("/usr/libexec/PlistBuddy", [
+      "-c",
+      `Add :${key} string ${value}`,
+      plistPath,
+    ]);
+  }
+}
+
+if (
+  plistGet("CFBundleName") === DESIRED_NAME &&
+  plistGet("CFBundleDisplayName") === DESIRED_NAME
+) {
+  process.exit(0);
+}
+
+// Break any pnpm hardlink to the global store: read, unlink, rewrite.
+// PlistBuddy would otherwise write through the hardlink and mutate the
+// shared store file (and every other project's Electron.app with it).
+const original = readFileSync(plistPath);
+unlinkSync(plistPath);
+writeFileSync(plistPath, original);
+
+plistSet("CFBundleName", DESIRED_NAME);
+plistSet("CFBundleDisplayName", DESIRED_NAME);
+
+console.log(`[brand-dev-electron] ${plistPath} → CFBundleName="${DESIRED_NAME}"`);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,10 +1,15 @@
-import { app, shell, BrowserWindow, ipcMain } from "electron";
+import { app, shell, BrowserWindow, ipcMain, nativeImage } from "electron";
 import { homedir } from "os";
 import { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 import fixPath from "fix-path";
 import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
+
+// Bundled icon used for dev-mode dock/taskbar branding. In production the
+// app bundle icon (from electron-builder) wins; this path is only consumed
+// by the `is.dev` branch below.
+const DEV_ICON_PATH = join(__dirname, "../../resources/icon.png");
 
 // macOS/Linux GUI launches inherit a minimal PATH from launchd that omits
 // the user's shell config (~/.zshrc, Homebrew, nvm, ~/.local/bin, etc.).
@@ -61,6 +66,9 @@ function createWindow(): void {
     trafficLightPosition: { x: 16, y: 13 },
     show: false,
     autoHideMenuBar: true,
+    // Windows/Linux pick up the window/taskbar icon from this option in
+    // dev — on macOS it's ignored (dock comes from app.dock.setIcon below).
+    ...(is.dev ? { icon: DEV_ICON_PATH } : {}),
     webPreferences: {
       preload: join(__dirname, "../preload/index.js"),
       sandbox: false,
@@ -101,9 +109,11 @@ function createWindow(): void {
 // is derived from the userData path. (Same approach VS Code uses for
 // Stable / Insiders coexistence.)
 
+const DEV_APP_NAME = "Multica Canary";
+
 if (is.dev) {
-  app.setName("Multica Dev");
-  app.setPath("userData", join(app.getPath("appData"), "Multica Dev"));
+  app.setName(DEV_APP_NAME);
+  app.setPath("userData", join(app.getPath("appData"), DEV_APP_NAME));
 }
 
 // --- Protocol registration -----------------------------------------------
@@ -140,6 +150,14 @@ if (!gotTheLock) {
     electronApp.setAppUserModelId(
       is.dev ? "ai.multica.desktop.dev" : "ai.multica.desktop",
     );
+
+    // macOS: replace the default Electron dock icon with the bundled logo
+    // so the Canary dev build is visually distinct from a stock Electron
+    // run. `app.dock` is macOS-only — guard the call.
+    if (is.dev && process.platform === "darwin" && app.dock) {
+      const icon = nativeImage.createFromPath(DEV_ICON_PATH);
+      if (!icon.isEmpty()) app.dock.setIcon(icon);
+    }
 
     app.on("browser-window-created", (_, window) => {
       optimizer.watchWindowShortcuts(window);

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,8 @@
     "MULTICA_SERVER_URL",
     "COMPOSE_PROJECT_NAME",
     "POSTGRES_DB",
-    "POSTGRES_PORT"
+    "POSTGRES_PORT",
+    "DESKTOP_RENDERER_PORT"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary
- Rename the dev-mode app from "Multica Dev" to **Multica Canary** (name + userData path).
- Set the macOS dock icon via `app.dock.setIcon(...)` in dev so the window no longer shows the default Electron logo.
- Pass `icon: DEV_ICON_PATH` to the dev `BrowserWindow` so Windows/Linux taskbars pick up the same logo.
- Production packaging is unchanged — the electron-builder `build/icon.*` assets still drive the installed app.

Closes [MUL-980](mention://issue/9ec51d03-25b4-4c57-8587-5e93c52f7457).

## Test plan
- [x] `pnpm --filter @multica/desktop typecheck`
- [x] `pnpm --filter @multica/desktop test`
- [ ] Manual: run `pnpm dev:desktop` on macOS and confirm the dock shows the Multica logo and the process is titled "Multica Canary".
- [ ] Manual: confirm the dev instance still has its own userData directory (`Multica Canary`) and coexists with a packaged Multica install.