### PR TITLE
fix(desktop): preserve last-opened workspace on app start (MUL-1269)

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -123,15 +123,21 @@ function AppContent() {
   // warning because `switchWorkspace` is a Zustand setState that the
   // TabBar is subscribed to. useLayoutEffect flushes both renders before
   // the user sees anything, so there's no visible flicker.
+  //
+  // Gate on `workspaceListFetched`: useQuery defaults `data` to `[]` before
+  // the first fetch, so without this guard we'd run validation against an
+  // empty slug set, wipe the persisted `activeWorkspaceSlug`, then fall
+  // back to `workspaces[0]` once the real list arrives — losing the user's
+  // last-opened workspace on every app start.
   useLayoutEffect(() => {
-    if (!workspaces) return;
+    if (!workspaceListFetched) return;
     const validSlugs = new Set(workspaces.map((w) => w.slug));
-    const tabStore = useTabStore.getState();
-    tabStore.validateWorkspaceSlugs(validSlugs);
-    if (!tabStore.activeWorkspaceSlug && workspaces.length > 0) {
-      tabStore.switchWorkspace(workspaces[0].slug);
+    useTabStore.getState().validateWorkspaceSlugs(validSlugs);
+    const { activeWorkspaceSlug, switchWorkspace } = useTabStore.getState();
+    if (!activeWorkspaceSlug && workspaces.length > 0) {
+      switchWorkspace(workspaces[0].slug);
     }
-  }, [workspaces]);
+  }, [workspaces, workspaceListFetched]);
 
   // null = undecided (pre-login or list hasn't settled yet)
   // true  = session started with zero workspaces; next transition to >=1 triggers restart


### PR DESCRIPTION
## Summary
- Fixes [MUL-1269](mention://issue/87fe9b14-77cf-42dc-ab6c-3317c9a140dd): on desktop, opening Multica always entered the default workspace instead of the last-opened one.
- Root cause: `useQuery` defaults `data` to `[]` before the first fetch, so the bootstrap effect in `App.tsx` ran immediately with an empty valid-slug set, `validateWorkspaceSlugs({})` wiped the persisted `activeWorkspaceSlug`, and the next pass fell back to `workspaces[0]`.
- Fix: gate the effect on `workspaceListFetched` so validation only runs against the real list. Also re-read the store after `validateWorkspaceSlugs` so the subsequent check no longer acts on a stale snapshot.

## Test plan
- [ ] Desktop: sign in, switch to a non-first workspace, quit the app, relaunch — the same workspace (and its last-active tab) should be restored.
- [ ] First-time sign-in still lands on `workspaces[0]` when no workspace is persisted.
- [ ] Logging out and signing back in (fresh session) still picks `workspaces[0]` (expected, since `reset()` wipes persisted tabs).
- [ ] Persisted slug that's no longer in the workspace list (membership revoked) falls back to the first valid workspace.