### PR TITLE
feat(help): mark external links with arrow, move Feedback last

### DIFF
--- a/packages/views/layout/help-launcher.tsx
+++ b/packages/views/layout/help-launcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, CircleHelp, History, MessageCircle } from "lucide-react";
+import { ArrowUpRight, BookOpen, CircleHelp, History, MessageCircle } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,12 +35,7 @@ export function HelpLauncher() {
         >
           <BookOpen className="h-3.5 w-3.5" />
           Docs
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => useModalStore.getState().open("feedback")}
-        >
-          <MessageCircle className="h-3.5 w-3.5" />
-          Feedback
+          <ArrowUpRight className="size-3 translate-y-px text-muted-foreground/50" />
         </DropdownMenuItem>
         <DropdownMenuItem
           render={
@@ -53,6 +48,13 @@ export function HelpLauncher() {
         >
           <History className="h-3.5 w-3.5" />
           Change log
+          <ArrowUpRight className="size-3 translate-y-px text-muted-foreground/50" />
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => useModalStore.getState().open("feedback")}
+        >
+          <MessageCircle className="h-3.5 w-3.5" />
+          Feedback
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
- Add `ArrowUpRight` glyph (size-3, muted/50, nudged 1px down for optical centering) after **Docs** and **Change log** in the Help launcher so users can tell at a glance that these open externally.
- Reorder the dropdown so **Feedback** (opens an in-app modal) sits at the bottom, below the two external links.

## Test plan
- [ ] Open the Help launcher (? icon in sidebar footer)
- [ ] Confirm Docs and Change log show a small ↗ arrow; Feedback does not
- [ ] Confirm Feedback is the last item
- [ ] Click Docs / Change log → opens in new tab
- [ ] Click Feedback → opens the in-app feedback modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)