### PR TITLE
feat(agents): show profile card on agent avatar hover

### DIFF
--- a/packages/views/agents/components/agent-detail.tsx
+++ b/packages/views/agents/components/agent-detail.tsx
@@ -92,7 +92,7 @@ export function AgentDetail({
 
       {/* Header */}
       <div className="flex h-12 shrink-0 items-center gap-3 border-b px-4">
-        <ActorAvatar actorType="agent" actorId={agent.id} size={28} className={`rounded-md ${isArchived ? "opacity-50" : ""}`} />
+        <ActorAvatar actorType="agent" actorId={agent.id} size={28} className={`rounded-md ${isArchived ? "opacity-50" : ""}`} disableHoverCard />
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <h2 className={`text-sm font-semibold truncate ${isArchived ? "text-muted-foreground" : ""}`}>{agent.name}</h2>

--- a/packages/views/agents/components/agent-list-item.tsx
+++ b/packages/views/agents/components/agent-list-item.tsx
@@ -24,7 +24,7 @@ export function AgentListItem({
         isSelected ? "bg-accent" : "hover:bg-accent/50"
       }`}
     >
-      <ActorAvatar actorType="agent" actorId={agent.id} size={32} className={`rounded-lg ${isArchived ? "opacity-50 grayscale" : ""}`} />
+      <ActorAvatar actorType="agent" actorId={agent.id} size={32} className={`rounded-lg ${isArchived ? "opacity-50 grayscale" : ""}`} disableHoverCard />
 
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">

--- a/packages/views/agents/components/agent-profile-card.tsx
+++ b/packages/views/agents/components/agent-profile-card.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { Cloud, Monitor, Wifi, WifiOff } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import type { Agent, AgentRuntime } from "@multica/core/types";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { agentListOptions, memberListOptions } from "@multica/core/workspace/queries";
+import { runtimeListOptions } from "@multica/core/runtimes/queries";
+import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { statusConfig } from "../config";
+import { formatLastSeen } from "../../runtimes/utils";
+
+interface AgentProfileCardProps {
+  agentId: string;
+}
+
+export function AgentProfileCard({ agentId }: AgentProfileCardProps) {
+  const wsId = useWorkspaceId();
+  const { data: agents = [], isLoading: agentsLoading } = useQuery(agentListOptions(wsId));
+  const { data: runtimes = [] } = useQuery(runtimeListOptions(wsId));
+  const { data: members = [] } = useQuery(memberListOptions(wsId));
+
+  const agent = agents.find((a) => a.id === agentId);
+
+  if (agentsLoading && !agent) {
+    return (
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-full" />
+        <div className="flex-1 space-y-1.5">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!agent) {
+    return (
+      <div className="text-xs text-muted-foreground">Agent unavailable</div>
+    );
+  }
+
+  const runtime = runtimes.find((r) => r.id === agent.runtime_id) ?? null;
+  const owner = agent.owner_id
+    ? members.find((m) => m.user_id === agent.owner_id) ?? null
+    : null;
+  const isArchived = !!agent.archived_at;
+  const initials = agent.name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+
+  return (
+    <div className="flex flex-col gap-3 text-left">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <ActorAvatarBase
+          name={agent.name}
+          initials={initials}
+          avatarUrl={agent.avatar_url}
+          isAgent
+          size={40}
+          className="rounded-md"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <p className="truncate text-sm font-semibold">{agent.name}</p>
+            {isArchived && (
+              <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                Archived
+              </span>
+            )}
+          </div>
+          <AgentStatusLine agent={agent} />
+        </div>
+      </div>
+
+      {/* Description */}
+      {agent.description && (
+        <p className="line-clamp-2 text-xs text-muted-foreground">
+          {agent.description}
+        </p>
+      )}
+
+      {/* Meta rows */}
+      <div className="flex flex-col gap-1.5 text-xs">
+        <RuntimeRow agent={agent} runtime={runtime} />
+        {agent.model && <MetaRow label="Model" value={agent.model} mono />}
+        {agent.skills.length > 0 && (
+          <SkillsRow skills={agent.skills.map((s) => s.name)} />
+        )}
+        {owner && <MetaRow label="Owner" value={owner.name} />}
+      </div>
+    </div>
+  );
+}
+
+function AgentStatusLine({ agent }: { agent: Agent }) {
+  const st = statusConfig[agent.status];
+  return (
+    <div className="mt-0.5 flex items-center gap-1.5">
+      <span className={`h-1.5 w-1.5 rounded-full ${st.dot}`} />
+      <span className={`text-xs ${st.color}`}>{st.label}</span>
+    </div>
+  );
+}
+
+function RuntimeRow({
+  agent,
+  runtime,
+}: {
+  agent: Agent;
+  runtime: AgentRuntime | null;
+}) {
+  const isCloud = agent.runtime_mode === "cloud";
+  const Icon = isCloud ? Cloud : Monitor;
+  const isOnline = runtime?.status === "online";
+  // Cloud runtimes are always reachable from the user's perspective.
+  const showOnline = isCloud || isOnline;
+
+  let detail: string;
+  if (isCloud) {
+    detail = runtime?.name ?? "Cloud";
+  } else if (runtime) {
+    detail = isOnline
+      ? runtime.name
+      : `${runtime.name} · last seen ${formatLastSeen(runtime.last_seen_at)}`;
+  } else {
+    detail = "Unknown runtime";
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="w-12 shrink-0 text-muted-foreground">Runtime</span>
+      <Icon className="h-3 w-3 shrink-0 text-muted-foreground" />
+      <span className="truncate" title={detail}>
+        {detail}
+      </span>
+      {showOnline ? (
+        <Wifi className="ml-auto h-3 w-3 shrink-0 text-success" />
+      ) : (
+        <WifiOff className="ml-auto h-3 w-3 shrink-0 text-muted-foreground" />
+      )}
+    </div>
+  );
+}
+
+function MetaRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="w-12 shrink-0 text-muted-foreground">{label}</span>
+      <span className={`truncate ${mono ? "font-mono text-[11px]" : ""}`} title={value}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function SkillsRow({ skills }: { skills: string[] }) {
+  const visible = skills.slice(0, 3);
+  const overflow = skills.length - visible.length;
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="w-12 shrink-0 text-muted-foreground">Skills</span>
+      <div className="flex min-w-0 flex-wrap gap-1">
+        {visible.map((s) => (
+          <span
+            key={s}
+            className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+          >
+            {s}
+          </span>
+        ))}
+        {overflow > 0 && (
+          <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+            +{overflow}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/views/agents/components/tabs/settings-tab.tsx
+++ b/packages/views/agents/components/tabs/settings-tab.tsx
@@ -130,7 +130,7 @@ export function SettingsTab({
             onClick={() => fileInputRef.current?.click()}
             disabled={uploading}
           >
-            <ActorAvatar actorType="agent" actorId={agent.id} size={64} className="rounded-none" />
+            <ActorAvatar actorType="agent" actorId={agent.id} size={64} className="rounded-none" disableHoverCard />
             <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
               {uploading ? (
                 <Loader2 className="h-5 w-5 animate-spin text-white" />

--- a/packages/views/autopilots/components/pickers/agent-picker.tsx
+++ b/packages/views/autopilots/components/pickers/agent-picker.tsx
@@ -52,7 +52,7 @@ export function AgentPicker({
           <>
             {selected ? (
               <>
-                <ActorAvatar actorType="agent" actorId={selected.id} size={16} />
+                <ActorAvatar actorType="agent" actorId={selected.id} size={16} disableHoverCard />
                 <span className="truncate">{selected.name}</span>
               </>
             ) : (
@@ -77,7 +77,7 @@ export function AgentPicker({
               setOpen(false);
             }}
           >
-            <ActorAvatar actorType="agent" actorId={a.id} size={16} />
+            <ActorAvatar actorType="agent" actorId={a.id} size={16} disableHoverCard />
             <span className="truncate">{a.name}</span>
           </PickerItem>
         ))

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -43,7 +43,11 @@ export function ActorAvatar({
 
   return (
     <HoverCard>
-      <HoverCardTrigger render={<span />} className="inline-flex cursor-default">
+      <HoverCardTrigger
+        render={<span />}
+        tabIndex={0}
+        className="inline-flex rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
         {avatar}
       </HoverCardTrigger>
       <HoverCardContent align="start" className="w-72">

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import {
   HoverCard,
@@ -17,6 +18,9 @@ interface ActorAvatarProps {
   /** Disable the hover-card preview (e.g. when the avatar is itself the page subject). */
   disableHoverCard?: boolean;
 }
+
+const FOCUSABLE_ANCESTOR_SELECTOR =
+  'a[href], button:not([disabled]), [role="button"]:not([aria-disabled="true"]), [tabindex]:not([tabindex="-1"])';
 
 export function ActorAvatar({
   actorType,
@@ -41,17 +45,47 @@ export function ActorAvatar({
     return avatar;
   }
 
+  return <AgentAvatarHoverCard agentId={actorId}>{avatar}</AgentAvatarHoverCard>;
+}
+
+/**
+ * Wraps an agent avatar in a hover-card. The trigger is keyboard-focusable
+ * only when no focusable ancestor (link/button) already provides a tab stop —
+ * this prevents nested tabbable descendants and keyboard-nav bloat at sites
+ * where the avatar lives inside a row link or click target.
+ */
+function AgentAvatarHoverCard({
+  agentId,
+  children,
+}: {
+  agentId: string;
+  children: React.ReactNode;
+}) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [standalone, setStandalone] = useState(false);
+
+  useEffect(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const ancestor = el.parentElement?.closest(FOCUSABLE_ANCESTOR_SELECTOR);
+    setStandalone(!ancestor);
+  }, []);
+
   return (
     <HoverCard>
       <HoverCardTrigger
-        render={<span />}
-        tabIndex={0}
-        className="inline-flex rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        render={<span ref={triggerRef} />}
+        tabIndex={standalone ? 0 : -1}
+        className={
+          standalone
+            ? "inline-flex rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            : "inline-flex"
+        }
       >
-        {avatar}
+        {children}
       </HoverCardTrigger>
       <HoverCardContent align="start" className="w-72">
-        <AgentProfileCard agentId={actorId} />
+        <AgentProfileCard agentId={agentId} />
       </HoverCardContent>
     </HoverCard>
   );

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -1,18 +1,32 @@
 "use client";
 
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from "@multica/ui/components/ui/hover-card";
 import { useActorName } from "@multica/core/workspace/hooks";
+import { AgentProfileCard } from "../agents/components/agent-profile-card";
 
 interface ActorAvatarProps {
   actorType: string;
   actorId: string;
   size?: number;
   className?: string;
+  /** Disable the hover-card preview (e.g. when the avatar is itself the page subject). */
+  disableHoverCard?: boolean;
 }
 
-export function ActorAvatar({ actorType, actorId, size, className }: ActorAvatarProps) {
+export function ActorAvatar({
+  actorType,
+  actorId,
+  size,
+  className,
+  disableHoverCard,
+}: ActorAvatarProps) {
   const { getActorName, getActorInitials, getActorAvatarUrl } = useActorName();
-  return (
+  const avatar = (
     <ActorAvatarBase
       name={getActorName(actorType, actorId)}
       initials={getActorInitials(actorType, actorId)}
@@ -21,5 +35,20 @@ export function ActorAvatar({ actorType, actorId, size, className }: ActorAvatar
       size={size}
       className={className}
     />
+  );
+
+  if (disableHoverCard || actorType !== "agent") {
+    return avatar;
+  }
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger render={<span />} className="inline-flex cursor-default">
+        {avatar}
+      </HoverCardTrigger>
+      <HoverCardContent align="start" className="w-72">
+        <AgentProfileCard agentId={actorId} />
+      </HoverCardContent>
+    </HoverCard>
   );
 }

--- a/packages/views/issues/components/pickers/assignee-picker.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.tsx
@@ -99,7 +99,7 @@ export function AssigneePicker({
       trigger={
         customTrigger ? customTrigger : assigneeType && assigneeId ? (
           <>
-            <ActorAvatar actorType={assigneeType} actorId={assigneeId} size={18} />
+            <ActorAvatar actorType={assigneeType} actorId={assigneeId} size={18} disableHoverCard />
             <span className="truncate">{triggerLabel}</span>
           </>
         ) : (
@@ -162,7 +162,7 @@ export function AssigneePicker({
                   setOpen(false);
                 }}
               >
-                <ActorAvatar actorType="agent" actorId={a.id} size={18} />
+                <ActorAvatar actorType="agent" actorId={a.id} size={18} disableHoverCard />
                 <span className={allowed ? "" : "text-muted-foreground"}>{a.name}</span>
                 {a.visibility === "private" && (
                   <Lock className="ml-auto h-3 w-3 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- Hovering an agent avatar opens a preview card with name, agent status, runtime mode + online/offline, last-seen, model, skills (top 3 + overflow), and owner.
- Implemented in a new shared `AgentProfileCard` and wired through the `ActorAvatar` views wrapper, so every render site (issue lists, comments, inbox, board cards, autopilots, mention surfaces, etc.) automatically gets it.
- Opted out in pickers (assignee, agent picker) and the agent's own detail-header avatar to avoid redundant cards or conflicts with click-to-select.

Closes [MUL-1321](mention://issue/ef43d7f4-7d23-4018-8367-451c3a0bba61).

## Test plan
- [ ] Hover an agent avatar in an issue list / comment author / inbox item — card appears with the right fields.
- [ ] Hover an agent whose runtime is local + online → green Wifi icon, runtime name shown.
- [ ] Hover an agent whose local runtime is offline → grey WifiOff icon and "last seen Xm ago".
- [ ] Hover a cloud-runtime agent → Cloud icon, no last-seen.
- [ ] Hover the avatar inside the assignee picker / agent picker — no card shown (opt-out preserved).
- [ ] Hover the avatar in the agent detail header — no card shown.