### PR TITLE
docs(selfhost): surface APP_ENV + 888888 gating in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,16 @@ POSTGRES_PORT=5432
 DATABASE_URL=postgres://multica:multica@localhost:5432/multica?sslmode=disable
 
 # Server
+# APP_ENV gates dev-only auth shortcuts (primarily the 888888 master code).
+#   - Docker self-host: docker-compose.selfhost.yml already pins APP_ENV to
+#     "production" by default, so 888888 is DISABLED — a public instance can't
+#     be logged into with any email + 888888.
+#   - Local dev (make dev): leave APP_ENV unset so 888888 works out of the box.
+#   - Docker self-host on a private network you fully control, or evaluation
+#     without Resend: set APP_ENV=development to re-enable 888888. Do NOT
+#     enable on a publicly reachable instance.
+# See SELF_HOSTING.md for the full login setup.
+APP_ENV=
 PORT=8080
 JWT_SECRET=change-me-in-production
 MULTICA_SERVER_URL=ws://localhost:8080/ws
@@ -22,7 +32,8 @@ MULTICA_CODEX_WORKDIR=
 MULTICA_CODEX_TIMEOUT=20m
 
 # Email (Resend)
-# For local/dev use, leave RESEND_API_KEY empty — codes print to stdout, and master code 888888 works.
+# For local/dev use, leave RESEND_API_KEY empty — codes print to stdout, and
+# master code 888888 works (only when APP_ENV != "production"; see above).
 # For production, set your Resend API key and change RESEND_FROM_EMAIL to a domain verified in your Resend account.
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=noreply@multica.ai

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ selfhost:
 		echo "  Frontend: http://localhost:$${FRONTEND_PORT:-3000}"; \
 		echo "  Backend:  http://localhost:$${PORT:-8080}"; \
 		echo ""; \
-		echo "Log in with any email + verification code: 888888"; \
+		echo "Log in: configure RESEND_API_KEY in .env for email codes,"; \
+		echo "        or set APP_ENV=development in .env (private networks only) to enable code 888888."; \
 		echo ""; \
 		echo "Next — install the CLI and connect your machine:"; \
 		echo "  brew install multica-ai/tap/multica"; \


### PR DESCRIPTION
## Summary

Surfaces `APP_ENV` — and the fact that it gates the `888888` dev master verification code — in `.env.example`, the file every self-hoster copies as their starting `.env`. Fixes the documentation gap that #1307 flagged but never landed (its description promised a `.env.example` update; only `docker-compose.selfhost.yml` was actually touched).

Context: [#1331](https://github.com/multica-ai/multica/issues/1331) — a v0.2.6 operator changed ports, `cp .env.example .env`, started the stack, and was stuck on "888888 doesn't work" because the `.env` file gave no hint that `APP_ENV` exists. [#1313](https://github.com/multica-ai/multica/pull/1313) updated `SELF_HOSTING.md` / installers but not the env template.

## Changes

- **`.env.example`**: add `APP_ENV=` with a comment block covering the three real cases (Docker self-host default is production-safe, local `make dev` keeps 888888 working, private-network eval can flip to `development`) and an explicit warning against enabling the bypass on a public instance.
- **`.env.example`**: fix the now-contradictory `# Email` note that still claimed "master code 888888 works" unconditionally — now says "only when `APP_ENV != \"production\"`".
- **`Makefile`** (`selfhost` target): the post-start banner still told operators to "Log in with any email + verification code: 888888", which has been wrong since #1307 flipped the default. Replaced with the same two-option guidance (`RESEND_API_KEY` or `APP_ENV=development`) that install.sh/ps1 already print.

## Why `APP_ENV=` (empty) and not `APP_ENV=production`

- `docker-compose.selfhost.yml` already pins `APP_ENV: \${APP_ENV:-production}`, so Docker self-host is production-safe regardless of what's in `.env`.
- `make dev` / `scripts/dev.sh` copies `.env.example` directly and the Go server reads it verbatim — if this file hard-coded `APP_ENV=production`, every local developer would silently lose the `888888` shortcut and have no email either. Empty value preserves today's local-dev UX while still making the variable visible and documented.

## Test plan

- [ ] `cp .env.example .env` then `docker compose -f docker-compose.selfhost.yml config` resolves `APP_ENV` to `production` on the backend service.
- [ ] Setting `APP_ENV=development` in `.env` resolves to `development` in the same check.
- [ ] `make dev` with a fresh `.env.example` → `.env` copy: local Go server logs show non-production mode; dev code printout / 888888 login still works.
- [ ] `make selfhost` fresh run: banner now prints the two login options instead of the outdated 888888 line.