### PR TITLE
test(daemon): cover cancelled classification in executeAndDrain

### DIFF
--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -421,6 +421,34 @@ func TestExecuteAndDrain_NoRetryWhenSessionEstablished(t *testing.T) {
 	}
 }
 
+// blockingBackend returns a Session whose Result channel is never written to,
+// so executeAndDrain can only exit via the drainCtx.Done() path.
+type blockingBackend struct{}
+
+func (blockingBackend) Execute(_ context.Context, _ string, _ agent.ExecOptions) (*agent.Session, error) {
+	msgCh := make(chan agent.Message)
+	resCh := make(chan agent.Result)
+	close(msgCh)
+	return &agent.Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func TestExecuteAndDrain_ContextCancelled_ReportsCancelled(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, _, err := d.executeAndDrain(ctx, blockingBackend{}, "p", agent.ExecOptions{}, slog.Default(), "t")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "cancelled" {
+		t.Fatalf("expected status=cancelled when parent ctx is cancelled, got %q (err=%q)", result.Status, result.Error)
+	}
+}
+
 func TestEnsureRepoReadyFastPathDoesNotRefresh(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -77,7 +77,7 @@ type TokenUsage struct {
 
 // Result is the final outcome after an agent session completes.
 type Result struct {
-	Status     string // "completed", "failed", "aborted", "timeout"
+	Status     string // "completed", "failed", "aborted", "timeout", "cancelled"
 	Output     string // accumulated text output
 	Error      string // error message if failed
 	DurationMs int64


### PR DESCRIPTION
## Summary

Follow-up to #1686 picking up the two non-blocking nits from the review:

- `agent.Result.Status` doc comment now lists `\"cancelled\"` alongside the other status values, so the documented enum matches actual usage after #1686.
- New `TestExecuteAndDrain_ContextCancelled_ReportsCancelled` locks in the cancel-vs-timeout classification: when the parent context is cancelled before the backend produces a `Result`, `executeAndDrain` must return `Status: \"cancelled\"` rather than `\"timeout\"`. A regression here would silently re-introduce the misleading log line that #1686 just fixed.

The test uses a tiny `blockingBackend` whose `Result` channel is never written to, so the only path out of `executeAndDrain` is `drainCtx.Done()`. The parent ctx is cancelled before the call, which propagates `context.Canceled` into `drainCtx.Err()` and exercises the new branch.

No production code change.

## Test plan

- [x] `cd server && go test ./internal/daemon/... -run TestExecuteAndDrain -count=1 -v` — all three pass
- [x] `cd server && go test ./internal/daemon/... ./pkg/agent/... -count=1` — green
- [x] `cd server && go vet ./internal/daemon/... ./pkg/agent/...` — clean