### PR TITLE
fix(daemon): agent status change triggers pickup + auto in_review on task complete

### DIFF
--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -290,6 +290,25 @@ func TestCommentTriggerOnComment(t *testing.T) {
 			t.Errorf("expected 1 pending task (assignee mentioned in thread root), got %d", n)
 		}
 	})
+
+	t.Run("comment from a different agent triggers the assignee agent", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// A second agent posts a comment on the issue (sequential chaining use case).
+		secondAgentID := createSecondAgent(t)
+		postCommentAsAgent(t, issueID, "Tu peux démarrer", secondAgentID, nil)
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (comment from different agent), got %d", n)
+		}
+	})
+
+	t.Run("comment from the assignee agent does not trigger itself", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// The assignee agent posts a comment on its own issue — must not loop.
+		postCommentAsAgent(t, issueID, "I am working on this", agentID, nil)
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (assignee self-comment), got %d", n)
+		}
+	})
 }
 
 // TestCommentTriggerAtAllSuppression verifies that @all mentions do not

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -260,7 +260,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// the user is talking to someone else, not requesting work from the assignee.
 	// Also skip when replying in a member-started thread without mentioning the
 	// assignee — the user is continuing a member-to-member conversation.
-	if authorType == "member" && h.shouldEnqueueOnComment(r.Context(), issue) &&
+	// Agent comments from any agent OTHER than the assignee are allowed — this
+	// enables sequential issue chaining where one agent hands off to the next.
+	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == authorID
+	if !isSelfComment && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {
 		// Resolve thread root: if the comment is a reply, agent should reply

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1121,10 +1121,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Trigger the assigned agent when a member moves an issue out of backlog.
-	// Backlog acts as a parking lot — moving to an active status signals the
-	// issue is ready for work.
-	if statusChanged && !assigneeChanged && actorType == "member" &&
+	// Trigger the assigned agent when anyone (member or another agent) moves an
+	// issue out of backlog. Skip only when the assignee agent moves its own issue
+	// to prevent self-loops.
+	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+	if statusChanged && !assigneeChanged && !isSelfActor &&
 		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 		if h.isAgentAssigneeReady(r.Context(), issue) {
 			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
@@ -1429,8 +1430,9 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Trigger agent when moving out of backlog (batch).
-		if statusChanged && !assigneeChanged && actorType == "member" &&
+		// Trigger agent when moving out of backlog (batch). Skip self-actor to prevent loops.
+		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+		if statusChanged && !assigneeChanged && !isSelfActorBatch &&
 			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 			if h.isAgentAssigneeReady(r.Context(), issue) {
 				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -325,6 +325,24 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		s.broadcastChatDone(ctx, task)
 	}
 
+	// Auto-advance issue to in_review when a non-chat issue task completes and
+	// the issue is still in an active state (the agent didn't set it manually).
+	if task.IssueID.Valid && !task.ChatSessionID.Valid {
+		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
+			active := issue.Status != "in_review" && issue.Status != "done" && issue.Status != "cancelled"
+			if active {
+				if _, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+					ID:     task.IssueID,
+					Status: "in_review",
+				}); err != nil {
+					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
+				} else {
+					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+				}
+			}
+		}
+	}
+
 	// Reconcile agent status
 	s.ReconcileAgentStatus(ctx, task.AgentID)
 


### PR DESCRIPTION
## Summary

- **Fix 1 (issue.go):** Removed `actorType == "member"` guard on backlog→active status change. Now any actor can trigger pickup, except the assignee agent itself (anti-self-loop, same pattern as comment.go fix f3bc0f98).
- **Fix 2 (task.go):** `CompleteTask` now auto-advances the issue to `in_review` when a non-chat task completes and the agent hasn't already set a terminal status.

## Root causes

- **Problème 1:** `UpdateIssue` and `BatchUpdateIssues` had `actorType == "member"` hardcoded, blocking pickup when an agent changed status. Agents chaining issues (backlog→todo) never triggered the daemon.
- **Problème 2:** `CompleteTask` explicitly stated "Issue status is NOT changed here — the agent manages it via the CLI." Agents weren't reliably calling `multica issue status in_review` themselves.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/...` passes (all ok)
- [ ] Restart daemon to pick up changes: `multica daemon stop && multica daemon start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)