### PR TITLE
fix(agent): inherit hidden console to grandchildren on Windows

### DIFF
--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -7,14 +7,23 @@ import (
 	"syscall"
 )
 
-const createNoWindow = 0x08000000
+// CREATE_NEW_CONSOLE allocates a fresh console for the child. Combined with
+// HideWindow=true (STARTF_USESHOWWINDOW + SW_HIDE) the console window stays
+// off-screen, and — critically — any grandchildren the agent spawns (tool
+// subprocesses like bash, cmd, netstat, findstr) inherit this hidden console
+// instead of each allocating their own visible one.
+//
+// Using CREATE_NO_WINDOW here instead would strip the console entirely, which
+// forces Windows to allocate a new console per grandchild — the popup storm
+// tracked in #1521.
+const createNewConsole = 0x00000010
 
-// hideAgentWindow configures cmd to suppress the console window on Windows.
-// CREATE_NO_WINDOW prevents window creation while preserving stdio pipes.
+// hideAgentWindow configures cmd so neither the agent nor its grandchildren
+// flash a console window on Windows, while preserving stdio pipes.
 func hideAgentWindow(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.HideWindow = true
-	cmd.SysProcAttr.CreationFlags |= createNoWindow
+	cmd.SysProcAttr.CreationFlags |= createNewConsole
 }


### PR DESCRIPTION
## Summary

Fixes the grandchild popup storm in #1521: switch `proc_windows.go` from `CREATE_NO_WINDOW` to `CREATE_NEW_CONSOLE` + `HideWindow=true`, so tool subprocesses spawned by the agent CLI inherit a hidden console instead of each allocating a new visible one.

## Context

PR #1474 fixed #1471 by setting `CREATE_NO_WINDOW` on the agent spawn. That works for the agent's own console, but it causes a secondary problem: with no console on the agent, any console-subsystem grandchildren the agent CLI spawns (e.g. `bash.exe` / `cmd.exe` / `netstat.exe` / `findstr.exe` / `timeout.exe` during health-check loops, or per tool call) have no parent console to inherit and no `windowsHide` flag of their own, so Windows allocates a fresh console window for each one. That's the behavior reported in #1521.

## Fix

`CREATE_NEW_CONSOLE` allocates a console for the agent; `HideWindow=true` sets `STARTF_USESHOWWINDOW` + `SW_HIDE` so the console window stays off-screen. Grandchildren then inherit a hidden console → no popups. Stdio piping via `cmd.StdoutPipe()` / `cmd.StdinPipe()` is unaffected because `STARTF_USESTDHANDLES` overrides the console for stdin/stdout/stderr.

## Diff

One file, one behavioral flag change + a comment explaining the trade-off for the next reader. No changes to any of the 10 `hideAgentWindow(cmd)` call sites.

## Testing

- `go vet ./server/pkg/agent/...` clean
- No-op on non-Windows (`proc_other.go` untouched)
- Manual Windows 11 repro: Multica Desktop agent run + idle daemon — no console windows popping in either case after the change.

## Caveat / follow-up

On a small number of older Windows 10 builds, a brief console flash can occur before `SW_HIDE` is applied. If that proves visible in practice, the fully flash-free path is ConPTY (`CreatePseudoConsole` + `STARTUPINFOEX`). That's a larger change and is a reasonable follow-up if needed. For the reported cases in #1521 the `CREATE_NEW_CONSOLE` + `SW_HIDE` idiom is the standard Windows pattern and should cover them.

Closes #1521.
