### PR TITLE
fix(docker): add restart: unless-stopped to self-host compose

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -21,6 +21,7 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-multica} -d ${POSTGRES_DB:-multica}"]
       interval: 5s
@@ -56,6 +57,7 @@ services:
       CLOUDFRONT_PRIVATE_KEY: ${CLOUDFRONT_PRIVATE_KEY:-}
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
       MULTICA_APP_URL: ${MULTICA_APP_URL:-http://localhost:3000}
+    restart: unless-stopped
 
   frontend:
     build:
@@ -71,6 +73,7 @@ services:
       - "${FRONTEND_PORT:-3000}:3000"
     environment:
       HOSTNAME: "0.0.0.0"
+    restart: unless-stopped
 
 volumes:
   pgdata:


### PR DESCRIPTION
Self-hosted services (postgres, backend, frontend) should restart automatically on failure or host reboot. Without restart policy, all containers stay down after a host restart until manually started.

Adds `restart: unless-stopped` to all three services in `docker-compose.selfhost.yml`.