### PR TITLE
fix(editor): use onMouseDown in mention suggestion to prevent blur-before-click (#1039)

### DIFF
--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -179,7 +179,10 @@ function MentionRow({
         className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors ${
           selected ? "bg-accent" : "hover:bg-accent/50"
         } ${isClosed ? "opacity-60" : ""}`}
-        onClick={onSelect}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onSelect();
+        }}
       >
         {item.status && (
           <StatusIcon status={item.status} className="h-3.5 w-3.5 shrink-0" />
@@ -202,7 +205,10 @@ function MentionRow({
       className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-xs transition-colors ${
         selected ? "bg-accent" : "hover:bg-accent/50"
       }`}
-      onClick={onSelect}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onSelect();
+      }}
     >
       <ActorAvatar
         actorType={item.type === "all" ? "member" : item.type}


### PR DESCRIPTION
## Problem

When selecting a mention item (especially agents) via **mouse click**, the editor's `blur` event fires before the `click` handler. This causes TipTap's suggestion plugin to tear down the popup (`onExit` → cleanup) and discard the `command` callback before `onClick` executes. The result is a bare `@` with no name inserted.

**Keyboard selection** (arrow keys + Enter) works fine because it goes through the imperative `onKeyDown` handler, which doesn't involve focus changes.

This was reported and confirmed by @NevilleQingNY in #1039:
> the mouse click path in our mention dropdown isn't inserting the agent name correctly, while the keyboard (arrow keys + Enter) path works fine

## Fix

Switch `MentionRow` buttons from `onClick` to `onMouseDown` with `preventDefault()`. This keeps the editor focused during the interaction, so the suggestion `command` executes before any cleanup.

This is a well-known pattern in TipTap suggestion implementations — `mousedown` + `preventDefault` prevents the editor blur that would otherwise destroy the popup before the selection can be processed.

## Changes

- `packages/views/editor/extensions/mention-suggestion.tsx`: Replace `onClick={onSelect}` with `onMouseDown` + `preventDefault()` in both `MentionRow` button variants (issue and member/agent)

## Testing

- Mouse click on any mention suggestion item (member, agent, or issue) should now correctly insert the mention with the full name
- Keyboard selection (arrow keys + Enter) continues to work as before
- The suggestion popup should dismiss correctly after selection via either method

Closes #1039