### PR TITLE
fix(editor): expand issue identifiers in real-time after save

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -169,6 +169,16 @@ export function useUpdateIssue() {
         );
       }
     },
+    onSuccess: (serverIssue, vars) => {
+      // Merge the authoritative server response into the detail cache. This is
+      // required for fields that the server rewrites on save — e.g. bare issue
+      // identifiers (`MUL-117`) in the description are expanded into mention
+      // links server-side, and the editor needs to pick up the expanded content
+      // so the capsules render immediately instead of only after a reload.
+      qc.setQueryData<Issue>(issueKeys.detail(wsId, vars.id), (old) =>
+        old ? { ...old, ...serverIssue } : serverIssue,
+      );
+    },
     onSettled: (_data, _err, vars, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.detail(wsId, vars.id) });
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -195,11 +195,26 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       };
     }, []);
 
-    // Readonly content update: when defaultValue changes and editor is readonly,
-    // re-set the content (e.g. after editing a comment, the readonly view updates)
+    // External content update: when defaultValue changes from outside, re-set
+    // the editor content. Two scenarios:
+    //   1. Readonly mode — e.g. after editing a comment, the readonly view
+    //      should reflect the new content.
+    //   2. Editable mode — the server may rewrite the content on save (e.g.
+    //      expanding bare issue identifiers like `MUL-117` into mention
+    //      capsules). We pick those changes up as long as the user is not
+    //      actively typing and the new value differs from what we last
+    //      emitted — otherwise we'd clobber in-progress edits.
     useEffect(() => {
-      if (!editor || editable) return;
+      if (!editor) return;
       if (defaultValue === prevContentRef.current) return;
+      if (editable) {
+        // Skip if the user is still typing — resyncing would steal focus and
+        // reset the cursor.
+        if (editor.isFocused) return;
+        // Skip if the incoming value matches what we last emitted (no external
+        // change to apply).
+        if (defaultValue === lastEmittedRef.current) return;
+      }
       prevContentRef.current = defaultValue;
       const processed = defaultValue ? preprocessMarkdown(defaultValue) : "";
       if (processed) {
@@ -207,6 +222,8 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       } else {
         editor.commands.clearContent();
       }
+      // Keep the emitted marker in sync so the next onUpdate diff is accurate.
+      lastEmittedRef.current = stripBlobUrls(editor.getMarkdown());
     }, [editor, editable, defaultValue]);
 
     useImperativeHandle(ref, () => ({

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/mention"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -865,6 +866,14 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	// Determine creator identity: agent (via X-Agent-ID header) or member.
 	creatorType, actualCreatorID := h.resolveActor(r, creatorID, workspaceID)
 
+	// Expand bare issue identifiers (e.g. MUL-117) in the description to mention
+	// links so the editor renders them as capsules immediately after save,
+	// consistent with how the comment handler expands identifiers.
+	if req.Description != nil && *req.Description != "" {
+		expanded := mention.ExpandIssueIdentifiers(r.Context(), h.Queries, parseUUID(workspaceID), *req.Description)
+		req.Description = &expanded
+	}
+
 	issue, err := qtx.CreateIssue(r.Context(), db.CreateIssueParams{
 		WorkspaceID:        parseUUID(workspaceID),
 		Title:              req.Title,
@@ -981,7 +990,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		params.Title = pgtype.Text{String: *req.Title, Valid: true}
 	}
 	if req.Description != nil {
-		params.Description = pgtype.Text{String: *req.Description, Valid: true}
+		// Expand bare issue identifiers (e.g. MUL-117) in the description to mention
+		// links so the editor renders them as capsules immediately after save,
+		// consistent with how the comment handler expands identifiers.
+		expanded := mention.ExpandIssueIdentifiers(r.Context(), h.Queries, prevIssue.WorkspaceID, *req.Description)
+		params.Description = pgtype.Text{String: expanded, Valid: true}
 	}
 	if req.Status != nil {
 		params.Status = pgtype.Text{String: *req.Status, Valid: true}


### PR DESCRIPTION
## Summary

- Extend `ExpandIssueIdentifiers` to the issue description: the `CreateIssue` and `UpdateIssue` handlers now expand bare identifiers (e.g. `MUL-117`) into mention links before persisting, matching the existing comment handler behaviour.
- `useUpdateIssue` merges the server response into the detail cache on success so the client picks up the rewritten description (not just the value it optimistically wrote).
- `ContentEditor` re-syncs its content when `defaultValue` changes externally and the editor is not currently focused, so the mention capsule replaces the plain text immediately after save instead of only after a reload.

Fixes #1320

## Test plan

- [x] `go test ./...` (484 tests pass)
- [x] `go vet ./...`
- [x] `pnpm --filter @multica/web lint`
- [x] `pnpm --filter @multica/web typecheck`
- [x] `pnpm test` (views 138, web 9, desktop 48 — all pass)
- [ ] Manual: type `MUL-56` in an issue description, blur to save, verify it renders as a mention capsule without reload.
- [ ] Manual: type `MUL-56` while the editor is focused — ensure the current selection/cursor is not clobbered by the resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)