### PR TITLE
feat(cli): add --instructions-file flag to agent update

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -124,6 +124,7 @@ func init() {
 	agentUpdateCmd.Flags().String("name", "", "New name")
 	agentUpdateCmd.Flags().String("description", "", "New description")
 	agentUpdateCmd.Flags().String("instructions", "", "New instructions")
+	agentUpdateCmd.Flags().String("instructions-file", "", "Path to a file containing the new instructions (mutually exclusive with --instructions)")
 	agentUpdateCmd.Flags().String("runtime-id", "", "New runtime ID")
 	agentUpdateCmd.Flags().String("runtime-config", "", "New runtime config as JSON string")
 	agentUpdateCmd.Flags().String("model", "", "New model identifier. Pass an empty string to clear and fall back to the runtime default.")
@@ -413,9 +414,20 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("description")
 		body["description"] = v
 	}
+	if cmd.Flags().Changed("instructions") && cmd.Flags().Changed("instructions-file") {
+		return fmt.Errorf("--instructions and --instructions-file are mutually exclusive")
+	}
 	if cmd.Flags().Changed("instructions") {
 		v, _ := cmd.Flags().GetString("instructions")
 		body["instructions"] = v
+	}
+	if cmd.Flags().Changed("instructions-file") {
+		path, _ := cmd.Flags().GetString("instructions-file")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("--instructions-file: %w", err)
+		}
+		body["instructions"] = string(data)
 	}
 	if cmd.Flags().Changed("runtime-id") {
 		v, _ := cmd.Flags().GetString("runtime-id")
@@ -455,7 +467,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --visibility, --status, or --max-concurrent-tasks")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --instructions-file, --runtime-id, --runtime-config, --model, --custom-args, --visibility, --status, or --max-concurrent-tasks")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/cli"
+	"github.com/spf13/cobra"
 )
 
 // TestResolveWorkspaceID_AgentContextSkipsConfig is a regression test for
@@ -82,3 +88,99 @@ func TestResolveWorkspaceID_AgentContextSkipsConfig(t *testing.T) {
 		}
 	})
 }
+
+// newUpdateCmd returns a fresh cobra.Command with all flags that runAgentUpdate
+// reads. The serverURL env var must be set by the caller via t.Setenv.
+func newUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.PersistentFlags().String("profile", "", "")
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("instructions", "", "")
+	cmd.Flags().String("instructions-file", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("runtime-config", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("custom-args", "", "")
+	cmd.Flags().String("visibility", "", "")
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().Int32("max-concurrent-tasks", 0, "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func TestAgentUpdate_InstructionsFile(t *testing.T) {
+	wantContent := "You are a helpful orchestrator agent.\nHandle all incoming tasks carefully."
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": "agent-1", "name": "Orchestrator"})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-test")
+
+	// Write instructions to a temp file.
+	dir := t.TempDir()
+	instrFile := filepath.Join(dir, "orchestrator.md")
+	if err := os.WriteFile(instrFile, []byte(wantContent), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	cmd := newUpdateCmd()
+	if err := cmd.Flags().Set("instructions-file", instrFile); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+
+	if err := runAgentUpdate(cmd, []string{"agent-1"}); err != nil {
+		t.Fatalf("runAgentUpdate: %v", err)
+	}
+
+	if got, ok := gotBody["instructions"].(string); !ok || got != wantContent {
+		t.Errorf("instructions = %q, want %q", gotBody["instructions"], wantContent)
+	}
+}
+
+func TestAgentUpdate_InstructionsFileMutuallyExclusive(t *testing.T) {
+	cmd := newUpdateCmd()
+	if err := cmd.Flags().Set("instructions", "inline text"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+	if err := cmd.Flags().Set("instructions-file", "/tmp/some-file.md"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+
+	err := runAgentUpdate(cmd, []string{"agent-1"})
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %q, want it to mention mutually exclusive", err.Error())
+	}
+}
+
+func TestAgentUpdate_InstructionsFileMissing(t *testing.T) {
+	t.Setenv("MULTICA_SERVER_URL", "http://localhost:9999")
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-test")
+
+	cmd := newUpdateCmd()
+	if err := cmd.Flags().Set("instructions-file", "/nonexistent/path/to/file.md"); err != nil {
+		t.Fatalf("set flag: %v", err)
+	}
+
+	err := runAgentUpdate(cmd, []string{"agent-1"})
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "--instructions-file") {
+		t.Errorf("error = %q, want it to mention --instructions-file", err.Error())
+	}
+}
+


### PR DESCRIPTION
## Summary

Adds `--instructions-file <path>` to `multica agent update` so the DB can be updated directly from a markdown file without shell substitution hacks.

**Motivation:** the [PersonalOS](https://github.com/chriscao99/personalos-poc) repo maintains `docs/agents/orchestrator.md` as the canonical source of truth for the Orchestrator agent's system prompt. Without this flag, syncing requires either manual UI edits or a bash wrapper that reads the file and pipes content via `--instructions`. This makes the native flag the clean solution.

## Changes

`server/cmd/multica/cmd_agent.go`:
- Registers `--instructions-file` flag on `agentUpdateCmd`
- Reads the file with `os.ReadFile` and sets `body["instructions"]`
- Returns an error if both `--instructions` and `--instructions-file` are set (mutually exclusive)
- Returns a readable error if the file is not found
- Updates the "no fields to update" error message to list the new flag

`server/cmd/multica/cmd_agent_test.go`:
- `TestAgentUpdate_InstructionsFile`: verifies file content is round-tripped to the API body
- `TestAgentUpdate_InstructionsFileMutuallyExclusive`: verifies both flags together return a clear error
- `TestAgentUpdate_InstructionsFileMissing`: verifies missing file returns a non-zero exit with readable message

## Usage

```sh
# Update by UUID
multica agent update e221c17c-0bf5-485b-9b7a-7cc35d6dd445 \
  --instructions-file docs/agents/orchestrator.md \
  --output json

# Or via CI after merge to main
multica agent update Orchestrator \
  --instructions-file docs/agents/orchestrator.md \
  --output json
```

## Test plan

- [x] `go test ./cmd/multica/...` passes (3 new tests, all green)
- [x] Built binary, verified end-to-end against live Multica instance
- [x] `multica agent update --help` shows the new flag with mutual-exclusion note
- [x] Invalid file path → non-zero exit, readable error
- [x] Both flags together → non-zero exit, "mutually exclusive" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)