### PR TITLE
feat(agent): auto-derive model for opencode provider agents

### DIFF
--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -8,6 +8,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -17,6 +20,12 @@ import (
 	"github.com/multica-ai/multica/server/internal/service"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+const (
+	ProviderOpencode    = "opencode"
+	OpencodeAgentPrefix = "opencode-"
+	OpencodeModelPrefix = "opencode-go/"
 )
 
 type AgentResponse struct {
@@ -324,6 +333,50 @@ func decodeJSONBodyWithRawFields(body io.Reader, dst any) (map[string]json.RawMe
 	return raw, nil
 }
 
+// deriveOpencodeGoModel maps opencode-* agent names to opencode-go models.
+// Numeric version groups are joined with dots, while family names keep hyphens.
+func deriveOpencodeGoModel(agentName string) (string, bool) {
+	model, ok := strings.CutPrefix(agentName, OpencodeAgentPrefix)
+	if !ok || model == "" {
+		return "", false
+	}
+
+	parts := strings.Split(model, "-")
+	var b strings.Builder
+	for i, part := range parts {
+		if i > 0 {
+			sep := "-"
+			if isDigits(part) && endsWithDigit(parts[i-1]) {
+				sep = "."
+			}
+			b.WriteString(sep)
+		}
+		b.WriteString(part)
+	}
+
+	return OpencodeModelPrefix + b.String(), true
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func endsWithDigit(value string) bool {
+	if value == "" {
+		return false
+	}
+	last, _ := utf8.DecodeLastRuneInString(value)
+	return unicode.IsDigit(last)
+}
+
 func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)
 
@@ -361,6 +414,11 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid runtime_id")
 		return
+	}
+	if req.Model == "" && runtime.Provider == ProviderOpencode {
+		if model, ok := deriveOpencodeGoModel(req.Name); ok {
+			req.Model = model
+		}
 	}
 
 	// Probe workspace agent count BEFORE the insert so the funnel has a

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -53,3 +53,203 @@ func TestCreateAgent_RejectsDuplicateName(t *testing.T) {
 		t.Fatalf("second CreateAgent with duplicate name: expected 409, got %d: %s", w2.Code, w2.Body.String())
 	}
 }
+
+func TestDeriveOpencodeGoModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+		wantOK    bool
+	}{
+		{
+			name:      "deepseek flash",
+			agentName: OpencodeAgentPrefix + "deepseek-v4-flash",
+			want:      OpencodeModelPrefix + "deepseek-v4-flash",
+			wantOK:    true,
+		},
+		{
+			name:      "deepseek pro",
+			agentName: OpencodeAgentPrefix + "deepseek-v4-pro",
+			want:      OpencodeModelPrefix + "deepseek-v4-pro",
+			wantOK:    true,
+		},
+		{
+			name:      "kimi decimal version",
+			agentName: OpencodeAgentPrefix + "kimi-k2-6",
+			want:      OpencodeModelPrefix + "kimi-k2.6",
+			wantOK:    true,
+		},
+		{
+			name:      "qwen decimal version",
+			agentName: OpencodeAgentPrefix + "qwen3-5-plus",
+			want:      OpencodeModelPrefix + "qwen3.5-plus",
+			wantOK:    true,
+		},
+		{
+			name:      "qwen next decimal version",
+			agentName: OpencodeAgentPrefix + "qwen3-6-plus",
+			want:      OpencodeModelPrefix + "qwen3.6-plus",
+			wantOK:    true,
+		},
+		{
+			name:      "mimo decimal version",
+			agentName: OpencodeAgentPrefix + "mimo-v2-5",
+			want:      OpencodeModelPrefix + "mimo-v2.5",
+			wantOK:    true,
+		},
+		{
+			name:      "glm major version",
+			agentName: OpencodeAgentPrefix + "glm-5",
+			want:      OpencodeModelPrefix + "glm-5",
+			wantOK:    true,
+		},
+		{
+			name:      "glm minor version",
+			agentName: OpencodeAgentPrefix + "glm-5-1",
+			want:      OpencodeModelPrefix + "glm-5.1",
+			wantOK:    true,
+		},
+		{
+			name:      "multiple version groups",
+			agentName: OpencodeAgentPrefix + "model-v1-2-3",
+			want:      OpencodeModelPrefix + "model-v1.2.3",
+			wantOK:    true,
+		},
+		{
+			name:      "custom name",
+			agentName: "custom-name",
+			wantOK:    false,
+		},
+		{
+			name:      "empty opencode suffix",
+			agentName: OpencodeAgentPrefix,
+			wantOK:    false,
+		},
+		{
+			name:      "opencode seul sans tiret",
+			agentName: ProviderOpencode,
+			wantOK:    false,
+		},
+		{
+			name:      "casing Opencode-glm-5",
+			agentName: "Opencode-glm-5",
+			wantOK:    false,
+		},
+		{
+			name:      "trailing dash opencode-foo-",
+			agentName: OpencodeAgentPrefix + "foo-",
+			want:      OpencodeModelPrefix + "foo-",
+			wantOK:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := deriveOpencodeGoModel(tt.agentName)
+			if ok != tt.wantOK {
+				t.Fatalf("deriveOpencodeGoModel(%q) ok = %v, want %v", tt.agentName, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("deriveOpencodeGoModel(%q) = %q, want %q", tt.agentName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateAgent_OpencodeProviderModelDefaults(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	tests := []struct {
+		name      string
+		provider  string
+		agentName string
+		model     string
+		wantModel string
+	}{
+		{
+			name:      "auto fills derived model",
+			provider:  ProviderOpencode,
+			agentName: OpencodeAgentPrefix + "qwen3-5-plus",
+			wantModel: OpencodeModelPrefix + "qwen3.5-plus",
+		},
+		{
+			name:      "keeps empty model for custom opencode name",
+			provider:  ProviderOpencode,
+			agentName: "custom-name-auto-model-test",
+		},
+		{
+			name:      "preserves explicit model",
+			provider:  ProviderOpencode,
+			agentName: OpencodeAgentPrefix + "glm-5-1",
+			model:     "custom/provider",
+			wantModel: "custom/provider",
+		},
+		{
+			name:      "does not fill for other provider",
+			provider:  "handler_test_runtime",
+			agentName: OpencodeAgentPrefix + "mimo-v2-5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtimeID := createHandlerTestRuntime(t, tt.provider)
+			body := map[string]any{
+				"name":                 tt.agentName,
+				"runtime_id":           runtimeID,
+				"visibility":           "private",
+				"max_concurrent_tasks": 1,
+			}
+			if tt.model != "" {
+				body["model"] = tt.model
+			}
+
+			created := createAgentForHandlerTest(t, body)
+			if created.Model != tt.wantModel {
+				t.Fatalf("CreateAgent model = %q, want %q", created.Model, tt.wantModel)
+			}
+		})
+	}
+}
+
+func createHandlerTestRuntime(t *testing.T, provider string) string {
+	t.Helper()
+
+	var runtimeID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, $2, 'cloud', $3, 'offline', $4, '{}'::jsonb, now())
+		RETURNING id
+	`, testWorkspaceID, "Handler Test Runtime "+t.Name(), provider, "Handler test runtime").Scan(&runtimeID); err != nil {
+		t.Fatalf("create handler test runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	return runtimeID
+}
+
+func createAgentForHandlerTest(t *testing.T, body map[string]any) AgentResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created AgentResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("CreateAgent: decode response: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, created.ID)
+	})
+
+	return created
+}


### PR DESCRIPTION
When creating an agent with provider=opencode and no explicit model, derive agent.model from opencode-* names using opencode-go/<n>.

The derivation keeps hyphenated family names and converts adjacent numeric version groups to dots, so qwen3-5-plus becomes qwen3.5-plus and glm-5-1 becomes glm-5.1. Names without opencode-* keep an empty model, and explicit models are not overwritten.

This prevents agents from launching `opencode run` without a selected model and falling back to the CLI default provider.

## Implementation

- `deriveOpencodeGoModel(name)` extracts the suffix after `opencode-` and joins numeric version groups with dots when adjacent.
- `CreateAgent` calls this helper only when `provider == "opencode"` and `req.Model == ""`. Explicit model values are never overridden.
- 3 constants extracted: `ProviderOpencode`, `OpencodeAgentPrefix`, `OpencodeModelPrefix`.

## Tests

- `TestDeriveOpencodeGoModel` (14 cases): all opencode model name mappings + edge cases (empty input, no prefix, casing `Opencode-glm-5`, trailing dash `opencode-foo-`, single segment).
- `TestCreateAgent_OpencodeProviderModelDefaults` (4 cases): auto-fill happens, no override on explicit model, no impact on other providers, no match keeps empty model.
- All existing tests pass (`go test ./...`).

## Note on UpdateAgent

UpdateAgent intentionally not covered. Renaming an opencode-* agent via UpdateAgent does not re-derive the model. This is by design to avoid surprising behavior on rename operations. Users should explicitly set the model field via UpdateAgent if they want to change it.

## Out of scope

- Rejecting opencode agents with unresolved model (e.g. agent named `my-ai`). Could be added as a follow-up: return 400 if `provider=opencode && model == ""` after derivation.
- Centralizing `ProviderOpencode` constant across the daemon packages (currently only used in handler).