### PR TITLE
(auto-filled from commit): fix(daemon): make API timeout configurable, raise default to 60s

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -81,6 +81,13 @@ func (c *Client) SetVersion(v string) {
 	c.version = v
 }
 
+// SetTimeout overrides the HTTP client timeout for all daemon API requests.
+// The daemon invokes this during startup with cfg.APITimeout so operators can
+// tune it via MULTICA_DAEMON_API_TIMEOUT when the hosted API is slow.
+func (c *Client) SetTimeout(d time.Duration) {
+	c.client.Timeout = d
+}
+
 // setIdentityHeaders attaches X-Client-Platform/Version/OS to req when set.
 func (c *Client) setIdentityHeaders(req *http.Request) {
 	if c.platform != "" {

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -7,7 +7,19 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"testing"
+	"time"
 )
+
+func TestClient_SetTimeout(t *testing.T) {
+	c := NewClient("http://example.com")
+	if c.client.Timeout != 30*time.Second {
+		t.Errorf("expected default 30s, got %v", c.client.Timeout)
+	}
+	c.SetTimeout(90 * time.Second)
+	if c.client.Timeout != 90*time.Second {
+		t.Errorf("expected 90s after SetTimeout, got %v", c.client.Timeout)
+	}
+}
 
 func TestClient_IdentityHeaders_PostJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -15,6 +15,7 @@ const (
 	DefaultPollInterval          = 3 * time.Second
 	DefaultHeartbeatInterval     = 15 * time.Second
 	DefaultAgentTimeout          = 2 * time.Hour
+	DefaultAPITimeout            = 60 * time.Second
 	DefaultRuntimeName           = "Local Agent"
 	DefaultWorkspaceSyncInterval = 30 * time.Second
 	DefaultHealthPort            = 19514
@@ -46,6 +47,7 @@ type Config struct {
 	PollInterval       time.Duration
 	HeartbeatInterval  time.Duration
 	AgentTimeout       time.Duration
+	APITimeout         time.Duration // HTTP timeout for daemon↔server calls (default 60s, env MULTICA_DAEMON_API_TIMEOUT)
 }
 
 // Overrides allows CLI flags to override environment variables and defaults.
@@ -56,6 +58,7 @@ type Overrides struct {
 	PollInterval       time.Duration
 	HeartbeatInterval  time.Duration
 	AgentTimeout       time.Duration
+	APITimeout         time.Duration
 	MaxConcurrentTasks int
 	DaemonID           string
 	DeviceName         string
@@ -184,6 +187,14 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		agentTimeout = overrides.AgentTimeout
 	}
 
+	apiTimeout, err := durationFromEnv("MULTICA_DAEMON_API_TIMEOUT", DefaultAPITimeout)
+	if err != nil {
+		return Config{}, err
+	}
+	if overrides.APITimeout > 0 {
+		apiTimeout = overrides.APITimeout
+	}
+
 	maxConcurrentTasks, err := intFromEnv("MULTICA_DAEMON_MAX_CONCURRENT_TASKS", DefaultMaxConcurrentTasks)
 	if err != nil {
 		return Config{}, err
@@ -307,6 +318,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		PollInterval:       pollInterval,
 		HeartbeatInterval:  heartbeatInterval,
 		AgentTimeout:       agentTimeout,
+		APITimeout:         apiTimeout,
 	}, nil
 }
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -59,6 +59,9 @@ type Daemon struct {
 func New(cfg Config, logger *slog.Logger) *Daemon {
 	cacheRoot := filepath.Join(cfg.WorkspacesRoot, ".repos")
 	client := NewClient(cfg.ServerBaseURL)
+	if cfg.APITimeout > 0 {
+		client.SetTimeout(cfg.APITimeout)
+	}
 	// Tag every daemon HTTP request with the daemon's CLI version so the
 	// server can split logs/metrics by client version (parallel to the CLI).
 	client.SetVersion(cfg.CLIVersion)


### PR DESCRIPTION
## What does this PR do?

  Makes the daemon's HTTP timeout configurable (via `MULTICA_DAEMON_API_TIMEOUT`) and raises the
  default from 30s → 60s.

  The daemon's HTTP client hardcoded a 30s `Timeout` for **all** server calls — heartbeat, task
  reports, task-message uploads, workspace sync. When `api.multica.ai` is slow enough to take >30s
  for response headers (observed in the wild at 12–24s nominal, occasional peaks past 30s), calls
  fail with `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` and
  runtimes flap offline/online.

  60s gives headroom for transient API slowness without making the daemon unresponsive to a truly
  dead server. Operators who want a different value can set `MULTICA_DAEMON_API_TIMEOUT=15s` (or
  `90s`, etc.).

  ## Related Issue

  Closes #1637

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `server/internal/daemon/config.go` — add `DefaultAPITimeout = 60s`, `Config.APITimeout`,
  `Overrides.APITimeout`, env-var loading (`MULTICA_DAEMON_API_TIMEOUT`).
  - `server/internal/daemon/client.go` — add `Client.SetTimeout(d time.Duration)` setter.
  `NewClient` keeps its 30s default so external callers aren't affected.
  - `server/internal/daemon/daemon.go` — in `New()`, call `client.SetTimeout(cfg.APITimeout)` when
  non-zero.
  - `server/internal/daemon/client_test.go` — new `TestClient_SetTimeout` covering default and
  override.

  ## How to Test

  1. Unit test: `cd server && go test -run TestClient_SetTimeout ./internal/daemon/` → passes.
  2. Full daemon suite: `cd server && go test ./internal/daemon/...` → `daemon` and `execenv`
  packages pass. (Two pre-existing failures in `repocache/cache_test.go` — `TestWorktreeFromCache`,
  `TestCreateWorktree` — reproduce on `main` unchanged; a `git show-branch` environment issue,
  unrelated to this change.)
  3. Reproduce on main (30s default), then this branch:
     MULTICA_DAEMON_API_TIMEOUT=60s multica daemon start --foreground --profile=dev-test
  In my test session, an unpatched daemon logged 8+ `heartbeat failed` events over 30 minutes while
  a patched daemon on the same machine/endpoint logged zero over a 7-minute side-by-side window.

  ## Checklist

  - [x] Tests run locally and pass
  - [x] Added test coverage for the new setter
  - [x] Non-breaking: `NewClient` default unchanged, existing callers unaffected
  - [ ] Docs note: happy to add `MULTICA_DAEMON_API_TIMEOUT` to `.env.example` if the maintainers
  want it there — kept the diff minimal for now.

  ## AI Disclosure

  **AI tool used:** Claude Code