### PR TITLE
fix(cli): exact-match-first in resolveAssignee prevents substring collision

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -1072,7 +1072,8 @@ func resolveAssignee(ctx context.Context, client *cli.APIClient, name string) (s
 	}
 
 	nameLower := strings.ToLower(name)
-	var matches []assigneeMatch
+	var exactMatches []assigneeMatch
+	var substringMatches []assigneeMatch
 	var errs []error
 
 	// Search members.
@@ -1082,12 +1083,11 @@ func resolveAssignee(ctx context.Context, client *cli.APIClient, name string) (s
 	} else {
 		for _, m := range members {
 			mName := strVal(m, "name")
-			if strings.Contains(strings.ToLower(mName), nameLower) {
-				matches = append(matches, assigneeMatch{
-					Type: "member",
-					ID:   strVal(m, "user_id"),
-					Name: mName,
-				})
+			match := assigneeMatch{Type: "member", ID: strVal(m, "user_id"), Name: mName}
+			if strings.ToLower(mName) == nameLower {
+				exactMatches = append(exactMatches, match)
+			} else if strings.Contains(strings.ToLower(mName), nameLower) {
+				substringMatches = append(substringMatches, match)
 			}
 		}
 	}
@@ -1100,12 +1100,11 @@ func resolveAssignee(ctx context.Context, client *cli.APIClient, name string) (s
 	} else {
 		for _, a := range agents {
 			aName := strVal(a, "name")
-			if strings.Contains(strings.ToLower(aName), nameLower) {
-				matches = append(matches, assigneeMatch{
-					Type: "agent",
-					ID:   strVal(a, "id"),
-					Name: aName,
-				})
+			match := assigneeMatch{Type: "agent", ID: strVal(a, "id"), Name: aName}
+			if strings.ToLower(aName) == nameLower {
+				exactMatches = append(exactMatches, match)
+			} else if strings.Contains(strings.ToLower(aName), nameLower) {
+				substringMatches = append(substringMatches, match)
 			}
 		}
 	}
@@ -1115,14 +1114,29 @@ func resolveAssignee(ctx context.Context, client *cli.APIClient, name string) (s
 		return "", "", fmt.Errorf("failed to resolve assignee: %v; %v", errs[0], errs[1])
 	}
 
-	switch len(matches) {
+	// Exact matches take priority: if exactly one exact match exists, return it regardless
+	// of how many substring matches exist. This prevents "Developer" from being ambiguous
+	// against "Lead Developer".
+	if len(exactMatches) == 1 {
+		return exactMatches[0].Type, exactMatches[0].ID, nil
+	}
+	if len(exactMatches) > 1 {
+		var parts []string
+		for _, m := range exactMatches {
+			parts = append(parts, fmt.Sprintf("  %s %q (%s)", m.Type, m.Name, truncateID(m.ID)))
+		}
+		return "", "", fmt.Errorf("ambiguous assignee %q; matches:\n%s", name, strings.Join(parts, "\n"))
+	}
+
+	// No exact match — fall back to substring matching.
+	switch len(substringMatches) {
 	case 0:
 		return "", "", fmt.Errorf("no member or agent found matching %q", name)
 	case 1:
-		return matches[0].Type, matches[0].ID, nil
+		return substringMatches[0].Type, substringMatches[0].ID, nil
 	default:
 		var parts []string
-		for _, m := range matches {
+		for _, m := range substringMatches {
 			parts = append(parts, fmt.Sprintf("  %s %q (%s)", m.Type, m.Name, truncateID(m.ID)))
 		}
 		return "", "", fmt.Errorf("ambiguous assignee %q; matches:\n%s", name, strings.Join(parts, "\n"))

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -128,6 +128,42 @@ func TestResolveAssignee(t *testing.T) {
 		}
 	})
 
+	t.Run("exact match wins over substring collision", func(t *testing.T) {
+		// "Developer" is a substring of "Lead Developer"; exact match must win.
+		collisionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/workspaces/ws-1/members":
+				json.NewEncoder(w).Encode([]map[string]any{})
+			case "/api/agents":
+				json.NewEncoder(w).Encode([]map[string]any{
+					{"id": "agent-dev", "name": "Developer"},
+					{"id": "agent-lead", "name": "Lead Developer"},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer collisionSrv.Close()
+
+		collisionClient := cli.NewAPIClient(collisionSrv.URL, "ws-1", "test-token")
+		aType, aID, err := resolveAssignee(ctx, collisionClient, "Developer")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if aType != "agent" || aID != "agent-dev" {
+			t.Errorf("got (%q, %q), want (agent, agent-dev)", aType, aID)
+		}
+
+		// Verify the longer name still resolves unambiguously.
+		aType, aID, err = resolveAssignee(ctx, collisionClient, "Lead Developer")
+		if err != nil {
+			t.Fatalf("unexpected error for Lead Developer: %v", err)
+		}
+		if aType != "agent" || aID != "agent-lead" {
+			t.Errorf("got (%q, %q), want (agent, agent-lead)", aType, aID)
+		}
+	})
+
 	t.Run("missing workspace ID", func(t *testing.T) {
 		noWSClient := cli.NewAPIClient(srv.URL, "", "test-token")
 		_, _, err := resolveAssignee(ctx, noWSClient, "alice")


### PR DESCRIPTION
## Problem

`multica issue assign <id> --to "Developer"` fails with an ambiguous error when an agent named `Developer` coexists with `Lead Developer`. The resolver uses `strings.Contains` for all matching, so the shorter name is always a substring of the longer one.

## Solution

**Option B from the issue** — exact-match-first. The resolver now separates candidates into two buckets:

1. **Exact** (`strings.ToLower(name) == strings.ToLower(input)`)
2. **Substring** (`strings.Contains`)

If exactly one exact match exists it is returned immediately, regardless of how many substring matches are found. Only when there are no exact matches does the resolver fall back to substring matching (preserving the existing partial-name UX).

## What changed

- `cmd/multica/cmd_issue.go` — `resolveAssignee()` uses separate `exactMatches`/`substringMatches` slices; exact wins over substring.
- `cmd/multica/cmd_issue_test.go` — new `"exact match wins over substring collision"` sub-test verifies `"Developer"` resolves to the exact agent while `"Lead Developer"` still resolves unambiguously.

## All three affected paths

`resolveAssignee` is shared by `issue assign --to`, `issue update --assignee`, and `issue create --assignee` — all three are fixed by this single change.