### PR TITLE
fix(skills): fast-path root-level SKILL.md with frontmatter guard

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -639,7 +639,8 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	//   skills/{name}/SKILL.md          (most common)
 	//   .claude/skills/{name}/SKILL.md  (Claude Code native discovery)
 	//   plugin/skills/{name}/SKILL.md   (e.g. microsoft repos)
-	//   {name}/SKILL.md                 (skill at repo root level)
+	//   {name}/SKILL.md                 (e.g. anthropics/skills layout)
+	//   SKILL.md                        (single-skill repo: the repo is the skill)
 	defaultBranch := fetchGitHubDefaultBranch(httpClient, owner, repo)
 	rawPrefix := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s",
 		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
@@ -659,6 +660,20 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 			skillMdBody = body
 			skillDir = dir
 			break
+		}
+	}
+	// Single-skill repos place SKILL.md at the repository root. Try it as a
+	// fast path before the tree-listing fallback to avoid a recursive tree
+	// API call for a common case. Verify the frontmatter name matches so a
+	// stray root SKILL.md in a multi-skill repo can't get picked up for an
+	// unrelated skill URL.
+	if skillMdBody == nil {
+		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, "SKILL.md"))
+		if err == nil {
+			if name, _ := parseSkillFrontmatter(string(body)); name == skillName {
+				skillMdBody = body
+				skillDir = ""
+			}
 		}
 	}
 	if skillMdBody == nil {

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -303,6 +303,160 @@ func TestFetchFromSkillsSh_ResolvesAliasedSkillNamesViaFrontmatter(t *testing.T)
 	}
 }
 
+func TestFetchFromSkillsSh_ResolvesRootLevelSkillMd(t *testing.T) {
+	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/alchaincyf/huashu-design":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "master"})
+			case "/repos/alchaincyf/huashu-design/git/trees/master":
+				if got := r.URL.Query().Get("recursive"); got != "1" {
+					t.Fatalf("tree recursive = %q, want 1", got)
+				}
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree: []githubTreeEntry{
+						{Path: "README.md", Type: "blob"},
+						{Path: "SKILL.md", Type: "blob"},
+						{Path: "assets", Type: "tree"},
+						{Path: "assets/logo.png", Type: "blob"},
+					},
+				})
+			case "/repos/alchaincyf/huashu-design/contents":
+				if got := r.URL.Query().Get("ref"); got != "master" {
+					t.Fatalf("root contents ref = %q, want master", got)
+				}
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "README.md",
+						Path:        "README.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/alchaincyf/huashu-design/master/README.md",
+					},
+					{
+						Name:        "SKILL.md",
+						Path:        "SKILL.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/alchaincyf/huashu-design/master/SKILL.md",
+					},
+					{
+						Name: "assets",
+						Path: "assets",
+						Type: "dir",
+						URL:  "https://api.github.com/repos/alchaincyf/huashu-design/contents/assets?ref=master",
+					},
+				})
+			case "/repos/alchaincyf/huashu-design/contents/assets":
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "logo.png",
+						Path:        "assets/logo.png",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/alchaincyf/huashu-design/master/assets/logo.png",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/alchaincyf/huashu-design/master/SKILL.md":
+				w.Write([]byte("---\nname: huashu-design\ndescription: hi-fi HTML prototypes\n---\nbody"))
+			case "/alchaincyf/huashu-design/master/README.md":
+				w.Write([]byte("# Readme"))
+			case "/alchaincyf/huashu-design/master/assets/logo.png":
+				w.Write([]byte("PNGBYTES"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(client, "https://skills.sh/alchaincyf/huashu-design/huashu-design")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh: %v", err)
+	}
+	if result.name != "huashu-design" {
+		t.Fatalf("name = %q, want huashu-design", result.name)
+	}
+	if !strings.HasPrefix(result.content, "---\nname: huashu-design") {
+		t.Fatalf("SKILL.md content not populated, got %q", result.content)
+	}
+	gotPaths := importedFilePaths(result.files)
+	wantPaths := []string{"README.md", "assets/logo.png"}
+	if !equalStrings(gotPaths, wantPaths) {
+		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
+	}
+	if !containsString(*requests, "api.github.com /repos/alchaincyf/huashu-design/contents?ref=master") {
+		t.Fatalf("expected root contents listing, got %v", *requests)
+	}
+}
+
+func TestFetchFromSkillsSh_RootSkillMdFastPathSkipsFrontmatterMismatch(t *testing.T) {
+	// Multi-skill repo with an unrelated root SKILL.md (skill "other") plus a
+	// subdir skill "wanted". URL requests "wanted". The fast-path must reject
+	// the root SKILL.md on frontmatter mismatch and fall through to the tree
+	// fallback, which then resolves "wanted" correctly.
+	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/multi":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/multi/git/trees/main":
+				writeJSON(w, http.StatusOK, githubTreeResponse{
+					Tree: []githubTreeEntry{
+						{Path: "SKILL.md", Type: "blob"},
+						{Path: "extras/wanted/SKILL.md", Type: "blob"},
+					},
+				})
+			case "/repos/acme/multi/contents/extras/wanted":
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "ref.md",
+						Path:        "extras/wanted/ref.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/multi/main/extras/wanted/ref.md",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/multi/main/SKILL.md":
+				w.Write([]byte("---\nname: other\n---\ncontent"))
+			case "/acme/multi/main/extras/wanted/SKILL.md":
+				w.Write([]byte("---\nname: wanted\ndescription: the right one\n---\ncontent"))
+			case "/acme/multi/main/extras/wanted/ref.md":
+				w.Write([]byte("ref"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(client, "https://skills.sh/acme/multi/wanted")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh: %v", err)
+	}
+	if result.name != "wanted" {
+		t.Fatalf("name = %q, want wanted (root SKILL.md must not hijack the mismatched request)", result.name)
+	}
+	gotPaths := importedFilePaths(result.files)
+	wantPaths := []string{"ref.md"}
+	if !equalStrings(gotPaths, wantPaths) {
+		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
+	}
+	if !containsString(*requests, "api.github.com /repos/acme/multi/git/trees/main?recursive=1") {
+		t.Fatalf("expected tree fallback to run after fast-path frontmatter miss, got %v", *requests)
+	}
+}
+
 func TestFetchFromSkillsSh_ReturnsActionableErrorForTruncatedTrees(t *testing.T) {
 	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.Header.Get("X-Test-Original-Host") {


### PR DESCRIPTION
## Problem

Reported in #1597: importing a skill from skills.sh fails with `SKILL.md not found` when the repo is a single-skill repo with SKILL.md at the repository root (e.g. `skills.sh/alchaincyf/huashu-design/huashu-design`).

## Root cause

`candidatePaths` in `fetchFromSkillsSh` only covered subdirectory layouts:

- `skills/{name}/SKILL.md`
- `.claude/skills/{name}/SKILL.md`
- `plugin/skills/{name}/SKILL.md`
- `{name}/SKILL.md`

It never tried `SKILL.md` at the repo root, so single-skill repos fell all the way through to the recursive tree fallback added in #1432. That fallback does resolve these repos today via `findMatchingSkillDirByFrontmatter` — so the reporter's functional case actually works on main post-#1432 — but it's one unnecessary recursive `git/trees?recursive=1` call per import for a pattern that's pretty common (`anthropics/skills`, `alchaincyf/huashu-design`, and every "the repo is the skill" layout).

## Fix

Add a root-level SKILL.md fast path between the subdirectory candidates and the tree fallback, gated by a frontmatter-name check:

```go
if skillMdBody == nil {
    body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, "SKILL.md"))
    if err == nil {
        if name, _ := parseSkillFrontmatter(string(body)); name == skillName {
            skillMdBody = body
            skillDir = ""
        }
    }
}
```

The frontmatter guard matters: without it, a multi-skill repo that happens to have its own root SKILL.md would hand that root skill back for any `skills.sh/owner/repo/<other-name>` URL. With the guard, a mismatch falls through to the tree scan just like it would today. The second test case below pins that behavior.

Everything downstream already tolerates `skillDir = ""`: the contents listing uses an empty path (GitHub lists the root), and `strings.TrimPrefix(p, "/")` is a no-op on relative entry paths.

Comment beside `candidatePaths` is clarified so the root layout is explicit, not implied.

## Tests

Two new cases in `skill_test.go`:

- `TestFetchFromSkillsSh_ResolvesRootLevelSkillMd` — models alchaincyf/huashu-design (default branch `master`, root SKILL.md with `name: huashu-design`, an `assets/` subdir). Verifies the fast path resolves it, supporting files come in from the root contents listing, and `skillDir = ""` flows correctly.
- `TestFetchFromSkillsSh_RootSkillMdFastPathSkipsFrontmatterMismatch` — a multi-skill repo where the root SKILL.md declares `name: other` and a nested `extras/wanted/SKILL.md` declares `name: wanted`. A request for `wanted` must skip the root (mismatch) and resolve via the tree fallback. Asserts the tree request is actually made.

Both pass locally:

```
=== RUN   TestFetchFromSkillsSh_ResolvesRootLevelSkillMd
--- PASS: TestFetchFromSkillsSh_ResolvesRootLevelSkillMd (0.01s)
=== RUN   TestFetchFromSkillsSh_RootSkillMdFastPathSkipsFrontmatterMismatch
--- PASS: TestFetchFromSkillsSh_RootSkillMdFastPathSkipsFrontmatterMismatch (0.00s)
```

Full `TestFetchFromSkillsSh*` suite stays green.

## Notes

Deliberately keeping this narrow: no refactor of `partitionSkillMdPaths`, no change to the truncated-tree path, no touch to other candidate layouts. Happy to broaden or split further if you'd prefer.