### PR TITLE
feat(skills): restore page description, link to docs, polish intro layout

### DIFF
--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -518,7 +518,7 @@ export default function SkillsPage() {
                 href="https://multica.ai/docs/skills"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+                className="text-xs text-muted-foreground underline decoration-muted-foreground/30 underline-offset-4 transition-colors hover:text-foreground"
               >
                 Learn more about Skills →
               </a>

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -430,7 +430,10 @@ export default function SkillsPage() {
       <div className="flex flex-1 min-h-0 flex-col">
         <PageHeaderBar totalCount={0} onCreate={() => setCreateOpen(true)} />
         <div className="flex flex-1 min-h-0 flex-col gap-4 p-6">
-          <Skeleton className="h-12 w-full max-w-3xl rounded-md" />
+          <div className="space-y-3 pl-4">
+            <Skeleton className="h-5 w-full max-w-2xl rounded-md" />
+            <Skeleton className="h-14 w-full max-w-3xl rounded-md" />
+          </div>
           <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-lg border">
             <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
               <Skeleton className="h-8 w-64 rounded-md" />
@@ -505,18 +508,31 @@ export default function SkillsPage() {
       )}
 
       {/* Page body — padding here keeps the card from touching the chrome,
-          and `gap-4` separates the sharing banner from the table card. */}
+          and `gap-4` separates the intro block from the table card. */}
       <div className="flex flex-1 min-h-0 flex-col gap-4 p-6">
         {!showEmpty && (
-          <div className="max-w-3xl rounded-r-md border-l-2 border-l-brand bg-brand/5 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
-            <span className="font-medium text-foreground">
-              Shared with your workspace.
-            </span>{" "}
-            Anyone can create a skill, import one from a URL, or copy one from
-            their local runtime — and every agent can use it.{" "}
-            <span className="font-semibold text-brand">
-              Local runtime skills stay private until you copy one here.
-            </span>
+          <div className="space-y-3 pl-4">
+            <p className="text-base text-foreground">
+              Instructions any agent in this workspace can use.{" "}
+              <a
+                href="https://multica.ai/docs/skills"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+              >
+                Learn more about Skills →
+              </a>
+            </p>
+            <div className="max-w-3xl rounded-r-md border-l-2 border-l-brand bg-brand/5 px-4 py-3 text-xs leading-relaxed text-muted-foreground">
+              <span className="font-medium text-foreground">
+                Shared with your workspace.
+              </span>{" "}
+              Anyone can create a skill, import one from a URL, or copy one
+              from their local runtime — and every agent can use it.{" "}
+              <span className="font-semibold text-brand">
+                Local runtime skills stay private until you copy one here.
+              </span>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Follow-up to #1614. That PR's card-layout refactor dropped the page-top description entirely; without it the page jumps straight from the `PageHeader` to a brand banner that explains *how sharing works*, with nothing answering "what IS a skill?". This PR brings the description back, adds a docs entry point, and tightens the visual hierarchy so the intro reads as one coherent unit above the table card.

- **Restore the description** — one line, primary text:
  > Instructions any agent in this workspace can use.
  Uses "any agent ... can use" (capability) rather than "every agent uses" (factual) — skills must be manually attached to take effect.
- **Inline docs link** — "Learn more about Skills →" mirrors the onboarding pattern (muted underline, opens in a new tab). Points at `https://multica.ai/docs/skills`.
- **Visual hierarchy** on the same line: description is `text-base text-foreground` (primary), link is `text-xs text-muted-foreground` (auxiliary).
- **Banner padding** bumped from `px-3 py-2` → `px-4 py-3` so it breathes and its inner text aligns with the table content's x-position.
- **Intro block** wraps description + banner in `pl-4 space-y-3` so they read as one indented unit above the card.
- Loading skeleton updated to mirror the new structure.

## Test plan

- [ ] Description and link sit on one line at normal viewport width; both wrap together gracefully when the viewport is narrow.
- [ ] Visual hierarchy: link looks subordinate (smaller, muted) without becoming invisible.
- [ ] Click "Learn more about Skills →" — opens `https://multica.ai/docs/skills` in a new tab.
- [ ] Empty state: intro block is hidden, EmptyState renders centered.
- [ ] Loading state: skeletons match the new layout (1-line description + banner-sized block + card with toolbar/rows skeletons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)