### PR TITLE
fix(server): use resolved issue ID in DeleteIssue handler

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1236,7 +1236,7 @@ func (h *Handler) DeleteIssue(w http.ResponseWriter, r *http.Request) {
 	// Collect all attachment URLs (issue-level + comment-level) before CASCADE delete.
 	attachmentURLs, _ := h.Queries.ListAttachmentURLsByIssueOrComments(r.Context(), issue.ID)
 
-	err := h.Queries.DeleteIssue(r.Context(), parseUUID(id))
+	err := h.Queries.DeleteIssue(r.Context(), issue.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete issue")
 		return


### PR DESCRIPTION
## Problem

`DELETE /api/issues/{id}` silently succeeds (returns 204) without actually deleting the issue when called with a human-readable identifier like `API-123` instead of a UUID.

## Root Cause

In `DeleteIssue` (handler/issue.go), the handler correctly resolves the identifier to an `issue` object via `loadIssueForUser` → `resolveIssueByIdentifier`, and uses `issue.ID` for `CancelTasksForIssue`, `FailAutopilotRunsByIssue`, and `ListAttachmentURLsByIssueOrComments`. However, the actual `DeleteIssue` query call passes `parseUUID(id)` using the raw URL parameter. For non-UUID strings, `parseUUID` returns a zero UUID, so the SQL DELETE matches nothing and no error is raised.

## Fix

Use `issue.ID` (the resolved UUID) instead of `parseUUID(id)`, consistent with how `BatchDeleteIssues` already handles this (line 1492).

## Verification

- `go vet ./internal/handler/` passes clean
- Existing `TestCRUD` in handler_test.go covers UUID-based delete; this fix extends correctness to identifier-based delete

Closes #1661

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.