### PR TITLE
fix(daemon/windows): break out of parent shell Job Object so daemon survives

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -174,11 +174,29 @@ func runDaemonBackground(cmd *cobra.Command) error {
 	child := exec.Command(exePath, args...)
 	child.Stdout = logFile
 	child.Stderr = logFile
-	child.SysProcAttr = daemonSysProcAttr()
+	// On Windows we want to break the child out of the parent shell's Job
+	// Object so the daemon survives parent-shell exit. If the parent's Job
+	// has not granted BREAKAWAY_OK, CreateProcess returns
+	// ERROR_ACCESS_DENIED — fall back to spawning without breakaway, which
+	// matches the pre-fix behaviour. On Unix the bool is a no-op.
+	child.SysProcAttr = daemonSysProcAttr(true)
 
 	if err := child.Start(); err != nil {
-		logFile.Close()
-		return fmt.Errorf("start daemon: %w", err)
+		if isAccessDeniedSpawnErr(err) {
+			// Retry without breakaway. Reset the cmd state — exec.Cmd is
+			// not safe to Start() twice, so build a fresh one.
+			child = exec.Command(exePath, args...)
+			child.Stdout = logFile
+			child.Stderr = logFile
+			child.SysProcAttr = daemonSysProcAttr(false)
+			if err := child.Start(); err != nil {
+				logFile.Close()
+				return fmt.Errorf("start daemon (no breakaway): %w", err)
+			}
+		} else {
+			logFile.Close()
+			return fmt.Errorf("start daemon: %w", err)
+		}
 	}
 	logFile.Close()
 	pid := child.Process.Pid
@@ -327,12 +345,26 @@ func runDaemonForeground(cmd *cobra.Command) error {
 		}
 		child.Stdout = logFile
 		child.Stderr = logFile
-		child.SysProcAttr = daemonSysProcAttr()
+		// Break out of the parent's Job Object on Windows; see the
+		// runDaemonBackground call site for rationale.
+		child.SysProcAttr = daemonSysProcAttr(true)
 
 		if err := child.Start(); err != nil {
-			logFile.Close()
-			logger.Error("failed to start new daemon", "error", err)
-			return nil
+			if isAccessDeniedSpawnErr(err) {
+				child = exec.Command(restartBin, args...)
+				child.Stdout = logFile
+				child.Stderr = logFile
+				child.SysProcAttr = daemonSysProcAttr(false)
+				if err := child.Start(); err != nil {
+					logFile.Close()
+					logger.Error("failed to start new daemon (no breakaway)", "error", err)
+					return nil
+				}
+			} else {
+				logFile.Close()
+				logger.Error("failed to start new daemon", "error", err)
+				return nil
+			}
 		}
 		logFile.Close()
 		child.Process.Release()

--- a/server/cmd/multica/cmd_daemon_unix.go
+++ b/server/cmd/multica/cmd_daemon_unix.go
@@ -11,9 +11,20 @@ import (
 	"syscall"
 )
 
-func daemonSysProcAttr() *syscall.SysProcAttr {
+// daemonSysProcAttr returns the attributes used when spawning the background
+// daemon. The withBreakaway argument exists only to share a signature with
+// the Windows version (where it controls CREATE_BREAKAWAY_FROM_JOB); on
+// Unix Setsid alone is sufficient to detach the child from its parent's
+// session and process group.
+func daemonSysProcAttr(_ bool) *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setsid: true}
 }
+
+// isAccessDeniedSpawnErr is always false on Unix. The Windows version
+// looks for ERROR_ACCESS_DENIED to detect "parent Job Object disallowed
+// breakaway" and trigger the breakaway-disabled retry; that retry is a
+// no-op on Unix.
+func isAccessDeniedSpawnErr(_ error) bool { return false }
 
 func notifyShutdownContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)

--- a/server/cmd/multica/cmd_daemon_windows.go
+++ b/server/cmd/multica/cmd_daemon_windows.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"os/signal"
@@ -12,23 +13,55 @@ import (
 )
 
 const (
+	// detachedProcess severs the inherited console so closing the parent
+	// cmd/PowerShell window no longer propagates CTRL_CLOSE_EVENT to the daemon.
 	detachedProcess = 0x00000008
-	sigBreak        = syscall.Signal(0x15)
+	// createBreakawayFromJob lets the daemon escape its parent shell's Job
+	// Object. Modern Windows Terminal / cmd.exe / PowerShell host the
+	// processes they spawn inside a Job Object that has KILL_ON_JOB_CLOSE
+	// set, so when the parent shell exits the kernel kills every process
+	// inside that job — including a child we tried to "detach" with
+	// detachedProcess alone. detachedProcess only severs the console, not
+	// the Job Object inheritance. Adding createBreakawayFromJob makes
+	// CreateProcess place the new process outside the parent's Job, so
+	// the daemon survives parent-shell exit.
+	//
+	// If the parent's Job has not granted BREAKAWAY_OK, CreateProcess
+	// returns ERROR_ACCESS_DENIED. In that case the caller falls back to
+	// detachedProcess alone — the daemon is then at the mercy of the
+	// parent's Job lifecycle, which is the pre-fix behaviour.
+	createBreakawayFromJob = 0x01000000
+	sigBreak               = syscall.Signal(0x15)
 )
 
 // daemonSysProcAttr returns the attributes used when spawning the background
-// daemon. DETACHED_PROCESS severs the inherited console so closing the parent
-// cmd/PowerShell window no longer propagates CTRL_CLOSE_EVENT to the daemon.
-// Because the detached daemon shares no console with the stop caller,
-// `daemon stop` talks to it via the HTTP /shutdown endpoint rather than
-// GenerateConsoleCtrlEvent. The daemon's stdout/stderr are already
-// redirected to the log file before Start() is called, so losing the
-// console is safe.
-func daemonSysProcAttr() *syscall.SysProcAttr {
+// daemon. The default is detachedProcess + createBreakawayFromJob so the
+// daemon survives both the parent's console close and the parent's Job
+// Object close. The daemon's stdout/stderr are already redirected to the
+// log file before Start() is called, so losing the console is safe; and
+// `daemon stop` talks to it via HTTP /shutdown rather than
+// GenerateConsoleCtrlEvent, so losing the process group is also safe.
+//
+// The withBreakaway argument exists so the caller can retry with
+// withBreakaway=false when CreateProcess fails with ERROR_ACCESS_DENIED
+// (the parent Job does not allow breakaway).
+func daemonSysProcAttr(withBreakaway bool) *syscall.SysProcAttr {
+	flags := uint32(detachedProcess)
+	if withBreakaway {
+		flags |= createBreakawayFromJob
+	}
 	return &syscall.SysProcAttr{
 		HideWindow:    true,
-		CreationFlags: detachedProcess,
+		CreationFlags: flags,
 	}
+}
+
+// isAccessDeniedSpawnErr reports whether the error returned from
+// (*exec.Cmd).Start() is the Windows ERROR_ACCESS_DENIED, which is what
+// CreateProcess returns when CREATE_BREAKAWAY_FROM_JOB is requested but
+// the parent's Job Object has not set JOB_OBJECT_LIMIT_BREAKAWAY_OK.
+func isAccessDeniedSpawnErr(err error) bool {
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED)
 }
 
 func notifyShutdownContext(parent context.Context) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
## Summary

Fix `multica daemon start` on Windows: the daemon used to **die within seconds of being reported as "started"**. Adding `CREATE_BREAKAWAY_FROM_JOB` to the spawn flags lets the daemon escape its parent shell's Job Object so it survives parent-shell exit.

## Symptom

```
$ multica daemon start
Daemon started (pid N, version 0beec0a8)
Logs: C:\Users\...\.multica\daemon.log

# … tail the log a few seconds later:
"starting daemon"
"authenticated"
"registered runtime"
"health server listening"
"poll: no tasks ... cycle=1"
# (silence — process gone, no shutdown line, no panic, no Win32 error)
```

The daemon completed its first poll cycle (5 s after start) then went away abruptly. Reproducible every time on every shell-launched start. `multica daemon start --foreground` worked fine because that mode kept the originating shell open.

## Root cause

Modern Windows shells (cmd.exe, PowerShell, Windows Terminal, SSH-launched cmd) place themselves and the processes they spawn into a **Job Object** with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. When the operator's shell exits — which `multica daemon start` causes by design as soon as `/health` returns "running" — the kernel closes the last handle to that Job and terminates every process inside. **Our "detached" daemon is inside the same Job and gets killed.**

`DETACHED_PROCESS` (the existing flag) only severs the **console** relationship. It does **not** break Job Object inheritance.

The kill is `TerminateJobObject`, which gives the daemon no chance to run any signal handler, no chance to log, no chance to flush stdio — exactly what the silent-exit symptom shows.

## Fix

Add `CREATE_BREAKAWAY_FROM_JOB` (`0x01000000`) to the daemon child's `CreationFlags`. `CreateProcess` then places the new process **outside** the parent's Job, so the parent's exit no longer takes the daemon down.

Two spawn sites in `cmd/multica/cmd_daemon.go` are updated:
- `runDaemonBackground` — the regular `daemon start` flow.
- The post-update restart path inside `runDaemonForeground` (when `daemon.RestartBinary()` returns a path after a CLI self-update).

### Fallback for `ERROR_ACCESS_DENIED`

If the parent's Job has not granted `JOB_OBJECT_LIMIT_BREAKAWAY_OK`, `CreateProcess` returns `ERROR_ACCESS_DENIED` (Win32 error 5). Both spawn sites catch that case via a tiny build-tag-split helper `isAccessDeniedSpawnErr(err)` and retry with breakaway disabled — restoring the pre-fix behavior on those (rare) hosts. Worst case is "no regression"; best case (most modern Windows hosts) is "daemon survives".

The Unix `cmd_daemon_unix.go` companion grows a no-op `isAccessDeniedSpawnErr` and a no-op bool argument on `daemonSysProcAttr`. `Setsid` already detaches Unix children from their session; nothing changes for Linux/macOS.

## Verification

End-to-end on a Windows test host:

| Binary           | Outcome                                                                     |
| ---------------- | --------------------------------------------------------------------------- |
| `main` (pre-fix) | Daemon dies after `cycle=1` log entry, every time. Uptime ~5–10 s.          |
| With this PR     | Daemon survives multiple SSH session boundaries; `/health` reports `uptime: 1m32s`; daemon log shows `cycle=21` (5 s × 21 = ~105 s elapsed). |

Pre-fix daemon log (every run):
```
... INF health server listening
... DBG poll: no tasks ... cycle=1
(silence — process gone)
```

Post-fix daemon log:
```
... INF health server listening
... DBG poll: no tasks ... cycle=1
... DBG poll: no tasks ... cycle=21
(continues; daemon serving /health and registering runtimes normally)
```

## Test plan

- [x] `go build ./...` (linux/amd64)
- [x] `GOOS=windows GOARCH=amd64 go build ./...`
- [x] `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go vet ./...`
- [x] Manual end-to-end on Windows: deploy fresh binary, `multica daemon start`, close SSH, reconnect 60 s+ later, `/health` returns running with growing uptime, log shows multiple poll cycles.
- [ ] No automated test added — Job Object propagation can't be exercised on Linux CI without spawning real Windows processes. The bug class is "the daemon survives shell exit", which is fundamentally a Windows-host integration test.

## Notes for reviewers

- This bug only manifests when the daemon is launched from an interactive shell that places its children in a Job Object. Older Windows or some CI runners don't, which is presumably why it's been latent.
- The fix is minimally invasive: 3 files touched, ~75 lines net diff. No public API change. No new dependency.
- A side benefit: this complements the upcoming `pkg/procgroup` work (#1670) — that one is about killing *child* subprocess trees, this one is about not getting killed *as* a child of the parent shell. They're symmetric Windows-Job-Object concerns.

---

Built and battle-tested on the [yizhisec](https://yizhisec.com) Multica deployment, where we use it to manage Windows kernel-security research workflows. Other upstream-able fixes from our fork: #1670, #1673, #1674, #1675, #1676, #1678.
