### PR TITLE
fix(daemon): inject AGENTS.md for Hermes provider

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -18,13 +18,14 @@ import (
 // For Gemini:   writes {workDir}/GEMINI.md  (discovered natively by the Gemini CLI)
 // For Pi:       writes {workDir}/AGENTS.md  (skills discovered natively from ~/.pi/agent/skills/)
 // For Cursor:   writes {workDir}/AGENTS.md  (skills discovered natively from .cursor/skills/)
+// For Hermes:   writes {workDir}/AGENTS.md  (Hermes reads AGENTS.md from workdir)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error {
 	content := buildMetaSkillContent(provider, ctx)
 
 	switch provider {
 	case "claude":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor":
+	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "hermes":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)
@@ -150,8 +151,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor":
-			// Codex, Copilot, OpenCode, OpenClaw, Pi, and Cursor discover skills natively from their respective paths — just list names.
+		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "hermes":
+			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, and Hermes discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
 		case "gemini":
 			// Gemini reads GEMINI.md directly; point it at the fallback skills dir.


### PR DESCRIPTION
## Summary

- Hermes was falling through to the `default` case in `InjectRuntimeConfig`, which skipped writing `AGENTS.md` to the workdir
- This meant Hermes only received instructions via prompt text prepending (lower priority), while all other agents (Claude, Codex, OpenCode, etc.) got file-based system config injection
- Adding `"hermes"` to the `AGENTS.md` switch case gives it the same runtime config injection as other providers

## Changes

- `server/internal/daemon/execenv/runtime_config.go`: Add `"hermes"` to both switch cases (file injection + skills discovery)

## Test plan

- [ ] Assign a task to a Hermes agent with custom Instructions configured
- [ ] Verify `AGENTS.md` is written to the task workdir (`~/multica_workspaces/...`)
- [ ] Verify Hermes reads and follows the instructions from `AGENTS.md`

**AI tool used:** Claude Code

**Prompt / approach:** Discovered that Hermes was missing from the `InjectRuntimeConfig` switch case while investigating why Hermes agents were not following configured Instructions. Traced the issue from `runtime_config.go` through the agent execution pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)