### PR TITLE
refactor(issues): lighten board card styling

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -67,7 +67,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showDueDate = storeProperties.dueDate && issue.due_date;
 
   return (
-    <div className="rounded-lg border bg-card p-3.5 shadow-[0_1px_2px_0_rgba(0,0,0,0.03)] transition-shadow group-hover:shadow-sm">
+    <div className="rounded-lg border-[0.5px] bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-shadow group-hover:shadow-sm">
       {/* Row 1: Identifier */}
       <p className="text-xs text-muted-foreground">{issue.identifier}</p>
 


### PR DESCRIPTION
## Summary
- Shrink the board card border to 0.5px for a lighter visual weight
- Switch to asymmetric 12/10 padding for a more compact information density
- Replace the single-layer shadow with a two-layer soft drop shadow so cards appear to hover slightly above the column

Only affects `packages/views/issues/components/board-card.tsx` — no behaviour changes.

## Test plan
- [x] Open the board view and confirm cards render with the new border / padding / shadow
- [x] Hover a card and confirm the shadow deepens as before
- [x] Verify dark mode still reads well (same semantic tokens)