### PR TITLE
refactor(cli): drop webhook/api from autopilot trigger-add

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -496,14 +496,15 @@ multica autopilot runs <id>
 multica autopilot runs <id> --limit 50 --output json
 ```
 
-### Triggers (Schedule / Webhook / API)
+### Schedule Triggers
 
 ```bash
-multica autopilot trigger-add <autopilot-id> --kind schedule --cron "0 9 * * 1-5" --timezone "America/New_York"
-multica autopilot trigger-add <autopilot-id> --kind webhook
+multica autopilot trigger-add <autopilot-id> --cron "0 9 * * 1-5" --timezone "America/New_York"
 multica autopilot trigger-update <autopilot-id> <trigger-id> --enabled=false
 multica autopilot trigger-delete <autopilot-id> <trigger-id>
 ```
+
+Only cron-based `schedule` triggers are currently exposed via the CLI. The data model also defines `webhook` and `api` kinds, but there is no server endpoint that fires them yet, so they're not surfaced here.
 
 ## Other Commands
 

--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -68,7 +68,7 @@ var autopilotRunsCmd = &cobra.Command{
 
 var autopilotTriggerAddCmd = &cobra.Command{
 	Use:   "trigger-add <autopilot-id>",
-	Short: "Add a trigger (schedule/webhook/api) to an autopilot",
+	Short: "Add a schedule trigger to an autopilot",
 	Args:  exactArgs(1),
 	RunE:  runAutopilotTriggerAdd,
 }
@@ -138,10 +138,9 @@ func init() {
 	autopilotRunsCmd.Flags().Int("offset", 0, "Pagination offset")
 	autopilotRunsCmd.Flags().String("output", "table", "Output format: table or json")
 
-	// trigger-add
-	autopilotTriggerAddCmd.Flags().String("kind", "", "Trigger kind: schedule, webhook, or api (required)")
-	autopilotTriggerAddCmd.Flags().String("cron", "", "Cron expression (required for kind=schedule)")
-	autopilotTriggerAddCmd.Flags().String("timezone", "", "IANA timezone for schedule (default UTC)")
+	// trigger-add — only schedule triggers are supported end-to-end today
+	autopilotTriggerAddCmd.Flags().String("cron", "", "Cron expression (required)")
+	autopilotTriggerAddCmd.Flags().String("timezone", "", "IANA timezone (default UTC)")
 	autopilotTriggerAddCmd.Flags().String("label", "", "Optional human-readable label")
 	autopilotTriggerAddCmd.Flags().String("output", "json", "Output format: table or json")
 
@@ -470,21 +469,18 @@ func runAutopilotTriggerAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	kind, _ := cmd.Flags().GetString("kind")
-	if kind == "" {
-		return fmt.Errorf("--kind is required (schedule, webhook, or api)")
-	}
-	if kind != "schedule" && kind != "webhook" && kind != "api" {
-		return fmt.Errorf("--kind must be schedule, webhook, or api")
-	}
+	// Only schedule triggers are dispatched end-to-end today. The server
+	// schema also defines "webhook" and "api" kinds, but no inbound endpoint
+	// fires them — they'd sit in the DB forever. Re-add kind selection here
+	// when those paths are implemented.
 	cron, _ := cmd.Flags().GetString("cron")
-	if kind == "schedule" && cron == "" {
-		return fmt.Errorf("--cron is required for kind=schedule")
+	if cron == "" {
+		return fmt.Errorf("--cron is required")
 	}
 
-	body := map[string]any{"kind": kind}
-	if cron != "" {
-		body["cron_expression"] = cron
+	body := map[string]any{
+		"kind":            "schedule",
+		"cron_expression": cron,
 	}
 	if v, _ := cmd.Flags().GetString("timezone"); v != "" {
 		body["timezone"] = v


### PR DESCRIPTION
## Summary

Follow-up to #1234. The autopilot trigger schema defines three kinds — `schedule`, `webhook`, `api` — but only `schedule` is wired end-to-end on the server:

- `autopilot_scheduler.ClaimDueScheduleTriggers` filters `kind = 'schedule'` (`pkg/db/queries/autopilot.sql:150`)
- `DispatchAutopilot` is only reachable from the scheduler (`source: schedule`) and `POST /api/autopilots/{id}/trigger` (`source: manual`) — no inbound webhook/api endpoint exists
- The UI (`AddTriggerDialog`) only creates `schedule` triggers

Exposing webhook/api in the CLI let users create triggers that'd sit in the DB forever. Drop `--kind` from `trigger-add`, require `--cron`, always send `kind=schedule`. Re-add the flag when the server grows a dispatch path for the other kinds.

## Changes

- `trigger-add`: remove `--kind`, make `--cron` required, always POST `kind: "schedule"`
- `trigger-add` short description updated ("Add a schedule trigger...")
- `CLI_AND_DAEMON.md`: rename the section from "Triggers (Schedule / Webhook / API)" to "Schedule Triggers", drop the webhook example, add a one-line note explaining why the other kinds aren't exposed

No server changes. `trigger-update` / `trigger-delete` / `list` / `get` continue to accept any existing trigger (read-side compatibility).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/multica/...`
- [x] `go test ./cmd/multica/...`
- [x] `multica autopilot trigger-add --help` shows only `--cron`, `--timezone`, `--label`, `--output`