### PR TITLE
fix: preserve markdown newlines in agent comments

### DIFF
--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -35,6 +35,24 @@ vi.mock("./utils/link-handler", () => ({
 import { ReadonlyContent } from "./readonly-content";
 
 describe("ReadonlyContent math rendering", () => {
+  it("renders real blank lines as separate markdown paragraphs", () => {
+    const { container } = render(
+      <ReadonlyContent content={["First paragraph", "", "Second paragraph"].join("\n")} />,
+    );
+
+    const paragraphs = Array.from(container.querySelectorAll("p")).map((p) => p.textContent);
+    expect(paragraphs).toEqual(["First paragraph", "Second paragraph"]);
+  });
+
+  it("does not decode escaped newline text at render time", () => {
+    const { container } = render(
+      <ReadonlyContent content={"First paragraph\\n\\nSecond paragraph"} />,
+    );
+
+    expect(container.querySelectorAll("p")).toHaveLength(1);
+    expect(container.textContent).toContain("First paragraph\\n\\nSecond paragraph");
+  });
+
   it("renders inline and block LaTeX with KaTeX markup", () => {
     const { container } = render(
       <ReadonlyContent

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -492,6 +492,12 @@ func TestInjectRuntimeConfigCodex(t *testing.T) {
 	if !strings.Contains(s, "Coding") {
 		t.Error("AGENTS.md missing skill name")
 	}
+	if !strings.Contains(s, "cat <<'COMMENT' | multica issue comment add test-issue-id --content-stdin") {
+		t.Error("AGENTS.md missing stdin-based final comment command")
+	}
+	if !strings.Contains(s, "do not use escaped `\\n` inside `--content`") {
+		t.Error("AGENTS.md missing escaped-newline warning")
+	}
 }
 
 func TestInjectRuntimeConfigNoSkills(t *testing.T) {
@@ -743,10 +749,13 @@ func TestInjectRuntimeConfigRequiresExplicitCommentPost(t *testing.T) {
 			}
 			s := string(data)
 
-			// The workflow must contain an explicit `multica issue comment add`
-			// invocation for this issue — not just a prose mention of posting.
+			// The workflow must contain an explicit stdin-based `multica issue
+			// comment add` invocation for this issue, not just a prose mention
+			// of posting. Using --content with escaped newlines stores literal
+			// backslash-n text in rendered comments.
 			mustContain := []string{
-				"multica issue comment add issue-1",
+				"cat <<'COMMENT' | multica issue comment add issue-1",
+				"--content-stdin",
 				"mandatory",
 			}
 			for _, want := range mustContain {
@@ -761,6 +770,7 @@ func TestInjectRuntimeConfigRequiresExplicitCommentPost(t *testing.T) {
 			for _, want := range []string{
 				"Final results MUST be delivered via `multica issue comment add`",
 				"does NOT see your terminal output",
+				"do not use escaped `\\n` inside `--content`",
 			} {
 				if !strings.Contains(s, want) {
 					t.Errorf("%s: Output warning missing %q", tc.name, want)

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -16,9 +16,14 @@ func BuildCommentReplyInstructions(issueID, triggerCommentID string) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"If you decide to reply, post it by running exactly this command — always use the trigger comment ID below, "+
+		"If you decide to reply, post it by piping the comment body through stdin. Always use the trigger comment ID below, "+
 			"do NOT reuse --parent values from previous turns in this session:\n\n"+
-			"    multica issue comment add %s --parent %s --content \"...\"\n",
+			"```sh\n"+
+			"cat <<'COMMENT' | multica issue comment add %s --parent %s --content-stdin\n"+
+			"...\n"+
+			"COMMENT\n"+
+			"```\n\n"+
+			"Do not use `--content \"...\\n...\"`; shell-escaped `\\n` is stored literally and renders as backslash-n text.\n",
 		issueID, triggerCommentID,
 	)
 }

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -18,10 +18,15 @@ func TestBuildCommentReplyInstructionsIncludesTriggerID(t *testing.T) {
 	for _, want := range []string{
 		"multica issue comment add " + issueID + " --parent " + triggerID,
 		"do NOT reuse --parent values from previous turns",
+		"--content-stdin",
+		"Do not use `--content \"...\\n...\"`",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("reply instructions missing %q\n---\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, "--content \"...\"") {
+		t.Fatalf("reply instructions should not recommend --content placeholder\n---\n%s", got)
 	}
 }
 
@@ -58,6 +63,8 @@ func TestInjectRuntimeConfigCommentTriggerUsesHelper(t *testing.T) {
 		triggerID,
 		"multica issue comment add " + issueID + " --parent " + triggerID,
 		"do NOT reuse --parent values from previous turns",
+		"--content-stdin",
+		"shell-escaped `\\n` is stored literally",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("CLAUDE.md missing %q", want)

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -86,7 +86,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica issue create --title \"...\" [--description \"...\"] [--priority X] [--assignee X] [--parent <issue-id>] [--status X]` — Create a new issue\n")
 	b.WriteString("- `multica issue assign <id> --to <name>` — Assign an issue to a member or agent by name (use --unassign to remove assignee)\n")
 	b.WriteString("- `multica issue comment add <issue-id> --content \"...\" [--parent <comment-id>]` — Post a comment (use --parent to reply to a specific comment)\n")
-	b.WriteString("  - For content with special characters (backticks, quotes), pipe via stdin: `cat <<'COMMENT' | multica issue comment add <issue-id> --content-stdin`\n")
+	b.WriteString("  - For Markdown or multi-line content, pipe via stdin: `cat <<'COMMENT' | multica issue comment add <issue-id> --content-stdin`\n")
+	b.WriteString("  - Do not put escaped newlines in `--content` (for example `--content \"a\\n\\nb\"`); they are stored literally and render as `\\n` text.\n")
 	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
 	b.WriteString("- `multica issue status <id> <status>` — Update issue status (todo, in_progress, in_review, done, blocked)\n")
 	b.WriteString("- `multica issue update <id> [--title X] [--description X] [--priority X]` — Update issue fields\n")
@@ -170,7 +171,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		fmt.Fprintf(&b, "2. Run `multica issue status %s in_progress`\n", ctx.IssueID)
 		b.WriteString("3. Read comments for additional context or human instructions\n")
 		b.WriteString("4. Follow your Skills and Agent Identity to complete the task (write code, investigate, etc.)\n")
-		fmt.Fprintf(&b, "5. **Post your final results as a comment — this step is mandatory**: `multica issue comment add %s --content \"...\"`. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID)
+		fmt.Fprintf(&b, "5. **Post your final results as a comment — this step is mandatory**. Use stdin so Markdown and paragraph breaks are preserved:\n\n```sh\ncat <<'COMMENT' | multica issue comment add %s --content-stdin\n...\nCOMMENT\n```\n\nYour results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID)
 		fmt.Fprintf(&b, "6. When done, run `multica issue status %s in_review`\n", ctx.IssueID)
 		fmt.Fprintf(&b, "7. If blocked, run `multica issue status %s blocked` and post a comment explaining why\n\n", ctx.IssueID)
 	}
@@ -236,6 +237,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("Good: \"Fixed the login redirect. PR: https://...\"\n")
 		b.WriteString("Bad: \"1. Read the issue 2. Found the bug in auth.go 3. Created branch 4. ...\"\n")
 		b.WriteString("When referencing an issue in a comment, use the issue mention format `[MUL-123](mention://issue/<issue-id>)` so it renders as a clickable link. (Issue mentions have no side effect; only member/agent mentions do — see the Mentions section above.)\n")
+		b.WriteString("For any multi-line or Markdown comment, use `--content-stdin`; do not use escaped `\\n` inside `--content`.\n")
 	}
 
 	return b.String()


### PR DESCRIPTION
Summary:
- Update generated Multica agent runtime instructions to use --content-stdin for multi-line issue comments and final results.
- Warn agents not to pass escaped newline sequences through --content.
- Add regression coverage for ReadonlyContent newline rendering boundaries and execenv instructions.

Testing:
- go test ./internal/daemon/...
- pnpm --filter @multica/views test -- editor/readonly-content.test.tsx (blocked locally: node_modules missing, vitest not found)