### PR TITLE
fix(slugs): audit admin/multica/new/www + reserve in slug list (MUL-972)

### DIFF
--- a/packages/core/paths/reserved-slugs.ts
+++ b/packages/core/paths/reserved-slugs.ts
@@ -28,6 +28,9 @@ export const RESERVED_SLUGS = new Set([
   // Platform / marketing routes (current + likely-future)
   "api",
   "admin",
+  "multica", // brand name — prevent impersonation workspaces
+  "www",     // hostname confusable; never a legitimate workspace slug
+  "new",     // ambiguous verb-as-slug; reserved for future global create routes
   "help",
   "about",
   "pricing",

--- a/server/internal/handler/workspace_reserved_slugs.go
+++ b/server/internal/handler/workspace_reserved_slugs.go
@@ -29,6 +29,9 @@ var reservedSlugs = map[string]bool{
 	// Platform / marketing routes (current + likely-future)
 	"api":       true,
 	"admin":     true,
+	"multica":   true, // brand name — prevent impersonation workspaces
+	"www":       true, // hostname confusable; never a legitimate workspace slug
+	"new":       true, // ambiguous verb-as-slug; reserved for future global create routes
 	"help":      true,
 	"about":     true,
 	"pricing":   true,

--- a/server/migrations/049_audit_legacy_reserved_slugs.down.sql
+++ b/server/migrations/049_audit_legacy_reserved_slugs.down.sql
@@ -1,0 +1,1 @@
+-- No-op: 049 is an audit-only migration. Nothing to roll back.

--- a/server/migrations/049_audit_legacy_reserved_slugs.up.sql
+++ b/server/migrations/049_audit_legacy_reserved_slugs.up.sql
@@ -1,0 +1,48 @@
+-- Audit `admin`, `multica`, `new`, `www` against the workspace.slug column.
+--
+-- Follow-up to migration 047 (extended reserved slugs). 047 intentionally
+-- omitted these four slugs from its audit because each had one conflicting
+-- workspace in production at the time, and blocking deploy on owner outreach
+-- was deemed unacceptable. MUL-972 closed that loop on prd:
+--
+--   * `admin`   (99cd10e4-…) → renamed to `legacy-admin-99cd10e4`
+--   * `multica` (dcd796aa-…) → renamed to `legacy-multica-dcd796aa`
+--   * `new`     (e391e3ed-…) → renamed to `legacy-new-e391e3ed`
+--   * `www`     (5e8d38b2-…) → workspace deleted (was empty: 0 issues /
+--                              projects / agents, owner-only member)
+--
+-- With the prd data clean, this migration promotes those four slugs into the
+-- audit set so any future workspace that slips in with one of them fails
+-- startup loudly instead of being silently shadowed by a global route.
+--
+-- `setup` is STILL omitted from this audit. The `setup` workspace
+-- (b43f0bc2-…) is a real production user (Roberto Betancourth, building a
+-- chants/Alabanzas app) and is being handled out-of-band via owner outreach
+-- to negotiate a rename. A separate follow-up migration will fold `setup`
+-- into the audit once that workspace's slug has been migrated.
+--
+-- Keep this slug list aligned with:
+--  - server/internal/handler/workspace_reserved_slugs.go
+--  - packages/core/paths/reserved-slugs.ts
+
+DO $$
+DECLARE
+  conflict_count INT;
+  conflict_list TEXT;
+BEGIN
+  SELECT
+    COUNT(*),
+    string_agg(slug, ', ' ORDER BY slug)
+  INTO conflict_count, conflict_list
+  FROM workspace
+  WHERE slug IN (
+    'admin',
+    'multica',
+    'new',
+    'www'
+  );
+
+  IF conflict_count > 0 THEN
+    RAISE EXCEPTION 'Found % workspace(s) with slugs that collide with the legacy reserved-slug audit set: %. Rename or delete before deploying (see MUL-972 for the playbook).', conflict_count, conflict_list;
+  END IF;
+END $$;


### PR DESCRIPTION
Closes the loop opened by PR #1188 / migration 047, which intentionally exempted five conflict slugs (`admin` / `multica` / `new` / `setup` / `www`) from the reserved-slug audit because each had one production workspace using it.

Tracked in [MUL-972](https://multica.ai/multica/issues/972). Parent: [MUL-723](https://multica.ai/multica/issues/723).

## prd data fix (already done by db-boy on 2026-04-20, in MUL-972)

| slug | workspace id | action |
|---|---|---|
| `admin` | `99cd10e4-…` | renamed → `legacy-admin-99cd10e4` |
| `multica` | `dcd796aa-…` | renamed → `legacy-multica-dcd796aa` |
| `new` | `e391e3ed-…` | renamed → `legacy-new-e391e3ed` |
| `www` | `5e8d38b2-…` | DELETE (workspace was empty: 0 issues / projects / agents, owner-only member; all 18 workspace-FK relations are CASCADE) |
| `setup` | `b43f0bc2-…` | **out of scope** — real production user, owner outreach in progress |

## What this PR does

1. **`server/migrations/049_audit_legacy_reserved_slugs.up.sql`** — audits `admin` / `multica` / `new` / `www` against `workspace.slug` at startup. Mirrors 047's `DO $$ … END $$` structure: `RAISE EXCEPTION` if any future workspace slips in with one of these slugs, instead of being silently shadowed by a global route.
2. **`packages/core/paths/reserved-slugs.ts` + `server/internal/handler/workspace_reserved_slugs.go`** — adds `multica` / `www` / `new` to the reserved set in both files (`admin` was already there). Keeps the two lists in lockstep per the convention enforced in the Go file's header comment.

## What this PR explicitly does NOT do

- **`setup` stays exempt** from the audit and is **not** added to the reserved list. The `setup` workspace is a real production user (owner: Roberto Betancourth, building a chants/Alabanzas app) and is being handled out-of-band via owner outreach. A separate follow-up migration will fold `setup` in once that workspace's slug has been migrated.

## Rollout ordering

Intentionally shipped **after** the prd data fix, not before — 049 will `RAISE EXCEPTION` on any remaining conflict, so we want the data state clean first.

  prd data fix (done by db-boy on 2026-04-20) → this PR.

## Tests

- `go test ./server/internal/handler/ -run TestReserved` → pass (the test iterates the `reservedSlugs` map directly so the new entries are picked up automatically).
- `pnpm --filter @multica/core test consistency` → pass (4/4 in `consistency.test.ts`; the "every global prefix's first segment is a reserved slug" invariant still holds).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>