### PR TITLE
fix(comment): assignee on_comment path should use reply id, not thread root

### DIFF
--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -58,6 +58,27 @@ func clearTasks(t *testing.T, issueID string) {
 	}
 }
 
+// latestTriggerCommentID returns the trigger_comment_id of the most recently
+// created queued/dispatched task for the given issue, or empty string if none.
+func latestTriggerCommentID(t *testing.T, issueID string) string {
+	t.Helper()
+	var triggerID *string
+	err := testPool.QueryRow(context.Background(),
+		`SELECT trigger_comment_id::text
+		   FROM agent_task_queue
+		  WHERE issue_id = $1 AND status IN ('queued', 'dispatched')
+		  ORDER BY created_at DESC
+		  LIMIT 1`,
+		issueID).Scan(&triggerID)
+	if err != nil {
+		t.Fatalf("failed to fetch trigger_comment_id: %v", err)
+	}
+	if triggerID == nil {
+		return ""
+	}
+	return *triggerID
+}
+
 // getAgentID returns the ID of the first agent in the test workspace.
 func getAgentID(t *testing.T) string {
 	t.Helper()
@@ -225,6 +246,25 @@ func TestCommentTriggerOnComment(t *testing.T) {
 		postComment(t, issueID, "Looks good, please proceed", strPtr(threadID))
 		if n := countPendingTasks(t, issueID); n != 1 {
 			t.Errorf("expected 1 pending task, got %d", n)
+		}
+	})
+
+	// Regression guard for #1301: the assignee on_comment path must record
+	// the NEW reply as trigger_comment_id, not the thread root. Otherwise
+	// the daemon feeds stale content to the agent prompt, which with
+	// `--resume` sessions surfaces as "already replied, no further action".
+	// Reply placement (flat-thread grouping) is handled downstream in
+	// TaskService.createAgentComment, not here.
+	t.Run("reply records new comment id (not thread root) as trigger_comment_id", func(t *testing.T) {
+		clearTasks(t, issueID)
+		threadID := postCommentAsAgent(t, issueID, "First pass analysis.", agentID, nil)
+		replyID := postComment(t, issueID, "Please also check the edge case", strPtr(threadID))
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Fatalf("expected 1 pending task, got %d", n)
+		}
+		if got := latestTriggerCommentID(t, issueID); got != replyID {
+			t.Errorf("trigger_comment_id = %q, want reply id %q (thread root was %q)",
+				got, replyID, threadID)
 		}
 	})
 

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -263,14 +263,12 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	if authorType == "member" && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {
-		// Resolve thread root: if the comment is a reply, agent should reply
-		// to the thread root (matching frontend behavior where all replies
-		// in a thread share the same top-level parent).
-		replyTo := comment.ID
-		if comment.ParentID.Valid {
-			replyTo = comment.ParentID
-		}
-		if _, err := h.TaskService.EnqueueTaskForIssue(r.Context(), issue, replyTo); err != nil {
+		// Always use the current comment as the trigger so the agent reads
+		// the actual new reply, not the thread root. Reply placement (flat
+		// thread grouping) is handled downstream by createAgentComment,
+		// which resolves parent_id to the thread root before posting. This
+		// mirrors the mention path's behavior (see enqueueMentionedAgentTasks).
+		if _, err := h.TaskService.EnqueueTaskForIssue(r.Context(), issue, comment.ID); err != nil {
 			slog.Warn("enqueue agent task on comment failed", "issue_id", issueID, "error", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Symmetric fix to #871 (which fixed the `@mention` path but missed the assignee `on_comment` path in the same file). Fixes #1301.

When a member posts a **reply** on an issue assigned to an agent with `on_comment=true`, the enqueued task's `trigger_comment_id` was set to the parent comment instead of the new reply itself. The daemon then fed the parent's content to the resumed Claude Code session, which either:

- exited with `"Already replied to comment <parent>, no further action"` (if the session had already processed that parent), or
- silently misrouted the answer / ignored the new instructions, depending on model and session state.

After #871 decoupled reply placement from `trigger_comment_id` (via `TaskService.createAgentComment`'s parent normalization), this field should always carry the actual triggering comment. This PR brings the assignee path in line with the mention path's post-#871 behavior.

## Change

`server/internal/handler/comment.go`: drop the `comment.ParentID` override in the assignee path; pass `comment.ID` directly to `EnqueueTaskForIssue`.

## Verification

Repro steps, flow diagram, and incident evidence are in #1301.

Local sanity:

- `go build ./...` under `server/` — clean
- `go test ./internal/handler/... ./internal/service/...` — pass
- Post-fix manual check: a reply with `parent=C0` produces a run with `trigger_comment_id = <reply.id>`, not `C0`
- Agent replies still thread under the root via `createAgentComment`'s parent normalization (unchanged)
