### PR TITLE
feat(issues): add newly created issue to cmd+k Recent list

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { issueKeys, CLOSED_PAGE_SIZE, type MyIssuesFilter } from "./queries";
 import { useWorkspaceId } from "../hooks";
+import { useRecentIssuesStore } from "./stores";
 import type { Issue, IssueReaction } from "../types";
 import type {
   CreateIssueRequest,
@@ -94,6 +95,9 @@ export function useCreateIssue() {
             }
           : old,
       );
+      // Surface the just-created issue in cmd+k's Recent list without
+      // requiring the user to open it first.
+      useRecentIssuesStore.getState().recordVisit(newIssue.id);
       // Invalidate parent's children query so sub-issues list updates immediately
       if (newIssue.parent_issue_id) {
         qc.invalidateQueries({ queryKey: issueKeys.children(wsId, newIssue.parent_issue_id) });


### PR DESCRIPTION
## Summary
- Hook `recordVisit` into `useCreateIssue`'s `onSuccess` so that issues the user just created immediately appear in the cmd+k command palette's Recent section — previously an issue only made it into Recent after the user explicitly opened the detail view.
- Single call site change in `packages/core/issues/mutations.ts`; reuses the existing `useRecentIssuesStore` (max 20 entries, workspace-scoped, already-persisted to localStorage).

Closes [MUL-983](mention://issue/6a28eed3-9c62-4e5f-9970-d796b59eaefc).

## Test plan
- [x] `pnpm --filter @multica/core typecheck` — passes
- [x] `pnpm --filter @multica/views exec vitest run modals/create-issue.test.tsx search/search-command.test.tsx issues/components/issue-detail.test.tsx` — 18/18 pass
- [ ] Manual: create an issue via cmd+k / sidebar → close modal without navigating → reopen cmd+k → new issue appears at the top of Recent