### PR TITLE
fix(settings): render invite role label via roleConfig in members tab

### DIFF
--- a/packages/views/settings/components/members-tab.tsx
+++ b/packages/views/settings/components/members-tab.tsx
@@ -310,10 +310,12 @@ export function MembersTab() {
                   }}
                 />
                 <Select value={inviteRole} onValueChange={(value) => setInviteRole(value as MemberRole)}>
-                  <SelectTrigger size="sm"><SelectValue /></SelectTrigger>
+                  <SelectTrigger size="sm">
+                    <SelectValue>{() => roleConfig[inviteRole].label}</SelectValue>
+                  </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="member">Member</SelectItem>
-                    <SelectItem value="admin">Admin</SelectItem>
+                    <SelectItem value="member">{roleConfig.member.label}</SelectItem>
+                    <SelectItem value="admin">{roleConfig.admin.label}</SelectItem>
                   </SelectContent>
                 </Select>
                 <Button


### PR DESCRIPTION
## What does this PR do?

Replaces the CSS-only fix from #1672 with the more idiomatic approach for the same bug ([#1671](https://github.com/multica-ai/multica/issues/1671)): the invite-member role `<Select>` was showing the raw value (`member`/`admin`) in the trigger instead of the display label, because Base UI's `<SelectValue />` renders the value by default.

This file already owns the `roleConfig` map (lines 46–50) — the canonical source of role display names that the rest of the file (e.g. `MemberRow`'s change-role dropdown) already uses. And the codebase already has an established render-prop pattern for `<SelectValue>` in:

- `packages/views/autopilots/components/trigger-config.tsx:301-303`
- `packages/views/skills/components/runtime-local-skill-import-panel.tsx:358-360`

So the fix here is:

```tsx
<SelectTrigger size="sm">
  <SelectValue>{() => roleConfig[inviteRole].label}</SelectValue>
</SelectTrigger>
<SelectContent>
  <SelectItem value="member">{roleConfig.member.label}</SelectItem>
  <SelectItem value="admin">{roleConfig.admin.label}</SelectItem>
</SelectContent>
```

Single source of truth for role labels; no CSS workaround.

## Related Issue

Closes #1671. Supersedes #1672.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor / code improvement (no behavior change)

## Changes Made

- `packages/views/settings/components/members-tab.tsx:312-318` — render `SelectValue` via `roleConfig[inviteRole].label`; reuse `roleConfig.{member,admin}.label` for the items.

## How to Test

1. Go to `/[workspace]/settings`, Members tab.
2. In the *Invite member* block, open the role select.
3. Pick *Member* — the trigger now shows `Member` (capitalized via the canonical label, not via CSS).
4. Pick *Admin* — trigger shows `Admin`.

## Why this instead of #1672

`className="capitalize"` happens to work today only because `MemberRole` is `"member" | "admin"` (single English words). The moment a multi-word role (`super_admin`, `Read Only`) or i18n is introduced, CSS `text-transform: capitalize` diverges from the dropdown labels; routing the trigger through `roleConfig.label` removes that whole class of future bug and keeps display-name logic in one place.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run `pnpm --filter @multica/views typecheck` locally — passes
- [x] No tests added — change is a 5-line render swap inside an existing UI block; covered by future E2E if needed
- [x] If this change affects the UI, I have included before/after screenshots — see #1672 for the same visual delta
- [x] I have updated relevant documentation to reflect my changes — N/A
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude (Multica agent J), invoked from Multica issue MUL-1411 after reviewing #1672.

**Prompt / approach:** Reviewed #1672, identified that the file already exposed `roleConfig` with proper labels and that two other files (`trigger-config.tsx`, `runtime-local-skill-import-panel.tsx`) used the `SelectValue` render-prop pattern; opened this PR per the maintainer's request.