### PR TITLE
fix: add .vercelignore for Vercel web deploys

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,45 @@
+# Deploy the Next.js web app from the monorepo root.
+# Keep apps/web, shared packages, and root workspace metadata.
+# Exclude unrelated workspaces and local artifacts that can make
+# `vercel deploy` upload far more than the web app needs.
+
+.agent_context
+.claude
+.context
+.tool-versions
+_features
+.kilo
+.idea
+.DS_Store
+
+.github
+docker
+docs
+e2e
+server
+apps/desktop
+apps/docs
+
+*.log
+*.pid
+*.tsbuildinfo
+
+.cache
+.next
+.pnpm-store
+.turbo
+.vercel
+coverage
+test-results
+playwright-report
+data
+
+node_modules
+bin
+dist
+out
+build
+dist-electron
+
+*.app
+*.dmg

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,16 +1,43 @@
-# Deploy the Next.js web app from the monorepo root.
-# Keep apps/web, shared packages, and root workspace metadata.
+# Deploy the frontend apps from the monorepo root.
+# Keep apps/web, apps/docs, shared packages, and root workspace metadata.
 # Exclude unrelated workspaces and local artifacts that can make
-# `vercel deploy` upload far more than the web app needs.
+# `vercel deploy` upload far more than the app needs.
 
 .agent_context
 .claude
 .context
+.env*
+.envrc
 .tool-versions
 _features
 .kilo
 .idea
 .DS_Store
+.husky
+.vscode
+
+!.env.example
+
+.dockerignore
+.goreleaser.yml
+AGENTS.md
+CLAUDE.md
+CLI_AND_DAEMON.md
+CLI_INSTALL.md
+CONTRIBUTING.md
+Dockerfile
+Dockerfile.web
+HANDOFF_ARCHITECTURE_AUDIT.md
+Makefile
+README.md
+README.zh-CN.md
+SELF_HOSTING.md
+SELF_HOSTING_ADVANCED.md
+SELF_HOSTING_AI.md
+docker-compose*.yml
+playwright.config.ts
+scripts
+skills-lock.json
 
 .github
 docker
@@ -18,7 +45,6 @@ docs
 e2e
 server
 apps/desktop
-apps/docs
 
 *.log
 *.pid


### PR DESCRIPTION
## Summary
- add a root .vercelignore for the web deployment path
- exclude unrelated workspaces and heavy local artifacts from Vercel uploads
- keep apps/web, shared packages, and root workspace metadata available for the Next.js build

## Testing
- not run (config-only change)