### PR TITLE
feat(agents): show launch mode preview in custom args tab

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -11,6 +11,7 @@ export interface RuntimeDevice {
   name: string;
   runtime_mode: AgentRuntimeMode;
   provider: string;
+  launch_header: string;
   status: "online" | "offline";
   device_info: string;
   metadata: Record<string, unknown>;

--- a/packages/views/agents/components/agent-detail.tsx
+++ b/packages/views/agents/components/agent-detail.tsx
@@ -178,6 +178,7 @@ export function AgentDetail({
         {activeTab === "custom_args" && (
           <CustomArgsTab
             agent={agent}
+            runtimeDevice={runtimeDevice}
             onSave={(updates) => onUpdate(agent.id, updates)}
           />
         )}

--- a/packages/views/agents/components/tabs/custom-args-tab.tsx
+++ b/packages/views/agents/components/tabs/custom-args-tab.tsx
@@ -7,7 +7,7 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
-import type { Agent } from "@multica/core/types";
+import type { Agent, RuntimeDevice } from "@multica/core/types";
 import { createSafeId } from "@multica/core/utils";
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
@@ -29,9 +29,11 @@ function entriesToArgs(entries: ArgEntry[]): string[] {
 
 export function CustomArgsTab({
   agent,
+  runtimeDevice,
   onSave,
 }: {
   agent: Agent;
+  runtimeDevice?: RuntimeDevice;
   onSave: (updates: Partial<Agent>) => Promise<void>;
 }) {
   const [entries, setEntries] = useState<ArgEntry[]>(
@@ -69,6 +71,8 @@ export function CustomArgsTab({
     }
   };
 
+  const launchHeader = runtimeDevice?.launch_header;
+
   return (
     <div className="max-w-lg space-y-4">
       <div className="flex items-center justify-between">
@@ -80,6 +84,14 @@ export function CustomArgsTab({
             Additional CLI arguments appended to the agent command at launch
             (e.g. --model claude-sonnet-4-20250514)
           </p>
+          {launchHeader && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Launch mode:{" "}
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">
+                {launchHeader} &lt;your args&gt;
+              </code>
+            </p>
+          )}
         </div>
         <Button
           type="button"

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -9,24 +9,26 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/pkg/agent"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
 type AgentRuntimeResponse struct {
-	ID          string  `json:"id"`
-	WorkspaceID string  `json:"workspace_id"`
-	DaemonID    *string `json:"daemon_id"`
-	Name        string  `json:"name"`
-	RuntimeMode string  `json:"runtime_mode"`
-	Provider    string  `json:"provider"`
-	Status      string  `json:"status"`
-	DeviceInfo  string  `json:"device_info"`
-	Metadata    any     `json:"metadata"`
-	OwnerID     *string `json:"owner_id"`
-	LastSeenAt  *string `json:"last_seen_at"`
-	CreatedAt   string  `json:"created_at"`
-	UpdatedAt   string  `json:"updated_at"`
+	ID           string  `json:"id"`
+	WorkspaceID  string  `json:"workspace_id"`
+	DaemonID     *string `json:"daemon_id"`
+	Name         string  `json:"name"`
+	RuntimeMode  string  `json:"runtime_mode"`
+	Provider     string  `json:"provider"`
+	LaunchHeader string  `json:"launch_header"`
+	Status       string  `json:"status"`
+	DeviceInfo   string  `json:"device_info"`
+	Metadata     any     `json:"metadata"`
+	OwnerID      *string `json:"owner_id"`
+	LastSeenAt   *string `json:"last_seen_at"`
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
 }
 
 func runtimeToResponse(rt db.AgentRuntime) AgentRuntimeResponse {
@@ -39,19 +41,20 @@ func runtimeToResponse(rt db.AgentRuntime) AgentRuntimeResponse {
 	}
 
 	return AgentRuntimeResponse{
-		ID:          uuidToString(rt.ID),
-		WorkspaceID: uuidToString(rt.WorkspaceID),
-		DaemonID:    textToPtr(rt.DaemonID),
-		Name:        rt.Name,
-		RuntimeMode: rt.RuntimeMode,
-		Provider:    rt.Provider,
-		Status:      rt.Status,
-		DeviceInfo:  rt.DeviceInfo,
-		Metadata:    metadata,
-		OwnerID:     uuidToPtr(rt.OwnerID),
-		LastSeenAt:  timestampToPtr(rt.LastSeenAt),
-		CreatedAt:   timestampToString(rt.CreatedAt),
-		UpdatedAt:   timestampToString(rt.UpdatedAt),
+		ID:           uuidToString(rt.ID),
+		WorkspaceID:  uuidToString(rt.WorkspaceID),
+		DaemonID:     textToPtr(rt.DaemonID),
+		Name:         rt.Name,
+		RuntimeMode:  rt.RuntimeMode,
+		Provider:     rt.Provider,
+		LaunchHeader: agent.LaunchHeader(rt.Provider),
+		Status:       rt.Status,
+		DeviceInfo:   rt.DeviceInfo,
+		Metadata:     metadata,
+		OwnerID:      uuidToPtr(rt.OwnerID),
+		LastSeenAt:   timestampToPtr(rt.LastSeenAt),
+		CreatedAt:    timestampToString(rt.CreatedAt),
+		UpdatedAt:    timestampToString(rt.UpdatedAt),
 	}
 }
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -125,3 +125,28 @@ func New(agentType string, cfg Config) (Backend, error) {
 func DetectVersion(ctx context.Context, executablePath string) (string, error) {
 	return detectCLIVersion(ctx, executablePath)
 }
+
+// launchHeaders maps each supported agent type to the user-visible skeleton
+// that the daemon spawns before any custom_args are appended. This is
+// intentionally minimal — only the command + subcommand (or a short mode
+// label when there is no subcommand). Internal flags, transport values, and
+// environment variables are deliberately omitted so the string is a hint
+// about *what* users are extending, not a dump of the full command line.
+var launchHeaders = map[string]string{
+	"claude":   "claude (stream-json)",
+	"codex":    "codex app-server",
+	"copilot":  "copilot (json)",
+	"cursor":   "cursor-agent (stream-json)",
+	"gemini":   "gemini (stream-json)",
+	"hermes":   "hermes acp",
+	"openclaw": "openclaw agent (json)",
+	"opencode": "opencode run (json)",
+	"pi":       "pi (json mode)",
+}
+
+// LaunchHeader returns the user-visible launch skeleton for agentType, or an
+// empty string if the type is unknown. Callers render this as a preview so
+// users understand which command their custom_args get appended to.
+func LaunchHeader(agentType string) string {
+	return launchHeaders[agentType]
+}

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -62,3 +62,28 @@ func TestDetectVersionFailsForMissingBinary(t *testing.T) {
 		t.Fatal("expected error for missing binary")
 	}
 }
+
+func TestLaunchHeaderCoversAllSupportedBackends(t *testing.T) {
+	t.Parallel()
+
+	// The factory in New() enumerates every supported agent type; LaunchHeader
+	// must stay in sync so the UI preview never shows an empty skeleton for a
+	// runtime the daemon actually spawns. If a new backend is added, add an
+	// entry to launchHeaders in agent.go and extend this list.
+	supported := []string{
+		"claude", "codex", "copilot", "cursor", "gemini",
+		"hermes", "openclaw", "opencode", "pi",
+	}
+	for _, t_ := range supported {
+		if header := LaunchHeader(t_); header == "" {
+			t.Errorf("LaunchHeader(%q) returned empty string — add it to launchHeaders", t_)
+		}
+	}
+}
+
+func TestLaunchHeaderReturnsEmptyForUnknownType(t *testing.T) {
+	t.Parallel()
+	if header := LaunchHeader("made-up-agent"); header != "" {
+		t.Errorf("expected empty header for unknown type, got %q", header)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1310 for #1308. Surfaces the daemon's hardcoded launch skeleton (e.g. `codex app-server`) in the agent's Custom Args tab so users understand which command their custom CLI args are being appended to — the root cause of #1308 was that users were appending `-m` / `--model` without seeing that the daemon spawns `codex app-server`, a subcommand that doesn't accept those flags.

- `server/pkg/agent/agent.go` — add a `launchHeaders` map + `LaunchHeader(agentType)` lookup. Single source of truth in Go; each entry is intentionally minimal (`binary subcommand` when one exists, otherwise a short mode tag like `claude (stream-json)`), deliberately omitting transport values / env / internal flags.
- `server/internal/handler/runtime.go` — populate `launch_header` on `AgentRuntimeResponse` from `agent.LaunchHeader(rt.Provider)`. Piggybacks on the existing runtime payload; no new endpoint, no DB query change.
- `packages/core/types/agent.ts` — add `launch_header: string` to `RuntimeDevice`.
- `packages/views/agents/components/agent-detail.tsx` — pass the resolved `runtimeDevice` into `<CustomArgsTab>` (it already knew the runtime to render the header chip).
- `packages/views/agents/components/tabs/custom-args-tab.tsx` — render a one-line preview "Launch mode: `<header> <your args>`" above the args list.

Intentionally **not** in scope:
- A new `/api/runtimes/meta` endpoint — the existing runtime response already fans out to every client.
- Per-provider placeholder examples — the preview alone addresses the "user doesn't know what they're extending" problem; richer examples can follow when/if we add an explicit `model` field (the long-term item tracked in #1308).
- Exposing env / sandbox flags — leaves the internal surface renaming-safe.

Stacks orthogonally with #1310: either can land first; custom-args-tab.tsx doesn't conflict (this PR adds a new preview block, #1310 only tweaks helper text + placeholder).

## Test plan

- [x] `go test ./pkg/agent/` — new `TestLaunchHeaderCoversAllSupportedBackends` guards against adding a backend without a launch header; `TestLaunchHeaderReturnsEmptyForUnknownType` covers the miss path.
- [x] `go test ./...` — full suite green.
- [x] `gofmt -l` clean, `go vet` clean.
- [ ] CI typecheck / frontend unit tests.
- [ ] Manual: open Agent detail → Custom Args for each runtime (codex, claude, hermes, cursor…); confirm the preview line shows the right skeleton and hides when `launch_header` is absent (e.g. if the agent's runtime hasn't loaded yet).