### PR TITLE
[codex] Add autopilot templates to create dialog

### DIFF
--- a/packages/views/autopilots/components/autopilot-dialog.tsx
+++ b/packages/views/autopilots/components/autopilot-dialog.tsx
@@ -50,6 +50,10 @@ import { TitleEditor, ContentEditor } from "../../editor";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { AgentPicker } from "./pickers/agent-picker";
 import {
+  AUTOPILOT_TEMPLATES,
+  type AutopilotTemplate,
+} from "./autopilot-templates";
+import {
   getDefaultTriggerConfig,
   getLocalTimezone,
   parseCronExpression,
@@ -76,6 +80,7 @@ export type AutopilotDialogProps =
       onOpenChange: (v: boolean) => void;
       initial?: Partial<AutopilotInitial>;
       initialTriggerConfig?: Partial<TriggerConfig>;
+      initialTemplate?: AutopilotTemplate | null;
     }
   | {
       mode: "edit";
@@ -248,8 +253,14 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const isCreate = props.mode === "create";
+  const initialTemplate = isCreate ? props.initialTemplate ?? null : null;
   const initial: Partial<AutopilotInitial> = isCreate
-    ? props.initial ?? {}
+    ? {
+        ...(props.initial ?? {}),
+        ...(initialTemplate
+          ? { title: initialTemplate.title, description: initialTemplate.prompt }
+          : {}),
+      }
     : props.initial;
 
   const [title, setTitle] = useState(initial.title ?? "");
@@ -258,10 +269,16 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
   const [executionMode, setExecutionMode] = useState<AutopilotExecutionMode>(
     initial.execution_mode ?? "create_issue",
   );
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
+    initialTemplate?.id ?? null,
+  );
+  const [editorVersion, setEditorVersion] = useState(0);
 
   const initialCfg: TriggerConfig = (() => {
     if (isCreate) {
-      const tpl = props.initialTriggerConfig;
+      const tpl = initialTemplate
+        ? { frequency: initialTemplate.frequency, time: initialTemplate.time }
+        : props.initialTriggerConfig;
       return tpl ? { ...getDefaultTriggerConfig(), ...tpl } : getDefaultTriggerConfig();
     }
     const first = props.triggers[0];
@@ -298,6 +315,18 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
 
   const canSubmit =
     title.trim().length > 0 && assigneeId.length > 0 && !submitting;
+
+  const handleApplyTemplate = (template: AutopilotTemplate) => {
+    setSelectedTemplateId(template.id);
+    setTitle(template.title);
+    setDescription(template.prompt);
+    setTriggerConfig({
+      ...getDefaultTriggerConfig(),
+      frequency: template.frequency,
+      time: template.time,
+    });
+    setEditorVersion((version) => version + 1);
+  };
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
@@ -366,7 +395,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
     }
   };
 
-  const contentKey = isCreate ? "create" : props.autopilotId;
+  const contentKey = isCreate ? `create-${editorVersion}` : props.autopilotId;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -445,7 +474,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
             <div className="px-6 pt-5 pb-3 shrink-0">
               <TitleEditor
                 autoFocus={isCreate}
-                defaultValue={initial.title ?? ""}
+                defaultValue={title}
                 placeholder="Autopilot name"
                 className="text-2xl font-semibold tracking-tight"
                 onChange={setTitle}
@@ -465,7 +494,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
             <div className="flex-1 min-h-0 px-6 pb-6 flex flex-col">
               <div className="h-full overflow-y-auto rounded-lg border border-border bg-background transition-colors focus-within:border-input px-4 py-3">
                 <ContentEditor
-                  defaultValue={initial.description ?? ""}
+                  defaultValue={description}
                   placeholder={`# Goal\nWhat should the agent accomplish?\n\n# Context\nWho is this for? Any constraints?\n\n# Steps\n1. …\n2. …`}
                   onUpdate={setDescription}
                   debounceMs={300}
@@ -477,6 +506,13 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
 
           {/* Right: Configuration */}
           <aside className="w-full lg:w-[340px] shrink-0 overflow-y-auto px-5 py-5 space-y-5 bg-muted/30">
+            {isCreate && (
+              <TemplateSection
+                selectedId={selectedTemplateId}
+                onApply={handleApplyTemplate}
+              />
+            )}
+
             <AgentSection
               selectedId={assigneeId}
               onChange={setAssigneeId}
@@ -535,6 +571,64 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="text-[11px] font-semibold tracking-[0.08em] text-muted-foreground uppercase mb-2">
       {children}
+    </div>
+  );
+}
+
+function TemplateSection({
+  selectedId,
+  onApply,
+}: {
+  selectedId: string | null;
+  onApply: (template: AutopilotTemplate) => void;
+}) {
+  return (
+    <div>
+      <SectionLabel>Templates</SectionLabel>
+      <div className="space-y-1.5">
+        {AUTOPILOT_TEMPLATES.map((template) => {
+          const Icon = template.icon;
+          const selected = template.id === selectedId;
+          return (
+            <button
+              key={template.id}
+              type="button"
+              onClick={() => onApply(template)}
+              className={cn(
+                "w-full flex items-start gap-2.5 rounded-md border px-3 py-2 text-left cursor-pointer transition-colors",
+                selected
+                  ? "border-primary bg-primary/5"
+                  : "bg-background hover:bg-accent/40",
+              )}
+            >
+              <span
+                className={cn(
+                  "mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-md",
+                  selected
+                    ? "bg-primary/15 text-primary"
+                    : "bg-muted text-muted-foreground",
+                )}
+              >
+                <Icon className="size-3.5" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">
+                  {template.title}
+                </span>
+                <span className="mt-0.5 block line-clamp-2 text-xs text-muted-foreground">
+                  {template.summary}
+                </span>
+              </span>
+              {selected && (
+                <Check
+                  className="mt-1 size-3.5 shrink-0 text-primary"
+                  strokeWidth={3}
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/packages/views/autopilots/components/autopilot-templates.ts
+++ b/packages/views/autopilots/components/autopilot-templates.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  BarChart3,
+  Bug,
+  FileSearch,
+  GitPullRequest,
+  Newspaper,
+  Shield,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { TriggerFrequency } from "./trigger-config";
+
+export interface AutopilotTemplate {
+  id: string;
+  title: string;
+  prompt: string;
+  summary: string;
+  icon: LucideIcon;
+  frequency: TriggerFrequency;
+  time: string;
+}
+
+export const AUTOPILOT_TEMPLATES: AutopilotTemplate[] = [
+  {
+    id: "daily-news-digest",
+    title: "Daily news digest",
+    summary: "Search and summarize today's news for the team",
+    prompt: `1. Search the web for news and announcements published today only (strictly today's date)
+2. Filter for topics relevant to our team and industry
+3. For each item, write a short summary including: title, source, key takeaways
+4. Compile everything into a single digest post
+5. Post the digest as a comment on this issue and @mention all workspace members`,
+    icon: Newspaper,
+    frequency: "daily",
+    time: "09:00",
+  },
+  {
+    id: "pr-review-reminder",
+    title: "PR review reminder",
+    summary: "Flag stale pull requests that need review",
+    prompt: `1. List all open pull requests in the repository
+2. Identify PRs that have been open for more than 24 hours without a review
+3. For each stale PR, note the author, age, and a one-line summary of the change
+4. Post a comment on this issue listing all stale PRs with links
+5. @mention the team to remind them to review`,
+    icon: GitPullRequest,
+    frequency: "weekdays",
+    time: "10:00",
+  },
+  {
+    id: "bug-triage",
+    title: "Bug triage",
+    summary: "Assess and prioritize new bug reports",
+    prompt: `1. List all issues with status "triage" or "backlog" that have not been prioritized
+2. For each issue, read the description and any attached logs or screenshots
+3. Assess severity (critical / high / medium / low) based on user impact and scope
+4. Set the priority field on the issue accordingly
+5. Add a comment explaining your assessment and suggested next steps`,
+    icon: Bug,
+    frequency: "weekdays",
+    time: "09:00",
+  },
+  {
+    id: "weekly-progress-report",
+    title: "Weekly progress report",
+    summary: "Compile a weekly summary of team progress",
+    prompt: `1. Gather all issues completed (status "done") in the past 7 days
+2. Gather all issues currently in progress
+3. Identify any blocked issues and their blockers
+4. Calculate key metrics: issues closed, issues opened, net change
+5. Write a structured weekly report with sections: Completed, In Progress, Blocked, Metrics
+6. Post the report as a comment on this issue`,
+    icon: BarChart3,
+    frequency: "weekly",
+    time: "17:00",
+  },
+  {
+    id: "dependency-audit",
+    title: "Dependency audit",
+    summary: "Scan for security vulnerabilities and outdated packages",
+    prompt: `1. Run dependency audit tools on the project (npm audit, go vuln check, etc.)
+2. Identify any packages with known security vulnerabilities
+3. List outdated packages that are more than 2 major versions behind
+4. For each finding, note the severity, affected package, and recommended fix
+5. Post a summary report as a comment with actionable items`,
+    icon: Shield,
+    frequency: "weekly",
+    time: "08:00",
+  },
+  {
+    id: "documentation-check",
+    title: "Documentation check",
+    summary: "Review recent changes for documentation gaps",
+    prompt: `1. List all code changes merged in the past 7 days (via git log)
+2. For each significant change, check if related documentation was updated
+3. Identify any new APIs, config options, or features missing documentation
+4. Create a list of documentation gaps with file paths and suggested content
+5. Post the findings as a comment on this issue`,
+    icon: FileSearch,
+    frequency: "weekly",
+    time: "14:00",
+  },
+];

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, Zap, Play, Pause, AlertCircle, Newspaper, GitPullRequest, Bug, BarChart3, Shield, FileSearch } from "lucide-react";
+import { Plus, Zap, Play, Pause, AlertCircle } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { autopilotListOptions } from "@multica/core/autopilots/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -14,93 +14,8 @@ import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { Button } from "@multica/ui/components/ui/button";
 import { cn } from "@multica/ui/lib/utils";
 import { AutopilotDialog } from "./autopilot-dialog";
+import { AUTOPILOT_TEMPLATES, type AutopilotTemplate } from "./autopilot-templates";
 import type { Autopilot } from "@multica/core/types";
-import type { TriggerFrequency } from "./trigger-config";
-
-interface AutopilotTemplate {
-  title: string;
-  prompt: string;
-  summary: string;
-  icon: typeof Zap;
-  frequency: TriggerFrequency;
-  time: string;
-}
-
-const TEMPLATES: AutopilotTemplate[] = [
-  {
-    title: "Daily news digest",
-    summary: "Search and summarize today's news for the team",
-    prompt: `1. Search the web for news and announcements published today only (strictly today's date)
-2. Filter for topics relevant to our team and industry
-3. For each item, write a short summary including: title, source, key takeaways
-4. Compile everything into a single digest post
-5. Post the digest as a comment on this issue and @mention all workspace members`,
-    icon: Newspaper,
-    frequency: "daily",
-    time: "09:00",
-  },
-  {
-    title: "PR review reminder",
-    summary: "Flag stale pull requests that need review",
-    prompt: `1. List all open pull requests in the repository
-2. Identify PRs that have been open for more than 24 hours without a review
-3. For each stale PR, note the author, age, and a one-line summary of the change
-4. Post a comment on this issue listing all stale PRs with links
-5. @mention the team to remind them to review`,
-    icon: GitPullRequest,
-    frequency: "weekdays",
-    time: "10:00",
-  },
-  {
-    title: "Bug triage",
-    summary: "Assess and prioritize new bug reports",
-    prompt: `1. List all issues with status "triage" or "backlog" that have not been prioritized
-2. For each issue, read the description and any attached logs or screenshots
-3. Assess severity (critical / high / medium / low) based on user impact and scope
-4. Set the priority field on the issue accordingly
-5. Add a comment explaining your assessment and suggested next steps`,
-    icon: Bug,
-    frequency: "weekdays",
-    time: "09:00",
-  },
-  {
-    title: "Weekly progress report",
-    summary: "Compile a weekly summary of team progress",
-    prompt: `1. Gather all issues completed (status "done") in the past 7 days
-2. Gather all issues currently in progress
-3. Identify any blocked issues and their blockers
-4. Calculate key metrics: issues closed, issues opened, net change
-5. Write a structured weekly report with sections: Completed, In Progress, Blocked, Metrics
-6. Post the report as a comment on this issue`,
-    icon: BarChart3,
-    frequency: "weekly",
-    time: "17:00",
-  },
-  {
-    title: "Dependency audit",
-    summary: "Scan for security vulnerabilities and outdated packages",
-    prompt: `1. Run dependency audit tools on the project (npm audit, go vuln check, etc.)
-2. Identify any packages with known security vulnerabilities
-3. List outdated packages that are more than 2 major versions behind
-4. For each finding, note the severity, affected package, and recommended fix
-5. Post a summary report as a comment with actionable items`,
-    icon: Shield,
-    frequency: "weekly",
-    time: "08:00",
-  },
-  {
-    title: "Documentation check",
-    summary: "Review recent changes for documentation gaps",
-    prompt: `1. List all code changes merged in the past 7 days (via git log)
-2. For each significant change, check if related documentation was updated
-3. Identify any new APIs, config options, or features missing documentation
-4. Create a list of documentation gaps with file paths and suggested content
-5. Post the findings as a comment on this issue`,
-    icon: FileSearch,
-    frequency: "weekly",
-    time: "14:00",
-  },
-];
 
 function formatRelativeDate(date: string): string {
   const diff = Date.now() - new Date(date).getTime();
@@ -220,7 +135,7 @@ export function AutopilotsPage() {
               Schedule recurring tasks for your AI agents. Pick a template or start from scratch.
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full max-w-3xl">
-              {TEMPLATES.map((t) => {
+              {AUTOPILOT_TEMPLATES.map((t) => {
                 const Icon = t.icon;
                 return (
                   <button
@@ -266,16 +181,7 @@ export function AutopilotsPage() {
           mode="create"
           open={createOpen}
           onOpenChange={setCreateOpen}
-          initial={
-            selectedTemplate
-              ? { title: selectedTemplate.title, description: selectedTemplate.prompt }
-              : undefined
-          }
-          initialTriggerConfig={
-            selectedTemplate
-              ? { frequency: selectedTemplate.frequency, time: selectedTemplate.time }
-              : undefined
-          }
+          initialTemplate={selectedTemplate}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

- centralize built-in Autopilot templates for reuse
- show the template picker in the New Autopilot dialog, even when the workspace already has autopilots
- preserve empty-state template cards by feeding the selected template into the same dialog path

Closes #1704
Refs #1468

## Issue search

I did not find an exact existing issue for Autopilot starter templates, so I created #1704 as the focused feature request for this PR. #1468 is the closest broad Autopilot usability request; #1343 is related to issue templates, not Autopilot templates.

## Validation

- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/web typecheck
- pnpm --filter @multica/desktop typecheck
- pnpm --filter @multica/views test
- pnpm --filter @multica/views exec eslint autopilots/components/autopilot-dialog.tsx autopilots/components/autopilots-page.tsx autopilots/components/autopilot-templates.ts

Full @multica/views lint still fails on pre-existing unrelated errors in agents/components/tabs/custom-args-tab.tsx and workspace/no-access-page.tsx.