### PR TITLE
fix(autopilot): subscribe creator to autopilot-created issues

### DIFF
--- a/server/cmd/server/subscriber_listeners.go
+++ b/server/cmd/server/subscriber_listeners.go
@@ -20,7 +20,9 @@ func registerSubscriberListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		// Issues created via handler use IssueResponse; autopilot-created issues
+		// use map[string]any (see service/autopilot.go → issueToMap).
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}
@@ -48,7 +50,7 @@ func registerSubscriberListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}
@@ -105,6 +107,31 @@ func registerSubscriberListeners(bus *events.Bus, queries *db.Queries) {
 
 		addSubscriber(bus, queries, e.WorkspaceID, issueID, authorType, authorID, "commenter")
 	})
+}
+
+// extractIssueFields normalizes an issue payload that may be either a
+// handler.IssueResponse struct (HTTP handler path) or a map[string]any
+// (autopilot service path) into a common shape.
+func extractIssueFields(v any) (handler.IssueResponse, bool) {
+	if issue, ok := v.(handler.IssueResponse); ok {
+		return issue, true
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return handler.IssueResponse{}, false
+	}
+	issue := handler.IssueResponse{}
+	issue.ID, _ = m["id"].(string)
+	issue.WorkspaceID, _ = m["workspace_id"].(string)
+	issue.CreatorType, _ = m["creator_type"].(string)
+	issue.CreatorID, _ = m["creator_id"].(string)
+	issue.AssigneeType, _ = m["assignee_type"].(*string)
+	issue.AssigneeID, _ = m["assignee_id"].(*string)
+	issue.Description, _ = m["description"].(*string)
+	if issue.ID == "" || issue.CreatorID == "" {
+		return handler.IssueResponse{}, false
+	}
+	return issue, true
 }
 
 // addSubscriber adds a user as an issue subscriber and publishes a

--- a/server/cmd/server/subscriber_listeners_test.go
+++ b/server/cmd/server/subscriber_listeners_test.go
@@ -357,6 +357,39 @@ func TestSubscriberAddedEventPublished(t *testing.T) {
 	}
 }
 
+// Autopilot publishes EventIssueCreated with a map[string]any payload (not handler.IssueResponse).
+// The listener must still subscribe the creator.
+func TestSubscriberIssueCreated_AutopilotMapPayload(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	registerSubscriberListeners(bus, queries)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() { cleanupTestIssue(t, issueID) })
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueCreated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": map[string]any{
+				"id":           issueID,
+				"workspace_id": testWorkspaceID,
+				"title":        "autopilot test issue",
+				"status":       "todo",
+				"priority":     "medium",
+				"creator_type": "member",
+				"creator_id":   testUserID,
+			},
+		},
+	})
+
+	if !isSubscribed(t, queries, issueID, "member", testUserID) {
+		t.Fatal("expected creator to be subscribed when autopilot publishes map payload")
+	}
+}
+
 // Verify parseUUID is consistent — pgtype.UUID from our local helper should match util.ParseUUID
 func TestParseUUIDConsistency(t *testing.T) {
 	uuid := "550e8400-e29b-41d4-a716-446655440000"


### PR DESCRIPTION
## Summary
- Closes [MUL-878](mention://issue/dbdad6b0-a04e-4ec6-ac96-ec6d0b22f459).
- The `issue:created` subscriber listener type-asserted `payload[\"issue\"]` to `handler.IssueResponse`, but autopilot publishes the issue as `map[string]any` via `service.issueToMap`. The assertion failed silently, so creators of autopilot issues were never added as subscribers — and therefore received no notifications when their autopilot run commented or changed status.
- Add an `extractIssueFields` helper that accepts either payload form and use it in both the `issue:created` and `issue:updated` listeners. Mirrors the dual-format pattern already used by the `comment:created` listener.

## Test plan
- [x] `go test -count=1 -run TestSubscriber ./cmd/server/...` (added `TestSubscriberIssueCreated_AutopilotMapPayload` covering the map payload path)
- [ ] Manual: trigger an autopilot, verify the creator appears in the issue's subscriber list and receives notifications when the agent comments or completes the issue