### PR TITLE
feat(storage): pre-signed PUT/GET attachment lifecycle for multi-GB uploads + private-bucket downloads

### DIFF
--- a/server/cmd/multica/cmd_attachment.go
+++ b/server/cmd/multica/cmd_attachment.go
@@ -42,7 +42,11 @@ func runAttachmentDownload(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	// The overall budget is generous because kernel-dump attachments can
+	// be multi-GB and the chengdu internal network routinely does
+	// 60 MB/s — so 30 min covers 100 GB. Signed URLs themselves expire
+	// in 30 min; we don't want to outlast the signature.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
 	// Fetch attachment metadata (includes signed download_url).
@@ -61,18 +65,16 @@ func runAttachmentDownload(cmd *cobra.Command, args []string) error {
 		filename = args[0]
 	}
 
-	// Download the file content.
-	data, err := client.DownloadFile(ctx, downloadURL)
-	if err != nil {
-		return fmt.Errorf("download file: %w", err)
-	}
-
 	// Write to the output directory.
 	outputDir, _ := cmd.Flags().GetString("output-dir")
 	destPath := filepath.Join(outputDir, filename)
 
-	if err := os.WriteFile(destPath, data, 0o644); err != nil {
-		return fmt.Errorf("write file: %w", err)
+	// Stream directly to disk. DownloadFile (in-memory) was capped at
+	// 100 MB and silently truncated anything bigger — catastrophic for
+	// kernel dumps which routinely exceed 1 GB.
+	n, err := client.DownloadFileToPath(ctx, downloadURL, destPath)
+	if err != nil {
+		return fmt.Errorf("download file: %w", err)
 	}
 
 	// Print the absolute path so agents can reference the file.
@@ -80,13 +82,13 @@ func runAttachmentDownload(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		abs = destPath
 	}
-	fmt.Fprintln(os.Stderr, "Downloaded:", abs)
+	fmt.Fprintf(os.Stderr, "Downloaded %d bytes to %s\n", n, abs)
 
 	// Also print as JSON for --output json compatibility.
 	return cli.PrintJSON(os.Stdout, map[string]any{
 		"id":       strVal(att, "id"),
 		"filename": filename,
 		"path":     abs,
-		"size":     strVal(att, "size_bytes"),
+		"size":     n,
 	})
 }

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -203,6 +203,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus, analytics
 		r.Post("/api/me/starter-content/dismiss", h.DismissStarterContent)
 		r.Post("/api/cli-token", h.IssueCliToken)
 		r.Post("/api/upload-file", h.UploadFile)
+		r.Post("/api/upload-file/presign", h.PresignUpload)
 		r.Post("/api/feedback", h.CreateFeedback)
 
 		r.Route("/api/workspaces", func(r chi.Router) {
@@ -327,6 +328,7 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus, analytics
 			// Attachments
 			r.Get("/api/attachments/{id}", h.GetAttachmentByID)
 			r.Delete("/api/attachments/{id}", h.DeleteAttachment)
+			r.Post("/api/attachments/{id}/confirm", h.ConfirmAttachmentUpload)
 
 			// Comments
 			r.Route("/api/comments/{commentId}", func(r chi.Router) {

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -325,7 +326,9 @@ func (c *APIClient) UploadFile(ctx context.Context, fileData []byte, filename st
 
 // DownloadFile downloads a file from the given URL and returns the response body.
 // This is used for downloading attachments via their signed download_url.
-// Downloads are limited to 100 MB to match the upload size limit.
+// Downloads are limited to 100 MB to match the upload size limit. For files
+// that may exceed 100 MB (kernel dumps, video, etc), use DownloadFileToPath
+// which streams directly to disk without a memory cap.
 //
 // The URL may be absolute (a signed CloudFront/S3 URL) or relative
 // (a server-relative path like "/uploads/...") depending on how the
@@ -362,6 +365,40 @@ func (c *APIClient) DownloadFile(ctx context.Context, downloadURL string) ([]byt
 
 	const maxDownloadSize = 100 << 20 // 100 MB
 	return io.ReadAll(io.LimitReader(resp.Body, maxDownloadSize))
+}
+
+// DownloadFileToPath streams the remote URL to the given local path without
+// buffering the whole body in memory. Used for attachment download, where
+// kernel dumps and video files can exceed the in-memory cap that
+// DownloadFile enforces. The destination file is truncated if it exists.
+// Returns the number of bytes written.
+func (c *APIClient) DownloadFileToPath(ctx context.Context, downloadURL, destPath string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return 0, fmt.Errorf("download returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return 0, fmt.Errorf("create %s: %w", destPath, err)
+	}
+	defer f.Close()
+
+	n, err := io.Copy(f, resp.Body)
+	if err != nil {
+		return n, fmt.Errorf("stream to %s: %w", destPath, err)
+	}
+	return n, nil
 }
 
 // HealthCheck hits the /health endpoint and returns the response body.

--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -61,8 +61,30 @@ func (h *Handler) attachmentToResponse(a db.Attachment) AttachmentResponse {
 		SizeBytes:    a.SizeBytes,
 		CreatedAt:    a.CreatedAt.Time.Format("2006-01-02T15:04:05Z07:00"),
 	}
+	// download_url resolution order (first matching wins):
+	//  1. CloudFront signed URL (production S3 + CloudFront setup)
+	//  2. S3 pre-signed GET URL (private bucket, e.g. 移动云 EOS)
+	//  3. raw a.Url (LocalStorage, or public-read bucket)
+	//
+	// We never fail attachmentToResponse over signing errors — we fall
+	// through to the unsigned URL so the UI at least shows the attachment
+	// metadata. Download will still 403 if the bucket is private, but
+	// that's no worse than the pre-signing-never-existed state.
 	if h.CFSigner != nil {
 		resp.DownloadURL = h.CFSigner.SignedURL(a.Url, time.Now().Add(30*time.Minute))
+	} else if h.Storage != nil {
+		key := h.Storage.KeyFromURL(a.Url)
+		if key != "" {
+			// Cap the sign call at 5s — it's a pure local compute on AWS
+			// SDK side but we don't want a misbehaving backend to hang the
+			// JSON response.
+			signCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			signed, err := h.Storage.PresignGet(signCtx, key, 30*time.Minute)
+			cancel()
+			if err == nil && signed != "" {
+				resp.DownloadURL = signed
+			}
+		}
 	}
 	if a.IssueID.Valid {
 		s := uuidToString(a.IssueID)

--- a/server/internal/handler/file_presign.go
+++ b/server/internal/handler/file_presign.go
@@ -161,7 +161,7 @@ func (h *Handler) PresignUpload(w http.ResponseWriter, r *http.Request) {
 		}
 		slog.Error("PresignPut failed",
 			append(logger.RequestAttrs(r), "key", key, "error", err)...)
-		writeError(w, http.StatusInternalServerError, "failed to issue upload URL")
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to issue upload URL: %v", err))
 		return
 	}
 

--- a/server/internal/handler/file_presign.go
+++ b/server/internal/handler/file_presign.go
@@ -1,0 +1,252 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"path"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/storage"
+)
+
+// PresignUploadRequest is the body of POST /api/upload-file/presign.
+// Called by clients that want to upload a file bigger than maxUploadSize
+// (100 MB) and therefore cannot go through the multipart path. The
+// flow is:
+//
+//  1. POST /api/upload-file/presign with filename + content_type +
+//     size_bytes + optional issue_id / comment_id. Server creates the
+//     attachment row with size_bytes=0 (sentinel for "upload in flight")
+//     and returns a pre-signed PUT URL.
+//  2. Client PUT <url> with the file bytes and the matching
+//     Content-Type header.
+//  3. POST /api/attachments/{id}/confirm. Server HeadObjects the key,
+//     updates size_bytes on the attachment row, and returns the final
+//     attachment response.
+//
+// Steps 2 and 3 can happen hours apart; we don't garbage-collect
+// "upload in flight" attachments. They remain with size_bytes=0 if the
+// client never confirms, and look like orphan rows — acceptable for
+// now.
+type PresignUploadRequest struct {
+	Filename    string  `json:"filename"`
+	ContentType string  `json:"content_type"`
+	SizeBytes   int64   `json:"size_bytes"`
+	IssueID     *string `json:"issue_id,omitempty"`
+	CommentID   *string `json:"comment_id,omitempty"`
+}
+
+// PresignUploadResponse echoes the client-driven upload payload plus
+// the attachment record so the client can reference it later without
+// a second round trip.
+type PresignUploadResponse struct {
+	Attachment     AttachmentResponse        `json:"attachment"`
+	Upload         storage.PresignedUpload   `json:"upload"`
+}
+
+// presignMinSize is the smallest size we'll issue a pre-signed URL
+// for. Anything under this should just go through the ordinary
+// POST /api/upload-file multipart path — presign is more complex for
+// the client, so we only recommend it when the file is too big to fit
+// in a single request body.
+const presignMinSize = 50 << 20 // 50 MB
+
+// presignMaxSize caps pre-signed uploads. 16 GB is plenty for kernel
+// dumps (the largest we've seen is ~2 GB) while still preventing an
+// attacker from using the endpoint to stage arbitrarily large objects
+// against our bucket. Adjust via env if needed.
+const presignMaxSize = 16 << 30 // 16 GiB
+
+// presignExpiry is how long the pre-signed PUT URL stays valid. We
+// give generous headroom so a flaky network / retries have a chance
+// to complete an upload of a multi-GB dump.
+const presignExpiry = 30 * time.Minute
+
+// PresignUpload issues a pre-signed S3 URL for direct client upload.
+// Storage backends without presign support (LocalStorage) reject with
+// 501 and the client should fall back to POST /api/upload-file.
+func (h *Handler) PresignUpload(w http.ResponseWriter, r *http.Request) {
+	if h.Storage == nil {
+		writeError(w, http.StatusServiceUnavailable, "file upload not configured")
+		return
+	}
+
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := h.resolveWorkspaceID(r)
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace context is required")
+		return
+	}
+	if _, err := h.getWorkspaceMember(r.Context(), userID, workspaceID); err != nil {
+		writeError(w, http.StatusForbidden, "not a member of this workspace")
+		return
+	}
+
+	var req PresignUploadRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Filename == "" {
+		writeError(w, http.StatusBadRequest, "filename is required")
+		return
+	}
+	if req.SizeBytes <= 0 {
+		writeError(w, http.StatusBadRequest, "size_bytes is required and must be > 0")
+		return
+	}
+	if req.SizeBytes < presignMinSize {
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("file smaller than %d bytes should use POST /api/upload-file directly", presignMinSize))
+		return
+	}
+	if req.SizeBytes > presignMaxSize {
+		writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("file exceeds pre-sign cap of %d bytes", presignMaxSize))
+		return
+	}
+	if req.ContentType == "" {
+		req.ContentType = "application/octet-stream"
+	}
+
+	// Validate optional issue_id / comment_id belong to this workspace.
+	var issueID, commentID pgtype.UUID
+	if req.IssueID != nil && *req.IssueID != "" {
+		issue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
+			ID:          parseUUID(*req.IssueID),
+			WorkspaceID: parseUUID(workspaceID),
+		})
+		if err != nil {
+			writeError(w, http.StatusForbidden, "invalid issue_id")
+			return
+		}
+		issueID = issue.ID
+	}
+	if req.CommentID != nil && *req.CommentID != "" {
+		comment, err := h.Queries.GetComment(r.Context(), parseUUID(*req.CommentID))
+		if err != nil || uuidToString(comment.WorkspaceID) != workspaceID {
+			writeError(w, http.StatusForbidden, "invalid comment_id")
+			return
+		}
+		commentID = comment.ID
+	}
+
+	// Generate the storage key. Shape matches the body-upload path so
+	// KeyFromURL and Delete handle both identically.
+	attID, err := uuid.NewV7()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	objName := attID.String() + path.Ext(req.Filename)
+	key := "workspaces/" + workspaceID + "/" + objName
+
+	presigned, err := h.Storage.PresignPut(r.Context(), key, req.ContentType, req.Filename, presignExpiry)
+	if err != nil {
+		if errors.Is(err, storage.ErrPresignUnsupported) {
+			writeError(w, http.StatusNotImplemented,
+				"configured storage backend does not support pre-signed uploads")
+			return
+		}
+		slog.Error("PresignPut failed",
+			append(logger.RequestAttrs(r), "key", key, "error", err)...)
+		writeError(w, http.StatusInternalServerError, "failed to issue upload URL")
+		return
+	}
+
+	uploaderType, uploaderID := h.resolveActor(r, userID, workspaceID)
+	link := h.Storage.PublicURL(key)
+
+	att, err := h.Queries.CreateAttachment(r.Context(), db.CreateAttachmentParams{
+		ID:           pgtype.UUID{Bytes: attID, Valid: true},
+		WorkspaceID:  parseUUID(workspaceID),
+		IssueID:      issueID,
+		CommentID:    commentID,
+		UploaderType: uploaderType,
+		UploaderID:   parseUUID(uploaderID),
+		Filename:     req.Filename,
+		Url:          link,
+		ContentType:  req.ContentType,
+		// size_bytes deliberately left at 0 until /confirm lands. 0 is
+		// the "upload in flight" sentinel — real uploads always have
+		// size >= 1.
+		SizeBytes: 0,
+	})
+	if err != nil {
+		slog.Error("CreateAttachment for presign failed",
+			append(logger.RequestAttrs(r), "key", key, "error", err)...)
+		writeError(w, http.StatusInternalServerError, "failed to create attachment record")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, PresignUploadResponse{
+		Attachment: h.attachmentToResponse(att),
+		Upload:     *presigned,
+	})
+}
+
+// ConfirmAttachmentUpload finalises an attachment after the client has
+// successfully PUT the bytes via the pre-signed URL from
+// /api/upload-file/presign. Does a HEAD against storage to make sure
+// the object actually exists, then updates size_bytes on the
+// attachment row.
+func (h *Handler) ConfirmAttachmentUpload(w http.ResponseWriter, r *http.Request) {
+	if h.Storage == nil {
+		writeError(w, http.StatusServiceUnavailable, "file upload not configured")
+		return
+	}
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := h.resolveWorkspaceID(r)
+	if _, err := h.getWorkspaceMember(r.Context(), userID, workspaceID); err != nil {
+		writeError(w, http.StatusForbidden, "not a member of this workspace")
+		return
+	}
+
+	attID := chi.URLParam(r, "id")
+	att, err := h.Queries.GetAttachment(r.Context(), db.GetAttachmentParams{
+		ID:          parseUUID(attID),
+		WorkspaceID: parseUUID(workspaceID),
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "attachment not found")
+		return
+	}
+	// No additional workspace check needed — GetAttachment filters on workspace_id.
+
+	key := h.Storage.KeyFromURL(att.Url)
+	size, err := h.Storage.StatObject(r.Context(), key)
+	if err != nil {
+		slog.Warn("ConfirmAttachmentUpload: StatObject failed",
+			append(logger.RequestAttrs(r), "key", key, "error", err)...)
+		writeError(w, http.StatusBadRequest,
+			"object not found in storage — client PUT either failed or has not reached the bucket yet; retry after the PUT succeeds")
+		return
+	}
+
+	updated, err := h.Queries.UpdateAttachmentSize(r.Context(), db.UpdateAttachmentSizeParams{
+		ID:        att.ID,
+		SizeBytes: size,
+	})
+	if err != nil {
+		slog.Error("UpdateAttachmentSize failed",
+			append(logger.RequestAttrs(r), "id", attID, "error", err)...)
+		writeError(w, http.StatusInternalServerError, "failed to finalise attachment")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, h.attachmentToResponse(updated))
+}

--- a/server/internal/handler/file_presign_test.go
+++ b/server/internal/handler/file_presign_test.go
@@ -1,0 +1,172 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TestPresignUpload_HappyPath verifies that a request with a valid
+// size / workspace / filename returns the pre-signed URL + an
+// attachment record with size_bytes=0 (sentinel for in-flight).
+func TestPresignUpload_HappyPath(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	origStorage := testHandler.Storage
+	testHandler.Storage = &mockStorage{}
+	defer func() { testHandler.Storage = origStorage }()
+
+	payload := map[string]any{
+		"filename":     "MEMORY.DMP",
+		"content_type": "application/octet-stream",
+		"size_bytes":   1710221071, // 1.71 GB — well over the 100 MB cap
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest("POST", "/api/upload-file/presign", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", testUserID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+
+	w := httptest.NewRecorder()
+	testHandler.PresignUpload(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Attachment struct {
+			ID        string `json:"id"`
+			Filename  string `json:"filename"`
+			SizeBytes int64  `json:"size_bytes"`
+			URL       string `json:"url"`
+		} `json:"attachment"`
+		Upload struct {
+			URL    string            `json:"upload_url"`
+			Method string            `json:"upload_method"`
+			Headers map[string]string `json:"required_headers"`
+		} `json:"upload"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Attachment.Filename != "MEMORY.DMP" {
+		t.Fatalf("filename mismatch: %q", resp.Attachment.Filename)
+	}
+	if resp.Attachment.SizeBytes != 0 {
+		t.Fatalf("expected size_bytes=0 pre-confirm, got %d", resp.Attachment.SizeBytes)
+	}
+	if resp.Upload.Method != "PUT" {
+		t.Fatalf("expected PUT, got %q", resp.Upload.Method)
+	}
+	if resp.Upload.URL == "" {
+		t.Fatal("empty pre-signed URL")
+	}
+	if resp.Upload.Headers["Content-Type"] != "application/octet-stream" {
+		t.Fatalf("missing Content-Type header in response: %+v", resp.Upload.Headers)
+	}
+
+	// Clean up so reruns don't accumulate.
+	_, _ = testPool.Exec(
+		context.Background(),
+		`DELETE FROM attachment WHERE id = $1`, resp.Attachment.ID,
+	)
+}
+
+// TestPresignUpload_RejectsSmallFile checks we steer clients back to
+// /api/upload-file for files that fit in a normal multipart request.
+// Pre-signed uploads are a two-round-trip protocol and not worth the
+// complexity for a 2 MB screenshot.
+func TestPresignUpload_RejectsSmallFile(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	origStorage := testHandler.Storage
+	testHandler.Storage = &mockStorage{}
+	defer func() { testHandler.Storage = origStorage }()
+
+	payload := map[string]any{
+		"filename":   "small.txt",
+		"size_bytes": 1024,
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/upload-file/presign", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-User-ID", testUserID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+
+	w := httptest.NewRecorder()
+	testHandler.PresignUpload(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for small file, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestConfirmAttachmentUpload_HappyPath finalises an in-flight
+// attachment and verifies size_bytes is populated from StatObject.
+func TestConfirmAttachmentUpload_HappyPath(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	origStorage := testHandler.Storage
+	testHandler.Storage = &mockStorage{}
+	defer func() { testHandler.Storage = origStorage }()
+
+	// Pre-create an in-flight attachment via presign.
+	presignBody, _ := json.Marshal(map[string]any{
+		"filename":   "confirm-test.bin",
+		"size_bytes": 1 << 30, // 1 GB
+	})
+	presignReq := httptest.NewRequest("POST", "/api/upload-file/presign",
+		bytes.NewReader(presignBody))
+	presignReq.Header.Set("Content-Type", "application/json")
+	presignReq.Header.Set("X-User-ID", testUserID)
+	presignReq.Header.Set("X-Workspace-ID", testWorkspaceID)
+	presignW := httptest.NewRecorder()
+	testHandler.PresignUpload(presignW, presignReq)
+	if presignW.Code != http.StatusOK {
+		t.Fatalf("presign failed: %d %s", presignW.Code, presignW.Body.String())
+	}
+	var presignResp struct {
+		Attachment struct {
+			ID string `json:"id"`
+		} `json:"attachment"`
+	}
+	if err := json.NewDecoder(presignW.Body).Decode(&presignResp); err != nil {
+		t.Fatalf("decode presign resp: %v", err)
+	}
+	defer func() {
+		_, _ = testPool.Exec(context.Background(),
+			`DELETE FROM attachment WHERE id = $1`, presignResp.Attachment.ID)
+	}()
+
+	confirmReq := httptest.NewRequest("POST",
+		"/api/attachments/"+presignResp.Attachment.ID+"/confirm", nil)
+	confirmReq.Header.Set("X-User-ID", testUserID)
+	confirmReq.Header.Set("X-Workspace-ID", testWorkspaceID)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", presignResp.Attachment.ID)
+	confirmReq = confirmReq.WithContext(context.WithValue(confirmReq.Context(), chi.RouteCtxKey, rctx))
+
+	confirmW := httptest.NewRecorder()
+	testHandler.ConfirmAttachmentUpload(confirmW, confirmReq)
+	if confirmW.Code != http.StatusOK {
+		t.Fatalf("confirm: expected 200, got %d: %s", confirmW.Code, confirmW.Body.String())
+	}
+	var confirmResp struct {
+		ID        string `json:"id"`
+		SizeBytes int64  `json:"size_bytes"`
+	}
+	if err := json.NewDecoder(confirmW.Body).Decode(&confirmResp); err != nil {
+		t.Fatalf("decode confirm resp: %v", err)
+	}
+	if confirmResp.SizeBytes != 123456 { // mockStorage.StatObject returns 123456
+		t.Fatalf("expected size=123456 from mock StatObject, got %d", confirmResp.SizeBytes)
+	}
+}

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -33,6 +33,9 @@ func (m *mockStorage) PresignPut(_ context.Context, key string, _ string, _ stri
 		ExpiresAt: time.Now().Add(15 * time.Minute),
 	}, nil
 }
+func (m *mockStorage) PresignGet(_ context.Context, key string, _ time.Duration) (string, error) {
+	return fmt.Sprintf("https://presign.example.com/%s?sig=mock-get", key), nil
+}
 func (m *mockStorage) StatObject(_ context.Context, _ string) (int64, error) {
 	return 123456, nil
 }

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -9,6 +9,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/storage"
 )
 
 type mockStorage struct{}
@@ -21,6 +24,18 @@ func (m *mockStorage) Delete(_ context.Context, _ string)        {}
 func (m *mockStorage) DeleteKeys(_ context.Context, _ []string)  {}
 func (m *mockStorage) KeyFromURL(rawURL string) string            { return rawURL }
 func (m *mockStorage) CdnDomain() string                         { return "cdn.example.com" }
+func (m *mockStorage) PublicURL(key string) string                { return fmt.Sprintf("https://cdn.example.com/%s", key) }
+func (m *mockStorage) PresignPut(_ context.Context, key string, _ string, _ string, _ time.Duration) (*storage.PresignedUpload, error) {
+	return &storage.PresignedUpload{
+		URL:       fmt.Sprintf("https://presign.example.com/%s?sig=mock", key),
+		Method:    "PUT",
+		Headers:   map[string]string{"Content-Type": "application/octet-stream"},
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	}, nil
+}
+func (m *mockStorage) StatObject(_ context.Context, _ string) (int64, error) {
+	return 123456, nil
+}
 
 func TestUploadFileForeignWorkspace(t *testing.T) {
 	origStorage := testHandler.Storage

--- a/server/internal/storage/errors.go
+++ b/server/internal/storage/errors.go
@@ -1,0 +1,8 @@
+package storage
+
+import "errors"
+
+// ErrPresignUnsupported is returned by storage backends that do not
+// implement PresignPut (currently: LocalStorage). Callers should fall
+// back to the body-upload path.
+var ErrPresignUnsupported = errors.New("storage backend does not support pre-signed uploads")

--- a/server/internal/storage/local.go
+++ b/server/internal/storage/local.go
@@ -132,6 +132,13 @@ func (s *LocalStorage) PresignPut(ctx context.Context, key string, contentType s
 	return nil, ErrPresignUnsupported
 }
 
+// PresignGet — not supported. Local files are served by the same-
+// process /uploads/* handler; PublicURL points at that handler
+// directly (no signing involved).
+func (s *LocalStorage) PresignGet(ctx context.Context, key string, expiresIn time.Duration) (string, error) {
+	return "", ErrPresignUnsupported
+}
+
 // PublicURL returns the public (served-by-this-server) URL for an
 // already-staged file under the local upload dir.
 func (s *LocalStorage) PublicURL(key string) string {

--- a/server/internal/storage/local.go
+++ b/server/internal/storage/local.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type LocalStorage struct {
@@ -122,4 +123,29 @@ func (s *LocalStorage) UploadFromReader(ctx context.Context, key string, reader 
 	}
 
 	return s.Upload(ctx, key, data, contentType, filename)
+}
+
+// PresignPut — not supported for the local backend because we have
+// no way to hand the caller a URL that bypasses this server. Callers
+// fall back to the body-upload path.
+func (s *LocalStorage) PresignPut(ctx context.Context, key string, contentType string, filename string, expiresIn time.Duration) (*PresignedUpload, error) {
+	return nil, ErrPresignUnsupported
+}
+
+// PublicURL returns the public (served-by-this-server) URL for an
+// already-staged file under the local upload dir.
+func (s *LocalStorage) PublicURL(key string) string {
+	return "/uploads/" + key
+}
+
+// StatObject returns the byte size of an already-uploaded object in
+// the local upload dir. Used by the /confirm endpoint, even though
+// local backends don't use presign themselves — keeping the interface
+// uniform makes call sites simpler.
+func (s *LocalStorage) StatObject(ctx context.Context, key string) (int64, error) {
+	fi, err := os.Stat(filepath.Join(s.uploadDir, key))
+	if err != nil {
+		return 0, fmt.Errorf("local StatObject: %w", err)
+	}
+	return fi.Size(), nil
 }

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -18,6 +18,7 @@ import (
 
 type S3Storage struct {
 	client      *s3.Client
+	getClient   *s3.Client // same config as client, but always virtual-hosted style; used for PresignGet
 	bucket      string
 	cdnDomain   string // if set, returned URLs use this instead of bucket name
 	endpointURL string // if set, use path-style URLs (e.g. MinIO)
@@ -71,9 +72,28 @@ func NewS3StorageFromEnv() *S3Storage {
 		})
 	}
 
-	slog.Info("S3 storage initialized", "bucket", bucket, "region", region, "cdn_domain", cdnDomain, "endpoint_url", endpointURL)
+	slog.Info("S3 storage initialized",
+		"bucket", bucket,
+		"region", region,
+		"cdn_domain", cdnDomain,
+		"endpoint_url", endpointURL,
+	)
+	// Separate client for PresignGet — always virtual-hosted style.
+	// Some non-AWS S3-compatible backends accept presigned PUT against
+	// path-style URLs but reject presigned GET against path-style with
+	// 403, even when the signature is correct. Virtual-hosted style
+	// works on those backends and is identical to path-style on real
+	// AWS, so this is safe everywhere.
+	getS3Opts := []func(*s3.Options){}
+	if endpointURL != "" {
+		getS3Opts = append(getS3Opts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(endpointURL)
+			o.UsePathStyle = false
+		})
+	}
 	return &S3Storage{
 		client:      s3.NewFromConfig(cfg, s3Opts...),
+		getClient:   s3.NewFromConfig(cfg, getS3Opts...),
 		bucket:      bucket,
 		cdnDomain:   cdnDomain,
 		endpointURL: endpointURL,
@@ -243,4 +263,37 @@ func (s *S3Storage) StatObject(ctx context.Context, key string) (int64, error) {
 		return 0, fmt.Errorf("s3 HeadObject: no ContentLength for %s", key)
 	}
 	return *out.ContentLength, nil
+}
+
+// PresignGet returns a short-lived signed GET URL for the object. Used
+// by the attachment download path when the bucket is private — without
+// a signed URL the client gets 403 AccessDenied. Only the bucket+key+
+// expiry are signed; the client does not need to send any custom
+// header on the GET.
+//
+// Important EOS compatibility detail: the upload path uses path-style
+// addressing (https://endpoint/bucket/key) because that's what the PUT
+// code path + STREAMING-UNSIGNED-PAYLOAD combo requires. But 移动云 EOS
+// rejects pre-signed GET requests issued against the path-style URL
+// with 403, while the same pre-signed GET against virtual-hosted style
+// (https://bucket.endpoint/key) works. Signing a distinct client for
+// GET lets both halves of the flow work independently.
+//
+// For real AWS S3 (no custom endpoint) both styles are accepted, so
+// the distinction is harmless.
+func (s *S3Storage) PresignGet(ctx context.Context, key string, expiresIn time.Duration) (string, error) {
+	if expiresIn <= 0 {
+		expiresIn = 15 * time.Minute
+	}
+	ps := s3.NewPresignClient(s.getClient)
+	req, err := ps.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	}, func(o *s3.PresignOptions) {
+		o.Expires = expiresIn
+	})
+	if err != nil {
+		return "", fmt.Errorf("presign GetObject: %w", err)
+	}
+	return req.URL, nil
 }

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -193,29 +193,30 @@ func (s *S3Storage) PresignPut(ctx context.Context, key string, contentType stri
 	if expiresIn <= 0 {
 		expiresIn = 15 * time.Minute
 	}
-	safe := sanitizeFilename(filename)
-	disposition := "attachment"
-	if isInlineContentType(contentType) {
-		disposition = "inline"
-	}
 	ps := s3.NewPresignClient(s.client)
+	// Keep the signed input minimal — only headers the client can easily
+	// reproduce on its PUT (Content-Type). Do NOT sign Content-Disposition
+	// here: the client would have to echo it byte-for-byte and 99% of
+	// clients (curl --upload-file, boto3, plain fetch) don't set it by
+	// default, so the PUT would fail with SignatureDoesNotMatch. If the
+	// caller needs a friendly download filename later, use
+	// response-content-disposition query params on the GET URL instead.
 	req, err := ps.PresignPutObject(ctx, &s3.PutObjectInput{
-		Bucket:             aws.String(s.bucket),
-		Key:                aws.String(key),
-		ContentType:        aws.String(contentType),
-		ContentDisposition: aws.String(fmt.Sprintf(`%s; filename="%s"`, disposition, safe)),
-		StorageClass:       s.storageClass(),
+		Bucket:       aws.String(s.bucket),
+		Key:          aws.String(key),
+		ContentType:  aws.String(contentType),
+		StorageClass: s.storageClass(),
 	}, func(o *s3.PresignOptions) {
 		o.Expires = expiresIn
 	})
 	if err != nil {
 		return nil, fmt.Errorf("presign PutObject: %w", err)
 	}
-	// Caller must echo the signed headers exactly. Per AWS SigV4 rules,
-	// Content-Type is signed; the client MUST set it to the same string
-	// we passed above or S3 rejects the PUT with SignatureDoesNotMatch.
-	// Other headers that went into the signature but are optional for
-	// the client to re-set are not surfaced here.
+	// Client MUST send the same Content-Type on the PUT — SigV4 signs
+	// it. filename parameter is kept for API symmetry with Upload()
+	// but is intentionally unused on this path; it's already part of
+	// the attachment record.
+	_ = filename
 	headers := map[string]string{
 		"Content-Type": contentType,
 	}

--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -173,4 +174,72 @@ func (s *S3Storage) uploadedURL(key string) string {
 		return fmt.Sprintf("%s/%s/%s", strings.TrimRight(s.endpointURL, "/"), s.bucket, key)
 	}
 	return fmt.Sprintf("https://%s/%s", s.bucket, key)
+}
+
+// PublicURL is the Storage-interface version of uploadedURL; it returns
+// the stable read-side URL for an object that has already been uploaded
+// (e.g. via a pre-signed PUT).
+func (s *S3Storage) PublicURL(key string) string {
+	return s.uploadedURL(key)
+}
+
+// PresignPut returns a pre-signed PUT URL for key. The returned URL
+// encodes content-type + content-disposition into the signature, so
+// the client MUST send the same Content-Type header on its PUT call.
+// This lets the client stream multi-GB uploads directly to S3 without
+// the server buffering the request body (which would OOM the daemon
+// box for kernel-dump-sized files).
+func (s *S3Storage) PresignPut(ctx context.Context, key string, contentType string, filename string, expiresIn time.Duration) (*PresignedUpload, error) {
+	if expiresIn <= 0 {
+		expiresIn = 15 * time.Minute
+	}
+	safe := sanitizeFilename(filename)
+	disposition := "attachment"
+	if isInlineContentType(contentType) {
+		disposition = "inline"
+	}
+	ps := s3.NewPresignClient(s.client)
+	req, err := ps.PresignPutObject(ctx, &s3.PutObjectInput{
+		Bucket:             aws.String(s.bucket),
+		Key:                aws.String(key),
+		ContentType:        aws.String(contentType),
+		ContentDisposition: aws.String(fmt.Sprintf(`%s; filename="%s"`, disposition, safe)),
+		StorageClass:       s.storageClass(),
+	}, func(o *s3.PresignOptions) {
+		o.Expires = expiresIn
+	})
+	if err != nil {
+		return nil, fmt.Errorf("presign PutObject: %w", err)
+	}
+	// Caller must echo the signed headers exactly. Per AWS SigV4 rules,
+	// Content-Type is signed; the client MUST set it to the same string
+	// we passed above or S3 rejects the PUT with SignatureDoesNotMatch.
+	// Other headers that went into the signature but are optional for
+	// the client to re-set are not surfaced here.
+	headers := map[string]string{
+		"Content-Type": contentType,
+	}
+	return &PresignedUpload{
+		URL:       req.URL,
+		Method:    req.Method,
+		Headers:   headers,
+		ExpiresAt: time.Now().Add(expiresIn),
+	}, nil
+}
+
+// StatObject returns the byte size of an existing object. The client's
+// /confirm endpoint uses this to verify the pre-signed PUT actually
+// completed before the attachment record flips to "ready".
+func (s *S3Storage) StatObject(ctx context.Context, key string) (int64, error) {
+	out, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("s3 HeadObject: %w", err)
+	}
+	if out.ContentLength == nil {
+		return 0, fmt.Errorf("s3 HeadObject: no ContentLength for %s", key)
+	}
+	return *out.ContentLength, nil
 }

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -32,6 +32,13 @@ type Storage interface {
 	// this (LocalStorage) should return (nil, ErrPresignUnsupported).
 	PresignPut(ctx context.Context, key string, contentType string, filename string, expiresIn time.Duration) (*PresignedUpload, error)
 
+	// PresignGet returns a time-limited URL that lets an un-authenticated
+	// client GET the object. Used for attachment download when the bucket
+	// itself is private (no public-read ACL). Backends that don't support
+	// signed reads (LocalStorage) should return ErrPresignUnsupported; the
+	// caller should fall back to the stable PublicURL.
+	PresignGet(ctx context.Context, key string, expiresIn time.Duration) (string, error)
+
 	// PublicURL returns the stable public URL for an already-uploaded
 	// object, without uploading anything. Used after a successful
 	// client-side PUT via PresignPut so the attachment record can point

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -2,7 +2,21 @@ package storage
 
 import (
 	"context"
+	"time"
 )
+
+// PresignedUpload describes a pre-signed URL that a client can PUT a file
+// to directly, bypassing the server's request-body path. The server
+// pre-allocates the storage key so that on successful upload the client
+// can call the /confirm endpoint and the attachment record becomes
+// usable. Only some backends support this (S3); LocalStorage returns
+// ErrPresignUnsupported.
+type PresignedUpload struct {
+	URL       string    `json:"upload_url"`
+	Method    string    `json:"upload_method"`   // always "PUT"
+	Headers   map[string]string `json:"required_headers,omitempty"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
 
 type Storage interface {
 	Upload(ctx context.Context, key string, data []byte, contentType string, filename string) (string, error)
@@ -10,4 +24,22 @@ type Storage interface {
 	DeleteKeys(ctx context.Context, keys []string)
 	KeyFromURL(rawURL string) string
 	CdnDomain() string
+
+	// PresignPut returns a URL the client can PUT to in order to upload
+	// the object directly, without buffering through this server. The
+	// returned URL encodes the content-type so the client MUST send the
+	// same Content-Type header on its PUT. Backends that don't support
+	// this (LocalStorage) should return (nil, ErrPresignUnsupported).
+	PresignPut(ctx context.Context, key string, contentType string, filename string, expiresIn time.Duration) (*PresignedUpload, error)
+
+	// PublicURL returns the stable public URL for an already-uploaded
+	// object, without uploading anything. Used after a successful
+	// client-side PUT via PresignPut so the attachment record can point
+	// at the real object location (CDN-aware).
+	PublicURL(key string) string
+
+	// StatObject returns the byte size of an existing object. Used by
+	// the /confirm endpoint to verify the client actually completed
+	// the PUT before marking the attachment ready.
+	StatObject(ctx context.Context, key string) (sizeBytes int64, err error)
 }

--- a/server/pkg/db/generated/attachment.sql.go
+++ b/server/pkg/db/generated/attachment.sql.go
@@ -320,3 +320,37 @@ func (q *Queries) ListAttachmentsByIssue(ctx context.Context, arg ListAttachment
 	}
 	return items, nil
 }
+
+const updateAttachmentSize = `-- name: UpdateAttachmentSize :one
+UPDATE attachment SET size_bytes = $2 WHERE id = $1 RETURNING id, workspace_id, issue_id, comment_id, uploader_type, uploader_id, filename, url, content_type, size_bytes, created_at
+`
+
+type UpdateAttachmentSizeParams struct {
+	ID        pgtype.UUID `json:"id"`
+	SizeBytes int64       `json:"size_bytes"`
+}
+
+// After a successful pre-signed S3 PUT, the client calls /confirm and
+// the handler sets the byte count to the value HeadObject reported.
+// The CreateAttachment that preceded the presign left size_bytes=0 as a
+// sentinel for "upload in progress"; this query flips it to the real
+// size and is idempotent — calling /confirm twice with the same byte
+// count is a no-op.
+func (q *Queries) UpdateAttachmentSize(ctx context.Context, arg UpdateAttachmentSizeParams) (Attachment, error) {
+	row := q.db.QueryRow(ctx, updateAttachmentSize, arg.ID, arg.SizeBytes)
+	var i Attachment
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.IssueID,
+		&i.CommentID,
+		&i.UploaderType,
+		&i.UploaderID,
+		&i.Filename,
+		&i.Url,
+		&i.ContentType,
+		&i.SizeBytes,
+		&i.CreatedAt,
+	)
+	return i, err
+}

--- a/server/pkg/db/queries/attachment.sql
+++ b/server/pkg/db/queries/attachment.sql
@@ -3,6 +3,15 @@ INSERT INTO attachment (id, workspace_id, issue_id, comment_id, uploader_type, u
 VALUES ($1, $2, sqlc.narg(issue_id), sqlc.narg(comment_id), $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
+-- name: UpdateAttachmentSize :one
+-- After a successful pre-signed S3 PUT, the client calls /confirm and
+-- the handler sets the byte count to the value HeadObject reported.
+-- The CreateAttachment that preceded the presign left size_bytes=0 as a
+-- sentinel for "upload in progress"; this query flips it to the real
+-- size and is idempotent — calling /confirm twice with the same byte
+-- count is a no-op.
+UPDATE attachment SET size_bytes = $2 WHERE id = $1 RETURNING *;
+
 -- name: ListAttachmentsByIssue :many
 SELECT * FROM attachment
 WHERE issue_id = $1 AND workspace_id = $2


### PR DESCRIPTION
## Summary

Adds full **pre-signed-URL attachment lifecycle** to Multica's `Storage` interface so:

1. **Large attachments (50 MB – 16 GB)** can be uploaded directly to S3 via a client-side pre-signed PUT, bypassing the server-side `io.ReadAll` memory cap that limited `POST /api/upload-file` to ~100 MB.
2. **Private-bucket downloads** (no public-read ACL) get pre-signed GET URLs in the `attachmentToResponse` payload, instead of the un-signed object URL that returned 403 AccessDenied to UI / CLI.
3. **CLI** can stream large attachment downloads straight to disk without the 100 MB in-memory cap.

The interface grows three methods (`PresignPut`, `PresignGet`, `PublicURL`, `StatObject`); `LocalStorage` returns `ErrPresignUnsupported` for the presign methods so callers fall back to the existing `/uploads/*` static path.

## Why

- Kernel dumps, video, archives — anything in the 100 MB – multi-GB range — can't be uploaded via `POST /api/upload-file` today because that handler buffers the whole body into Go heap before streaming to S3. Symptom: client gets "file too large" or the server OOMs.
- Private S3 buckets (the recommended config for attachment storage with no public-read ACL) are usable for upload via the existing CFSigner flow but unusable for download — `attachmentToResponse` returned the raw `a.Url` and any client GET hit `403 AccessDenied`. Fix is symmetric to the upload side.
- Some non-AWS S3-compatible backends require **virtual-hosted-style** for presigned GET while accepting **path-style** for presigned PUT. The PR wires two `s3.Client` instances inside `S3Storage`: one for the existing path-style PUT flow, one fixed to virtual-hosted for `PresignGet`. On real AWS both styles resolve identically — no regression.

## Commits in this PR (5)

1. **`feat(storage): pre-signed S3 upload + confirm for large attachments`** — adds `Storage.PresignPut`, `Storage.PublicURL`, `Storage.StatObject`, the new endpoints `POST /api/upload-file/presign` + `POST /api/attachments/{id}/confirm`, and the supporting handler tests. Pre-created attachment rows carry `size_bytes=0` as the "upload in flight" sentinel; `/confirm` flips them to the real `HeadObject` size.
2. **`fix(storage): drop Content-Disposition from pre-signed PUT input`** — signing `Content-Disposition` forces the client to reproduce the exact header on its `PUT`. Real-world clients (curl, boto3, browser fetch) don't emit Content-Disposition by default, so every `PUT` against the signed URL came back as `403 SignatureDoesNotMatch`. Keep the presigned PUT minimal (just `Content-Type`, which is trivial for clients to echo). For per-download filenames use `response-content-disposition` query param on the GET URL — that's how S3 supports filename overrides without requiring the client to sign anything on upload.
3. **`feat(storage): pre-signed GET for private-bucket attachment downloads`** — `attachmentToResponse` now resolves `download_url` in this order:
    1. CloudFront signed URL (if `CFSigner` configured)
    2. S3 pre-signed GET URL (via the new path)
    3. raw `a.Url` (fallback — `LocalStorage` or public-read bucket)

   `PresignGet` is called with a 5-second context timeout inside `attachmentToResponse` so a misbehaving backend doesn't stall the JSON response; on signing error, falls through to raw URL.
4. **`fix(cli): stream attachment download to disk instead of capping at 100 MB`** — `DownloadFile` used `io.ReadAll(io.LimitReader(resp.Body, 100<<20))`, silently truncating any download larger than 100 MB. New `DownloadFileToPath` does `io.Copy` straight to file, no memory cap. `multica attachment download` switches to the new method and bumps its CLI-side context deadline to 30 minutes to match the pre-signed URL TTL.
5. **`fix(storage): surface PresignPut error detail in HTTP response`** — same rationale as the `UploadFile` bubble-up that already shipped: the presign handler was emitting a generic "failed to issue upload URL" that forced the caller to tail the server log to diagnose. Now returns the real SDK error.

## Test plan

- [x] `go build ./...` (linux/amd64)
- [x] `GOOS=windows GOARCH=amd64 go build ./...`
- [x] `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/handler ./internal/storage ./internal/cli ./pkg/agent -count=1` — all green
- [x] New tests in `file_presign_test.go` cover: presign accepts 50 MB..16 GB; rejects out-of-range size; creates attachment row with `size_bytes=0`; confirm endpoint flips size to HeadObject result
- [x] `mockStorage` extended with `PresignPut` / `PresignGet` / `PublicURL` / `StatObject` so existing handler tests stay self-contained
- [x] **End-to-end against an S3-compatible backend** that requires virtual-hosted-style for GET: pre-signed PUT (path-style) + pre-signed GET (virtual-hosted) both succeed, including a 1.7 GB upload + download round trip

## API surface (new)

```
POST /api/upload-file/presign       → 200 { id, upload_url, expires_at, ... }
POST /api/attachments/{id}/confirm  → 200 (server HEADs and updates size_bytes)
```

Old `POST /api/upload-file` is unchanged; existing clients still work.

## Caveats

- Pre-creates an attachment row with `size_bytes=0` before the upload even starts. If the client never PUTs, the row will sit there. Cleanup is a separate concern — could be handled by a TTL sweep on `attachment WHERE size_bytes = 0 AND created_at < now() - interval`. Not in this PR.
- Presign accepts 50 MB..16 GB to steer small uploads back to `/api/upload-file` (presign is a two-round-trip protocol, not worth the complexity for screenshots). The bounds are tunable in `file_presign.go` if upstream wants different limits.

## Recommended merge order

This PR depends on #1676 (`fix(storage): disable auto CRC32 checksum so non-AWS S3 backends work`) for end-to-end functionality on any non-AWS S3-compatible backend (MinIO, Ceph, Yandex, Chinese-cloud S3 services). Without #1676, the upload PUT path will fail with `XAmzContentSHA256Mismatch` on those backends. On real AWS S3 the two PRs are independent — this one works standalone.

---

Built and battle-tested on the [yizhisec](https://yizhisec.com) Multica deployment, where we use it to manage Windows kernel-security research workflows. Other upstream-able fixes from our fork: #1670, #1673, #1674, #1675, #1676, #1679.

---

Built and battle-tested on the [yizhisec](https://yizhisec.com) Multica deployment, where we use it to manage Windows kernel-security research workflows. Other upstream-able fixes from our fork: #1670, #1673, #1674, #1675, #1676, #1679.