### PR TITLE
fix(desktop): use localhost web URL for shareable links in dev

### DIFF
--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -15,10 +15,11 @@ import {
 } from "@/stores/tab-store";
 import { useWindowOverlayStore } from "@/stores/window-overlay-store";
 
-// Public web app URL — injected at build time via .env.production. Falls
-// back to the production host for dev builds so "Copy link" yields a URL
-// that actually points somewhere a teammate can open.
-const APP_URL = import.meta.env.VITE_APP_URL || "https://multica.ai";
+// Public web app URL — injected at build time via .env.production. In dev
+// (no VITE_APP_URL set) falls back to the local web dev server so "Copy
+// link" in a dev build yields a URL that points at the running dev
+// frontend, not the prod host. Matches the fallback used in pages/login.tsx.
+const APP_URL = import.meta.env.VITE_APP_URL || "http://localhost:3000";
 
 /**
  * Extract the leading workspace slug from a path, or null if the path isn't


### PR DESCRIPTION
## Summary

- `platform/navigation.tsx` defaulted `VITE_APP_URL` to the hardcoded production host `https://multica.ai`, so "Copy link" in a dev build always produced a prod URL regardless of the dev frontend running locally.
- Switch the dev fallback to `http://localhost:3000`, matching what `pages/login.tsx` already does.
- Production builds are unaffected because `.env.production` still injects `VITE_APP_URL=https://multica.ai`.

Fixes [MUL-1200](mention://issue/e7c69f04-17d1-4379-9983-2941bbd02ac2).

## Test plan

- [ ] In a dev desktop build (no `VITE_APP_URL` set), open an issue → "Copy link" → paste → URL should be `http://localhost:3000/...`.
- [ ] Repeat from the `⌘K` search command "Copy Issue Link" action → same expectation.
- [ ] In a packaged (production) build, "Copy link" still produces a `https://multica.ai/...` URL.