### PR TITLE
feat(daemon): log agent invocation at info level

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -59,7 +59,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}()
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -100,7 +100,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 	codexArgs := append([]string{"app-server", "--listen", "stdio://"}, filterCustomArgs(opts.CustomArgs, codexBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, codexArgs...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", codexArgs)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", codexArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/copilot.go
+++ b/server/pkg/agent/copilot.go
@@ -198,7 +198,7 @@ func (b *copilotBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 	args := buildCopilotArgs(prompt, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -38,7 +38,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	args := buildCursorArgs(prompt, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 20 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -35,7 +35,7 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	args := buildGeminiArgs(prompt, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -47,7 +47,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 	hermesArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, hermesBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, hermesArgs...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", hermesArgs)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", hermesArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -51,7 +51,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	// "approve_for_session" to every session/request_permission request.
 	kimiArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, kimiBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, kimiArgs...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", kimiArgs)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", kimiArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -52,7 +52,7 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	args := buildOpenclawArgs(prompt, sessionID, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -55,7 +55,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	args = append(args, prompt)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
-	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -54,6 +54,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 	args := buildPiArgs(prompt, sessionPath, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd


### PR DESCRIPTION
## Summary
- Promote the `"agent command"` log from Debug to Info across all agent backends (claude, codex, copilot, cursor, gemini, hermes, kimi, openclaw, opencode), so operators can see `exec` + `args` in default logs without flipping to `--log-level=debug`.
- Add the missing log line in `pi.go` for consistency with the other nine backends.

Addresses [MUL-1192](mention://issue/e238f114-9abb-4710-8281-5c49d13fbd81). Custom args don't contain secrets, so making them visible by default helps debug agent runs faster.

## Test plan
- [x] `go build ./pkg/agent/...` passes
- [x] `go vet ./pkg/agent/...` passes
- [x] `go test ./pkg/agent/...` passes
- [ ] Manual: run daemon at default log level, confirm `agent command exec=... args=[...]` appears when an agent is started