### PR TITLE
fix(views): use createSafeId in custom args tab

### DIFF
--- a/packages/views/agents/components/tabs/custom-args-tab.tsx
+++ b/packages/views/agents/components/tabs/custom-args-tab.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
 } from "lucide-react";
 import type { Agent } from "@multica/core/types";
+import { createSafeId } from "@multica/core/utils";
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
@@ -19,7 +20,7 @@ interface ArgEntry {
 }
 
 function argsToEntries(args: string[]): ArgEntry[] {
-  return args.map((value) => ({ id: crypto.randomUUID(), value }));
+  return args.map((value) => ({ id: createSafeId(), value }));
 }
 
 function entriesToArgs(entries: ArgEntry[]): string[] {
@@ -43,7 +44,7 @@ export function CustomArgsTab({
   const dirty = JSON.stringify(currentArgs) !== JSON.stringify(originalArgs);
 
   const addEntry = () => {
-    setEntries([...entries, { id: crypto.randomUUID(), value: "" }]);
+    setEntries([...entries, { id: createSafeId(), value: "" }]);
   };
 
   const removeEntry = (index: number) => {


### PR DESCRIPTION
## Summary

- `packages/views/agents/components/tabs/custom-args-tab.tsx` called `crypto.randomUUID()` directly, which only exists in secure contexts (HTTPS or localhost). Self-hosted HTTP deployments were throwing `TypeError: crypto.randomUUID is not a function` on the Custom Args tab — the tab crashed on mount whenever an agent already had `custom_args`, and the **Add** button did nothing otherwise.
- Route both id generations through the existing `createSafeId()` helper in `@multica/core/utils`, which was added in #749 for the same class of bug and already has a fallback test.

## Related

- Fixes #1214
- Prior art: #749 (introduced `createSafeId` to fix #708 / #784 — same root cause in the login flow)

## Test plan

- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/core test` (covers `createSafeId` fallback)
- [x] `pnpm --filter @multica/views test`
- [x] ESLint on the modified file
- [ ] Manual: open Custom Args tab on a non-secure context deployment → Add / remove / edit entries