### PR TITLE
fix(sidebar): prevent pin drag from reloading page and smooth drop animation

### DIFF
--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@multica/ui/lib/utils";
 import { AppLink, useNavigation } from "../navigation";
 import {
@@ -139,7 +139,7 @@ function SortablePinItem({ pin, href, pathname, onUnpin }: { pin: PinnedItem; hr
       <SidebarMenuButton
         size="sm"
         isActive={isActive}
-        render={<AppLink href={href} />}
+        render={<AppLink href={href} draggable={false} />}
         onClick={(event) => {
           if (wasDragged.current) {
             wasDragged.current = false;
@@ -147,7 +147,10 @@ function SortablePinItem({ pin, href, pathname, onUnpin }: { pin: PinnedItem; hr
             return;
           }
         }}
-        className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
+        className={cn(
+          "text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground",
+          isDragging && "pointer-events-none",
+        )}
       >
         {pin.item_type === "issue" && pin.status ? (
           /* Override parent [&_svg]:size-4 — pinned items need smaller icons to match sm size */
@@ -220,17 +223,35 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   const deletePin = useDeletePin();
   const reorderPins = useReorderPins();
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  // Local presentational copy of pinnedItems for drop-animation stability.
+  // Follows TQ at rest; frozen during a drag gesture so a mid-drag cache
+  // write (our own optimistic update, or a WS refetch) cannot reorder the
+  // DOM under dnd-kit while its drop animation is still interpolating.
+  const [localPinned, setLocalPinned] = useState<PinnedItem[]>(pinnedItems);
+  const isDraggingRef = useRef(false);
+  useEffect(() => {
+    if (!isDraggingRef.current) {
+      setLocalPinned(pinnedItems);
+    }
+  }, [pinnedItems]);
+
+  const handleDragStart = useCallback(() => {
+    isDraggingRef.current = true;
+  }, []);
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      isDraggingRef.current = false;
       const { active, over } = event;
       if (!over || active.id === over.id) return;
-      const oldIndex = pinnedItems.findIndex((p) => p.id === active.id);
-      const newIndex = pinnedItems.findIndex((p) => p.id === over.id);
+      const oldIndex = localPinned.findIndex((p) => p.id === active.id);
+      const newIndex = localPinned.findIndex((p) => p.id === over.id);
       if (oldIndex === -1 || newIndex === -1) return;
-      const reordered = arrayMove(pinnedItems, oldIndex, newIndex);
+      const reordered = arrayMove(localPinned, oldIndex, newIndex);
+      setLocalPinned(reordered);
       reorderPins.mutate(reordered);
     },
-    [pinnedItems, reorderPins],
+    [localPinned, reorderPins],
   );
 
   const queryClient = useQueryClient();
@@ -445,7 +466,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
             </SidebarGroupContent>
           </SidebarGroup>
 
-          {pinnedItems.length > 0 && (
+          {localPinned.length > 0 && (
             <Collapsible defaultOpen>
               <SidebarGroup className="group/pinned">
                 <SidebarGroupLabel
@@ -454,14 +475,14 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                 >
                   <span>Pinned</span>
                   <ChevronRight className="!size-3 ml-1 stroke-[2.5] transition-transform duration-200 group-data-[panel-open]/trigger:rotate-90" />
-                  <span className="ml-auto text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover/pinned:opacity-100">{pinnedItems.length}</span>
+                  <span className="ml-auto text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover/pinned:opacity-100">{localPinned.length}</span>
                 </SidebarGroupLabel>
                 <CollapsibleContent>
                   <SidebarGroupContent>
-                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-                      <SortableContext items={pinnedItems.map((p) => p.id)} strategy={verticalListSortingStrategy}>
+                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+                      <SortableContext items={localPinned.map((p) => p.id)} strategy={verticalListSortingStrategy}>
                         <SidebarMenu className="gap-0.5">
-                          {pinnedItems.map((pin: PinnedItem) => (
+                          {localPinned.map((pin: PinnedItem) => (
                             <SortablePinItem
                               key={pin.id}
                               pin={pin}


### PR DESCRIPTION
## Summary

Two bugs in the sidebar **Pinned** section's drag-to-reorder, fixed in one change:

1. **Dragging a pin reloads the whole page.** On mouse release the browser would navigate to the pin's href, causing a full document reload (HMR reconnect, `/api/config`/`/api/me`/`/api/workspaces` all re-fetched from scratch).
2. **Drop animation jumps.** Even after fixing (1), the item would "jump back" to its original slot then slide into the new one, instead of landing smoothly.

## Why it happened

**(1) Native HTML5 drag leak through `<a>`.** `<a href>` is implicitly `draggable=true` per HTML spec. The browser runs a parallel native drag behind dnd-kit's pointer flow, with the URL as drag-data. On mouse release Chromium hit-tests the drop position — if a link-element is hit, the default action is to navigate the current tab to that URL (bypasses Next router). `board-card.tsx` was already guarding against this by adding `pointer-events-none` while dragging; the pin code was missing this guard.

**(2) TQ optimistic update races dnd-kit's drop animation.** `onDragEnd` → `reorderPins.mutate(reordered)` → `onMutate` writes new order to TQ cache → `useQuery` returns a new reference → React re-renders with reordered DOM. But dnd-kit's drop animation is still interpolating `transform` based on the old DOM positions. Reference frame shifts mid-animation → visible jump. `board-view.tsx` already solved this by keeping a local `useState` snapshot gated by an `isDraggingRef`; the pin code was reading directly from TQ.

## Fix

- `SortablePinItem`: add `draggable={false}` to `AppLink` (source-level prevention) AND `isDragging && "pointer-events-none"` on the button (defensive, matches board-card).
- `AppSidebar`: introduce `localPinned` (`useState`) + `isDraggingRef` (`useRef`). `useEffect` syncs from TQ only when `!isDraggingRef.current`. `onDragStart` flips the ref; `onDragEnd` clears it, calls `setLocalPinned(reordered)` first, then `mutate(reordered)`. Render, `SortableContext`, and the length guard all read from `localPinned`.

This `localPinned` is a short-lived presentational buffer, not a second source of truth — always derived from TQ, only one component reads it, reconverges the moment the drag ends. Does not belong in Zustand (same reasoning `board-view.tsx` uses `useState`, not a global store).

## Test plan

- [ ] Drag a pin to reorder — page does not reload, URL doesn't change
- [ ] Drop animation lands smoothly; no "jump back then swap"
- [ ] Pin list stays intact across workspace switches and WS reconnects
- [ ] Board card drag-to-reorder still works (regression check for the shared pattern)
- [ ] Clicking a pin still navigates to its href (non-drag click path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)