### PR TITLE
feat(agents): per-agent model selection

### DIFF
--- a/packages/core/models.ts
+++ b/packages/core/models.ts
@@ -1,0 +1,25 @@
+export interface ModelOption {
+  id: string;
+  label: string;
+}
+
+export const PROVIDER_MODELS: Record<string, ModelOption[]> = {
+  claude: [
+    { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+    { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+    { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+    { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+  ],
+  codex: [
+    { id: "o3", label: "o3" },
+    { id: "o4-mini", label: "o4-mini" },
+    { id: "gpt-4.1", label: "GPT-4.1" },
+  ],
+  gemini: [
+    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  ],
+  opencode: [],
+  openclaw: [],
+  hermes: [],
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,7 @@
     "./query-client": "./query-client.ts",
     "./provider": "./provider.tsx",
     "./logger": "./logger.ts",
+    "./models": "./models.ts",
     "./utils": "./utils.ts",
     "./constants/*": "./constants/*.ts",
     "./platform": "./platform/index.ts"

--- a/packages/views/agents/components/tabs/settings-tab.tsx
+++ b/packages/views/agents/components/tabs/settings-tab.tsx
@@ -10,8 +10,11 @@ import {
   Lock,
   Camera,
   ChevronDown,
+  Cpu,
+  Check,
 } from "lucide-react";
 import type { Agent, AgentVisibility, RuntimeDevice } from "@multica/core/types";
+import { PROVIDER_MODELS } from "@multica/core/models";
 import {
   Popover,
   PopoverTrigger,
@@ -39,12 +42,24 @@ export function SettingsTab({
   const [visibility, setVisibility] = useState<AgentVisibility>(agent.visibility);
   const [maxTasks, setMaxTasks] = useState(agent.max_concurrent_tasks);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState(agent.runtime_id);
+  const [selectedModel, setSelectedModel] = useState(
+    (agent.runtime_config?.model as string) ?? "",
+  );
+  const [customModelInput, setCustomModelInput] = useState("");
   const [runtimeOpen, setRuntimeOpen] = useState(false);
+  const [modelOpen, setModelOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const { upload, uploading } = useFileUpload(api);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const selectedRuntime = runtimes.find((d) => d.id === selectedRuntimeId) ?? null;
+  const provider = selectedRuntime?.provider ?? "";
+  const availableModels = PROVIDER_MODELS[provider] ?? [];
+  const isKnownModel = availableModels.some((m) => m.id === selectedModel);
+  const modelLabel =
+    selectedModel === ""
+      ? "Runtime default"
+      : availableModels.find((m) => m.id === selectedModel)?.label ?? selectedModel;
 
   const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -60,12 +75,14 @@ export function SettingsTab({
     }
   };
 
+  const currentModel = (agent.runtime_config?.model as string) ?? "";
   const dirty =
     name !== agent.name ||
     description !== (agent.description ?? "") ||
     visibility !== agent.visibility ||
     maxTasks !== agent.max_concurrent_tasks ||
-    selectedRuntimeId !== agent.runtime_id;
+    selectedRuntimeId !== agent.runtime_id ||
+    selectedModel !== currentModel;
 
   const handleSave = async () => {
     if (!name.trim()) {
@@ -81,6 +98,10 @@ export function SettingsTab({
         visibility,
         max_concurrent_tasks: maxTasks,
         runtime_id: selectedRuntimeId,
+        runtime_config: {
+          ...agent.runtime_config,
+          model: selectedModel || undefined,
+        },
       });
       toast.success("Settings saved");
     } catch {
@@ -224,6 +245,9 @@ export function SettingsTab({
               <button
                 key={device.id}
                 onClick={() => {
+                  if (device.provider !== selectedRuntime?.provider) {
+                    setSelectedModel("");
+                  }
                   setSelectedRuntimeId(device.id);
                   setRuntimeOpen(false);
                 }}
@@ -254,6 +278,86 @@ export function SettingsTab({
                 />
               </button>
             ))}
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <div>
+        <Label className="text-xs text-muted-foreground">Model</Label>
+        <p className="text-xs text-muted-foreground mt-0.5 mb-1.5">
+          Override the default model for this agent
+        </p>
+        <Popover open={modelOpen} onOpenChange={setModelOpen}>
+          <PopoverTrigger
+            className="flex w-full items-center gap-3 rounded-lg border border-border bg-background px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted"
+          >
+            <Cpu className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className={`min-w-0 flex-1 truncate ${selectedModel === "" ? "text-muted-foreground" : "font-medium"}`}>
+              {modelLabel}
+            </span>
+            <ChevronDown className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${modelOpen ? "rotate-180" : ""}`} />
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-[var(--anchor-width)] p-1 max-h-72 overflow-y-auto">
+            <button
+              onClick={() => {
+                setSelectedModel("");
+                setModelOpen(false);
+              }}
+              className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                selectedModel === "" ? "bg-accent" : "hover:bg-accent/50"
+              }`}
+            >
+              <span className="min-w-0 flex-1 text-muted-foreground">Runtime default</span>
+              {selectedModel === "" && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
+            </button>
+            {availableModels.length > 0 && (
+              <div className="my-1 h-px bg-border" />
+            )}
+            {availableModels.map((m) => (
+              <button
+                key={m.id}
+                onClick={() => {
+                  setSelectedModel(m.id);
+                  setModelOpen(false);
+                }}
+                className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                  m.id === selectedModel ? "bg-accent" : "hover:bg-accent/50"
+                }`}
+              >
+                <span className="min-w-0 flex-1 font-medium">{m.label}</span>
+                <span className="shrink-0 text-xs text-muted-foreground">{m.id}</span>
+                {m.id === selectedModel && <Check className="h-3.5 w-3.5 shrink-0 text-foreground" />}
+              </button>
+            ))}
+            <div className="my-1 h-px bg-border" />
+            <form
+              className="flex items-center gap-1.5 px-1 py-1"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const val = customModelInput.trim();
+                if (val) {
+                  setSelectedModel(val);
+                  setCustomModelInput("");
+                  setModelOpen(false);
+                }
+              }}
+            >
+              <Input
+                value={customModelInput}
+                onChange={(e) => setCustomModelInput(e.target.value)}
+                placeholder="Custom model ID..."
+                className="h-8 text-xs"
+                onClick={(e) => e.stopPropagation()}
+              />
+              <Button type="submit" size="sm" variant="ghost" className="h-8 px-2 text-xs shrink-0" disabled={!customModelInput.trim()}>
+                Use
+              </Button>
+            </form>
+            {selectedModel !== "" && !isKnownModel && (
+              <div className="px-3 py-1 text-xs text-muted-foreground">
+                Custom: {selectedModel}
+              </div>
+            )}
           </PopoverContent>
         </Popover>
       </div>

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1039,11 +1039,16 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)
 	}
 
+	model := entry.Model
+	if task.Agent != nil && task.Agent.Model != "" {
+		model = task.Agent.Model
+	}
+
 	reused := task.PriorWorkDir != "" && env.WorkDir == task.PriorWorkDir
 	taskLog.Info("starting agent",
 		"provider", provider,
 		"workdir", env.WorkDir,
-		"model", entry.Model,
+		"model", model,
 		"reused", reused,
 	)
 	if task.PriorSessionID != "" {
@@ -1054,7 +1059,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 
 	execOpts := agent.ExecOptions{
 		Cwd:             env.WorkDir,
-		Model:           entry.Model,
+		Model:           model,
 		Timeout:         d.cfg.AgentTimeout,
 		ResumeSessionID: task.PriorSessionID,
 	}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -45,6 +45,7 @@ type AgentData struct {
 	Instructions string            `json:"instructions"`
 	Skills       []SkillData       `json:"skills"`
 	CustomEnv    map[string]string `json:"custom_env,omitempty"`
+	Model        string            `json:"model,omitempty"`
 }
 
 // SkillData represents a structured skill for task execution.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -116,6 +116,7 @@ type TaskAgentData struct {
 	Instructions string                   `json:"instructions"`
 	Skills       []service.AgentSkillData `json:"skills,omitempty"`
 	CustomEnv    map[string]string        `json:"custom_env,omitempty"`
+	Model        string                   `json:"model,omitempty"`
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -399,6 +399,14 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			Skills:       skills,
 			CustomEnv:    customEnv,
 		}
+		if agent.RuntimeConfig != nil {
+			var rc map[string]any
+			if err := json.Unmarshal(agent.RuntimeConfig, &rc); err == nil {
+				if model, ok := rc["model"].(string); ok && model != "" {
+					resp.Agent.Model = model
+				}
+			}
+		}
 	}
 
 	// Include workspace ID and repos so the daemon can set up worktrees.


### PR DESCRIPTION
## Summary
- Adds a **Model** dropdown in agent settings that lets users override the default model per agent
- Stores the selected model in the existing `runtime_config` JSONB field (`runtime_config.model`)
- Backend extracts the model during task claim and passes it to the daemon, which uses it as `--model` flag when spawning agent CLIs
- Supports predefined models per provider (Claude, Codex, Gemini) plus freeform input for custom model IDs
- Falls back to the daemon's default model when no override is set

## Files changed
| File | Change |
|---|---|
| `packages/core/models.ts` | New — static provider→models map |
| `packages/core/package.json` | Add `./models` export |
| `packages/views/.../settings-tab.tsx` | Model selector UI (Popover + freeform input) |
| `server/internal/handler/agent.go` | Add `Model` to `TaskAgentData` |
| `server/internal/handler/daemon.go` | Extract model from `runtime_config` in claim endpoint |
| `server/internal/daemon/types.go` | Add `Model` to `AgentData` |
| `server/internal/daemon/daemon.go` | Prefer per-agent model over daemon default |

## Test plan
- [x] Set model on agent via settings UI, verify it persists in DB
- [x] Chat with agent, confirm it uses the selected model (tested with Haiku 4.5, Opus 4.7)
- [x] Verify "Runtime default" option clears the model override
- [x] Verify switching runtime to a different provider resets the model selection
- [ ] TypeScript typecheck passes (`pnpm typecheck`)
- [ ] Go builds clean (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)