### PR TITLE
fix(windows): suppress agent cmd windows + add per-agent local repo path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,3 +345,77 @@ All queries filter by `workspace_id`. Membership checks gate access. `X-Workspac
 ## Agent Assignees
 
 Assignees are polymorphic — can be a member or an agent. `assignee_type` + `assignee_id` on issues. Agents render with distinct styling (purple background, robot icon).
+
+---
+
+## Fork 专属上下文（WYQ425/multica）
+
+当前工作分支：`fix/windows-hide-windows-and-local-repo-path`
+
+### 部署状态
+
+- **自托管服务器**：GCP Linux，路径 `/opt/multica`
+  - 前端：https://multica.kiqq.top → localhost:3000
+  - 后端 API + WebSocket：https://multica-api.kiqq.top → localhost:8080
+  - 通过 Cloudflare Tunnel 暴露，`APP_ENV=development`，登录码 `888888`
+- **本地 Daemon**：Windows 本机，运行本 fork 编译的 `multica.exe`
+- **重新构建**：`make selfhost-build`（Docker Compose，自动跑 DB migration）
+
+### 已完成的改动
+
+**1. Windows Agent 弹窗修复**
+
+每次启动 Agent CLI 时 Windows 弹出可见 cmd 窗口的问题。
+
+- 新增 `server/pkg/agent/proc_windows.go`：`hideAgentWindow()` 设置 `HideWindow=true` + `CREATE_NO_WINDOW`
+- 新增 `server/pkg/agent/proc_other.go`：非 Windows 平台 no-op
+- 在所有 10 个 agent runner（claude, codex, copilot, cursor, gemini, hermes, kimi, openclaw, opencode, pi）的 `exec.CommandContext()` 后调用 `hideAgentWindow(cmd)`
+
+**2. Per-Agent 本地仓库路径（local_repo_path）**
+
+让每个 Agent 可以在前端 Settings 页面配置本地代码路径，Agent 执行时直接在该目录运行而不是创建隔离 workdir。
+
+已改动链路：
+- `server/migrations/057_agent_local_repo_path.up.sql` — DB 新增列
+- `server/pkg/db/queries/agent.sql` — UpdateAgent 查询加字段
+- `server/pkg/db/generated/models.go` — Agent struct 加 `LocalRepoPath pgtype.Text`
+- `server/pkg/db/generated/agent.sql.go` — **UpdateAgent** 的 const/params/scan 已更新（其余函数尚未更新，见下方 Bug）
+- `server/internal/handler/agent.go` — AgentResponse, UpdateAgentRequest, TaskAgentData 加字段
+- `server/internal/handler/daemon.go` — claim 接口填充 TaskAgentData.LocalRepoPath
+- `server/internal/daemon/types.go` — AgentData 加 LocalRepoPath
+- `server/internal/daemon/daemon.go` — 从 task.Agent.LocalRepoPath 传给 execenv
+- `server/internal/daemon/execenv/execenv.go` — PrepareParams 加 LocalRepoPath，Prepare() 支持跳过隔离目录
+- `packages/core/types/agent.ts` — Agent 和 UpdateAgentRequest 加 `local_repo_path?: string`
+- `packages/views/agents/components/tabs/settings-tab.tsx` — Settings Tab 加输入框（在 Model 下方）
+
+### 当前待修复的 Bug
+
+**Bug：切换页面后 local_repo_path 显示为空**
+
+现象：前端保存成功、数据库已有值，但导航离开再回来后输入框重置为空，Agent 执行时仍用默认隔离 workdir。
+
+根本原因：`server/pkg/db/generated/agent.sql.go` 中只有 `UpdateAgent` 函数的 `row.Scan()` 加了 `&i.LocalRepoPath`。其余所有返回 Agent 的函数（`GetAgent`, `ListAgents`, `ListAllAgents`, `GetAgentInWorkspace`, `CreateAgent`, `ArchiveAgent`, `RestoreAgent`, `ClearAgentMcpConfig`, `UpdateAgentStatus` 等）的 Scan 都没有加，导致读取时该字段始终为零值。
+
+**修复方法**：
+
+在 `server/pkg/db/generated/agent.sql.go` 里，找到**所有**包含 `&i.Model,` 的 Scan 调用，在其后加上 `&i.LocalRepoPath,`（已有的 UpdateAgent 处跳过，避免重复）。
+
+同时检查有显式 `RETURNING` 列表的 SQL const 字符串（非 `SELECT *` / `RETURNING *`），在末尾加 `local_repo_path`。
+
+验证：
+```bash
+# 修复后，LocalRepoPath 出现次数应等于返回 Agent 的函数数量
+grep -c "LocalRepoPath" server/pkg/db/generated/agent.sql.go
+
+# API 测试（替换为实际 agent ID 和 token）
+curl -s -H "Authorization: Bearer <token>" \
+  https://multica-api.kiqq.top/api/agents/<agent-id> | python3 -m json.tool | grep local_repo
+# 应返回之前设置的值，而不是空字符串
+```
+
+修复后重新构建：`make selfhost-build`
+
+### 上游 PR / Issue
+
+- PR #1548：https://github.com/multica-ai/multica/pull/1548（本次所有改动）
+- Issue #1521：https://github.com/multica-ai/multica/issues/1521（心跳检查弹窗，待修复）

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -62,6 +62,7 @@ export interface Agent {
   status: AgentStatus;
   max_concurrent_tasks: number;
   model: string;
+  local_repo_path: string;
   owner_id: string | null;
   skills: Skill[];
   created_at: string;
@@ -100,6 +101,7 @@ export interface UpdateAgentRequest {
   status?: AgentStatus;
   max_concurrent_tasks?: number;
   model?: string;
+  local_repo_path?: string;
 }
 
 // Skills

--- a/packages/views/agents/components/tabs/settings-tab.tsx
+++ b/packages/views/agents/components/tabs/settings-tab.tsx
@@ -46,6 +46,7 @@ export function SettingsTab({
   const [maxTasks, setMaxTasks] = useState(agent.max_concurrent_tasks);
   const [selectedRuntimeId, setSelectedRuntimeId] = useState(agent.runtime_id);
   const [model, setModel] = useState(agent.model ?? "");
+  const [localRepoPath, setLocalRepoPath] = useState(agent.local_repo_path ?? "");
   const [runtimeOpen, setRuntimeOpen] = useState(false);
   const [runtimeFilter, setRuntimeFilter] = useState<RuntimeFilter>("mine");
   const [saving, setSaving] = useState(false);
@@ -93,7 +94,8 @@ export function SettingsTab({
     visibility !== agent.visibility ||
     maxTasks !== agent.max_concurrent_tasks ||
     selectedRuntimeId !== agent.runtime_id ||
-    model !== (agent.model ?? "");
+    model !== (agent.model ?? "") ||
+    localRepoPath !== (agent.local_repo_path ?? "");
 
   const handleSave = async () => {
     if (!name.trim()) {
@@ -110,6 +112,7 @@ export function SettingsTab({
         max_concurrent_tasks: maxTasks,
         runtime_id: selectedRuntimeId,
         model,
+        local_repo_path: localRepoPath,
       });
       toast.success("Settings saved");
     } catch {
@@ -332,6 +335,20 @@ export function SettingsTab({
         onChange={setModel}
         disabled={!selectedRuntime}
       />
+
+      <div>
+        <Label className="text-xs text-muted-foreground">Local Repo Path</Label>
+        <p className="text-xs text-muted-foreground/70 mt-0.5 mb-1.5">
+          When set, the agent runs directly in this local directory instead of an isolated workspace.
+          Leave empty to use the default isolated workdir.
+        </p>
+        <Input
+          value={localRepoPath}
+          onChange={(e) => setLocalRepoPath(e.target.value)}
+          placeholder="e.g. C:\Users\you\projects\my-repo"
+          className="font-mono text-xs"
+        />
+      </div>
 
       <Button onClick={handleSave} disabled={!dirty || saving} size="sm">
         {saving ? <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" /> : <Save className="h-3.5 w-3.5 mr-1.5" />}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1070,6 +1070,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	}
 	if env == nil {
 		var err error
+		localRepoPath := ""
+		if task.Agent != nil && task.Agent.LocalRepoPath != "" {
+			localRepoPath = task.Agent.LocalRepoPath
+		}
 		env, err = execenv.Prepare(execenv.PrepareParams{
 			WorkspacesRoot: d.cfg.WorkspacesRoot,
 			WorkspaceID:    task.WorkspaceID,
@@ -1078,6 +1082,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 			Provider:       provider,
 			CodexVersion:   codexVersion,
 			Task:           taskCtx,
+			LocalRepoPath:  localRepoPath,
 		}, d.logger)
 		if err != nil {
 			return TaskResult{}, fmt.Errorf("prepare execution environment: %w", err)

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -27,6 +27,7 @@ type PrepareParams struct {
 	Provider       string            // agent provider ("claude", "codex") — determines skill injection paths
 	CodexVersion   string            // detected Codex CLI version (only used when Provider == "codex")
 	Task           TaskContextForEnv // context data for writing files
+	LocalRepoPath  string            // if set, agent runs directly in this local directory instead of an isolated workdir
 }
 
 // TaskContextForEnv is the subset of task context used for writing context files.
@@ -78,6 +79,25 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	}
 	if params.TaskID == "" {
 		return nil, fmt.Errorf("execenv: task ID is required")
+	}
+
+	// If LocalRepoPath is set, run the agent directly in that directory
+	// instead of creating an isolated workdir. Context files are still
+	// injected so skills and issue context are available.
+	if params.LocalRepoPath != "" {
+		if _, err := os.Stat(params.LocalRepoPath); err != nil {
+			return nil, fmt.Errorf("execenv: local repo path does not exist: %s", params.LocalRepoPath)
+		}
+		env := &Environment{
+			RootDir: params.LocalRepoPath,
+			WorkDir: params.LocalRepoPath,
+			logger:  logger,
+		}
+		if err := writeContextFiles(params.LocalRepoPath, params.Provider, params.Task); err != nil {
+			return nil, fmt.Errorf("execenv: write context files to local repo: %w", err)
+		}
+		logger.Info("execenv: using local repo path", "path", params.LocalRepoPath)
+		return env, nil
 	}
 
 	envRoot := filepath.Join(params.WorkspacesRoot, params.WorkspaceID, shortID(params.TaskID))

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -42,14 +42,15 @@ type Task struct {
 
 // AgentData holds agent details returned by the claim endpoint.
 type AgentData struct {
-	ID           string            `json:"id"`
-	Name         string            `json:"name"`
-	Instructions string            `json:"instructions"`
-	Skills       []SkillData       `json:"skills"`
-	CustomEnv    map[string]string `json:"custom_env,omitempty"`
-	CustomArgs   []string          `json:"custom_args,omitempty"`
-	McpConfig    json.RawMessage   `json:"mcp_config,omitempty"`
-	Model        string            `json:"model,omitempty"`
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Instructions  string            `json:"instructions"`
+	Skills        []SkillData       `json:"skills"`
+	CustomEnv     map[string]string `json:"custom_env,omitempty"`
+	CustomArgs    []string          `json:"custom_args,omitempty"`
+	McpConfig     json.RawMessage   `json:"mcp_config,omitempty"`
+	Model         string            `json:"model,omitempty"`
+	LocalRepoPath string            `json:"local_repo_path,omitempty"`
 }
 
 // SkillData represents a structured skill for task execution.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -34,6 +34,7 @@ type AgentResponse struct {
 	McpConfig          json.RawMessage   `json:"mcp_config"`
 	CustomEnvRedacted  bool              `json:"custom_env_redacted"`
 	McpConfigRedacted  bool              `json:"mcp_config_redacted"`
+	LocalRepoPath      string            `json:"local_repo_path"`
 	Visibility         string            `json:"visibility"`
 	Status             string            `json:"status"`
 	MaxConcurrentTasks int32             `json:"max_concurrent_tasks"`
@@ -93,6 +94,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		CustomEnv:          customEnv,
 		CustomArgs:         customArgs,
 		McpConfig:          mcpConfig,
+		LocalRepoPath:      a.LocalRepoPath.String,
 		Visibility:         a.Visibility,
 		Status:             a.Status,
 		MaxConcurrentTasks: a.MaxConcurrentTasks,
@@ -145,14 +147,15 @@ type AgentTaskResponse struct {
 // TaskAgentData holds agent info included in claim responses so the daemon
 // can set up the execution environment (branch naming, skill files, instructions).
 type TaskAgentData struct {
-	ID           string                   `json:"id"`
-	Name         string                   `json:"name"`
-	Instructions string                   `json:"instructions"`
-	Skills       []service.AgentSkillData `json:"skills,omitempty"`
-	CustomEnv    map[string]string        `json:"custom_env,omitempty"`
-	CustomArgs   []string                 `json:"custom_args,omitempty"`
-	McpConfig    json.RawMessage          `json:"mcp_config,omitempty"`
-	Model        string                   `json:"model,omitempty"`
+	ID            string                   `json:"id"`
+	Name          string                   `json:"name"`
+	Instructions  string                   `json:"instructions"`
+	Skills        []service.AgentSkillData `json:"skills,omitempty"`
+	CustomEnv     map[string]string        `json:"custom_env,omitempty"`
+	CustomArgs    []string                 `json:"custom_args,omitempty"`
+	McpConfig     json.RawMessage          `json:"mcp_config,omitempty"`
+	Model         string                   `json:"model,omitempty"`
+	LocalRepoPath string                   `json:"local_repo_path,omitempty"`
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
@@ -452,6 +455,7 @@ type UpdateAgentRequest struct {
 	Status             *string            `json:"status"`
 	MaxConcurrentTasks *int32             `json:"max_concurrent_tasks"`
 	Model              *string            `json:"model"`
+	LocalRepoPath      *string            `json:"local_repo_path"`
 }
 
 // canViewAgentEnv checks whether the requesting user is allowed to see the
@@ -576,6 +580,9 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Model != nil {
 		params.Model = pgtype.Text{String: *req.Model, Valid: true}
+	}
+	if req.LocalRepoPath != nil {
+		params.LocalRepoPath = pgtype.Text{String: *req.LocalRepoPath, Valid: true}
 	}
 
 	agent, err = h.Queries.UpdateAgent(r.Context(), params)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -636,14 +636,15 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			mcpConfig = json.RawMessage(agent.McpConfig)
 		}
 		resp.Agent = &TaskAgentData{
-			ID:           uuidToString(agent.ID),
-			Name:         agent.Name,
-			Instructions: agent.Instructions,
-			Skills:       skills,
-			CustomEnv:    customEnv,
-			CustomArgs:   customArgs,
-			McpConfig:    mcpConfig,
-			Model:        agent.Model.String,
+			ID:            uuidToString(agent.ID),
+			Name:          agent.Name,
+			Instructions:  agent.Instructions,
+			Skills:        skills,
+			CustomEnv:     customEnv,
+			CustomArgs:    customArgs,
+			McpConfig:     mcpConfig,
+			Model:         agent.Model.String,
+			LocalRepoPath: agent.LocalRepoPath.String,
 		}
 	}
 

--- a/server/migrations/057_agent_local_repo_path.down.sql
+++ b/server/migrations/057_agent_local_repo_path.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent DROP COLUMN IF EXISTS local_repo_path;

--- a/server/migrations/057_agent_local_repo_path.up.sql
+++ b/server/migrations/057_agent_local_repo_path.up.sql
@@ -1,0 +1,4 @@
+-- Adds a per-agent local repository path. When set, the daemon runs the agent
+-- directly in this directory instead of creating an isolated workdir.
+-- Useful for users who want the agent to operate on an existing local codebase.
+ALTER TABLE agent ADD COLUMN local_repo_path TEXT;

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -61,6 +61,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -101,6 +101,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	codexArgs := append([]string{"app-server", "--listen", "stdio://"}, filterCustomArgs(opts.CustomArgs, codexBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, codexArgs...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", codexArgs)
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/copilot.go
+++ b/server/pkg/agent/copilot.go
@@ -200,6 +200,7 @@ func (b *copilotBackend) Execute(ctx context.Context, prompt string, opts ExecOp
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -40,6 +40,7 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 20 * time.Second
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -37,6 +37,7 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -48,6 +48,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	hermesArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, hermesBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, hermesArgs...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", hermesArgs)
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -52,6 +52,7 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 	kimiArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, kimiBlockedArgs, b.cfg.Logger)...)
 	cmd := exec.CommandContext(runCtx, execPath, kimiArgs...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", kimiArgs)
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -54,6 +54,7 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -57,6 +57,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -56,6 +56,7 @@ func (b *piBackend) Execute(ctx context.Context, prompt string, opts ExecOptions
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
 	cmd.WaitDelay = 10 * time.Second
+	hideAgentWindow(cmd)
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}

--- a/server/pkg/agent/proc_other.go
+++ b/server/pkg/agent/proc_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package agent
+
+import "os/exec"
+
+// hideAgentWindow is a no-op on non-Windows platforms.
+func hideAgentWindow(cmd *exec.Cmd) {}

--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package agent
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// hideAgentWindow suppresses the console window that Windows creates when
+// spawning a child process. Without this, every agent invocation (claude,
+// codex, etc.) opens a visible cmd window that steals desktop focus.
+func hideAgentWindow(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: 0x08000000, // CREATE_NO_WINDOW
+	}
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1262,9 +1262,10 @@ UPDATE agent SET
     custom_args = COALESCE($13, custom_args),
     mcp_config = COALESCE($14, mcp_config),
     model = COALESCE($15, model),
+    local_repo_path = COALESCE($16, local_repo_path),
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model
+RETURNING id, workspace_id, name, avatar_url, runtime_mode, runtime_config, visibility, status, max_concurrent_tasks, owner_id, created_at, updated_at, description, runtime_id, instructions, archived_at, archived_by, custom_env, custom_args, mcp_config, model, local_repo_path
 `
 
 type UpdateAgentParams struct {
@@ -1283,6 +1284,7 @@ type UpdateAgentParams struct {
 	CustomArgs         []byte      `json:"custom_args"`
 	McpConfig          []byte      `json:"mcp_config"`
 	Model              pgtype.Text `json:"model"`
+	LocalRepoPath      pgtype.Text `json:"local_repo_path"`
 }
 
 func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent, error) {
@@ -1302,6 +1304,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		arg.CustomArgs,
 		arg.McpConfig,
 		arg.Model,
+		arg.LocalRepoPath,
 	)
 	var i Agent
 	err := row.Scan(
@@ -1326,6 +1329,7 @@ func (q *Queries) UpdateAgent(ctx context.Context, arg UpdateAgentParams) (Agent
 		&i.CustomArgs,
 		&i.McpConfig,
 		&i.Model,
+		&i.LocalRepoPath,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -41,6 +41,7 @@ type Agent struct {
 	CustomArgs         []byte             `json:"custom_args"`
 	McpConfig          []byte             `json:"mcp_config"`
 	Model              pgtype.Text        `json:"model"`
+	LocalRepoPath      pgtype.Text        `json:"local_repo_path"`
 }
 
 type AgentRuntime struct {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -40,6 +40,7 @@ UPDATE agent SET
     custom_args = COALESCE(sqlc.narg('custom_args'), custom_args),
     mcp_config = COALESCE(sqlc.narg('mcp_config'), mcp_config),
     model = COALESCE(sqlc.narg('model'), model),
+    local_repo_path = COALESCE(sqlc.narg('local_repo_path'), local_repo_path),
     updated_at = now()
 WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## Summary

Two related improvements for Windows users, submitted together since they share the same root area:

### 1. Fix: Agent cmd windows stealing focus on Windows (closes #1471, related to #1521)

Every agent invocation on Windows opens a visible `cmd` terminal window that steals desktop focus. Root cause: `exec.CommandContext()` calls in all agent runner files have no `SysProcAttr`, so Windows creates a console window for each process.

**Fix:** Add a platform-specific `hideAgentWindow(cmd)` helper:
- `proc_windows.go`: sets `HideWindow = true` and `CreationFlags = CREATE_NO_WINDOW (0x08000000)`
- `proc_other.go`: no-op stub for non-Windows platforms
- Called immediately after `exec.CommandContext()` in all 10 agent runners: claude, codex, copilot, cursor, gemini, hermes, kimi, openclaw, opencode, pi

This also suppresses the child processes that those agents spawn (e.g. `netstat`/`findstr` health checks from Claude Code), fixing the cascading window flicker described in #1521.

### 2. Feature: Per-agent local repo path (UI configurable)

Currently agents always run in an isolated workdir under `MULTICA_WORKSPACES_ROOT`. For users who want an agent to operate directly on an existing local codebase (without cloning), there was no way to configure this.

**Changes across all layers:**

| Layer | Change |
|-------|--------|
| DB | Migration `057`: `ALTER TABLE agent ADD COLUMN local_repo_path TEXT` |
| SQL/generated | `UpdateAgent` query + `UpdateAgentParams` + `Agent` model struct |
| API handler | `AgentResponse`, `UpdateAgentRequest`, `TaskAgentData` — all gain `local_repo_path` |
| Daemon claim | `local_repo_path` included in `TaskAgentData` returned by claim endpoint |
| Daemon exec | `daemon.go` reads `task.Agent.LocalRepoPath` → passes to `execenv.PrepareParams` |
| execenv | `Prepare()` skips isolated workdir creation when `LocalRepoPath` is set |
| Frontend types | `Agent` and `UpdateAgentRequest` interfaces gain `local_repo_path` |
| Frontend UI | Input field added to Agent Settings tab below Model dropdown |

When `local_repo_path` is empty (default), behaviour is identical to before.

## Testing

- `go vet ./server/pkg/agent/... ./server/internal/...` — passes clean
- Non-Windows: `proc_other.go` stub is a no-op, zero behavioural change
- Windows: agent processes no longer create visible console windows

Fixes #1471
Related to #1521