### PR TITLE
fix(daemon/execenv): default windows to danger-full-access (codex 0.122+ Windows sandbox blocks Multica CLI)

### DIFF
--- a/server/internal/daemon/execenv/codex_sandbox.go
+++ b/server/internal/daemon/execenv/codex_sandbox.go
@@ -45,8 +45,19 @@ type codexSandboxPolicy struct {
 // codexSandboxPolicyFor picks the right policy for the given platform and
 // detected Codex CLI version.
 //
-// - Non-darwin: always workspace-write with network access (Landlock is not
-//   affected by the macOS Seatbelt bug).
+// - Linux: workspace-write with network access. Landlock honors
+//   network_access and Multica CLI can reach ~/.multica through regular
+//   filesystem read/write of user home.
+// - Windows: danger-full-access. Starting with codex 0.122+, workspace-write
+//   on Windows is enforced by the experimental native Windows sandbox which
+//   spawns each exec_command under CreateProcessWithLogonW. That sandbox
+//   refuses access to user profile paths outside the workspace (including
+//   ~/.multica where the CLI stores credentials), making `multica issue get`
+//   and every other CLI call fail with "blocked by policy". We fall back to
+//   danger-full-access so the daemon-injected Multica CLI works. Users who
+//   need tighter Windows sandboxing should disable the experimental Windows
+//   sandbox in their own ~/.codex/config.toml via
+//   `[features] experimental_windows_sandbox = false`.
 // - darwin with a version at or above CodexDarwinNetworkAccessFixedVersion:
 //   workspace-write with network access (upstream bug fixed).
 // - darwin otherwise (including when the version is unknown): fall back to
@@ -55,13 +66,20 @@ func codexSandboxPolicyFor(goos, detectedVersion string) codexSandboxPolicy {
 	if goos == "" {
 		goos = runtime.GOOS
 	}
-	if goos != "darwin" {
+	switch goos {
+	case "linux":
 		return codexSandboxPolicy{
 			Mode:          "workspace-write",
 			NetworkAccess: true,
-			Reason:        "non-darwin platform — seatbelt bug does not apply",
+			Reason:        "linux: Landlock honors workspace-write + network_access",
+		}
+	case "windows":
+		return codexSandboxPolicy{
+			Mode:   "danger-full-access",
+			Reason: "windows: native sandbox blocks Multica CLI access to ~/.multica credentials under workspace-write",
 		}
 	}
+	// darwin branch below
 	if codexDarwinNetworkAccessFixed(detectedVersion) {
 		return codexSandboxPolicy{
 			Mode:          "workspace-write",

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1274,6 +1274,8 @@ func TestCodexSandboxPolicyFor(t *testing.T) {
 	}{
 		{"linux any version", "linux", "0.100.0", "workspace-write", true},
 		{"linux unknown version", "linux", "", "workspace-write", true},
+		{"windows any version", "windows", "0.122.0", "danger-full-access", false},
+		{"windows unknown version", "windows", "", "danger-full-access", false},
 		{"darwin old version", "darwin", "0.121.0", "danger-full-access", false},
 		{"darwin unknown version", "darwin", "", "danger-full-access", false},
 	}


### PR DESCRIPTION
## Summary

On Windows, codex 0.122+ implements the `workspace-write` sandbox via an experimental Windows native sandbox that spawns each `exec_command` under `CreateProcessWithLogonW`. That sandbox refuses access to user profile paths outside the workspace — including the directory where the Multica CLI stores its auth credentials (`%USERPROFILE%\.multica`). Every `multica issue get` / `multica issue comment add` / similar CLI invocation made from inside an agent turn fails with "blocked by policy", which stalls common workflows at step 1.

This treats Windows the same way `darwin` is treated: default to `danger-full-access` and rely on Multica's own per-task isolation (per-task `CODEX_HOME` + workdir) for the security boundary.

- **Linux** stays on `workspace-write` with network access (Landlock honors `workspace-write` + `network_access` so `~/.multica` is reachable).
- **Windows** → `danger-full-access` (this change).
- **darwin** unchanged — version-dependent behavior preserved.

The switch is also folded from the old "non-darwin vs darwin" binary into `linux` / `windows` / `darwin` / default — Windows really is a third platform now.

## Why not fix the sandbox profile?

Codex 0.122's Windows sandbox can be opted out via the user's `~/.codex/config.toml`:

```toml
[features]
experimental_windows_sandbox = false
```

We could not unilaterally write that file from the daemon (would corrupt user-side codex config). And users running Multica daemon on Windows don't expect the daemon's process-level execution policy to be tightened by codex's experimental sandbox; they expect Multica's own workspace isolation to apply, which is the same model `darwin` already uses.

## Test plan

- [x] `go build ./...` (linux/amd64)
- [x] `GOOS=windows GOARCH=amd64 go build ./...`
- [x] `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/daemon/execenv -run TestCodexSandboxPolicyFor -v` — 7/7 pass (added `windows_any_version` + `windows_unknown_version` cases)

---

Built and battle-tested on the [yizhisec](https://yizhisec.com) Multica deployment, where we use it to manage Windows kernel-security research workflows. Other upstream-able fixes from our fork: #1670, #1674, #1675, #1676, #1678, #1679.