### PR TITLE
fix(editor): render markdown blockquote in issue comments

### DIFF
--- a/packages/views/editor/utils/preprocess.test.ts
+++ b/packages/views/editor/utils/preprocess.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@multica/core/config", () => ({
+  configStore: { getState: () => ({ cdnDomain: "" }) },
+}));
+
+import { preprocessMarkdown } from "./preprocess";
+
+describe("preprocessMarkdown — blockquote rendering (issue #1303)", () => {
+  it("decodes line-leading &gt; back to > so blockquotes render", () => {
+    // @tiptap/markdown encodes > as &gt; when serializing paragraph text.
+    // remark/marked then sees the entity instead of the blockquote marker,
+    // which previously rendered as a literal '>'.
+    const input = "Some context:\n\n&gt; quoted line\n\nAfter quote.";
+    const out = preprocessMarkdown(input);
+    expect(out).toContain("\n> quoted line\n");
+    expect(out).not.toContain("&gt; quoted line");
+  });
+
+  it("preserves inline &gt; in prose (only line-leading is decoded)", () => {
+    const input = "Compare 2 &gt; 1 in the middle of a line.";
+    const out = preprocessMarkdown(input);
+    expect(out).toContain("2 &gt; 1");
+  });
+
+  it("decodes leading &gt; even with leading whitespace", () => {
+    const input = "  &gt; indented quote";
+    const out = preprocessMarkdown(input);
+    expect(out.startsWith("  > ")).toBe(true);
+  });
+
+  it("handles multiple consecutive blockquote lines", () => {
+    const input = "&gt; line one\n&gt; line two\n&gt; line three";
+    const out = preprocessMarkdown(input);
+    expect(out).toBe("> line one\n> line two\n> line three");
+  });
+
+  it("leaves already-literal > blockquotes untouched", () => {
+    const input = "> normal blockquote\n\ntext";
+    const out = preprocessMarkdown(input);
+    expect(out).toContain("> normal blockquote");
+  });
+});

--- a/packages/views/editor/utils/preprocess.ts
+++ b/packages/views/editor/utils/preprocess.ts
@@ -2,18 +2,37 @@ import { preprocessLinks, preprocessMentionShortcodes, preprocessFileCards } fro
 import { configStore } from "@multica/core/config";
 
 /**
+ * Decode line-leading `&gt;` entities back to literal `>`.
+ *
+ * Why: @tiptap/markdown's text serializer calls `encodeHtmlEntities` on
+ * paragraph text (@tiptap/core), turning any `>` at the start of a line into
+ * `&gt;`. When that serialized markdown is later parsed by remark/marked, the
+ * entity no longer triggers blockquote parsing, so a user-typed quote shows
+ * up as a literal `>` character instead of a real blockquote.
+ *
+ * We only touch `&gt;` that appears at the very start of a line (optionally
+ * after whitespace) so inline `&gt;` in prose (e.g. "2 &gt; 1") is left
+ * alone. This restores blockquote rendering without affecting other content.
+ */
+function decodeLeadingBlockquoteEntities(markdown: string): string {
+  return markdown.replace(/^([ \t]*)&gt;/gm, "$1>");
+}
+
+/**
  * Preprocess a markdown string before loading into Tiptap via contentType: 'markdown'.
  *
  * This is the ONLY transform applied before @tiptap/markdown parses the content.
  * It does NOT convert to HTML — that was the old markdownToHtml.ts pipeline which
  * was deleted in the April 2026 refactor.
  *
- * Three string→string transforms on raw Markdown:
+ * Four string→string transforms on raw Markdown:
  * 1. Legacy mention shortcodes [@ id="..." label="..."] → [@Label](mention://member/id)
  *    (old serialization format in database, migrated on read)
  * 2. Raw URLs → markdown links via linkify-it (so they render as clickable Link nodes)
  * 3. File card syntax (new !file[name](url) + legacy [name](cdnUrl)) → HTML div for
  *    fileCard node parsing
+ * 4. Decode `&gt;` at the start of a line back to `>` so Tiptap-serialized
+ *    blockquotes render as real blockquotes (see decodeLeadingBlockquoteEntities).
  */
 export function preprocessMarkdown(markdown: string): string {
   if (!markdown) return "";
@@ -21,5 +40,6 @@ export function preprocessMarkdown(markdown: string): string {
   const step1 = preprocessMentionShortcodes(markdown);
   const step2 = preprocessLinks(step1);
   const step3 = preprocessFileCards(step2, cdnDomain);
-  return step3;
+  const step4 = decodeLeadingBlockquoteEntities(step3);
+  return step4;
 }


### PR DESCRIPTION
## Summary
Fixes the bug where a markdown `> quote` typed into an issue comment or description displayed as a literal `>` after submission instead of a real blockquote.

Root cause: Tiptap's `@tiptap/markdown` serializer runs paragraph text through `encodeHtmlEntities` (from `@tiptap/core`), which converts `>` to `&gt;`. When the serialized content is later parsed for display by remark/marked, the entity no longer triggers blockquote parsing, so the `>` is rendered as plain text.

Fix: in `preprocessMarkdown` (shared by `ContentEditor` and `ReadonlyContent`), decode `&gt;` at the start of a line back to `>` before handing the content off to the markdown parser. Inline `&gt;` in prose (e.g. `2 > 1`) is left untouched — only line-leading entities are decoded, which is the exact shape Tiptap produces for blockquotes.

## Test plan
- [x] New unit tests in `packages/views/editor/utils/preprocess.test.ts` cover line-leading decoding, inline preservation, indented quotes, multi-line blockquotes, and already-literal `>` passthrough
- [x] `pnpm --filter @multica/views test run editor` — 11 tests pass
- [x] `pnpm --filter @multica/views typecheck` — clean
- [ ] Manual: type `> some quote` in an issue comment, submit, verify the rendered comment shows a styled blockquote

Fixes #1303