### PR TITLE
[codex] Skip non-UTF-8 skill files

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -29,6 +29,41 @@ describe("ApiClient", () => {
         message: "workspace slug already exists",
         status: 409,
         statusText: "Conflict",
+        details: { error: "workspace slug already exists" },
+      });
+    }
+  });
+
+  it("preserves structured error details", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({
+          error: "skill import contains files that cannot be stored as text",
+          code: "skill_import_skipped_files",
+          skipped_files: ["assets/logo.png"],
+        }), {
+          status: 409,
+          statusText: "Conflict",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const client = new ApiClient("https://api.example.test");
+
+    try {
+      await client.importSkill({ url: "https://skills.sh/acme/skills/demo" });
+      throw new Error("expected importSkill to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({
+        message: "skill import contains files that cannot be stored as text",
+        status: 409,
+        details: {
+          code: "skill_import_skipped_files",
+          skipped_files: ["assets/logo.png"],
+        },
       });
     }
   });

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -26,6 +26,7 @@ import type {
   Skill,
   CreateSkillRequest,
   UpdateSkillRequest,
+  ImportSkillRequest,
   SetAgentSkillsRequest,
   PersonalAccessToken,
   CreatePersonalAccessTokenRequest,
@@ -146,12 +147,14 @@ export interface ImportStarterContentResponse {
 export class ApiError extends Error {
   readonly status: number;
   readonly statusText: string;
+  readonly details: unknown;
 
-  constructor(message: string, status: number, statusText: string) {
+  constructor(message: string, status: number, statusText: string, details?: unknown) {
     super(message);
     this.name = "ApiError";
     this.status = status;
     this.statusText = statusText;
+    this.details = details;
   }
 }
 
@@ -206,14 +209,17 @@ export class ApiClient {
     this.options.onUnauthorized?.();
   }
 
-  private async parseErrorMessage(res: Response, fallback: string): Promise<string> {
+  private async parseError(res: Response, fallback: string): Promise<{ message: string; details?: unknown }> {
     try {
       const data = await res.json() as { error?: string };
-      if (typeof data.error === "string" && data.error) return data.error;
+      if (typeof data.error === "string" && data.error) {
+        return { message: data.error, details: data };
+      }
+      return { message: fallback, details: data };
     } catch {
       // Ignore non-JSON error bodies.
     }
-    return fallback;
+    return { message: fallback };
   }
 
   private async fetch<T>(path: string, init?: RequestInit): Promise<T> {
@@ -238,10 +244,10 @@ export class ApiClient {
 
     if (!res.ok) {
       if (res.status === 401) this.handleUnauthorized();
-      const message = await this.parseErrorMessage(res, `API error: ${res.status} ${res.statusText}`);
+      const { message, details } = await this.parseError(res, `API error: ${res.status} ${res.statusText}`);
       const logLevel = res.status === 404 ? "warn" : "error";
       this.logger[logLevel](`← ${res.status} ${path}`, { rid, duration: `${Date.now() - start}ms`, error: message });
-      throw new ApiError(message, res.status, res.statusText);
+      throw new ApiError(message, res.status, res.statusText, details);
     }
 
     this.logger.info(`← ${res.status} ${path}`, { rid, duration: `${Date.now() - start}ms` });
@@ -830,7 +836,7 @@ export class ApiClient {
     await this.fetch(`/api/skills/${id}`, { method: "DELETE" });
   }
 
-  async importSkill(data: { url: string }): Promise<Skill> {
+  async importSkill(data: ImportSkillRequest): Promise<Skill> {
     return this.fetch("/api/skills/import", {
       method: "POST",
       body: JSON.stringify(data),
@@ -884,7 +890,7 @@ export class ApiClient {
 
     if (!res.ok) {
       if (res.status === 401) this.handleUnauthorized();
-      const message = await this.parseErrorMessage(res, `Upload failed: ${res.status}`);
+      const { message } = await this.parseError(res, `Upload failed: ${res.status}`);
       this.logger.error(`← ${res.status} /api/upload-file`, { rid, duration: `${Date.now() - start}ms`, error: message });
       throw new Error(message);
     }

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -142,6 +142,17 @@ export interface UpdateSkillRequest {
   files?: { path: string; content: string }[];
 }
 
+export interface ImportSkillRequest {
+  url: string;
+  allow_skipped_files?: boolean;
+}
+
+export interface SkillImportSkippedFilesError {
+  error: string;
+  code: "skill_import_skipped_files";
+  skipped_files: string[];
+}
+
 export interface SetAgentSkillsRequest {
   skill_ids: string[];
 }

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -13,6 +13,8 @@ export type {
   SkillFile,
   CreateSkillRequest,
   UpdateSkillRequest,
+  ImportSkillRequest,
+  SkillImportSkippedFilesError,
   SetAgentSkillsRequest,
   RuntimeUsage,
   RuntimeHourlyActivity,

--- a/packages/views/skills/components/create-skill-dialog.test.tsx
+++ b/packages/views/skills/components/create-skill-dialog.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Skill } from "@multica/core/types";
+
+const mockImportSkill = vi.hoisted(() => vi.fn());
+const mockToastCustom = vi.hoisted(() => vi.fn());
+const mockToastDismiss = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/api", async () => {
+  const actual = await vi.importActual<typeof import("@multica/core/api")>(
+    "@multica/core/api",
+  );
+  return {
+    ...actual,
+    api: {
+      importSkill: (...args: unknown[]) => mockImportSkill(...args),
+    },
+  };
+});
+
+vi.mock("@multica/ui/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock("@multica/ui/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    render,
+    children,
+  }: {
+    render?: ReactNode;
+    children?: ReactNode;
+  }) => <>{render ?? children}</>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    custom: mockToastCustom,
+    dismiss: mockToastDismiss,
+    success: mockToastSuccess,
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../platform", () => ({
+  openExternal: vi.fn(),
+}));
+
+import { ApiError } from "@multica/core/api";
+import { CreateSkillDialog } from "./create-skill-dialog";
+
+const importedSkill: Skill = {
+  id: "skill-1",
+  workspace_id: "ws-1",
+  name: "shadcn",
+  description: "",
+  content: "",
+  config: {},
+  files: [],
+  created_by: "user-1",
+  created_at: "2026-04-26T00:00:00Z",
+  updated_at: "2026-04-26T00:00:00Z",
+};
+
+function renderDialog() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CreateSkillDialog onClose={vi.fn()} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("CreateSkillDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("asks for confirmation before skipping unsupported import files", async () => {
+    const user = userEvent.setup();
+    mockImportSkill
+      .mockRejectedValueOnce(
+        new ApiError(
+          "skill import contains files that cannot be stored as text",
+          409,
+          "Conflict",
+          {
+            error: "skill import contains files that cannot be stored as text",
+            code: "skill_import_skipped_files",
+            skipped_files: [
+              "assets/shadcn.png",
+              "assets/shadcn-small.png",
+            ],
+          },
+        ),
+      )
+      .mockResolvedValueOnce(importedSkill);
+
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /Import from URL/i }));
+    await user.type(
+      screen.getByLabelText("Skill URL"),
+      "https://skills.sh/shadcn/ui/shadcn",
+    );
+    await user.click(screen.getByRole("button", { name: /^Import$/i }));
+
+    await waitFor(() => {
+      expect(mockToastCustom).toHaveBeenCalledTimes(1);
+    });
+    expect(mockImportSkill).toHaveBeenCalledWith({
+      url: "https://skills.sh/shadcn/ui/shadcn",
+      allow_skipped_files: undefined,
+    });
+
+    const [renderToast] = mockToastCustom.mock.calls[0]!;
+    render(<>{renderToast("skip-toast")}</>);
+
+    expect(
+      screen.getByText("Some files cannot be imported"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("assets/shadcn.png")).toBeInTheDocument();
+    expect(screen.getByText("assets/shadcn-small.png")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(mockImportSkill).toHaveBeenLastCalledWith({
+        url: "https://skills.sh/shadcn/ui/shadcn",
+        allow_skipped_files: true,
+      });
+    });
+    expect(mockToastDismiss).toHaveBeenCalledWith("skip-toast");
+    expect(mockToastSuccess).toHaveBeenCalledWith("Skill imported");
+  });
+});

--- a/packages/views/skills/components/create-skill-dialog.tsx
+++ b/packages/views/skills/components/create-skill-dialog.tsx
@@ -14,8 +14,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
-import { api } from "@multica/core/api";
-import type { Skill } from "@multica/core/types";
+import { api, ApiError } from "@multica/core/api";
+import type { Skill, SkillImportSkippedFilesError } from "@multica/core/types";
 import { useWorkspaceId } from "@multica/core/hooks";
 import {
   skillDetailOptions,
@@ -262,6 +262,31 @@ function detectUrlSource(url: string): DetectedSource {
   return null;
 }
 
+function getSkippedFilesError(
+  err: unknown,
+): SkillImportSkippedFilesError | null {
+  if (!(err instanceof ApiError) || err.status !== 409) return null;
+  const details = err.details;
+  if (!details || typeof details !== "object") return null;
+  const payload = details as Partial<SkillImportSkippedFilesError>;
+  if (
+    payload.code !== "skill_import_skipped_files" ||
+    !Array.isArray(payload.skipped_files)
+  ) {
+    return null;
+  }
+  return {
+    error:
+      typeof payload.error === "string"
+        ? payload.error
+        : "Some files cannot be imported.",
+    code: payload.code,
+    skipped_files: payload.skipped_files.filter(
+      (path): path is string => typeof path === "string",
+    ),
+  };
+}
+
 function SourceCard({
   label,
   exampleHost,
@@ -309,20 +334,97 @@ function UrlForm({
   const scrollRef = useRef<HTMLDivElement>(null);
   const fadeStyle = useScrollFade(scrollRef);
 
-  const submit = async () => {
-    const trimmed = url.trim();
-    if (!trimmed) return;
+  const importUrl = async (trimmed: string, allowSkippedFiles = false) => {
     setLoading(true);
     setError("");
     try {
-      const skill = await api.importSkill({ url: trimmed });
+      const skill = await api.importSkill({
+        url: trimmed,
+        allow_skipped_files: allowSkippedFiles || undefined,
+      });
       seedAfterCreate(qc, wsId, skill);
       toast.success("Skill imported");
       onCreated(skill);
     } catch (err) {
+      const skippedFilesError = getSkippedFilesError(err);
+      if (skippedFilesError && !allowSkippedFiles) {
+        showSkippedFilesToast(trimmed, skippedFilesError.skipped_files);
+        setLoading(false);
+        return;
+      }
       setError(err instanceof Error ? err.message : "Import failed");
       setLoading(false);
     }
+  };
+
+  const showSkippedFilesToast = (trimmed: string, skippedFiles: string[]) => {
+    const visibleFiles = skippedFiles.slice(0, 3);
+    const remaining = skippedFiles.length - visibleFiles.length;
+
+    toast.custom(
+      (t) => (
+        <div
+          role="alert"
+          className="w-[380px] max-w-[calc(100vw-2rem)] rounded-lg border bg-popover p-4 text-popover-foreground shadow-lg"
+        >
+          <div className="flex items-center gap-2">
+            <div className="flex size-5 shrink-0 items-center justify-center rounded-full bg-amber-500/15 text-amber-600">
+              <AlertCircle className="size-3" />
+            </div>
+            <span className="text-sm font-medium">
+              Some files cannot be imported
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {skippedFiles.length === 1
+              ? "This file is binary or not valid UTF-8 and will be skipped."
+              : `${skippedFiles.length} files are binary or not valid UTF-8 and will be skipped.`}
+          </p>
+          <div className="mt-2 space-y-1">
+            {visibleFiles.map((path) => (
+              <div
+                key={path}
+                className="truncate rounded bg-muted px-2 py-1 font-mono text-xs text-muted-foreground"
+              >
+                {path}
+              </div>
+            ))}
+            {remaining > 0 && (
+              <div className="px-2 text-xs text-muted-foreground">
+                +{remaining} more
+              </div>
+            )}
+          </div>
+          <div className="mt-3 flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => toast.dismiss(t)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                toast.dismiss(t);
+                void importUrl(trimmed, true);
+              }}
+            >
+              Continue
+            </Button>
+          </div>
+        </div>
+      ),
+      { duration: Infinity },
+    );
+  };
+
+  const submit = async () => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    await importUrl(trimmed);
   };
 
   const submittingLabel = (() => {

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -388,6 +389,14 @@ type importedFile struct {
 	content string
 }
 
+func appendImportedTextFile(files []importedFile, path string, body []byte) []importedFile {
+	if !utf8.Valid(body) {
+		slog.Warn("skill import: skipping non-UTF-8 supporting file", "path", path)
+		return files
+	}
+	return append(files, importedFile{path: path, content: string(body)})
+}
+
 // --- ClawHub types ---
 
 type clawhubGetSkillResponse struct {
@@ -606,7 +615,7 @@ func fetchFromClawHub(httpClient *http.Client, rawURL string) (*importedSkill, e
 		if fp == "SKILL.md" {
 			result.content = string(body)
 		} else {
-			result.files = append(result.files, importedFile{path: fp, content: string(body)})
+			result.files = appendImportedTextFile(result.files, fp, body)
 		}
 	}
 
@@ -735,7 +744,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 		}
 		// Convert absolute GitHub path to relative path within skill
 		relPath := strings.TrimPrefix(entry.Path, basePath)
-		result.files = append(result.files, importedFile{path: relPath, content: string(body)})
+		result.files = appendImportedTextFile(result.files, relPath, body)
 	}
 
 	return result, nil

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -373,15 +373,17 @@ func (h *Handler) DeleteSkill(w http.ResponseWriter, r *http.Request) {
 // --- Skill import ---
 
 type ImportSkillRequest struct {
-	URL string `json:"url"`
+	URL               string `json:"url"`
+	AllowSkippedFiles bool   `json:"allow_skipped_files"`
 }
 
 // importedSkill holds the data extracted from an external source.
 type importedSkill struct {
-	name        string
-	description string
-	content     string // SKILL.md body
-	files       []importedFile
+	name         string
+	description  string
+	content      string // SKILL.md body
+	files        []importedFile
+	skippedFiles []string
 }
 
 type importedFile struct {
@@ -389,12 +391,13 @@ type importedFile struct {
 	content string
 }
 
-func appendImportedTextFile(files []importedFile, path string, body []byte) []importedFile {
+func (s *importedSkill) appendTextFile(path string, body []byte) {
 	if !utf8.Valid(body) {
 		slog.Warn("skill import: skipping non-UTF-8 supporting file", "path", path)
-		return files
+		s.skippedFiles = append(s.skippedFiles, path)
+		return
 	}
-	return append(files, importedFile{path: path, content: string(body)})
+	s.files = append(s.files, importedFile{path: path, content: string(body)})
 }
 
 // --- ClawHub types ---
@@ -615,7 +618,7 @@ func fetchFromClawHub(httpClient *http.Client, rawURL string) (*importedSkill, e
 		if fp == "SKILL.md" {
 			result.content = string(body)
 		} else {
-			result.files = appendImportedTextFile(result.files, fp, body)
+			result.appendTextFile(fp, body)
 		}
 	}
 
@@ -744,7 +747,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 		}
 		// Convert absolute GitHub path to relative path within skill
 		relPath := strings.TrimPrefix(entry.Path, basePath)
-		result.files = appendImportedTextFile(result.files, relPath, body)
+		result.appendTextFile(relPath, body)
 	}
 
 	return result, nil
@@ -1106,6 +1109,14 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	if len(imported.skippedFiles) > 0 && !req.AllowSkippedFiles {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":         "skill import contains files that cannot be stored as text",
+			"code":          "skill_import_skipped_files",
+			"skipped_files": imported.skippedFiles,
+		})
 		return
 	}
 

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -108,6 +108,59 @@ func TestFetchFromSkillsSh_UsesEntryURLForNestedDirectories(t *testing.T) {
 	}
 }
 
+func TestFetchFromSkillsSh_SkipsNonUTF8SupportingFiles(t *testing.T) {
+	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/skills":
+				writeJSON(w, http.StatusOK, map[string]any{"default_branch": "main"})
+			case "/repos/acme/skills/contents/skills/pptx":
+				writeJSON(w, http.StatusOK, []githubContentEntry{
+					{
+						Name:        "guide.md",
+						Path:        "skills/pptx/guide.md",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/skills/pptx/guide.md",
+					},
+					{
+						Name:        "preview.png",
+						Path:        "skills/pptx/preview.png",
+						Type:        "file",
+						DownloadURL: "https://raw.githubusercontent.com/acme/skills/main/skills/pptx/preview.png",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/skills/main/skills/pptx/SKILL.md":
+				w.Write([]byte("---\nname: PPTX\n---\ncontent"))
+			case "/acme/skills/main/skills/pptx/guide.md":
+				w.Write([]byte("guide"))
+			case "/acme/skills/main/skills/pptx/preview.png":
+				w.Write([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a})
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	result, err := fetchFromSkillsSh(client, "https://skills.sh/acme/skills/pptx")
+	if err != nil {
+		t.Fatalf("fetchFromSkillsSh: %v", err)
+	}
+
+	gotPaths := importedFilePaths(result.files)
+	wantPaths := []string{"guide.md"}
+	if !equalStrings(gotPaths, wantPaths) {
+		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
+	}
+}
+
 func TestFetchFromSkillsSh_FallbackDoesNotDoubleEscapeDirectoryNames(t *testing.T) {
 	client, requests := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.Header.Get("X-Test-Original-Host") {

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -159,6 +159,10 @@ func TestFetchFromSkillsSh_SkipsNonUTF8SupportingFiles(t *testing.T) {
 	if !equalStrings(gotPaths, wantPaths) {
 		t.Fatalf("files = %v, want %v", gotPaths, wantPaths)
 	}
+	wantSkipped := []string{"preview.png"}
+	if !equalStrings(result.skippedFiles, wantSkipped) {
+		t.Fatalf("skippedFiles = %v, want %v", result.skippedFiles, wantSkipped)
+	}
 }
 
 func TestFetchFromSkillsSh_FallbackDoesNotDoubleEscapeDirectoryNames(t *testing.T) {


### PR DESCRIPTION
Fixes #1705

## Summary

- Detect non-UTF-8 supporting files during skill imports and report them with a structured 409 response before creating the skill
- Show a confirmation toast in the URL import flow listing the files that will be skipped
- Retry the import with `allow_skipped_files` only when the user clicks Continue
- Preserve structured API error details on `ApiError` so callers can handle typed server responses
- Add regression coverage for the backend skip detection, API error details, and the import confirmation toast

## Root Cause

The importer recursively fetched every supporting file and converted each response body to a Go string before storing it in a PostgreSQL `TEXT` column. Binary assets such as PNG files can start with byte `0x89`, which PostgreSQL rejects as invalid UTF-8 for text storage.

## Validation

```text
cd server && go test ./internal/handler
pnpm --filter @multica/core exec vitest run api/client.test.ts
pnpm --filter @multica/views exec vitest run skills/components/create-skill-dialog.test.tsx
pnpm --filter @multica/core typecheck
pnpm --filter @multica/views typecheck
```