### PR TITLE
feat(desktop): hourly update poll + manual check button in settings

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -53,12 +53,17 @@ export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): voi
     try {
       const result = await autoUpdater.checkForUpdates();
       const currentVersion = app.getVersion();
-      const latestVersion = result?.updateInfo.version ?? currentVersion;
+      // Trust electron-updater's own decision rather than re-deriving it from
+      // a version-string compare. The two diverge for pre-release channels,
+      // staged rollouts, downgrades, and minimum-system-version gates — in
+      // those cases updateInfo.version differs from app.getVersion() but no
+      // `update-available` event fires, so showing "available" here would
+      // promise a download prompt that never appears.
       return {
         ok: true,
         currentVersion,
-        latestVersion,
-        available: latestVersion !== currentVersion,
+        latestVersion: result?.updateInfo.version ?? currentVersion,
+        available: result?.isUpdateAvailable ?? false,
       };
     } catch (err) {
       return {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,8 +1,20 @@
 import { autoUpdater } from "electron-updater";
-import { BrowserWindow, ipcMain } from "electron";
+import { app, BrowserWindow, ipcMain } from "electron";
 
 autoUpdater.autoDownload = false;
 autoUpdater.autoInstallOnAppQuit = true;
+
+const STARTUP_CHECK_DELAY_MS = 5_000;
+const PERIODIC_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+export type ManualUpdateCheckResult =
+  | {
+      ok: true;
+      currentVersion: string;
+      latestVersion: string;
+      available: boolean;
+    }
+  | { ok: false; error: string };
 
 export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): void {
   autoUpdater.on("update-available", (info) => {
@@ -37,10 +49,37 @@ export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): voi
     autoUpdater.quitAndInstall(false, true);
   });
 
-  // Check for updates after a short delay to avoid blocking startup
+  ipcMain.handle("updater:check", async (): Promise<ManualUpdateCheckResult> => {
+    try {
+      const result = await autoUpdater.checkForUpdates();
+      const currentVersion = app.getVersion();
+      const latestVersion = result?.updateInfo.version ?? currentVersion;
+      return {
+        ok: true,
+        currentVersion,
+        latestVersion,
+        available: latestVersion !== currentVersion,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  });
+
+  // Initial check shortly after startup so we don't block boot.
   setTimeout(() => {
     autoUpdater.checkForUpdates().catch((err) => {
       console.error("Failed to check for updates:", err);
     });
-  }, 5000);
+  }, STARTUP_CHECK_DELAY_MS);
+
+  // Background poll so long-running sessions still pick up new releases
+  // without requiring the user to restart the app.
+  setInterval(() => {
+    autoUpdater.checkForUpdates().catch((err) => {
+      console.error("Periodic update check failed:", err);
+    });
+  }, PERIODIC_CHECK_INTERVAL_MS);
 }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -53,6 +53,10 @@ interface UpdaterAPI {
   onUpdateDownloaded: (callback: () => void) => () => void;
   downloadUpdate: () => Promise<void>;
   installUpdate: () => Promise<void>;
+  checkForUpdates: () => Promise<
+    | { ok: true; currentVersion: string; latestVersion: string; available: boolean }
+    | { ok: false; error: string }
+  >;
 }
 
 declare global {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -96,6 +96,10 @@ const updaterAPI = {
   },
   downloadUpdate: () => ipcRenderer.invoke("updater:download"),
   installUpdate: () => ipcRenderer.invoke("updater:install"),
+  checkForUpdates: (): Promise<
+    | { ok: true; currentVersion: string; latestVersion: string; available: boolean }
+    | { ok: false; error: string }
+  > => ipcRenderer.invoke("updater:check"),
 };
 
 if (process.contextIsolated) {

--- a/apps/desktop/src/renderer/src/components/updates-settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/updates-settings-tab.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useState } from "react";
+import { AlertCircle, ArrowDownToLine, Check, Loader2 } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+
+type CheckState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "up-to-date"; currentVersion: string }
+  | { status: "available"; latestVersion: string }
+  | { status: "error"; message: string };
+
+export function UpdatesSettingsTab() {
+  const [state, setState] = useState<CheckState>({ status: "idle" });
+
+  const handleCheck = useCallback(async () => {
+    setState({ status: "checking" });
+    const result = await window.updater.checkForUpdates();
+    if (!result.ok) {
+      setState({ status: "error", message: result.error });
+      return;
+    }
+    setState(
+      result.available
+        ? { status: "available", latestVersion: result.latestVersion }
+        : { status: "up-to-date", currentVersion: result.currentVersion },
+    );
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold">Updates</h2>
+      <p className="text-sm text-muted-foreground mt-1">
+        The desktop app checks for new versions automatically once an hour and
+        shortly after launch.
+      </p>
+
+      <div className="mt-6 divide-y">
+        <div className="flex items-start justify-between gap-6 py-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium">Check for updates</p>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Trigger a check now instead of waiting for the next automatic
+              poll. Available updates appear as a notification in the corner.
+            </p>
+            {state.status === "up-to-date" && (
+              <p className="text-sm text-muted-foreground mt-2 inline-flex items-center gap-1.5">
+                <Check className="size-3.5 text-success" />
+                You&apos;re on the latest version (v{state.currentVersion}).
+              </p>
+            )}
+            {state.status === "available" && (
+              <p className="text-sm text-muted-foreground mt-2 inline-flex items-center gap-1.5">
+                <ArrowDownToLine className="size-3.5 text-primary" />
+                v{state.latestVersion} is available — see the download prompt
+                in the corner.
+              </p>
+            )}
+            {state.status === "error" && (
+              <p className="text-sm text-destructive mt-2 inline-flex items-center gap-1.5">
+                <AlertCircle className="size-3.5" />
+                {state.message}
+              </p>
+            )}
+          </div>
+          <div className="shrink-0">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCheck}
+              disabled={state.status === "checking"}
+            >
+              {state.status === "checking" ? (
+                <>
+                  <Loader2 className="size-3.5 animate-spin" />
+                  Checking…
+                </>
+              ) : (
+                "Check now"
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/routes.tsx
+++ b/apps/desktop/src/renderer/src/routes.tsx
@@ -19,8 +19,9 @@ import { DaemonRuntimeCard } from "./components/daemon-runtime-card";
 import { AgentsPage } from "@multica/views/agents";
 import { InboxPage } from "@multica/views/inbox";
 import { SettingsPage } from "@multica/views/settings";
-import { Server } from "lucide-react";
+import { Download, Server } from "lucide-react";
 import { DaemonSettingsTab } from "./components/daemon-settings-tab";
+import { UpdatesSettingsTab } from "./components/updates-settings-tab";
 import { WorkspaceRouteLayout } from "./components/workspace-route-layout";
 
 /**
@@ -129,6 +130,12 @@ export const appRoutes: RouteObject[] = [
                     label: "Daemon",
                     icon: Server,
                     content: <DaemonSettingsTab />,
+                  },
+                  {
+                    value: "updates",
+                    label: "Updates",
+                    icon: Download,
+                    content: <UpdatesSettingsTab />,
                   },
                 ]}
               />


### PR DESCRIPTION
## Summary

Resolves [MUL-1121](mention://issue/9b60b358-c63c-4492-8fef-6b44d2097b25) — the desktop update prompt felt random because it only ran once 5s after launch and never again. If that single check was lost (network hiccup, GitHub Releases slow), users had to fully restart the app to see a new release.

- **1h background poll** in `setupAutoUpdater` so long-running sessions still pick up new releases without an app restart.
- **"Check now" button** under a new **Updates** tab in Settings (desktop-only, sits next to the existing Daemon tab) — calls `autoUpdater.checkForUpdates()` on demand and shows immediate feedback (up-to-date / available / error).
- The button reuses the existing autoUpdater pipeline — when an update is available the corner `UpdateNotification` still drives the download flow; the tab only surfaces the check result.

## Test plan

- [ ] `pnpm --filter @multica/desktop typecheck` — passes
- [ ] `pnpm --filter @multica/desktop lint` — no new warnings
- [ ] Run `pnpm dev:desktop`, open Settings → Updates, click **Check now**, confirm the result text appears (up-to-date in dev = expected error since no `app-update.yml` is present; that surfaces in the destructive line as designed)
- [ ] In a packaged build, leave the app open >1h and confirm a periodic check fires (visible in the main-process console as a `checkForUpdates` call)