### PR TITLE
fix: three small bugs (workspace marshal errors, auth nil-deref, stale parent cache)

### DIFF
--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -33,11 +33,16 @@ export function onIssueUpdated(
   // the parent issue page).
   const listData = qc.getQueryData<ListIssuesResponse>(issueKeys.list(wsId));
   const detailData = qc.getQueryData<Issue>(issueKeys.detail(wsId, issue.id));
-  const parentId =
-    issue.parent_issue_id ??
+  const cachedParentId =
     detailData?.parent_issue_id ??
     listData?.issues.find((i) => i.id === issue.id)?.parent_issue_id ??
     null;
+  // When an issue is re-parented, both the old and new parents' children
+  // lists must be refreshed, not just one.
+  const newParentId =
+    issue.parent_issue_id !== undefined
+      ? issue.parent_issue_id
+      : cachedParentId;
 
   qc.setQueryData<ListIssuesResponse>(issueKeys.list(wsId), (old) => {
     if (!old) return old;
@@ -62,10 +67,25 @@ export function onIssueUpdated(
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issue.id), (old) =>
     old ? { ...old, ...issue } : old,
   );
-  if (parentId) {
-    qc.setQueryData<Issue[]>(issueKeys.children(wsId, parentId), (old) =>
+  if (newParentId) {
+    qc.setQueryData<Issue[]>(issueKeys.children(wsId, newParentId), (old) =>
       old?.map((c) => (c.id === issue.id ? { ...c, ...issue } : c)),
     );
+  }
+  // If the issue was re-parented, invalidate both parents so the old parent
+  // drops the stale child and the new parent picks it up.
+  if (
+    cachedParentId &&
+    newParentId !== cachedParentId
+  ) {
+    qc.invalidateQueries({
+      queryKey: issueKeys.children(wsId, cachedParentId),
+    });
+    if (newParentId) {
+      qc.invalidateQueries({
+        queryKey: issueKeys.children(wsId, newParentId),
+      });
+    }
   }
 }
 

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -411,7 +411,11 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch user info from Google.
-	userInfoReq, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://www.googleapis.com/oauth2/v2/userinfo", nil)
+	userInfoReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://www.googleapis.com/oauth2/v2/userinfo", nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to build Google userinfo request")
+		return
+	}
 	userInfoReq.Header.Set("Authorization", "Bearer "+gToken.AccessToken)
 
 	userInfoResp, err := http.DefaultClient.Do(userInfoReq)

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -232,11 +232,19 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 		params.Context = pgtype.Text{String: *req.Context, Valid: true}
 	}
 	if req.Settings != nil {
-		s, _ := json.Marshal(req.Settings)
+		s, err := json.Marshal(req.Settings)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid settings payload")
+			return
+		}
 		params.Settings = s
 	}
 	if req.Repos != nil {
-		reposJSON, _ := json.Marshal(req.Repos)
+		reposJSON, err := json.Marshal(req.Repos)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid repos payload")
+			return
+		}
 		params.Repos = reposJSON
 	}
 	if req.IssuePrefix != nil {


### PR DESCRIPTION
## Summary

Three independent small bug fixes discovered while auditing error paths.

1. **`fix(workspace)`** — `server/internal/handler/workspace.go`: the update handler silently dropped `json.Marshal` errors for settings and repos, which could store nil JSON bytes in the DB when the payload had a non-marshalable value. Returns 400 instead so the caller sees the failure.

2. **`fix(auth)`** — `server/internal/handler/auth.go`: the error from `http.NewRequestWithContext` was discarded and the next line dereferenced the returned `*http.Request`. Although the inputs are static, any failure would have caused a nil-pointer panic. Returns 500 instead.

3. **`fix(issues)`** — `packages/core/issues/ws-updaters.ts`: when an issue's `parent_issue_id` changes in a WS update, the old parent's children cache still contained the stale child. Resolves both the cached parent and the new parent from the update, and invalidates both when they differ so the sub-issues list on each parent stays correct.

Each fix is a standalone commit — happy to split into separate PRs if preferred.

## Test plan

- [ ] `fix(workspace)` — send an update with a non-marshalable settings/repos payload; expect 400 rather than a silent nil-bytes row.
- [ ] `fix(auth)` — no behavior change on the happy path; verify 500 surfaces if `http.NewRequestWithContext` fails (e.g. forced via invalid URL in a unit test).
- [ ] `fix(issues)` — re-parent an issue via WS; verify both the old parent and new parent's children lists reflect the move without a refetch.