### PR TITLE
feat(auth): add Feishu OAuth login provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,16 @@ GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 
+# Feishu (飞书) OAuth — enterprise internal app only.
+# Grant `contact:user.base:readonly` + `contact:user.email:readonly` permissions
+# to the app in the Feishu developer console, and register the redirect URI
+# (http://localhost:3000/auth/feishu/callback for local dev).
+# Feishu users without a bound email address are rejected at login.
+FEISHU_APP_ID=
+FEISHU_APP_SECRET=
+FEISHU_REDIRECT_URI=http://localhost:3000/auth/feishu/callback
+NEXT_PUBLIC_FEISHU_APP_ID=
+
 # S3 / CloudFront
 S3_BUCKET=
 S3_REGION=us-west-2

--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,16 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback
 
+# Feishu (飞书) OAuth — enterprise internal app only.
+# Grant `contact:user.base:readonly` + `contact:user.email:readonly` permissions
+# to the app in the Feishu developer console, and register the redirect URI
+# (http://localhost:3000/auth/feishu/callback for local dev).
+# Feishu users without a bound email address are rejected at login.
+FEISHU_APP_ID=
+FEISHU_APP_SECRET=
+FEISHU_REDIRECT_URI=http://localhost:3000/auth/feishu/callback
+NEXT_PUBLIC_FEISHU_APP_ID=
+
 # S3 / CloudFront
 # S3_BUCKET — bucket NAME only (e.g. "my-bucket"). Do NOT include the
 # ".s3.<region>.amazonaws.com" suffix; the server builds the public URL

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -54,6 +54,11 @@ async function resolveLoggedInDestination(
   return resolvePostAuthDestination(workspaces, hasOnboarded);
 }
 
+// Feishu app id stays as a build-time env var. The Google client id was
+// migrated to useConfigStore in main; Feishu can follow that pattern in a
+// later refactor — for now keep it inline so the rebase stays narrow.
+const feishuAppId = process.env.NEXT_PUBLIC_FEISHU_APP_ID;
+
 function LoginPageContent() {
   const router = useRouter();
   const qc = useQueryClient();
@@ -126,9 +131,10 @@ function LoginPageContent() {
     router.push(dest);
   };
 
-  // Build Google OAuth state: encode platform + next URL so the callback
-  // can redirect to the right place after login.
-  const googleState = [
+  // Build OAuth state: encode platform + next URL so the callback can
+  // redirect to the right place after login. Shared between Google and
+  // Feishu since the encoding is the same.
+  const oauthState = [
     platform === "desktop" ? "platform:desktop" : "",
     nextUrl ? `next:${nextUrl}` : "",
   ]
@@ -188,7 +194,7 @@ function LoginPageContent() {
   // Next.js will SSR this client component on first request, so window is
   // undefined during the server render. Compute origin lazily and substitute
   // an empty string on the server; hydration replaces it with the real value
-  // before the user can click the OAuth button.
+  // before the user can click either OAuth button.
   const origin = typeof window !== "undefined" ? window.location.origin : "";
 
   return (
@@ -199,7 +205,16 @@ function LoginPageContent() {
           ? {
               clientId: googleClientId,
               redirectUri: `${origin}/auth/callback`,
-              state: googleState,
+              state: oauthState,
+            }
+          : undefined
+      }
+      feishu={
+        feishuAppId
+          ? {
+              appId: feishuAppId,
+              redirectUri: `${origin}/auth/feishu/callback`,
+              state: oauthState,
             }
           : undefined
       }

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -185,6 +185,12 @@ function LoginPageContent() {
     );
   }
 
+  // Next.js will SSR this client component on first request, so window is
+  // undefined during the server render. Compute origin lazily and substitute
+  // an empty string on the server; hydration replaces it with the real value
+  // before the user can click the OAuth button.
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+
   return (
     <LoginPage
       onSuccess={handleSuccess}
@@ -192,7 +198,7 @@ function LoginPageContent() {
         googleClientId
           ? {
               clientId: googleClientId,
-              redirectUri: `${window.location.origin}/auth/callback`,
+              redirectUri: `${origin}/auth/callback`,
               state: googleState,
             }
           : undefined

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -145,6 +145,12 @@ function LoginPageContent() {
     );
   }
 
+  // Next.js will SSR this client component on first request, so window is
+  // undefined during the server render. Compute origin lazily and substitute
+  // an empty string on the server; hydration replaces it with the real value
+  // before the user can click the OAuth button.
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+
   return (
     <LoginPage
       onSuccess={handleSuccess}
@@ -152,7 +158,7 @@ function LoginPageContent() {
         googleClientId
           ? {
               clientId: googleClientId,
-              redirectUri: `${window.location.origin}/auth/callback`,
+              redirectUri: `${origin}/auth/callback`,
               state: googleState,
             }
           : undefined

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -21,6 +21,7 @@ import { setLoggedInCookie } from "@/features/auth/auth-cookie";
 import { LoginPage, validateCliCallback } from "@multica/views/auth";
 
 const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+const feishuAppId = process.env.NEXT_PUBLIC_FEISHU_APP_ID;
 
 function LoginPageContent() {
   const router = useRouter();
@@ -90,9 +91,10 @@ function LoginPageContent() {
     );
   };
 
-  // Build Google OAuth state: encode platform + next URL so the callback
-  // can redirect to the right place after login.
-  const googleState = [
+  // Build OAuth state: encode platform + next URL so the callback can
+  // redirect to the right place after login. Shared between Google and
+  // Feishu since the encoding is the same.
+  const oauthState = [
     platform === "desktop" ? "platform:desktop" : "",
     nextUrl ? `next:${nextUrl}` : "",
   ]
@@ -148,7 +150,7 @@ function LoginPageContent() {
   // Next.js will SSR this client component on first request, so window is
   // undefined during the server render. Compute origin lazily and substitute
   // an empty string on the server; hydration replaces it with the real value
-  // before the user can click the OAuth button.
+  // before the user can click either OAuth button.
   const origin = typeof window !== "undefined" ? window.location.origin : "";
 
   return (
@@ -159,7 +161,16 @@ function LoginPageContent() {
           ? {
               clientId: googleClientId,
               redirectUri: `${origin}/auth/callback`,
-              state: googleState,
+              state: oauthState,
+            }
+          : undefined
+      }
+      feishu={
+        feishuAppId
+          ? {
+              appId: feishuAppId,
+              redirectUri: `${origin}/auth/feishu/callback`,
+              state: oauthState,
             }
           : undefined
       }

--- a/apps/web/app/auth/feishu/callback/page.test.tsx
+++ b/apps/web/app/auth/feishu/callback/page.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { paths } from "@multica/core/paths";
+
+const { mockPush, mockSearchParams, mockLoginWithFeishu, mockListWorkspaces } =
+  vi.hoisted(() => ({
+    mockPush: vi.fn(),
+    mockSearchParams: new URLSearchParams(),
+    mockLoginWithFeishu: vi.fn(),
+    mockListWorkspaces: vi.fn(),
+  }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ setQueryData: vi.fn() }),
+}));
+
+vi.mock("@multica/core/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/auth")>(
+      "@multica/core/auth",
+    );
+  return {
+    ...actual,
+    useAuthStore: (selector: (s: unknown) => unknown) =>
+      selector({ loginWithFeishu: mockLoginWithFeishu }),
+  };
+});
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  workspaceKeys: { list: () => ["workspaces"] },
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    listWorkspaces: mockListWorkspaces,
+    feishuLogin: vi.fn(),
+  },
+}));
+
+import CallbackPage from "./page";
+
+describe("Feishu CallbackPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams.forEach((_v, k) => mockSearchParams.delete(k));
+    mockSearchParams.set("code", "test-code");
+    mockLoginWithFeishu.mockResolvedValue(undefined);
+    mockListWorkspaces.mockResolvedValue([]);
+  });
+
+  it("falls back to paths.newWorkspace() when no next= and user has no workspace", async () => {
+    render(<CallbackPage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(paths.newWorkspace());
+    });
+  });
+
+  it("ignores unsafe next= targets from the OAuth state", async () => {
+    mockSearchParams.set("state", "next:https://evil.example");
+
+    render(<CallbackPage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(paths.newWorkspace());
+    });
+    expect(mockPush).not.toHaveBeenCalledWith("https://evil.example");
+  });
+
+  it("honors a safe next= target (e.g. /invite/{id})", async () => {
+    mockSearchParams.set("state", "next:/invite/abc123");
+
+    render(<CallbackPage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/invite/abc123");
+    });
+  });
+});

--- a/apps/web/app/auth/feishu/callback/page.tsx
+++ b/apps/web/app/auth/feishu/callback/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { sanitizeNextUrl, useAuthStore } from "@multica/core/auth";
+import { workspaceKeys } from "@multica/core/workspace/queries";
+import { paths } from "@multica/core/paths";
+import { api } from "@multica/core/api";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@multica/ui/components/ui/card";
+import { Button } from "@multica/ui/components/ui/button";
+import { Loader2 } from "lucide-react";
+
+function CallbackContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const qc = useQueryClient();
+  const loginWithFeishu = useAuthStore((s) => s.loginWithFeishu);
+  const [error, setError] = useState("");
+  const [desktopToken, setDesktopToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const code = searchParams.get("code");
+    if (!code) {
+      setError("Missing authorization code");
+      return;
+    }
+
+    const errorParam = searchParams.get("error");
+    if (errorParam) {
+      setError(errorParam);
+      return;
+    }
+
+    const state = searchParams.get("state") || "";
+    const stateParts = state.split(",");
+    const isDesktop = stateParts.includes("platform:desktop");
+    const nextPart = stateParts.find((p) => p.startsWith("next:"));
+    const nextUrl = sanitizeNextUrl(nextPart ? nextPart.slice(5) : null);
+
+    const redirectUri = `${window.location.origin}/auth/feishu/callback`;
+
+    if (isDesktop) {
+      api
+        .feishuLogin(code, redirectUri)
+        .then(({ token }) => {
+          setDesktopToken(token);
+          window.location.href = `multica://auth/callback?token=${encodeURIComponent(token)}`;
+        })
+        .catch((err) => {
+          setError(err instanceof Error ? err.message : "Login failed");
+        });
+    } else {
+      loginWithFeishu(code, redirectUri)
+        .then(async () => {
+          const wsList = await api.listWorkspaces();
+          qc.setQueryData(workspaceKeys.list(), wsList);
+          const [first] = wsList;
+          const defaultDest = first
+            ? paths.workspace(first.slug).issues()
+            : paths.newWorkspace();
+          router.push(nextUrl || defaultDest);
+        })
+        .catch((err) => {
+          setError(err instanceof Error ? err.message : "Login failed");
+        });
+    }
+  }, [searchParams, loginWithFeishu, router, qc]);
+
+  if (desktopToken) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Card className="w-full max-w-sm">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl">Opening Multica</CardTitle>
+            <CardDescription>
+              You should see a prompt to open the Multica desktop app. If
+              nothing happens, click the button below.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <Button
+              variant="outline"
+              onClick={() => {
+                window.location.href = `multica://auth/callback?token=${encodeURIComponent(desktopToken)}`;
+              }}
+            >
+              Open Multica Desktop
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Card className="w-full max-w-sm">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl">Login Failed</CardTitle>
+            <CardDescription>{error}</CardDescription>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <a href={paths.login()} className="text-primary underline-offset-4 hover:underline">
+              Back to login
+            </a>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Signing in...</CardTitle>
+          <CardDescription>Please wait while we complete your login</CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function CallbackPage() {
+  return (
+    <Suspense fallback={null}>
+      <CallbackContent />
+    </Suspense>
+  );
+}

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -377,6 +377,13 @@ export class ApiClient {
     });
   }
 
+  async feishuLogin(code: string, redirectUri: string): Promise<LoginResponse> {
+    return this.fetch("/auth/feishu", {
+      method: "POST",
+      body: JSON.stringify({ code, redirect_uri: redirectUri }),
+    });
+  }
+
   async logout(): Promise<void> {
     await this.fetch("/auth/logout", { method: "POST" });
   }

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -208,6 +208,13 @@ export class ApiClient {
     });
   }
 
+  async feishuLogin(code: string, redirectUri: string): Promise<LoginResponse> {
+    return this.fetch("/auth/feishu", {
+      method: "POST",
+      body: JSON.stringify({ code, redirect_uri: redirectUri }),
+    });
+  }
+
   async logout(): Promise<void> {
     await this.fetch("/auth/logout", { method: "POST" });
   }

--- a/packages/core/auth/store.ts
+++ b/packages/core/auth/store.ts
@@ -21,6 +21,7 @@ export interface AuthState {
   sendCode: (email: string) => Promise<void>;
   verifyCode: (email: string, code: string) => Promise<User>;
   loginWithGoogle: (code: string, redirectUri: string) => Promise<User>;
+  loginWithFeishu: (code: string, redirectUri: string) => Promise<User>;
   loginWithToken: (token: string) => Promise<User>;
   logout: () => void;
   setUser: (user: User) => void;
@@ -99,6 +100,17 @@ export function createAuthStore(options: AuthStoreOptions) {
       }
       onLogin?.();
       identifyAnalytics(user.id, { email: user.email, name: user.name });
+      set({ user });
+      return user;
+    },
+
+    loginWithFeishu: async (code: string, redirectUri: string) => {
+      const { token, user } = await api.feishuLogin(code, redirectUri);
+      if (!cookieAuth) {
+        storage.setItem("multica_token", token);
+        api.setToken(token);
+      }
+      onLogin?.();
       set({ user });
       return user;
     },

--- a/packages/core/auth/store.ts
+++ b/packages/core/auth/store.ts
@@ -20,6 +20,7 @@ export interface AuthState {
   sendCode: (email: string) => Promise<void>;
   verifyCode: (email: string, code: string) => Promise<User>;
   loginWithGoogle: (code: string, redirectUri: string) => Promise<User>;
+  loginWithFeishu: (code: string, redirectUri: string) => Promise<User>;
   loginWithToken: (token: string) => Promise<User>;
   logout: () => void;
   setUser: (user: User) => void;
@@ -90,6 +91,17 @@ export function createAuthStore(options: AuthStoreOptions) {
 
     loginWithGoogle: async (code: string, redirectUri: string) => {
       const { token, user } = await api.googleLogin(code, redirectUri);
+      if (!cookieAuth) {
+        storage.setItem("multica_token", token);
+        api.setToken(token);
+      }
+      onLogin?.();
+      set({ user });
+      return user;
+    },
+
+    loginWithFeishu: async (code: string, redirectUri: string) => {
+      const { token, user } = await api.feishuLogin(code, redirectUri);
       if (!cookieAuth) {
         storage.setItem("multica_token", token);
         api.setToken(token);

--- a/packages/views/auth/login-page.test.tsx
+++ b/packages/views/auth/login-page.test.tsx
@@ -390,6 +390,66 @@ describe("LoginPage", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Feishu OAuth
+  // -------------------------------------------------------------------------
+
+  it("renders Feishu OAuth button when feishu prop provided", () => {
+    render(
+      <LoginPage
+        onSuccess={onSuccess}
+        feishu={{ appId: "cli_abc", redirectUri: "http://localhost/fcb" }}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /continue with feishu/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Feishu OAuth button when feishu prop omitted", () => {
+    render(<LoginPage onSuccess={onSuccess} />);
+    expect(
+      screen.queryByRole("button", { name: /continue with feishu/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("builds Feishu authorize URL with required scopes on click", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const originalLocation = window.location;
+    // jsdom blocks assigning through window.location, but we can replace it
+    // with a writable stub for the duration of the test.
+    // @ts-expect-error — deliberately narrow
+    delete window.location;
+    // @ts-expect-error — minimal stub
+    window.location = { href: "", origin: "http://localhost" };
+
+    render(
+      <LoginPage
+        onSuccess={onSuccess}
+        feishu={{
+          appId: "cli_abc",
+          redirectUri: "http://localhost/fcb",
+          state: "platform:desktop",
+        }}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /continue with feishu/i }),
+    );
+
+    expect(window.location.href).toContain(
+      "accounts.feishu.cn/open-apis/authen/v1/authorize",
+    );
+    expect(window.location.href).toContain("app_id=cli_abc");
+    expect(window.location.href).toContain(
+      "scope=contact%3Auser.base%3Areadonly+contact%3Auser.email%3Areadonly",
+    );
+    expect(window.location.href).toContain("state=platform%3Adesktop");
+
+    // @ts-expect-error — restore
+    window.location = originalLocation;
+  });
+
+  // -------------------------------------------------------------------------
   // CLI callback — existing session
   // -------------------------------------------------------------------------
 

--- a/packages/views/auth/login-page.test.tsx
+++ b/packages/views/auth/login-page.test.tsx
@@ -369,6 +369,66 @@ describe("LoginPage", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Feishu OAuth
+  // -------------------------------------------------------------------------
+
+  it("renders Feishu OAuth button when feishu prop provided", () => {
+    render(
+      <LoginPage
+        onSuccess={onSuccess}
+        feishu={{ appId: "cli_abc", redirectUri: "http://localhost/fcb" }}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /continue with feishu/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Feishu OAuth button when feishu prop omitted", () => {
+    render(<LoginPage onSuccess={onSuccess} />);
+    expect(
+      screen.queryByRole("button", { name: /continue with feishu/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("builds Feishu authorize URL with required scopes on click", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const originalLocation = window.location;
+    // jsdom blocks assigning through window.location, but we can replace it
+    // with a writable stub for the duration of the test.
+    // @ts-expect-error — deliberately narrow
+    delete window.location;
+    // @ts-expect-error — minimal stub
+    window.location = { href: "", origin: "http://localhost" };
+
+    render(
+      <LoginPage
+        onSuccess={onSuccess}
+        feishu={{
+          appId: "cli_abc",
+          redirectUri: "http://localhost/fcb",
+          state: "platform:desktop",
+        }}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /continue with feishu/i }),
+    );
+
+    expect(window.location.href).toContain(
+      "accounts.feishu.cn/open-apis/authen/v1/authorize",
+    );
+    expect(window.location.href).toContain("app_id=cli_abc");
+    expect(window.location.href).toContain(
+      "scope=contact%3Auser.base%3Areadonly+contact%3Auser.email%3Areadonly",
+    );
+    expect(window.location.href).toContain("state=platform%3Adesktop");
+
+    // @ts-expect-error — restore
+    window.location = originalLocation;
+  });
+
+  // -------------------------------------------------------------------------
   // CLI callback — existing session
   // -------------------------------------------------------------------------
 

--- a/packages/views/auth/login-page.tsx
+++ b/packages/views/auth/login-page.tsx
@@ -35,6 +35,13 @@ interface GoogleAuthConfig {
   state?: string;
 }
 
+interface FeishuAuthConfig {
+  appId: string;
+  redirectUri: string;
+  /** Opaque state passed through Feishu OAuth. */
+  state?: string;
+}
+
 interface CliCallbackConfig {
   /** Validated localhost callback URL */
   url: string;
@@ -50,12 +57,16 @@ interface LoginPageProps {
   onSuccess: () => void;
   /** Google OAuth config. Omit to disable Google login. */
   google?: GoogleAuthConfig;
+  /** Feishu (飞书) OAuth config. Omit to disable Feishu login. */
+  feishu?: FeishuAuthConfig;
   /** CLI callback config for authorizing CLI tools. */
   cliCallback?: CliCallbackConfig;
   /** Called after a token is obtained (e.g. to set cookies). */
   onTokenObtained?: () => void;
   /** Override Google login handler (e.g. desktop opens browser externally). When provided, renders the Google button even if `google` config is omitted. */
   onGoogleLogin?: () => void;
+  /** Override Feishu login handler (e.g. desktop opens browser externally). When provided, renders the Feishu button even if `feishu` config is omitted. */
+  onFeishuLogin?: () => void;
   /** Slot rendered at the bottom of the sign-in card, below the
    *  Google button. The web shell uses it for a "Prefer the desktop
    *  app?" prompt; desktop omits it (a download prompt inside the app
@@ -101,9 +112,11 @@ export function LoginPage({
   logo,
   onSuccess,
   google,
+  feishu,
   cliCallback,
   onTokenObtained,
   onGoogleLogin,
+  onFeishuLogin,
   extra,
 }: LoginPageProps) {
   const { t } = useT("auth");
@@ -286,6 +299,24 @@ export function LoginPage({
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
   };
 
+  const handleFeishuLogin = () => {
+    if (onFeishuLogin) {
+      onFeishuLogin();
+      return;
+    }
+    if (!feishu) return;
+    const params = new URLSearchParams({
+      app_id: feishu.appId,
+      redirect_uri: feishu.redirectUri,
+      // Both scopes are needed: email for login (we reject users without
+      // one), base for name/avatar backfill. The tenant admin must grant
+      // these permissions to the app in the Feishu developer console.
+      scope: "contact:user.base:readonly contact:user.email:readonly",
+    });
+    if (feishu.state) params.set("state", feishu.state);
+    window.location.href = `https://accounts.feishu.cn/open-apis/authen/v1/authorize?${params}`;
+  };
+
   // -------------------------------------------------------------------------
   // CLI confirm step
   // -------------------------------------------------------------------------
@@ -448,47 +479,69 @@ export function LoginPage({
               ? t(($) => $.signin.sending)
               : t(($) => $.signin.continue)}
           </Button>
-          {(google || onGoogleLogin) && (
-            <>
-              <div className="relative w-full">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-card px-2 text-muted-foreground">
-                    {t(($) => $.signin.divider)}
-                  </span>
-                </div>
+          {(google || onGoogleLogin || feishu || onFeishuLogin) && (
+            <div className="relative w-full">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
               </div>
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full"
-                size="lg"
-                onClick={handleGoogleLogin}
-                disabled={loading}
-              >
-                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-                {t(($) => $.signin.google)}
-              </Button>
-            </>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-card px-2 text-muted-foreground">
+                  {t(($) => $.signin.divider)}
+                </span>
+              </div>
+            </div>
+          )}
+          {(google || onGoogleLogin) && (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              size="lg"
+              onClick={handleGoogleLogin}
+              disabled={loading}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
+              {t(($) => $.signin.google)}
+            </Button>
+          )}
+          {(feishu || onFeishuLogin) && (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              size="lg"
+              onClick={handleFeishuLogin}
+              disabled={loading}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M3 6.75C3 5.784 3.784 5 4.75 5h14.5C20.216 5 21 5.784 21 6.75v10.5c0 .966-.784 1.75-1.75 1.75H4.75A1.75 1.75 0 0 1 3 17.25V6.75Z"
+                  fill="#00D6B9"
+                />
+                <path
+                  d="M7.5 9.5c2 2 4.5 3.25 7.5 3.75v1.75c-3.5-.5-6.25-2-8.25-4.25L7.5 9.5Z"
+                  fill="#fff"
+                />
+              </svg>
+              Continue with Feishu
+            </Button>
           )}
           {extra && <div className="w-full pt-1 text-center">{extra}</div>}
         </CardFooter>

--- a/packages/views/auth/login-page.tsx
+++ b/packages/views/auth/login-page.tsx
@@ -34,6 +34,13 @@ interface GoogleAuthConfig {
   state?: string;
 }
 
+interface FeishuAuthConfig {
+  appId: string;
+  redirectUri: string;
+  /** Opaque state passed through Feishu OAuth. */
+  state?: string;
+}
+
 interface CliCallbackConfig {
   /** Validated localhost callback URL */
   url: string;
@@ -49,12 +56,16 @@ interface LoginPageProps {
   onSuccess: () => void;
   /** Google OAuth config. Omit to disable Google login. */
   google?: GoogleAuthConfig;
+  /** Feishu (飞书) OAuth config. Omit to disable Feishu login. */
+  feishu?: FeishuAuthConfig;
   /** CLI callback config for authorizing CLI tools. */
   cliCallback?: CliCallbackConfig;
   /** Called after a token is obtained (e.g. to set cookies). */
   onTokenObtained?: () => void;
   /** Override Google login handler (e.g. desktop opens browser externally). When provided, renders the Google button even if `google` config is omitted. */
   onGoogleLogin?: () => void;
+  /** Override Feishu login handler (e.g. desktop opens browser externally). When provided, renders the Feishu button even if `feishu` config is omitted. */
+  onFeishuLogin?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,9 +106,11 @@ export function LoginPage({
   logo,
   onSuccess,
   google,
+  feishu,
   cliCallback,
   onTokenObtained,
   onGoogleLogin,
+  onFeishuLogin,
 }: LoginPageProps) {
   const qc = useQueryClient();
   const [step, setStep] = useState<"email" | "code" | "cli_confirm">("email");
@@ -276,6 +289,24 @@ export function LoginPage({
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
   };
 
+  const handleFeishuLogin = () => {
+    if (onFeishuLogin) {
+      onFeishuLogin();
+      return;
+    }
+    if (!feishu) return;
+    const params = new URLSearchParams({
+      app_id: feishu.appId,
+      redirect_uri: feishu.redirectUri,
+      // Both scopes are needed: email for login (we reject users without
+      // one), base for name/avatar backfill. The tenant admin must grant
+      // these permissions to the app in the Feishu developer console.
+      scope: "contact:user.base:readonly contact:user.email:readonly",
+    });
+    if (feishu.state) params.set("state", feishu.state);
+    window.location.href = `https://accounts.feishu.cn/open-apis/authen/v1/authorize?${params}`;
+  };
+
   // -------------------------------------------------------------------------
   // CLI confirm step
   // -------------------------------------------------------------------------
@@ -431,45 +462,67 @@ export function LoginPage({
           >
             {loading ? "Sending code..." : "Continue"}
           </Button>
-          {(google || onGoogleLogin) && (
-            <>
-              <div className="relative w-full">
-                <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t" />
-                </div>
-                <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-card px-2 text-muted-foreground">or</span>
-                </div>
+          {(google || onGoogleLogin || feishu || onFeishuLogin) && (
+            <div className="relative w-full">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
               </div>
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full"
-                size="lg"
-                onClick={handleGoogleLogin}
-                disabled={loading}
-              >
-                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-                Continue with Google
-              </Button>
-            </>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-card px-2 text-muted-foreground">or</span>
+              </div>
+            </div>
+          )}
+          {(google || onGoogleLogin) && (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              size="lg"
+              onClick={handleGoogleLogin}
+              disabled={loading}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
+              Continue with Google
+            </Button>
+          )}
+          {(feishu || onFeishuLogin) && (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              size="lg"
+              onClick={handleFeishuLogin}
+              disabled={loading}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none">
+                <path
+                  d="M3 6.75C3 5.784 3.784 5 4.75 5h14.5C20.216 5 21 5.784 21 6.75v10.5c0 .966-.784 1.75-1.75 1.75H4.75A1.75 1.75 0 0 1 3 17.25V6.75Z"
+                  fill="#00D6B9"
+                />
+                <path
+                  d="M7.5 9.5c2 2 4.5 3.25 7.5 3.75v1.75c-3.5-.5-6.25-2-8.25-4.25L7.5 9.5Z"
+                  fill="#fff"
+                />
+              </svg>
+              Continue with Feishu
+            </Button>
           )}
         </CardFooter>
       </Card>

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -209,6 +209,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	r.Post("/auth/send-code", h.SendCode)
 	r.Post("/auth/verify-code", h.VerifyCode)
 	r.Post("/auth/google", h.GoogleLogin)
+	r.Post("/auth/feishu", h.FeishuLogin)
 	r.Post("/auth/logout", h.Logout)
 
 	// Public API

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -130,6 +130,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 	r.Post("/auth/send-code", h.SendCode)
 	r.Post("/auth/verify-code", h.VerifyCode)
 	r.Post("/auth/google", h.GoogleLogin)
+	r.Post("/auth/feishu", h.FeishuLogin)
 	r.Post("/auth/logout", h.Logout)
 
 	// Daemon API routes (require daemon token or valid user token)

--- a/server/internal/handler/auth_feishu.go
+++ b/server/internal/handler/auth_feishu.go
@@ -1,0 +1,238 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/auth"
+	"github.com/multica-ai/multica/server/internal/logger"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Feishu (飞书) enterprise OAuth login. Uses the v2 token endpoint which
+// accepts client_id / client_secret directly and does not require a prior
+// app_access_token exchange.
+//
+// Docs: https://open.feishu.cn/document/server-docs/authentication-management/access-token/get-user-access-token
+const (
+	feishuTokenURL    = "https://open.feishu.cn/open-apis/authen/v2/oauth/token"
+	feishuUserInfoURL = "https://open.feishu.cn/open-apis/authen/v1/user_info"
+)
+
+type FeishuLoginRequest struct {
+	Code        string `json:"code"`
+	RedirectURI string `json:"redirect_uri"`
+}
+
+// feishuTokenResponse is the v2 oauth/token success body. Feishu follows the
+// OAuth 2.0 standard here, so fields match RFC 6749.
+type feishuTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+}
+
+// feishuUserInfoResponse wraps Feishu's standard response envelope.
+// An email may be absent if the user hasn't bound one; enterprise_email is
+// populated when the tenant issues mailboxes, and we prefer it when present.
+type feishuUserInfoResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		Name            string `json:"name"`
+		EnName          string `json:"en_name"`
+		AvatarURL       string `json:"avatar_url"`
+		Email           string `json:"email"`
+		EnterpriseEmail string `json:"enterprise_email"`
+	} `json:"data"`
+}
+
+func (h *Handler) FeishuLogin(w http.ResponseWriter, r *http.Request) {
+	var req FeishuLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Code == "" {
+		writeError(w, http.StatusBadRequest, "code is required")
+		return
+	}
+
+	appID := os.Getenv("FEISHU_APP_ID")
+	appSecret := os.Getenv("FEISHU_APP_SECRET")
+	if appID == "" || appSecret == "" {
+		writeError(w, http.StatusServiceUnavailable, "Feishu login is not configured")
+		return
+	}
+
+	redirectURI := req.RedirectURI
+	if redirectURI == "" {
+		redirectURI = os.Getenv("FEISHU_REDIRECT_URI")
+	}
+
+	// Exchange authorization code for a user access token.
+	tokenBody, err := json.Marshal(map[string]string{
+		"grant_type":    "authorization_code",
+		"client_id":     appID,
+		"client_secret": appSecret,
+		"code":          req.Code,
+		"redirect_uri":  redirectURI,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	tokenReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, feishuTokenURL, bytes.NewReader(tokenBody))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	tokenReq.Header.Set("Content-Type", "application/json")
+
+	tokenResp, err := http.DefaultClient.Do(tokenReq)
+	if err != nil {
+		slog.Error("feishu oauth token exchange failed", "error", err)
+		writeError(w, http.StatusBadGateway, "failed to exchange code with Feishu")
+		return
+	}
+	defer tokenResp.Body.Close()
+
+	tokenRespBytes, err := io.ReadAll(tokenResp.Body)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to read Feishu token response")
+		return
+	}
+
+	if tokenResp.StatusCode != http.StatusOK {
+		slog.Error("feishu oauth token exchange returned error", "status", tokenResp.StatusCode, "body", string(tokenRespBytes))
+		writeError(w, http.StatusBadRequest, "failed to exchange code with Feishu")
+		return
+	}
+
+	var fToken feishuTokenResponse
+	if err := json.Unmarshal(tokenRespBytes, &fToken); err != nil {
+		writeError(w, http.StatusBadGateway, "failed to parse Feishu token response")
+		return
+	}
+	if fToken.AccessToken == "" {
+		slog.Error("feishu oauth token missing from response", "body", string(tokenRespBytes))
+		writeError(w, http.StatusBadGateway, "invalid Feishu token response")
+		return
+	}
+
+	// Fetch user profile with the user access token.
+	userInfoReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, feishuUserInfoURL, nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	userInfoReq.Header.Set("Authorization", "Bearer "+fToken.AccessToken)
+
+	userInfoResp, err := http.DefaultClient.Do(userInfoReq)
+	if err != nil {
+		slog.Error("feishu userinfo fetch failed", "error", err)
+		writeError(w, http.StatusBadGateway, "failed to fetch user info from Feishu")
+		return
+	}
+	defer userInfoResp.Body.Close()
+
+	var fUser feishuUserInfoResponse
+	if err := json.NewDecoder(userInfoResp.Body).Decode(&fUser); err != nil {
+		writeError(w, http.StatusBadGateway, "failed to parse Feishu user info")
+		return
+	}
+	if fUser.Code != 0 {
+		slog.Error("feishu userinfo returned error", "code", fUser.Code, "msg", fUser.Msg)
+		writeError(w, http.StatusBadGateway, "failed to fetch user info from Feishu")
+		return
+	}
+
+	// Email is required — we reject login when absent. enterprise_email is
+	// the company-issued address (preferred when set), email is the personal
+	// one the user linked to their Feishu account.
+	rawEmail := fUser.Data.EnterpriseEmail
+	if rawEmail == "" {
+		rawEmail = fUser.Data.Email
+	}
+	if rawEmail == "" {
+		writeError(w, http.StatusBadRequest, "Feishu account has no email. Please bind an email to your Feishu account or contact your tenant admin to enable enterprise email.")
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(rawEmail))
+
+	user, err := h.findOrCreateUser(r.Context(), email)
+	if err != nil {
+		var signupErr SignupError
+		if errors.As(err, &signupErr) {
+			writeError(w, http.StatusForbidden, signupErr.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to create user")
+		return
+	}
+
+	// Backfill name and avatar from Feishu profile if the user was just
+	// created (default name is email prefix) or has no avatar yet.
+	displayName := fUser.Data.Name
+	if displayName == "" {
+		displayName = fUser.Data.EnName
+	}
+
+	needsUpdate := false
+	newName := user.Name
+	newAvatar := user.AvatarUrl
+
+	if displayName != "" && user.Name == strings.Split(email, "@")[0] {
+		newName = displayName
+		needsUpdate = true
+	}
+	if fUser.Data.AvatarURL != "" && !user.AvatarUrl.Valid {
+		newAvatar = pgtype.Text{String: fUser.Data.AvatarURL, Valid: true}
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		updated, err := h.Queries.UpdateUser(r.Context(), db.UpdateUserParams{
+			ID:        user.ID,
+			Name:      newName,
+			AvatarUrl: newAvatar,
+		})
+		if err == nil {
+			user = updated
+		}
+	}
+
+	tokenString, err := h.issueJWT(user)
+	if err != nil {
+		slog.Warn("feishu login failed", append(logger.RequestAttrs(r), "error", err, "email", email)...)
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+
+	if err := auth.SetAuthCookies(w, tokenString); err != nil {
+		slog.Warn("failed to set auth cookies", "error", err)
+	}
+
+	if h.CFSigner != nil {
+		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(72 * time.Hour)) {
+			http.SetCookie(w, cookie)
+		}
+	}
+
+	slog.Info("user logged in via feishu", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email)...)
+	writeJSON(w, http.StatusOK, LoginResponse{
+		Token: tokenString,
+		User:  userToResponse(user),
+	})
+}

--- a/server/internal/handler/auth_feishu.go
+++ b/server/internal/handler/auth_feishu.go
@@ -1,0 +1,244 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/analytics"
+	"github.com/multica-ai/multica/server/internal/auth"
+	"github.com/multica-ai/multica/server/internal/logger"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// Feishu (飞书) enterprise OAuth login. Uses the v2 token endpoint which
+// accepts client_id / client_secret directly and does not require a prior
+// app_access_token exchange.
+//
+// Docs: https://open.feishu.cn/document/server-docs/authentication-management/access-token/get-user-access-token
+const (
+	feishuTokenURL    = "https://open.feishu.cn/open-apis/authen/v2/oauth/token"
+	feishuUserInfoURL = "https://open.feishu.cn/open-apis/authen/v1/user_info"
+)
+
+type FeishuLoginRequest struct {
+	Code        string `json:"code"`
+	RedirectURI string `json:"redirect_uri"`
+}
+
+// feishuTokenResponse is the v2 oauth/token success body. Feishu follows the
+// OAuth 2.0 standard here, so fields match RFC 6749.
+type feishuTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+}
+
+// feishuUserInfoResponse wraps Feishu's standard response envelope.
+// An email may be absent if the user hasn't bound one; enterprise_email is
+// populated when the tenant issues mailboxes, and we prefer it when present.
+type feishuUserInfoResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		Name            string `json:"name"`
+		EnName          string `json:"en_name"`
+		AvatarURL       string `json:"avatar_url"`
+		Email           string `json:"email"`
+		EnterpriseEmail string `json:"enterprise_email"`
+	} `json:"data"`
+}
+
+func (h *Handler) FeishuLogin(w http.ResponseWriter, r *http.Request) {
+	var req FeishuLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Code == "" {
+		writeError(w, http.StatusBadRequest, "code is required")
+		return
+	}
+
+	appID := os.Getenv("FEISHU_APP_ID")
+	appSecret := os.Getenv("FEISHU_APP_SECRET")
+	if appID == "" || appSecret == "" {
+		writeError(w, http.StatusServiceUnavailable, "Feishu login is not configured")
+		return
+	}
+
+	redirectURI := req.RedirectURI
+	if redirectURI == "" {
+		redirectURI = os.Getenv("FEISHU_REDIRECT_URI")
+	}
+
+	// Exchange authorization code for a user access token.
+	tokenBody, err := json.Marshal(map[string]string{
+		"grant_type":    "authorization_code",
+		"client_id":     appID,
+		"client_secret": appSecret,
+		"code":          req.Code,
+		"redirect_uri":  redirectURI,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	tokenReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, feishuTokenURL, bytes.NewReader(tokenBody))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	tokenReq.Header.Set("Content-Type", "application/json")
+
+	tokenResp, err := http.DefaultClient.Do(tokenReq)
+	if err != nil {
+		slog.Error("feishu oauth token exchange failed", "error", err)
+		writeError(w, http.StatusBadGateway, "failed to exchange code with Feishu")
+		return
+	}
+	defer tokenResp.Body.Close()
+
+	tokenRespBytes, err := io.ReadAll(tokenResp.Body)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to read Feishu token response")
+		return
+	}
+
+	if tokenResp.StatusCode != http.StatusOK {
+		slog.Error("feishu oauth token exchange returned error", "status", tokenResp.StatusCode, "body", string(tokenRespBytes))
+		writeError(w, http.StatusBadRequest, "failed to exchange code with Feishu")
+		return
+	}
+
+	var fToken feishuTokenResponse
+	if err := json.Unmarshal(tokenRespBytes, &fToken); err != nil {
+		writeError(w, http.StatusBadGateway, "failed to parse Feishu token response")
+		return
+	}
+	if fToken.AccessToken == "" {
+		slog.Error("feishu oauth token missing from response", "body", string(tokenRespBytes))
+		writeError(w, http.StatusBadGateway, "invalid Feishu token response")
+		return
+	}
+
+	// Fetch user profile with the user access token.
+	userInfoReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, feishuUserInfoURL, nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	userInfoReq.Header.Set("Authorization", "Bearer "+fToken.AccessToken)
+
+	userInfoResp, err := http.DefaultClient.Do(userInfoReq)
+	if err != nil {
+		slog.Error("feishu userinfo fetch failed", "error", err)
+		writeError(w, http.StatusBadGateway, "failed to fetch user info from Feishu")
+		return
+	}
+	defer userInfoResp.Body.Close()
+
+	var fUser feishuUserInfoResponse
+	if err := json.NewDecoder(userInfoResp.Body).Decode(&fUser); err != nil {
+		writeError(w, http.StatusBadGateway, "failed to parse Feishu user info")
+		return
+	}
+	if fUser.Code != 0 {
+		slog.Error("feishu userinfo returned error", "code", fUser.Code, "msg", fUser.Msg)
+		writeError(w, http.StatusBadGateway, "failed to fetch user info from Feishu")
+		return
+	}
+
+	// Email is required — we reject login when absent. enterprise_email is
+	// the company-issued address (preferred when set), email is the personal
+	// one the user linked to their Feishu account.
+	rawEmail := fUser.Data.EnterpriseEmail
+	if rawEmail == "" {
+		rawEmail = fUser.Data.Email
+	}
+	if rawEmail == "" {
+		writeError(w, http.StatusBadRequest, "Feishu account has no email. Please bind an email to your Feishu account or contact your tenant admin to enable enterprise email.")
+		return
+	}
+	email := strings.ToLower(strings.TrimSpace(rawEmail))
+
+	user, isNew, err := h.findOrCreateUser(r.Context(), email)
+	if err != nil {
+		var signupErr SignupError
+		if errors.As(err, &signupErr) {
+			writeError(w, http.StatusForbidden, signupErr.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to create user")
+		return
+	}
+	if isNew {
+		evt := analytics.Signup(uuidToString(user.ID), user.Email, signupSourceFromRequest(r))
+		evt.Properties["auth_method"] = "feishu"
+		h.Analytics.Capture(evt)
+	}
+
+	// Backfill name and avatar from Feishu profile if the user was just
+	// created (default name is email prefix) or has no avatar yet.
+	displayName := fUser.Data.Name
+	if displayName == "" {
+		displayName = fUser.Data.EnName
+	}
+
+	needsUpdate := false
+	newName := user.Name
+	newAvatar := user.AvatarUrl
+
+	if displayName != "" && user.Name == strings.Split(email, "@")[0] {
+		newName = displayName
+		needsUpdate = true
+	}
+	if fUser.Data.AvatarURL != "" && !user.AvatarUrl.Valid {
+		newAvatar = pgtype.Text{String: fUser.Data.AvatarURL, Valid: true}
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		updated, err := h.Queries.UpdateUser(r.Context(), db.UpdateUserParams{
+			ID:        user.ID,
+			Name:      newName,
+			AvatarUrl: newAvatar,
+		})
+		if err == nil {
+			user = updated
+		}
+	}
+
+	tokenString, err := h.issueJWT(user)
+	if err != nil {
+		slog.Warn("feishu login failed", append(logger.RequestAttrs(r), "error", err, "email", email)...)
+		writeError(w, http.StatusInternalServerError, "failed to generate token")
+		return
+	}
+
+	if err := auth.SetAuthCookies(w, tokenString); err != nil {
+		slog.Warn("failed to set auth cookies", "error", err)
+	}
+
+	if h.CFSigner != nil {
+		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(72 * time.Hour)) {
+			http.SetCookie(w, cookie)
+		}
+	}
+
+	slog.Info("user logged in via feishu", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email)...)
+	writeJSON(w, http.StatusOK, LoginResponse{
+		Token: tokenString,
+		User:  userToResponse(user),
+	})
+}


### PR DESCRIPTION
## Summary

Adds Feishu (飞书) enterprise OAuth as a login provider, mirroring the existing Google path. Users can sign in with their enterprise Feishu account; new users are auto-provisioned with name and avatar backfilled from the Feishu profile.

## Scope

- **Enterprise Feishu only** (`open.feishu.cn`). Lark (`open.larksuite.com`) can be added later with endpoint tweaks.
- Uses the **v2 `oauth/token`** endpoint, which accepts `client_id`/`client_secret` directly — no `app_access_token` round-trip.
- **Rejects logins without an email** (prefers `enterprise_email`, falls back to `email`). Tenant admins must grant `contact:user.base:readonly` + `contact:user.email:readonly` to the Feishu app.
- Desktop and CLI inherit support via the shared browser callback — no changes under `apps/desktop` or `server/cmd/multica`.

## Changes

| Area | File |
|---|---|
| Backend handler | `server/internal/handler/auth_feishu.go` (new) |
| Route | `server/cmd/server/router.go` |
| API client | `packages/core/api/client.ts` |
| Auth store | `packages/core/auth/store.ts` |
| Shared login view | `packages/views/auth/login-page.tsx` |
| Web callback page | `apps/web/app/auth/feishu/callback/page.tsx` (new) |
| Web login config plumbing | `apps/web/app/(auth)/login/page.tsx` |
| Env doc | `.env.example` |

The preceding commit (`fix(auth/login-page)`) addresses a latent SSR bug where `window.location.origin` was read during the initial server render in `LoginPageContent`. It was dormant because the Google OAuth ternary short-circuited to `undefined` whenever `NEXT_PUBLIC_GOOGLE_CLIENT_ID` was unset; adding a second OAuth provider surfaced the crash. Guarded with `typeof window !== \"undefined\"` and shared between both providers.

## Configuration

Self-hosters add to `.env`:

```
FEISHU_APP_ID=cli_xxxxxxxxxxxxxxxx
FEISHU_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
FEISHU_REDIRECT_URI=http://localhost:3000/auth/feishu/callback
NEXT_PUBLIC_FEISHU_APP_ID=cli_xxxxxxxxxxxxxxxx
```

In the Feishu developer console, register the same redirect URI and grant the two `contact:*` scopes above, then publish a version.

## Tests

- 3 shared-view tests (button render/hide, authorize URL construction including scope encoding and state)
- 3 web callback tests (default destination, unsafe `next=` rejection, safe `next=` passthrough)
- `pnpm typecheck`, `pnpm test`, `go vet`, `go build` all clean
- Manually validated full sign-in against a real Feishu enterprise app (enterprise_email populated, name + avatar backfilled on first login, session persisted across reload)

## Test plan

- [ ] Set the four env vars above against a Feishu enterprise app with the two scopes granted
- [ ] Click "Continue with Feishu" on `/login`, authorize, land on the workspace or `/workspaces/new`
- [ ] Try a user whose Feishu account has no email → expect 400 with a clear error message
- [ ] Sign out and sign back in → user record is reused (no duplicate created)
