### PR TITLE
storage: prefer CDN domain over custom endpoint URL in attachment links

### DIFF
--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -158,14 +158,18 @@ func (s *S3Storage) Upload(ctx context.Context, key string, data []byte, content
 		return "", fmt.Errorf("s3 PutObject: %w", err)
 	}
 
+	// Prefer the configured CDN/public-read domain when set. This allows S3-compatible
+	// backends (MinIO, R2, B2, Wasabi, etc.) to be paired with a separate public domain
+	// for reads — the custom endpoint is still used for writes via the SDK, but the URL
+	// stored for client consumption points at the reader-facing domain.
+	if s.cdnDomain != "" {
+		link := fmt.Sprintf("https://%s/%s", s.cdnDomain, key)
+		return link, nil
+	}
 	if s.endpointURL != "" {
 		link := fmt.Sprintf("%s/%s/%s", strings.TrimRight(s.endpointURL, "/"), s.bucket, key)
 		return link, nil
 	}
-	domain := s.bucket
-	if s.cdnDomain != "" {
-		domain = s.cdnDomain
-	}
-	link := fmt.Sprintf("https://%s/%s", domain, key)
+	link := fmt.Sprintf("https://%s/%s", s.bucket, key)
 	return link, nil
 }


### PR DESCRIPTION
## What

When both \`AWS_ENDPOINT_URL\` and \`CLOUDFRONT_DOMAIN\` are set, \`S3Storage.Upload()\` now returns the CDN URL instead of the raw endpoint URL.

## Why

With any S3-compatible backend that uses a custom endpoint (R2, Backblaze B2, Wasabi, MinIO, DigitalOcean Spaces), the current code silently overrides \`CLOUDFRONT_DOMAIN\` whenever \`AWS_ENDPOINT_URL\` is set:

\`\`\`go
if s.endpointURL != "" {
    link := fmt.Sprintf("%s/%s/%s", strings.TrimRight(s.endpointURL, "/"), s.bucket, key)
    return link, nil  // ← raw S3 API endpoint, requires signed requests
}
\`\`\`

The S3 API endpoint requires signed requests, so browsers rendering the URL directly (attachments in issue/comment markdown) see a blank image or an auth error. The only way to get a usable URL today for these backends is to make the bucket publicly accessible — which forces a security posture the operator may not want.

After the change, \`CLOUDFRONT_DOMAIN\` is checked first, so operators can configure a private bucket + separate public-read domain (CDN, Worker, reverse proxy, etc.). Writes still go through the SDK with the custom endpoint; only the URL stored for client consumption changes.

## Behavior matrix

| \`AWS_ENDPOINT_URL\` | \`CLOUDFRONT_DOMAIN\` | Before | After |
|---|---|---|---|
| empty | empty | \`https://<bucket>/<key>\` | same |
| empty | set | \`https://<cdn>/<key>\` | same |
| set | empty | raw endpoint URL | same |
| set | set | raw endpoint URL (bug — CDN ignored) | \`https://<cdn>/<key>\` (fixed) |

Only the fourth row changes. Anyone currently running with both set is already hitting the bug (bucket URLs aren't browser-fetchable) — this fix makes their intended configuration work.

## Other behavior

- \`storageClass()\` is untouched — still returns \`STANDARD\` when an endpoint is set (needed for R2/MinIO/etc. which don't support \`INTELLIGENT_TIERING\`) and \`INTELLIGENT_TIERING\` otherwise.
- \`KeyFromURL()\` is untouched — already handles both endpoint-prefixed and CDN-prefixed URLs in any order, so existing DB rows with old-format URLs still get parsed correctly after upgrade.

## How I tested

Deployed a self-hosted Multica instance using Cloudflare R2 as the S3 backend with a separate CDN domain fronted by a Cloudflare Worker that validates CloudFront signed URLs/cookies before serving from the private R2 bucket. Without this patch, attachment URLs are the raw R2 S3 API endpoint (returns \`AccessDenied\` to browsers). With this patch, attachment URLs use \`CLOUDFRONT_DOMAIN\` correctly; browsers render inline images via CloudFront signed cookies, and the CLI's \`multica attachment download\` works via query-string signed URLs unchanged.

## Related

- [Discussion #1316](https://github.com/multica-ai/multica/discussions/1316)