### PR TITLE
fix(agent/claude): surface stderr tail on writeClaudeInput failure + lock with e2e test

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -97,10 +98,16 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		return nil, fmt.Errorf("start claude: %w", err)
 	}
 	if err := writeClaudeInput(stdin, prompt); err != nil {
+		// claude almost certainly died during startup (broken pipe). The
+		// real reason is sitting in stderrBuf — surface it the same way the
+		// post-handshake error path does, otherwise the daemon log is the
+		// only place that knows whether it was a V8 abort, a missing native
+		// module, or anything else. cmd.Wait() flushes os/exec's stderr
+		// copy goroutine, so stderrBuf.Tail() is safe to read.
 		closeStdin()
 		cancel()
 		_ = cmd.Wait()
-		return nil, fmt.Errorf("write claude input: %w", err)
+		return nil, errors.New(withAgentStderr(fmt.Sprintf("write claude input: %v", err), "claude", stderrBuf.Tail()))
 	}
 	closeStdin()
 

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -2,11 +2,15 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestClaudeHandleAssistantText(t *testing.T) {
@@ -530,6 +534,63 @@ func TestResolveSessionID(t *testing.T) {
 					tc.requested, tc.emitted, tc.failed, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestClaudeExecuteSurfacesStderrWhenChildExitsEarly(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	// Fake claude binary: drains stdin so writeClaudeInput succeeds, writes a
+	// canonical V8-abort line to stderr, then exits non-zero before emitting
+	// any stream-json to stdout. This is the exact failure mode that motivated
+	// PR #1674 — without sampling stderrBuf.Tail() after cmd.Wait() returns,
+	// Result.Error would be a useless "exit status 3".
+	fakePath := filepath.Join(t.TempDir(), "claude")
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"echo \"FATAL ERROR: V8 abort: assertion failed\" >&2\n" +
+		"exit 3\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("claude", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	// Drain message stream so the lifecycle goroutine can progress.
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "failed" {
+			t.Fatalf("expected status=failed, got %q (error=%q)", result.Status, result.Error)
+		}
+		if !strings.Contains(result.Error, "claude exited with error") {
+			t.Fatalf("expected error to mention exit, got %q", result.Error)
+		}
+		if !strings.Contains(result.Error, "V8 abort: assertion failed") {
+			t.Fatalf("expected error to include stderr hint, got %q", result.Error)
+		}
+		if !strings.Contains(result.Error, "claude stderr:") {
+			t.Fatalf("expected stderr label in error, got %q", result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1674. Two small fixes from the review thread:

1. **Wire the `writeClaudeInput` failure path through `withAgentStderr`.** #1674 plugged the post-handshake error branch into the shared stderr-tail helper, but the early branch in `claude.go:99-104` (which fires when claude dies during startup → broken pipe) was still returning a bare \"write claude input: broken pipe\". That's exactly the failure mode where the stderr tail matters most — a V8 abort, missing native module, or anything else that kills claude before it gets to ack stdin lands here, and the real reason was getting silently dropped on the floor. After this change, the daemon-visible error string carries the same `claude stderr: <tail>` suffix that the lifecycle goroutine path already produces. `cmd.Wait()` runs before `stderrBuf.Tail()` is sampled, matching the Wait→Tail synchronization contract documented in `stderr_tail.go`.

2. **Add `TestClaudeExecuteSurfacesStderrWhenChildExitsEarly`.** Direct analogue of the codex test in #1674: a fake claude binary drains stdin (so `writeClaudeInput` succeeds), writes a canonical V8-abort line to stderr, and exits 3. Asserts `Result.Status == \"failed\"` and `Result.Error` contains both `\"claude exited with error\"` and the stderr tail. This locks in the post-handshake contract for the claude backend the same way `TestCodexExecuteSurfacesStderrWhenChildExitsEarly` locks it for codex.

I considered also adding a deterministic test for the `writeClaudeInput` early-failure path, but it's race-prone: pipe buffering means the parent's small JSON write usually completes regardless of how fast the child exits, so the failure branch can't be reliably triggered from a shell-script fake. The code change is small and reads cleanly from the diff.

## Test plan

- [x] `go build ./...` (linux/amd64)
- [x] `GOOS=windows GOARCH=amd64 go build ./...`
- [x] `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go vet ./pkg/agent/...`
- [x] `go test ./pkg/agent -count=1` — all green; new test passes in ~0.4s on macOS arm64.