### PR TITLE
fix(claude): clear fresh session_id on resume failure so daemon fallback fires

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -189,12 +189,20 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 		b.cfg.Logger.Info("claude finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
+		reportedSessionID := resolveSessionID(opts.ResumeSessionID, sessionID, finalStatus == "failed")
+		if reportedSessionID != sessionID {
+			b.cfg.Logger.Info("claude resume did not land; clearing fresh session id for daemon fallback",
+				"requested_resume", opts.ResumeSessionID,
+				"emitted_session", sessionID,
+			)
+		}
+
 		resCh <- Result{
 			Status:     finalStatus,
 			Output:     output.String(),
 			Error:      finalError,
 			DurationMs: duration.Milliseconds(),
-			SessionID:  sessionID,
+			SessionID:  reportedSessionID,
 			Usage:      usage,
 		}
 	}()
@@ -436,6 +444,20 @@ func buildClaudeInput(prompt string) ([]byte, error) {
 		return nil, fmt.Errorf("marshal claude input: %w", err)
 	}
 	return append(data, '\n'), nil
+}
+
+// resolveSessionID decides which session id to report on the Result. When the
+// caller requested --resume but claude emitted a fresh, different session id
+// AND the run failed, the resume did not land (claude prints
+// "No conversation found with session ID: ..." to stderr, generates a fresh
+// session, and exits). Returning "" in that case keeps the daemon's
+// retry-with-fresh-session fallback able to trigger, instead of silently
+// persisting a brand-new id as if resume had succeeded.
+func resolveSessionID(requestedResume, emitted string, failed bool) string {
+	if failed && requestedResume != "" && emitted != "" && emitted != requestedResume {
+		return ""
+	}
+	return emitted
 }
 
 func buildEnv(extra map[string]string) []string {

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -466,6 +466,73 @@ func TestWriteMcpConfigToTemp(t *testing.T) {
 	}
 }
 
+func TestResolveSessionID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		requested string
+		emitted   string
+		failed    bool
+		want      string
+	}{
+		{
+			name:      "no resume requested propagates emitted",
+			requested: "",
+			emitted:   "fresh-abc",
+			failed:    false,
+			want:      "fresh-abc",
+		},
+		{
+			name:      "resume succeeded keeps matching id",
+			requested: "sess-old",
+			emitted:   "sess-old",
+			failed:    false,
+			want:      "sess-old",
+		},
+		{
+			name:      "resume succeeded but run failed mid-turn keeps id for later retry",
+			requested: "sess-old",
+			emitted:   "sess-old",
+			failed:    true,
+			want:      "sess-old",
+		},
+		{
+			name:      "resume did not land and run failed clears id so daemon fallback fires",
+			requested: "sess-dead",
+			emitted:   "fresh-new",
+			failed:    true,
+			want:      "",
+		},
+		{
+			name:      "resume did not land but run succeeded keeps fresh id (defensive)",
+			requested: "sess-dead",
+			emitted:   "fresh-new",
+			failed:    false,
+			want:      "fresh-new",
+		},
+		{
+			name:      "no emitted id leaves result empty",
+			requested: "sess-old",
+			emitted:   "",
+			failed:    true,
+			want:      "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveSessionID(tc.requested, tc.emitted, tc.failed)
+			if got != tc.want {
+				t.Fatalf("resolveSessionID(%q, %q, %v) = %q, want %q",
+					tc.requested, tc.emitted, tc.failed, got, tc.want)
+			}
+		})
+	}
+}
+
 func mustMarshal(t *testing.T, v any) json.RawMessage {
 	t.Helper()
 	data, err := json.Marshal(v)


### PR DESCRIPTION
Closes #1284.

## Problem

When `--resume <dead-id>` is sent to `claude`, the CLI prints `No conversation found with session ID: ...` to stderr, emits a stream-json `system` init carrying a **fresh** session id, then exits 1. The backend currently adopts that fresh id as `Result.SessionID`, so the daemon's retry-with-fresh-session fallback (`daemon.go:1028`, gated on `result.SessionID == ""`) never fires. Tasks for any `(issue, agent)` whose persisted session became unresumable fail forever.

## Change

Drop the fresh id from `Result` only when **all three** hold: `--resume` was requested, the emitted id differs, and the run failed. Any other combination keeps today's behavior. Logic lives in a pure helper `resolveSessionID` so it's unit-tested without driving a full `Execute` round-trip.

| requested resume | emitted | failed | reported | note |
|---|---|---|---|---|
| `""`    | `fresh` | false | `fresh` | fresh run, adopt |
| `old`   | `old`   | false | `old`   | resume succeeded |
| `old`   | `old`   | true  | `old`   | resume succeeded, run failed mid-turn — keep id for next retry |
| `dead`  | `fresh` | true  | `""`    | resume didn't land → let daemon fall back |
| `dead`  | `fresh` | false | `fresh` | defensive: if claude recovered into a fresh session and succeeded, don't discard work |
| `old`   | `""`    | true  | `""`    | no emitted id, no change |

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/agent/ -run TestResolveSessionID -count=1`
- [x] Full `pkg/agent/...` suite stays green
- [x] Dogfooded on the affected `(issue, agent)` pair: with the patch, next task logs `session resume failed, retrying with fresh session`, spawns a second `claude`, and completes. The server-side persisted `session_id` flips to the newly-established one.

## Scope

Claude backend only. **cursor**, **copilot**, **codex**, **opencode**, **hermes** may exhibit the same pattern — worth a follow-up audit, not bundled here to keep this focused.

An orthogonal server-side improvement (auto-clearing `session_id` on session-related failures so the landmine doesn't survive the first failure) is complementary but out of scope.