### PR TITLE
fix(daemon): adopt agents from offline runtimes on register (#1326)

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -314,6 +314,12 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 		// the stale row so there's only ever one runtime per machine.
 		h.mergeLegacyRuntimes(r, registered, provider, req.LegacyDaemonIDs)
 
+		// Adopt agents and pending tasks that are still bound to an offline
+		// runtime of the same provider. This covers daemon restarts where
+		// the runtime UUID changed (e.g. pre-persistent-identity daemons,
+		// daemon_id file loss, or cross-machine migration).
+		h.adoptOrphanedAgents(r, registered, provider)
+
 		resp = append(resp, runtimeToResponse(registered))
 	}
 
@@ -410,6 +416,53 @@ func (h *Handler) mergeLegacyRuntimes(r *http.Request, registered db.AgentRuntim
 				"tasks_reassigned", tasks,
 			)
 		}
+	}
+}
+
+// adoptOrphanedAgents reassigns agents (and their pending tasks) that are
+// still bound to an offline runtime of the same provider in this workspace.
+// This is a server-side safety net: even when daemon identity is persistent
+// (#1220), edge cases (daemon_id file loss, cross-machine migration, pre-
+// persistent-identity upgrades) can leave agents stranded on a stale runtime
+// UUID. Rather than requiring manual `agent update --runtime-id` for each
+// affected agent, the server auto-adopts them at registration time.
+func (h *Handler) adoptOrphanedAgents(r *http.Request, registered db.AgentRuntime, provider string) {
+	newID := uuidToString(registered.ID)
+
+	agents, err := h.Queries.AdoptAgentsFromOfflineRuntimes(r.Context(), db.AdoptAgentsFromOfflineRuntimesParams{
+		NewRuntimeID: registered.ID,
+		WorkspaceID:  registered.WorkspaceID,
+		Provider:     provider,
+	})
+	if err != nil {
+		slog.Warn("adopt orphaned agents: reassign failed",
+			"runtime_id", newID,
+			"provider", provider,
+			"error", err,
+		)
+		return
+	}
+
+	tasks, err := h.Queries.AdoptTasksFromOfflineRuntimes(r.Context(), db.AdoptTasksFromOfflineRuntimesParams{
+		NewRuntimeID: registered.ID,
+		WorkspaceID:  registered.WorkspaceID,
+		Provider:     provider,
+	})
+	if err != nil {
+		slog.Warn("adopt orphaned agents: reassign tasks failed",
+			"runtime_id", newID,
+			"provider", provider,
+			"error", err,
+		)
+	}
+
+	if agents > 0 || tasks > 0 {
+		slog.Info("adopted orphaned agents from offline runtimes",
+			"runtime_id", newID,
+			"provider", provider,
+			"agents_adopted", agents,
+			"tasks_adopted", tasks,
+		)
 	}
 }
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -429,10 +429,22 @@ func (h *Handler) mergeLegacyRuntimes(r *http.Request, registered db.AgentRuntim
 func (h *Handler) adoptOrphanedAgents(r *http.Request, registered db.AgentRuntime, provider string) {
 	newID := uuidToString(registered.ID)
 
+	// Skip adoption when OwnerID is unknown (daemon-token auth). Without an
+	// owner scope the queries would match all offline runtimes in the
+	// workspace, which could silently migrate another user's agents.
+	if !registered.OwnerID.Valid {
+		slog.Debug("adopt orphaned agents: skipping, no owner_id on runtime",
+			"runtime_id", newID,
+			"provider", provider,
+		)
+		return
+	}
+
 	agents, err := h.Queries.AdoptAgentsFromOfflineRuntimes(r.Context(), db.AdoptAgentsFromOfflineRuntimesParams{
 		NewRuntimeID: registered.ID,
 		WorkspaceID:  registered.WorkspaceID,
 		Provider:     provider,
+		OwnerID:      registered.OwnerID,
 	})
 	if err != nil {
 		slog.Warn("adopt orphaned agents: reassign failed",
@@ -447,11 +459,13 @@ func (h *Handler) adoptOrphanedAgents(r *http.Request, registered db.AgentRuntim
 		NewRuntimeID: registered.ID,
 		WorkspaceID:  registered.WorkspaceID,
 		Provider:     provider,
+		OwnerID:      registered.OwnerID,
 	})
 	if err != nil {
 		slog.Warn("adopt orphaned agents: reassign tasks failed",
 			"runtime_id", newID,
 			"provider", provider,
+			"agents_adopted", agents,
 			"error", err,
 		)
 	}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1493,3 +1493,173 @@ func TestCompleteTask_CommentTriggered_SkipsSynthesisWhenAgentAlreadyCommented(t
 		t.Fatalf("expected 1 agent comment (the agent's own reply), got %d — synthesis duplicated", count)
 	}
 }
+
+func TestDaemonRegister_AdoptsAgentsFromOfflineRuntime(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	const oldDaemonID = "old-daemon-adopt-test"
+	const newDaemonID = "new-daemon-adopt-test"
+
+	// Seed an offline runtime (simulating a previous daemon that is no longer running).
+	var offlineRuntimeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, last_seen_at)
+		VALUES ($1, $2, 'old-runtime', 'local', 'claude', 'offline', 'old-machine', '{}'::jsonb, $3, now() - interval '1 hour')
+		RETURNING id
+	`, testWorkspaceID, oldDaemonID, testUserID).Scan(&offlineRuntimeID); err != nil {
+		t.Fatalf("seed offline runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, offlineRuntimeID)
+	})
+
+	// An agent bound to the offline runtime.
+	var orphanedAgentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks)
+		VALUES ($1, 'orphaned-agent', 'local', '{}'::jsonb, $2, 'workspace', 1)
+		RETURNING id
+	`, testWorkspaceID, offlineRuntimeID).Scan(&orphanedAgentID); err != nil {
+		t.Fatalf("seed orphaned agent: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, orphanedAgentID)
+	})
+
+	// A pending task bound to the offline runtime.
+	var orphanedIssueID, orphanedTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'orphaned-task-issue', 'todo', 'medium', $2, 'member', 97601, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&orphanedIssueID); err != nil {
+		t.Fatalf("seed orphaned issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, orphanedIssueID) })
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id)
+		VALUES ($1, $2, 'queued', $3)
+		RETURNING id
+	`, orphanedAgentID, orphanedIssueID, offlineRuntimeID).Scan(&orphanedTaskID); err != nil {
+		t.Fatalf("seed orphaned task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, orphanedTaskID) })
+
+	// Register a NEW daemon (different daemon_id, same provider).
+	// This simulates a fresh install or daemon_id file loss.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/daemon/register", map[string]any{
+		"workspace_id": testWorkspaceID,
+		"daemon_id":    newDaemonID,
+		"device_name":  "NewMachine",
+		"runtimes": []map[string]any{
+			{"name": "new-runtime", "type": "claude", "version": "2.0.0", "status": "online"},
+		},
+	})
+	testHandler.DaemonRegister(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DaemonRegister: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	runtimes := resp["runtimes"].([]any)
+	newRuntimeID := runtimes[0].(map[string]any)["id"].(string)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, newRuntimeID)
+	})
+
+	// Agent should have been adopted — now points at the new runtime.
+	var agentRuntimeID string
+	if err := testPool.QueryRow(ctx, `SELECT runtime_id FROM agent WHERE id = $1`, orphanedAgentID).Scan(&agentRuntimeID); err != nil {
+		t.Fatalf("read agent runtime_id: %v", err)
+	}
+	if agentRuntimeID != newRuntimeID {
+		t.Fatalf("agent not adopted: got runtime_id=%s, want %s", agentRuntimeID, newRuntimeID)
+	}
+
+	// Pending task should also have been adopted.
+	var taskRuntimeID string
+	if err := testPool.QueryRow(ctx, `SELECT runtime_id FROM agent_task_queue WHERE id = $1`, orphanedTaskID).Scan(&taskRuntimeID); err != nil {
+		t.Fatalf("read task runtime_id: %v", err)
+	}
+	if taskRuntimeID != newRuntimeID {
+		t.Fatalf("task not adopted: got runtime_id=%s, want %s", taskRuntimeID, newRuntimeID)
+	}
+}
+
+func TestDaemonRegister_DoesNotAdoptFromOnlineRuntime(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	const existingDaemonID = "existing-online-daemon"
+	const newDaemonID = "new-daemon-no-steal"
+
+	// Seed an ONLINE runtime (another machine that is currently active).
+	var onlineRuntimeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, last_seen_at)
+		VALUES ($1, $2, 'online-runtime', 'local', 'claude', 'online', 'active-machine', '{}'::jsonb, $3, now())
+		RETURNING id
+	`, testWorkspaceID, existingDaemonID, testUserID).Scan(&onlineRuntimeID); err != nil {
+		t.Fatalf("seed online runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, onlineRuntimeID)
+	})
+
+	// An agent bound to the online runtime.
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (workspace_id, name, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks)
+		VALUES ($1, 'active-agent', 'local', '{}'::jsonb, $2, 'workspace', 1)
+		RETURNING id
+	`, testWorkspaceID, onlineRuntimeID).Scan(&agentID); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, agentID)
+	})
+
+	// Register a different daemon — should NOT steal agents from the online runtime.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/daemon/register", map[string]any{
+		"workspace_id": testWorkspaceID,
+		"daemon_id":    newDaemonID,
+		"device_name":  "AnotherMachine",
+		"runtimes": []map[string]any{
+			{"name": "another-runtime", "type": "claude", "version": "2.0.0", "status": "online"},
+		},
+	})
+	testHandler.DaemonRegister(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("DaemonRegister: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	runtimes := resp["runtimes"].([]any)
+	newRuntimeID := runtimes[0].(map[string]any)["id"].(string)
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, newRuntimeID)
+	})
+
+	// Agent should still point at the original online runtime — not stolen.
+	var agentRuntimeID string
+	if err := testPool.QueryRow(ctx, `SELECT runtime_id FROM agent WHERE id = $1`, agentID).Scan(&agentRuntimeID); err != nil {
+		t.Fatalf("read agent runtime_id: %v", err)
+	}
+	if agentRuntimeID != onlineRuntimeID {
+		t.Fatalf("agent was stolen from online runtime: got runtime_id=%s, want %s", agentRuntimeID, onlineRuntimeID)
+	}
+}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1507,7 +1507,7 @@ func TestDaemonRegister_AdoptsAgentsFromOfflineRuntime(t *testing.T) {
 	var offlineRuntimeID string
 	if err := testPool.QueryRow(ctx, `
 		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, last_seen_at)
-		VALUES ($1, $2, 'old-runtime', 'local', 'claude', 'offline', 'old-machine', '{}'::jsonb, $3, now() - interval '1 hour')
+		VALUES ($1, $2, 'old-runtime', 'local', 'claude-adopt-test', 'offline', 'old-machine', '{}'::jsonb, $3, now() - interval '1 hour')
 		RETURNING id
 	`, testWorkspaceID, oldDaemonID, testUserID).Scan(&offlineRuntimeID); err != nil {
 		t.Fatalf("seed offline runtime: %v", err)
@@ -1557,7 +1557,7 @@ func TestDaemonRegister_AdoptsAgentsFromOfflineRuntime(t *testing.T) {
 		"daemon_id":    newDaemonID,
 		"device_name":  "NewMachine",
 		"runtimes": []map[string]any{
-			{"name": "new-runtime", "type": "claude", "version": "2.0.0", "status": "online"},
+			{"name": "new-runtime", "type": "claude-adopt-test", "version": "2.0.0", "status": "online"},
 		},
 	})
 	testHandler.DaemonRegister(w, req)
@@ -1607,7 +1607,7 @@ func TestDaemonRegister_DoesNotAdoptFromOnlineRuntime(t *testing.T) {
 	var onlineRuntimeID string
 	if err := testPool.QueryRow(ctx, `
 		INSERT INTO agent_runtime (workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, owner_id, last_seen_at)
-		VALUES ($1, $2, 'online-runtime', 'local', 'claude', 'online', 'active-machine', '{}'::jsonb, $3, now())
+		VALUES ($1, $2, 'online-runtime', 'local', 'claude-adopt-test', 'online', 'active-machine', '{}'::jsonb, $3, now())
 		RETURNING id
 	`, testWorkspaceID, existingDaemonID, testUserID).Scan(&onlineRuntimeID); err != nil {
 		t.Fatalf("seed online runtime: %v", err)
@@ -1636,7 +1636,7 @@ func TestDaemonRegister_DoesNotAdoptFromOnlineRuntime(t *testing.T) {
 		"daemon_id":    newDaemonID,
 		"device_name":  "AnotherMachine",
 		"runtimes": []map[string]any{
-			{"name": "another-runtime", "type": "claude", "version": "2.0.0", "status": "online"},
+			{"name": "another-runtime", "type": "claude-adopt-test", "version": "2.0.0", "status": "online"},
 		},
 	})
 	testHandler.DaemonRegister(w, req)

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -11,6 +11,67 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const adoptAgentsFromOfflineRuntimes = `-- name: AdoptAgentsFromOfflineRuntimes :execrows
+UPDATE agent
+SET runtime_id = $1, updated_at = now()
+WHERE runtime_id != $1
+  AND runtime_id IN (
+    SELECT id FROM agent_runtime
+    WHERE workspace_id = $2
+      AND provider = $3
+      AND status = 'offline'
+  )
+`
+
+type AdoptAgentsFromOfflineRuntimesParams struct {
+	NewRuntimeID pgtype.UUID `json:"new_runtime_id"`
+	WorkspaceID  pgtype.UUID `json:"workspace_id"`
+	Provider     string      `json:"provider"`
+}
+
+// Re-points agents from offline runtimes of the same (workspace, provider) to
+// the newly-registered online runtime. This is a server-side safety net that
+// prevents agents from being silently stranded on stale runtime_ids after a
+// daemon restart (e.g. when daemon_id changes or the CLI is upgraded across
+// identity format changes).
+func (q *Queries) AdoptAgentsFromOfflineRuntimes(ctx context.Context, arg AdoptAgentsFromOfflineRuntimesParams) (int64, error) {
+	result, err := q.db.Exec(ctx, adoptAgentsFromOfflineRuntimes, arg.NewRuntimeID, arg.WorkspaceID, arg.Provider)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const adoptTasksFromOfflineRuntimes = `-- name: AdoptTasksFromOfflineRuntimes :execrows
+UPDATE agent_task_queue
+SET runtime_id = $1
+WHERE status IN ('queued', 'dispatched')
+  AND runtime_id != $1
+  AND runtime_id IN (
+    SELECT id FROM agent_runtime
+    WHERE workspace_id = $2
+      AND provider = $3
+      AND status = 'offline'
+  )
+`
+
+type AdoptTasksFromOfflineRuntimesParams struct {
+	NewRuntimeID pgtype.UUID `json:"new_runtime_id"`
+	WorkspaceID  pgtype.UUID `json:"workspace_id"`
+	Provider     string      `json:"provider"`
+}
+
+// Re-points pending tasks from offline runtimes of the same (workspace,
+// provider) to the newly-registered online runtime. Companion to
+// AdoptAgentsFromOfflineRuntimes.
+func (q *Queries) AdoptTasksFromOfflineRuntimes(ctx context.Context, arg AdoptTasksFromOfflineRuntimesParams) (int64, error) {
+	result, err := q.db.Exec(ctx, adoptTasksFromOfflineRuntimes, arg.NewRuntimeID, arg.WorkspaceID, arg.Provider)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countActiveAgentsByRuntime = `-- name: CountActiveAgentsByRuntime :one
 SELECT count(*) FROM agent WHERE runtime_id = $1 AND archived_at IS NULL
 `

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -19,6 +19,7 @@ WHERE runtime_id != $1
     SELECT id FROM agent_runtime
     WHERE workspace_id = $2
       AND provider = $3
+      AND owner_id = $4
       AND status = 'offline'
   )
 `
@@ -27,15 +28,16 @@ type AdoptAgentsFromOfflineRuntimesParams struct {
 	NewRuntimeID pgtype.UUID `json:"new_runtime_id"`
 	WorkspaceID  pgtype.UUID `json:"workspace_id"`
 	Provider     string      `json:"provider"`
+	OwnerID      pgtype.UUID `json:"owner_id"`
 }
 
-// Re-points agents from offline runtimes of the same (workspace, provider) to
-// the newly-registered online runtime. This is a server-side safety net that
-// prevents agents from being silently stranded on stale runtime_ids after a
-// daemon restart (e.g. when daemon_id changes or the CLI is upgraded across
-// identity format changes).
+// Re-points agents from offline runtimes of the same (workspace, provider,
+// owner) to the newly-registered online runtime. This is a server-side safety
+// net that prevents agents from being silently stranded on stale runtime_ids
+// after a daemon restart (e.g. when daemon_id changes or the CLI is upgraded
+// across identity format changes).
 func (q *Queries) AdoptAgentsFromOfflineRuntimes(ctx context.Context, arg AdoptAgentsFromOfflineRuntimesParams) (int64, error) {
-	result, err := q.db.Exec(ctx, adoptAgentsFromOfflineRuntimes, arg.NewRuntimeID, arg.WorkspaceID, arg.Provider)
+	result, err := q.db.Exec(ctx, adoptAgentsFromOfflineRuntimes, arg.NewRuntimeID, arg.WorkspaceID, arg.Provider, arg.OwnerID)
 	if err != nil {
 		return 0, err
 	}
@@ -51,6 +53,7 @@ WHERE status IN ('queued', 'dispatched')
     SELECT id FROM agent_runtime
     WHERE workspace_id = $2
       AND provider = $3
+      AND owner_id = $4
       AND status = 'offline'
   )
 `
@@ -59,13 +62,14 @@ type AdoptTasksFromOfflineRuntimesParams struct {
 	NewRuntimeID pgtype.UUID `json:"new_runtime_id"`
 	WorkspaceID  pgtype.UUID `json:"workspace_id"`
 	Provider     string      `json:"provider"`
+	OwnerID      pgtype.UUID `json:"owner_id"`
 }
 
 // Re-points pending tasks from offline runtimes of the same (workspace,
-// provider) to the newly-registered online runtime. Companion to
+// provider, owner) to the newly-registered online runtime. Companion to
 // AdoptAgentsFromOfflineRuntimes.
 func (q *Queries) AdoptTasksFromOfflineRuntimes(ctx context.Context, arg AdoptTasksFromOfflineRuntimesParams) (int64, error) {
-	result, err := q.db.Exec(ctx, adoptTasksFromOfflineRuntimes, arg.NewRuntimeID, arg.WorkspaceID, arg.Provider)
+	result, err := q.db.Exec(ctx, adoptTasksFromOfflineRuntimes, arg.NewRuntimeID, arg.WorkspaceID, arg.Provider, arg.OwnerID)
 	if err != nil {
 		return 0, err
 	}

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -126,6 +126,37 @@ UPDATE agent_runtime
 SET legacy_daemon_id = COALESCE(legacy_daemon_id, $2)
 WHERE id = $1;
 
+-- name: AdoptAgentsFromOfflineRuntimes :execrows
+-- Re-points agents from offline runtimes of the same (workspace, provider) to
+-- the newly-registered online runtime. This is a server-side safety net that
+-- prevents agents from being silently stranded on stale runtime_ids after a
+-- daemon restart (e.g. when daemon_id changes or the CLI is upgraded across
+-- identity format changes).
+UPDATE agent
+SET runtime_id = @new_runtime_id, updated_at = now()
+WHERE runtime_id != @new_runtime_id
+  AND runtime_id IN (
+    SELECT id FROM agent_runtime
+    WHERE workspace_id = @workspace_id
+      AND provider = @provider
+      AND status = 'offline'
+  );
+
+-- name: AdoptTasksFromOfflineRuntimes :execrows
+-- Re-points pending tasks from offline runtimes of the same (workspace,
+-- provider) to the newly-registered online runtime. Companion to
+-- AdoptAgentsFromOfflineRuntimes.
+UPDATE agent_task_queue
+SET runtime_id = @new_runtime_id
+WHERE status IN ('queued', 'dispatched')
+  AND runtime_id != @new_runtime_id
+  AND runtime_id IN (
+    SELECT id FROM agent_runtime
+    WHERE workspace_id = @workspace_id
+      AND provider = @provider
+      AND status = 'offline'
+  );
+
 -- name: DeleteStaleOfflineRuntimes :many
 -- Deletes runtimes that have been offline for longer than the TTL and have
 -- no agents bound (active or archived). The FK constraint on agent.runtime_id

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -139,6 +139,7 @@ WHERE runtime_id != @new_runtime_id
     SELECT id FROM agent_runtime
     WHERE workspace_id = @workspace_id
       AND provider = @provider
+      AND owner_id = @owner_id
       AND status = 'offline'
   );
 
@@ -154,6 +155,7 @@ WHERE status IN ('queued', 'dispatched')
     SELECT id FROM agent_runtime
     WHERE workspace_id = @workspace_id
       AND provider = @provider
+      AND owner_id = @owner_id
       AND status = 'offline'
   );
 


### PR DESCRIPTION
## Problem

After a daemon restart, agents can be left pointing at a stale `runtime_id` that now resolves to an offline runtime. Tasks assigned to these agents sit in `queued` forever — no error, no retry, no visible signal.

While #1220 (persistent daemon identity) prevents this in the common case by reusing the same runtime UUID across restarts, edge cases remain:
- Upgrading from a pre-#1220 daemon version where `daemon.id` doesn't exist yet
- `daemon.id` file loss (disk corruption, accidental deletion)
- Cross-machine migration (user moves agents to a different host)

## Solution

Add a **server-side safety net**: when a daemon registers a runtime (setting it to `online`), automatically reassign agents and pending tasks from any **offline** runtime of the same `(workspace_id, provider)` to the newly-online runtime.

This runs after the existing `mergeLegacyRuntimes` call in `DaemonRegister` and is a no-op when there are no offline runtimes to adopt from (the common case with persistent identity).

### Key design decisions

- **Only adopts from offline runtimes** — never steals agents from another online runtime (multi-machine setups are safe)
- **Only adopts pending tasks** (`queued`/`dispatched`) — completed/failed tasks retain their original runtime_id for audit history
- **Logs adoption count** — visible in server logs for debugging without being noisy in the no-op case

### Changes

| File | Change |
|------|--------|
| `server/pkg/db/queries/runtime.sql` | Add `AdoptAgentsFromOfflineRuntimes` and `AdoptTasksFromOfflineRuntimes` queries |
| `server/pkg/db/generated/runtime.sql.go` | Regenerated sqlc output |
| `server/internal/handler/daemon.go` | Add `adoptOrphanedAgents` method, called after `mergeLegacyRuntimes` in `DaemonRegister` |
| `server/internal/handler/daemon_test.go` | Two integration tests: adoption from offline runtime + non-stealing from online runtime |

Fixes #1326