### PR TITLE
feat(task): add /rerun-fresh API + skip_session_resume column for tasks that should drop the prior session

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -274,6 +274,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus, analytics
 					r.Get("/active-task", h.GetActiveTaskForIssue)
 					r.Post("/tasks/{taskId}/cancel", h.CancelTask)
 					r.Post("/rerun", h.RerunIssue)
+					r.Post("/rerun-fresh", h.RerunIssueFresh)
 					r.Get("/task-runs", h.ListTasksByIssue)
 					r.Get("/usage", h.GetIssueUsage)
 					r.Post("/reactions", h.AddIssueReaction)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -784,13 +784,19 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 
 		// Look up the prior session for this (agent, issue) pair so the daemon
 		// can resume the Claude Code conversation context.
-		if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
-			AgentID: task.AgentID,
-			IssueID: task.IssueID,
-		}); err == nil && prior.SessionID.Valid {
-			resp.PriorSessionID = prior.SessionID.String
-			if prior.WorkDir.Valid {
-				resp.PriorWorkDir = prior.WorkDir.String
+		//
+		// Skipped when the task was created with skip_session_resume=true — used
+		// by the fresh-task API when the skill/prompt has changed and resuming
+		// would silently keep executing the outdated plan.
+		if !task.SkipSessionResume {
+			if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
+				AgentID: task.AgentID,
+				IssueID: task.IssueID,
+			}); err == nil && prior.SessionID.Valid {
+				resp.PriorSessionID = prior.SessionID.String
+				if prior.WorkDir.Valid {
+					resp.PriorWorkDir = prior.WorkDir.String
+				}
 			}
 		}
 	}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1617,3 +1617,192 @@ func TestCompleteTask_CommentTriggered_SkipsSynthesisWhenAgentAlreadyCommented(t
 		t.Fatalf("expected 1 agent comment (the agent's own reply), got %d — synthesis duplicated", count)
 	}
 }
+
+// TestClaimTask_SkipSessionResume_ClearsPriorSession verifies that when a task
+// is created with skip_session_resume=true, ClaimTaskByRuntime returns the
+// task to the daemon WITHOUT a prior_session_id, even when a prior completed
+// task on the same (agent, issue) pair has a session_id recorded. This is the
+// core of the fresh-task API contract: the daemon must start from scratch
+// instead of resuming the outdated conversation.
+func TestClaimTask_SkipSessionResume_ClearsPriorSession(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, assignee_type, assignee_id,
+			creator_type, creator_id
+		)
+		VALUES ($1, 'fresh-task fixture', 'in_progress', 'none', 'agent', $2, 'member', $3)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	defer testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+
+	// Seed a COMPLETED task on the same (agent, issue) pair with a real
+	// session_id so GetLastTaskSession would find it under the normal flow.
+	priorSession := "seeded-session-" + strings.ReplaceAll(issueID, "-", "")[:8]
+	var priorTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			session_id, completed_at
+		)
+		VALUES ($1, $2, $3, 'completed', 0, $4, now())
+		RETURNING id
+	`, agentID, runtimeID, issueID, priorSession).Scan(&priorTaskID); err != nil {
+		t.Fatalf("setup: insert prior task: %v", err)
+	}
+	defer testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, priorTaskID)
+
+	// Now create a fresh task with skip_session_resume=true that is queued
+	// and ready to be claimed.
+	var freshTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			skip_session_resume
+		)
+		VALUES ($1, $2, $3, 'queued', 0, true)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&freshTaskID); err != nil {
+		t.Fatalf("setup: insert fresh task: %v", err)
+	}
+	defer testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, freshTaskID)
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil,
+		testWorkspaceID, "test-daemon-claim")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("runtimeId", runtimeID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Task *struct {
+			ID             string `json:"id"`
+			PriorSessionID string `json:"prior_session_id"`
+			PriorWorkDir   string `json:"prior_work_dir"`
+		} `json:"task"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Task == nil {
+		t.Fatal("expected a task in response, got nil")
+	}
+	if resp.Task.ID != freshTaskID {
+		t.Fatalf("expected claim to return fresh task %q, got %q", freshTaskID, resp.Task.ID)
+	}
+	if resp.Task.PriorSessionID != "" {
+		t.Fatalf("skip_session_resume=true: expected empty prior_session_id, got %q", resp.Task.PriorSessionID)
+	}
+	if resp.Task.PriorWorkDir != "" {
+		t.Fatalf("skip_session_resume=true: expected empty prior_work_dir, got %q", resp.Task.PriorWorkDir)
+	}
+}
+
+// TestClaimTask_DefaultResumeBehaviour_PreservesPriorSession is the companion
+// negative test: when skip_session_resume is NOT set (the default),
+// ClaimTaskByRuntime SHOULD populate prior_session_id from the most recent
+// session recorded for the (agent, issue) pair. Asserts that the new flag
+// doesn't accidentally break the long-standing resume path.
+func TestClaimTask_DefaultResumeBehaviour_PreservesPriorSession(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, assignee_type, assignee_id,
+			creator_type, creator_id
+		)
+		VALUES ($1, 'default-resume fixture', 'in_progress', 'none', 'agent', $2, 'member', $3)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	defer testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+
+	priorSession := "seeded-default-" + strings.ReplaceAll(issueID, "-", "")[:8]
+	var priorTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority,
+			session_id, completed_at
+		)
+		VALUES ($1, $2, $3, 'completed', 0, $4, now())
+		RETURNING id
+	`, agentID, runtimeID, issueID, priorSession).Scan(&priorTaskID); err != nil {
+		t.Fatalf("setup: insert prior task: %v", err)
+	}
+	defer testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, priorTaskID)
+
+	// A normal task — skip_session_resume defaults to false.
+	var normalTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority
+		)
+		VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&normalTaskID); err != nil {
+		t.Fatalf("setup: insert normal task: %v", err)
+	}
+	defer testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, normalTaskID)
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil,
+		testWorkspaceID, "test-daemon-claim")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("runtimeId", runtimeID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Task *struct {
+			ID             string `json:"id"`
+			PriorSessionID string `json:"prior_session_id"`
+		} `json:"task"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Task == nil {
+		t.Fatal("expected a task in response, got nil")
+	}
+	if resp.Task.PriorSessionID != priorSession {
+		t.Fatalf("default path: expected prior_session_id=%q, got %q",
+			priorSession, resp.Task.PriorSessionID)
+	}
+}

--- a/server/internal/handler/task_lifecycle.go
+++ b/server/internal/handler/task_lifecycle.go
@@ -113,3 +113,24 @@ func (h *Handler) RerunIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusAccepted, taskToResponse(*task))
 }
+
+// RerunIssueFresh manually re-enqueues the issue's current agent assignment as
+// a fresh task that explicitly opts out of session resumption. Use when the
+// skill definition or prompt template has changed and the caller needs the
+// agent to start a brand-new conversation instead of continuing the previous
+// one. Any active tasks for (issue, current assignee) are cancelled first.
+func (h *Handler) RerunIssueFresh(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	issue, ok := h.loadIssueForUser(w, r, id)
+	if !ok {
+		return
+	}
+
+	task, err := h.TaskService.RerunIssueFresh(r.Context(), issue.ID, pgtype.UUID{})
+	if err != nil {
+		slog.Warn("issue rerun-fresh failed", "issue_id", id, "error", err)
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusAccepted, taskToResponse(*task))
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -76,6 +76,55 @@ func (s *TaskService) EnqueueTaskForIssue(ctx context.Context, issue db.Issue, t
 	return task, nil
 }
 
+// EnqueueFreshTaskForIssue creates a queued task that explicitly opts out of the
+// usual "resume the prior session" lookup on task claim. Used when the issue's
+// skill definition, prompt template, or instructions have changed and the caller
+// needs the agent to read the new version from scratch instead of continuing the
+// old conversation. Behaviour is otherwise identical to EnqueueTaskForIssue: same
+// agent, same runtime, same priority, same optional trigger comment.
+func (s *TaskService) EnqueueFreshTaskForIssue(ctx context.Context, issue db.Issue, triggerCommentID ...pgtype.UUID) (db.AgentTaskQueue, error) {
+	if !issue.AssigneeID.Valid {
+		slog.Error("fresh task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", "issue has no assignee")
+		return db.AgentTaskQueue{}, fmt.Errorf("issue has no assignee")
+	}
+
+	agent, err := s.Queries.GetAgent(ctx, issue.AssigneeID)
+	if err != nil {
+		slog.Error("fresh task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", err)
+		return db.AgentTaskQueue{}, fmt.Errorf("load agent: %w", err)
+	}
+	if agent.ArchivedAt.Valid {
+		return db.AgentTaskQueue{}, fmt.Errorf("agent is archived")
+	}
+	if !agent.RuntimeID.Valid {
+		return db.AgentTaskQueue{}, fmt.Errorf("agent has no runtime")
+	}
+
+	var commentID pgtype.UUID
+	if len(triggerCommentID) > 0 {
+		commentID = triggerCommentID[0]
+	}
+
+	task, err := s.Queries.CreateFreshAgentTask(ctx, db.CreateFreshAgentTaskParams{
+		AgentID:          issue.AssigneeID,
+		RuntimeID:        agent.RuntimeID,
+		IssueID:          issue.ID,
+		Priority:         priorityToInt(issue.Priority),
+		TriggerCommentID: commentID,
+	})
+	if err != nil {
+		slog.Error("fresh task enqueue failed", "issue_id", util.UUIDToString(issue.ID), "error", err)
+		return db.AgentTaskQueue{}, fmt.Errorf("create fresh task: %w", err)
+	}
+
+	slog.Info("fresh task enqueued",
+		"task_id", util.UUIDToString(task.ID),
+		"issue_id", util.UUIDToString(issue.ID),
+		"agent_id", util.UUIDToString(issue.AssigneeID),
+	)
+	return task, nil
+}
+
 // EnqueueTaskForMention creates a queued task for a mentioned agent on an issue.
 // Unlike EnqueueTaskForIssue, this takes an explicit agent ID rather than
 // deriving it from the issue assignee.
@@ -656,6 +705,47 @@ func (s *TaskService) RerunIssue(ctx context.Context, issueID pgtype.UUID, trigg
 		return nil, err
 	}
 	slog.Info("issue rerun enqueued",
+		"task_id", util.UUIDToString(task.ID),
+		"issue_id", util.UUIDToString(issueID),
+		"agent_id", util.UUIDToString(issue.AssigneeID),
+		"cancelled_prior", len(cancelled),
+	)
+	return &task, nil
+}
+
+// RerunIssueFresh is like RerunIssue but uses EnqueueFreshTaskForIssue so the
+// new task explicitly skips the "resume previous session" lookup on claim. Used
+// when the skill definition or prompt template has changed and the caller needs
+// the agent to start from scratch instead of continuing the prior conversation.
+func (s *TaskService) RerunIssueFresh(ctx context.Context, issueID pgtype.UUID, triggerCommentID pgtype.UUID) (*db.AgentTaskQueue, error) {
+	issue, err := s.Queries.GetIssue(ctx, issueID)
+	if err != nil {
+		return nil, fmt.Errorf("load issue: %w", err)
+	}
+	if !issue.AssigneeID.Valid || issue.AssigneeType.String != "agent" {
+		return nil, fmt.Errorf("issue is not assigned to an agent")
+	}
+	cancelled, err := s.Queries.CancelAgentTasksByIssueAndAgent(ctx, db.CancelAgentTasksByIssueAndAgentParams{
+		IssueID: issueID,
+		AgentID: issue.AssigneeID,
+	})
+	if err != nil {
+		slog.Warn("rerun-fresh: cancel prior tasks failed",
+			"issue_id", util.UUIDToString(issueID),
+			"agent_id", util.UUIDToString(issue.AssigneeID),
+			"error", err,
+		)
+	}
+	for _, t := range cancelled {
+		s.ReconcileAgentStatus(ctx, t.AgentID)
+		s.broadcastTaskEvent(ctx, protocol.EventTaskCancelled, t)
+	}
+
+	task, err := s.EnqueueFreshTaskForIssue(ctx, issue, triggerCommentID)
+	if err != nil {
+		return nil, err
+	}
+	slog.Info("issue rerun-fresh enqueued",
 		"task_id", util.UUIDToString(task.ID),
 		"issue_id", util.UUIDToString(issueID),
 		"agent_id", util.UUIDToString(issue.AssigneeID),

--- a/server/migrations/059_skip_session_resume.down.sql
+++ b/server/migrations/059_skip_session_resume.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_task_queue
+    DROP COLUMN skip_session_resume;

--- a/server/migrations/059_skip_session_resume.up.sql
+++ b/server/migrations/059_skip_session_resume.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE agent_task_queue
+    ADD COLUMN skip_session_resume BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN agent_task_queue.skip_session_resume IS
+    'When true, server skips the usual "resume previous session" lookup on task claim. '
+    'Used when the issue''s skill definition or instructions have changed and a fresh '
+    'conversation is required.';

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -55,7 +55,7 @@ const cancelAgentTask = `-- name: CancelAgentTask :one
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE id = $1 AND status IN ('queued', 'dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -85,6 +85,7 @@ func (q *Queries) CancelAgentTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }
@@ -115,7 +116,7 @@ const cancelAgentTasksByIssueAndAgent = `-- name: CancelAgentTasksByIssueAndAgen
 UPDATE agent_task_queue
 SET status = 'cancelled', completed_at = now()
 WHERE issue_id = $1 AND agent_id = $2 AND status IN ('queued', 'dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 type CancelAgentTasksByIssueAndAgentParams struct {
@@ -160,6 +161,7 @@ func (q *Queries) CancelAgentTasksByIssueAndAgent(ctx context.Context, arg Cance
 			&i.ParentTaskID,
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
+			&i.SkipSessionResume,
 		); err != nil {
 			return nil, err
 		}
@@ -190,7 +192,7 @@ WHERE id = (
     LIMIT 1
     FOR UPDATE SKIP LOCKED
 )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 // Claims the next queued task for an agent, enforcing per-(issue, agent) serialization:
@@ -225,6 +227,7 @@ func (q *Queries) ClaimAgentTask(ctx context.Context, agentID pgtype.UUID) (Agen
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }
@@ -268,7 +271,7 @@ const completeAgentTask = `-- name: CompleteAgentTask :one
 UPDATE agent_task_queue
 SET status = 'completed', completed_at = now(), result = $2, session_id = $3, work_dir = $4
 WHERE id = $1 AND status = 'running'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 type CompleteAgentTaskParams struct {
@@ -310,6 +313,7 @@ func (q *Queries) CompleteAgentTask(ctx context.Context, arg CompleteAgentTaskPa
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }
@@ -401,7 +405,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Agent
 const createAgentTask = `-- name: CreateAgentTask :one
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, trigger_comment_id)
 VALUES ($1, $2, $3, 'queued', $4, $5)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 type CreateAgentTaskParams struct {
@@ -445,6 +449,66 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
+	)
+	return i, err
+}
+
+const createFreshAgentTask = `-- name: CreateFreshAgentTask :one
+INSERT INTO agent_task_queue (
+    agent_id, runtime_id, issue_id, status, priority, trigger_comment_id,
+    skip_session_resume
+)
+VALUES ($1, $2, $3, 'queued', $4, $5, true)
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
+`
+
+type CreateFreshAgentTaskParams struct {
+	AgentID          pgtype.UUID `json:"agent_id"`
+	RuntimeID        pgtype.UUID `json:"runtime_id"`
+	IssueID          pgtype.UUID `json:"issue_id"`
+	Priority         int32       `json:"priority"`
+	TriggerCommentID pgtype.UUID `json:"trigger_comment_id"`
+}
+
+// Same as CreateAgentTask but marks the task with skip_session_resume=true so the
+// runtime handler skips the "look up prior session" branch and the agent starts a
+// brand-new conversation. Used when the skill or prompt template has changed and
+// resuming the previous session would silently re-run the outdated plan.
+func (q *Queries) CreateFreshAgentTask(ctx context.Context, arg CreateFreshAgentTaskParams) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, createFreshAgentTask,
+		arg.AgentID,
+		arg.RuntimeID,
+		arg.IssueID,
+		arg.Priority,
+		arg.TriggerCommentID,
+	)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+		&i.AutopilotRunID,
+		&i.Attempt,
+		&i.MaxAttempts,
+		&i.ParentTaskID,
+		&i.FailureReason,
+		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }
@@ -463,7 +527,7 @@ SELECT
     p.attempt + 1, p.max_attempts, p.id
 FROM agent_task_queue p
 WHERE p.id = $1
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 // Clones a parent task into a fresh queued attempt. Carries forward the
@@ -497,6 +561,7 @@ func (q *Queries) CreateRetryTask(ctx context.Context, id pgtype.UUID) (AgentTas
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }
@@ -510,7 +575,7 @@ SET status = 'failed',
     session_id = COALESCE($4, session_id),
     work_dir = COALESCE($5, work_dir)
 WHERE id = $1 AND status IN ('dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 type FailAgentTaskParams struct {
@@ -563,6 +628,7 @@ func (q *Queries) FailAgentTask(ctx context.Context, arg FailAgentTaskParams) (A
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }
@@ -573,7 +639,7 @@ SET status = 'failed', completed_at = now(), error = 'task timed out',
     failure_reason = 'timeout'
 WHERE (status = 'dispatched' AND dispatched_at < now() - make_interval(secs => $1::double precision))
    OR (status = 'running' AND started_at < now() - make_interval(secs => $2::double precision))
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 type FailStaleTasksParams struct {
@@ -617,6 +683,7 @@ func (q *Queries) FailStaleTasks(ctx context.Context, arg FailStaleTasksParams) 
 			&i.ParentTaskID,
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
+			&i.SkipSessionResume,
 		); err != nil {
 			return nil, err
 		}
@@ -702,7 +769,7 @@ func (q *Queries) GetAgentInWorkspace(ctx context.Context, arg GetAgentInWorkspa
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume FROM agent_task_queue
 WHERE id = $1
 `
 
@@ -733,6 +800,7 @@ func (q *Queries) GetAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQu
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }
@@ -820,7 +888,7 @@ func (q *Queries) HasPendingTaskForIssueAndAgent(ctx context.Context, arg HasPen
 }
 
 const listActiveTasksByIssue = `-- name: ListActiveTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume FROM agent_task_queue
 WHERE issue_id = $1 AND status IN ('dispatched', 'running')
 ORDER BY created_at DESC
 `
@@ -858,6 +926,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 			&i.ParentTaskID,
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
+			&i.SkipSessionResume,
 		); err != nil {
 			return nil, err
 		}
@@ -870,7 +939,7 @@ func (q *Queries) ListActiveTasksByIssue(ctx context.Context, issueID pgtype.UUI
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume FROM agent_task_queue
 WHERE agent_id = $1
 ORDER BY created_at DESC
 `
@@ -908,6 +977,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, agentID pgtype.UUID) ([]Ag
 			&i.ParentTaskID,
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
+			&i.SkipSessionResume,
 		); err != nil {
 			return nil, err
 		}
@@ -1016,7 +1086,7 @@ func (q *Queries) ListAllAgents(ctx context.Context, workspaceID pgtype.UUID) ([
 }
 
 const listPendingTasksByRuntime = `-- name: ListPendingTasksByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume FROM agent_task_queue
 WHERE runtime_id = $1 AND status IN ('queued', 'dispatched')
 ORDER BY priority DESC, created_at ASC
 `
@@ -1054,6 +1124,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 			&i.ParentTaskID,
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
+			&i.SkipSessionResume,
 		); err != nil {
 			return nil, err
 		}
@@ -1066,7 +1137,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listTasksByIssue = `-- name: ListTasksByIssue :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume FROM agent_task_queue
 WHERE issue_id = $1
 ORDER BY created_at DESC
 `
@@ -1104,6 +1175,7 @@ func (q *Queries) ListTasksByIssue(ctx context.Context, issueID pgtype.UUID) ([]
 			&i.ParentTaskID,
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
+			&i.SkipSessionResume,
 		); err != nil {
 			return nil, err
 		}
@@ -1122,7 +1194,7 @@ SET status = 'failed',
     error = 'daemon restarted while task was in flight',
     failure_reason = 'runtime_recovery'
 WHERE runtime_id = $1 AND status IN ('dispatched', 'running')
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 // Called by the daemon at startup. Atomically fails any dispatched/running
@@ -1162,6 +1234,7 @@ func (q *Queries) RecoverOrphanedTasksForRuntime(ctx context.Context, runtimeID 
 			&i.ParentTaskID,
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
+			&i.SkipSessionResume,
 		); err != nil {
 			return nil, err
 		}
@@ -1212,7 +1285,7 @@ const startAgentTask = `-- name: StartAgentTask :one
 UPDATE agent_task_queue
 SET status = 'running', started_at = now()
 WHERE id = $1 AND status = 'dispatched'
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTaskQueue, error) {
@@ -1242,6 +1315,7 @@ func (q *Queries) StartAgentTask(ctx context.Context, id pgtype.UUID) (AgentTask
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/autopilot.sql.go
+++ b/server/pkg/db/generated/autopilot.sql.go
@@ -204,7 +204,7 @@ const createAutopilotTask = `-- name: CreateAutopilotTask :one
 
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, autopilot_run_id)
 VALUES ($1, $2, NULL, 'queued', $3, $4)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 type CreateAutopilotTaskParams struct {
@@ -249,6 +249,7 @@ func (q *Queries) CreateAutopilotTask(ctx context.Context, arg CreateAutopilotTa
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -93,7 +93,7 @@ func (q *Queries) CreateChatSession(ctx context.Context, arg CreateChatSessionPa
 const createChatTask = `-- name: CreateChatTask :one
 INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, chat_session_id)
 VALUES ($1, $2, NULL, 'queued', $3, $4)
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 type CreateChatTaskParams struct {
@@ -135,6 +135,7 @@ func (q *Queries) CreateChatTask(ctx context.Context, arg CreateChatTaskParams) 
 		&i.ParentTaskID,
 		&i.FailureReason,
 		&i.LastHeartbeatAt,
+		&i.SkipSessionResume,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -90,6 +90,8 @@ type AgentTaskQueue struct {
 	ParentTaskID     pgtype.UUID        `json:"parent_task_id"`
 	FailureReason    pgtype.Text        `json:"failure_reason"`
 	LastHeartbeatAt  pgtype.Timestamptz `json:"last_heartbeat_at"`
+	// When true, server skips the usual "resume previous session" lookup on task claim. Used when the issue's skill definition or instructions have changed and a fresh conversation is required.
+	SkipSessionResume bool `json:"skip_session_resume"`
 }
 
 type Attachment struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -84,7 +84,7 @@ WHERE status IN ('dispatched', 'running')
   AND runtime_id IN (
     SELECT id FROM agent_runtime WHERE status = 'offline'
   )
-RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, skip_session_resume
 `
 
 // Marks dispatched/running tasks as failed when their runtime is offline.
@@ -122,6 +122,7 @@ func (q *Queries) FailTasksForOfflineRuntimes(ctx context.Context) ([]AgentTaskQ
 			&i.ParentTaskID,
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
+			&i.SkipSessionResume,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -69,6 +69,18 @@ INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, 
 VALUES ($1, $2, $3, 'queued', $4, sqlc.narg(trigger_comment_id))
 RETURNING *;
 
+-- name: CreateFreshAgentTask :one
+-- Same as CreateAgentTask but marks the task with skip_session_resume=true so the
+-- runtime handler skips the "look up prior session" branch and the agent starts a
+-- brand-new conversation. Used when the skill or prompt template has changed and
+-- resuming the previous session would silently re-run the outdated plan.
+INSERT INTO agent_task_queue (
+    agent_id, runtime_id, issue_id, status, priority, trigger_comment_id,
+    skip_session_resume
+)
+VALUES ($1, $2, $3, 'queued', $4, sqlc.narg(trigger_comment_id), true)
+RETURNING *;
+
 -- name: CreateRetryTask :one
 -- Clones a parent task into a fresh queued attempt. Carries forward the
 -- agent's resume context (session_id/work_dir) so the child can continue


### PR DESCRIPTION
## Summary

Adds a deliberate escape hatch for the **"task re-dispatched after skill update → agent stubbornly resumes the old conversation"** loop.

Today, `ClaimTaskByRuntime` always looks up the last `session_id` for the `(agent, issue)` pair and feeds it to the daemon as `prior_session_id`. The agent then resumes the prior conversation — including any plan it had built before the operator updated the issue's skill / instructions / system prompt. The user has no way to say "drop the prior session, start fresh".

This PR adds a **fresh-task** path:

- New column `agent_task_queue.skip_session_resume BOOL DEFAULT false` (migration 059).
- New query `CreateFreshAgentTask` that sets the column to `true`.
- New service methods `TaskService.EnqueueFreshTaskForIssue` and `TaskService.RerunIssueFresh` (mirror `EnqueueTaskForIssue` / `RerunIssue`, but use the fresh path; `RerunIssueFresh` also cancels active tasks first).
- New endpoint `POST /api/issues/{id}/rerun-fresh` → `TaskService.RerunIssueFresh`.
- `ClaimTaskByRuntime`: when `skip_session_resume = true`, skip `GetLastTaskSession` and leave `prior_session_id` / `prior_work_dir` empty, so the daemon starts a brand-new session.

Default behavior is unchanged: existing callers continue to dispatch via `EnqueueTaskForIssue` / `RerunIssue`, which leave `skip_session_resume = false` and resume the prior session as before.

## Use cases

- Operator updates a skill that ships with prompts / system instructions, then needs the next task run to actually pick up the new content (instead of resuming a session built against the old skill).
- A task got into a stuck plan loop and the cleanest recovery is "forget what you knew, look at the issue fresh".
- An issue's parent context shifted (e.g. comment thread now contains crucial info that wasn't there at the prior turn) and resuming would miss it.

## Migration numbering

`059_skip_session_resume` (the next free slot after upstream's `058_drop_autopilot_priority_and_project_id`).

## Test plan

- [x] `go build ./...` (linux/amd64)
- [x] `GOOS=windows GOARCH=amd64 go build ./...`
- [x] `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/handler -count=1` — passes
- [x] Two new live-DB integration tests in `daemon_test.go` (skipped when no pgpool):
  - `TestClaimTask_SkipSessionResume_ClearsPriorSession` — the fresh path emits empty `prior_session_id` / `prior_work_dir`.
  - `TestClaimTask_DefaultResumeBehaviour_PreservesPriorSession` — pinning that the *default* path still resumes (no behavior change for existing callers).

## API surface (new)

```
POST /api/issues/{id}/rerun-fresh
  → 202 Accepted, taskToResponse(*task)
  Errors:
    400 if no agent assignee
    404 if issue not found
    500 on TaskService error
```

Same shape as the existing `POST /api/issues/{id}/rerun`.

---

Built and battle-tested on the [yizhisec](https://yizhisec.com) Multica deployment, where we use it to manage Windows kernel-security research workflows. Other upstream-able fixes from our fork: #1670, #1673, #1674, #1676, #1678, #1679.