### PR TITLE
fix(runtimes): fix dark mode chart visibility and invalid CSS color syntax

### DIFF
--- a/apps/web/features/landing/components/features-section.tsx
+++ b/apps/web/features/landing/components/features-section.tsx
@@ -701,14 +701,9 @@ const mockUsageData = USAGE_SEEDS.map((s, i) => ({
 
 /* Heatmap color helper — same as real ActivityHeatmap */
 function getHeatmapColor(level: number): string {
-  const colors = [
-    "var(--color-muted, hsl(var(--muted)))",
-    "hsl(var(--chart-3) / 0.3)",
-    "hsl(var(--chart-3) / 0.5)",
-    "hsl(var(--chart-3) / 0.75)",
-    "hsl(var(--chart-3) / 1)",
-  ];
-  return colors[level] ?? colors[0]!;
+  if (level === 0) return "var(--color-muted)";
+  const opacities = ["25%", "45%", "68%", "90%"];
+  return `color-mix(in oklch, var(--color-foreground) ${opacities[level - 1]}, transparent)`;
 }
 
 /* Generate heatmap cells — simplified version of real ActivityHeatmap */
@@ -766,7 +761,7 @@ function DailyCostBars({ data }: { data: typeof mockUsageData }) {
             width={8}
             height={Math.max(h, 2)}
             rx={1}
-            fill="hsl(var(--chart-1))"
+            fill="var(--color-chart-1)"
           />
         );
       })}

--- a/packages/ui/styles/tokens.css
+++ b/packages/ui/styles/tokens.css
@@ -115,10 +115,10 @@
     --input: oklch(1 0 0 / 15%);
     --ring: oklch(0.552 0.016 285.938);
     --chart-1: oklch(0.871 0.006 286.286);
-    --chart-2: oklch(0.552 0.016 285.938);
-    --chart-3: oklch(0.442 0.017 285.786);
-    --chart-4: oklch(0.37 0.013 285.805);
-    --chart-5: oklch(0.274 0.006 286.033);
+    --chart-2: oklch(0.75 0.016 285.938);
+    --chart-3: oklch(0.62 0.017 285.786);
+    --chart-4: oklch(0.52 0.013 285.805);
+    --chart-5: oklch(0.42 0.006 286.033);
     --sidebar: oklch(0.21 0.006 285.885);
     --sidebar-foreground: oklch(0.985 0 0);
     --sidebar-primary: oklch(0.488 0.243 264.376);

--- a/packages/views/runtimes/components/charts/activity-heatmap.tsx
+++ b/packages/views/runtimes/components/charts/activity-heatmap.tsx
@@ -8,14 +8,9 @@ const CELL_GAP = 2;
 const DAY_LABELS = ["", "Mon", "", "Wed", "", "Fri", ""];
 
 function getHeatmapColor(level: number): string {
-  const colors = [
-    "var(--color-muted, hsl(var(--muted)))",
-    "hsl(var(--chart-3) / 0.3)",
-    "hsl(var(--chart-3) / 0.5)",
-    "hsl(var(--chart-3) / 0.75)",
-    "hsl(var(--chart-3) / 1)",
-  ];
-  return colors[level] ?? colors[0]!;
+  if (level === 0) return "var(--color-muted)";
+  const opacities = ["25%", "45%", "68%", "90%"];
+  return `color-mix(in oklch, var(--color-foreground) ${opacities[level - 1]}, transparent)`;
 }
 
 export function ActivityHeatmap({ usage }: { usage: RuntimeUsage[] }) {

--- a/packages/views/runtimes/components/charts/daily-cost-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-cost-chart.tsx
@@ -14,7 +14,7 @@ import {
 import type { DailyCostData } from "../../utils";
 
 const costChartConfig = {
-  cost: { label: "Cost", color: "hsl(var(--chart-1))" },
+  cost: { label: "Cost", color: "var(--color-chart-1)" },
 } satisfies ChartConfig;
 
 export function DailyCostChart({ data }: { data: DailyCostData[] }) {

--- a/packages/views/runtimes/components/charts/daily-token-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-token-chart.tsx
@@ -15,7 +15,7 @@ import type { DailyTokenData } from "../../utils";
 import { formatTokens } from "../../utils";
 
 const tokenChartConfig = {
-  total: { label: "Total", color: "hsl(var(--chart-1))" },
+  total: { label: "Total", color: "var(--color-chart-1)" },
 } satisfies ChartConfig;
 
 type DailyTokenRow = DailyTokenData & { total: number };

--- a/packages/views/runtimes/components/charts/hourly-activity-chart.tsx
+++ b/packages/views/runtimes/components/charts/hourly-activity-chart.tsx
@@ -17,7 +17,7 @@ import { api } from "@multica/core/api";
 import type { RuntimeHourlyActivity } from "@multica/core/types";
 
 const hourlyChartConfig = {
-  count: { label: "Tasks", color: "hsl(var(--chart-2))" },
+  count: { label: "Tasks", color: "var(--color-chart-2)" },
 } satisfies ChartConfig;
 
 export function HourlyActivityChart({ runtimeId }: { runtimeId: string }) {

--- a/packages/views/runtimes/components/charts/model-distribution-chart.tsx
+++ b/packages/views/runtimes/components/charts/model-distribution-chart.tsx
@@ -9,11 +9,11 @@ import type { ModelDistribution } from "../../utils";
 import { formatTokens } from "../../utils";
 
 const MODEL_COLORS = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
+  "var(--color-chart-1)",
+  "var(--color-chart-2)",
+  "var(--color-chart-3)",
+  "var(--color-chart-4)",
+  "var(--color-chart-5)",
 ];
 
 export function ModelDistributionChart({ data }: { data: ModelDistribution[] }) {


### PR DESCRIPTION
All chart components used `hsl(var(--chart-X))` but `--chart-X` holds a full oklch value, not bare HSL components — making the expression
   invalid CSS. Browsers silently fell back to black, so bars/areas/heatmap cells were invisible against the dark background.

  - Replace `hsl(var(--chart-X))` with `var(--color-chart-X)` across all runtime chart components and the landing feature section
  - Fix heatmap opacity using `color-mix(in oklch, ...)` instead of the invalid `hsl(var(--chart-3) / 0.3)` syntax; switch to foreground
  color so cells blend with the neutral theme in both light and dark mode
  - Raise dark-mode chart-2 through chart-5 lightness values so they contrast clearly against the dark background

  ## What does this PR do?

  Fix chart elements being invisible in dark mode on the runtimes page and landing page.

  All chart components used `hsl(var(--chart-X))` which is invalid CSS — `--chart-X` stores a full oklch value, not bare HSL components.
  Browsers silently fell back to black, making bars/areas/heatmap cells invisible against the dark background. Switching to
  `var(--color-chart-X)` fixes the syntax. The heatmap opacity is also fixed using `color-mix(in oklch, ...)`. Dark-mode chart token
  lightness values are raised to ensure sufficient contrast.

  ## Related Issue

  Closes #

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Refactor / code improvement (no behavior change)
  - [ ] Documentation update
  - [ ] Tests (adding or improving test coverage)
  - [ ] CI / infrastructure

  ## Changes Made

  - `packages/ui/styles/tokens.css` — raise dark-mode chart-2 through chart-5 lightness for contrast
  - `packages/views/runtimes/components/charts/hourly-activity-chart.tsx` — fix color syntax
  - `packages/views/runtimes/components/charts/daily-token-chart.tsx` — fix color syntax
  - `packages/views/runtimes/components/charts/daily-cost-chart.tsx` — fix color syntax
  - `packages/views/runtimes/components/charts/model-distribution-chart.tsx` — fix color syntax
  - `packages/views/runtimes/components/charts/activity-heatmap.tsx` — fix opacity via color-mix, use foreground color
  - `apps/web/features/landing/components/features-section.tsx` — same heatmap fix

  ## How to Test

  1. Run `make dev`, switch to dark mode
  2. Open any workspace's `/runtimes` page and select a runtime
  3. Confirm the Activity heatmap shows visible light/dark gradient cells
  4. Confirm Hourly Distribution bars and Daily Token Usage area are clearly visible
  5. Switch back to light mode and confirm charts still render correctly

  ## Checklist

  - [x] I have included a thinking path that traces from project context to this change
  - [x] I have run tests locally and they pass
  - [ ] I have added or updated tests where applicable
  - [ ] If this change affects the UI, I have included before/after screenshots
  - [ ] I have updated relevant documentation to reflect my changes
  - [x] I have considered and documented any risks above
  - [ ] I will address all reviewer comments before requesting merge

  ## AI Disclosure

  **AI tool used:** Claude Code

  **Prompt / approach:**
  Reported the dark mode contrast issue via screenshot to Claude Code. It identified the root cause (invalid `hsl()` wrapping a full oklch
  value), fixed the CSS syntax across all 5 chart components and the landing demo, and updated the dark-mode design tokens for better
  contrast.

  ## Screenshots (optional)

  <!-- If applicable, add screenshots showing the change in action. -->
before：
<img width="1917" height="1236" alt="image" src="https://github.com/user-attachments/assets/093d7f28-82c6-466c-a8f0-dd9f49d9c485" />

after：
<img width="1908" height="1162" alt="image" src="https://github.com/user-attachments/assets/07337a6c-244a-4071-a903-30855da8f472" />
