### PR TITLE
fix(daemon): suppress agent terminal windows on Windows

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -553,6 +553,7 @@ func writeMcpConfigToTemp(raw json.RawMessage) (string, error) {
 
 func detectCLIVersion(ctx context.Context, execPath string) (string, error) {
 	cmd := exec.CommandContext(ctx, execPath, "--version")
+	hideAgentWindow(cmd)
 	data, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("detect version for %s: %w", execPath, err)

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -59,6 +59,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	}()
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -100,6 +100,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 
 	codexArgs := append([]string{"app-server", "--listen", "stdio://"}, filterCustomArgs(opts.CustomArgs, codexBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, codexArgs...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", codexArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/copilot.go
+++ b/server/pkg/agent/copilot.go
@@ -198,6 +198,7 @@ func (b *copilotBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 	args := buildCopilotArgs(prompt, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -38,6 +38,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	args := buildCursorArgs(prompt, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 20 * time.Second
 	if opts.Cwd != "" {

--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -35,6 +35,7 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	args := buildGeminiArgs(prompt, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -47,6 +47,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 	hermesArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, hermesBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, hermesArgs...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", hermesArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -51,6 +51,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	// "approve_for_session" to every session/request_permission request.
 	kimiArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, kimiBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, kimiArgs...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", kimiArgs)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -203,6 +203,7 @@ func discoverOpenCodeModels(ctx context.Context, executablePath string) ([]Model
 	runCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, executablePath, "models")
+	hideAgentWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return []Model{}, nil
@@ -261,6 +262,7 @@ func discoverPiModels(ctx context.Context, executablePath string) ([]Model, erro
 	runCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, executablePath, "--list-models")
+	hideAgentWindow(cmd)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	stdout, err := cmd.Output()
@@ -375,6 +377,7 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 	defer cancel()
 
 	cmd := exec.CommandContext(runCtx, executablePath, "acp")
+	hideAgentWindow(cmd)
 	if len(p.extraEnv) > 0 {
 		cmd.Env = append(os.Environ(), p.extraEnv...)
 	}
@@ -553,6 +556,7 @@ func discoverCursorModels(ctx context.Context, executablePath string) ([]Model, 
 	runCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(runCtx, executablePath, "--list-models")
+	hideAgentWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return cursorStaticModels(), nil
@@ -649,6 +653,7 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 		{"agents", "list", "-o", "json"},
 	} {
 		cmd := exec.CommandContext(runCtx, executablePath, jsonArgs...)
+		hideAgentWindow(cmd)
 		out, err := cmd.Output()
 		if err != nil {
 			continue
@@ -662,6 +667,7 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 	// banner with box-drawing and section headers, and picking up
 	// the wrong tokens produces nonsense entries like "Identity:".
 	cmd := exec.CommandContext(runCtx, executablePath, "agents", "list")
+	hideAgentWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return []Model{}, nil

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -52,6 +52,7 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	args := buildOpenclawArgs(prompt, sessionID, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -55,6 +55,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	args = append(args, prompt)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -54,6 +54,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 	args := buildPiArgs(prompt, sessionPath, opts, b.cfg.Logger)
 
 	cmd := exec.CommandContext(runCtx, execPath, args...)
+	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.Cwd != "" {

--- a/server/pkg/agent/proc_other.go
+++ b/server/pkg/agent/proc_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package agent
+
+import "os/exec"
+
+// hideAgentWindow is a no-op on non-Windows platforms.
+func hideAgentWindow(cmd *exec.Cmd) {}

--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -12,8 +12,9 @@ const createNoWindow = 0x08000000
 // hideAgentWindow configures cmd to suppress the console window on Windows.
 // CREATE_NO_WINDOW prevents window creation while preserving stdio pipes.
 func hideAgentWindow(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		HideWindow:    true,
-		CreationFlags: createNoWindow,
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= createNoWindow
 }

--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package agent
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const createNoWindow = 0x08000000
+
+// hideAgentWindow configures cmd to suppress the console window on Windows.
+// CREATE_NO_WINDOW prevents window creation while preserving stdio pipes.
+func hideAgentWindow(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: createNoWindow,
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1471

When the multica daemon spawns agent CLI processes (Claude, Codex, Cursor, etc.) on Windows, each invocation opens a visible `cmd` terminal window that steals desktop focus. This is disruptive when working on the same machine.

## Root Cause

The daemon itself already uses `HideWindow: true` and `DETACHED_PROCESS` in `cmd_daemon_windows.go`, but the agent processes spawned via `exec.CommandContext` in `server/pkg/agent/*.go` do not set any `SysProcAttr`, so Windows creates a new console window for each one.

## Fix

Added a `hideAgentWindow(cmd)` helper with platform-specific implementations:

- **`proc_windows.go`**: Sets `SysProcAttr.HideWindow = true` and `CreationFlags = CREATE_NO_WINDOW` (0x08000000). Uses `CREATE_NO_WINDOW` instead of `DETACHED_PROCESS` to suppress the console while preserving stdio pipes for agent communication.
- **`proc_other.go`**: No-op on non-Windows platforms.

Called `hideAgentWindow(cmd)` immediately after every `exec.CommandContext()` in all 11 agent runner files (claude, codex, copilot, cursor, gemini, hermes, kimi, openclaw, opencode, pi, models).

## Testing

- `go vet ./pkg/agent/...` passes clean
- No behavioral change on non-Windows platforms (no-op stub)
- Windows: agent processes will no longer create visible console windows