### PR TITLE
fix(agent): expose Gemini 3 + CLI aliases in Gemini runtime

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -155,11 +155,28 @@ func codexStaticModels() []Model {
 	}
 }
 
+// geminiStaticModels lists the values we pass via `gemini -m`. Gemini
+// CLI has no `models list` subcommand, so dynamic discovery isn't
+// possible; the next best thing is to expose the CLI's own aliases
+// (auto / pro / flash / flash-lite and the `auto-gemini-*` family)
+// alongside a few explicit version pins. Aliases track whatever the
+// installed CLI considers current (see `resolveModel` in the CLI's
+// packages/core/src/config/models.ts), so new Gemini releases light
+// up without a Multica redeploy. Default is `auto` to match Google's
+// recommendation — the CLI picks Pro vs Flash per task and falls back
+// when quota is exhausted.
 func geminiStaticModels() []Model {
 	return []Model{
-		{ID: "gemini-2.5-pro", Label: "Gemini 2.5 Pro", Provider: "google", Default: true},
+		{ID: "auto", Label: "Auto (Gemini 3)", Provider: "google", Default: true},
+		{ID: "auto-gemini-2.5", Label: "Auto (Gemini 2.5)", Provider: "google"},
+		{ID: "pro", Label: "Pro", Provider: "google"},
+		{ID: "flash", Label: "Flash", Provider: "google"},
+		{ID: "flash-lite", Label: "Flash Lite", Provider: "google"},
+		{ID: "gemini-3-pro-preview", Label: "Gemini 3 Pro (preview)", Provider: "google"},
+		{ID: "gemini-3-flash-preview", Label: "Gemini 3 Flash (preview)", Provider: "google"},
+		{ID: "gemini-2.5-pro", Label: "Gemini 2.5 Pro", Provider: "google"},
 		{ID: "gemini-2.5-flash", Label: "Gemini 2.5 Flash", Provider: "google"},
-		{ID: "gemini-2.0-flash", Label: "Gemini 2.0 Flash", Provider: "google"},
+		{ID: "gemini-2.5-flash-lite", Label: "Gemini 2.5 Flash Lite", Provider: "google"},
 	}
 }
 

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -27,6 +27,37 @@ func TestListModelsStaticProviders(t *testing.T) {
 	}
 }
 
+func TestGeminiStaticModelsExposesAliasesAndGemini3(t *testing.T) {
+	// Gemini CLI has no `models list` subcommand, so we expose the
+	// CLI's own aliases (auto / pro / flash / flash-lite) plus
+	// explicit version pins including Gemini 3. Regression guard
+	// for multica-ai/multica#1503 — Gemini 3 must be selectable.
+	models := geminiStaticModels()
+	ids := map[string]Model{}
+	for _, m := range models {
+		ids[m.ID] = m
+	}
+	for _, want := range []string{
+		"auto", "auto-gemini-2.5",
+		"pro", "flash", "flash-lite",
+		"gemini-3-pro-preview", "gemini-3-flash-preview",
+		"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+	} {
+		if _, ok := ids[want]; !ok {
+			t.Errorf("missing expected Gemini model %q in: %+v", want, models)
+		}
+	}
+	auto, ok := ids["auto"]
+	if !ok || !auto.Default {
+		t.Errorf("expected `auto` to be the default Gemini entry, got %+v", auto)
+	}
+	for _, m := range models {
+		if m.Provider != "google" {
+			t.Errorf("all Gemini entries must carry Provider=google, got %+v", m)
+		}
+	}
+}
+
 func TestListModelsHermesWithoutBinary(t *testing.T) {
 	// With no `hermes` binary on PATH the discovery fast-paths to
 	// an empty list (the UI then falls back to creatable manual


### PR DESCRIPTION
## Summary

- Fixes [#1503](https://github.com/multica-ai/multica/issues/1503) — Gemini runtime was only listing Gemini 2.x models because `geminiStaticModels()` was a hardcoded three-entry list (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`).
- Gemini CLI exposes no `models list` subcommand, so true dynamic discovery isn't available today. Next best: expose the CLI's own aliases (`auto`, `pro`, `flash`, `flash-lite`, `auto-gemini-2.5`) alongside explicit pins for Gemini 3 preview and 2.5 variants. Aliases are resolved inside the CLI per entitlement + quota, so future model releases (3.2 / 4.0 / ...) light up without a Multica redeploy.
- Also addresses the feature request in the original issue body — "auto-mode based on task + quota" is exactly the `auto` alias that Gemini CLI itself recommends as the default.

## Why these IDs

Discovered from the installed `@google/gemini-cli@0.37.1` bundle (`packages/core/src/config/models.ts`):

| Constant | Value |
|---|---|
| `GEMINI_MODEL_ALIAS_AUTO` | `auto` |
| `PREVIEW_GEMINI_MODEL_AUTO` | `auto-gemini-3` (route to Gemini 3 Pro/Flash) |
| `DEFAULT_GEMINI_MODEL_AUTO` | `auto-gemini-2.5` |
| `GEMINI_MODEL_ALIAS_{PRO,FLASH,FLASH_LITE}` | `pro`, `flash`, `flash-lite` |
| `PREVIEW_GEMINI_MODEL` | `gemini-3-pro-preview` |
| `PREVIEW_GEMINI_FLASH_MODEL` | `gemini-3-flash-preview` |
| `DEFAULT_GEMINI_*_MODEL` | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` |

Default is set to `auto`, matching Google's own [recommendation](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/model.md). The CLI handles `hasAccessToPreview` fallback internally, so accounts without Gemini 3 entitlement will be routed to 2.5 automatically when picking `auto`.

The daemon-side plumbing (`buildGeminiArgs` in `server/pkg/agent/gemini.go:252-266`) passes `opts.Model` through to `gemini -m` verbatim with zero local validation, so alias strings flow through unchanged.

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go vet ./pkg/agent/...` — clean
- [x] `go test ./pkg/agent/...` — all existing tests still pass
- [x] New test `TestGeminiStaticModelsExposesAliasesAndGemini3` asserts all expected IDs are present, `auto` is marked default, and all entries carry `Provider=google`
- [x] Existing `TestStaticCatalogsHaveAtMostOneDefault` still passes (still exactly one default)
- [ ] Manual: assign a Gemini agent, open model dropdown, verify Gemini 3 + alias entries appear and selecting `auto` / `gemini-3-pro-preview` works end-to-end