### PR TITLE
fix(analytics): disable posthog-js default autocapture and recording

### DIFF
--- a/packages/core/analytics/index.ts
+++ b/packages/core/analytics/index.ts
@@ -64,9 +64,19 @@ export function initAnalytics(config: AnalyticsConfig | null | undefined): boole
     // the billed events until they actually identify, which aligns with how
     // our funnel is set up: signup is the first real funnel step.
     person_profiles: "identified_only",
-    // We set attribution ourselves (see captureSignupSource); posthog's own
-    // autocapture-based attribution would double-count.
+    // Turn off every on-by-default auto-capture surface. Our funnel is
+    // narrow and explicit (the events in docs/analytics.md + a manual
+    // $pageview). Autocapture floods the Activity view with anonymous
+    // "clicked button" / "clicked link" noise, burns the billed event
+    // budget, and risks capturing user-typed content in input values.
+    // Turn things back on deliberately if we ever want them.
     capture_pageview: false,
+    autocapture: false,
+    capture_heatmaps: false,
+    capture_dead_clicks: false,
+    capture_exceptions: false,
+    disable_session_recording: true,
+    disable_surveys: true,
   });
   initialized = true;
 


### PR DESCRIPTION
## Summary

posthog-js ships with autocapture (clicks / form submits), heatmaps, dead-click detection, session recording, exception capture, and surveys all **on by default**. Staging verification for [MUL-1122](https://github.com/multica-ai/multica) showed the PostHog Activity view flooded with events like \`clicked button\`, \`clicked link with text \"Issues\"\`, \`clicked span with text \"…\"\` — dumping user-typed / UI text into PostHog, burning the billed event budget, and drowning the explicit funnel events.

Our product analytics surface is narrow and intentional (see \`docs/analytics.md\`): only the events the backend emits plus one manual \`$pageview\` per route change. This PR opts out of every auto surface at \`posthog.init\` time.

## Test plan

- [x] \`pnpm --filter @multica/core exec tsc --noEmit\` clean
- [ ] After deploy to staging, refresh and click around — PostHog Live events should **only** show \`$pageview\`, \`signup\`, \`workspace_created\`, \`runtime_registered\`, \`issue_executed\`, \`team_invite_sent\`, \`team_invite_accepted\`. No \`clicked …\` entries.