### PR TITLE
fix(daemon): populate workspace_id in ClaimTaskByRuntime for autopilot run_only tasks

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -614,6 +614,21 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Autopilot run_only task: resolve workspace from autopilot_run → autopilot.
+	if task.AutopilotRunID.Valid && resp.WorkspaceID == "" {
+		if run, err := h.Queries.GetAutopilotRun(r.Context(), task.AutopilotRunID); err == nil {
+			if ap, err := h.Queries.GetAutopilot(r.Context(), run.AutopilotID); err == nil {
+				resp.WorkspaceID = uuidToString(ap.WorkspaceID)
+				if ws, err := h.Queries.GetWorkspace(r.Context(), ap.WorkspaceID); err == nil && ws.Repos != nil {
+					var repos []RepoData
+					if json.Unmarshal(ws.Repos, &repos) == nil && len(repos) > 0 {
+						resp.Repos = repos
+					}
+				}
+			}
+		}
+	}
+
 	slog.Info("task claimed by runtime", "task_id", uuidToString(task.ID), "runtime_id", runtimeID, "agent_id", uuidToString(task.AgentID), "prior_session", resp.PriorSessionID)
 	writeJSON(w, http.StatusOK, map[string]any{"task": resp})
 }

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1137,3 +1137,88 @@ func TestStartTask_AutopilotRunOnlyTask_ResolvesWorkspace(t *testing.T) {
 		t.Fatalf("expected task status 'running' after StartTask, got %q", status)
 	}
 }
+
+// Regression test for #1276: ClaimTaskByRuntime must populate workspace_id in
+// the response for run_only autopilot tasks. Before the fix, resp.WorkspaceID
+// stayed empty because ClaimTaskByRuntime only handled IssueID and
+// ChatSessionID branches, causing the daemon's execenv to fail with
+// "workspace ID is required".
+func TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceID(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var autopilotID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot (
+			workspace_id, title, assignee_id, execution_mode,
+			created_by_type, created_by_id
+		)
+		VALUES ($1, 'claim workspace fixture', $2, 'run_only', 'member', $3)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&autopilotID); err != nil {
+		t.Fatalf("setup: create autopilot: %v", err)
+	}
+	defer testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, autopilotID)
+
+	var runID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO autopilot_run (autopilot_id, source, status)
+		VALUES ($1, 'manual', 'running')
+		RETURNING id
+	`, autopilotID).Scan(&runID); err != nil {
+		t.Fatalf("setup: create autopilot_run: %v", err)
+	}
+
+	// Create a queued task with only AutopilotRunID (no IssueID, no ChatSessionID).
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority, autopilot_run_id
+		)
+		VALUES ($1, $2, NULL, 'queued', 0, $3)
+		RETURNING id
+	`, agentID, runtimeID, runID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create autopilot task: %v", err)
+	}
+	defer testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil,
+		testWorkspaceID, "test-daemon-claim")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("runtimeId", runtimeID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Task *struct {
+			WorkspaceID string `json:"workspace_id"`
+		} `json:"task"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Task == nil {
+		t.Fatal("expected a task in response, got nil")
+	}
+	if resp.Task.WorkspaceID == "" {
+		t.Fatal("ClaimTaskByRuntime for run_only autopilot: workspace_id is empty in response")
+	}
+	if resp.Task.WorkspaceID != testWorkspaceID {
+		t.Fatalf("expected workspace_id %q, got %q", testWorkspaceID, resp.Task.WorkspaceID)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1276.

`ClaimTaskByRuntime` populates `resp.WorkspaceID` (and `resp.Repos`) from the task's linked entity — `IssueID` for issue tasks, `ChatSessionID` for chat tasks. However, `run_only` autopilot tasks have neither; they only carry an `AutopilotRunID`. The missing branch left `resp.WorkspaceID` empty, which caused the daemon's `execenv.Prepare()` to reject the task with:

```
prepare execution environment: execenv: workspace ID is required
```

## Fix

Add an `AutopilotRunID` branch after the existing `ChatSessionID` block. It resolves the workspace via the same chain used by `ResolveTaskWorkspaceID`: `autopilot_run → autopilot → workspace_id`. Also populates `resp.Repos` so the daemon can set up worktrees.

The guard `resp.WorkspaceID == ""` ensures this branch only fires when no earlier branch already resolved the workspace (defensive, since `run_only` tasks should never have an `IssueID`).

## Related

- #1224 / PR #1249 — fixed the `resolveTaskWorkspaceID` auth check (different code path, same root pattern)
- #1259 — consolidated the resolver into `TaskService`
- This PR fixes the **response population** path that #1249/#1259 did not cover

## Test

Added `TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceID` — creates a `run_only` autopilot task (no issue, no chat session), claims it via `ClaimTaskByRuntime`, and asserts `workspace_id` is present and correct in the response.