### PR TITLE
feat(chat): focus mode — share current page as context

### DIFF
--- a/packages/core/chat/index.ts
+++ b/packages/core/chat/index.ts
@@ -1,5 +1,5 @@
 export { createChatStore, CHAT_MIN_W, CHAT_MIN_H, CHAT_DEFAULT_W, CHAT_DEFAULT_H, DRAFT_NEW_SESSION } from "./store";
-export type { ChatStoreOptions, ChatState, ChatTimelineItem } from "./store";
+export type { ChatStoreOptions, ChatState, ChatTimelineItem, ContextAnchor } from "./store";
 
 import type { createChatStore as CreateChatStoreFn } from "./store";
 

--- a/packages/core/chat/store.ts
+++ b/packages/core/chat/store.ts
@@ -14,6 +14,8 @@ export const DRAFT_NEW_SESSION = "__new__";
 const CHAT_WIDTH_KEY = "multica:chat:width";
 const CHAT_HEIGHT_KEY = "multica:chat:height";
 const CHAT_EXPANDED_KEY = "multica:chat:expanded";
+/** Focus mode is a personal preference — global across workspaces/sessions. */
+const FOCUS_MODE_KEY = "multica:chat:focusMode";
 
 function readDrafts(storage: StorageAdapter, key: string): Record<string, string> {
   const raw = storage.getItem(key);
@@ -58,6 +60,21 @@ export interface ChatTimelineItem {
   output?: string;
 }
 
+/**
+ * A derived "where I am" pointer — not stored, recomputed each render from
+ * the current route + react-query cache. The type is exported because
+ * consumers (buildAnchorMarkdown, chip props) share the same shape.
+ */
+export interface ContextAnchor {
+  type: "issue" | "project";
+  /** UUID for `issue`, UUID for `project`. */
+  id: string;
+  /** Human-readable label: issue identifier (MUL-1) or project title. */
+  label: string;
+  /** Optional secondary text — issue title for issue anchors. */
+  subtitle?: string;
+}
+
 export interface ChatState {
   isOpen: boolean;
   activeSessionId: string | null;
@@ -65,6 +82,12 @@ export interface ChatState {
   showHistory: boolean;
   /** Drafts per session: sessionId (or DRAFT_NEW_SESSION) → markdown text. */
   inputDrafts: Record<string, string>;
+  /**
+   * When on, the chat tracks whatever issue/project/inbox-item the user is
+   * looking at and prepends it to outgoing messages. Persisted globally so
+   * the preference survives workspace switches and reloads.
+   */
+  focusMode: boolean;
   /** Raw user-chosen size — no clamp applied. UI layer clamps at render time. */
   chatWidth: number;
   chatHeight: number;
@@ -77,6 +100,7 @@ export interface ChatState {
   /** sessionId accepts a real session UUID or DRAFT_NEW_SESSION. */
   setInputDraft: (sessionId: string, draft: string) => void;
   clearInputDraft: (sessionId: string) => void;
+  setFocusMode: (on: boolean) => void;
   /** Persist raw size and auto-exit expanded mode. */
   setChatSize: (width: number, height: number) => void;
   setExpanded: (expanded: boolean) => void;
@@ -100,6 +124,7 @@ export function createChatStore(options: ChatStoreOptions) {
     selectedAgentId: storage.getItem(wsKey(AGENT_STORAGE_KEY)),
     showHistory: false,
     inputDrafts: readDrafts(storage, wsKey(DRAFTS_KEY)),
+    focusMode: storage.getItem(FOCUS_MODE_KEY) === "true",
     chatWidth: Number(storage.getItem(CHAT_WIDTH_KEY)) || CHAT_DEFAULT_W,
     chatHeight: Number(storage.getItem(CHAT_HEIGHT_KEY)) || CHAT_DEFAULT_H,
     isExpanded: storage.getItem(wsKey(CHAT_EXPANDED_KEY)) === "true",
@@ -136,6 +161,12 @@ export function createChatStore(options: ChatStoreOptions) {
       const next = { ...get().inputDrafts, [sessionId]: draft };
       writeDrafts(storage, wsKey(DRAFTS_KEY), next);
       set({ inputDrafts: next });
+    },
+    setFocusMode: (on) => {
+      logger.info("setFocusMode", { to: on });
+      if (on) storage.setItem(FOCUS_MODE_KEY, "true");
+      else storage.removeItem(FOCUS_MODE_KEY);
+      set({ focusMode: on });
     },
     clearInputDraft: (sessionId) => {
       const current = get().inputDrafts;

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -18,6 +18,11 @@ interface ChatInputProps {
   agentName?: string;
   /** Rendered at the bottom-left of the input bar — typically the agent picker. */
   leftAdornment?: ReactNode;
+  /** Rendered just before the submit button — used for context-anchor action. */
+  rightAdornment?: ReactNode;
+  /** Rendered inside the rounded container, above the editor — attached
+   *  context cards, drafts, etc. */
+  topSlot?: ReactNode;
 }
 
 export function ChatInput({
@@ -27,6 +32,8 @@ export function ChatInput({
   disabled,
   agentName,
   leftAdornment,
+  rightAdornment,
+  topSlot,
 }: ChatInputProps) {
   const editorRef = useRef<ContentEditorRef>(null);
   const activeSessionId = useChatStore((s) => s.activeSessionId);
@@ -75,6 +82,7 @@ export function ChatInput({
   return (
     <div className="px-5 pb-3 pt-0">
       <div className="relative mx-auto flex min-h-16 max-h-40 w-full max-w-4xl flex-col rounded-lg bg-card pb-9 border-1 border-border transition-colors focus-within:border-brand">
+        {topSlot}
         <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
           <ContentEditor
             // Remount the editor when the active session changes so its
@@ -101,7 +109,8 @@ export function ChatInput({
             {leftAdornment}
           </div>
         )}
-        <div className="absolute bottom-1 right-1.5 flex items-center gap-1">
+        <div className="absolute bottom-1 right-1.5 flex items-center gap-2">
+          {rightAdornment}
           <SubmitButton
             onClick={handleSend}
             disabled={isEmpty || !!disabled}

--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -31,6 +31,12 @@ import { useCreateChatSession, useMarkChatSessionRead } from "@multica/core/chat
 import { useChatStore } from "@multica/core/chat";
 import { ChatMessageList, ChatMessageSkeleton } from "./chat-message-list";
 import { ChatInput } from "./chat-input";
+import {
+  ContextAnchorButton,
+  ContextAnchorCard,
+  buildAnchorMarkdown,
+  useRouteAnchorCandidate,
+} from "./context-anchor";
 import { ChatResizeHandles } from "./chat-resize-handles";
 import { useChatResize } from "./use-chat-resize";
 import { createLogger } from "@multica/core/logger";
@@ -154,12 +160,22 @@ export function ChatWindow() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- markRead ref stable
   }, [isOpen, activeSessionId, currentHasUnread]);
 
+  // Focus-mode anchor: derived from route each render. Prepended to the
+  // outgoing message when focus is on; the anchor persists across sends
+  // (focus mode tracks the user's page, not a per-message attachment).
+  const { candidate: anchorCandidate } = useRouteAnchorCandidate(wsId);
+
   const handleSend = useCallback(
     async (content: string) => {
       if (!activeAgent) {
         apiLogger.warn("sendChatMessage skipped: no active agent");
         return;
       }
+
+      const focusOn = useChatStore.getState().focusMode;
+      const finalContent = focusOn && anchorCandidate
+        ? `${buildAnchorMarkdown(anchorCandidate)}\n\n${content}`
+        : content;
 
       let sessionId = activeSessionId;
       const isNewSession = !sessionId;
@@ -168,13 +184,14 @@ export function ChatWindow() {
         sessionId,
         isNewSession,
         agentId: activeAgent.id,
-        contentLength: content.length,
+        contentLength: finalContent.length,
+        hasAnchor: focusOn && !!anchorCandidate,
       });
 
       if (!sessionId) {
         const session = await createSession.mutateAsync({
           agent_id: activeAgent.id,
-          title: content.slice(0, 50),
+          title: finalContent.slice(0, 50),
         });
         sessionId = session.id;
         setActiveSession(sessionId);
@@ -185,7 +202,7 @@ export function ChatWindow() {
         id: `optimistic-${Date.now()}`,
         chat_session_id: sessionId,
         role: "user",
-        content,
+        content: finalContent,
         task_id: null,
         created_at: new Date().toISOString(),
       };
@@ -195,7 +212,7 @@ export function ChatWindow() {
       );
       apiLogger.debug("sendChatMessage.optimistic", { sessionId, optimisticId: optimistic.id });
 
-      const result = await api.sendChatMessage(sessionId, content);
+      const result = await api.sendChatMessage(sessionId, finalContent);
       apiLogger.info("sendChatMessage.success", {
         sessionId,
         messageId: result.message_id,
@@ -212,6 +229,7 @@ export function ChatWindow() {
     [
       activeSessionId,
       activeAgent,
+      anchorCandidate,
       createSession,
       setActiveSession,
       qc,
@@ -401,6 +419,7 @@ export function ChatWindow() {
         isRunning={!!pendingTaskId}
         disabled={isSessionArchived}
         agentName={activeAgent?.name}
+        topSlot={<ContextAnchorCard />}
         leftAdornment={
           <AgentDropdown
             agents={availableAgents}
@@ -409,6 +428,7 @@ export function ChatWindow() {
             onSelect={handleSelectAgent}
           />
         }
+        rightAdornment={<ContextAnchorButton />}
       />
     </div>
   );

--- a/packages/views/chat/components/context-anchor.test.ts
+++ b/packages/views/chat/components/context-anchor.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { buildAnchorMarkdown } from "./context-anchor";
+
+describe("buildAnchorMarkdown", () => {
+  it("formats an issue anchor as a mention link with title subtitle", () => {
+    const md = buildAnchorMarkdown({
+      type: "issue",
+      id: "uuid-123",
+      label: "MUL-42",
+      subtitle: "Fix login redirect",
+    });
+    expect(md).toBe(
+      'Context: [MUL-42](mention://issue/uuid-123) — "Fix login redirect"',
+    );
+  });
+
+  it("omits the subtitle clause when none is provided", () => {
+    const md = buildAnchorMarkdown({
+      type: "issue",
+      id: "uuid-x",
+      label: "MUL-7",
+    });
+    expect(md).toBe("Context: [MUL-7](mention://issue/uuid-x)");
+  });
+
+  it("formats a project anchor as plain text (no mention type)", () => {
+    const md = buildAnchorMarkdown({
+      type: "project",
+      id: "proj-uuid",
+      label: "Authentication",
+    });
+    expect(md).toBe('Context: Project "Authentication"');
+  });
+});

--- a/packages/views/chat/components/context-anchor.tsx
+++ b/packages/views/chat/components/context-anchor.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Focus } from "lucide-react";
+import type { ContextAnchor } from "@multica/core/chat";
+import { useChatStore } from "@multica/core/chat";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { issueDetailOptions } from "@multica/core/issues/queries";
+import { projectDetailOptions } from "@multica/core/projects/queries";
+import { inboxListOptions } from "@multica/core/inbox/queries";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@multica/ui/components/ui/tooltip";
+import { IssueChip } from "../../issues/components/issue-chip";
+import { ProjectChip } from "../../projects/components/project-chip";
+import { AppLink, useNavigation } from "../../navigation";
+import { useWorkspacePaths } from "@multica/core/paths";
+
+/**
+ * Format a derived ContextAnchor as the markdown prefix prepended to the
+ * outgoing chat message. Uses the same `mention://issue/<uuid>` scheme as
+ * the editor's mention extension, so the AI sees an identical token whether
+ * the user typed `@MUL-1` in-line or focus-mode attached it.
+ */
+export function buildAnchorMarkdown(anchor: ContextAnchor): string {
+  if (anchor.type === "issue") {
+    const base = `Context: [${anchor.label}](mention://issue/${anchor.id})`;
+    return anchor.subtitle ? `${base} — "${anchor.subtitle}"` : base;
+  }
+  return `Context: Project "${anchor.label}"`;
+}
+
+/**
+ * Resolve the current page into an anchorable candidate, or null if the user
+ * is somewhere without a natural focus object. Subscribes via react-query so
+ * the result updates the instant the relevant cache fills.
+ *
+ * `wsId` is passed in (per CLAUDE.md convention) so this hook works outside
+ * a WorkspaceIdProvider if ever reused elsewhere.
+ */
+export function useRouteAnchorCandidate(wsId: string): {
+  candidate: ContextAnchor | null;
+  isResolving: boolean;
+} {
+  const { pathname, searchParams } = useNavigation();
+
+  const issueMatch = pathname.match(/^\/[^/]+\/issues\/([^/]+)$/);
+  const projectMatch = pathname.match(/^\/[^/]+\/projects\/([^/]+)$/);
+  const isInbox = /^\/[^/]+\/inbox$/.test(pathname);
+
+  const routeIssueId = issueMatch ? decodeURIComponent(issueMatch[1]!) : null;
+  const routeProjectId = projectMatch
+    ? decodeURIComponent(projectMatch[1]!)
+    : null;
+
+  // Inbox: the anchor is the issue behind the currently selected notification.
+  const { data: inboxItems = [] } = useQuery({
+    ...inboxListOptions(wsId),
+    enabled: isInbox,
+  });
+  const inboxKey = isInbox ? searchParams.get("issue") : null;
+  const inboxSelectedIssueId =
+    isInbox && inboxKey
+      ? inboxItems.find((i) => (i.issue_id ?? i.id) === inboxKey)?.issue_id ??
+        null
+      : null;
+
+  // One issue fetch covers both /issues/:id and inbox-derived anchors.
+  const issueIdToFetch = routeIssueId ?? inboxSelectedIssueId;
+  const { data: issue, isLoading: issueLoading } = useQuery({
+    ...issueDetailOptions(wsId, issueIdToFetch ?? ""),
+    enabled: !!issueIdToFetch,
+  });
+
+  const { data: project, isLoading: projectLoading } = useQuery({
+    ...projectDetailOptions(wsId, routeProjectId ?? ""),
+    enabled: !!routeProjectId,
+  });
+
+  if (issueIdToFetch) {
+    if (!issue) return { candidate: null, isResolving: issueLoading };
+    return {
+      candidate: {
+        type: "issue",
+        id: issue.id,
+        label: issue.identifier,
+        subtitle: issue.title,
+      },
+      isResolving: false,
+    };
+  }
+
+  if (routeProjectId) {
+    if (!project) return { candidate: null, isResolving: projectLoading };
+    return {
+      candidate: {
+        type: "project",
+        id: project.id,
+        label: project.title,
+      },
+      isResolving: false,
+    };
+  }
+
+  return { candidate: null, isResolving: false };
+}
+
+/**
+ * Focus-mode toggle. Three visual states driven by two dimensions:
+ *   - focusMode (persisted)       on | off
+ *   - candidate present           yes | no
+ *
+ *   off                   →  ghost + muted, clickable (→ turns on)
+ *   on  + candidate       →  secondary (bright), clickable (→ turns off)
+ *   on  + no candidate    →  disabled (can't click until a focus target exists)
+ */
+export function ContextAnchorButton() {
+  const wsId = useWorkspaceId();
+  const { candidate, isResolving } = useRouteAnchorCandidate(wsId);
+  const focusMode = useChatStore((s) => s.focusMode);
+  const setFocusMode = useChatStore((s) => s.setFocusMode);
+
+  const hasAnchor = !!candidate;
+  const isDisabled = focusMode && !hasAnchor && !isResolving;
+  const isBright = focusMode && hasAnchor;
+
+  const tooltipText = !focusMode
+    ? "Let Multica know what you're viewing"
+    : hasAnchor
+      ? candidate.type === "issue"
+        ? `Multica knows you're viewing ${candidate.label} · Click to turn off`
+        : `Multica knows you're viewing project "${candidate.label}" · Click to turn off`
+      : "Nothing to share with Multica on this page";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant={isBright ? "secondary" : "ghost"}
+            size="icon-sm"
+            className={isBright ? undefined : "text-muted-foreground"}
+            onClick={() => setFocusMode(!focusMode)}
+            disabled={isDisabled}
+            aria-label={
+              focusMode ? "Stop sharing current page" : "Share current page with Multica"
+            }
+            aria-pressed={focusMode}
+          />
+        }
+      >
+        <Focus />
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltipText}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * Renders the derived focus target above the input. Shows only when focus
+ * mode is on *and* the current route resolves to an anchorable object.
+ * No dismiss affordance — use the button to leave focus mode.
+ */
+export function ContextAnchorCard() {
+  const wsId = useWorkspaceId();
+  const paths = useWorkspacePaths();
+  const { candidate } = useRouteAnchorCandidate(wsId);
+  const focusMode = useChatStore((s) => s.focusMode);
+
+  if (!focusMode || !candidate) return null;
+
+  const href =
+    candidate.type === "issue"
+      ? paths.issueDetail(candidate.id)
+      : paths.projectDetail(candidate.id);
+
+  const tooltipText =
+    candidate.type === "issue"
+      ? `Multica knows you're viewing ${candidate.label}${candidate.subtitle ? ` — ${candidate.subtitle}` : ""}`
+      : `Multica knows you're viewing project "${candidate.label}"`;
+
+  // Same pattern as IssueMentionCard: wrap the pure chip in an AppLink and
+  // layer cursor + hover affordance onto the chip. Makes the anchor feel
+  // alive (text-cursor → pointer, hover background) and behave consistently
+  // with @mentions — clicking jumps to the entity.
+  return (
+    <div className="mx-2 mt-2 flex items-center">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <AppLink href={href} className="inline-flex">
+              {candidate.type === "issue" ? (
+                <IssueChip
+                  issueId={candidate.id}
+                  fallbackLabel={candidate.label}
+                  className="cursor-pointer hover:bg-accent transition-colors"
+                />
+              ) : (
+                <ProjectChip
+                  projectId={candidate.id}
+                  fallbackLabel={candidate.label}
+                  className="cursor-pointer hover:bg-accent transition-colors"
+                />
+              )}
+            </AppLink>
+          }
+        />
+        <TooltipContent side="top">{tooltipText}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/packages/views/editor/extensions/mention-view.tsx
+++ b/packages/views/editor/extensions/mention-view.tsx
@@ -4,28 +4,21 @@
  * MentionView — NodeView for rendering @mentions inline in the editor.
  *
  * Member/agent mentions: plain "@Name" text with .mention class styling.
- * Issue mentions: inline card with StatusIcon + identifier + title.
+ * Issue mentions: IssueChip inside a custom <a> that supports cmd/shift-click
+ * to open in a new tab (AppLink doesn't expose that intent hook).
  *
- * Issue card sizing: must fit within the paragraph line box (14px * 1.625
- * = 22.75px). Card uses text-xs (12px) + py-0.5 + border ≈ 22px total.
- * vertical-align: middle is set on the [data-node-view-wrapper] in CSS
- * (not on the <a> tag) because the wrapper is the outermost inline element
- * that participates in line box calculation. Setting it on the inner <a>
- * had no effect since the wrapper was already positioned.
- *
- * Fallback: when issue is not in the Zustand store (deleted or other
- * workspace), the same card style is used with just the identifier from
- * fallbackLabel — no visual degradation to a plain text link.
+ * Issue chip sizing: must fit within the paragraph line box (14px * 1.625 =
+ * 22.75px). Card is text-xs (12px) + py-0.5 + border ≈ 22px total. The
+ * `vertical-align: middle` rule on `[data-node-view-wrapper]` in CSS handles
+ * line-box alignment; setting it on the inner <a> has no effect because the
+ * wrapper is the outermost inline element.
  */
 
 import { NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
-import { useQuery } from "@tanstack/react-query";
-import { issueListOptions, issueDetailOptions } from "@multica/core/issues/queries";
-import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useNavigation } from "../../navigation";
-import { StatusIcon } from "../../issues/components/status-icon";
+import { IssueChip } from "../../issues/components/issue-chip";
 
 export function MentionView({ node }: NodeViewProps) {
   const { type, id, label } = node.attrs;
@@ -52,51 +45,27 @@ function IssueMention({
   issueId: string;
   fallbackLabel?: string;
 }) {
-  const wsId = useWorkspaceId();
   const p = useWorkspacePaths();
-  const { data: issues = [] } = useQuery(issueListOptions(wsId));
   const { push, openInNewTab } = useNavigation();
-  const listIssue = issues.find((i) => i.id === issueId);
-
-  const { data: detailIssue } = useQuery({
-    ...issueDetailOptions(wsId, issueId),
-    enabled: !listIssue,
-  });
-
-  const issue = listIssue ?? detailIssue;
-
   const issuePath = p.issueDetail(issueId);
-  const tabTitle = issue ? `${issue.identifier}: ${issue.title}` : undefined;
+
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
     if (e.metaKey || e.ctrlKey || e.shiftKey) {
-      if (openInNewTab) {
-        openInNewTab(issuePath, tabTitle);
-      }
+      if (openInNewTab) openInNewTab(issuePath, fallbackLabel);
       return;
     }
     push(issuePath);
   };
 
-  const cardClass =
-    "issue-mention inline-flex items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-xs hover:bg-accent transition-colors cursor-pointer max-w-72";
-
-  if (!issue) {
-    return (
-      <a href={issuePath} onClick={handleClick} className={cardClass}>
-        <span className="font-medium text-muted-foreground">
-          {fallbackLabel ?? issueId.slice(0, 8)}
-        </span>
-      </a>
-    );
-  }
-
   return (
-    <a href={issuePath} onClick={handleClick} className={cardClass}>
-      <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
-      <span className="font-medium text-muted-foreground shrink-0">{issue.identifier}</span>
-      <span className="text-foreground truncate">{issue.title}</span>
+    <a href={issuePath} onClick={handleClick} className="inline-flex">
+      <IssueChip
+        issueId={issueId}
+        fallbackLabel={fallbackLabel}
+        className="cursor-pointer hover:bg-accent transition-colors"
+      />
     </a>
   );
 }

--- a/packages/views/issues/components/index.ts
+++ b/packages/views/issues/components/index.ts
@@ -7,3 +7,4 @@ export { CommentCard } from "./comment-card";
 export { CommentInput } from "./comment-input";
 export { ReplyInput } from "./reply-input";
 export { IssueMentionCard } from "./issue-mention-card";
+export { IssueChip } from "./issue-chip";

--- a/packages/views/issues/components/issue-chip.tsx
+++ b/packages/views/issues/components/issue-chip.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { issueListOptions, issueDetailOptions } from "@multica/core/issues/queries";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { StatusIcon } from "./status-icon";
+
+/**
+ * Compact, presentation-only representation of an issue —
+ * `<StatusIcon> <identifier> <title>`, bordered, truncating to max-w-72.
+ *
+ * This is the single source of truth for the "issue-mention card" look.
+ * It is intentionally **not** a link or button: callers wrap it in whatever
+ * interactive shell they need (AppLink for markdown mentions, an <a> with
+ * cmd-click support inside the editor's NodeView, a plain span next to a
+ * dismiss button in chat's context anchor card, …).
+ *
+ * Size budget: must fit within a 14px line-box when used inline — hence
+ * `py-0.5` + text-xs (see MentionView docstring for the math).
+ */
+export interface IssueChipProps {
+  issueId: string;
+  /** Shown when the issue can't be resolved (deleted, other workspace, …). */
+  fallbackLabel?: string;
+  /** Extra classes — callers layer interaction hints here
+   *  (e.g. `hover:bg-accent cursor-pointer` for navigable variants). */
+  className?: string;
+}
+
+const BASE_CLASS =
+  "issue-mention inline-flex items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-xs max-w-72";
+
+export function IssueChip({ issueId, fallbackLabel, className }: IssueChipProps) {
+  const wsId = useWorkspaceId();
+  const { data: issues = [] } = useQuery(issueListOptions(wsId));
+  const listIssue = issues.find((i) => i.id === issueId);
+
+  // Fallback fetch for issues outside the first page of the list (e.g. Done).
+  const { data: detailIssue } = useQuery({
+    ...issueDetailOptions(wsId, issueId),
+    enabled: !listIssue,
+  });
+
+  const issue = listIssue ?? detailIssue;
+  const cls = className ? `${BASE_CLASS} ${className}` : BASE_CLASS;
+
+  if (!issue) {
+    return (
+      <span className={cls}>
+        <span className="font-medium text-muted-foreground">
+          {fallbackLabel ?? issueId.slice(0, 8)}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={cls}>
+      <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
+      <span className="font-medium text-muted-foreground shrink-0">
+        {issue.identifier}
+      </span>
+      <span className="text-foreground truncate">{issue.title}</span>
+    </span>
+  );
+}

--- a/packages/views/issues/components/issue-mention-card.tsx
+++ b/packages/views/issues/components/issue-mention-card.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import { AppLink } from "../../navigation";
-import { useQuery } from "@tanstack/react-query";
-import { issueListOptions, issueDetailOptions } from "@multica/core/issues/queries";
-import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
-import { StatusIcon } from "./status-icon";
+import { IssueChip } from "./issue-chip";
 
 interface IssueMentionCardProps {
   issueId: string;
@@ -13,42 +10,20 @@ interface IssueMentionCardProps {
   fallbackLabel?: string;
 }
 
+/**
+ * Navigable chip — wraps IssueChip in an AppLink pointing at the issue's
+ * detail page. Hover/cursor affordance is layered onto the chip itself so
+ * the visual target matches the clickable target.
+ */
 export function IssueMentionCard({ issueId, fallbackLabel }: IssueMentionCardProps) {
-  const wsId = useWorkspaceId();
   const p = useWorkspacePaths();
-  const { data: issues = [] } = useQuery(issueListOptions(wsId));
-  const listIssue = issues.find((i) => i.id === issueId);
-
-  // Fetch individual issue when not found in the list (e.g. done issues beyond
-  // the first page). Only fires when listIssue is undefined.
-  const { data: detailIssue } = useQuery({
-    ...issueDetailOptions(wsId, issueId),
-    enabled: !listIssue,
-  });
-
-  const issue = listIssue ?? detailIssue;
-
-  if (!issue) {
-    return (
-      <AppLink
-        href={p.issueDetail(issueId)}
-        className="issue-mention inline-flex items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-xs hover:bg-accent transition-colors cursor-pointer max-w-72"
-      >
-        <span className="font-medium text-muted-foreground">
-          {fallbackLabel ?? issueId.slice(0, 8)}
-        </span>
-      </AppLink>
-    );
-  }
-
   return (
-    <AppLink
-      href={p.issueDetail(issueId)}
-      className="issue-mention inline-flex items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-xs hover:bg-accent transition-colors cursor-pointer max-w-72"
-    >
-      <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
-      <span className="font-medium text-muted-foreground shrink-0">{issue.identifier}</span>
-      <span className="text-foreground truncate">{issue.title}</span>
+    <AppLink href={p.issueDetail(issueId)} className="inline-flex">
+      <IssueChip
+        issueId={issueId}
+        fallbackLabel={fallbackLabel}
+        className="cursor-pointer hover:bg-accent transition-colors"
+      />
     </AppLink>
   );
 }

--- a/packages/views/projects/components/index.ts
+++ b/packages/views/projects/components/index.ts
@@ -1,3 +1,4 @@
 export { ProjectsPage } from "./projects-page";
 export { ProjectDetail } from "./project-detail";
 export { ProjectPicker } from "./project-picker";
+export { ProjectChip } from "./project-chip";

--- a/packages/views/projects/components/project-chip.tsx
+++ b/packages/views/projects/components/project-chip.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { projectListOptions, projectDetailOptions } from "@multica/core/projects/queries";
+import { useWorkspaceId } from "@multica/core/hooks";
+
+/**
+ * Compact presentational representation of a project —
+ * `<emoji> <title>`, bordered, truncating to max-w-72. Mirror of IssueChip.
+ *
+ * Not a link / button: callers wrap it in whatever interactive shell they
+ * need. Pure UI — data is queried internally so callers can pass just an id.
+ *
+ * `📁` matches the fallback used elsewhere (project-picker, projects-page,
+ * project-detail) so project affordances feel consistent across the app.
+ */
+export interface ProjectChipProps {
+  projectId: string;
+  /** Shown when the project can't be resolved. */
+  fallbackLabel?: string;
+  /** Extra classes — callers layer interaction hints here. */
+  className?: string;
+}
+
+const BASE_CLASS =
+  "project-chip inline-flex items-center gap-1.5 rounded-md border mx-0.5 px-2 py-0.5 text-xs max-w-72";
+
+export function ProjectChip({
+  projectId,
+  fallbackLabel,
+  className,
+}: ProjectChipProps) {
+  const wsId = useWorkspaceId();
+  const { data: projects = [] } = useQuery(projectListOptions(wsId));
+  const listProject = projects.find((p) => p.id === projectId);
+
+  const { data: detailProject } = useQuery({
+    ...projectDetailOptions(wsId, projectId),
+    enabled: !listProject,
+  });
+
+  const project = listProject ?? detailProject;
+  const cls = className ? `${BASE_CLASS} ${className}` : BASE_CLASS;
+
+  if (!project) {
+    return (
+      <span className={cls}>
+        <span className="shrink-0">📁</span>
+        <span className="text-muted-foreground truncate">
+          {fallbackLabel ?? "Project"}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={cls}>
+      <span className="shrink-0">{project.icon || "📁"}</span>
+      <span className="text-foreground truncate">{project.title}</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a Focus button next to Chat Submit. On = Multica auto-attaches the page the user is viewing (issue / project / inbox-selected issue) as a prefix on outgoing messages, so the agent knows what "this" refers to without the user pasting ids.
- Extracts a shared **IssueChip** primitive; kills the parallel mention-card markup in editor's `MentionView`. Adds a symmetric **ProjectChip** for the focus-mode case. Consumers (mention-card, editor NodeView, anchor card) are now thin shells around the same chip.
- Pure frontend — backend `buildChatPrompt` untouched. The prefix uses the same `[MUL-1](mention://issue/<uuid>)` markdown the editor already produces for inline @mentions, so the agent sees one canonical token.

## Behaviour

### Button — three visual states driven by two dimensions (focusMode × candidate)

| focusMode | candidate | button |
|---|---|---|
| off | — | ghost + muted, click → turn on |
| on | present | secondary (bright), click → turn off |
| on | absent (e.g. /settings) | disabled — "nothing to share on this page" |

### Anchor chip (above input)

- Shown only when `focusMode && candidate`
- Renders IssueChip / ProjectChip wrapped in AppLink (same hover + click semantics as inline mentions)
- Tooltip: "Multica knows you're viewing MUL-1 — Fix login bug"

### Persistence

- `focusMode: boolean` persisted to localStorage, **global** (survives workspace switch / reload)
- The anchor object itself is NOT persisted — it's derived from route + react-query cache each render

### Prefix format

\`\`\`
Context: [MUL-1](mention://issue/<uuid>) — "Fix login bug"

{user message}
\`\`\`

Project variant uses plain text (mention-extension has no project type):
\`\`\`
Context: Project "Authentication"

{user message}
\`\`\`

## Test plan

- [ ] Issue page — toggle focus → chip shows `MUL-X + title` → send → bubble shows prefix; hover chip tooltip reads "Multica knows you're viewing …"
- [ ] Project page — chip shows emoji + title → send uses `Context: Project "…"`
- [ ] Inbox — select a notification that's linked to an issue → chip shows that issue; select a pure notification (no `issue_id`) → button disabled
- [ ] Settings page — button disabled, tooltip "Nothing to share with Multica on this page"
- [ ] Click chip → navigates to the underlying issue / project
- [ ] Reload after turning focus on → focus stays on
- [ ] Switch workspace with focus on → focus stays on; new workspace's current page derives correctly
- [ ] Focus off → no prefix in outgoing content
- [ ] Editor `@MUL-X` mention still renders as before (chip refactor didn't regress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)