### PR TITLE
ci(release): restrict tag pattern to semver and reject -dirty tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 permissions:
   contents: write
@@ -16,6 +17,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Validate tag name
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          echo "Triggered by tag: $tag"
+          if [[ "$tag" == *-dirty* ]]; then
+            echo "::error::Refusing to release from dirty tag '$tag'."
+            exit 1
+          fi
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Root cause of the broken Homebrew formula: a `v0.2.5-dirty` tag (likely produced by `git describe --tags --dirty`) matched the `v*` trigger and re-ran GoReleaser, overwriting the tap with a 0.2.5-dirty formula whose tarballs 404.

- Narrow tag trigger to `v[0-9]+.[0-9]+.[0-9]+` and `v[0-9]+.[0-9]+.[0-9]+-*` (to still allow pre-release tags like `-rc.1`).
- Add an explicit guard that fails fast if the tag name contains `-dirty`.

Paired with multica-ai/homebrew-tap#<tap-pr> to restore the formula.