### PR TITLE
fix(editor): blur ContentEditor on Escape

### DIFF
--- a/packages/views/editor/extensions/blur-shortcut.ts
+++ b/packages/views/editor/extensions/blur-shortcut.ts
@@ -1,0 +1,20 @@
+import { Extension } from "@tiptap/core";
+
+/**
+ * Escape → blur the editor. Without this, pressing ESC inside the
+ * contenteditable does nothing (browsers don't blur contenteditables by
+ * default), leaving users stuck in the editor with no keyboard escape hatch.
+ */
+export function createBlurShortcutExtension() {
+  return Extension.create({
+    name: "blurShortcut",
+    addKeyboardShortcuts() {
+      return {
+        Escape: ({ editor }) => {
+          editor.commands.blur();
+          return true;
+        },
+      };
+    },
+  });
+}

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -40,6 +40,7 @@ import { createMentionSuggestion } from "./mention-suggestion";
 import { CodeBlockView } from "./code-block-view";
 import { createMarkdownPasteExtension } from "./markdown-paste";
 import { createSubmitExtension } from "./submit-shortcut";
+import { createBlurShortcutExtension } from "./blur-shortcut";
 import { createFileUploadExtension } from "./file-upload";
 import { FileCardExtension } from "./file-card";
 import { ImageView } from "./image-view";
@@ -137,6 +138,7 @@ export function createEditorExtensions(
         },
         { submitOnEnter: options.submitOnEnter ?? false },
       ),
+      createBlurShortcutExtension(),
       createFileUploadExtension(options.onUploadFileRef!),
     );
   }


### PR DESCRIPTION
## Summary
- ESC inside the issue description editor did nothing — browsers don't blur `contenteditable` by default, so users got stuck in the editor with no keyboard escape hatch (MUL-733).
- Add a `blur-shortcut` Tiptap extension and wire it into `ContentEditor`'s edit-mode extensions. Mirrors what `title-editor.tsx` already does for its own editor.

## Test plan
- [ ] Focus the description editor on an issue, press ESC → input loses focus.
- [ ] `@`-mention popup is open, press ESC → popup closes (suggestion handler still owns ESC while active), editor keeps focus.
- [ ] Readonly rendering (comments, activity) unaffected — blur shortcut is only registered in edit mode.