### PR TITLE
feat(agent): add Kimi Code CLI as a runtime backend

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -142,8 +142,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_COPILOT_MODEL")),
 		}
 	}
+	kimiPath := envOrDefault("MULTICA_KIMI_PATH", "kimi")
+	if _, err := exec.LookPath(kimiPath); err == nil {
+		agents["kimi"] = AgentEntry{
+			Path:  kimiPath,
+			Model: strings.TrimSpace(os.Getenv("MULTICA_KIMI_MODEL")),
+		}
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, or cursor-agent and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, or kimi and ensure it is on PATH")
 	}
 
 	// Host info

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -17,6 +17,7 @@ import (
 // OpenCode: skills → {workDir}/.config/opencode/skills/{name}/SKILL.md  (native discovery)
 // Pi:       skills → {workDir}/.pi/agent/skills/{name}/SKILL.md  (native discovery)
 // Cursor:   skills → {workDir}/.cursor/skills/{name}/SKILL.md  (native discovery)
+// Kimi:     skills → {workDir}/.kimi/skills/{name}/SKILL.md    (native discovery)
 // Default:  skills → {workDir}/.agent_context/skills/{name}/SKILL.md
 func writeContextFiles(workDir, provider string, ctx TaskContextForEnv) error {
 	contextDir := filepath.Join(workDir, ".agent_context")
@@ -69,6 +70,9 @@ func resolveSkillsDir(workDir, provider string) (string, error) {
 	case "cursor":
 		// Cursor natively discovers skills from .cursor/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".cursor", "skills")
+	case "kimi":
+		// Kimi natively discovers skills from .kimi/skills/ in the workdir.
+		skillsDir = filepath.Join(workDir, ".kimi", "skills")
 	default:
 		// Fallback: write to .agent_context/skills/ (referenced by meta config).
 		skillsDir = filepath.Join(workDir, ".agent_context", "skills")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -18,13 +18,14 @@ import (
 // For Gemini:   writes {workDir}/GEMINI.md  (discovered natively by the Gemini CLI)
 // For Pi:       writes {workDir}/AGENTS.md  (skills discovered natively from ~/.pi/agent/skills/)
 // For Cursor:   writes {workDir}/AGENTS.md  (skills discovered natively from .cursor/skills/)
+// For Kimi:     writes {workDir}/AGENTS.md  (skills discovered natively via KIMI_AGENTS_MD)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error {
 	content := buildMetaSkillContent(provider, ctx)
 
 	switch provider {
 	case "claude":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor":
+	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)
@@ -150,7 +151,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor":
+		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi":
 			// Codex, Copilot, OpenCode, OpenClaw, Pi, and Cursor discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
 		case "gemini":

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -116,8 +116,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &piBackend{cfg: cfg}, nil
 	case "cursor":
 		return &cursorBackend{cfg: cfg}, nil
+	case "kimi":
+		return &kimiBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi)", agentType)
 	}
 }
 
@@ -139,6 +141,7 @@ var launchHeaders = map[string]string{
 	"cursor":   "cursor-agent (stream-json)",
 	"gemini":   "gemini (stream-json)",
 	"hermes":   "hermes acp",
+	"kimi":     "kimi (stream-json)",
 	"openclaw": "openclaw agent (json)",
 	"opencode": "opencode run (json)",
 	"pi":       "pi (json mode)",

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -1,0 +1,343 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// kimiBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args.
+var kimiBlockedArgs = map[string]blockedArgMode{
+	"--print":         blockedStandalone, // non-interactive mode
+	"--output-format": blockedWithValue,  // stream-json protocol for daemon communication
+	"--input-format":  blockedWithValue,  // text input format
+	"-y":              blockedStandalone, // auto-approve (implied by --print)
+	"--yolo":          blockedStandalone, // auto-approve
+	"--yes":           blockedStandalone, // auto-approve alias
+	"-p":              blockedWithValue,  // prompt is piped via stdin
+	"--prompt":        blockedWithValue,  // prompt is piped via stdin
+	"-S":              blockedWithValue,  // session ID managed by daemon
+	"--session":       blockedWithValue,  // session ID managed by daemon
+	"-r":              blockedWithValue,  // resume session managed by daemon
+}
+
+// kimiBackend implements Backend by spawning the Kimi Code CLI
+// with `--print --output-format stream-json` and parsing its NDJSON event stream.
+type kimiBackend struct {
+	cfg Config
+}
+
+func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "kimi"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("kimi executable not found at %q: %w", execPath, err)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	sessionID := opts.ResumeSessionID
+	if sessionID == "" {
+		sessionID = fmt.Sprintf("multica-%d", time.Now().UnixNano())
+	}
+
+	args := buildKimiArgs(sessionID, opts, b.cfg.Logger)
+
+	cmd := exec.CommandContext(runCtx, execPath, args...)
+	b.cfg.Logger.Debug("agent command", "exec", execPath, "args", args)
+	cmd.WaitDelay = 10 * time.Second
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	// Pipe prompt via stdin.
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("kimi stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("kimi stdout pipe: %w", err)
+	}
+	cmd.Stderr = newLogWriter(b.cfg.Logger, "[kimi:stderr] ")
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start kimi: %w", err)
+	}
+
+	// Write prompt to stdin and close.
+	go func() {
+		defer stdin.Close()
+		if _, err := io.WriteString(stdin, prompt); err != nil {
+			b.cfg.Logger.Warn("kimi stdin write failed", "error", err)
+		}
+	}()
+
+	b.cfg.Logger.Info("kimi started", "pid", cmd.Process.Pid, "cwd", opts.Cwd, "model", opts.Model, "session", sessionID)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	// Close stdout when the context is cancelled so scanner.Scan() unblocks.
+	go func() {
+		<-runCtx.Done()
+		_ = stdout.Close()
+	}()
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		startTime := time.Now()
+		scanResult := b.processEvents(stdout, msgCh)
+
+		// Wait for process exit.
+		exitErr := cmd.Wait()
+		duration := time.Since(startTime)
+
+		if runCtx.Err() == context.DeadlineExceeded {
+			scanResult.status = "timeout"
+			scanResult.errMsg = fmt.Sprintf("kimi timed out after %s", timeout)
+		} else if runCtx.Err() == context.Canceled {
+			scanResult.status = "aborted"
+			scanResult.errMsg = "execution cancelled"
+		} else if exitErr != nil && scanResult.status == "completed" {
+			scanResult.status = "failed"
+			scanResult.errMsg = fmt.Sprintf("kimi exited with error: %v", exitErr)
+		}
+
+		b.cfg.Logger.Info("kimi finished", "pid", cmd.Process.Pid, "status", scanResult.status, "duration", duration.Round(time.Millisecond).String())
+
+		// Build usage map. Kimi doesn't report token usage in stream-json
+		// output, so we attribute any accumulated usage to the configured model.
+		var usage map[string]TokenUsage
+		u := scanResult.usage
+		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 || u.CacheWriteTokens > 0 {
+			model := opts.Model
+			if model == "" {
+				model = "unknown"
+			}
+			usage = map[string]TokenUsage{model: u}
+		}
+
+		resCh <- Result{
+			Status:     scanResult.status,
+			Output:     scanResult.output,
+			Error:      scanResult.errMsg,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  scanResult.sessionID,
+			Usage:      usage,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// ── Event handlers ──
+
+// kimiEventResult holds accumulated state from processing the event stream.
+type kimiEventResult struct {
+	status    string
+	errMsg    string
+	output    string
+	sessionID string
+	usage     TokenUsage
+}
+
+// processEvents reads JSON lines from r, dispatches events to ch, and returns
+// the accumulated result.
+//
+// Kimi's stream-json output emits one JSON object per message turn:
+//
+//   - {"role":"assistant","content":[...],"tool_calls":[...]} — agent response
+//   - {"role":"tool","content":[...],"tool_call_id":"..."} — tool result
+func (b *kimiBackend) processEvents(r io.Reader, ch chan<- Message) kimiEventResult {
+	var output strings.Builder
+	sessionID := ""
+	finalStatus := "completed"
+	var finalError string
+	var usage TokenUsage
+	emittedStatus := false
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var evt kimiMessage
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			continue
+		}
+
+		switch evt.Role {
+		case "assistant":
+			// Emit running status on first assistant message.
+			if !emittedStatus {
+				trySend(ch, Message{Type: MessageStatus, Status: "running"})
+				emittedStatus = true
+			}
+
+			// Process content blocks.
+			for _, block := range evt.Content {
+				switch block.Type {
+				case "text":
+					if block.Text != "" {
+						output.WriteString(block.Text)
+						trySend(ch, Message{Type: MessageText, Content: block.Text})
+					}
+				case "think":
+					if block.Think != "" {
+						trySend(ch, Message{Type: MessageThinking, Content: block.Think})
+					}
+				}
+			}
+
+			// Process tool calls.
+			for _, tc := range evt.ToolCalls {
+				var input map[string]any
+				if tc.Function.Arguments != "" {
+					_ = json.Unmarshal([]byte(tc.Function.Arguments), &input)
+				}
+				trySend(ch, Message{
+					Type:   MessageToolUse,
+					Tool:   tc.Function.Name,
+					CallID: tc.ID,
+					Input:  input,
+				})
+			}
+
+		case "tool":
+			// Concatenate text content blocks.
+			var textParts []string
+			for _, block := range evt.Content {
+				if block.Type == "text" && block.Text != "" {
+					textParts = append(textParts, block.Text)
+				}
+			}
+			toolOutput := strings.Join(textParts, "\n")
+			trySend(ch, Message{
+				Type:   MessageToolResult,
+				CallID: evt.ToolCallID,
+				Output: toolOutput,
+			})
+
+		case "system":
+			// System messages are informational; skip.
+
+		case "error":
+			errMsg := ""
+			for _, block := range evt.Content {
+				if block.Type == "text" && block.Text != "" {
+					errMsg = block.Text
+					break
+				}
+			}
+			if errMsg == "" {
+				errMsg = "unknown kimi error"
+			}
+			trySend(ch, Message{Type: MessageError, Content: errMsg})
+			finalStatus = "failed"
+			finalError = errMsg
+		}
+	}
+
+	if scanErr := scanner.Err(); scanErr != nil {
+		b.cfg.Logger.Warn("kimi stdout scanner error", "error", scanErr)
+		if finalStatus == "completed" {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("stdout read error: %v", scanErr)
+		}
+	}
+
+	return kimiEventResult{
+		status:    finalStatus,
+		errMsg:    finalError,
+		output:    output.String(),
+		sessionID: sessionID,
+		usage:     usage,
+	}
+}
+
+// ── JSON types for kimi --print --output-format stream-json ──
+
+// kimiMessage represents a single JSON message from Kimi's stream-json output.
+type kimiMessage struct {
+	Role       string            `json:"role"`
+	Content    []kimiContentBlock `json:"content,omitempty"`
+	ToolCalls  []kimiToolCall    `json:"tool_calls,omitempty"`
+	ToolCallID string            `json:"tool_call_id,omitempty"`
+}
+
+// kimiContentBlock represents a content block within a Kimi message.
+type kimiContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+	// "think" type
+	Think string `json:"think,omitempty"`
+}
+
+// kimiToolCall represents a tool call within a Kimi assistant message.
+type kimiToolCall struct {
+	Type     string           `json:"type"`
+	ID       string           `json:"id"`
+	Function kimiFunctionCall `json:"function"`
+}
+
+// kimiFunctionCall represents the function details of a tool call.
+type kimiFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON string of arguments
+}
+
+// ── Arg builder ──
+
+// buildKimiArgs assembles the argv for a one-shot kimi invocation.
+//
+// Flags:
+//
+//	--print                     non-interactive mode (implies --yolo)
+//	--output-format stream-json streaming NDJSON output for live events
+//	--input-format text         text input via stdin
+//	-y                          auto-approve all tool use
+//	-S <id>                     session ID for resumption
+//	-m <model>                  optional model override
+//	--skills-dir <dir>          skills directory
+func buildKimiArgs(sessionID string, opts ExecOptions, logger *slog.Logger) []string {
+	args := []string{
+		"--print",
+		"--output-format", "stream-json",
+		"--input-format", "text",
+		"-y",
+	}
+	if sessionID != "" {
+		args = append(args, "-S", sessionID)
+	}
+	if opts.Model != "" {
+		args = append(args, "-m", opts.Model)
+	}
+	args = append(args, filterCustomArgs(opts.CustomArgs, kimiBlockedArgs, logger)...)
+	return args
+}

--- a/server/pkg/agent/kimi_test.go
+++ b/server/pkg/agent/kimi_test.go
@@ -1,0 +1,357 @@
+package agent
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestKimiProcessAssistantText(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	line := `{"role":"assistant","content":[{"type":"text","text":"Hello, world!"}]}`
+
+	result := b.processEvents(strings.NewReader(line), ch)
+
+	if result.status != "completed" {
+		t.Fatalf("expected completed, got %q", result.status)
+	}
+	if result.output != "Hello, world!" {
+		t.Fatalf("expected output 'Hello, world!', got %q", result.output)
+	}
+
+	// Should have 2 messages: status "running" + text
+	var msgs []Message
+	for len(msgs) < 2 {
+		select {
+		case m := <-ch:
+			msgs = append(msgs, m)
+		default:
+			t.Fatal("expected 2 messages, got", len(msgs))
+		}
+	}
+	if msgs[0].Type != MessageStatus || msgs[0].Status != "running" {
+		t.Fatalf("expected first message to be status running, got %+v", msgs[0])
+	}
+	if msgs[1].Type != MessageText || msgs[1].Content != "Hello, world!" {
+		t.Fatalf("expected second message to be text, got %+v", msgs[1])
+	}
+}
+
+func TestKimiProcessAssistantThinking(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	line := `{"role":"assistant","content":[{"type":"think","think":"I need to check the files"},{"type":"text","text":"Let me look at the files."}]}`
+
+	result := b.processEvents(strings.NewReader(line), ch)
+
+	if result.output != "Let me look at the files." {
+		t.Fatalf("expected text output, got %q", result.output)
+	}
+
+	var msgs []Message
+	for len(msgs) < 3 {
+		select {
+		case m := <-ch:
+			msgs = append(msgs, m)
+		default:
+			t.Fatal("expected 3 messages")
+		}
+	}
+
+	// status, thinking, text
+	if msgs[1].Type != MessageThinking || msgs[1].Content != "I need to check the files" {
+		t.Fatalf("expected thinking message, got %+v", msgs[1])
+	}
+	if msgs[2].Type != MessageText || msgs[2].Content != "Let me look at the files." {
+		t.Fatalf("expected text message, got %+v", msgs[2])
+	}
+}
+
+func TestKimiProcessToolCalls(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	line := `{"role":"assistant","content":[{"type":"think","think":"Running ls"},{"type":"text","text":"Let me list the files."}],"tool_calls":[{"type":"function","id":"tool_abc123","function":{"name":"Shell","arguments":"{\"command\": \"ls -la\"}"}}]}`
+
+	result := b.processEvents(strings.NewReader(line), ch)
+
+	if result.output != "Let me list the files." {
+		t.Fatalf("expected text output, got %q", result.output)
+	}
+
+	// Drain all messages
+	var msgs []Message
+drain:
+	for {
+		select {
+		case m := <-ch:
+			msgs = append(msgs, m)
+		default:
+			break drain
+		}
+	}
+
+	// Find the tool_use message
+	var toolMsg *Message
+	for i := range msgs {
+		if msgs[i].Type == MessageToolUse {
+			toolMsg = &msgs[i]
+			break
+		}
+	}
+	if toolMsg == nil {
+		t.Fatal("expected a tool_use message")
+	}
+	if toolMsg.Tool != "Shell" {
+		t.Fatalf("expected tool 'Shell', got %q", toolMsg.Tool)
+	}
+	if toolMsg.CallID != "tool_abc123" {
+		t.Fatalf("expected callID 'tool_abc123', got %q", toolMsg.CallID)
+	}
+	if toolMsg.Input["command"] != "ls -la" {
+		t.Fatalf("expected input command 'ls -la', got %v", toolMsg.Input["command"])
+	}
+}
+
+func TestKimiProcessToolResult(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	line := `{"role":"tool","content":[{"type":"text","text":"<system>Command executed successfully.</system>"},{"type":"text","text":"total 42\ndrwxr-xr-x 5 user staff 160 Apr 21 ."}],"tool_call_id":"tool_abc123"}`
+
+	b.processEvents(strings.NewReader(line), ch)
+
+	var msgs []Message
+drain:
+	for {
+		select {
+		case m := <-ch:
+			msgs = append(msgs, m)
+		default:
+			break drain
+		}
+	}
+
+	var resultMsg *Message
+	for i := range msgs {
+		if msgs[i].Type == MessageToolResult {
+			resultMsg = &msgs[i]
+			break
+		}
+	}
+	if resultMsg == nil {
+		t.Fatal("expected a tool_result message")
+	}
+	if resultMsg.CallID != "tool_abc123" {
+		t.Fatalf("expected callID 'tool_abc123', got %q", resultMsg.CallID)
+	}
+	if !strings.Contains(resultMsg.Output, "total 42") {
+		t.Fatalf("expected output to contain 'total 42', got %q", resultMsg.Output)
+	}
+}
+
+func TestKimiProcessMultipleToolResults(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	// Multiple content blocks in tool result should be joined with newline
+	line := `{"role":"tool","content":[{"type":"text","text":"line1"},{"type":"text","text":"line2"}],"tool_call_id":"tool_xyz"}`
+
+	b.processEvents(strings.NewReader(line), ch)
+
+	var msgs []Message
+drain:
+	for {
+		select {
+		case m := <-ch:
+			msgs = append(msgs, m)
+		default:
+			break drain
+		}
+	}
+
+	var resultMsg *Message
+	for i := range msgs {
+		if msgs[i].Type == MessageToolResult {
+			resultMsg = &msgs[i]
+			break
+		}
+	}
+	if resultMsg == nil {
+		t.Fatal("expected a tool_result message")
+	}
+	if resultMsg.Output != "line1\nline2" {
+		t.Fatalf("expected joined output 'line1\\nline2', got %q", resultMsg.Output)
+	}
+}
+
+func TestKimiProcessFullTurn(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	// Simulate a full turn: assistant with tool call, then tool result, then assistant text
+	input := `{"role":"assistant","content":[{"type":"think","think":"I should check the files"},{"type":"text","text":"Let me list the files."}],"tool_calls":[{"type":"function","id":"tool_1","function":{"name":"Shell","arguments":"{\"command\": \"ls\"}"}}]}
+{"role":"tool","content":[{"type":"text","text":"file1.txt\nfile2.txt"}],"tool_call_id":"tool_1"}
+{"role":"assistant","content":[{"type":"text","text":"I found 2 files: file1.txt and file2.txt"}]}`
+
+	result := b.processEvents(strings.NewReader(input), ch)
+
+	if result.status != "completed" {
+		t.Fatalf("expected completed, got %q", result.status)
+	}
+	// Output should be the concatenated text from assistant messages
+	expected := "Let me list the files.I found 2 files: file1.txt and file2.txt"
+	if result.output != expected {
+		t.Fatalf("expected output %q, got %q", expected, result.output)
+	}
+}
+
+func TestKimiProcessEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	result := b.processEvents(strings.NewReader(""), ch)
+
+	if result.status != "completed" {
+		t.Fatalf("expected completed, got %q", result.status)
+	}
+	if result.output != "" {
+		t.Fatalf("expected empty output, got %q", result.output)
+	}
+}
+
+func TestKimiProcessInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	// Invalid JSON lines should be skipped
+	input := "not json\nalso not json\n"
+
+	result := b.processEvents(strings.NewReader(input), ch)
+
+	if result.status != "completed" {
+		t.Fatalf("expected completed, got %q", result.status)
+	}
+	if result.output != "" {
+		t.Fatalf("expected empty output, got %q", result.output)
+	}
+}
+
+func TestKimiProcessEmptyLines(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	input := "\n\n{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}\n\n"
+
+	result := b.processEvents(strings.NewReader(input), ch)
+
+	if result.output != "hi" {
+		t.Fatalf("expected 'hi', got %q", result.output)
+	}
+}
+
+func TestKimiBlockedArgs(t *testing.T) {
+	t.Parallel()
+
+	expectedBlocked := []string{"--print", "--output-format", "--input-format", "-y", "--yolo", "--yes", "-p", "--prompt", "-S", "--session", "-r"}
+	for _, arg := range expectedBlocked {
+		if _, ok := kimiBlockedArgs[arg]; !ok {
+			t.Errorf("expected %q to be in kimiBlockedArgs", arg)
+		}
+	}
+}
+
+func TestKimiBuildArgs(t *testing.T) {
+	t.Parallel()
+
+	args := buildKimiArgs("test-session", ExecOptions{Model: "kimi-for-coding"}, slog.Default())
+
+	// Check essential flags are present
+	argStr := strings.Join(args, " ")
+	if !strings.Contains(argStr, "--print") {
+		t.Error("expected --print in args")
+	}
+	if !strings.Contains(argStr, "--output-format stream-json") {
+		t.Error("expected --output-format stream-json in args")
+	}
+	if !strings.Contains(argStr, "-y") {
+		t.Error("expected -y in args")
+	}
+	if !strings.Contains(argStr, "-S test-session") {
+		t.Error("expected -S test-session in args")
+	}
+	if !strings.Contains(argStr, "-m kimi-for-coding") {
+		t.Error("expected -m kimi-for-coding in args")
+	}
+}
+
+func TestKimiBuildArgsWithResumeSession(t *testing.T) {
+	t.Parallel()
+
+	args := buildKimiArgs("prior-session-id", ExecOptions{ResumeSessionID: "prior-session-id"}, slog.Default())
+
+	argStr := strings.Join(args, " ")
+	if !strings.Contains(argStr, "-S prior-session-id") {
+		t.Error("expected -S prior-session-id in args")
+	}
+}
+
+func TestKimiBuildArgsFiltersBlocked(t *testing.T) {
+	t.Parallel()
+
+	// User tries to override blocked flags via custom_args — should be filtered.
+	args := buildKimiArgs("s1", ExecOptions{
+		CustomArgs: []string{"--output-format", "text", "--yolo"},
+	}, slog.Default())
+
+	for _, arg := range args {
+		if arg == "--yolo" {
+			t.Error("--yolo should have been filtered from custom_args")
+		}
+		if arg == "text" {
+			// Could be a legitimate value if not preceded by --output-format
+			// But --output-format should have been filtered, so "text" shouldn't
+			// appear as its value either.
+		}
+	}
+}
+
+func TestKimiProcessSystemRole(t *testing.T) {
+	t.Parallel()
+
+	b := &kimiBackend{cfg: Config{}}
+	ch := make(chan Message, 256)
+
+	// System messages should be silently skipped
+	line := `{"role":"system","content":[{"type":"text","text":"system info"}]}`
+
+	result := b.processEvents(strings.NewReader(line), ch)
+
+	if result.status != "completed" {
+		t.Fatalf("expected completed, got %q", result.status)
+	}
+	if result.output != "" {
+		t.Fatalf("expected empty output (system messages ignored), got %q", result.output)
+	}
+}

--- a/server/pkg/agent/version.go
+++ b/server/pkg/agent/version.go
@@ -12,6 +12,7 @@ var MinVersions = map[string]string{
 	"claude":  "2.0.0",
 	"codex":   "0.100.0", // app-server --listen stdio:// added in 0.100.0
 	"copilot": "1.0.0",   // --output-format json envelope stable from 1.0.x
+	"kimi":    "1.0.0",   // --print --output-format stream-json stable from 1.0.x
 }
 
 // semver holds a parsed semantic version (major.minor.patch).


### PR DESCRIPTION
## Summary

- Add **Kimi Code CLI** (`kimi`) as a supported agent runtime, enabling Multica to dispatch tasks to Kimi alongside existing agents (Claude, Codex, Gemini, etc.)
- Implement `kimiBackend` using `--print --output-format stream-json` for non-interactive NDJSON communication over stdin/stdout
- Parse Kimi's stream-json events: assistant text, thinking, tool calls, and tool results

## Changes

| File | Change |
|------|--------|
| `server/pkg/agent/kimi.go` | New — Backend implementation (Execute, event parsing, arg builder) |
| `server/pkg/agent/kimi_test.go` | New — 14 unit tests covering event parsing and arg filtering |
| `server/pkg/agent/agent.go` | Register `"kimi"` in `New()` switch + `launchHeaders` |
| `server/pkg/agent/version.go` | Minimum version `1.0.0` |
| `server/internal/daemon/config.go` | Auto-detect `kimi` CLI on PATH (`MULTICA_KIMI_PATH` override) |
| `server/internal/daemon/execenv/runtime_config.go` | Kimi uses `AGENTS.md` for runtime config injection |
| `server/internal/daemon/execenv/context.go` | Skills dir: `.kimi/skills/` (native discovery) |

## How it works

Kimi's `--print --output-format stream-json` mode outputs one JSON object per message turn to stdout:

```json
{"role":"assistant","content":[{"type":"think","think":"..."},{"type":"text","text":"Hello!"}],"tool_calls":[{"type":"function","id":"tool_xxx","function":{"name":"Shell","arguments":"{\"command\": \"ls\"}"}}]}
{"role":"tool","content":[{"type":"text","text":"output here"}],"tool_call_id":"tool_xxx"}
```

The backend maps these to Multica's unified `Message` types (Text, Thinking, ToolUse, ToolResult, Status). Session resumption is supported via `-S <id>` flag.

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./pkg/agent/ -run TestKimi -v` — 14/14 tests pass
- [x] `go test ./pkg/agent/` — full agent package tests pass (no regressions)
- [x] Daemon restart detects `kimi` on PATH and registers runtime
- [x] Health endpoint confirms `agents: [..., "kimi"]`