### PR TITLE
fix: allow agent-initiated comments and status changes to trigger task pickup

### DIFF
--- a/server/cmd/server/activity_listeners.go
+++ b/server/cmd/server/activity_listeners.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 
 	"github.com/multica-ai/multica/server/internal/events"
-	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -25,7 +24,7 @@ func registerActivityListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}
@@ -53,7 +52,7 @@ func registerActivityListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}

--- a/server/cmd/server/activity_listeners_test.go
+++ b/server/cmd/server/activity_listeners_test.go
@@ -123,6 +123,46 @@ func TestActivityIssueUpdated_StatusChanged(t *testing.T) {
 	}
 }
 
+func TestActivityIssueUpdated_StatusChanged_MapPayload(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	registerActivityListeners(bus, queries)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupActivities(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "system",
+		ActorID:     "",
+		Payload: map[string]any{
+			"issue": map[string]any{
+				"id":           issueID,
+				"workspace_id": testWorkspaceID,
+				"title":        "activity test issue",
+				"status":       "in_review",
+				"priority":     "medium",
+				"creator_type": "member",
+				"creator_id":   testUserID,
+			},
+			"status_changed": true,
+			"prev_status":    "in_progress",
+		},
+	})
+
+	activities := listActivitiesForIssue(t, queries, issueID)
+	if len(activities) != 1 {
+		t.Fatalf("expected 1 activity, got %d", len(activities))
+	}
+	if activities[0].Action != "status_changed" {
+		t.Fatalf("expected action 'status_changed', got %q", activities[0].Action)
+	}
+}
+
 func TestActivityIssueUpdated_AssigneeChanged(t *testing.T) {
 	queries := db.New(testPool)
 	bus := events.New()
@@ -156,7 +196,7 @@ func TestActivityIssueUpdated_AssigneeChanged(t *testing.T) {
 				AssigneeType: &assigneeType,
 				AssigneeID:   &assigneeID,
 			},
-			"assignee_changed":  true,
+			"assignee_changed":   true,
 			"prev_assignee_type": (*string)(nil),
 			"prev_assignee_id":   (*string)(nil),
 		},

--- a/server/cmd/server/autopilot_listeners.go
+++ b/server/cmd/server/autopilot_listeners.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 
 	"github.com/multica-ai/multica/server/internal/events"
-	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -26,7 +25,7 @@ func registerAutopilotListeners(bus *events.Bus, svc *service.AutopilotService) 
 		if !statusChanged {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -14,6 +14,14 @@ import (
 // causing the server to resolve the actor as an agent instead of a member.
 func authRequestWithAgent(t *testing.T, method, path string, body any, agentID string) *http.Response {
 	t.Helper()
+	return authRequestWithAgentTask(t, method, path, body, agentID, "")
+}
+
+// authRequestWithAgentTask makes an authenticated request with X-Agent-ID and
+// optional X-Task-ID headers, modelling an agent acting from within an
+// executing task (the CLI sets both).
+func authRequestWithAgentTask(t *testing.T, method, path string, body any, agentID, taskID string) *http.Response {
+	t.Helper()
 	var bodyReader io.Reader
 	if body != nil {
 		b, _ := json.Marshal(body)
@@ -27,12 +35,37 @@ func authRequestWithAgent(t *testing.T, method, path string, body any, agentID s
 	req.Header.Set("Authorization", "Bearer "+testToken)
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
 	req.Header.Set("X-Agent-ID", agentID)
+	if taskID != "" {
+		req.Header.Set("X-Task-ID", taskID)
+	}
 
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
 	return r
+}
+
+// insertRunningTask inserts a dispatched agent_task_queue row for the given
+// (agent, issue) pair and returns its ID. Used to simulate an agent acting
+// from within an executing task context.
+func insertRunningTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	var id string
+	err := testPool.QueryRow(context.Background(),
+		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id)
+		 VALUES ($1, $2, 'dispatched',
+			 (SELECT runtime_id FROM agent WHERE id = $1))
+		 RETURNING id`,
+		agentID, issueID).Scan(&id)
+	if err != nil {
+		t.Fatalf("failed to insert running task: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE id = $1`, id)
+	})
+	return id
 }
 
 // countPendingTasks returns the number of queued/dispatched tasks for an issue.
@@ -347,6 +380,52 @@ func TestCommentTriggerOnComment(t *testing.T) {
 		postCommentAsAgent(t, issueID, "I am working on this", agentID, nil)
 		if n := countPendingTasks(t, issueID); n != 0 {
 			t.Errorf("expected 0 pending tasks (assignee self-comment), got %d", n)
+		}
+	})
+
+	t.Run("assignee agent commenting from a task on a different issue triggers hand-off", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// Simulate the agent completing another issue and posting a hand-off
+		// comment on THIS issue (both assigned to the same agent). The task
+		// context points at the OTHER issue, so this is a chain, not a loop.
+		otherIssueID := createIssueAssignedToAgent(t, "Previous issue in chain", agentID)
+		t.Cleanup(func() {
+			clearTasks(t, otherIssueID)
+			resp := authRequest(t, "DELETE", "/api/issues/"+otherIssueID, nil)
+			resp.Body.Close()
+		})
+		clearTasks(t, issueID)
+		clearTasks(t, otherIssueID)
+		otherTaskID := insertRunningTask(t, agentID, otherIssueID)
+		body := map[string]any{"content": "Previous issue done, you can start", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, otherTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("hand-off comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (hand-off from different-issue task), got %d", n)
+		}
+	})
+
+	t.Run("assignee agent commenting from a task on the same issue does not loop", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// Same agent, same issue, same task — classic self-loop, must not trigger.
+		ownTaskID := insertRunningTask(t, agentID, issueID)
+		body := map[string]any{"content": "Progress update", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, ownTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("self-task comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 1 {
+			// The dispatched task inserted above counts toward the pending set
+			// (status='dispatched'); we assert no NEW task was enqueued.
+			t.Errorf("expected 1 pending task (only the original dispatched task), got %d", n)
 		}
 	})
 }

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -46,26 +46,37 @@ func authRequestWithAgentTask(t *testing.T, method, path string, body any, agent
 	return r
 }
 
-// insertRunningTask inserts a dispatched agent_task_queue row for the given
-// (agent, issue) pair and returns its ID. Used to simulate an agent acting
-// from within an executing task context.
-func insertRunningTask(t *testing.T, agentID, issueID string) string {
+// insertTaskWithStatus inserts an agent_task_queue row for the given
+// (agent, issue, status) tuple and returns its ID.
+func insertTaskWithStatus(t *testing.T, agentID, issueID, status string) string {
 	t.Helper()
 	var id string
 	err := testPool.QueryRow(context.Background(),
-		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id)
-		 VALUES ($1, $2, 'dispatched',
-			 (SELECT runtime_id FROM agent WHERE id = $1))
+		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id, started_at, completed_at)
+		 VALUES ($1, $2, $3,
+			 (SELECT runtime_id FROM agent WHERE id = $1),
+			 CASE WHEN $3 = 'running' THEN now() ELSE NULL END,
+			 CASE WHEN $3 = 'completed' THEN now() ELSE NULL END)
 		 RETURNING id`,
-		agentID, issueID).Scan(&id)
+		agentID, issueID, status).Scan(&id)
 	if err != nil {
-		t.Fatalf("failed to insert running task: %v", err)
+		t.Fatalf("failed to insert %s task: %v", status, err)
 	}
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(),
 			`DELETE FROM agent_task_queue WHERE id = $1`, id)
 	})
 	return id
+}
+
+func insertRunningTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	return insertTaskWithStatus(t, agentID, issueID, "running")
+}
+
+func insertCompletedTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	return insertTaskWithStatus(t, agentID, issueID, "completed")
 }
 
 // countPendingTasks returns the number of queued/dispatched tasks for an issue.
@@ -422,10 +433,31 @@ func TestCommentTriggerOnComment(t *testing.T) {
 			t.Fatalf("self-task comment: expected 201, got %d: %s", resp.StatusCode, b)
 		}
 		resp.Body.Close()
-		if n := countPendingTasks(t, issueID); n != 1 {
-			// The dispatched task inserted above counts toward the pending set
-			// (status='dispatched'); we assert no NEW task was enqueued.
-			t.Errorf("expected 1 pending task (only the original dispatched task), got %d", n)
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (self-loop suppressed), got %d", n)
+		}
+	})
+
+	t.Run("completed task context does not bypass assignee self-comment guard", func(t *testing.T) {
+		clearTasks(t, issueID)
+		otherIssueID := createIssueAssignedToAgent(t, "Completed task issue", agentID)
+		t.Cleanup(func() {
+			clearTasks(t, otherIssueID)
+			resp := authRequest(t, "DELETE", "/api/issues/"+otherIssueID, nil)
+			resp.Body.Close()
+		})
+		clearTasks(t, otherIssueID)
+		completedTaskID := insertCompletedTask(t, agentID, otherIssueID)
+		body := map[string]any{"content": "Manual follow-up", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, completedTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("completed-task comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (completed task must not bypass guard), got %d", n)
 		}
 	})
 }

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 )
 
 // authRequestWithAgent makes an authenticated request with X-Agent-ID header,
@@ -148,8 +149,12 @@ func createSecondAgent(t *testing.T) string {
 	}
 	runtimeID := agents[0]["runtime_id"].(string)
 
+	// Use a unique name so repeated runs (go test -count=N) don't collide with
+	// archived agents left over from prior runs — archive keeps the row, and
+	// (workspace_id, name) is unique.
+	name := fmt.Sprintf("Second Test Agent %d", time.Now().UnixNano())
 	resp = authRequest(t, "POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
-		"name":       "Second Test Agent",
+		"name":       name,
 		"runtime_id": runtimeID,
 		"visibility": "workspace",
 	})

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -330,6 +330,25 @@ func TestCommentTriggerOnComment(t *testing.T) {
 			t.Errorf("expected 1 pending task (assignee mentioned in thread root), got %d", n)
 		}
 	})
+
+	t.Run("comment from a different agent triggers the assignee agent", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// A second agent posts a comment on the issue (sequential chaining use case).
+		secondAgentID := createSecondAgent(t)
+		postCommentAsAgent(t, issueID, "Tu peux démarrer", secondAgentID, nil)
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (comment from different agent), got %d", n)
+		}
+	})
+
+	t.Run("comment from the assignee agent does not trigger itself", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// The assignee agent posts a comment on its own issue — must not loop.
+		postCommentAsAgent(t, issueID, "I am working on this", agentID, nil)
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (assignee self-comment), got %d", n)
+		}
+	})
 }
 
 // TestCommentTriggerAtAllSuppression verifies that @all mentions do not

--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -18,7 +18,6 @@ type mention struct {
 	ID   string // user_id, agent_id, issue_id, or "all"
 }
 
-
 // statusLabels maps DB status values to human-readable labels for notifications.
 var statusLabels = map[string]string{
 	"backlog":     "Backlog",
@@ -356,7 +355,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}
@@ -391,7 +390,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}

--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -316,6 +316,51 @@ func TestNotification_StatusChanged(t *testing.T) {
 	}
 }
 
+func TestNotification_StatusChanged_MapPayload(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+
+	subEmail := "notif-map-status@multica.ai"
+	subID := createTestUser(t, subEmail)
+	t.Cleanup(func() { cleanupTestUser(t, subEmail) })
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	addTestSubscriber(t, issueID, "member", subID, "commenter")
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "system",
+		ActorID:     "",
+		Payload: map[string]any{
+			"issue": map[string]any{
+				"id":           issueID,
+				"workspace_id": testWorkspaceID,
+				"title":        "status test issue",
+				"status":       "in_review",
+				"priority":     "medium",
+				"creator_type": "member",
+				"creator_id":   testUserID,
+			},
+			"status_changed": true,
+			"prev_status":    "in_progress",
+		},
+	})
+
+	items := inboxItemsForRecipient(t, queries, subID)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 inbox item for subscriber, got %d", len(items))
+	}
+	if items[0].Type != "status_changed" {
+		t.Fatalf("expected type 'status_changed', got %q", items[0].Type)
+	}
+}
+
 // TestNotification_CommentCreated verifies that all subscribers except the
 // commenter receive a "new_comment" notification.
 func TestNotification_CommentCreated(t *testing.T) {
@@ -439,8 +484,8 @@ func TestNotification_AssigneeChanged(t *testing.T) {
 				AssigneeType: &newAssigneeType,
 				AssigneeID:   &newAssigneeID,
 			},
-			"assignee_changed":  true,
-			"status_changed":    false,
+			"assignee_changed":   true,
+			"status_changed":     false,
 			"prev_assignee_type": &oldAssigneeType,
 			"prev_assignee_id":   &oldAssigneeID,
 		},

--- a/server/cmd/server/subscriber_listeners.go
+++ b/server/cmd/server/subscriber_listeners.go
@@ -123,11 +123,15 @@ func extractIssueFields(v any) (handler.IssueResponse, bool) {
 	issue := handler.IssueResponse{}
 	issue.ID, _ = m["id"].(string)
 	issue.WorkspaceID, _ = m["workspace_id"].(string)
+	issue.Title, _ = m["title"].(string)
+	issue.Status, _ = m["status"].(string)
+	issue.Priority, _ = m["priority"].(string)
 	issue.CreatorType, _ = m["creator_type"].(string)
 	issue.CreatorID, _ = m["creator_id"].(string)
 	issue.AssigneeType, _ = m["assignee_type"].(*string)
 	issue.AssigneeID, _ = m["assignee_id"].(*string)
 	issue.Description, _ = m["description"].(*string)
+	issue.DueDate, _ = m["due_date"].(*string)
 	if issue.ID == "" || issue.CreatorID == "" {
 		return handler.IssueResponse{}, false
 	}

--- a/server/cmd/server/task_completion_integration_test.go
+++ b/server/cmd/server/task_completion_integration_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+func TestCompleteTaskAutoInReviewPublishesStatusChange(t *testing.T) {
+	bus := events.New()
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, nil, bus)
+
+	var issueUpdatedEvents []events.Event
+	bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
+		issueUpdatedEvents = append(issueUpdatedEvents, e)
+	})
+
+	agentID := getAgentID(t)
+	issueID := createIssueAssignedToAgent(t, "Complete task auto in_review", agentID)
+	t.Cleanup(func() {
+		clearTasks(t, issueID)
+		resp := authRequest(t, "DELETE", "/api/issues/"+issueID, nil)
+		resp.Body.Close()
+	})
+
+	clearTasks(t, issueID)
+
+	taskID := insertRunningTask(t, agentID, issueID)
+	result, err := json.Marshal(protocol.TaskCompletedPayload{Output: "Travail terminé"})
+	if err != nil {
+		t.Fatalf("marshal task result: %v", err)
+	}
+	if _, err := taskSvc.CompleteTask(context.Background(), util.ParseUUID(taskID), result, "", ""); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	issue, err := queries.GetIssue(context.Background(), util.ParseUUID(issueID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.Status != "in_review" {
+		t.Fatalf("expected issue status 'in_review', got %q", issue.Status)
+	}
+
+	if len(issueUpdatedEvents) != 1 {
+		t.Fatalf("expected 1 issue.updated event after completion, got %d", len(issueUpdatedEvents))
+	}
+	payload, ok := issueUpdatedEvents[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("expected issue.updated payload to be map[string]any, got %T", issueUpdatedEvents[0].Payload)
+	}
+	if statusChanged, _ := payload["status_changed"].(bool); !statusChanged {
+		t.Fatal("expected status_changed=true in issue.updated payload")
+	}
+	issuePayload, ok := payload["issue"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected issue payload to be map[string]any, got %T", payload["issue"])
+	}
+	if got, _ := issuePayload["status"].(string); got != "in_review" {
+		t.Fatalf("expected published issue status 'in_review', got %q", got)
+	}
+}

--- a/server/cmd/server/task_completion_integration_test.go
+++ b/server/cmd/server/task_completion_integration_test.go
@@ -15,7 +15,7 @@ import (
 func TestCompleteTaskAutoInReviewPublishesStatusChange(t *testing.T) {
 	bus := events.New()
 	queries := db.New(testPool)
-	taskSvc := service.NewTaskService(queries, nil, bus)
+	taskSvc := service.NewTaskService(queries, nil, nil, bus)
 
 	var issueUpdatedEvents []events.Event
 	bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
@@ -75,7 +75,7 @@ func TestCompleteTaskKeepsNonActiveIssueStatus(t *testing.T) {
 		t.Run(status, func(t *testing.T) {
 			bus := events.New()
 			queries := db.New(testPool)
-			taskSvc := service.NewTaskService(queries, nil, bus)
+			taskSvc := service.NewTaskService(queries, nil, nil, bus)
 
 			var issueUpdatedEvents []events.Event
 			bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
@@ -114,5 +114,50 @@ func TestCompleteTaskKeepsNonActiveIssueStatus(t *testing.T) {
 				t.Fatalf("expected no issue.updated event for preserved %q status, got %d", status, len(issueUpdatedEvents))
 			}
 		})
+	}
+}
+
+func TestCompleteTaskDoesNotAdvanceWhileAnotherIssueTaskIsActive(t *testing.T) {
+	bus := events.New()
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, nil, nil, bus)
+
+	var issueUpdatedEvents []events.Event
+	bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
+		issueUpdatedEvents = append(issueUpdatedEvents, e)
+	})
+
+	agentID := getAgentID(t)
+	issueID := createIssueAssignedToAgent(t, "Complete task with follow-up still queued", agentID)
+	t.Cleanup(func() {
+		clearTasks(t, issueID)
+		resp := authRequest(t, "DELETE", "/api/issues/"+issueID, nil)
+		resp.Body.Close()
+	})
+
+	clearTasks(t, issueID)
+	resp := authRequest(t, "PUT", "/api/issues/"+issueID, map[string]any{"status": "in_progress"})
+	resp.Body.Close()
+
+	runningTaskID := insertRunningTask(t, agentID, issueID)
+	_ = insertTaskWithStatus(t, agentID, issueID, "queued")
+
+	result, err := json.Marshal(protocol.TaskCompletedPayload{Output: "Travail terminé"})
+	if err != nil {
+		t.Fatalf("marshal task result: %v", err)
+	}
+	if _, err := taskSvc.CompleteTask(context.Background(), util.ParseUUID(runningTaskID), result, "", ""); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	issue, err := queries.GetIssue(context.Background(), util.ParseUUID(issueID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.Status != "in_progress" {
+		t.Fatalf("expected issue status 'in_progress' to be preserved while another task is active, got %q", issue.Status)
+	}
+	if len(issueUpdatedEvents) != 0 {
+		t.Fatalf("expected no issue.updated event while another task is active, got %d", len(issueUpdatedEvents))
 	}
 }

--- a/server/cmd/server/task_completion_integration_test.go
+++ b/server/cmd/server/task_completion_integration_test.go
@@ -67,3 +67,52 @@ func TestCompleteTaskAutoInReviewPublishesStatusChange(t *testing.T) {
 		t.Fatalf("expected published issue status 'in_review', got %q", got)
 	}
 }
+
+func TestCompleteTaskKeepsNonActiveIssueStatus(t *testing.T) {
+	tests := []string{"backlog", "blocked"}
+
+	for _, status := range tests {
+		t.Run(status, func(t *testing.T) {
+			bus := events.New()
+			queries := db.New(testPool)
+			taskSvc := service.NewTaskService(queries, nil, bus)
+
+			var issueUpdatedEvents []events.Event
+			bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
+				issueUpdatedEvents = append(issueUpdatedEvents, e)
+			})
+
+			agentID := getAgentID(t)
+			issueID := createIssueAssignedToAgent(t, "Complete task preserves "+status, agentID)
+			t.Cleanup(func() {
+				clearTasks(t, issueID)
+				resp := authRequest(t, "DELETE", "/api/issues/"+issueID, nil)
+				resp.Body.Close()
+			})
+
+			clearTasks(t, issueID)
+			resp := authRequest(t, "PUT", "/api/issues/"+issueID, map[string]any{"status": status})
+			resp.Body.Close()
+
+			taskID := insertRunningTask(t, agentID, issueID)
+			result, err := json.Marshal(protocol.TaskCompletedPayload{Output: "Travail terminé"})
+			if err != nil {
+				t.Fatalf("marshal task result: %v", err)
+			}
+			if _, err := taskSvc.CompleteTask(context.Background(), util.ParseUUID(taskID), result, "", ""); err != nil {
+				t.Fatalf("CompleteTask: %v", err)
+			}
+
+			issue, err := queries.GetIssue(context.Background(), util.ParseUUID(issueID))
+			if err != nil {
+				t.Fatalf("GetIssue: %v", err)
+			}
+			if issue.Status != status {
+				t.Fatalf("expected issue status %q to be preserved, got %q", status, issue.Status)
+			}
+			if len(issueUpdatedEvents) != 0 {
+				t.Fatalf("expected no issue.updated event for preserved %q status, got %d", status, len(issueUpdatedEvents))
+			}
+		})
+	}
+}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -281,13 +281,23 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// If the issue is assigned to an agent with on_comment trigger, enqueue a new task.
 	// Skip when the comment comes from the assigned agent itself to avoid loops.
+	// Exception: when the author agent is currently running a task on a
+	// DIFFERENT issue, the comment is a chained hand-off (e.g. finishing
+	// MOIK-12 and kicking off MOIK-13 where both are assigned to the same
+	// agent) and must still trigger pickup. Without any task context we stay
+	// conservative and suppress to preserve the anti-loop guarantee for manual
+	// same-agent actions.
 	// Also skip when the comment @mentions others but not the assignee agent —
 	// the user is talking to someone else, not requesting work from the assignee.
 	// Also skip when replying in a member-started thread without mentioning the
 	// assignee — the user is continuing a member-to-member conversation.
-	// Agent comments from any agent OTHER than the assignee are allowed — this
-	// enables sequential issue chaining where one agent hands off to the next.
-	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == authorID
+	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" &&
+		uuidToString(issue.AssigneeID) == authorID
+	if isSelfComment {
+		if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+			isSelfComment = false
+		}
+	}
 	if !isSelfComment && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -285,7 +285,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// the user is talking to someone else, not requesting work from the assignee.
 	// Also skip when replying in a member-started thread without mentioning the
 	// assignee — the user is continuing a member-to-member conversation.
-	if authorType == "member" && h.shouldEnqueueOnComment(r.Context(), issue) &&
+	// Agent comments from any agent OTHER than the assignee are allowed — this
+	// enables sequential issue chaining where one agent hands off to the next.
+	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == authorID
+	if !isSelfComment && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {
 		// Always use the current comment as the trigger so the agent reads

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -198,6 +198,23 @@ func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (act
 	return "agent", agentID
 }
 
+// actorCurrentIssueID returns the issue_id of the agent's currently running
+// task when X-Task-ID is present and valid, or "" otherwise. Used to scope
+// self-loop guards: an agent acting on its own assigned issue FROM a task on
+// that same issue is a loop, but an agent acting from a task on a DIFFERENT
+// issue is a hand-off and must still trigger pickup.
+func (h *Handler) actorCurrentIssueID(r *http.Request) string {
+	taskID := r.Header.Get("X-Task-ID")
+	if taskID == "" {
+		return ""
+	}
+	task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	if err != nil {
+		return ""
+	}
+	return uuidToString(task.IssueID)
+}
+
 func requireUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	userID := requestUserID(r)
 	if userID == "" {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -212,6 +212,9 @@ func (h *Handler) actorCurrentIssueID(r *http.Request) string {
 	if err != nil {
 		return ""
 	}
+	if task.Status != "running" {
+		return ""
+	}
 	return uuidToString(task.IssueID)
 }
 

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1288,6 +1288,118 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 	testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
 }
 
+func TestBacklogToTodoAgentSelfLoopGuard(t *testing.T) {
+	ctx := context.Background()
+
+	var agentID string
+	err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	newBacklogIssue := func(t *testing.T, title string) string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+			"title":         title,
+			"status":        "backlog",
+			"assignee_type": "agent",
+			"assignee_id":   agentID,
+		})
+		req.Header.Set("X-Agent-ID", agentID)
+		testHandler.CreateIssue(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		var created IssueResponse
+		if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+			t.Fatalf("decode issue: %v", err)
+		}
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+			cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+			cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+			testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+		})
+		return created.ID
+	}
+
+	insertTask := func(t *testing.T, issueID, status string) string {
+		t.Helper()
+		var taskID string
+		err := testPool.QueryRow(ctx,
+			`INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at, completed_at)
+			 VALUES ($1, $2, $3, $4, 0,
+				CASE WHEN $4 = 'running' THEN now() ELSE NULL END,
+				CASE WHEN $4 = 'completed' THEN now() ELSE NULL END)
+			 RETURNING id`,
+			agentID, testRuntimeID, issueID, status,
+		).Scan(&taskID)
+		if err != nil {
+			t.Fatalf("failed to insert %s task: %v", status, err)
+		}
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+		})
+		return taskID
+	}
+
+	countQueued := func(t *testing.T, issueID string) int {
+		t.Helper()
+		var n int
+		err := testPool.QueryRow(ctx,
+			`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND status = 'queued'`,
+			issueID,
+		).Scan(&n)
+		if err != nil {
+			t.Fatalf("count queued tasks: %v", err)
+		}
+		return n
+	}
+
+	tests := []struct {
+		name         string
+		taskStatus   string
+		taskOnOther  bool
+		expectQueued int
+	}{
+		{name: "no task context keeps self-loop suppressed", expectQueued: 0},
+		{name: "running task on different issue enables hand-off", taskStatus: "running", taskOnOther: true, expectQueued: 1},
+		{name: "completed task on different issue does not bypass guard", taskStatus: "completed", taskOnOther: true, expectQueued: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issueID := newBacklogIssue(t, tt.name)
+			req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": "todo"})
+			req = withURLParam(req, "id", issueID)
+			req.Header.Set("X-Agent-ID", agentID)
+
+			if tt.taskStatus != "" {
+				taskIssueID := issueID
+				if tt.taskOnOther {
+					taskIssueID = newBacklogIssue(t, tt.name+" other")
+				}
+				taskID := insertTask(t, taskIssueID, tt.taskStatus)
+				req.Header.Set("X-Task-ID", taskID)
+			}
+
+			w := httptest.NewRecorder()
+			testHandler.UpdateIssue(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			if got := countQueued(t, issueID); got != tt.expectQueued {
+				t.Fatalf("queued tasks = %d, want %d", got, tt.expectQueued)
+			}
+		})
+	}
+}
+
 func TestDaemonRegisterMissingWorkspaceReturns404(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/daemon/register", bytes.NewBufferString(`{

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1123,10 +1123,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Trigger the assigned agent when a member moves an issue out of backlog.
-	// Backlog acts as a parking lot — moving to an active status signals the
-	// issue is ready for work.
-	if statusChanged && !assigneeChanged && actorType == "member" &&
+	// Trigger the assigned agent when anyone (member or another agent) moves an
+	// issue out of backlog. Skip only when the assignee agent moves its own issue
+	// to prevent self-loops.
+	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+	if statusChanged && !assigneeChanged && !isSelfActor &&
 		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 		if h.isAgentAssigneeReady(r.Context(), issue) {
 			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
@@ -1431,8 +1432,9 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Trigger agent when moving out of backlog (batch).
-		if statusChanged && !assigneeChanged && actorType == "member" &&
+		// Trigger agent when moving out of backlog (batch). Skip self-actor to prevent loops.
+		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+		if statusChanged && !assigneeChanged && !isSelfActorBatch &&
 			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 			if h.isAgentAssigneeReady(r.Context(), issue) {
 				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1124,9 +1124,18 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Trigger the assigned agent when anyone (member or another agent) moves an
-	// issue out of backlog. Skip only when the assignee agent moves its own issue
-	// to prevent self-loops.
-	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+	// issue out of backlog. Skip when the assignee agent moves its own issue
+	// to prevent self-loops. Exception: when the author agent is currently
+	// running a task on a DIFFERENT issue, the status change is a chained
+	// hand-off (e.g. agent finishing MOIK-12 sets MOIK-13 to todo where both
+	// are assigned to the same agent) and must still trigger pickup.
+	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" &&
+		uuidToString(issue.AssigneeID) == actorID
+	if isSelfActor {
+		if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+			isSelfActor = false
+		}
+	}
 	if statusChanged && !assigneeChanged && !isSelfActor &&
 		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 		if h.isAgentAssigneeReady(r.Context(), issue) {
@@ -1432,8 +1441,16 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Trigger agent when moving out of backlog (batch). Skip self-actor to prevent loops.
-		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+		// Trigger agent when moving out of backlog (batch). Same rule as the
+		// single-update handler: self-loop unless the agent is currently
+		// running a task on a different issue (chained hand-off).
+		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" &&
+			uuidToString(issue.AssigneeID) == actorID
+		if isSelfActorBatch {
+			if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+				isSelfActorBatch = false
+			}
+		}
 		if statusChanged && !assigneeChanged && !isSelfActorBatch &&
 			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 			if h.isAgentAssigneeReady(r.Context(), issue) {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -338,7 +338,9 @@ func (s *TaskService) StartTask(ctx context.Context, taskID pgtype.UUID) (*db.Ag
 }
 
 // CompleteTask marks a task as completed.
-// Issue status is NOT changed here — the agent manages it via the CLI.
+// Issue status is NOT changed here directly — the agent manages it via the CLI.
+// Issue tasks may auto-advance to in_review once the final active task for the
+// issue finishes; chat tasks never touch issue status.
 //
 // For chat tasks, CompleteAgentTask and the chat_session resume-pointer
 // update run in a single transaction. This closes a race where the next
@@ -453,39 +455,45 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		s.broadcastChatDone(ctx, task)
 	}
 
-	// Auto-advance issue to in_review when a non-chat issue task completes and
-	// the issue is still in an active work state. Parking/terminal states must
-	// be preserved: backlog stays backlog, blocked stays blocked, and terminal
-	// statuses are left untouched if the agent already set them manually.
+	// Auto-advance issue to in_review when a non-chat issue task completes, the
+	// issue is still in an active work state, and no other active tasks remain
+	// for that issue. Parking/terminal states must be preserved: backlog stays
+	// backlog, blocked stays blocked, and terminal statuses are left untouched
+	// if the agent already set them manually.
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
 			prevStatus := issue.Status
 			active := prevStatus == "todo" || prevStatus == "in_progress"
 			if active {
-				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
-					ID:     task.IssueID,
-					Status: "in_review",
-				}); err != nil {
-					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
-				} else {
-					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
-					s.broadcastIssueUpdated(updatedIssue, map[string]any{
-						"assignee_changed":    false,
-						"status_changed":      true,
-						"priority_changed":    false,
-						"due_date_changed":    false,
-						"description_changed": false,
-						"title_changed":       false,
-						"prev_title":          issue.Title,
-						"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
-						"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
-						"prev_status":         prevStatus,
-						"prev_priority":       issue.Priority,
-						"prev_due_date":       util.TimestampToPtr(issue.DueDate),
-						"prev_description":    util.TextToPtr(issue.Description),
-						"creator_type":        issue.CreatorType,
-						"creator_id":          util.UUIDToString(issue.CreatorID),
-					})
+				hasActive, checkErr := s.Queries.HasActiveTaskForIssue(ctx, task.IssueID)
+				if checkErr != nil {
+					slog.Warn("auto in_review skipped: failed to check active tasks", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", checkErr)
+				} else if !hasActive {
+					if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+						ID:     task.IssueID,
+						Status: "in_review",
+					}); err != nil {
+						slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
+					} else {
+						slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+						s.broadcastIssueUpdated(updatedIssue, map[string]any{
+							"assignee_changed":    false,
+							"status_changed":      true,
+							"priority_changed":    false,
+							"due_date_changed":    false,
+							"description_changed": false,
+							"title_changed":       false,
+							"prev_title":          issue.Title,
+							"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
+							"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
+							"prev_status":         prevStatus,
+							"prev_priority":       issue.Priority,
+							"prev_due_date":       util.TimestampToPtr(issue.DueDate),
+							"prev_description":    util.TextToPtr(issue.Description),
+							"creator_type":        issue.CreatorType,
+							"creator_id":          util.UUIDToString(issue.CreatorID),
+						})
+					}
 				}
 			}
 		}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -454,11 +454,13 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	}
 
 	// Auto-advance issue to in_review when a non-chat issue task completes and
-	// the issue is still in an active state (the agent didn't set it manually).
+	// the issue is still in an active work state. Parking/terminal states must
+	// be preserved: backlog stays backlog, blocked stays blocked, and terminal
+	// statuses are left untouched if the agent already set them manually.
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
 			prevStatus := issue.Status
-			active := prevStatus != "in_review" && prevStatus != "done" && prevStatus != "cancelled"
+			active := prevStatus == "todo" || prevStatus == "in_progress"
 			if active {
 				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 					ID:     task.IssueID,

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -453,6 +453,24 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		s.broadcastChatDone(ctx, task)
 	}
 
+	// Auto-advance issue to in_review when a non-chat issue task completes and
+	// the issue is still in an active state (the agent didn't set it manually).
+	if task.IssueID.Valid && !task.ChatSessionID.Valid {
+		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
+			active := issue.Status != "in_review" && issue.Status != "done" && issue.Status != "cancelled"
+			if active {
+				if _, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+					ID:     task.IssueID,
+					Status: "in_review",
+				}); err != nil {
+					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
+				} else {
+					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+				}
+			}
+		}
+	}
+
 	// Reconcile agent status
 	s.ReconcileAgentStatus(ctx, task.AgentID)
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -457,15 +457,33 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	// the issue is still in an active state (the agent didn't set it manually).
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
-			active := issue.Status != "in_review" && issue.Status != "done" && issue.Status != "cancelled"
+			prevStatus := issue.Status
+			active := prevStatus != "in_review" && prevStatus != "done" && prevStatus != "cancelled"
 			if active {
-				if _, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 					ID:     task.IssueID,
 					Status: "in_review",
 				}); err != nil {
 					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
 				} else {
 					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+					s.broadcastIssueUpdated(updatedIssue, map[string]any{
+						"assignee_changed":    false,
+						"status_changed":      true,
+						"priority_changed":    false,
+						"due_date_changed":    false,
+						"description_changed": false,
+						"title_changed":       false,
+						"prev_title":          issue.Title,
+						"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
+						"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
+						"prev_status":         prevStatus,
+						"prev_priority":       issue.Priority,
+						"prev_due_date":       util.TimestampToPtr(issue.DueDate),
+						"prev_description":    util.TextToPtr(issue.Description),
+						"creator_type":        issue.CreatorType,
+						"creator_id":          util.UUIDToString(issue.CreatorID),
+					})
 				}
 			}
 		}
@@ -978,14 +996,20 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 	})
 }
 
-func (s *TaskService) broadcastIssueUpdated(issue db.Issue) {
+func (s *TaskService) broadcastIssueUpdated(issue db.Issue, extra map[string]any) {
 	prefix := s.getIssuePrefix(issue.WorkspaceID)
+	payload := map[string]any{
+		"issue": issueToMap(issue, prefix),
+	}
+	for k, v := range extra {
+		payload[k] = v
+	}
 	s.Bus.Publish(events.Event{
 		Type:        protocol.EventIssueUpdated,
 		WorkspaceID: util.UUIDToString(issue.WorkspaceID),
 		ActorType:   "system",
 		ActorID:     "",
-		Payload:     map[string]any{"issue": issueToMap(issue, prefix)},
+		Payload:     payload,
 	})
 }
 


### PR DESCRIPTION
## Problem

When agents work on sequential issue chains (Agent A finishes issue 1, then triggers issue 2 for Agent B), the daemon does not pick up the next issue because:

1. **Comment trigger** (`comment.go`): `shouldEnqueueOnComment` is gated by `authorType == "member"`, so agent comments are ignored
2. **Status change trigger** (`issue.go`): same pattern -- when an agent moves an issue from `backlog` to `todo`, the daemon does not enqueue it

This makes fully automated sequential chains impossible without human intervention.

## Solution

Replace the strict `authorType == "member"` guard with an anti-self-loop check scoped to the current task context:

- **Agent A comments on Agent B's issue** -> triggers pickup (chaining)
- **Agent comments on its own running task's issue** -> no trigger (prevents infinite loops)
- **Member comments** -> triggers as before (no behavior change)

The self-loop guard uses `X-Task-ID` to scope the check to the agent's currently running task, and only allows bypass for tasks in `running` state.

Additionally, `CompleteTask` now auto-transitions issues to `in_review` (only from `todo`/`in_progress`, not from `backlog`/`blocked`) and publishes the `issue.updated` event so listeners and notifications fire correctly.

## Use case

This enables fully autonomous sequential issue chains:
- Agent A works on issue 1
- Agent A finishes, moves issue 2 from backlog to todo, posts a comment mentioning Agent B
- Agent B picks up issue 2 automatically
- Repeat for N issues -- no human intervention needed

We use this pattern daily to run 10+ issue chains overnight (design reviews, code audits, multi-step refactors).

## Testing

- Integration tests cover all cases: agent-to-agent handoff, self-loop prevention, member regression, status change from different task context
- Pre-existing flaky test `TestCommentTriggerThreadInheritedMention` is unrelated to this change

Closes #1290