### PR TITLE
fix(views): prevent infinite re-render loops in sidebar and chat resize

### DIFF
--- a/packages/views/chat/components/use-chat-resize.ts
+++ b/packages/views/chat/components/use-chat-resize.ts
@@ -34,11 +34,16 @@ export function useChatResize(
     if (!parent) return;
 
     const update = () => {
-      boundsRef.current = {
-        maxW: Math.floor(parent.clientWidth * MAX_RATIO),
-        maxH: Math.floor(parent.clientHeight * MAX_RATIO),
-      };
-      setBoundsReady(true);
+      const maxW = Math.floor(parent.clientWidth * MAX_RATIO);
+      const maxH = Math.floor(parent.clientHeight * MAX_RATIO);
+      setBoundsReady(true); // idempotent once true
+      // Only trigger a re-render if the bounds actually changed. Without this
+      // guard, any spurious ResizeObserver notification (including sub-pixel
+      // layout jitter during mount) schedules a setState that feeds back into
+      // the observer, producing "Maximum update depth exceeded".
+      const prev = boundsRef.current;
+      if (prev.maxW === maxW && prev.maxH === maxH) return;
+      boundsRef.current = { maxW, maxH };
       setRevision((r) => r + 1);
     };
 

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -78,6 +78,16 @@ import { useDeletePin, useReorderPins } from "@multica/core/pins/mutations";
 import type { PinnedItem } from "@multica/core/types";
 import { useLogout } from "../auth";
 
+// Stable empty arrays for query defaults. Using an inline `= []` default on
+// `useQuery` creates a new array reference on every render when `data` is
+// undefined (e.g. query disabled or loading) — which in turn breaks any
+// `useEffect`/`useMemo` that depends on the value, and can trigger infinite
+// re-render loops when the effect itself calls `setState`.
+const EMPTY_PINS: PinnedItem[] = [];
+const EMPTY_WORKSPACES: Awaited<ReturnType<typeof api.listWorkspaces>> = [];
+const EMPTY_INVITATIONS: Awaited<ReturnType<typeof api.listMyInvitations>> = [];
+const EMPTY_INBOX: Awaited<ReturnType<typeof api.listInbox>> = [];
+
 // Nav items reference WorkspacePaths method names so they can be resolved
 // against the current workspace slug at render time (see AppSidebar body).
 // Only parameterless paths are valid nav destinations.
@@ -202,11 +212,11 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   const logout = useLogout();
   const workspace = useCurrentWorkspace();
   const p = useWorkspacePaths();
-  const { data: workspaces = [] } = useQuery(workspaceListOptions());
-  const { data: myInvitations = [] } = useQuery(myInvitationListOptions());
+  const { data: workspaces = EMPTY_WORKSPACES } = useQuery(workspaceListOptions());
+  const { data: myInvitations = EMPTY_INVITATIONS } = useQuery(myInvitationListOptions());
 
   const wsId = workspace?.id;
-  const { data: inboxItems = [] } = useQuery({
+  const { data: inboxItems = EMPTY_INBOX } = useQuery({
     queryKey: wsId ? inboxKeys.list(wsId) : ["inbox", "disabled"],
     queryFn: () => api.listInbox(),
     enabled: !!wsId,
@@ -216,7 +226,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
     [inboxItems],
   );
   const hasRuntimeUpdates = useMyRuntimesNeedUpdate(wsId);
-  const { data: pinnedItems = [] } = useQuery({
+  const { data: pinnedItems = EMPTY_PINS } = useQuery({
     ...pinListOptions(wsId ?? "", userId ?? ""),
     enabled: !!wsId && !!userId,
   });


### PR DESCRIPTION
## What does this PR do?

Fixes two independent sources of "Maximum update depth exceeded" errors that surface together whenever the backend is unreachable (e.g. running only `pnpm dev:desktop` without `make server`, or during WebSocket reconnect storms). Symptom: repeated `app-sidebar.tsx:235` and `use-chat-resize.ts:41` errors, sidebar frozen, navigation blocked.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

### 1. `packages/views/layout/app-sidebar.tsx` — stable query defaults

`const { data: pinnedItems = [] } = useQuery(...)` returns a **new** `[]` on every render whenever `data` is `undefined` (query disabled because `wsId`/`userId` not yet loaded, or the request keeps failing). The downstream effect:

```ts
useEffect(() => {
  if (!isDraggingRef.current) setLocalPinned(pinnedItems);
}, [pinnedItems]);
```

…then fires every render, setting new state, re-rendering, producing yet another `[]`, and so on. React hits its update-depth guard and aborts the tree.

Replaced inline `= []` with module-level constants (`EMPTY_PINS`, `EMPTY_WORKSPACES`, `EMPTY_INVITATIONS`, `EMPTY_INBOX`) so identity is stable across renders.

### 2. `packages/views/chat/components/use-chat-resize.ts` — guard ResizeObserver

`ResizeObserver` callback unconditionally did `setRevision(r => r + 1)`. Any spurious notification (sub-pixel jitter on mount, ancestor reflow) scheduled a re-render that could feed back into the observer. Added an equality check: only bump `revision` when `maxW`/`maxH` actually changed. `setBoundsReady(true)` stays outside the guard since it's idempotent.

## How to Test

1. Stop the backend (`make stop` or don't start it)
2. Run only the frontend: `pnpm dev:desktop` or `pnpm dev:web`
3. Open the app and let WebSocket fail to connect
4. **Before this PR:** console floods with "Maximum update depth exceeded" pointing at `app-sidebar.tsx:235` and `use-chat-resize.ts:41`; app becomes unresponsive and navigation is blocked
5. **After this PR:** WebSocket reconnect attempts still log warnings (expected — backend is down), but the React tree stays stable and navigation works

Also verified:
- `pnpm --filter @multica/views typecheck` passes
- `pnpm --filter @multica/views test` — 138 tests pass

## Risk

Low. Both changes are purely defensive: they replace unstable references with stable ones and short-circuit redundant state updates. No behavior change when data/bounds are legitimately updating.

## Why this matters beyond the "backend down" case

Even with a healthy backend, both paths are technically only working by luck — fast query resolution and stable layout mean the loop window is too short to trip React's threshold. Edge cases that could still bite: slow network, query invalidation bursts, race between workspace load and sidebar mount, layout reflow cascades. This PR makes both loops structurally impossible rather than statistically unlikely.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Reported the error symptoms + screenshots to Claude Code, which traced the infinite loop to two root causes (unstable query defaults + unconditional ResizeObserver setState), verified with typecheck and tests, then split into atomic commits.