### PR TITLE
fix(autopilots): spin the Loader2 icon while a run is in progress

### DIFF
--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -52,9 +52,9 @@ function formatDate(date: string): string {
   });
 }
 
-const RUN_STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof CheckCircle2 }> = {
+const RUN_STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof CheckCircle2; spin?: boolean }> = {
   issue_created: { label: "Issue Created", color: "text-blue-500", icon: Clock },
-  running: { label: "Running", color: "text-blue-500", icon: Loader2 },
+  running: { label: "Running", color: "text-blue-500", icon: Loader2, spin: true },
   completed: { label: "Completed", color: "text-emerald-500", icon: CheckCircle2 },
   failed: { label: "Failed", color: "text-destructive", icon: XCircle },
 };
@@ -66,7 +66,7 @@ function RunRow({ run }: { run: AutopilotRun }) {
 
   const content = (
     <>
-      <StatusIcon className={cn("h-4 w-4 shrink-0", cfg.color)} />
+      <StatusIcon className={cn("h-4 w-4 shrink-0", cfg.color, cfg.spin && "animate-spin")} />
       <span className={cn("w-24 shrink-0 text-xs font-medium", cfg.color)}>{cfg.label}</span>
       <span className="w-16 shrink-0 text-xs text-muted-foreground capitalize">{run.source}</span>
       <span className="flex-1 min-w-0 text-xs text-muted-foreground truncate">


### PR DESCRIPTION
## Summary

The autopilot detail page maps `run.status === \"running\"` to a `Loader2` icon, but renders it without the `animate-spin` class. So a manually-triggered run sits on a static circle until the row flips to `completed` / `failed`, giving the user no visual signal that anything is actually happening.

Found while testing a run_only autopilot — manual trigger fired, backend was working, but the run history row looked frozen on \"Running\".

## Change

`packages/views/autopilots/components/autopilot-detail-page.tsx`: add an optional `spin?: boolean` field to `RUN_STATUS_CONFIG` entries, set it on `running`, and pass `cfg.spin && \"animate-spin\"` to the icon's className. Same one-config-entry pattern as the existing `color`.

## Test plan

- [x] `pnpm --filter @multica/views exec tsc --noEmit` — passes
- [ ] Manual: trigger an autopilot, verify the Loader2 icon spins on the new row until status flips