### PR TITLE
fix(desktop): set electron-builder publishingType to release

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -42,4 +42,10 @@ publish:
   provider: github
   owner: multica-ai
   repo: multica
+  # Align with our CLI release flow which pre-creates a *published* GitHub
+  # Release via `gh release create`. The electron-builder default of
+  # `publishingType: draft` conflicts with `existingType=release` and causes
+  # uploads of the DMG/ZIP/blockmaps/latest-mac.yml to be silently skipped,
+  # which breaks electron-updater auto-update on installed clients.
+  publishingType: release
 npmRebuild: false


### PR DESCRIPTION
## What & Why

Set `publishingType: release` in `apps/desktop/electron-builder.yml` so electron-builder uploads desktop artifacts to our pre-created, already-published GitHub Release.

## Background

Our CLI release flow uses `gh release create` to create a **published** GitHub Release up front. electron-builder defaults to `publishingType: draft`, which expects to create/reuse a draft release. When it runs against a release that's already published, it errors out with:

```
existingType=release is not compatible with publishingType=draft
```

…and silently **skips** uploading the DMG / DMG blockmap / ZIP / ZIP blockmap / `latest-mac.yml`. That's exactly what happened on the v0.2.4 desktop release — build / sign / notarize all succeeded, but nothing landed on GitHub and we had to fall back to `gh release upload` manually. Without `latest-mac.yml`, electron-updater clients can't auto-update.

## Fix

Explicitly tell electron-builder to target the existing published release:

```yaml
publish:
  provider: github
  owner: multica-ai
  repo: multica
  publishingType: release
```

## Test plan

- [ ] Next desktop release cuts cleanly with artifacts uploaded to the published release automatically (no manual `gh release upload` fallback).
- [ ] `latest-mac.yml` is present on the release and electron-updater picks up the update.

Refs: [MUL-950](https://github.com/multica-ai/multica/issues) discussion, v0.2.4 desktop release fallback.