### PR TITLE
docs(handler): document /api/config as public-only endpoint

### DIFF
--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -22,6 +22,10 @@ type AppConfig struct {
 	PosthogHost string `json:"posthog_host"`
 }
 
+// GetConfig is mounted on the public (unauthenticated) route group because
+// the web app calls it before login to decide whether to render the Google
+// sign-in button and signup UI. Only add fields here that are safe to expose
+// to anonymous callers — never user- or tenant-scoped data.
 func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	config := AppConfig{
 		AllowSignup:    os.Getenv("ALLOW_SIGNUP") != "false",


### PR DESCRIPTION
## What does this PR do?

Adds a doc comment to `GetConfig` in `server/internal/handler/config.go` spelling out:

- The handler is mounted on the **public** (unauthenticated) route group, because the web app calls `/api/config` before login to decide whether to render the Google sign-in button and signup UI.
- Only instance-level public fields may be returned here — never user- or tenant-scoped data.

This is a follow-up to #1530 (which moved the route to the public group to fix #1525). The intent is to prevent a future contributor from accidentally adding user-scoped or sensitive fields to this response, which would silently expose them to anonymous callers.

## Reasoning path

- #1530 already moved `/api/config` to the public route group — fix is in.
- The handler itself has no marker explaining *why* it's public or what is/isn't safe to add. Easy footgun for the next person extending it.
- A four-line doc comment is the smallest change that captures the constraint at the only place future edits will land.

## Risk

None — comment-only change, no behavior change, no test impact.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Tests
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/config.go` — add doc comment on `GetConfig`.

## How to Test

N/A (comment-only). `gofmt` and `go vet ./internal/handler/...` clean.

## Checklist

- [x] Comment-only change with no behavior impact
- [x] `gofmt` / `go vet` clean
- [x] Captures the public-endpoint contract at the handler

## AI Disclosure

AI tool used: Claude (this PR was authored by the J agent in the Multica workspace).