### PR TITLE
fix(inbox): redirect to issue page when notification not in inbox

### DIFF
--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -61,6 +61,22 @@ export function InboxPage() {
     setSelectedKeyState(urlIssue);
   }, [urlIssue]);
 
+  const wsId = useWorkspaceId();
+  const { data: rawItems = [], isLoading: loading } = useQuery(inboxListOptions(wsId));
+  const items = useMemo(() => deduplicateInboxItems(rawItems), [rawItems]);
+
+  const selected = items.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
+
+  // Shared inbox links (?issue=<id>) may point to notifications not in this
+  // user's inbox (archived, or never received). Fall back to the issue page
+  // so the URL still resolves to something meaningful.
+  useEffect(() => {
+    if (loading) return;
+    if (!selectedKey) return;
+    if (selected) return;
+    replace(wsPaths.issueDetail(selectedKey));
+  }, [loading, selectedKey, selected, replace, wsPaths]);
+
   const setSelectedKey = useCallback((key: string) => {
     setSelectedKeyState(key);
     const inboxPath = wsPaths.inbox();
@@ -68,16 +84,11 @@ export function InboxPage() {
     replace(url);
   }, [replace, wsPaths]);
 
-  const wsId = useWorkspaceId();
-  const { data: rawItems = [], isLoading: loading } = useQuery(inboxListOptions(wsId));
-  const items = useMemo(() => deduplicateInboxItems(rawItems), [rawItems]);
-
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "multica_inbox_layout",
   });
 
   const isMobile = useIsMobile();
-  const selected = items.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
   const unreadCount = items.filter((i) => !i.read).length;
 
   const markReadMutation = useMarkInboxRead();


### PR DESCRIPTION
## Summary
- Shared inbox links (`?issue=<id>`) that no longer match a notification in the current user's inbox (archived, or received by a different user) used to land on an empty detail pane with no way forward.
- After the inbox query loads, if the selected key has no match, we now `replace` the URL with `/<ws>/issues/<id>` so the link still resolves to the underlying issue.

## Test plan
- [ ] Open `/<ws>/inbox?issue=<id>` where the id exists in your inbox — detail renders as before, URL unchanged.
- [ ] Open `/<ws>/inbox?issue=<id>` where the id is NOT in your inbox — auto-redirects to `/<ws>/issues/<id>`.
- [ ] Open a shared inbox link from another user — redirects to the issue page.
- [ ] Archive the currently selected inbox item — URL clears to `/<ws>/inbox`, no redirect loop.
- [ ] Switch workspace while URL has `?issue=<id>` — waits for new inbox load before deciding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)