### PR TITLE
ci(release): skip homebrew-tap publish on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,12 @@ jobs:
 
   release:
     needs: verify
+    # Only run on the canonical upstream repo. Forks don't have the
+    # HOMEBREW_TAP_GITHUB_TOKEN secret and should not be publishing to
+    # `multica-ai/homebrew-tap` anyway. Without this guard, every fork's
+    # tag push fails this job (401 against the upstream tap), which makes
+    # downstream CI go red without affecting the actual artifact pipeline.
+    if: github.repository_owner == 'multica-ai'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem

The release job uses GoReleaser to bump the formula in `multica-ai/homebrew-tap`. Forks don't have `HOMEBREW_TAP_GITHUB_TOKEN` and should not publish to that tap, so the job currently fails on every fork tag push:

```
error checking for default branch
projectID=multica-ai/homebrew-tap statusCode=401
error=GET https://api.github.com/repos/multica-ai/homebrew-tap: 401 Bad credentials
homebrew formula: could not get default branch: GET https://api.github.com/repos/multica-ai/homebrew-tap: 401 Bad credentials
```

This makes the workflow red on downstream forks (e.g. anyone running their own patched build), even though the actual artifact pipeline (`verify` → `docker-backend-build` → `docker-backend-merge`) succeeds and produces a usable image. The red CI is purely cosmetic but discourages contributors from running their own builds.

## Fix

Gate the release job on `github.repository_owner == 'multica-ai'`:

```yaml
release:
  needs: verify
  if: github.repository_owner == 'multica-ai'
  ...
```

## Behaviour

- **Upstream**: unchanged. `multica-ai/multica` still runs the release job on every tag push.
- **Forks**: release job is skipped. `verify`, `docker-backend-build`, `docker-backend-merge` and the web equivalents still run, producing usable docker artifacts in the fork's GHCR namespace.