### PR TITLE
refactor(desktop): centralize shell.openExternal through a single wrapper

### DIFF
--- a/apps/desktop/eslint.config.mjs
+++ b/apps/desktop/eslint.config.mjs
@@ -10,4 +10,28 @@ export default [
       globals: { ...globals.node },
     },
   },
+  // Security: every renderer-controlled URL that reaches the OS shell must
+  // flow through openExternalSafely in src/main/external-url.ts (scheme
+  // allowlist). Enforce it statically so a direct shell.openExternal call
+  // cannot silently regress the protection.
+  {
+    files: ["src/main/**/*.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.object.name='shell'][callee.property.name='openExternal']",
+          message:
+            "Do not call shell.openExternal directly. Use openExternalSafely from './external-url' so the http/https allowlist stays enforced.",
+        },
+      ],
+    },
+  },
+  {
+    files: ["src/main/external-url.ts"],
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
 ];

--- a/apps/desktop/src/main/external-url.test.ts
+++ b/apps/desktop/src/main/external-url.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { isSafeExternalHttpUrl } from "./external-url";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("electron", () => ({
+  shell: { openExternal: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { shell } from "electron";
+import { isSafeExternalHttpUrl, openExternalSafely } from "./external-url";
 
 describe("isSafeExternalHttpUrl", () => {
   it("allows http and https URLs", () => {
@@ -7,10 +13,61 @@ describe("isSafeExternalHttpUrl", () => {
     expect(isSafeExternalHttpUrl("http://localhost:3000/auth")).toBe(true);
   });
 
-  it("rejects invalid and non-http schemes", () => {
-    expect(isSafeExternalHttpUrl("not a url")).toBe(false);
+  it("allows https URLs with embedded credentials", () => {
+    // WHATWG URL parses these as https; OS-level handling is the shell's concern.
+    expect(isSafeExternalHttpUrl("https://user:pass@example.com")).toBe(true);
+  });
+
+  it("normalizes scheme casing so uppercase variants can't bypass", () => {
+    expect(isSafeExternalHttpUrl("HTTPS://example.com")).toBe(true);
+    expect(isSafeExternalHttpUrl("FILE:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects dangerous pseudo-schemes", () => {
+    expect(isSafeExternalHttpUrl("javascript:alert(1)")).toBe(false);
+    expect(
+      isSafeExternalHttpUrl("data:text/html,<script>alert(1)</script>"),
+    ).toBe(false);
+  });
+
+  it("rejects filesystem and network transport schemes", () => {
     expect(isSafeExternalHttpUrl("file:///etc/passwd")).toBe(false);
+    expect(isSafeExternalHttpUrl("ftp://example.com/x")).toBe(false);
+    expect(isSafeExternalHttpUrl("smb://share/x")).toBe(false);
+  });
+
+  it("rejects local-handler schemes used in past RCE chains", () => {
     expect(isSafeExternalHttpUrl("vscode://file/test")).toBe(false);
+    expect(isSafeExternalHttpUrl("ms-msdt:/id%20PCWDiagnostic")).toBe(false);
+  });
+
+  it("rejects mailto and other non-web schemes", () => {
     expect(isSafeExternalHttpUrl("mailto:test@example.com")).toBe(false);
+    expect(isSafeExternalHttpUrl("tel:+15551234567")).toBe(false);
+  });
+
+  it("rejects empty, whitespace, and malformed input", () => {
+    expect(isSafeExternalHttpUrl("")).toBe(false);
+    expect(isSafeExternalHttpUrl(" ")).toBe(false);
+    expect(isSafeExternalHttpUrl("not a url")).toBe(false);
+    expect(isSafeExternalHttpUrl("http://")).toBe(false);
+  });
+});
+
+describe("openExternalSafely", () => {
+  beforeEach(() => {
+    vi.mocked(shell.openExternal).mockClear();
+  });
+
+  it("forwards http/https URLs to shell.openExternal", () => {
+    openExternalSafely("https://multica.ai");
+    expect(shell.openExternal).toHaveBeenCalledWith("https://multica.ai");
+  });
+
+  it("does not call shell.openExternal for rejected schemes", () => {
+    openExternalSafely("file:///etc/passwd");
+    openExternalSafely("javascript:alert(1)");
+    openExternalSafely("not a url");
+    expect(shell.openExternal).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/external-url.ts
+++ b/apps/desktop/src/main/external-url.ts
@@ -1,10 +1,38 @@
-export function isSafeExternalHttpUrl(url: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return false;
-  }
+import { shell } from "electron";
 
-  return parsed.protocol === "https:" || parsed.protocol === "http:";
+// True when the URL parses and uses http/https — the only schemes we let
+// reach `shell.openExternal`. Scheme comparison is safe because the WHATWG
+// URL parser lowercases the protocol field.
+export function isSafeExternalHttpUrl(url: string): boolean {
+  return getHttpProtocol(url) !== null;
+}
+
+// Canonical wrapper around shell.openExternal. All renderer-controlled URLs
+// that eventually reach the OS shell MUST flow through here; direct calls
+// to `shell.openExternal` elsewhere in the main process are banned by the
+// no-restricted-syntax rule in apps/desktop/eslint.config.mjs.
+export function openExternalSafely(url: string): Promise<void> | void {
+  if (getHttpProtocol(url) === null) {
+    console.warn(`[security] blocked openExternal: ${describeScheme(url)}`);
+    return;
+  }
+  return shell.openExternal(url);
+}
+
+function getHttpProtocol(url: string): "http:" | "https:" | null {
+  try {
+    const { protocol } = new URL(url);
+    if (protocol === "http:" || protocol === "https:") return protocol;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function describeScheme(url: string): string {
+  try {
+    return `scheme=${new URL(url).protocol}`;
+  } catch {
+    return "invalid URL";
+  }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,11 +1,11 @@
-import { app, shell, BrowserWindow, ipcMain, nativeImage } from "electron";
+import { app, BrowserWindow, ipcMain, nativeImage } from "electron";
 import { homedir } from "os";
 import { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 import fixPath from "fix-path";
 import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
-import { isSafeExternalHttpUrl } from "./external-url";
+import { openExternalSafely } from "./external-url";
 
 // Bundled icon used for dev-mode dock/taskbar branding. In production the
 // app bundle icon (from electron-builder) wins; this path is only consumed
@@ -105,11 +105,7 @@ function createWindow(): void {
   });
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    if (!isSafeExternalHttpUrl(details.url)) {
-      console.warn("[security] blocked window.open external URL");
-      return { action: "deny" };
-    }
-    shell.openExternal(details.url);
+    openExternalSafely(details.url);
     return { action: "deny" };
   });
 
@@ -189,16 +185,12 @@ if (!gotTheLock) {
     });
 
     // IPC: open URL in default browser (used by renderer for Google login).
-    // Restrict to http/https so the renderer can't dispatch arbitrary OS
-    // protocol handlers (file://, smb://, ms-msdt:, vscode://, ...) which
-    // become a concern under this app's intentional webSecurity: false +
-    // sandbox: false configuration.
+    // All scheme-allowlist enforcement lives in openExternalSafely — this
+    // is the single audit point for renderer-controlled URLs reaching the
+    // OS shell under the app's intentional webSecurity: false + sandbox:
+    // false configuration.
     ipcMain.handle("shell:openExternal", (_event, url: string) => {
-      if (!isSafeExternalHttpUrl(url)) {
-        console.warn("[security] blocked openExternal: invalid external URL");
-        return;
-      }
-      return shell.openExternal(url);
+      return openExternalSafely(url);
     });
 
     // IPC: toggle immersive mode — hides the macOS traffic lights so full-screen


### PR DESCRIPTION
## Summary

Follow-up to #1124 — make the http/https scheme allowlist **structurally enforced** instead of a hand-applied convention.

- **Single entry point**: `openExternalSafely(url)` in `apps/desktop/src/main/external-url.ts` owns the scheme check + `shell.openExternal` call. Both call sites (the `shell:openExternal` IPC handler and `webContents.setWindowOpenHandler`) delegate to it.
- **ESLint guard**: a `no-restricted-syntax` rule under `apps/desktop/src/main/**/*.ts` blocks bare `shell.openExternal(…)` calls (with an opt-out for `external-url.ts` itself). A future contributor can't quietly reintroduce an unchecked call site — CI will fail.
- **Richer log**: the warn now includes the rejected scheme (`[security] blocked openExternal: scheme=file:` / `… invalid URL`), restoring diagnostic info that was lost when the helper was extracted in the previous PR.
- **Tests**: extended `external-url.test.ts` with the edge cases the #1124 review flagged but didn't ship — scheme casing (`FILE://`, `HTTPS://`), `javascript:` / `data:`, `ftp:` / `smb:`, `vscode:` / `ms-msdt:`, `mailto:` / `tel:`, URL with embedded credentials, empty / whitespace / malformed inputs. Added two `openExternalSafely` tests (electron mocked) for the allow + deny paths.

Why this is worth doing as its own PR: #1124 is correct, but both call sites still manually chain `isSafeExternalHttpUrl` → `shell.openExternal`, and there's no structural guarantee that a third, fourth, nth call site would remember to do the same. The lint rule turns "reviewers must remember to check this" into "the build fails if you forget."

### Scope of the lint rule

Selector: `CallExpression[callee.object.name='shell'][callee.property.name='openExternal']`. Catches the realistic mistake (`shell.openExternal(…)`), not pathological aliases like `const s = shell; s.openExternal(…)`. The wrapper pattern makes such aliases unnecessary.

### Not done in this PR (intentional)

- Routing warn logs through a structured logger / Sentry — desktop main has no logger yet, that's a bigger change and belongs in its own follow-up.
- Relaxing `webSecurity: false` — also a separate follow-up (see discussion on the internal tracking issue). Even after it's relaxed, the allowlist here stays load-bearing (preload APIs bypass the browser security model).

## Test plan

- [x] `pnpm --filter @multica/desktop typecheck` — passes
- [x] `pnpm --filter @multica/desktop test` — 48 tests pass (expanded `external-url.test.ts` ships 10 cases + 2 `openExternalSafely` cases)
- [x] `pnpm --filter @multica/desktop lint` — passes (no new warnings in my files; pre-existing warnings on unrelated files unchanged)
- [x] `pnpm build` — desktop bundle builds clean
- [x] Lint-rule probe: temporarily introducing `shell.openExternal("https://…")` in a new file under `src/main/` trips the rule with the intended error. Removed after verification.
- [ ] Manual smoke — Google login redirect (https) still opens in the default browser; a devtools `window.desktopAPI.openExternal("file:///etc/passwd")` is rejected with the new warn.

## Related

- Follows up #1124 (closed #1115)