### PR TITLE
fix(daemon): resolve workspace ID for autopilot run_only tasks

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -96,7 +96,8 @@ func (h *Handler) verifyDaemonWorkspaceAccess(r *http.Request, workspaceID strin
 	return err == nil
 }
 
-// resolveTaskWorkspaceID derives the workspace ID from a task's issue or chat session.
+// resolveTaskWorkspaceID derives the workspace ID from a task's linked entity
+// (issue, chat session, or autopilot run).
 func (h *Handler) resolveTaskWorkspaceID(r *http.Request, task db.AgentTaskQueue) string {
 	if task.IssueID.Valid {
 		if issue, err := h.Queries.GetIssue(r.Context(), task.IssueID); err == nil {
@@ -106,6 +107,13 @@ func (h *Handler) resolveTaskWorkspaceID(r *http.Request, task db.AgentTaskQueue
 	if task.ChatSessionID.Valid {
 		if cs, err := h.Queries.GetChatSession(r.Context(), task.ChatSessionID); err == nil {
 			return uuidToString(cs.WorkspaceID)
+		}
+	}
+	if task.AutopilotRunID.Valid {
+		if run, err := h.Queries.GetAutopilotRun(r.Context(), task.AutopilotRunID); err == nil {
+			if ap, err := h.Queries.GetAutopilot(r.Context(), run.AutopilotID); err == nil {
+				return uuidToString(ap.WorkspaceID)
+			}
 		}
 	}
 	return ""


### PR DESCRIPTION
## Problem

`resolveTaskWorkspaceID` (daemon.go:99-112) only handles tasks linked via `IssueID` or `ChatSessionID`. Tasks created by `run_only` autopilots (introduced in #1028) set only `AutopilotRunID`, so the resolver returns an empty workspace ID. `requireDaemonTaskAccess` treats this as "task not found" and responds with 404, causing 100% failure for all `run_only` autopilot tasks.

Fixes #1224

## Solution

Add an `AutopilotRunID` branch to `resolveTaskWorkspaceID` that:
1. Looks up the `AutopilotRun` via `GetAutopilotRun`
2. Looks up the parent `Autopilot` via `GetAutopilot`
3. Returns the autopilot's `WorkspaceID`

This follows the same pattern as the existing `IssueID` and `ChatSessionID` branches, using queries that already exist in the generated DB layer (`autopilot.sql.go` lines 344 and 405).

## Changes

- `server/internal/handler/daemon.go`: Add `AutopilotRunID` resolution branch to `resolveTaskWorkspaceID`

## Testing

- Verified that `GetAutopilotRun` returns `AutopilotID` and `GetAutopilot` returns `WorkspaceID` (confirmed from generated model types)
- The fix mirrors the existing resolution pattern, adding no new dependencies