### PR TITLE
fix(task): use ReconcileAgentStatus in ClaimTask to prevent race (#1707)

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -235,10 +235,12 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 
 	slog.Info("task claimed", "task_id", util.UUIDToString(task.ID), "agent_id", util.UUIDToString(agentID))
 
-	// Update agent status to working. Hits the DB and may publish events,
-	// so it must be inside the timed window.
+	// Reconcile agent status based on running task count instead of
+	// unconditionally setting "working". This prevents a race where a
+	// concurrent CancelTask sets the agent back to "idle" before this
+	// write lands, leaving the agent stuck at "working" (#1707).
 	t0 = time.Now()
-	s.updateAgentStatus(ctx, agentID, "working")
+	s.ReconcileAgentStatus(ctx, agentID)
 	updateStatusMs = time.Since(t0).Milliseconds()
 
 	// Broadcast task:dispatch. ResolveTaskWorkspaceID inside this path can


### PR DESCRIPTION
## Summary

Fixes #1707 — cancelling a just-claimed task can leave the agent stuck at `status=working` indefinitely.

## Root Cause

`ClaimTask` unconditionally calls `updateAgentStatus(ctx, agentID, "working")` after claiming a task. When a concurrent `CancelTask` interleaves:

| t | Event | Effect |
|---|---|---|
| t0 | `CancelTask`: reconcile sees count=0 → sets `idle` | agent → idle |
| t0+ε | `ClaimTask`: unconditional `updateAgentStatus("working")` lands | **agent stuck at `working`** |

The cancel-side reconcile lands first, then the claim-side blind write overwrites it.

## Fix

Replace the unconditional `updateAgentStatus("working")` with `ReconcileAgentStatus`, which gates on `CountRunningTasks`. If the task was already cancelled by the time the status update runs, the count is 0 and the agent correctly stays/returns to `idle`.

This is the same pattern already used by `CancelTask`, `CompleteTask`, `FailTask`, and all other status-affecting paths — `ClaimTask` was the only outlier.

## Changes

- `server/internal/service/task.go`: `ClaimTask` line 241 — `updateAgentStatus → ReconcileAgentStatus`

## Verification

- `go vet ./internal/service/...` passes clean