### PR TITLE
 fix(auth): make /api/config publicly accessible

### DIFF
--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -221,6 +221,23 @@ func TestHealth(t *testing.T) {
 	}
 }
 
+func TestConfigRouteIsPublic(t *testing.T) {
+	resp, err := http.Get(testServer.URL + "/api/config")
+	if err != nil {
+		t.Fatalf("config request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		CdnDomain string `json:"cdn_domain"`
+	}
+	readJSON(t, resp, &result)
+}
+
 // ---- Auth ----
 
 func TestSendCodeAndVerify(t *testing.T) {

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -126,6 +126,9 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 	r.Post("/auth/google", h.GoogleLogin)
 	r.Post("/auth/logout", h.Logout)
 
+	// Public API
+	r.Get("/api/config", h.GetConfig)
+
 	// Daemon API routes (require daemon token or valid user token)
 	r.Route("/api/daemon", func(r chi.Router) {
 		r.Use(middleware.DaemonAuth(queries))
@@ -159,7 +162,6 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus) chi.Route
 		r.Use(middleware.RefreshCloudFrontCookies(cfSigner))
 
 		// --- User-scoped routes (no workspace context required) ---
-		r.Get("/api/config", h.GetConfig)
 		r.Get("/api/me", h.GetMe)
 		r.Patch("/api/me", h.UpdateMe)
 		r.Post("/api/cli-token", h.IssueCliToken)


### PR DESCRIPTION
## What does this PR do?

  Moves `GET /api/config` out of the authenticated API route group and registers it as a public API route.

  This endpoint serves instance-level public configuration needed before login. Keeping it behind `middleware.Auth` caused unauthenticated requests to
  return `401 Unauthorized`, which blocked the login page from receiving config required for auth-related UI.

  Reasoning path:
  - `/api/config` is fetched before a user is authenticated.
  - The handler only returns public instance configuration.
  - The route was incorrectly registered inside the protected route group.
  - Moving the route to the public API section fixes the regression with the smallest backend change.
  - A regression test now verifies unauthenticated access returns `200 OK`.

  Risk:
  Low. This only changes auth middleware coverage for `/api/config`, whose response is public, instance-level configuration and contains no user-specific
  data.

  ## Related Issue

  Closes #1525

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Refactor / code improvement (no behavior change)
  - [ ] Documentation update
  - [x] Tests (adding or improving test coverage)
  - [ ] CI / infrastructure

  ## Changes Made

  - `server/cmd/server/router.go`
    - Registered `GET /api/config` in the public API route section.
    - Removed `GET /api/config` from the authenticated route group.

  - `server/cmd/server/integration_test.go`
    - Added `TestConfigRouteIsPublic` to verify unauthenticated requests to `/api/config` return `200 OK`.

  ## How to Test

  1. Run:
     ```bash
     go test ./cmd/server -run TestConfigRouteIsPublic -count=1

  2. Start the backend and request /api/config without an auth token.
  3. Confirm the response is 200 OK instead of 401 Unauthorized.

  ## Checklist

  - [x] I have included a thinking path that traces from project context to this change
  - [x] I have run tests locally and they pass
  - [x] I have added or updated tests where applicable
  - [x] If this change affects the UI, I have included before/after screenshots
      - N/A: backend route registration only
  - [x] I have updated relevant documentation to reflect my changes
      - N/A: no documentation change required
  - [x] I have considered and documented any risks above
  - [x] I will address all reviewer comments before requesting merge

  ## AI Disclosure

  AI tool used: ChatGPT / OpenAI coding assistant

  Prompt / approach:
  I used AI assistance to inspect the backend router, move /api/config from the authenticated route group to the public route section, add a regression
  test, run formatting, and verify the targeted Go test locally.

  ## Screenshots (optional)

  N/A
