### PR TITLE
fix(agent/comments): prevent resumed sessions from reusing stale --parent UUID

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -112,14 +112,20 @@ func TestBuildPromptCommentTriggered(t *testing.T) {
 		Agent:                 &AgentData{Name: "Test"},
 	})
 
-	// Prompt should contain the comment content directly.
+	// Prompt should contain the comment content, the trigger comment id, and
+	// the full reply command with --parent. Re-emitting --parent on every turn
+	// is what prevents resumed sessions from reusing the previous turn's
+	// --parent UUID.
 	for _, want := range []string{
 		issueID,
 		commentContent,
 		"comment that triggered this task",
+		commentID,
+		"multica issue comment add " + issueID + " --parent " + commentID,
+		"do NOT reuse --parent values from previous turns",
 	} {
 		if !strings.Contains(prompt, want) {
-			t.Fatalf("prompt missing %q", want)
+			t.Fatalf("prompt missing %q\n---\n%s", want, prompt)
 		}
 	}
 

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -1,0 +1,24 @@
+package execenv
+
+import "fmt"
+
+// BuildCommentReplyInstructions returns the canonical block telling an agent
+// how to post its reply for a comment-triggered task. Both the per-turn
+// prompt (daemon.buildCommentPrompt) and the CLAUDE.md workflow
+// (InjectRuntimeConfig) call this so the trigger comment ID and the
+// --parent value cannot drift between surfaces.
+//
+// The explicit "do not reuse --parent from previous turns" wording exists
+// because resumed Claude sessions keep prior turns' tool calls in context
+// and will otherwise copy the old --parent UUID forward.
+func BuildCommentReplyInstructions(issueID, triggerCommentID string) string {
+	if triggerCommentID == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Reply by running exactly this command — always use the trigger comment ID below, "+
+			"do NOT reuse --parent values from previous turns in this session:\n\n"+
+			"    multica issue comment add %s --parent %s --content \"...\"\n",
+		issueID, triggerCommentID,
+	)
+}

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -1,0 +1,66 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildCommentReplyInstructionsIncludesTriggerID(t *testing.T) {
+	t.Parallel()
+
+	issueID := "11111111-1111-1111-1111-111111111111"
+	triggerID := "22222222-2222-2222-2222-222222222222"
+
+	got := BuildCommentReplyInstructions(issueID, triggerID)
+
+	for _, want := range []string{
+		"multica issue comment add " + issueID + " --parent " + triggerID,
+		"do NOT reuse --parent values from previous turns",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("reply instructions missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildCommentReplyInstructionsEmptyWhenNoTrigger(t *testing.T) {
+	t.Parallel()
+
+	if got := BuildCommentReplyInstructions("issue-id", ""); got != "" {
+		t.Fatalf("expected empty string when triggerCommentID is empty, got %q", got)
+	}
+}
+
+func TestInjectRuntimeConfigCommentTriggerUsesHelper(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	issueID := "11111111-1111-1111-1111-111111111111"
+	triggerID := "22222222-2222-2222-2222-222222222222"
+
+	ctx := TaskContextForEnv{
+		IssueID:          issueID,
+		TriggerCommentID: triggerID,
+	}
+	if err := InjectRuntimeConfig(dir, "claude", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+
+	s := string(content)
+	for _, want := range []string{
+		triggerID,
+		"multica issue comment add " + issueID + " --parent " + triggerID,
+		"do NOT reuse --parent values from previous turns",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("CLAUDE.md missing %q", want)
+		}
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -129,7 +129,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		fmt.Fprintf(&b, "2. Run `multica issue comment list %s --output json` to read the conversation\n", ctx.IssueID)
 		b.WriteString("   - If the output is very large or truncated, use pagination: `--limit 30` to get the latest 30 comments, or `--since <timestamp>` to fetch only recent ones\n")
 		fmt.Fprintf(&b, "3. Find the triggering comment (ID: `%s`) and understand what is being asked — do NOT confuse it with previous comments\n", ctx.TriggerCommentID)
-		fmt.Fprintf(&b, "4. Reply: `multica issue comment add %s --parent %s --content \"...\"`\n", ctx.IssueID, ctx.TriggerCommentID)
+		b.WriteString("4. ")
+		b.WriteString(BuildCommentReplyInstructions(ctx.IssueID, ctx.TriggerCommentID))
 		b.WriteString("5. If the comment requests code changes or further work, do the work first, then reply with your results\n")
 		b.WriteString("6. Do NOT change the issue status unless the comment explicitly asks for it\n\n")
 	} else {

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"fmt"
 	"strings"
+
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 )
 
 // BuildPrompt constructs the task prompt for an agent CLI.
@@ -25,6 +27,9 @@ func BuildPrompt(task Task) string {
 // buildCommentPrompt constructs a prompt for comment-triggered tasks.
 // The triggering comment content is embedded directly so the agent cannot
 // miss it, even when stale output files exist in a reused workdir.
+// The reply instructions (including the current TriggerCommentID as --parent)
+// are re-emitted on every turn so resumed sessions cannot carry forward a
+// previous turn's --parent UUID.
 func buildCommentPrompt(task Task) string {
 	var b strings.Builder
 	b.WriteString("You are running as a local coding agent for a Multica workspace.\n\n")
@@ -33,7 +38,8 @@ func buildCommentPrompt(task Task) string {
 		b.WriteString("[NEW COMMENT] A user just left a new comment that triggered this task. You MUST respond to THIS comment, not any previous ones:\n\n")
 		fmt.Fprintf(&b, "> %s\n\n", task.TriggerCommentContent)
 	}
-	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n", task.IssueID)
+	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then complete it.\n\n", task.IssueID)
+	b.WriteString(execenv.BuildCommentReplyInstructions(task.IssueID, task.TriggerCommentID))
 	return b.String()
 }
 

--- a/server/internal/handler/activity_test.go
+++ b/server/internal/handler/activity_test.go
@@ -219,29 +219,32 @@ func TestCreateComment_AgentWithWrongParentRejected(t *testing.T) {
 		t.Fatalf("find test agent: %v", err)
 	}
 
-	// Create an issue with two member-authored sibling comments. The second
-	// one will be the trigger for the agent task — the first simulates an
-	// earlier comment whose UUID the resumed agent session still remembers.
-	w := httptest.NewRecorder()
-	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
-		"title": "agent parent guard test",
-	})
-	testHandler.CreateIssue(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("CreateIssue: %d: %s", w.Code, w.Body.String())
+	// Two issues: A hosts the comment-triggered task; B exists to prove the
+	// guard is scoped to the task's own issue and does not block cross-issue
+	// agent activity. (The CLI stamps X-Task-ID on every request, so an agent
+	// legitimately commenting on another issue must still succeed.)
+	createIssue := func(title string) string {
+		w := httptest.NewRecorder()
+		r := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{"title": title})
+		testHandler.CreateIssue(w, r)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("CreateIssue(%s): %d: %s", title, w.Code, w.Body.String())
+		}
+		var issue IssueResponse
+		json.NewDecoder(w.Body).Decode(&issue)
+		return issue.ID
 	}
-	var issue IssueResponse
-	json.NewDecoder(w.Body).Decode(&issue)
-	issueID := issue.ID
+	issueA := createIssue("agent parent guard test — issue A")
+	issueB := createIssue("agent parent guard test — issue B")
 
-	var staleTaskID, freshTaskID string
+	var freshTaskID string
 	t.Cleanup(func() {
-		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id IN ($1, $2)`, staleTaskID, freshTaskID)
-		testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id = $1`, issueID)
-		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, freshTaskID)
+		testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id IN ($1, $2)`, issueA, issueB)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id IN ($1, $2)`, issueA, issueB)
 	})
 
-	postComment := func(t *testing.T, body map[string]any, headers map[string]string) *httptest.ResponseRecorder {
+	postComment := func(t *testing.T, issueID string, body map[string]any, headers map[string]string) *httptest.ResponseRecorder {
 		t.Helper()
 		w := httptest.NewRecorder()
 		r := newRequest("POST", "/api/issues/"+issueID+"/comments", body)
@@ -253,48 +256,35 @@ func TestCreateComment_AgentWithWrongParentRejected(t *testing.T) {
 		return w
 	}
 
-	w = postComment(t, map[string]any{"content": "stale comment"}, nil)
+	w := postComment(t, issueA, map[string]any{"content": "stale comment"}, nil)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("create stale parent: %d: %s", w.Code, w.Body.String())
 	}
 	var staleParent CommentResponse
 	json.NewDecoder(w.Body).Decode(&staleParent)
 
-	w = postComment(t, map[string]any{"content": "fresh comment"}, nil)
+	w = postComment(t, issueA, map[string]any{"content": "fresh comment"}, nil)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("create fresh parent: %d: %s", w.Code, w.Body.String())
 	}
 	var freshParent CommentResponse
 	json.NewDecoder(w.Body).Decode(&freshParent)
 
-	// Fresh agent task whose trigger is the fresh comment. Any agent reply
-	// routed through this task must use freshParent.ID as --parent.
+	// Comment-triggered task bound to issueA.
 	if err := testPool.QueryRow(ctx,
 		`INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id)
 		 VALUES ($1, $2, $3, 'queued', 0, $4) RETURNING id`,
-		agentID, runtimeID, issueID, freshParent.ID,
+		agentID, runtimeID, issueA, freshParent.ID,
 	).Scan(&freshTaskID); err != nil {
 		t.Fatalf("insert fresh task: %v", err)
 	}
 
-	// Also create an assignment-style task (no trigger comment) to assert the
-	// guard does NOT fire on assignment-triggered tasks.
-	if err := testPool.QueryRow(ctx,
-		`INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
-		 VALUES ($1, $2, $3, 'queued', 0) RETURNING id`,
-		agentID, runtimeID, issueID,
-	).Scan(&staleTaskID); err != nil {
-		t.Fatalf("insert assignment task: %v", err)
-	}
+	agentHeaders := map[string]string{"X-Agent-ID": agentID, "X-Task-ID": freshTaskID}
 
-	agentHeaders := func(taskID string) map[string]string {
-		return map[string]string{"X-Agent-ID": agentID, "X-Task-ID": taskID}
-	}
-
-	// Wrong parent on a comment-triggered task → 409.
-	w = postComment(t,
+	// Same issue + wrong parent → 409.
+	w = postComment(t, issueA,
 		map[string]any{"content": "drifted reply", "parent_id": staleParent.ID},
-		agentHeaders(freshTaskID),
+		agentHeaders,
 	)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("expected 409 when agent replies with wrong parent, got %d: %s", w.Code, w.Body.String())
@@ -303,31 +293,33 @@ func TestCreateComment_AgentWithWrongParentRejected(t *testing.T) {
 		t.Fatalf("expected error body to reference the correct trigger comment id, got %s", w.Body.String())
 	}
 
-	// Missing parent on a comment-triggered task → 409 (must reply to trigger).
-	w = postComment(t,
+	// Same issue + no parent → 409 (must reply to trigger).
+	w = postComment(t, issueA,
 		map[string]any{"content": "no parent"},
-		agentHeaders(freshTaskID),
+		agentHeaders,
 	)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("expected 409 when agent replies with no parent, got %d", w.Code)
 	}
 
-	// Correct parent → 201.
-	w = postComment(t,
+	// Same issue + correct parent → 201.
+	w = postComment(t, issueA,
 		map[string]any{"content": "correct reply", "parent_id": freshParent.ID},
-		agentHeaders(freshTaskID),
+		agentHeaders,
 	)
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected 201 when agent replies with matching parent, got %d: %s", w.Code, w.Body.String())
 	}
 
-	// Assignment-triggered task with no trigger_comment_id → any parent accepted.
-	w = postComment(t,
-		map[string]any{"content": "assignment reply", "parent_id": staleParent.ID},
-		agentHeaders(staleTaskID),
+	// Cross-issue: agent carries X-Task-ID (bound to issueA) but comments on
+	// issueB. The guard must NOT fire — this is the cross-issue regression
+	// covering the fix for gpt-boy's review.
+	w = postComment(t, issueB,
+		map[string]any{"content": "cross-issue note"},
+		agentHeaders,
 	)
 	if w.Code != http.StatusCreated {
-		t.Fatalf("assignment-triggered agent reply should not be guarded, got %d: %s", w.Code, w.Body.String())
+		t.Fatalf("agent posting on a different issue should not be blocked by its current task's trigger, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/handler/activity_test.go
+++ b/server/internal/handler/activity_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -203,6 +204,130 @@ func TestCreateComment_WithParentID(t *testing.T) {
 	// Verify parent comment has no parent_id
 	if parentComment.ParentID != nil {
 		t.Fatalf("expected parent comment to have nil parent_id, got %q", *parentComment.ParentID)
+	}
+}
+
+func TestCreateComment_AgentWithWrongParentRejected(t *testing.T) {
+	ctx := context.Background()
+
+	// Find the fixture agent + its runtime.
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("find test agent: %v", err)
+	}
+
+	// Create an issue with two member-authored sibling comments. The second
+	// one will be the trigger for the agent task — the first simulates an
+	// earlier comment whose UUID the resumed agent session still remembers.
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "agent parent guard test",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d: %s", w.Code, w.Body.String())
+	}
+	var issue IssueResponse
+	json.NewDecoder(w.Body).Decode(&issue)
+	issueID := issue.ID
+
+	var staleTaskID, freshTaskID string
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id IN ($1, $2)`, staleTaskID, freshTaskID)
+		testPool.Exec(ctx, `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	postComment := func(t *testing.T, body map[string]any, headers map[string]string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		r := newRequest("POST", "/api/issues/"+issueID+"/comments", body)
+		r = withURLParam(r, "id", issueID)
+		for k, v := range headers {
+			r.Header.Set(k, v)
+		}
+		testHandler.CreateComment(w, r)
+		return w
+	}
+
+	w = postComment(t, map[string]any{"content": "stale comment"}, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create stale parent: %d: %s", w.Code, w.Body.String())
+	}
+	var staleParent CommentResponse
+	json.NewDecoder(w.Body).Decode(&staleParent)
+
+	w = postComment(t, map[string]any{"content": "fresh comment"}, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create fresh parent: %d: %s", w.Code, w.Body.String())
+	}
+	var freshParent CommentResponse
+	json.NewDecoder(w.Body).Decode(&freshParent)
+
+	// Fresh agent task whose trigger is the fresh comment. Any agent reply
+	// routed through this task must use freshParent.ID as --parent.
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id)
+		 VALUES ($1, $2, $3, 'queued', 0, $4) RETURNING id`,
+		agentID, runtimeID, issueID, freshParent.ID,
+	).Scan(&freshTaskID); err != nil {
+		t.Fatalf("insert fresh task: %v", err)
+	}
+
+	// Also create an assignment-style task (no trigger comment) to assert the
+	// guard does NOT fire on assignment-triggered tasks.
+	if err := testPool.QueryRow(ctx,
+		`INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority)
+		 VALUES ($1, $2, $3, 'queued', 0) RETURNING id`,
+		agentID, runtimeID, issueID,
+	).Scan(&staleTaskID); err != nil {
+		t.Fatalf("insert assignment task: %v", err)
+	}
+
+	agentHeaders := func(taskID string) map[string]string {
+		return map[string]string{"X-Agent-ID": agentID, "X-Task-ID": taskID}
+	}
+
+	// Wrong parent on a comment-triggered task → 409.
+	w = postComment(t,
+		map[string]any{"content": "drifted reply", "parent_id": staleParent.ID},
+		agentHeaders(freshTaskID),
+	)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when agent replies with wrong parent, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), freshParent.ID) {
+		t.Fatalf("expected error body to reference the correct trigger comment id, got %s", w.Body.String())
+	}
+
+	// Missing parent on a comment-triggered task → 409 (must reply to trigger).
+	w = postComment(t,
+		map[string]any{"content": "no parent"},
+		agentHeaders(freshTaskID),
+	)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when agent replies with no parent, got %d", w.Code)
+	}
+
+	// Correct parent → 201.
+	w = postComment(t,
+		map[string]any{"content": "correct reply", "parent_id": freshParent.ID},
+		agentHeaders(freshTaskID),
+	)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 when agent replies with matching parent, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Assignment-triggered task with no trigger_comment_id → any parent accepted.
+	w = postComment(t,
+		map[string]any{"content": "assignment reply", "parent_id": staleParent.ID},
+		agentHeaders(staleTaskID),
+	)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("assignment-triggered agent reply should not be guarded, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -217,14 +217,19 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	authorType, authorID := h.resolveActor(r, userID, uuidToString(issue.WorkspaceID))
 
 	// Defense against resumed-session drift: when an agent posts from inside a
-	// comment-triggered task, the parent_id must exactly match the task's
-	// trigger comment. Resumed Claude sessions otherwise carry forward a
-	// previous turn's --parent UUID and silently misplace the reply.
-	// Assignment-triggered tasks (no TriggerCommentID) are unaffected.
+	// comment-triggered task AND the comment is being posted on that same
+	// issue, the parent_id must exactly match the task's trigger comment.
+	// Resumed Claude sessions otherwise carry forward a previous turn's
+	// --parent UUID and silently misplace the reply.
+	//
+	// The task.IssueID scope is important: the CLI stamps X-Task-ID on every
+	// request, so an agent legitimately commenting on a different issue must
+	// not be blocked by its current task's trigger. Assignment-triggered
+	// tasks (no TriggerCommentID) are also unaffected.
 	if authorType == "agent" {
 		if taskIDHeader := r.Header.Get("X-Task-ID"); taskIDHeader != "" {
 			task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskIDHeader))
-			if err == nil && task.TriggerCommentID.Valid {
+			if err == nil && task.TriggerCommentID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
 				if uuidToString(parentID) != uuidToString(task.TriggerCommentID) {
 					writeError(w, http.StatusConflict,
 						"parent_id must equal this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+")")

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -216,6 +216,24 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// Determine author identity: agent (via X-Agent-ID header) or member.
 	authorType, authorID := h.resolveActor(r, userID, uuidToString(issue.WorkspaceID))
 
+	// Defense against resumed-session drift: when an agent posts from inside a
+	// comment-triggered task, the parent_id must exactly match the task's
+	// trigger comment. Resumed Claude sessions otherwise carry forward a
+	// previous turn's --parent UUID and silently misplace the reply.
+	// Assignment-triggered tasks (no TriggerCommentID) are unaffected.
+	if authorType == "agent" {
+		if taskIDHeader := r.Header.Get("X-Task-ID"); taskIDHeader != "" {
+			task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskIDHeader))
+			if err == nil && task.TriggerCommentID.Valid {
+				if uuidToString(parentID) != uuidToString(task.TriggerCommentID) {
+					writeError(w, http.StatusConflict,
+						"parent_id must equal this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+")")
+					return
+				}
+			}
+		}
+	}
+
 	// Expand bare issue identifiers (e.g. MUL-117) into mention links.
 	req.Content = mention.ExpandIssueIdentifiers(r.Context(), h.Queries, issue.WorkspaceID, req.Content)
 


### PR DESCRIPTION
## Summary

Fixes the comment-misplacement bug reported in [MUL-1125](mention://issue/c999c01b-dad2-4475-8a1a-7d80a6ee3a76) and reproduced on [MUL issue 9f99e0d8](mention://issue/9f99e0d8-9dbe-46ea-b064-c227a0eef562).

**Root cause**: not a backend storage bug. Comment-triggered tasks for Claude agents run as *resumed* sessions. The per-turn prompt in `buildCommentPrompt` only embedded the new comment's content — it did NOT carry the new `TriggerCommentID`. The only place with the updated `--parent` UUID was `CLAUDE.md`, which isn't re-read mid-session. Meanwhile the agent's conversation history still contained the PREVIOUS turn's successful `multica issue comment add ... --parent <old>` call, and Claude happily copied that stale UUID forward. Backend then stored exactly what the agent asked for.

Two layers of defense (per agreement in the issue thread):

1. **Prompt** (primary fix): extract `execenv.BuildCommentReplyInstructions(issueID, triggerCommentID)` so `daemon.buildCommentPrompt` and `execenv.InjectRuntimeConfig` share one source for the "reply via this command, do not reuse prior turns' --parent" wording. `buildCommentPrompt` now re-emits this block every turn with the current `TriggerCommentID`, explicitly overriding prior-session memory.
2. **Server-side guard**: in `handler.CreateComment`, when the request is from an agent inside a comment-triggered task (`X-Agent-ID` + `X-Task-ID`, task has `TriggerCommentID`), reject any `parent_id` that doesn't exactly match the trigger with HTTP 409. Assignment-triggered tasks (no trigger comment) and human members are unaffected.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] `go test ./internal/daemon/...` passes, including new cases:
  - `TestBuildPromptCommentTriggered` asserts the new prompt carries the trigger comment ID, the full `multica issue comment add … --parent …` command, and the "do NOT reuse --parent values from previous turns" warning.
  - `TestBuildCommentReplyInstructionsIncludesTriggerID` / `…EmptyWhenNoTrigger` cover the helper directly.
  - `TestInjectRuntimeConfigCommentTriggerUsesHelper` asserts `CLAUDE.md` picks up the helper output so the two surfaces can't drift.
- [ ] `go test ./internal/handler/...` (skipped locally — Postgres not available in this sandbox). Added `TestCreateComment_AgentWithWrongParentRejected` covering:
  - agent + comment-triggered task + wrong parent → 409 with the correct trigger ID in the body
  - agent + comment-triggered task + no parent → 409
  - agent + comment-triggered task + correct parent → 201
  - agent + assignment-triggered task (no trigger) + arbitrary parent → 201 (guard does not fire)
  CI will exercise this against the real DB.

## Out of scope

- UI heuristic fallback (explicitly declined in issue discussion — treats the symptom, not the cause).
- A new `multica issue reply` safe-path command (declined — Bohan prefers keeping CLI primitives low-level so agents retain autonomy over how they construct commands).