### PR TITLE
fix(openclaw): remove unsupported --model and --system-prompt flags (#1332)

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -14,10 +14,12 @@ import (
 // openclawBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args.
 var openclawBlockedArgs = map[string]blockedArgMode{
-	"--local":      blockedStandalone, // local mode for daemon execution
-	"--json":       blockedStandalone, // JSON output for daemon communication
-	"--session-id": blockedWithValue,  // managed by daemon for session resumption
-	"--message":    blockedWithValue,  // prompt is set by daemon
+	"--local":         blockedStandalone, // local mode for daemon execution
+	"--json":          blockedStandalone, // JSON output for daemon communication
+	"--session-id":    blockedWithValue,  // managed by daemon for session resumption
+	"--message":       blockedWithValue,  // prompt is set by daemon
+	"--model":         blockedWithValue,  // openclaw agent does not accept --model; model is bound at agent registration
+	"--system-prompt": blockedWithValue,  // openclaw agent does not accept --system-prompt; injected into --message
 }
 
 // openclawBackend implements Backend by spawning `openclaw agent --message <prompt>
@@ -47,16 +49,19 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		sessionID = fmt.Sprintf("multica-%d", time.Now().UnixNano())
 	}
 	args := []string{"agent", "--local", "--json", "--session-id", sessionID}
-	if opts.Model != "" {
-		args = append(args, "--model", opts.Model)
-	}
-	if opts.SystemPrompt != "" {
-		args = append(args, "--system-prompt", opts.SystemPrompt)
-	}
+	// Note: openclaw agent does not accept --model or --system-prompt.
+	// Model is bound at agent registration time via `openclaw agents update --model`.
+	// SystemPrompt (AgentInstructions) is prepended to the message below.
 	if opts.Timeout > 0 {
 		args = append(args, "--timeout", fmt.Sprintf("%d", int(opts.Timeout.Seconds())))
 	}
 	args = append(args, filterCustomArgs(opts.CustomArgs, openclawBlockedArgs, b.cfg.Logger)...)
+
+	// OpenClaw loads AGENTS.md from its own workspace directory, not from cwd.
+	// Prepend system prompt to the message so the agent receives it.
+	if opts.SystemPrompt != "" {
+		prompt = opts.SystemPrompt + "\n\n" + prompt
+	}
 	args = append(args, "--message", prompt)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)


### PR DESCRIPTION
## Summary

Fixes #1332 — two bugs in how Multica invokes the OpenClaw provider.

### Bug 1: `--model` and `--system-prompt` crash tasks

`openclaw agent` does not accept `--model` or `--system-prompt` flags. When the agent's Model field is set in the Multica UI, the task fails in ~700ms with `exit status 1`.

**Fix:** Remove both flag forwards from arg construction. OpenClaw binds model at agent registration time via `openclaw agents update --model <id>`, not at invocation.

### Bug 2: AgentInstructions silently discarded

`InjectRuntimeConfig` writes `AGENTS.md` to the task worktree, but OpenClaw loads bootstrap files from its own workspace directory (`~/.openclaw/workspace-<name>/`), not from `cwd`. The entire Instructions field is discarded.

**Fix:** Prepend `opts.SystemPrompt` (which carries AgentInstructions) to the `--message` body so the agent receives it inline. This works with any OpenClaw version and requires no file I/O coordination.

### Defense in depth

Added `--model` and `--system-prompt` to `openclawBlockedArgs` so they are also filtered from `custom_args`, preventing users from accidentally passing them.

### Changes

- `server/pkg/agent/openclaw.go` (+15/−10)
  - Remove `--model` and `--system-prompt` arg appends
  - Prepend SystemPrompt to prompt message
  - Add both flags to blocked args map