### PR TITLE
feat(desktop): add right-click context menu with clipboard actions

### DIFF
--- a/apps/desktop/src/main/context-menu.ts
+++ b/apps/desktop/src/main/context-menu.ts
@@ -1,0 +1,33 @@
+import { BrowserWindow, Menu, MenuItem, type WebContents } from "electron";
+
+// Electron ships with no default right-click menu, so a user selecting text
+// in the renderer has no way to copy it. Mirror Chrome's minimal clipboard
+// menu using `roles`, which keeps i18n + accelerator handling native.
+export function installContextMenu(webContents: WebContents): void {
+  webContents.on("context-menu", (_event, params) => {
+    const { editFlags, selectionText, isEditable } = params;
+    const hasSelection = selectionText.trim().length > 0;
+
+    const menu = new Menu();
+
+    if (isEditable && editFlags.canCut) {
+      menu.append(new MenuItem({ role: "cut" }));
+    }
+    if (hasSelection && editFlags.canCopy) {
+      menu.append(new MenuItem({ role: "copy" }));
+    }
+    if (isEditable && editFlags.canPaste) {
+      menu.append(new MenuItem({ role: "paste" }));
+    }
+    if (isEditable && editFlags.canSelectAll) {
+      if (menu.items.length > 0) {
+        menu.append(new MenuItem({ type: "separator" }));
+      }
+      menu.append(new MenuItem({ role: "selectAll" }));
+    }
+
+    if (menu.items.length === 0) return;
+    const window = BrowserWindow.fromWebContents(webContents) ?? undefined;
+    menu.popup({ window });
+  });
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import fixPath from "fix-path";
 import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
 import { openExternalSafely } from "./external-url";
+import { installContextMenu } from "./context-menu";
 
 // Bundled icon used for dev-mode dock/taskbar branding. In production the
 // app bundle icon (from electron-builder) wins; this path is only consumed
@@ -108,6 +109,8 @@ function createWindow(): void {
     openExternalSafely(details.url);
     return { action: "deny" };
   });
+
+  installContextMenu(mainWindow.webContents);
 
   if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
     mainWindow.loadURL(process.env["ELECTRON_RENDERER_URL"]);


### PR DESCRIPTION
## Summary
- Electron ships with no default right-click menu, so selected text had no way to be copied via mouse
- Adds a minimal native context menu (Cut / Copy / Paste / Select All) wired up via `webContents.on('context-menu')`, gated by `editFlags` so items only appear when usable

Closes [MUL-1095](https://multica.ai/i/7645897a-fbaa-40f8-9ed0-b236914a578e)

## Test plan
- [ ] In dev, select some text in any view and right-click → "Copy" appears and copies to clipboard
- [ ] Right-click inside an input/textarea → Cut/Copy/Paste/Select All appear as appropriate
- [ ] Right-click on a plain area (no selection, not editable) → no menu appears