### PR TITLE
fix(task): reconcile agent status when cancelling tasks by issue (#1587)

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -140,9 +140,25 @@ func (s *TaskService) EnqueueChatTask(ctx context.Context, chatSession db.ChatSe
 	return task, nil
 }
 
-// CancelTasksForIssue cancels all active tasks for an issue.
+// CancelTasksForIssue cancels every active task on the issue, reconciles each
+// affected agent's status, and broadcasts task:cancelled events so frontends
+// clear their live cards.
+//
+// Before #1587 this path was "cancel rows and return" — issue-status flips
+// (e.g. user marks the issue `done` or `cancelled` while a task is still
+// running) left the agent stuck at status="working" indefinitely, requiring a
+// manual `multica agent update <id> --status idle` to unwedge. Matches the
+// pattern already used by CancelTask and RerunIssue.
 func (s *TaskService) CancelTasksForIssue(ctx context.Context, issueID pgtype.UUID) error {
-	return s.Queries.CancelAgentTasksByIssue(ctx, issueID)
+	cancelled, err := s.Queries.CancelAgentTasksByIssue(ctx, issueID)
+	if err != nil {
+		return err
+	}
+	for _, t := range cancelled {
+		s.ReconcileAgentStatus(ctx, t.AgentID)
+		s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, t)
+	}
+	return nil
 }
 
 // CancelTask cancels a single task by ID. It broadcasts a task:cancelled event

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -100,15 +100,60 @@ func (q *Queries) CancelAgentTasksByAgent(ctx context.Context, agentID pgtype.UU
 	return err
 }
 
-const cancelAgentTasksByIssue = `-- name: CancelAgentTasksByIssue :exec
+const cancelAgentTasksByIssue = `-- name: CancelAgentTasksByIssue :many
 UPDATE agent_task_queue
-SET status = 'cancelled'
+SET status = 'cancelled', completed_at = now()
 WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running')
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
 `
 
-func (q *Queries) CancelAgentTasksByIssue(ctx context.Context, issueID pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, cancelAgentTasksByIssue, issueID)
-	return err
+// Cancels every active task on the issue and returns the affected rows so the
+// caller can reconcile each agent's status and broadcast task:cancelled
+// events (#1587). Prior :exec form silently dropped that info, so internal
+// cancel paths (issue status flips to cancelled/done, etc.) left agents stuck
+// at status="working" with no self-correction.
+func (q *Queries) CancelAgentTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]AgentTaskQueue, error) {
+	rows, err := q.db.Query(ctx, cancelAgentTasksByIssue, issueID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentTaskQueue{}
+	for rows.Next() {
+		var i AgentTaskQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.AgentID,
+			&i.IssueID,
+			&i.Status,
+			&i.Priority,
+			&i.DispatchedAt,
+			&i.StartedAt,
+			&i.CompletedAt,
+			&i.Result,
+			&i.Error,
+			&i.CreatedAt,
+			&i.Context,
+			&i.RuntimeID,
+			&i.SessionID,
+			&i.WorkDir,
+			&i.TriggerCommentID,
+			&i.ChatSessionID,
+			&i.AutopilotRunID,
+			&i.Attempt,
+			&i.MaxAttempts,
+			&i.ParentTaskID,
+			&i.FailureReason,
+			&i.LastHeartbeatAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const cancelAgentTasksByIssueAndAgent = `-- name: CancelAgentTasksByIssueAndAgent :many

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -89,10 +89,16 @@ FROM agent_task_queue p
 WHERE p.id = $1
 RETURNING *;
 
--- name: CancelAgentTasksByIssue :exec
+-- name: CancelAgentTasksByIssue :many
+-- Cancels every active task on the issue and returns the affected rows so the
+-- caller can reconcile each agent's status and broadcast task:cancelled events
+-- (#1587). Prior :exec form silently dropped that info, so internal cancel
+-- paths (issue status flips to cancelled/done, etc.) left agents stuck at
+-- status="working" with no self-correction.
 UPDATE agent_task_queue
-SET status = 'cancelled'
-WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running');
+SET status = 'cancelled', completed_at = now()
+WHERE issue_id = $1 AND status IN ('queued', 'dispatched', 'running')
+RETURNING *;
 
 -- name: CancelAgentTasksByIssueAndAgent :many
 -- Cancels active tasks for a single (issue, agent) pair without touching


### PR DESCRIPTION
 ## What does this PR do?

  Makes `CancelTasksForIssue` reconcile each affected agent's status and broadcast `task:cancelled`
  events, so server-side cancel paths triggered by issue-status flips (done/cancelled) no longer
  leave agents stuck at `status="working"` indefinitely. Matches the pattern already used by
  `CancelTask` and `RerunIssue`.

  Before this patch, `CancelAgentTasksByIssue` was a `:exec` query that silently dropped the set of
  affected rows. Its sole call site, `CancelTasksForIssue`, therefore couldn't tell which agents had
   just had a task cancelled — so no reconcile ran. The 6 callers of `CancelTasksForIssue` in
  `handler/issue.go` all trigger on internal paths (issue transitions to cancelled/done), which
  exactly matches the repro from #1587: *"task row moves to status: cancelled without me having
  invoked multica task cancel"* and the agent status then never self-corrects.

  ## Related Issue

  Refs #1587
  Refs #1149 (the prior fix this patch extends)

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `server/pkg/db/queries/agent.sql` — `CancelAgentTasksByIssue` from `:exec` to `:many`, adds
  `completed_at = now()` for consistency with `CancelAgentTasksByIssueAndAgent`, and `RETURNING *`.
  - `server/pkg/db/generated/agent.sql.go` — regenerated-style output matching the `:many` pattern.
  Maintainers: run `sqlc generate` to verify my hand-edit matches.
  - `server/internal/service/task.go` — `CancelTasksForIssue` now iterates the returned rows and
  calls `ReconcileAgentStatus` + `broadcastTaskEvent(EventTaskCancelled, t)` per task.

  ## How to Test

  1. `cd server && go build ./...` — clean.
  2. `go test ./internal/service/... ./internal/handler/...` — all existing tests pass; no
  regressions.
  3. Repro the original symptom pre-patch (transition an in-progress issue to `done` or `cancelled`,
   observe agent stuck at `working`), then confirm post-patch the agent's status returns to `idle`
  without manual intervention.

  ## Checklist

  - [x] Tests run locally and pass (no regressions from the signature change)
  - [x] Minimal diff; mirrors the well-covered `CancelTask` / `RerunIssue` patterns
  - [ ] Dedicated test for `CancelTasksForIssue` — happy to add in a follow-up using the existing
  `mockRow` harness from `task_complete_race_test.go` if reviewers prefer

  ## AI Disclosure

  **AI tool used:** Claude Code