### PR TITLE
fix(autopilot): use readable UTC timestamp in issue description

### DIFF
--- a/server/internal/service/autopilot.go
+++ b/server/internal/service/autopilot.go
@@ -321,7 +321,7 @@ func (s *AutopilotService) publishRunDone(workspaceID string, run db.AutopilotRu
 // user-provided description, asking the agent to rename the issue after
 // it understands the actual work.
 func (s *AutopilotService) buildIssueDescription(ap db.Autopilot) pgtype.Text {
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format("2006-01-02 15:04 UTC")
 	note := fmt.Sprintf("\n\n---\n*Autopilot run triggered at %s. After starting work, rename this issue to accurately reflect what you are doing.*", now)
 	base := ap.Description.String
 	return pgtype.Text{String: base + note, Valid: true}


### PR DESCRIPTION
## Summary

- Fixes multica-ai/multica#1197.
- `buildIssueDescription` in `server/internal/service/autopilot.go` was embedding the autopilot trigger time using `time.RFC3339` (e.g. `2026-04-16T14:54:32Z`). For users in non-UTC timezones the `Z` suffix reads like a mistake rather than a UTC marker, and the dense ISO format is hard to parse at a glance.
- Switch to the format `2006-01-02 15:04 UTC` → e.g. `2026-04-16 14:54 UTC`. Only the hour differs from local time; minutes match across any timezone, making the value trivial to reconcile.
- No workspace/user timezone concept is introduced — that is a larger scope change and out of scope here.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass.
- [ ] After deploy to staging, trigger an Autopilot run and confirm the created issue's description contains the new format (e.g. `*Autopilot run triggered at 2026-04-17 05:47 UTC. ...*`).