### PR TITLE
fix(cli): resolve relative attachment download_url against base URL

### DIFF
--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -269,11 +270,34 @@ func (c *APIClient) UploadFile(ctx context.Context, fileData []byte, filename st
 
 // DownloadFile downloads a file from the given URL and returns the response body.
 // This is used for downloading attachments via their signed download_url.
+//
+// download_url may be either a workspace-relative path served by this server
+// (e.g. "/uploads/workspaces/.../foo.png" when using LocalStorage) or an
+// absolute URL pointing at external object storage (e.g. an S3 signed URL).
+// Relative paths are resolved against c.BaseURL and carry the API client's
+// auth/context headers; absolute URLs are passed through untouched so we don't
+// leak Bearer tokens to third-party hosts and don't override their own auth
+// (signed query strings, etc.).
+//
 // Downloads are limited to 100 MB to match the upload size limit.
 func (c *APIClient) DownloadFile(ctx context.Context, downloadURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	u, err := url.Parse(downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse download url: %w", err)
+	}
+
+	resolved := downloadURL
+	sameOrigin := !u.IsAbs()
+	if sameOrigin {
+		resolved = c.BaseURL + downloadURL
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolved, nil)
 	if err != nil {
 		return nil, err
+	}
+	if sameOrigin {
+		c.setHeaders(req)
 	}
 
 	resp, err := c.HTTPClient.Do(req)

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -110,3 +110,81 @@ func TestPostJSON(t *testing.T) {
 		}
 	})
 }
+
+// TestDownloadFile guards the bug from ZAR-27 where a relative `download_url`
+// was passed straight to http.Get and produced "unsupported protocol scheme".
+func TestDownloadFile(t *testing.T) {
+	const payload = "hello-bytes"
+
+	t.Run("relative URL resolves against base URL and sends auth headers", func(t *testing.T) {
+		var seenAuth, seenWS string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/uploads/workspaces/ws-abc/file.png" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			seenAuth = r.Header.Get("Authorization")
+			seenWS = r.Header.Get("X-Workspace-ID")
+			io.WriteString(w, payload)
+		}))
+		defer srv.Close()
+
+		client := NewAPIClient(srv.URL, "ws-abc", "test-token")
+		got, err := client.DownloadFile(context.Background(), "/uploads/workspaces/ws-abc/file.png")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(got) != payload {
+			t.Errorf("expected body %q, got %q", payload, string(got))
+		}
+		if seenAuth != "Bearer test-token" {
+			t.Errorf("expected Authorization 'Bearer test-token', got %q", seenAuth)
+		}
+		if seenWS != "ws-abc" {
+			t.Errorf("expected X-Workspace-ID 'ws-abc', got %q", seenWS)
+		}
+	})
+
+	t.Run("absolute URL passes through and does not send auth headers", func(t *testing.T) {
+		var seenAuth, seenWS string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			seenAuth = r.Header.Get("Authorization")
+			seenWS = r.Header.Get("X-Workspace-ID")
+			io.WriteString(w, payload)
+		}))
+		defer srv.Close()
+
+		// Configure the client against a different base URL to prove that
+		// absolute URLs are not rewritten to point at it.
+		client := NewAPIClient("https://api.example.invalid", "ws-abc", "test-token")
+		got, err := client.DownloadFile(context.Background(), srv.URL+"/some/external/object?sig=abc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(got) != payload {
+			t.Errorf("expected body %q, got %q", payload, string(got))
+		}
+		if seenAuth != "" {
+			t.Errorf("expected no Authorization header on absolute URL, got %q", seenAuth)
+		}
+		if seenWS != "" {
+			t.Errorf("expected no X-Workspace-ID header on absolute URL, got %q", seenWS)
+		}
+	})
+
+	t.Run("error status surfaces server message", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			io.WriteString(w, "nope")
+		}))
+		defer srv.Close()
+
+		client := NewAPIClient(srv.URL, "", "")
+		_, err := client.DownloadFile(context.Background(), "/uploads/x.png")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if got := err.Error(); got != "download returned 403: nope" {
+			t.Errorf("unexpected error: %s", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`multica attachment download <id>` fails with `unsupported protocol scheme ""` whenever the workspace uses LocalStorage (the default for self-host / dev). The API returns a workspace-relative `download_url` like `/uploads/workspaces/<ws>/<id>.png`, and `APIClient.DownloadFile` was passing it straight to `http.NewRequest`.

This PR resolves relative URLs against `c.BaseURL` and sends the API client's auth/context headers so the same-origin `/uploads/...` request is authenticated. Absolute URLs (e.g. S3 signed URLs) pass through untouched — we don't want to leak Bearer tokens to third-party hosts or override their own auth.

## Repro (before fix)

```
$ multica attachment download 019da322-6700-74ec-ac4f-b98ed7232e3b
Error: download file: Get "/uploads/workspaces/.../019da322-...png": unsupported protocol scheme ""
```

## After fix (verified end-to-end on a real attachment)

```
$ multica attachment download 019da322-6700-74ec-ac4f-b98ed7232e3b -o /tmp/zar27-out
Downloaded: /tmp/zar27-out/CleanShot 2026-04-18 at 19.27.02@2x.png
{
  "filename": "CleanShot 2026-04-18 at 19.27.02@2x.png",
  "id": "019da322-6700-74ec-ac4f-b98ed7232e3b",
  "path": "/tmp/zar27-out/CleanShot 2026-04-18 at 19.27.02@2x.png",
  "size": "25168"
}
$ file "/tmp/zar27-out/CleanShot 2026-04-18 at 19.27.02@2x.png"
PNG image data, 286 x 442, 8-bit/color RGBA, non-interlaced
```

## Test plan

- [x] `go test ./internal/cli/...` — added `TestDownloadFile` covering:
  - relative URL resolves against base URL **and** sends `Authorization` + `X-Workspace-ID` headers
  - absolute URL is passed through untouched and does **not** send auth headers (proves we don't leak Bearer tokens to e.g. S3)
  - non-2xx surfaces server error message
- [x] `go vet ./internal/cli/...` clean
- [x] End-to-end `multica attachment download <id>` against a real PNG attachment succeeds and writes a valid PNG

Closes ZAR-27 (Multica platform tracking issue in the `zarq` workspace).