### PR TITLE
ci: exclude apps/docs from frontend build/typecheck/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm install
 
       - name: Build, type check, and test
-        run: pnpm build && pnpm typecheck && pnpm test
+        run: pnpm exec turbo build typecheck test --filter='!@multica/docs'
 
   backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

Removes `apps/docs` from the frontend CI job. Replaces the sequential `pnpm build && pnpm typecheck && pnpm test` with a single `turbo build typecheck test --filter='!@multica/docs'` invocation.

## Related Issue

Closes [MUL-1059](https://multica.copilothub.ai/multica/issues/MUL-1059)

## Why

Docs site is no longer auto-deployed via Vercel (auto-deploy was disabled in the Vercel dashboard because external fork PRs can't authenticate to Vercel). Building the docs app on every PR adds ~seconds without catching anything actionable now that the deployment path is gone.

Turbo still runs build/typecheck/test across all other workspaces (`@multica/core`, `@multica/desktop`, `@multica/eslint-config`, `@multica/tsconfig`, `@multica/ui`, `@multica/views`, `@multica/web`), and the task graph wiring in `turbo.json` is unchanged.

## How to Test

1. Check the CI run on this PR — `frontend` job should succeed without executing any `@multica/docs` tasks.
2. Locally: `pnpm exec turbo build typecheck test --filter='!@multica/docs'` runs end-to-end; `pnpm exec turbo build typecheck test --filter='@multica/docs' --dry=json` confirms docs is still runnable on demand.

## AI Disclosure

**AI tool used:** Multica Agent (J)