### PR TITLE
refactor(pin): derive sidebar display fields client-side

### DIFF
--- a/packages/core/types/pin.ts
+++ b/packages/core/types/pin.ts
@@ -1,5 +1,11 @@
 export type PinnedItemType = "issue" | "project";
 
+/**
+ * Pin metadata only. Title / status / identifier / icon are NOT here —
+ * consumers derive them from `issueDetailOptions` / `projectDetailOptions`
+ * so the sidebar reacts to `issue:updated` / `project:updated` events
+ * automatically, without needing a cross-entity invalidate on `pinKeys`.
+ */
 export interface PinnedItem {
   id: string;
   workspace_id: string;
@@ -8,10 +14,6 @@ export interface PinnedItem {
   item_id: string;
   position: number;
   created_at: string;
-  title: string;
-  identifier?: string;
-  icon?: string;
-  status?: string;
 }
 
 export interface CreatePinRequest {

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -36,7 +36,6 @@ import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@multica/ui/components/ui/collapsible";
 import { StatusIcon } from "../issues/components/status-icon";
-import type { IssueStatus } from "@multica/core/types";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import {
   Sidebar,
@@ -75,6 +74,8 @@ import { useModalStore } from "@multica/core/modals";
 import { useMyRuntimesNeedUpdate } from "@multica/core/runtimes/hooks";
 import { pinListOptions } from "@multica/core/pins/queries";
 import { useDeletePin, useReorderPins } from "@multica/core/pins/mutations";
+import { issueDetailOptions } from "@multica/core/issues/queries";
+import { projectDetailOptions } from "@multica/core/projects/queries";
 import type { PinnedItem } from "@multica/core/types";
 import { useLogout } from "../auth";
 
@@ -126,7 +127,27 @@ function DraftDot() {
   return <span className="absolute top-0 right-0 size-1.5 rounded-full bg-brand" />;
 }
 
-function SortablePinItem({ pin, href, pathname, onUnpin }: { pin: PinnedItem; href: string; pathname: string; onUnpin: () => void }) {
+/**
+ * Presentational pin row. The `label` and `iconNode` are computed by the
+ * parent `PinRow` from cached issue / project detail queries — keeping
+ * this component dumb means the dnd-kit / navigation wiring lives in
+ * one place and the data flow is explicit.
+ */
+function SortablePinItem({
+  pin,
+  href,
+  pathname,
+  onUnpin,
+  label,
+  iconNode,
+}: {
+  pin: PinnedItem;
+  href: string;
+  pathname: string;
+  onUnpin: () => void;
+  label: string;
+  iconNode: React.ReactNode;
+}) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: pin.id });
   const wasDragged = useRef(false);
 
@@ -136,7 +157,6 @@ function SortablePinItem({ pin, href, pathname, onUnpin }: { pin: PinnedItem; hr
 
   const style = { transform: CSS.Transform.toString(transform), transition };
   const isActive = pathname === href;
-  const label = pin.item_type === "issue" && pin.identifier ? `${pin.identifier} ${pin.title}` : pin.title;
 
   return (
     <SidebarMenuItem
@@ -162,12 +182,7 @@ function SortablePinItem({ pin, href, pathname, onUnpin }: { pin: PinnedItem; hr
           isDragging && "pointer-events-none",
         )}
       >
-        {pin.item_type === "issue" && pin.status ? (
-          /* Override parent [&_svg]:size-4 — pinned items need smaller icons to match sm size */
-          <StatusIcon status={pin.status as IssueStatus} className="!size-3.5 shrink-0" />
-        ) : (
-          <span className="flex size-3.5 shrink-0 items-center justify-center text-xs leading-none">{pin.icon || "📁"}</span>
-        )}
+        {iconNode}
         <span
           className="min-w-0 flex-1 overflow-hidden whitespace-nowrap"
           style={{
@@ -190,6 +205,91 @@ function SortablePinItem({ pin, href, pathname, onUnpin }: { pin: PinnedItem; hr
           <TooltipContent side="top" sideOffset={4}>Unpin</TooltipContent>
         </Tooltip>
       </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+/**
+ * Smart wrapper that resolves a pin's display data (label + status/icon)
+ * from the issue / project detail query cache. Both queries are declared
+ * unconditionally with `enabled` gates so the hook order stays stable
+ * regardless of `pin.item_type`.
+ *
+ * Loading: render a flat skeleton so the sidebar height doesn't jump.
+ * Missing (deleted item / 404): render nothing — the row hides itself
+ * until the user unpins manually or a server-side cascade catches up.
+ */
+function PinRow({
+  pin,
+  href,
+  pathname,
+  onUnpin,
+  wsId,
+}: {
+  pin: PinnedItem;
+  href: string;
+  pathname: string;
+  onUnpin: () => void;
+  wsId: string;
+}) {
+  const isIssue = pin.item_type === "issue";
+  const issueQuery = useQuery({
+    ...issueDetailOptions(wsId, pin.item_id),
+    enabled: isIssue,
+  });
+  const projectQuery = useQuery({
+    ...projectDetailOptions(wsId, pin.item_id),
+    enabled: !isIssue,
+  });
+
+  if (isIssue) {
+    if (issueQuery.isPending) return <PinSkeleton />;
+    if (issueQuery.isError || !issueQuery.data) return null;
+    const issue = issueQuery.data;
+    const label = issue.identifier ? `${issue.identifier} ${issue.title}` : issue.title;
+    const iconNode = (
+      /* Override parent [&_svg]:size-4 — pinned items need smaller icons to match sm size */
+      <StatusIcon status={issue.status} className="!size-3.5 shrink-0" />
+    );
+    return (
+      <SortablePinItem
+        pin={pin}
+        href={href}
+        pathname={pathname}
+        onUnpin={onUnpin}
+        label={label}
+        iconNode={iconNode}
+      />
+    );
+  }
+
+  if (projectQuery.isPending) return <PinSkeleton />;
+  if (projectQuery.isError || !projectQuery.data) return null;
+  const project = projectQuery.data;
+  const iconNode = (
+    <span className="flex size-3.5 shrink-0 items-center justify-center text-xs leading-none">
+      {project.icon || "📁"}
+    </span>
+  );
+  return (
+    <SortablePinItem
+      pin={pin}
+      href={href}
+      pathname={pathname}
+      onUnpin={onUnpin}
+      label={project.title}
+      iconNode={iconNode}
+    />
+  );
+}
+
+function PinSkeleton() {
+  return (
+    <SidebarMenuItem>
+      <div className="flex h-7 w-full items-center gap-2 px-2">
+        <div className="size-3.5 shrink-0 rounded-sm bg-sidebar-accent/40" />
+        <div className="h-3 w-24 rounded bg-sidebar-accent/40" />
+      </div>
     </SidebarMenuItem>
   );
 }
@@ -493,12 +593,13 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                       <SortableContext items={localPinned.map((p) => p.id)} strategy={verticalListSortingStrategy}>
                         <SidebarMenu className="gap-0.5">
                           {localPinned.map((pin: PinnedItem) => (
-                            <SortablePinItem
+                            <PinRow
                               key={pin.id}
                               pin={pin}
                               href={pin.item_type === "issue" ? p.issueDetail(pin.item_id) : p.projectDetail(pin.item_id)}
                               pathname={pathname}
                               onUnpin={() => deletePin.mutate({ itemType: pin.item_type, itemId: pin.item_id })}
+                              wsId={wsId ?? ""}
                             />
                           ))}
                         </SidebarMenu>

--- a/server/internal/handler/pin.go
+++ b/server/internal/handler/pin.go
@@ -3,13 +3,16 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
+// PinnedItemResponse carries pin metadata only. Title / status / identifier /
+// icon are intentionally NOT included — clients derive them from their own
+// issue / project query cache so that an `issue:updated` event flows naturally
+// into the sidebar without needing a cross-entity invalidate on `pinKeys`.
 type PinnedItemResponse struct {
 	ID          string  `json:"id"`
 	WorkspaceID string  `json:"workspace_id"`
@@ -18,11 +21,6 @@ type PinnedItemResponse struct {
 	ItemID      string  `json:"item_id"`
 	Position    float64 `json:"position"`
 	CreatedAt   string  `json:"created_at"`
-	// Enriched fields (set by list endpoint)
-	Title      string  `json:"title"`
-	Identifier *string `json:"identifier,omitempty"`
-	Icon       *string `json:"icon,omitempty"`
-	Status     string  `json:"status,omitempty"`
 }
 
 func pinnedItemToResponse(p db.PinnedItem) PinnedItemResponse {
@@ -67,33 +65,10 @@ func (h *Handler) ListPins(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enrich with item details
 	resp := make([]PinnedItemResponse, 0, len(pins))
 	for _, p := range pins {
-		pr := pinnedItemToResponse(p)
-		switch p.ItemType {
-		case "issue":
-			issue, err := h.Queries.GetIssue(r.Context(), p.ItemID)
-			if err != nil {
-				continue // Skip deleted items
-			}
-			pr.Title = issue.Title
-			prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
-			identifier := formatIdentifier(prefix, issue.Number)
-			pr.Identifier = &identifier
-			pr.Status = issue.Status
-		case "project":
-			project, err := h.Queries.GetProject(r.Context(), p.ItemID)
-			if err != nil {
-				continue // Skip deleted items
-			}
-			pr.Title = project.Title
-			pr.Icon = textToPtr(project.Icon)
-			pr.Status = project.Status
-		}
-		resp = append(resp, pr)
+		resp = append(resp, pinnedItemToResponse(p))
 	}
-
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -225,11 +200,4 @@ func (h *Handler) ReorderPins(w http.ResponseWriter, r *http.Request) {
 	h.publish(protocol.EventPinReordered, workspaceID, "member", userID, map[string]any{"items": req.Items})
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func formatIdentifier(prefix string, number int32) string {
-	if prefix == "" {
-		prefix = "ISS"
-	}
-	return prefix + "-" + strconv.Itoa(int(number))
 }


### PR DESCRIPTION
## Summary

`ListPins` previously joined `issues` / `projects` so each pin row carried `title`, `status`, `identifier`, `icon`. Convenient for the sidebar, but architecturally wrong — those fields live on a different cache key than the pin query, so `issue:updated` invalidates `issueKeys` and never touches `pinKeys`. Pinned issue rows showed stale status / titles until a hard refresh.

This refactor moves the join to the client so display data flows from its real source of truth.

### Server (`server/internal/handler/pin.go`)

- `PinnedItemResponse` keeps only pin-owned columns (id, workspace_id, user_id, item_type, item_id, position, created_at).
- `ListPins` no longer fetches issues / projects in the loop and no longer hides orphaned pins; the client decides how to render a pin whose target was deleted.
- `formatIdentifier` helper deleted (it was only used by the enrichment branch); `strconv` import dropped with it.

### Types (`packages/core/types/pin.ts`)

- `PinnedItem` mirrors the bare server shape. The four enriched fields removed.

### Sidebar (`packages/views/layout/app-sidebar.tsx`)

- New smart wrapper `PinRow` resolves each pin's display data via `useQuery(issueDetailOptions(...))` or `useQuery(projectDetailOptions(...))` with `enabled` gates on `pin.item_type` so the hook order stays stable.
- Loading renders a flat skeleton (no list height jump); error / 404 renders `null` (orphan pins hide themselves).
- `SortablePinItem` becomes purely presentational — takes `label` + `iconNode` as props instead of reading them off the pin object. dnd-kit / navigation wiring untouched.
- Same pattern as `packages/views/search/search-command.tsx:151` (Recent issues already uses per-row detail queries this way).

### WS sync layer — no change

`onIssueUpdated` already patches `issueKeys.detail`, so changing an issue's status now flows directly into the sidebar with zero new invalidate wiring. The `pin:*` prefix handler still invalidates `pinKeys` for create / delete / reorder — that's still the correct signal for the pin LIST itself.

## Why this matters

The bug was a symptom of a recurring pattern. Every time someone added an enriched field to the pin response (or a similar joined query), they had to remember to wire a manual cross-entity invalidate. Easy to forget, easy to silently regress. With pin metadata standing alone, the data flow becomes single-direction:

```
pin metadata        → pinKeys query    (invalidated by pin:* events)
issue / project data → issueKeys / projectKeys queries  (invalidated by their own events)
display = derive(pin, issue / project)  (auto re-renders on either source change)
```

## Verification

- `pnpm --filter @multica/{views,core,web,desktop} typecheck` — all green
- `cd server && go build ./... && go test ./internal/handler/...` — green
- `pnpm --filter @multica/{views,core} test` — 248 tests pass
- Manual E2E (run locally before merging):
  - [ ] Pin a Todo issue → sidebar shows `PREFIX-N title` + Todo icon
  - [ ] Change that issue's status to Done → sidebar icon updates without refresh ✅ core fix
  - [ ] Rename the issue → sidebar label updates without refresh
  - [ ] Delete the pinned issue → row disappears (PinRow error state)
  - [ ] Pin a project, change its icon emoji → sidebar updates
  - [ ] Reorder pins → drag-and-drop unchanged, WS sync to second client works
  - [ ] Cold-load: clear cache + hard refresh → pin rows show skeleton briefly, then resolve. No empty-label flash.

## Follow-up

Server-side cascade cleanup of orphan pins (when the referenced issue / project is deleted) is intentionally out of scope. The client hides orphans for now; a separate change can wire `DeleteIssue` / `DeleteProject` to also publish `pin:deleted` for affected pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)