### PR TITLE
fix(chat): prevent chatbox jump when sending first message

### DIFF
--- a/packages/views/chat/components/chat-page.tsx
+++ b/packages/views/chat/components/chat-page.tsx
@@ -256,12 +256,7 @@ export function ChatPage() {
           <EmptyState agentName={activeAgent?.name} onPickPrompt={handleSend} />
         )}
 
-        <div
-          className={cn(
-            "mx-auto w-full max-w-3xl pb-4",
-            hasMessages ? "" : "pb-8",
-          )}
-        >
+        <div className="mx-auto w-full max-w-3xl pb-4">
           <ChatInput
             onSend={handleSend}
             onStop={handleStop}


### PR DESCRIPTION
## Summary
- The ChatInput wrapper in `chat-page.tsx` toggled bottom padding between `pb-8` (empty state) and `pb-4` (has messages). The moment `hasMessages` flipped after the user sent the first message, the input visibly jumped down by 16px.
- `EmptyState` already centers itself inside the `flex-1` region above the input, so the extra padding isn't needed to push the input up. Collapsed to a single `pb-4` so the input stays put across the transition.

Fixes [MUL-1331](mention://issue/418619fd-1201-4ec6-9787-32c4240fd12d).

## Test plan
- [ ] Open Chat tab with no active session (empty state); verify input sits where it does today.
- [ ] Type a message and press Enter; verify the input does NOT shift vertically when the message list appears.
- [ ] Switch back to "New chat" and repeat with a starter prompt click.