### PR TITLE
feat(server): configurable pgxpool size with sane defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ POSTGRES_USER=multica
 POSTGRES_PASSWORD=multica
 POSTGRES_PORT=5432
 DATABASE_URL=postgres://multica:multica@localhost:5432/multica?sslmode=disable
+# Optional pgxpool tuning. Defaults are 25 / 5 per pod and are usually fine.
+# You can also set pool_max_conns / pool_min_conns as query params on
+# DATABASE_URL; env vars below take precedence over URL params.
+# DATABASE_MAX_CONNS=25
+# DATABASE_MIN_CONNS=5
 
 # Server
 # APP_ENV gates dev-only auth shortcuts (primarily the 888888 master code).

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -11,6 +11,8 @@ All configuration is done via environment variables. Copy `.env.example` as a st
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `DATABASE_URL` | PostgreSQL connection string | `postgres://multica:multica@localhost:5432/multica?sslmode=disable` |
+| `DATABASE_MAX_CONNS` | pgxpool max connections per pod (default `25`). Total `pod_count × DATABASE_MAX_CONNS` should stay well below the Postgres `max_connections` limit. | `25` |
+| `DATABASE_MIN_CONNS` | pgxpool warm baseline connections per pod (default `5`). | `5` |
 | `JWT_SECRET` | **Must change from default.** Secret key for signing JWT tokens. Use a long random string. | `openssl rand -hex 32` |
 | `FRONTEND_ORIGIN` | URL where the frontend is served (used for CORS) | `https://app.example.com` |
 

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -11,10 +11,17 @@ All configuration is done via environment variables. Copy `.env.example` as a st
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `DATABASE_URL` | PostgreSQL connection string | `postgres://multica:multica@localhost:5432/multica?sslmode=disable` |
-| `DATABASE_MAX_CONNS` | pgxpool max connections per pod (default `25`). Total `pod_count × DATABASE_MAX_CONNS` should stay well below the Postgres `max_connections` limit. | `25` |
-| `DATABASE_MIN_CONNS` | pgxpool warm baseline connections per pod (default `5`). | `5` |
 | `JWT_SECRET` | **Must change from default.** Secret key for signing JWT tokens. Use a long random string. | `openssl rand -hex 32` |
 | `FRONTEND_ORIGIN` | URL where the frontend is served (used for CORS) | `https://app.example.com` |
+
+### Database Pool Tuning (Optional)
+
+These have sensible defaults and only need to be set when tuning a large or constrained deployment. Precedence (highest first): env var → `pool_*` query params on `DATABASE_URL` → built-in default.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DATABASE_MAX_CONNS` | pgxpool max connections per pod. `pod_count × DATABASE_MAX_CONNS` should stay well below the Postgres `max_connections` ceiling. With a connection pooler (PgBouncer / RDS Proxy / Supavisor) in front, this can be raised significantly. | `25` |
+| `DATABASE_MIN_CONNS` | pgxpool warm baseline connections per pod. Auto-clamped to `DATABASE_MAX_CONNS`. | `5` |
 
 ### Email (Required for Authentication)
 

--- a/server/cmd/server/dbstats.go
+++ b/server/cmd/server/dbstats.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -13,7 +16,62 @@ const (
 	// 15s lines up with the daemon heartbeat cadence so it's easy to
 	// correlate with traffic patterns in the prod logs.
 	dbStatsInterval = 15 * time.Second
+
+	// defaultMaxConns / defaultMinConns are the per-pod pgxpool sizing
+	// defaults. They replace pgx's built-in default of max(4, NumCPU),
+	// which is far too small for our daemon-poll traffic pattern (~3800
+	// acquires/s observed in prod) and was the root cause of the 3s+
+	// /tasks/claim tail latency.
+	//
+	// The numbers follow the conventional "small pool, lots of waiters"
+	// guidance for Postgres (HikariCP / PG community formula
+	// `(core_count * 2) + effective_spindle_count`): 25 leaves headroom
+	// for bursts and the occasional long-running query while staying well
+	// below typical managed-Postgres `max_connections` ceilings when
+	// multiplied across pods. MinConns=5 keeps a warm baseline so cold
+	// pods don't pay handshake cost on first traffic.
+	//
+	// Both values are overridable via DATABASE_MAX_CONNS / DATABASE_MIN_CONNS.
+	defaultMaxConns int32 = 25
+	defaultMinConns int32 = 5
 )
+
+// newDBPool builds a pgxpool with sane production defaults and env overrides.
+//
+// pgxpool.New(ctx, url) — used previously — silently picks MaxConns =
+// max(4, NumCPU). On our prod pods (small CPU request) that resolved to 4,
+// which got fully saturated by the daemon claim/heartbeat traffic and showed
+// up as ~900ms acquire waits on every query.
+func newDBPool(ctx context.Context, dbURL string) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(dbURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse database url: %w", err)
+	}
+
+	cfg.MaxConns = envInt32("DATABASE_MAX_CONNS", defaultMaxConns)
+	cfg.MinConns = envInt32("DATABASE_MIN_CONNS", defaultMinConns)
+	if cfg.MinConns > cfg.MaxConns {
+		cfg.MinConns = cfg.MaxConns
+	}
+
+	return pgxpool.NewWithConfig(ctx, cfg)
+}
+
+// envInt32 reads an int32 from the named env var. Empty / invalid values fall
+// back to def and emit a warn so misconfiguration is visible in startup logs.
+func envInt32(name string, def int32) int32 {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || v <= 0 {
+		slog.Warn("invalid env var, using default",
+			"name", name, "value", raw, "default", def, "error", err)
+		return def
+	}
+	return int32(v)
+}
 
 // logPoolConfig prints the effective pgxpool configuration once at startup.
 // Surfacing this is critical because pgxpool defaults are surprisingly small
@@ -41,10 +99,10 @@ func runDBStatsLogger(ctx context.Context, pool *pgxpool.Pool) {
 	defer ticker.Stop()
 
 	var (
-		lastEmpty       int64
-		lastAcquire     int64
-		lastAcquireDur  time.Duration
-		lastCanceled    int64
+		lastEmpty      int64
+		lastAcquire    int64
+		lastAcquireDur time.Duration
+		lastCanceled   int64
 	)
 	for {
 		select {

--- a/server/cmd/server/dbstats.go
+++ b/server/cmd/server/dbstats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -42,19 +43,56 @@ const (
 // max(4, NumCPU). On our prod pods (small CPU request) that resolved to 4,
 // which got fully saturated by the daemon claim/heartbeat traffic and showed
 // up as ~900ms acquire waits on every query.
+//
+// Configuration precedence (highest first):
+//  1. DATABASE_MAX_CONNS / DATABASE_MIN_CONNS env vars
+//  2. pool_max_conns / pool_min_conns query params on DATABASE_URL
+//     (honored natively by pgxpool.ParseConfig)
+//  3. The defaults defined here (defaultMaxConns / defaultMinConns)
+//
+// pgx's own built-in default (max(4, NumCPU)) is intentionally NOT used as a
+// fallback — it is the value that caused the prod incident.
 func newDBPool(ctx context.Context, dbURL string) (*pgxpool.Pool, error) {
 	cfg, err := pgxpool.ParseConfig(dbURL)
 	if err != nil {
 		return nil, fmt.Errorf("parse database url: %w", err)
 	}
 
-	cfg.MaxConns = envInt32("DATABASE_MAX_CONNS", defaultMaxConns)
-	cfg.MinConns = envInt32("DATABASE_MIN_CONNS", defaultMinConns)
+	urlParams := poolParamsFromURL(dbURL)
+
+	if env := os.Getenv("DATABASE_MAX_CONNS"); env != "" {
+		cfg.MaxConns = envInt32("DATABASE_MAX_CONNS", cfg.MaxConns)
+	} else if !urlParams["pool_max_conns"] {
+		cfg.MaxConns = defaultMaxConns
+	}
+
+	if env := os.Getenv("DATABASE_MIN_CONNS"); env != "" {
+		cfg.MinConns = envInt32("DATABASE_MIN_CONNS", cfg.MinConns)
+	} else if !urlParams["pool_min_conns"] {
+		cfg.MinConns = defaultMinConns
+	}
+
 	if cfg.MinConns > cfg.MaxConns {
 		cfg.MinConns = cfg.MaxConns
 	}
 
 	return pgxpool.NewWithConfig(ctx, cfg)
+}
+
+// poolParamsFromURL returns the set of pool_* query params present on the
+// database URL. Used to detect whether the operator already tuned the pool
+// via the connection string, so env-less upgrades don't silently override
+// existing configuration.
+func poolParamsFromURL(dbURL string) map[string]bool {
+	out := map[string]bool{}
+	u, err := url.Parse(dbURL)
+	if err != nil {
+		return out
+	}
+	for k := range u.Query() {
+		out[k] = true
+	}
+	return out
 }
 
 // envInt32 reads an int32 from the named env var. Empty / invalid values fall

--- a/server/cmd/server/dbstats.go
+++ b/server/cmd/server/dbstats.go
@@ -60,17 +60,21 @@ func newDBPool(ctx context.Context, dbURL string) (*pgxpool.Pool, error) {
 
 	urlParams := poolParamsFromURL(dbURL)
 
-	if env := os.Getenv("DATABASE_MAX_CONNS"); env != "" {
-		cfg.MaxConns = envInt32("DATABASE_MAX_CONNS", cfg.MaxConns)
-	} else if !urlParams["pool_max_conns"] {
-		cfg.MaxConns = defaultMaxConns
+	// Compute the non-env fallback first: honor URL pool_* params if the
+	// operator set them, otherwise use our code default. This fallback is
+	// also what an *invalid* env value falls back to — never pgx's built-in
+	// default of 4/0, which is the value that caused the prod incident.
+	maxFallback := defaultMaxConns
+	if urlParams["pool_max_conns"] {
+		maxFallback = cfg.MaxConns
 	}
+	cfg.MaxConns = envInt32("DATABASE_MAX_CONNS", maxFallback)
 
-	if env := os.Getenv("DATABASE_MIN_CONNS"); env != "" {
-		cfg.MinConns = envInt32("DATABASE_MIN_CONNS", cfg.MinConns)
-	} else if !urlParams["pool_min_conns"] {
-		cfg.MinConns = defaultMinConns
+	minFallback := defaultMinConns
+	if urlParams["pool_min_conns"] {
+		minFallback = cfg.MinConns
 	}
+	cfg.MinConns = envInt32("DATABASE_MIN_CONNS", minFallback)
 
 	if cfg.MinConns > cfg.MaxConns {
 		cfg.MinConns = cfg.MaxConns

--- a/server/cmd/server/dbstats_test.go
+++ b/server/cmd/server/dbstats_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// applyPoolSizing mirrors the env+URL precedence logic in newDBPool but
+// without actually opening a connection, so the resolution rules can be
+// asserted in unit tests.
+func applyPoolSizing(t *testing.T, dbURL string, envMax, envMin string) (max, min int32) {
+	t.Helper()
+	cfg, err := pgxpool.ParseConfig(dbURL)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	urlParams := poolParamsFromURL(dbURL)
+
+	if envMax != "" {
+		t.Setenv("DATABASE_MAX_CONNS", envMax)
+		cfg.MaxConns = envInt32("DATABASE_MAX_CONNS", cfg.MaxConns)
+	} else if !urlParams["pool_max_conns"] {
+		cfg.MaxConns = defaultMaxConns
+	}
+
+	if envMin != "" {
+		t.Setenv("DATABASE_MIN_CONNS", envMin)
+		cfg.MinConns = envInt32("DATABASE_MIN_CONNS", cfg.MinConns)
+	} else if !urlParams["pool_min_conns"] {
+		cfg.MinConns = defaultMinConns
+	}
+
+	if cfg.MinConns > cfg.MaxConns {
+		cfg.MinConns = cfg.MaxConns
+	}
+	return cfg.MaxConns, cfg.MinConns
+}
+
+func TestPoolSizing_DefaultsWhenNothingSet(t *testing.T) {
+	max, min := applyPoolSizing(t, "postgres://u:p@h/db?sslmode=disable", "", "")
+	if max != defaultMaxConns || min != defaultMinConns {
+		t.Fatalf("got max=%d min=%d, want %d/%d", max, min, defaultMaxConns, defaultMinConns)
+	}
+}
+
+func TestPoolSizing_URLParamsHonoredWhenEnvUnset(t *testing.T) {
+	url := "postgres://u:p@h/db?sslmode=disable&pool_max_conns=40&pool_min_conns=8"
+	max, min := applyPoolSizing(t, url, "", "")
+	if max != 40 || min != 8 {
+		t.Fatalf("URL params should win when env unset; got max=%d min=%d", max, min)
+	}
+}
+
+func TestPoolSizing_EnvOverridesURL(t *testing.T) {
+	url := "postgres://u:p@h/db?sslmode=disable&pool_max_conns=40&pool_min_conns=8"
+	max, min := applyPoolSizing(t, url, "100", "20")
+	if max != 100 || min != 20 {
+		t.Fatalf("env should win over URL; got max=%d min=%d", max, min)
+	}
+}
+
+func TestPoolSizing_PartialURLParam(t *testing.T) {
+	// Only pool_max_conns is set in URL — pool_min_conns should fall back to
+	// the code default, not pgx's built-in default (which would be 0).
+	url := "postgres://u:p@h/db?sslmode=disable&pool_max_conns=40"
+	max, min := applyPoolSizing(t, url, "", "")
+	if max != 40 {
+		t.Fatalf("URL pool_max_conns should be honored; got max=%d", max)
+	}
+	if min != defaultMinConns {
+		t.Fatalf("min should default; got min=%d, want %d", min, defaultMinConns)
+	}
+}
+
+func TestPoolSizing_InvalidEnvFallsBack(t *testing.T) {
+	// Invalid env value falls back to whatever was already on cfg (URL or
+	// pgx default). With no URL param, that's the pgx default — but our
+	// code path then keeps it as-is, since the env is non-empty. This
+	// documents the chosen behavior so a future change is intentional.
+	max, _ := applyPoolSizing(t, "postgres://u:p@h/db?sslmode=disable", "not-a-number", "")
+	if max <= 0 {
+		t.Fatalf("invalid env should not produce non-positive max_conns; got %d", max)
+	}
+}
+
+func TestPoolSizing_MinClampedToMax(t *testing.T) {
+	max, min := applyPoolSizing(t, "postgres://u:p@h/db?sslmode=disable", "10", "50")
+	if min > max {
+		t.Fatalf("min should be clamped to max; got max=%d min=%d", max, min)
+	}
+}

--- a/server/cmd/server/dbstats_test.go
+++ b/server/cmd/server/dbstats_test.go
@@ -17,19 +17,23 @@ func applyPoolSizing(t *testing.T, dbURL string, envMax, envMin string) (max, mi
 	}
 	urlParams := poolParamsFromURL(dbURL)
 
+	maxFallback := defaultMaxConns
+	if urlParams["pool_max_conns"] {
+		maxFallback = cfg.MaxConns
+	}
 	if envMax != "" {
 		t.Setenv("DATABASE_MAX_CONNS", envMax)
-		cfg.MaxConns = envInt32("DATABASE_MAX_CONNS", cfg.MaxConns)
-	} else if !urlParams["pool_max_conns"] {
-		cfg.MaxConns = defaultMaxConns
 	}
+	cfg.MaxConns = envInt32("DATABASE_MAX_CONNS", maxFallback)
 
+	minFallback := defaultMinConns
+	if urlParams["pool_min_conns"] {
+		minFallback = cfg.MinConns
+	}
 	if envMin != "" {
 		t.Setenv("DATABASE_MIN_CONNS", envMin)
-		cfg.MinConns = envInt32("DATABASE_MIN_CONNS", cfg.MinConns)
-	} else if !urlParams["pool_min_conns"] {
-		cfg.MinConns = defaultMinConns
 	}
+	cfg.MinConns = envInt32("DATABASE_MIN_CONNS", minFallback)
 
 	if cfg.MinConns > cfg.MaxConns {
 		cfg.MinConns = cfg.MaxConns
@@ -73,14 +77,27 @@ func TestPoolSizing_PartialURLParam(t *testing.T) {
 	}
 }
 
-func TestPoolSizing_InvalidEnvFallsBack(t *testing.T) {
-	// Invalid env value falls back to whatever was already on cfg (URL or
-	// pgx default). With no URL param, that's the pgx default — but our
-	// code path then keeps it as-is, since the env is non-empty. This
-	// documents the chosen behavior so a future change is intentional.
-	max, _ := applyPoolSizing(t, "postgres://u:p@h/db?sslmode=disable", "not-a-number", "")
-	if max <= 0 {
-		t.Fatalf("invalid env should not produce non-positive max_conns; got %d", max)
+func TestPoolSizing_InvalidEnvFallsBackToCodeDefault(t *testing.T) {
+	// Invalid env value with no URL pool param → code default, NOT pgx's
+	// built-in 4. This is the regression that was fixed; pinning it here
+	// so we don't silently fall back to the bad value again.
+	max, min := applyPoolSizing(t, "postgres://u:p@h/db?sslmode=disable", "not-a-number", "")
+	if max != defaultMaxConns {
+		t.Fatalf("invalid env should fall back to code default; got max=%d, want %d", max, defaultMaxConns)
+	}
+	if min != defaultMinConns {
+		t.Fatalf("got min=%d, want %d", min, defaultMinConns)
+	}
+}
+
+func TestPoolSizing_InvalidEnvFallsBackToURLParam(t *testing.T) {
+	// Invalid env value with a URL pool param → URL param wins, NOT pgx
+	// default. This is what makes the precedence chain end at "URL or code
+	// default" rather than at "pgx default" on misconfiguration.
+	url := "postgres://u:p@h/db?sslmode=disable&pool_max_conns=40"
+	max, _ := applyPoolSizing(t, url, "not-a-number", "")
+	if max != 40 {
+		t.Fatalf("invalid env should fall back to URL param; got max=%d, want 40", max)
 	}
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -9,8 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/logger"
 	"github.com/multica-ai/multica/server/internal/realtime"
@@ -41,7 +39,7 @@ func main() {
 
 	// Connect to database
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dbURL)
+	pool, err := newDBPool(ctx, dbURL)
 	if err != nil {
 		slog.Error("unable to connect to database", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
## Why

Confirmed via #1378 stats logging: production was running pgxpool's default `MaxConns = max(4, NumCPU)` → resolved to **4 conns/pod**. Daemon claim/heartbeat traffic (~3800 acquires/s) pinned the pool at 100% utilization, every query waited ~900ms for a connection, and ~7 req/s timed out. That was the actual root cause of the 3s+ `/tasks/claim` tail latency — not slow SQL.

```
WRN db pool pressure max_conns=4 acquired_conns=4 idle_conns=0
    acquire_count_delta=57486 empty_acquire_delta=57486
    canceled_acquire_delta=111 avg_acquire_ms=925
```

## What

- Switch `pgxpool.New` → `pgxpool.ParseConfig` + `NewWithConfig` in `server/cmd/server/main.go`.
- Add `newDBPool` helper in `dbstats.go` (pool-init lives next to pool-stats).
- New env vars, both optional:
  - `DATABASE_MAX_CONNS` (default **25**)
  - `DATABASE_MIN_CONNS` (default **5**)
- Document them in `SELF_HOSTING_ADVANCED.md`.
- Invalid env values fall back to defaults with a startup warn; `MinConns` is auto-clamped to `MaxConns`.

## Why these defaults

Following the standard "small pool, lots of waiters" guidance for Postgres (PG community / HikariCP formula `(core_count * 2) + effective_spindle_count`). Going much larger (100+) typically *hurts* Postgres throughput because each connection is a forked OS process competing for CPU/buffers. Little's Law on the observed traffic puts real concurrency need at single digits once SQL itself is fast — 25 leaves ~6× headroom for bursts and the occasional long query.

`pod_count × DATABASE_MAX_CONNS` should stay below DB `max_connections`; if there's a PgBouncer / RDS Proxy / Supavisor in front, MaxConns can safely be raised much higher via the env var without code change.

## Verification

- `go build ./...` ✓
- `go test ./cmd/server/ -count=1` ✓
- After deploy, expect:
  - `db pool config` startup line shows `max_conns=25 min_conns=5`
  - `db pool pressure` warns disappear; `db pool stats` info lines instead
  - `claim_endpoint slow` lines drop sharply; `avg_acquire_ms` ≈ 0

## Follow-ups (separate PRs)

- Collapse `ClaimTaskForRuntime` N+1 into single SQL claim by `runtime_id`
- Consider lengthening daemon `DefaultPollInterval` (3s) or moving to long-poll/WS

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>