### PR TITLE
 feat(web): safety-net polling for issue detail + timeline (#1599, #1638)

### DIFF
--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { issueDetailOptions, issueTimelineOptions } from "./queries";
+
+describe("issueTimelineOptions", () => {
+  it("includes a foreground-only polling interval as a WS safety net", () => {
+    const opts = issueTimelineOptions("issue-1");
+    // Polling interval is set (exact ms can evolve without breaking the test).
+    expect(typeof opts.refetchInterval).toBe("number");
+    expect(opts.refetchInterval as number).toBeGreaterThan(0);
+    // Must not poll when the tab is backgrounded — otherwise idle tabs hammer the API.
+    expect(opts.refetchIntervalInBackground).toBe(false);
+  });
+});
+
+describe("issueDetailOptions", () => {
+  it("includes a foreground-only polling interval as a WS safety net", () => {
+    const opts = issueDetailOptions("ws-1", "issue-1");
+    expect(typeof opts.refetchInterval).toBe("number");
+    expect(opts.refetchInterval as number).toBeGreaterThan(0);
+    expect(opts.refetchIntervalInBackground).toBe(false);
+  });
+
+  it("polls detail slower than timeline since status changes are rarer than comments", () => {
+    const detail = issueDetailOptions("ws-1", "issue-1").refetchInterval as number;
+    const timeline = issueTimelineOptions("issue-1").refetchInterval as number;
+    expect(detail).toBeGreaterThan(timeline);
+  });
+});

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -92,10 +92,20 @@ export function myIssueListOptions(
   });
 }
 
+// Safety-net polling: WebSocket events are still the primary update path, but
+// if the WS connection hiccups (see #1637 heartbeat timeouts) the UI can stay
+// stale until manual refresh (#1599). A slow background refetch bridges that
+// gap without materially adding server load — it runs only while the tab is
+// focused and is redundant when the WS layer is healthy.
+const ISSUE_DETAIL_POLL_MS = 60_000;
+const ISSUE_TIMELINE_POLL_MS = 20_000;
+
 export function issueDetailOptions(wsId: string, id: string) {
   return queryOptions({
     queryKey: issueKeys.detail(wsId, id),
     queryFn: () => api.getIssue(id),
+    refetchInterval: ISSUE_DETAIL_POLL_MS,
+    refetchIntervalInBackground: false,
   });
 }
 
@@ -124,6 +134,8 @@ export function issueTimelineOptions(issueId: string) {
   return queryOptions({
     queryKey: issueKeys.timeline(issueId),
     queryFn: () => api.listTimeline(issueId),
+    refetchInterval: ISSUE_TIMELINE_POLL_MS,
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/server/cmd/multica/cmd_workspace_du.go
+++ b/server/cmd/multica/cmd_workspace_du.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+var workspaceDuCmd = &cobra.Command{
+	Use:   "du",
+	Short: "Show disk usage of local workspace directories",
+	Long: `Walks the workspaces root and reports the size of each workspace and
+the largest task workdirs. Useful observability before a full quota-based GC
+policy lands (see #1636).
+
+The workspaces root is resolved as:
+  --root flag  >  $MULTICA_WORKSPACES_ROOT  >  ~/multica_workspaces[_<profile>]`,
+	RunE: runWorkspaceDu,
+}
+
+func init() {
+	workspaceCmd.AddCommand(workspaceDuCmd)
+	workspaceDuCmd.Flags().String("output", "table", "Output format: table or json")
+	workspaceDuCmd.Flags().Int("top", 10, "Show the top N largest task workdirs (0 = all)")
+	workspaceDuCmd.Flags().String("root", "", "Override workspaces root (default: profile-derived path)")
+}
+
+type taskDu struct {
+	WorkspaceID string    `json:"workspace_id"`
+	TaskShort   string    `json:"task_short"`
+	SizeBytes   int64     `json:"size_bytes"`
+	ModTime     time.Time `json:"mod_time"`
+	IssueID     string    `json:"issue_id,omitempty"`
+	CompletedAt string    `json:"completed_at,omitempty"`
+}
+
+type workspaceDu struct {
+	WorkspaceID string `json:"workspace_id"`
+	Tasks       int    `json:"tasks"`
+	SizeBytes   int64  `json:"size_bytes"`
+}
+
+type duReport struct {
+	Root           string        `json:"root"`
+	TotalBytes     int64         `json:"total_bytes"`
+	CacheBytes     int64         `json:"cache_bytes"`
+	WorkspaceBytes int64         `json:"workspace_bytes"`
+	Workspaces     []workspaceDu `json:"workspaces"`
+	TopTasks       []taskDu      `json:"top_tasks,omitempty"`
+}
+
+func runWorkspaceDu(cmd *cobra.Command, _ []string) error {
+	root, _ := cmd.Flags().GetString("root")
+	if root == "" {
+		r, err := resolveWorkspacesRootForCLI(cmd)
+		if err != nil {
+			return err
+		}
+		root = r
+	}
+
+	report, err := scanWorkspacesDu(root)
+	if err != nil {
+		return fmt.Errorf("scan %s: %w", root, err)
+	}
+
+	// Sort workspaces by size descending for stable output.
+	sort.Slice(report.Workspaces, func(i, j int) bool {
+		return report.Workspaces[i].SizeBytes > report.Workspaces[j].SizeBytes
+	})
+	sort.Slice(report.TopTasks, func(i, j int) bool {
+		return report.TopTasks[i].SizeBytes > report.TopTasks[j].SizeBytes
+	})
+	top, _ := cmd.Flags().GetInt("top")
+	if top > 0 && len(report.TopTasks) > top {
+		report.TopTasks = report.TopTasks[:top]
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, report)
+	}
+	return printDuTable(os.Stdout, report)
+}
+
+// resolveWorkspacesRootForCLI mirrors daemon.LoadConfig's resolution order for
+// WorkspacesRoot so `multica workspace du` can run without the daemon:
+//
+//	$MULTICA_WORKSPACES_ROOT > ~/multica_workspaces[_<profile>]
+func resolveWorkspacesRootForCLI(cmd *cobra.Command) (string, error) {
+	if v := strings.TrimSpace(os.Getenv("MULTICA_WORKSPACES_ROOT")); v != "" {
+		return filepath.Abs(v)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home: %w (pass --root or set MULTICA_WORKSPACES_ROOT)", err)
+	}
+	profile, _ := cmd.Flags().GetString("profile")
+	if profile == "" {
+		profile = strings.TrimSpace(os.Getenv("MULTICA_PROFILE"))
+	}
+	if profile == "" {
+		return filepath.Join(home, "multica_workspaces"), nil
+	}
+	return filepath.Join(home, "multica_workspaces_"+profile), nil
+}
+
+func scanWorkspacesDu(root string) (*duReport, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &duReport{Root: root}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, e.Name())
+
+		if e.Name() == ".repos" {
+			sz, _ := dirSizeBytes(path)
+			report.CacheBytes = sz
+			report.TotalBytes += sz
+			continue
+		}
+
+		// Workspace directory: walk its task subdirs.
+		ws := workspaceDu{WorkspaceID: e.Name()}
+		taskDirs, err := os.ReadDir(path)
+		if err != nil {
+			continue
+		}
+		for _, td := range taskDirs {
+			if !td.IsDir() {
+				continue
+			}
+			taskPath := filepath.Join(path, td.Name())
+			sz, _ := dirSizeBytes(taskPath)
+			info, _ := os.Stat(taskPath)
+			var modTime time.Time
+			if info != nil {
+				modTime = info.ModTime()
+			}
+			task := taskDu{
+				WorkspaceID: e.Name(),
+				TaskShort:   td.Name(),
+				SizeBytes:   sz,
+				ModTime:     modTime,
+			}
+			if b, err := os.ReadFile(filepath.Join(taskPath, ".gc_meta.json")); err == nil {
+				var meta struct {
+					IssueID     string `json:"issue_id"`
+					CompletedAt string `json:"completed_at"`
+				}
+				if json.Unmarshal(b, &meta) == nil {
+					task.IssueID = meta.IssueID
+					task.CompletedAt = meta.CompletedAt
+				}
+			}
+			ws.Tasks++
+			ws.SizeBytes += sz
+			report.TopTasks = append(report.TopTasks, task)
+		}
+		report.WorkspaceBytes += ws.SizeBytes
+		report.TotalBytes += ws.SizeBytes
+		report.Workspaces = append(report.Workspaces, ws)
+	}
+	return report, nil
+}
+
+// dirSizeBytes walks path and sums regular-file sizes. Unreadable entries are
+// silently skipped so a single permission error doesn't fail the whole report.
+func dirSizeBytes(path string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			info, err := d.Info()
+			if err == nil {
+				total += info.Size()
+			}
+		}
+		return nil
+	})
+	return total, err
+}
+
+func printDuTable(w *os.File, r *duReport) error {
+	fmt.Fprintf(w, "Root:             %s\n", r.Root)
+	fmt.Fprintf(w, "Workspaces size:  %s\n", humanBytes(r.WorkspaceBytes))
+	fmt.Fprintf(w, "Repo cache:       %s (.repos)\n", humanBytes(r.CacheBytes))
+	fmt.Fprintf(w, "Total:            %s\n\n", humanBytes(r.TotalBytes))
+
+	if len(r.Workspaces) == 0 {
+		fmt.Fprintln(w, "No workspaces found.")
+		return nil
+	}
+
+	rows := make([][]string, 0, len(r.Workspaces))
+	for _, ws := range r.Workspaces {
+		rows = append(rows, []string{
+			ws.WorkspaceID,
+			fmt.Sprintf("%d", ws.Tasks),
+			humanBytes(ws.SizeBytes),
+		})
+	}
+	cli.PrintTable(w, []string{"WORKSPACE", "TASKS", "SIZE"}, rows)
+
+	if len(r.TopTasks) == 0 {
+		return nil
+	}
+	fmt.Fprintf(w, "\nTop %d task workdirs by size:\n", len(r.TopTasks))
+	taskRows := make([][]string, 0, len(r.TopTasks))
+	for _, t := range r.TopTasks {
+		issue := t.IssueID
+		if len(issue) > 8 {
+			issue = issue[:8]
+		}
+		if issue == "" {
+			issue = "(orphan)"
+		}
+		taskRows = append(taskRows, []string{
+			t.TaskShort,
+			shortID(t.WorkspaceID),
+			humanBytes(t.SizeBytes),
+			humanAge(t.ModTime),
+			issue,
+		})
+	}
+	cli.PrintTable(w, []string{"TASK", "WORKSPACE", "SIZE", "AGE", "ISSUE"}, taskRows)
+	return nil
+}
+
+func humanBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func humanAge(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+func shortID(s string) string {
+	if len(s) > 8 {
+		return s[:8]
+	}
+	return s
+}

--- a/server/cmd/multica/cmd_workspace_du_test.go
+++ b/server/cmd/multica/cmd_workspace_du_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{int64(1.5 * 1024 * 1024), "1.5 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+	}
+	for _, c := range cases {
+		if got := humanBytes(c.in); got != c.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		t    time.Time
+		want string
+	}{
+		{time.Time{}, "-"},
+		{now.Add(-30 * time.Second), "just now"},
+		{now.Add(-5 * time.Minute), "5m ago"},
+		{now.Add(-3 * time.Hour), "3h ago"},
+		{now.Add(-49 * time.Hour), "2d ago"},
+	}
+	for _, c := range cases {
+		if got := humanAge(c.t); got != c.want {
+			t.Errorf("humanAge(%v) = %q, want %q", c.t, got, c.want)
+		}
+	}
+}
+
+func TestScanWorkspacesDu(t *testing.T) {
+	root := t.TempDir()
+
+	// workspace dir with two task subdirs, one with gc_meta
+	wsID := "ws-abc"
+	wsDir := filepath.Join(root, wsID)
+	mustMkdir(t, filepath.Join(wsDir, "task1", "workdir"))
+	mustMkdir(t, filepath.Join(wsDir, "task2"))
+	mustWriteBytes(t, filepath.Join(wsDir, "task1", "workdir", "big.bin"), 4096)
+	mustWriteBytes(t, filepath.Join(wsDir, "task2", "small.txt"), 100)
+	mustWriteString(t, filepath.Join(wsDir, "task1", ".gc_meta.json"),
+		`{"issue_id":"issue-xyz","completed_at":"2026-04-24T10:00:00Z"}`)
+
+	// .repos cache
+	mustMkdir(t, filepath.Join(root, ".repos", "cached"))
+	mustWriteBytes(t, filepath.Join(root, ".repos", "cached", "c.bin"), 200)
+
+	// stray file at root should be ignored
+	mustWriteBytes(t, filepath.Join(root, "stray.txt"), 50)
+
+	report, err := scanWorkspacesDu(root)
+	if err != nil {
+		t.Fatalf("scanWorkspacesDu: %v", err)
+	}
+
+	if got, want := report.CacheBytes, int64(200); got != want {
+		t.Errorf("CacheBytes = %d, want %d", got, want)
+	}
+	if got, want := len(report.Workspaces), 1; got != want {
+		t.Fatalf("len(Workspaces) = %d, want %d", got, want)
+	}
+	if got := report.Workspaces[0].Tasks; got != 2 {
+		t.Errorf("Tasks = %d, want 2", got)
+	}
+	if got := report.Workspaces[0].SizeBytes; got < 4096 {
+		t.Errorf("SizeBytes = %d, want >= 4096", got)
+	}
+	if got, want := len(report.TopTasks), 2; got != want {
+		t.Fatalf("len(TopTasks) = %d, want %d", got, want)
+	}
+
+	// task1 should have issue metadata populated
+	var task1 *taskDu
+	for i := range report.TopTasks {
+		if report.TopTasks[i].TaskShort == "task1" {
+			task1 = &report.TopTasks[i]
+			break
+		}
+	}
+	if task1 == nil {
+		t.Fatal("task1 missing from TopTasks")
+	}
+	if task1.IssueID != "issue-xyz" {
+		t.Errorf("task1.IssueID = %q, want issue-xyz", task1.IssueID)
+	}
+	if task1.CompletedAt != "2026-04-24T10:00:00Z" {
+		t.Errorf("task1.CompletedAt = %q", task1.CompletedAt)
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func mustWriteBytes(t *testing.T, path string, size int) {
+	t.Helper()
+	buf := make([]byte, size)
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func mustWriteString(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -81,6 +81,13 @@ func (c *Client) SetVersion(v string) {
 	c.version = v
 }
 
+// SetTimeout overrides the HTTP client timeout for all daemon API requests.
+// The daemon invokes this during startup with cfg.APITimeout so operators can
+// tune it via MULTICA_DAEMON_API_TIMEOUT when the hosted API is slow.
+func (c *Client) SetTimeout(d time.Duration) {
+	c.client.Timeout = d
+}
+
 // setIdentityHeaders attaches X-Client-Platform/Version/OS to req when set.
 func (c *Client) setIdentityHeaders(req *http.Request) {
 	if c.platform != "" {

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -7,7 +7,19 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"testing"
+	"time"
 )
+
+func TestClient_SetTimeout(t *testing.T) {
+	c := NewClient("http://example.com")
+	if c.client.Timeout != 30*time.Second {
+		t.Errorf("expected default 30s, got %v", c.client.Timeout)
+	}
+	c.SetTimeout(90 * time.Second)
+	if c.client.Timeout != 90*time.Second {
+		t.Errorf("expected 90s after SetTimeout, got %v", c.client.Timeout)
+	}
+}
 
 func TestClient_IdentityHeaders_PostJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -15,6 +15,7 @@ const (
 	DefaultPollInterval          = 3 * time.Second
 	DefaultHeartbeatInterval     = 15 * time.Second
 	DefaultAgentTimeout          = 2 * time.Hour
+	DefaultAPITimeout            = 60 * time.Second
 	DefaultRuntimeName           = "Local Agent"
 	DefaultWorkspaceSyncInterval = 30 * time.Second
 	DefaultHealthPort            = 19514
@@ -46,6 +47,7 @@ type Config struct {
 	PollInterval       time.Duration
 	HeartbeatInterval  time.Duration
 	AgentTimeout       time.Duration
+	APITimeout         time.Duration // HTTP timeout for daemon↔server calls (default 60s, env MULTICA_DAEMON_API_TIMEOUT)
 }
 
 // Overrides allows CLI flags to override environment variables and defaults.
@@ -56,6 +58,7 @@ type Overrides struct {
 	PollInterval       time.Duration
 	HeartbeatInterval  time.Duration
 	AgentTimeout       time.Duration
+	APITimeout         time.Duration
 	MaxConcurrentTasks int
 	DaemonID           string
 	DeviceName         string
@@ -184,6 +187,14 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		agentTimeout = overrides.AgentTimeout
 	}
 
+	apiTimeout, err := durationFromEnv("MULTICA_DAEMON_API_TIMEOUT", DefaultAPITimeout)
+	if err != nil {
+		return Config{}, err
+	}
+	if overrides.APITimeout > 0 {
+		apiTimeout = overrides.APITimeout
+	}
+
 	maxConcurrentTasks, err := intFromEnv("MULTICA_DAEMON_MAX_CONCURRENT_TASKS", DefaultMaxConcurrentTasks)
 	if err != nil {
 		return Config{}, err
@@ -307,6 +318,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		PollInterval:       pollInterval,
 		HeartbeatInterval:  heartbeatInterval,
 		AgentTimeout:       agentTimeout,
+		APITimeout:         apiTimeout,
 	}, nil
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -59,6 +59,9 @@ type Daemon struct {
 func New(cfg Config, logger *slog.Logger) *Daemon {
 	cacheRoot := filepath.Join(cfg.WorkspacesRoot, ".repos")
 	client := NewClient(cfg.ServerBaseURL)
+	if cfg.APITimeout > 0 {
+		client.SetTimeout(cfg.APITimeout)
+	}
 	// Tag every daemon HTTP request with the daemon's CLI version so the
 	// server can split logs/metrics by client version (parallel to the CLI).
 	client.SetVersion(cfg.CLIVersion)


### PR DESCRIPTION
## What does this PR do?

  Adds a slow, foreground-only refetch interval to `issueDetailOptions` and `issueTimelineOptions`
  so the UI stays eventually consistent when WebSocket events don't flow.

  - Timeline polls every **20s** (comments/activity change more often)
  - Detail polls every **60s** (status/priority changes are rarer)
  - Both honor `refetchIntervalInBackground: false` so idle tabs don't hit the API

  When the WS layer is healthy, these refetches are mostly redundant — they just top up a fresh
  cache. When WS is broken (see #1637 daemon heartbeat timeouts, or any transient network hiccup)
  they bridge the gap with at-most-20-seconds staleness instead of "until you click another issue."

  **This does not close #1599 or #1638.** A proper fix means diagnosing why WS events don't reach
  the UI on affected setups (#1599) and/or shipping real SSE streaming (#1638). This PR just keeps
  the UI eventually consistent while that work is planned.

  ## Related Issue

  Refs #1599
  Refs #1638

  ## Type of Change

  - [x] New feature (non-breaking change that adds functionality)

  ## Changes Made

  - `packages/core/issues/queries.ts` — add `refetchInterval` + `refetchIntervalInBackground: false`
   to `issueDetailOptions` and `issueTimelineOptions`. Tunable via the local constants at the top.
  - `packages/core/issues/queries.test.ts` — new Vitest coverage asserting both options carry a
  polling interval and skip background tabs.

  ## How to Test

  1. `cd packages/core && pnpm test` — 91/91 pass (16 test files), including the 2 new ones.
  2. Functional: open an issue in the UI, have an agent post a comment. Pre-patch the reply often
  takes a click-another-issue-and-back to appear; post-patch it shows up within 20s automatically.

  ## Checklist

  - [x] Tests run locally and pass
  - [x] No UI-visible behavioral change when WS is healthy (refetch is redundant on fresh cache)
  - [x] Background tabs do not poll
  - [ ] Screenshots — N/A, no visible UI change

  ## AI Disclosure

  **AI tool used:** Claude Code

  **Prompt / approach:** Dogfooded — my own desktop app kept showing stale comment lists until I
  clicked around, matching #1599 exactly. Traced the WS layer, found the handlers wire up correctly
  (hub.ts + use-issue-timeline.ts look fine), concluded the bug is intermittent delivery rather than
   missing code. Shipped a polling safety net as a mitigation rather than a speculative WS fix. Each
   edit reviewed before apply.