### PR TITLE
refactor(search): collapse cmd+k empty-state commands to primary action

### DIFF
--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -161,19 +161,21 @@ describe("SearchCommand", () => {
     expect(screen.queryByPlaceholderText("Type a command or search...")).not.toBeInTheDocument();
   });
 
-  it("shows Commands by default but hides Pages and Switch Workspace until query", () => {
+  it("shows only New Issue by default and hides Pages / Switch Workspace / low-frequency commands until query", () => {
     render(<SearchCommand />);
 
     expect(screen.queryByText("Pages")).not.toBeInTheDocument();
     expect(screen.queryByText("Switch Workspace")).not.toBeInTheDocument();
-    // Commands surface by default for discoverability.
+    // Only the primary creation action surfaces on empty query; everything
+    // else (theme, copy, New Project) must be revealed by typing.
     expect(screen.getByText("Commands")).toBeInTheDocument();
     expect(
       screen.getByText((_, el) => el?.textContent === "New Issue" && el?.tagName === "SPAN"),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText((_, el) => el?.textContent === "New Project" && el?.tagName === "SPAN"),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("New Project")).not.toBeInTheDocument();
+    expect(screen.queryByText("Switch to Light Theme")).not.toBeInTheDocument();
+    expect(screen.queryByText("Switch to Dark Theme")).not.toBeInTheDocument();
+    expect(screen.queryByText("Use System Theme")).not.toBeInTheDocument();
   });
 
   it("filters navigation pages by query", async () => {

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -281,9 +281,10 @@ export function SearchCommand() {
 
   const filteredCommands = useMemo(() => {
     const q = query.trim().toLowerCase();
-    // No query: surface the whole Commands list so users can discover what's
-    // available without having to guess keywords (Linear/Raycast pattern).
-    if (!q) return commands;
+    // No query: only surface the primary creation action. Other commands
+    // (theme switches, copy actions, New Project) are revealed as the user
+    // types, leaving the empty-state space to Recent.
+    if (!q) return commands.filter((c) => c.key === "new-issue");
     return commands.filter(
       (c) =>
         c.label.toLowerCase().includes(q) ||


### PR DESCRIPTION
## Summary
- On empty query, the cmd+k palette previously rendered the entire Commands list (New Issue, New Project, 3 theme switches, plus contextual Copy actions on issue pages), leaving only 3–5 rows for Recent in the 400px panel.
- Only "New Issue" now surfaces on empty query; theme / copy / New Project are revealed by typing, matching the existing progressive-disclosure pattern used for Pages and Switch Workspace.
- Updated `search-command.test.tsx` to assert the new empty-state behavior.

Refs MUL-991.

## Test plan
- [x] `pnpm --filter @multica/views exec vitest run search/search-command.test.tsx` (14 passed)
- [x] `pnpm --filter @multica/views typecheck`
- [ ] Manual: open cmd+k, confirm only "New Issue" + Recent visible; type "theme" / "copy" / "project" and confirm those commands appear