### PR TITLE
chore(server): log pgxpool config + periodic stats to confirm pool exhaustion

### DIFF
--- a/server/cmd/server/dbstats.go
+++ b/server/cmd/server/dbstats.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	// dbStatsInterval is how often the pool stats are sampled and logged.
+	// 15s lines up with the daemon heartbeat cadence so it's easy to
+	// correlate with traffic patterns in the prod logs.
+	dbStatsInterval = 15 * time.Second
+)
+
+// logPoolConfig prints the effective pgxpool configuration once at startup.
+// Surfacing this is critical because pgxpool defaults are surprisingly small
+// (MaxConns = max(4, NumCPU)) — without seeing the value in the log it's
+// easy to mistake pool exhaustion for "the database is slow".
+func logPoolConfig(pool *pgxpool.Pool) {
+	cfg := pool.Config()
+	slog.Info("db pool config",
+		"max_conns", cfg.MaxConns,
+		"min_conns", cfg.MinConns,
+		"max_conn_lifetime", cfg.MaxConnLifetime.String(),
+		"max_conn_idle_time", cfg.MaxConnIdleTime.String(),
+		"health_check_period", cfg.HealthCheckPeriod.String(),
+	)
+}
+
+// runDBStatsLogger samples pool.Stat() periodically. It always emits an INFO
+// line so operators can see baseline pressure, and emits a WARN whenever the
+// EmptyAcquireCount delta is positive — that's the direct symptom of pool
+// exhaustion (a request had to wait because no idle conn was available) and
+// the smoking gun we're looking for to confirm the slow /tasks/claim
+// hypothesis.
+func runDBStatsLogger(ctx context.Context, pool *pgxpool.Pool) {
+	ticker := time.NewTicker(dbStatsInterval)
+	defer ticker.Stop()
+
+	var (
+		lastEmpty       int64
+		lastAcquire     int64
+		lastAcquireDur  time.Duration
+		lastCanceled    int64
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		s := pool.Stat()
+		emptyDelta := s.EmptyAcquireCount() - lastEmpty
+		acquireDelta := s.AcquireCount() - lastAcquire
+		acquireDurDelta := s.AcquireDuration() - lastAcquireDur
+		canceledDelta := s.CanceledAcquireCount() - lastCanceled
+
+		// Average wait per acquire over the last sampling window. Useful
+		// because cumulative AcquireDuration alone hides whether the
+		// situation is improving or worsening.
+		var avgAcquireMs int64
+		if acquireDelta > 0 {
+			avgAcquireMs = (acquireDurDelta).Milliseconds() / acquireDelta
+		}
+
+		fields := []any{
+			"max_conns", s.MaxConns(),
+			"total_conns", s.TotalConns(),
+			"acquired_conns", s.AcquiredConns(),
+			"idle_conns", s.IdleConns(),
+			"constructing_conns", s.ConstructingConns(),
+			"acquire_count_delta", acquireDelta,
+			"empty_acquire_delta", emptyDelta,
+			"canceled_acquire_delta", canceledDelta,
+			"avg_acquire_ms", avgAcquireMs,
+		}
+
+		if emptyDelta > 0 || canceledDelta > 0 {
+			slog.Warn("db pool pressure", fields...)
+		} else {
+			slog.Info("db pool stats", fields...)
+		}
+
+		lastEmpty = s.EmptyAcquireCount()
+		lastAcquire = s.AcquireCount()
+		lastAcquireDur = s.AcquireDuration()
+		lastCanceled = s.CanceledAcquireCount()
+	}
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -53,6 +53,7 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("connected to database")
+	logPoolConfig(pool)
 
 	bus := events.New()
 	hub := realtime.NewHub()
@@ -84,6 +85,7 @@ func main() {
 	// Start background sweeper to mark stale runtimes as offline.
 	go runRuntimeSweeper(sweepCtx, queries, bus)
 	go runAutopilotScheduler(autopilotCtx, queries, autopilotSvc)
+	go runDBStatsLogger(sweepCtx, pool)
 
 	// Graceful shutdown
 	go func() {


### PR DESCRIPTION
## Why

Following up on the prod data we got after #1376 merged. The slow logs revealed a strong pattern that single-query optimization can't explain:

```
08:25:34.044 claim_endpoint slow ... outcome=no_task total_ms=2152 auth_ms=1437 claim_ms=714 build_ms=0
08:25:34.044 claim_for_runtime ... outcome=no_task total_ms=713 list_pending_ms=713 list_pending_count=0
```

Two anomalies:

1. **`list_pending_ms=713` with `list_pending_count=0`** — a 0-row scan against a partial index (`idx_agent_task_queue_runtime_pending`) cannot take 713ms.
2. **Unrelated endpoints completed at the same wall-clock instant** — within a few ms of `08:25:34.044`: `/tasks/claim`, multiple `/api/daemon/heartbeat`, `/api/workspaces`, `/api/runtimes/.../ping`, all with durations clustered at ~1.4s and ~2.88s.

Independent endpoints don't synchronize completion by accident. The only explanation that fits is **requests blocking on a shared resource and being released together**. The most likely culprit is **pgxpool acquire wait**: `server/cmd/server/main.go` calls `pgxpool.New(ctx, dbURL)` with no config, so `MaxConns` defaults to `max(4, NumCPU)`. Under the daemon poll fan-in (every daemon polls every 3s) this is trivially exhausted.

The math also fits: each of the timed phases adds ~700ms, suggesting each DB call waits ~700ms for a connection (auth makes 2 queries → ~1437ms; claim's `ListPendingTasksByRuntime` makes 1 query → ~713ms).

## What

Pure observability. Pool sizing is intentionally **not** changed yet — we want the data first.

### `logPoolConfig` (one-shot, at startup)
Prints `MaxConns / MinConns / MaxConnLifetime / MaxConnIdleTime / HealthCheckPeriod`. Surfacing the effective limit is critical: the default is surprisingly small and easy to mistake for 'the database is slow'.

### `runDBStatsLogger` (every 15s)
Samples `pool.Stat()` and emits:
- INFO baseline: `total_conns`, `acquired_conns`, `idle_conns`, `constructing_conns`
- Per-window deltas: `acquire_count_delta`, `empty_acquire_delta`, `canceled_acquire_delta`, `avg_acquire_ms`
- **Auto-upgrades to WARN** when `empty_acquire_delta > 0` or `canceled_acquire_delta > 0` — those are the direct symptom of a request waiting because no idle connection was available.

15s cadence matches the daemon heartbeat interval so timestamps line up cleanly with traffic patterns.

## Verification plan after deploy

If the hypothesis is right, we should see `db pool pressure` WARN lines coincident with the existing `claim_endpoint slow` lines, with `acquired_conns == max_conns` and rising `empty_acquire_delta`. Once confirmed, the fix is a one-liner (raise `MaxConns` via `ParseConfig`, possibly bound by pgbouncer config) plus the previously-discussed N+1 reduction to lower demand.

## Risk

Background goroutine, no request-path changes. Builds and `cmd/server` tests pass.