### PR TITLE
docs(cli): document project commands and --project flag for issues (MUL-867)

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -278,7 +278,7 @@ multica issue list --priority urgent --assignee "Agent Name"
 multica issue list --limit 20 --output json
 ```
 
-Available filters: `--status`, `--priority`, `--assignee`, `--limit`.
+Available filters: `--status`, `--priority`, `--assignee`, `--project`, `--limit`.
 
 ### Get Issue
 
@@ -293,7 +293,7 @@ multica issue get <id> --output json
 multica issue create --title "Fix login bug" --description "..." --priority high --assignee "Lambda"
 ```
 
-Flags: `--title` (required), `--description`, `--status`, `--priority`, `--assignee`, `--parent`, `--due-date`.
+Flags: `--title` (required), `--description`, `--status`, `--priority`, `--assignee`, `--parent`, `--project`, `--due-date`.
 
 ### Update Issue
 
@@ -348,6 +348,70 @@ multica issue run-messages <task-id> --since 42 --output json
 ```
 
 The `runs` command shows all past and current executions for an issue, including running tasks. The `run-messages` command shows the detailed message log (tool calls, thinking, text, errors) for a single run. Use `--since` for efficient polling of in-progress runs.
+
+## Projects
+
+Projects group related issues (e.g. a sprint, an epic, a workstream). Every project
+belongs to a workspace and can optionally have a lead (member or agent).
+
+### List Projects
+
+```bash
+multica project list
+multica project list --status in_progress
+multica project list --output json
+```
+
+Available filters: `--status`.
+
+### Get Project
+
+```bash
+multica project get <id>
+multica project get <id> --output json
+```
+
+### Create Project
+
+```bash
+multica project create --title "2026 Week 16 Sprint" --icon "🏃" --lead "Lambda"
+```
+
+Flags: `--title` (required), `--description`, `--status`, `--icon`, `--lead`.
+
+### Update Project
+
+```bash
+multica project update <id> --title "New title" --status in_progress
+multica project update <id> --lead "Lambda"
+```
+
+Flags: `--title`, `--description`, `--status`, `--icon`, `--lead`.
+
+### Change Status
+
+```bash
+multica project status <id> in_progress
+```
+
+Valid statuses: `planned`, `in_progress`, `paused`, `completed`, `cancelled`.
+
+### Delete Project
+
+```bash
+multica project delete <id>
+```
+
+### Associating Issues with Projects
+
+Use the `--project` flag on `issue create` / `issue update` to attach an issue to a
+project, or on `issue list` to filter issues by project:
+
+```bash
+multica issue create --title "Login bug" --project <project-id>
+multica issue update <issue-id> --project <project-id>
+multica issue list --project <project-id>
+```
 
 ## Setup
 

--- a/apps/docs/content/docs/cli/reference.mdx
+++ b/apps/docs/content/docs/cli/reference.mdx
@@ -212,7 +212,7 @@ multica issue list --priority urgent --assignee "Agent Name"
 multica issue list --limit 20 --output json
 ```
 
-Available filters: `--status`, `--priority`, `--assignee`, `--limit`.
+Available filters: `--status`, `--priority`, `--assignee`, `--project`, `--limit`.
 
 ### Get Issue
 
@@ -227,7 +227,7 @@ multica issue get <id> --output json
 multica issue create --title "Fix login bug" --description "..." --priority high --assignee "Lambda"
 ```
 
-Flags: `--title` (required), `--description`, `--status`, `--priority`, `--assignee`, `--parent`, `--due-date`.
+Flags: `--title` (required), `--description`, `--status`, `--priority`, `--assignee`, `--parent`, `--project`, `--due-date`.
 
 ### Update Issue
 
@@ -279,6 +279,70 @@ multica issue run-messages <task-id> --output json
 
 # Incremental fetch (only messages after a given sequence number)
 multica issue run-messages <task-id> --since 42 --output json
+```
+
+## Projects
+
+Projects group related issues (e.g. a sprint, an epic, a workstream). Every project
+belongs to a workspace and can optionally have a lead (member or agent).
+
+### List Projects
+
+```bash
+multica project list
+multica project list --status in_progress
+multica project list --output json
+```
+
+Available filters: `--status`.
+
+### Get Project
+
+```bash
+multica project get <id>
+multica project get <id> --output json
+```
+
+### Create Project
+
+```bash
+multica project create --title "2026 Week 16 Sprint" --icon "🏃" --lead "Lambda"
+```
+
+Flags: `--title` (required), `--description`, `--status`, `--icon`, `--lead`.
+
+### Update Project
+
+```bash
+multica project update <id> --title "New title" --status in_progress
+multica project update <id> --lead "Lambda"
+```
+
+Flags: `--title`, `--description`, `--status`, `--icon`, `--lead`.
+
+### Change Status
+
+```bash
+multica project status <id> in_progress
+```
+
+Valid statuses: `planned`, `in_progress`, `paused`, `completed`, `cancelled`.
+
+### Delete Project
+
+```bash
+multica project delete <id>
+```
+
+### Associating Issues with Projects
+
+Use the `--project` flag on `issue create` / `issue update` to attach an issue to a
+project, or on `issue list` to filter issues by project:
+
+```bash
+multica issue create --title "Login bug" --project <project-id>
+multica issue update <issue-id> --project <project-id>
+multica issue list --project <project-id>
 ```
 
 ## Configuration


### PR DESCRIPTION
## Background

Issue [MUL-867](https://github.com/multica-ai/multica/issues) tracks CLI support for `project` commands. The commands themselves (`list`, `get`, `create`, `update`, `delete`, `status`) and the `--project` flag on `issue list/create/update` already landed in #072ccc90 (feat(cli): add project commands and --project flag for issues), but the user-facing reference docs never mentioned them — so the feature was effectively hidden.

## Changes

- `apps/docs/content/docs/cli/reference.mdx` — new `## Projects` section covering list / get / create / update / status / delete, plus a short "Associating Issues with Projects" subsection for the `--project` flag.
- `CLI_AND_DAEMON.md` — mirrors the same section so the in-repo doc stays aligned.
- Also added `--project` to the documented filter lists for `issue list` and `issue create`.

## Test notes

- Verified on the installed CLI: `multica project list --output json` returns projects, matching the flags documented here.
- Docs-only change; no code paths affected, no tests needed.

Closes MUL-867