### PR TITLE
fix(tasks): block child issues from running while parent is incomplete (#970)

### DIFF
--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -176,7 +176,14 @@ UPDATE agent_task_queue
 SET status = 'dispatched', dispatched_at = now()
 WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
+    LEFT JOIN issue i ON atq.issue_id = i.id
+    LEFT JOIN issue parent ON i.parent_issue_id = parent.id
     WHERE atq.agent_id = $1 AND atq.status = 'queued'
+      AND (
+        atq.issue_id IS NULL
+        OR i.parent_issue_id IS NULL
+        OR parent.status IN ('done', 'cancelled')
+      )
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id
@@ -198,6 +205,10 @@ RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, c
 // already dispatched or running. This allows different agents to work on the same
 // issue in parallel while preventing a single agent from running duplicate tasks.
 // Chat tasks (issue_id IS NULL) use chat_session_id for serialization instead.
+//
+// Also enforces parent-child issue dependencies (#970): a task whose issue
+// has a parent in todo/in_progress/in_review/blocked is skipped so children
+// don't start until the parent is done or cancelled.
 func (q *Queries) ClaimAgentTask(ctx context.Context, agentID pgtype.UUID) (AgentTaskQueue, error) {
 	row := q.db.QueryRow(ctx, claimAgentTask, agentID)
 	var i AgentTaskQueue
@@ -1016,11 +1027,25 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at FROM agent_task_queue
-WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
-ORDER BY priority DESC, created_at ASC
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.last_heartbeat_at
+FROM agent_task_queue atq
+LEFT JOIN issue i ON atq.issue_id = i.id
+LEFT JOIN issue parent ON i.parent_issue_id = parent.id
+WHERE atq.runtime_id = $1
+  AND atq.status IN ('queued', 'dispatched')
+  AND (
+    atq.issue_id IS NULL
+    OR i.parent_issue_id IS NULL
+    OR parent.status IN ('done', 'cancelled')
+  )
+ORDER BY atq.priority DESC, atq.created_at ASC
 `
 
+// Returns queued/dispatched tasks for a runtime that are ready to run.
+// Parent-child dependencies are enforced here (#970): a task whose issue has
+// a parent in todo/in_progress/in_review/blocked is excluded, so children
+// don't execute in parallel with an incomplete parent. Chat tasks (no
+// issue_id) and top-level issues (no parent_issue_id) are always eligible.
 func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtype.UUID) ([]AgentTaskQueue, error) {
 	rows, err := q.db.Query(ctx, listPendingTasksByRuntime, runtimeID)
 	if err != nil {

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -119,11 +119,22 @@ WHERE id = $1;
 -- already dispatched or running. This allows different agents to work on the same
 -- issue in parallel while preventing a single agent from running duplicate tasks.
 -- Chat tasks (issue_id IS NULL) use chat_session_id for serialization instead.
+--
+-- Also enforces parent-child issue dependencies (#970): a task whose issue
+-- has a parent in todo/in_progress/in_review/blocked is skipped so children
+-- don't start until the parent is done or cancelled.
 UPDATE agent_task_queue
 SET status = 'dispatched', dispatched_at = now()
 WHERE id = (
     SELECT atq.id FROM agent_task_queue atq
+    LEFT JOIN issue i ON atq.issue_id = i.id
+    LEFT JOIN issue parent ON i.parent_issue_id = parent.id
     WHERE atq.agent_id = $1 AND atq.status = 'queued'
+      AND (
+        atq.issue_id IS NULL
+        OR i.parent_issue_id IS NULL
+        OR parent.status IN ('done', 'cancelled')
+      )
       AND NOT EXISTS (
           SELECT 1 FROM agent_task_queue active
           WHERE active.agent_id = atq.agent_id
@@ -251,9 +262,23 @@ SELECT count(*) > 0 AS has_pending FROM agent_task_queue
 WHERE issue_id = $1 AND agent_id = $2 AND status IN ('queued', 'dispatched');
 
 -- name: ListPendingTasksByRuntime :many
-SELECT * FROM agent_task_queue
-WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
-ORDER BY priority DESC, created_at ASC;
+-- Returns queued/dispatched tasks for a runtime that are ready to run.
+-- Parent-child dependencies are enforced here (#970): a task whose issue has
+-- a parent in todo/in_progress/in_review/blocked is excluded, so children
+-- don't execute in parallel with an incomplete parent. Chat tasks (no
+-- issue_id) and top-level issues (no parent_issue_id) are always eligible.
+SELECT atq.id, atq.agent_id, atq.issue_id, atq.status, atq.priority, atq.dispatched_at, atq.started_at, atq.completed_at, atq.result, atq.error, atq.created_at, atq.context, atq.runtime_id, atq.session_id, atq.work_dir, atq.trigger_comment_id, atq.chat_session_id, atq.autopilot_run_id, atq.attempt, atq.max_attempts, atq.parent_task_id, atq.failure_reason, atq.last_heartbeat_at
+FROM agent_task_queue atq
+LEFT JOIN issue i ON atq.issue_id = i.id
+LEFT JOIN issue parent ON i.parent_issue_id = parent.id
+WHERE atq.runtime_id = $1
+  AND atq.status IN ('queued', 'dispatched')
+  AND (
+    atq.issue_id IS NULL
+    OR i.parent_issue_id IS NULL
+    OR parent.status IN ('done', 'cancelled')
+  )
+ORDER BY atq.priority DESC, atq.created_at ASC;
 
 -- name: ListActiveTasksByIssue :many
 SELECT * FROM agent_task_queue


### PR DESCRIPTION
 ## What does this PR do?

  Makes the task scheduler respect the `parent_issue_id` relationship. Previously child issues were
  picked up in parallel with their still-running parents, which defeated the sub-issue hierarchy
  users rely on to model ordered work.

  Applies the reporter's preferred SQL-level fix (Option A in #970) to both scheduling paths:

  - `ListPendingTasksByRuntime` — LEFT JOINs `issue` twice (task's own issue + its parent) and
  excludes tasks whose parent is not `done`/`cancelled`.
  - `ClaimAgentTask` — same filter inside the atomic claim subquery so the claim can't sneak a
  blocked child through.

  Both queries treat chat tasks (`issue_id IS NULL`) and top-level issues (`parent_issue_id IS
  NULL`) as always-eligible so nothing else changes.

  ## Related Issue

  Refs #970

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `server/pkg/db/queries/agent.sql` — add parent-status filter to `ListPendingTasksByRuntime` and
  `ClaimAgentTask`.
  - `server/pkg/db/generated/agent.sql.go` — regenerated-style output matching the SQL change. Run
  `sqlc generate` to verify my hand-edit matches.

  ## How to Test

  1. `cd server && go build ./...` — clean.
  2. `go test ./internal/service/... ./internal/handler/...` — existing tests (mock-based) still
  pass. The SQL change is straightforward and will be exercised by the integration suite on CI.
  3. Integration: create a parent issue + child issue both assigned to agents; set parent to
  `in_progress`; observe that only the parent task starts. Transition parent to `done`; child task
  starts on the next claim cycle.

  ## Checklist

  - [x] Tests run locally and pass
  - [x] No breaking changes to data model or API shape
  - [ ] Dedicated integration test for parent-gate — happy to add in a follow-up if reviewers prefer
   (would need the fixture harness used by repocache tests, not the mock Queries used by service
  tests)

  ## AI Disclosure

  **AI tool used:** Claude Code

  **Prompt / approach:** Followed the reporter's clear root-cause diagnosis in #970, applied their
  preferred SQL-level fix across both scheduler entry points (not just `ListPendingTasksByRuntime`).
   Each edit reviewed before apply.