### PR TITLE
feat(changelog): surface release notes from sidebar menu + update prompt

### DIFF
--- a/apps/desktop/src/renderer/src/components/update-notification.tsx
+++ b/apps/desktop/src/renderer/src/components/update-notification.tsx
@@ -110,12 +110,25 @@ export function UpdateNotification() {
             <p className="text-xs text-muted-foreground mt-0.5">
               Restart to apply the update
             </p>
-            <button
-              onClick={handleInstall}
-              className="mt-2 inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-            >
-              Restart now
-            </button>
+            <div className="mt-2 flex items-center gap-1.5">
+              {/* Secondary "See changes" — gives the user a reason to
+                  restart by surfacing what they're about to get. Opens
+                  in the default browser via the shared openExternal
+                  bridge so the URL hits the same allow-list as every
+                  other outbound link. */}
+              <button
+                onClick={() => window.desktopAPI.openExternal("https://multica.ai/changelog")}
+                className="inline-flex items-center rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent transition-colors"
+              >
+                See changes
+              </button>
+              <button
+                onClick={handleInstall}
+                className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Restart now
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -28,6 +28,7 @@ import {
   SquarePen,
   CircleUser,
   FolderKanban,
+  Sparkles,
   X,
   Zap,
 } from "lucide-react";
@@ -415,6 +416,22 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                   )}
                   <DropdownMenuSeparator />
                   <DropdownMenuGroup>
+                    {/* Plain anchor with target=_blank works on both web
+                        (new tab) and desktop (intercepted by the main
+                        process's setWindowOpenHandler → openExternalSafely),
+                        so the shared component doesn't need to branch. */}
+                    <DropdownMenuItem
+                      render={
+                        <a
+                          href="https://multica.ai/changelog"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        />
+                      }
+                    >
+                      <Sparkles className="h-3.5 w-3.5" />
+                      What&apos;s new
+                    </DropdownMenuItem>
                     <DropdownMenuItem variant="destructive" onClick={logout}>
                       <LogOut className="h-3.5 w-3.5" />
                       Log out
@@ -599,6 +616,15 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                   </div>
                 </div>
                 <div className="p-1">
+                  <a
+                    href="https://multica.ai/changelog"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-accent transition-colors cursor-pointer"
+                  >
+                    <Sparkles className="h-3.5 w-3.5" />
+                    What&apos;s new
+                  </a>
                   <button
                     onClick={logout}
                     className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"


### PR DESCRIPTION
## Summary

Two entry points to `multica.ai/changelog` so users actually find out what shipped — neither was reachable from inside the app before.

### 1. Sidebar user menu — `What's new`

Both the expanded footer popover (full-width sidebar) and the collapsed dropdown menu gain a `What's new` item with a Sparkles icon, sitting just above `Log out`.

Implementation note: a plain `<a target=\"_blank\" rel=\"noopener noreferrer\">` works on both surfaces:
- **Web**: browser opens a new tab.
- **Desktop**: the main process's `setWindowOpenHandler` (`apps/desktop/src/main/index.ts`) intercepts the open and routes the URL through `openExternalSafely`, so it pops in the system browser with the same scheme allow-list as every other outbound link. The shared view in `packages/views` stays platform-agnostic.

### 2. Desktop update prompt — `See changes`

When `UpdateNotification` reaches the `ready` state (electron-updater downloaded the new build, waiting on the user to restart), it now offers a secondary `See changes` button next to `Restart now`. Mirrors Conductor's prompt pattern — gives the user a reason to restart instead of dismissing.

Only the `ready` state changes; `available` and `downloading` stay action-only because the changelog isn't useful before the download finishes.

## What this PR does NOT do

- No version detection / unread tracking. The Linear-style \"new\" red dot is a separate piece of work — needs server-side `latest_changelog_version` + client localStorage tracking — and we agreed to ship the basic entry points first.
- No web-side update prompt. Web reloads pick up new builds passively; mirroring desktop's restart prompt without an explicit \"restart\" action would be noise.

## Test plan

- [x] `pnpm --filter @multica/views exec tsc --noEmit` — passes
- [x] `pnpm --filter @multica/desktop exec tsc --noEmit -p tsconfig.web.json --composite false` — passes
- [ ] Manual web: open user menu, click \"What's new\" → opens https://multica.ai/changelog in new tab
- [ ] Manual desktop expanded: same flow opens in system browser via openExternalSafely
- [ ] Manual desktop collapsed sidebar: dropdown variant works the same way
- [ ] Manual desktop update flow: when an update is downloaded, the \"See changes\" button appears next to \"Restart now\"