### PR TITLE
fix(agent/opencode): keep server alive until background sub-agents finish

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -182,6 +182,7 @@ Agent-specific overrides:
 | `MULTICA_CODEX_MODEL` | Override the Codex model used |
 | `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
 | `MULTICA_OPENCODE_MODEL` | Override the OpenCode model used |
+| `MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT` | Set to `1` to disable the persistent `opencode serve` keep-alive and revert to the legacy embedded-server mode. See [OpenCode keep-alive](#opencode-keep-alive-sub-agent-waiting) below. |
 | `MULTICA_OPENCLAW_PATH` | Custom path to the `openclaw` binary |
 | `MULTICA_OPENCLAW_MODEL` | Override the OpenClaw model used |
 | `MULTICA_HERMES_PATH` | Custom path to the `hermes` binary |
@@ -192,6 +193,27 @@ Agent-specific overrides:
 | `MULTICA_PI_MODEL` | Override the Pi model used |
 | `MULTICA_CURSOR_PATH` | Custom path to the `cursor-agent` binary |
 | `MULTICA_CURSOR_MODEL` | Override the Cursor Agent model used |
+
+### OpenCode keep-alive (sub-agent waiting)
+
+Some OpenCode plugins — for example [`oh-my-openagent`](https://github.com/Zaratustra-x/oh-my-openagent) — spawn **background sub-agents in child sessions** that keep working after the parent `opencode run` returns. To prevent the daemon from completing a task while those children are still running, the OpenCode runner runs in **server keep-alive mode** by default:
+
+1. The daemon spawns a dedicated `opencode serve` process on a random port, secured with an auto-generated `OPENCODE_SERVER_PASSWORD`.
+2. `opencode run` is invoked with `--attach` against that server, so any sessions it (or its plugins) create live on the long-running server rather than on a per-run embedded one.
+3. After `opencode run` exits, the daemon polls `GET /session/status` until **every non-parent session has been idle for 3 consecutive polls** (3 s interval, 10 s HTTP timeout per poll). The parent run session is filtered out because OpenCode keeps it in `/session/status` after the CLI returns.
+4. A **45 s grace window** before trusting an empty status map covers the race where child sessions register slightly after the parent run returns.
+5. Then the server is stopped (SIGTERM, then SIGKILL after a short timeout) and the task is marked completed.
+
+If `opencode serve` fails to come up, the daemon **silently falls back** to the legacy embedded-server mode (single `opencode run`, no polling), so existing setups never regress.
+
+To opt out and force the legacy mode (e.g. to debug a runner issue or shave a few seconds on tasks that never use sub-agents):
+
+```bash
+export MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT=1
+multica daemon restart
+```
+
+The flag is read once at backend construction. Restart the daemon for changes to take effect.
 
 ### Self-Hosted Server
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -105,7 +105,7 @@ func New(agentType string, cfg Config) (Backend, error) {
 	case "copilot":
 		return &copilotBackend{cfg: cfg}, nil
 	case "opencode":
-		return &opencodeBackend{cfg: cfg}, nil
+		return newOpencodeBackend(cfg), nil
 	case "openclaw":
 		return &openclawBackend{cfg: cfg}, nil
 	case "hermes":

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -3,11 +3,18 @@ package agent
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
+	"net/http"
+	"os"
 	"os/exec"
+	"regexp"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -15,12 +22,38 @@ import (
 // overridden by user-configured custom_args.
 var opencodeBlockedArgs = map[string]blockedArgMode{
 	"--format": blockedWithValue, // json output format for daemon communication
+	"--attach": blockedWithValue, // server URL is daemon-managed in keep-alive mode
+	"--port":   blockedWithValue, // server port is daemon-managed in keep-alive mode
 }
 
 // opencodeBackend implements Backend by spawning `opencode run --format json`
 // and reading streaming JSON events from stdout — the same pattern as Claude.
+//
+// When waitForSubAgents is enabled (default), the daemon also spawns a
+// dedicated `opencode serve` process and uses `--attach` so that any
+// background sub-agents launched by plugins (e.g. oh-my-openagent) keep
+// running after the parent run exits. The daemon then polls the server's
+// /session/status endpoint until all sessions are idle before completing.
+//
+// The waitForSubAgents knob is opencode-specific and intentionally lives
+// on this struct rather than on the generic agent.Config so the public
+// Backend contract stays uniform across runtimes (claude, codex, …).
+// It defaults to enabled and can be turned off via the
+// MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT env var, captured at construction
+// time.
 type opencodeBackend struct {
-	cfg Config
+	cfg              Config
+	waitForSubAgents bool
+}
+
+// newOpencodeBackend constructs an opencodeBackend with the wait-for-sub-agents
+// behavior resolved from the environment. Tests can mutate waitForSubAgents
+// directly after construction.
+func newOpencodeBackend(cfg Config) *opencodeBackend {
+	return &opencodeBackend{
+		cfg:              cfg,
+		waitForSubAgents: resolveOpencodeWaitForSubAgents(),
+	}
 }
 
 func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
@@ -36,9 +69,30 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	if timeout == 0 {
 		timeout = 20 * time.Minute
 	}
+
+	waitForSubAgents := b.waitForSubAgents
+
+	// Start the persistent server BEFORE the run. We tie its lifetime to ctx
+	// (not the per-run timeout context) so a SIGTERM cleanup at the very end
+	// of Execute() can wait gracefully even after the run timed out. If the
+	// server fails to come up, log and fall back silently to the legacy
+	// embedded-server mode so the task still runs.
+	var server *opencodeServer
+	if waitForSubAgents {
+		srv, err := startOpencodeServer(ctx, execPath, buildEnv(b.cfg.Env), b.cfg.Logger)
+		if err != nil {
+			b.cfg.Logger.Warn("opencode persistent server unavailable, falling back to embedded mode", "error", err)
+		} else {
+			server = srv
+		}
+	}
+
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
 	args := []string{"run", "--format", "json"}
+	if server != nil {
+		args = append(args, "--attach", server.URL)
+	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}
@@ -64,26 +118,43 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	env := buildEnv(b.cfg.Env)
 	// Auto-approve all tool use in daemon mode.
 	env = append(env, `OPENCODE_PERMISSION={"*":"allow"}`)
+	if server != nil {
+		// Strip any inherited password and inject the per-task one so `run
+		// --attach` authenticates against our private serve process.
+		env = stripEnvKey(env, "OPENCODE_SERVER_PASSWORD")
+		env = append(env, "OPENCODE_SERVER_PASSWORD="+server.Password)
+	}
 	cmd.Env = env
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		if server != nil {
+			server.Stop(5 * time.Second)
+		}
 		cancel()
 		return nil, fmt.Errorf("opencode stdout pipe: %w", err)
 	}
 	cmd.Stderr = newLogWriter(b.cfg.Logger, "[opencode:stderr] ")
 
 	if err := cmd.Start(); err != nil {
+		if server != nil {
+			server.Stop(5 * time.Second)
+		}
 		cancel()
 		return nil, fmt.Errorf("start opencode: %w", err)
 	}
 
-	b.cfg.Logger.Info("opencode started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model)
+	b.cfg.Logger.Info("opencode started",
+		"pid", cmd.Process.Pid,
+		"cwd", opts.Cwd,
+		"model", opts.Model,
+		"wait_sub_agents", server != nil,
+	)
 
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
-	// Close stdout when the context is cancelled so the scanner unblocks.
+	// Close stdout when the run context is cancelled so the scanner unblocks.
 	go func() {
 		<-runCtx.Done()
 		_ = stdout.Close()
@@ -93,12 +164,36 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
+		// Always tear down the persistent server when this goroutine exits,
+		// regardless of how (success, timeout, panic propagation, etc.).
+		defer func() {
+			if server != nil {
+				server.Stop(5 * time.Second)
+			}
+		}()
 
 		startTime := time.Now()
 		scanResult := b.processEvents(stdout, msgCh)
 
-		// Wait for process exit.
+		// Wait for the run process to exit.
 		exitErr := cmd.Wait()
+		runDuration := time.Since(startTime)
+
+		// If the run finished cleanly and we have a persistent server, give
+		// the embedded BackgroundManager (oh-my-openagent et al.) a chance
+		// to finish its sub-agent sessions before we report completion.
+		if server != nil && scanResult.status == "completed" && exitErr == nil && runCtx.Err() == nil {
+			b.cfg.Logger.Info("opencode run exited; waiting for sub-agents to finish",
+				"session", scanResult.sessionID,
+			)
+			waitTimeout := remainingTimeout(runCtx, timeout)
+			if waitErr := server.WaitForIdle(runCtx, waitTimeout, b.cfg.Logger, scanResult.sessionID); waitErr != nil {
+				b.cfg.Logger.Warn("opencode sub-agent wait ended with error",
+					"error", waitErr,
+				)
+			}
+		}
+
 		duration := time.Since(startTime)
 
 		if runCtx.Err() == context.DeadlineExceeded {
@@ -112,7 +207,13 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 			scanResult.errMsg = fmt.Sprintf("opencode exited with error: %v", exitErr)
 		}
 
-		b.cfg.Logger.Info("opencode finished", "pid", cmd.Process.Pid, "status", scanResult.status, "duration", duration.Round(time.Millisecond).String())
+		b.cfg.Logger.Info("opencode finished",
+			"pid", cmd.Process.Pid,
+			"status", scanResult.status,
+			"run_duration", runDuration.Round(time.Millisecond).String(),
+			"total_duration", duration.Round(time.Millisecond).String(),
+			"wait_sub_agents", server != nil,
+		)
 
 		// Build usage map. OpenCode doesn't report model per-step, so we
 		// attribute all usage to the configured model (or "unknown").
@@ -137,6 +238,364 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// resolveOpencodeWaitForSubAgents picks the effective wait mode from the
+// environment. Default is enabled; MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT
+// set to "1" / "true" / "yes" (case-insensitive, trimmed) disables it.
+func resolveOpencodeWaitForSubAgents() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT"))) {
+	case "1", "true", "yes":
+		return false
+	}
+	return true
+}
+
+// remainingTimeout returns the time remaining before runCtx's deadline,
+// or fallback if the context has no deadline. Always returns at least 5s
+// so the wait loop has a chance to make at least one observation.
+func remainingTimeout(runCtx context.Context, fallback time.Duration) time.Duration {
+	const minWait = 5 * time.Second
+	d, ok := runCtx.Deadline()
+	if !ok {
+		return fallback
+	}
+	left := time.Until(d)
+	if left < minWait {
+		return minWait
+	}
+	return left
+}
+
+// stripEnvKey returns env with any KEY=... entries for the given key removed.
+func stripEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	out := env[:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// ── Persistent opencode server (`opencode serve` + `run --attach`) ──
+
+// opencodeServer holds a running `opencode serve` process owned by the daemon.
+// The server outlives the `opencode run` command so that background sub-agent
+// sessions launched by plugins keep running and can be polled to completion.
+type opencodeServer struct {
+	URL      string             // base URL, e.g. http://127.0.0.1:54321
+	Password string             // basic-auth password shared with the attached run
+	cmd      *exec.Cmd          // the serve process
+	cancel   context.CancelFunc // tied to the server's independent context
+	logger   *slog.Logger
+}
+
+// opencodeServerListenRe matches the announce line from `opencode serve`,
+// e.g. "opencode server listening on http://127.0.0.1:54321".
+// Source: opencode/packages/opencode/src/cli/cmd/serve.ts:16.
+var opencodeServerListenRe = regexp.MustCompile(`opencode server listening on (https?://[^\s]+)`)
+
+// startOpencodeServer launches `opencode serve` on a random local port and
+// blocks (with a 10s handshake timeout) until the server announces its URL.
+// On success it returns a handle the caller uses to poll the server and stop
+// it. On failure the server process (if any) is reaped before returning.
+//
+// The server runs under its own background context so a per-run timeout on
+// `opencode run` does not kill the server prematurely. Cancellation of the
+// caller's parent ctx still propagates because we register a watcher.
+func startOpencodeServer(parent context.Context, execPath string, parentEnv []string, logger *slog.Logger) (*opencodeServer, error) {
+	password, err := randomHex(32)
+	if err != nil {
+		return nil, fmt.Errorf("generate opencode server password: %w", err)
+	}
+
+	serverCtx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(serverCtx, execPath, "serve", "--port", "0", "--hostname", "127.0.0.1")
+
+	serverEnv := stripEnvKey(append([]string{}, parentEnv...), "OPENCODE_SERVER_PASSWORD")
+	serverEnv = append(serverEnv, "OPENCODE_SERVER_PASSWORD="+password)
+	// The serve process must auto-approve permissions like the run does, so
+	// plugin-spawned sub-agents are never blocked on a UI prompt.
+	if !envHasKey(serverEnv, "OPENCODE_PERMISSION") {
+		serverEnv = append(serverEnv, `OPENCODE_PERMISSION={"*":"allow"}`)
+	}
+	cmd.Env = serverEnv
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("opencode serve stdout pipe: %w", err)
+	}
+	cmd.Stderr = newLogWriter(logger, "[opencode-serve:stderr] ")
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start opencode serve: %w", err)
+	}
+
+	logger.Info("opencode serve started", "pid", cmd.Process.Pid)
+
+	urlCh := make(chan string, 1)
+	scanErrCh := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		announced := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			logger.Debug("[opencode-serve:stdout] " + line)
+			if !announced {
+				if m := opencodeServerListenRe.FindStringSubmatch(line); m != nil {
+					urlCh <- m[1]
+					announced = true
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil && !announced {
+			scanErrCh <- err
+		}
+	}()
+
+	// Watcher: if the parent ctx is cancelled (task abort, daemon shutdown),
+	// kill the server too. Also handles the normal serverCtx cancellation
+	// path so this goroutine always exits.
+	go func() {
+		select {
+		case <-parent.Done():
+			cancel()
+		case <-serverCtx.Done():
+		}
+	}()
+
+	handshakeDeadline := time.NewTimer(10 * time.Second)
+	defer handshakeDeadline.Stop()
+
+	select {
+	case url := <-urlCh:
+		return &opencodeServer{
+			URL:      url,
+			Password: password,
+			cmd:      cmd,
+			cancel:   cancel,
+			logger:   logger,
+		}, nil
+	case err := <-scanErrCh:
+		cancel()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("opencode serve stdout error before announce: %w", err)
+	case <-handshakeDeadline.C:
+		cancel()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("opencode serve did not announce listen URL within 10s")
+	case <-parent.Done():
+		cancel()
+		_ = cmd.Wait()
+		return nil, parent.Err()
+	}
+}
+
+// Stop terminates the server. Sends SIGTERM and waits up to gracefulTimeout
+// for a clean exit; then escalates to SIGKILL. Safe to call multiple times.
+func (s *opencodeServer) Stop(gracefulTimeout time.Duration) {
+	if s == nil || s.cmd == nil || s.cmd.Process == nil {
+		return
+	}
+	pid := s.cmd.Process.Pid
+	s.logger.Debug("opencode serve: SIGTERM", "pid", pid)
+	_ = s.cmd.Process.Signal(syscall.SIGTERM)
+
+	done := make(chan struct{})
+	go func() {
+		_ = s.cmd.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		s.logger.Debug("opencode serve: exited cleanly", "pid", pid)
+	case <-time.After(gracefulTimeout):
+		s.logger.Warn("opencode serve: SIGTERM timeout, sending SIGKILL", "pid", pid)
+		_ = s.cmd.Process.Kill()
+		<-done
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+// WaitForIdle polls the server's /session/status endpoint until 3 successive
+// polls return zero non-idle sessions (after optional filtering), the timeout
+// elapses, or ctx is done.
+//
+// /session/status returns a map[sessionID]Status that omits idle sessions
+// (cf. opencode session/status.ts:74-78: "data.delete(sessionID)" on idle).
+//
+// mainSessionID: OpenCode often keeps the **parent** run session in "busy"
+// in SessionStatus even after `opencode run` exits (child sessions are
+// separate IDs). Waiting for a fully empty map would then block until the
+// global timeout. When mainSessionID is non-empty, that key is ignored so we
+// only wait for sub-agent / child sessions to go idle.
+//
+// To avoid completing before child sessions appear in /session/status, idle
+// debounce only starts once we have seen a non-main busy session or
+// opencodeSubagentIdleGrace has elapsed (see var in opencode.go).
+//
+// The 3-poll debounce avoids false positives between two sub-agents that
+// briefly relay each other (e.g. one finishes, BackgroundManager schedules
+// the next ~100ms later: two consecutive empty responses by chance, third
+// catches the new session).
+func (s *opencodeServer) WaitForIdle(ctx context.Context, timeout time.Duration, logger *slog.Logger, mainSessionID string) error {
+	const (
+		pollInterval         = 3 * time.Second
+		requiredStablePolls  = 3
+		httpTimeoutPerPoll   = 10 * time.Second
+		maxConsecutiveErrors = 5
+	)
+
+	deadline := time.Now().Add(timeout)
+	httpClient := &http.Client{Timeout: httpTimeoutPerPoll}
+	statusURL := strings.TrimRight(s.URL, "/") + "/session/status"
+
+	consecutiveIdle := 0
+	consecutiveErrors := 0
+	sawOtherBusy := false
+	waitStart := time.Now()
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("waiting for opencode sub-agents timed out after %s", timeout)
+		}
+
+		raw, err := s.queryActiveSessions(ctx, httpClient, statusURL)
+		if err != nil {
+			consecutiveErrors++
+			consecutiveIdle = 0
+			logger.Warn("opencode serve: status poll failed",
+				"error", err,
+				"consecutive_errors", consecutiveErrors,
+			)
+			if consecutiveErrors >= maxConsecutiveErrors {
+				return fmt.Errorf("opencode serve: %d consecutive status polls failed; assuming server is dead", consecutiveErrors)
+			}
+		} else {
+			consecutiveErrors = 0
+			active := nonIdleSessionsExcludingMain(raw, mainSessionID)
+			if len(active) > 0 {
+				sawOtherBusy = true
+			}
+			canTrustIdle := sawOtherBusy || time.Since(waitStart) >= opencodeSubagentIdleGrace
+			if len(active) == 0 {
+				if !canTrustIdle {
+					consecutiveIdle = 0
+					logger.Debug("opencode serve: idle poll deferred (sub-agent grace)",
+						"elapsed", time.Since(waitStart).Round(time.Second),
+						"grace", opencodeSubagentIdleGrace,
+					)
+				} else {
+					consecutiveIdle++
+					logger.Debug("opencode serve: idle poll",
+						"consecutive", consecutiveIdle,
+						"required", requiredStablePolls,
+					)
+					if consecutiveIdle >= requiredStablePolls {
+						return nil
+					}
+				}
+			} else {
+				consecutiveIdle = 0
+				logger.Debug("opencode serve: still busy",
+					"active_sessions", len(active),
+					"first", firstKey(active),
+				)
+			}
+		}
+
+		select {
+		case <-time.After(pollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// queryActiveSessions fetches /session/status and returns the decoded map.
+// Exported via interface only conceptually — this is a method to allow
+// future swapping in tests via a fake HTTP transport.
+func (s *opencodeServer) queryActiveSessions(ctx context.Context, c *http.Client, statusURL string) (map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", statusURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth("opencode", s.Password)
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var sessions map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+		return nil, fmt.Errorf("decode /session/status: %w", err)
+	}
+	return sessions, nil
+}
+
+// ── Small helpers ──
+
+func envHasKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstKey(m map[string]any) string {
+	for k := range m {
+		return k
+	}
+	return ""
+}
+
+// opencodeSubagentIdleGrace is the minimum time after opencode run exits before we
+// treat an empty filtered /session/status as "no sub-agents" when we have never
+// seen any non-main busy session. This avoids a race: child sessions are created
+// asynchronously right after the parent run returns, so the status map can be
+// {} or {parent} briefly even while background agents are starting.
+var opencodeSubagentIdleGrace = 45 * time.Second
+
+// nonIdleSessionsExcludingMain returns a copy of raw minus mainSessionID.
+// Keys in /session/status are already non-idle only; we drop the parent
+// session so WaitForIdle tracks child/sub-agent work. If mainSessionID is
+// empty, returns raw unchanged.
+func nonIdleSessionsExcludingMain(raw map[string]any, mainSessionID string) map[string]any {
+	if mainSessionID == "" || len(raw) == 0 {
+		return raw
+	}
+	out := make(map[string]any)
+	for k, v := range raw {
+		if k == mainSessionID {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // ── Event handlers ──
@@ -327,8 +786,8 @@ type opencodeEventPart struct {
 
 // opencodeTokens represents token usage in a step_finish event.
 type opencodeTokens struct {
-	Input  int64              `json:"input"`
-	Output int64              `json:"output"`
+	Input  int64                `json:"input"`
+	Output int64                `json:"output"`
 	Cache  *opencodeCacheTokens `json:"cache,omitempty"`
 }
 

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -1,11 +1,16 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestNewReturnsOpencodeBackend(t *testing.T) {
@@ -708,4 +713,495 @@ func TestOpencodeProcessEventsErrorDoesNotRevertToCompleted(t *testing.T) {
 	}
 
 	close(ch)
+}
+
+// ── opencode keep-alive server: helper tests ──
+
+func TestOpencodeServerListenRe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "ipv4 loopback random port",
+			line: "opencode server listening on http://127.0.0.1:54321",
+			want: "http://127.0.0.1:54321",
+		},
+		{
+			name: "https hostname with path-less url",
+			line: "opencode server listening on https://opencode.local:8080",
+			want: "https://opencode.local:8080",
+		},
+		{
+			name: "embedded in longer log prefix",
+			line: "12:34:56 INFO opencode server listening on http://0.0.0.0:4096 ready",
+			want: "http://0.0.0.0:4096",
+		},
+		{
+			name: "no match",
+			line: "warming up plugins...",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := opencodeServerListenRe.FindStringSubmatch(tt.line)
+			if tt.want == "" {
+				if m != nil {
+					t.Errorf("expected no match, got %v", m)
+				}
+				return
+			}
+			if m == nil || len(m) < 2 {
+				t.Fatalf("expected match, got %v", m)
+			}
+			if m[1] != tt.want {
+				t.Errorf("url: got %q, want %q", m[1], tt.want)
+			}
+		})
+	}
+}
+
+func TestStripEnvKey(t *testing.T) {
+	t.Parallel()
+
+	in := []string{
+		"PATH=/usr/bin",
+		"OPENCODE_SERVER_PASSWORD=old",
+		"HOME=/root",
+		"OPENCODE_SERVER_PASSWORD=duplicate",
+	}
+	out := stripEnvKey(in, "OPENCODE_SERVER_PASSWORD")
+	if len(out) != 2 {
+		t.Fatalf("expected 2 entries left, got %d: %v", len(out), out)
+	}
+	for _, kv := range out {
+		if strings.HasPrefix(kv, "OPENCODE_SERVER_PASSWORD=") {
+			t.Errorf("unexpected entry kept: %q", kv)
+		}
+	}
+}
+
+func TestEnvHasKey(t *testing.T) {
+	t.Parallel()
+
+	env := []string{"FOO=1", "OPENCODE_PERMISSION={\"*\":\"allow\"}", "BAR=2"}
+	if !envHasKey(env, "OPENCODE_PERMISSION") {
+		t.Errorf("expected key to be present")
+	}
+	if envHasKey(env, "BAZ") {
+		t.Errorf("expected key to be absent")
+	}
+	// Substring should not match (BAR != BA).
+	if envHasKey(env, "BA") {
+		t.Errorf("substring match leaked through (BA matched BAR)")
+	}
+}
+
+func TestRandomHexLength(t *testing.T) {
+	t.Parallel()
+
+	s, err := randomHex(32)
+	if err != nil {
+		t.Fatalf("randomHex: %v", err)
+	}
+	if len(s) != 64 {
+		t.Errorf("len: got %d, want 64", len(s))
+	}
+	// Two consecutive calls should produce different values.
+	s2, _ := randomHex(32)
+	if s == s2 {
+		t.Errorf("expected different values on successive calls")
+	}
+}
+
+func TestFirstKey(t *testing.T) {
+	t.Parallel()
+
+	if firstKey(nil) != "" {
+		t.Errorf("nil map should yield empty string")
+	}
+	if firstKey(map[string]any{}) != "" {
+		t.Errorf("empty map should yield empty string")
+	}
+	got := firstKey(map[string]any{"only": 1})
+	if got != "only" {
+		t.Errorf("singleton: got %q, want %q", got, "only")
+	}
+}
+
+func TestResolveOpencodeWaitForSubAgents(t *testing.T) {
+	// Don't t.Parallel(): we mutate process env.
+
+	t.Run("env unset defaults to enabled", func(t *testing.T) {
+		t.Setenv("MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT", "")
+		if !resolveOpencodeWaitForSubAgents() {
+			t.Errorf("default should be enabled, got false")
+		}
+	})
+
+	for _, v := range []string{"1", "true", "TRUE", "yes", "  yes  "} {
+		t.Run("env="+v+" disables", func(t *testing.T) {
+			t.Setenv("MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT", v)
+			if resolveOpencodeWaitForSubAgents() {
+				t.Errorf("env=%q should disable, got enabled", v)
+			}
+		})
+	}
+
+	for _, v := range []string{"0", "false", "no", "off", "anythingelse"} {
+		t.Run("env="+v+" leaves enabled", func(t *testing.T) {
+			t.Setenv("MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT", v)
+			if !resolveOpencodeWaitForSubAgents() {
+				t.Errorf("env=%q should leave enabled, got disabled", v)
+			}
+		})
+	}
+}
+
+func TestNewOpencodeBackendCapturesEnvAtConstruction(t *testing.T) {
+	// Don't t.Parallel(): we mutate process env.
+
+	t.Run("env disables → backend disabled", func(t *testing.T) {
+		t.Setenv("MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT", "1")
+		b := newOpencodeBackend(Config{})
+		if b.waitForSubAgents {
+			t.Errorf("waitForSubAgents: got true, want false (env=1 at construction)")
+		}
+	})
+
+	t.Run("env unset → backend enabled", func(t *testing.T) {
+		t.Setenv("MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT", "")
+		b := newOpencodeBackend(Config{})
+		if !b.waitForSubAgents {
+			t.Errorf("waitForSubAgents: got false, want true (env unset)")
+		}
+	})
+
+	t.Run("env mutated after construction does not affect backend", func(t *testing.T) {
+		t.Setenv("MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT", "")
+		b := newOpencodeBackend(Config{})
+		t.Setenv("MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT", "1")
+		if !b.waitForSubAgents {
+			t.Errorf("backend should ignore post-construction env changes, got disabled")
+		}
+	})
+}
+
+func TestRemainingTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no deadline returns fallback", func(t *testing.T) {
+		got := remainingTimeout(context.Background(), 7*time.Minute)
+		if got != 7*time.Minute {
+			t.Errorf("got %s, want 7m", got)
+		}
+	})
+
+	t.Run("deadline far in future returns time-until", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		got := remainingTimeout(ctx, 1*time.Hour)
+		if got < 25*time.Second || got > 30*time.Second {
+			t.Errorf("got %s, want roughly 30s", got)
+		}
+	})
+
+	t.Run("expired deadline floors at minimum", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+		defer cancel()
+		time.Sleep(2 * time.Millisecond)
+		got := remainingTimeout(ctx, 1*time.Hour)
+		if got != 5*time.Second {
+			t.Errorf("got %s, want 5s minimum", got)
+		}
+	})
+}
+
+// ── opencodeServer.queryActiveSessions ──
+
+func TestQueryActiveSessionsBasicAuthAndDecode(t *testing.T) {
+	t.Parallel()
+
+	var observedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observedAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/session/status" {
+			t.Errorf("path: got %q, want /session/status", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ses_a":{"type":"busy"},"ses_b":{"type":"retry","attempt":1,"message":"x","next":1000}}`))
+	}))
+	defer srv.Close()
+
+	s := &opencodeServer{URL: srv.URL, Password: "secret123"}
+	got, err := s.queryActiveSessions(context.Background(), srv.Client(), srv.URL+"/session/status")
+	if err != nil {
+		t.Fatalf("queryActiveSessions: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("count: got %d, want 2", len(got))
+	}
+	if observedAuth == "" || !strings.HasPrefix(observedAuth, "Basic ") {
+		t.Errorf("auth header: got %q, want Basic ...", observedAuth)
+	}
+}
+
+func TestQueryActiveSessionsNon200(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+		_, _ = w.Write([]byte("temporarily unavailable"))
+	}))
+	defer srv.Close()
+
+	s := &opencodeServer{URL: srv.URL, Password: "x"}
+	_, err := s.queryActiveSessions(context.Background(), srv.Client(), srv.URL+"/session/status")
+	if err == nil {
+		t.Fatal("expected error on 503, got nil")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("error should mention status code, got %q", err)
+	}
+}
+
+func TestQueryActiveSessionsBadJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json at all`))
+	}))
+	defer srv.Close()
+
+	s := &opencodeServer{URL: srv.URL, Password: "x"}
+	_, err := s.queryActiveSessions(context.Background(), srv.Client(), srv.URL+"/session/status")
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+}
+
+// ── opencodeServer.WaitForIdle: integration with a fake server ──
+
+// fakeStatusServer simulates opencode's /session/status endpoint. It returns
+// the i-th response from the responses slice for the i-th request, capping
+// at the last entry. Useful for scripting "active for N polls then idle".
+func fakeStatusServer(t *testing.T, password string, responses []string) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify Basic auth so the test catches a missing header.
+		if u, p, ok := r.BasicAuth(); !ok || u != "opencode" || p != password {
+			w.WriteHeader(401)
+			return
+		}
+		idx := int(calls.Add(1) - 1)
+		if idx >= len(responses) {
+			idx = len(responses) - 1
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(responses[idx]))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func TestNonIdleSessionsExcludingMain(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{"ses_main": map[string]any{"type": "busy"}, "ses_child": map[string]any{"type": "busy"}}
+	got := nonIdleSessionsExcludingMain(raw, "ses_main")
+	if len(got) != 1 {
+		t.Fatalf("len: got %d, want 1", len(got))
+	}
+	if _, ok := got["ses_child"]; !ok {
+		t.Fatalf("expected ses_child to remain, got %v", got)
+	}
+	if got := nonIdleSessionsExcludingMain(raw, ""); len(got) != len(raw) {
+		t.Fatalf("empty exclude: len got %d, want %d", len(got), len(raw))
+	}
+	empty := nonIdleSessionsExcludingMain(map[string]any{"ses_main": 1}, "ses_main")
+	if len(empty) != 0 {
+		t.Fatalf("got %v, want empty", empty)
+	}
+}
+
+func TestWaitForIdleIgnoresStuckParentSession(t *testing.T) {
+	t.Parallel()
+
+	// Parent stays "busy" forever in /session/status (OpenCode quirk after run exits).
+	// Excluding that ID, filtered map is always empty → debounce completes only after
+	// sub-agent idle grace (shortened in this test).
+	const password = "test-pw"
+	prevGrace := opencodeSubagentIdleGrace
+	opencodeSubagentIdleGrace = 150 * time.Millisecond
+	t.Cleanup(func() { opencodeSubagentIdleGrace = prevGrace })
+
+	srv, calls := fakeStatusServer(t, password, []string{
+		`{"ses_parent":{"type":"busy"}}`,
+	})
+
+	s := &opencodeServer{URL: srv.URL, Password: password}
+	start := time.Now()
+	err := s.WaitForIdle(context.Background(), 60*time.Second, slog.Default(), "ses_parent")
+	if err != nil {
+		t.Fatalf("WaitForIdle: %v", err)
+	}
+	if time.Since(start) > 45*time.Second {
+		t.Errorf("took too long: %s", time.Since(start))
+	}
+	if calls.Load() < 3 {
+		t.Errorf("expected at least 3 polls for debounce, got %d", calls.Load())
+	}
+}
+
+func TestWaitForIdleDefersEmptyUntilGraceWithoutSubagents(t *testing.T) {
+	t.Parallel()
+
+	// Status is empty from the start (child sessions not registered yet). Without a
+	// grace period we would debounce-complete immediately; with grace we wait.
+	const password = "test-pw"
+	prevGrace := opencodeSubagentIdleGrace
+	opencodeSubagentIdleGrace = 250 * time.Millisecond
+	t.Cleanup(func() { opencodeSubagentIdleGrace = prevGrace })
+
+	srv, calls := fakeStatusServer(t, password, []string{
+		`{}`,
+	})
+
+	s := &opencodeServer{URL: srv.URL, Password: password}
+	start := time.Now()
+	err := s.WaitForIdle(context.Background(), 60*time.Second, slog.Default(), "ses_main")
+	if err != nil {
+		t.Fatalf("WaitForIdle: %v", err)
+	}
+	elapsed := time.Since(start)
+	// Grace 250ms + 3 polls × 3s interval between polls ≈ 9s minimum.
+	if elapsed < 8*time.Second {
+		t.Errorf("expected at least ~8s (grace + debounce), got %s", elapsed)
+	}
+	if calls.Load() < 3 {
+		t.Errorf("expected at least 3 polls, got %d", calls.Load())
+	}
+}
+
+func TestWaitForIdleReturnsAfterDebounce(t *testing.T) {
+	t.Parallel()
+
+	// 1 active poll, then idle forever. With requiredStablePolls = 3 the
+	// loop returns after 1 (busy) + 3 (idle) = 4 polls minimum.
+	const password = "test-pw"
+	srv, calls := fakeStatusServer(t, password, []string{
+		`{"ses_a":{"type":"busy"}}`, // poll 1: busy
+		`{}`,                        // poll 2..n: idle
+	})
+
+	s := &opencodeServer{URL: srv.URL, Password: password}
+	logger := slog.Default()
+
+	// Speed: poll interval is 3s in production. We rely on the fact that
+	// the loop calls time.After(3s) AFTER each successful response. To keep
+	// the test under 1s we don't override the constant; instead we accept
+	// a longer wall-clock and use a generous timeout.
+	// To keep tests fast we cap the test at 30s (the loop will succeed in
+	// roughly 1*0 + 3*3s = ~9s real time).
+	start := time.Now()
+	err := s.WaitForIdle(context.Background(), 30*time.Second, logger, "")
+	if err != nil {
+		t.Fatalf("WaitForIdle: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 20*time.Second {
+		t.Errorf("WaitForIdle took too long: %s", elapsed)
+	}
+	if calls.Load() < 4 {
+		t.Errorf("expected at least 4 polls (1 busy + 3 idle), got %d", calls.Load())
+	}
+}
+
+func TestWaitForIdleResetsDebounceOnReactivation(t *testing.T) {
+	t.Parallel()
+
+	// idle, idle, BUSY (resets), idle, idle, idle → returns on poll 6.
+	const password = "test-pw"
+	srv, calls := fakeStatusServer(t, password, []string{
+		`{}`,
+		`{}`,
+		`{"ses_a":{"type":"busy"}}`,
+		`{}`,
+		`{}`,
+		`{}`,
+	})
+
+	s := &opencodeServer{URL: srv.URL, Password: password}
+	if err := s.WaitForIdle(context.Background(), 60*time.Second, slog.Default(), ""); err != nil {
+		t.Fatalf("WaitForIdle: %v", err)
+	}
+	if got := calls.Load(); got < 6 {
+		t.Errorf("expected at least 6 polls (debounce reset by busy), got %d", got)
+	}
+}
+
+func TestWaitForIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Always busy → must hit the timeout.
+	const password = "test-pw"
+	srv, _ := fakeStatusServer(t, password, []string{
+		`{"ses_a":{"type":"busy"}}`,
+	})
+
+	s := &opencodeServer{URL: srv.URL, Password: password}
+	err := s.WaitForIdle(context.Background(), 100*time.Millisecond, slog.Default(), "")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error should mention timeout, got %q", err)
+	}
+}
+
+func TestWaitForIdleContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	const password = "test-pw"
+	srv, _ := fakeStatusServer(t, password, []string{
+		`{"ses_a":{"type":"busy"}}`,
+	})
+
+	s := &opencodeServer{URL: srv.URL, Password: password}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	err := s.WaitForIdle(ctx, 30*time.Second, slog.Default(), "")
+	if err == nil {
+		t.Fatal("expected ctx.Err(), got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("error: got %v, want context.Canceled", err)
+	}
+}
+
+func TestWaitForIdleConsecutivePollErrorsBail(t *testing.T) {
+	t.Parallel()
+
+	// Server always returns 500 → 5 consecutive errors → bail with explicit error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	s := &opencodeServer{URL: srv.URL, Password: "x"}
+	err := s.WaitForIdle(context.Background(), 60*time.Second, slog.Default(), "")
+	if err == nil {
+		t.Fatal("expected error after consecutive failures, got nil")
+	}
+	if !strings.Contains(err.Error(), "consecutive") {
+		t.Errorf("error should mention consecutive failures, got %q", err)
+	}
 }


### PR DESCRIPTION
## What does this PR do?

When a runtime uses the `opencode` runner with plugins that spawn **background sub-agents** (e.g. [`oh-my-openagent`](https://github.com/Zaratustra-x/oh-my-openagent)), the daemon was marking tasks as **completed** as soon as the parent `opencode run` exited — killing the embedded server that hosted those sub-agent sessions and losing their work.

Three-layer mismatch behind the bug:

- `opencode run` exits on its **own** session, not on its child sessions.
- plugins spawn sub-agents as **separate sessions** on the same server.
- the daemon treated parent process exit as task completion.

This PR fixes it by running `opencode` against a **daemon-managed `opencode serve`** (random port + `OPENCODE_SERVER_PASSWORD`) using `opencode run --attach`. After `run` returns, the daemon polls `GET /session/status` until every **non-parent** session has been idle for 3 consecutive polls. The parent session id is filtered out (OpenCode keeps it in `/session/status` after the CLI returns; waiting for an empty map would otherwise block until the global timeout). A 45 s grace window before trusting an empty status map covers the race where children register slightly after the parent run returns.

The behavior is **on by default** for the opencode backend, opt-out via `MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT=1`. If `opencode serve` fails to come up, the daemon **silently falls back** to the legacy embedded-server mode so existing setups never regress.

## Related Issue

Closes #1404

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/opencode.go`
  - new `opencodeBackend.waitForSubAgents` (resolved once from `MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT` at construction)
  - `startOpencodeServer()` spawns `opencode serve` with random port + auto-generated `OPENCODE_SERVER_PASSWORD`, parses the listen line from stdout, and exposes a typed `*opencodeServer`
  - `Execute()` runs `opencode run --attach <serveURL>` against that server, then calls `server.WaitForIdle(ctx, timeout, logger, mainSessionID)` after `run` returns
  - `WaitForIdle()` polls `/session/status` every 3 s, requires 3 consecutive idle polls, filters out `mainSessionID` via `nonIdleSessionsExcludingMain`, defers the idle decision for `opencodeSubagentIdleGrace` (45 s) when no non-parent activity has been observed
  - `Stop()` does graceful SIGTERM then SIGKILL of the server, with a goroutine guard on `ctx.Done()`
  - silent fallback to embedded-server mode if `serve` fails to start
  - `opencodeBlockedArgs` now also blocks `--attach` and `--port` so user-supplied `custom_args` cannot collide with daemon-managed flags
- `server/pkg/agent/agent.go`
  - factory routes `"opencode"` through `newOpencodeBackend(cfg)` (kept the generic `agent.Config` untouched — the new knob lives on the backend struct, not on the public contract)
- `server/pkg/agent/opencode_test.go`
  - `TestResolveOpencodeWaitForSubAgents` and `TestNewOpencodeBackendCapturesEnvAtConstruction`
  - `TestNonIdleSessionsExcludingMain`
  - `TestWaitForIdleIgnoresStuckParentSession` and `TestWaitForIdleDefersEmptyUntilGraceWithoutSubagents` (httptest-based)
  - all existing `TestWaitForIdle*` tests updated to pass `mainSessionID = ""`
- `CLI_AND_DAEMON.md`
  - new env-var entry `MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT`
  - new section **OpenCode keep-alive (sub-agent waiting)** explaining the mechanism, the polling + grace window, and the opt-out

## How to Test

1. Self-host Multica via `docker-compose.selfhost.yml` and start the daemon from this branch (`make daemon` or via the worktree flow in `CONTRIBUTING.md`).
2. Configure a runtime with `runner = opencode` and install [`oh-my-openagent`](https://github.com/Zaratustra-x/oh-my-openagent) so that it spawns at least one background sub-agent.
3. Create an issue whose prompt triggers a background sub-agent (any plugin task that uses `BackgroundManager`, e.g. a Documentor / hephaestus delegation).
4. Assign it to the agent and watch the daemon logs:
   - `opencode serve: started url=http://127.0.0.1:<port>`
   - `opencode run: process exited code=0`
   - `opencode serve: still busy active_sessions=N first=ses_…` (sub-agents)
   - `opencode serve: idle poll consecutive=1/3` … `2/3` … `3/3`
   - then `opencode serve: stopped` and the task transitions to **completed**.
5. Confirm the issue stays in **running** while sub-agents are working and only flips to **completed** once `/session/status` (minus the parent id) has been empty for 3 polls.
6. Opt-out check: re-run with `MULTICA_OPENCODE_DISABLE_SUBAGENT_WAIT=1 multica daemon restart` — the daemon should fall back to the legacy single-`opencode run` flow.
7. Unit tests: `cd server && go test ./pkg/agent/... -count=1` (15 s, all passing).

## Checklist

- [x] I have included a thinking path that traces from project context to this change (see "What does this PR do?" — three-layer mismatch + chosen fix)
- [x] I have run tests locally and they pass (`go vet ./pkg/agent/...` clean, `go test ./pkg/agent/... -count=1` green in `golang:1.26-alpine`)
- [x] I have added or updated tests where applicable (httptest coverage for the new polling logic + filter helper + env resolver)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — daemon-only change)
- [x] I have updated relevant documentation to reflect my changes (`CLI_AND_DAEMON.md`)
- [x] I have considered and documented any risks above (silent fallback to embedded-server mode if `opencode serve` fails to come up, opt-out env var)
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Cursor (Claude)

**Prompt / approach:**

Started from a self-hosted reproduction (frontend `13000`, backend `18080`, daemon health `19514`) where tasks using the `opencode` runner + `oh-my-openagent` plugin were closing prematurely. Asked the assistant to analyze the multi-layer session model (opencode CLI vs server vs plugin) and propose a fix that lives **only in `multica`** (so it could ship without waiting on an upstream `opencode` change). Iterated through three rounds:

1. orchestrate `opencode serve` + `opencode run --attach`, poll `/session/status` after run exits;
2. after a first reload showed the polling stuck on `active_sessions=1`, traced it to the parent session being kept "busy" in OpenCode's status map → added the `mainSessionID` filter;
3. then noticed a race where `/session/status` could be empty before sub-agents even register → added the 45 s grace window + `sawOtherBusy` flag.

Each iteration was validated against the live Docker stack and httptest unit tests. The new knob was deliberately placed on `opencodeBackend` (not on the generic `agent.Config`) to keep the public `Backend` contract uniform across runtimes (claude, codex, …).
