### PR TITLE
feat(cli): support agent custom env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ MULTICA_CODEX_PATH=codex
 MULTICA_CODEX_MODEL=
 MULTICA_CODEX_WORKDIR=
 MULTICA_CODEX_TIMEOUT=20m
+OPENCODE_GO_API_KEY=
 
 # Self-host image channel
 # Default stable release channel. Pin to an exact release like v0.2.4 if you

--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -182,6 +182,7 @@ Agent-specific overrides:
 | `MULTICA_CODEX_MODEL` | Override the Codex model used |
 | `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
 | `MULTICA_OPENCODE_MODEL` | Override the OpenCode model used |
+| `OPENCODE_GO_API_KEY` | OpenCode Go API key for OpenCode Go agents |
 | `MULTICA_OPENCLAW_PATH` | Custom path to the `openclaw` binary |
 | `MULTICA_OPENCLAW_MODEL` | Override the OpenClaw model used |
 | `MULTICA_HERMES_PATH` | Custom path to the `hermes` binary |

--- a/apps/docs/content/docs/agents-create.mdx
+++ b/apps/docs/content/docs/agents-create.mdx
@@ -59,6 +59,7 @@ Changing the model **only applies to new tasks**. Already-dispatched tasks conti
 ```
 ANTHROPIC_API_KEY = sk-...
 ANTHROPIC_BASE_URL = https://my-proxy.example.com
+OPENCODE_GO_API_KEY = ocgo_...
 ```
 
 System-critical variables cannot be overridden: `PATH`, `HOME`, `USER`, `SHELL`, `TERM`, `CODEX_HOME`, and any key starting with `MULTICA_*` are silently ignored by the daemon (with a warn log — no error).

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -115,6 +115,7 @@ func init() {
 	agentCreateCmd.Flags().String("runtime-id", "", "Runtime ID (required)")
 	agentCreateCmd.Flags().String("runtime-config", "", "Runtime config as JSON string")
 	agentCreateCmd.Flags().String("model", "", "Model identifier (e.g. claude-sonnet-4-6, openai/gpt-4o). Prefer this over passing --model in --custom-args.")
+	agentCreateCmd.Flags().String("custom-env", "", "Custom environment variables as JSON object. Values are stored on the server and injected into the agent process.")
 	agentCreateCmd.Flags().String("custom-args", "", "Custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
 	agentCreateCmd.Flags().String("visibility", "private", "Visibility: private or workspace")
 	agentCreateCmd.Flags().Int32("max-concurrent-tasks", 6, "Maximum concurrent tasks")
@@ -127,6 +128,7 @@ func init() {
 	agentUpdateCmd.Flags().String("runtime-id", "", "New runtime ID")
 	agentUpdateCmd.Flags().String("runtime-config", "", "New runtime config as JSON string")
 	agentUpdateCmd.Flags().String("model", "", "New model identifier. Pass an empty string to clear and fall back to the runtime default.")
+	agentUpdateCmd.Flags().String("custom-env", "", "New custom environment variables as JSON object. Values are stored on the server and injected into the agent process.")
 	agentUpdateCmd.Flags().String("custom-args", "", "New custom CLI arguments as JSON array. For model selection prefer --model; some providers (codex app-server, openclaw) reject --model in custom_args.")
 	agentUpdateCmd.Flags().String("visibility", "", "New visibility: private or workspace")
 	agentUpdateCmd.Flags().String("status", "", "New status")
@@ -368,6 +370,14 @@ func runAgentCreate(cmd *cobra.Command, _ []string) error {
 		}
 		body["custom_args"] = ca
 	}
+	if cmd.Flags().Changed("custom-env") {
+		v, _ := cmd.Flags().GetString("custom-env")
+		var ce map[string]string
+		if err := json.Unmarshal([]byte(v), &ce); err != nil {
+			return fmt.Errorf("--custom-env must be a valid JSON object with string values: %w", err)
+		}
+		body["custom_env"] = ce
+	}
 	if cmd.Flags().Changed("model") {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
@@ -437,6 +447,14 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 		}
 		body["custom_args"] = ca
 	}
+	if cmd.Flags().Changed("custom-env") {
+		v, _ := cmd.Flags().GetString("custom-env")
+		var ce map[string]string
+		if err := json.Unmarshal([]byte(v), &ce); err != nil {
+			return fmt.Errorf("--custom-env must be a valid JSON object with string values: %w", err)
+		}
+		body["custom_env"] = ce
+	}
 	if cmd.Flags().Changed("model") {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
@@ -455,7 +473,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --visibility, --status, or --max-concurrent-tasks")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-env, --custom-args, --visibility, --status, or --max-concurrent-tasks")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/cli"
+	"github.com/spf13/cobra"
 )
 
 // TestResolveWorkspaceID_AgentContextSkipsConfig is a regression test for
@@ -81,4 +85,63 @@ func TestResolveWorkspaceID_AgentContextSkipsConfig(t *testing.T) {
 			t.Fatalf("requireWorkspaceID() error = %q, want it to mention agent execution context", err.Error())
 		}
 	})
+}
+
+func TestRunAgentCreateSendsCustomEnv(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agents" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "agent-1",
+			"name": got["name"],
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+
+	cmd := newAgentCreateTestCmd()
+	cmd.Flags().Set("name", "opencode-kimi-k2-6")
+	cmd.Flags().Set("runtime-id", "runtime-1")
+	cmd.Flags().Set("custom-env", `{"OPENCODE_GO_API_KEY":"test-key"}`)
+
+	if err := runAgentCreate(cmd, nil); err != nil {
+		t.Fatalf("runAgentCreate: %v", err)
+	}
+
+	customEnv, ok := got["custom_env"].(map[string]any)
+	if !ok {
+		t.Fatalf("custom_env = %#v, want object", got["custom_env"])
+	}
+	if customEnv["OPENCODE_GO_API_KEY"] != "test-key" {
+		t.Fatalf("custom_env OPENCODE_GO_API_KEY = %#v, want test-key", customEnv["OPENCODE_GO_API_KEY"])
+	}
+}
+
+func newAgentCreateTestCmd() *cobra.Command {
+	cmd := testCmd()
+	cmd.Flags().String("name", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("instructions", "", "")
+	cmd.Flags().String("runtime-id", "", "")
+	cmd.Flags().String("runtime-config", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("custom-env", "", "")
+	cmd.Flags().String("custom-args", "", "")
+	cmd.Flags().String("visibility", "private", "")
+	cmd.Flags().Int32("max-concurrent-tasks", 6, "")
+	cmd.Flags().String("output", "json", "")
+	return cmd
 }


### PR DESCRIPTION
## Summary
- Add --custom-env to multica agent create/update so automation can configure agent process env vars.
- Document OPENCODE_GO_API_KEY in daemon/env docs.
- Add CLI coverage for create payload custom_env.

## Tests
- go test ./cmd/multica
- go test ./...