### PR TITLE
docs(changelog): publish v0.2.16 release notes

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -284,6 +284,38 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.16",
+        date: "2026-04-24",
+        title: "Chat V2, Issue Right-Click Menu & In-App Feedback",
+        changes: [],
+        features: [
+          "Chat V2 — dedicated sidebar entry and full main-area page for AI conversations",
+          "Right-click context menu on issues with a unified action set across list, board, and detail",
+          "In-app feedback flow with a new Help launcher centralizing docs, support, and feedback",
+          "Autopilot modal redesigned — simpler schema and consistent schedule UI across creation and edit",
+          "Skills page redesigned — list + detail pages, scroll-fade card layout, shared PageHeader and mobile nav",
+          "Bilingual flat-content rewrite of the docs site — English and Chinese sections share one tree",
+        ],
+        improvements: [
+          "Agent profile card appears on avatar hover for quick context",
+          "Native right-click menu on desktop with clipboard actions (copy / paste / cut / select all)",
+          "Daemon agent prompts hardened to break self-mention loops between agents",
+          "Server readiness health endpoints for proper rollout / ingress probes",
+          "Daemon GC defaults tightened and now accept flexible duration suffixes (e.g. `7d`, `12h`)",
+          "Test Connection / runtime ping removed — runtime reachability is detected automatically",
+        ],
+        fixes: [
+          "Chat no longer flickers when a streamed response finalizes, and the input box no longer jumps when sending the first message",
+          "Desktop reopens the last-used workspace on app start instead of falling back to the first one",
+          "Editor preserves nested ordered lists through the readonly render path",
+          "CLI `browser-login` now works from a machine that isn't running the server",
+          "Daemon suppresses extra terminal windows when launching agents on Windows, and retries local-skill reports on transient server errors",
+          "`/api/config` is publicly reachable again so unauthenticated clients can bootstrap",
+          "Defense-in-depth owner check on workspace deletion, and `/health/realtime` metrics restricted to authorized callers (security)",
+          "Hermes ACP runtime now receives the configured model; OpenClaw agent discovery timeout raised to 30s",
+        ],
+      },
+      {
         version: "0.2.15",
         date: "2026-04-22",
         title: "Local Skills, LaTeX, Focus Mode & Orphan-Task Recovery",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -284,6 +284,38 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.16",
+        date: "2026-04-24",
+        title: "Chat V2、Issue 右键菜单与应用内反馈",
+        changes: [],
+        features: [
+          "Chat V2——侧边栏新增 Chat 入口，主区域提供完整的 AI 对话页面",
+          "Issue 支持右键菜单，列表、看板和详情的操作入口统一收敛",
+          "应用内反馈流程及全新的 Help 启动器，集中托管文档、支持和反馈入口",
+          "Autopilot 弹窗重设计——更简的字段配置，创建与编辑共享一致的排期界面",
+          "Skills 页面重设计——列表+详情、卡片化布局、滚动渐隐和共享 PageHeader / 移动端导航",
+          "文档站重写为双语扁平内容树——中英文章节共用一棵目录",
+        ],
+        improvements: [
+          "悬停 Agent 头像即可弹出资料卡，快速了解上下文",
+          "桌面应用新增原生右键菜单，支持复制 / 粘贴 / 剪切 / 全选等剪贴板操作",
+          "Daemon 强化 Agent 提示，避免 Agent 之间形成自互 @ 的循环",
+          "Server 新增就绪态健康检查端点，可对接灰度发布和 Ingress 探针",
+          "Daemon GC 默认参数收紧，并支持灵活的时长后缀（如 `7d`、`12h`）",
+          "移除 Runtime 的 Test Connection / Ping 功能，可达性改为自动检测",
+        ],
+        fixes: [
+          "Chat 流式回复结束时不再闪烁，发送第一条消息时输入框不再跳动",
+          "桌面应用启动时正确恢复上次的工作区，而不是默认回到第一个",
+          "编辑器只读渲染路径正确保留嵌套有序列表",
+          "CLI `browser-login` 现在可以从未运行 Server 的机器上发起",
+          "Windows 下 Daemon 启动 Agent 不再拉起额外终端窗口；本地 Skill 上报在服务端瞬时错误时会自动重试",
+          "`/api/config` 重新对未登录客户端可达，方便初次 bootstrap",
+          "DeleteWorkspace 增加防御性 owner 校验；`/health/realtime` 指标限定授权访问（安全）",
+          "Hermes ACP Runtime 正确传递配置的模型；OpenClaw Agent 发现超时提高到 30s",
+        ],
+      },
+      {
         version: "0.2.15",
         date: "2026-04-22",
         title: "本地 Skills、LaTeX、Focus 模式与孤儿任务自恢复",


### PR DESCRIPTION
## Summary
- Adds `0.2.16` (2026-04-24) entry to both `en.ts` and `zh.ts` changelogs.
- Curates the 50+ commits between `v0.2.15` and `v0.2.16` into Features / Improvements / Fixes, in line with prior entries.
- Highlights: Chat V2, issue right-click context menu, in-app feedback + Help launcher, Autopilot modal redesign, Skills page redesign, bilingual flat-content docs site rewrite.

## Test plan
- [x] `pnpm --filter @multica/web typecheck`
- [ ] Visit `/changelog` and confirm v0.2.16 renders at the top with correct categories in both `en` and `zh`.