### PR TITLE
fix(execenv): drop 'coding agent' framing from injected runtime header (#1216)

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -42,7 +42,12 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	var b strings.Builder
 
 	b.WriteString("# Multica Agent Runtime\n\n")
-	b.WriteString("You are a coding agent in the Multica platform. Use the `multica` CLI to interact with the platform.\n\n")
+	// Neutral framing — Multica increasingly hosts non-coding agents (CEO
+	// orchestrators, marketing, analysts, etc.) whose configured identity
+	// shouldn't be overridden by a hardcoded "coding agent" header (#1216).
+	// Coding agents still get their specifics from their own instructions
+	// and from the code-oriented workflow sections below.
+	b.WriteString("You are an agent in the Multica platform. Use the `multica` CLI to interact with the platform.\n\n")
 
 	// Always emit agent identity so the agent knows who it is, even when
 	// dispatched via @mention on an issue assigned to a different agent.

--- a/server/internal/daemon/execenv/runtime_header_test.go
+++ b/server/internal/daemon/execenv/runtime_header_test.go
@@ -1,0 +1,47 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInjectRuntimeConfigHeaderIsRoleNeutral guards the fix for #1216.
+// The platform-injected header must not claim "coding agent" — Multica hosts
+// CEO/analyst/marketing/etc. agents whose configured identity would be
+// contradicted by that framing. Coding specifics belong in skills, workflow
+// sections, or the agent's own instructions.
+func TestInjectRuntimeConfigHeaderIsRoleNeutral(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID:   "11111111-1111-1111-1111-111111111111",
+		AgentName: "Victor",
+	}
+	if err := InjectRuntimeConfig(dir, "claude", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	content := string(b)
+
+	// Header must not prejudge the agent's role.
+	if strings.Contains(content, "You are a coding agent") {
+		t.Errorf("injected header should not claim 'coding agent' — breaks non-coding roles (#1216)\n---\n%s", content)
+	}
+
+	// But it must still identify the environment so agents know how to interact.
+	for _, want := range []string{
+		"Multica platform",
+		"`multica` CLI",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("header dropped required phrase %q\n---\n%s", want, content)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

  Drops the hardcoded "coding agent" phrasing from the platform-injected `CLAUDE.md` / `AGENTS.md` /
   `GEMINI.md` header so non-coding agents (CEO orchestrators, marketing, analysts, PM) aren't
  primed against their own configured identity.

  Before:
  > You are a coding agent in the Multica platform. Use the `multica` CLI to interact with the
  platform.

  After:
  > You are an agent in the Multica platform. Use the `multica` CLI to interact with the platform.

  Reporter's Option C in #1216 — simplest fix that unblocks non-coding agents. Coding specifics
  still come from Skills, workflow sections, and the agent's own `instructions`.

  ## Related Issue

  Refs #1216

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `server/internal/daemon/execenv/runtime_config.go` — one-line header change + rationale comment.
  - `server/internal/daemon/execenv/runtime_header_test.go` — regression test: header is
  role-neutral but still identifies the runtime + CLI.

  ## How to Test

  1. `cd server && go test ./internal/daemon/execenv/...` — passes.
  2. On a live workspace, dispatch a task to a non-coding agent, inspect the generated `CLAUDE.md`
  in the task workdir — header should say "You are an agent".

  ## Checklist

  - [x] Tests run locally and pass
  - [x] Added regression test
  - [x] No data-model or API changes

  ## AI Disclosure

  **AI tool used:** Claude Code

  **Prompt / approach:** Inspected the auto-generated CLAUDE.md injected into my marketing agents'
  task workdirs; confirmed the "coding agent" header exactly as #1216 describes. 
