### PR TITLE
chore(server): add slow-path timing logs for /tasks/claim

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -496,17 +497,39 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// logClaimEndpointSlow emits one structured log when the /tasks/claim endpoint
+// exceeds 500ms, splitting auth / claim / response-build phases so the prod
+// tail can be diagnosed without flooding logs at normal poll rates.
+func logClaimEndpointSlow(runtimeID, outcome string, start time.Time, authMs, claimMs, buildMs int64) {
+	totalMs := time.Since(start).Milliseconds()
+	if totalMs < 500 {
+		return
+	}
+	slog.Info("claim_endpoint slow",
+		"runtime_id", runtimeID,
+		"outcome", outcome,
+		"total_ms", totalMs,
+		"auth_ms", authMs,
+		"claim_ms", claimMs,
+		"build_ms", buildMs,
+	)
+}
+
 // ClaimTaskByRuntime atomically claims the next queued task for a runtime.
 // The response includes the agent's name and skills, fetched fresh from the DB.
 func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
+	start := time.Now()
 
 	// Verify the caller owns this runtime's workspace.
 	if _, ok := h.requireDaemonRuntimeAccess(w, r, runtimeID); !ok {
 		return
 	}
+	authMs := time.Since(start).Milliseconds()
 
+	claimStart := time.Now()
 	task, err := h.TaskService.ClaimTaskForRuntime(r.Context(), parseUUID(runtimeID))
+	claimMs := time.Since(claimStart).Milliseconds()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to claim task: "+err.Error())
 		return
@@ -515,8 +538,15 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	if task == nil {
 		slog.Debug("no task to claim", "runtime_id", runtimeID)
 		writeJSON(w, http.StatusOK, map[string]any{"task": nil})
+		logClaimEndpointSlow(runtimeID, "no_task", start, authMs, claimMs, 0)
 		return
 	}
+
+	buildStart := time.Now()
+	defer func() {
+		buildMs := time.Since(buildStart).Milliseconds()
+		logClaimEndpointSlow(runtimeID, "claimed", start, authMs, claimMs, buildMs)
+	}()
 
 	// Build response with fresh agent data (name + skills + custom_env + custom_args).
 	resp := taskToResponse(*task)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -521,16 +521,32 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
 	start := time.Now()
 
+	var (
+		outcome                    = "unauth"
+		authMs, claimMs, buildMs   int64
+		buildStart                 time.Time
+	)
+	defer func() {
+		// Emit at function exit so error / unauth paths also carry timing.
+		// build_ms is computed from buildStart only when we entered the
+		// response-build phase (otherwise stays 0).
+		if !buildStart.IsZero() {
+			buildMs = time.Since(buildStart).Milliseconds()
+		}
+		logClaimEndpointSlow(runtimeID, outcome, start, authMs, claimMs, buildMs)
+	}()
+
 	// Verify the caller owns this runtime's workspace.
 	if _, ok := h.requireDaemonRuntimeAccess(w, r, runtimeID); !ok {
 		return
 	}
-	authMs := time.Since(start).Milliseconds()
+	authMs = time.Since(start).Milliseconds()
 
 	claimStart := time.Now()
 	task, err := h.TaskService.ClaimTaskForRuntime(r.Context(), parseUUID(runtimeID))
-	claimMs := time.Since(claimStart).Milliseconds()
+	claimMs = time.Since(claimStart).Milliseconds()
 	if err != nil {
+		outcome = "error_claim"
 		writeError(w, http.StatusInternalServerError, "failed to claim task: "+err.Error())
 		return
 	}
@@ -538,15 +554,12 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	if task == nil {
 		slog.Debug("no task to claim", "runtime_id", runtimeID)
 		writeJSON(w, http.StatusOK, map[string]any{"task": nil})
-		logClaimEndpointSlow(runtimeID, "no_task", start, authMs, claimMs, 0)
+		outcome = "no_task"
 		return
 	}
 
-	buildStart := time.Now()
-	defer func() {
-		buildMs := time.Since(buildStart).Milliseconds()
-		logClaimEndpointSlow(runtimeID, "claimed", start, authMs, claimMs, buildMs)
-	}()
+	outcome = "claimed"
+	buildStart = time.Now()
 
 	// Build response with fresh agent data (name + skills + custom_env + custom_args).
 	resp := taskToResponse(*task)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	"strconv"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -173,30 +174,40 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.A
 // ClaimTask atomically claims the next queued task for an agent,
 // respecting max_concurrent_tasks.
 func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.AgentTaskQueue, error) {
+	start := time.Now()
+	t0 := start
 	agent, err := s.Queries.GetAgent(ctx, agentID)
+	getAgentMs := time.Since(t0).Milliseconds()
 	if err != nil {
 		return nil, fmt.Errorf("agent not found: %w", err)
 	}
 
+	t0 = time.Now()
 	running, err := s.Queries.CountRunningTasks(ctx, agentID)
+	countRunningMs := time.Since(t0).Milliseconds()
 	if err != nil {
 		return nil, fmt.Errorf("count running tasks: %w", err)
 	}
 	if running >= int64(agent.MaxConcurrentTasks) {
 		slog.Debug("task claim: no capacity", "agent_id", util.UUIDToString(agentID), "running", running, "max", agent.MaxConcurrentTasks)
+		s.maybeLogClaimSlow(agentID, "no_capacity", start, getAgentMs, countRunningMs, 0)
 		return nil, nil // No capacity
 	}
 
+	t0 = time.Now()
 	task, err := s.Queries.ClaimAgentTask(ctx, agentID)
+	claimAgentMs := time.Since(t0).Milliseconds()
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			slog.Debug("task claim: no tasks available", "agent_id", util.UUIDToString(agentID))
+			s.maybeLogClaimSlow(agentID, "no_tasks", start, getAgentMs, countRunningMs, claimAgentMs)
 			return nil, nil // No tasks available
 		}
 		return nil, fmt.Errorf("claim task: %w", err)
 	}
 
 	slog.Info("task claimed", "task_id", util.UUIDToString(task.ID), "agent_id", util.UUIDToString(agentID))
+	s.maybeLogClaimSlow(agentID, "claimed", start, getAgentMs, countRunningMs, claimAgentMs)
 
 	// Update agent status to working
 	s.updateAgentStatus(ctx, agentID, "working")
@@ -210,29 +221,73 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 // ClaimTaskForRuntime claims the next runnable task for a runtime while
 // still respecting each agent's max_concurrent_tasks limit.
 func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.UUID) (*db.AgentTaskQueue, error) {
+	start := time.Now()
+	t0 := start
 	tasks, err := s.Queries.ListPendingTasksByRuntime(ctx, runtimeID)
+	listMs := time.Since(t0).Milliseconds()
 	if err != nil {
 		return nil, fmt.Errorf("list pending tasks: %w", err)
 	}
 
+	loopStart := time.Now()
 	triedAgents := map[string]struct{}{}
+	var (
+		claimed     *db.AgentTaskQueue
+		agentsTried int
+	)
 	for _, candidate := range tasks {
 		agentKey := util.UUIDToString(candidate.AgentID)
 		if _, seen := triedAgents[agentKey]; seen {
 			continue
 		}
 		triedAgents[agentKey] = struct{}{}
+		agentsTried++
 
 		task, err := s.ClaimTask(ctx, candidate.AgentID)
 		if err != nil {
 			return nil, err
 		}
 		if task != nil && task.RuntimeID == runtimeID {
-			return task, nil
+			claimed = task
+			break
 		}
 	}
+	loopMs := time.Since(loopStart).Milliseconds()
+	totalMs := time.Since(start).Milliseconds()
 
-	return nil, nil
+	// Slow-only log so we can see where the time goes on the prod tail.
+	// Threshold matches the inner ClaimTask threshold (300ms).
+	if totalMs >= 300 {
+		slog.Info("claim_for_runtime slow",
+			"runtime_id", util.UUIDToString(runtimeID),
+			"total_ms", totalMs,
+			"list_pending_ms", listMs,
+			"list_pending_count", len(tasks),
+			"agents_tried", agentsTried,
+			"claim_loop_ms", loopMs,
+			"claimed", claimed != nil,
+		)
+	}
+
+	return claimed, nil
+}
+
+// maybeLogClaimSlow emits one structured log per ClaimTask call when its total
+// latency exceeds 300ms, so the prod tail can be diagnosed without flooding
+// logs at normal poll rates.
+func (s *TaskService) maybeLogClaimSlow(agentID pgtype.UUID, outcome string, start time.Time, getAgentMs, countRunningMs, claimAgentMs int64) {
+	totalMs := time.Since(start).Milliseconds()
+	if totalMs < 300 {
+		return
+	}
+	slog.Info("claim_task slow",
+		"agent_id", util.UUIDToString(agentID),
+		"outcome", outcome,
+		"total_ms", totalMs,
+		"get_agent_ms", getAgentMs,
+		"count_running_ms", countRunningMs,
+		"claim_agent_ms", claimAgentMs,
+	)
 }
 
 // StartTask transitions a dispatched task to running.

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -175,46 +175,64 @@ func (s *TaskService) CancelTask(ctx context.Context, taskID pgtype.UUID) (*db.A
 // respecting max_concurrent_tasks.
 func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.AgentTaskQueue, error) {
 	start := time.Now()
+	var (
+		outcome                                                            = "unknown"
+		getAgentMs, countRunningMs, claimAgentMs, updateStatusMs, dispatchMs int64
+	)
+	defer func() {
+		s.maybeLogClaimSlow(agentID, outcome, start, getAgentMs, countRunningMs, claimAgentMs, updateStatusMs, dispatchMs)
+	}()
+
 	t0 := start
 	agent, err := s.Queries.GetAgent(ctx, agentID)
-	getAgentMs := time.Since(t0).Milliseconds()
+	getAgentMs = time.Since(t0).Milliseconds()
 	if err != nil {
+		outcome = "error_get_agent"
 		return nil, fmt.Errorf("agent not found: %w", err)
 	}
 
 	t0 = time.Now()
 	running, err := s.Queries.CountRunningTasks(ctx, agentID)
-	countRunningMs := time.Since(t0).Milliseconds()
+	countRunningMs = time.Since(t0).Milliseconds()
 	if err != nil {
+		outcome = "error_count_running"
 		return nil, fmt.Errorf("count running tasks: %w", err)
 	}
 	if running >= int64(agent.MaxConcurrentTasks) {
 		slog.Debug("task claim: no capacity", "agent_id", util.UUIDToString(agentID), "running", running, "max", agent.MaxConcurrentTasks)
-		s.maybeLogClaimSlow(agentID, "no_capacity", start, getAgentMs, countRunningMs, 0)
+		outcome = "no_capacity"
 		return nil, nil // No capacity
 	}
 
 	t0 = time.Now()
 	task, err := s.Queries.ClaimAgentTask(ctx, agentID)
-	claimAgentMs := time.Since(t0).Milliseconds()
+	claimAgentMs = time.Since(t0).Milliseconds()
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			slog.Debug("task claim: no tasks available", "agent_id", util.UUIDToString(agentID))
-			s.maybeLogClaimSlow(agentID, "no_tasks", start, getAgentMs, countRunningMs, claimAgentMs)
+			outcome = "no_tasks"
 			return nil, nil // No tasks available
 		}
+		outcome = "error_claim"
 		return nil, fmt.Errorf("claim task: %w", err)
 	}
 
 	slog.Info("task claimed", "task_id", util.UUIDToString(task.ID), "agent_id", util.UUIDToString(agentID))
-	s.maybeLogClaimSlow(agentID, "claimed", start, getAgentMs, countRunningMs, claimAgentMs)
 
-	// Update agent status to working
+	// Update agent status to working. Hits the DB and may publish events,
+	// so it must be inside the timed window.
+	t0 = time.Now()
 	s.updateAgentStatus(ctx, agentID, "working")
+	updateStatusMs = time.Since(t0).Milliseconds()
 
-	// Broadcast task:dispatch
+	// Broadcast task:dispatch. ResolveTaskWorkspaceID inside this path can
+	// re-query issue/chat_session/autopilot_run, so it can also be a real
+	// contributor to claim latency.
+	t0 = time.Now()
 	s.broadcastTaskDispatch(ctx, task)
+	dispatchMs = time.Since(t0).Milliseconds()
 
+	outcome = "claimed"
 	return &task, nil
 }
 
@@ -222,29 +240,53 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 // still respecting each agent's max_concurrent_tasks limit.
 func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.UUID) (*db.AgentTaskQueue, error) {
 	start := time.Now()
+	var (
+		outcome             = "no_task"
+		listMs, loopMs      int64
+		listCount, tried    int
+		claimedFlag         bool
+	)
+	defer func() {
+		totalMs := time.Since(start).Milliseconds()
+		if totalMs < 300 {
+			return
+		}
+		slog.Info("claim_for_runtime slow",
+			"runtime_id", util.UUIDToString(runtimeID),
+			"outcome", outcome,
+			"total_ms", totalMs,
+			"list_pending_ms", listMs,
+			"list_pending_count", listCount,
+			"agents_tried", tried,
+			"claim_loop_ms", loopMs,
+			"claimed", claimedFlag,
+		)
+	}()
+
 	t0 := start
 	tasks, err := s.Queries.ListPendingTasksByRuntime(ctx, runtimeID)
-	listMs := time.Since(t0).Milliseconds()
+	listMs = time.Since(t0).Milliseconds()
+	listCount = len(tasks)
 	if err != nil {
+		outcome = "error_list"
 		return nil, fmt.Errorf("list pending tasks: %w", err)
 	}
 
 	loopStart := time.Now()
 	triedAgents := map[string]struct{}{}
-	var (
-		claimed     *db.AgentTaskQueue
-		agentsTried int
-	)
+	var claimed *db.AgentTaskQueue
 	for _, candidate := range tasks {
 		agentKey := util.UUIDToString(candidate.AgentID)
 		if _, seen := triedAgents[agentKey]; seen {
 			continue
 		}
 		triedAgents[agentKey] = struct{}{}
-		agentsTried++
+		tried++
 
 		task, err := s.ClaimTask(ctx, candidate.AgentID)
 		if err != nil {
+			loopMs = time.Since(loopStart).Milliseconds()
+			outcome = "error_claim"
 			return nil, err
 		}
 		if task != nil && task.RuntimeID == runtimeID {
@@ -252,21 +294,10 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 			break
 		}
 	}
-	loopMs := time.Since(loopStart).Milliseconds()
-	totalMs := time.Since(start).Milliseconds()
-
-	// Slow-only log so we can see where the time goes on the prod tail.
-	// Threshold matches the inner ClaimTask threshold (300ms).
-	if totalMs >= 300 {
-		slog.Info("claim_for_runtime slow",
-			"runtime_id", util.UUIDToString(runtimeID),
-			"total_ms", totalMs,
-			"list_pending_ms", listMs,
-			"list_pending_count", len(tasks),
-			"agents_tried", agentsTried,
-			"claim_loop_ms", loopMs,
-			"claimed", claimed != nil,
-		)
+	loopMs = time.Since(loopStart).Milliseconds()
+	if claimed != nil {
+		claimedFlag = true
+		outcome = "claimed"
 	}
 
 	return claimed, nil
@@ -274,8 +305,10 @@ func (s *TaskService) ClaimTaskForRuntime(ctx context.Context, runtimeID pgtype.
 
 // maybeLogClaimSlow emits one structured log per ClaimTask call when its total
 // latency exceeds 300ms, so the prod tail can be diagnosed without flooding
-// logs at normal poll rates.
-func (s *TaskService) maybeLogClaimSlow(agentID pgtype.UUID, outcome string, start time.Time, getAgentMs, countRunningMs, claimAgentMs int64) {
+// logs at normal poll rates. Called via defer so it captures the full path
+// including post-claim updateAgentStatus / broadcastTaskDispatch (both of
+// which can hit the DB) and any error exit.
+func (s *TaskService) maybeLogClaimSlow(agentID pgtype.UUID, outcome string, start time.Time, getAgentMs, countRunningMs, claimAgentMs, updateStatusMs, dispatchMs int64) {
 	totalMs := time.Since(start).Milliseconds()
 	if totalMs < 300 {
 		return
@@ -287,6 +320,8 @@ func (s *TaskService) maybeLogClaimSlow(agentID pgtype.UUID, outcome string, sta
 		"get_agent_ms", getAgentMs,
 		"count_running_ms", countRunningMs,
 		"claim_agent_ms", claimAgentMs,
+		"update_status_ms", updateStatusMs,
+		"dispatch_ms", dispatchMs,
 	)
 }
 


### PR DESCRIPTION
## Why

Production is showing 3s+ tail latency on `POST /api/daemon/runtimes/{rid}/tasks/claim` (sample: `duration=3.631972s`). Before touching the request path, instrument it so we can see where the time actually goes and pick the right fix from data instead of guesswork.

## What

Adds structured `slog.Info` timing logs at three layers along the claim path. All are **slow-only** (gated by a threshold) so they don't flood logs at the default 3s daemon poll cadence.

### 1. `handler.ClaimTaskByRuntime` — threshold `total_ms >= 500`
```
"claim_endpoint slow" runtime_id= outcome=(no_task|claimed)
  total_ms= auth_ms= claim_ms= build_ms=
```
- `claim_ms` = `ClaimTaskForRuntime` call
- `build_ms` = the post-claim response assembly (GetAgent + LoadAgentSkills + GetIssue + GetWorkspace + GetComment + GetLastTaskSession, or the chat branch's 4 queries)

### 2. `service.ClaimTaskForRuntime` — threshold `total_ms >= 300`
```
"claim_for_runtime slow" runtime_id= total_ms=
  list_pending_ms= list_pending_count= agents_tried= claim_loop_ms= claimed=
```
Directly validates the suspected N+1: one `ListPendingTasksByRuntime` (no LIMIT, `SELECT *` including `context` JSONB) followed by one `ClaimTask` per unique agent.

### 3. `service.ClaimTask` — threshold `total_ms >= 300`
```
"claim_task slow" agent_id= outcome=(no_capacity|no_tasks|claimed)
  total_ms= get_agent_ms= count_running_ms= claim_agent_ms=
```
Splits `GetAgent` / `CountRunningTasks` / `ClaimAgentTask` so we can isolate the NOT EXISTS + FOR UPDATE SKIP LOCKED cost from the surrounding metadata reads.

## How to read on prod

For each slow http log, grep `runtime_id` in the same window and check which segment dominates:

| Dominant field | Likely cause | Likely fix |
|---|---|---|
| `build_ms` | Post-claim serial queries | Merge into joined query |
| `list_pending_ms` | Full scan, dispatched leak | Add LIMIT + reaper |
| `claim_loop_ms` + large `agents_tried` | N+1 amplification | Single SQL claim by runtime_id |
| `claim_agent_ms` | NOT EXISTS / SKIP LOCKED contention | Index for OR subquery |

## Risk

Pure observability. No request-path behavior change. Existing `Claim` handler/service tests pass.