### PR TITLE
fix(usage): attribute tokens to configured model instead of "unknown"

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1141,10 +1141,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	)
 
 	// Convert agent usage map to task usage entries.
+	// Backends that cannot extract the model from the agent stream use
+	// "unknown" as the key; substitute the configured model when available.
 	var usageEntries []TaskUsageEntry
 	for model, u := range result.Usage {
 		if u.InputTokens == 0 && u.OutputTokens == 0 && u.CacheReadTokens == 0 && u.CacheWriteTokens == 0 {
 			continue
+		}
+		if (model == "unknown" || model == "") && execOpts.Model != "" {
+			model = execOpts.Model
 		}
 		usageEntries = append(usageEntries, TaskUsageEntry{
 			Provider:         provider,

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -189,6 +189,19 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 		b.cfg.Logger.Info("claude finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
 
+		// When the provider omits the model name from streamed messages
+		// (e.g. OpenRouter), usage is keyed under "". Re-key it under
+		// the configured model so the dashboard shows a useful name.
+		if u, ok := usage[""]; ok && opts.Model != "" {
+			existing := usage[opts.Model]
+			existing.InputTokens += u.InputTokens
+			existing.OutputTokens += u.OutputTokens
+			existing.CacheReadTokens += u.CacheReadTokens
+			existing.CacheWriteTokens += u.CacheWriteTokens
+			usage[opts.Model] = existing
+			delete(usage, "")
+		}
+
 		reportedSessionID := resolveSessionID(opts.ResumeSessionID, sessionID, finalStatus == "failed")
 		if reportedSessionID != sessionID {
 			b.cfg.Logger.Info("claude resume did not land; clearing fresh session id for daemon fallback",
@@ -216,14 +229,17 @@ func (b *claudeBackend) handleAssistant(msg claudeSDKMessage, ch chan<- Message,
 		return
 	}
 
-	// Accumulate token usage per model.
-	if content.Usage != nil && content.Model != "" {
-		u := usage[content.Model]
+	// Accumulate token usage per model. When the provider omits the
+	// model field (e.g. OpenRouter-proxied responses), key under "" so
+	// the caller can re-key against the configured model.
+	if content.Usage != nil {
+		key := content.Model // may be "" if provider doesn't populate it
+		u := usage[key]
 		u.InputTokens += content.Usage.InputTokens
 		u.OutputTokens += content.Usage.OutputTokens
 		u.CacheReadTokens += content.Usage.CacheReadInputTokens
 		u.CacheWriteTokens += content.Usage.CacheCreationInputTokens
-		usage[content.Model] = u
+		usage[key] = u
 	}
 
 	for _, block := range content.Content {


### PR DESCRIPTION
## Summary

When a provider (e.g. OpenRouter) omits the model field from streamed messages, the usage dashboard shows "unknown" instead of the actual model name.

## Root Cause

Two places where model attribution falls through:

1. **Claude backend** (`claude.go`): `handleAssistant` only accumulates usage when `content.Model != ""`. If the provider omits the model field (common with OpenRouter-proxied responses), usage tokens are silently dropped.

2. **All other backends** (opencode, hermes, pi, codex, kimi, openclaw): fall back to `opts.Model`, but if that is also empty (no per-agent model configured), they key usage under `"unknown"`.

## Fix

Two-layer approach:

1. **`claude.go`**: Accumulate usage even when `content.Model` is empty (keyed under `""`), then re-key from `""` → `opts.Model` before returning the result.

2. **`daemon.go`** (safety net): When converting backend usage to task usage entries, replace `"unknown"` or `""` model keys with the configured model (`agent.model` → `MULTICA_<PROVIDER>_MODEL`).

## Testing

- All existing tests pass (`go test ./pkg/agent/ ./internal/daemon/ ./internal/handler/`)
- The fix is backward-compatible: if the provider does populate `content.Model`, the original behavior is preserved

Closes #1395