### PR TITLE
feat(local-path): add workspace/project local folder binding

### DIFF
--- a/docs/local-path-binding.md
+++ b/docs/local-path-binding.md
@@ -1,0 +1,39 @@
+# Local Path Binding (MVP)
+
+This document describes the current MVP behavior for binding workspace/project entities to local folders.
+
+## Scope
+
+- `workspace.local_path` is optional and stored in the workspace row.
+- `project.local_path` is optional and stored in the project row.
+- The feature is designed for single-machine/self-hosted usage.
+
+## Constraints
+
+- `local_path` must be an absolute path.
+- The backend trims and normalizes `local_path` before storing it.
+- Control characters are rejected.
+- Empty/blank values are rejected on create; update supports explicit clear via `null`.
+- Maximum normalized path length is 1024 characters.
+
+## API Semantics
+
+- Create:
+  - `POST /api/workspaces` accepts optional `local_path`.
+  - `POST /api/projects` accepts optional `local_path`.
+- Update:
+  - Omitting `local_path` preserves existing value.
+  - Sending `"local_path": null` clears existing value.
+  - Sending a non-empty string updates the value after normalization.
+
+## UI Behavior
+
+- Workspace creation forms expose `Create from existing folder`.
+- Project creation modal exposes `Create from existing folder`.
+- When enabled, folder path is required and trimmed before submission.
+
+## Operational Notes
+
+- The path must be valid on the machine where daemon/runtime actually executes tasks.
+- In multi-device teams the same absolute path may not exist on other machines.
+- Device-specific path mapping is out of scope for this MVP and should be introduced as a follow-up feature.

--- a/feature.md
+++ b/feature.md
@@ -1,0 +1,199 @@
+# План: привязка Workspace/Project к физическим папкам и создание из существующей папки
+
+## Краткий вывод по реализуемости
+
+Функционал **реализуем**, но сейчас в продукте нет единой сущности «локальная папка»:
+
+- `workspace` хранит удалённые репозитории (`repos` JSON), но не локальные пути.
+- `project` не хранит ссылку на путь на диске.
+- daemon работает от общего `WorkspacesRoot` и временных рабочих директорий по задачам, а не от пользовательских «постоянных» путей.
+
+Т.е. нужно добавить новый слой модели данных и синхронизации, а не только поле в UI.
+
+## Что есть сейчас (важное для дизайна)
+
+1. **Workspace:**
+   - Бэкенд сериализует `workspace` с полями `context`, `repos`, `issue_prefix` и т.д.
+   - Создание workspace (`POST /api/workspaces`) принимает только `name/slug/...`, без пути.
+   - Обновление workspace (`PUT /api/workspaces/{id}`) сейчас уже умеет обновлять `repos`, но не filesystem path.
+
+2. **Project:**
+   - `project` таблица и API создания/обновления не содержат поля пути.
+   - Frontend-модалки/формы создания проекта не запрашивают путь.
+
+3. **Daemon / CLI:**
+   - Daemon имеет глобальный `WorkspacesRoot` (на уровне машины/профиля).
+   - Для workspace daemon получает только список repo URL (`/api/daemon/workspaces/{id}/repos`).
+   - Нет API контракта «workspace/project -> local path».
+
+## Архитектурные решения (рекомендуемые)
+
+### 1) Разделить **глобальную логическую привязку** и **машино-специфичную локальную привязку**
+
+Критичный момент: один и тот же workspace открыт у разных пользователей/машин/OS, и «локальный абсолютный путь» не может быть универсальным серверным атрибутом.
+
+Рекомендация:
+
+- На сервере хранить **опциональный canonical path intent** (для self-hosted/single-machine сценариев), но не считать его единственным источником истины.
+- Отдельно хранить (или вычислять) **machine-specific mapping**: `workspace_id + device_id -> local_path`.
+
+Если сделать одно поле `workspace.local_path`, сразу появятся конфликты между устройствами и утечки приватных путей.
+
+### 2) Для Project — путь может быть относительным к workspace
+
+Для проекта лучше поддержать две модели:
+
+- `project.local_path_mode = "relative"`, `project.local_path = "services/api"` (от workspace root)
+- `project.local_path_mode = "absolute"`, `project.local_path = "/Users/alex/dev/other-repo"`
+
+По умолчанию рекомендовать relative.
+
+### 3) Создание «из папки» должно быть двухфазным
+
+1. Выбор папки на клиенте (desktop/web + local helper).
+2. Валидация и нормализация пути на стороне daemon/desktop bridge.
+3. Создание сущности (workspace/project) с передачей безопасного payload в API.
+
+Нельзя доверять пути напрямую из browser-only web-клиента (без локального bridge).
+
+## Подводные камни
+
+1. **Мульти-девайс и shared workspaces**
+   - Разные участники имеют разные файловые системы.
+   - Серверный абсолютный путь для одного пользователя невалиден для другого.
+
+2. **Безопасность и приватность**
+   - Путь может раскрывать имя пользователя/структуру системы.
+   - Нужна проверка прав (кто может менять path): owner/admin.
+
+3. **Кросс-платформенность путей**
+   - Windows (`C:\...`), POSIX (`/home/...`), symlink, UNC path.
+   - Нужен единый валидатор/нормализатор и правила сериализации.
+
+4. **Существующие процессы daemon**
+   - Сейчас daemon ориентирован на repo URL + рабочие директории задач.
+   - Добавление постоянных путей не должно ломать GC, checkout и sandbox поведение.
+
+5. **Web-продукт без локального доступа к ФС**
+   - Для web нужна интеграция через daemon API или File System Access API (ограничено браузером/разрешениями).
+   - Desktop реализуется проще через Electron dialog.
+
+6. **Миграции и backward compatibility данных**
+   - Новые поля должны быть nullable и опциональными.
+   - Текущие сценарии без path должны работать как раньше.
+
+## Предлагаемый поэтапный план реализации
+
+## Этап 0 — Product/Domain decisions (обязательно)
+
+- Зафиксировать точную семантику:
+  - path на workspace — глобальный или device-specific?
+  - path на project — absolute, relative, или оба?
+  - кто может менять path?
+  - нужен ли аудит изменений пути?
+
+Deliverable: ADR/документ решения.
+
+## Этап 1 — Data model + migrations
+
+1. **Workspace**
+   - Вариант A (минимальный): `workspace.local_path TEXT NULL`.
+   - Вариант B (правильнее): новая таблица `workspace_local_binding(workspace_id, device_id, local_path, ...)`.
+
+2. **Project**
+   - Добавить поля:
+     - `local_path TEXT NULL`
+     - `local_path_mode TEXT CHECK (absolute|relative) NULL`
+
+3. SQLC:
+   - Обновить `server/pkg/db/queries/*.sql`.
+   - Перегенерировать `server/pkg/db/generated`.
+
+## Этап 2 — Backend API
+
+1. **Workspace API**
+   - `CreateWorkspaceRequest` + `UpdateWorkspaceRequest` расширить path-полями.
+   - Валидация (пустые строки, max length, mode).
+
+2. **Project API**
+   - `CreateProjectRequest` + `UpdateProjectRequest` расширить path-полями.
+
+3. **Создание из папки**
+   - Новые endpoint-ы (пример):
+     - `POST /api/workspaces/from-folder`
+     - `POST /api/projects/from-folder`
+   - Или флаг в существующих create endpoint-ах (`source: "folder"`).
+
+4. Права доступа:
+   - Только owner/admin для workspace path.
+   - Для project path — как минимум editor/admin (по текущей RBAC модели).
+
+## Этап 3 — Core types + API client + React Query
+
+- Обновить `packages/core/types/workspace.ts`, `project.ts`.
+- Обновить `packages/core/api/client.ts` DTO и методы create/update.
+- Проверить invalidation/query keys (чтобы новое поле корректно попадало в кеш).
+
+## Этап 4 — UI/UX (web + desktop)
+
+1. **Workspace**
+   - В форме создания workspace добавить переключатель:
+     - обычное создание
+     - создание из существующей папки
+   - В settings добавить редактирование привязанной папки.
+
+2. **Project**
+   - В create-project modal добавить поле `Path` + mode (`relative/absolute`).
+   - В project detail/settings показать и редактировать путь.
+
+3. **Desktop**
+   - Использовать native folder picker.
+
+4. **Web**
+   - Если нет daemon/bridge — либо read-only, либо manual input path (с предупреждением).
+
+## Этап 5 — Daemon integration
+
+- Расширить daemon API payload, чтобы daemon мог получать локальные пути.
+- В task execution resolver: при наличии project/workspace path — использовать его как preferred root.
+- Fallback на текущий `WorkspacesRoot` оставить как default.
+
+## Этап 6 — Тесты
+
+1. Backend:
+   - unit/integration тесты на create/update + from-folder flow.
+   - тесты валидации path (invalid/empty/long/platform-specific).
+
+2. Frontend:
+   - tests для новых полей форм, submit payload, optimistic updates.
+
+3. Daemon:
+   - tests на выбор рабочей директории и fallback.
+
+## Этап 7 — Rollout
+
+- Feature flag `local_folder_binding`.
+- Поэтапное включение: desktop first -> web.
+- Наблюдаемость: логирование ошибок валидации и количества привязок путей.
+
+## Рекомендуемый MVP (самый практичный старт)
+
+1. Добавить только **workspace.local_path (nullable)** + UI в Settings.
+2. Для project пока добавить только `relative_path` (без absolute).
+3. Добавить создание project/workspace из папки **в desktop**, а web оставить без folder picker на первом шаге.
+4. Daemon: использовать путь, если задан; иначе старое поведение.
+
+Это даст быстрый value и минимальный риск, затем расширить до device-specific mappings.
+
+---
+
+## Текущий статус реализации (MVP)
+
+- Реализованы поля `local_path` для `workspace` и `project`.
+- Добавлена backend-нормализация/валидация путей (absolute-only, trim/clean, reject control chars).
+- Исправлена PATCH-семантика: отсутствие `local_path` в payload не затирает поле; `null` очищает значение.
+- В UI добавлены и ужесточены сценарии `Create from existing folder` для workspace/project.
+- Миграция local-path перенесена на `059_*` для совместимости с `origin/main` (`058` уже занят autopilot-миграцией).
+
+Ограничение MVP: модель хранит глобальный `local_path` и рассчитана на single-machine/self-hosted сценарии.
+Для multi-device требуется отдельная device-specific mapping модель.

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -721,14 +721,14 @@ export class ApiClient {
     return this.fetch(`/api/workspaces/${id}`);
   }
 
-  async createWorkspace(data: { name: string; slug: string; description?: string; context?: string }): Promise<Workspace> {
+  async createWorkspace(data: { name: string; slug: string; description?: string; context?: string; local_path?: string }): Promise<Workspace> {
     return this.fetch("/api/workspaces", {
       method: "POST",
       body: JSON.stringify(data),
     });
   }
 
-  async updateWorkspace(id: string, data: { name?: string; description?: string; context?: string; settings?: Record<string, unknown>; repos?: WorkspaceRepo[] }): Promise<Workspace> {
+  async updateWorkspace(id: string, data: { name?: string; description?: string; context?: string; local_path?: string | null; settings?: Record<string, unknown>; repos?: WorkspaceRepo[] }): Promise<Workspace> {
     return this.fetch(`/api/workspaces/${id}`, {
       method: "PATCH",
       body: JSON.stringify(data),

--- a/packages/core/types/project.ts
+++ b/packages/core/types/project.ts
@@ -8,6 +8,7 @@ export interface Project {
   title: string;
   description: string | null;
   icon: string | null;
+  local_path?: string | null;
   status: ProjectStatus;
   priority: ProjectPriority;
   lead_type: "member" | "agent" | null;
@@ -22,6 +23,7 @@ export interface CreateProjectRequest {
   title: string;
   description?: string;
   icon?: string;
+  local_path?: string;
   status?: ProjectStatus;
   priority?: ProjectPriority;
   lead_type?: "member" | "agent";
@@ -32,6 +34,7 @@ export interface UpdateProjectRequest {
   title?: string;
   description?: string | null;
   icon?: string | null;
+  local_path?: string | null;
   status?: ProjectStatus;
   priority?: ProjectPriority;
   lead_type?: "member" | "agent" | null;

--- a/packages/core/types/workspace.ts
+++ b/packages/core/types/workspace.ts
@@ -11,6 +11,7 @@ export interface Workspace {
   slug: string;
   description: string | null;
   context: string | null;
+  local_path?: string | null;
   settings: Record<string, unknown>;
   repos: WorkspaceRepo[];
   issue_prefix: string;

--- a/packages/core/workspace/mutations.ts
+++ b/packages/core/workspace/mutations.ts
@@ -6,7 +6,7 @@ import { workspaceKeys } from "./queries";
 export function useCreateWorkspace() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { name: string; slug: string; description?: string }) =>
+    mutationFn: (data: { name: string; slug: string; description?: string; context?: string; local_path?: string }) =>
       api.createWorkspace(data),
     // Seed the workspace list cache BEFORE callers navigate to /{newWs.slug}/issues.
     // The destination [workspaceSlug]/layout queries by slug from this cache;

--- a/packages/views/modals/create-project.local-path.test.tsx
+++ b/packages/views/modals/create-project.local-path.test.tsx
@@ -1,0 +1,248 @@
+import { type ChangeEvent, type ReactNode, type Ref, forwardRef, useImperativeHandle, useState } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CreateProjectModal } from "./create-project";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockCreateProject = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
+const mockToastError = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [] }),
+}));
+
+vi.mock("../navigation", () => ({
+  useNavigation: () => ({ push: mockPush }),
+}));
+
+vi.mock("@multica/core/projects/mutations", () => ({
+  useCreateProject: () => ({ mutateAsync: mockCreateProject }),
+}));
+
+vi.mock("@multica/core/projects/config", () => ({
+  PROJECT_STATUS_CONFIG: { planned: { label: "Planned", dotColor: "bg-gray-400" } },
+  PROJECT_STATUS_ORDER: ["planned"],
+  PROJECT_PRIORITY_CONFIG: { none: { label: "No Priority" } },
+  PROJECT_PRIORITY_ORDER: ["none"],
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-test",
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useCurrentWorkspace: () => ({ name: "Workspace" }),
+  useWorkspacePaths: () => ({
+    projectDetail: (id: string) => `/ws-test/projects/${id}`,
+  }),
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({ queryKey: ["members"], queryFn: async () => [] }),
+  agentListOptions: () => ({ queryKey: ["agents"], queryFn: async () => [] }),
+}));
+
+vi.mock("@multica/core/workspace/hooks", () => ({
+  useActorName: () => ({ getActorName: () => "Lead" }),
+}));
+
+vi.mock("@multica/ui/lib/utils", () => ({
+  cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(" "),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError,
+  },
+}));
+
+vi.mock("@multica/ui/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ render }: { render: ReactNode }) => <>{render}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ render }: { render: ReactNode }) => <>{render}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ render }: { render: ReactNode }) => <>{render}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@multica/ui/components/ui/button", () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+    type = "button",
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+    type?: "button" | "submit" | "reset";
+  }) => (
+    <button type={type} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/input", () => ({
+  Input: ({
+    value,
+    onChange,
+    placeholder,
+    disabled,
+    id,
+    "aria-describedby": ariaDescribedBy,
+  }: {
+    value?: string;
+    onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    id?: string;
+    "aria-describedby"?: string;
+  }) => (
+    <input
+      id={id}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      disabled={disabled}
+      aria-describedby={ariaDescribedBy}
+    />
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    id,
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+    id?: string;
+  }) => (
+    <input
+      id={id}
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+    />
+  ),
+}));
+
+vi.mock("@multica/ui/components/common/emoji-picker", () => ({
+  EmojiPicker: () => null,
+}));
+
+vi.mock("../issues/components/priority-icon", () => ({
+  PriorityIcon: () => <span>priority</span>,
+}));
+
+vi.mock("../common/actor-avatar", () => ({
+  ActorAvatar: () => <span>avatar</span>,
+}));
+
+vi.mock("../editor", () => {
+  const ContentEditor = forwardRef((_props: unknown, ref: Ref<{ getMarkdown: () => string }>) => {
+    useImperativeHandle(ref, () => ({
+      getMarkdown: () => "",
+    }));
+    return <div data-testid="content-editor" />;
+  });
+  ContentEditor.displayName = "ContentEditor";
+
+  return {
+    ContentEditor,
+    TitleEditor: ({ placeholder, onChange, onSubmit }: any) => {
+      const [value, setValue] = useState("");
+      return (
+        <input
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => {
+            setValue(e.target.value);
+            onChange?.(e.target.value);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onSubmit?.();
+          }}
+        />
+      );
+    },
+  };
+});
+
+describe("CreateProjectModal local_path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateProject.mockResolvedValue({ id: "project-1" });
+  });
+
+  it("does not send local_path when create-from-folder is disabled", async () => {
+    render(<CreateProjectModal onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Project title"), {
+      target: { value: "Project A" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => expect(mockCreateProject).toHaveBeenCalledTimes(1));
+    expect(mockCreateProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Project A",
+        local_path: undefined,
+      }),
+    );
+  });
+
+  it("disables submit when create-from-folder is enabled and path is empty", () => {
+    render(<CreateProjectModal onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Project title"), {
+      target: { value: "Project B" },
+    });
+    fireEvent.click(screen.getByLabelText(/create from existing folder/i));
+
+    expect(screen.getByRole("button", { name: "Create Project" })).toBeDisabled();
+  });
+
+  it("trims and sends local_path when create-from-folder is enabled", async () => {
+    render(<CreateProjectModal onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Project title"), {
+      target: { value: "Project C" },
+    });
+    fireEvent.click(screen.getByLabelText(/create from existing folder/i));
+    fireEvent.change(screen.getByPlaceholderText("/home/user/projects/my-app"), {
+      target: { value: "  /home/user/projects/project-c  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Project" }));
+
+    await waitFor(() => expect(mockCreateProject).toHaveBeenCalledTimes(1));
+    expect(mockCreateProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Project C",
+        local_path: "/home/user/projects/project-c",
+      }),
+    );
+  });
+});

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -27,6 +27,8 @@ import {
 import { Popover, PopoverTrigger, PopoverContent } from "@multica/ui/components/ui/popover";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
+import { Input } from "@multica/ui/components/ui/input";
+import { Checkbox } from "@multica/ui/components/ui/checkbox";
 import { EmojiPicker } from "@multica/ui/components/common/emoji-picker";
 import { ContentEditor, type ContentEditorRef, TitleEditor } from "../editor";
 import { PriorityIcon } from "../issues/components/priority-icon";
@@ -70,6 +72,8 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
   const [leadType, setLeadType] = useState<"member" | "agent" | undefined>();
   const [leadId, setLeadId] = useState<string | undefined>();
   const [icon, setIcon] = useState<string | undefined>();
+  const [useExistingFolder, setUseExistingFolder] = useState(false);
+  const [localPath, setLocalPath] = useState("");
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -88,13 +92,16 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
   const createProject = useCreateProject();
 
   const handleSubmit = async () => {
-    if (!title.trim() || submitting) return;
+    const normalizedPath = localPath.trim();
+    const localPathPayload = useExistingFolder && normalizedPath ? normalizedPath : undefined;
+    if (!title.trim() || submitting || (useExistingFolder && !localPath.trim())) return;
     setSubmitting(true);
     try {
       const project = await createProject.mutateAsync({
         title: title.trim(),
         description: descEditorRef.current?.getMarkdown()?.trim() || undefined,
         icon,
+        local_path: localPathPayload,
         status,
         priority,
         lead_type: leadType,
@@ -203,6 +210,28 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
         </div>
 
         <div className="flex items-center gap-1.5 px-4 py-2 shrink-0 flex-wrap">
+          <label htmlFor="project-existing-folder" className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Checkbox
+              id="project-existing-folder"
+              checked={useExistingFolder}
+              onCheckedChange={(checked) => setUseExistingFolder(Boolean(checked))}
+            />
+            Create from existing folder
+          </label>
+          {useExistingFolder && (
+            <div className="flex items-center gap-2">
+              <Input
+                value={localPath}
+                onChange={(e) => setLocalPath(e.target.value)}
+                placeholder="/home/user/projects/my-app"
+                aria-describedby="project-local-path-help"
+                className="h-8 w-72"
+              />
+              <span id="project-local-path-help" className="text-xs text-muted-foreground">
+                Absolute path on daemon host
+              </span>
+            </div>
+          )}
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -342,7 +371,11 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
         </div>
 
         <div className="flex items-center justify-end px-4 py-3 border-t shrink-0">
-          <Button size="sm" onClick={handleSubmit} disabled={!title.trim() || submitting}>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!title.trim() || submitting || (useExistingFolder && !localPath.trim())}
+          >
             {submitting ? "Creating..." : "Create Project"}
           </Button>
         </div>

--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@multica/ui/components/ui/button";
+import { Checkbox } from "@multica/ui/components/ui/checkbox";
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
@@ -94,6 +95,8 @@ export function StepWorkspace({
   // the footer CTA can read `canCreate` and trigger `handleCreate`.
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  const [useExistingFolder, setUseExistingFolder] = useState(false);
+  const [localPath, setLocalPath] = useState("");
   const [slugServerError, setSlugServerError] = useState<string | null>(null);
   const slugTouched = useRef(false);
 
@@ -103,7 +106,10 @@ export function StepWorkspace({
       : null;
   const slugError = slugValidationError ?? slugServerError;
   const canCreate =
-    name.trim().length > 0 && slug.trim().length > 0 && !slugError;
+    name.trim().length > 0 &&
+    slug.trim().length > 0 &&
+    !slugError &&
+    (!useExistingFolder || localPath.trim().length > 0);
 
   const handleNameChange = (value: string) => {
     setName(value);
@@ -123,8 +129,14 @@ export function StepWorkspace({
 
   const handleCreate = () => {
     if (!canCreate || createWorkspace.isPending) return;
+    const normalizedPath = localPath.trim();
+    const localPathPayload = useExistingFolder && normalizedPath ? normalizedPath : undefined;
     createWorkspace.mutate(
-      { name: name.trim(), slug: slug.trim() },
+      {
+        name: name.trim(),
+        slug: slug.trim(),
+        local_path: localPathPayload,
+      },
       {
         onSuccess: onCreated,
         onError: (error) => {
@@ -235,6 +247,41 @@ export function StepWorkspace({
           </span>
           . You can change this later in settings.
         </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <label
+          htmlFor="onboarding-ws-existing-folder"
+          className="flex items-center gap-2 text-sm text-muted-foreground"
+        >
+          <Checkbox
+            id="onboarding-ws-existing-folder"
+            checked={useExistingFolder}
+            onCheckedChange={(checked) => setUseExistingFolder(Boolean(checked))}
+          />
+          Create from existing folder
+        </label>
+        {useExistingFolder && (
+          <div className="flex flex-col gap-1.5">
+            <Label
+              htmlFor="onboarding-ws-local-path"
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Folder path
+            </Label>
+            <Input
+              id="onboarding-ws-local-path"
+              type="text"
+              value={localPath}
+              onChange={(e) => setLocalPath(e.target.value)}
+              placeholder="/home/user/projects/my-workspace"
+              aria-describedby="onboarding-ws-local-path-help"
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            />
+            <p id="onboarding-ws-local-path-help" className="text-xs text-muted-foreground">
+              Absolute path on the machine where daemon runs.
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/views/workspace/create-workspace-form.test.tsx
+++ b/packages/views/workspace/create-workspace-form.test.tsx
@@ -82,4 +82,60 @@ describe("CreateWorkspaceForm", () => {
       screen.getByRole("button", { name: /create workspace/i }),
     ).toBeDisabled();
   });
+
+  it("does not send local_path when create-from-folder is disabled", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText(/workspace name/i), {
+      target: { value: "Acme Root" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create workspace/i }));
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalledTimes(1));
+    expect(mockMutate.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        name: "Acme Root",
+        slug: "acme-root",
+      }),
+    );
+    expect(mockMutate.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        local_path: undefined,
+      }),
+    );
+  });
+
+  it("requires folder path when create-from-folder is enabled", () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText(/workspace name/i), {
+      target: { value: "Acme Root" },
+    });
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(
+      screen.getByRole("button", { name: /create workspace/i }),
+    ).toBeDisabled();
+  });
+
+  it("trims and sends local_path when create-from-folder is enabled", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText(/workspace name/i), {
+      target: { value: "Acme Root" },
+    });
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.change(screen.getByLabelText(/folder path/i), {
+      target: { value: "  /home/user/projects/acme-root  " },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create workspace/i }));
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalledTimes(1));
+    expect(mockMutate.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        name: "Acme Root",
+        slug: "acme-root",
+        local_path: "/home/user/projects/acme-root",
+      }),
+    );
+  });
 });

--- a/packages/views/workspace/create-workspace-form.tsx
+++ b/packages/views/workspace/create-workspace-form.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
 import { Button } from "@multica/ui/components/ui/button";
+import { Checkbox } from "@multica/ui/components/ui/checkbox";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import { useCreateWorkspace } from "@multica/core/workspace/mutations";
 import type { Workspace } from "@multica/core/types";
@@ -24,6 +25,8 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
   const createWorkspace = useCreateWorkspace();
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  const [useExistingFolder, setUseExistingFolder] = useState(false);
+  const [localPath, setLocalPath] = useState("");
   const [slugServerError, setSlugServerError] = useState<string | null>(null);
   const slugTouched = useRef(false);
 
@@ -33,7 +36,10 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
       : null;
   const slugError = slugValidationError ?? slugServerError;
   const canSubmit =
-    name.trim().length > 0 && slug.trim().length > 0 && !slugError;
+    name.trim().length > 0 &&
+    slug.trim().length > 0 &&
+    !slugError &&
+    (!useExistingFolder || localPath.trim().length > 0);
 
   const handleNameChange = (value: string) => {
     setName(value);
@@ -51,8 +57,14 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
 
   const handleCreate = () => {
     if (!canSubmit) return;
+    const normalizedPath = localPath.trim();
+    const localPathPayload = useExistingFolder && normalizedPath ? normalizedPath : undefined;
     createWorkspace.mutate(
-      { name: name.trim(), slug: slug.trim() },
+      {
+        name: name.trim(),
+        slug: slug.trim(),
+        local_path: localPathPayload,
+      },
       {
         onSuccess,
         onError: (error) => {
@@ -100,6 +112,33 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
           </div>
           {slugError && (
             <p className="text-xs text-destructive">{slugError}</p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="ws-existing-folder" className="flex items-center gap-2 text-sm">
+            <Checkbox
+              id="ws-existing-folder"
+              checked={useExistingFolder}
+              onCheckedChange={(checked) => setUseExistingFolder(Boolean(checked))}
+            />
+            Create from existing folder
+          </label>
+          {useExistingFolder && (
+            <div className="space-y-1.5">
+              <Label htmlFor="ws-local-path">Folder path</Label>
+              <Input
+                id="ws-local-path"
+                type="text"
+                value={localPath}
+                onChange={(e) => setLocalPath(e.target.value)}
+                placeholder="/home/user/projects/my-workspace"
+                aria-describedby="ws-local-path-help"
+                onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              />
+              <p id="ws-local-path-help" className="text-xs text-muted-foreground">
+                Absolute path on the machine where daemon runs.
+              </p>
+            </div>
           )}
         </div>
         <Button

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/pathutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -22,6 +23,7 @@ type ProjectResponse struct {
 	Title       string  `json:"title"`
 	Description *string `json:"description"`
 	Icon        *string `json:"icon"`
+	LocalPath   *string `json:"local_path"`
 	Status      string  `json:"status"`
 	Priority    string  `json:"priority"`
 	LeadType    *string `json:"lead_type"`
@@ -39,6 +41,7 @@ func projectToResponse(p db.Project) ProjectResponse {
 		Title:       p.Title,
 		Description: textToPtr(p.Description),
 		Icon:        textToPtr(p.Icon),
+		LocalPath:   textToPtr(p.LocalPath),
 		Status:      p.Status,
 		Priority:    p.Priority,
 		LeadType:    textToPtr(p.LeadType),
@@ -60,6 +63,7 @@ type CreateProjectRequest struct {
 	Title       string  `json:"title"`
 	Description *string `json:"description"`
 	Icon        *string `json:"icon"`
+	LocalPath   *string `json:"local_path"`
 	Status      string  `json:"status"`
 	Priority    string  `json:"priority"`
 	LeadType    *string `json:"lead_type"`
@@ -70,6 +74,7 @@ type UpdateProjectRequest struct {
 	Title       *string `json:"title"`
 	Description *string `json:"description"`
 	Icon        *string `json:"icon"`
+	LocalPath   *string `json:"local_path"`
 	Status      *string `json:"status"`
 	Priority    *string `json:"priority"`
 	LeadType    *string `json:"lead_type"`
@@ -162,17 +167,27 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	var leadType pgtype.Text
 	var leadID pgtype.UUID
+	var localPath pgtype.Text
 	if req.LeadType != nil {
 		leadType = pgtype.Text{String: *req.LeadType, Valid: true}
 	}
 	if req.LeadID != nil {
 		leadID = parseUUID(*req.LeadID)
 	}
+	if req.LocalPath != nil {
+		normalized, err := pathutil.NormalizeLocalPath(*req.LocalPath)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid local_path: "+err.Error())
+			return
+		}
+		localPath = pgtype.Text{String: normalized, Valid: true}
+	}
 	project, err := h.Queries.CreateProject(r.Context(), db.CreateProjectParams{
 		WorkspaceID: parseUUID(workspaceID),
 		Title:       req.Title,
 		Description: ptrToText(req.Description),
 		Icon:        ptrToText(req.Icon),
+		LocalPath:   localPath,
 		Status:      status,
 		LeadType:    leadType,
 		LeadID:      leadID,
@@ -220,6 +235,7 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		Icon:        prevProject.Icon,
 		LeadType:    prevProject.LeadType,
 		LeadID:      prevProject.LeadID,
+		LocalPath:   prevProject.LocalPath,
 	}
 	if req.Title != nil {
 		params.Title = pgtype.Text{String: *req.Title, Valid: true}
@@ -256,6 +272,18 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 			params.LeadID = parseUUID(*req.LeadID)
 		} else {
 			params.LeadID = pgtype.UUID{Valid: false}
+		}
+	}
+	if _, ok := rawFields["local_path"]; ok {
+		if req.LocalPath == nil {
+			params.LocalPath = pgtype.Text{Valid: false}
+		} else {
+			normalized, err := pathutil.NormalizeLocalPath(*req.LocalPath)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "invalid local_path: "+err.Error())
+				return
+			}
+			params.LocalPath = pgtype.Text{String: normalized, Valid: true}
 		}
 	}
 	project, err := h.Queries.UpdateProject(r.Context(), params)

--- a/server/internal/handler/project_local_path_test.go
+++ b/server/internal/handler/project_local_path_test.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpdateProject_DoesNotResetLocalPathWhenFieldAbsent(t *testing.T) {
+	ctx := context.Background()
+	const originalPath = "/tmp/project-preserve"
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO project (workspace_id, title, status, priority, local_path)
+VALUES ($1, $2, 'planned', 'none', $3)
+RETURNING id
+`, testWorkspaceID, "Project local_path preserve", originalPath).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodPatch, "/api/projects/"+projectID, map[string]any{
+		"title": "Project local_path preserve updated",
+	})
+	req = withURLParam(req, "id", projectID)
+	testHandler.UpdateProject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateProject expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var localPath *string
+	if err := testPool.QueryRow(ctx, `SELECT local_path FROM project WHERE id = $1`, projectID).Scan(&localPath); err != nil {
+		t.Fatalf("load project local_path: %v", err)
+	}
+	if localPath == nil || *localPath != originalPath {
+		t.Fatalf("project local_path = %v, want %q", localPath, originalPath)
+	}
+}
+
+func TestUpdateProject_ClearsLocalPathWhenNullPassed(t *testing.T) {
+	ctx := context.Background()
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO project (workspace_id, title, status, priority, local_path)
+VALUES ($1, $2, 'planned', 'none', $3)
+RETURNING id
+`, testWorkspaceID, "Project local_path clear", "/tmp/project-clear").Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodPatch, "/api/projects/"+projectID, map[string]any{
+		"local_path": nil,
+	})
+	req = withURLParam(req, "id", projectID)
+	testHandler.UpdateProject(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateProject expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var localPath *string
+	if err := testPool.QueryRow(ctx, `SELECT local_path FROM project WHERE id = $1`, projectID).Scan(&localPath); err != nil {
+		t.Fatalf("load project local_path: %v", err)
+	}
+	if localPath != nil {
+		t.Fatalf("project local_path = %q, want NULL", *localPath)
+	}
+}

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -11,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/pathutil"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -38,6 +40,7 @@ type WorkspaceResponse struct {
 	Slug        string  `json:"slug"`
 	Description *string `json:"description"`
 	Context     *string `json:"context"`
+	LocalPath   *string `json:"local_path"`
 	Settings    any     `json:"settings"`
 	Repos       any     `json:"repos"`
 	IssuePrefix string  `json:"issue_prefix"`
@@ -66,6 +69,7 @@ func workspaceToResponse(w db.Workspace) WorkspaceResponse {
 		Slug:        w.Slug,
 		Description: textToPtr(w.Description),
 		Context:     textToPtr(w.Context),
+		LocalPath:   textToPtr(w.LocalPath),
 		Settings:    settings,
 		Repos:       repos,
 		IssuePrefix: w.IssuePrefix,
@@ -128,6 +132,7 @@ type CreateWorkspaceRequest struct {
 	Slug        string  `json:"slug"`
 	Description *string `json:"description"`
 	Context     *string `json:"context"`
+	LocalPath   *string `json:"local_path"`
 	IssuePrefix *string `json:"issue_prefix"`
 }
 
@@ -169,6 +174,15 @@ func (h *Handler) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	if req.IssuePrefix != nil && strings.TrimSpace(*req.IssuePrefix) != "" {
 		issuePrefix = strings.ToUpper(strings.TrimSpace(*req.IssuePrefix))
 	}
+	var localPath pgtype.Text
+	if req.LocalPath != nil {
+		normalized, err := pathutil.NormalizeLocalPath(*req.LocalPath)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid local_path: "+err.Error())
+			return
+		}
+		localPath = pgtype.Text{String: normalized, Valid: true}
+	}
 
 	qtx := h.Queries.WithTx(tx)
 	ws, err := qtx.CreateWorkspace(r.Context(), db.CreateWorkspaceParams{
@@ -177,6 +191,7 @@ func (h *Handler) CreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		Description: ptrToText(req.Description),
 		Context:     ptrToText(req.Context),
 		IssuePrefix: issuePrefix,
+		LocalPath:   localPath,
 	})
 	if err != nil {
 		if isUniqueViolation(err) {
@@ -216,6 +231,7 @@ type UpdateWorkspaceRequest struct {
 	Name        *string `json:"name"`
 	Description *string `json:"description"`
 	Context     *string `json:"context"`
+	LocalPath   *string `json:"local_path"`
 	Settings    any     `json:"settings"`
 	Repos       any     `json:"repos"`
 	IssuePrefix *string `json:"issue_prefix"`
@@ -224,14 +240,28 @@ type UpdateWorkspaceRequest struct {
 func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := workspaceIDFromURL(r, "id")
 
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
 	var req UpdateWorkspaceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	var rawFields map[string]json.RawMessage
+	_ = json.Unmarshal(bodyBytes, &rawFields)
+
+	prevWorkspace, err := h.Queries.GetWorkspace(r.Context(), parseUUID(id))
+	if err != nil {
+		writeError(w, http.StatusNotFound, "workspace not found")
 		return
 	}
 
 	params := db.UpdateWorkspaceParams{
-		ID: parseUUID(id),
+		ID:        parseUUID(id),
+		LocalPath: prevWorkspace.LocalPath,
 	}
 	if req.Name != nil {
 		name := strings.TrimSpace(*req.Name)
@@ -259,6 +289,18 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 		prefix := strings.ToUpper(strings.TrimSpace(*req.IssuePrefix))
 		if prefix != "" {
 			params.IssuePrefix = pgtype.Text{String: prefix, Valid: true}
+		}
+	}
+	if _, ok := rawFields["local_path"]; ok {
+		if req.LocalPath == nil {
+			params.LocalPath = pgtype.Text{Valid: false}
+		} else {
+			normalized, err := pathutil.NormalizeLocalPath(*req.LocalPath)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "invalid local_path: "+err.Error())
+				return
+			}
+			params.LocalPath = pgtype.Text{String: normalized, Valid: true}
 		}
 	}
 

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -126,5 +127,66 @@ VALUES ($1, $2, 'owner')
 	}
 	if exists {
 		t.Fatal("workspace still exists after owner DELETE")
+	}
+}
+
+func TestUpdateWorkspace_DoesNotResetLocalPathWhenFieldAbsent(t *testing.T) {
+	ctx := context.Background()
+	original := "/tmp/ws-preserve"
+	if _, err := testPool.Exec(ctx, `UPDATE workspace SET local_path = $1 WHERE id = $2`, original, testWorkspaceID); err != nil {
+		t.Fatalf("seed local_path: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodPatch, "/api/workspaces/"+testWorkspaceID, map[string]any{
+		"description": "workspace local_path preserve test",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspace(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateWorkspace expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var localPath *string
+	if err := testPool.QueryRow(ctx, `SELECT local_path FROM workspace WHERE id = $1`, testWorkspaceID).Scan(&localPath); err != nil {
+		t.Fatalf("load local_path: %v", err)
+	}
+	if localPath == nil || *localPath != original {
+		t.Fatalf("local_path = %v, want %q", localPath, original)
+	}
+}
+
+func TestUpdateWorkspace_ClearsLocalPathWhenNullPassed(t *testing.T) {
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx, `UPDATE workspace SET local_path = $1 WHERE id = $2`, "/tmp/ws-clear", testWorkspaceID); err != nil {
+		t.Fatalf("seed local_path: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest(http.MethodPatch, "/api/workspaces/"+testWorkspaceID, map[string]any{
+		"local_path": nil,
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspace(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateWorkspace expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var localPath *string
+	if err := testPool.QueryRow(ctx, `SELECT local_path FROM workspace WHERE id = $1`, testWorkspaceID).Scan(&localPath); err != nil {
+		t.Fatalf("load local_path: %v", err)
+	}
+	if localPath != nil {
+		t.Fatalf("local_path = %q, want NULL", *localPath)
+	}
+
+	var resp WorkspaceResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.LocalPath != nil {
+		t.Fatalf("response local_path = %q, want nil", *resp.LocalPath)
 	}
 }

--- a/server/internal/pathutil/local_path.go
+++ b/server/internal/pathutil/local_path.go
@@ -1,0 +1,37 @@
+package pathutil
+
+import (
+	"errors"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var windowsAbsPathRe = regexp.MustCompile(`^[A-Za-z]:\\`)
+
+// NormalizeLocalPath validates and normalizes a user-provided local path.
+func NormalizeLocalPath(raw string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", errors.New("path must not be empty")
+	}
+	if strings.IndexFunc(path, unicode.IsControl) >= 0 {
+		return "", errors.New("path contains control characters")
+	}
+
+	path = filepath.Clean(path)
+	if path == "." || path == "" {
+		return "", errors.New("path must not be empty")
+	}
+	if len(path) > 1024 {
+		return "", errors.New("path is too long")
+	}
+
+	// filepath.IsAbs is OS-specific; also allow Windows abs/UNC when running on non-Windows hosts.
+	if !(filepath.IsAbs(path) || windowsAbsPathRe.MatchString(path) || strings.HasPrefix(path, `\\`)) {
+		return "", errors.New("path must be absolute")
+	}
+
+	return path, nil
+}

--- a/server/internal/pathutil/local_path_test.go
+++ b/server/internal/pathutil/local_path_test.go
@@ -1,0 +1,61 @@
+package pathutil
+
+import "testing"
+
+func TestNormalizeLocalPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "trim and clean posix",
+			in:   "  /tmp/my/../proj  ",
+			want: "/tmp/proj",
+		},
+		{
+			name:    "reject empty",
+			in:      "   ",
+			wantErr: true,
+		},
+		{
+			name:    "reject control characters",
+			in:      "/tmp/proj\nname",
+			wantErr: true,
+		},
+		{
+			name: "accept windows absolute path",
+			in:   `C:\Work\Repo`,
+			want: `C:\Work\Repo`,
+		},
+		{
+			name: "accept unc path",
+			in:   `\\server\share\repo`,
+			want: `\\server\share\repo`,
+		},
+		{
+			name:    "reject relative path",
+			in:      "repo/subdir",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeLocalPath(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got path %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("NormalizeLocalPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/migrations/059_workspace_project_local_path.down.sql
+++ b/server/migrations/059_workspace_project_local_path.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE project
+DROP COLUMN local_path;
+
+ALTER TABLE workspace
+DROP COLUMN local_path;

--- a/server/migrations/059_workspace_project_local_path.up.sql
+++ b/server/migrations/059_workspace_project_local_path.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE workspace
+ADD COLUMN local_path TEXT;
+
+ALTER TABLE project
+ADD COLUMN local_path TEXT;

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -344,6 +344,7 @@ type Project struct {
 	Title       string             `json:"title"`
 	Description pgtype.Text        `json:"description"`
 	Icon        pgtype.Text        `json:"icon"`
+	LocalPath   pgtype.Text        `json:"local_path"`
 	Status      string             `json:"status"`
 	LeadType    pgtype.Text        `json:"lead_type"`
 	LeadID      pgtype.UUID        `json:"lead_id"`
@@ -426,6 +427,7 @@ type Workspace struct {
 	Name         string             `json:"name"`
 	Slug         string             `json:"slug"`
 	Description  pgtype.Text        `json:"description"`
+	LocalPath    pgtype.Text        `json:"local_path"`
 	Settings     []byte             `json:"settings"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`

--- a/server/pkg/db/generated/project.sql.go
+++ b/server/pkg/db/generated/project.sql.go
@@ -26,10 +26,10 @@ func (q *Queries) CountIssuesByProject(ctx context.Context, projectID pgtype.UUI
 const createProject = `-- name: CreateProject :one
 INSERT INTO project (
     workspace_id, title, description, icon, status,
-    lead_type, lead_id, priority
+    lead_type, lead_id, priority, local_path
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
-) RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
+) RETURNING id, workspace_id, title, description, icon, local_path, status, lead_type, lead_id, created_at, updated_at, priority
 `
 
 type CreateProjectParams struct {
@@ -41,6 +41,7 @@ type CreateProjectParams struct {
 	LeadType    pgtype.Text `json:"lead_type"`
 	LeadID      pgtype.UUID `json:"lead_id"`
 	Priority    string      `json:"priority"`
+	LocalPath   pgtype.Text `json:"local_path"`
 }
 
 func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (Project, error) {
@@ -53,6 +54,7 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 		arg.LeadType,
 		arg.LeadID,
 		arg.Priority,
+		arg.LocalPath,
 	)
 	var i Project
 	err := row.Scan(
@@ -61,6 +63,7 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 		&i.Title,
 		&i.Description,
 		&i.Icon,
+		&i.LocalPath,
 		&i.Status,
 		&i.LeadType,
 		&i.LeadID,
@@ -81,7 +84,7 @@ func (q *Queries) DeleteProject(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getProject = `-- name: GetProject :one
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, local_path, status, lead_type, lead_id, created_at, updated_at, priority FROM project
 WHERE id = $1
 `
 
@@ -94,6 +97,7 @@ func (q *Queries) GetProject(ctx context.Context, id pgtype.UUID) (Project, erro
 		&i.Title,
 		&i.Description,
 		&i.Icon,
+		&i.LocalPath,
 		&i.Status,
 		&i.LeadType,
 		&i.LeadID,
@@ -105,7 +109,7 @@ func (q *Queries) GetProject(ctx context.Context, id pgtype.UUID) (Project, erro
 }
 
 const getProjectInWorkspace = `-- name: GetProjectInWorkspace :one
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, local_path, status, lead_type, lead_id, created_at, updated_at, priority FROM project
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -123,6 +127,7 @@ func (q *Queries) GetProjectInWorkspace(ctx context.Context, arg GetProjectInWor
 		&i.Title,
 		&i.Description,
 		&i.Icon,
+		&i.LocalPath,
 		&i.Status,
 		&i.LeadType,
 		&i.LeadID,
@@ -169,7 +174,7 @@ func (q *Queries) GetProjectIssueStats(ctx context.Context, projectIds []pgtype.
 }
 
 const listProjects = `-- name: ListProjects :many
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, local_path, status, lead_type, lead_id, created_at, updated_at, priority FROM project
 WHERE workspace_id = $1
   AND ($2::text IS NULL OR status = $2)
   AND ($3::text IS NULL OR priority = $3)
@@ -197,6 +202,7 @@ func (q *Queries) ListProjects(ctx context.Context, arg ListProjectsParams) ([]P
 			&i.Title,
 			&i.Description,
 			&i.Icon,
+			&i.LocalPath,
 			&i.Status,
 			&i.LeadType,
 			&i.LeadID,
@@ -223,9 +229,10 @@ UPDATE project SET
     priority = COALESCE($6, priority),
     lead_type = $7,
     lead_id = $8,
+    local_path = $9,
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority
+RETURNING id, workspace_id, title, description, icon, local_path, status, lead_type, lead_id, created_at, updated_at, priority
 `
 
 type UpdateProjectParams struct {
@@ -237,6 +244,7 @@ type UpdateProjectParams struct {
 	Priority    pgtype.Text `json:"priority"`
 	LeadType    pgtype.Text `json:"lead_type"`
 	LeadID      pgtype.UUID `json:"lead_id"`
+	LocalPath   pgtype.Text `json:"local_path"`
 }
 
 func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (Project, error) {
@@ -249,6 +257,7 @@ func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (P
 		arg.Priority,
 		arg.LeadType,
 		arg.LeadID,
+		arg.LocalPath,
 	)
 	var i Project
 	err := row.Scan(
@@ -257,6 +266,7 @@ func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (P
 		&i.Title,
 		&i.Description,
 		&i.Icon,
+		&i.LocalPath,
 		&i.Status,
 		&i.LeadType,
 		&i.LeadID,

--- a/server/pkg/db/generated/workspace.sql.go
+++ b/server/pkg/db/generated/workspace.sql.go
@@ -12,9 +12,9 @@ import (
 )
 
 const createWorkspace = `-- name: CreateWorkspace :one
-INSERT INTO workspace (name, slug, description, context, issue_prefix)
-VALUES ($1, $2, $3, $4, $5)
-RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter
+INSERT INTO workspace (name, slug, description, context, issue_prefix, local_path)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id, name, slug, description, local_path, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter
 `
 
 type CreateWorkspaceParams struct {
@@ -23,6 +23,7 @@ type CreateWorkspaceParams struct {
 	Description pgtype.Text `json:"description"`
 	Context     pgtype.Text `json:"context"`
 	IssuePrefix string      `json:"issue_prefix"`
+	LocalPath   pgtype.Text `json:"local_path"`
 }
 
 func (q *Queries) CreateWorkspace(ctx context.Context, arg CreateWorkspaceParams) (Workspace, error) {
@@ -32,6 +33,7 @@ func (q *Queries) CreateWorkspace(ctx context.Context, arg CreateWorkspaceParams
 		arg.Description,
 		arg.Context,
 		arg.IssuePrefix,
+		arg.LocalPath,
 	)
 	var i Workspace
 	err := row.Scan(
@@ -39,6 +41,7 @@ func (q *Queries) CreateWorkspace(ctx context.Context, arg CreateWorkspaceParams
 		&i.Name,
 		&i.Slug,
 		&i.Description,
+		&i.LocalPath,
 		&i.Settings,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -60,7 +63,7 @@ func (q *Queries) DeleteWorkspace(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getWorkspace = `-- name: GetWorkspace :one
-SELECT id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter FROM workspace
+SELECT id, name, slug, description, local_path, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter FROM workspace
 WHERE id = $1
 `
 
@@ -72,6 +75,7 @@ func (q *Queries) GetWorkspace(ctx context.Context, id pgtype.UUID) (Workspace, 
 		&i.Name,
 		&i.Slug,
 		&i.Description,
+		&i.LocalPath,
 		&i.Settings,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -84,7 +88,7 @@ func (q *Queries) GetWorkspace(ctx context.Context, id pgtype.UUID) (Workspace, 
 }
 
 const getWorkspaceBySlug = `-- name: GetWorkspaceBySlug :one
-SELECT id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter FROM workspace
+SELECT id, name, slug, description, local_path, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter FROM workspace
 WHERE slug = $1
 `
 
@@ -96,6 +100,7 @@ func (q *Queries) GetWorkspaceBySlug(ctx context.Context, slug string) (Workspac
 		&i.Name,
 		&i.Slug,
 		&i.Description,
+		&i.LocalPath,
 		&i.Settings,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -121,7 +126,7 @@ func (q *Queries) IncrementIssueCounter(ctx context.Context, id pgtype.UUID) (in
 }
 
 const listWorkspaces = `-- name: ListWorkspaces :many
-SELECT w.id, w.name, w.slug, w.description, w.settings, w.created_at, w.updated_at, w.context, w.repos, w.issue_prefix, w.issue_counter FROM workspace w
+SELECT w.id, w.name, w.slug, w.description, w.local_path, w.settings, w.created_at, w.updated_at, w.context, w.repos, w.issue_prefix, w.issue_counter FROM workspace w
 JOIN member m ON m.workspace_id = w.id
 WHERE m.user_id = $1
 ORDER BY w.created_at ASC
@@ -141,6 +146,7 @@ func (q *Queries) ListWorkspaces(ctx context.Context, userID pgtype.UUID) ([]Wor
 			&i.Name,
 			&i.Slug,
 			&i.Description,
+			&i.LocalPath,
 			&i.Settings,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -167,9 +173,10 @@ UPDATE workspace SET
     settings = COALESCE($5, settings),
     repos = COALESCE($6, repos),
     issue_prefix = COALESCE($7, issue_prefix),
+    local_path = $8,
     updated_at = now()
 WHERE id = $1
-RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter
+RETURNING id, name, slug, description, local_path, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter
 `
 
 type UpdateWorkspaceParams struct {
@@ -180,6 +187,7 @@ type UpdateWorkspaceParams struct {
 	Settings    []byte      `json:"settings"`
 	Repos       []byte      `json:"repos"`
 	IssuePrefix pgtype.Text `json:"issue_prefix"`
+	LocalPath   pgtype.Text `json:"local_path"`
 }
 
 func (q *Queries) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (Workspace, error) {
@@ -191,6 +199,7 @@ func (q *Queries) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams
 		arg.Settings,
 		arg.Repos,
 		arg.IssuePrefix,
+		arg.LocalPath,
 	)
 	var i Workspace
 	err := row.Scan(
@@ -198,6 +207,7 @@ func (q *Queries) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams
 		&i.Name,
 		&i.Slug,
 		&i.Description,
+		&i.LocalPath,
 		&i.Settings,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/pkg/db/queries/project.sql
+++ b/server/pkg/db/queries/project.sql
@@ -16,9 +16,9 @@ WHERE id = $1 AND workspace_id = $2;
 -- name: CreateProject :one
 INSERT INTO project (
     workspace_id, title, description, icon, status,
-    lead_type, lead_id, priority
+    lead_type, lead_id, priority, local_path
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
 ) RETURNING *;
 
 -- name: UpdateProject :one
@@ -30,6 +30,7 @@ UPDATE project SET
     priority = COALESCE(sqlc.narg('priority'), priority),
     lead_type = sqlc.narg('lead_type'),
     lead_id = sqlc.narg('lead_id'),
+    local_path = sqlc.narg('local_path'),
     updated_at = now()
 WHERE id = $1
 RETURNING *;

--- a/server/pkg/db/queries/workspace.sql
+++ b/server/pkg/db/queries/workspace.sql
@@ -13,8 +13,8 @@ SELECT * FROM workspace
 WHERE slug = $1;
 
 -- name: CreateWorkspace :one
-INSERT INTO workspace (name, slug, description, context, issue_prefix)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO workspace (name, slug, description, context, issue_prefix, local_path)
+VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
 -- name: UpdateWorkspace :one
@@ -25,6 +25,7 @@ UPDATE workspace SET
     settings = COALESCE(sqlc.narg('settings'), settings),
     repos = COALESCE(sqlc.narg('repos'), repos),
     issue_prefix = COALESCE(sqlc.narg('issue_prefix'), issue_prefix),
+    local_path = sqlc.narg('local_path'),
     updated_at = now()
 WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## What does this PR do?

Adds local folder binding for workspaces/projects so users can map Multica entities to local filesystem paths during creation and persist this mapping end-to-end (UI -> API -> DB).

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added workspace/project local path fields to shared types and API client:
  - `packages/core/types/workspace.ts`
  - `packages/core/types/project.ts`
  - `packages/core/api/client.ts`
  - `packages/core/workspace/mutations.ts`
- Updated UI flows to capture and submit local paths:
  - `packages/views/workspace/create-workspace-form.tsx`
  - `packages/views/onboarding/steps/step-workspace.tsx`
  - `packages/views/modals/create-project.tsx`
- Added frontend tests for local-path behavior:
  - `packages/views/workspace/create-workspace-form.test.tsx`
  - `packages/views/modals/create-project.local-path.test.tsx`
- Added backend validation + persistence for local paths:
  - `server/internal/pathutil/local_path.go`
  - `server/internal/handler/workspace.go`
  - `server/internal/handler/project.go`
- Added backend tests:
  - `server/internal/pathutil/local_path_test.go`
  - `server/internal/handler/workspace_test.go`
  - `server/internal/handler/project_local_path_test.go`
- Added DB migration and sqlc updates:
  - `server/migrations/059_workspace_project_local_path.up.sql`
  - `server/migrations/059_workspace_project_local_path.down.sql`
  - `server/pkg/db/queries/workspace.sql`
  - `server/pkg/db/queries/project.sql`
  - `server/pkg/db/generated/*`
- Added documentation/spec notes:
  - `docs/local-path-binding.md`
  - `feature.md`

## How to Test

1. Run backend tests: `make test`
2. Run frontend/desktop tests: `pnpm test`
3. Manually verify create workspace/project flows with and without local-path binding enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex (GPT-5 family)

**Prompt / approach:**
Implemented local path binding end-to-end from feature spec, then iterated with focused fixes and verification (`make test`, `pnpm test`).

## Screenshots (optional)

N/A