### PR TITLE
feat: add workspace telegram notifications

### DIFF
--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -22,7 +22,17 @@ export type {
   RuntimeUpdateStatus,
   IssueUsageSummary,
 } from "./agent";
-export type { Workspace, WorkspaceRepo, Member, MemberRole, User, MemberWithUser, Invitation } from "./workspace";
+export type {
+  Workspace,
+  WorkspaceRepo,
+  WorkspaceSettings,
+  WorkspaceTelegramSettings,
+  Member,
+  MemberRole,
+  User,
+  MemberWithUser,
+  Invitation,
+} from "./workspace";
 export type { InboxItem, InboxSeverity, InboxItemType } from "./inbox";
 export type { Comment, CommentType, CommentAuthorType, Reaction } from "./comment";
 export type { TimelineEntry, AssigneeFrequencyEntry } from "./activity";

--- a/packages/core/types/workspace.ts
+++ b/packages/core/types/workspace.ts
@@ -5,13 +5,23 @@ export interface WorkspaceRepo {
   description: string;
 }
 
+export interface WorkspaceTelegramSettings {
+  bot_token: string;
+  user_id: string;
+}
+
+export interface WorkspaceSettings {
+  telegram?: WorkspaceTelegramSettings;
+  [key: string]: unknown;
+}
+
 export interface Workspace {
   id: string;
   name: string;
   slug: string;
   description: string | null;
   context: string | null;
-  settings: Record<string, unknown>;
+  settings: WorkspaceSettings;
   repos: WorkspaceRepo[];
   issue_prefix: string;
   created_at: string;

--- a/packages/views/settings/components/notifications-tab.test.tsx
+++ b/packages/views/settings/components/notifications-tab.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const {
+  mockUpdateWorkspace,
+  mockSetQueryData,
+  mockToastSuccess,
+  mockToastError,
+} = vi.hoisted(() => ({
+  mockUpdateWorkspace: vi.fn(),
+  mockSetQueryData: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+const workspace = {
+  id: "ws-1",
+  name: "Workspace",
+  slug: "workspace",
+  description: null,
+  context: null,
+  settings: {
+    existing: "kept",
+    telegram: {
+      bot_token: "old-token",
+      user_id: "old-user",
+    },
+  },
+  repos: [],
+  issue_prefix: "WS",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector: (state: { user: { id: string } }) => unknown) => selector({ user: { id: "user-1" } }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useCurrentWorkspace: () => workspace,
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({ queryKey: ["members", "ws-1"] }),
+  workspaceKeys: { list: () => ["workspaces"] },
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    updateWorkspace: (...args: unknown[]) => mockUpdateWorkspace(...args),
+  },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({
+    data: [{ user_id: "user-1", role: "owner" }],
+  }),
+  useQueryClient: () => ({
+    setQueryData: mockSetQueryData,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError,
+  },
+}));
+
+import { NotificationsTab } from "./notifications-tab";
+
+describe("NotificationsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateWorkspace.mockResolvedValue(workspace);
+  });
+
+  it("merges Telegram settings into existing workspace settings on save", async () => {
+    const user = userEvent.setup();
+    render(<NotificationsTab />);
+
+    const botTokenInput = screen.getByPlaceholderText("123456:ABCDEF...");
+    const userIdInput = screen.getByPlaceholderText("123456789");
+
+    await user.clear(botTokenInput);
+    await user.type(botTokenInput, "new-token");
+    await user.clear(userIdInput);
+    await user.type(userIdInput, "new-user");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockUpdateWorkspace).toHaveBeenCalledWith("ws-1", {
+      settings: {
+        existing: "kept",
+        telegram: {
+          bot_token: "new-token",
+          user_id: "new-user",
+        },
+      },
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith("Telegram notifications saved");
+    expect(mockSetQueryData).toHaveBeenCalled();
+  });
+});

--- a/packages/views/settings/components/notifications-tab.tsx
+++ b/packages/views/settings/components/notifications-tab.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Bell, Save } from "lucide-react";
+import { Input } from "@multica/ui/components/ui/input";
+import { Button } from "@multica/ui/components/ui/button";
+import { Card, CardContent } from "@multica/ui/components/ui/card";
+import { Label } from "@multica/ui/components/ui/label";
+import { toast } from "sonner";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAuthStore } from "@multica/core/auth";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useCurrentWorkspace } from "@multica/core/paths";
+import { memberListOptions, workspaceKeys } from "@multica/core/workspace/queries";
+import { api } from "@multica/core/api";
+import type { Workspace, WorkspaceSettings } from "@multica/core/types";
+
+function nextWorkspaceSettings(
+  settings: WorkspaceSettings | undefined,
+  botToken: string,
+  userId: string,
+): WorkspaceSettings {
+  const next: WorkspaceSettings = { ...(settings ?? {}) };
+  const trimmedBotToken = botToken.trim();
+  const trimmedUserID = userId.trim();
+
+  if (!trimmedBotToken && !trimmedUserID) {
+    delete next.telegram;
+    return next;
+  }
+
+  next.telegram = {
+    bot_token: trimmedBotToken,
+    user_id: trimmedUserID,
+  };
+  return next;
+}
+
+export function NotificationsTab() {
+  const user = useAuthStore((s) => s.user);
+  const workspace = useCurrentWorkspace();
+  const wsId = useWorkspaceId();
+  const qc = useQueryClient();
+  const { data: members = [] } = useQuery(memberListOptions(wsId));
+
+  const [botToken, setBotToken] = useState(workspace?.settings.telegram?.bot_token ?? "");
+  const [userId, setUserId] = useState(workspace?.settings.telegram?.user_id ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const currentMember = members.find((m) => m.user_id === user?.id) ?? null;
+  const canManageWorkspace = currentMember?.role === "owner" || currentMember?.role === "admin";
+
+  useEffect(() => {
+    setBotToken(workspace?.settings.telegram?.bot_token ?? "");
+    setUserId(workspace?.settings.telegram?.user_id ?? "");
+  }, [workspace]);
+
+  const hasPartialConfig = useMemo(() => {
+    const hasBotToken = botToken.trim().length > 0;
+    const hasUserId = userId.trim().length > 0;
+    return hasBotToken !== hasUserId;
+  }, [botToken, userId]);
+
+  const handleSave = async () => {
+    if (!workspace) return;
+    if (hasPartialConfig) {
+      toast.error("Enter both Telegram bot token and user ID, or clear both fields.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const updated = await api.updateWorkspace(workspace.id, {
+        settings: nextWorkspaceSettings(workspace.settings, botToken, userId),
+      });
+      qc.setQueryData(workspaceKeys.list(), (old: Workspace[] | undefined) =>
+        old?.map((ws) => (ws.id === updated.id ? updated : ws)),
+      );
+      toast.success("Telegram notifications saved");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save Telegram notifications");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!workspace) return null;
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Bell className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">Telegram</h2>
+        </div>
+
+        <Card>
+          <CardContent className="space-y-3">
+            <p className="text-xs text-muted-foreground">
+              Send workspace Telegram notifications for task status transitions and every item that lands in the workspace inbox.
+            </p>
+
+            <div>
+              <Label className="text-xs text-muted-foreground">Bot token</Label>
+              <Input
+                type="password"
+                value={botToken}
+                onChange={(e) => setBotToken(e.target.value)}
+                disabled={!canManageWorkspace}
+                className="mt-1"
+                placeholder="123456:ABCDEF..."
+                autoComplete="off"
+              />
+            </div>
+
+            <div>
+              <Label className="text-xs text-muted-foreground">User ID</Label>
+              <Input
+                type="text"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+                disabled={!canManageWorkspace}
+                className="mt-1"
+                placeholder="123456789"
+              />
+            </div>
+
+            {hasPartialConfig && (
+              <p className="text-xs text-destructive">
+                Telegram notifications require both a bot token and a user ID.
+              </p>
+            )}
+
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={!canManageWorkspace || saving || hasPartialConfig}
+              >
+                <Save className="h-3 w-3" />
+                {saving ? "Saving..." : "Save"}
+              </Button>
+            </div>
+
+            {!canManageWorkspace && (
+              <p className="text-xs text-muted-foreground">
+                Only admins and owners can manage Telegram notifications.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/packages/views/settings/components/settings-page.tsx
+++ b/packages/views/settings/components/settings-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { User, Palette, Key, Settings, Users, FolderGit2 } from "lucide-react";
+import { User, Palette, Key, Settings, Users, FolderGit2, Bell } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@multica/ui/components/ui/tabs";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { AccountTab } from "./account-tab";
@@ -10,6 +10,7 @@ import { TokensTab } from "./tokens-tab";
 import { WorkspaceTab } from "./workspace-tab";
 import { MembersTab } from "./members-tab";
 import { RepositoriesTab } from "./repositories-tab";
+import { NotificationsTab } from "./notifications-tab";
 
 const accountTabs = [
   { value: "profile", label: "Profile", icon: User },
@@ -19,6 +20,7 @@ const accountTabs = [
 
 const workspaceTabs = [
   { value: "workspace", label: "General", icon: Settings },
+  { value: "notifications", label: "Notifications", icon: Bell },
   { value: "repositories", label: "Repositories", icon: FolderGit2 },
   { value: "members", label: "Members", icon: Users },
 ];
@@ -81,6 +83,7 @@ export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
           <TabsContent value="appearance"><AppearanceTab /></TabsContent>
           <TabsContent value="tokens"><TokensTab /></TabsContent>
           <TabsContent value="workspace"><WorkspaceTab /></TabsContent>
+          <TabsContent value="notifications"><NotificationsTab /></TabsContent>
           <TabsContent value="repositories"><RepositoriesTab /></TabsContent>
           <TabsContent value="members"><MembersTab /></TabsContent>
           {extraAccountTabs?.map((tab) => (

--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 	"unicode/utf8"
@@ -38,13 +39,25 @@ var workspaceMembersCmd = &cobra.Command{
 	RunE:  runWorkspaceMembers,
 }
 
+var workspaceTelegramCmd = &cobra.Command{
+	Use:   "telegram [workspace-id]",
+	Short: "Configure Telegram notifications for a workspace",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runWorkspaceTelegram,
+}
+
 func init() {
 	workspaceCmd.AddCommand(workspaceListCmd)
 	workspaceCmd.AddCommand(workspaceGetCmd)
 	workspaceCmd.AddCommand(workspaceMembersCmd)
+	workspaceCmd.AddCommand(workspaceTelegramCmd)
 
 	workspaceGetCmd.Flags().String("output", "json", "Output format: table or json")
 	workspaceMembersCmd.Flags().String("output", "table", "Output format: table or json")
+	workspaceTelegramCmd.Flags().String("bot-token", "", "Telegram bot token")
+	workspaceTelegramCmd.Flags().String("user-id", "", "Telegram user ID / chat ID")
+	workspaceTelegramCmd.Flags().Bool("clear", false, "Clear the Telegram configuration for this workspace")
+	workspaceTelegramCmd.Flags().String("output", "json", "Output format: table or json")
 }
 
 func runWorkspaceList(cmd *cobra.Command, _ []string) error {
@@ -170,3 +183,86 @@ func runWorkspaceMembers(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func runWorkspaceTelegram(cmd *cobra.Command, args []string) error {
+	wsID := workspaceIDFromArgs(cmd, args)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: pass as argument or set MULTICA_WORKSPACE_ID")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	botToken, _ := cmd.Flags().GetString("bot-token")
+	userID, _ := cmd.Flags().GetString("user-id")
+	clearConfig, _ := cmd.Flags().GetBool("clear")
+
+	botToken = strings.TrimSpace(botToken)
+	userID = strings.TrimSpace(userID)
+
+	if clearConfig {
+		if botToken != "" || userID != "" {
+			return fmt.Errorf("--clear cannot be combined with --bot-token or --user-id")
+		}
+	} else if botToken == "" || userID == "" {
+		return fmt.Errorf("both --bot-token and --user-id are required unless --clear is set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var ws map[string]any
+	if err := client.GetJSON(ctx, "/api/workspaces/"+wsID, &ws); err != nil {
+		return fmt.Errorf("get workspace: %w", err)
+	}
+
+	settings, ok := ws["settings"].(map[string]any)
+	if !ok || settings == nil {
+		settings = map[string]any{}
+	}
+
+	nextSettings := make(map[string]any, len(settings))
+	for key, value := range settings {
+		nextSettings[key] = value
+	}
+
+	if clearConfig {
+		delete(nextSettings, "telegram")
+	} else {
+		nextSettings["telegram"] = map[string]any{
+			"bot_token": botToken,
+			"user_id":   userID,
+		}
+	}
+
+	var updated map[string]any
+	if err := client.PatchJSON(ctx, "/api/workspaces/"+wsID, map[string]any{
+		"settings": nextSettings,
+	}, &updated); err != nil {
+		return fmt.Errorf("update workspace telegram settings: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		telegram, _ := nextSettings["telegram"].(map[string]any)
+		configured := "no"
+		configuredUserID := ""
+		if telegram != nil {
+			configured = "yes"
+			configuredUserID = strVal(telegram, "user_id")
+		}
+		cli.PrintTable(os.Stdout,
+			[]string{"ID", "NAME", "TELEGRAM CONFIGURED", "TELEGRAM USER ID"},
+			[][]string{{
+				strVal(updated, "id"),
+				strVal(updated, "name"),
+				configured,
+				configuredUserID,
+			}},
+		)
+		return nil
+	}
+
+	return cli.PrintJSON(os.Stdout, updated)
+}

--- a/server/cmd/multica/cmd_workspace_test.go
+++ b/server/cmd/multica/cmd_workspace_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func workspaceTelegramTestCmd() *cobra.Command {
+	cmd := testCmd()
+	cmd.Flags().String("server-url", "", "")
+	cmd.Flags().String("workspace-id", "", "")
+	cmd.Flags().String("bot-token", "", "")
+	cmd.Flags().String("user-id", "", "")
+	cmd.Flags().Bool("clear", false, "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func TestRunWorkspaceTelegramMergesSettings(t *testing.T) {
+	var patchBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces/ws-1":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":   "ws-1",
+				"name": "Workspace",
+				"settings": map[string]any{
+					"existing": "kept",
+				},
+			})
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/workspaces/ws-1":
+			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+				t.Fatalf("decode patch body: %v", err)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":       "ws-1",
+				"name":     "Workspace",
+				"settings": patchBody["settings"],
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", server.URL)
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+
+	cmd := workspaceTelegramTestCmd()
+	if err := cmd.Flags().Set("bot-token", "123:abc"); err != nil {
+		t.Fatalf("set bot-token flag: %v", err)
+	}
+	if err := cmd.Flags().Set("user-id", "987654"); err != nil {
+		t.Fatalf("set user-id flag: %v", err)
+	}
+
+	if err := runWorkspaceTelegram(cmd, nil); err != nil {
+		t.Fatalf("runWorkspaceTelegram() error = %v", err)
+	}
+
+	settings, ok := patchBody["settings"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected settings object, got %T", patchBody["settings"])
+	}
+	if got := settings["existing"]; got != "kept" {
+		t.Fatalf("existing setting = %v, want %q", got, "kept")
+	}
+	telegram, ok := settings["telegram"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected telegram object, got %T", settings["telegram"])
+	}
+	if got := telegram["bot_token"]; got != "123:abc" {
+		t.Fatalf("bot_token = %v, want %q", got, "123:abc")
+	}
+	if got := telegram["user_id"]; got != "987654" {
+		t.Fatalf("user_id = %v, want %q", got, "987654")
+	}
+}
+
+func TestRunWorkspaceTelegramClearRemovesSettings(t *testing.T) {
+	var patchBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces/ws-1":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":   "ws-1",
+				"name": "Workspace",
+				"settings": map[string]any{
+					"existing": "kept",
+					"telegram": map[string]any{
+						"bot_token": "old-token",
+						"user_id":   "old-user",
+					},
+				},
+			})
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/workspaces/ws-1":
+			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+				t.Fatalf("decode patch body: %v", err)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":       "ws-1",
+				"name":     "Workspace",
+				"settings": patchBody["settings"],
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", server.URL)
+	t.Setenv("MULTICA_TOKEN", "test-token")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+
+	cmd := workspaceTelegramTestCmd()
+	if err := cmd.Flags().Set("clear", "true"); err != nil {
+		t.Fatalf("set clear flag: %v", err)
+	}
+
+	if err := runWorkspaceTelegram(cmd, nil); err != nil {
+		t.Fatalf("runWorkspaceTelegram(clear) error = %v", err)
+	}
+
+	settings, ok := patchBody["settings"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected settings object, got %T", patchBody["settings"])
+	}
+	if got := settings["existing"]; got != "kept" {
+		t.Fatalf("existing setting = %v, want %q", got, "kept")
+	}
+	if _, exists := settings["telegram"]; exists {
+		t.Fatalf("expected telegram settings to be removed, got %+v", settings["telegram"])
+	}
+}
+
+func TestWorkspaceTelegramCommandExists(t *testing.T) {
+	if _, _, err := workspaceCmd.Find([]string{"telegram"}); err != nil {
+		t.Fatalf("expected workspace telegram command to exist: %v", err)
+	}
+}

--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"strings"
+	"time"
 
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/handler"
@@ -17,7 +23,6 @@ type mention struct {
 	Type string // "member", "agent", "issue", or "all"
 	ID   string // user_id, agent_id, issue_id, or "all"
 }
-
 
 // statusLabels maps DB status values to human-readable labels for notifications.
 var statusLabels = map[string]string{
@@ -54,6 +59,142 @@ func priorityLabel(p string) string {
 }
 
 var emptyDetails = []byte("{}")
+
+type telegramSettings struct {
+	BotToken string `json:"bot_token"`
+	UserID   string `json:"user_id"`
+}
+
+type workspaceNotificationSettings struct {
+	Telegram *telegramSettings `json:"telegram"`
+}
+
+var telegramSendMessage = func(ctx context.Context, botToken, userID, text string) error {
+	payload, err := json.Marshal(map[string]any{
+		"chat_id":                  userID,
+		"text":                     text,
+		"disable_web_page_preview": true,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal telegram payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", botToken),
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("build telegram request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("telegram request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("telegram sendMessage returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+func workspaceTelegramConfig(ctx context.Context, queries *db.Queries, workspaceID string) *telegramSettings {
+	ws, err := queries.GetWorkspace(ctx, parseUUID(workspaceID))
+	if err != nil {
+		slog.Error("failed to load workspace for telegram notification", "workspace_id", workspaceID, "error", err)
+		return nil
+	}
+	if len(ws.Settings) == 0 {
+		return nil
+	}
+
+	var settings workspaceNotificationSettings
+	if err := json.Unmarshal(ws.Settings, &settings); err != nil {
+		slog.Error("failed to parse workspace notification settings", "workspace_id", workspaceID, "error", err)
+		return nil
+	}
+	if settings.Telegram == nil {
+		return nil
+	}
+	if strings.TrimSpace(settings.Telegram.BotToken) == "" || strings.TrimSpace(settings.Telegram.UserID) == "" {
+		return nil
+	}
+	return settings.Telegram
+}
+
+func sendWorkspaceTelegramMessage(ctx context.Context, queries *db.Queries, workspaceID, text string) {
+	cfg := workspaceTelegramConfig(ctx, queries, workspaceID)
+	if cfg == nil {
+		return
+	}
+	if err := telegramSendMessage(ctx, cfg.BotToken, cfg.UserID, text); err != nil {
+		slog.Error("failed to send telegram notification", "workspace_id", workspaceID, "error", err)
+	}
+}
+
+func valueAsString(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	value, ok := m[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return v
+	case *string:
+		if v == nil {
+			return ""
+		}
+		return *v
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func formatTelegramInboxMessage(queries *db.Queries, workspaceID string, item map[string]any) string {
+	workspaceName := workspaceID
+	if ws, err := queries.GetWorkspace(context.Background(), parseUUID(workspaceID)); err == nil && strings.TrimSpace(ws.Name) != "" {
+		workspaceName = ws.Name
+	}
+
+	var lines []string
+	lines = append(lines, fmt.Sprintf("[%s] Inbox notification", workspaceName))
+	if title := valueAsString(item, "title"); title != "" {
+		lines = append(lines, title)
+	}
+	if issueID := valueAsString(item, "issue_id"); issueID != "" {
+		lines = append(lines, "Issue ID: "+issueID)
+	}
+	if body := strings.TrimSpace(valueAsString(item, "body")); body != "" {
+		lines = append(lines, body)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatTelegramStatusTransitionMessage(queries *db.Queries, workspaceID string, issue handler.IssueResponse, fromStatus string) string {
+	workspaceName := workspaceID
+	if ws, err := queries.GetWorkspace(context.Background(), parseUUID(workspaceID)); err == nil && strings.TrimSpace(ws.Name) != "" {
+		workspaceName = ws.Name
+	}
+
+	identifier := strings.TrimSpace(issue.Identifier)
+	if identifier == "" {
+		identifier = issue.ID
+	}
+
+	return strings.Join([]string{
+		fmt.Sprintf("[%s] Task transition", workspaceName),
+		fmt.Sprintf("%s — %s", identifier, issue.Title),
+		fmt.Sprintf("%s → %s", statusLabel(fromStatus), statusLabel(issue.Status)),
+	}, "\n")
+}
 
 // parseMentions extracts mentions from markdown content.
 // Delegates to the shared util.ParseMentions and converts to the local type.
@@ -336,6 +477,18 @@ func notifyMentionedMembers(
 func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 	ctx := context.Background()
 
+	bus.Subscribe(protocol.EventInboxNew, func(e events.Event) {
+		payload, ok := e.Payload.(map[string]any)
+		if !ok {
+			return
+		}
+		item, ok := payload["item"].(map[string]any)
+		if !ok {
+			return
+		}
+		sendWorkspaceTelegramMessage(ctx, queries, e.WorkspaceID, formatTelegramInboxMessage(queries, e.WorkspaceID, item))
+	})
+
 	// issue:created — Direct notification to assignee if assignee != actor
 	bus.Subscribe(protocol.EventIssueCreated, func(e events.Event) {
 		payload, ok := e.Payload.(map[string]any)
@@ -454,6 +607,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 				nil, "status_changed", "info",
 				issue.Title, "",
 				statusDetails)
+			sendWorkspaceTelegramMessage(ctx, queries, e.WorkspaceID, formatTelegramStatusTransitionMessage(queries, e.WorkspaceID, issue, prevStatus))
 		}
 
 		if priorityChanged, _ := payload["priority_changed"].(bool); priorityChanged {

--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/events"
@@ -54,6 +56,26 @@ func newNotificationBus(t *testing.T, queries *db.Queries) *events.Bus {
 	registerSubscriberListeners(bus, queries)
 	registerNotificationListeners(bus, queries)
 	return bus
+}
+
+func setWorkspaceTelegramSettings(t *testing.T, botToken, userID string) {
+	t.Helper()
+	var settings []byte
+	if strings.TrimSpace(botToken) != "" && strings.TrimSpace(userID) != "" {
+		payload, err := json.Marshal(map[string]any{
+			"telegram": map[string]string{
+				"bot_token": botToken,
+				"user_id":   userID,
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal telegram settings: %v", err)
+		}
+		settings = payload
+	}
+	if _, err := testPool.Exec(context.Background(), `UPDATE workspace SET settings = $2 WHERE id = $1`, testWorkspaceID, settings); err != nil {
+		t.Fatalf("update workspace settings: %v", err)
+	}
 }
 
 // TestNotification_IssueCreated_AssigneeNotified verifies that when an issue is
@@ -419,8 +441,8 @@ func TestNotification_AssigneeChanged(t *testing.T) {
 				AssigneeType: &newAssigneeType,
 				AssigneeID:   &newAssigneeID,
 			},
-			"assignee_changed":  true,
-			"status_changed":    false,
+			"assignee_changed":   true,
+			"status_changed":     false,
 			"prev_assignee_type": &oldAssigneeType,
 			"prev_assignee_id":   &oldAssigneeID,
 		},
@@ -673,5 +695,96 @@ func TestNotification_DueDateChanged(t *testing.T) {
 	}
 	if sub1Items[0].Severity != "info" {
 		t.Fatalf("expected severity 'info', got %q", sub1Items[0].Severity)
+	}
+}
+
+func TestNotification_InboxNew_SendsTelegramWhenConfigured(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+	setWorkspaceTelegramSettings(t, "bot-token", "chat-123")
+	t.Cleanup(func() { setWorkspaceTelegramSettings(t, "", "") })
+
+	var calls []string
+	original := telegramSendMessage
+	telegramSendMessage = func(_ context.Context, botToken, userID, text string) error {
+		calls = append(calls, botToken+"|"+userID+"|"+text)
+		return nil
+	}
+	t.Cleanup(func() { telegramSendMessage = original })
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventInboxNew,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"item": map[string]any{
+				"recipient_id": testUserID,
+				"title":        "Inbox title",
+				"body":         "Inbox body",
+				"issue_id":     "issue-123",
+			},
+		},
+	})
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 telegram send, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0], "bot-token|chat-123|") {
+		t.Fatalf("unexpected telegram recipient payload: %q", calls[0])
+	}
+	if !strings.Contains(calls[0], "Inbox title") || !strings.Contains(calls[0], "Inbox body") {
+		t.Fatalf("expected inbox title/body in telegram message, got %q", calls[0])
+	}
+}
+
+func TestNotification_StatusChanged_SendsTelegramWhenConfigured(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+	setWorkspaceTelegramSettings(t, "bot-token", "chat-456")
+	t.Cleanup(func() { setWorkspaceTelegramSettings(t, "", "") })
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+	addTestSubscriber(t, issueID, "member", testUserID, "creator")
+
+	var texts []string
+	original := telegramSendMessage
+	telegramSendMessage = func(_ context.Context, _, _ string, text string) error {
+		texts = append(texts, text)
+		return nil
+	}
+	t.Cleanup(func() { telegramSendMessage = original })
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:          issueID,
+				WorkspaceID: testWorkspaceID,
+				Identifier:  "INT-42",
+				Title:       "Status transition issue",
+				Status:      "in_progress",
+				Priority:    "medium",
+				CreatorType: "member",
+				CreatorID:   testUserID,
+			},
+			"assignee_changed": false,
+			"status_changed":   true,
+			"prev_status":      "todo",
+		},
+	})
+
+	if len(texts) != 1 {
+		t.Fatalf("expected 1 telegram status message, got %d", len(texts))
+	}
+	if !strings.Contains(texts[0], "INT-42") || !strings.Contains(texts[0], "Todo → In Progress") {
+		t.Fatalf("unexpected telegram status message: %q", texts[0])
 	}
 }

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,5 +32,66 @@ func TestCreateWorkspace_RejectsReservedSlug(t *testing.T) {
 				t.Fatalf("slug %q: expected 400, got %d: %s", slug, w.Code, w.Body.String())
 			}
 		})
+	}
+}
+
+func TestUpdateWorkspace_PersistsTelegramSettings(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID, map[string]any{
+		"settings": map[string]any{
+			"existing": "kept",
+			"telegram": map[string]any{
+				"bot_token": "123:token",
+				"user_id":   "456789",
+			},
+		},
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+
+	testHandler.UpdateWorkspace(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateWorkspace: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp WorkspaceResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	settingsMap, ok := resp.Settings.(map[string]any)
+	if !ok {
+		t.Fatalf("expected settings object in response, got %T", resp.Settings)
+	}
+	telegramMap, ok := settingsMap["telegram"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected telegram settings in response, got %T", settingsMap["telegram"])
+	}
+	if got := telegramMap["bot_token"]; got != "123:token" {
+		t.Fatalf("bot_token = %v, want %q", got, "123:token")
+	}
+	if got := telegramMap["user_id"]; got != "456789" {
+		t.Fatalf("user_id = %v, want %q", got, "456789")
+	}
+	if got := settingsMap["existing"]; got != "kept" {
+		t.Fatalf("existing setting = %v, want %q", got, "kept")
+	}
+
+	var rawSettings []byte
+	if err := testPool.QueryRow(context.Background(), `SELECT settings FROM workspace WHERE id = $1`, testWorkspaceID).Scan(&rawSettings); err != nil {
+		t.Fatalf("load persisted settings: %v", err)
+	}
+	var persisted map[string]any
+	if err := json.Unmarshal(rawSettings, &persisted); err != nil {
+		t.Fatalf("unmarshal persisted settings: %v", err)
+	}
+	persistedTelegram, ok := persisted["telegram"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected persisted telegram settings, got %T", persisted["telegram"])
+	}
+	if got := persistedTelegram["bot_token"]; got != "123:token" {
+		t.Fatalf("persisted bot_token = %v, want %q", got, "123:token")
+	}
+	if got := persistedTelegram["user_id"]; got != "456789" {
+		t.Fatalf("persisted user_id = %v, want %q", got, "456789")
 	}
 }


### PR DESCRIPTION
## Summary
- add workspace-level Telegram notification settings stored in workspace settings
- add a Settings UI tab and CLI command for configuring Telegram bot token and user ID
- send Telegram notifications for inbox items and issue status transitions

## Test Plan
- `go test ./internal/handler -run 'TestUpdateWorkspace_PersistsTelegramSettings'`
- `go test ./cmd/server -run 'TestNotification_(InboxNew_SendsTelegramWhenConfigured|StatusChanged_SendsTelegramWhenConfigured)'`
- `go test ./cmd/multica -run 'TestRunWorkspaceTelegram|TestWorkspaceTelegramCommandExists'`
- `corepack pnpm --filter @multica/views exec vitest run settings/components/notifications-tab.test.tsx`
- `corepack pnpm --filter @multica/core typecheck`
- `corepack pnpm --filter @multica/views typecheck`

Closes #1347

Implements Multica workspace issue HER-2 (4251e05a-4ec8-4bda-985e-d45c3fe4861f).
