### PR TITLE
fix(chat): invalidate workspace pending tasks cache on manual stop

### DIFF
--- a/packages/views/chat/components/chat-page.tsx
+++ b/packages/views/chat/components/chat-page.tsx
@@ -179,7 +179,10 @@ export function ChatPage() {
       qc.setQueryData(chatKeys.pendingTask(activeSessionId), {});
       qc.invalidateQueries({ queryKey: chatKeys.messages(activeSessionId) });
     }
-  }, [pendingTaskId, activeSessionId, qc]);
+    if (wsId) {
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTasks(wsId) });
+    }
+  }, [pendingTaskId, activeSessionId, wsId, qc]);
 
   const handleSelectAgent = useCallback(
     (agent: Agent) => {


### PR DESCRIPTION
## Summary

- When manually stopping a chat, the sidebar loading spinner kept spinning because `handleStop` only cleared the per-session pending task cache (`chatKeys.pendingTask(sessionId)`), but not the workspace-level aggregate cache (`chatKeys.pendingTasks(wsId)`) that the sidebar reads via `pendingChatTasksOptions(wsId)`.
- Added `qc.invalidateQueries({ queryKey: chatKeys.pendingTasks(wsId) })` to the stop handler so the sidebar immediately reflects the cancelled state.

Closes MUL-1384

## Test plan

- [ ] Open chat mode, start a conversation with an agent
- [ ] While the agent is responding, click Stop
- [ ] Verify the sidebar loading spinner stops immediately
- [ ] Verify the chat input re-enables correctly