### PR TITLE
fix(install): remove root-level name from docker-compose files for older compose compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ selfhost:
 		echo "==> Generated random JWT_SECRET"; \
 	fi
 	@echo "==> Starting Multica via Docker Compose..."
-	docker compose -f docker-compose.selfhost.yml up -d --build
+	docker compose -p multica -f docker-compose.selfhost.yml up -d --build
 	@echo "==> Waiting for backend to be ready..."
 	@for i in $$(seq 1 30); do \
 		if curl -sf http://localhost:$${PORT:-8080}/health > /dev/null 2>&1; then \
@@ -75,13 +75,13 @@ selfhost:
 	else \
 		echo ""; \
 		echo "Services are still starting. Check logs:"; \
-		echo "  docker compose -f docker-compose.selfhost.yml logs"; \
+		echo "  docker compose -p multica -f docker-compose.selfhost.yml logs"; \
 	fi
 
 # Stop all Docker Compose self-host services
 selfhost-stop:
 	@echo "==> Stopping Multica services..."
-	docker compose -f docker-compose.selfhost.yml down
+	docker compose -p multica -f docker-compose.selfhost.yml down
 	@echo "✓ All services stopped."
 
 # ---------- One-click commands ----------

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -8,8 +8,6 @@
 # Frontend: http://localhost:3000
 # Backend:  http://localhost:8080 (also used by CLI/daemon)
 
-name: multica
-
 services:
   postgres:
     image: pgvector/pgvector:pg17

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-name: multica
-
 services:
   postgres:
     image: pgvector/pgvector:pg17

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -233,7 +233,7 @@ function Install-Server {
     }
 
     Write-Info "Starting Multica services (this may take a few minutes on first run)..."
-    docker compose -f docker-compose.selfhost.yml up -d --build
+    docker compose -p multica -f docker-compose.selfhost.yml up -d --build
 
     Write-Info "Waiting for backend to be ready..."
     $ready = $false
@@ -251,7 +251,7 @@ function Install-Server {
         Write-Ok "Multica server is running"
     } else {
         Write-Warn "Server is still starting. Check logs with:"
-        Write-Host "  cd $InstallDir; docker compose -f docker-compose.selfhost.yml logs"
+        Write-Host "  cd $InstallDir; docker compose -p multica -f docker-compose.selfhost.yml logs"
     }
 
     Pop-Location
@@ -327,7 +327,7 @@ function Start-Stop {
     if (Test-Path $InstallDir) {
         Push-Location $InstallDir
         if (Test-Path "docker-compose.selfhost.yml") {
-            docker compose -f docker-compose.selfhost.yml down
+            docker compose -p multica -f docker-compose.selfhost.yml down
             Write-Ok "Docker services stopped"
         } else {
             Write-Warn "No docker-compose.selfhost.yml found at $InstallDir"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -261,7 +261,7 @@ setup_server() {
 
   # Start Docker Compose
   info "Starting Multica services (this may take a few minutes on first run)..."
-  docker compose -f docker-compose.selfhost.yml up -d --build
+  docker compose -p multica -f docker-compose.selfhost.yml up -d --build
 
   # Wait for health check
   info "Waiting for backend to be ready..."
@@ -278,7 +278,7 @@ setup_server() {
     ok "Multica server is running"
   else
     warn "Server is still starting. You can check logs with:"
-    echo "  cd $INSTALL_DIR && docker compose -f docker-compose.selfhost.yml logs"
+    echo "  cd $INSTALL_DIR && docker compose -p multica -f docker-compose.selfhost.yml logs"
     echo ""
   fi
 }
@@ -355,7 +355,7 @@ run_stop() {
   if [ -d "$INSTALL_DIR" ]; then
     cd "$INSTALL_DIR"
     if [ -f docker-compose.selfhost.yml ]; then
-      docker compose -f docker-compose.selfhost.yml down
+      docker compose -p multica -f docker-compose.selfhost.yml down
       ok "Docker services stopped"
     else
       warn "No docker-compose.selfhost.yml found at $INSTALL_DIR"


### PR DESCRIPTION
Fixes #1401

The `name` property at the root level of docker-compose files is only supported in Docker Compose v2+. Older versions validate against a JSON schema that rejects it, causing the self-host installer to fail with `(root) Additional property name is not allowed`.

To preserve the same project name behavior, this PR passes `-p multica` explicitly in all docker compose invocations in the install scripts and Makefile.

**Changes:**
- Removed `name: multica` from `docker-compose.yml` and `docker-compose.selfhost.yml`
- Added `-p multica` to all `docker compose` commands in `scripts/install.sh`, `scripts/install.ps1`, and `Makefile`