### PR TITLE
fix(skills): remove double-flicker on CreateSkillDialog close

### DIFF
--- a/packages/views/skills/components/create-skill-dialog.tsx
+++ b/packages/views/skills/components/create-skill-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
   AlertCircle,
   ArrowLeft,
@@ -452,20 +452,13 @@ const METHOD_DESCS: Record<Method, string> = {
 };
 
 export function CreateSkillDialog({
-  open,
   onClose,
   onCreated,
 }: {
-  open: boolean;
   onClose: () => void;
   onCreated?: (skill: Skill) => void;
 }) {
   const [method, setMethod] = useState<Method>("chooser");
-
-  // Reset to chooser each time the dialog opens.
-  useEffect(() => {
-    if (open) setMethod("chooser");
-  }, [open]);
 
   const handleCreated = (skill: Skill) => {
     onCreated?.(skill);
@@ -474,8 +467,12 @@ export function CreateSkillDialog({
 
   const wide = method === "runtime";
 
+  // Mount pattern mirrors CreateIssue / CreateProject: the parent conditionally
+  // renders this component and `<Dialog open>` is hard-coded. Toggling `open`
+  // via prop (controlled) causes a second data-open → data-closed flip with a
+  // tail re-render, which shows up as a "double blink" on close.
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+    <Dialog open onOpenChange={(v) => !v && onClose()}>
       <DialogContent
         showCloseButton={false}
         className={cn(

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -538,11 +538,12 @@ export default function SkillsPage() {
         </div>
       )}
 
-      <CreateSkillDialog
-        open={createOpen}
-        onClose={() => setCreateOpen(false)}
-        onCreated={handleCreated}
-      />
+      {createOpen && (
+        <CreateSkillDialog
+          onClose={() => setCreateOpen(false)}
+          onCreated={handleCreated}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Closing the New Skill dialog flashes twice: first the close animation, then a brief second fade before the overlay clears.

## Root cause

`CreateSkillDialog` used a controlled `open` prop while staying mounted (`<Dialog open={open} ...>`), unlike the other dialog patterns in this repo (`CreateIssue`, `CreateProject`) which hard-code `<Dialog open>` and rely on the parent to conditionally render the whole component.

The controlled-toggle path on an already-mounted Popup produces a `data-open → data-closed` flip plus a tail re-render from `useEffect([open])` that resets `method` back to `chooser`. That second render is what shows up as a second fade frame.

## Fix

Align with the repo's existing pattern:

- `SkillsPage` renders `{createOpen && <CreateSkillDialog ... />}`.
- `CreateSkillDialog` hard-codes `<Dialog open>`.
- The per-open `method` reset effect is dropped — fresh mount means fresh state automatically.

On close, the parent unmounts and Base UI's Portal owns the single exit animation.

## Test plan

- [x] Close the dialog via the X button — single clean fade-out, no double-blink (confirmed by reporter)
- [ ] Close via ESC — same
- [ ] Close via backdrop click — same
- [ ] Open → pick "Copy from runtime" (wide mode) → close — still a single fade-out
- [ ] Reopen and verify the dialog starts on the method chooser

🤖 Generated with [Claude Code](https://claude.com/claude-code)