### PR TITLE
fix(server/task): synthesize result comment for comment-triggered tasks too

### DIFF
--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1304,3 +1304,192 @@ func TestClaimTaskByRuntime_TaskWorkspaceMismatch_CancelsAndRejects(t *testing.T
 		t.Fatalf("ClaimTaskByRuntime (mismatch): expected task status=cancelled, got %q", status)
 	}
 }
+
+// Regression test for MUL-1198: comment-triggered tasks that finish without
+// the agent posting any comment must still deliver a synthesized result
+// comment, threaded under the trigger. Before the fix, CompleteTask exempted
+// comment-triggered tasks from the auto-synthesis path, so a Claude Code /
+// Codex / etc. agent that ended its run with only terminal text (no
+// `multica issue comment add` call) left the user staring at a "Completed"
+// badge with no reply.
+func TestCompleteTask_CommentTriggered_SynthesizesCommentWhenAgentSilent(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'mul-1198 fixture', 'in_progress', 'none', $2, 'member', 81198, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var triggerCommentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'member', $3, 'please take a look', 'comment')
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID).Scan(&triggerCommentID); err != nil {
+		t.Fatalf("setup: create trigger comment: %v", err)
+	}
+
+	// Comment-triggered, already running (as CompleteAgentTask requires).
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, trigger_comment_id,
+			status, priority, started_at
+		)
+		VALUES ($1, $2, $3, $4, 'running', 0, now())
+		RETURNING id
+	`, agentID, runtimeID, issueID, triggerCommentID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create comment-triggered task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	const agentFinalOutput = "sure, will look into it shortly"
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
+		map[string]any{"output": agentFinalOutput},
+		testWorkspaceID, "legit-daemon")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", taskID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.CompleteTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Exactly one agent comment on the issue, threaded under the trigger,
+	// carrying the agent's final output.
+	rows, err := testPool.Query(ctx, `
+		SELECT content, parent_id FROM comment
+		WHERE issue_id = $1 AND author_type = 'agent' AND author_id = $2
+		ORDER BY created_at ASC
+	`, issueID, agentID)
+	if err != nil {
+		t.Fatalf("query synthesized comments: %v", err)
+	}
+	defer rows.Close()
+
+	var (
+		content  string
+		parentID *string
+		seen     int
+	)
+	for rows.Next() {
+		if err := rows.Scan(&content, &parentID); err != nil {
+			t.Fatalf("scan comment: %v", err)
+		}
+		seen++
+	}
+	if seen != 1 {
+		t.Fatalf("expected exactly 1 synthesized agent comment, got %d", seen)
+	}
+	if content != agentFinalOutput {
+		t.Fatalf("synthesized comment content = %q, want %q", content, agentFinalOutput)
+	}
+	if parentID == nil || *parentID != triggerCommentID {
+		got := "<nil>"
+		if parentID != nil {
+			got = *parentID
+		}
+		t.Fatalf("synthesized comment parent_id = %s, want trigger comment %s", got, triggerCommentID)
+	}
+}
+
+// Companion to the above: when the agent DID post its own comment during the
+// run, CompleteTask must not synthesize a duplicate. Guards against the
+// common case where the fix is over-eager and creates two comments per task.
+func TestCompleteTask_CommentTriggered_SkipsSynthesisWhenAgentAlreadyCommented(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'mul-1198 dedup fixture', 'in_progress', 'none', $2, 'member', 81199, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var triggerCommentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'member', $3, 'please take a look', 'comment')
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID).Scan(&triggerCommentID); err != nil {
+		t.Fatalf("setup: create trigger comment: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, trigger_comment_id,
+			status, priority, started_at
+		)
+		VALUES ($1, $2, $3, $4, 'running', 0, now())
+		RETURNING id
+	`, agentID, runtimeID, issueID, triggerCommentID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create comment-triggered task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	// Agent posts its own reply during the run — exactly the compliant path.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id)
+		VALUES ($1, $2, 'agent', $3, 'done, see PR', 'comment', $4)
+	`, issueID, testWorkspaceID, agentID, triggerCommentID); err != nil {
+		t.Fatalf("setup: create agent reply: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
+		map[string]any{"output": "final terminal text that must NOT become a comment"},
+		testWorkspaceID, "legit-daemon")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", taskID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.CompleteTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var count int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM comment
+		WHERE issue_id = $1 AND author_type = 'agent' AND author_id = $2
+	`, issueID, agentID).Scan(&count); err != nil {
+		t.Fatalf("count agent comments: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 agent comment (the agent's own reply), got %d — synthesis duplicated", count)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -393,12 +393,15 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 
 	slog.Info("task completed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
 
-	// Post agent output as a comment, but only for assignment-triggered issue tasks
-	// where the agent did NOT already post a comment during execution.
-	// Comment-triggered tasks: the agent replies via CLI with --parent, so
-	// posting here would create a duplicate.
-	// Chat tasks: no comment posting needed.
-	if task.IssueID.Valid && !task.TriggerCommentID.Valid {
+	// Invariant: every completed issue task must have at least one agent
+	// comment on the issue, so the user always sees something when a run
+	// ends. If the agent posted a comment during execution (result, progress
+	// ping, or CLI reply), HasAgentCommentedSince returns true and we skip.
+	// Otherwise, synthesize one from the final output. For comment-triggered
+	// tasks, TriggerCommentID threads the fallback under the original comment;
+	// for assignment-triggered tasks it is NULL and the fallback is top-level.
+	// Chat tasks have no IssueID and are handled separately below.
+	if task.IssueID.Valid {
 		agentCommented, _ := s.Queries.HasAgentCommentedSince(ctx, db.HasAgentCommentedSinceParams{
 			IssueID:  task.IssueID,
 			AuthorID: task.AgentID,


### PR DESCRIPTION
## Summary

Closes MUL-1198.

- Lift the `!task.TriggerCommentID.Valid` exemption in `CompleteTask` so the server's existing result-comment synthesis runs for **all** issue tasks, not just assignment-triggered ones.
- PR #1372 tried to close this gap with prompt wording (`CLAUDE.md` now has a bold mandatory step). That's best-effort — some agents still end with terminal-only text and leave a "Completed" run panel with zero comments on the issue.
- The server already had the right mechanism on the other branch: `HasAgentCommentedSince` (guards against duplicates) + `createAgentComment(..., task.TriggerCommentID)` (threads the fallback correctly). Removing one boolean clause is enough to extend the safety net to the branch that was failing.

Invariant after this PR: **every completed issue task has at least one agent comment on the issue.** Compliant agents still skip synthesis (they posted their own comment). Non-compliant agents get their final `payload.Output` auto-posted under the trigger comment.

## Test plan

- [ ] `TestCompleteTask_CommentTriggered_SynthesizesCommentWhenAgentSilent` — silent agent → synthesized comment, `parent_id = trigger`
- [ ] `TestCompleteTask_CommentTriggered_SkipsSynthesisWhenAgentAlreadyCommented` — compliant agent → no duplicate
- [ ] Existing assignment-triggered path unchanged (no test regression)
- [ ] Manual: trigger a comment on an issue, run an agent whose skill posts only terminal text → confirm a fallback comment appears threaded under the trigger