### PR TITLE
fix(agent/claude): allow account-level MCPs to reach spawned Claude

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -34,11 +34,12 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
-	args := buildClaudeArgs(opts, b.cfg.Logger)
-
-	// If the caller provided an MCP config, write it to a temp file and pass
-	// --mcp-config <path> so the agent uses a controlled set of MCP servers
-	// instead of inheriting from the outer Claude Code session.
+	// If the caller provided an MCP config, write it to a temp file; the
+	// exclusivity contract (use ONLY those servers) is enforced inside
+	// buildClaudeArgs by pairing --mcp-config with --strict-mcp-config.
+	// With no per-agent config, the child inherits account-level MCPs from
+	// the outer Claude Code session — this is what surfaces connectors like
+	// claude.ai Figma.
 	var mcpConfigPath string
 	var mcpFileCleanup func() // non-nil while this function owns the temp file
 	if len(opts.McpConfig) > 0 {
@@ -49,8 +50,8 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 		mcpConfigPath = path
 		mcpFileCleanup = func() { os.Remove(mcpConfigPath) }
-		args = append(args, "--mcp-config", mcpConfigPath)
 	}
+	args := buildClaudeArgs(opts, mcpConfigPath, b.cfg.Logger)
 	// Clean up the temp file if we return before the goroutine takes ownership.
 	defer func() {
 		if mcpFileCleanup != nil {
@@ -390,7 +391,16 @@ var claudeBlockedArgs = map[string]blockedArgMode{
 	"--mcp-config":      blockedWithValue,  // set by daemon from agent.mcp_config
 }
 
-func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
+// buildClaudeArgs produces the CLI args for the Claude child process.
+//
+// The mcp-config branch preserves the exclusivity contract from #1168:
+// when an explicit per-agent MCP config is provided, we also pass
+// --strict-mcp-config so the child sees ONLY those servers and does not
+// inherit account-level MCPs from the outer Claude Code session. When no
+// per-agent config is provided, --strict-mcp-config is omitted and the
+// child falls back to its normal account-level MCP list (Figma, etc.).
+// Pass mcpConfigPath="" to take the account-level path.
+func buildClaudeArgs(opts ExecOptions, mcpConfigPath string, logger *slog.Logger) []string {
 	args := []string{
 		"-p",
 		"--output-format", "stream-json",
@@ -409,6 +419,9 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 	}
 	if opts.ResumeSessionID != "" {
 		args = append(args, "--resume", opts.ResumeSessionID)
+	}
+	if mcpConfigPath != "" {
+		args = append(args, "--mcp-config", mcpConfigPath, "--strict-mcp-config")
 	}
 	args = append(args, filterCustomArgs(opts.CustomArgs, claudeBlockedArgs, logger)...)
 	return args

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -396,7 +396,6 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
-		"--strict-mcp-config",
 		"--permission-mode", "bypassPermissions",
 	}
 	if opts.Model != "" {

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -37,6 +37,14 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	// If the caller provided an MCP config, write it to a temp file and pass
 	// --mcp-config <path> so the agent uses a controlled set of MCP servers
 	// instead of inheriting from the outer Claude Code session.
+	//
+	// --strict-mcp-config is paired here, NOT set unconditionally in
+	// buildClaudeArgs: it makes --mcp-config the EXCLUSIVE source (the #1168
+	// per-agent isolation contract). When no per-agent config is provided we
+	// deliberately omit it so the spawned Claude inherits the operator's
+	// account-level MCP connectors (e.g. claude.ai Figma) authorized on the
+	// daemon's Max account. Without this, every agent started with zero MCP
+	// servers (devrushit fork PR #1451, still unmerged upstream on v0.3.22).
 	var mcpConfigPath string
 	var mcpFileCleanup func() // non-nil while this function owns the temp file
 	if len(opts.McpConfig) > 0 {
@@ -47,7 +55,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 		mcpConfigPath = path
 		mcpFileCleanup = func() { os.Remove(mcpConfigPath) }
-		args = append(args, "--mcp-config", mcpConfigPath)
+		args = append(args, "--mcp-config", mcpConfigPath, "--strict-mcp-config")
 	}
 	// Clean up the temp file if we return before the goroutine takes ownership.
 	defer func() {
@@ -503,7 +511,10 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
-		"--strict-mcp-config",
+		// NOTE: --strict-mcp-config is intentionally NOT here. It is paired with
+		// --mcp-config at the call site so it only applies when a per-agent MCP
+		// config is supplied; otherwise account-level connectors flow through.
+		// See the --mcp-config block in Execute (devrushit fork PR #1451).
 		"--permission-mode", "bypassPermissions",
 		// AskUserQuestion is Claude Code's built-in interactive question tool.
 		// The daemon runs Claude in non-interactive stream-json mode and has

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -195,10 +195,10 @@ func TestTrySendDropsWhenFull(t *testing.T) {
 	}
 }
 
-func TestBuildClaudeArgsOmitsStrictMCPConfig(t *testing.T) {
+func TestBuildClaudeArgsOmitsStrictMCPConfigWhenNoMcpConfig(t *testing.T) {
 	t.Parallel()
 
-	args := buildClaudeArgs(ExecOptions{}, slog.Default())
+	args := buildClaudeArgs(ExecOptions{}, "", slog.Default())
 	expected := []string{
 		"-p",
 		"--output-format", "stream-json",
@@ -214,6 +214,40 @@ func TestBuildClaudeArgsOmitsStrictMCPConfig(t *testing.T) {
 		if args[i] != want {
 			t.Fatalf("expected args[%d] = %q, got %q", i, want, args[i])
 		}
+	}
+	for _, a := range args {
+		if a == "--strict-mcp-config" {
+			t.Fatalf("--strict-mcp-config should NOT appear when mcpConfigPath is empty, got %v", args)
+		}
+	}
+}
+
+func TestBuildClaudeArgsIncludesStrictMCPConfigWhenMcpConfigProvided(t *testing.T) {
+	t.Parallel()
+
+	mcpPath := "/tmp/fake-mcp-config.json"
+	args := buildClaudeArgs(ExecOptions{}, mcpPath, slog.Default())
+
+	var sawMcpConfig, sawStrict bool
+	var mcpValue string
+	for i, a := range args {
+		if a == "--mcp-config" && i+1 < len(args) {
+			sawMcpConfig = true
+			mcpValue = args[i+1]
+		}
+		if a == "--strict-mcp-config" {
+			sawStrict = true
+		}
+	}
+
+	if !sawMcpConfig {
+		t.Fatalf("--mcp-config missing from args: %v", args)
+	}
+	if mcpValue != mcpPath {
+		t.Fatalf("--mcp-config value = %q, want %q", mcpValue, mcpPath)
+	}
+	if !sawStrict {
+		t.Fatalf("--strict-mcp-config missing — the #1168 exclusivity contract requires it to be paired with --mcp-config: %v", args)
 	}
 }
 
@@ -269,7 +303,7 @@ func TestBuildClaudeArgsPassesThroughCustomArgs(t *testing.T) {
 
 	args := buildClaudeArgs(ExecOptions{
 		CustomArgs: []string{"--max-turns", "50", "--verbose"},
-	}, slog.Default())
+	}, "", slog.Default())
 
 	// Custom args should appear at the end
 	found := 0
@@ -288,7 +322,7 @@ func TestBuildClaudeArgsFiltersBlockedCustomArgs(t *testing.T) {
 
 	args := buildClaudeArgs(ExecOptions{
 		CustomArgs: []string{"--output-format", "text", "--model", "o3"},
-	}, slog.Default())
+	}, "", slog.Default())
 
 	// --output-format text should be stripped
 	for _, a := range args[len(args)-2:] {
@@ -415,7 +449,7 @@ func TestBuildClaudeArgsBlocksMcpConfig(t *testing.T) {
 	// --mcp-config is hardcoded by the daemon — it must not be overridable via custom_args.
 	args := buildClaudeArgs(ExecOptions{
 		CustomArgs: []string{"--mcp-config", "/tmp/evil.json", "--model", "o3"},
-	}, slog.Default())
+	}, "", slog.Default())
 
 	for i, a := range args {
 		if a == "--mcp-config" {

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -195,7 +195,7 @@ func TestTrySendDropsWhenFull(t *testing.T) {
 	}
 }
 
-func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
+func TestBuildClaudeArgsOmitsStrictMCPConfig(t *testing.T) {
 	t.Parallel()
 
 	args := buildClaudeArgs(ExecOptions{}, slog.Default())
@@ -204,7 +204,6 @@ func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
-		"--strict-mcp-config",
 		"--permission-mode", "bypassPermissions",
 	}
 

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -199,16 +199,19 @@ func TestTrySendDropsWhenFull(t *testing.T) {
 	}
 }
 
-func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
+func TestBuildClaudeArgsOmitsStrictMCPConfigByDefault(t *testing.T) {
 	t.Parallel()
 
+	// devrushit fork PR #1451: with no per-agent MCP config, --strict-mcp-config
+	// must NOT be present, so the spawned Claude inherits the operator's
+	// account-level MCP connectors (e.g. claude.ai Figma). It is paired with
+	// --mcp-config at the Execute call site for the #1168 isolation contract.
 	args := buildClaudeArgs(ExecOptions{}, slog.Default())
 	expected := []string{
 		"-p",
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
-		"--strict-mcp-config",
 		"--permission-mode", "bypassPermissions",
 		"--disallowedTools", "AskUserQuestion",
 	}
@@ -219,6 +222,11 @@ func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
 	for i, want := range expected {
 		if args[i] != want {
 			t.Fatalf("expected args[%d] = %q, got %q", i, want, args[i])
+		}
+	}
+	for _, a := range args {
+		if a == "--strict-mcp-config" {
+			t.Fatalf("--strict-mcp-config must be omitted when no per-agent MCP config is set: %v", args)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Stop passing `--strict-mcp-config` when the daemon spawns the Claude CLI.

The daemon never invokes Claude with an explicit `--mcp-config` by default (only when the agent carries an `opts.McpConfig` blob), so combining `--strict-mcp-config` with an empty MCP config meant every spawned agent started with **zero MCP servers**, regardless of what the operator had authorized on the Max account via `claude.ai/settings/connectors`.

Dropping the flag lets Claude read its normal account-level MCP list, so connectors like `claude.ai Figma` reach the agent as intended. When the caller DOES provide an explicit `opts.McpConfig`, the existing `--mcp-config <tmpfile>` append path remains the sole MCP source for that run (unchanged).

## Context

We hit this on our self-hosted Multica deployment: 35+ UI tickets were completed with agents that believed they had Figma MCP access (because `claude mcp list` under the daemon user showed `Figma ✓ Connected`), but the actual spawned agents had no MCP tools at all due to `--strict-mcp-config`. Agents silently fabricated designs instead of reading Figma Variables, forcing a full refonte retry.

Verified locally against our daemon (`0.2.6+figma-mcp-fix`): post-patch, an agent given a task `call mcp__claude_ai_Figma__whoami` now returns the real OAuth-backed identity instead of WAITING on a missing tool.

## Test plan

- [x] `go test ./server/pkg/agent/...` — green (renamed `TestBuildClaudeArgsIncludesStrictMCPConfig` → `TestBuildClaudeArgsOmitsStrictMCPConfig`, expectations updated).
- [x] Built `GOOS=linux GOARCH=amd64 CGO_ENABLED=0` and hot-swapped on a production daemon.
- [x] Smoke-tested end-to-end: agent task with body `call mcp__claude_ai_Figma__whoami and commit the JSON output` → Builder produced a real whoami JSON (Max-tier account) in the merged MR.