### PR TITLE
feat(editor): create sub-issue from selected text in bubble menu

### DIFF
--- a/packages/views/editor/bubble-menu.tsx
+++ b/packages/views/editor/bubble-menu.tsx
@@ -32,6 +32,8 @@ import { useEditorState } from "@tiptap/react";
 import type { Editor } from "@tiptap/core";
 import { posToDOMRect } from "@tiptap/core";
 import { NodeSelection } from "@tiptap/pm/state";
+import { toast } from "sonner";
+import { useCreateIssue } from "@multica/core/issues/mutations";
 import { Toggle } from "@multica/ui/components/ui/toggle";
 import { Separator } from "@multica/ui/components/ui/separator";
 import {
@@ -64,6 +66,8 @@ import {
   Heading1,
   Heading2,
   Heading3,
+  FilePlus,
+  Loader2,
 } from "lucide-react";
 
 // ---------------------------------------------------------------------------
@@ -345,10 +349,105 @@ function ListDropdown({ editor, onOpenChange, isBullet, isOrdered }: { editor: E
 }
 
 // ---------------------------------------------------------------------------
+// Create Sub-Issue Button
+// ---------------------------------------------------------------------------
+
+/**
+ * Turns the current selection into a sub-issue of `parentIssueId` and replaces
+ * the selection with a mention link to the new issue. Title is the selected
+ * text (trimmed, collapsed whitespace, capped). Only rendered when a parent
+ * issue is in scope; otherwise there's no meaningful "sub-issue of" target.
+ */
+function CreateSubIssueButton({
+  editor,
+  parentIssueId,
+}: {
+  editor: Editor;
+  parentIssueId: string;
+}) {
+  const createIssue = useCreateIssue();
+  const [pending, setPending] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    if (pending) return;
+    const { from, to } = editor.state.selection;
+    if (from === to) return;
+
+    // Title from selection: collapse whitespace, cap length. The full selection
+    // still becomes the link text — only the issue title is capped.
+    const rawTitle = editor.state.doc.textBetween(from, to, " ", " ").trim();
+    const title = rawTitle.replace(/\s+/g, " ").slice(0, 200);
+    if (!title) return;
+
+    setPending(true);
+    try {
+      const newIssue = await createIssue.mutateAsync({
+        title,
+        parent_issue_id: parentIssueId,
+      });
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(
+          { from, to },
+          [
+            {
+              type: "mention",
+              attrs: {
+                id: newIssue.id,
+                label: newIssue.identifier,
+                type: "issue",
+              },
+            },
+            { type: "text", text: " " },
+          ],
+        )
+        .run();
+      toast.success(`Created ${newIssue.identifier}`);
+    } catch {
+      toast.error("Failed to create sub-issue");
+    } finally {
+      setPending(false);
+    }
+  }, [editor, parentIssueId, createIssue, pending]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Toggle
+            size="sm"
+            pressed={false}
+            disabled={pending}
+            onPressedChange={handleClick}
+            onMouseDown={(e) => e.preventDefault()}
+          />
+        }
+      >
+        {pending ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : (
+          <FilePlus className="size-3.5" />
+        )}
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={8}>
+        Create sub-issue from selection
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main Bubble Menu — @floating-ui/dom + portal to body
 // ---------------------------------------------------------------------------
 
-function EditorBubbleMenu({ editor }: { editor: Editor }) {
+function EditorBubbleMenu({
+  editor,
+  currentIssueId,
+}: {
+  editor: Editor;
+  currentIssueId?: string;
+}) {
   const [visible, setVisible] = useState(false);
   const [mode, setMode] = useState<"toolbar" | "link-edit">("toolbar");
   const floatingRef = useRef<HTMLDivElement>(null);
@@ -502,6 +601,12 @@ function EditorBubbleMenu({ editor }: { editor: Editor }) {
               </TooltipTrigger>
               <TooltipContent side="top" sideOffset={8}>Quote</TooltipContent>
             </Tooltip>
+            {currentIssueId && (
+              <>
+                <Separator orientation="vertical" className="mx-0.5 h-5" />
+                <CreateSubIssueButton editor={editor} parentIssueId={currentIssueId} />
+              </>
+            )}
           </div>
         </TooltipProvider>
       )}

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -75,6 +75,12 @@ interface ContentEditorProps {
   showBubbleMenu?: boolean;
   /** When true, bare Enter submits (chat-style). Mod-Enter always submits. */
   submitOnEnter?: boolean;
+  /**
+   * ID of the issue this editor belongs to. When set, the bubble menu exposes
+   * a "Create sub-issue from selection" action that parents the new issue
+   * under this ID and replaces the selection with a mention link.
+   */
+  currentIssueId?: string;
 }
 
 interface ContentEditorRef {
@@ -104,6 +110,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       onUploadFile,
       showBubbleMenu = true,
       submitOnEnter = false,
+      currentIssueId,
     },
     ref,
   ) {
@@ -258,7 +265,9 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
         onMouseDown={handleContainerMouseDown}
       >
         <EditorContent className="flex-1 min-h-full" editor={editor} />
-        {editable && showBubbleMenu && <EditorBubbleMenu editor={editor} />}
+        {editable && showBubbleMenu && (
+          <EditorBubbleMenu editor={editor} currentIssueId={currentIssueId} />
+        )}
         <LinkHoverCard {...hover} />
       </div>
     );

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -291,6 +291,7 @@ function CommentRow({
               onSubmit={saveEdit}
               onUploadFile={(file) => uploadWithToast(file, { issueId })}
               debounceMs={100}
+              currentIssueId={issueId}
             />
           </div>
           <div className="flex items-center justify-between mt-2">
@@ -511,6 +512,7 @@ function CommentCard({
                     onSubmit={saveEdit}
                     onUploadFile={(file) => uploadWithToast(file, { issueId })}
                     debounceMs={100}
+                    currentIssueId={issueId}
                   />
                 </div>
                 <div className="flex items-center justify-between mt-2">

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -63,6 +63,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           onSubmit={handleSubmit}
           onUploadFile={handleUpload}
           debounceMs={100}
+          currentIssueId={issueId}
         />
       </div>
       <div className="absolute bottom-1 right-1.5 flex items-center gap-1">

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1049,6 +1049,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
               onUpdate={(md) => handleUpdateField({ description: md })}
               onUploadFile={handleDescriptionUpload}
               debounceMs={1500}
+              currentIssueId={id}
             />
 
             <div className="flex items-center gap-1 mt-3">

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -110,6 +110,7 @@ function ReplyInput({
               onSubmit={handleSubmit}
               onUploadFile={handleUpload}
               debounceMs={100}
+              currentIssueId={issueId}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add a "Create sub-issue from selection" action to the editor bubble menu
- Selected text becomes the new issue's title; the selection is replaced with a mention link `[IDENTIFIER](mention://issue/<id>)` on success
- The new issue defaults to being a sub-issue of the current issue (parent_issue_id)
- Button is only rendered when the editor is given a `currentIssueId` prop (description editor, comment input, reply input, comment edit)

Resolves MUL-1107.

## Test plan
- [ ] In an issue description, select some text and click the new "Create sub-issue from selection" button in the bubble menu
- [ ] Verify a new issue is created with the selection as its title and the current issue as its parent
- [ ] Verify the selection is replaced inline with a mention link to the new issue
- [ ] Repeat from a comment input / reply input / edited comment on the same issue
- [ ] Verify the button is hidden in editors without issue context (create-issue modal description, project description)