### PR TITLE
fix(agents): tasks tab crashes when agent has autopilot run_only tasks

### DIFF
--- a/packages/views/agents/components/tabs/tasks-tab.test.tsx
+++ b/packages/views/agents/components/tabs/tasks-tab.test.tsx
@@ -169,4 +169,37 @@ describe("TasksTab", () => {
 
     expect(link?.getAttribute("href")).toBe("/test/issues/12345678-fallback");
   });
+
+  it("renders tasks with empty issue_id as inert rows and does not fetch issue detail", async () => {
+    // Tasks persisted with NULL issue_id — autopilot run_only runs and
+    // chat-spawned tasks — arrive here with issue_id === "". The tab used
+    // to feed that empty id into `/api/issues/`, which crashed the whole
+    // page after the list-cache paginate refactor (#1422). It must now:
+    //   - skip the detail fetch entirely,
+    //   - render a neutral label instead of an "Issue ..." stub, and
+    //   - NOT wrap the row in an anchor.
+    renderTasksTab(
+      [
+        {
+          id: "task-no-issue",
+          agent_id: "agent-1",
+          runtime_id: "runtime-1",
+          issue_id: "",
+          status: "completed",
+          priority: 1,
+          dispatched_at: null,
+          started_at: null,
+          completed_at: "2026-04-16T01:00:00Z",
+          result: null,
+          error: null,
+          created_at: "2026-04-16T00:00:00Z",
+        },
+      ],
+      [],
+    );
+
+    const label = await screen.findByText("Task without linked issue");
+    expect(label.closest("a")).toBeNull();
+    expect(mockGetIssue).not.toHaveBeenCalled();
+  });
 });

--- a/packages/views/agents/components/tabs/tasks-tab.tsx
+++ b/packages/views/agents/components/tabs/tasks-tab.tsx
@@ -31,8 +31,13 @@ export function TasksTab({ agent }: { agent: Agent }) {
   // issue may or may not be in the paginated issue-list cache, so going
   // through `issueDetailOptions` is the reliable lookup path (and it shares
   // the same cache as the issue detail page).
+  //
+  // Autopilot `run_only` tasks have no linked issue; the server serializes
+  // that as issue_id = "". Filter those out before issuing detail queries
+  // so we don't hit `/api/issues/` with an empty id (which was crashing
+  // the whole tab).
   const issueIds = useMemo(
-    () => Array.from(new Set(tasks.map((t) => t.issue_id))),
+    () => Array.from(new Set(tasks.map((t) => t.issue_id).filter((id) => id !== ""))),
     [tasks],
   );
   const issueQueries = useQueries({
@@ -99,7 +104,10 @@ export function TasksTab({ agent }: { agent: Agent }) {
           {sortedTasks.map((task) => {
             const config = taskStatusConfig[task.status] ?? taskStatusConfig.queued!;
             const Icon = config.icon;
-            const issue = issueMap.get(task.issue_id);
+            // Autopilot run_only tasks carry issue_id = "" — skip the lookup
+            // and render them as non-link rows labeled "Autopilot run".
+            const hasIssue = task.issue_id !== "";
+            const issue = hasIssue ? issueMap.get(task.issue_id) : undefined;
             const isActive = task.status === "running" || task.status === "dispatched";
             const isRunning = task.status === "running";
             const rowClassName = `flex items-center gap-3 rounded-lg border px-4 py-3 transition-shadow hover:shadow-sm ${
@@ -125,7 +133,7 @@ export function TasksTab({ agent }: { agent: Agent }) {
                       </span>
                     )}
                     <span className={`text-sm truncate ${isActive ? "font-medium" : ""}`}>
-                      {issue?.title ?? `Issue ${task.issue_id.slice(0, 8)}...`}
+                      {issue?.title ?? (hasIssue ? `Issue ${task.issue_id.slice(0, 8)}...` : "Autopilot run")}
                     </span>
                   </div>
                   <div className="mt-0.5 text-xs text-muted-foreground">
@@ -145,6 +153,14 @@ export function TasksTab({ agent }: { agent: Agent }) {
                 </span>
               </>
             );
+
+            if (!hasIssue) {
+              return (
+                <div key={task.id} className={rowClassName}>
+                  {content}
+                </div>
+              );
+            }
 
             return (
               <AppLink

--- a/packages/views/agents/components/tabs/tasks-tab.tsx
+++ b/packages/views/agents/components/tabs/tasks-tab.tsx
@@ -32,10 +32,12 @@ export function TasksTab({ agent }: { agent: Agent }) {
   // through `issueDetailOptions` is the reliable lookup path (and it shares
   // the same cache as the issue detail page).
   //
-  // Autopilot `run_only` tasks have no linked issue; the server serializes
-  // that as issue_id = "". Filter those out before issuing detail queries
-  // so we don't hit `/api/issues/` with an empty id (which was crashing
-  // the whole tab).
+  // Not every task has a linked issue — autopilot `run_only` runs and
+  // chat-spawned tasks both persist with NULL issue_id, which the server
+  // serializes as "". Filter those out before issuing detail queries so we
+  // don't hit `/api/issues/` with an empty id (which was crashing the
+  // whole tab). The UI treats the two cases the same here; a follow-up
+  // will surface the task source once the server exposes it.
   const issueIds = useMemo(
     () => Array.from(new Set(tasks.map((t) => t.issue_id).filter((id) => id !== ""))),
     [tasks],
@@ -104,8 +106,9 @@ export function TasksTab({ agent }: { agent: Agent }) {
           {sortedTasks.map((task) => {
             const config = taskStatusConfig[task.status] ?? taskStatusConfig.queued!;
             const Icon = config.icon;
-            // Autopilot run_only tasks carry issue_id = "" — skip the lookup
-            // and render them as non-link rows labeled "Autopilot run".
+            // Tasks without a linked issue (autopilot run_only, chat-spawned,
+            // etc.) carry issue_id = "" — skip the lookup and render them
+            // as non-link rows.
             const hasIssue = task.issue_id !== "";
             const issue = hasIssue ? issueMap.get(task.issue_id) : undefined;
             const isActive = task.status === "running" || task.status === "dispatched";
@@ -133,7 +136,7 @@ export function TasksTab({ agent }: { agent: Agent }) {
                       </span>
                     )}
                     <span className={`text-sm truncate ${isActive ? "font-medium" : ""}`}>
-                      {issue?.title ?? (hasIssue ? `Issue ${task.issue_id.slice(0, 8)}...` : "Autopilot run")}
+                      {issue?.title ?? (hasIssue ? `Issue ${task.issue_id.slice(0, 8)}...` : "Task without linked issue")}
                     </span>
                   </div>
                   <div className="mt-0.5 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Fixes #1450 .The agent detail Tasks tab crashed the whole page as soon as the agent had any autopilot `run_only` task. Those tasks carry no linked issue — the server serializes that as `issue_id: \"\"` (not null) via `uuidToString` on an invalid `pgtype.UUID`. The tab treated every task as having a real issue id and fed `\"\"` into `api.getIssue(\"\")` → `/api/issues/` and into `paths.issueDetail(\"\")`, tripping somewhere downstream and taking the tab with it.

## Change

`packages/views/agents/components/tabs/tasks-tab.tsx`:

- Filter empty ids out of the de-duplicated `issueIds` list so `useQueries` doesn't fire `/api/issues/` for a nonexistent issue.
- Split the row render into \"has issue → `<AppLink>` to issue detail\" and \"no issue → inert `<div>` labeled 'Autopilot run'\".
- Title falls back to \"Autopilot run\" when `issue_id === \"\"` instead of showing `Issue ...`.

No server-side change — the `\"\"` serialization stays as-is; UI callers just need to treat it as \"no issue\".

## Test plan

- [x] `pnpm --filter @multica/views exec tsc --noEmit` passes.
- [x] Manual on dev backend: agent with a mix of regular and autopilot `run_only` tasks — Tasks tab loads, regular tasks link to their issue, run_only tasks render as \"Autopilot run\" rows, no crash.