### PR TITLE
fix(views): skip submit on Enter during IME composition

### DIFF
--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -120,7 +120,10 @@ export function CreateAgentDialog({
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Deep Research Agent"
               className="mt-1"
-              onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              onKeyDown={(e) => {
+                if (e.key !== "Enter" || e.nativeEvent.isComposing) return;
+                handleSubmit();
+              }}
             />
           </div>
 

--- a/packages/views/settings/components/members-tab.tsx
+++ b/packages/views/settings/components/members-tab.tsx
@@ -306,7 +306,8 @@ export function MembersTab() {
                   onChange={(e) => setInviteEmail(e.target.value)}
                   placeholder="user@company.com"
                   onKeyDown={(e) => {
-                    if (e.key === "Enter" && inviteEmail.trim()) handleInviteMember();
+                    if (e.key !== "Enter" || e.nativeEvent.isComposing) return;
+                    if (inviteEmail.trim()) handleInviteMember();
                   }}
                 />
                 <Select value={inviteRole} onValueChange={(value) => setInviteRole(value as MemberRole)}>

--- a/packages/views/skills/components/create-skill-dialog.tsx
+++ b/packages/views/skills/components/create-skill-dialog.tsx
@@ -177,7 +177,8 @@ function ManualForm({
             }}
             placeholder="e.g. review-helper"
             onKeyDown={(e) => {
-              if (e.key === "Enter") submit();
+              if (e.key !== "Enter" || e.nativeEvent.isComposing) return;
+              submit();
             }}
           />
           <p className="text-xs text-muted-foreground">
@@ -354,7 +355,8 @@ function UrlForm({
             placeholder="https://clawhub.ai/owner/skill"
             className="font-mono text-sm"
             onKeyDown={(e) => {
-              if (e.key === "Enter") submit();
+              if (e.key !== "Enter" || e.nativeEvent.isComposing) return;
+              submit();
             }}
           />
         </div>

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -111,8 +111,12 @@ function AddFileInline({
           setError("");
         }}
         onKeyDown={(e) => {
-          if (e.key === "Enter") submit();
-          if (e.key === "Escape") onCancel();
+          if (e.key === "Escape") {
+            onCancel();
+            return;
+          }
+          if (e.key !== "Enter" || e.nativeEvent.isComposing) return;
+          submit();
         }}
         placeholder="templates/review.md"
         className="h-7 font-mono text-xs"

--- a/packages/views/workspace/create-workspace-form.tsx
+++ b/packages/views/workspace/create-workspace-form.tsx
@@ -79,7 +79,10 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
             value={name}
             onChange={(e) => handleNameChange(e.target.value)}
             placeholder="My Workspace"
-            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            onKeyDown={(e) => {
+              if (e.key !== "Enter" || e.nativeEvent.isComposing) return;
+              handleCreate();
+            }}
           />
         </div>
         <div className="space-y-1.5">
@@ -95,7 +98,10 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
               onChange={(e) => handleSlugChange(e.target.value)}
               placeholder="my-workspace"
               className="border-0 shadow-none focus-visible:ring-0"
-              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              onKeyDown={(e) => {
+              if (e.key !== "Enter" || e.nativeEvent.isComposing) return;
+              handleCreate();
+            }}
             />
           </div>
           {slugError && (


### PR DESCRIPTION
## Summary

Pressing Enter while an IME composition is in progress (Chinese pinyin, Japanese kana, Korean Hangul, etc.) was immediately triggering the form's submit action instead of committing the composed character. Most visibly in the Create Agent dialog where a half-typed name would create an agent as soon as the user hit Enter to select an IME candidate.

Guarded every Enter-submit keydown handler in `packages/views/` with `e.nativeEvent.isComposing`, matching the existing pattern already used in `packages/views/editor/extensions/submit-shortcut.ts` (which checks `editor.view.composing`).

## Changes

- `agents/create-agent-dialog`: name input
- `workspace/create-workspace-form`: name + slug inputs
- `skills/skills-page`: create form name, import URL, file path dialog
- `settings/members-tab`: invite email

## Test plan

- [x] `pnpm --filter @multica/views typecheck`
- [x] Existing `create-workspace-form.test.tsx` still passes (5/5)
- [ ] Manual: open Create Agent dialog, switch to Chinese IME, type `yan jiu` → space to show candidates → Enter to pick "研究" → verify dialog stays open and the composed text lands in the input instead of submitting.
- [ ] Repeat for workspace create, skill create/import/file-path, member invite forms.
