### PR TITLE
fix(views): clear agent live state when switching issues

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1273,12 +1273,14 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
             </div>
 
             {/* Agent live output — sticky inside the Activity section so it
-                stays pinned while scrolling through TaskRunHistory + comments. */}
-            <AgentLiveCard issueId={id} />
+                stays pinned while scrolling through TaskRunHistory + comments.
+                Keyed by issue id so switching issues remounts the card and
+                clears any in-flight task state from the previous issue. */}
+            <AgentLiveCard key={id} issueId={id} />
 
             {/* Agent execution history */}
             <div className="mt-3">
-              <TaskRunHistory issueId={id} />
+              <TaskRunHistory key={id} issueId={id} />
             </div>
 
             {/* Timeline entries */}


### PR DESCRIPTION
## Summary

Fixes [MUL-1147](mention://issue/1da4177f-c364-4597-96a0-43880456e081) — when an agent is working on Issue A and the user jumps to Issue B via cmd+k, Issue A's sticky agent status card remains pinned on Issue B's page.

## Root cause

`AgentLiveCard` keeps a `taskStates` map in local state keyed by task id. When the `issueId` prop changes, its effect refetches active tasks for the new issue but the merge logic only adds new entries (`if (!next.has(task.id)) ...`) — it never removes tasks left over from the previous issue. Completion events for the old issue are also filtered out by `payload.issue_id !== issueId`, so they can never clean up the stale entry either. The sticky CSS wrapper then keeps that stale card anchored at the top of Issue B.

## Fix

Pass `key={id}` to `AgentLiveCard` (and `TaskRunHistory` for the same reason) so React remounts them with fresh state whenever the issue changes. Per-issue live state is issue-scoped by definition, so fully resetting on navigation is the correct lifecycle.

## Test plan

- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx`
- [ ] Manual: start an agent on Issue A, cmd+k → Issue B, verify no sticky agent card leaks onto B
- [ ] Manual: navigate back to Issue A, verify the running task card reappears correctly