### PR TITLE
fix(issues): stop expand button from covering text in comment/reply editors (MUL-1297)

### DIFF
--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -57,7 +57,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
     <div
       {...dropZoneProps}
       className={cn(
-        "relative flex flex-col rounded-lg bg-card pb-8 ring-1 ring-border",
+        "relative flex flex-col rounded-lg bg-card ring-1 ring-border",
         isExpanded ? "h-[70vh]" : "max-h-56",
       )}
     >
@@ -72,7 +72,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           currentIssueId={issueId}
         />
       </div>
-      <div className="absolute bottom-1 right-1.5 flex items-center gap-1">
+      <div className="flex items-center justify-end gap-1 px-1.5 pb-1">
         <Tooltip>
           <TooltipTrigger
             render={
@@ -82,9 +82,9 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
                   setIsExpanded((v) => !v);
                   editorRef.current?.focus();
                 }}
-                className="rounded-sm p-1.5 text-muted-foreground opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
+                className="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
               >
-                {isExpanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+                {isExpanded ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
               </button>
             }
           />

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useEffect, useCallback } from "react";
+import { useRef, useState, useCallback } from "react";
 import { ArrowUp, Loader2, Maximize2, Minimize2 } from "lucide-react";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
@@ -36,9 +36,7 @@ function ReplyInput({
   size = "default",
 }: ReplyInputProps) {
   const editorRef = useRef<ContentEditorRef>(null);
-  const measureRef = useRef<HTMLDivElement>(null);
   const [isEmpty, setIsEmpty] = useState(true);
-  const [hasOverflowContent, setHasOverflowContent] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const uploadMapRef = useRef<Map<string, string>>(new Map());
@@ -46,17 +44,6 @@ function ReplyInput({
   const { isDragOver, dropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => editorRef.current?.uploadFile(f)),
   });
-
-  useEffect(() => {
-    const el = measureRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (entry) setHasOverflowContent(entry.contentRect.height > 32);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
 
   const handleUpload = useCallback(async (file: File) => {
     const result = await uploadWithToast(file, { issueId });
@@ -102,23 +89,20 @@ function ReplyInput({
           isExpanded
             ? "h-[60vh]"
             : size === "sm" ? "max-h-40" : "max-h-56",
-          (hasOverflowContent || isExpanded) && "pb-7",
         )}
       >
-        <div className="flex-1 min-h-0 overflow-y-auto pr-14">
-          <div ref={measureRef}>
-            <ContentEditor
-              ref={editorRef}
-              placeholder={placeholder}
-              onUpdate={(md) => setIsEmpty(!md.trim())}
-              onSubmit={handleSubmit}
-              onUploadFile={handleUpload}
-              debounceMs={100}
-              currentIssueId={issueId}
-            />
-          </div>
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <ContentEditor
+            ref={editorRef}
+            placeholder={placeholder}
+            onUpdate={(md) => setIsEmpty(!md.trim())}
+            onSubmit={handleSubmit}
+            onUploadFile={handleUpload}
+            debounceMs={100}
+            currentIssueId={issueId}
+          />
         </div>
-        <div className="absolute bottom-0 right-0 flex items-center gap-1 text-muted-foreground transition-colors group-focus-within/editor:text-foreground">
+        <div className="flex items-center justify-end gap-1 text-muted-foreground transition-colors group-focus-within/editor:text-foreground">
           <Tooltip>
             <TooltipTrigger
               render={


### PR DESCRIPTION
## Summary

Fixes [MUL-1297](https://multica.ai) where the expand button visually overlaps the trailing characters of text in the comment/reply editors.

Root cause is architectural, not styling:

- The three trailing buttons (expand, attach, submit) were positioned `absolute` in the bottom-right of the editor.
- Space was "reserved" for them via `pr-14` (56px) on the scroll area — but the actual button row is 80px wide (3 × `h-6` + gap-1 × 2).
- The leftmost button (expand) sits in the 24px gap, directly on top of text that wraps near the right edge.

The fix restructures the button row as a regular flex sibling below the editor, so text and buttons can never overlap by construction:

- Remove `pr-14` magic padding from `reply-input.tsx`.
- Remove `pb-8` container padding from `comment-input.tsx`.
- Delete the `ResizeObserver` / `hasOverflowContent` state that toggled `pb-7` when content overflowed — no longer needed.
- Align the expand button in `comment-input.tsx` with the `reply-input.tsx` version (`h-6 w-6` + `h-3.5 w-3.5` icon) so both entry points match.

Net: +16 / −32 lines.

## Test plan

- [ ] Type a long single-line comment in both the inline reply and the main comment input — trailing text no longer sits behind the expand icon.
- [ ] Type multi-line content that overflows the editor — buttons stay below the scrollable area, text scrolls independently.
- [ ] Toggle expand/collapse on both editors — container resizes between `max-h-56` / `max-h-40` / `h-[70vh]` / `h-[60vh]` as before.
- [ ] Drag-and-drop a file onto both editors — `FileDropOverlay` still renders.
- [ ] Submit + attach both work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)