### PR TITLE
feat(chat): expose session_id and work_dir in chat session API responses

### DIFF
--- a/packages/core/types/chat.ts
+++ b/packages/core/types/chat.ts
@@ -7,6 +7,8 @@ export interface ChatSession {
   status: "active" | "archived";
   /** True when the session has any unread assistant replies. List-only. */
   has_unread: boolean;
+  session_id?: string;
+  work_dir?: string;
   created_at: string;
   updated_at: string;
 }

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -95,6 +95,8 @@ func (h *Handler) ListChatSessions(w http.ResponseWriter, r *http.Request) {
 				Title:       s.Title,
 				Status:      s.Status,
 				HasUnread:   s.HasUnread,
+				SessionID:   textToPtr(s.SessionID),
+				WorkDir:     textToPtr(s.WorkDir),
 				CreatedAt:   timestampToString(s.CreatedAt),
 				UpdatedAt:   timestampToString(s.UpdatedAt),
 			}
@@ -118,6 +120,8 @@ func (h *Handler) ListChatSessions(w http.ResponseWriter, r *http.Request) {
 				Title:       s.Title,
 				Status:      s.Status,
 				HasUnread:   s.HasUnread,
+				SessionID:   textToPtr(s.SessionID),
+				WorkDir:     textToPtr(s.WorkDir),
 				CreatedAt:   timestampToString(s.CreatedAt),
 				UpdatedAt:   timestampToString(s.UpdatedAt),
 			}
@@ -489,9 +493,11 @@ type ChatSessionResponse struct {
 	Title       string `json:"title"`
 	Status      string `json:"status"`
 	// Only populated by list endpoints — single-session fetches return false.
-	HasUnread bool   `json:"has_unread"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	HasUnread bool    `json:"has_unread"`
+	SessionID *string `json:"session_id,omitempty"`
+	WorkDir   *string `json:"work_dir,omitempty"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
 }
 
 type ChatMessageResponse struct {
@@ -511,6 +517,8 @@ func chatSessionToResponse(s db.ChatSession) ChatSessionResponse {
 		CreatorID:   uuidToString(s.CreatorID),
 		Title:       s.Title,
 		Status:      s.Status,
+		SessionID:   textToPtr(s.SessionID),
+		WorkDir:     textToPtr(s.WorkDir),
 		CreatedAt:   timestampToString(s.CreatedAt),
 		UpdatedAt:   timestampToString(s.UpdatedAt),
 	}


### PR DESCRIPTION
The chat_session table has always stored session_id and work_dir (the agent's Claude Code resume pointer), and SELECT * queries already fetched them, but the handler silently dropped both fields when building ChatSessionResponse.


## What does this PR do?

Add SessionID and WorkDir to the Go response struct and wire them through all three code paths: chatSessionToResponse (used by Get), and both branches of ListChatSessions (status=all / active-only). Also add the corresponding optional fields to the TypeScript ChatSession type so the frontend can access them.

Need SessionID and WorkDir when trying  to resume session in daemon.
