### PR TITLE
docs(make): add help description for db-reset target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ db-down: ## Stop the shared PostgreSQL container without removing its Docker vol
 # Use for a clean slate in local dev. Only affects the DB named in
 # ENV_FILE (POSTGRES_DB); the shared postgres container and other
 # worktree DBs are untouched. Refuses to run against a remote host.
-db-reset:
+db-reset: ## Drop and recreate the current env's database, then re-run all migrations
 	$(REQUIRE_ENV)
 	@case "$(DATABASE_URL)" in \
 		""|*@localhost:*|*@localhost/*|*@127.0.0.1:*|*@127.0.0.1/*|*@\[::1\]:*|*@\[::1\]/*) ;; \


### PR DESCRIPTION
## What does this PR do?

One-line follow-up to #1434. That PR's merge-conflict resolution brought in the `db-reset` target from `main`, but the target didn't get a `##` description — so it doesn't surface in `make help` even though every other `db-*` command does.

Adds a single-line `##` description so `db-reset` appears next to `db-up` / `db-down` under the One-click group.

## Related Issue

Follow-up to #1434.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Verification

Before:

```
$ make help | grep db-reset
(nothing)
```

After:

```
$ make help | grep db-reset
  db-reset           Drop and recreate the current env's database, then re-run all migrations
```

Target behavior unchanged — pure documentation.

## AI Disclosure

**AI tool used:** Multica Agent (J)

**Prompt / approach:** Reviewed #1434 and spotted the missing `##` description on `db-reset` during the conflict-resolution commit review. Opened this as a follow-up at the maintainer's request rather than blocking #1434.