### PR TITLE
fix(agents): drop auto-loading Local Runtime Skills section from Skills tab

### DIFF
--- a/packages/views/agents/components/tabs/skills-tab.test.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.test.tsx
@@ -2,12 +2,10 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import type { Agent } from "@multica/core/types";
 
 const mockListSkills = vi.hoisted(() => vi.fn());
-const mockRuntimeListOptions = vi.hoisted(() => vi.fn());
-const mockRuntimeLocalSkillsOptions = vi.hoisted(() => vi.fn());
 
 vi.mock("@multica/core/hooks", () => ({
   useWorkspaceId: () => "ws-1",
@@ -18,12 +16,6 @@ vi.mock("@multica/core/api", () => ({
     listSkills: (...args: unknown[]) => mockListSkills(...args),
     setAgentSkills: vi.fn(),
   },
-}));
-
-vi.mock("@multica/core/runtimes", () => ({
-  runtimeListOptions: (...args: unknown[]) => mockRuntimeListOptions(...args),
-  runtimeLocalSkillsOptions: (...args: unknown[]) =>
-    mockRuntimeLocalSkillsOptions(...args),
 }));
 
 vi.mock("sonner", () => ({
@@ -79,61 +71,35 @@ function renderSkillsTab() {
 describe("SkillsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
     mockListSkills.mockResolvedValue([]);
-    mockRuntimeListOptions.mockReturnValue({
-      queryKey: ["runtimes", "ws-1", "list"],
-      queryFn: () =>
-        Promise.resolve([
-          {
-            id: "runtime-1",
-            workspace_id: "ws-1",
-            daemon_id: "daemon-1",
-            name: "Claude (MacBook)",
-            runtime_mode: "local",
-            provider: "claude",
-            launch_header: "",
-            status: "online",
-            device_info: "",
-            metadata: {},
-            owner_id: "user-1",
-            last_seen_at: null,
-            created_at: "2026-04-16T00:00:00Z",
-            updated_at: "2026-04-16T00:00:00Z",
-          },
-        ]),
-    });
-    mockRuntimeLocalSkillsOptions.mockReturnValue({
-      queryKey: ["runtimes", "local-skills", "runtime-1"],
-      queryFn: () =>
-        Promise.resolve({
-          supported: true,
-          skills: [
-            {
-              key: "review-helper",
-              name: "Review Helper",
-              description: "Review pull requests",
-              provider: "claude",
-              source_path: "~/.claude/skills/review-helper",
-              file_count: 2,
-            },
-          ],
-        }),
-    });
   });
 
-  it("shows runtime local skills for local agents", async () => {
+  it("does not render the inline Local Runtime Skills section even for local-runtime agents", async () => {
+    // The inline section auto-loaded local skills on every Skills-tab
+    // entry, which was both noisy and (under multi-replica deploys) prone
+    // to "request not found" because the request store is in-process.
+    // Local-skill import now lives behind the explicit Skills page →
+    // Add Skill → From Runtime tab; nothing here may auto-load.
     renderSkillsTab();
 
-    expect(await screen.findByText("Local Runtime Skills")).toBeInTheDocument();
-    expect(await screen.findByText("Review Helper")).toBeInTheDocument();
-    expect(screen.getByText("claude")).toBeInTheDocument();
-    expect(screen.getByText("~/.claude/skills/review-helper")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Import to Workspace/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Import From Runtime/i })).not.toBeInTheDocument();
+    // Top informational callout should still render; that's how we know
+    // the tab body itself rendered (not stuck in a loading state).
+    expect(
+      await screen.findByText(/Local runtime skills are always available/i),
+    ).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(mockRuntimeLocalSkillsOptions).toHaveBeenCalledWith("runtime-1");
-    });
+    // The removed section's heading and its trigger button must be gone.
+    expect(screen.queryByText("Local Runtime Skills")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Import to Workspace/i }),
+    ).not.toBeInTheDocument();
+
+    // No runtime list / local-skills query should be wired up either —
+    // we removed @multica/core/runtimes from this file's imports.
+    // Surface it via behaviour: the `agent` here has runtime_id but the
+    // tab must not invoke any runtime-list mock to render. (Both are
+    // already deleted from the mock setup above; this assertion is
+    // implicit — the test file would fail to import if the component
+    // still referenced runtimeListOptions / runtimeLocalSkillsOptions.)
   });
 });

--- a/packages/views/agents/components/tabs/skills-tab.tsx
+++ b/packages/views/agents/components/tabs/skills-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, FileText, Trash2, Info, Download, AlertCircle } from "lucide-react";
+import { Plus, FileText, Trash2, Info } from "lucide-react";
 import type { Agent } from "@multica/core/types";
 import {
   Dialog,
@@ -16,10 +16,7 @@ import { toast } from "sonner";
 import { api } from "@multica/core/api";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { skillListOptions, workspaceKeys } from "@multica/core/workspace/queries";
-import { runtimeListOptions, runtimeLocalSkillsOptions } from "@multica/core/runtimes";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { RuntimeLocalSkillImportDialog } from "../../../skills/components/runtime-local-skill-import-dialog";
-import { RuntimeLocalSkillRow } from "../../../skills/components/runtime-local-skill-row";
 
 export function SkillsTab({
   agent,
@@ -29,22 +26,11 @@ export function SkillsTab({
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   const { data: workspaceSkills = [] } = useQuery(skillListOptions(wsId));
-  const { data: runtimes = [] } = useQuery(runtimeListOptions(wsId));
   const [saving, setSaving] = useState(false);
   const [showPicker, setShowPicker] = useState(false);
-  const [showRuntimeImport, setShowRuntimeImport] = useState(false);
-  const [runtimeImportSkillKey, setRuntimeImportSkillKey] = useState<string | null>(null);
 
   const agentSkillIds = new Set(agent.skills.map((s) => s.id));
   const availableSkills = workspaceSkills.filter((s) => !agentSkillIds.has(s.id));
-  const runtime = runtimes.find((item) => item.id === agent.runtime_id);
-  const localSkillsQuery = useQuery({
-    ...runtimeLocalSkillsOptions(runtime?.id ?? null),
-    enabled:
-      agent.runtime_mode === "local" &&
-      !!runtime?.id &&
-      runtime.status === "online",
-  });
 
   const handleAdd = async (skillId: string) => {
     setSaving(true);
@@ -151,77 +137,6 @@ export function SkillsTab({
         </div>
       )}
 
-      {agent.runtime_mode === "local" && (
-        <div className="space-y-3 rounded-lg border p-4">
-          <div>
-            <h4 className="text-sm font-semibold">Local Runtime Skills</h4>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Browse local skills discovered from this runtime. They are read-only here until imported into the workspace.
-            </p>
-          </div>
-
-          {!runtime ? (
-            <div className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
-              Runtime details are unavailable for this agent right now.
-            </div>
-          ) : runtime.status !== "online" ? (
-            <div className="flex items-start gap-2 rounded-md bg-warning/10 px-3 py-2 text-xs text-muted-foreground">
-              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
-              Runtime must be online to browse local skills.
-            </div>
-          ) : localSkillsQuery.isLoading ? (
-            <div className="space-y-2">
-              {Array.from({ length: 2 }).map((_, index) => (
-                <div key={index} className="rounded-lg border px-4 py-3">
-                  <div className="h-4 w-36 rounded bg-muted" />
-                  <div className="mt-2 h-3 w-52 rounded bg-muted" />
-                </div>
-              ))}
-            </div>
-          ) : localSkillsQuery.error ? (
-            <div className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
-              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              {localSkillsQuery.error instanceof Error
-                ? localSkillsQuery.error.message
-                : "Failed to load runtime local skills"}
-            </div>
-          ) : !localSkillsQuery.data?.supported ? (
-            <div className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
-              This runtime provider does not expose local skill inventory yet.
-            </div>
-          ) : (localSkillsQuery.data.skills ?? []).length === 0 ? (
-            <div className="rounded-md border border-dashed px-4 py-8 text-center">
-              <p className="text-sm text-muted-foreground">No local skills found</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Add local skills to this runtime first, then import the ones you want to share.
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {(localSkillsQuery.data.skills ?? []).map((skill) => (
-                <RuntimeLocalSkillRow
-                  key={skill.key}
-                  skill={skill}
-                  action={
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      onClick={() => {
-                        setRuntimeImportSkillKey(skill.key);
-                        setShowRuntimeImport(true);
-                      }}
-                    >
-                      <Download className="h-3 w-3" />
-                      Import to Workspace
-                    </Button>
-                  }
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
       {/* Skill Picker Dialog */}
       {showPicker && (
         <Dialog open onOpenChange={(v) => { if (!v) setShowPicker(false); }}>
@@ -266,15 +181,6 @@ export function SkillsTab({
         </Dialog>
       )}
 
-      {showRuntimeImport && runtime && (
-        <RuntimeLocalSkillImportDialog
-          open={showRuntimeImport}
-          onClose={() => setShowRuntimeImport(false)}
-          fixedRuntimeId={runtime.id}
-          initialRuntimeId={runtime.id}
-          initialSkillKey={runtimeImportSkillKey}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Every visit to an agent's Skills tab fired `POST /api/runtimes/<id>/local-skills` followed by a polling `GET /local-skills/<requestId>`, which:

- **Noisy by default** — the inline section was rarely the user's reason for entering the tab; most enter it for workspace skills. Auto-loading on every entry was annoying per the team's testing.
- **Broken on the dev backend** right now: the runtime-local-skills request store is in-process (`server/internal/handler/runtime_local_skills.go:67-74` — plain `sync.Mutex` + `map`). With multiple replicas behind the LB, the polling `GET` frequently lands on a different replica than the `POST`, so the request lookup misses and the UI shows `request not found`. Protocol fix is being tracked separately; this PR stops the unsolicited polling.

## Change

`packages/views/agents/components/tabs/skills-tab.tsx`:

- Remove the entire `Local Runtime Skills` inline section (the runtime selector → skeleton → list flow).
- Remove the `runtimeLocalSkillsOptions` query that auto-fired on tab mount.
- Remove the per-row Import dialog mount + its state (`showRuntimeImport`, `runtimeImportSkillKey`).
- Drop now-unused imports: `RuntimeLocalSkillImportDialog`, `RuntimeLocalSkillRow`, `runtimeListOptions`, `runtimeLocalSkillsOptions`, `Download`, `AlertCircle`, and the `runtimes` query (it was only consumed by the removed block).

The blue informational callout at the top stays — still accurate: local runtime skills are auto-available to the agent, importing creates an editable workspace copy.

## Where the import flow lives now

Users who want to import a local skill go through the **Skills page → `+ Add Skill` → `From Runtime` tab** (added in #1480). Same backing dialog, same backing endpoint — the difference is the user explicitly opens it instead of the agent tab firing the request on every render.

## Test plan

- [x] `pnpm --filter @multica/views exec tsc --noEmit` — passes
- [ ] Manual: open an agent → Skills tab; no `request not found` error, no network call to `/local-skills` in DevTools, the section is gone.
- [ ] Manual: Skills page → `+ Add Skill` → `From Runtime` tab still works for importing a local skill.