### PR TITLE
fix(issues): unify board card hover and active visual

### DIFF
--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -79,7 +79,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showChildProgress = storeProperties.childProgress && childProgress;
 
   return (
-    <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-[border-color,box-shadow,background-color] group-hover/card:shadow-md group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
+    <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-colors group-hover/card:border-accent group-hover/card:bg-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
       {/* Row 1: Identifier */}
       <p className="text-xs text-muted-foreground">{issue.identifier}</p>
 


### PR DESCRIPTION
## Summary

- Hover and popup-open (right-click menu open) now share the same `bg-accent + border-accent` treatment — the two states are visually identical.
- Drop the `shadow-md` on hover (it's invisible in dark mode anyway) and the multi-property transition in favor of a single `transition-colors`.
- One-line change in `packages/views/issues/components/board-card.tsx`.

## Rationale

Previously hover used an elevation change (`shadow-md`) while right-click active state used a color change (`bg-accent`). Two different visual languages for two similar states, and the shadow didn't read in dark mode. Unifying on the color change keeps the interaction simple and consistent across themes.

## Test plan

- [ ] Board view: hover a card → background + border go to `accent`.
- [ ] Board view: right-click a card → same visual, stays sticky while menu is open.
- [ ] Dark mode: both states read clearly.
- [ ] No regression to drag/drop or navigation on card click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)