### PR TITLE
Implement sharded Redis realtime relay

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -41,6 +43,69 @@ func closeRedisClient(label string, client *redis.Client) {
 	if err := client.Close(); err != nil {
 		slog.Warn("redis client close failed", "client", label, "error", err)
 	}
+}
+
+func shardedRelayConfigFromEnv() realtime.ShardedStreamRelayConfig {
+	cfg := realtime.DefaultShardedStreamRelayConfig()
+	cfg.Shards = envPositiveInt("REALTIME_RELAY_SHARDS", cfg.Shards)
+	cfg.StreamMaxLen = envPositiveInt64("REALTIME_RELAY_STREAM_MAXLEN", cfg.StreamMaxLen)
+	cfg.ReadCount = envPositiveInt64("REALTIME_RELAY_XREAD_COUNT", cfg.ReadCount)
+	cfg.ReadBlock = envDuration("REALTIME_RELAY_XREAD_BLOCK", cfg.ReadBlock)
+	return cfg
+}
+
+func realtimeRelayModeFromEnv() string {
+	const defaultMode = "sharded"
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("REALTIME_RELAY_MODE")))
+	if raw == "" {
+		return defaultMode
+	}
+	switch raw {
+	case "sharded", "dual", "legacy":
+		return raw
+	default:
+		slog.Warn("invalid env var, using default", "name", "REALTIME_RELAY_MODE", "value", raw, "default", defaultMode)
+		return defaultMode
+	}
+}
+
+func envPositiveInt(name string, def int) int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		slog.Warn("invalid env var, using default", "name", name, "value", raw, "default", def, "error", err)
+		return def
+	}
+	return v
+}
+
+func envPositiveInt64(name string, def int64) int64 {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v <= 0 {
+		slog.Warn("invalid env var, using default", "name", name, "value", raw, "default", def, "error", err)
+		return def
+	}
+	return v
+}
+
+func envDuration(name string, def time.Duration) time.Duration {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return def
+	}
+	v, err := time.ParseDuration(raw)
+	if err != nil || v <= 0 {
+		slog.Warn("invalid env var, using default", "name", name, "value", raw, "default", def.String(), "error", err)
+		return def
+	}
+	return v
 }
 
 func main() {
@@ -95,7 +160,7 @@ func main() {
 	var storeRedis *redis.Client
 	var relayWriteRedis *redis.Client
 	var relayReadRedis *redis.Client
-	var relay *realtime.RedisRelay
+	var relay realtime.ManagedRelay
 	defer func() {
 		if relay != nil {
 			relay.Stop()
@@ -117,12 +182,28 @@ func main() {
 			relayWriteRedis = newNamedRedisClient(opts, "realtime-write")
 			relayReadRedis = newNamedRedisClient(opts, "realtime-read")
 
-			relay = realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
+			relayMode := realtimeRelayModeFromEnv()
+			relayConfig := shardedRelayConfigFromEnv()
+			switch relayMode {
+			case "legacy":
+				relay = realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
+			case "dual":
+				sharded := realtime.NewShardedStreamRelay(hub, relayWriteRedis, relayReadRedis, relayConfig)
+				legacy := realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
+				relay = realtime.NewMirroredRelay(sharded, legacy)
+			default:
+				relay = realtime.NewShardedStreamRelay(hub, relayWriteRedis, relayReadRedis, relayConfig)
+			}
 			relay.Start(relayCtx)
 			broadcaster = realtime.NewDualWriteBroadcaster(hub, relay)
 			slog.Info(
 				"realtime: Redis relay enabled",
 				"node_id", relay.NodeID(),
+				"mode", relayMode,
+				"shards", relayConfig.Shards,
+				"stream_max_len", relayConfig.StreamMaxLen,
+				"xread_count", relayConfig.ReadCount,
+				"xread_block", relayConfig.ReadBlock.String(),
 				"store_pool_size", opts.PoolSize,
 				"realtime_write_pool_size", opts.PoolSize,
 				"realtime_read_pool_size", opts.PoolSize,

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -160,6 +160,8 @@ func main() {
 	var storeRedis *redis.Client
 	var relayWriteRedis *redis.Client
 	var relayReadRedis *redis.Client
+	var shardedReadRedis *redis.Client
+	var legacyReadRedis *redis.Client
 	var relay realtime.ManagedRelay
 	defer func() {
 		if relay != nil {
@@ -169,6 +171,8 @@ func main() {
 		if relay != nil {
 			relay.Wait()
 		}
+		closeRedisClient("realtime-read-legacy", legacyReadRedis)
+		closeRedisClient("realtime-read-sharded", shardedReadRedis)
 		closeRedisClient("realtime-read", relayReadRedis)
 		closeRedisClient("realtime-write", relayWriteRedis)
 		closeRedisClient("store", storeRedis)
@@ -180,18 +184,21 @@ func main() {
 		} else {
 			storeRedis = newNamedRedisClient(opts, "store")
 			relayWriteRedis = newNamedRedisClient(opts, "realtime-write")
-			relayReadRedis = newNamedRedisClient(opts, "realtime-read")
 
 			relayMode := realtimeRelayModeFromEnv()
 			relayConfig := shardedRelayConfigFromEnv()
 			switch relayMode {
 			case "legacy":
+				relayReadRedis = newNamedRedisClient(opts, "realtime-read")
 				relay = realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
 			case "dual":
-				sharded := realtime.NewShardedStreamRelay(hub, relayWriteRedis, relayReadRedis, relayConfig)
-				legacy := realtime.NewRedisRelayWithClients(hub, relayWriteRedis, relayReadRedis)
+				shardedReadRedis = newNamedRedisClient(opts, "realtime-read-sharded")
+				legacyReadRedis = newNamedRedisClient(opts, "realtime-read-legacy")
+				sharded := realtime.NewShardedStreamRelay(hub, relayWriteRedis, shardedReadRedis, relayConfig)
+				legacy := realtime.NewRedisRelayWithClients(hub, relayWriteRedis, legacyReadRedis)
 				relay = realtime.NewMirroredRelay(sharded, legacy)
 			default:
+				relayReadRedis = newNamedRedisClient(opts, "realtime-read")
 				relay = realtime.NewShardedStreamRelay(hub, relayWriteRedis, relayReadRedis, relayConfig)
 			}
 			relay.Start(relayCtx)

--- a/server/internal/realtime/metrics.go
+++ b/server/internal/realtime/metrics.go
@@ -32,12 +32,15 @@ type Metrics struct {
 	scopeRooms           sync.Map
 
 	// Redis relay counters. Zero unless the Redis broadcaster is enabled.
-	RedisXAddTotal    atomic.Int64
-	RedisXAddErrors   atomic.Int64
-	RedisXReadTotal   atomic.Int64
-	RedisXReadErrors  atomic.Int64
-	RedisAckTotal     atomic.Int64
-	RedisLastXAddLagMicros atomic.Int64
+	RedisXAddTotal             atomic.Int64
+	RedisXAddErrors            atomic.Int64
+	RedisXReadTotal            atomic.Int64
+	RedisXReadErrors           atomic.Int64
+	RedisAckTotal              atomic.Int64
+	RedisLastXAddLagMicros     atomic.Int64
+	RedisMirrorPrimaryErrors   atomic.Int64
+	RedisMirrorSecondaryErrors atomic.Int64
+	RedisMirrorDivergenceTotal atomic.Int64
 
 	// RedisConnected is set by the relay on startup / reconnect.
 	RedisConnected atomic.Bool
@@ -141,15 +144,18 @@ func (m *Metrics) Snapshot() map[string]any {
 		"subscribe_denied_total": snapshotCounters(&m.subscribeDeniedTotal),
 		"active_scope_rooms":     snapshotCounters(&m.scopeRooms),
 		"redis": map[string]any{
-			"connected":             m.RedisConnected.Load(),
-			"node_id":               nodeID,
-			"xadd_total":            m.RedisXAddTotal.Load(),
-			"xadd_errors":           m.RedisXAddErrors.Load(),
-			"xread_total":           m.RedisXReadTotal.Load(),
-			"xread_errors":          m.RedisXReadErrors.Load(),
-			"ack_total":             m.RedisAckTotal.Load(),
-			"last_xadd_lag_micros":  m.RedisLastXAddLagMicros.Load(),
-			"last_error":            m.lastRedisErr(),
+			"connected":               m.RedisConnected.Load(),
+			"node_id":                 nodeID,
+			"xadd_total":              m.RedisXAddTotal.Load(),
+			"xadd_errors":             m.RedisXAddErrors.Load(),
+			"xread_total":             m.RedisXReadTotal.Load(),
+			"xread_errors":            m.RedisXReadErrors.Load(),
+			"ack_total":               m.RedisAckTotal.Load(),
+			"last_xadd_lag_micros":    m.RedisLastXAddLagMicros.Load(),
+			"mirror_primary_errors":   m.RedisMirrorPrimaryErrors.Load(),
+			"mirror_secondary_errors": m.RedisMirrorSecondaryErrors.Load(),
+			"mirror_divergence_total": m.RedisMirrorDivergenceTotal.Load(),
+			"last_error":              m.lastRedisErr(),
 		},
 	}
 }
@@ -173,6 +179,9 @@ func (m *Metrics) Reset() {
 	m.RedisXReadErrors.Store(0)
 	m.RedisAckTotal.Store(0)
 	m.RedisLastXAddLagMicros.Store(0)
+	m.RedisMirrorPrimaryErrors.Store(0)
+	m.RedisMirrorSecondaryErrors.Store(0)
+	m.RedisMirrorDivergenceTotal.Store(0)
 	m.RedisConnected.Store(false)
 	m.SetRedisLastError("")
 }

--- a/server/internal/realtime/redis_relay.go
+++ b/server/internal/realtime/redis_relay.go
@@ -497,7 +497,7 @@ type DualWriteBroadcaster struct {
 // RelayPublisher is implemented by Redis relay backends that can publish a
 // caller-supplied event id for local/Redis loopback deduplication.
 type RelayPublisher interface {
-	PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string)
+	PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error
 }
 
 func NewDualWriteBroadcaster(local *Hub, relay RelayPublisher) *DualWriteBroadcaster {
@@ -514,7 +514,7 @@ func (d *DualWriteBroadcaster) BroadcastToScope(scopeType, scopeID string, messa
 	// Local fast path: BroadcastToScopeDedup marks each client as having
 	// seen `id`, so the Redis loopback for the same id will be ignored.
 	d.local.BroadcastToScopeDedup(scopeType, scopeID, frame, id)
-	d.relay.PublishWithID(scopeType, scopeID, "", message, id)
+	_ = d.relay.PublishWithID(scopeType, scopeID, "", message, id)
 }
 
 func (d *DualWriteBroadcaster) BroadcastToWorkspace(workspaceID string, message []byte) {
@@ -529,19 +529,19 @@ func (d *DualWriteBroadcaster) SendToUser(userID string, message []byte, exclude
 	id := ulid.Make().String()
 	frame := injectEventID(message, id)
 	d.local.fanoutUser(userID, frame, exclude, id)
-	d.relay.PublishWithID(ScopeUser, userID, exclude, message, id)
+	_ = d.relay.PublishWithID(ScopeUser, userID, exclude, message, id)
 }
 
 func (d *DualWriteBroadcaster) Broadcast(message []byte) {
 	id := ulid.Make().String()
 	frame := injectEventID(message, id)
 	d.local.fanoutAllDedup(frame, "", id)
-	d.relay.PublishWithID("global", "all", "", message, id)
+	_ = d.relay.PublishWithID("global", "all", "", message, id)
 }
 
 // PublishWithID is like publish but uses a caller-supplied event id so the
 // dual-write path can dedup.
-func (r *RedisRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+func (r *RedisRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error {
 	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, id)
 	args := &redis.XAddArgs{
 		Stream: StreamKey(scopeType, scopeID),
@@ -556,10 +556,11 @@ func (r *RedisRelay) PublishWithID(scopeType, scopeID, exclude string, frame []b
 		M.RedisXAddErrors.Add(1)
 		M.SetRedisLastError(err.Error())
 		slog.Warn("realtime/redis: XADD failed", "error", err, "scope", scopeType, "scope_id", scopeID)
-		return
+		return err
 	}
 	M.RedisXAddTotal.Add(1)
 	M.RedisLastXAddLagMicros.Store(time.Since(start).Microseconds())
+	return nil
 }
 
 var _ Broadcaster = (*RedisRelay)(nil)

--- a/server/internal/realtime/redis_relay.go
+++ b/server/internal/realtime/redis_relay.go
@@ -47,6 +47,80 @@ type envelope struct {
 	PayloadJSON string `json:"payload_json"` // raw JSON of the original ws frame
 }
 
+func newEnvelope(nodeID, scopeType, scopeID, exclude string, frame []byte, id string) envelope {
+	ev := envelope{
+		EventID:     id,
+		Scope:       scopeType,
+		ScopeID:     scopeID,
+		NodeID:      nodeID,
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		PayloadJSON: string(frame),
+	}
+	if exclude != "" {
+		ev.WorkspaceID = exclude
+	}
+	if t, a := peekTypeActor(frame); t != "" {
+		ev.EventType = t
+		ev.ActorID = a
+	}
+	return ev
+}
+
+func envelopeRedisValues(ev envelope) map[string]any {
+	return map[string]any{
+		"event_id":     ev.EventID,
+		"event_type":   ev.EventType,
+		"scope":        ev.Scope,
+		"scope_id":     ev.ScopeID,
+		"workspace_id": ev.WorkspaceID,
+		"actor_id":     ev.ActorID,
+		"created_at":   ev.CreatedAt,
+		"node_id":      ev.NodeID,
+		"payload_json": ev.PayloadJSON,
+	}
+}
+
+func envelopeFromXMessage(msg redis.XMessage) (envelope, bool) {
+	ev := envelope{
+		EventID:     redisString(msg.Values["event_id"]),
+		EventType:   redisString(msg.Values["event_type"]),
+		Scope:       redisString(msg.Values["scope"]),
+		ScopeID:     redisString(msg.Values["scope_id"]),
+		WorkspaceID: redisString(msg.Values["workspace_id"]),
+		ActorID:     redisString(msg.Values["actor_id"]),
+		CreatedAt:   redisString(msg.Values["created_at"]),
+		NodeID:      redisString(msg.Values["node_id"]),
+		PayloadJSON: redisString(msg.Values["payload_json"]),
+	}
+	return ev, ev.PayloadJSON != ""
+}
+
+func redisString(v any) string {
+	switch s := v.(type) {
+	case string:
+		return s
+	case []byte:
+		return string(s)
+	default:
+		return ""
+	}
+}
+
+func deliverEnvelope(hub *Hub, ev envelope) {
+	if ev.PayloadJSON == "" {
+		return
+	}
+	frame := injectEventID([]byte(ev.PayloadJSON), ev.EventID)
+	switch ev.Scope {
+	case "global":
+		hub.fanoutAllDedup(frame, "", ev.EventID)
+	case ScopeUser:
+		hub.fanoutUser(ev.ScopeID, frame, ev.WorkspaceID, ev.EventID)
+	default:
+		hub.BroadcastToScopeDedup(ev.Scope, ev.ScopeID, frame, ev.EventID)
+	}
+}
+
 // RedisRelay is a Broadcaster implementation that writes every message to a
 // per-scope Redis Stream and consumes streams for which there are local
 // subscribers. Local fanout is delegated to the wrapped *Hub.
@@ -182,38 +256,13 @@ func (r *RedisRelay) Broadcast(message []byte) {
 }
 
 func (r *RedisRelay) publish(scopeType, scopeID, exclude string, frame []byte) {
-	ev := envelope{
-		EventID:     ulid.Make().String(),
-		Scope:       scopeType,
-		ScopeID:     scopeID,
-		NodeID:      r.nodeID,
-		CreatedAt:   time.Now().UTC().Format(time.RFC3339Nano),
-		PayloadJSON: string(frame),
-	}
-	if exclude != "" {
-		ev.WorkspaceID = exclude
-	}
-	// Best-effort: peek inside the JSON for event_type / actor_id.
-	if t, a := peekTypeActor(frame); t != "" {
-		ev.EventType = t
-		ev.ActorID = a
-	}
+	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, ulid.Make().String())
 
 	args := &redis.XAddArgs{
 		Stream: StreamKey(scopeType, scopeID),
 		MaxLen: streamMaxLen,
 		Approx: true,
-		Values: map[string]any{
-			"event_id":     ev.EventID,
-			"event_type":   ev.EventType,
-			"scope":        ev.Scope,
-			"scope_id":     ev.ScopeID,
-			"workspace_id": ev.WorkspaceID,
-			"actor_id":     ev.ActorID,
-			"created_at":   ev.CreatedAt,
-			"node_id":      ev.NodeID,
-			"payload_json": ev.PayloadJSON,
-		},
+		Values: envelopeRedisValues(ev),
 	}
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -335,28 +384,17 @@ func (r *RedisRelay) runConsumer(ctx context.Context, c *scopeConsumer, scopeTyp
 }
 
 func (r *RedisRelay) deliverMessage(scopeType, scopeID string, msg redis.XMessage) {
-	payloadAny, ok := msg.Values["payload_json"]
+	ev, ok := envelopeFromXMessage(msg)
 	if !ok {
 		return
 	}
-	payload, _ := payloadAny.(string)
-	if payload == "" {
-		return
+	if ev.Scope == "" {
+		ev.Scope = scopeType
 	}
-	exclude, _ := msg.Values["workspace_id"].(string)
-	eventID, _ := msg.Values["event_id"].(string)
-
-	// Inject event_id into the outgoing frame for client-side dedup.
-	frame := injectEventID([]byte(payload), eventID)
-
-	switch scopeType {
-	case "global":
-		r.hub.fanoutAllDedup(frame, "", eventID)
-	case ScopeUser:
-		r.hub.fanoutUser(scopeID, frame, exclude, eventID)
-	default:
-		r.hub.BroadcastToScopeDedup(scopeType, scopeID, frame, eventID)
+	if ev.ScopeID == "" {
+		ev.ScopeID = scopeID
 	}
+	deliverEnvelope(r.hub, ev)
 }
 
 // fanoutUser is implemented in hub.go.
@@ -453,18 +491,20 @@ func injectEventID(frame []byte, eventID string) []byte {
 // the Redis relay loops the message back.
 type DualWriteBroadcaster struct {
 	local *Hub
-	relay relayPublisher
+	relay RelayPublisher
 }
 
-func NewDualWriteBroadcaster(local *Hub, relay *RedisRelay) *DualWriteBroadcaster {
+// RelayPublisher is implemented by Redis relay backends that can publish a
+// caller-supplied event id for local/Redis loopback deduplication.
+type RelayPublisher interface {
+	PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string)
+}
+
+func NewDualWriteBroadcaster(local *Hub, relay RelayPublisher) *DualWriteBroadcaster {
 	return newDualWriteBroadcaster(local, relay)
 }
 
-type relayPublisher interface {
-	publishWithID(scopeType, scopeID, exclude string, frame []byte, id string)
-}
-
-func newDualWriteBroadcaster(local *Hub, relay relayPublisher) *DualWriteBroadcaster {
+func newDualWriteBroadcaster(local *Hub, relay RelayPublisher) *DualWriteBroadcaster {
 	return &DualWriteBroadcaster{local: local, relay: relay}
 }
 
@@ -474,7 +514,7 @@ func (d *DualWriteBroadcaster) BroadcastToScope(scopeType, scopeID string, messa
 	// Local fast path: BroadcastToScopeDedup marks each client as having
 	// seen `id`, so the Redis loopback for the same id will be ignored.
 	d.local.BroadcastToScopeDedup(scopeType, scopeID, frame, id)
-	d.relay.publishWithID(scopeType, scopeID, "", message, id)
+	d.relay.PublishWithID(scopeType, scopeID, "", message, id)
 }
 
 func (d *DualWriteBroadcaster) BroadcastToWorkspace(workspaceID string, message []byte) {
@@ -489,49 +529,25 @@ func (d *DualWriteBroadcaster) SendToUser(userID string, message []byte, exclude
 	id := ulid.Make().String()
 	frame := injectEventID(message, id)
 	d.local.fanoutUser(userID, frame, exclude, id)
-	d.relay.publishWithID(ScopeUser, userID, exclude, message, id)
+	d.relay.PublishWithID(ScopeUser, userID, exclude, message, id)
 }
 
 func (d *DualWriteBroadcaster) Broadcast(message []byte) {
 	id := ulid.Make().String()
 	frame := injectEventID(message, id)
 	d.local.fanoutAllDedup(frame, "", id)
-	d.relay.publishWithID("global", "all", "", message, id)
+	d.relay.PublishWithID("global", "all", "", message, id)
 }
 
-// publishWithID is like publish but uses a caller-supplied event id so the
+// PublishWithID is like publish but uses a caller-supplied event id so the
 // dual-write path can dedup.
-func (r *RedisRelay) publishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
-	ev := envelope{
-		EventID:     id,
-		Scope:       scopeType,
-		ScopeID:     scopeID,
-		NodeID:      r.nodeID,
-		CreatedAt:   time.Now().UTC().Format(time.RFC3339Nano),
-		PayloadJSON: string(frame),
-	}
-	if exclude != "" {
-		ev.WorkspaceID = exclude
-	}
-	if t, a := peekTypeActor(frame); t != "" {
-		ev.EventType = t
-		ev.ActorID = a
-	}
+func (r *RedisRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, id)
 	args := &redis.XAddArgs{
 		Stream: StreamKey(scopeType, scopeID),
 		MaxLen: streamMaxLen,
 		Approx: true,
-		Values: map[string]any{
-			"event_id":     ev.EventID,
-			"event_type":   ev.EventType,
-			"scope":        ev.Scope,
-			"scope_id":     ev.ScopeID,
-			"workspace_id": ev.WorkspaceID,
-			"actor_id":     ev.ActorID,
-			"created_at":   ev.CreatedAt,
-			"node_id":      ev.NodeID,
-			"payload_json": ev.PayloadJSON,
-		},
+		Values: envelopeRedisValues(ev),
 	}
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -548,3 +564,4 @@ func (r *RedisRelay) publishWithID(scopeType, scopeID, exclude string, frame []b
 
 var _ Broadcaster = (*RedisRelay)(nil)
 var _ Broadcaster = (*DualWriteBroadcaster)(nil)
+var _ RelayPublisher = (*RedisRelay)(nil)

--- a/server/internal/realtime/redis_relay_test.go
+++ b/server/internal/realtime/redis_relay_test.go
@@ -112,7 +112,7 @@ type localFirstPublisher struct {
 	localFrame []byte
 }
 
-func (p *localFirstPublisher) publishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+func (p *localFirstPublisher) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
 	p.called = true
 	p.scopeType = scopeType
 	p.scopeID = scopeID

--- a/server/internal/realtime/redis_relay_test.go
+++ b/server/internal/realtime/redis_relay_test.go
@@ -112,7 +112,7 @@ type localFirstPublisher struct {
 	localFrame []byte
 }
 
-func (p *localFirstPublisher) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+func (p *localFirstPublisher) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error {
 	p.called = true
 	p.scopeType = scopeType
 	p.scopeID = scopeID
@@ -125,4 +125,5 @@ func (p *localFirstPublisher) PublishWithID(scopeType, scopeID, exclude string, 
 	default:
 		p.t.Fatal("expected local fanout to happen before relay publish")
 	}
+	return nil
 }

--- a/server/internal/realtime/relay_lifecycle.go
+++ b/server/internal/realtime/relay_lifecycle.go
@@ -2,6 +2,8 @@ package realtime
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 
 	"github.com/oklog/ulid/v2"
 )
@@ -51,7 +53,7 @@ func (r *MirroredRelay) Wait() {
 }
 
 func (r *MirroredRelay) BroadcastToScope(scopeType, scopeID string, message []byte) {
-	r.PublishWithID(scopeType, scopeID, "", message, ulid.Make().String())
+	_ = r.PublishWithID(scopeType, scopeID, "", message, ulid.Make().String())
 }
 
 func (r *MirroredRelay) BroadcastToWorkspace(workspaceID string, message []byte) {
@@ -63,16 +65,37 @@ func (r *MirroredRelay) SendToUser(userID string, message []byte, excludeWorkspa
 	if len(excludeWorkspace) > 0 {
 		exclude = excludeWorkspace[0]
 	}
-	r.PublishWithID(ScopeUser, userID, exclude, message, ulid.Make().String())
+	_ = r.PublishWithID(ScopeUser, userID, exclude, message, ulid.Make().String())
 }
 
 func (r *MirroredRelay) Broadcast(message []byte) {
-	r.PublishWithID("global", "all", "", message, ulid.Make().String())
+	_ = r.PublishWithID("global", "all", "", message, ulid.Make().String())
 }
 
-func (r *MirroredRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
-	r.primary.PublishWithID(scopeType, scopeID, exclude, frame, id)
-	r.mirror.PublishWithID(scopeType, scopeID, exclude, frame, id)
+func (r *MirroredRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error {
+	primaryErr := r.primary.PublishWithID(scopeType, scopeID, exclude, frame, id)
+	mirrorErr := r.mirror.PublishWithID(scopeType, scopeID, exclude, frame, id)
+
+	if primaryErr != nil {
+		M.RedisMirrorPrimaryErrors.Add(1)
+		slog.Warn("realtime/redis mirror: primary publish failed", "error", primaryErr, "scope", scopeType, "scope_id", scopeID, "event_id", id)
+	}
+	if mirrorErr != nil {
+		M.RedisMirrorSecondaryErrors.Add(1)
+		slog.Warn("realtime/redis mirror: secondary publish failed", "error", mirrorErr, "scope", scopeType, "scope_id", scopeID, "event_id", id)
+	}
+	if (primaryErr == nil) != (mirrorErr == nil) {
+		M.RedisMirrorDivergenceTotal.Add(1)
+		slog.Warn(
+			"realtime/redis mirror: divergent publish result",
+			"primary_error", primaryErr,
+			"secondary_error", mirrorErr,
+			"scope", scopeType,
+			"scope_id", scopeID,
+			"event_id", id,
+		)
+	}
+	return errors.Join(primaryErr, mirrorErr)
 }
 
 var _ ManagedRelay = (*RedisRelay)(nil)

--- a/server/internal/realtime/relay_lifecycle.go
+++ b/server/internal/realtime/relay_lifecycle.go
@@ -1,0 +1,80 @@
+package realtime
+
+import (
+	"context"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// ManagedRelay is a Redis-backed realtime relay with explicit goroutine
+// lifecycle management.
+type ManagedRelay interface {
+	RelayPublisher
+	Broadcaster
+
+	NodeID() string
+	Start(context.Context)
+	Stop()
+	Wait()
+}
+
+// MirroredRelay is a temporary rollout helper: it starts two relay backends,
+// reads from both, and publishes every event to both with the same event id.
+// Client-side dedup keeps loopback delivery idempotent.
+type MirroredRelay struct {
+	primary ManagedRelay
+	mirror  ManagedRelay
+}
+
+func NewMirroredRelay(primary, mirror ManagedRelay) *MirroredRelay {
+	return &MirroredRelay{primary: primary, mirror: mirror}
+}
+
+func (r *MirroredRelay) NodeID() string {
+	return r.primary.NodeID()
+}
+
+func (r *MirroredRelay) Start(ctx context.Context) {
+	r.primary.Start(ctx)
+	r.mirror.Start(ctx)
+	M.NodeID.Store(r.NodeID())
+}
+
+func (r *MirroredRelay) Stop() {
+	r.primary.Stop()
+	r.mirror.Stop()
+}
+
+func (r *MirroredRelay) Wait() {
+	r.primary.Wait()
+	r.mirror.Wait()
+}
+
+func (r *MirroredRelay) BroadcastToScope(scopeType, scopeID string, message []byte) {
+	r.PublishWithID(scopeType, scopeID, "", message, ulid.Make().String())
+}
+
+func (r *MirroredRelay) BroadcastToWorkspace(workspaceID string, message []byte) {
+	r.BroadcastToScope(ScopeWorkspace, workspaceID, message)
+}
+
+func (r *MirroredRelay) SendToUser(userID string, message []byte, excludeWorkspace ...string) {
+	exclude := ""
+	if len(excludeWorkspace) > 0 {
+		exclude = excludeWorkspace[0]
+	}
+	r.PublishWithID(ScopeUser, userID, exclude, message, ulid.Make().String())
+}
+
+func (r *MirroredRelay) Broadcast(message []byte) {
+	r.PublishWithID("global", "all", "", message, ulid.Make().String())
+}
+
+func (r *MirroredRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+	r.primary.PublishWithID(scopeType, scopeID, exclude, frame, id)
+	r.mirror.PublishWithID(scopeType, scopeID, exclude, frame, id)
+}
+
+var _ ManagedRelay = (*RedisRelay)(nil)
+var _ ManagedRelay = (*ShardedStreamRelay)(nil)
+var _ ManagedRelay = (*MirroredRelay)(nil)

--- a/server/internal/realtime/relay_lifecycle_test.go
+++ b/server/internal/realtime/relay_lifecycle_test.go
@@ -1,0 +1,66 @@
+package realtime
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMirroredRelayPublishesSameEventIDToBothBackends(t *testing.T) {
+	primary := &recordingManagedRelay{nodeID: "primary"}
+	mirror := &recordingManagedRelay{nodeID: "mirror"}
+	relay := NewMirroredRelay(primary, mirror)
+
+	relay.PublishWithID(ScopeWorkspace, "workspace-1", "", []byte(`{"type":"issue:updated"}`), "event-1")
+
+	if len(primary.calls) != 1 {
+		t.Fatalf("expected primary publish call, got %d", len(primary.calls))
+	}
+	if len(mirror.calls) != 1 {
+		t.Fatalf("expected mirror publish call, got %d", len(mirror.calls))
+	}
+	if primary.calls[0].eventID != "event-1" || mirror.calls[0].eventID != "event-1" {
+		t.Fatalf("expected same event id, got primary=%q mirror=%q", primary.calls[0].eventID, mirror.calls[0].eventID)
+	}
+}
+
+type relayPublishCall struct {
+	scopeType string
+	scopeID   string
+	exclude   string
+	frame     string
+	eventID   string
+}
+
+type recordingManagedRelay struct {
+	nodeID string
+	calls  []relayPublishCall
+}
+
+func (r *recordingManagedRelay) NodeID() string                      { return r.nodeID }
+func (r *recordingManagedRelay) Start(context.Context)               {}
+func (r *recordingManagedRelay) Stop()                               {}
+func (r *recordingManagedRelay) Wait()                               {}
+func (r *recordingManagedRelay) BroadcastToWorkspace(string, []byte) {}
+func (r *recordingManagedRelay) Broadcast([]byte)                    {}
+
+func (r *recordingManagedRelay) BroadcastToScope(scopeType, scopeID string, frame []byte) {
+	r.PublishWithID(scopeType, scopeID, "", frame, "")
+}
+
+func (r *recordingManagedRelay) SendToUser(userID string, frame []byte, excludeWorkspace ...string) {
+	exclude := ""
+	if len(excludeWorkspace) > 0 {
+		exclude = excludeWorkspace[0]
+	}
+	r.PublishWithID(ScopeUser, userID, exclude, frame, "")
+}
+
+func (r *recordingManagedRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+	r.calls = append(r.calls, relayPublishCall{
+		scopeType: scopeType,
+		scopeID:   scopeID,
+		exclude:   exclude,
+		frame:     string(frame),
+		eventID:   id,
+	})
+}

--- a/server/internal/realtime/relay_lifecycle_test.go
+++ b/server/internal/realtime/relay_lifecycle_test.go
@@ -2,6 +2,7 @@ package realtime
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -10,7 +11,9 @@ func TestMirroredRelayPublishesSameEventIDToBothBackends(t *testing.T) {
 	mirror := &recordingManagedRelay{nodeID: "mirror"}
 	relay := NewMirroredRelay(primary, mirror)
 
-	relay.PublishWithID(ScopeWorkspace, "workspace-1", "", []byte(`{"type":"issue:updated"}`), "event-1")
+	if err := relay.PublishWithID(ScopeWorkspace, "workspace-1", "", []byte(`{"type":"issue:updated"}`), "event-1"); err != nil {
+		t.Fatalf("PublishWithID: %v", err)
+	}
 
 	if len(primary.calls) != 1 {
 		t.Fatalf("expected primary publish call, got %d", len(primary.calls))
@@ -23,6 +26,30 @@ func TestMirroredRelayPublishesSameEventIDToBothBackends(t *testing.T) {
 	}
 }
 
+func TestMirroredRelayRecordsDivergenceWhenOneBackendFails(t *testing.T) {
+	M.Reset()
+	t.Cleanup(M.Reset)
+
+	primary := &recordingManagedRelay{nodeID: "primary"}
+	mirror := &recordingManagedRelay{nodeID: "mirror", publishErr: errors.New("mirror unavailable")}
+	relay := NewMirroredRelay(primary, mirror)
+
+	err := relay.PublishWithID(ScopeWorkspace, "workspace-1", "", []byte(`{"type":"issue:updated"}`), "event-1")
+
+	if err == nil {
+		t.Fatal("expected mirrored publish to return backend error")
+	}
+	if got := M.RedisMirrorPrimaryErrors.Load(); got != 0 {
+		t.Fatalf("expected 0 primary errors, got %d", got)
+	}
+	if got := M.RedisMirrorSecondaryErrors.Load(); got != 1 {
+		t.Fatalf("expected 1 secondary error, got %d", got)
+	}
+	if got := M.RedisMirrorDivergenceTotal.Load(); got != 1 {
+		t.Fatalf("expected 1 divergence, got %d", got)
+	}
+}
+
 type relayPublishCall struct {
 	scopeType string
 	scopeID   string
@@ -32,8 +59,9 @@ type relayPublishCall struct {
 }
 
 type recordingManagedRelay struct {
-	nodeID string
-	calls  []relayPublishCall
+	nodeID     string
+	publishErr error
+	calls      []relayPublishCall
 }
 
 func (r *recordingManagedRelay) NodeID() string                      { return r.nodeID }
@@ -55,7 +83,7 @@ func (r *recordingManagedRelay) SendToUser(userID string, frame []byte, excludeW
 	r.PublishWithID(ScopeUser, userID, exclude, frame, "")
 }
 
-func (r *recordingManagedRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+func (r *recordingManagedRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error {
 	r.calls = append(r.calls, relayPublishCall{
 		scopeType: scopeType,
 		scopeID:   scopeID,
@@ -63,4 +91,5 @@ func (r *recordingManagedRelay) PublishWithID(scopeType, scopeID, exclude string
 		frame:     string(frame),
 		eventID:   id,
 	})
+	return r.publishErr
 }

--- a/server/internal/realtime/sharded_stream_relay.go
+++ b/server/internal/realtime/sharded_stream_relay.go
@@ -1,0 +1,269 @@
+package realtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	defaultShardedRelayShards       = 8
+	defaultShardedRelayStreamMaxLen = 100000
+	defaultShardedRelayReadCount    = 128
+	defaultShardedRelayReadBlock    = 5 * time.Second
+)
+
+// ShardedStreamKey returns the Redis Stream key used by a fixed relay shard.
+func ShardedStreamKey(shard int) string {
+	return fmt.Sprintf("ws:relay:shard:%d", shard)
+}
+
+// ShardedStreamRelayConfig controls the fixed-reader Redis Stream relay.
+type ShardedStreamRelayConfig struct {
+	Shards       int
+	StreamMaxLen int64
+	ReadCount    int64
+	ReadBlock    time.Duration
+}
+
+// DefaultShardedStreamRelayConfig returns production-safe defaults: a small
+// fixed number of blocking readers per pod, bounded stream retention, and
+// batched reads.
+func DefaultShardedStreamRelayConfig() ShardedStreamRelayConfig {
+	return ShardedStreamRelayConfig{
+		Shards:       defaultShardedRelayShards,
+		StreamMaxLen: defaultShardedRelayStreamMaxLen,
+		ReadCount:    defaultShardedRelayReadCount,
+		ReadBlock:    defaultShardedRelayReadBlock,
+	}
+}
+
+func (c ShardedStreamRelayConfig) withDefaults() ShardedStreamRelayConfig {
+	def := DefaultShardedStreamRelayConfig()
+	if c.Shards <= 0 {
+		c.Shards = def.Shards
+	}
+	if c.StreamMaxLen <= 0 {
+		c.StreamMaxLen = def.StreamMaxLen
+	}
+	if c.ReadCount <= 0 {
+		c.ReadCount = def.ReadCount
+	}
+	if c.ReadBlock <= 0 {
+		c.ReadBlock = def.ReadBlock
+	}
+	return c
+}
+
+// ShardedStreamRelay publishes all realtime events into a fixed set of Redis
+// Streams. Every API node runs one XREAD BLOCK loop per shard and locally
+// filters events by hub subscriptions. This keeps blocked Redis connections
+// bounded by pod_count * shard_count instead of active_scope_count.
+type ShardedStreamRelay struct {
+	hub      *Hub
+	writeRDB *redis.Client
+	readRDB  *redis.Client
+	nodeID   string
+	config   ShardedStreamRelayConfig
+
+	mu       sync.Mutex
+	stopping bool
+	wg       sync.WaitGroup
+}
+
+func NewShardedStreamRelay(hub *Hub, writeRDB, readRDB *redis.Client, config ShardedStreamRelayConfig) *ShardedStreamRelay {
+	if readRDB == nil {
+		readRDB = writeRDB
+	}
+	return &ShardedStreamRelay{
+		hub:      hub,
+		writeRDB: writeRDB,
+		readRDB:  readRDB,
+		nodeID:   ulid.Make().String(),
+		config:   config.withDefaults(),
+	}
+}
+
+func (r *ShardedStreamRelay) NodeID() string { return r.nodeID }
+
+func (r *ShardedStreamRelay) Start(ctx context.Context) {
+	M.NodeID.Store(r.nodeID)
+	if err := r.writeRDB.Ping(ctx).Err(); err != nil {
+		slog.Error("realtime/sharded-redis: initial ping failed", "error", err)
+		M.RedisConnected.Store(false)
+		M.SetRedisLastError(err.Error())
+	} else if r.readRDB != r.writeRDB {
+		if err := r.readRDB.Ping(ctx).Err(); err != nil {
+			slog.Error("realtime/sharded-redis: initial read-client ping failed", "error", err)
+			M.RedisConnected.Store(false)
+			M.SetRedisLastError(err.Error())
+		} else {
+			M.RedisConnected.Store(true)
+		}
+	} else {
+		M.RedisConnected.Store(true)
+	}
+
+	r.wg.Add(1 + r.config.Shards)
+	go func() {
+		defer r.wg.Done()
+		r.heartbeatLoop(ctx)
+	}()
+	for shard := 0; shard < r.config.Shards; shard++ {
+		shard := shard
+		go func() {
+			defer r.wg.Done()
+			r.readShard(ctx, shard)
+		}()
+	}
+}
+
+func (r *ShardedStreamRelay) Stop() {
+	r.mu.Lock()
+	r.stopping = true
+	r.mu.Unlock()
+}
+
+func (r *ShardedStreamRelay) Wait() {
+	r.wg.Wait()
+}
+
+func (r *ShardedStreamRelay) BroadcastToScope(scopeType, scopeID string, message []byte) {
+	r.PublishWithID(scopeType, scopeID, "", message, ulid.Make().String())
+}
+
+func (r *ShardedStreamRelay) BroadcastToWorkspace(workspaceID string, message []byte) {
+	r.BroadcastToScope(ScopeWorkspace, workspaceID, message)
+}
+
+func (r *ShardedStreamRelay) SendToUser(userID string, message []byte, excludeWorkspace ...string) {
+	exclude := ""
+	if len(excludeWorkspace) > 0 {
+		exclude = excludeWorkspace[0]
+	}
+	r.PublishWithID(ScopeUser, userID, exclude, message, ulid.Make().String())
+}
+
+func (r *ShardedStreamRelay) Broadcast(message []byte) {
+	r.PublishWithID("global", "all", "", message, ulid.Make().String())
+}
+
+func (r *ShardedStreamRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, id)
+	stream := ShardedStreamKey(r.shardFor(scopeType, scopeID))
+	args := &redis.XAddArgs{
+		Stream: stream,
+		MaxLen: r.config.StreamMaxLen,
+		Approx: true,
+		Values: envelopeRedisValues(ev),
+	}
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := r.writeRDB.XAdd(ctx, args).Err(); err != nil {
+		M.RedisXAddErrors.Add(1)
+		M.SetRedisLastError(err.Error())
+		slog.Warn("realtime/sharded-redis: XADD failed", "error", err, "scope", scopeType, "scope_id", scopeID, "stream", stream)
+		return
+	}
+	M.RedisXAddTotal.Add(1)
+	M.RedisLastXAddLagMicros.Store(time.Since(start).Microseconds())
+}
+
+func (r *ShardedStreamRelay) shardFor(scopeType, scopeID string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(scopeType))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(scopeID))
+	return int(h.Sum32() % uint32(r.config.Shards))
+}
+
+func (r *ShardedStreamRelay) readShard(ctx context.Context, shard int) {
+	stream := ShardedStreamKey(shard)
+	lastID := "$"
+	for {
+		if ctx.Err() != nil || r.isStopping() {
+			return
+		}
+
+		readCtx, cancel := context.WithTimeout(ctx, r.config.ReadBlock+time.Second)
+		res, err := r.readRDB.XRead(readCtx, &redis.XReadArgs{
+			Streams: []string{stream, lastID},
+			Count:   r.config.ReadCount,
+			Block:   r.config.ReadBlock,
+		}).Result()
+		cancel()
+
+		if errors.Is(err, redis.Nil) || (err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled))) {
+			continue
+		}
+		if err != nil {
+			M.RedisXReadErrors.Add(1)
+			M.SetRedisLastError(err.Error())
+			slog.Warn("realtime/sharded-redis: XREAD failed", "error", err, "shard", shard, "stream", stream)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+
+		for _, s := range res {
+			for _, msg := range s.Messages {
+				lastID = msg.ID
+				M.RedisXReadTotal.Add(1)
+				r.deliverMessage(msg)
+			}
+		}
+	}
+}
+
+func (r *ShardedStreamRelay) deliverMessage(msg redis.XMessage) {
+	ev, ok := envelopeFromXMessage(msg)
+	if !ok || ev.Scope == "" || ev.ScopeID == "" {
+		return
+	}
+	deliverEnvelope(r.hub, ev)
+}
+
+func (r *ShardedStreamRelay) heartbeatLoop(ctx context.Context) {
+	t := time.NewTicker(heartbeatPeriod)
+	defer t.Stop()
+	for {
+		r.heartbeatOnce(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+	}
+}
+
+func (r *ShardedStreamRelay) heartbeatOnce(ctx context.Context) {
+	hbCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if err := r.writeRDB.Set(hbCtx, HeartbeatKey(r.nodeID), time.Now().UTC().Format(time.RFC3339Nano), heartbeatTTL).Err(); err != nil {
+		M.RedisConnected.Store(false)
+		M.SetRedisLastError(err.Error())
+		return
+	}
+	M.RedisConnected.Store(true)
+}
+
+func (r *ShardedStreamRelay) isStopping() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stopping
+}
+
+var _ Broadcaster = (*ShardedStreamRelay)(nil)
+var _ RelayPublisher = (*ShardedStreamRelay)(nil)

--- a/server/internal/realtime/sharded_stream_relay.go
+++ b/server/internal/realtime/sharded_stream_relay.go
@@ -136,7 +136,7 @@ func (r *ShardedStreamRelay) Wait() {
 }
 
 func (r *ShardedStreamRelay) BroadcastToScope(scopeType, scopeID string, message []byte) {
-	r.PublishWithID(scopeType, scopeID, "", message, ulid.Make().String())
+	_ = r.PublishWithID(scopeType, scopeID, "", message, ulid.Make().String())
 }
 
 func (r *ShardedStreamRelay) BroadcastToWorkspace(workspaceID string, message []byte) {
@@ -148,14 +148,14 @@ func (r *ShardedStreamRelay) SendToUser(userID string, message []byte, excludeWo
 	if len(excludeWorkspace) > 0 {
 		exclude = excludeWorkspace[0]
 	}
-	r.PublishWithID(ScopeUser, userID, exclude, message, ulid.Make().String())
+	_ = r.PublishWithID(ScopeUser, userID, exclude, message, ulid.Make().String())
 }
 
 func (r *ShardedStreamRelay) Broadcast(message []byte) {
-	r.PublishWithID("global", "all", "", message, ulid.Make().String())
+	_ = r.PublishWithID("global", "all", "", message, ulid.Make().String())
 }
 
-func (r *ShardedStreamRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) {
+func (r *ShardedStreamRelay) PublishWithID(scopeType, scopeID, exclude string, frame []byte, id string) error {
 	ev := newEnvelope(r.nodeID, scopeType, scopeID, exclude, frame, id)
 	stream := ShardedStreamKey(r.shardFor(scopeType, scopeID))
 	args := &redis.XAddArgs{
@@ -172,10 +172,11 @@ func (r *ShardedStreamRelay) PublishWithID(scopeType, scopeID, exclude string, f
 		M.RedisXAddErrors.Add(1)
 		M.SetRedisLastError(err.Error())
 		slog.Warn("realtime/sharded-redis: XADD failed", "error", err, "scope", scopeType, "scope_id", scopeID, "stream", stream)
-		return
+		return err
 	}
 	M.RedisXAddTotal.Add(1)
 	M.RedisLastXAddLagMicros.Store(time.Since(start).Microseconds())
+	return nil
 }
 
 func (r *ShardedStreamRelay) shardFor(scopeType, scopeID string) int {

--- a/server/internal/realtime/sharded_stream_relay_test.go
+++ b/server/internal/realtime/sharded_stream_relay_test.go
@@ -1,0 +1,73 @@
+package realtime
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestShardedStreamRelayConfigDefaults(t *testing.T) {
+	relay := NewShardedStreamRelay(NewHub(), nil, nil, ShardedStreamRelayConfig{})
+
+	if relay.config.Shards != defaultShardedRelayShards {
+		t.Fatalf("expected default shard count %d, got %d", defaultShardedRelayShards, relay.config.Shards)
+	}
+	if relay.config.StreamMaxLen != defaultShardedRelayStreamMaxLen {
+		t.Fatalf("expected default stream max len %d, got %d", defaultShardedRelayStreamMaxLen, relay.config.StreamMaxLen)
+	}
+	if relay.config.ReadCount != defaultShardedRelayReadCount {
+		t.Fatalf("expected default read count %d, got %d", defaultShardedRelayReadCount, relay.config.ReadCount)
+	}
+	if relay.config.ReadBlock != defaultShardedRelayReadBlock {
+		t.Fatalf("expected default read block %s, got %s", defaultShardedRelayReadBlock, relay.config.ReadBlock)
+	}
+}
+
+func TestShardedStreamRelayShardForScopeIsStableAndBounded(t *testing.T) {
+	relay := NewShardedStreamRelay(NewHub(), nil, nil, ShardedStreamRelayConfig{Shards: 8})
+
+	first := relay.shardFor(ScopeWorkspace, "workspace-1")
+	second := relay.shardFor(ScopeWorkspace, "workspace-1")
+	if first != second {
+		t.Fatalf("expected stable shard selection, got %d then %d", first, second)
+	}
+	if first < 0 || first >= relay.config.Shards {
+		t.Fatalf("shard %d out of range [0,%d)", first, relay.config.Shards)
+	}
+}
+
+func TestShardedStreamRelayDeliverMessageUsesEnvelopeScope(t *testing.T) {
+	hub := NewHub()
+	client := attachRealtimeTestClient(hub, ScopeTask, "task-1")
+	relay := NewShardedStreamRelay(hub, nil, nil, ShardedStreamRelayConfig{})
+	ev := envelope{
+		EventID:     "event-1",
+		Scope:       ScopeTask,
+		ScopeID:     "task-1",
+		PayloadJSON: `{"type":"task:updated"}`,
+	}
+
+	relay.deliverMessage(redis.XMessage{Values: envelopeRedisValues(ev)})
+
+	select {
+	case raw := <-client.send:
+		var frame map[string]any
+		if err := json.Unmarshal(raw, &frame); err != nil {
+			t.Fatalf("delivered frame is not JSON: %v", err)
+		}
+		if frame["event_id"] != ev.EventID {
+			t.Fatalf("expected event_id %q, got %v", ev.EventID, frame["event_id"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected sharded relay message to be delivered")
+	}
+
+	relay.deliverMessage(redis.XMessage{Values: envelopeRedisValues(ev)})
+	select {
+	case duplicate := <-client.send:
+		t.Fatalf("expected duplicate event id to be deduped, got %s", duplicate)
+	case <-time.After(20 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## Summary

- replace the production realtime Redis relay with a fixed-shard stream relay
- publish all realtime events to `ws:relay:shard:{n}` based on a stable scope hash
- run one `XREAD BLOCK` reader per shard per pod instead of one `XREADGROUP BLOCK` consumer per active scope
- keep local direct fanout through `DualWriteBroadcaster`
- keep isolated Redis clients from the P0 change: store, realtime write/control, realtime read
- add `REALTIME_RELAY_MODE=sharded|dual|legacy`
  - `sharded` is the default and final mode
  - `dual` reads/writes both sharded streams and legacy per-scope streams for zero-gap rolling rollout
  - `legacy` is a rollback mode

## Runtime knobs

- `REALTIME_RELAY_SHARDS` default `8`
- `REALTIME_RELAY_STREAM_MAXLEN` default `100000`
- `REALTIME_RELAY_XREAD_COUNT` default `128`
- `REALTIME_RELAY_XREAD_BLOCK` default `5s`

## Expected impact

In `sharded` mode, Redis blocked client count should be bounded by approximately:

```text
api_pods * REALTIME_RELAY_SHARDS
```

instead of scaling with active workspace/user/task/chat scopes.

## Validation

- `go test ./internal/realtime`
- `go test ./cmd/server -run '^$'`

Full `go test ./cmd/server` was attempted locally and still fails due to the existing local test database schema mismatch (`project_id` column missing, `autopilot` table missing), unrelated to this relay change.
