### PR TITLE
fix(editor): prevent duplicate image attachments showing as file cards

### DIFF
--- a/packages/views/editor/extensions/file-upload.ts
+++ b/packages/views/editor/extensions/file-upload.ts
@@ -132,6 +132,18 @@ export async function uploadAndInsertFile(
   }
 }
 
+/** Deduplicate files from the same paste/drop event.
+ *  macOS/Chrome can put the same file in the FileList twice. */
+function dedupFiles(files: FileList): File[] {
+  const seen = new Set<string>();
+  return Array.from(files).filter((file) => {
+    const key = `${file.name}\0${file.size}\0${file.type}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 export function createFileUploadExtension(
   onUploadFileRef: React.RefObject<((file: File) => Promise<UploadResult | null>) | undefined>,
 ) {
@@ -143,7 +155,7 @@ export function createFileUploadExtension(
       const handleFiles = async (files: FileList) => {
         const handler = onUploadFileRef.current;
         if (!handler) return false;
-        for (const file of Array.from(files)) {
+        for (const file of dedupFiles(files)) {
           await uploadAndInsertFile(editor, file, handler);
         }
         return true;
@@ -170,10 +182,10 @@ export function createFileUploadExtension(
               // Only the first file uses the drop position; subsequent files
               // append to the end to avoid stale position issues.
               const dropPos = view.posAtCoords({ left: dragEvent.clientX, top: dragEvent.clientY });
-              const fileArray = Array.from(files);
-              for (let i = 0; i < fileArray.length; i++) {
+              const unique = dedupFiles(files);
+              for (let i = 0; i < unique.length; i++) {
                 const insertPos = i === 0 ? dropPos?.pos : undefined;
-                uploadAndInsertFile(editor, fileArray[i]!, handler, insertPos);
+                uploadAndInsertFile(editor, unique[i]!, handler, insertPos);
               }
               return true;
             },

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -98,9 +98,24 @@ function DeleteCommentDialog({
 
 function AttachmentList({ attachments, content, className }: { attachments?: Attachment[]; content?: string; className?: string }) {
   if (!attachments?.length) return null;
-  // Skip attachments whose URL is already referenced in the markdown content
+  // Skip attachments whose URL is already referenced in the markdown content,
+  // and duplicates of the same file (same name/type/size) that are referenced.
   const standalone = content
-    ? attachments.filter((a) => !content.includes(a.url))
+    ? attachments.filter((a) => {
+        if (content.includes(a.url)) return false;
+        // Dedup: if another attachment with the same file identity is already
+        // inline in the content, this is a duplicate upload — skip it.
+        const hasSiblingInContent = attachments.some(
+          (other) =>
+            other.id !== a.id &&
+            other.filename === a.filename &&
+            other.content_type === a.content_type &&
+            other.size_bytes === a.size_bytes &&
+            content.includes(other.url),
+        );
+        if (hasSiblingInContent) return false;
+        return true;
+      })
     : attachments;
   if (!standalone.length) return null;
 

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useCallback } from "react";
 import { ArrowUp, Loader2 } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
@@ -17,29 +17,34 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
   const editorRef = useRef<ContentEditorRef>(null);
   const [isEmpty, setIsEmpty] = useState(true);
   const [submitting, setSubmitting] = useState(false);
-  const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
+  const uploadMapRef = useRef<Map<string, string>>(new Map());
   const { uploadWithToast } = useFileUpload(api);
   const { isDragOver, dropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
   });
 
-  const handleUpload = async (file: File) => {
+  const handleUpload = useCallback(async (file: File) => {
     const result = await uploadWithToast(file, { issueId });
     if (result) {
-      setAttachmentIds((prev) => [...prev, result.id]);
+      uploadMapRef.current.set(result.link, result.id);
     }
     return result;
-  };
+  }, [uploadWithToast, issueId]);
 
   const handleSubmit = async () => {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
     if (!content || submitting) return;
+    // Only send attachment IDs for uploads still present in the content.
+    const activeIds: string[] = [];
+    for (const [url, id] of uploadMapRef.current) {
+      if (content.includes(url)) activeIds.push(id);
+    }
     setSubmitting(true);
     try {
-      await onSubmit(content, attachmentIds.length > 0 ? attachmentIds : undefined);
+      await onSubmit(content, activeIds.length > 0 ? activeIds : undefined);
       editorRef.current?.clearContent();
       setIsEmpty(true);
-      setAttachmentIds([]);
+      uploadMapRef.current.clear();
     } finally {
       setSubmitting(false);
     }

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect, useCallback } from "react";
 import { ArrowUp, Loader2 } from "lucide-react";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
@@ -39,7 +39,7 @@ function ReplyInput({
   const [isEmpty, setIsEmpty] = useState(true);
   const [isExpanded, setIsExpanded] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
+  const uploadMapRef = useRef<Map<string, string>>(new Map());
   const { uploadWithToast } = useFileUpload(api);
   const { isDragOver, dropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
@@ -56,23 +56,28 @@ function ReplyInput({
     return () => observer.disconnect();
   }, []);
 
-  const handleUpload = async (file: File) => {
+  const handleUpload = useCallback(async (file: File) => {
     const result = await uploadWithToast(file, { issueId });
     if (result) {
-      setAttachmentIds((prev) => [...prev, result.id]);
+      uploadMapRef.current.set(result.link, result.id);
     }
     return result;
-  };
+  }, [uploadWithToast, issueId]);
 
   const handleSubmit = async () => {
     const content = editorRef.current?.getMarkdown()?.replace(/(\n\s*)+$/, "").trim();
     if (!content || submitting) return;
+    // Only send attachment IDs for uploads still present in the content.
+    const activeIds: string[] = [];
+    for (const [url, id] of uploadMapRef.current) {
+      if (content.includes(url)) activeIds.push(id);
+    }
     setSubmitting(true);
     try {
-      await onSubmit(content, attachmentIds.length > 0 ? attachmentIds : undefined);
+      await onSubmit(content, activeIds.length > 0 ? activeIds : undefined);
       editorRef.current?.clearContent();
       setIsEmpty(true);
-      setAttachmentIds([]);
+      uploadMapRef.current.clear();
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Summary
- **Dedup clipboard files**: macOS/Chrome can put the same file in `clipboardData.files` twice; deduplicate by `name+size+type` in both paste and drop handlers
- **Fix attachment ID tracking**: Replace blind `useState<string[]>` accumulator with `useRef<Map<url, id>>` in `CommentInput` and `ReplyInput`; on submit, only send IDs for uploads whose URLs are still present in the content
- **Backward-compat filter**: `AttachmentList` now detects duplicate uploads (same `filename + content_type + size_bytes`) where a sibling attachment is already referenced inline — handles existing data without migration

## Test plan
- [ ] Paste a screenshot into a comment → ONE inline image, NO file card below
- [ ] Paste image, delete it in editor, type text, submit → no orphaned attachment IDs sent
- [ ] View existing comments with the duplicate-attachment bug → file card no longer appears
- [ ] CLI-uploaded attachments (not in markdown) still render as file cards
- [ ] Drag-and-drop image upload still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)