### PR TITLE
fix(issues): keep reply editor expand icon muted on focus

### DIFF
--- a/packages/views/issues/components/reply-input.tsx
+++ b/packages/views/issues/components/reply-input.tsx
@@ -103,7 +103,7 @@ function ReplyInput({
             currentIssueId={issueId}
           />
         </div>
-        <div className="absolute bottom-0 right-0 flex items-center gap-1 text-muted-foreground transition-colors group-focus-within/editor:text-foreground">
+        <div className="absolute bottom-0 right-0 flex items-center gap-1">
           <Tooltip>
             <TooltipTrigger
               render={
@@ -113,7 +113,7 @@ function ReplyInput({
                     setIsExpanded((v) => !v);
                     editorRef.current?.focus();
                   }}
-                  className="inline-flex h-6 w-6 items-center justify-center rounded-sm opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
+                  className="inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground opacity-70 hover:opacity-100 hover:bg-accent/60 transition-all cursor-pointer"
                 >
                   {isExpanded ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
                 </button>


### PR DESCRIPTION
## Summary

The expand icon in `reply-input.tsx` relied on the parent button row's inherited color (`text-muted-foreground` + `group-focus-within/editor:text-foreground`). The moment the editor was focused, the expand icon flipped to `text-foreground`, while the attach and submit icons — which set `text-muted-foreground` on themselves — stayed muted.

Our convention for this editor's icon buttons is **default muted**, and the other two already follow it. Expand was the odd one out.

Fix: give expand its own `text-muted-foreground` class, and drop the now-unused color + transition classes from the button row container (no remaining children depend on them).

## Test plan

- [ ] Focus the inline reply editor — expand icon stays muted (same shade as the attach / paperclip icon).
- [ ] Hover the expand icon — it still brightens to full opacity and shows the accent background (hover styling unchanged).
- [ ] Click to toggle expand / collapse — state switching works; color remains muted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)