### PR TITLE
fix(issues): board card hover uses border color instead of shadow

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -79,7 +79,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showChildProgress = storeProperties.childProgress && childProgress;
 
   return (
-    <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-[border-color,box-shadow,background-color] group-hover/card:shadow-md group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
+    <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-[border-color,background-color] group-hover/card:border-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
       {/* Row 1: Identifier */}
       <p className="text-xs text-muted-foreground">{issue.identifier}</p>
 


### PR DESCRIPTION
## Summary

Follow-up to the previous hover polish. In dark mode, `shadow-md` was effectively invisible — a dark shadow on a dark card has almost no contrast, so hover read as "nothing changed". This PR drops shadow-based hover entirely and uses `border-accent` instead, which is visible in both themes.

Hover and active now sit on the **same axis** (color), with active being a clear step up:

| State | Border | Background |
|---|---|---|
| Default | `border-border` | `bg-card` |
| **Hover** | `border-accent` | `bg-card` |
| **Active** (popup-open) | `border-accent` | `bg-accent` |

Also removes `box-shadow` from the transition list (no longer animating).

## Why not opacity (e.g. `bg-accent/60` for hover)?

Considered and rejected. In light mode `--card` is pure white and `--accent` is near-white — `bg-accent/60` resolves to ~1.3% lightness difference from the base, which is visually indistinguishable. This was the exact bug the earlier hover polish tried to fix. Going solid on border + adding bg on active is the cleanest way to give hover/active clear, theme-consistent signals.

## Test plan

- [ ] Board view, **light mode**: hover a card → border turns darker/accent; no shadow change
- [ ] Board view, **dark mode**: hover a card → border clearly visible (main regression this PR fixes)
- [ ] Board view, both modes: right-click a card → border + accent background while menu is open
- [ ] List view: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)