### PR TITLE
feat(issues): right-click context menu + unified issue actions

### DIFF
--- a/packages/core/modals/store.ts
+++ b/packages/core/modals/store.ts
@@ -2,7 +2,16 @@
 
 import { create } from "zustand";
 
-type ModalType = "create-workspace" | "create-issue" | "create-project" | "feedback" | null;
+type ModalType =
+  | "create-workspace"
+  | "create-issue"
+  | "create-project"
+  | "feedback"
+  | "issue-set-parent"
+  | "issue-add-child"
+  | "issue-delete-confirm"
+  | "issue-backlog-agent-hint"
+  | null;
 
 interface ModalStore {
   modal: ModalType;

--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Issue } from "@multica/core/types";
+
+// ---------------------------------------------------------------------------
+// Mocks — same pattern as the issue-detail test suite.
+// ---------------------------------------------------------------------------
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+const mockOpenModal = vi.fn();
+vi.mock("@multica/core/modals", () => ({
+  useModalStore: Object.assign(
+    (selector?: any) => {
+      const state = { open: mockOpenModal };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ open: mockOpenModal }) },
+  ),
+}));
+
+const mockAuthState = { user: { id: "user-1" }, isAuthenticated: true };
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: Object.assign(
+    (selector?: any) => (selector ? selector(mockAuthState) : mockAuthState),
+    { getState: () => mockAuthState },
+  ),
+  registerAuthStore: vi.fn(),
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "members"],
+    queryFn: () =>
+      Promise.resolve([
+        { user_id: "user-1", name: "Test User", email: "t@t.com", role: "admin" },
+      ]),
+  }),
+  agentListOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "agents"],
+    queryFn: () => Promise.resolve([]),
+  }),
+}));
+
+vi.mock("@multica/core/pins", () => ({
+  pinListOptions: () => ({
+    queryKey: ["pins", "ws-1", "user-1"],
+    queryFn: () => Promise.resolve([]),
+  }),
+  useCreatePin: () => ({ mutate: vi.fn() }),
+  useDeletePin: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@multica/core/issues/mutations", () => ({
+  useUpdateIssue: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@multica/core/paths", async () => {
+  const actual = await vi.importActual<typeof import("@multica/core/paths")>(
+    "@multica/core/paths",
+  );
+  return {
+    ...actual,
+    useCurrentWorkspace: () => ({ id: "ws-1", name: "Test", slug: "test" }),
+    useWorkspacePaths: () => actual.paths.workspace("test"),
+  };
+});
+
+vi.mock("../../../navigation", () => ({
+  useNavigation: () => ({
+    push: vi.fn(),
+    pathname: "/test/issues/issue-1",
+    searchParams: new URLSearchParams(),
+    back: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../../common/actor-avatar", () => ({
+  ActorAvatar: ({ actorId }: any) => <span data-testid="actor">{actorId}</span>,
+}));
+
+// Import after mocks.
+import { IssueActionsDropdown } from "../issue-actions-dropdown";
+import { IssueActionsContextMenu } from "../issue-actions-context-menu";
+
+const mockIssue: Issue = {
+  id: "issue-1",
+  workspace_id: "ws-1",
+  number: 1,
+  identifier: "TES-1",
+  title: "Example",
+  description: null,
+  status: "todo",
+  priority: "medium",
+  assignee_type: null,
+  assignee_id: null,
+  creator_type: "member",
+  creator_id: "user-1",
+  parent_issue_id: null,
+  due_date: null,
+  project_id: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+} as Issue;
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  mockOpenModal.mockReset();
+});
+
+describe("IssueActionsDropdown", () => {
+  it("renders the top-level items when the trigger is clicked", async () => {
+    render(
+      wrap(
+        <IssueActionsDropdown
+          issue={mockIssue}
+          trigger={<button data-testid="trigger">Menu</button>}
+        />,
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("trigger"));
+
+    // Base UI portals the popup; role=menu lands on the popup wrapper.
+    expect(await screen.findByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Priority")).toBeInTheDocument();
+    expect(screen.getByText("Assignee")).toBeInTheDocument();
+    expect(screen.getByText("Due date")).toBeInTheDocument();
+    expect(screen.getByText("Create sub-issue")).toBeInTheDocument();
+    expect(screen.getByText("Set parent issue...")).toBeInTheDocument();
+    expect(screen.getByText("Add sub-issue...")).toBeInTheDocument();
+    expect(screen.getByText("Copy link")).toBeInTheDocument();
+    expect(screen.getByText("Delete issue")).toBeInTheDocument();
+  });
+
+  it("clicking Delete issue opens the delete-confirm modal", async () => {
+    render(
+      wrap(
+        <IssueActionsDropdown
+          issue={mockIssue}
+          trigger={<button data-testid="trigger">Menu</button>}
+          onDeletedNavigateTo="/test/issues"
+        />,
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("trigger"));
+    const del = await screen.findByText("Delete issue");
+    fireEvent.click(del);
+
+    expect(mockOpenModal).toHaveBeenCalledWith("issue-delete-confirm", {
+      issueId: "issue-1",
+      identifier: "TES-1",
+      onDeletedNavigateTo: "/test/issues",
+    });
+  });
+});
+
+describe("IssueActionsContextMenu", () => {
+  it("renders the menu when the wrapped element receives a contextmenu event", async () => {
+    render(
+      wrap(
+        <IssueActionsContextMenu issue={mockIssue}>
+          <div data-testid="row">Row</div>
+        </IssueActionsContextMenu>,
+      ),
+    );
+
+    fireEvent.contextMenu(screen.getByTestId("row"));
+
+    expect(await screen.findByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Delete issue")).toBeInTheDocument();
+  });
+});

--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -140,11 +140,13 @@ describe("IssueActionsDropdown", () => {
     expect(screen.getByText("Priority")).toBeInTheDocument();
     expect(screen.getByText("Assignee")).toBeInTheDocument();
     expect(screen.getByText("Due date")).toBeInTheDocument();
-    expect(screen.getByText("Create sub-issue")).toBeInTheDocument();
-    expect(screen.getByText("Set parent issue...")).toBeInTheDocument();
-    expect(screen.getByText("Add sub-issue...")).toBeInTheDocument();
     expect(screen.getByText("Copy link")).toBeInTheDocument();
+    expect(screen.getByText("More")).toBeInTheDocument();
     expect(screen.getByText("Delete issue")).toBeInTheDocument();
+    // Relationship actions are hidden inside the "More" submenu by default.
+    expect(screen.queryByText("Create sub-issue")).not.toBeInTheDocument();
+    expect(screen.queryByText("Set parent issue...")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add sub-issue...")).not.toBeInTheDocument();
   });
 
   it("clicking Delete issue opens the delete-confirm modal", async () => {

--- a/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
+++ b/packages/views/issues/actions/__tests__/use-issue-actions.test.tsx
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Issue } from "@multica/core/types";
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+const mockOpenModal = vi.fn();
+vi.mock("@multica/core/modals", () => ({
+  useModalStore: Object.assign(
+    (selector?: any) => {
+      const state = { open: mockOpenModal };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ open: mockOpenModal }) },
+  ),
+}));
+
+const mockAuthState = { user: { id: "user-1" }, isAuthenticated: true };
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: Object.assign(
+    (selector?: any) => (selector ? selector(mockAuthState) : mockAuthState),
+    { getState: () => mockAuthState },
+  ),
+  registerAuthStore: vi.fn(),
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "members"],
+    queryFn: () =>
+      Promise.resolve([
+        { user_id: "user-1", name: "Test User", email: "t@t.com", role: "admin" },
+      ]),
+  }),
+  agentListOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "agents"],
+    queryFn: () => Promise.resolve([]),
+  }),
+}));
+
+// Mutable so individual tests can seed the pin list.
+const pinListRef: { value: Array<{ item_type: string; item_id: string }> } = {
+  value: [],
+};
+const mockCreatePinMutate = vi.fn();
+const mockDeletePinMutate = vi.fn();
+vi.mock("@multica/core/pins", () => ({
+  pinListOptions: () => ({
+    queryKey: ["pins", "ws-1", "user-1"],
+    queryFn: () => Promise.resolve(pinListRef.value),
+  }),
+  useCreatePin: () => ({ mutate: mockCreatePinMutate }),
+  useDeletePin: () => ({ mutate: mockDeletePinMutate }),
+}));
+
+const mockUpdateMutate = vi.fn();
+vi.mock("@multica/core/issues/mutations", () => ({
+  useUpdateIssue: () => ({ mutate: mockUpdateMutate }),
+}));
+
+vi.mock("@multica/core/paths", async () => {
+  const actual = await vi.importActual<typeof import("@multica/core/paths")>(
+    "@multica/core/paths",
+  );
+  return {
+    ...actual,
+    useCurrentWorkspace: () => ({ id: "ws-1", name: "Test", slug: "test" }),
+    useWorkspacePaths: () => actual.paths.workspace("test"),
+  };
+});
+
+vi.mock("../../../navigation", () => ({
+  useNavigation: () => ({
+    push: vi.fn(),
+    pathname: "/test/issues/issue-1",
+    searchParams: new URLSearchParams(),
+    back: vi.fn(),
+    replace: vi.fn(),
+    getShareableUrl: (p: string) => `https://app.multica.com${p}`,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Import AFTER mocks are registered.
+import { useIssueActions } from "../use-issue-actions";
+
+const mockIssue: Issue = {
+  id: "issue-1",
+  workspace_id: "ws-1",
+  number: 1,
+  identifier: "TES-1",
+  title: "Example",
+  description: null,
+  status: "todo",
+  priority: "medium",
+  assignee_type: null,
+  assignee_id: null,
+  creator_type: "member",
+  creator_id: "user-1",
+  parent_issue_id: null,
+  due_date: null,
+  project_id: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+} as Issue;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  mockOpenModal.mockReset();
+  mockUpdateMutate.mockReset();
+  mockCreatePinMutate.mockReset();
+  mockDeletePinMutate.mockReset();
+  pinListRef.value = [];
+  localStorage.clear();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+describe("useIssueActions", () => {
+  it("updateField dispatches useUpdateIssue.mutate with the correct payload", () => {
+    const { result } = renderHook(() => useIssueActions(mockIssue), { wrapper });
+
+    act(() => {
+      result.current.updateField({ status: "done" });
+    });
+
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      { id: "issue-1", status: "done" },
+      expect.any(Object),
+    );
+  });
+
+  it("assigning an agent to a backlog issue opens the backlog-hint modal", () => {
+    const backlogIssue = { ...mockIssue, status: "backlog" } as Issue;
+    const { result } = renderHook(() => useIssueActions(backlogIssue), { wrapper });
+
+    act(() => {
+      result.current.updateField({
+        assignee_type: "agent",
+        assignee_id: "agent-1",
+      });
+    });
+
+    expect(mockOpenModal).toHaveBeenCalledWith("issue-backlog-agent-hint", {
+      issueId: "issue-1",
+    });
+  });
+
+  it("does not re-open backlog-hint when the user has dismissed it", () => {
+    localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
+    const backlogIssue = { ...mockIssue, status: "backlog" } as Issue;
+    const { result } = renderHook(() => useIssueActions(backlogIssue), { wrapper });
+
+    act(() => {
+      result.current.updateField({
+        assignee_type: "agent",
+        assignee_id: "agent-1",
+      });
+    });
+
+    expect(mockOpenModal).not.toHaveBeenCalled();
+  });
+
+  it("copyLink writes the issue's shareable URL to the clipboard", async () => {
+    const { result } = renderHook(() => useIssueActions(mockIssue), { wrapper });
+
+    await act(async () => {
+      await result.current.copyLink();
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "https://app.multica.com/test/issues/issue-1",
+    );
+  });
+
+  it("openSetParent / openAddChild / openDeleteConfirm / openCreateSubIssue open the correct modal with payload", () => {
+    const { result } = renderHook(() => useIssueActions(mockIssue), { wrapper });
+
+    act(() => {
+      result.current.openSetParent();
+    });
+    expect(mockOpenModal).toHaveBeenLastCalledWith("issue-set-parent", {
+      issueId: "issue-1",
+    });
+
+    act(() => {
+      result.current.openAddChild();
+    });
+    expect(mockOpenModal).toHaveBeenLastCalledWith("issue-add-child", {
+      issueId: "issue-1",
+    });
+
+    act(() => {
+      result.current.openCreateSubIssue();
+    });
+    expect(mockOpenModal).toHaveBeenLastCalledWith("create-issue", {
+      parent_issue_id: "issue-1",
+      parent_issue_identifier: "TES-1",
+    });
+
+    act(() => {
+      result.current.openDeleteConfirm({ onDeletedNavigateTo: "/test/issues" });
+    });
+    expect(mockOpenModal).toHaveBeenLastCalledWith("issue-delete-confirm", {
+      issueId: "issue-1",
+      identifier: "TES-1",
+      onDeletedNavigateTo: "/test/issues",
+    });
+  });
+
+  it("togglePin calls createPin when not pinned and deletePin when pinned", async () => {
+    pinListRef.value = [];
+    const { result: r1 } = renderHook(() => useIssueActions(mockIssue), { wrapper });
+    await waitFor(() => {
+      expect(r1.current.isPinned).toBe(false);
+    });
+    act(() => {
+      r1.current.togglePin();
+    });
+    expect(mockCreatePinMutate).toHaveBeenCalledWith({
+      item_type: "issue",
+      item_id: "issue-1",
+    });
+    expect(mockDeletePinMutate).not.toHaveBeenCalled();
+
+    mockCreatePinMutate.mockReset();
+    mockDeletePinMutate.mockReset();
+    pinListRef.value = [{ item_type: "issue", item_id: "issue-1" }];
+    const { result: r2 } = renderHook(() => useIssueActions(mockIssue), { wrapper });
+    await waitFor(() => {
+      expect(r2.current.isPinned).toBe(true);
+    });
+    act(() => {
+      r2.current.togglePin();
+    });
+    expect(mockDeletePinMutate).toHaveBeenCalledWith({
+      itemType: "issue",
+      itemId: "issue-1",
+    });
+    expect(mockCreatePinMutate).not.toHaveBeenCalled();
+  });
+
+  it("is a safe no-op when issue is null", () => {
+    const { result } = renderHook(() => useIssueActions(null), { wrapper });
+
+    act(() => {
+      result.current.updateField({ status: "done" });
+      result.current.togglePin();
+      result.current.openSetParent();
+    });
+
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+    expect(mockOpenModal).not.toHaveBeenCalled();
+  });
+
+  it("members and filtered agents are exposed on the result", async () => {
+    const { result } = renderHook(() => useIssueActions(mockIssue), { wrapper });
+    await waitFor(() => {
+      expect(result.current.members.length).toBe(1);
+    });
+    expect(result.current.members[0]!.user_id).toBe("user-1");
+    expect(result.current.agents).toEqual([]);
+  });
+});

--- a/packages/views/issues/actions/index.ts
+++ b/packages/views/issues/actions/index.ts
@@ -1,0 +1,4 @@
+export { useIssueActions } from "./use-issue-actions";
+export type { UseIssueActionsResult } from "./use-issue-actions";
+export { IssueActionsDropdown } from "./issue-actions-dropdown";
+export { IssueActionsContextMenu } from "./issue-actions-context-menu";

--- a/packages/views/issues/actions/issue-actions-context-menu.tsx
+++ b/packages/views/issues/actions/issue-actions-context-menu.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { ReactElement } from "react";
+import type { Issue } from "@multica/core/types";
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+} from "@multica/ui/components/ui/context-menu";
+import { useIssueActions } from "./use-issue-actions";
+import {
+  IssueActionsMenuItems,
+  contextPrimitives,
+} from "./issue-actions-menu-items";
+
+interface IssueActionsContextMenuProps {
+  issue: Issue;
+  /** A single React element cloned by Base UI as the trigger (via `render` prop). */
+  children: ReactElement;
+}
+
+export function IssueActionsContextMenu({
+  issue,
+  children,
+}: IssueActionsContextMenuProps) {
+  const actions = useIssueActions(issue);
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger render={children} />
+      <ContextMenuContent>
+        <IssueActionsMenuItems
+          issue={issue}
+          actions={actions}
+          primitives={contextPrimitives}
+        />
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/packages/views/issues/actions/issue-actions-dropdown.tsx
+++ b/packages/views/issues/actions/issue-actions-dropdown.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactElement } from "react";
+import type { Issue } from "@multica/core/types";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+} from "@multica/ui/components/ui/dropdown-menu";
+import { useIssueActions } from "./use-issue-actions";
+import {
+  IssueActionsMenuItems,
+  dropdownPrimitives,
+} from "./issue-actions-menu-items";
+
+interface IssueActionsDropdownProps {
+  issue: Issue;
+  /** A single React element cloned by Base UI as the trigger (via `render` prop). */
+  trigger: ReactElement;
+  align?: "start" | "end" | "center";
+  /** If set, navigate here after the issue is deleted. */
+  onDeletedNavigateTo?: string;
+}
+
+export function IssueActionsDropdown({
+  issue,
+  trigger,
+  align = "end",
+  onDeletedNavigateTo,
+}: IssueActionsDropdownProps) {
+  const actions = useIssueActions(issue);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger render={trigger} />
+      <DropdownMenuContent align={align} className="w-auto">
+        <IssueActionsMenuItems
+          issue={issue}
+          actions={actions}
+          primitives={dropdownPrimitives}
+          onDeletedNavigateTo={onDeletedNavigateTo}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import {
+  ArrowDown,
+  ArrowUp,
+  Calendar,
+  Link2,
+  Pin,
+  PinOff,
+  Plus,
+  Trash2,
+  UserMinus,
+} from "lucide-react";
+import type { Issue } from "@multica/core/types";
+import {
+  ALL_STATUSES,
+  STATUS_CONFIG,
+  PRIORITY_ORDER,
+  PRIORITY_CONFIG,
+} from "@multica/core/issues/config";
+import { StatusIcon } from "../components/status-icon";
+import { PriorityIcon } from "../components/priority-icon";
+import { ActorAvatar } from "../../common/actor-avatar";
+import {
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuSeparator,
+} from "@multica/ui/components/ui/dropdown-menu";
+import {
+  ContextMenuItem,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+  ContextMenuSeparator,
+} from "@multica/ui/components/ui/context-menu";
+import type { UseIssueActionsResult } from "./use-issue-actions";
+
+// Both Dropdown and Context menu wrappers expose an API-compatible surface
+// (variant, inset, onClick, etc.). We bundle the primitives we need into a
+// single object so `IssueActionsMenuItems` can render the same JSX for both.
+export interface MenuPrimitives {
+  Item: typeof DropdownMenuItem;
+  Sub: typeof DropdownMenuSub;
+  SubTrigger: typeof DropdownMenuSubTrigger;
+  SubContent: typeof DropdownMenuSubContent;
+  Separator: typeof DropdownMenuSeparator;
+}
+
+export const dropdownPrimitives: MenuPrimitives = {
+  Item: DropdownMenuItem,
+  Sub: DropdownMenuSub,
+  SubTrigger: DropdownMenuSubTrigger,
+  SubContent: DropdownMenuSubContent,
+  Separator: DropdownMenuSeparator,
+};
+
+// Context primitives are API-compatible with Dropdown primitives, but their
+// TypeScript identities differ. Cast once here and call it a day — this is the
+// single bridge between the two primitive sets.
+export const contextPrimitives: MenuPrimitives = {
+  Item: ContextMenuItem as unknown as typeof DropdownMenuItem,
+  Sub: ContextMenuSub as unknown as typeof DropdownMenuSub,
+  SubTrigger: ContextMenuSubTrigger as unknown as typeof DropdownMenuSubTrigger,
+  SubContent: ContextMenuSubContent as unknown as typeof DropdownMenuSubContent,
+  Separator: ContextMenuSeparator as unknown as typeof DropdownMenuSeparator,
+};
+
+interface IssueActionsMenuItemsProps {
+  issue: Issue;
+  actions: UseIssueActionsResult;
+  primitives: MenuPrimitives;
+  /** If set, navigate here after the issue is deleted (used by the detail page). */
+  onDeletedNavigateTo?: string;
+}
+
+export function IssueActionsMenuItems({
+  issue,
+  actions,
+  primitives: P,
+  onDeletedNavigateTo,
+}: IssueActionsMenuItemsProps) {
+  const {
+    members,
+    agents,
+    isPinned,
+    updateField,
+    togglePin,
+    copyLink,
+    openCreateSubIssue,
+    openSetParent,
+    openAddChild,
+    openDeleteConfirm,
+  } = actions;
+
+  const now = () => new Date();
+  const inDays = (days: number) => {
+    const d = new Date();
+    d.setDate(d.getDate() + days);
+    return d.toISOString();
+  };
+
+  return (
+    <>
+      {/* Status */}
+      <P.Sub>
+        <P.SubTrigger>
+          <StatusIcon status={issue.status} className="h-3.5 w-3.5" />
+          Status
+        </P.SubTrigger>
+        <P.SubContent>
+          {ALL_STATUSES.map((s) => (
+            <P.Item key={s} onClick={() => updateField({ status: s })}>
+              <StatusIcon status={s} className="h-3.5 w-3.5" />
+              {STATUS_CONFIG[s].label}
+              {issue.status === s && (
+                <span className="ml-auto text-xs text-muted-foreground">✓</span>
+              )}
+            </P.Item>
+          ))}
+        </P.SubContent>
+      </P.Sub>
+
+      {/* Priority */}
+      <P.Sub>
+        <P.SubTrigger>
+          <PriorityIcon priority={issue.priority} />
+          Priority
+        </P.SubTrigger>
+        <P.SubContent>
+          {PRIORITY_ORDER.map((p) => (
+            <P.Item key={p} onClick={() => updateField({ priority: p })}>
+              <span
+                className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${PRIORITY_CONFIG[p].badgeBg} ${PRIORITY_CONFIG[p].badgeText}`}
+              >
+                <PriorityIcon priority={p} className="h-3 w-3" inheritColor />
+                {PRIORITY_CONFIG[p].label}
+              </span>
+              {issue.priority === p && (
+                <span className="ml-auto text-xs text-muted-foreground">✓</span>
+              )}
+            </P.Item>
+          ))}
+        </P.SubContent>
+      </P.Sub>
+
+      {/* Assignee */}
+      <P.Sub>
+        <P.SubTrigger>
+          <UserMinus className="h-3.5 w-3.5" />
+          Assignee
+        </P.SubTrigger>
+        <P.SubContent>
+          <P.Item
+            onClick={() =>
+              updateField({ assignee_type: null, assignee_id: null })
+            }
+          >
+            <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
+            Unassigned
+            {!issue.assignee_type && (
+              <span className="ml-auto text-xs text-muted-foreground">✓</span>
+            )}
+          </P.Item>
+          {members.map((m) => (
+            <P.Item
+              key={m.user_id}
+              onClick={() =>
+                updateField({ assignee_type: "member", assignee_id: m.user_id })
+              }
+            >
+              <ActorAvatar actorType="member" actorId={m.user_id} size={16} />
+              {m.name}
+              {issue.assignee_type === "member" &&
+                issue.assignee_id === m.user_id && (
+                  <span className="ml-auto text-xs text-muted-foreground">✓</span>
+                )}
+            </P.Item>
+          ))}
+          {agents.map((a) => (
+            <P.Item
+              key={a.id}
+              onClick={() =>
+                updateField({ assignee_type: "agent", assignee_id: a.id })
+              }
+            >
+              <ActorAvatar actorType="agent" actorId={a.id} size={16} />
+              {a.name}
+              {issue.assignee_type === "agent" && issue.assignee_id === a.id && (
+                <span className="ml-auto text-xs text-muted-foreground">✓</span>
+              )}
+            </P.Item>
+          ))}
+        </P.SubContent>
+      </P.Sub>
+
+      {/* Due date */}
+      <P.Sub>
+        <P.SubTrigger>
+          <Calendar className="h-3.5 w-3.5" />
+          Due date
+        </P.SubTrigger>
+        <P.SubContent>
+          <P.Item onClick={() => updateField({ due_date: now().toISOString() })}>
+            Today
+          </P.Item>
+          <P.Item onClick={() => updateField({ due_date: inDays(1) })}>
+            Tomorrow
+          </P.Item>
+          <P.Item onClick={() => updateField({ due_date: inDays(7) })}>
+            Next week
+          </P.Item>
+          {issue.due_date && (
+            <>
+              <P.Separator />
+              <P.Item onClick={() => updateField({ due_date: null })}>
+                Clear date
+              </P.Item>
+            </>
+          )}
+        </P.SubContent>
+      </P.Sub>
+
+      <P.Separator />
+
+      <P.Item onClick={openCreateSubIssue}>
+        <Plus className="h-3.5 w-3.5" />
+        Create sub-issue
+      </P.Item>
+      <P.Item onClick={openSetParent}>
+        <ArrowUp className="h-3.5 w-3.5" />
+        Set parent issue...
+      </P.Item>
+      <P.Item onClick={openAddChild}>
+        <ArrowDown className="h-3.5 w-3.5" />
+        Add sub-issue...
+      </P.Item>
+      <P.Item onClick={togglePin}>
+        {isPinned ? (
+          <PinOff className="h-3.5 w-3.5" />
+        ) : (
+          <Pin className="h-3.5 w-3.5" />
+        )}
+        {isPinned ? "Unpin from sidebar" : "Pin to sidebar"}
+      </P.Item>
+      <P.Item onClick={copyLink}>
+        <Link2 className="h-3.5 w-3.5" />
+        Copy link
+      </P.Item>
+
+      <P.Separator />
+
+      <P.Item
+        variant="destructive"
+        onClick={() => openDeleteConfirm({ onDeletedNavigateTo })}
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+        Delete issue
+      </P.Item>
+    </>
+  );
+}

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -224,18 +224,6 @@ export function IssueActionsMenuItems({
 
       <P.Separator />
 
-      <P.Item onClick={openCreateSubIssue}>
-        <Plus className="h-3.5 w-3.5" />
-        Create sub-issue
-      </P.Item>
-      <P.Item onClick={openSetParent}>
-        <ArrowUp className="h-3.5 w-3.5" />
-        Set parent issue...
-      </P.Item>
-      <P.Item onClick={openAddChild}>
-        <ArrowDown className="h-3.5 w-3.5" />
-        Add sub-issue...
-      </P.Item>
       <P.Item onClick={togglePin}>
         {isPinned ? (
           <PinOff className="h-3.5 w-3.5" />
@@ -248,6 +236,28 @@ export function IssueActionsMenuItems({
         <Link2 className="h-3.5 w-3.5" />
         Copy link
       </P.Item>
+
+      <P.Separator />
+
+      {/* Relationship actions live under "More" — they're lower-frequency and
+          will grow (blocks, duplicates, related) as we add more relation types. */}
+      <P.Sub>
+        <P.SubTrigger inset>More</P.SubTrigger>
+        <P.SubContent>
+          <P.Item onClick={openCreateSubIssue}>
+            <Plus className="h-3.5 w-3.5" />
+            Create sub-issue
+          </P.Item>
+          <P.Item onClick={openSetParent}>
+            <ArrowUp className="h-3.5 w-3.5" />
+            Set parent issue...
+          </P.Item>
+          <P.Item onClick={openAddChild}>
+            <ArrowDown className="h-3.5 w-3.5" />
+            Add sub-issue...
+          </P.Item>
+        </P.SubContent>
+      </P.Sub>
 
       <P.Separator />
 

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUp,
   Calendar,
   Link2,
+  MoreHorizontal,
   Pin,
   PinOff,
   Plus,
@@ -242,7 +243,10 @@ export function IssueActionsMenuItems({
       {/* Relationship actions live under "More" — they're lower-frequency and
           will grow (blocks, duplicates, related) as we add more relation types. */}
       <P.Sub>
-        <P.SubTrigger inset>More</P.SubTrigger>
+        <P.SubTrigger>
+          <MoreHorizontal className="h-3.5 w-3.5" />
+          More
+        </P.SubTrigger>
         <P.SubContent>
           <P.Item onClick={openCreateSubIssue}>
             <Plus className="h-3.5 w-3.5" />

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -1,0 +1,176 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type {
+  Issue,
+  MemberWithUser,
+  Agent,
+  UpdateIssueRequest,
+} from "@multica/core/types";
+import { useAuthStore } from "@multica/core/auth";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useWorkspacePaths } from "@multica/core/paths";
+import { useModalStore } from "@multica/core/modals";
+import { useUpdateIssue } from "@multica/core/issues/mutations";
+import {
+  memberListOptions,
+  agentListOptions,
+} from "@multica/core/workspace/queries";
+import { pinListOptions, useCreatePin, useDeletePin } from "@multica/core/pins";
+import { canAssignAgent } from "../components/pickers";
+import { useNavigation } from "../../navigation";
+
+const BACKLOG_HINT_LS_KEY = "multica:backlog-agent-hint-dismissed";
+
+export interface UseIssueActionsResult {
+  // Derived data for rendering menu rows
+  members: MemberWithUser[];
+  agents: Agent[];
+  isPinned: boolean;
+  // Handlers
+  updateField: (updates: Partial<UpdateIssueRequest>) => void;
+  togglePin: () => void;
+  copyLink: () => Promise<void>;
+  openCreateSubIssue: () => void;
+  openSetParent: () => void;
+  openAddChild: () => void;
+  openDeleteConfirm: (opts?: { onDeletedNavigateTo?: string }) => void;
+}
+
+/**
+ * Accepts a nullable issue so callers can invoke the hook before they've
+ * early-returned on a missing issue. Returned handlers are safe no-ops when
+ * `issue` is null.
+ */
+export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
+  const wsId = useWorkspaceId();
+  const paths = useWorkspacePaths();
+  const navigation = useNavigation();
+  const user = useAuthStore((s) => s.user);
+  const userId = user?.id;
+
+  const { data: members = [] } = useQuery(memberListOptions(wsId));
+  const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const { data: pinnedItems = [] } = useQuery({
+    ...pinListOptions(wsId, userId ?? ""),
+    enabled: !!userId,
+  });
+
+  const currentMemberRole = useMemo(
+    () => members.find((m) => m.user_id === userId)?.role,
+    [members, userId],
+  );
+  const filteredAgents = useMemo(
+    () =>
+      agents.filter(
+        (a) => !a.archived_at && canAssignAgent(a, userId, currentMemberRole),
+      ),
+    [agents, userId, currentMemberRole],
+  );
+  const isPinned =
+    !!issue &&
+    pinnedItems.some(
+      (p) => p.item_type === "issue" && p.item_id === issue.id,
+    );
+
+  const updateIssue = useUpdateIssue();
+  const createPin = useCreatePin();
+  const deletePin = useDeletePin();
+  const openModal = useModalStore((s) => s.open);
+
+  const issueId = issue?.id ?? null;
+  const issueStatus = issue?.status ?? null;
+  const issueIdentifier = issue?.identifier ?? null;
+
+  const updateField = useCallback(
+    (updates: Partial<UpdateIssueRequest>) => {
+      if (!issueId) return;
+      updateIssue.mutate(
+        { id: issueId, ...updates },
+        { onError: () => toast.error("Failed to update issue") },
+      );
+      // Hint: assigning an agent to a backlog issue won't trigger execution
+      // until the issue is moved to an active status.
+      if (
+        updates.assignee_type === "agent" &&
+        updates.assignee_id &&
+        issueStatus === "backlog" &&
+        typeof window !== "undefined" &&
+        localStorage.getItem(BACKLOG_HINT_LS_KEY) !== "true"
+      ) {
+        openModal("issue-backlog-agent-hint", { issueId });
+      }
+    },
+    [issueId, issueStatus, updateIssue, openModal],
+  );
+
+  const togglePin = useCallback(() => {
+    if (!issueId) return;
+    if (isPinned) {
+      deletePin.mutate({ itemType: "issue", itemId: issueId });
+    } else {
+      createPin.mutate({ item_type: "issue", item_id: issueId });
+    }
+  }, [isPinned, issueId, createPin, deletePin]);
+
+  const copyLink = useCallback(async () => {
+    if (!issueId) return;
+    const path = paths.issueDetail(issueId);
+    const url = navigation.getShareableUrl
+      ? navigation.getShareableUrl(path)
+      : typeof window !== "undefined"
+        ? window.location.origin + path
+        : path;
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success("Link copied");
+    } catch {
+      toast.error("Failed to copy link");
+    }
+  }, [paths, issueId, navigation]);
+
+  const openCreateSubIssue = useCallback(() => {
+    if (!issueId) return;
+    openModal("create-issue", {
+      parent_issue_id: issueId,
+      parent_issue_identifier: issueIdentifier,
+    });
+  }, [openModal, issueId, issueIdentifier]);
+
+  const openSetParent = useCallback(() => {
+    if (!issueId) return;
+    openModal("issue-set-parent", { issueId });
+  }, [openModal, issueId]);
+
+  const openAddChild = useCallback(() => {
+    if (!issueId) return;
+    openModal("issue-add-child", { issueId });
+  }, [openModal, issueId]);
+
+  const openDeleteConfirm = useCallback(
+    (opts?: { onDeletedNavigateTo?: string }) => {
+      if (!issueId) return;
+      openModal("issue-delete-confirm", {
+        issueId,
+        identifier: issueIdentifier,
+        onDeletedNavigateTo: opts?.onDeletedNavigateTo,
+      });
+    },
+    [openModal, issueId, issueIdentifier],
+  );
+
+  return {
+    members,
+    agents: filteredAgents,
+    isPinned,
+    updateField,
+    togglePin,
+    copyLink,
+    openCreateSubIssue,
+    openSetParent,
+    openAddChild,
+    openDeleteConfirm,
+  };
+}

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -20,6 +20,7 @@ import { PRIORITY_CONFIG } from "@multica/core/issues/config";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { ProgressRing } from "./progress-ring";
 import type { ChildProgress } from "./list-row";
+import { IssueActionsContextMenu } from "../actions";
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString("en-US", {
@@ -228,19 +229,21 @@ export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, chil
   };
 
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      {...listeners}
-      className={isDragging ? "opacity-30" : ""}
-    >
-      <AppLink
-        href={p.issueDetail(issue.id)}
-        className={`group block transition-colors ${isDragging ? "pointer-events-none" : ""}`}
+    <IssueActionsContextMenu issue={issue}>
+      <div
+        ref={setNodeRef}
+        style={style}
+        {...attributes}
+        {...listeners}
+        className={isDragging ? "opacity-30" : ""}
       >
-        <BoardCardContent issue={issue} editable childProgress={childProgress} />
-      </AppLink>
-    </div>
+        <AppLink
+          href={p.issueDetail(issue.id)}
+          className={`group block transition-colors ${isDragging ? "pointer-events-none" : ""}`}
+        >
+          <BoardCardContent issue={issue} editable childProgress={childProgress} />
+        </AppLink>
+      </div>
+    </IssueActionsContextMenu>
   );
 });

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -79,7 +79,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showChildProgress = storeProperties.childProgress && childProgress;
 
   return (
-    <div className="rounded-lg border-[0.5px] bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-shadow group-hover:shadow-sm">
+    <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-[border-color,box-shadow,background-color] group-hover/card:border-accent/50 group-hover/card:bg-accent/20 group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent/40 group-hover:shadow-sm">
       {/* Row 1: Identifier */}
       <p className="text-xs text-muted-foreground">{issue.identifier}</p>
 
@@ -235,7 +235,7 @@ export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, chil
         style={style}
         {...attributes}
         {...listeners}
-        className={isDragging ? "opacity-30" : ""}
+        className={`group/card ${isDragging ? "opacity-30" : ""}`}
       >
         <AppLink
           href={p.issueDetail(issue.id)}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -5,46 +5,20 @@ import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { AppLink } from "../../navigation";
 import { useNavigation } from "../../navigation";
 import {
-  ArrowDown,
-  ArrowUp,
   Calendar,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
-  Link2,
   MoreHorizontal,
   PanelRight,
   Pin,
   PinOff,
   Plus,
-  Trash2,
-  UserMinus,
   Users,
 } from "lucide-react";
 import { PageHeader } from "../../layout/page-header";
-import { toast } from "sonner";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@multica/ui/components/ui/alert-dialog";
 import { Button } from "@multica/ui/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubTrigger,
-  DropdownMenuSubContent,
-} from "@multica/ui/components/ui/dropdown-menu";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@multica/ui/components/ui/resizable";
 import { Sheet, SheetContent } from "@multica/ui/components/ui/sheet";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
@@ -57,17 +31,17 @@ import {
 } from "@multica/ui/components/ui/tooltip";
 import { Popover, PopoverTrigger, PopoverContent } from "@multica/ui/components/ui/popover";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
-import { Command, CommandDialog, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from "@multica/ui/components/ui/command";
+import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from "@multica/ui/components/ui/command";
 import { AvatarGroup, AvatarGroupCount } from "@multica/ui/components/ui/avatar";
 import { ActorAvatar } from "../../common/actor-avatar";
-import type { UpdateIssueRequest, IssueStatus, IssuePriority, TimelineEntry, Issue } from "@multica/core/types";
-import { ALL_STATUSES, STATUS_CONFIG, PRIORITY_ORDER, PRIORITY_CONFIG } from "@multica/core/issues/config";
-import { StatusIcon, PriorityIcon, StatusPicker, PriorityPicker, DueDatePicker, AssigneePicker, canAssignAgent } from ".";
+import type { IssueStatus, IssuePriority, TimelineEntry } from "@multica/core/types";
+import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
+import { StatusIcon, PriorityIcon, StatusPicker, PriorityPicker, DueDatePicker, AssigneePicker } from ".";
+import { IssueActionsDropdown, useIssueActions } from "../actions";
 import { ProjectPicker } from "../../projects/components/project-picker";
 import { CommentCard } from "./comment-card";
 import { CommentInput } from "./comment-input";
 import { AgentLiveCard, TaskRunHistory } from "./agent-live-card";
-import { BacklogAgentHintDialog } from "./backlog-agent-hint-dialog";
 import { useQuery } from "@tanstack/react-query";
 import { useAuthStore } from "@multica/core/auth";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
@@ -75,7 +49,6 @@ import { useActorName } from "@multica/core/workspace/hooks";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions } from "@multica/core/issues/queries";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
-import { useUpdateIssue, useDeleteIssue } from "@multica/core/issues/mutations";
 import { useRecentIssuesStore } from "@multica/core/issues/stores";
 import { useIssueTimeline } from "../hooks/use-issue-timeline";
 import { useIssueReactions } from "../hooks/use-issue-reactions";
@@ -86,8 +59,6 @@ import { api } from "@multica/core/api";
 import { useModalStore } from "@multica/core/modals";
 import { timeAgo } from "@multica/core/utils";
 import { cn } from "@multica/ui/lib/utils";
-import { pinListOptions } from "@multica/core/pins";
-import { useCreatePin, useDeletePin } from "@multica/core/pins";
 
 import { ProgressRing } from "./progress-ring";
 
@@ -181,132 +152,6 @@ function PropRow({
 
 
 // ---------------------------------------------------------------------------
-// Issue Picker Dialog
-// ---------------------------------------------------------------------------
-
-function IssuePickerDialog({
-  open,
-  onOpenChange,
-  title,
-  description,
-  excludeIds,
-  onSelect,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  title: string;
-  description: string;
-  excludeIds: string[];
-  onSelect: (issue: Issue) => void;
-}) {
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<Issue[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const abortRef = useRef<AbortController>(undefined);
-
-  // Reset state when dialog opens/closes
-  useEffect(() => {
-    if (!open) {
-      setQuery("");
-      setResults([]);
-      setIsLoading(false);
-    }
-  }, [open]);
-
-  const search = useCallback(
-    (q: string) => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      if (abortRef.current) abortRef.current.abort();
-
-      if (!q.trim()) {
-        setResults([]);
-        setIsLoading(false);
-        return;
-      }
-
-      setIsLoading(true);
-      debounceRef.current = setTimeout(async () => {
-        const controller = new AbortController();
-        abortRef.current = controller;
-        try {
-          const res = await api.searchIssues({
-            q: q.trim(),
-            limit: 20,
-            include_closed: true,
-            signal: controller.signal,
-          });
-          if (!controller.signal.aborted) {
-            setResults(
-              res.issues.filter((i) => !excludeIds.includes(i.id)),
-            );
-            setIsLoading(false);
-          }
-        } catch {
-          if (!controller.signal.aborted) {
-            setIsLoading(false);
-          }
-        }
-      }, 300);
-    },
-    [excludeIds],
-  );
-
-  return (
-    <CommandDialog
-      open={open}
-      onOpenChange={onOpenChange}
-      title={title}
-      description={description}
-    >
-      <Command shouldFilter={false}>
-        <CommandInput
-          placeholder="Search issues..."
-          value={query}
-          onValueChange={(v) => {
-            setQuery(v);
-            search(v);
-          }}
-        />
-        <CommandList>
-          {isLoading && (
-            <div className="py-6 text-center text-sm text-muted-foreground">
-              Searching...
-            </div>
-          )}
-          {!isLoading && query.trim() && results.length === 0 && (
-            <CommandEmpty>No issues found.</CommandEmpty>
-          )}
-          {!isLoading && !query.trim() && (
-            <div className="py-6 text-center text-sm text-muted-foreground">
-              Type to search issues
-            </div>
-          )}
-          {results.length > 0 && (
-            <CommandGroup>
-              {results.map((issue) => (
-                <CommandItem
-                  key={issue.id}
-                  value={issue.id}
-                  onSelect={() => {
-                    onSelect(issue);
-                    onOpenChange(false);
-                  }}
-                >
-                  <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
-                  <span className="text-muted-foreground shrink-0">{issue.identifier}</span>
-                  <span className="truncate">{issue.title}</span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          )}
-        </CommandList>
-      </Command>
-    </CommandDialog>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
@@ -327,7 +172,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const id = issueId;
   const router = useNavigation();
   const user = useAuthStore((s) => s.user);
-  const userId = useAuthStore((s) => s.user?.id);
   const workspace = useCurrentWorkspace();
   const paths = useWorkspacePaths();
 
@@ -335,7 +179,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const wsId = useWorkspaceId();
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
-  const currentMemberRole = members.find((m) => m.user_id === user?.id)?.role;
   const { data: allIssues = [] } = useQuery(issueListOptions(wsId));
   const { getActorName } = useActorName();
   const { uploadWithToast } = useFileUpload(api);
@@ -352,9 +195,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
       sidebarRef.current?.collapse();
     }
   }, [isMobile]);
-  const [deleting, setDeleting] = useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [backlogHintOpen, setBacklogHintOpen] = useState(false);
   const [propertiesOpen, setPropertiesOpen] = useState(true);
   const [detailsOpen, setDetailsOpen] = useState(true);
   const [parentIssueOpen, setParentIssueOpen] = useState(true);
@@ -362,8 +202,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const didHighlightRef = useRef<string | null>(null);
-  const [parentPickerOpen, setParentPickerOpen] = useState(false);
-  const [childPickerOpen, setChildPickerOpen] = useState(false);
 
   // Issue data from TQ — uses detail query, seeded from list cache if available.
   // Only seed when description is present; list API omits it, and ContentEditor
@@ -384,6 +222,30 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
     }
   }, [issue?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Fire `onDelete` once when the issue transitions from loaded to missing.
+  // Delete goes through a shell-level modal, so the caller (e.g. inbox) can't
+  // be notified directly — instead, the detail page observes its own cache
+  // clearing and runs the callback. We navigate via `onDeletedNavigateTo` on
+  // the actions menu when no callback is supplied (standalone routes).
+  const hadIssueRef = useRef(false);
+  const firedDeleteCallbackRef = useRef(false);
+  useEffect(() => {
+    if (issue) {
+      hadIssueRef.current = true;
+      firedDeleteCallbackRef.current = false;
+      return;
+    }
+    if (
+      hadIssueRef.current &&
+      !issueLoading &&
+      !firedDeleteCallbackRef.current &&
+      onDelete
+    ) {
+      firedDeleteCallbackRef.current = true;
+      onDelete();
+    }
+  }, [issue, issueLoading, onDelete]);
+
   // Custom hooks — encapsulate timeline, reactions, subscribers
   const {
     timeline, submitComment, submitReply,
@@ -401,15 +263,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
 
   // Token usage
   const { data: usage } = useQuery(issueUsageOptions(id));
-
-  // Pinned state
-  const { data: pinnedItems = [] } = useQuery({
-    ...pinListOptions(wsId, userId ?? ""),
-    enabled: !!userId,
-  });
-  const isPinned = pinnedItems.some((p) => p.item_type === "issue" && p.item_id === id);
-  const createPin = useCreatePin();
-  const deletePin = useDeletePin();
 
   // Sub-issue queries
   const parentIssueId = issue?.parent_issue_id;
@@ -448,29 +301,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
     }
   }, [highlightCommentId, timeline.length]);
 
-  // Issue field updates via TQ mutation (optimistic update + rollback in mutation hook)
-  const updateIssueMutation = useUpdateIssue();
-  const handleUpdateField = useCallback(
-    (updates: Partial<UpdateIssueRequest>) => {
-      if (!issue) return;
-      updateIssueMutation.mutate(
-        { id, ...updates },
-        { onError: () => toast.error("Failed to update issue") },
-      );
-      // Hint: assigning an agent to a backlog issue won't trigger execution
-      // until the issue is moved to an active status.
-      if (
-        updates.assignee_type === "agent" &&
-        updates.assignee_id &&
-        issue.status === "backlog" &&
-        localStorage.getItem("multica:backlog-agent-hint-dismissed") !== "true"
-      ) {
-        setBacklogHintOpen(true);
-      }
-    },
-    [issue, id, updateIssueMutation],
-  );
-
   const descEditorRef = useRef<ContentEditorRef>(null);
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => descEditorRef.current?.uploadFile(f)),
@@ -482,19 +312,10 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
     [uploadWithToast],
   );
 
-  const deleteIssueMutation = useDeleteIssue();
-  const handleDelete = async () => {
-    setDeleting(true);
-    try {
-      await deleteIssueMutation.mutateAsync(issue!.id);
-      toast.success("Issue deleted");
-      if (onDelete) onDelete();
-      else router.push(paths.issues());
-    } catch {
-      toast.error("Failed to delete issue");
-      setDeleting(false);
-    }
-  };
+  // Shared issue actions (mutations, pin, copy-link, modal dispatch, etc.).
+  // Called before the `if (!issue)` early return so hook order stays stable.
+  const actions = useIssueActions(issue);
+  const handleUpdateField = actions.updateField;
 
   if (loading) {
     return (
@@ -711,203 +532,27 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    className={cn("text-muted-foreground", isPinned && "text-foreground")}
-                    onClick={() => {
-                      if (isPinned) {
-                        deletePin.mutate({ itemType: "issue", itemId: issue.id });
-                      } else {
-                        createPin.mutate({ item_type: "issue", item_id: issue.id });
-                      }
-                    }}
+                    className={cn("text-muted-foreground", actions.isPinned && "text-foreground")}
+                    onClick={actions.togglePin}
                   >
-                    {isPinned ? <PinOff /> : <Pin />}
+                    {actions.isPinned ? <PinOff /> : <Pin />}
                   </Button>
                 }
               />
-              <TooltipContent side="bottom">{isPinned ? "Unpin from sidebar" : "Pin to sidebar"}</TooltipContent>
+              <TooltipContent side="bottom">{actions.isPinned ? "Unpin from sidebar" : "Pin to sidebar"}</TooltipContent>
             </Tooltip>
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <Button variant="ghost" size="icon-sm" className="text-muted-foreground">
-                    <MoreHorizontal />
-                  </Button>
-                }
-              />
-              <DropdownMenuContent align="end" className="w-auto">
-                {/* Status */}
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    <StatusIcon status={issue.status} className="h-3.5 w-3.5" />
-                    Status
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    {ALL_STATUSES.map((s) => (
-                      <DropdownMenuItem
-                        key={s}
-                        onClick={() => handleUpdateField({ status: s })}
-                      >
-                        <StatusIcon status={s} className="h-3.5 w-3.5" />
-                        {STATUS_CONFIG[s].label}
-                        {issue.status === s && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-
-                {/* Priority */}
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    <PriorityIcon priority={issue.priority} />
-                    Priority
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    {PRIORITY_ORDER.map((p) => (
-                      <DropdownMenuItem
-                        key={p}
-                        onClick={() => handleUpdateField({ priority: p })}
-                      >
-                        <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${PRIORITY_CONFIG[p].badgeBg} ${PRIORITY_CONFIG[p].badgeText}`}>
-                          <PriorityIcon priority={p} className="h-3 w-3" inheritColor />
-                          {PRIORITY_CONFIG[p].label}
-                        </span>
-                        {issue.priority === p && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-
-                {/* Assignee */}
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    <UserMinus className="h-3.5 w-3.5" />
-                    Assignee
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    <DropdownMenuItem
-                      onClick={() => handleUpdateField({ assignee_type: null, assignee_id: null })}
-                    >
-                      <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
-                      Unassigned
-                      {!issue.assignee_type && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
-                    </DropdownMenuItem>
-                    {members.map((m) => (
-                      <DropdownMenuItem
-                        key={m.user_id}
-                        onClick={() => handleUpdateField({ assignee_type: "member", assignee_id: m.user_id })}
-                      >
-                        <ActorAvatar actorType="member" actorId={m.user_id} size={16} />
-                        {m.name}
-                        {issue.assignee_type === "member" && issue.assignee_id === m.user_id && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
-                      </DropdownMenuItem>
-                    ))}
-                    {agents.filter((a) => !a.archived_at && canAssignAgent(a, user?.id, currentMemberRole)).map((a) => (
-                      <DropdownMenuItem
-                        key={a.id}
-                        onClick={() => handleUpdateField({ assignee_type: "agent", assignee_id: a.id })}
-                      >
-                        <ActorAvatar actorType="agent" actorId={a.id} size={16} />
-                        {a.name}
-                        {issue.assignee_type === "agent" && issue.assignee_id === a.id && <span className="ml-auto text-xs text-muted-foreground">✓</span>}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-
-                {/* Due date */}
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    <Calendar className="h-3.5 w-3.5" />
-                    Due date
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    <DropdownMenuItem onClick={() => handleUpdateField({ due_date: new Date().toISOString() })}>
-                      Today
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => {
-                      const d = new Date(); d.setDate(d.getDate() + 1);
-                      handleUpdateField({ due_date: d.toISOString() });
-                    }}>
-                      Tomorrow
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => {
-                      const d = new Date(); d.setDate(d.getDate() + 7);
-                      handleUpdateField({ due_date: d.toISOString() });
-                    }}>
-                      Next week
-                    </DropdownMenuItem>
-                    {issue.due_date && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={() => handleUpdateField({ due_date: null })}>
-                          Clear date
-                        </DropdownMenuItem>
-                      </>
-                    )}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-
-                <DropdownMenuSeparator />
-
-                {/* Create sub-issue */}
-                <DropdownMenuItem onClick={() => {
-                  useModalStore.getState().open("create-issue", {
-                    parent_issue_id: issue.id,
-                    parent_issue_identifier: issue.identifier,
-                  });
-                }}>
-                  <Plus className="h-3.5 w-3.5" />
-                  Create sub-issue
-                </DropdownMenuItem>
-
-                {/* Add as sub-issue of another issue */}
-                <DropdownMenuItem onClick={() => setParentPickerOpen(true)}>
-                  <ArrowUp className="h-3.5 w-3.5" />
-                  Set parent issue...
-                </DropdownMenuItem>
-
-                {/* Add another issue as sub-issue */}
-                <DropdownMenuItem onClick={() => setChildPickerOpen(true)}>
-                  <ArrowDown className="h-3.5 w-3.5" />
-                  Add sub-issue...
-                </DropdownMenuItem>
-
-                {/* Pin / Unpin */}
-                <DropdownMenuItem onClick={() => {
-                  if (isPinned) {
-                    deletePin.mutate({ itemType: "issue", itemId: issue.id });
-                  } else {
-                    createPin.mutate({ item_type: "issue", item_id: issue.id });
-                  }
-                }}>
-                  {isPinned ? <PinOff className="h-3.5 w-3.5" /> : <Pin className="h-3.5 w-3.5" />}
-                  {isPinned ? "Unpin from sidebar" : "Pin to sidebar"}
-                </DropdownMenuItem>
-
-                {/* Copy link */}
-                <DropdownMenuItem onClick={() => {
-                  const url = router.getShareableUrl
-                    ? router.getShareableUrl(router.pathname)
-                    : window.location.href;
-                  navigator.clipboard.writeText(url);
-                  toast.success("Link copied");
-                }}>
-                  <Link2 className="h-3.5 w-3.5" />
-                  Copy link
-                </DropdownMenuItem>
-
-                <DropdownMenuSeparator />
-
-                {/* Delete */}
-                <DropdownMenuItem
-                  variant="destructive"
-                  onClick={() => setDeleteDialogOpen(true)}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                  Delete issue
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <IssueActionsDropdown
+              issue={issue}
+              align="end"
+              // When a parent passes `onDelete`, we detect deletion via effect
+              // above and skip navigation. Otherwise the modal navigates for us.
+              onDeletedNavigateTo={onDelete ? undefined : paths.issues()}
+              trigger={
+                <Button variant="ghost" size="icon-sm" className="text-muted-foreground">
+                  <MoreHorizontal />
+                </Button>
+              }
+            />
             <Tooltip>
               <TooltipTrigger
                 render={
@@ -934,72 +579,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
             </Tooltip>
           </div>
         </PageHeader>
-
-            {/* Delete confirmation dialog (controlled by state) */}
-            <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete issue</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will permanently delete this issue and all its comments. This action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={handleDelete}
-                    disabled={deleting}
-                    className="bg-destructive text-white hover:bg-destructive/90"
-                  >
-                    {deleting ? "Deleting..." : "Delete"}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-
-            <BacklogAgentHintDialog
-              open={backlogHintOpen}
-              onOpenChange={setBacklogHintOpen}
-              onDismissPermanently={() => {
-                localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
-              }}
-              onMoveToTodo={() => {
-                updateIssueMutation.mutate(
-                  { id, status: "todo" },
-                  { onError: () => toast.error("Failed to update status") },
-                );
-                setBacklogHintOpen(false);
-              }}
-            />
-
-            {/* Set parent issue picker */}
-            <IssuePickerDialog
-              open={parentPickerOpen}
-              onOpenChange={setParentPickerOpen}
-              title="Set parent issue"
-              description="Search for an issue to set as the parent of this issue"
-              excludeIds={[id, ...childIssues.map((c) => c.id)]}
-              onSelect={(selected) => {
-                handleUpdateField({ parent_issue_id: selected.id });
-                toast.success(`Set ${selected.identifier} as parent issue`);
-              }}
-            />
-
-            {/* Add sub-issue picker */}
-            <IssuePickerDialog
-              open={childPickerOpen}
-              onOpenChange={setChildPickerOpen}
-              title="Add sub-issue"
-              description="Search for an issue to add as a sub-issue"
-              excludeIds={[id, ...(parentIssueId ? [parentIssueId] : []), ...childIssues.map((c) => c.id)]}
-              onSelect={(selected) => {
-                updateIssueMutation.mutate(
-                  { id: selected.id, parent_issue_id: id },
-                  { onError: () => toast.error("Failed to add sub-issue") },
-                );
-                toast.success(`Added ${selected.identifier} as sub-issue`);
-              }}
-            />
 
         {/* Content — scrollable */}
         <div ref={scrollContainerRef} className="relative flex-1 overflow-y-auto">

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -12,6 +12,7 @@ import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { PriorityIcon } from "./priority-icon";
 import { ProgressRing } from "./progress-ring";
+import { IssueActionsContextMenu } from "../actions";
 
 export interface ChildProgress {
   done: number;
@@ -49,62 +50,64 @@ export const ListRow = memo(function ListRow({
   const showDueDate = storeProperties.dueDate && issue.due_date;
 
   return (
-    <div
-      className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/50 ${
-        selected ? "bg-accent/30" : ""
-      }`}
-    >
-      <div className="relative flex shrink-0 items-center justify-center w-4 h-4">
-        <PriorityIcon
-          priority={issue.priority}
-          className={selected ? "hidden" : "group-hover/row:hidden"}
-        />
-        <input
-          type="checkbox"
-          checked={selected}
-          onChange={() => toggle(issue.id)}
-          className={`absolute inset-0 cursor-pointer accent-primary ${
-            selected ? "" : "hidden group-hover/row:block"
-          }`}
-        />
-      </div>
-      <AppLink
-        href={p.issueDetail(issue.id)}
-        className="flex flex-1 items-center gap-2 min-w-0"
+    <IssueActionsContextMenu issue={issue}>
+      <div
+        className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/50 ${
+          selected ? "bg-accent/30" : ""
+        }`}
       >
-        <span className="w-16 shrink-0 text-xs text-muted-foreground">
-          {issue.identifier}
-        </span>
-        <span className="flex min-w-0 flex-1 items-center gap-1.5">
-          <span className="truncate">{issue.title}</span>
-          {showChildProgress && (
-            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
-              <ProgressRing done={childProgress!.done} total={childProgress!.total} size={14} />
-              <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
-                {childProgress!.done}/{childProgress!.total}
+        <div className="relative flex shrink-0 items-center justify-center w-4 h-4">
+          <PriorityIcon
+            priority={issue.priority}
+            className={selected ? "hidden" : "group-hover/row:hidden"}
+          />
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => toggle(issue.id)}
+            className={`absolute inset-0 cursor-pointer accent-primary ${
+              selected ? "" : "hidden group-hover/row:block"
+            }`}
+          />
+        </div>
+        <AppLink
+          href={p.issueDetail(issue.id)}
+          className="flex flex-1 items-center gap-2 min-w-0"
+        >
+          <span className="w-16 shrink-0 text-xs text-muted-foreground">
+            {issue.identifier}
+          </span>
+          <span className="flex min-w-0 flex-1 items-center gap-1.5">
+            <span className="truncate">{issue.title}</span>
+            {showChildProgress && (
+              <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
+                <ProgressRing done={childProgress!.done} total={childProgress!.total} size={14} />
+                <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
+                  {childProgress!.done}/{childProgress!.total}
+                </span>
               </span>
+            )}
+          </span>
+          {showProject && (
+            <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground max-w-[140px]">
+              <span aria-hidden="true" className="shrink-0">{project!.icon || "📁"}</span>
+              <span className="truncate">{project!.title}</span>
             </span>
           )}
-        </span>
-        {showProject && (
-          <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground max-w-[140px]">
-            <span aria-hidden="true" className="shrink-0">{project!.icon || "📁"}</span>
-            <span className="truncate">{project!.title}</span>
-          </span>
-        )}
-        {showDueDate && (
-          <span className="shrink-0 text-xs text-muted-foreground">
-            {formatDate(issue.due_date!)}
-          </span>
-        )}
-        {showAssignee && (
-          <ActorAvatar
-            actorType={issue.assignee_type!}
-            actorId={issue.assignee_id!}
-            size={20}
-          />
-        )}
-      </AppLink>
-    </div>
+          {showDueDate && (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {formatDate(issue.due_date!)}
+            </span>
+          )}
+          {showAssignee && (
+            <ActorAvatar
+              actorType={issue.assignee_type!}
+              actorId={issue.assignee_id!}
+              size={20}
+            />
+          )}
+        </AppLink>
+      </div>
+    </IssueActionsContextMenu>
   );
 });

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -52,7 +52,7 @@ export const ListRow = memo(function ListRow({
   return (
     <IssueActionsContextMenu issue={issue}>
       <div
-        className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/50 ${
+        className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
         }`}
       >

--- a/packages/views/modals/add-child-issue.tsx
+++ b/packages/views/modals/add-child-issue.tsx
@@ -45,6 +45,8 @@ export function AddChildIssueModal({
       title="Add sub-issue"
       description="Search for an issue to add as a sub-issue"
       excludeIds={excludeIds}
+      contextIssue={issue ?? undefined}
+      contextLabel="Adding sub-issue to"
       onSelect={(selected) => {
         updateIssue.mutate(
           { id: selected.id, parent_issue_id: issueId },

--- a/packages/views/modals/add-child-issue.tsx
+++ b/packages/views/modals/add-child-issue.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useWorkspaceId } from "@multica/core/hooks";
+import {
+  issueDetailOptions,
+  childIssuesOptions,
+} from "@multica/core/issues/queries";
+import { useUpdateIssue } from "@multica/core/issues/mutations";
+import { IssuePickerModal } from "./issue-picker-modal";
+
+export function AddChildIssueModal({
+  onClose,
+  data,
+}: {
+  onClose: () => void;
+  data: Record<string, unknown> | null;
+}) {
+  const issueId = (data?.issueId as string) || "";
+  const wsId = useWorkspaceId();
+  const updateIssue = useUpdateIssue();
+
+  const { data: issue = null } = useQuery({
+    ...issueDetailOptions(wsId, issueId),
+    enabled: !!issueId,
+  });
+  const { data: children = [] } = useQuery({
+    ...childIssuesOptions(wsId, issueId),
+    enabled: !!issueId,
+  });
+
+  const excludeIds = [
+    issueId,
+    ...(issue?.parent_issue_id ? [issue.parent_issue_id] : []),
+    ...children.map((c) => c.id),
+  ];
+
+  return (
+    <IssuePickerModal
+      open
+      onOpenChange={(v) => {
+        if (!v) onClose();
+      }}
+      title="Add sub-issue"
+      description="Search for an issue to add as a sub-issue"
+      excludeIds={excludeIds}
+      onSelect={(selected) => {
+        updateIssue.mutate(
+          { id: selected.id, parent_issue_id: issueId },
+          { onError: () => toast.error("Failed to add sub-issue") },
+        );
+        toast.success(`Added ${selected.identifier} as sub-issue`);
+      }}
+    />
+  );
+}

--- a/packages/views/modals/add-child-issue.tsx
+++ b/packages/views/modals/add-child-issue.tsx
@@ -45,8 +45,6 @@ export function AddChildIssueModal({
       title="Add sub-issue"
       description="Search for an issue to add as a sub-issue"
       excludeIds={excludeIds}
-      contextIssue={issue ?? undefined}
-      contextLabel="Adding sub-issue to"
       onSelect={(selected) => {
         updateIssue.mutate(
           { id: selected.id, parent_issue_id: issueId },

--- a/packages/views/modals/backlog-agent-hint.tsx
+++ b/packages/views/modals/backlog-agent-hint.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { toast } from "sonner";
+import { BacklogAgentHintDialog } from "../issues/components/backlog-agent-hint-dialog";
+import { useUpdateIssue } from "@multica/core/issues/mutations";
+
+export function BacklogAgentHintModal({
+  onClose,
+  data,
+}: {
+  onClose: () => void;
+  data: Record<string, unknown> | null;
+}) {
+  const issueId = (data?.issueId as string) || "";
+  const updateIssue = useUpdateIssue();
+
+  return (
+    <BacklogAgentHintDialog
+      open
+      onOpenChange={(v) => {
+        if (!v) onClose();
+      }}
+      onDismissPermanently={() => {
+        localStorage.setItem("multica:backlog-agent-hint-dismissed", "true");
+      }}
+      onMoveToTodo={() => {
+        if (issueId) {
+          updateIssue.mutate(
+            { id: issueId, status: "todo" },
+            { onError: () => toast.error("Failed to update status") },
+          );
+        }
+        onClose();
+      }}
+    />
+  );
+}

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mockPush = vi.hoisted(() => vi.fn());
 const mockCreateIssue = vi.hoisted(() => vi.fn());
@@ -33,6 +34,17 @@ vi.mock("@multica/core/paths", () => ({
   useCurrentWorkspace: () => ({ name: "Test Workspace" }),
   useWorkspacePaths: () => ({
     issueDetail: (id: string) => `/ws-test/issues/${id}`,
+  }),
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-test",
+}));
+
+vi.mock("@multica/core/issues/queries", () => ({
+  issueDetailOptions: (wsId: string, id: string) => ({
+    queryKey: ["issues", wsId, "detail", id],
+    queryFn: () => Promise.resolve(null),
   }),
 }));
 
@@ -124,6 +136,20 @@ vi.mock("@multica/ui/components/ui/dialog", () => ({
   ),
 }));
 
+vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  ),
+  DropdownMenuSeparator: () => null,
+}));
+
+vi.mock("./issue-picker-modal", () => ({
+  IssuePickerModal: () => null,
+}));
+
 vi.mock("@multica/ui/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ render }: { render: React.ReactNode }) => <>{render}</>,
@@ -170,6 +196,13 @@ vi.mock("sonner", () => ({
 
 import { CreateIssueModal } from "./create-issue";
 
+function renderModal(element: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={qc}>{element}</QueryClientProvider>);
+}
+
 describe("CreateIssueModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -185,7 +218,7 @@ describe("CreateIssueModal", () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
 
-    render(<CreateIssueModal onClose={onClose} />);
+    renderModal(<CreateIssueModal onClose={onClose} />);
 
     await user.type(screen.getByPlaceholderText("Issue title"), "  Ship create issue regression coverage  ");
     await user.click(screen.getByRole("button", { name: "Create Issue" }));

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -450,7 +450,10 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
               onOpenChange={setParentPickerOpen}
               title="Set parent issue"
               description="Search for an issue to set as the parent of the new issue"
-              excludeIds={childIssues.map((c) => c.id)}
+              excludeIds={[
+                ...childIssues.map((c) => c.id),
+                ...(parentIssueId ? [parentIssueId] : []),
+              ]}
               onSelect={(selected) => {
                 setParentIssueId(selected.id);
               }}

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigation } from "../navigation";
 import {
+  ArrowDown,
   ArrowUp,
   Check,
   ChevronRight,
@@ -14,7 +15,7 @@ import {
 } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
 import { toast } from "sonner";
-import type { IssueStatus, IssuePriority, IssueAssigneeType } from "@multica/core/types";
+import type { Issue, IssueStatus, IssuePriority, IssueAssigneeType } from "@multica/core/types";
 import {
   Dialog,
   DialogContent,
@@ -75,6 +76,10 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
     (data?.parent_issue_id as string) || undefined,
   );
   const [parentPickerOpen, setParentPickerOpen] = useState(false);
+  // Children live as full Issue objects — the picker always returns the whole
+  // object, and we never need to hydrate from an ID the way we do for parent.
+  const [childIssues, setChildIssues] = useState<Issue[]>([]);
+  const [childPickerOpen, setChildPickerOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [backlogHintIssueId, setBacklogHintIssueId] = useState<string | null>(null);
 
@@ -125,6 +130,29 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         parent_issue_id: parentIssueId,
         project_id: projectId,
       });
+
+      // Link queued children to the new parent. Deferred to after create
+      // because the new issue's ID doesn't exist yet. Partial failures don't
+      // roll back the new issue — it's already committed.
+      if (childIssues.length > 0) {
+        const results = await Promise.allSettled(
+          childIssues.map((child) =>
+            updateIssueMutation.mutateAsync({
+              id: child.id,
+              parent_issue_id: issue.id,
+            }),
+          ),
+        );
+        const failed = results.filter((r) => r.status === "rejected").length;
+        if (failed > 0) {
+          toast.error(
+            failed === childIssues.length
+              ? "Failed to link sub-issues"
+              : `Failed to link ${failed} of ${childIssues.length} sub-issues`,
+          );
+        }
+      }
+
       clearDraft();
       const shouldShowBacklogHint =
         status === "backlog" && assigneeType === "agent" && assigneeId &&
@@ -349,6 +377,30 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
                 </div>
               )}
 
+              {/* Child chips — one per queued sub-issue. Links are deferred
+                  until create resolves (see handleSubmit). */}
+              {childIssues.map((c) => (
+                <div
+                  key={c.id}
+                  className="inline-flex items-center rounded-full border text-xs transition-colors hover:bg-accent/60"
+                >
+                  <div className="flex items-center gap-1.5 py-1 pl-2.5">
+                    <ArrowDown className="size-3 text-muted-foreground" />
+                    <span>Sub-issue: {c.identifier}</span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setChildIssues((prev) => prev.filter((x) => x.id !== c.id))
+                    }
+                    className="p-1 pr-2 text-muted-foreground hover:text-foreground cursor-pointer"
+                    aria-label={`Remove sub-issue ${c.identifier}`}
+                  >
+                    <XIcon className="size-3" />
+                  </button>
+                </div>
+              ))}
+
               {/* Overflow — always the last child so DOM order keeps it at the
                   end of the wrap flow, no matter how many chips are present. */}
               <DropdownMenu>
@@ -361,11 +413,22 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
                 />
                 <DropdownMenuContent align="start" className="w-auto">
                   {parentIssueId && parentIssue ? (
+                    <DropdownMenuItem onClick={() => setParentPickerOpen(true)}>
+                      <ArrowUp className="h-3.5 w-3.5" />
+                      Parent: {parentIssue.identifier}
+                    </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem onClick={() => setParentPickerOpen(true)}>
+                      <ArrowUp className="h-3.5 w-3.5" />
+                      Set parent issue...
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem onClick={() => setChildPickerOpen(true)}>
+                    <ArrowDown className="h-3.5 w-3.5" />
+                    Add sub-issue...
+                  </DropdownMenuItem>
+                  {parentIssueId && parentIssue && (
                     <>
-                      <DropdownMenuItem onClick={() => setParentPickerOpen(true)}>
-                        <ArrowUp className="h-3.5 w-3.5" />
-                        Parent: {parentIssue.identifier}
-                      </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         variant="destructive"
@@ -375,26 +438,36 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
                         Remove parent
                       </DropdownMenuItem>
                     </>
-                  ) : (
-                    <DropdownMenuItem onClick={() => setParentPickerOpen(true)}>
-                      <ArrowUp className="h-3.5 w-3.5" />
-                      Set parent issue...
-                    </DropdownMenuItem>
                   )}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
 
-            {/* Parent picker — rendered inline so it stacks over this modal
-                instead of replacing it via useModalStore. */}
+            {/* Parent / child pickers — rendered inline so they stack over this
+                modal instead of replacing it via useModalStore. */}
             <IssuePickerModal
               open={parentPickerOpen}
               onOpenChange={setParentPickerOpen}
               title="Set parent issue"
               description="Search for an issue to set as the parent of the new issue"
-              excludeIds={[]}
+              excludeIds={childIssues.map((c) => c.id)}
               onSelect={(selected) => {
                 setParentIssueId(selected.id);
+              }}
+            />
+            <IssuePickerModal
+              open={childPickerOpen}
+              onOpenChange={setChildPickerOpen}
+              title="Add sub-issue"
+              description="Search for an issue to add as a sub-issue of the new issue"
+              excludeIds={[
+                ...childIssues.map((c) => c.id),
+                ...(parentIssueId ? [parentIssueId] : []),
+              ]}
+              onSelect={(selected) => {
+                setChildIssues((prev) =>
+                  prev.some((x) => x.id === selected.id) ? prev : [...prev, selected],
+                );
               }}
             />
 

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -1,8 +1,17 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useNavigation } from "../navigation";
-import { Check, ChevronRight, Maximize2, Minimize2, X as XIcon } from "lucide-react";
+import {
+  ArrowUp,
+  Check,
+  ChevronRight,
+  Maximize2,
+  Minimize2,
+  MoreHorizontal,
+  X as XIcon,
+} from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
 import { toast } from "sonner";
 import type { IssueStatus, IssuePriority, IssueAssigneeType } from "@multica/core/types";
@@ -11,6 +20,13 @@ import {
   DialogContent,
   DialogTitle,
 } from "@multica/ui/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@multica/ui/components/ui/dropdown-menu";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../editor";
@@ -18,12 +34,15 @@ import { StatusIcon, StatusPicker, PriorityPicker, AssigneePicker, DueDatePicker
 import { BacklogAgentHintContent } from "../issues/components/backlog-agent-hint-dialog";
 import { ProjectPicker } from "../projects/components/project-picker";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
+import { useWorkspaceId } from "@multica/core/hooks";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
+import { issueDetailOptions } from "@multica/core/issues/queries";
 import { useCreateIssue, useUpdateIssue } from "@multica/core/issues/mutations";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { PillButton } from "../common/pill-button";
+import { IssuePickerModal } from "./issue-picker-modal";
 
 // ---------------------------------------------------------------------------
 // CreateIssueModal
@@ -52,8 +71,20 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
   const [projectId, setProjectId] = useState<string | undefined>(
     (data?.project_id as string) || undefined,
   );
+  const [parentIssueId, setParentIssueId] = useState<string | undefined>(
+    (data?.parent_issue_id as string) || undefined,
+  );
+  const [parentPickerOpen, setParentPickerOpen] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [backlogHintIssueId, setBacklogHintIssueId] = useState<string | null>(null);
+
+  // Fetch parent issue details for the chip (status/identifier/title).
+  // List cache usually has it already, so this resolves synchronously.
+  const wsId = useWorkspaceId();
+  const { data: parentIssue } = useQuery({
+    ...issueDetailOptions(wsId, parentIssueId ?? ""),
+    enabled: !!parentIssueId,
+  });
 
   // File upload — collect attachment IDs so we can link them after issue creation.
   const [attachmentIds, setAttachmentIds] = useState<string[]>([]);
@@ -91,7 +122,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
         assignee_id: assigneeId,
         due_date: dueDate || undefined,
         attachment_ids: attachmentIds.length > 0 ? attachmentIds : undefined,
-        parent_issue_id: (data?.parent_issue_id as string) || undefined,
+        parent_issue_id: parentIssueId,
         project_id: projectId,
       });
       clearDraft();
@@ -191,13 +222,7 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
               <div className="flex items-center gap-1.5 text-xs">
                 <span className="text-muted-foreground">{workspaceName}</span>
                 <ChevronRight className="size-3 text-muted-foreground/50" />
-                {typeof data?.parent_issue_identifier === "string" && (
-                  <>
-                    <span className="text-muted-foreground">{data.parent_issue_identifier}</span>
-                    <ChevronRight className="size-3 text-muted-foreground/50" />
-                  </>
-                )}
-                <span className="font-medium">{data?.parent_issue_id ? "New sub-issue" : "New issue"}</span>
+                <span className="font-medium">New issue</span>
               </div>
               <div className="flex items-center gap-1">
                 <Tooltip>
@@ -299,7 +324,79 @@ export function CreateIssueModal({ onClose, data }: { onClose: () => void; data?
                 triggerRender={<PillButton />}
                 align="start"
               />
+
+              {/* Parent chip — appears when parent is set.
+                  Placed before the ⋯ so it wraps to a new line with ⋯ if
+                  space is tight, but ⋯ always stays last in DOM order. */}
+              {parentIssueId && parentIssue && (
+                <div className="inline-flex items-center rounded-full border text-xs transition-colors hover:bg-accent/60">
+                  <button
+                    type="button"
+                    onClick={() => setParentPickerOpen(true)}
+                    className="flex items-center gap-1.5 py-1 pl-2.5 cursor-pointer"
+                  >
+                    <ArrowUp className="size-3 text-muted-foreground" />
+                    <span>Sub-issue of {parentIssue.identifier}</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setParentIssueId(undefined)}
+                    className="p-1 pr-2 text-muted-foreground hover:text-foreground cursor-pointer"
+                    aria-label="Remove parent"
+                  >
+                    <XIcon className="size-3" />
+                  </button>
+                </div>
+              )}
+
+              {/* Overflow — always the last child so DOM order keeps it at the
+                  end of the wrap flow, no matter how many chips are present. */}
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <PillButton aria-label="More options">
+                      <MoreHorizontal className="size-3.5" />
+                    </PillButton>
+                  }
+                />
+                <DropdownMenuContent align="start" className="w-auto">
+                  {parentIssueId && parentIssue ? (
+                    <>
+                      <DropdownMenuItem onClick={() => setParentPickerOpen(true)}>
+                        <ArrowUp className="h-3.5 w-3.5" />
+                        Parent: {parentIssue.identifier}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onClick={() => setParentIssueId(undefined)}
+                      >
+                        <XIcon className="h-3.5 w-3.5" />
+                        Remove parent
+                      </DropdownMenuItem>
+                    </>
+                  ) : (
+                    <DropdownMenuItem onClick={() => setParentPickerOpen(true)}>
+                      <ArrowUp className="h-3.5 w-3.5" />
+                      Set parent issue...
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
+
+            {/* Parent picker — rendered inline so it stacks over this modal
+                instead of replacing it via useModalStore. */}
+            <IssuePickerModal
+              open={parentPickerOpen}
+              onOpenChange={setParentPickerOpen}
+              title="Set parent issue"
+              description="Search for an issue to set as the parent of the new issue"
+              excludeIds={[]}
+              onSelect={(selected) => {
+                setParentIssueId(selected.id);
+              }}
+            />
 
             {/* Footer */}
             <div className="flex items-center justify-between px-4 py-3 border-t shrink-0">

--- a/packages/views/modals/delete-issue-confirm.tsx
+++ b/packages/views/modals/delete-issue-confirm.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@multica/ui/components/ui/alert-dialog";
+import { useDeleteIssue } from "@multica/core/issues/mutations";
+import { useNavigation } from "../navigation";
+
+export function DeleteIssueConfirmModal({
+  onClose,
+  data,
+}: {
+  onClose: () => void;
+  data: Record<string, unknown> | null;
+}) {
+  const issueId = (data?.issueId as string) || "";
+  const navigateTo = (data?.onDeletedNavigateTo as string | undefined) || undefined;
+  const [deleting, setDeleting] = useState(false);
+  const deleteIssue = useDeleteIssue();
+  const navigation = useNavigation();
+
+  const handleDelete = async () => {
+    if (!issueId) return;
+    setDeleting(true);
+    try {
+      await deleteIssue.mutateAsync(issueId);
+      toast.success("Issue deleted");
+      onClose();
+      if (navigateTo) navigation.push(navigateTo);
+    } catch {
+      toast.error("Failed to delete issue");
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open onOpenChange={(v) => { if (!v && !deleting) onClose(); }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete issue</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete this issue and all its comments. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            disabled={deleting}
+            className="bg-destructive text-white hover:bg-destructive/90"
+          >
+            {deleting ? "Deleting..." : "Delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/views/modals/issue-picker-modal.tsx
+++ b/packages/views/modals/issue-picker-modal.tsx
@@ -21,6 +21,10 @@ interface IssuePickerModalProps {
   description: string;
   excludeIds: string[];
   onSelect: (issue: Issue) => void;
+  /** Shows a banner at the top indicating which issue the link operates on. */
+  contextIssue?: Issue;
+  /** Small label displayed above the context issue, e.g. "Setting parent of". */
+  contextLabel?: string;
 }
 
 export function IssuePickerModal({
@@ -30,6 +34,8 @@ export function IssuePickerModal({
   description,
   excludeIds,
   onSelect,
+  contextIssue,
+  contextLabel,
 }: IssuePickerModalProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<Issue[]>([]);
@@ -88,6 +94,18 @@ export function IssuePickerModal({
       title={title}
       description={description}
     >
+      {contextIssue && (
+        <div className="border-b px-3 py-2">
+          {contextLabel && (
+            <p className="text-xs text-muted-foreground">{contextLabel}</p>
+          )}
+          <div className="mt-0.5 flex items-center gap-1.5 text-sm">
+            <StatusIcon status={contextIssue.status} className="h-3.5 w-3.5 shrink-0" />
+            <span className="shrink-0 text-muted-foreground">{contextIssue.identifier}</span>
+            <span className="truncate font-medium">{contextIssue.title}</span>
+          </div>
+        </div>
+      )}
       <Command shouldFilter={false}>
         <CommandInput
           placeholder="Search issues..."

--- a/packages/views/modals/issue-picker-modal.tsx
+++ b/packages/views/modals/issue-picker-modal.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { Issue } from "@multica/core/types";
+import { api } from "@multica/core/api";
+import {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@multica/ui/components/ui/command";
+import { StatusIcon } from "../issues/components/status-icon";
+
+interface IssuePickerModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  excludeIds: string[];
+  onSelect: (issue: Issue) => void;
+}
+
+export function IssuePickerModal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  excludeIds,
+  onSelect,
+}: IssuePickerModalProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Issue[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const abortRef = useRef<AbortController>(undefined);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setResults([]);
+      setIsLoading(false);
+    }
+  }, [open]);
+
+  const search = useCallback(
+    (q: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (abortRef.current) abortRef.current.abort();
+
+      if (!q.trim()) {
+        setResults([]);
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      debounceRef.current = setTimeout(async () => {
+        const controller = new AbortController();
+        abortRef.current = controller;
+        try {
+          const res = await api.searchIssues({
+            q: q.trim(),
+            limit: 20,
+            include_closed: true,
+            signal: controller.signal,
+          });
+          if (!controller.signal.aborted) {
+            setResults(res.issues.filter((i) => !excludeIds.includes(i.id)));
+            setIsLoading(false);
+          }
+        } catch {
+          if (!controller.signal.aborted) {
+            setIsLoading(false);
+          }
+        }
+      }, 300);
+    },
+    [excludeIds],
+  );
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      description={description}
+    >
+      <Command shouldFilter={false}>
+        <CommandInput
+          placeholder="Search issues..."
+          value={query}
+          onValueChange={(v) => {
+            setQuery(v);
+            search(v);
+          }}
+        />
+        <CommandList>
+          {isLoading && (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              Searching...
+            </div>
+          )}
+          {!isLoading && query.trim() && results.length === 0 && (
+            <CommandEmpty>No issues found.</CommandEmpty>
+          )}
+          {!isLoading && !query.trim() && (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              Type to search issues
+            </div>
+          )}
+          {results.length > 0 && (
+            <CommandGroup>
+              {results.map((issue) => (
+                <CommandItem
+                  key={issue.id}
+                  value={issue.id}
+                  onSelect={() => {
+                    onSelect(issue);
+                    onOpenChange(false);
+                  }}
+                >
+                  <StatusIcon status={issue.status} className="h-3.5 w-3.5 shrink-0" />
+                  <span className="text-muted-foreground shrink-0">{issue.identifier}</span>
+                  <span className="truncate">{issue.title}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </CommandDialog>
+  );
+}

--- a/packages/views/modals/issue-picker-modal.tsx
+++ b/packages/views/modals/issue-picker-modal.tsx
@@ -21,10 +21,6 @@ interface IssuePickerModalProps {
   description: string;
   excludeIds: string[];
   onSelect: (issue: Issue) => void;
-  /** Shows a banner at the top indicating which issue the link operates on. */
-  contextIssue?: Issue;
-  /** Small label displayed above the context issue, e.g. "Setting parent of". */
-  contextLabel?: string;
 }
 
 export function IssuePickerModal({
@@ -34,8 +30,6 @@ export function IssuePickerModal({
   description,
   excludeIds,
   onSelect,
-  contextIssue,
-  contextLabel,
 }: IssuePickerModalProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<Issue[]>([]);
@@ -94,18 +88,6 @@ export function IssuePickerModal({
       title={title}
       description={description}
     >
-      {contextIssue && (
-        <div className="border-b px-3 py-2">
-          {contextLabel && (
-            <p className="text-xs text-muted-foreground">{contextLabel}</p>
-          )}
-          <div className="mt-0.5 flex items-center gap-1.5 text-sm">
-            <StatusIcon status={contextIssue.status} className="h-3.5 w-3.5 shrink-0" />
-            <span className="shrink-0 text-muted-foreground">{contextIssue.identifier}</span>
-            <span className="truncate font-medium">{contextIssue.title}</span>
-          </div>
-        </div>
-      )}
       <Command shouldFilter={false}>
         <CommandInput
           placeholder="Search issues..."

--- a/packages/views/modals/registry.tsx
+++ b/packages/views/modals/registry.tsx
@@ -5,6 +5,10 @@ import { CreateWorkspaceModal } from "./create-workspace";
 import { CreateIssueModal } from "./create-issue";
 import { CreateProjectModal } from "./create-project";
 import { FeedbackModal } from "./feedback";
+import { SetParentIssueModal } from "./set-parent-issue";
+import { AddChildIssueModal } from "./add-child-issue";
+import { DeleteIssueConfirmModal } from "./delete-issue-confirm";
+import { BacklogAgentHintModal } from "./backlog-agent-hint";
 
 export function ModalRegistry() {
   const modal = useModalStore((s) => s.modal);
@@ -20,6 +24,14 @@ export function ModalRegistry() {
       return <CreateProjectModal onClose={close} />;
     case "feedback":
       return <FeedbackModal onClose={close} />;
+    case "issue-set-parent":
+      return <SetParentIssueModal onClose={close} data={data} />;
+    case "issue-add-child":
+      return <AddChildIssueModal onClose={close} data={data} />;
+    case "issue-delete-confirm":
+      return <DeleteIssueConfirmModal onClose={close} data={data} />;
+    case "issue-backlog-agent-hint":
+      return <BacklogAgentHintModal onClose={close} data={data} />;
     default:
       return null;
   }

--- a/packages/views/modals/set-parent-issue.tsx
+++ b/packages/views/modals/set-parent-issue.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { childIssuesOptions } from "@multica/core/issues/queries";
+import { useUpdateIssue } from "@multica/core/issues/mutations";
+import { IssuePickerModal } from "./issue-picker-modal";
+
+export function SetParentIssueModal({
+  onClose,
+  data,
+}: {
+  onClose: () => void;
+  data: Record<string, unknown> | null;
+}) {
+  const issueId = (data?.issueId as string) || "";
+  const wsId = useWorkspaceId();
+  const updateIssue = useUpdateIssue();
+
+  const { data: children = [] } = useQuery({
+    ...childIssuesOptions(wsId, issueId),
+    enabled: !!issueId,
+  });
+
+  const excludeIds = [issueId, ...children.map((c) => c.id)];
+
+  return (
+    <IssuePickerModal
+      open
+      onOpenChange={(v) => {
+        if (!v) onClose();
+      }}
+      title="Set parent issue"
+      description="Search for an issue to set as the parent of this issue"
+      excludeIds={excludeIds}
+      onSelect={(selected) => {
+        updateIssue.mutate(
+          { id: issueId, parent_issue_id: selected.id },
+          { onError: () => toast.error("Failed to update issue") },
+        );
+        toast.success(`Set ${selected.identifier} as parent issue`);
+      }}
+    />
+  );
+}

--- a/packages/views/modals/set-parent-issue.tsx
+++ b/packages/views/modals/set-parent-issue.tsx
@@ -3,7 +3,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { childIssuesOptions } from "@multica/core/issues/queries";
+import {
+  childIssuesOptions,
+  issueDetailOptions,
+} from "@multica/core/issues/queries";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { IssuePickerModal } from "./issue-picker-modal";
 
@@ -18,6 +21,10 @@ export function SetParentIssueModal({
   const wsId = useWorkspaceId();
   const updateIssue = useUpdateIssue();
 
+  const { data: contextIssue } = useQuery({
+    ...issueDetailOptions(wsId, issueId),
+    enabled: !!issueId,
+  });
   const { data: children = [] } = useQuery({
     ...childIssuesOptions(wsId, issueId),
     enabled: !!issueId,
@@ -34,6 +41,8 @@ export function SetParentIssueModal({
       title="Set parent issue"
       description="Search for an issue to set as the parent of this issue"
       excludeIds={excludeIds}
+      contextIssue={contextIssue ?? undefined}
+      contextLabel="Setting parent of"
       onSelect={(selected) => {
         updateIssue.mutate(
           { id: issueId, parent_issue_id: selected.id },

--- a/packages/views/modals/set-parent-issue.tsx
+++ b/packages/views/modals/set-parent-issue.tsx
@@ -3,10 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
-import {
-  childIssuesOptions,
-  issueDetailOptions,
-} from "@multica/core/issues/queries";
+import { childIssuesOptions } from "@multica/core/issues/queries";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { IssuePickerModal } from "./issue-picker-modal";
 
@@ -21,10 +18,6 @@ export function SetParentIssueModal({
   const wsId = useWorkspaceId();
   const updateIssue = useUpdateIssue();
 
-  const { data: contextIssue } = useQuery({
-    ...issueDetailOptions(wsId, issueId),
-    enabled: !!issueId,
-  });
   const { data: children = [] } = useQuery({
     ...childIssuesOptions(wsId, issueId),
     enabled: !!issueId,
@@ -41,8 +34,6 @@ export function SetParentIssueModal({
       title="Set parent issue"
       description="Search for an issue to set as the parent of this issue"
       excludeIds={excludeIds}
-      contextIssue={contextIssue ?? undefined}
-      contextLabel="Setting parent of"
       onSelect={(selected) => {
         updateIssue.mutate(
           { id: issueId, parent_issue_id: selected.id },


### PR DESCRIPTION
## Summary

- **Right-click context menu** on list rows and board cards — same action set as the detail page's ⋯ (status/priority/assignee/due date + relationship ops + pin/copy link/delete). Users no longer have to enter the detail page to update an issue.
- **Unified action hook** (`useIssueActions`) owns every Issue mutation, pin state, clipboard, and modal dispatch. Two thin shells (`IssueActionsDropdown`, `IssueActionsContextMenu`) render the same JSX using a primitives lookup — Base UI's `ContextMenuTrigger render={children}` keeps DOM, dnd-kit listeners, and Tailwind `group-hover` untouched.
- **"More" submenu** groups relationship actions (Create sub-issue / Set parent / Add sub-issue) under one branch, keeping the top level clean and leaving room for future relations (blocks, duplicates, related).
- **Create modal ⋯** gains the missing "bidirectional" linking — you can now set the new issue's parent AND queue existing issues as sub-issues at creation time. Sub-issues are deferred-linked after create resolves; partial failures toast but don't roll back the new issue.
- **Shell-level modals** for Set Parent / Add Sub-issue / Delete Confirm / Backlog Hint replace the detail-page local state. Detail page detects its own deletion via a `useEffect` watching the cache transition, firing `onDelete` once (keeps inbox's selection-clear behavior working).
- **Hover / active styling** on list rows and board cards mirrors the sidebar's same-color / different-intensity pattern, keyed off Base UI's `data-popup-open` — pure CSS, zero state.

## Scope

9 commits, 19 files, +1714 / -550. No backend changes.

## Test plan

- [x] \`pnpm typecheck\` green across all 6 packages
- [x] \`pnpm --filter @multica/views test\` — 29 files / 198 tests pass (new: 11 hook + menu tests, 1 updated create-issue test)
- [x] \`pnpm --filter @multica/web test\` — 3 files / 17 tests pass
- [x] Independent code review — 0 must-fix, 0 should-fix, all "nice to have" items are polish-level (1 shipped as polish commit, rest deferred)
- [ ] Manual QA:
  - [ ] Right-click list row → all actions work, no native browser menu
  - [ ] Right-click board card → menu opens, card doesn't drag
  - [ ] Hover vs active visual — board card bg tint + border, list row bg tint; active state clearly stronger
  - [ ] Detail ⋯ → More > → relationship ops
  - [ ] "+ New issue" → ⋯ → Set parent / Add sub-issue → chips appear → Create → children linked
  - [ ] Delete from list right-click on current detail page → inbox / list / board all update
  - [ ] Esc closes inline pickers inside create modal without closing the create modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)