### PR TITLE
fix(skills): support root-level SKILL.md imports from skills.sh

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -639,7 +639,8 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	//   skills/{name}/SKILL.md          (most common)
 	//   .claude/skills/{name}/SKILL.md  (Claude Code native discovery)
 	//   plugin/skills/{name}/SKILL.md   (e.g. microsoft repos)
-	//   {name}/SKILL.md                 (skill at repo root level)
+	//   {name}/SKILL.md                 (named directory at repo root)
+	//   SKILL.md                        (single-skill repo root)
 	defaultBranch := fetchGitHubDefaultBranch(httpClient, owner, repo)
 	rawPrefix := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s",
 		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
@@ -649,6 +650,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 		".claude/skills/" + skillName,
 		"plugin/skills/" + skillName,
 		skillName,
+		"",
 	}
 
 	var skillMdBody []byte

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -172,6 +172,83 @@ func TestFetchFromSkillsSh_FallbackDoesNotDoubleEscapeDirectoryNames(t *testing.
 	}
 }
 
+func TestFetchFromSkillsSh_SupportsRootLevelSkillMD(t *testing.T) {
+	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/root-skill":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/root-skill/contents":
+				if got := r.URL.Query().Get("ref"); got != "main" {
+					t.Fatalf("root contents ref = %q, want main", got)
+				}
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "README.md",
+						Path:        "README.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/root-skill/main/README.md",
+					},
+					{
+						Name: "scripts",
+						Path: "scripts",
+						Type: "dir",
+						URL:  "https://api.github.com/repos/acme/root-skill/contents/scripts?ref=main",
+					},
+				})
+			case "/repos/acme/root-skill/contents/scripts":
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "run.sh",
+						Path:        "scripts/run.sh",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/root-skill/main/scripts/run.sh",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/root-skill/main/SKILL.md":
+				w.Write([]byte("---\nname: Root Skill\ndescription: Root-level skill\n---\ncontent"))
+			case "/acme/root-skill/main/README.md":
+				w.Write([]byte("readme"))
+			case "/acme/root-skill/main/scripts/run.sh":
+				w.Write([]byte("echo run"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(client, "https://skills.sh/acme/root-skill/root-skill")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh: %v", err)
+	}
+
+	if result.name != "Root Skill" {
+		t.Fatalf("name = %q, want Root Skill", result.name)
+	}
+	if result.description != "Root-level skill" {
+		t.Fatalf("description = %q, want Root-level skill", result.description)
+	}
+	gotPaths := importedFilePaths(result.files)
+	wantPaths := []string{"README.md", "scripts/run.sh"}
+	if !equalStrings(gotPaths, wantPaths) {
+		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
+	}
+	if !containsString(*requests, "raw.githubusercontent.com /acme/root-skill/main/SKILL.md") {
+		t.Fatalf("expected root SKILL.md request, got %v", *requests)
+	}
+	if !containsString(*requests, "api.github.com /repos/acme/root-skill/contents?ref=main") {
+		t.Fatalf("expected root contents request, got %v", *requests)
+	}
+}
+
 func TestFetchFromSkillsSh_LogsSubdirectoryFailures(t *testing.T) {
 	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.Header.Get("X-Test-Original-Host") {


### PR DESCRIPTION
## What does this PR do?

Fixes skills.sh imports for single-skill repositories where `SKILL.md` lives at the repository root.

Before this change, `fetchFromSkillsSh` only checked these layouts:

- `skills/{name}/SKILL.md`
- `.claude/skills/{name}/SKILL.md`
- `plugin/skills/{name}/SKILL.md`
- `{name}/SKILL.md`

That meant repos whose root is the skill itself failed with `SKILL.md not found`.

This PR adds root-level `SKILL.md` as a final candidate path while preserving the existing lookup order for multi-skill repositories.

## Related Issue

Closes #1597

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `server/internal/handler/skill.go` to try root-level `SKILL.md` as a fallback for single-skill repos.
- Updated the lookup comment to distinguish named root directories from true repository-root skills.
- Added `TestFetchFromSkillsSh_SupportsRootLevelSkillMD` in `server/internal/handler/skill_test.go`.
- The test verifies root `SKILL.md` detection and supporting file import from the repository root.

## How to Test

1. Import a skills.sh URL backed by a single-skill repo with root-level `SKILL.md`, such as the repo described in #1597.
2. Confirm the import no longer fails with `SKILL.md not found`.
3. Run:

```bash
GOCACHE=～/multica/.cache/go-build go test ./internal/handler -run 'TestFetchFromSkillsSh'
