### PR TITLE
feat: identify clients via X-Client-Platform/Version/OS

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -193,6 +193,16 @@ if (!gotTheLock) {
       return openExternalSafely(url);
     });
 
+    // Sync IPC: app version + normalized OS for preload. Sync (not invoke) so
+    // preload can attach the values to `desktopAPI.appInfo` before any renderer
+    // code reads them, ensuring the very first HTTP request from the renderer
+    // already carries X-Client-Version and X-Client-OS.
+    ipcMain.on("app:get-info", (event) => {
+      const p = process.platform;
+      const os = p === "darwin" ? "macos" : p === "win32" ? "windows" : p === "linux" ? "linux" : "unknown";
+      event.returnValue = { version: app.getVersion(), os };
+    });
+
     // IPC: toggle immersive mode — hides the macOS traffic lights so full-screen
     // modals (e.g. create-workspace) can place UI in the top-left corner
     // without fighting the native window controls' hit-test.

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,6 +1,11 @@
 import { ElectronAPI } from "@electron-toolkit/preload";
 
 interface DesktopAPI {
+  /** App version + normalized OS, captured synchronously at preload time. */
+  appInfo: {
+    version: string;
+    os: "macos" | "windows" | "linux" | "unknown";
+  };
   /** Listen for auth token delivered via deep link. Returns an unsubscribe function. */
   onAuthToken: (callback: (token: string) => void) => () => void;
   /** Listen for invitation IDs delivered via deep link. Returns an unsubscribe function. */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,7 +1,32 @@
 import { contextBridge, ipcRenderer } from "electron";
 import { electronAPI } from "@electron-toolkit/preload";
 
+// Synchronously fetch app metadata from main at preload time so the renderer
+// can pass it into CoreProvider during the initial render — the alternative
+// (async ipc.invoke) would race the ApiClient construction in initCore and
+// the first few HTTP requests would go out without X-Client-Version/OS.
+function fetchAppInfo(): { version: string; os: "macos" | "windows" | "linux" | "unknown" } {
+  try {
+    const info = ipcRenderer.sendSync("app:get-info") as
+      | { version: string; os: "macos" | "windows" | "linux" | "unknown" }
+      | undefined;
+    if (info && typeof info.version === "string" && typeof info.os === "string") return info;
+  } catch {
+    // fall through
+  }
+  // Fallback: derive OS from process.platform; version unknown.
+  const p = process.platform;
+  const os: "macos" | "windows" | "linux" | "unknown" =
+    p === "darwin" ? "macos" : p === "win32" ? "windows" : p === "linux" ? "linux" : "unknown";
+  return { version: "unknown", os };
+}
+
+const appInfo = fetchAppInfo();
+
 const desktopAPI = {
+  /** App version + normalized OS. Read once at preload time so the renderer
+   *  can use it synchronously when initializing the API client. */
+  appInfo,
   /** Listen for auth token delivered via deep link */
   onAuthToken: (callback: (token: string) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, token: string) =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -189,12 +189,14 @@ async function handleDaemonLogout() {
 }
 
 export default function App() {
+  const { version, os } = window.desktopAPI.appInfo;
   return (
     <ThemeProvider>
       <CoreProvider
         apiBaseUrl={import.meta.env.VITE_API_URL || "http://localhost:8080"}
         wsUrl={import.meta.env.VITE_WS_URL || "ws://localhost:8080/ws"}
         onLogout={handleDaemonLogout}
+        identity={{ platform: "desktop", version, os }}
       >
         <AppContent />
       </CoreProvider>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CoreProvider } from "@multica/core/platform";
 import { useAuthStore } from "@multica/core/auth";
@@ -190,13 +190,19 @@ async function handleDaemonLogout() {
 
 export default function App() {
   const { version, os } = window.desktopAPI.appInfo;
+  // Stable identity reference so downstream effects (WS reconnect) don't
+  // tear down on every parent render.
+  const identity = useMemo(
+    () => ({ platform: "desktop", version, os }),
+    [version, os],
+  );
   return (
     <ThemeProvider>
       <CoreProvider
         apiBaseUrl={import.meta.env.VITE_API_URL || "http://localhost:8080"}
         wsUrl={import.meta.env.VITE_WS_URL || "ws://localhost:8080/ws"}
         onLogout={handleDaemonLogout}
-        identity={{ platform: "desktop", version, os }}
+        identity={identity}
       >
         <AppContent />
       </CoreProvider>

--- a/apps/web/components/web-providers.tsx
+++ b/apps/web/components/web-providers.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense } from "react";
 import { CoreProvider } from "@multica/core/platform";
+import packageJson from "../package.json";
 import { WebNavigationProvider } from "@/platform/navigation";
 import {
   setLoggedInCookie,
@@ -34,6 +35,12 @@ function deriveWsUrl(): string | undefined {
   return `${proto}//${window.location.host}/ws`;
 }
 
+// Build-time version preferred (CI sets NEXT_PUBLIC_APP_VERSION to a git tag
+// or sha so different deploys are distinguishable in server logs); fall back
+// to the package.json version so local dev still reports something useful.
+const WEB_VERSION =
+  process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version || "dev";
+
 export function WebProviders({ children }: { children: React.ReactNode }) {
   const cookieAuth = !hasLegacyToken();
   return (
@@ -43,6 +50,7 @@ export function WebProviders({ children }: { children: React.ReactNode }) {
       cookieAuth={cookieAuth}
       onLogin={setLoggedInCookie}
       onLogout={clearLoggedInCookie}
+      identity={{ platform: "web", version: WEB_VERSION }}
     >
       {/* Suspense boundary is required by Next.js for useSearchParams in
           a client component mounted this high in the tree. */}

--- a/apps/web/components/web-providers.tsx
+++ b/apps/web/components/web-providers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useMemo } from "react";
 import { CoreProvider } from "@multica/core/platform";
 import packageJson from "../package.json";
 import { WebNavigationProvider } from "@/platform/navigation";
@@ -43,6 +43,12 @@ const WEB_VERSION =
 
 export function WebProviders({ children }: { children: React.ReactNode }) {
   const cookieAuth = !hasLegacyToken();
+  // Stable identity reference so downstream effects keyed on it don't see a
+  // new object on every parent render.
+  const identity = useMemo(
+    () => ({ platform: "web", version: WEB_VERSION }),
+    [],
+  );
   return (
     <CoreProvider
       apiBaseUrl={process.env.NEXT_PUBLIC_API_URL}
@@ -50,7 +56,7 @@ export function WebProviders({ children }: { children: React.ReactNode }) {
       cookieAuth={cookieAuth}
       onLogin={setLoggedInCookie}
       onLogout={clearLoggedInCookie}
-      identity={{ platform: "web", version: WEB_VERSION }}
+      identity={identity}
     >
       {/* Suspense boundary is required by Next.js for useSearchParams in
           a client component mounted this high in the tree. */}

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -106,4 +106,42 @@ describe("ApiClient", () => {
       { url: "https://api.example.test/api/autopilots/ap-1/triggers/tr-1", method: "DELETE" },
     ]);
   });
+
+  it("emits X-Client-* headers when identity is configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test", {
+      identity: { platform: "desktop", version: "1.2.3", os: "macos" },
+    });
+    await client.listWorkspaces();
+
+    const headers = fetchMock.mock.calls[0]![1]!.headers as Record<string, string>;
+    expect(headers["X-Client-Platform"]).toBe("desktop");
+    expect(headers["X-Client-Version"]).toBe("1.2.3");
+    expect(headers["X-Client-OS"]).toBe("macos");
+  });
+
+  it("omits X-Client-* headers when identity is not configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test");
+    await client.listWorkspaces();
+
+    const headers = fetchMock.mock.calls[0]![1]!.headers as Record<string, string>;
+    expect(headers["X-Client-Platform"]).toBeUndefined();
+    expect(headers["X-Client-Version"]).toBeUndefined();
+    expect(headers["X-Client-OS"]).toBeUndefined();
+  });
 });

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -69,9 +69,24 @@ import { type Logger, noopLogger } from "../logger";
 import { createRequestId } from "../utils";
 import { getCurrentSlug } from "../platform/workspace-storage";
 
+/** Identifies the calling client to the server.
+ *  Sent on every HTTP request as X-Client-Platform / X-Client-Version /
+ *  X-Client-OS so the backend can log, gate, or split metrics by client.
+ *  See server/internal/middleware/client.go for the receiving end. */
+export interface ApiClientIdentity {
+  /** Logical client kind. Server expects: "web" | "desktop" | "cli" | "daemon". */
+  platform?: string;
+  /** Client/app version string (e.g. "0.1.0", git tag, commit). */
+  version?: string;
+  /** Operating system the client is running on: "macos" | "windows" | "linux". */
+  os?: string;
+}
+
 export interface ApiClientOptions {
   logger?: Logger;
   onUnauthorized?: () => void;
+  /** Identifies the client to the server. Sent as X-Client-* headers. */
+  identity?: ApiClientIdentity;
 }
 
 export interface LoginResponse {
@@ -172,6 +187,10 @@ export class ApiClient {
     if (slug) headers["X-Workspace-Slug"] = slug;
     const csrf = this.readCsrfToken();
     if (csrf) headers["X-CSRF-Token"] = csrf;
+    const id = this.options.identity;
+    if (id?.platform) headers["X-Client-Platform"] = id.platform;
+    if (id?.version) headers["X-Client-Version"] = id.version;
+    if (id?.os) headers["X-Client-OS"] = id.os;
     return headers;
   }
 

--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WSClient } from "./ws-client";
+
+// Capture URL passed to WebSocket so we can assert the connect-time
+// query string.  We don't simulate the full WS lifecycle here — only the
+// upgrade URL construction, which is what carries client identity.
+class FakeWebSocket {
+  static lastUrl: string | null = null;
+  // Fields read by WSClient.connect()/disconnect(), all no-op here.
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = 0;
+  constructor(url: string) {
+    FakeWebSocket.lastUrl = url;
+  }
+  close() {}
+  send() {}
+}
+
+describe("WSClient", () => {
+  beforeEach(() => {
+    FakeWebSocket.lastUrl = null;
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("includes client identity in the upgrade URL when configured", () => {
+    const ws = new WSClient("ws://example.test/ws", {
+      identity: { platform: "desktop", version: "1.2.3", os: "macos" },
+    });
+    ws.setAuth("tok", "acme");
+    ws.connect();
+
+    const url = new URL(FakeWebSocket.lastUrl!);
+    expect(url.searchParams.get("workspace_slug")).toBe("acme");
+    expect(url.searchParams.get("client_platform")).toBe("desktop");
+    expect(url.searchParams.get("client_version")).toBe("1.2.3");
+    expect(url.searchParams.get("client_os")).toBe("macos");
+    // Token must never appear in the URL — it is delivered as the first
+    // WS message in token mode.
+    expect(url.searchParams.has("token")).toBe(false);
+  });
+
+  it("omits client_* params when identity is not configured", () => {
+    const ws = new WSClient("ws://example.test/ws");
+    ws.setAuth("tok", "acme");
+    ws.connect();
+
+    const url = new URL(FakeWebSocket.lastUrl!);
+    expect(url.searchParams.has("client_platform")).toBe(false);
+    expect(url.searchParams.has("client_version")).toBe(false);
+    expect(url.searchParams.has("client_os")).toBe(false);
+  });
+
+  it("only includes the identity fields that are set", () => {
+    const ws = new WSClient("ws://example.test/ws", {
+      identity: { platform: "cli" },
+    });
+    ws.setAuth("tok", "acme");
+    ws.connect();
+
+    const url = new URL(FakeWebSocket.lastUrl!);
+    expect(url.searchParams.get("client_platform")).toBe("cli");
+    expect(url.searchParams.has("client_version")).toBe(false);
+    expect(url.searchParams.has("client_os")).toBe(false);
+  });
+});

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -3,12 +3,23 @@ import { type Logger, noopLogger } from "../logger";
 
 type EventHandler = (payload: unknown, actorId?: string) => void;
 
+/** Identifies the WS client to the server. Sent as `client_platform`,
+ *  `client_version`, and `client_os` query parameters on the upgrade URL —
+ *  browsers cannot set custom headers on WebSocket handshakes, so query
+ *  params are the only portable channel. */
+export interface WSClientIdentity {
+  platform?: string;
+  version?: string;
+  os?: string;
+}
+
 export class WSClient {
   private ws: WebSocket | null = null;
   private baseUrl: string;
   private token: string | null = null;
   private workspaceSlug: string | null = null;
   private cookieAuth = false;
+  private identity: WSClientIdentity | undefined;
   private handlers = new Map<WSEventType, Set<EventHandler>>();
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private hasConnectedBefore = false;
@@ -16,10 +27,18 @@ export class WSClient {
   private anyHandlers = new Set<(msg: WSMessage) => void>();
   private logger: Logger;
 
-  constructor(url: string, options?: { logger?: Logger; cookieAuth?: boolean }) {
+  constructor(
+    url: string,
+    options?: {
+      logger?: Logger;
+      cookieAuth?: boolean;
+      identity?: WSClientIdentity;
+    },
+  ) {
     this.baseUrl = url;
     this.logger = options?.logger ?? noopLogger;
     this.cookieAuth = options?.cookieAuth ?? false;
+    this.identity = options?.identity;
   }
 
   setAuth(token: string | null, workspaceSlug: string) {
@@ -35,6 +54,12 @@ export class WSClient {
     // is delivered as the first WebSocket message after the connection opens.
     if (this.workspaceSlug)
       url.searchParams.set("workspace_slug", this.workspaceSlug);
+    if (this.identity?.platform)
+      url.searchParams.set("client_platform", this.identity.platform);
+    if (this.identity?.version)
+      url.searchParams.set("client_version", this.identity.version);
+    if (this.identity?.os)
+      url.searchParams.set("client_os", this.identity.os);
 
     this.ws = new WebSocket(url.toString());
 

--- a/packages/core/platform/core-provider.tsx
+++ b/packages/core/platform/core-provider.tsx
@@ -10,7 +10,7 @@ import { QueryProvider } from "../provider";
 import { createLogger } from "../logger";
 import { defaultStorage } from "./storage";
 import { AuthInitializer } from "./auth-initializer";
-import type { CoreProviderProps } from "./types";
+import type { CoreProviderProps, ClientIdentity } from "./types";
 import type { StorageAdapter } from "../types/storage";
 
 // Module-level singletons — created once at first render, never recreated.
@@ -24,6 +24,7 @@ function initCore(
   onLogin?: () => void,
   onLogout?: () => void,
   cookieAuth?: boolean,
+  identity?: ClientIdentity,
 ) {
   if (initialized) return;
 
@@ -32,6 +33,7 @@ function initCore(
     onUnauthorized: () => {
       storage.removeItem("multica_token");
     },
+    identity,
   });
   setApiInstance(api);
 
@@ -62,11 +64,12 @@ export function CoreProvider({
   cookieAuth,
   onLogin,
   onLogout,
+  identity,
 }: CoreProviderProps) {
   // Initialize singletons on first render only. Dependencies are read-once:
   // apiBaseUrl, storage, and callbacks are set at app boot and never change at runtime.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useMemo(() => initCore(apiBaseUrl, storage, onLogin, onLogout, cookieAuth), []);
+  useMemo(() => initCore(apiBaseUrl, storage, onLogin, onLogout, cookieAuth, identity), []);
 
   return (
     <QueryProvider>
@@ -76,6 +79,7 @@ export function CoreProvider({
           authStore={authStore}
           storage={storage}
           cookieAuth={cookieAuth}
+          identity={identity}
         >
           {children}
         </WSProvider>

--- a/packages/core/platform/index.ts
+++ b/packages/core/platform/index.ts
@@ -1,5 +1,5 @@
 export { CoreProvider } from "./core-provider";
-export type { CoreProviderProps } from "./types";
+export type { CoreProviderProps, ClientIdentity } from "./types";
 export { AuthInitializer } from "./auth-initializer";
 export { defaultStorage } from "./storage";
 export { createPersistStorage } from "./persist-storage";

--- a/packages/core/platform/types.ts
+++ b/packages/core/platform/types.ts
@@ -1,5 +1,17 @@
 import type { StorageAdapter } from "../types/storage";
 
+/** Identifies the calling client to the server. Threaded through to
+ *  ApiClient and WSClient so all HTTP requests and WS connections from
+ *  this app instance are tagged with platform / version / os. */
+export interface ClientIdentity {
+  /** Logical client kind: "web" | "desktop" | "cli" | "daemon". */
+  platform?: string;
+  /** Client/app version string (e.g. "0.1.0"). */
+  version?: string;
+  /** Operating system: "macos" | "windows" | "linux". */
+  os?: string;
+}
+
 export interface CoreProviderProps {
   children: React.ReactNode;
   /** API base URL. Default: "" (same-origin). */
@@ -14,4 +26,6 @@ export interface CoreProviderProps {
   onLogin?: () => void;
   /** Called after logout (e.g. clear cookie). */
   onLogout?: () => void;
+  /** Identifies the calling client (web/desktop + version + os) to the server. */
+  identity?: ClientIdentity;
 }

--- a/packages/core/realtime/provider.tsx
+++ b/packages/core/realtime/provider.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { WSClient } from "../api/ws-client";
 import type { WSEventType, StorageAdapter } from "../types";
+import type { ClientIdentity } from "../platform/types";
 import type { StoreApi, UseBoundStore } from "zustand";
 import type { AuthState } from "../auth/store";
 import {
@@ -39,6 +40,8 @@ export interface WSProviderProps {
   storage: StorageAdapter;
   /** When true, use HttpOnly cookies instead of token query param for WS auth. */
   cookieAuth?: boolean;
+  /** Identifies the WS client to the server (sent as query params on the upgrade URL). */
+  identity?: ClientIdentity;
   /** Optional callback for showing toast messages (platform-specific, e.g. sonner) */
   onToast?: (message: string, type?: "info" | "error") => void;
 }
@@ -49,6 +52,7 @@ export function WSProvider({
   authStore,
   storage,
   cookieAuth,
+  identity,
   onToast,
 }: WSProviderProps) {
   const user = authStore((s) => s.user);
@@ -75,6 +79,7 @@ export function WSProvider({
     const ws = new WSClient(wsUrl, {
       logger: createLogger("ws"),
       cookieAuth,
+      identity,
     });
     ws.setAuth(token, wsSlug);
     setWsClient(ws);
@@ -84,7 +89,7 @@ export function WSProvider({
       ws.disconnect();
       setWsClient(null);
     };
-  }, [user, wsSlug, wsUrl, storage, cookieAuth]);
+  }, [user, wsSlug, wsUrl, storage, cookieAuth, identity]);
 
   const stores: RealtimeSyncStores = { authStore };
 

--- a/packages/core/realtime/provider.tsx
+++ b/packages/core/realtime/provider.tsx
@@ -68,6 +68,14 @@ export function WSProvider({
   );
   const [wsClient, setWsClient] = useState<WSClient | null>(null);
 
+  // Depend on identity primitives instead of the object reference so a parent
+  // re-render that passes a new `{ platform, version, os }` literal does not
+  // tear down and reconnect the WS when nothing about the identity actually
+  // changed.
+  const identityPlatform = identity?.platform;
+  const identityVersion = identity?.version;
+  const identityOS = identity?.os;
+
   useEffect(() => {
     if (!user || !wsSlug) return;
 
@@ -79,7 +87,14 @@ export function WSProvider({
     const ws = new WSClient(wsUrl, {
       logger: createLogger("ws"),
       cookieAuth,
-      identity,
+      identity:
+        identityPlatform || identityVersion || identityOS
+          ? {
+              platform: identityPlatform,
+              version: identityVersion,
+              os: identityOS,
+            }
+          : undefined,
     });
     ws.setAuth(token, wsSlug);
     setWsClient(ws);
@@ -89,7 +104,16 @@ export function WSProvider({
       ws.disconnect();
       setWsClient(null);
     };
-  }, [user, wsSlug, wsUrl, storage, cookieAuth, identity]);
+  }, [
+    user,
+    wsSlug,
+    wsUrl,
+    storage,
+    cookieAuth,
+    identityPlatform,
+    identityVersion,
+    identityOS,
+  ]);
 
   const stores: RealtimeSyncStores = { authStore };
 

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -28,6 +28,10 @@ func init() {
 	rootCmd.Version = fmt.Sprintf("%s (commit: %s, built: %s)\ngo: %s, os/arch: %s/%s", version, commit, date, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	rootCmd.SetVersionTemplate("multica {{.Version}}\n")
 
+	// Tag every CLI HTTP request with this binary's build version so the
+	// server can split logs/metrics by client version.
+	cli.ClientVersion = version
+
 	rootCmd.PersistentFlags().String("server-url", "", "Multica server URL (env: MULTICA_SERVER_URL)")
 	rootCmd.PersistentFlags().String("workspace-id", "", "Workspace ID (env: MULTICA_WORKSPACE_ID)")
 	rootCmd.PersistentFlags().String("profile", "", "Configuration profile name (e.g. dev) — isolates config, daemon state, and workspaces")

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -83,6 +83,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus, analytics
 
 	// Global middleware
 	r.Use(chimw.RequestID)
+	r.Use(middleware.ClientMetadata)
 	r.Use(middleware.RequestLogger)
 	r.Use(chimw.Recoverer)
 	r.Use(middleware.ContentSecurityPolicy)
@@ -94,7 +95,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus, analytics
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   origins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-Workspace-ID", "X-Workspace-Slug", "X-Request-ID", "X-Agent-ID", "X-Task-ID", "X-CSRF-Token"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-Workspace-ID", "X-Workspace-Slug", "X-Request-ID", "X-Agent-ID", "X-Task-ID", "X-CSRF-Token", "X-Client-Platform", "X-Client-Version", "X-Client-OS"},
 		AllowCredentials: true,
 		MaxAge:           300,
 	}))

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -9,9 +9,37 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
+
+// ClientVersion is the CLI version sent on every request as X-Client-Version.
+// Set by the multica binary at init() so the package doesn't depend on the
+// concrete cmd package. Defaults to "dev" when running unset (e.g. tests).
+var ClientVersion = "dev"
+
+// ClientPlatform identifies this client to the server. Override for tests
+// or alternative entry points; defaults to "cli".
+var ClientPlatform = "cli"
+
+// ClientOS is the normalized operating system string sent as X-Client-OS.
+// Computed once from runtime.GOOS so the server doesn't need to reverse-map
+// Go's os names ("darwin"/"windows"/"linux") into the protocol vocabulary.
+var ClientOS = normalizeGOOS(runtime.GOOS)
+
+func normalizeGOOS(goos string) string {
+	switch goos {
+	case "darwin":
+		return "macos"
+	case "windows":
+		return "windows"
+	case "linux":
+		return "linux"
+	default:
+		return goos
+	}
+}
 
 // APIClient is a REST client for the Multica server API.
 // Used by ctrl subcommands (agent, runtime, status, etc.). Requests
@@ -23,6 +51,12 @@ type APIClient struct {
 	AgentID     string // When set, requests are attributed to this agent instead of the user.
 	TaskID      string // When set, sent as X-Task-ID for agent-task validation.
 	HTTPClient  *http.Client
+
+	// Identity overrides. Empty values fall back to the package-level
+	// ClientPlatform / ClientVersion / ClientOS.
+	Platform string
+	Version  string
+	OS       string
 }
 
 // NewAPIClient creates a new API client for ctrl commands.
@@ -47,6 +81,28 @@ func (c *APIClient) setHeaders(req *http.Request) {
 	}
 	if c.TaskID != "" {
 		req.Header.Set("X-Task-ID", c.TaskID)
+	}
+
+	platform := c.Platform
+	if platform == "" {
+		platform = ClientPlatform
+	}
+	if platform != "" {
+		req.Header.Set("X-Client-Platform", platform)
+	}
+	version := c.Version
+	if version == "" {
+		version = ClientVersion
+	}
+	if version != "" {
+		req.Header.Set("X-Client-Version", version)
+	}
+	osName := c.OS
+	if osName == "" {
+		osName = ClientOS
+	}
+	if osName != "" {
+		req.Header.Set("X-Client-OS", osName)
 	}
 }
 

--- a/server/internal/cli/client_test.go
+++ b/server/internal/cli/client_test.go
@@ -109,4 +109,71 @@ func TestPostJSON(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("client identity headers", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("X-Client-Platform"); got != "cli-test" {
+				t.Errorf("expected X-Client-Platform cli-test, got %s", got)
+			}
+			if got := r.Header.Get("X-Client-Version"); got != "9.9.9" {
+				t.Errorf("expected X-Client-Version 9.9.9, got %s", got)
+			}
+			if got := r.Header.Get("X-Client-OS"); got != "linux" {
+				t.Errorf("expected X-Client-OS linux, got %s", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		client := NewAPIClient(srv.URL, "", "")
+		client.Platform = "cli-test"
+		client.Version = "9.9.9"
+		client.OS = "linux"
+		if err := client.PostJSON(context.Background(), "/test", reqBody{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("client identity headers fall back to package defaults", func(t *testing.T) {
+		origPlatform, origVersion, origOS := ClientPlatform, ClientVersion, ClientOS
+		ClientPlatform = "cli"
+		ClientVersion = "1.2.3-test"
+		ClientOS = "macos"
+		t.Cleanup(func() {
+			ClientPlatform, ClientVersion, ClientOS = origPlatform, origVersion, origOS
+		})
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("X-Client-Platform"); got != "cli" {
+				t.Errorf("expected X-Client-Platform cli, got %s", got)
+			}
+			if got := r.Header.Get("X-Client-Version"); got != "1.2.3-test" {
+				t.Errorf("expected X-Client-Version 1.2.3-test, got %s", got)
+			}
+			if got := r.Header.Get("X-Client-OS"); got != "macos" {
+				t.Errorf("expected X-Client-OS macos, got %s", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		client := NewAPIClient(srv.URL, "", "")
+		if err := client.PostJSON(context.Background(), "/test", reqBody{}, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestNormalizeGOOS(t *testing.T) {
+	cases := map[string]string{
+		"darwin":  "macos",
+		"windows": "windows",
+		"linux":   "linux",
+		"freebsd": "freebsd",
+	}
+	for in, want := range cases {
+		if got := normalizeGOOS(in); got != want {
+			t.Errorf("normalizeGOOS(%q) = %q, want %q", in, got, want)
+		}
+	}
 }

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -41,13 +42,55 @@ type Client struct {
 	baseURL string
 	token   string
 	client  *http.Client
+
+	// Identity headers sent on every request as X-Client-*. Populated by
+	// SetIdentity(); empty values are simply omitted.
+	platform string
+	version  string
+	os       string
 }
 
 // NewClient creates a new daemon API client.
 func NewClient(baseURL string) *Client {
 	return &Client{
-		baseURL: baseURL,
-		client:  &http.Client{Timeout: 30 * time.Second},
+		baseURL:  baseURL,
+		client:   &http.Client{Timeout: 30 * time.Second},
+		platform: "daemon",
+		os:       normalizeGOOS(runtime.GOOS),
+	}
+}
+
+// normalizeGOOS maps Go's runtime.GOOS values to the protocol vocabulary
+// used by X-Client-OS / client_os ("macos" / "windows" / "linux").
+func normalizeGOOS(goos string) string {
+	switch goos {
+	case "darwin":
+		return "macos"
+	case "windows":
+		return "windows"
+	case "linux":
+		return "linux"
+	default:
+		return goos
+	}
+}
+
+// SetVersion records the daemon's CLI version, sent as X-Client-Version.
+// Called by Daemon.Run after config is loaded.
+func (c *Client) SetVersion(v string) {
+	c.version = v
+}
+
+// setIdentityHeaders attaches X-Client-Platform/Version/OS to req when set.
+func (c *Client) setIdentityHeaders(req *http.Request) {
+	if c.platform != "" {
+		req.Header.Set("X-Client-Platform", c.platform)
+	}
+	if c.version != "" {
+		req.Header.Set("X-Client-Version", c.version)
+	}
+	if c.os != "" {
+		req.Header.Set("X-Client-OS", c.os)
 	}
 }
 
@@ -276,6 +319,7 @@ func (c *Client) postJSON(ctx context.Context, path string, reqBody any, respBod
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
+	c.setIdentityHeaders(req)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -302,6 +346,7 @@ func (c *Client) getJSON(ctx context.Context, path string, respBody any) error {
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
+	c.setIdentityHeaders(req)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+)
+
+func TestClient_IdentityHeaders_PostJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Client-Platform"); got != "daemon" {
+			t.Errorf("expected X-Client-Platform daemon, got %q", got)
+		}
+		if got := r.Header.Get("X-Client-Version"); got != "9.9.9" {
+			t.Errorf("expected X-Client-Version 9.9.9, got %q", got)
+		}
+		if got := r.Header.Get("X-Client-OS"); got != normalizeGOOS(runtime.GOOS) {
+			t.Errorf("expected X-Client-OS %q, got %q", normalizeGOOS(runtime.GOOS), got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("expected Authorization Bearer tok, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"ok": "1"})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	c.SetToken("tok")
+	c.SetVersion("9.9.9")
+
+	if err := c.postJSON(context.Background(), "/api/daemon/test", map[string]any{}, nil); err != nil {
+		t.Fatalf("postJSON: %v", err)
+	}
+}
+
+func TestClient_IdentityHeaders_GetJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Client-Platform"); got != "daemon" {
+			t.Errorf("expected X-Client-Platform daemon, got %q", got)
+		}
+		if got := r.Header.Get("X-Client-Version"); got != "1.2.3" {
+			t.Errorf("expected X-Client-Version 1.2.3, got %q", got)
+		}
+		if got := r.Header.Get("X-Client-OS"); got == "" {
+			t.Errorf("expected X-Client-OS to be set")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	c.SetToken("tok")
+	c.SetVersion("1.2.3")
+
+	var out map[string]any
+	if err := c.getJSON(context.Background(), "/api/daemon/test", &out); err != nil {
+		t.Fatalf("getJSON: %v", err)
+	}
+}
+
+func TestClient_VersionOmittedWhenUnset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Client-Platform"); got != "daemon" {
+			t.Errorf("expected X-Client-Platform daemon, got %q", got)
+		}
+		// SetVersion not called → header must be omitted (not "").
+		if vals := r.Header.Values("X-Client-Version"); len(vals) != 0 {
+			t.Errorf("expected X-Client-Version absent, got %v", vals)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	if err := c.postJSON(context.Background(), "/api/daemon/test", nil, nil); err != nil {
+		t.Fatalf("postJSON: %v", err)
+	}
+}
+
+func TestNormalizeGOOS(t *testing.T) {
+	cases := map[string]string{
+		"darwin":  "macos",
+		"windows": "windows",
+		"linux":   "linux",
+		"freebsd": "freebsd",
+	}
+	for in, want := range cases {
+		if got := normalizeGOOS(in); got != want {
+			t.Errorf("normalizeGOOS(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -58,9 +58,13 @@ type Daemon struct {
 // New creates a new Daemon instance.
 func New(cfg Config, logger *slog.Logger) *Daemon {
 	cacheRoot := filepath.Join(cfg.WorkspacesRoot, ".repos")
+	client := NewClient(cfg.ServerBaseURL)
+	// Tag every daemon HTTP request with the daemon's CLI version so the
+	// server can split logs/metrics by client version (parallel to the CLI).
+	client.SetVersion(cfg.CLIVersion)
 	return &Daemon{
 		cfg:           cfg,
-		client:        NewClient(cfg.ServerBaseURL),
+		client:        client,
 		repoCache:     repocache.New(cacheRoot, logger),
 		logger:        logger,
 		workspaces:    make(map[string]*workspaceState),

--- a/server/internal/logger/logger.go
+++ b/server/internal/logger/logger.go
@@ -8,6 +8,8 @@ import (
 
 	chimw "github.com/go-chi/chi/v5/middleware"
 	"github.com/lmittmann/tint"
+
+	"github.com/multica-ai/multica/server/internal/middleware"
 )
 
 // isTerminal reports whether the given file descriptor is connected to a
@@ -47,15 +49,27 @@ func NewLogger(component string) *slog.Logger {
 	return slog.New(handler).With("component", component)
 }
 
-// RequestAttrs extracts request_id and user_id from an HTTP request
-// for use in handler-level structured logging.
+// RequestAttrs extracts request_id, user_id, and X-Client-* metadata from
+// an HTTP request for use in handler-level structured logging. Mirrors the
+// global request logger so handler logs end up with the same observability
+// dimensions as the access log.
 func RequestAttrs(r *http.Request) []any {
-	attrs := make([]any, 0, 4)
+	attrs := make([]any, 0, 10)
 	if rid := chimw.GetReqID(r.Context()); rid != "" {
 		attrs = append(attrs, "request_id", rid)
 	}
 	if uid := r.Header.Get("X-User-ID"); uid != "" {
 		attrs = append(attrs, "user_id", uid)
+	}
+	platform, version, os := middleware.ClientMetadataFromContext(r.Context())
+	if platform != "" {
+		attrs = append(attrs, "client_platform", platform)
+	}
+	if version != "" {
+		attrs = append(attrs, "client_version", version)
+	}
+	if os != "" {
+		attrs = append(attrs, "client_os", os)
 	}
 	return attrs
 }

--- a/server/internal/middleware/client.go
+++ b/server/internal/middleware/client.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+)
+
+// Client metadata context keys.
+//
+// Populated by ClientMetadata middleware from X-Client-Platform / X-Client-Version /
+// X-Client-OS request headers. Sent by every first-party client (Web, Desktop, CLI,
+// Daemon) so the server can split logs / metrics / gating decisions by caller
+// without having to reverse-engineer User-Agent strings or upgrade payloads.
+//
+// All three values are best-effort: handlers must treat missing values as
+// "unknown" and never make security decisions based on them — these headers
+// are client-controlled and trivial to spoof.
+type clientMetadataKey int
+
+const (
+	ctxKeyClientPlatform clientMetadataKey = iota
+	ctxKeyClientVersion
+	ctxKeyClientOS
+)
+
+// Header names — exported so other packages (request logger, realtime hub)
+// can stay in sync without re-declaring magic strings.
+const (
+	HeaderClientPlatform = "X-Client-Platform"
+	HeaderClientVersion  = "X-Client-Version"
+	HeaderClientOS       = "X-Client-OS"
+)
+
+// ClientMetadata extracts X-Client-Platform / X-Client-Version / X-Client-OS
+// from the request and stashes them in the request context so downstream
+// handlers and the request logger can read them via ClientMetadataFromContext.
+//
+// Wired in router.go before route mounting so every authenticated and
+// unauthenticated handler benefits from the same observability dimensions.
+func ClientMetadata(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		if v := r.Header.Get(HeaderClientPlatform); v != "" {
+			ctx = context.WithValue(ctx, ctxKeyClientPlatform, v)
+		}
+		if v := r.Header.Get(HeaderClientVersion); v != "" {
+			ctx = context.WithValue(ctx, ctxKeyClientVersion, v)
+		}
+		if v := r.Header.Get(HeaderClientOS); v != "" {
+			ctx = context.WithValue(ctx, ctxKeyClientOS, v)
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ClientMetadataFromContext returns the platform/version/os captured from
+// X-Client-* headers. Empty strings are returned for any value that wasn't
+// sent — callers must treat missing values as "unknown" rather than failing.
+func ClientMetadataFromContext(ctx context.Context) (platform, version, os string) {
+	platform, _ = ctx.Value(ctxKeyClientPlatform).(string)
+	version, _ = ctx.Value(ctxKeyClientVersion).(string)
+	os, _ = ctx.Value(ctxKeyClientOS).(string)
+	return platform, version, os
+}
+
+// SetClientMetadata explicitly attaches client metadata to a context. Used
+// by the realtime hub, where metadata arrives via WS query parameters
+// (`client_platform`, `client_version`, `client_os`) instead of headers.
+func SetClientMetadata(ctx context.Context, platform, version, os string) context.Context {
+	if platform != "" {
+		ctx = context.WithValue(ctx, ctxKeyClientPlatform, platform)
+	}
+	if version != "" {
+		ctx = context.WithValue(ctx, ctxKeyClientVersion, version)
+	}
+	if os != "" {
+		ctx = context.WithValue(ctx, ctxKeyClientOS, os)
+	}
+	return ctx
+}

--- a/server/internal/middleware/client_test.go
+++ b/server/internal/middleware/client_test.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientMetadataExtractsHeaders(t *testing.T) {
+	var gotPlatform, gotVersion, gotOS string
+	handler := ClientMetadata(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotPlatform, gotVersion, gotOS = ClientMetadataFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(HeaderClientPlatform, "desktop")
+	req.Header.Set(HeaderClientVersion, "1.2.3")
+	req.Header.Set(HeaderClientOS, "macos")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotPlatform != "desktop" {
+		t.Errorf("platform: got %q, want desktop", gotPlatform)
+	}
+	if gotVersion != "1.2.3" {
+		t.Errorf("version: got %q, want 1.2.3", gotVersion)
+	}
+	if gotOS != "macos" {
+		t.Errorf("os: got %q, want macos", gotOS)
+	}
+}
+
+func TestClientMetadataMissingHeadersReturnEmpty(t *testing.T) {
+	var gotPlatform, gotVersion, gotOS string
+	handler := ClientMetadata(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotPlatform, gotVersion, gotOS = ClientMetadataFromContext(r.Context())
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if gotPlatform != "" || gotVersion != "" || gotOS != "" {
+		t.Errorf("expected empty metadata, got (%q,%q,%q)", gotPlatform, gotVersion, gotOS)
+	}
+}
+
+func TestSetClientMetadataAttachesValues(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := SetClientMetadata(req.Context(), "cli", "0.5.1", "linux")
+
+	platform, version, os := ClientMetadataFromContext(ctx)
+	if platform != "cli" || version != "0.5.1" || os != "linux" {
+		t.Errorf("got (%q,%q,%q), want (cli,0.5.1,linux)", platform, version, os)
+	}
+}

--- a/server/internal/middleware/request_logger.go
+++ b/server/internal/middleware/request_logger.go
@@ -38,6 +38,17 @@ func RequestLogger(next http.Handler) http.Handler {
 		if uid := r.Header.Get("X-User-ID"); uid != "" {
 			attrs = append(attrs, "user_id", uid)
 		}
+		if platform, version, os := ClientMetadataFromContext(r.Context()); platform != "" || version != "" || os != "" {
+			if platform != "" {
+				attrs = append(attrs, "client_platform", platform)
+			}
+			if version != "" {
+				attrs = append(attrs, "client_version", version)
+			}
+			if os != "" {
+				attrs = append(attrs, "client_os", os)
+			}
+		}
 
 		switch {
 		case status >= 500:

--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -419,6 +419,21 @@ func HandleWebSocket(hub *Hub, mc MembershipChecker, pr PATResolver, resolveSlug
 		conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"auth_ack"}`))
 	}
 
+	// Capture client metadata from query params (browsers cannot set custom
+	// headers on WebSocket upgrades, so the WSClient passes them via the URL).
+	// Logged with every connect so the same observability dimensions exist
+	// for WS as for HTTP.
+	clientPlatform := r.URL.Query().Get("client_platform")
+	clientVersion := r.URL.Query().Get("client_version")
+	clientOS := r.URL.Query().Get("client_os")
+	slog.Info("websocket connected",
+		"user_id", userID,
+		"workspace_id", workspaceID,
+		"client_platform", clientPlatform,
+		"client_version", clientVersion,
+		"client_os", clientOS,
+	)
+
 	client := &Client{
 		hub:         hub,
 		conn:        conn,

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -1,11 +1,14 @@
 package realtime
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -221,4 +224,94 @@ func TestHub_MultipleBroadcasts(t *testing.T) {
 			t.Fatalf("message %d: expected %s, got %s", i, expected, received)
 		}
 	}
+}
+
+// TestHandleWebSocket_ClientIdentityFromQuery verifies that client_platform,
+// client_version, and client_os query params on the WS upgrade URL are read
+// by the handler and surfaced to the access log. Browsers cannot set custom
+// headers on WS upgrades, so this query-param channel is the only way to
+// preserve the same observability dimensions HTTP clients get via X-Client-*.
+func TestHandleWebSocket_ClientIdentityFromQuery(t *testing.T) {
+var buf bytes.Buffer
+var mu sync.Mutex
+handler := slog.NewJSONHandler(&lockedWriter{w: &buf, mu: &mu}, &slog.HandlerOptions{Level: slog.LevelDebug})
+prevDefault := slog.Default()
+slog.SetDefault(slog.New(handler))
+t.Cleanup(func() { slog.SetDefault(prevDefault) })
+
+_, server := newTestHub(t)
+defer server.Close()
+
+token := makeTestToken(t)
+wsURL := "ws" + strings.TrimPrefix(server.URL, "http") +
+"/ws?workspace_id=" + testWorkspaceID +
+"&client_platform=desktop&client_version=1.2.3&client_os=macos"
+conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+if err != nil {
+t.Fatalf("dial: %v", err)
+}
+defer conn.Close()
+
+authMsg, _ := json.Marshal(map[string]any{
+"type":    "auth",
+"payload": map[string]string{"token": token},
+})
+if err := conn.WriteMessage(websocket.TextMessage, authMsg); err != nil {
+t.Fatalf("write auth: %v", err)
+}
+conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+if _, _, err := conn.ReadMessage(); err != nil {
+t.Fatalf("read auth_ack: %v", err)
+}
+
+// Wait briefly for the "websocket connected" log line to be flushed.
+deadline := time.Now().Add(2 * time.Second)
+var found map[string]any
+for time.Now().Before(deadline) {
+mu.Lock()
+raw := buf.String()
+mu.Unlock()
+for _, line := range strings.Split(raw, "\n") {
+if line == "" {
+continue
+}
+var entry map[string]any
+if err := json.Unmarshal([]byte(line), &entry); err != nil {
+continue
+}
+if msg, _ := entry["msg"].(string); msg == "websocket connected" {
+found = entry
+break
+}
+}
+if found != nil {
+break
+}
+time.Sleep(20 * time.Millisecond)
+}
+
+if found == nil {
+t.Fatalf("did not observe \"websocket connected\" log entry; buffered logs:\n%s", buf.String())
+}
+if got, _ := found["client_platform"].(string); got != "desktop" {
+t.Errorf("client_platform = %q, want %q", got, "desktop")
+}
+if got, _ := found["client_version"].(string); got != "1.2.3" {
+t.Errorf("client_version = %q, want %q", got, "1.2.3")
+}
+if got, _ := found["client_os"].(string); got != "macos" {
+t.Errorf("client_os = %q, want %q", got, "macos")
+}
+}
+
+// lockedWriter is a thread-safe writer used to capture concurrent slog output.
+type lockedWriter struct {
+w  *bytes.Buffer
+mu *sync.Mutex
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+l.mu.Lock()
+defer l.mu.Unlock()
+return l.w.Write(p)
 }


### PR DESCRIPTION
Adds client identification headers (and matching WS query params) across Web, Desktop, CLI, and Daemon so the server can split logs/metrics/gating decisions by caller without parsing User-Agent.

## Wire format
- **HTTP**: `X-Client-Platform`, `X-Client-Version`, `X-Client-OS`
- **WS** (browsers can't set headers on upgrades): `client_platform`, `client_version`, `client_os` query params
- Platform ∈ {web, desktop, cli, daemon}; OS ∈ {macos, windows, linux}; OS is a separate dimension from platform.

## Clients
- **Shared TS** (`packages/core/api/client.ts`, `ws-client.ts`) — new `identity` option threaded through `CoreProvider`.
- **Web** — pulls version from `NEXT_PUBLIC_APP_VERSION` (CI-injected) with `package.json` fallback. No OS (browser abstracts it).
- **Desktop** — Electron preload calls `ipcRenderer.sendSync("app:get-info")` so version + OS are available *synchronously* before first render. Renderer reads `window.desktopAPI.appInfo`.
- **Go CLI** — package vars in `internal/cli/client.go`; `cmd/multica/main.go init()` mirrors the build-time `version` ldflag into `cli.ClientVersion`.
- **Go daemon** — `internal/daemon/client.go` with `SetVersion` called from `daemon.New(cfg.CLIVersion)`. OS via `runtime.GOOS` normalized to macos/windows/linux.

## Server
- New `internal/middleware/ClientMetadata` extracts headers into request context.
- Wired in `router.go` after `RequestID` and before `RequestLogger`.
- `request_logger.go` and `logger.RequestAttrs` append `client_platform/version/os` to every access log and handler-level log.
- `realtime/hub.go` reads the three query params and logs them on websocket connect.
- CORS `AllowedHeaders` extended.

## Backwards compat
All headers/fields are additive; missing values are simply omitted. No DB schema change. Daemon's existing `cli_version`/`launched_by` register fields are retained.

## Tests
- `packages/core/api/client.test.ts` — asserts X-Client-* headers are emitted when `identity` is configured and omitted when not.
- `server/internal/middleware/client_test.go` — tests middleware extraction, missing-header behavior, and `SetClientMetadata`.
- `go test ./...` and `pnpm -w typecheck` + `pnpm -w test` all pass.

Closes [MUL-1235](https://app.multica.ai/issues/c1381158-efe8-473d-ac81-3ce8c84377c0)