### PR TITLE
fix(issues): cleaner board card hover with shadow elevation

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -79,7 +79,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showChildProgress = storeProperties.childProgress && childProgress;
 
   return (
-    <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-[border-color,box-shadow,background-color] group-hover/card:border-accent/50 group-hover/card:bg-accent/20 group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent/40 group-hover:shadow-sm">
+    <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-[border-color,box-shadow,background-color] group-hover/card:shadow-md group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
       {/* Row 1: Identifier */}
       <p className="text-xs text-muted-foreground">{issue.identifier}</p>
 


### PR DESCRIPTION
## Summary

- Replace the translucent tinted hover (`border-accent/50` + `bg-accent/20`) on board cards with a single shadow lift (`shadow-md`). The previous overlay was visually weak because `--accent` is nearly identical to `--card` in light mode — a 20% tint rendered as almost no change.
- Active (popup-open) state now uses solid `bg-accent` instead of `bg-accent/40`, so hover and active are distinguished on **different dimensions** (elevation vs color) rather than competing on the same axis.
- Also drops the anonymous `group-hover:shadow-sm` in favor of the explicit `group-hover/card:` group name for consistency.

No change to list rows — the dense row layout can't use shadow elevation and the existing `bg-accent/60` already reads clearly.

## Test plan

- [ ] Board view: hover a card → card lifts via shadow, no color tint
- [ ] Board view: right-click a card → card shows solid accent background + accent border while context menu is open
- [ ] Verify in both light and dark mode
- [ ] List view: no regression (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)