### PR TITLE
fix(skills): resolve aliased skills.sh imports

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -701,7 +701,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	if skillMdBody == nil {
 		skillDir, skillMdBody, err = resolveGitHubSkillDirByName(httpClient, owner, repo, defaultBranch, rawPrefix, skillName)
 		if err != nil {
-			return nil, fmt.Errorf("SKILL.md not found in repository %s/%s for skill %s", owner, repo, skillName)
+			return nil, err
 		}
 	}
 
@@ -768,37 +768,35 @@ func resolveGitHubSkillDirByName(httpClient *http.Client, owner, repo, defaultBr
 		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
 	resp, err := httpClient.Get(apiURL)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("failed to inspect repository %s/%s for skill %s: %w", owner, repo, skillName, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+		return "", nil, fmt.Errorf("failed to inspect repository %s/%s for skill %s: HTTP %d", owner, repo, skillName, resp.StatusCode)
 	}
 
 	var tree githubTreeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
-		return "", nil, err
-	}
-	if tree.Truncated {
-		slog.Warn("skills.sh import: repository tree listing truncated", "owner", owner, "repo", repo, "branch", defaultBranch)
+		return "", nil, fmt.Errorf("failed to inspect repository %s/%s for skill %s: %w", owner, repo, skillName, err)
 	}
 
-	for _, entry := range tree.Tree {
-		if entry.Type != "blob" || !strings.HasSuffix(entry.Path, "/SKILL.md") && entry.Path != "SKILL.md" {
-			continue
+	skillPaths := extractSkillMdPaths(tree.Tree)
+	preferred, remaining := partitionSkillMdPaths(skillName, skillPaths)
+	if dir, body, ok := findMatchingSkillDirByFrontmatter(httpClient, rawPrefix, skillName, preferred); ok {
+		return dir, body, nil
+	}
+	if !tree.Truncated {
+		if dir, body, ok := findMatchingSkillDirByFrontmatter(httpClient, rawPrefix, skillName, remaining); ok {
+			return dir, body, nil
 		}
-		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, entry.Path))
-		if err != nil {
-			slog.Warn("skills.sh import: fallback SKILL.md fetch failed", "path", entry.Path, "error", err)
-			continue
-		}
-		name, _ := parseSkillFrontmatter(string(body))
-		if name == skillName {
-			return skillDirFromSkillFilePath(entry.Path), body, nil
-		}
+		return "", nil, skillMdNotFoundError(owner, repo, skillName)
 	}
 
-	return "", nil, fmt.Errorf("skill %q not found", skillName)
+	slog.Warn("skills.sh import: repository tree listing truncated", "owner", owner, "repo", repo, "branch", defaultBranch)
+	if dir, body, ok := findSkillDirFromConventionalPrefixes(httpClient, owner, repo, defaultBranch, rawPrefix, skillName); ok {
+		return dir, body, nil
+	}
+	return "", nil, fmt.Errorf("repository %s/%s tree is too large to scan exhaustively for skill %s", owner, repo, skillName)
 }
 
 // collectGitHubFiles recursively collects file entries from a GitHub directory listing.
@@ -845,6 +843,174 @@ func collectGitHubFiles(httpClient *http.Client, entries []githubContentEntry, o
 			collectGitHubFiles(httpClient, subEntries, out, subURL)
 		}
 	}
+}
+
+func findSkillDirFromConventionalPrefixes(httpClient *http.Client, owner, repo, defaultBranch, rawPrefix, skillName string) (string, []byte, bool) {
+	prefixes := []string{"skills", ".claude/skills", "plugin/skills"}
+	var skillPaths []string
+	for _, prefix := range prefixes {
+		paths, err := listGitHubSkillMdPaths(httpClient, owner, repo, prefix, defaultBranch)
+		if err != nil {
+			slog.Warn("skills.sh import: failed to list conventional skill prefix", "prefix", prefix, "error", err)
+			continue
+		}
+		skillPaths = append(skillPaths, paths...)
+	}
+
+	preferred, remaining := partitionSkillMdPaths(skillName, skillPaths)
+	if dir, body, ok := findMatchingSkillDirByFrontmatter(httpClient, rawPrefix, skillName, preferred); ok {
+		return dir, body, true
+	}
+	return findMatchingSkillDirByFrontmatter(httpClient, rawPrefix, skillName, remaining)
+}
+
+func listGitHubSkillMdPaths(httpClient *http.Client, owner, repo, repoPath, ref string) ([]string, error) {
+	apiURL := buildGitHubContentsURL(owner, repo, repoPath, ref)
+	resp, err := httpClient.Get(apiURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var entries []githubContentEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	collectGitHubSkillMdPaths(httpClient, entries, &paths, apiURL)
+	return paths, nil
+}
+
+func collectGitHubSkillMdPaths(httpClient *http.Client, entries []githubContentEntry, out *[]string, parentURL string) {
+	for _, entry := range entries {
+		lower := strings.ToLower(entry.Name)
+		if entry.Type == "file" {
+			if lower == "skill.md" {
+				*out = append(*out, entry.Path)
+			}
+			continue
+		}
+		if entry.Type != "dir" {
+			continue
+		}
+
+		subURL := entry.URL
+		if subURL == "" {
+			parsed, err := url.Parse(parentURL)
+			if err != nil {
+				slog.Warn("skills.sh import: invalid parent directory url", "url", parentURL, "error", err)
+				continue
+			}
+			parsed.Path = strings.TrimSuffix(parsed.Path, "/") + "/" + entry.Name
+			subURL = parsed.String()
+		}
+
+		subResp, err := httpClient.Get(subURL)
+		if err != nil || subResp.StatusCode != http.StatusOK {
+			attrs := []any{"url", subURL}
+			if subResp != nil {
+				attrs = append(attrs, "status", subResp.StatusCode)
+				subResp.Body.Close()
+			}
+			if err != nil {
+				attrs = append(attrs, "error", err)
+			}
+			slog.Warn("skills.sh import: failed to list skill metadata subdirectory", attrs...)
+			continue
+		}
+
+		var subEntries []githubContentEntry
+		if err := json.NewDecoder(subResp.Body).Decode(&subEntries); err != nil {
+			subResp.Body.Close()
+			slog.Warn("skills.sh import: failed to decode skill metadata subdirectory", "url", subURL, "error", err)
+			continue
+		}
+		subResp.Body.Close()
+		collectGitHubSkillMdPaths(httpClient, subEntries, out, subURL)
+	}
+}
+
+func extractSkillMdPaths(entries []githubTreeEntry) []string {
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Type != "blob" || (!strings.HasSuffix(entry.Path, "/SKILL.md") && entry.Path != "SKILL.md") {
+			continue
+		}
+		paths = append(paths, entry.Path)
+	}
+	return paths
+}
+
+func partitionSkillMdPaths(skillName string, skillPaths []string) (preferred []string, remaining []string) {
+	for _, skillPath := range skillPaths {
+		if isLikelySkillPathMatch(skillName, skillPath) {
+			preferred = append(preferred, skillPath)
+			continue
+		}
+		remaining = append(remaining, skillPath)
+	}
+	return preferred, remaining
+}
+
+func findMatchingSkillDirByFrontmatter(httpClient *http.Client, rawPrefix, skillName string, skillPaths []string) (string, []byte, bool) {
+	for _, skillPath := range skillPaths {
+		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, skillPath))
+		if err != nil {
+			slog.Warn("skills.sh import: fallback SKILL.md fetch failed", "path", skillPath, "error", err)
+			continue
+		}
+		name, _ := parseSkillFrontmatter(string(body))
+		if name == skillName {
+			return skillDirFromSkillFilePath(skillPath), body, true
+		}
+	}
+	return "", nil, false
+}
+
+func isLikelySkillPathMatch(skillName, skillPath string) bool {
+	dir := strings.ToLower(skillDirFromSkillFilePath(skillPath))
+	base := strings.ToLower(filepath.Base(dir))
+	for _, hint := range skillNameHints(skillName) {
+		if strings.Contains(dir, hint) || strings.Contains(base, hint) || strings.Contains(hint, base) {
+			return true
+		}
+	}
+	return false
+}
+
+func skillNameHints(skillName string) []string {
+	skillName = strings.ToLower(skillName)
+	parts := strings.Split(skillName, "-")
+	seen := map[string]struct{}{}
+	var hints []string
+
+	addHint := func(value string) {
+		value = strings.TrimSpace(value)
+		if len(value) < 3 {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		hints = append(hints, value)
+	}
+
+	addHint(skillName)
+	for i := 1; i < len(parts); i++ {
+		addHint(strings.Join(parts[i:], "-"))
+	}
+	for _, part := range parts {
+		addHint(part)
+	}
+	return hints
 }
 
 // parseSkillFrontmatter extracts name and description from YAML frontmatter in SKILL.md.
@@ -914,6 +1080,10 @@ func skillDirFromSkillFilePath(path string) string {
 		return ""
 	}
 	return strings.TrimSuffix(path, "/SKILL.md")
+}
+
+func skillMdNotFoundError(owner, repo, skillName string) error {
+	return fmt.Errorf("SKILL.md not found in repository %s/%s for skill %s", owner, repo, skillName)
 }
 
 // --- Import handler ---

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -471,6 +471,16 @@ type githubRepoInfo struct {
 	DefaultBranch string `json:"default_branch"`
 }
 
+type githubTreeResponse struct {
+	Tree      []githubTreeEntry `json:"tree"`
+	Truncated bool              `json:"truncated"`
+}
+
+type githubTreeEntry struct {
+	Path string `json:"path"`
+	Type string `json:"type"` // "blob" or "tree"
+}
+
 // fetchGitHubDefaultBranch returns the default branch of a GitHub repository.
 // Falls back to "main" if the API call fails.
 func fetchGitHubDefaultBranch(httpClient *http.Client, owner, repo string) string {
@@ -681,7 +691,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	var skillMdBody []byte
 	var skillDir string
 	for _, dir := range candidatePaths {
-		body, err := fetchRawFile(httpClient, rawPrefix+"/"+dir+"/SKILL.md")
+		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, dir+"/SKILL.md"))
 		if err == nil {
 			skillMdBody = body
 			skillDir = dir
@@ -689,7 +699,10 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 		}
 	}
 	if skillMdBody == nil {
-		return nil, fmt.Errorf("SKILL.md not found in repository %s/%s for skill %s", owner, repo, skillName)
+		skillDir, skillMdBody, err = resolveGitHubSkillDirByName(httpClient, owner, repo, defaultBranch, rawPrefix, skillName)
+		if err != nil {
+			return nil, fmt.Errorf("SKILL.md not found in repository %s/%s for skill %s", owner, repo, skillName)
+		}
 	}
 
 	// Parse name and description from YAML frontmatter
@@ -705,8 +718,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	}
 
 	// 2. List supporting files via GitHub API
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s?ref=%s",
-		url.PathEscape(owner), url.PathEscape(repo), skillDir, url.QueryEscape(defaultBranch))
+	apiURL := buildGitHubContentsURL(owner, repo, skillDir, defaultBranch)
 	dirResp, err := httpClient.Get(apiURL)
 	if err != nil || dirResp.StatusCode != http.StatusOK {
 		// Can't list files — return what we have (SKILL.md only)
@@ -730,7 +742,10 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	slog.Info("skills.sh import: collected supporting files", "skill", skillName, "files", len(allFiles))
 
 	// 4. Download each file
-	basePath := skillDir + "/"
+	basePath := ""
+	if skillDir != "" {
+		basePath = skillDir + "/"
+	}
 	for _, entry := range allFiles {
 		if entry.DownloadURL == "" {
 			continue
@@ -746,6 +761,44 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	}
 
 	return result, nil
+}
+
+func resolveGitHubSkillDirByName(httpClient *http.Client, owner, repo, defaultBranch, rawPrefix, skillName string) (string, []byte, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/git/trees/%s?recursive=1",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
+	resp, err := httpClient.Get(apiURL)
+	if err != nil {
+		return "", nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var tree githubTreeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
+		return "", nil, err
+	}
+	if tree.Truncated {
+		slog.Warn("skills.sh import: repository tree listing truncated", "owner", owner, "repo", repo, "branch", defaultBranch)
+	}
+
+	for _, entry := range tree.Tree {
+		if entry.Type != "blob" || !strings.HasSuffix(entry.Path, "/SKILL.md") && entry.Path != "SKILL.md" {
+			continue
+		}
+		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, entry.Path))
+		if err != nil {
+			slog.Warn("skills.sh import: fallback SKILL.md fetch failed", "path", entry.Path, "error", err)
+			continue
+		}
+		name, _ := parseSkillFrontmatter(string(body))
+		if name == skillName {
+			return skillDirFromSkillFilePath(entry.Path), body, nil
+		}
+	}
+
+	return "", nil, fmt.Errorf("skill %q not found", skillName)
 }
 
 // collectGitHubFiles recursively collects file entries from a GitHub directory listing.
@@ -830,6 +883,37 @@ func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
 		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+}
+
+func buildRawGitHubURL(rawPrefix, repoPath string) string {
+	parts := strings.Split(strings.Trim(repoPath, "/"), "/")
+	escaped := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		escaped = append(escaped, url.PathEscape(part))
+	}
+	if len(escaped) == 0 {
+		return rawPrefix
+	}
+	return rawPrefix + "/" + strings.Join(escaped, "/")
+}
+
+func buildGitHubContentsURL(owner, repo, repoPath, ref string) string {
+	base := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents",
+		url.PathEscape(owner), url.PathEscape(repo))
+	if repoPath == "" {
+		return base + "?ref=" + url.QueryEscape(ref)
+	}
+	return base + "/" + strings.TrimPrefix(buildRawGitHubURL("", repoPath), "/") + "?ref=" + url.QueryEscape(ref)
+}
+
+func skillDirFromSkillFilePath(path string) string {
+	if path == "SKILL.md" {
+		return ""
+	}
+	return strings.TrimSuffix(path, "/SKILL.md")
 }
 
 // --- Import handler ---

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -296,6 +296,71 @@ func TestFetchFromSkillsSh_ResolvesAliasedSkillNamesViaFrontmatter(t *testing.T)
 	if !containsString(*requests, "api.github.com /repos/vercel-labs/agent-skills/git/trees/main?recursive=1") {
 		t.Fatalf("expected fallback tree lookup, got requests %v", *requests)
 	}
+	for _, request := range *requests {
+		if request == "raw.githubusercontent.com /vercel-labs/agent-skills/main/skills/react-best-practices/SKILL.md" {
+			t.Fatalf("unexpected non-matching fallback fetch: %v", *requests)
+		}
+	}
+}
+
+func TestFetchFromSkillsSh_ReturnsActionableErrorForTruncatedTrees(t *testing.T) {
+	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/git/trees/main":
+				if got := r.URL.Query().Get("recursive"); got != "1" {
+					t.Fatalf("tree recursive = %q, want 1", got)
+				}
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree: []githubTreeEntry{
+						{Path: "skills/deploy-to-vercel/SKILL.md", Type: "blob"},
+					},
+					Truncated: true,
+				})
+			case "/repos/acme/skills/contents/skills":
+				if got := r.URL.Query().Get("ref"); got != "main" {
+					t.Fatalf("skills ref = %q, want main", got)
+				}
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "SKILL.md",
+						Path:        "skills/deploy-to-vercel/SKILL.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/skills/deploy-to-vercel/SKILL.md",
+					},
+				})
+			case "/repos/acme/skills/contents/.claude/skills":
+				http.NotFound(w, r)
+			case "/repos/acme/skills/contents/plugin/skills":
+				http.NotFound(w, r)
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/skills/main/skills/deploy-to-vercel/SKILL.md":
+				w.Write([]byte("---\nname: deploy-to-vercel\n---\ncontent"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	_, err := fetchFromSkillsSh(client, "https://skills.sh/acme/skills/vercel-composition-patterns")
+	if err == nil {
+		t.Fatal("expected error for truncated tree fallback miss")
+	}
+	if !strings.Contains(err.Error(), "tree is too large to scan exhaustively") {
+		t.Fatalf("error = %q, want actionable truncated-tree message", err.Error())
+	}
+	if !containsString(*requests, "api.github.com /repos/acme/skills/contents/skills?ref=main") {
+		t.Fatalf("expected conventional prefix listing, got %v", *requests)
+	}
 }
 
 func TestFetchFromSkillsSh_AnthropicPptxIntegration(t *testing.T) {

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -232,6 +232,72 @@ func TestFetchFromSkillsSh_LogsSubdirectoryFailures(t *testing.T) {
 	}
 }
 
+func TestFetchFromSkillsSh_ResolvesAliasedSkillNamesViaFrontmatter(t *testing.T) {
+	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/vercel-labs/agent-skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/vercel-labs/agent-skills/git/trees/main":
+				if got := r.URL.Query().Get("recursive"); got != "1" {
+					t.Fatalf("tree recursive = %q, want 1", got)
+				}
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree: []githubTreeEntry{
+						{Path: "skills/composition-patterns/SKILL.md", Type: "blob"},
+						{Path: "skills/react-best-practices/SKILL.md", Type: "blob"},
+					},
+				})
+			case "/repos/vercel-labs/agent-skills/contents/skills/composition-patterns":
+				if got := r.URL.Query().Get("ref"); got != "main" {
+					t.Fatalf("resolved dir ref = %q, want main", got)
+				}
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "rules.md",
+						Path:        "skills/composition-patterns/rules.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/composition-patterns/rules.md",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/vercel-labs/agent-skills/main/skills/composition-patterns/SKILL.md":
+				w.Write([]byte("---\nname: vercel-composition-patterns\ndescription: aliased skill\n---\ncontent"))
+			case "/vercel-labs/agent-skills/main/skills/react-best-practices/SKILL.md":
+				w.Write([]byte("---\nname: vercel-react-best-practices\n---\ncontent"))
+			case "/vercel-labs/agent-skills/main/skills/composition-patterns/rules.md":
+				w.Write([]byte("rules"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(client, "https://skills.sh/vercel-labs/agent-skills/vercel-composition-patterns")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh: %v", err)
+	}
+
+	if result.name != "vercel-composition-patterns" {
+		t.Fatalf("name = %q, want vercel-composition-patterns", result.name)
+	}
+	gotPaths := importedFilePaths(result.files)
+	wantPaths := []string{"rules.md"}
+	if !equalStrings(gotPaths, wantPaths) {
+		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
+	}
+	if !containsString(*requests, "api.github.com /repos/vercel-labs/agent-skills/git/trees/main?recursive=1") {
+		t.Fatalf("expected fallback tree lookup, got requests %v", *requests)
+	}
+}
+
 func TestFetchFromSkillsSh_AnthropicPptxIntegration(t *testing.T) {
 	if os.Getenv("MULTICA_RUN_SKILLS_SH_INTEGRATION") == "" {
 		t.Skip("set MULTICA_RUN_SKILLS_SH_INTEGRATION=1 to run live GitHub integration test")


### PR DESCRIPTION
Fixes #1437

## Summary
- keep the fast path for skills.sh repos where the URL slug matches the directory name
- fall back to scanning repository `SKILL.md` files and matching their frontmatter `name` when the slug is an alias
- reuse escaped GitHub URL builders for raw file and contents lookups, and add a regression test for aliased skills

## Repro
1. Import `https://skills.sh/vercel-labs/agent-skills/vercel-composition-patterns`
2. The existing importer probes `skills/vercel-composition-patterns/SKILL.md` and returns `SKILL.md not found in repository vercel-labs/agent-skills for skill vercel-composition-patterns`
3. The real file is `skills/composition-patterns/SKILL.md`, and its frontmatter declares `name: vercel-composition-patterns`

## Testing
- `docker run --rm -v /Users/affe/.codex/worktrees/f434/multica:/src -w /src/server golang:1.26.1 go test ./internal/handler -run 'TestFetchFromSkillsSh'`
