### PR TITLE
fix(workspace): surface json.Marshal errors on settings and repos

### DIFF
--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -241,11 +241,19 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 		params.Context = pgtype.Text{String: *req.Context, Valid: true}
 	}
 	if req.Settings != nil {
-		s, _ := json.Marshal(req.Settings)
+		s, err := json.Marshal(req.Settings)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid settings payload")
+			return
+		}
 		params.Settings = s
 	}
 	if req.Repos != nil {
-		reposJSON, _ := json.Marshal(req.Repos)
+		reposJSON, err := json.Marshal(req.Repos)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid repos payload")
+			return
+		}
 		params.Repos = reposJSON
 	}
 	if req.IssuePrefix != nil {


### PR DESCRIPTION
## Summary

`UpdateWorkspace` silently drops the `json.Marshal` error on both `Settings` and `Repos`:

```go
s, _ := json.Marshal(req.Settings)
params.Settings = s
```

If `req.Settings` or `req.Repos` ever contains a non-marshalable value (e.g. `json.Number` in an invalid state, a channel smuggled via a custom `MarshalJSON`, a cyclic ref), `s` is `nil` and we happily write that into the DB row. The caller sees 200 OK, then the workspace row has a nil JSON column — which depending on schema either corrupts it or blows up on the next read.

This PR swaps both to `s, err := ...` + `writeError(w, http.StatusBadRequest, ...)` on failure. Unreachable for well-formed JSON bodies (since `req` itself came through `json.Decode`), but the defensive 400 beats a silent data-corruption path if an upstream handler ever starts building `req.Settings` programmatically.

## Verification
- `go build ./...` clean
- `go vet ./internal/handler/...` clean
- `go test ./internal/handler/...` passes (including existing `TestWorkspace*`)

## Test plan
- [ ] Send an `UpdateWorkspace` request with a valid body — no behavior change (200 OK).
- [ ] (If you want to exercise the error path explicitly) add a unit test that calls `json.Marshal` with a cyclic struct via a fake `Settings` type.