### PR TITLE
P0: isolate Redis relay pools

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -18,6 +18,31 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+func newNamedRedisClient(base *redis.Options, suffix string) *redis.Client {
+	opts := *base
+	opts.ClientName = redisClientName(opts.ClientName, suffix)
+	return redis.NewClient(&opts)
+}
+
+func redisClientName(existing, suffix string) string {
+	if suffix == "" {
+		return existing
+	}
+	if existing != "" {
+		return existing + ":" + suffix
+	}
+	return "multica-api:" + suffix
+}
+
+func closeRedisClient(label string, client *redis.Client) {
+	if client == nil {
+		return
+	}
+	if err := client.Close(); err != nil {
+		slog.Warn("redis client close failed", "client", label, "error", err)
+	}
+}
+
 func main() {
 	logger.Init()
 
@@ -62,22 +87,35 @@ func main() {
 	// MUL-1138: when REDIS_URL is set, route fanout through a Redis relay so
 	// multiple API nodes can deliver each other's events. Without it the hub
 	// is the sole broadcaster and the server stays single-node (legacy).
-	// The same client is also used for cross-node request stores (e.g. runtime
-	// local-skill pending requests) so every node sees the same pending set.
+	// Runtime local-skill stores and realtime relay traffic use separate Redis
+	// clients so blocking stream consumers cannot starve request-path Redis
+	// operations.
 	relayCtx, relayCancel := context.WithCancel(context.Background())
 	defer relayCancel()
 	var broadcaster realtime.Broadcaster = hub
-	var rdb *redis.Client
+	var storeRedis *redis.Client
 	if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {
 		opts, err := redis.ParseURL(redisURL)
 		if err != nil {
 			slog.Error("invalid REDIS_URL — falling back to in-memory hub", "error", err)
 		} else {
-			rdb = redis.NewClient(opts)
-			relay := realtime.NewRedisRelay(hub, rdb)
+			storeRedis = newNamedRedisClient(opts, "store")
+			relayWriteRedis := newNamedRedisClient(opts, "realtime-write")
+			relayReadRedis := newNamedRedisClient(opts, "realtime-read")
+			defer closeRedisClient("store", storeRedis)
+			defer closeRedisClient("realtime-write", relayWriteRedis)
+			defer closeRedisClient("realtime-read", relayReadRedis)
+
+			relay := realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
 			relay.Start(relayCtx)
-			broadcaster = relay
-			slog.Info("realtime: Redis relay enabled", "node_id", relay.NodeID())
+			broadcaster = realtime.NewDualWriteBroadcaster(hub, relay)
+			slog.Info(
+				"realtime: Redis relay enabled",
+				"node_id", relay.NodeID(),
+				"store_pool_size", opts.PoolSize,
+				"realtime_write_pool_size", opts.PoolSize,
+				"realtime_read_pool_size", opts.PoolSize,
+			)
 		}
 	} else {
 		slog.Info("realtime: REDIS_URL not set — using in-memory hub (single-node mode)")
@@ -96,7 +134,7 @@ func main() {
 	registerActivityListeners(bus, queries)
 	registerNotificationListeners(bus, queries)
 
-	r := NewRouter(pool, hub, bus, analyticsClient, rdb)
+	r := NewRouter(pool, hub, bus, analyticsClient, storeRedis)
 
 	srv := &http.Server{
 		Addr:    ":" + port,

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -91,22 +91,33 @@ func main() {
 	// clients so blocking stream consumers cannot starve request-path Redis
 	// operations.
 	relayCtx, relayCancel := context.WithCancel(context.Background())
-	defer relayCancel()
 	var broadcaster realtime.Broadcaster = hub
 	var storeRedis *redis.Client
+	var relayWriteRedis *redis.Client
+	var relayReadRedis *redis.Client
+	var relay *realtime.RedisRelay
+	defer func() {
+		if relay != nil {
+			relay.Stop()
+		}
+		relayCancel()
+		if relay != nil {
+			relay.Wait()
+		}
+		closeRedisClient("realtime-read", relayReadRedis)
+		closeRedisClient("realtime-write", relayWriteRedis)
+		closeRedisClient("store", storeRedis)
+	}()
 	if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {
 		opts, err := redis.ParseURL(redisURL)
 		if err != nil {
 			slog.Error("invalid REDIS_URL — falling back to in-memory hub", "error", err)
 		} else {
 			storeRedis = newNamedRedisClient(opts, "store")
-			relayWriteRedis := newNamedRedisClient(opts, "realtime-write")
-			relayReadRedis := newNamedRedisClient(opts, "realtime-read")
-			defer closeRedisClient("store", storeRedis)
-			defer closeRedisClient("realtime-write", relayWriteRedis)
-			defer closeRedisClient("realtime-read", relayReadRedis)
+			relayWriteRedis = newNamedRedisClient(opts, "realtime-write")
+			relayReadRedis = newNamedRedisClient(opts, "realtime-read")
 
-			relay := realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
+			relay = realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
 			relay.Start(relayCtx)
 			broadcaster = realtime.NewDualWriteBroadcaster(hub, relay)
 			slog.Info(

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -57,8 +57,10 @@ func allowedOrigins() []string {
 // NewRouter creates the fully-configured Chi router with all middleware and routes.
 // rdb is optional: when non-nil the runtime local-skill request stores are
 // swapped for Redis-backed implementations so multiple API nodes share the
-// same pending queue (required for multi-node prod). A nil rdb keeps the
-// default in-memory stores which are fine for single-node dev and tests.
+// same pending queue (required for multi-node prod). This should be a request
+// path Redis client, not the realtime relay's blocking read client. A nil rdb
+// keeps the default in-memory stores which are fine for single-node dev and
+// tests.
 func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus, analyticsClient analytics.Client, rdb *redis.Client) chi.Router {
 	queries := db.New(pool)
 	emailSvc := service.NewEmailService()

--- a/server/internal/realtime/redis_relay.go
+++ b/server/internal/realtime/redis_relay.go
@@ -58,6 +58,8 @@ type RedisRelay struct {
 
 	mu        sync.Mutex
 	consumers map[scopeKey]*scopeConsumer
+	stopping  bool
+	wg        sync.WaitGroup
 }
 
 type scopeConsumer struct {
@@ -91,6 +93,26 @@ func NewRedisRelayWithClients(hub *Hub, writeRDB, readRDB *redis.Client) *RedisR
 // NodeID returns this relay's randomly-assigned node identifier.
 func (r *RedisRelay) NodeID() string { return r.nodeID }
 
+// Wait blocks until all relay-owned goroutines have exited after the Start
+// context is canceled.
+func (r *RedisRelay) Wait() {
+	r.wg.Wait()
+}
+
+// Stop prevents new scope consumers from being started and cancels any active
+// consumers. The Start context still controls heartbeat and sweeper shutdown;
+// callers should cancel it before calling Wait.
+func (r *RedisRelay) Stop() {
+	r.hub.SetSubscriptionCallbacks(nil, nil)
+
+	r.mu.Lock()
+	r.stopping = true
+	for _, c := range r.consumers {
+		c.cancel()
+	}
+	r.mu.Unlock()
+}
+
 // Start wires the hub→relay subscription callbacks, kicks off the heartbeat
 // goroutine, and spins up consumers for any scopes the hub already knows
 // about. ctx controls all background goroutines: cancelling it shuts the
@@ -122,8 +144,15 @@ func (r *RedisRelay) Start(ctx context.Context) {
 		r.startConsumer(ctx, key.Type, key.ID)
 	}
 
-	go r.heartbeatLoop(ctx)
-	go r.consumerSweeper(ctx)
+	r.wg.Add(2)
+	go func() {
+		defer r.wg.Done()
+		r.heartbeatLoop(ctx)
+	}()
+	go func() {
+		defer r.wg.Done()
+		r.consumerSweeper(ctx)
+	}()
 }
 
 // BroadcastToScope publishes message into the scope's Redis stream. The
@@ -204,6 +233,10 @@ func (r *RedisRelay) publish(scopeType, scopeID, exclude string, frame []byte) {
 func (r *RedisRelay) startConsumer(parent context.Context, scopeType, scopeID string) {
 	key := sk(scopeType, scopeID)
 	r.mu.Lock()
+	if r.stopping || parent.Err() != nil {
+		r.mu.Unlock()
+		return
+	}
 	if _, exists := r.consumers[key]; exists {
 		r.mu.Unlock()
 		return
@@ -211,9 +244,13 @@ func (r *RedisRelay) startConsumer(parent context.Context, scopeType, scopeID st
 	ctx, cancel := context.WithCancel(parent)
 	c := &scopeConsumer{cancel: cancel, done: make(chan struct{})}
 	r.consumers[key] = c
+	r.wg.Add(1)
 	r.mu.Unlock()
 
-	go r.runConsumer(ctx, c, scopeType, scopeID)
+	go func() {
+		defer r.wg.Done()
+		r.runConsumer(ctx, c, scopeType, scopeID)
+	}()
 }
 
 func (r *RedisRelay) stopConsumer(scopeType, scopeID string) {

--- a/server/internal/realtime/redis_relay.go
+++ b/server/internal/realtime/redis_relay.go
@@ -51,9 +51,10 @@ type envelope struct {
 // per-scope Redis Stream and consumes streams for which there are local
 // subscribers. Local fanout is delegated to the wrapped *Hub.
 type RedisRelay struct {
-	hub    *Hub
-	rdb    *redis.Client
-	nodeID string
+	hub      *Hub
+	writeRDB *redis.Client
+	readRDB  *redis.Client
+	nodeID   string
 
 	mu        sync.Mutex
 	consumers map[scopeKey]*scopeConsumer
@@ -67,9 +68,21 @@ type scopeConsumer struct {
 // NewRedisRelay constructs a relay. The caller is responsible for invoking
 // Start before producing messages.
 func NewRedisRelay(hub *Hub, rdb *redis.Client) *RedisRelay {
+	return NewRedisRelayWithClients(hub, rdb, rdb)
+}
+
+// NewRedisRelayWithClients constructs a relay with separate Redis clients for
+// writes and blocking reads. The read client is reserved for XREADGROUP BLOCK
+// calls so long-polling stream consumers cannot exhaust the pool used by XADD,
+// heartbeats, acks, and other request-path Redis operations.
+func NewRedisRelayWithClients(hub *Hub, writeRDB, readRDB *redis.Client) *RedisRelay {
+	if readRDB == nil {
+		readRDB = writeRDB
+	}
 	return &RedisRelay{
 		hub:       hub,
-		rdb:       rdb,
+		writeRDB:  writeRDB,
+		readRDB:   readRDB,
 		nodeID:    ulid.Make().String(),
 		consumers: make(map[scopeKey]*scopeConsumer),
 	}
@@ -84,10 +97,18 @@ func (r *RedisRelay) NodeID() string { return r.nodeID }
 // relay down.
 func (r *RedisRelay) Start(ctx context.Context) {
 	M.NodeID.Store(r.nodeID)
-	if err := r.rdb.Ping(ctx).Err(); err != nil {
+	if err := r.writeRDB.Ping(ctx).Err(); err != nil {
 		slog.Error("realtime/redis: initial ping failed", "error", err)
 		M.RedisConnected.Store(false)
 		M.SetRedisLastError(err.Error())
+	} else if r.readRDB != r.writeRDB {
+		if err := r.readRDB.Ping(ctx).Err(); err != nil {
+			slog.Error("realtime/redis: initial read-client ping failed", "error", err)
+			M.RedisConnected.Store(false)
+			M.SetRedisLastError(err.Error())
+		} else {
+			M.RedisConnected.Store(true)
+		}
 	} else {
 		M.RedisConnected.Store(true)
 	}
@@ -168,7 +189,7 @@ func (r *RedisRelay) publish(scopeType, scopeID, exclude string, frame []byte) {
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := r.rdb.XAdd(ctx, args).Err(); err != nil {
+	if err := r.writeRDB.XAdd(ctx, args).Err(); err != nil {
 		M.RedisXAddErrors.Add(1)
 		M.SetRedisLastError(err.Error())
 		slog.Warn("realtime/redis: XADD failed", "error", err, "scope", scopeType, "scope_id", scopeID)
@@ -218,14 +239,14 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 
 	// MKSTREAM ensures the stream exists. Ignore BUSYGROUP.
 	createCtx, createCancel := context.WithTimeout(ctx, 2*time.Second)
-	if err := r.rdb.XGroupCreateMkStream(createCtx, stream, group, "$").Err(); err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
+	if err := r.writeRDB.XGroupCreateMkStream(createCtx, stream, group, "$").Err(); err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
 		slog.Warn("realtime/redis: XGROUP CREATE failed", "error", err, "scope", scopeType, "scope_id", scopeID)
 	}
 	createCancel()
 
 	// Register ourselves as a node interested in this scope.
 	regCtx, regCancel := context.WithTimeout(ctx, 2*time.Second)
-	r.rdb.ZAdd(regCtx, NodesKey(scopeType, scopeID), redis.Z{Score: float64(time.Now().Add(heartbeatTTL).Unix()), Member: r.nodeID})
+	r.writeRDB.ZAdd(regCtx, NodesKey(scopeType, scopeID), redis.Z{Score: float64(time.Now().Add(heartbeatTTL).Unix()), Member: r.nodeID})
 	regCancel()
 
 	for {
@@ -233,7 +254,7 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 			break
 		}
 		readCtx, readCancel := context.WithTimeout(ctx, 6*time.Second)
-		res, err := r.rdb.XReadGroup(readCtx, &redis.XReadGroupArgs{
+		res, err := r.readRDB.XReadGroup(readCtx, &redis.XReadGroupArgs{
 			Group:    group,
 			Consumer: consumerName,
 			Streams:  []string{stream, ">"},
@@ -260,7 +281,7 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 				M.RedisXReadTotal.Add(1)
 				r.deliverMessage(scopeType, scopeID, msg)
 				ackCtx, ackCancel := context.WithTimeout(ctx, time.Second)
-				if err := r.rdb.XAck(ackCtx, stream, group, msg.ID).Err(); err != nil {
+				if err := r.writeRDB.XAck(ackCtx, stream, group, msg.ID).Err(); err != nil {
 					slog.Debug("realtime/redis: XACK failed", "error", err, "id", msg.ID)
 				} else {
 					M.RedisAckTotal.Add(1)
@@ -272,7 +293,7 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 
 	// Best-effort consumer cleanup.
 	cleanCtx, cleanCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	r.rdb.XGroupDelConsumer(cleanCtx, stream, group, consumerName)
+	r.writeRDB.XGroupDelConsumer(cleanCtx, stream, group, consumerName)
 	cleanCancel()
 }
 
@@ -319,7 +340,7 @@ func (r *RedisRelay) heartbeatLoop(ctx context.Context) {
 func (r *RedisRelay) heartbeatOnce(ctx context.Context) {
 	hbCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	if err := r.rdb.Set(hbCtx, HeartbeatKey(r.nodeID), time.Now().UTC().Format(time.RFC3339Nano), heartbeatTTL).Err(); err != nil {
+	if err := r.writeRDB.Set(hbCtx, HeartbeatKey(r.nodeID), time.Now().UTC().Format(time.RFC3339Nano), heartbeatTTL).Err(); err != nil {
 		M.RedisConnected.Store(false)
 		M.SetRedisLastError(err.Error())
 		return
@@ -327,7 +348,7 @@ func (r *RedisRelay) heartbeatOnce(ctx context.Context) {
 	M.RedisConnected.Store(true)
 	expiry := float64(time.Now().Add(heartbeatTTL).Unix())
 	for _, key := range r.hub.LocalScopes() {
-		r.rdb.ZAdd(hbCtx, NodesKey(key.Type, key.ID), redis.Z{Score: expiry, Member: r.nodeID})
+		r.writeRDB.ZAdd(hbCtx, NodesKey(key.Type, key.ID), redis.Z{Score: expiry, Member: r.nodeID})
 	}
 }
 
@@ -347,7 +368,7 @@ func (r *RedisRelay) consumerSweeper(ctx context.Context) {
 		now := float64(time.Now().Unix())
 		for _, key := range r.hub.LocalScopes() {
 			swCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			r.rdb.ZRemRangeByScore(swCtx, NodesKey(key.Type, key.ID), "-inf", fmt.Sprintf("%f", now))
+			r.writeRDB.ZRemRangeByScore(swCtx, NodesKey(key.Type, key.ID), "-inf", fmt.Sprintf("%f", now))
 			cancel()
 		}
 	}
@@ -395,10 +416,18 @@ func injectEventID(frame []byte, eventID string) []byte {
 // the Redis relay loops the message back.
 type DualWriteBroadcaster struct {
 	local *Hub
-	relay *RedisRelay
+	relay relayPublisher
 }
 
 func NewDualWriteBroadcaster(local *Hub, relay *RedisRelay) *DualWriteBroadcaster {
+	return newDualWriteBroadcaster(local, relay)
+}
+
+type relayPublisher interface {
+	publishWithID(scopeType, scopeID, exclude string, frame []byte, id string)
+}
+
+func newDualWriteBroadcaster(local *Hub, relay relayPublisher) *DualWriteBroadcaster {
 	return &DualWriteBroadcaster{local: local, relay: relay}
 }
 
@@ -470,9 +499,10 @@ func (r *RedisRelay) publishWithID(scopeType, scopeID, exclude string, frame []b
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := r.rdb.XAdd(ctx, args).Err(); err != nil {
+	if err := r.writeRDB.XAdd(ctx, args).Err(); err != nil {
 		M.RedisXAddErrors.Add(1)
 		M.SetRedisLastError(err.Error())
+		slog.Warn("realtime/redis: XADD failed", "error", err, "scope", scopeType, "scope_id", scopeID)
 		return
 	}
 	M.RedisXAddTotal.Add(1)

--- a/server/internal/realtime/redis_relay_test.go
+++ b/server/internal/realtime/redis_relay_test.go
@@ -1,6 +1,7 @@
 package realtime
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -25,6 +26,24 @@ func TestNewRedisRelayWithClientsSeparatesBlockingReadPool(t *testing.T) {
 	if relay.readRDB != readClient {
 		t.Fatal("expected relay to reserve the read client for blocking XREADGROUP calls")
 	}
+}
+
+func TestRedisRelayStopPreventsNewConsumers(t *testing.T) {
+	hub := NewHub()
+	client := redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})
+	t.Cleanup(func() { client.Close() })
+
+	relay := NewRedisRelay(hub, client)
+	relay.Stop()
+	relay.startConsumer(context.Background(), ScopeWorkspace, "workspace-1")
+
+	relay.mu.Lock()
+	consumerCount := len(relay.consumers)
+	relay.mu.Unlock()
+	if consumerCount != 0 {
+		t.Fatalf("expected no consumers after Stop, got %d", consumerCount)
+	}
+	relay.Wait()
 }
 
 func TestDualWriteBroadcasterFansOutLocallyBeforePublishing(t *testing.T) {

--- a/server/internal/realtime/redis_relay_test.go
+++ b/server/internal/realtime/redis_relay_test.go
@@ -1,0 +1,109 @@
+package realtime
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestNewRedisRelayWithClientsSeparatesBlockingReadPool(t *testing.T) {
+	hub := NewHub()
+	writeClient := redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})
+	readClient := redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})
+	t.Cleanup(func() {
+		writeClient.Close()
+		readClient.Close()
+	})
+
+	relay := NewRedisRelayWithClients(hub, writeClient, readClient)
+
+	if relay.writeRDB != writeClient {
+		t.Fatal("expected relay to use the write client for non-blocking Redis commands")
+	}
+	if relay.readRDB != readClient {
+		t.Fatal("expected relay to reserve the read client for blocking XREADGROUP calls")
+	}
+}
+
+func TestDualWriteBroadcasterFansOutLocallyBeforePublishing(t *testing.T) {
+	hub := NewHub()
+	client := attachRealtimeTestClient(hub, ScopeWorkspace, "workspace-1")
+	publisher := &localFirstPublisher{t: t, client: client}
+	broadcaster := newDualWriteBroadcaster(hub, publisher)
+	message := []byte(`{"type":"issue:updated"}`)
+
+	broadcaster.BroadcastToScope(ScopeWorkspace, "workspace-1", message)
+
+	if !publisher.called {
+		t.Fatal("expected relay publish to be invoked")
+	}
+	if publisher.scopeType != ScopeWorkspace || publisher.scopeID != "workspace-1" {
+		t.Fatalf("unexpected relay scope: %s/%s", publisher.scopeType, publisher.scopeID)
+	}
+	if string(publisher.frame) != string(message) {
+		t.Fatalf("expected relay payload to remain unchanged, got %s", publisher.frame)
+	}
+
+	var localFrame map[string]any
+	if err := json.Unmarshal(publisher.localFrame, &localFrame); err != nil {
+		t.Fatalf("local frame is not JSON: %v", err)
+	}
+	if localFrame["event_id"] != publisher.eventID {
+		t.Fatalf("expected local frame event_id %q, got %v", publisher.eventID, localFrame["event_id"])
+	}
+
+	hub.BroadcastToScopeDedup(ScopeWorkspace, "workspace-1", injectEventID(message, publisher.eventID), publisher.eventID)
+	select {
+	case duplicate := <-client.send:
+		t.Fatalf("expected redis loopback to dedup, got duplicate %s", duplicate)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func attachRealtimeTestClient(hub *Hub, scopeType, scopeID string) *Client {
+	client := &Client{
+		send:          make(chan []byte, 2),
+		workspaceID:   "workspace-1",
+		userID:        "user-1",
+		subscriptions: map[scopeKey]bool{},
+	}
+	key := sk(scopeType, scopeID)
+	client.subscriptions[key] = true
+
+	hub.mu.Lock()
+	hub.clients[client] = true
+	hub.rooms[key] = map[*Client]bool{client: true}
+	hub.mu.Unlock()
+
+	return client
+}
+
+type localFirstPublisher struct {
+	t      *testing.T
+	client *Client
+
+	called     bool
+	scopeType  string
+	scopeID    string
+	exclude    string
+	frame      []byte
+	eventID    string
+	localFrame []byte
+}
+
+func (p *localFirstPublisher) publishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+	p.called = true
+	p.scopeType = scopeType
+	p.scopeID = scopeID
+	p.exclude = exclude
+	p.frame = append([]byte(nil), frame...)
+	p.eventID = id
+
+	select {
+	case p.localFrame = <-p.client.send:
+	default:
+		p.t.Fatal("expected local fanout to happen before relay publish")
+	}
+}


### PR DESCRIPTION
## Summary

- split production Redis usage into separate clients for local-skill state, realtime write/control commands, and blocking realtime stream reads
- enable the existing dual-write broadcaster so local WebSocket clients receive events before the Redis relay publish path
- reserve the realtime read client for `XREADGROUP BLOCK`; `XADD`, `XACK`, `XGROUP`, heartbeat, and registry writes now use the non-blocking write client

## Validation

- `go test ./internal/realtime`
- `go test ./cmd/server -run '^$'`

Full `go test ./cmd/server` was also attempted, but the local test DB schema is stale and fails before this change path (`project_id` column missing, `autopilot` table missing, readiness/auth integration failures).
