### PR TITLE
fix(daemon): report cancelled tasks as "cancelled", not "timeout"

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1272,6 +1272,20 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 			EnvRoot:   env.RootDir,
 			Usage:     usageEntries,
 		}, nil
+	case "cancelled":
+		// Server cancelled the task (e.g. issue reassignment, user cancel).
+		// handleTask's cancelledByPoll branch already discards this result,
+		// so this case is mainly defensive — and preserves the "cancelled"
+		// status string for the "agent finished" log line so operators can
+		// distinguish "task cancelled by server" from a real timeout.
+		return TaskResult{
+			Status:    "cancelled",
+			Comment:   "task cancelled by server",
+			SessionID: result.SessionID,
+			WorkDir:   env.WorkDir,
+			EnvRoot:   env.RootDir,
+			Usage:     usageEntries,
+		}, nil
 	default:
 		errMsg := result.Error
 		if errMsg == "" {
@@ -1467,6 +1481,17 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 	case result := <-session.Result:
 		return result, toolCount.Load(), nil
 	case <-drainCtx.Done():
+		// Distinguish external cancellation (e.g. server-initiated cancel
+		// because the issue was reassigned, or the user invoked CancelTask)
+		// from genuine drain-deadline timeouts. context.Canceled means the
+		// upstream runCtx fired runCancel(); context.DeadlineExceeded is the
+		// drain deadline expiring on its own.
+		if errors.Is(drainCtx.Err(), context.Canceled) {
+			return agent.Result{
+				Status: "cancelled",
+				Error:  "task cancelled by upstream context (server cancel or daemon shutdown)",
+			}, toolCount.Load(), nil
+		}
 		return agent.Result{
 			Status: "timeout",
 			Error:  "agent did not produce result within drain timeout",


### PR DESCRIPTION
## Problem

When the server cancels a task (e.g. `assigneeChanged` while running, explicit user cancel, or workspace_isolation check fail), the daemon's polling goroutine calls `runCancel()` on the run context. The drain context derived from `runCtx` then signals `Done()`, but `executeAndDrain()` returned `Status: "timeout"` regardless of *why* the context ended.

The "agent finished status=timeout" log line was misleading — it suggests an actual deadline timeout when really the task was cancelled by upstream. We spent hours misdiagnosing a healthy handoff (executor → reviewer reassignment correctly cancelling the executor's now-redundant task) as a broken timeout because of this single misclassified log line.

## Fix

Distinguish `context.Canceled` from `context.DeadlineExceeded` in `executeAndDrain`, and add a `cancelled` case to `runTask` so the status propagates through the existing log path.

```go
case <-drainCtx.Done():
    if errors.Is(drainCtx.Err(), context.Canceled) {
        return agent.Result{
            Status: "cancelled",
            Error:  "task cancelled by upstream context (server cancel or daemon shutdown)",
        }, toolCount.Load(), nil
    }
    // ... existing timeout path
```

## Behaviour

- **No change** for genuine timeouts (`drainCtx` deadline expires on its own).
- **No change** for the `cancelledByPoll` discard path in `handleTask` (still discards result).
- **Accurate label** in the "agent finished" log line and `TaskResult.Status` so operators can distinguish "task cancelled by server" from a real timeout.

## Verification

Built locally, side-by-side comparison on the same `assignee_change → CancelTasksForIssue` flow:

```
Unpatched (v0.2.16):       agent finished status=timeout duration=13m25s
Patched (this PR):         agent finished status=cancelled duration=25s
```

Tests pass: `cd server && go test ./...`