### PR TITLE
docs(prompt): warn agents that mention syntax is an action, not a reference

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -169,7 +169,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("When referencing issues or people in comments, use the mention format so they render as interactive links:\n\n")
 	b.WriteString("- **Issue**: `[MUL-123](mention://issue/<issue-id>)` — renders as a clickable link to the issue\n")
 	b.WriteString("- **Member**: `[@Name](mention://member/<user-id>)` — renders as a styled mention and sends a notification\n")
-	b.WriteString("- **Agent**: `[@Name](mention://agent/<agent-id>)` — renders as a styled mention\n\n")
+	b.WriteString("- **Agent**: `[@Name](mention://agent/<agent-id>)` — renders as a styled mention and re-triggers the agent\n\n")
+	b.WriteString("⚠️ Agent and member mentions are **actions**, not text references: agent mentions enqueue a new task for the agent, and member mentions send a notification. ")
+	b.WriteString("If you only want to refer to someone by name in prose (e.g. \"GPT-Boy is correct\"), write the plain name without the mention link.\n\n")
 	b.WriteString("Use `multica issue list --output json` to look up issue IDs, and `multica workspace members --output json` for member IDs.\n\n")
 
 	b.WriteString("## Attachments\n\n")


### PR DESCRIPTION
## Summary

Closes [MUL-1069](mention://issue/12a66a65-d77c-4e2f-88ee-64c3e74d16a2).

Agents have repeatedly used `[@Name](mention://agent/<id>)` in prose (e.g. writing "GPT-Boy is correct") and accidentally re-triggered the referenced agent. The current `## Mentions` section in the agent prompt only documents the format; it never says **when not to use it**.

This PR amends the prompt section produced by `buildMetaSkillContent()` in `server/internal/daemon/execenv/runtime_config.go`:

- Tightens the Agent bullet to state the side-effect explicitly: "renders as a styled mention **and re-triggers the agent**".
- Adds a one-paragraph caveat after the bullet list: agent/member mentions are actions (enqueue task / send notification); for plain prose references, write the bare name with no link.

Member mentions get the same caveat in passing, since they have an analogous failure mode (unwanted notifications).

## Test plan

- [x] `go build ./internal/daemon/execenv/` — passes
- [x] `go test ./internal/daemon/execenv/` — passes (no fixtures pin the prompt text)
- [ ] Manual sanity check: next agent run sees the updated `CLAUDE.md` injected into its workdir