### PR TITLE
fix(chat): disable focus button on pages without an anchor

### DIFF
--- a/packages/views/chat/components/context-anchor.tsx
+++ b/packages/views/chat/components/context-anchor.tsx
@@ -109,13 +109,13 @@ export function useRouteAnchorCandidate(wsId: string): {
 }
 
 /**
- * Focus-mode toggle. Three visual states driven by two dimensions:
- *   - focusMode (persisted)       on | off
- *   - candidate present           yes | no
+ * Focus-mode toggle. Disabled whenever the current page has no anchor
+ * (nothing to share) — focusMode persists across such pages, so returning
+ * to an anchorable page restores the user's prior on/off choice.
  *
- *   off                   →  ghost + muted, clickable (→ turns on)
+ *   no candidate          →  disabled
+ *   off + candidate       →  ghost + muted, clickable (→ turns on)
  *   on  + candidate       →  secondary (bright), clickable (→ turns off)
- *   on  + no candidate    →  disabled (can't click until a focus target exists)
  */
 export function ContextAnchorButton() {
   const wsId = useWorkspaceId();
@@ -124,16 +124,16 @@ export function ContextAnchorButton() {
   const setFocusMode = useChatStore((s) => s.setFocusMode);
 
   const hasAnchor = !!candidate;
-  const isDisabled = focusMode && !hasAnchor && !isResolving;
+  const isDisabled = !hasAnchor && !isResolving;
   const isBright = focusMode && hasAnchor;
 
-  const tooltipText = !focusMode
-    ? "Let Multica know what you're viewing"
-    : hasAnchor
+  const tooltipText = isDisabled
+    ? "Nothing to share with Multica on this page"
+    : focusMode && candidate
       ? candidate.type === "issue"
         ? `Multica knows you're viewing ${candidate.label} · Click to turn off`
         : `Multica knows you're viewing project "${candidate.label}" · Click to turn off`
-      : "Nothing to share with Multica on this page";
+      : "Let Multica know what you're viewing";
 
   return (
     <Tooltip>


### PR DESCRIPTION
## Summary
- Focus-mode button now disables on any page without an anchor, regardless of the persisted `focusMode` state — closes the "click once, button instantly greys out" UX gap introduced in #1502.
- Tooltip reads *"Nothing to share with Multica on this page"* whenever the button is disabled, so the reason is explicit.
- `focusMode` remains persistent; returning to an anchorable page restores the user's prior on/off choice.

## Root cause
The original three-state design coupled disabled-ness to `focusMode`:
```ts
// before
const isDisabled = focusMode && !hasAnchor && !isResolving;
```
That covered "on + no anchor" but left "off + no anchor" clickable. Clicking it flipped `focusMode` on, and the button immediately entered the disabled state — exposing the missing fourth quadrant.

Separating concerns: clickability is a function of `hasAnchor` alone. `focusMode` only drives the bright/muted visual when the button *is* usable.
```ts
// after
const isDisabled = !hasAnchor && !isResolving;
```

## Why this is safe
The other two consumers of `focusMode` already gate on candidate presence:
- `ContextAnchorCard` (chip render): `if (!focusMode || !candidate) return null`
- `chat-window.tsx` handleSend: `focusOn && anchorCandidate ? prepend : content`

So leaving `focusMode=true` while on an unanchorable page has zero side effects — no phantom chip, no bogus context prefix on outgoing messages.

## Test plan
- [ ] `/issues` (list) → focus button disabled, tooltip says *"Nothing to share…"*
- [ ] `/issues/:id` with focusMode off → clickable, ghost + muted, click turns on
- [ ] `/issues/:id` with focusMode on → clickable, bright, click turns off
- [ ] Turn focus on at `/issues/:id`, navigate to `/issues` → button disables, chip disappears
- [ ] Navigate back to `/issues/:id` → focus resumes on (persistence preserved)
- [ ] `/projects/:id` and inbox with selected issue → same matrix as issue
- [ ] `/settings/*`, `/inbox` without selection → always disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)