### PR TITLE
fix: harden desktop packaging PATH lookup

### DIFF
--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -25,7 +25,7 @@
 // version-derivation logic without shelling out.
 
 import { execFileSync, spawnSync, execSync } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { delimiter, dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -118,6 +118,23 @@ function deriveVersion() {
 
 function uniqueOrdered(values) {
   return [...new Set(values)];
+}
+
+export function envWithLocalBins(env = process.env, root = desktopRoot) {
+  const pathKey =
+    Object.keys(env).find((key) => key.toUpperCase() === "PATH") ?? "PATH";
+  const existingPath = env[pathKey] ?? "";
+  const localBins = uniqueOrdered([
+    resolve(root, "node_modules", ".bin"),
+    resolve(root, "..", "..", "node_modules", ".bin"),
+  ]);
+  const mergedPath = uniqueOrdered([
+    ...localBins,
+    ...String(existingPath)
+      .split(delimiter)
+      .filter(Boolean),
+  ]).join(delimiter);
+  return { ...env, [pathKey]: mergedPath };
 }
 
 function hostPlatformKey(platform = process.platform) {
@@ -309,9 +326,13 @@ function main() {
   // this step electron-builder silently packages whatever is already in
   // out/, which on a fresh checkout (or after a partial build) ships an
   // app that white-screens because the renderer bundle is missing.
+  //
+  // CI invokes this script via `node scripts/package.mjs`, so we cannot
+  // rely on pnpm/npm to inject package-local binaries into PATH.
   const viteResult = spawnSync("electron-vite", ["build"], {
     stdio: "inherit",
     cwd: desktopRoot,
+    env: envWithLocalBins(),
   });
   if (viteResult.error) {
     console.error(
@@ -373,6 +394,7 @@ function main() {
     const result = spawnSync("electron-builder", builderArgs, {
       stdio: "inherit",
       cwd: desktopRoot,
+      env: envWithLocalBins(),
     });
 
     if (result.error) {

--- a/apps/desktop/scripts/package.test.mjs
+++ b/apps/desktop/scripts/package.test.mjs
@@ -1,6 +1,8 @@
+import { delimiter, resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   builderArgsForTarget,
+  envWithLocalBins,
   normalizeGitVersion,
   parsePackageArgs,
   resolveBuildMatrix,
@@ -234,6 +236,38 @@ describe("builderArgsForTarget", () => {
       "--x64",
       "--publish",
       "never",
+    ]);
+  });
+});
+
+describe("envWithLocalBins", () => {
+  it("prepends desktop-local binary directories to PATH", () => {
+    const desktopRoot = "/repo/apps/desktop";
+    const result = envWithLocalBins(
+      { PATH: ["/usr/local/bin", "/usr/bin"].join(delimiter) },
+      desktopRoot,
+    );
+    expect(result.PATH.split(delimiter)).toEqual([
+      resolve(desktopRoot, "node_modules", ".bin"),
+      resolve(desktopRoot, "..", "..", "node_modules", ".bin"),
+      "/usr/local/bin",
+      "/usr/bin",
+    ]);
+  });
+
+  it("preserves an existing Path key and avoids duplicate entries", () => {
+    const desktopRoot = "/repo/apps/desktop";
+    const desktopBin = resolve(desktopRoot, "node_modules", ".bin");
+    const workspaceBin = resolve(desktopRoot, "..", "..", "node_modules", ".bin");
+    const result = envWithLocalBins(
+      { Path: [desktopBin, "runner-bin", workspaceBin].join(delimiter) },
+      desktopRoot,
+    );
+    expect(result).not.toHaveProperty("PATH");
+    expect(result.Path.split(delimiter)).toEqual([
+      desktopBin,
+      workspaceBin,
+      "runner-bin",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- prepend desktop-local and workspace-level node binary directories before spawning desktop packaging tools
- keep the existing PATH/Path env key and avoid duplicate entries so direct node invocations work on Linux and Windows runners
- add targeted tests for the PATH injection helper

## Testing
- pnpm --dir apps/desktop exec vitest run scripts/package.test.mjs