### PR TITLE
fix: correct inconsistent progress bars in project detail

### DIFF
--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -269,7 +269,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
     return <div className="flex items-center justify-center h-full text-muted-foreground">Project not found</div>;
   }
 
-  const issueMetrics = getProjectIssueMetrics(project, projectIssues);
+  const issueMetrics = getProjectIssueMetrics(projectIssues);
   const statusCfg = PROJECT_STATUS_CONFIG[project.status];
   const priorityCfg = PROJECT_PRIORITY_CONFIG[project.priority];
 

--- a/packages/views/projects/components/project-issue-metrics.test.ts
+++ b/packages/views/projects/components/project-issue-metrics.test.ts
@@ -27,21 +27,28 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
 }
 
 describe("getProjectIssueMetrics", () => {
-  it("uses project totals for progress and project-local done issues for the kanban done count", () => {
-    const metrics = getProjectIssueMetrics(
-      { issue_count: 9, done_count: 5 },
-      [
-        makeIssue({ id: "issue-1", status: "done" }),
-        makeIssue({ id: "issue-2", status: "done" }),
-        makeIssue({ id: "issue-3", status: "cancelled" }),
-        makeIssue({ id: "issue-4", status: "todo" }),
-      ],
-    );
+  it("computes metrics from actual loaded issues, not denormalized project counts", () => {
+    const metrics = getProjectIssueMetrics([
+      makeIssue({ id: "issue-1", status: "done" }),
+      makeIssue({ id: "issue-2", status: "done" }),
+      makeIssue({ id: "issue-3", status: "cancelled" }),
+      makeIssue({ id: "issue-4", status: "todo" }),
+    ]);
 
     expect(metrics).toEqual({
-      totalCount: 9,
-      completedCount: 5,
+      totalCount: 4,
+      completedCount: 2,
       doneColumnCount: 2,
+    });
+  });
+
+  it("returns zeros for empty issue list", () => {
+    const metrics = getProjectIssueMetrics([]);
+
+    expect(metrics).toEqual({
+      totalCount: 0,
+      completedCount: 0,
+      doneColumnCount: 0,
     });
   });
 });

--- a/packages/views/projects/components/project-issue-metrics.ts
+++ b/packages/views/projects/components/project-issue-metrics.ts
@@ -1,12 +1,11 @@
-import type { Issue, Project } from "@multica/core/types";
+import type { Issue } from "@multica/core/types";
 
-export function getProjectIssueMetrics(
-  project: Pick<Project, "issue_count" | "done_count">,
-  projectIssues: Issue[],
-) {
+export function getProjectIssueMetrics(projectIssues: Issue[]) {
+  const totalCount = projectIssues.length;
+  const completedCount = projectIssues.filter((issue) => issue.status === "done").length;
   return {
-    totalCount: project.issue_count,
-    completedCount: project.done_count,
-    doneColumnCount: projectIssues.filter((issue) => issue.status === "done").length,
+    totalCount,
+    completedCount,
+    doneColumnCount: completedCount,
   };
 }


### PR DESCRIPTION
## Problem
The project detail sidebar progress bar used denormalized `project.done_count` / `project.issue_count` fields from the database, while the board view computed counts from actual loaded issues. These could diverge, showing inconsistent values.

## Fix
`getProjectIssueMetrics()` now derives all three metrics (`totalCount`, `completedCount`, `doneColumnCount`) from the actual `projectIssues` array, ensuring a single source of truth.

## Changes
- **project-issue-metrics.ts**: Removed dependency on stale `project.issue_count`/`done_count`. Now computes everything from the loaded issues array.
- **project-detail.tsx**: Updated call site (simpler signature).
- **project-issue-metrics.test.ts**: Updated tests to match new API and added empty-list test.

Fixes COR-8