### PR TITLE
docs: add v0.2.8 changelog (2026-04-20)

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -283,6 +283,22 @@ export const en: LandingDict = {
     },
     entries: [
       {
+        version: "0.2.8",
+        date: "2026-04-20",
+        title: "Per-Agent Models, Kimi Runtime & Self-Host Auth",
+        changes: [],
+        features: [
+          "Per-agent `model` field with a provider-aware dropdown — pick the LLM model for each agent from the UI or via `multica agent create/update --model`, with live discovery from each runtime's CLI",
+          "Kimi CLI as a new agent runtime (Moonshot AI's `kimi-cli` over ACP), with model selection, auto-approved tool permissions, and streaming tool-call rendering",
+          "Expand toggle on inline comment and reply editors for composing long text",
+        ],
+        fixes: [
+          "Posting the result comment is now an explicit, numbered step in agent workflows so final replies reach the issue instead of terminal output",
+          "Agent live status card no longer leaks across issues when switching via Cmd+K",
+          "Self-hosted session cookies honor the `FRONTEND_ORIGIN` scheme — plain-HTTP deployments stop silently dropping cookies, and `COOKIE_DOMAIN=<ip>` now falls back to host-only with a warning instead of breaking login",
+        ],
+      },
+      {
         version: "0.2.7",
         date: "2026-04-18",
         title: "Sub-Issues from Editor, Self-Host Gating & MCP",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -283,6 +283,22 @@ export const zh: LandingDict = {
     },
     entries: [
       {
+        version: "0.2.8",
+        date: "2026-04-20",
+        title: "Agent 模型选择、Kimi Runtime 与自部署登录",
+        changes: [],
+        features: [
+          "Agent 新增 `model` 字段及按 Provider 聚合的模型下拉框——可在界面或通过 `multica agent create/update --model` 为每个 Agent 选择 LLM 模型，并从各 Runtime CLI 实时发现可用模型",
+          "新增 Kimi CLI Agent Runtime（Moonshot AI 的 `kimi-cli`，基于 ACP），支持模型选择、自动授权工具权限以及流式工具调用渲染",
+          "评论和回复编辑器新增放大按钮，便于撰写长文本",
+        ],
+        fixes: [
+          "Agent 工作流将“发布结果评论”提升为独立的显式步骤，确保最终回复送达 Issue 而不是只留在终端输出",
+          "通过 Cmd+K 切换 Issue 时不再出现其他 Issue 的 Agent 实时状态残留",
+          "自部署会话 Cookie 的 Secure 标志改由 `FRONTEND_ORIGIN` 协议决定——HTTP 部署不再因浏览器丢弃 Cookie 导致登录失败；`COOKIE_DOMAIN=<ip>` 会自动回退到 host-only 并输出警告",
+        ],
+      },
+      {
         version: "0.2.7",
         date: "2026-04-18",
         title: "编辑器创建子 Issue、自部署门禁与 MCP",


### PR DESCRIPTION
## Summary
Adds the missing landing-page Change Log entry for v0.2.8 in both `en.ts` and `zh.ts`. Follows the Cursor/Notion style of summarizing a release's headline items rather than a commit-by-commit log.

v0.2.6 is intentionally skipped (single docs commit). v0.2.9 is the same git commit as v0.2.8, so the one entry covers both.

**Highlights captured**
- Per-agent `model` field with provider-aware dropdown (#1399)
- Kimi CLI agent runtime (#1400)
- Expand toggle on comment and reply editors (#1386)
- Result-comment step hoisted in agent workflows (#1372)
- Agent live state isolated per issue on Cmd+K switch (#1389, MUL-1147)
- `FRONTEND_ORIGIN`-derived cookie Secure flag for self-host (#1390)

Refs [MUL-1170](mention://issue/bb662988-c868-4279-bf02-9539b2a7cdde).

## Test plan
- [ ] Visit `/changelog` on the landing site and confirm v0.2.8 renders at the top with features/fixes sections.
- [ ] Toggle language to 中文 and confirm the zh entry renders.