### PR TITLE
feat(agent): add Windows/WSL support for Hermes agent discovery and path translation

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -113,7 +114,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Path:  resolved,
 			Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
 		}
-	} else if appData := os.Getenv("APPDATA"); appData != "" {
+	} else if runtime.GOOS == "windows" {
 		// Windows fallback: check the managed wrapper at %APPDATA%\Multica\bin\hermes.cmd.
 		// Hermes is a Python agent typically installed inside WSL on Windows.
 		// The daemon process (spawned by the Desktop app or background start)
@@ -122,11 +123,14 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		// Windows binary named "hermes" on PATH.
 		// A lightweight .cmd wrapper placed at this well-known location
 		// delegates to the WSL-resident Hermes binary transparently.
-		fallback := filepath.Join(appData, "Multica", "bin", "hermes.cmd")
-		if _, statErr := os.Stat(fallback); statErr == nil {
-			agents["hermes"] = AgentEntry{
-				Path:  fallback,
-				Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			fallback := filepath.Join(appData, "Multica", "bin", "hermes.cmd")
+			if _, statErr := os.Stat(fallback); statErr == nil {
+				agents["hermes"] = AgentEntry{
+					Path:         fallback,
+					Model:        strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+					NeedsWSLPath: true, // discovered via WSL bridge — translate Windows paths to /mnt/...
+				}
 			}
 		}
 	}

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -108,10 +108,26 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		}
 	}
 	hermesPath := envOrDefault("MULTICA_HERMES_PATH", "hermes")
-	if _, err := exec.LookPath(hermesPath); err == nil {
+	if resolved, err := exec.LookPath(hermesPath); err == nil {
 		agents["hermes"] = AgentEntry{
-			Path:  hermesPath,
+			Path:  resolved,
 			Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+		}
+	} else if appData := os.Getenv("APPDATA"); appData != "" {
+		// Windows fallback: check the managed wrapper at %APPDATA%\Multica\bin\hermes.cmd.
+		// Hermes is a Python agent typically installed inside WSL on Windows.
+		// The daemon process (spawned by the Desktop app or background start)
+		// does not load .env files, so MULTICA_HERMES_PATH is usually empty
+		// and exec.LookPath("hermes") fails because there is no native
+		// Windows binary named "hermes" on PATH.
+		// A lightweight .cmd wrapper placed at this well-known location
+		// delegates to the WSL-resident Hermes binary transparently.
+		fallback := filepath.Join(appData, "Multica", "bin", "hermes.cmd")
+		if _, statErr := os.Stat(fallback); statErr == nil {
+			agents["hermes"] = AgentEntry{
+				Path:  fallback,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+			}
 		}
 	}
 	geminiPath := envOrDefault("MULTICA_GEMINI_PATH", "gemini")

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1062,6 +1062,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,
 		Logger:         d.logger,
+		NeedsWSLPath:   entry.NeedsWSLPath,
 	})
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -4,8 +4,9 @@ import "encoding/json"
 
 // AgentEntry describes a single available agent CLI.
 type AgentEntry struct {
-	Path  string // path to CLI binary
-	Model string // model override (optional)
+	Path         string // path to CLI binary
+	Model        string // model override (optional)
+	NeedsWSLPath bool   // true when discovered via a WSL bridge wrapper (e.g. hermes.cmd); signals that Windows paths must be translated to /mnt/... before passing to the agent
 }
 
 // Runtime represents a registered daemon runtime.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -89,6 +89,7 @@ type Config struct {
 	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
+	NeedsWSLPath   bool // when true, translate Windows paths to WSL mount paths (/mnt/...) before passing to the agent
 }
 
 // New creates a Backend for the given agent type.

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -9,26 +9,29 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
-// windowsToWSLPath translates a Windows-style path (e.g. C:\Users\...)
-// into a WSL mount path (e.g. /mnt/c/Users/...). This allows the
-// daemon running on Windows to pass working directories to a Hermes
-// binary installed inside WSL via a .cmd wrapper.
+// windowsToWSLPath converts a Windows drive-letter path (e.g. C:\Users\...)
+// to the corresponding WSL mount path (/mnt/c/Users/...). Paths that are not
+// drive-letter paths (UNC, empty, already POSIX) are returned unchanged.
+// This is a pure function — the caller decides whether to call it based on
+// the NeedsWSLPath flag, not runtime.GOOS.
 func windowsToWSLPath(windowsPath string) string {
-	if runtime.GOOS != "windows" {
-		return windowsPath
-	}
 	vol := filepath.VolumeName(windowsPath)
 	if vol == "" {
 		return windowsPath
 	}
-	driveLetter := strings.ToLower(strings.TrimSuffix(vol, ":"))
+	// Only translate drive-letter paths (e.g. "C:"). UNC paths like
+	// \\host\share have a VolumeName without a colon — don't attempt
+	// to translate those.
+	if len(vol) != 2 || vol[1] != ':' {
+		return windowsPath // not a drive-letter path; return as-is
+	}
+	driveLetter := strings.ToLower(string(vol[0]))
 	rest := strings.TrimPrefix(windowsPath, vol)
 	rest = filepath.ToSlash(rest)
 	return fmt.Sprintf("/mnt/%s%s", driveLetter, rest)
@@ -184,7 +187,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cwd := opts.Cwd
 		if cwd == "" {
 			cwd = "."
-		} else {
+		} else if b.cfg.NeedsWSLPath {
 			cwd = windowsToWSLPath(cwd)
 		}
 

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -7,12 +7,32 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
+
+// windowsToWSLPath translates a Windows-style path (e.g. C:\Users\...)
+// into a WSL mount path (e.g. /mnt/c/Users/...). This allows the
+// daemon running on Windows to pass working directories to a Hermes
+// binary installed inside WSL via a .cmd wrapper.
+func windowsToWSLPath(windowsPath string) string {
+	if runtime.GOOS != "windows" {
+		return windowsPath
+	}
+	vol := filepath.VolumeName(windowsPath)
+	if vol == "" {
+		return windowsPath
+	}
+	driveLetter := strings.ToLower(strings.TrimSuffix(vol, ":"))
+	rest := strings.TrimPrefix(windowsPath, vol)
+	rest = filepath.ToSlash(rest)
+	return fmt.Sprintf("/mnt/%s%s", driveLetter, rest)
+}
 
 // hermesBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args. `acp` is the protocol
@@ -164,6 +184,8 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		cwd := opts.Cwd
 		if cwd == "" {
 			cwd = "."
+		} else {
+			cwd = windowsToWSLPath(cwd)
 		}
 
 		if opts.ResumeSessionID != "" {

--- a/server/pkg/agent/hermes_wsl_test.go
+++ b/server/pkg/agent/hermes_wsl_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import "testing"
+
+func TestWindowsToWSLPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "drive letter path",
+			input: `C:\Users\foo\project`,
+			want:  "/mnt/c/Users/foo/project",
+		},
+		{
+			name:  "drive root",
+			input: `C:\`,
+			want:  "/mnt/c/",
+		},
+		{
+			name:  "lowercase drive letter",
+			input: `d:\work\repo`,
+			want:  "/mnt/d/work/repo",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "already posix path",
+			input: "/mnt/c/Users/foo",
+			want:  "/mnt/c/Users/foo",
+		},
+		{
+			name:  "relative path",
+			input: "relative/path",
+			want:  "relative/path",
+		},
+		{
+			name:  "dot path",
+			input: ".",
+			want:  ".",
+		},
+		{
+			name:  "drive letter with forward slashes",
+			input: `E:\some/mixed\path`,
+			want:  "/mnt/e/some/mixed/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := windowsToWSLPath(tt.input)
+			if got != tt.want {
+				t.Errorf("windowsToWSLPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

On Windows, the [Hermes](https://github.com/AgenStack/hermes-agent) agent is typically installed inside WSL (Windows Subsystem for Linux) rather than as a native Windows binary. This causes two problems when the daemon tries to register it:

1. **Discovery failure**: `exec.LookPath("hermes")` fails because there is no native `hermes.exe` on the Windows PATH. The daemon process -- especially when spawned by the Desktop app -- does not load `.env` files, so `MULTICA_HERMES_PATH` remains empty.
2. **Path mismatch**: The CWD passed via ACP JSON-RPC is a Windows path (C:\Users\...) that the Linux-side Hermes cannot resolve, causing `session/new` and `session/resume` to fail.
## Changes

### `server/internal/daemon/config.go`
- After `exec.LookPath` fails for Hermes, check for a .cmd wrapper at the well-known location %APPDATA%\Multica\bin\hermes.cmd
- - This wrapper delegates to the WSL-resident Hermes binary transparently via wsl
- - No-op on non-Windows platforms (the APPDATA env var won't be set)
### `server/pkg/agent/hermes.go`
- Add `windowsToWSLPath()` helper that translates Windows drive paths (C:\Users\...) to WSL mount paths (/mnt/c/Users/...)
- - Applied to the CWD before sending `session/new` and `session/resume` JSON-RPC payloads
- - Guarded by `runtime.GOOS != "windows"` -- no-op on Linux/macOS
## Setup (User Side)

Users install the bridge by creating a 2-line wrapper:

```cmd
:: %APPDATA%\Multica\bin\hermes.cmd
@echo off
wsl ~/.hermes/hermes-agent/venv/bin/hermes %*
```

The daemon then auto-discovers it without requiring any environment variable configuration.

## Testing

- Verified on Windows 11 + WSL2 (Ubuntu 22.04)
- - Daemon log before: `agents="[claude gemini pi]"`
- - Daemon log after: `agents="[claude hermes gemini pi]"` (Verified)
- - `hermes.cmd --version` returns correct version from WSL venv
- - ACP JSON-RPC lifecycle (initialize -> session/new -> task/create) works with translated paths
- 