### PR TITLE
feat(server): /fresh comment directive to skip session resume

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -219,6 +219,11 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// Expand bare issue identifiers (e.g. MUL-117) into mention links.
 	req.Content = mention.ExpandIssueIdentifiers(r.Context(), h.Queries, issue.WorkspaceID, req.Content)
 
+	// Parse /fresh directive before sanitization — strip it from the saved
+	// comment and propagate to task enqueue so the daemon skips session resume.
+	var isFresh bool
+	req.Content, isFresh = util.ParseFreshDirective(req.Content)
+
 	// Sanitize HTML to prevent stored XSS.
 	req.Content = sanitize.HTML(req.Content)
 
@@ -270,14 +275,18 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		if comment.ParentID.Valid {
 			replyTo = comment.ParentID
 		}
-		if _, err := h.TaskService.EnqueueTaskForIssue(r.Context(), issue, replyTo); err != nil {
+		if task, err := h.TaskService.EnqueueTaskForIssue(r.Context(), issue, replyTo); err != nil {
 			slog.Warn("enqueue agent task on comment failed", "issue_id", issueID, "error", err)
+		} else if isFresh {
+			if err := h.Queries.SetTaskSkipResume(r.Context(), task.ID); err != nil {
+				slog.Warn("set task skip_resume failed", "task_id", uuidToString(task.ID), "error", err)
+			}
 		}
 	}
 
 	// Trigger @mentioned agents: parse agent mentions and enqueue tasks for each.
 	// Pass parentComment so that replies inherit mentions from the thread root.
-	h.enqueueMentionedAgentTasks(r.Context(), issue, comment, parentComment, authorType, authorID)
+	h.enqueueMentionedAgentTasks(r.Context(), issue, comment, parentComment, authorType, authorID, isFresh)
 
 	writeJSON(w, http.StatusCreated, resp)
 }
@@ -380,7 +389,7 @@ func (h *Handler) isReplyToMemberThread(ctx context.Context, parent *db.Comment,
 // admin/owner can mention a private agent).
 // Note: no status gate here — @mention is an explicit action and should work
 // even on done/cancelled issues (the agent can reopen the issue if needed).
-func (h *Handler) enqueueMentionedAgentTasks(ctx context.Context, issue db.Issue, comment db.Comment, parentComment *db.Comment, authorType, authorID string) {
+func (h *Handler) enqueueMentionedAgentTasks(ctx context.Context, issue db.Issue, comment db.Comment, parentComment *db.Comment, authorType, authorID string, skipResume bool) {
 	wsID := uuidToString(issue.WorkspaceID)
 	mentions := util.ParseMentions(comment.Content)
 	// When replying in a thread, inherit mentions from the parent comment
@@ -425,8 +434,12 @@ func (h *Handler) enqueueMentionedAgentTasks(ctx context.Context, issue db.Issue
 		}
 		// Always use the current comment as the trigger so the agent reads the
 		// actual reply that mentioned it, not the thread root.
-		if _, err := h.TaskService.EnqueueTaskForMention(ctx, issue, agentUUID, comment.ID); err != nil {
+		if task, err := h.TaskService.EnqueueTaskForMention(ctx, issue, agentUUID, comment.ID); err != nil {
 			slog.Warn("enqueue mention agent task failed", "issue_id", uuidToString(issue.ID), "agent_id", m.ID, "error", err)
+		} else if skipResume {
+			if err := h.Queries.SetTaskSkipResume(ctx, task.ID); err != nil {
+				slog.Warn("set task skip_resume failed", "task_id", uuidToString(task.ID), "error", err)
+			}
 		}
 	}
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -572,13 +572,25 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 
 		// Look up the prior session for this (agent, issue) pair so the daemon
 		// can resume the Claude Code conversation context.
-		if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
-			AgentID: task.AgentID,
-			IssueID: task.IssueID,
-		}); err == nil && prior.SessionID.Valid {
-			resp.PriorSessionID = prior.SessionID.String
-			if prior.WorkDir.Valid {
-				resp.PriorWorkDir = prior.WorkDir.String
+		// Skip if the task was created with /fresh directive.
+		skipResume := false
+		if len(task.Context) > 0 {
+			var taskCtx map[string]any
+			if json.Unmarshal(task.Context, &taskCtx) == nil {
+				if sr, _ := taskCtx["skip_resume"].(bool); sr {
+					skipResume = true
+				}
+			}
+		}
+		if !skipResume {
+			if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
+				AgentID: task.AgentID,
+				IssueID: task.IssueID,
+			}); err == nil && prior.SessionID.Valid {
+				resp.PriorSessionID = prior.SessionID.String
+				if prior.WorkDir.Valid {
+					resp.PriorWorkDir = prior.WorkDir.String
+				}
 			}
 		}
 	}

--- a/server/internal/util/mention.go
+++ b/server/internal/util/mention.go
@@ -1,6 +1,9 @@
 package util
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // Mention represents a parsed @mention from markdown content.
 type Mention struct {
@@ -31,6 +34,64 @@ func ParseMentions(content string) []Mention {
 		result = append(result, Mention{Type: m[1], ID: m[2]})
 	}
 	return result
+}
+
+// ParseFreshDirective checks whether the comment starts with /fresh (optionally
+// preceded by mention links). If found, it returns the cleaned content with
+// /fresh stripped and isFresh=true. The directive only triggers at the very
+// start of the content so that /fresh inside code blocks or mid-sentence is
+// ignored.
+func ParseFreshDirective(content string) (cleaned string, isFresh bool) {
+	s := content
+	pos := 0 // byte offset into content consumed by leading mentions
+
+	// Skip past leading mention links.
+	for {
+		// Trim whitespace between mentions.
+		trimmed := 0
+		for pos+trimmed < len(s) && (s[pos+trimmed] == ' ' || s[pos+trimmed] == '\t' || s[pos+trimmed] == '\n' || s[pos+trimmed] == '\r') {
+			trimmed++
+		}
+		rest := s[pos+trimmed:]
+		loc := MentionRe.FindStringIndex(rest)
+		if loc == nil || loc[0] != 0 {
+			pos += trimmed
+			break
+		}
+		pos += trimmed + loc[1]
+	}
+
+	rest := s[pos:]
+	// Trim whitespace between last mention and /fresh.
+	trimmedRest := rest
+	for len(trimmedRest) > 0 && (trimmedRest[0] == ' ' || trimmedRest[0] == '\t') {
+		trimmedRest = trimmedRest[1:]
+	}
+	if !strings.HasPrefix(trimmedRest, "/fresh") {
+		return content, false
+	}
+	after := trimmedRest[len("/fresh"):]
+	if len(after) > 0 && after[0] != ' ' && after[0] != '\n' && after[0] != '\r' && after[0] != '\t' {
+		return content, false
+	}
+
+	// Strip /fresh from the original content, collapsing surrounding whitespace.
+	freshStart := len(s) - len(trimmedRest)
+	freshEnd := freshStart + len("/fresh")
+	// Consume one trailing space if present.
+	if freshEnd < len(s) && s[freshEnd] == ' ' {
+		freshEnd++
+	}
+	prefix := strings.TrimRight(s[:freshStart], " \t")
+	suffix := s[freshEnd:]
+	if prefix == "" {
+		cleaned = suffix
+	} else if len(suffix) > 0 && suffix[0] != '\n' && suffix[0] != '\r' {
+		cleaned = prefix + " " + suffix
+	} else {
+		cleaned = prefix + suffix
+	}
+	return strings.TrimSpace(cleaned), true
 }
 
 // HasMentionAll returns true if any mention in the slice is an @all mention.

--- a/server/internal/util/mention_test.go
+++ b/server/internal/util/mention_test.go
@@ -1,0 +1,83 @@
+package util
+
+import "testing"
+
+func TestParseFreshDirective(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		isFresh bool
+	}{
+		{
+			name:    "bare /fresh with message",
+			input:   "/fresh do something",
+			want:    "do something",
+			isFresh: true,
+		},
+		{
+			name:    "bare /fresh only",
+			input:   "/fresh",
+			want:    "",
+			isFresh: true,
+		},
+		{
+			name:    "mention then /fresh",
+			input:   "[@Agent](mention://agent/550e8400-e29b-41d4-a716-446655440000) /fresh plan the next step",
+			want:    "[@Agent](mention://agent/550e8400-e29b-41d4-a716-446655440000) plan the next step",
+			isFresh: true,
+		},
+		{
+			name:    "multiple mentions then /fresh",
+			input:   "[@A](mention://agent/aaaa) [@B](mention://agent/bbbb) /fresh go",
+			want:    "[@A](mention://agent/aaaa) [@B](mention://agent/bbbb) go",
+			isFresh: true,
+		},
+		{
+			name:    "mid-sentence /fresh is not a directive",
+			input:   "please /fresh this",
+			want:    "please /fresh this",
+			isFresh: false,
+		},
+		{
+			name:    "/freshwater is not a directive (word boundary)",
+			input:   "/freshwater analysis",
+			want:    "/freshwater analysis",
+			isFresh: false,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			want:    "",
+			isFresh: false,
+		},
+		{
+			name:    "leading whitespace then /fresh",
+			input:   "  /fresh do it",
+			want:    "do it",
+			isFresh: true,
+		},
+		{
+			name:    "mention with /fresh and newline",
+			input:   "[@Bot](mention://agent/1234) /fresh\ndo the thing",
+			want:    "[@Bot](mention://agent/1234)\ndo the thing",
+			isFresh: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, isFresh := ParseFreshDirective(tc.input)
+			if isFresh != tc.isFresh {
+				t.Fatalf("ParseFreshDirective(%q): isFresh = %v, want %v", tc.input, isFresh, tc.isFresh)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseFreshDirective(%q): cleaned = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -894,6 +894,17 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 	return items, nil
 }
 
+const setTaskSkipResume = `-- name: SetTaskSkipResume :exec
+UPDATE agent_task_queue
+SET context = jsonb_set(COALESCE(context, '{}'), '{skip_resume}', 'true')
+WHERE id = $1
+`
+
+func (q *Queries) SetTaskSkipResume(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, setTaskSkipResume, id)
+	return err
+}
+
 const restoreAgent = `-- name: RestoreAgent :one
 UPDATE agent SET archived_at = NULL, archived_by = NULL, updated_at = now()
 WHERE id = $1

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -188,6 +188,13 @@ SELECT * FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC;
 
+-- name: SetTaskSkipResume :exec
+-- Marks a task so the daemon skips session resumption for this dispatch.
+-- Used by the /fresh comment directive.
+UPDATE agent_task_queue
+SET context = jsonb_set(COALESCE(context, '{}'), '{skip_resume}', 'true')
+WHERE id = $1;
+
 -- name: UpdateAgentStatus :one
 UPDATE agent SET status = $2, updated_at = now()
 WHERE id = $1


### PR DESCRIPTION
## Summary

- Adds `/fresh` directive parsing: when a comment starts with `/fresh` or `@agent /fresh ...`, the server strips the directive and marks the enqueued task with `skip_resume=true` in the existing `context` JSONB column
- Daemon handler checks this flag before the `GetLastTaskSession` lookup — if set, `PriorSessionID` stays empty and the agent starts a fresh session
- `session_id` is still written on completion, so the next normal dispatch resumes as usual
- Zero schema migration — reuses the existing `context` column

## Test plan

- [x] Unit tests for `ParseFreshDirective` (9 cases: bare, with mentions, mid-sentence, word boundary, empty, whitespace, newline)
- [x] `go build ./...` passes
- [ ] Integration: comment with `@agent /fresh do something` → daemon log shows no `--resume` flag
- [ ] Integration: next normal comment → resumes normally (session_id preserved in DB)

Ref: #1296