### PR TITLE
fix(selfhost): disable dev master code by default in Docker deployment

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -56,6 +56,7 @@ services:
       CLOUDFRONT_KEY_PAIR_ID: ${CLOUDFRONT_KEY_PAIR_ID:-}
       CLOUDFRONT_PRIVATE_KEY: ${CLOUDFRONT_PRIVATE_KEY:-}
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
+      APP_ENV: ${APP_ENV:-production}
       MULTICA_APP_URL: ${MULTICA_APP_URL:-http://localhost:3000}
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary

Self-hosted Docker deployments leave the development master verification code (`888888`) enabled because `docker-compose.selfhost.yml` does not pass `APP_ENV` to the backend container. Even if a user sets `APP_ENV=production` in their `.env` file, the container never receives it.

This means any public self-hosted instance can be accessed with any email address + code `888888`.

## Changes

1. **`docker-compose.selfhost.yml`**: Add `APP_ENV: ${APP_ENV:-production}` to the backend environment — defaults to production when not explicitly set
2. **`.env.example`**: Add `APP_ENV=production` with a comment explaining the master code behavior

## Why this approach

- **Minimal change**: No logic changes to `auth.go` — the existing `APP_ENV != "production"` check works correctly once the env var is actually passed through
- **Safe default**: Self-hosted deployments default to production (master code disabled). Developers who want the dev bypass can explicitly set `APP_ENV=development`
- **Backward compatible**: Existing deployments that already set `APP_ENV` in their `.env` will now have it properly forwarded

## Testing

- Verified that the backend environment block in the compose file now includes `APP_ENV`
- Verified `.env.example` documents the setting with clear explanation

Closes #1304