### PR TITLE
feat(agents): surface task source on AgentTaskResponse + use it in Tasks tab

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -27,6 +27,9 @@ export interface AgentTask {
   id: string;
   agent_id: string;
   runtime_id: string;
+  // Empty string ("") when the task has no linked issue — either chat- or
+  // autopilot-spawned. Check chat_session_id / autopilot_run_id to tell
+  // which source produced it.
   issue_id: string;
   status: "queued" | "dispatched" | "running" | "completed" | "failed" | "cancelled";
   priority: number;
@@ -36,6 +39,10 @@ export interface AgentTask {
   result: unknown;
   error: string | null;
   created_at: string;
+  /** Non-empty when the task was spawned from a chat session. */
+  chat_session_id?: string;
+  /** Non-empty when the task was spawned by an autopilot run. */
+  autopilot_run_id?: string;
 }
 
 export interface Agent {

--- a/packages/views/agents/components/tabs/tasks-tab.test.tsx
+++ b/packages/views/agents/components/tabs/tasks-tab.test.tsx
@@ -202,4 +202,56 @@ describe("TasksTab", () => {
     expect(label.closest("a")).toBeNull();
     expect(mockGetIssue).not.toHaveBeenCalled();
   });
+
+  it("labels chat-spawned tasks as 'Chat session'", async () => {
+    renderTasksTab(
+      [
+        {
+          id: "task-chat",
+          agent_id: "agent-1",
+          runtime_id: "runtime-1",
+          issue_id: "",
+          chat_session_id: "chat-42",
+          status: "running",
+          priority: 1,
+          dispatched_at: "2026-04-16T00:30:00Z",
+          started_at: "2026-04-16T00:31:00Z",
+          completed_at: null,
+          result: null,
+          error: null,
+          created_at: "2026-04-16T00:00:00Z",
+        },
+      ],
+      [],
+    );
+
+    const label = await screen.findByText("Chat session");
+    expect(label.closest("a")).toBeNull();
+  });
+
+  it("labels autopilot-spawned tasks as 'Autopilot run'", async () => {
+    renderTasksTab(
+      [
+        {
+          id: "task-autopilot",
+          agent_id: "agent-1",
+          runtime_id: "runtime-1",
+          issue_id: "",
+          autopilot_run_id: "run-7",
+          status: "completed",
+          priority: 1,
+          dispatched_at: null,
+          started_at: null,
+          completed_at: "2026-04-16T01:00:00Z",
+          result: null,
+          error: null,
+          created_at: "2026-04-16T00:00:00Z",
+        },
+      ],
+      [],
+    );
+
+    const label = await screen.findByText("Autopilot run");
+    expect(label.closest("a")).toBeNull();
+  });
 });

--- a/packages/views/agents/components/tabs/tasks-tab.tsx
+++ b/packages/views/agents/components/tabs/tasks-tab.tsx
@@ -106,11 +106,18 @@ export function TasksTab({ agent }: { agent: Agent }) {
           {sortedTasks.map((task) => {
             const config = taskStatusConfig[task.status] ?? taskStatusConfig.queued!;
             const Icon = config.icon;
-            // Tasks without a linked issue (autopilot run_only, chat-spawned,
-            // etc.) carry issue_id = "" — skip the lookup and render them
-            // as non-link rows.
+            // Tasks without a linked issue carry issue_id = "" — skip the
+            // detail lookup and render them as non-link rows. The source
+            // label is picked from chat_session_id / autopilot_run_id,
+            // which the server populates for chat- and autopilot-spawned
+            // tasks respectively.
             const hasIssue = task.issue_id !== "";
             const issue = hasIssue ? issueMap.get(task.issue_id) : undefined;
+            const sourcelessLabel = task.chat_session_id
+              ? "Chat session"
+              : task.autopilot_run_id
+                ? "Autopilot run"
+                : "Task without linked issue";
             const isActive = task.status === "running" || task.status === "dispatched";
             const isRunning = task.status === "running";
             const rowClassName = `flex items-center gap-3 rounded-lg border px-4 py-3 transition-shadow hover:shadow-sm ${
@@ -136,7 +143,7 @@ export function TasksTab({ agent }: { agent: Agent }) {
                       </span>
                     )}
                     <span className={`text-sm truncate ${isActive ? "font-medium" : ""}`}>
-                      {issue?.title ?? (hasIssue ? `Issue ${task.issue_id.slice(0, 8)}...` : "Task without linked issue")}
+                      {issue?.title ?? (hasIssue ? `Issue ${task.issue_id.slice(0, 8)}...` : sourcelessLabel)}
                     </span>
                   </div>
                   <div className="mt-0.5 text-xs text-muted-foreground">

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -134,6 +134,7 @@ type AgentTaskResponse struct {
 	TriggerCommentContent string         `json:"trigger_comment_content,omitempty"` // content of the triggering comment
 	ChatSessionID         string         `json:"chat_session_id,omitempty"`         // non-empty for chat tasks
 	ChatMessage           string         `json:"chat_message,omitempty"`            // user message for chat tasks
+	AutopilotRunID        string         `json:"autopilot_run_id,omitempty"`        // non-empty for autopilot-spawned tasks
 }
 
 // TaskAgentData holds agent info included in claim responses so the daemon
@@ -168,6 +169,11 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		Error:            textToPtr(t.Error),
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
+		// Surface task source so the UI can distinguish issue-linked tasks
+		// from chat-spawned or autopilot-spawned ones; all three may arrive
+		// with issue_id = "" once a task has no linked issue.
+		ChatSessionID:  uuidToString(t.ChatSessionID),
+		AutopilotRunID: uuidToString(t.AutopilotRunID),
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1453 per the MUL-1217 review. The hotfix filtered empty `issue_id` out of the Tasks tab to stop the crash and labeled every issue-less task as \"Task without linked issue\", which correctly declined to guess but lost the actual source. The database already distinguishes chat-spawned vs autopilot-spawned tasks in `agent_task_queue.chat_session_id` / `autopilot_run_id`; only the HTTP serializer was dropping them.

## Change

### Server — `server/internal/handler/agent.go`

- `AgentTaskResponse` declares a new `autopilot_run_id` JSON field (the struct already had `chat_session_id` declared but unpopulated).
- `taskToResponse` now fills both from the task row via `uuidToString`. Empty string when the UUID is invalid (the existing convention), `omitempty` keeps the wire format tidy for the common issue-linked case.

Additive change; old clients ignore unknown fields, so no coordinated rollout is needed.

### Types — `packages/core/types/agent.ts`

- `AgentTask` gains optional `chat_session_id` and `autopilot_run_id`.
- Comment on `issue_id` documents that `\"\"` means \"no linked issue\" and points readers at the other two fields to disambiguate source.

### Tasks tab — `packages/views/agents/components/tabs/tasks-tab.tsx`

- When `issue_id === \"\"`, pick the label from the source field:
  - `chat_session_id` → \"Chat session\"
  - `autopilot_run_id` → \"Autopilot run\"
  - neither → \"Task without linked issue\" (unchanged neutral fallback)
- Rows stay inert (no anchor) in all three no-issue cases; the issue-linked path is untouched.

### Tests

- Two new tests exercise the chat and autopilot label paths and confirm neither wraps the row in an anchor.
- The existing \"renders tasks with empty issue_id as inert rows and does not fetch issue detail\" test keeps covering the truly sourceless fallback.

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./internal/handler/` — passes
- [x] `pnpm --filter @multica/views exec vitest run agents/components/tabs/tasks-tab.test.tsx` — 5 tests pass
- [x] `pnpm typecheck` (all packages) — passes
- [ ] Manual on dev: an agent with a mix of issue-linked / chat / autopilot tasks shows the right labels for each on the Tasks tab.

Refs: MUL-1217, #1453