### PR TITLE
fix(desktop): unblock Windows + Linux release packaging

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,6 +2,18 @@
   "name": "@multica/desktop",
   "version": "0.1.0",
   "private": true,
+  "description": "Multica Desktop — native desktop client for the Multica platform.",
+  "homepage": "https://multica.ai",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/multica-ai/multica.git",
+    "directory": "apps/desktop"
+  },
+  "author": {
+    "name": "Multica",
+    "email": "support@multica.ai"
+  },
+  "license": "UNLICENSED",
   "main": "./out/main/index.js",
   "scripts": {
     "bundle-cli": "node scripts/bundle-cli.mjs",

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -329,10 +329,18 @@ function main() {
   //
   // CI invokes this script via `node scripts/package.mjs`, so we cannot
   // rely on pnpm/npm to inject package-local binaries into PATH.
+  //
+  // `shell: true` is required on Windows: `node_modules/.bin/electron-vite`
+  // ships as a `.cmd` shim there, and Node's `spawnSync` does not honour
+  // PATHEXT when spawning a bare command without a shell — it would fail
+  // with `ENOENT`. On POSIX hosts the shim is a real executable so going
+  // through the shell is harmless. See
+  // https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
   const viteResult = spawnSync("electron-vite", ["build"], {
     stdio: "inherit",
     cwd: desktopRoot,
     env: envWithLocalBins(),
+    shell: true,
   });
   if (viteResult.error) {
     console.error(
@@ -391,10 +399,13 @@ function main() {
     });
 
     // Step 4: invoke electron-builder for the current target only.
+    // `shell: true` for the same Windows `.cmd` shim reason as the
+    // electron-vite invocation above.
     const result = spawnSync("electron-builder", builderArgs, {
       stdio: "inherit",
       cwd: desktopRoot,
       env: envWithLocalBins(),
+      shell: true,
     });
 
     if (result.error) {


### PR DESCRIPTION
## Background

Run [#24711313389](https://github.com/multica-ai/multica/actions/runs/24711313389) of the desktop release workflow failed on both `windows-latest` and `ubuntu-latest` jobs. After analysis (see issue MUL-1201), the failures are two **independent** bugs in the repo, not GitHub Runner limitations.

## Changes

### 1. `apps/desktop/scripts/package.mjs` — Windows `.cmd` shim spawn

**Symptom**:
```
[package] failed to spawn electron-vite: spawnSync electron-vite ENOENT
```

**Root cause**: On Windows, `node_modules/.bin/electron-vite` is a `.cmd` shim. Node's `spawnSync` does not consult `PATHEXT` when spawning a bare command name, so it cannot resolve the shim unless we go through a shell. POSIX hosts ship a real executable shebang script and worked fine, which is why only the Windows job was failing.

**Fix**: Pass `shell: true` to both the `electron-vite` and `electron-builder` `spawnSync` calls. Harmless on macOS/Linux; required on Windows.

Reference: <https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows>

### 2. `apps/desktop/package.json` — Linux `.deb`/`.rpm` metadata

**Symptom**:
```
⨯ Please specify project homepage, see https://www.electron.build/configuration#metadata
Please specify author 'email' in the application package.json
It is required to set Linux .deb package maintainer.
```

**Root cause**: `fpm` (used by electron-builder for `.deb`/`.rpm`) requires a maintainer, and electron-builder derives it from the app's `package.json` `author.email`. The app `package.json` only had `name` + `version`.

**Fix**: Add `description`, `homepage`, `repository`, `author` (with `email`), and `license` fields.

Reference: <https://www.electron.build/configuration.html#metadata>

## Verification

- `pnpm test scripts/package.test.mjs` → 21/21 passing locally.
- The fix re-enables the existing GitHub-hosted runner release matrix; once merged, retriggering the tag/release workflow should produce both Windows (x64 + arm64) and Linux (AppImage/deb/rpm, x64 + arm64) artifacts.

Closes the regression discussed in [MUL-1201](https://github.com/multica-ai/multica/issues).