### PR TITLE
fix(daemon): use CREATE_NEW_CONSOLE to stop grandchild console popups on Windows (#1521)

### DIFF
--- a/server/pkg/agent/proc_windows.go
+++ b/server/pkg/agent/proc_windows.go
@@ -7,14 +7,26 @@ import (
 	"syscall"
 )
 
-const createNoWindow = 0x08000000
+// createNewConsole allocates a fresh console for the child process. Combined
+// with HideWindow=true (STARTF_USESHOWWINDOW + SW_HIDE) the console window
+// stays off-screen, and — critically — any grandchildren the agent spawns
+// (tool subprocesses like bash, cmd, netstat, findstr) inherit this hidden
+// console instead of each allocating their own visible one.
+//
+// Using CREATE_NO_WINDOW here instead would strip the console entirely,
+// which forces Windows to allocate a new visible console per grandchild
+// when the grandchild is a console-subsystem program that doesn't itself
+// pass CREATE_NO_WINDOW — the exact popup storm reported in #1521.
+const createNewConsole = 0x00000010
 
-// hideAgentWindow configures cmd to suppress the console window on Windows.
-// CREATE_NO_WINDOW prevents window creation while preserving stdio pipes.
+// hideAgentWindow configures cmd to suppress the console window on Windows
+// while still giving descendant processes a hidden console to inherit.
+// Stdio pipes set via cmd.StdoutPipe/StdinPipe keep working because
+// STARTF_USESTDHANDLES takes precedence over the new console's stdio.
 func hideAgentWindow(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.HideWindow = true
-	cmd.SysProcAttr.CreationFlags |= createNoWindow
+	cmd.SysProcAttr.CreationFlags |= createNewConsole
 }

--- a/server/pkg/agent/proc_windows_test.go
+++ b/server/pkg/agent/proc_windows_test.go
@@ -36,14 +36,28 @@ func TestHideAgentWindowSetsCreateNewConsole(t *testing.T) {
 }
 
 // TestHideAgentWindowPreservesExistingSysProcAttr ensures hideAgentWindow
-// does not overwrite fields set by callers — a regression caught in PR #1474.
+// does not overwrite fields set by callers — a regression caught in PR #1474
+// where the whole SysProcAttr struct was replaced. We verify both a
+// non-CreationFlags field and a pre-existing CreationFlags bit survive.
+//
+// CREATE_UNICODE_ENVIRONMENT (0x00000400) is chosen because it is documented
+// as compatible with CREATE_NEW_CONSOLE (unlike CREATE_NEW_PROCESS_GROUP,
+// which Windows silently ignores when combined with CREATE_NEW_CONSOLE), so
+// a surviving bit here is semantically meaningful, not just bitwise intact.
 func TestHideAgentWindowPreservesExistingSysProcAttr(t *testing.T) {
+	const createUnicodeEnvironment = 0x00000400
 	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x00000200} // CREATE_NEW_PROCESS_GROUP
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags:    createUnicodeEnvironment,
+		NoInheritHandles: true,
+	}
 	hideAgentWindow(cmd)
 
-	if cmd.SysProcAttr.CreationFlags&0x00000200 == 0 {
-		t.Error("existing CreationFlags bits should be preserved")
+	if !cmd.SysProcAttr.NoInheritHandles {
+		t.Error("NoInheritHandles set by caller should be preserved")
+	}
+	if cmd.SysProcAttr.CreationFlags&createUnicodeEnvironment == 0 {
+		t.Error("existing CreationFlags bits (CREATE_UNICODE_ENVIRONMENT) should be preserved")
 	}
 	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
 		t.Error("CREATE_NEW_CONSOLE should be OR'd into existing flags")

--- a/server/pkg/agent/proc_windows_test.go
+++ b/server/pkg/agent/proc_windows_test.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package agent
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+// TestHideAgentWindowSetsCreateNewConsole guards against a regression where
+// hideAgentWindow reverts to CREATE_NO_WINDOW. CREATE_NO_WINDOW strips the
+// console entirely, which forces Windows to allocate a new visible console
+// per grandchild that doesn't itself pass CREATE_NO_WINDOW — the popup
+// storm reported in #1521.
+func TestHideAgentWindowSetsCreateNewConsole(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
+	hideAgentWindow(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr should be initialized")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("HideWindow should be true")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
+		t.Errorf("CreationFlags should include CREATE_NEW_CONSOLE (0x%x), got 0x%x",
+			createNewConsole, cmd.SysProcAttr.CreationFlags)
+	}
+	const createNoWindow = 0x08000000
+	if cmd.SysProcAttr.CreationFlags&createNoWindow != 0 {
+		t.Errorf("CreationFlags must NOT include CREATE_NO_WINDOW (0x%x), got 0x%x — "+
+			"see #1521 for why this causes grandchild popups",
+			createNoWindow, cmd.SysProcAttr.CreationFlags)
+	}
+}
+
+// TestHideAgentWindowPreservesExistingSysProcAttr ensures hideAgentWindow
+// does not overwrite fields set by callers — a regression caught in PR #1474.
+func TestHideAgentWindowPreservesExistingSysProcAttr(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "echo", "hi")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x00000200} // CREATE_NEW_PROCESS_GROUP
+	hideAgentWindow(cmd)
+
+	if cmd.SysProcAttr.CreationFlags&0x00000200 == 0 {
+		t.Error("existing CreationFlags bits should be preserved")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNewConsole == 0 {
+		t.Error("CREATE_NEW_CONSOLE should be OR'd into existing flags")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1474 to fix the grandchild-process popup regression reported in #1521 by @matrenitski.

`CREATE_NO_WINDOW` strips the console entirely. When the agent CLI (Claude Code, Codex, Gemini, etc.) then spawns a console-subsystem grandchild (`bash`, `cmd`, `netstat`, `findstr`, `timeout`) without itself passing `CREATE_NO_WINDOW`, Windows allocates a **brand-new visible console window per invocation** — trading one popup per agent run for N popups per tool call. That's the `netstat :18789` idle storm in #1521.

This PR switches `server/pkg/agent/proc_windows.go` to `CREATE_NEW_CONSOLE` + `HideWindow=true`. The agent gets a hidden console (STARTF_USESHOWWINDOW + SW_HIDE), and grandchildren **inherit** that hidden console instead of allocating their own visible one. Stdio pipes still work because `STARTF_USESTDHANDLES` takes precedence over the new console for stdin/stdout/stderr — ACP / stream-json keeps flowing through `cmd.StdoutPipe()` / `cmd.StdinPipe()` as today.

No changes needed at the 17 `hideAgentWindow` call sites (10 agent runners + 6 `models.go` discovery paths + `detectCLIVersion`).

Root-cause diagnosis by @matrenitski — verified against the shipped `multica.exe` and the Claude Code CLI's internal subprocess calls. Full write-up: https://github.com/multica-ai/multica/issues/1521#issuecomment-...

## Changes

- `server/pkg/agent/proc_windows.go` — swap `createNoWindow (0x08000000)` → `createNewConsole (0x00000010)`, expand comment explaining why.
- `server/pkg/agent/proc_windows_test.go` (new) — Windows-only regression test asserting `CREATE_NEW_CONSOLE` is set, `CREATE_NO_WINDOW` is not, and existing `SysProcAttr` fields are preserved. This is the `nit 3` test follow-up from the #1474 review.

## Test plan

- [ ] CI passes on Windows + Linux.
- [ ] On Windows Desktop: run `multica setup`, let the daemon idle ~60s — no `timeout` / `netstat` / `findstr` popups.
- [ ] On Windows Desktop: dispatch an agent task that uses tool calls (bash/edit) — no per-tool-call popups.
- [ ] Agent output still streams normally in the UI (ACP / stream-json pipes unaffected).

## Known caveat

On a small number of older Windows 10 builds there can be a brief console flash before `SW_HIDE` applies. Fully flash-free requires ConPTY (`CreatePseudoConsole` via `STARTUPINFOEX`), which is a larger change — tracked as a potential follow-up if it turns out to matter in practice. `CREATE_NEW_CONSOLE` + `SW_HIDE` is the conventional Windows idiom and covers the 99% case.

Fixes #1521.