### PR TITLE
fix(execenv): inject AGENTS.md for hermes provider

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -455,6 +455,40 @@ func TestInjectRuntimeConfigCodex(t *testing.T) {
 	}
 }
 
+func TestInjectRuntimeConfigHermes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID:           "test-issue-id",
+		AgentName:         "Hermes Agent",
+		AgentInstructions: "Communication style: /caveman full.",
+		AgentSkills:       []SkillContextForEnv{{Name: "Coding", Content: "Write good code."}},
+	}
+
+	if err := InjectRuntimeConfig(dir, "hermes", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("failed to read AGENTS.md: %v", err)
+	}
+
+	s := string(content)
+	for _, want := range []string{
+		"Multica Agent Runtime",
+		"Hermes Agent",
+		"Communication style: /caveman full.",
+		"Coding",
+		".agent_context/skills/",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("AGENTS.md missing %q", want)
+		}
+	}
+}
+
 func TestInjectRuntimeConfigNoSkills(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -25,7 +25,7 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error 
 	switch provider {
 	case "claude":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi":
+	case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "hermes":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)


### PR DESCRIPTION
## Summary
- add `hermes` to the `InjectRuntimeConfig` AGENTS.md provider list
- ensure Hermes task workdirs receive the same runtime identity/instruction file as other AGENTS-backed providers
- add a focused `execenv` test that verifies Hermes writes `AGENTS.md` with agent identity, agent instructions, and skill references

## Why
Hermes task runs were getting the generic Multica task prompt, but not the Multica agent instructions layer, because `InjectRuntimeConfig` fell through the default case for the `hermes` provider and skipped writing `AGENTS.md` to the workdir.

That meant Hermes never got the workdir-level file context that its prompt builder reads from cwd.

## Test Plan
- `go test ./internal/daemon/execenv`

## Notes
- kept scope intentionally narrow to the Hermes instruction propagation path
- local main checkout was left untouched; work was done in a clean worktree off `origin/main`
