### PR TITLE
fix(markdown): treat CJK full-width punctuation as URL boundary

### DIFF
--- a/packages/ui/markdown/linkify.ts
+++ b/packages/ui/markdown/linkify.ts
@@ -15,6 +15,15 @@ const linkify = new LinkifyIt()
 const FILE_PATH_REGEX =
   /(?:^|[\s([{<])((\/|~\/|\.\/)[\w\-./@]+\.(?:ts|tsx|js|jsx|mjs|cjs|md|json|yaml|yml|py|go|rs|css|scss|less|html|htm|txt|log|sh|bash|zsh|swift|kt|java|c|cpp|h|hpp|rb|php|xml|toml|ini|cfg|conf|env|sql|graphql|vue|svelte|astro|prisma|dockerfile|makefile|gitignore))(?=[\s)\]}.,;:!?>]|$)/gi
 
+// CJK full-width punctuation that should terminate a URL.
+// linkify-it only treats ASCII punctuation as URL boundaries, so in Chinese /
+// Japanese text a URL followed by e.g. "。" gets the punctuation and every
+// character up to the next whitespace swallowed into the href. We truncate the
+// detected URL at the first occurrence of any of these characters. Character
+// set mirrors the fix applied in mattermost/marked#22.
+const CJK_URL_TERMINATOR_REGEX =
+  /[！-／：-＠［-｀｛-～、。「-】]/
+
 interface DetectedLink {
   type: 'url' | 'email' | 'file'
   text: string
@@ -117,22 +126,53 @@ function rangesOverlap(
 }
 
 /**
+ * Run linkify-it on `text` and push normalized link records into `out`,
+ * shifted by `offset`. When linkify-it merges multiple URLs into one match
+ * because they are separated only by CJK punctuation (which it doesn't treat
+ * as a URL boundary), we truncate at that punctuation and re-scan the tail.
+ */
+function collectLinkifyMatches(text: string, offset: number, out: DetectedLink[]): void {
+  const matches = linkify.match(text)
+  if (!matches) return
+
+  for (const match of matches) {
+    const cjkIdx = match.text.search(CJK_URL_TERMINATOR_REGEX)
+    if (cjkIdx === 0) continue // match starts with CJK punct — skip
+
+    const truncate = cjkIdx > 0
+    const matchText = truncate ? match.text.slice(0, cjkIdx) : match.text
+    // linkify-it may prepend a scheme (e.g. "http://" or "mailto:") to url
+    // while leaving text as the raw substring. Preserve that prefix.
+    const schemePrefix = match.url.slice(0, match.url.length - match.text.length)
+    const matchUrl = truncate ? schemePrefix + matchText : match.url
+    const matchEnd = truncate ? match.index + cjkIdx : match.lastIndex
+
+    out.push({
+      type: match.schema === 'mailto:' ? 'email' : 'url',
+      text: matchText,
+      url: matchUrl,
+      start: match.index + offset,
+      end: matchEnd + offset
+    })
+
+    if (truncate) {
+      // Rescan the tail after the CJK punct — linkify-it had greedily swallowed
+      // it, so any additional URLs after the punct were never emitted.
+      const tailStart = matchEnd + 1
+      collectLinkifyMatches(text.slice(tailStart), offset + tailStart, out)
+      return
+    }
+  }
+}
+
+/**
  * Detect all links (URLs, emails, file paths) in text
  */
 export function detectLinks(text: string): DetectedLink[] {
   const links: DetectedLink[] = []
 
-  // 1. Detect URLs and emails with linkify-it
-  const urlMatches = linkify.match(text) || []
-  for (const match of urlMatches) {
-    links.push({
-      type: match.schema === 'mailto:' ? 'email' : 'url',
-      text: match.text,
-      url: match.url,
-      start: match.index,
-      end: match.lastIndex
-    })
-  }
+  // 1. Detect URLs and emails with linkify-it, applying CJK boundary handling.
+  collectLinkifyMatches(text, 0, links)
 
   // 2. Detect file paths with custom regex
   // Reset regex state

--- a/packages/views/editor/utils/preprocess-links.test.ts
+++ b/packages/views/editor/utils/preprocess-links.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { preprocessLinks } from "@multica/ui/markdown/linkify";
+
+// The bug: linkify-it does not treat CJK full-width punctuation as a URL
+// boundary, so the href can swallow trailing punctuation and the Chinese
+// characters that follow it (up to the next space). The fix truncates the
+// detected URL at the first CJK full-width punctuation character.
+
+describe("preprocessLinks — CJK punctuation boundary", () => {
+  it("stops URL at ideographic full stop 。", () => {
+    const out = preprocessLinks("见 https://example.com/path。然后继续");
+    expect(out).toBe("见 [https://example.com/path](https://example.com/path)。然后继续");
+  });
+
+  it("stops URL at fullwidth comma ，", () => {
+    const out = preprocessLinks("打开 https://example.com/a，以及其他");
+    expect(out).toBe("打开 [https://example.com/a](https://example.com/a)，以及其他");
+  });
+
+  it("stops URL at ideographic comma 、", () => {
+    const out = preprocessLinks("两个地址 https://a.com/x、https://b.com/y");
+    expect(out).toBe(
+      "两个地址 [https://a.com/x](https://a.com/x)、[https://b.com/y](https://b.com/y)",
+    );
+  });
+
+  it("stops URL at fullwidth right paren ）", () => {
+    const out = preprocessLinks("（见 https://example.com/x）后文");
+    expect(out).toBe("（见 [https://example.com/x](https://example.com/x)）后文");
+  });
+
+  it("stops URL at corner bracket 」", () => {
+    const out = preprocessLinks("「https://example.com/a」后文");
+    expect(out).toBe("「[https://example.com/a](https://example.com/a)」后文");
+  });
+
+  it("stops URL at fullwidth exclamation ！", () => {
+    const out = preprocessLinks("太好了 https://example.com/x！继续");
+    expect(out).toBe("太好了 [https://example.com/x](https://example.com/x)！继续");
+  });
+
+  it("handles the original bug report (PR link then 。 then more text)", () => {
+    const out = preprocessLinks(
+      "已合并 PR #1623：https://github.com/multica-ai/multica/pull/1623。merge commit",
+    );
+    expect(out).toBe(
+      "已合并 PR #1623：[https://github.com/multica-ai/multica/pull/1623](https://github.com/multica-ai/multica/pull/1623)。merge commit",
+    );
+  });
+
+  it("does not swallow the entire remainder when there is no trailing space", () => {
+    const out = preprocessLinks("https://github.com/x/y/issues/1619。我接下来把这个");
+    expect(out).toBe(
+      "[https://github.com/x/y/issues/1619](https://github.com/x/y/issues/1619)。我接下来把这个",
+    );
+  });
+
+  it("preserves ASCII trailing period handling (no regression)", () => {
+    const out = preprocessLinks("visit https://example.com/path. next.");
+    expect(out).toBe("visit [https://example.com/path](https://example.com/path). next.");
+  });
+
+  it("preserves plain URL with no trailing punctuation (no regression)", () => {
+    const out = preprocessLinks("go https://example.com/path");
+    expect(out).toBe("go [https://example.com/path](https://example.com/path)");
+  });
+
+  it("preserves CJK letters inside URL path (only trims on punctuation)", () => {
+    const out = preprocessLinks("https://zh.wikipedia.org/wiki/中国 参考");
+    expect(out).toBe(
+      "[https://zh.wikipedia.org/wiki/中国](https://zh.wikipedia.org/wiki/中国) 参考",
+    );
+  });
+
+  it("does not re-link an already-linked URL that contains 。", () => {
+    // If a user or upstream already wrote [text](url。), we leave it alone.
+    const input = "见 [link](https://example.com/x。)后文";
+    expect(preprocessLinks(input)).toBe(input);
+  });
+});


### PR DESCRIPTION
## 背景

在 issue [MUL-1383](mention://issue/2b5d1653-5830-4da1-9ca4-aa4f3486ee0a) 里反馈：评论渲染的 URL 把后面跟着的中文全角标点（例如 `。`）和后续中文内容一起吞进了 href，例如：

```
https://github.com/multica-ai/multica/pull/1623。merge commit
```

生成的 href 是 `https://github.com/multica-ai/multica/pull/1623。merge`（URL-encode 后 `%E3%80%82merge` 直接 404）。实际在真实数据里更严重——`https://.../issues/1619。我接下来把这个` 会把整段中文都吞进去，直到下一个空格。

## 根因

`packages/ui/markdown/linkify.ts` 用 [linkify-it](https://github.com/markdown-it/linkify-it) 把裸 URL 转成 markdown 链接。linkify-it 的 URL tokenizer 只把 ASCII 标点（`.,;:!?` 等）当作 URL 结束边界；CJK 全角标点（`。`、`，`、`）`、`】`、`！` 等）没有特殊处理，所以会被当成普通可打印字符纳入 URL，一直扫到下一个空格才停。

GFM autolink（remark-gfm）同样只裁剪 ASCII 尾部标点，整条管线没有 CJK 兜底。

## 方案

在 `detectLinks()` 里：把 linkify-it 返回的 `match.text` 在**第一个 CJK 全角标点处截断**，同时把后续 tail 递归交还给 linkify-it，这样 `https://a.com/x、https://b.com/y` 这种 CJK 标点分隔的相邻 URL 也能各自被识别。终止字符集参照 Mattermost 的同类修复（[mattermost/marked#22](https://github.com/mattermost/marked/pull/22)）：

```
！-／  ！＂＃＄％＆＇（）＊＋，－．／
：-＠  ：；＜＝＞？＠
［-｀  ［＼］＾＿｀
｛-～  ｛｜｝～
、         、
。         。
「-】  「」『』【】〈〉《》
```

注意仅排除**标点**范围，不含 CJK 文字（如 `中国`），所以 `https://zh.wikipedia.org/wiki/中国` 仍然正常识别。

## 备选方案（未采用）

- **配置 linkify-it 的 validate 回调**：API 是按 schema 粒度注册的，覆盖 http/https/ftp/mailto/fuzzy 比较繁琐；可读性不如直接后处理。
- **下游（remark-gfm）层修 href**：remark-gfm 对 CJK 同样无处理，在更下游修不如上游源头一刀切干净。

## 验证

新增 `packages/views/editor/utils/preprocess-links.test.ts`，12 个用例全绿，覆盖：
- 全角句号 `。` / 全角逗号 `，` / 全角右括号 `）` / 方头括号 `」` / 全角感叹 `！`
- bug 报告里的真实字符串
- 两个 URL 仅以 `、` 分隔（递归 rescan 场景）
- ASCII `.` 尾部（回归保护）
- URL 含 CJK 文字但不含 CJK 标点（不误伤）
- 已是 markdown 链接的 `[text](url。)` 不再处理

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run editor/utils/preprocess-links.test.ts` — 12/12 通过
- [x] `pnpm --filter @multica/views test` — 217/217 通过（全量无回归）
- [x] `pnpm --filter @multica/ui typecheck` — 通过
- [x] `pnpm --filter @multica/views typecheck` — 通过
- [x] `pnpm --filter @multica/ui lint` — 通过（`@multica/views` 有 3 条 pre-existing 错误，与本 PR 无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)