### PR TITLE
fix(runtimes): skip CLI update prompts for desktop-managed runtimes

### DIFF
--- a/packages/core/runtimes/hooks.ts
+++ b/packages/core/runtimes/hooks.ts
@@ -28,6 +28,11 @@ function runtimeNeedsUpdate(
   if (rt.runtime_mode !== "local") return false;
   // Only show to the user who owns this runtime.
   if (rt.owner_id !== userId) return false;
+  // Desktop-managed runtimes are updated by the Desktop app's own auto-updater;
+  // the platform should not surface CLI update prompts for them.
+  if (rt.metadata && rt.metadata.launched_by === "desktop") {
+    return false;
+  }
   const cliVersion =
     rt.metadata && typeof rt.metadata.cli_version === "string"
       ? rt.metadata.cli_version


### PR DESCRIPTION
Fix for MUL-993: Desktop runtime 一直显示需要升级的状态.

## 背景
Desktop 托管的 daemon 启动时 CLI 二进制会被 Desktop 应用覆盖/同步,任何 App 内触发的 CLI 升级会在下次启动被 reset。详情面板 `UpdateSection` 通过 `metadata.launched_by === 'desktop'` 已经走 "Managed by Desktop" 分支隐藏 Update 按钮,但侧边栏红点 (`useMyRuntimesNeedUpdate`) 和列表蓝色上箭头 (`useUpdatableRuntimeIds`) 共用的 `runtimeNeedsUpdate()` 只检查 mode/owner/cli_version,因此仍会对 Desktop 托管的 runtime 提示升级 —— 出现截图里自相矛盾的"幽灵升级提示"。

## 变更
在 `packages/core/runtimes/hooks.ts` 的 `runtimeNeedsUpdate()` 中,对 `metadata.launched_by === 'desktop'` 直接返回 `false`,让三处入口(侧栏红点 / 列表箭头 / 详情面板)对 Desktop 托管场景的判断保持一致,CLI 升级完全交由 Desktop 自身的 auto-updater 管理。

非 Desktop 启动的 local runtime 行为保持不变。

## 验证
- `pnpm --filter @multica/core typecheck` ✅
- `pnpm --filter @multica/core test` ✅ (32/32)

Closes [MUL-993](https://multica.copilothub.ai/issues/d2297915-acd1-486f-8917-8b7a26d26f46)