### PR TITLE
fix(issues): restore compact single-line reply editor (MUL-1297 follow-up)

### DIFF
--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -57,7 +57,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
     <div
       {...dropZoneProps}
       className={cn(
-        "relative flex flex-col rounded-lg bg-card ring-1 ring-border",
+        "relative flex flex-col rounded-lg bg-card pb-8 ring-1 ring-border",
         isExpanded ? "h-[70vh]" : "max-h-56",
       )}
     >
@@ -72,7 +72,7 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           currentIssueId={issueId}
         />
       </div>
-      <div className="flex items-center justify-end gap-1 px-1.5 pb-1">
+      <div className="absolute bottom-1 right-1.5 flex items-center gap-1">
         <Tooltip>
           <TooltipTrigger
             render={
@@ -82,9 +82,9 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
                   setIsExpanded((v) => !v);
                   editorRef.current?.focus();
                 }}
-                className="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
+                className="rounded-sm p-1.5 text-muted-foreground opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
               >
-                {isExpanded ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+                {isExpanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
               </button>
             }
           />

--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -89,6 +89,7 @@ function ReplyInput({
           isExpanded
             ? "h-[60vh]"
             : size === "sm" ? "max-h-40" : "max-h-56",
+          (!isEmpty || isExpanded) && "pb-7",
         )}
       >
         <div className="flex-1 min-h-0 overflow-y-auto">
@@ -102,7 +103,7 @@ function ReplyInput({
             currentIssueId={issueId}
           />
         </div>
-        <div className="flex items-center justify-end gap-1 text-muted-foreground transition-colors group-focus-within/editor:text-foreground">
+        <div className="absolute bottom-0 right-0 flex items-center gap-1 text-muted-foreground transition-colors group-focus-within/editor:text-foreground">
           <Tooltip>
             <TooltipTrigger
               render={


### PR DESCRIPTION
## Summary

Follow-up to #1558. The prior PR fixed the expand button overlapping trailing text, but inadvertently collapsed the reply editor's original **"empty = 1 line, has content = 2 lines"** behavior — because the button row was moved from `absolute` to a permanent flex sibling below the editor, it now always reserves its own vertical space.

This PR restores the compact single-line feel without reintroducing the overlap bug:

- **`comment-input.tsx`**: back to pre-#1558 layout (`pb-8` container + `absolute bottom-1 right-1.5` buttons). This editor never had the overlap bug in the first place — its buttons lived in the permanent `pb-8` strip, so the "structural" refactor was unnecessary.
- **`reply-input.tsx`**: buttons back to `absolute bottom-0 right-0`. A new single-line `(!isEmpty || isExpanded) && "pb-7"` gate drives the "1 row ↔ 2 rows" transition:
  - Empty → no `pb-7`, editor is a compact 1-line input with buttons overlaying the empty right side.
  - Any content typed → `pb-7` kicks in, buttons fall into the 28px bottom strip, text occupies the full width above — no overlap possible by construction.
  - Cleared or submitted → `setIsEmpty(true)` resets back to the compact 1-line form.

Net diff: +6 / −5 lines.

## Test plan

- [ ] Inline reply: empty state shows a single-line input with buttons on the right.
- [ ] Type any character → editor instantly grows to a 2-row layout (buttons below, text full width).
- [ ] Type a long line that wraps — trailing text is no longer covered by the expand icon.
- [ ] Submit or fully delete content → editor collapses back to the 1-line state.
- [ ] Main comment input: `pb-8` + absolute buttons render as before #1558, with no overlap.
- [ ] Toggle expand/collapse on both editors — container sizes between `max-h-56` / `max-h-40` / `h-[70vh]` / `h-[60vh]` as before.
- [ ] Drag-and-drop + file attach + submit all behave unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)