### PR TITLE
fix(workspace): defense-in-depth owner check in DeleteWorkspace handler

### DIFF
--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -765,8 +765,8 @@ func TestDeleteWorkspaceRequiresOwner(t *testing.T) {
 		t.Fatalf("request failed: %v", err)
 	}
 	resp.Body.Close()
-	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected 403/404 for non-owner DELETE, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-owner DELETE, got %d", resp.StatusCode)
 	}
 
 	var exists bool

--- a/server/cmd/server/integration_test.go
+++ b/server/cmd/server/integration_test.go
@@ -722,6 +722,62 @@ func TestWorkspacesThroughRouter(t *testing.T) {
 	}
 }
 
+// TestDeleteWorkspaceRequiresOwner is a defense-in-depth regression test for the
+// permission gate on DELETE /api/workspaces/{id}. It creates a separate workspace
+// in which the integration test user is only an "admin" (not "owner") and asserts
+// that DELETE returns 403, leaving the workspace intact. This guards against both
+// router misconfiguration (missing middleware) and handler regressions.
+func TestDeleteWorkspaceRequiresOwner(t *testing.T) {
+	ctx := context.Background()
+
+	const slug = "integration-tests-delete-403"
+	// Best-effort cleanup from any prior run.
+	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
+
+	var wsID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`, "Integration Tests Delete 403", slug, "DeleteWorkspace permission test").Scan(&wsID); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role)
+		VALUES ($1, $2, 'admin')
+	`, wsID, testUserID); err != nil {
+		t.Fatalf("create admin member: %v", err)
+	}
+
+	req, err := http.NewRequest("DELETE", testServer.URL+"/api/workspaces/"+wsID, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	req.Header.Set("X-Workspace-ID", wsID)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 403/404 for non-owner DELETE, got %d", resp.StatusCode)
+	}
+
+	var exists bool
+	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {
+		t.Fatalf("verify workspace: %v", err)
+	}
+	if !exists {
+		t.Fatal("workspace was deleted despite non-owner request")
+	}
+}
+
 // ---- Inbox through full router ----
 
 func TestInboxThroughRouter(t *testing.T) {

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -599,6 +599,19 @@ func (h *Handler) LeaveWorkspace(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	workspaceID := workspaceIDFromURL(r, "id")
 
+	// Defense in depth: the route is already gated by the
+	// RequireWorkspaceRoleFromURL("owner") middleware, but we re-check here
+	// so that the handler is safe regardless of how it gets wired up
+	// (direct calls in tests, future router refactors, etc.).
+	requester, ok := h.workspaceMember(w, r, workspaceID)
+	if !ok {
+		return
+	}
+	if requester.Role != "owner" {
+		writeError(w, http.StatusForbidden, "insufficient permissions")
+		return
+	}
+
 	if err := h.Queries.DeleteWorkspace(r.Context(), parseUUID(workspaceID)); err != nil {
 		slog.Warn("delete workspace failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID)...)
 		writeError(w, http.StatusInternalServerError, "failed to delete workspace")

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -41,90 +41,90 @@ func TestCreateWorkspace_RejectsReservedSlug(t *testing.T) {
 // workspace; with it, the handler must return 403 and leave the workspace
 // intact.
 func TestDeleteWorkspace_RequiresOwner(t *testing.T) {
-ctx := context.Background()
+	ctx := context.Background()
 
-const slug = "handler-tests-delete-403"
-_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
+	const slug = "handler-tests-delete-403"
+	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
 
-var wsID string
-if err := testPool.QueryRow(ctx, `
+	var wsID string
+	if err := testPool.QueryRow(ctx, `
 INSERT INTO workspace (name, slug, description)
 VALUES ($1, $2, $3)
 RETURNING id
 `, "Handler Test Delete 403", slug, "DeleteWorkspace handler permission test").Scan(&wsID); err != nil {
-t.Fatalf("create workspace: %v", err)
-}
-t.Cleanup(func() {
-_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
-})
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
 
-if _, err := testPool.Exec(ctx, `
+	if _, err := testPool.Exec(ctx, `
 INSERT INTO member (workspace_id, user_id, role)
 VALUES ($1, $2, 'admin')
 `, wsID, testUserID); err != nil {
-t.Fatalf("create admin member: %v", err)
-}
+		t.Fatalf("create admin member: %v", err)
+	}
 
-w := httptest.NewRecorder()
-req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
-req = withURLParam(req, "id", wsID)
-testHandler.DeleteWorkspace(w, req)
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
+	req = withURLParam(req, "id", wsID)
+	testHandler.DeleteWorkspace(w, req)
 
-if w.Code != http.StatusForbidden {
-t.Fatalf("expected 403 from DeleteWorkspace handler for admin (non-owner), got %d: %s", w.Code, w.Body.String())
-}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 from DeleteWorkspace handler for admin (non-owner), got %d: %s", w.Code, w.Body.String())
+	}
 
-var exists bool
-if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {
-t.Fatalf("verify workspace: %v", err)
-}
-if !exists {
-t.Fatal("workspace was deleted despite non-owner request — handler-level check did not fire")
-}
+	var exists bool
+	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {
+		t.Fatalf("verify workspace: %v", err)
+	}
+	if !exists {
+		t.Fatal("workspace was deleted despite non-owner request — handler-level check did not fire")
+	}
 }
 
 // TestDeleteWorkspace_OwnerSucceeds is the positive counterpart: an owner
 // calling DeleteWorkspace directly must succeed (204) and the workspace must
 // be gone. This guards the handler check against being too strict.
 func TestDeleteWorkspace_OwnerSucceeds(t *testing.T) {
-ctx := context.Background()
+	ctx := context.Background()
 
-const slug = "handler-tests-delete-ok"
-_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
+	const slug = "handler-tests-delete-ok"
+	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
 
-var wsID string
-if err := testPool.QueryRow(ctx, `
+	var wsID string
+	if err := testPool.QueryRow(ctx, `
 INSERT INTO workspace (name, slug, description)
 VALUES ($1, $2, $3)
 RETURNING id
 `, "Handler Test Delete OK", slug, "DeleteWorkspace handler owner test").Scan(&wsID); err != nil {
-t.Fatalf("create workspace: %v", err)
-}
-t.Cleanup(func() {
-_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
-})
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
 
-if _, err := testPool.Exec(ctx, `
+	if _, err := testPool.Exec(ctx, `
 INSERT INTO member (workspace_id, user_id, role)
 VALUES ($1, $2, 'owner')
 `, wsID, testUserID); err != nil {
-t.Fatalf("create owner member: %v", err)
-}
+		t.Fatalf("create owner member: %v", err)
+	}
 
-w := httptest.NewRecorder()
-req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
-req = withURLParam(req, "id", wsID)
-testHandler.DeleteWorkspace(w, req)
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
+	req = withURLParam(req, "id", wsID)
+	testHandler.DeleteWorkspace(w, req)
 
-if w.Code != http.StatusNoContent {
-t.Fatalf("expected 204 from DeleteWorkspace handler for owner, got %d: %s", w.Code, w.Body.String())
-}
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 from DeleteWorkspace handler for owner, got %d: %s", w.Code, w.Body.String())
+	}
 
-var exists bool
-if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {
-t.Fatalf("verify workspace: %v", err)
-}
-if exists {
-t.Fatal("workspace still exists after owner DELETE")
-}
+	var exists bool
+	if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {
+		t.Fatalf("verify workspace: %v", err)
+	}
+	if exists {
+		t.Fatal("workspace still exists after owner DELETE")
+	}
 }

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -31,4 +32,99 @@ func TestCreateWorkspace_RejectsReservedSlug(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDeleteWorkspace_RequiresOwner exercises the in-handler authorization
+// added to DeleteWorkspace by calling the handler directly (bypassing the
+// router-level RequireWorkspaceRoleFromURL middleware). Without the handler
+// check, a non-owner member request would reach DeleteWorkspace and erase the
+// workspace; with it, the handler must return 403 and leave the workspace
+// intact.
+func TestDeleteWorkspace_RequiresOwner(t *testing.T) {
+ctx := context.Background()
+
+const slug = "handler-tests-delete-403"
+_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
+
+var wsID string
+if err := testPool.QueryRow(ctx, `
+INSERT INTO workspace (name, slug, description)
+VALUES ($1, $2, $3)
+RETURNING id
+`, "Handler Test Delete 403", slug, "DeleteWorkspace handler permission test").Scan(&wsID); err != nil {
+t.Fatalf("create workspace: %v", err)
+}
+t.Cleanup(func() {
+_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
+})
+
+if _, err := testPool.Exec(ctx, `
+INSERT INTO member (workspace_id, user_id, role)
+VALUES ($1, $2, 'admin')
+`, wsID, testUserID); err != nil {
+t.Fatalf("create admin member: %v", err)
+}
+
+w := httptest.NewRecorder()
+req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
+req = withURLParam(req, "id", wsID)
+testHandler.DeleteWorkspace(w, req)
+
+if w.Code != http.StatusForbidden {
+t.Fatalf("expected 403 from DeleteWorkspace handler for admin (non-owner), got %d: %s", w.Code, w.Body.String())
+}
+
+var exists bool
+if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {
+t.Fatalf("verify workspace: %v", err)
+}
+if !exists {
+t.Fatal("workspace was deleted despite non-owner request — handler-level check did not fire")
+}
+}
+
+// TestDeleteWorkspace_OwnerSucceeds is the positive counterpart: an owner
+// calling DeleteWorkspace directly must succeed (204) and the workspace must
+// be gone. This guards the handler check against being too strict.
+func TestDeleteWorkspace_OwnerSucceeds(t *testing.T) {
+ctx := context.Background()
+
+const slug = "handler-tests-delete-ok"
+_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
+
+var wsID string
+if err := testPool.QueryRow(ctx, `
+INSERT INTO workspace (name, slug, description)
+VALUES ($1, $2, $3)
+RETURNING id
+`, "Handler Test Delete OK", slug, "DeleteWorkspace handler owner test").Scan(&wsID); err != nil {
+t.Fatalf("create workspace: %v", err)
+}
+t.Cleanup(func() {
+_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
+})
+
+if _, err := testPool.Exec(ctx, `
+INSERT INTO member (workspace_id, user_id, role)
+VALUES ($1, $2, 'owner')
+`, wsID, testUserID); err != nil {
+t.Fatalf("create owner member: %v", err)
+}
+
+w := httptest.NewRecorder()
+req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
+req = withURLParam(req, "id", wsID)
+testHandler.DeleteWorkspace(w, req)
+
+if w.Code != http.StatusNoContent {
+t.Fatalf("expected 204 from DeleteWorkspace handler for owner, got %d: %s", w.Code, w.Body.String())
+}
+
+var exists bool
+if err := testPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM workspace WHERE id = $1)`, wsID).Scan(&exists); err != nil {
+t.Fatalf("verify workspace: %v", err)
+}
+if exists {
+t.Fatal("workspace still exists after owner DELETE")
+}
 }


### PR DESCRIPTION
Closes [MUL-1343](https://multica.ai) — see issue c3286088-0476-4ca1-8573-38ed9926e90b.

## Summary

The DELETE `/api/workspaces/{id}` route is already gated by `middleware.RequireWorkspaceRoleFromURL(queries, "id", "owner")` (`server/cmd/server/router.go:233`), so the issue's claim that any authenticated user can delete any workspace is **not** a live exploit. However, the `DeleteWorkspace` handler itself does no in-handler authorization, unlike sibling handlers (`DeleteMember`, `UpdateMember`, `CreateMember`) which all call `h.workspaceMember(...)` and enforce role explicitly. This PR closes that defense-in-depth gap.

## Changes

- `server/internal/handler/workspace.go` — `DeleteWorkspace` now re-validates the requester is a workspace member with `role == owner` before deleting; returns 403 otherwise. Mirrors the pattern used by `DeleteMember`.
- `server/cmd/server/integration_test.go` — adds `TestDeleteWorkspaceRequiresOwner` which provisions a separate workspace, joins the test user as `admin` (non-owner), issues DELETE, and asserts the workspace survives with a 403/404 response.

## Verification

```
go build ./...                                # OK
go test ./internal/middleware -count=1        # OK
go test ./internal/handler -run Workspace -count=1   # OK
go test ./cmd/server -run "TestWorkspacesThroughRouter|TestProtectedRoutesRequireAuth|TestDeleteWorkspaceRequiresOwner" -count=1 -v   # all PASS
```

The new test currently exercises the middleware (which returns 403 first); the in-handler check is the safety net for any future routing change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>