### PR TITLE
feat(desktop): native OS notifications for inbox:new events

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, nativeImage } from "electron";
+import { app, BrowserWindow, ipcMain, nativeImage, Notification } from "electron";
 import { homedir } from "os";
 import { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
@@ -200,6 +200,18 @@ if (!gotTheLock) {
       if (process.platform !== "darwin") return;
       mainWindow?.setWindowButtonVisibility(!immersive);
     });
+
+    // IPC: show a native OS notification. Triggered by the renderer when a
+    // new inbox item arrives via WebSocket. Uses Electron's Notification API
+    // so the OS handles permission, sound, and Notification Center delivery.
+    ipcMain.on(
+      "notification:show",
+      (_event, { title, body }: { title: string; body: string }) => {
+        if (Notification.isSupported()) {
+          new Notification({ title, body }).show();
+        }
+      },
+    );
 
     createWindow();
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -25,6 +25,9 @@ const desktopAPI = {
   /** Toggle immersive mode — hide macOS traffic lights for full-screen modals */
   setImmersiveMode: (immersive: boolean) =>
     ipcRenderer.invoke("window:setImmersive", immersive),
+  /** Show a native OS notification. Used for inbox:new events. */
+  showNotification: (title: string, body: string) =>
+    ipcRenderer.send("notification:show", { title, body }),
 };
 
 interface DaemonStatus {

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -197,6 +197,10 @@ export function useRealtimeSync(
       if (!item) return;
       const wsId = getCurrentWsId();
       if (wsId) onInboxNew(qc, wsId, item);
+      // Fire a native OS notification in the Electron desktop app. `desktopAPI`
+      // is injected by the preload script; its absence means we're in the browser.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).desktopAPI?.showNotification?.(item.title, item.body ?? "");
     });
 
     // --- Timeline event handlers (global fallback) ---


### PR DESCRIPTION
## Summary

- Add native macOS/Windows/Linux desktop notification banners when new inbox items arrive via WebSocket (`inbox:new` event)
- Wire the full IPC chain: WebSocket event → renderer → preload bridge → Electron main process → OS notification API

## Changes

- **`packages/core/realtime/use-realtime-sync.ts`**: Call `desktopAPI.showNotification()` on `inbox:new`. Uses optional chaining so the call is silently skipped in the browser (no `desktopAPI`).
- **`apps/desktop/src/preload/index.ts`**: Expose `showNotification(title, body)` as an IPC bridge in `desktopAPI`.
- **`apps/desktop/src/main/index.ts`**: Register `ipcMain.on("notification:show")` handler that calls `new Notification({ title, body }).show()`.

## Test plan

- [ ] Install the app, trigger an inbox notification (assign an issue or @-mention yourself from another account)
- [ ] Notification banner appears in the top-right corner on first use (macOS prompts for permission)
- [ ] No banner shown in browser (web app) — `desktopAPI` guard skips silently

🤖 Co-authored with Claude Code