### PR TITLE
chore(desktop): DESKTOP_APP_SUFFIX env for parallel-worktree dev

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -109,7 +109,14 @@ function createWindow(): void {
 // is derived from the userData path. (Same approach VS Code uses for
 // Stable / Insiders coexistence.)
 
-const DEV_APP_NAME = "Multica Canary";
+// DESKTOP_APP_SUFFIX lets parallel worktrees run dev Electron side-by-side
+// without fighting for the shared single-instance lock. The suffix is
+// appended to the app name + userData path, so each worktree gets its own
+// lock file. Default (no env var) keeps behavior unchanged — the common
+// single-worktree case still lands at "Multica Canary".
+const DEV_APP_NAME = process.env.DESKTOP_APP_SUFFIX
+  ? `Multica Canary ${process.env.DESKTOP_APP_SUFFIX}`
+  : "Multica Canary";
 
 if (is.dev) {
   app.setName(DEV_APP_NAME);


### PR DESCRIPTION
## Summary

Extends #1210's parallel-worktree story. #1210 added `DESKTOP_RENDERER_PORT` so Vite's renderer port can be overridden, which solves the port-5173 clash. But the dev app still uses a **single shared userData path** (`~/Library/Application Support/Multica Canary`), and Electron derives the single-instance lock from that path. So two worktrees running dev simultaneously still fight for the lock — the second `app.quit()`s silently before opening a window (no error, just nothing happens).

This PR adds a small sibling env var, `DESKTOP_APP_SUFFIX`, that suffixes the app name + userData path so each worktree can claim its own lock:

```
DESKTOP_APP_SUFFIX=foo  →  "Multica Canary foo"
```

Default (no env var) keeps behavior identical to today — the common single-worktree case still lands at `Multica Canary`.

**Full "run a second dev Electron" recipe after this lands:**
```bash
DESKTOP_RENDERER_PORT=15173 DESKTOP_APP_SUFFIX=foo pnpm dev:desktop
```

### Note on Info.plist branding

I intentionally did **not** touch `brand-dev-electron.mjs`. That script patches the bundled `Electron.app/Contents/Info.plist` so macOS shows "Multica Canary" in the menubar / Cmd+Tab / Activity Monitor. With `DESKTOP_APP_SUFFIX=foo`, the userData path + single-instance lock are distinct (which is what matters), but the Info.plist display name stays `Multica Canary`. Users distinguish by the dev tools / window contents. Making the menubar dynamic would require per-worktree Info.plist patches, which races against the shared pnpm-store hardlink — out of scope for this PR.

## Use case

Agent-driven E2E testing: an agent spins up a dev Electron from a feature-branch worktree while the developer keeps their primary `Multica Canary` Electron running for daily work. I hit this exact case while testing PR #1208.

## Test plan
- [x] `pnpm --filter @multica/desktop typecheck` — green
- [ ] Manual (single worktree, no env set): `pnpm dev:desktop` → window still titled `Multica Canary`, userData path unchanged
- [ ] Manual (two worktrees): worktree A with no env, worktree B with `DESKTOP_RENDERER_PORT=15173 DESKTOP_APP_SUFFIX=b pnpm dev:desktop` → both open successfully, distinct userData dirs

Split out from #1208 per review feedback.