### PR TITLE
fix(desktop): use releaseType instead of publishingType in electron-builder publish config

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -44,8 +44,8 @@ publish:
   repo: multica
   # Align with our CLI release flow which pre-creates a *published* GitHub
   # Release via `gh release create`. The electron-builder default of
-  # `publishingType: draft` conflicts with `existingType=release` and causes
+  # `releaseType: draft` conflicts with `existingType=release` and causes
   # uploads of the DMG/ZIP/blockmaps/latest-mac.yml to be silently skipped,
   # which breaks electron-updater auto-update on installed clients.
-  publishingType: release
+  releaseType: release
 npmRebuild: false


### PR DESCRIPTION
## 背景

electron-builder 26.8.1 校验 `apps/desktop/electron-builder.yml` 时拒绝 `publish.publishingType: release`：该字段不属于 GitHub publisher 的合法 schema，导致打包流程失败。

## 核心改动

GitHub publisher 用于选择发行类型（draft / prerelease / release）的正确字段是 `releaseType`，而非 `publishingType`（`publishingType` 仅存在于 Snap Store publisher）。将配置项和对应注释一起改为 `releaseType`。

```diff
-  # `publishingType: draft` conflicts with `existingType=release` …
-  publishingType: release
+  # `releaseType: draft` conflicts with `existingType=release` …
+  releaseType: release
```

保持语义一致：仍与 `gh release create` 预先创建的已发布 Release 对齐，避免 DMG/ZIP/blockmaps/latest-mac.yml 被静默跳过而破坏 electron-updater 自动更新。

## 测试重点

- `pnpm --filter @multica/desktop package` 不再因 schema 校验报错。
- macOS 构建产物仍会上传到现有的已发布 Release（release 行为保持不变）。

Refs MUL-1053