### PR TITLE
feat(cli): add 'multica workspace repo' subcommands

### DIFF
--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 	"unicode/utf8"
@@ -52,15 +53,58 @@ var workspaceUnwatchCmd = &cobra.Command{
 	RunE:  runUnwatch,
 }
 
+var workspaceRepoCmd = &cobra.Command{
+	Use:   "repo",
+	Short: "Manage repositories attached to the workspace",
+}
+
+var workspaceRepoListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List repositories attached to the workspace",
+	Args:  cobra.NoArgs,
+	RunE:  runWorkspaceRepoList,
+}
+
+var workspaceRepoAddCmd = &cobra.Command{
+	Use:   "add <url>",
+	Short: "Add a repository to the workspace",
+	Args:  exactArgs(1),
+	RunE:  runWorkspaceRepoAdd,
+}
+
+var workspaceRepoRemoveCmd = &cobra.Command{
+	Use:   "remove <url>",
+	Short: "Remove a repository from the workspace",
+	Args:  exactArgs(1),
+	RunE:  runWorkspaceRepoRemove,
+}
+
+var workspaceRepoUpdateCmd = &cobra.Command{
+	Use:   "update <url>",
+	Short: "Update the description of an existing workspace repository",
+	Args:  exactArgs(1),
+	RunE:  runWorkspaceRepoUpdate,
+}
+
 func init() {
 	workspaceCmd.AddCommand(workspaceListCmd)
 	workspaceCmd.AddCommand(workspaceGetCmd)
 	workspaceCmd.AddCommand(workspaceMembersCmd)
 	workspaceCmd.AddCommand(workspaceWatchCmd)
 	workspaceCmd.AddCommand(workspaceUnwatchCmd)
+	workspaceCmd.AddCommand(workspaceRepoCmd)
+
+	workspaceRepoCmd.AddCommand(workspaceRepoListCmd)
+	workspaceRepoCmd.AddCommand(workspaceRepoAddCmd)
+	workspaceRepoCmd.AddCommand(workspaceRepoRemoveCmd)
+	workspaceRepoCmd.AddCommand(workspaceRepoUpdateCmd)
 
 	workspaceGetCmd.Flags().String("output", "json", "Output format: table or json")
 	workspaceMembersCmd.Flags().String("output", "table", "Output format: table or json")
+
+	workspaceRepoListCmd.Flags().String("output", "table", "Output format: table or json")
+	workspaceRepoAddCmd.Flags().String("description", "", "Description for the repository")
+	workspaceRepoUpdateCmd.Flags().String("description", "", "New description for the repository (required)")
 }
 
 func runWorkspaceList(cmd *cobra.Command, _ []string) error {
@@ -261,5 +305,218 @@ func runUnwatch(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Stopped watching workspace %s\n", workspaceID)
+	return nil
+}
+
+type workspaceRepoEntry struct {
+	URL         string `json:"url"`
+	Description string `json:"description"`
+}
+
+// fetchWorkspaceRepos retrieves the current repos attached to a workspace.
+// It returns the normalised slice plus the workspace ID for use in the PATCH.
+func fetchWorkspaceRepos(ctx context.Context, client *cli.APIClient, wsID string) ([]workspaceRepoEntry, error) {
+	var ws struct {
+		Repos []workspaceRepoEntry `json:"repos"`
+	}
+	if err := client.GetJSON(ctx, "/api/workspaces/"+wsID, &ws); err != nil {
+		return nil, fmt.Errorf("get workspace: %w", err)
+	}
+	return ws.Repos, nil
+}
+
+func saveWorkspaceRepos(ctx context.Context, client *cli.APIClient, wsID string, repos []workspaceRepoEntry) ([]workspaceRepoEntry, error) {
+	// PATCH always replaces the full list; ensure non-nil slice so we can clear it.
+	if repos == nil {
+		repos = []workspaceRepoEntry{}
+	}
+	body := map[string]any{"repos": repos}
+	var out struct {
+		Repos []workspaceRepoEntry `json:"repos"`
+	}
+	if err := client.PatchJSON(ctx, "/api/workspaces/"+wsID, body, &out); err != nil {
+		return nil, fmt.Errorf("update workspace repos: %w", err)
+	}
+	return out.Repos, nil
+}
+
+func runWorkspaceRepoList(cmd *cobra.Command, _ []string) error {
+	wsID := resolveWorkspaceID(cmd)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: set MULTICA_WORKSPACE_ID or pass --workspace-id")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	repos, err := fetchWorkspaceRepos(ctx, client, wsID)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, repos)
+	}
+
+	if len(repos) == 0 {
+		fmt.Fprintln(os.Stderr, "No repositories attached to this workspace.")
+		return nil
+	}
+
+	headers := []string{"URL", "DESCRIPTION"}
+	rows := make([][]string, 0, len(repos))
+	for _, r := range repos {
+		desc := r.Description
+		if utf8.RuneCountInString(desc) > 80 {
+			runes := []rune(desc)
+			desc = string(runes[:77]) + "..."
+		}
+		rows = append(rows, []string{r.URL, desc})
+	}
+	cli.PrintTable(os.Stdout, headers, rows)
+	return nil
+}
+
+func runWorkspaceRepoAdd(cmd *cobra.Command, args []string) error {
+	url := strings.TrimSpace(args[0])
+	if url == "" {
+		return fmt.Errorf("repo URL is required")
+	}
+
+	wsID := resolveWorkspaceID(cmd)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: set MULTICA_WORKSPACE_ID or pass --workspace-id")
+	}
+
+	description, _ := cmd.Flags().GetString("description")
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	repos, err := fetchWorkspaceRepos(ctx, client, wsID)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range repos {
+		if r.URL == url {
+			return fmt.Errorf("repo already attached to workspace: %s (use 'workspace repo update' to change its description)", url)
+		}
+	}
+
+	repos = append(repos, workspaceRepoEntry{URL: url, Description: description})
+
+	updated, err := saveWorkspaceRepos(ctx, client, wsID, repos)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Added repo %s (workspace now has %d repos).\n", url, len(updated))
+	return nil
+}
+
+func runWorkspaceRepoRemove(cmd *cobra.Command, args []string) error {
+	url := strings.TrimSpace(args[0])
+	if url == "" {
+		return fmt.Errorf("repo URL is required")
+	}
+
+	wsID := resolveWorkspaceID(cmd)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: set MULTICA_WORKSPACE_ID or pass --workspace-id")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	repos, err := fetchWorkspaceRepos(ctx, client, wsID)
+	if err != nil {
+		return err
+	}
+
+	filtered := make([]workspaceRepoEntry, 0, len(repos))
+	removed := false
+	for _, r := range repos {
+		if r.URL == url {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	if !removed {
+		return fmt.Errorf("repo not attached to workspace: %s", url)
+	}
+
+	updated, err := saveWorkspaceRepos(ctx, client, wsID, filtered)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Removed repo %s (workspace now has %d repos).\n", url, len(updated))
+	return nil
+}
+
+func runWorkspaceRepoUpdate(cmd *cobra.Command, args []string) error {
+	url := strings.TrimSpace(args[0])
+	if url == "" {
+		return fmt.Errorf("repo URL is required")
+	}
+
+	if !cmd.Flags().Changed("description") {
+		return fmt.Errorf("--description is required")
+	}
+	description, _ := cmd.Flags().GetString("description")
+
+	wsID := resolveWorkspaceID(cmd)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: set MULTICA_WORKSPACE_ID or pass --workspace-id")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	repos, err := fetchWorkspaceRepos(ctx, client, wsID)
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i, r := range repos {
+		if r.URL == url {
+			repos[i].Description = description
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("repo not attached to workspace: %s (use 'workspace repo add' first)", url)
+	}
+
+	if _, err := saveWorkspaceRepos(ctx, client, wsID, repos); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Updated description for repo %s.\n", url)
 	return nil
 }

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -183,6 +183,36 @@ func (c *APIClient) PutJSON(ctx context.Context, path string, body any, out any)
 	return json.NewDecoder(resp.Body).Decode(out)
 }
 
+// PatchJSON performs a PATCH request with a JSON body.
+func (c *APIClient) PatchJSON(ctx context.Context, path string, body any, out any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.BaseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.setHeaders(req)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respData, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("PATCH %s returned %d: %s", path, resp.StatusCode, strings.TrimSpace(string(respData)))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
 // UploadFile uploads a file via multipart form to /api/upload-file.
 // It returns the attachment ID from the server response.
 func (c *APIClient) UploadFile(ctx context.Context, fileData []byte, filename string, issueID string) (string, error) {


### PR DESCRIPTION
## Summary
- Adds `multica workspace repo {list,add,remove,update}` so the workspace `repos` field can be managed from the CLI instead of a raw `PATCH /api/workspaces/:id`.
- Adds a small `PatchJSON` helper to the shared CLI APIClient (parallel to the existing `PostJSON` / `PutJSON`).

Motivated by a workspace-level ticket (ELS-33 in the elsolve workspace): an agent was asked to populate the repositories section but had to shell out to curl + the CLI token because no command existed. This closes that gap.

## UX

```
$ multica workspace repo --help
Manage repositories attached to the workspace

COMMANDS
  list    List repositories attached to the workspace
  add     Add a repository to the workspace
  remove  Remove a repository from the workspace
  update  Update the description of an existing workspace repository
```

- `list` respects `--output table|json` (table by default so the \`ID   DESCRIPTION\` layout matches other workspace commands).
- `add <url>` takes `--description`, refuses to add a URL that's already attached.
- `update <url>` requires `--description` (it has no other mutable fields today).
- `remove <url>` errors if the URL isn't attached.
- All commands pick up the workspace via `--workspace-id` / `MULTICA_WORKSPACE_ID`, same as the rest of the `workspace` subtree.

The list is mutated via a read-modify-write round-trip because `workspace.repos` is a single JSONB column and the existing `UpdateWorkspace` handler replaces it wholesale; keeping this concern in the CLI avoids introducing a new server endpoint.

## Test plan
- [x] `go vet ./cmd/multica ./internal/cli`
- [x] `go test ./cmd/multica ./internal/cli -count=1`
- [x] Manual round-trip against a real workspace: add → list → update → add (dup, rejects) → remove → remove (missing, rejects) → list. Final state matches the starting state.
- [ ] Run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)