### PR TITLE
fix(inbox): stop remounting IssueDetail on new comment/reaction (MUL-1199)

### DIFF
--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -212,8 +212,12 @@ export function InboxPage() {
   );
 
   const detailContent = selected?.issue_id ? (
+    // Key by issue_id (not inbox-item id): a new comment/reaction generates a
+    // new inbox notification for the same issue, and the dedup helper picks the
+    // newest one — keying on its id would remount IssueDetail on every event,
+    // wiping the comment composer draft and resetting scroll position.
     <IssueDetail
-      key={selected.id}
+      key={selected.issue_id}
       issueId={selected.issue_id}
       defaultSidebarOpen={false}
       layoutId="multica_inbox_issue_detail_layout"


### PR DESCRIPTION
## Summary

- The inbox detail panel keyed `<IssueDetail>` by `selected.id` (the inbox-item id). `deduplicateInboxItems` picks the most recent inbox notification per issue, so every new `comment:created` / `reaction:added` event for the currently open issue produced a fresh inbox item with a new id — flipping the React `key` and forcing a full unmount/remount of `IssueDetail`. That wiped the comment composer draft, dropped focus, and reset scroll.
- Switched the key to `selected.issue_id`: stable for the life of an open issue (so input + scroll survive incoming events), and still changes when the user picks a different issue (so state resets between issues, as before).

Fixes MUL-1199.

## Test plan

- [ ] Open Inbox, click into an issue with comments
- [ ] Type something into the comment composer, do **not** submit
- [ ] In a second session/tab, post a new comment on the same issue
- [ ] In a second session/tab, add a reaction to one of the comments
- [ ] Confirm: composer draft + caret position + scroll position survive both events; the new comment/reaction renders inline without remount
- [ ] Click a different inbox notification → IssueDetail still resets to the new issue (regression check)