### PR TITLE
fix(desktop): expose search params from root navigation adapter

### DIFF
--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -114,18 +114,32 @@ export function DesktopNavigationProvider({
   // resolve the active router here only to subscribe once per tab switch.
   const { tabId: activeTabId } = useActiveTabIdentity();
   const router = useActiveTabRouter();
-  const [pathname, setPathname] = useState(
-    router?.state.location.pathname ?? "/",
+  // Mirror the active tab router's full location (pathname + search) so
+  // shell-level consumers of useNavigation() — ChatWindow in particular —
+  // can read URL search params. Must stay in sync with TabNavigationProvider
+  // below; a partial shape here (just pathname) silently broke focus-mode
+  // anchor resolution on `/inbox?issue=…`.
+  const [location, setLocation] = useState<{ pathname: string; search: string }>(
+    () => ({
+      pathname: router?.state.location.pathname ?? "/",
+      search: router?.state.location.search ?? "",
+    }),
   );
 
   useEffect(() => {
     if (!router) {
-      setPathname("/");
+      setLocation({ pathname: "/", search: "" });
       return;
     }
-    setPathname(router.state.location.pathname);
+    setLocation({
+      pathname: router.state.location.pathname,
+      search: router.state.location.search,
+    });
     return router.subscribe((state) => {
-      setPathname(state.location.pathname);
+      setLocation({
+        pathname: state.location.pathname,
+        search: state.location.search,
+      });
     });
   }, [activeTabId, router]);
 
@@ -150,8 +164,8 @@ export function DesktopNavigationProvider({
       back: () => {
         currentActiveTab()?.router.navigate(-1);
       },
-      pathname,
-      searchParams: new URLSearchParams(),
+      pathname: location.pathname,
+      searchParams: new URLSearchParams(location.search),
       openInNewTab: (path: string, title?: string) => {
         // Cross-workspace "open in new tab" switches workspace and opens
         // the path there; same-workspace just adds a tab in the current group.
@@ -167,7 +181,7 @@ export function DesktopNavigationProvider({
       },
       getShareableUrl: (path: string) => `${APP_URL}${path}`,
     }),
-    [pathname],
+    [location],
   );
 
   return <NavigationProvider value={adapter}>{children}</NavigationProvider>;


### PR DESCRIPTION
## Summary
- `DesktopNavigationProvider` (shell-root adapter) stubbed `searchParams` to an empty `URLSearchParams`, so any component mounted above the per-tab `TabNavigationProvider` read blanks from `useNavigation().searchParams`.
- Surfaced as a focus-mode bug: on `/inbox?issue=<id>`, `ChatWindow`'s `useRouteAnchorCandidate` couldn't see the selected inbox issue, so the Focus button stayed disabled.
- Fix: mirror the full `location` (pathname + search) from the active tab's router, matching the subscription pattern already used by `TabNavigationProvider` ~30 lines below in the same file.

## Why this only affected inbox focus
| Consumer of `searchParams` | Provider it reads from | Status |
|---|---|---|
| `InboxPage` (`packages/views/inbox/...`) | per-tab `TabNavigationProvider` | ✅ already correct |
| `ContextAnchor` inside `ChatWindow` | shell-root `DesktopNavigationProvider` | ❌ broken — this PR fixes it |

Web was unaffected (its adapter delegates to `useSearchParams()` from `next/navigation`). `/issues/:id` and `/projects/:id` focus on desktop weren't affected either — those derive from `pathname` alone, which was already tracked correctly.

## Test plan
- [x] `pnpm typecheck` — all 6 packages green
- [ ] Reviewer / manual: open desktop app → navigate to Inbox → click any notification → verify the Focus button in ChatFab/ChatWindow becomes active (currently disabled)
- [ ] Reviewer / manual: also spot-check `/issues/:id` and `/projects/:id` to confirm no regression

## Notes
- No unit test added. The fix is a literal copy of the subscription pattern used by `TabNavigationProvider` in the same file (which has been in production since the tabs refactor), and the mock surface required to exercise `DesktopNavigationProvider` in isolation (`useActiveTabRouter` + memory router + tab-store stub) is larger than the fix itself. Happy to add one if reviewer disagrees.
- No analytics added. Per `docs/analytics.md` governance (events must feed a named funnel/insight), focus-mode adoption didn't clear that bar for this PR. Separate discussion if we later want chat engagement analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)