### PR TITLE
feat(issues): optional project and sub-issue progress on issue cards (MUL-996)

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -18,6 +18,8 @@ export interface CardProperties {
   description: boolean;
   assignee: boolean;
   dueDate: boolean;
+  project: boolean;
+  childProgress: boolean;
 }
 
 export interface ActorFilterValue {
@@ -38,6 +40,8 @@ export const CARD_PROPERTY_OPTIONS: { key: keyof CardProperties; label: string }
   { key: "description", label: "Description" },
   { key: "assignee", label: "Assignee" },
   { key: "dueDate", label: "Due date" },
+  { key: "project", label: "Project" },
+  { key: "childProgress", label: "Sub-issue progress" },
 ];
 
 export interface IssueViewState {
@@ -86,6 +90,8 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
     description: true,
     assignee: true,
     dueDate: true,
+    project: true,
+    childProgress: true,
   },
   listCollapsedStatuses: [],
 

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -8,9 +8,12 @@ import { CSS } from "@dnd-kit/utilities";
 import { toast } from "sonner";
 import type { Issue, UpdateIssueRequest } from "@multica/core/types";
 import { CalendarDays } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { projectListOptions } from "@multica/core/projects/queries";
 import { PriorityIcon } from "./priority-icon";
 import { PriorityPicker, AssigneePicker, DueDatePicker } from "./pickers";
 import { PRIORITY_CONFIG } from "@multica/core/issues/config";
@@ -49,6 +52,12 @@ export const BoardCardContent = memo(function BoardCardContent({
 }) {
   const storeProperties = useViewStore((s) => s.cardProperties);
   const priorityCfg = PRIORITY_CONFIG[issue.priority];
+  const wsId = useWorkspaceId();
+  const { data: projects = [] } = useQuery({
+    ...projectListOptions(wsId),
+    enabled: storeProperties.project && !!issue.project_id,
+  });
+  const project = issue.project_id ? projects.find((p) => p.id === issue.project_id) : undefined;
 
   const updateIssueMutation = useUpdateIssue();
   const handleUpdate = useCallback(
@@ -65,6 +74,8 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showDescription = storeProperties.description && issue.description;
   const showAssignee = storeProperties.assignee && issue.assignee_type && issue.assignee_id;
   const showDueDate = storeProperties.dueDate && issue.due_date;
+  const showProject = storeProperties.project && project;
+  const showChildProgress = storeProperties.childProgress && childProgress;
 
   return (
     <div className="rounded-lg border-[0.5px] bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-shadow group-hover:shadow-sm">
@@ -76,13 +87,23 @@ export const BoardCardContent = memo(function BoardCardContent({
         {issue.title}
       </p>
 
-      {/* Sub-issue progress */}
-      {childProgress && (
-        <div className="mt-1.5 inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
-          <ProgressRing done={childProgress.done} total={childProgress.total} size={14} />
-          <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
-            {childProgress.done}/{childProgress.total}
-          </span>
+      {/* Sub-issue progress + project */}
+      {(showChildProgress || showProject) && (
+        <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
+          {showChildProgress && (
+            <div className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
+              <ProgressRing done={childProgress!.done} total={childProgress!.total} size={14} />
+              <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
+                {childProgress!.done}/{childProgress!.total}
+              </span>
+            </div>
+          )}
+          {showProject && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground max-w-[160px]">
+              <span aria-hidden="true" className="shrink-0">{project!.icon || "📁"}</span>
+              <span className="truncate">{project!.title}</span>
+            </span>
+          )}
         </div>
       )}
 

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -108,7 +108,7 @@ const mockViewState = {
   includeNoProject: false,
   sortBy: "position" as const,
   sortDirection: "asc" as const,
-  cardProperties: { priority: true, description: true, assignee: true, dueDate: true },
+  cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true },
   listCollapsedStatuses: [] as string[],
   setViewMode: vi.fn(),
   toggleStatusFilter: vi.fn(),
@@ -152,6 +152,8 @@ vi.mock("@multica/core/issues/stores/view-store", () => ({
     { key: "description", label: "Description" },
     { key: "assignee", label: "Assignee" },
     { key: "dueDate", label: "Due date" },
+    { key: "project", label: "Project" },
+    { key: "childProgress", label: "Sub-issue progress" },
   ],
 }));
 

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { memo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { useWorkspacePaths } from "@multica/core/paths";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useViewStore } from "@multica/core/issues/stores/view-store-context";
+import { projectListOptions } from "@multica/core/projects/queries";
 import { PriorityIcon } from "./priority-icon";
 import { ProgressRing } from "./progress-ring";
 
@@ -31,6 +35,18 @@ export const ListRow = memo(function ListRow({
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
   const p = useWorkspacePaths();
+  const storeProperties = useViewStore((s) => s.cardProperties);
+  const wsId = useWorkspaceId();
+  const { data: projects = [] } = useQuery({
+    ...projectListOptions(wsId),
+    enabled: storeProperties.project && !!issue.project_id,
+  });
+  const project = issue.project_id ? projects.find((pr) => pr.id === issue.project_id) : undefined;
+
+  const showProject = storeProperties.project && project;
+  const showChildProgress = storeProperties.childProgress && childProgress;
+  const showAssignee = storeProperties.assignee && issue.assignee_type && issue.assignee_id;
+  const showDueDate = storeProperties.dueDate && issue.due_date;
 
   return (
     <div
@@ -61,24 +77,30 @@ export const ListRow = memo(function ListRow({
         </span>
         <span className="flex min-w-0 flex-1 items-center gap-1.5">
           <span className="truncate">{issue.title}</span>
-          {childProgress && (
+          {showChildProgress && (
             <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
-              <ProgressRing done={childProgress.done} total={childProgress.total} size={14} />
+              <ProgressRing done={childProgress!.done} total={childProgress!.total} size={14} />
               <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
-                {childProgress.done}/{childProgress.total}
+                {childProgress!.done}/{childProgress!.total}
               </span>
             </span>
           )}
         </span>
-        {issue.due_date && (
-          <span className="shrink-0 text-xs text-muted-foreground">
-            {formatDate(issue.due_date)}
+        {showProject && (
+          <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground max-w-[140px]">
+            <span aria-hidden="true" className="shrink-0">{project!.icon || "📁"}</span>
+            <span className="truncate">{project!.title}</span>
           </span>
         )}
-        {issue.assignee_type && issue.assignee_id && (
+        {showDueDate && (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {formatDate(issue.due_date!)}
+          </span>
+        )}
+        {showAssignee && (
           <ActorAvatar
-            actorType={issue.assignee_type}
-            actorId={issue.assignee_id}
+            actorType={issue.assignee_type!}
+            actorId={issue.assignee_id!}
             size={20}
           />
         )}


### PR DESCRIPTION
## Summary
- Adds `project` and `childProgress` to the issue-card property toggles, so users can opt in/out from the Display popover.
- When enabled, board cards and list rows show the parent project (icon + title) and the sub-issue completion ring.
- Both default to on; the sub-issue ring was previously always rendered and is now gated behind the new toggle.

## Test plan
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/core typecheck`
- [x] `pnpm --filter @multica/views test`
- [x] `pnpm --filter @multica/core test`
- [ ] Manually toggle Project / Sub-issue progress in the Display popover on `/issues` and verify cards update.