### PR TITLE
feat(daemon): inject control-plane context repo

### DIFF
--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -65,6 +65,8 @@ These are configured on each user's machine, not on the server:
 | `MULTICA_APP_URL` | `http://localhost:3000` | Frontend URL for CLI login flow |
 | `MULTICA_DAEMON_POLL_INTERVAL` | `3s` | How often the daemon polls for tasks |
 | `MULTICA_DAEMON_HEARTBEAT_INTERVAL` | `15s` | Heartbeat frequency |
+| `MULTICA_CONTEXT_REPO_NAME` | `shared-ai-context` | Repo basename the daemon auto-checks out as the agent control-plane repo |
+| `MULTICA_CONTEXT_REPO` | Auto-injected | Absolute path to the checked-out control-plane repo in each agent session; do not set manually. See [`shared-ai-context/AGENTS.md#control-plane`](https://github.com/n-leezy/shared-ai-context/blob/main/AGENTS.md#control-plane). |
 
 Agent-specific overrides:
 

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -20,32 +20,34 @@ const (
 	DefaultHealthPort            = 19514
 	DefaultMaxConcurrentTasks    = 20
 	DefaultGCInterval            = 1 * time.Hour
-	DefaultGCTTL                 = 5 * 24 * time.Hour // 5 days
+	DefaultGCTTL                 = 5 * 24 * time.Hour  // 5 days
 	DefaultGCOrphanTTL           = 30 * 24 * time.Hour // 30 days
+	DefaultControlPlaneRepoName  = "shared-ai-context"
 )
 
 // Config holds all daemon configuration.
 type Config struct {
-	ServerBaseURL      string
-	DaemonID           string
-	LegacyDaemonIDs    []string              // historical daemon_ids this machine may have registered under; reported at register time so the server can merge old runtime rows
-	DeviceName         string
-	RuntimeName        string
-	CLIVersion         string                // multica CLI version (e.g. "0.1.13")
-	LaunchedBy         string                // "desktop" when spawned by the Electron app, empty for standalone
-	Profile            string                // profile name (empty = default)
-	Agents             map[string]AgentEntry // keyed by provider: claude, codex, opencode, openclaw, hermes, gemini, pi
-	WorkspacesRoot     string                // base path for execution envs (default: ~/multica_workspaces)
-	KeepEnvAfterTask   bool                  // preserve env after task for debugging
-	HealthPort         int                   // local HTTP port for health checks (default: 19514)
-	MaxConcurrentTasks int                   // max tasks running in parallel (default: 20)
-	GCEnabled          bool                  // enable periodic workspace garbage collection (default: true)
-	GCInterval         time.Duration         // how often the GC loop runs (default: 1h)
-	GCTTL              time.Duration         // clean dirs whose issue is done/canceled and updated_at < now()-TTL (default: 5d)
-	GCOrphanTTL        time.Duration         // clean orphan dirs (no meta or unknown issue) older than this (default: 30d)
-	PollInterval       time.Duration
-	HeartbeatInterval  time.Duration
-	AgentTimeout       time.Duration
+	ServerBaseURL        string
+	DaemonID             string
+	LegacyDaemonIDs      []string // historical daemon_ids this machine may have registered under; reported at register time so the server can merge old runtime rows
+	DeviceName           string
+	RuntimeName          string
+	CLIVersion           string                // multica CLI version (e.g. "0.1.13")
+	LaunchedBy           string                // "desktop" when spawned by the Electron app, empty for standalone
+	Profile              string                // profile name (empty = default)
+	Agents               map[string]AgentEntry // keyed by provider: claude, codex, opencode, openclaw, hermes, gemini, pi
+	WorkspacesRoot       string                // base path for execution envs (default: ~/multica_workspaces)
+	KeepEnvAfterTask     bool                  // preserve env after task for debugging
+	HealthPort           int                   // local HTTP port for health checks (default: 19514)
+	MaxConcurrentTasks   int                   // max tasks running in parallel (default: 20)
+	GCEnabled            bool                  // enable periodic workspace garbage collection (default: true)
+	GCInterval           time.Duration         // how often the GC loop runs (default: 1h)
+	GCTTL                time.Duration         // clean dirs whose issue is done/canceled and updated_at < now()-TTL (default: 5d)
+	GCOrphanTTL          time.Duration         // clean orphan dirs (no meta or unknown issue) older than this (default: 30d)
+	ControlPlaneRepoName string                // repo basename used for MULTICA_CONTEXT_REPO auto-checkout
+	PollInterval         time.Duration
+	HeartbeatInterval    time.Duration
+	AgentTimeout         time.Duration
 }
 
 // Overrides allows CLI flags to override environment variables and defaults.
@@ -280,26 +282,28 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	controlPlaneRepoName := envOrDefault("MULTICA_CONTEXT_REPO_NAME", DefaultControlPlaneRepoName)
 
 	return Config{
-		ServerBaseURL:      serverBaseURL,
-		DaemonID:           daemonID,
-		LegacyDaemonIDs:    legacyDaemonIDs,
-		DeviceName:         deviceName,
-		RuntimeName:        runtimeName,
-		Profile:            profile,
-		Agents:             agents,
-		WorkspacesRoot:     workspacesRoot,
-		KeepEnvAfterTask:   keepEnv,
-		GCEnabled:          gcEnabled,
-		GCInterval:         gcInterval,
-		GCTTL:              gcTTL,
-		GCOrphanTTL:        gcOrphanTTL,
-		HealthPort:         healthPort,
-		MaxConcurrentTasks: maxConcurrentTasks,
-		PollInterval:       pollInterval,
-		HeartbeatInterval:  heartbeatInterval,
-		AgentTimeout:       agentTimeout,
+		ServerBaseURL:        serverBaseURL,
+		DaemonID:             daemonID,
+		LegacyDaemonIDs:      legacyDaemonIDs,
+		DeviceName:           deviceName,
+		RuntimeName:          runtimeName,
+		Profile:              profile,
+		Agents:               agents,
+		WorkspacesRoot:       workspacesRoot,
+		KeepEnvAfterTask:     keepEnv,
+		GCEnabled:            gcEnabled,
+		GCInterval:           gcInterval,
+		GCTTL:                gcTTL,
+		GCOrphanTTL:          gcOrphanTTL,
+		ControlPlaneRepoName: controlPlaneRepoName,
+		HealthPort:           healthPort,
+		MaxConcurrentTasks:   maxConcurrentTasks,
+		PollInterval:         pollInterval,
+		HeartbeatInterval:    heartbeatInterval,
+		AgentTimeout:         agentTimeout,
 	}, nil
 }
 

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func loadConfigForTest(t *testing.T) Config {
+	t.Helper()
+
+	binDir := t.TempDir()
+	codexPath := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(codexPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake codex binary: %v", err)
+	}
+	t.Setenv("MULTICA_CODEX_PATH", codexPath)
+
+	cfg, err := LoadConfig(Overrides{
+		DaemonID:       "test-daemon",
+		WorkspacesRoot: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	return cfg
+}
+
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+
+	original, hadOriginal := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if hadOriginal {
+			_ = os.Setenv(key, original)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func TestLoadConfigControlPlaneRepoNameDefault(t *testing.T) {
+	unsetEnvForTest(t, "MULTICA_CONTEXT_REPO_NAME")
+
+	cfg := loadConfigForTest(t)
+
+	if cfg.ControlPlaneRepoName != DefaultControlPlaneRepoName {
+		t.Fatalf("expected %q, got %q", DefaultControlPlaneRepoName, cfg.ControlPlaneRepoName)
+	}
+}
+
+func TestLoadConfigControlPlaneRepoNameFromEnv(t *testing.T) {
+	t.Setenv("MULTICA_CONTEXT_REPO_NAME", "control-plane")
+
+	cfg := loadConfigForTest(t)
+
+	if cfg.ControlPlaneRepoName != "control-plane" {
+		t.Fatalf("expected custom repo name, got %q", cfg.ControlPlaneRepoName)
+	}
+}
+
+func TestLoadConfigControlPlaneRepoNameEmptyFallsBackToDefault(t *testing.T) {
+	t.Setenv("MULTICA_CONTEXT_REPO_NAME", "")
+
+	cfg := loadConfigForTest(t)
+
+	if cfg.ControlPlaneRepoName != DefaultControlPlaneRepoName {
+		t.Fatalf("expected %q, got %q", DefaultControlPlaneRepoName, cfg.ControlPlaneRepoName)
+	}
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -940,6 +940,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	if err := execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx); err != nil {
 		d.logger.Warn("execenv: inject runtime config failed (non-fatal)", "error", err)
 	}
+	controlPlaneRepoPath, hasControlPlaneRepo := d.resolveControlPlaneCheckout(ctx, task, env.WorkDir, taskLog)
 	// NOTE: No cleanup — workdir is preserved for reuse by future tasks on
 	// the same (agent, issue) pair. The work_dir path is stored in DB on
 	// task completion and passed back via PriorWorkDir on the next claim.
@@ -956,6 +957,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		"MULTICA_AGENT_NAME":   agentName,
 		"MULTICA_AGENT_ID":     task.AgentID,
 		"MULTICA_TASK_ID":      task.ID,
+	}
+	if hasControlPlaneRepo {
+		agentEnv["MULTICA_CONTEXT_REPO"] = controlPlaneRepoPath
 	}
 	// Ensure the multica CLI is on PATH inside the agent's environment.
 	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not
@@ -1088,6 +1092,57 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		}
 		return TaskResult{Status: "blocked", Comment: errMsg, EnvRoot: env.RootDir, Usage: usageEntries}, nil
 	}
+}
+
+func (d *Daemon) resolveControlPlaneCheckout(ctx context.Context, task Task, workDir string, taskLog *slog.Logger) (string, bool) {
+	repoName := strings.TrimSpace(d.cfg.ControlPlaneRepoName)
+	if repoName == "" {
+		taskLog.Debug("control-plane repo checkout skipped: repo name is empty")
+		return "", false
+	}
+
+	for _, repo := range task.Repos {
+		repoURL := strings.TrimSpace(repo.URL)
+		if repoURL == "" || repocache.RepoNameFromURL(repoURL) != repoName {
+			continue
+		}
+
+		if err := d.ensureRepoReady(ctx, task.WorkspaceID, repoURL); err != nil {
+			taskLog.Debug("control-plane repo readiness failed",
+				"url", repoURL,
+				"error", err,
+			)
+			return "", false
+		}
+
+		agentName := "agent"
+		if task.Agent != nil && strings.TrimSpace(task.Agent.Name) != "" {
+			agentName = task.Agent.Name
+		}
+		result, err := d.repoCache.CreateWorktree(repocache.WorktreeParams{
+			WorkspaceID: task.WorkspaceID,
+			RepoURL:     repoURL,
+			WorkDir:     workDir,
+			AgentName:   agentName,
+			TaskID:      task.ID,
+		})
+		if err != nil {
+			taskLog.Debug("control-plane repo checkout failed",
+				"url", repoURL,
+				"error", err,
+			)
+			return "", false
+		}
+		if result == nil || result.Path == "" {
+			taskLog.Debug("control-plane repo checkout returned no path", "url", repoURL)
+			return "", false
+		}
+
+		return result.Path, true
+	}
+
+	taskLog.Debug("control-plane repo not configured", "repo_name", repoName)
+	return "", false
 }
 
 // executeAndDrain runs a backend, drains its message stream (forwarding to the

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -235,6 +236,10 @@ func newRepoReadyTestDaemon(t *testing.T, handler http.HandlerFunc) *Daemon {
 		workspaces:   make(map[string]*workspaceState),
 		runtimeIndex: make(map[string]Runtime),
 	}
+}
+
+func discardTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {
@@ -476,5 +481,130 @@ func TestEnsureRepoReadyConcurrentMissRefreshesOnce(t *testing.T) {
 	// must serialize them so the server is only called once.
 	if got := refreshCalls.Load(); got != 1 {
 		t.Fatalf("expected exactly 1 refresh call, got %d", got)
+	}
+}
+
+func TestResolveControlPlaneCheckoutMatchesRepo(t *testing.T) {
+	sourceRepo := createDaemonTestRepo(t)
+	repoName := repocache.RepoNameFromURL(sourceRepo)
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected refresh", http.StatusInternalServerError)
+	})
+	d.cfg.ControlPlaneRepoName = repoName
+	if err := d.repoCache.Sync("ws-1", []repocache.RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("seed repo cache: %v", err)
+	}
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", nil, "v1", []RepoData{{URL: sourceRepo}})
+
+	workDir := t.TempDir()
+	path, ok := d.resolveControlPlaneCheckout(context.Background(), Task{
+		ID:          "task-1",
+		WorkspaceID: "ws-1",
+		Repos:       []RepoData{{URL: sourceRepo}},
+		Agent:       &AgentData{Name: "Code Executor"},
+	}, workDir, discardTestLogger())
+
+	if !ok {
+		t.Fatal("expected control-plane checkout to succeed")
+	}
+	if want := filepath.Join(workDir, repoName); path != want {
+		t.Fatalf("expected path %q, got %q", want, path)
+	}
+	if !filepath.IsAbs(path) {
+		t.Fatalf("expected absolute path, got %q", path)
+	}
+	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+		t.Fatalf("expected checked-out directory at %q, info=%v err=%v", path, info, err)
+	}
+}
+
+func TestResolveControlPlaneCheckoutSkipsEmptyName(t *testing.T) {
+	sourceRepo := createDaemonTestRepo(t)
+	var refreshCalls atomic.Int32
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		refreshCalls.Add(1)
+		http.Error(w, "unexpected refresh", http.StatusInternalServerError)
+	})
+
+	path, ok := d.resolveControlPlaneCheckout(context.Background(), Task{
+		ID:          "task-1",
+		WorkspaceID: "ws-1",
+		Repos:       []RepoData{{URL: sourceRepo}},
+	}, t.TempDir(), discardTestLogger())
+
+	if ok || path != "" {
+		t.Fatalf("expected no checkout, got ok=%v path=%q", ok, path)
+	}
+	if got := refreshCalls.Load(); got != 0 {
+		t.Fatalf("expected no refresh calls, got %d", got)
+	}
+}
+
+func TestResolveControlPlaneCheckoutSkipsNoMatch(t *testing.T) {
+	sourceRepo := createDaemonTestRepo(t)
+	var refreshCalls atomic.Int32
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		refreshCalls.Add(1)
+		http.Error(w, "unexpected refresh", http.StatusInternalServerError)
+	})
+	d.cfg.ControlPlaneRepoName = "not-" + repocache.RepoNameFromURL(sourceRepo)
+
+	path, ok := d.resolveControlPlaneCheckout(context.Background(), Task{
+		ID:          "task-1",
+		WorkspaceID: "ws-1",
+		Repos:       []RepoData{{URL: sourceRepo}},
+	}, t.TempDir(), discardTestLogger())
+
+	if ok || path != "" {
+		t.Fatalf("expected no checkout, got ok=%v path=%q", ok, path)
+	}
+	if got := refreshCalls.Load(); got != 0 {
+		t.Fatalf("expected no refresh calls, got %d", got)
+	}
+}
+
+func TestResolveControlPlaneCheckoutReturnsFalseWhenEnsureRepoReadyFails(t *testing.T) {
+	sourceRepo := createDaemonTestRepo(t)
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "refresh failed", http.StatusInternalServerError)
+	})
+	d.cfg.ControlPlaneRepoName = repocache.RepoNameFromURL(sourceRepo)
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", nil, "v1", []RepoData{{URL: sourceRepo}})
+
+	path, ok := d.resolveControlPlaneCheckout(context.Background(), Task{
+		ID:          "task-1",
+		WorkspaceID: "ws-1",
+		Repos:       []RepoData{{URL: sourceRepo}},
+	}, t.TempDir(), discardTestLogger())
+
+	if ok || path != "" {
+		t.Fatalf("expected ensure failure to skip checkout, got ok=%v path=%q", ok, path)
+	}
+}
+
+func TestResolveControlPlaneCheckoutReturnsFalseWhenCreateWorktreeFails(t *testing.T) {
+	sourceRepo := createDaemonTestRepo(t)
+	repoName := repocache.RepoNameFromURL(sourceRepo)
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected refresh", http.StatusInternalServerError)
+	})
+	d.cfg.ControlPlaneRepoName = repoName
+	if err := d.repoCache.Sync("ws-1", []repocache.RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("seed repo cache: %v", err)
+	}
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", nil, "v1", []RepoData{{URL: sourceRepo}})
+
+	workDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workDir, repoName), 0o755); err != nil {
+		t.Fatalf("create path collision: %v", err)
+	}
+	path, ok := d.resolveControlPlaneCheckout(context.Background(), Task{
+		ID:          "task-1",
+		WorkspaceID: "ws-1",
+		Repos:       []RepoData{{URL: sourceRepo}},
+	}, workDir, discardTestLogger())
+
+	if ok || path != "" {
+		t.Fatalf("expected worktree failure to skip checkout, got ok=%v path=%q", ok, path)
 	}
 }

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -336,7 +336,7 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 	branchName := fmt.Sprintf("agent/%s/%s", sanitizeName(params.AgentName), shortID(params.TaskID))
 
 	// Derive directory name from repo URL.
-	dirName := repoNameFromURL(params.RepoURL)
+	dirName := RepoNameFromURL(params.RepoURL)
 	worktreePath := filepath.Join(params.WorkDir, dirName)
 
 	// If worktree already exists (reused environment from a prior task),
@@ -636,9 +636,9 @@ func excludeFromGit(worktreePath, pattern string) error {
 	return nil
 }
 
-// repoNameFromURL extracts a short directory name from a git remote URL.
+// RepoNameFromURL extracts a short directory name from a git remote URL.
 // e.g. "https://github.com/org/my-repo.git" → "my-repo"
-func repoNameFromURL(url string) string {
+func RepoNameFromURL(url string) string {
 	url = strings.TrimRight(url, "/")
 	url = strings.TrimSuffix(url, ".git")
 

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -492,7 +492,7 @@ func TestCreateWorktreePathCollisionDoesNotLeakBranch(t *testing.T) {
 
 	// Pre-create the target worktree path as a plain non-empty directory.
 	workDir := t.TempDir()
-	dirName := repoNameFromURL(sourceRepo)
+	dirName := RepoNameFromURL(sourceRepo)
 	worktreePath := filepath.Join(workDir, dirName)
 	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
 		t.Fatalf("pre-create worktree path: %v", err)


### PR DESCRIPTION
Source issue: [ZAR-34](mention://issue/8912a324-e5cd-48a9-8921-df5686bd773e)

## Scope checklist
- implemented: add `ControlPlaneRepoName` config populated from `MULTICA_CONTEXT_REPO_NAME` with default `shared-ai-context`
- implemented: export `repocache.RepoNameFromURL`
- implemented: pre-check out the matching control-plane repo before agent launch and inject `MULTICA_CONTEXT_REPO` only on success
- implemented: preserve graceful fallback when there is no match, repo readiness fails, or worktree creation fails
- implemented: document `MULTICA_CONTEXT_REPO_NAME` and auto-injected `MULTICA_CONTEXT_REPO`

## Validation
- pass: `cd server && go test ./internal/daemon/... -run ControlPlaneRepoName`
- pass: `cd server && go test ./internal/daemon/... -run 'ControlPlaneRepoName|ResolveControlPlaneCheckout'`
- pass: `cd server && go test ./internal/daemon/...`
- pass: `cd server && go test ./...`
- blocked: `make test ENV_FILE=.env.worktree` could not run because `scripts/ensure-postgres.sh` requires Docker and this environment has no `docker` binary
- attempted: `make check ENV_FILE=.env.worktree` emitted the same missing-Docker error before the pipeline steps; the script returned 0 via cleanup, so I am not treating it as a valid full check

## Residual risk
- Manual daemon smoke was not run because the local PostgreSQL/Docker prerequisite is unavailable in this environment.
- Existing script-side validation of `MULTICA_CONTEXT_REPO` remains responsible for rejecting a checked-out repo that lacks `ROUTING.yaml`.
