### PR TITLE
docs: add v0.2.5 changelog (2026-04-17)

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -280,6 +280,31 @@ export const en: LandingDict = {
     },
     entries: [
       {
+        version: "0.2.5",
+        date: "2026-04-17",
+        title: "CLI Autopilot, Cmd+K & Daemon Identity",
+        changes: [],
+        features: [
+          "CLI `autopilot` commands for managing scheduled and triggered automations",
+          "CLI `issue subscriber` commands for subscription management",
+          "Cmd+K palette extended — theme toggle, quick new issue/project, copy link, switch workspace",
+          "Project and sub-issue progress as optional card properties on the issue list",
+          "Persistent daemon UUID identity — CLI and desktop share one daemon across restarts and machine moves",
+          "Sole-owner workspace leave preflight check",
+          "Persist comment collapse state across sessions",
+        ],
+        fixes: [
+          "Agents now triggered on comments regardless of issue status",
+          "Codex sandbox config fixed for macOS network access",
+          "Editor bubble menu rewritten with @floating-ui/dom for reliable scroll hiding",
+          "Autopilot creator automatically subscribed to autopilot-created issues",
+          "Autopilot workspace ID correctly resolved for run-only tasks",
+          "Desktop restricts `shell.openExternal` to http/https schemes (security)",
+          "Duplicate agent names return 409 instead of silently failing",
+          "New tabs in desktop inherit current workspace",
+        ],
+      },
+      {
         version: "0.2.1",
         date: "2026-04-16",
         title: "New Agent Runtimes",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -280,6 +280,31 @@ export const zh: LandingDict = {
     },
     entries: [
       {
+        version: "0.2.5",
+        date: "2026-04-17",
+        title: "CLI Autopilot、Cmd+K 与 Daemon 身份",
+        changes: [],
+        features: [
+          "CLI `autopilot` 命令，管理定时和触发式自动化",
+          "CLI `issue subscriber` 订阅管理命令",
+          "Cmd+K 命令面板扩展——主题切换、快速创建 Issue/项目、复制链接、切换工作区",
+          "Issue 列表卡片可选显示项目和子 Issue 进度",
+          "Daemon 持久化 UUID 身份——CLI 和桌面应用共用同一个 daemon，跨重启和机器迁移保持一致",
+          "唯一所有者退出工作区的前置检查",
+          "评论折叠状态跨会话持久化",
+        ],
+        fixes: [
+          "Agent 现在在任意 Issue 状态下都会响应评论触发",
+          "修复 Codex 沙箱在 macOS 上的网络访问配置",
+          "编辑器气泡菜单改用 @floating-ui/dom 重写，滚动时正确隐藏",
+          "Autopilot 创建者自动订阅其生成的 Issue",
+          "Autopilot run-only 任务正确解析工作区 ID",
+          "桌面应用 `shell.openExternal` 限制仅允许 http/https 协议（安全）",
+          "重名 Agent 创建返回 409 而非静默失败",
+          "桌面应用新建标签页继承当前工作区",
+        ],
+      },
+      {
         version: "0.2.1",
         date: "2026-04-16",
         title: "新增 Agent 运行时",


### PR DESCRIPTION
## Summary
- Add v0.2.5 changelog — CLI autopilot/subscriber commands, extended Cmd+K palette, persistent daemon UUID identity
- 7 features + 8 fixes, concise
- Both en and zh updated