### PR TITLE
test(agent): regression tests for codex subagent threadId filter

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -618,6 +618,12 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 	// Ignore notifications from threads other than the one we are tracking.
 	// Codex multiplexes subagent threads (e.g. memory consolidation) on the
 	// same stdio pipe; only our thread should drive turn lifecycle and output.
+	//
+	// The v2 app-server-protocol schema guarantees a top-level threadId on
+	// every notification, so this dispatch-level guard transparently covers
+	// every handler below. If a future codex revision introduces notifications
+	// without threadId, they fall through (ok=false) — re-audit this guard
+	// when bumping codex.
 	if threadID, ok := params["threadId"].(string); ok && c.threadID != "" && threadID != c.threadID {
 		return
 	}

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -501,6 +501,63 @@ func TestCodexRawThreadStatusIdle(t *testing.T) {
 	}
 }
 
+// Regression for #1181: subagent threads (e.g. memory consolidation)
+// are multiplexed on the same stdio pipe. Their turn/completed must not
+// terminate the main turn.
+func TestCodexRawTurnCompletedFromSubagentIgnored(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	c.threadID = "thr_main"
+
+	var doneCount int
+	c.onTurnDone = func(aborted bool) {
+		doneCount++
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr_subagent","turn":{"id":"turn-sub","status":"completed"}}}`)
+
+	if doneCount != 0 {
+		t.Fatalf("subagent turn/completed must not trigger onTurnDone, got %d calls", doneCount)
+	}
+
+	// Sanity check: a matching threadId still drives completion.
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr_main","turn":{"id":"turn-main","status":"completed"}}}`)
+	if doneCount != 1 {
+		t.Fatalf("matching threadId should trigger onTurnDone exactly once, got %d", doneCount)
+	}
+}
+
+// Regression for #1181: subagent agentMessage/final_answer must not
+// trigger turn completion or leak text into the main output stream.
+func TestCodexRawItemAgentMessageFinalAnswerFromSubagentIgnored(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	c.threadID = "thr_main"
+	c.turnStarted = true
+
+	var messages []Message
+	var doneCount int
+	c.onMessage = func(msg Message) {
+		messages = append(messages, msg)
+	}
+	c.onTurnDone = func(aborted bool) {
+		doneCount++
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"thr_subagent","item":{"type":"agentMessage","id":"sub-1","text":"subagent leakage","phase":"final_answer"}}}`)
+
+	if len(messages) != 0 {
+		t.Fatalf("subagent text must not leak into output builder, got %+v", messages)
+	}
+	if doneCount != 0 {
+		t.Fatalf("subagent final_answer must not trigger onTurnDone, got %d calls", doneCount)
+	}
+}
+
 func TestCodexCloseAllPending(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Follow-up to #1192. Hardens the just-merged dispatch-level `threadId` guard in `handleRawNotification` along two axes:

- **Documentation** — adds an inline note by the guard explaining the v2 app-server-protocol contract it relies on (every notification carries a top-level `threadId`), so the implicit assumption is visible to anyone bumping the codex version later.
- **Tests** — adds two regression tests covering the leakage paths the guard closes:
  1. `turn/completed` from a subagent thread must not invoke `onTurnDone`, and a subsequent matching-thread `turn/completed` still does (sanity check).
  2. `item/completed` (`agentMessage`, `phase=final_answer`) from a subagent thread must neither leak text into the output builder nor terminate the turn.

Existing notification tests omit the top-level `threadId` field, so they pass through unfiltered (`ok=false`) and would not catch a regression that drops or relocates the guard. These two new tests close that blind spot.

## Test plan

- [x] `go test ./pkg/agent/ -run 'TestCodexRaw'` — all green
- [x] `go vet ./pkg/agent/`
- [x] Mentally reverted the guard in `handleRawNotification` to confirm both new tests fail without the fix