### PR TITLE
refactor(execenv): collapse codex plugin cache stale-link branches

### DIFF
--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -131,17 +131,13 @@ func exposeSharedCodexPluginCache(codexHome, sharedHome string) error {
 	}
 
 	if fi, err := os.Lstat(dst); err == nil {
-		target, readlinkErr := os.Readlink(dst)
-		if readlinkErr == nil {
-			if target == src {
+		isLink := fi.Mode()&os.ModeSymlink != 0
+		if isLink {
+			if target, readlinkErr := os.Readlink(dst); readlinkErr == nil && target == src {
 				return nil
 			}
 			if err := os.Remove(dst); err != nil {
 				return fmt.Errorf("remove stale plugin cache link: %w", err)
-			}
-		} else if fi.Mode()&os.ModeSymlink != 0 {
-			if err := os.Remove(dst); err != nil {
-				return fmt.Errorf("remove stale plugin cache symlink: %w", err)
 			}
 		} else {
 			if err := os.RemoveAll(dst); err != nil {
@@ -212,7 +208,6 @@ func ensureSymlink(src, dst string) error {
 // sandbox/network directives now live in a managed block rendered by
 // codex_sandbox.go's ensureCodexSandboxConfig so they can be updated
 // idempotently without touching user-managed keys.)
-
 
 // copyFileIfExists copies src to dst. If src doesn't exist, it's a no-op.
 // If dst already exists, it's not overwritten.


### PR DESCRIPTION
## What does this PR do?

Follow-up nit from the review of #1668. `exposeSharedCodexPluginCache` had two `os.Remove` branches for stale symlinks — one when `Readlink` succeeded with a wrong target, one when `Readlink` failed but `Lstat` reported `ModeSymlink`. Both ran the same `os.Remove(dst)` + recreate-via-`createDirLink` flow, only the error message differed (`"remove stale plugin cache link"` vs `"remove stale plugin cache symlink"`).

This PR collapses them: branch on `Lstat`'s `ModeSymlink` bit, then call `Readlink` only as a fast-path for the already-correct link. Behaviour is unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests
- [ ] CI / infrastructure

## Changes Made

- Single symlink branch in `exposeSharedCodexPluginCache`, keyed off `Lstat` mode.
- One unified error message for stale-link removal.

## How to Test

- `cd server && go test -count=1 ./internal/daemon/execenv/` — existing regression tests in #1668 still cover the early-return, stale-link replacement, and reused-environment paths.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (no behaviour change → existing tests sufficient)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — backend-only)
- [x] I have updated relevant documentation to reflect my changes (no doc impact)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude (Multica agent J).

**Prompt / approach:** Cleanup follow-up to the PR #1668 review nit. No behaviour change, single-file diff.