### PR TITLE
fix(views): restore issue-mention class on <a> for mention card

### DIFF
--- a/packages/views/editor/extensions/mention-view.tsx
+++ b/packages/views/editor/extensions/mention-view.tsx
@@ -60,7 +60,7 @@ function IssueMention({
   };
 
   return (
-    <a href={issuePath} onClick={handleClick} className="inline-flex">
+    <a href={issuePath} onClick={handleClick} className="issue-mention inline-flex">
       <IssueChip
         issueId={issueId}
         fallbackLabel={fallbackLabel}

--- a/packages/views/issues/components/issue-mention-card.tsx
+++ b/packages/views/issues/components/issue-mention-card.tsx
@@ -18,7 +18,7 @@ interface IssueMentionCardProps {
 export function IssueMentionCard({ issueId, fallbackLabel }: IssueMentionCardProps) {
   const p = useWorkspacePaths();
   return (
-    <AppLink href={p.issueDetail(issueId)} className="inline-flex">
+    <AppLink href={p.issueDetail(issueId)} className="issue-mention not-prose inline-flex">
       <IssueChip
         issueId={issueId}
         fallbackLabel={fallbackLabel}


### PR DESCRIPTION
## Summary

- Mention cards regained a spurious underline after PR #1502. Root cause: that PR's `IssueChip` extraction moved the `issue-mention` class from the wrapper `<a>` into `IssueChip`'s inner `<span>`, breaking three distinct consumers that select on `<a>.issue-mention` (editor CSS underline-exemption, `link-hover-card` suppression check, and `AppLink` styling).
- Putting `issue-mention` back on the `<a>` in both wrappers (`IssueMentionCard` and the editor's `MentionView`) re-lands the editor-side CSS exemption and repairs `link-hover-card.tsx:71`'s classList check.
- Chat bubbles render markdown inside Tailwind Typography (`prose`), which is a separate path untouched by the editor CSS. Added `not-prose` to the markdown-side wrapper (`IssueMentionCard`) — `prose a`'s specificity (0,1,1) outranks `.no-underline` (0,1,0), so `not-prose` is the correct escape hatch.
- `IssueChip` BASE_CLASS keeps `issue-mention` as inert redundancy; removing it is a separate scope that needs a full consumer audit (e.g. E2E selectors).

## Test plan

- [ ] Issue detail (readonly description) containing `@MUL-X` — chip renders with no underline; hovering the chip does NOT pop up a URL preview card
- [ ] Open the description editor — chip (Tiptap NodeView) has no underline; cmd-click still opens in a new tab
- [ ] Chat bubble containing `[MUL-X](mention://issue/<uuid>)` — chip renders with no underline inside `prose`; click navigates to the issue
- [ ] Focus-mode anchor above chat input — `IssueChip` / `ProjectChip` visual unchanged (not regressed by this fix)
- [ ] `pnpm --filter @multica/views typecheck`, `pnpm --filter @multica/web typecheck`, `pnpm --filter @multica/views exec vitest run editor/readonly-content.test.tsx` — all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)