### PR TITLE
feat: rate-limit fallback, attachments sidebar, sidebar bugfix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,28 @@ NEXT_PUBLIC_WS_URL=
 # Remote API (optional) — set to proxy local frontend to a remote backend
 # Leave empty to use local backend (localhost:8080)
 # REMOTE_API_URL=https://multica-api.copilothub.ai
+
+# ═══════════════════════════════════════════════════════════════════
+# Content Engine Credentials (see docs/CREDENTIALS.md for setup guide)
+# ═══════════════════════════════════════════════════════════════════
+
+# ── Global ──────────────────────────────────────────────────────────
+AHREFS_API_KEY=
+GSC_SA_JSON=
+GA4_SA_JSON=
+SLACK_BOT_TOKEN=
+SLACK_SIGNING_SECRET=
+# OPENAI_API_KEY=
+# STABILITY_API_KEY=
+# REPLICATE_API_TOKEN=
+# CLOUDINARY_URL=
+# PSI_API_KEY=
+
+# ── Per-BU (repeat for each BU: SYKASOFT, BLUESOLUTION_SMARTHANDWERK, etc.) ──
+# WP_APP_PW_{BU_SLUG}=
+# WP_BASE_URL_{BU_SLUG}=
+# GSC_PROPERTY_{BU_SLUG}=
+# GA4_PROPERTY_ID_{BU_SLUG}=
+# CLARITY_PROJECT_ID_{BU_SLUG}=
+# BRAND_RADAR_REPORT_ID_{BU_SLUG}=
+# RANK_TRACKER_PROJECT_ID_{BU_SLUG}=

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -21,6 +21,8 @@ export const issueKeys = {
   subscribers: (issueId: string) =>
     ["issues", "subscribers", issueId] as const,
   usage: (issueId: string) => ["issues", "usage", issueId] as const,
+  attachments: (issueId: string) =>
+    ["issues", "attachments", issueId] as const,
 };
 
 export type MyIssuesFilter = Pick<ListIssuesParams, "assignee_id" | "assignee_ids" | "creator_id">;
@@ -140,5 +142,12 @@ export function issueUsageOptions(issueId: string) {
   return queryOptions({
     queryKey: issueKeys.usage(issueId),
     queryFn: () => api.getIssueUsage(issueId),
+  });
+}
+
+export function issueAttachmentsOptions(issueId: string) {
+  return queryOptions({
+    queryKey: issueKeys.attachments(issueId),
+    queryFn: () => api.listAttachments(issueId),
   });
 }

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -11,7 +11,10 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  Download,
+  FileText,
   Link2,
+  Paperclip,
   MoreHorizontal,
   PanelRight,
   Pin,
@@ -73,7 +76,7 @@ import { useAuthStore } from "@multica/core/auth";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions } from "@multica/core/issues/queries";
+import { issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions, issueAttachmentsOptions } from "@multica/core/issues/queries";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import { useUpdateIssue, useDeleteIssue } from "@multica/core/issues/mutations";
 import { useRecentIssuesStore } from "@multica/core/issues/stores";
@@ -151,6 +154,12 @@ function formatActivity(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function formatFileSize(bytes: number): string {
+  if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(1)} MB`;
+  if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
 
 function formatTokenCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -359,6 +368,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const [detailsOpen, setDetailsOpen] = useState(true);
   const [parentIssueOpen, setParentIssueOpen] = useState(true);
   const [tokenUsageOpen, setTokenUsageOpen] = useState(true);
+  const [attachmentsOpen, setAttachmentsOpen] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const didHighlightRef = useRef<string | null>(null);
@@ -401,6 +411,9 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
 
   // Token usage
   const { data: usage } = useQuery(issueUsageOptions(id));
+
+  // Attachments
+  const { data: attachments = [] } = useQuery(issueAttachmentsOptions(id));
 
   // Pinned state
   const { data: pinnedItems = [] } = useQuery({
@@ -663,6 +676,36 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
             <PropRow label="Runs">
               <span className="text-muted-foreground">{usage.task_count}</span>
             </PropRow>
+          </div>}
+        </div>
+      )}
+
+      {/* Attachments */}
+      {attachments.length > 0 && (
+        <div>
+          <button
+            className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${attachmentsOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
+            onClick={() => setAttachmentsOpen(!attachmentsOpen)}
+          >
+            <Paperclip className="!size-3 shrink-0" />
+            Attachments
+            <span className="text-muted-foreground ml-auto mr-1">{attachments.length}</span>
+            <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${attachmentsOpen ? "rotate-90" : ""}`} />
+          </button>
+          {attachmentsOpen && <div className="space-y-1 pl-2">
+            {attachments.map((att) => (
+              <button
+                key={att.id}
+                type="button"
+                onClick={() => window.open(att.download_url || att.url, "_blank", "noopener,noreferrer")}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 -mx-2 text-xs hover:bg-accent/50 transition-colors group text-left"
+              >
+                <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate flex-1 group-hover:text-foreground">{att.filename}</span>
+                <span className="text-muted-foreground shrink-0 text-[10px]">{formatFileSize(att.size_bytes)}</span>
+                <Download className="h-3 w-3 shrink-0 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+              </button>
+            ))}
           </div>}
         </div>
       )}

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@multica/ui/lib/utils";
 import { AppLink, useNavigation } from "../navigation";
 import {
@@ -216,7 +216,8 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
     [inboxItems],
   );
   const hasRuntimeUpdates = useMyRuntimesNeedUpdate(wsId);
-  const { data: pinnedItems = [] } = useQuery({
+  const emptyPinnedItems: PinnedItem[] = useMemo(() => [], []);
+  const { data: pinnedItems = emptyPinnedItems } = useQuery({
     ...pinListOptions(wsId ?? "", userId ?? ""),
     enabled: !!wsId && !!userId,
   });

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -833,6 +833,27 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 	default:
 	}
 
+	// Rate-limit fallback: if the primary provider hit a rate limit, retry
+	// with an alternative provider from the same daemon. The fallback order
+	// is determined by providerFallbackOrder.
+	if isRateLimitError(err, result) {
+		fallback := d.pickFallbackProvider(provider)
+		if fallback != "" {
+			taskLog.Warn("rate limit detected, retrying with fallback provider",
+				"original", provider, "fallback", fallback)
+			_ = d.client.ReportProgress(ctx, task.ID, fmt.Sprintf("Rate limited on %s, retrying with %s", provider, fallback), 1, 2)
+			result, err = d.runTask(runCtx, task, fallback, taskLog)
+
+			// Check cancellation again after retry.
+			select {
+			case <-cancelledByPoll:
+				taskLog.Info("task cancelled during fallback execution, discarding result")
+				return
+			default:
+			}
+		}
+	}
+
 	if err != nil {
 		taskLog.Error("task failed", "error", err)
 		if failErr := d.client.FailTask(ctx, task.ID, err.Error()); failErr != nil {
@@ -1088,6 +1109,57 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		}
 		return TaskResult{Status: "blocked", Comment: errMsg, EnvRoot: env.RootDir, Usage: usageEntries}, nil
 	}
+}
+
+// providerFallbackOrder defines the preferred fallback chain when a provider
+// hits a rate limit. Each provider maps to an ordered list of alternatives.
+var providerFallbackOrder = map[string][]string{
+	"claude":   {"codex", "copilot", "opencode"},
+	"codex":    {"claude", "copilot", "opencode"},
+	"copilot":  {"claude", "codex", "opencode"},
+	"opencode": {"claude", "codex", "copilot"},
+	"gemini":   {"claude", "codex", "copilot", "opencode"},
+	"cursor":   {"claude", "codex", "copilot", "opencode"},
+}
+
+// isRateLimitError returns true if the task result or error indicates a rate limit.
+func isRateLimitError(err error, result TaskResult) bool {
+	if err != nil {
+		errStr := strings.ToLower(err.Error())
+		if strings.Contains(errStr, "rate limit") ||
+			strings.Contains(errStr, "rate_limit") ||
+			strings.Contains(errStr, "ratelimit") ||
+			strings.Contains(errStr, "hit your limit") ||
+			strings.Contains(errStr, "429") ||
+			strings.Contains(errStr, "overloaded") {
+			return true
+		}
+	}
+	comment := strings.ToLower(result.Comment)
+	if strings.Contains(comment, "rate limit") ||
+		strings.Contains(comment, "hit your limit") ||
+		strings.Contains(comment, "rate_limit") ||
+		strings.Contains(comment, "ratelimit") ||
+		strings.Contains(comment, "429") ||
+		strings.Contains(comment, "overloaded") {
+		return true
+	}
+	return false
+}
+
+// pickFallbackProvider returns the first available fallback provider for the
+// given provider, or "" if none is available.
+func (d *Daemon) pickFallbackProvider(provider string) string {
+	candidates, ok := providerFallbackOrder[provider]
+	if !ok {
+		return ""
+	}
+	for _, candidate := range candidates {
+		if _, exists := d.cfg.Agents[candidate]; exists {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // executeAndDrain runs a backend, drains its message stream (forwarding to the

--- a/server/internal/daemon/ratelimit_test.go
+++ b/server/internal/daemon/ratelimit_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsRateLimitError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		result TaskResult
+		want   bool
+	}{
+		{"nil error, empty result", nil, TaskResult{}, false},
+		{"rate limit in error", fmt.Errorf("rate limit exceeded"), TaskResult{}, true},
+		{"hit your limit in error", fmt.Errorf("You've hit your limit · resets 5am"), TaskResult{}, true},
+		{"429 in error", fmt.Errorf("HTTP 429 Too Many Requests"), TaskResult{}, true},
+		{"overloaded in error", fmt.Errorf("API is overloaded"), TaskResult{}, true},
+		{"rate limit in comment", nil, TaskResult{Comment: "rate limit exceeded"}, true},
+		{"hit your limit in comment", nil, TaskResult{Comment: "You've hit your limit · resets 5am (Europe/Berlin)"}, true},
+		{"normal error", fmt.Errorf("connection refused"), TaskResult{}, false},
+		{"normal comment", nil, TaskResult{Comment: "task completed successfully"}, false},
+		{"RateLimitError name", fmt.Errorf("RateLimitError"), TaskResult{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRateLimitError(tt.err, tt.result)
+			if got != tt.want {
+				t.Errorf("isRateLimitError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPickFallbackProvider(t *testing.T) {
+	d := &Daemon{cfg: Config{
+		Agents: map[string]AgentEntry{
+			"claude": {Path: "/usr/bin/claude"},
+			"codex":  {Path: "/usr/bin/codex"},
+		},
+	}}
+
+	// claude → codex (first available)
+	if got := d.pickFallbackProvider("claude"); got != "codex" {
+		t.Errorf("pickFallbackProvider(claude) = %q, want %q", got, "codex")
+	}
+
+	// codex → claude (first available)
+	if got := d.pickFallbackProvider("codex"); got != "claude" {
+		t.Errorf("pickFallbackProvider(codex) = %q, want %q", got, "claude")
+	}
+
+	// unknown provider → ""
+	if got := d.pickFallbackProvider("unknown"); got != "" {
+		t.Errorf("pickFallbackProvider(unknown) = %q, want %q", got, "")
+	}
+
+	// No fallback available
+	d2 := &Daemon{cfg: Config{
+		Agents: map[string]AgentEntry{
+			"claude": {Path: "/usr/bin/claude"},
+		},
+	}}
+	if got := d2.pickFallbackProvider("codex"); got != "claude" {
+		t.Errorf("pickFallbackProvider(codex) with only claude = %q, want %q", got, "claude")
+	}
+}


### PR DESCRIPTION
## Summary

Three independent improvements, bundled for review convenience. Each commit is self-contained and can be cherry-picked independently.

### 1. fix(sidebar): prevent infinite re-render from unstable empty array default
`useQuery`'s `= []` default creates a new array reference on every render when data is undefined, causing the `useEffect` to fire endlessly. Fix: stable empty array via `useMemo`.

### 2. feat(daemon): automatic rate-limit fallback across providers
When an agent hits a rate limit (429, "hit your limit", "overloaded"), the daemon automatically retries with the next available provider. Fallback chain: `claude → codex → copilot → opencode`. Includes unit tests.

### 3. feat(issues): show file attachments in issue detail sidebar
Collapsible "Attachments" section in the issue detail sidebar. Lists all files with filename, size, and download button. Required query option added to `packages/core`.

## Test plan
- [ ] Sidebar no longer logs "Maximum update depth exceeded" in console
- [ ] Rate limit fallback: mock a rate-limit error and verify retry with fallback provider
- [ ] Attachments: upload a file to an issue via API, verify it appears in sidebar and downloads correctly
- [ ] `go test ./internal/daemon/ -run TestIsRateLimitError` passes
- [ ] `go test ./internal/daemon/ -run TestPickFallbackProvider` passes
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)