### PR TITLE
feat(views): show issue title in detail page header

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -697,8 +697,11 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                 <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
               </>
             )}
-            <span className="shrink-0">
+            <span className="shrink-0 text-muted-foreground">
               {issue.identifier}
+            </span>
+            <span className="truncate font-medium text-foreground">
+              {issue.title}
             </span>
           </div>
           <div className="flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## Summary
- Issue detail top bar previously only showed `workspace name > identifier`. Now the issue title is displayed next to the identifier, matching Linear-style headers.
- Identifier is rendered in muted color; title uses the foreground color with `truncate` so long titles stay on one line.

Closes [MUL-1102](mention://issue/a231297a-21fb-457b-9c2a-af565faafe72).

## Test plan
- [x] `pnpm --filter @multica/views typecheck`
- [ ] Open an issue detail page and confirm the title appears in the top bar alongside the identifier
- [ ] Verify long titles truncate gracefully and don't push the action buttons off-screen