### PR TITLE
fix(views): align skeleton loading states with actual page layouts

### DIFF
--- a/apps/web/app/[workspaceSlug]/layout.tsx
+++ b/apps/web/app/[workspaceSlug]/layout.tsx
@@ -8,6 +8,7 @@ import { workspaceBySlugOptions } from "@multica/core/workspace";
 import { setCurrentWorkspace } from "@multica/core/platform";
 import { useAuthStore } from "@multica/core/auth";
 import { NoAccessPage } from "@multica/views/workspace/no-access-page";
+import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
 import { useWorkspaceSeen } from "@multica/views/workspace/use-workspace-seen";
 
 export default function WorkspaceLayout({
@@ -60,11 +61,17 @@ export default function WorkspaceLayout({
   // and we just need to hold null briefly.
   const hasBeenSeen = useWorkspaceSeen(workspaceSlug, !!workspace);
 
-  if (isAuthLoading) return null;
+  const loadingIndicator = (
+    <div className="flex h-svh items-center justify-center">
+      <MulticaIcon className="size-6 animate-pulse" />
+    </div>
+  );
+
+  if (isAuthLoading) return loadingIndicator;
   // Don't render children until workspace is resolved. useWorkspaceId()
   // throws when the list hasn't populated or the slug is unknown — gating
   // here makes that invariant hold for every descendant.
-  if (!listFetched) return null;
+  if (!listFetched) return loadingIndicator;
   if (!workspace) {
     // If we've resolved this slug before in this session, it was just
     // removed from our list (deleted/left/evicted). A navigate is almost

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -24,11 +24,10 @@ import { AgentListItem } from "./agent-list-item";
 import { AgentDetail } from "./agent-detail";
 
 export function AgentsPage() {
-  const isLoading = useAuthStore((s) => s.isLoading);
   const currentUser = useAuthStore((s) => s.user);
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
-  const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const { data: agents = [], isLoading } = useQuery(agentListOptions(wsId));
   const [selectedId, setSelectedId] = useState<string>("");
   const [showArchived, setShowArchived] = useState(false);
   const [showCreate, setShowCreate] = useState(false);

--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -385,9 +385,39 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
 
   if (isLoading) {
     return (
-      <div className="p-6 space-y-4">
-        <Skeleton className="h-8 w-64" />
-        <Skeleton className="h-40 w-full" />
+      <div className="flex h-full flex-col">
+        <div className="flex h-12 shrink-0 items-center gap-2 border-b px-5">
+          <Skeleton className="h-4 w-4" />
+          <span className="text-muted-foreground">/</span>
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <div className="max-w-4xl mx-auto p-6 space-y-8">
+            <section className="space-y-4">
+              <Skeleton className="h-3 w-20" />
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-12" />
+                  <Skeleton className="h-5 w-32" />
+                </div>
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-12" />
+                  <Skeleton className="h-5 w-24" />
+                </div>
+              </div>
+            </section>
+            <section className="space-y-3">
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-10 w-full rounded-md" />
+            </section>
+            <section className="space-y-3">
+              <Skeleton className="h-4 w-24" />
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </section>
+          </div>
+        </div>
       </div>
     );
   }

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -366,11 +366,21 @@ export function AutopilotsPage() {
       {/* Table */}
       <div className="flex-1 overflow-y-auto">
         {isLoading ? (
-          <div className="p-5 space-y-1">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-11 w-full" />
-            ))}
-          </div>
+          <>
+            <div className="sticky top-0 z-[1] flex h-8 items-center gap-2 border-b bg-muted/30 px-5">
+              <span className="shrink-0 w-4" />
+              <Skeleton className="h-3 w-12 flex-1 max-w-[48px]" />
+              <Skeleton className="h-3 w-12 shrink-0" />
+              <Skeleton className="h-3 w-10 shrink-0" />
+              <Skeleton className="h-3 w-10 shrink-0" />
+              <Skeleton className="h-3 w-12 shrink-0" />
+            </div>
+            <div className="p-5 pt-1 space-y-1">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-11 w-full" />
+              ))}
+            </div>
+          </>
         ) : autopilots.length === 0 ? (
           <div className="flex flex-col items-center py-16 px-5">
             <Zap className="h-10 w-10 mb-3 text-muted-foreground opacity-30" />

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { cn } from "@multica/ui/lib/utils";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import {
   Collapsible,
   CollapsibleContent,
@@ -86,16 +87,16 @@ export function ChatMessageSkeleton() {
     <div className="flex-1 overflow-hidden">
       <div className="mx-auto w-full max-w-4xl px-5 py-4 space-y-5">
         <div className="space-y-2">
-          <div className="h-3.5 w-3/4 rounded bg-muted animate-pulse" />
-          <div className="h-3.5 w-1/2 rounded bg-muted animate-pulse" />
+          <Skeleton className="h-3.5 w-3/4" />
+          <Skeleton className="h-3.5 w-1/2" />
         </div>
         <div className="flex justify-end">
-          <div className="h-8 w-48 rounded-2xl bg-muted animate-pulse" />
+          <Skeleton className="h-8 w-48 rounded-2xl" />
         </div>
         <div className="space-y-2">
-          <div className="h-3.5 w-2/3 rounded bg-muted animate-pulse" />
-          <div className="h-3.5 w-5/6 rounded bg-muted animate-pulse" />
-          <div className="h-3.5 w-1/3 rounded bg-muted animate-pulse" />
+          <Skeleton className="h-3.5 w-2/3" />
+          <Skeleton className="h-3.5 w-5/6" />
+          <Skeleton className="h-3.5 w-1/3" />
         </div>
       </div>
     </div>

--- a/packages/views/invite/invite-page.tsx
+++ b/packages/views/invite/invite-page.tsx
@@ -12,6 +12,7 @@ import { useNavigation } from "../navigation";
 import { useLogout } from "../auth";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { ArrowLeft, LogOut, Users, Check, X } from "lucide-react";
 
 export interface InvitePageProps {
@@ -94,7 +95,14 @@ export function InvitePage({ invitationId, onBack }: InvitePageProps) {
   if (isLoading) {
     return (
       <InviteShell onBack={onBack}>
-        <div className="text-sm text-muted-foreground">Loading invitation...</div>
+        <Card className="w-full max-w-md">
+          <CardContent className="flex flex-col items-center gap-4 py-12">
+            <Skeleton className="h-12 w-12 rounded-full" />
+            <Skeleton className="h-5 w-48" />
+            <Skeleton className="h-4 w-64" />
+            <Skeleton className="h-9 w-32 rounded-md" />
+          </CardContent>
+        </Card>
       </InviteShell>
     );
   }

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -386,17 +386,17 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
 
   // Custom hooks — encapsulate timeline, reactions, subscribers
   const {
-    timeline, loading: timelineLoading, submitComment, submitReply,
+    timeline, submitComment, submitReply,
     editComment, deleteComment, toggleReaction: handleToggleReaction,
   } = useIssueTimeline(id, user?.id);
 
   const {
-    reactions: issueReactions, loading: reactionsLoading,
+    reactions: issueReactions,
     toggleReaction: handleToggleIssueReaction,
   } = useIssueReactions(id, user?.id);
 
   const {
-    subscribers, loading: subscribersLoading, isSubscribed, toggleSubscribe: handleToggleSubscribe, toggleSubscriber,
+    subscribers, isSubscribed, toggleSubscribe: handleToggleSubscribe, toggleSubscriber,
   } = useIssueSubscribers(id, user?.id);
 
   // Token usage
@@ -499,45 +499,44 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   if (loading) {
     return (
       <div className="flex flex-1 min-h-0 flex-col">
-        {/* Header skeleton */}
         <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
           <Skeleton className="h-4 w-16" />
           <Skeleton className="h-4 w-4" />
           <Skeleton className="h-4 w-24" />
         </div>
         <div className="flex flex-1 min-h-0">
-          {/* Content skeleton */}
-          <div className="flex-1 p-8 space-y-6">
-            <Skeleton className="h-8 w-3/4" />
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-5/6" />
-              <Skeleton className="h-4 w-2/3" />
-            </div>
-            <Skeleton className="h-px w-full" />
-            <div className="space-y-3">
-              <Skeleton className="h-4 w-20" />
-              <div className="flex items-start gap-3">
-                <Skeleton className="h-8 w-8 rounded-full" />
-                <div className="flex-1 space-y-2">
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-16 w-full rounded-lg" />
+          <div className="flex-1 overflow-y-auto">
+            <div className="mx-auto w-full max-w-4xl px-8 py-8 space-y-6">
+              <Skeleton className="h-8 w-3/4" />
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-5/6" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
+              <Skeleton className="h-px w-full" />
+              <div className="space-y-3">
+                <Skeleton className="h-4 w-20" />
+                <div className="flex items-start gap-3">
+                  <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-32" />
+                    <Skeleton className="h-16 w-full rounded-lg" />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-          {/* Sidebar skeleton */}
-          <div className="w-64 border-l p-4 space-y-4">
+          <div className="hidden md:block w-80 border-l p-4 space-y-5">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="flex items-center justify-between">
-                <Skeleton className="h-3 w-16" />
+              <div key={i} className="flex items-center gap-2">
+                <Skeleton className="h-3 w-16 shrink-0" />
                 <Skeleton className="h-5 w-24" />
               </div>
             ))}
             <Skeleton className="h-px w-full" />
             {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="flex items-center justify-between">
-                <Skeleton className="h-3 w-16" />
+              <div key={i} className="flex items-center gap-2">
+                <Skeleton className="h-3 w-16 shrink-0" />
                 <Skeleton className="h-4 w-28" />
               </div>
             ))}
@@ -1050,19 +1049,12 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
             />
 
             <div className="flex items-center gap-1 mt-3">
-              {reactionsLoading ? (
-                <div className="flex items-center gap-1">
-                  <Skeleton className="h-7 w-14 rounded-full" />
-                  <Skeleton className="h-7 w-14 rounded-full" />
-                </div>
-              ) : (
-                <ReactionBar
-                  reactions={issueReactions}
-                  currentUserId={user?.id}
-                  onToggle={handleToggleIssueReaction}
-                  getActorName={getActorName}
-                />
-              )}
+              <ReactionBar
+                reactions={issueReactions}
+                currentUserId={user?.id}
+                onToggle={handleToggleIssueReaction}
+                getActorName={getActorName}
+              />
               <FileUploadButton
                 size="sm"
                 onSelect={(file) => descEditorRef.current?.uploadFile(file)}
@@ -1196,15 +1188,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                 <h2 className="text-base font-semibold">Activity</h2>
               </div>
               <div className="flex items-center gap-2">
-                {subscribersLoading ? (
-                  <div className="flex items-center gap-1">
-                    <Skeleton className="h-4 w-16" />
-                    <div className="flex -space-x-1">
-                      <Skeleton className="h-6 w-6 rounded-full" />
-                      <Skeleton className="h-6 w-6 rounded-full" />
-                    </div>
-                  </div>
-                ) : (<>
                 <button
                   onClick={handleToggleSubscribe}
                   className="text-xs text-muted-foreground hover:text-foreground transition-colors"
@@ -1282,7 +1265,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                     </Command>
                   </PopoverContent>
                 </Popover>
-                </>)}
               </div>
             </div>
 
@@ -1297,19 +1279,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
 
             {/* Timeline entries */}
             <div className="mt-4 flex flex-col gap-3">
-              {timelineLoading ? (
-                <div className="space-y-4">
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <div key={i} className="flex items-start gap-3 px-4">
-                      <Skeleton className="h-8 w-8 rounded-full shrink-0" />
-                      <div className="flex-1 space-y-2">
-                        <Skeleton className="h-4 w-32" />
-                        <Skeleton className="h-16 w-full rounded-lg" />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (() => {
+              {(() => {
                 const topLevel = timeline.filter((e) => e.type === "activity" || !e.parent_id);
                 const repliesByParent = new Map<string, TimelineEntry[]>();
                 for (const e of timeline) {

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -103,19 +103,35 @@ export function IssuesPage() {
           <Skeleton className="h-5 w-5 rounded" />
           <Skeleton className="h-4 w-32" />
         </div>
-        <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
-          <Skeleton className="h-5 w-24" />
-          <Skeleton className="h-8 w-24" />
+        <div className="flex h-12 shrink-0 items-center justify-between px-4">
+          <div className="flex items-center gap-1">
+            <Skeleton className="h-8 w-14 rounded-md" />
+            <Skeleton className="h-8 w-20 rounded-md" />
+            <Skeleton className="h-8 w-16 rounded-md" />
+          </div>
+          <div className="flex items-center gap-1">
+            <Skeleton className="h-8 w-8 rounded-md" />
+            <Skeleton className="h-8 w-8 rounded-md" />
+            <Skeleton className="h-8 w-8 rounded-md" />
+          </div>
         </div>
-        <div className="flex flex-1 min-h-0 gap-4 overflow-x-auto p-4">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex min-w-52 flex-1 flex-col gap-2">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-24 w-full rounded-lg" />
-              <Skeleton className="h-24 w-full rounded-lg" />
-            </div>
-          ))}
-        </div>
+        {viewMode === "list" ? (
+          <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-1">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full rounded-lg" />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-1 min-h-0 gap-4 overflow-x-auto p-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex min-w-52 flex-1 flex-col gap-2">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-24 w-full rounded-lg" />
+                <Skeleton className="h-24 w-full rounded-lg" />
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -129,19 +129,35 @@ export function MyIssuesPage() {
           <Skeleton className="h-5 w-5 rounded" />
           <Skeleton className="h-4 w-32" />
         </div>
-        <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
-          <Skeleton className="h-5 w-24" />
-          <Skeleton className="h-8 w-24" />
+        <div className="flex h-12 shrink-0 items-center justify-between px-4">
+          <div className="flex items-center gap-1">
+            <Skeleton className="h-8 w-14 rounded-md" />
+            <Skeleton className="h-8 w-20 rounded-md" />
+            <Skeleton className="h-8 w-16 rounded-md" />
+          </div>
+          <div className="flex items-center gap-1">
+            <Skeleton className="h-8 w-8 rounded-md" />
+            <Skeleton className="h-8 w-8 rounded-md" />
+            <Skeleton className="h-8 w-8 rounded-md" />
+          </div>
         </div>
-        <div className="flex flex-1 min-h-0 gap-4 overflow-x-auto p-4">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex min-w-52 flex-1 flex-col gap-2">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-24 w-full rounded-lg" />
-              <Skeleton className="h-24 w-full rounded-lg" />
-            </div>
-          ))}
-        </div>
+        {viewMode === "list" ? (
+          <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-1">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full rounded-lg" />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-1 min-h-0 gap-4 overflow-x-auto p-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex min-w-52 flex-1 flex-col gap-2">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-24 w-full rounded-lg" />
+                <Skeleton className="h-24 w-full rounded-lg" />
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -252,11 +252,22 @@ export function ProjectsPage() {
       {/* Table */}
       <div className="flex-1 overflow-y-auto">
         {isLoading ? (
-          <div className="p-5 space-y-1">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-11 w-full" />
-            ))}
-          </div>
+          <>
+            <div className="sticky top-0 z-[1] flex h-8 items-center gap-2 border-b bg-muted/30 px-5">
+              <span className="shrink-0 w-[24px]" />
+              <Skeleton className="h-3 w-12 flex-1 max-w-[48px]" />
+              <Skeleton className="h-3 w-12 shrink-0" />
+              <Skeleton className="h-3 w-12 shrink-0" />
+              <Skeleton className="h-3 w-12 shrink-0" />
+              <Skeleton className="h-3 w-8 shrink-0" />
+              <Skeleton className="h-3 w-12 shrink-0" />
+            </div>
+            <div className="p-5 pt-1 space-y-1">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-11 w-full" />
+              ))}
+            </div>
+          </>
         ) : projects.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-24 text-muted-foreground">
             <FolderKanban className="h-10 w-10 mb-3 opacity-30" />

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -34,7 +34,6 @@ import { toast } from "sonner";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { api } from "@multica/core/api";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { skillListOptions, workspaceKeys } from "@multica/core/workspace/queries";
 
@@ -614,10 +613,9 @@ function SkillDetail({
 // ---------------------------------------------------------------------------
 
 export default function SkillsPage() {
-  const isLoading = useAuthStore((s) => s.isLoading);
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
-  const { data: skills = [] } = useQuery(skillListOptions(wsId));
+  const { data: skills = [], isLoading } = useQuery(skillListOptions(wsId));
   const [selectedId, setSelectedId] = useState<string>("");
   const [showCreate, setShowCreate] = useState(false);
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
@@ -700,7 +698,7 @@ export default function SkillsPage() {
             <Skeleton className="h-8 w-56" />
           </div>
           <div className="flex flex-1 min-h-0">
-            <div className="w-48 border-r p-3 space-y-2">
+            <div className="w-52 border-r p-3 space-y-2">
               <Skeleton className="h-4 w-full" />
               <Skeleton className="h-4 w-3/4" />
             </div>


### PR DESCRIPTION
## Summary

- **Issues/MyIssues**: removed incorrect `border-b` from toolbar skeleton row, added `viewMode`-aware skeleton (list rows vs board columns)
- **Issue Detail**: fixed content padding (`max-w-4xl mx-auto px-8 py-8`) and sidebar width (`w-80` matching 320px default), eliminated 3 independent sub-area skeleton flashes (reactions/subscribers/timeline now render with empty defaults instead of separate loading ternaries)
- **Agents/Skills**: gate skeleton on data query `isLoading` instead of auth store `isLoading`, so skeleton covers actual data fetch window
- **Projects/Autopilots**: added sticky column header skeleton row matching real table headers
- **Autopilot Detail**: added missing `PageHeader` skeleton, fleshed out from 2 elements to full 3-section layout
- **Invite**: replaced plain "Loading invitation..." text with Card-shaped skeleton
- **Chat**: migrated `ChatMessageSkeleton` from raw `animate-pulse` divs to `<Skeleton>` component
- **Workspace layout**: show `MulticaIcon` loading indicator instead of blank screen during auth/workspace resolution

## Risk

Low. 9/11 changes are pure skeleton JSX adjustments (zero logic change). Two behavioral changes:
1. Agents/Skills loading gate source changed (auth → data query) — same pattern as all other pages
2. Issue Detail sub-area skeleton ternaries removed — components handle empty defaults gracefully

All changes are frontend rendering only. No API, state management, or data flow changes.

## Test plan

- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm test` — 136 tests pass (including 11 issue-detail tests)
- [ ] Visual verification: navigate to each page and confirm skeleton → content transition is smooth
- [ ] Workspace switch: switch between workspaces and verify no blank screens
- [ ] Issue Detail: open an issue and verify no multi-flash (reactions/subscribers/timeline load silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)