### PR TITLE
fix(agent/cursor): route Windows launcher through PowerShell -File to…

### DIFF
--- a/server/pkg/agent/cursor.go
+++ b/server/pkg/agent/cursor.go
@@ -21,12 +21,13 @@ type cursorBackend struct {
 }
 
 func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
-	execPath := b.cfg.ExecutablePath
-	if execPath == "" {
-		execPath = "cursor-agent"
+	execName := b.cfg.ExecutablePath
+	if execName == "" {
+		execName = "cursor-agent"
 	}
-	if _, err := exec.LookPath(execPath); err != nil {
-		return nil, fmt.Errorf("cursor-agent executable not found at %q: %w", execPath, err)
+	lookedUp, err := exec.LookPath(execName)
+	if err != nil {
+		return nil, fmt.Errorf("cursor-agent executable not found at %q: %w", execName, err)
 	}
 
 	timeout := opts.Timeout
@@ -36,10 +37,11 @@ func (b *cursorBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
 	args := buildCursorArgs(prompt, opts, b.cfg.Logger)
+	argv0, cmdArgs := chooseCursorInvocation(execName, lookedUp, args, b.cfg.Logger)
 
-	cmd := exec.CommandContext(runCtx, execPath, args...)
+	cmd := exec.CommandContext(runCtx, argv0, cmdArgs...)
 	hideAgentWindow(cmd)
-	b.cfg.Logger.Info("agent command", "exec", execPath, "args", args)
+	b.cfg.Logger.Info("agent command", "exec", argv0, "args", cmdArgs)
 	cmd.WaitDelay = 20 * time.Second
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
@@ -280,10 +282,10 @@ func (b *cursorBackend) accumulateResultUsage(usage map[string]TokenUsage, evt *
 // ── Cursor stream-json types ──
 
 type cursorStreamEvent struct {
-	Type      string          `json:"type"`
-	Subtype   string          `json:"subtype,omitempty"`
-	SessionID string          `json:"session_id,omitempty"`
-	Model     string          `json:"model,omitempty"`
+	Type      string `json:"type"`
+	Subtype   string `json:"subtype,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
+	Model     string `json:"model,omitempty"`
 
 	// assistant fields
 	Message json.RawMessage `json:"message,omitempty"`
@@ -297,10 +299,10 @@ type cursorStreamEvent struct {
 	Output string `json:"output,omitempty"`
 
 	// result fields
-	ResultText string          `json:"result,omitempty"`
-	IsError    bool            `json:"is_error,omitempty"`
-	Usage      *cursorUsage    `json:"usage,omitempty"`
-	TotalCost  float64         `json:"total_cost_usd,omitempty"`
+	ResultText string       `json:"result,omitempty"`
+	IsError    bool         `json:"is_error,omitempty"`
+	Usage      *cursorUsage `json:"usage,omitempty"`
+	TotalCost  float64      `json:"total_cost_usd,omitempty"`
 
 	// error fields
 	ErrorMsg string `json:"error,omitempty"`

--- a/server/pkg/agent/cursor_invocation.go
+++ b/server/pkg/agent/cursor_invocation.go
@@ -1,0 +1,28 @@
+package agent
+
+import "log/slog"
+
+// chooseCursorInvocation selects the actual program (argv[0]) and the full
+// argv to spawn a cursor-agent run.
+//
+// Background:
+//   - On macOS/Linux, cursor-agent is a real binary and we can pass argv
+//     directly via os/exec — no rewriting needed.
+//   - On Windows, the official installer ships cursor-agent.cmd whose body is
+//     "powershell ... -File cursor-agent.ps1 %*". CreateProcess for a .cmd
+//     file goes through cmd.exe, and %* in a .cmd batch file is expanded by
+//     re-tokenising the original command line, which mangles arguments that
+//     contain newlines or other whitespace (e.g. multi-line `-p` prompts).
+//     To stay on the official launch path while avoiding that re-tokenisation,
+//     we resolve cursor-agent.ps1 next to the .cmd and invoke PowerShell with
+//     `-File <ps1>` directly, letting Go pass each argv as a separate token.
+//
+// The Windows-specific behaviour is implemented in
+// cursor_invocation_windows.go; on other platforms we fall through to a
+// passthrough.
+func chooseCursorInvocation(execName, lookedUp string, args []string, logger *slog.Logger) (string, []string) {
+	if argv0, full, ok := platformCursorInvocation(lookedUp, args, logger); ok {
+		return argv0, full
+	}
+	return execName, args
+}

--- a/server/pkg/agent/cursor_invocation_other.go
+++ b/server/pkg/agent/cursor_invocation_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package agent
+
+import "log/slog"
+
+// platformCursorInvocation is a no-op on non-Windows platforms: cursor-agent
+// is a native binary and Go's os/exec can pass argv unchanged.
+func platformCursorInvocation(_ string, _ []string, _ *slog.Logger) (string, []string, bool) {
+	return "", nil, false
+}

--- a/server/pkg/agent/cursor_invocation_test.go
+++ b/server/pkg/agent/cursor_invocation_test.go
@@ -1,0 +1,31 @@
+package agent
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestChooseCursorInvocation_PassthroughForNonLauncher verifies that when the
+// resolved executable is not a Windows .cmd/.bat launcher, both argv[0] and
+// the argv list are returned unchanged on every platform. This guards against
+// accidental rewriting on macOS/Linux and for direct binary launches on
+// Windows.
+func TestChooseCursorInvocation_PassthroughForNonLauncher(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	execName := "cursor-agent"
+	lookedUp := filepath.Join(t.TempDir(), "cursor-agent") // no .cmd / .bat
+	args := []string{"chat", "-p", "hello\nworld", "--output-format", "stream-json", "--yolo"}
+
+	gotExec, gotArgs := chooseCursorInvocation(execName, lookedUp, args, logger)
+
+	if gotExec != execName {
+		t.Errorf("argv0 changed unexpectedly: got %q want %q", gotExec, execName)
+	}
+	if !reflect.DeepEqual(gotArgs, args) {
+		t.Errorf("argv changed unexpectedly:\n got  %#v\n want %#v", gotArgs, args)
+	}
+}

--- a/server/pkg/agent/cursor_invocation_windows.go
+++ b/server/pkg/agent/cursor_invocation_windows.go
@@ -1,0 +1,80 @@
+//go:build windows
+
+package agent
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// powerShellLookup resolves the PowerShell host to use. It is overridable in
+// tests; production callers should leave it at its default.
+var powerShellLookup = defaultPowerShellLookup
+
+// platformCursorInvocation rewrites the cursor-agent invocation on Windows
+// when the resolved executable is the official cursor-agent.cmd launcher
+// (or a .bat alias) that delegates to cursor-agent.ps1.
+//
+// We replace
+//
+//	cursor-agent.cmd <args...>
+//
+// with
+//
+//	powershell.exe -NoProfile -ExecutionPolicy Bypass -File cursor-agent.ps1 <args...>
+//
+// which is exactly what the .cmd does internally, but lets Go pass each arg
+// as a discrete token instead of routing through cmd.exe's %* re-expansion
+// (which mangles multi-line / whitespace-heavy prompts such as a long -p).
+func platformCursorInvocation(lookedUp string, args []string, logger *slog.Logger) (string, []string, bool) {
+	ext := strings.ToLower(filepath.Ext(lookedUp))
+	if ext != ".cmd" && ext != ".bat" {
+		return "", nil, false
+	}
+	dir := filepath.Dir(lookedUp)
+	ps1 := filepath.Join(dir, "cursor-agent.ps1")
+	if st, err := os.Stat(ps1); err != nil || st.IsDir() {
+		return "", nil, false
+	}
+
+	psExe, ok := powerShellLookup()
+	if !ok {
+		return "", nil, false
+	}
+
+	full := make([]string, 0, 5+len(args))
+	full = append(full, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", ps1)
+	full = append(full, args...)
+
+	if logger != nil {
+		logger.Info("cursor-agent: routing through powershell -File to preserve argv tokens",
+			"powershell", psExe,
+			"ps1", ps1,
+			"original", lookedUp,
+		)
+	}
+	return psExe, full, true
+}
+
+// defaultPowerShellLookup prefers PowerShell on PATH (PowerShell 7's pwsh.exe
+// or any user-overridden powershell.exe) and falls back to the system path
+// shipped with Windows.
+func defaultPowerShellLookup() (string, bool) {
+	for _, name := range []string{"pwsh.exe", "powershell.exe"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p, true
+		}
+	}
+	root := os.Getenv("SystemRoot")
+	if root == "" {
+		root = `C:\Windows`
+	}
+	candidate := filepath.Join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+	if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
+		return candidate, true
+	}
+	return "", false
+}

--- a/server/pkg/agent/cursor_invocation_windows_test.go
+++ b/server/pkg/agent/cursor_invocation_windows_test.go
@@ -1,0 +1,125 @@
+//go:build windows
+
+package agent
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// stubPowerShell installs a deterministic PowerShell lookup for the duration
+// of a test and restores the original on cleanup.
+func stubPowerShell(t *testing.T, path string, ok bool) {
+	t.Helper()
+	prev := powerShellLookup
+	powerShellLookup = func() (string, bool) { return path, ok }
+	t.Cleanup(func() { powerShellLookup = prev })
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestPlatformCursorInvocation_RewritesCmdLauncherToPowerShellFile is the core
+// Windows test: when LookPath resolves cursor-agent to the official .cmd
+// launcher and a sibling cursor-agent.ps1 exists, we should invoke
+// PowerShell with -File <ps1> and forward every original arg unchanged
+// (including a multi-line -p prompt that would otherwise be mangled by the
+// cmd.exe %* re-expansion in the .cmd launcher).
+func TestPlatformCursorInvocation_RewritesCmdLauncherToPowerShellFile(t *testing.T) {
+	dir := t.TempDir()
+	cmdPath := filepath.Join(dir, "cursor-agent.cmd")
+	ps1Path := filepath.Join(dir, "cursor-agent.ps1")
+	writeFile(t, cmdPath, "@echo off\r\npowershell -NoProfile -ExecutionPolicy Bypass -File \"%~dp0cursor-agent.ps1\" %*\r\n")
+	writeFile(t, ps1Path, "# fake cursor-agent.ps1\r\n")
+
+	fakePS := filepath.Join(dir, "powershell.exe")
+	writeFile(t, fakePS, "")
+	stubPowerShell(t, fakePS, true)
+
+	args := []string{
+		"chat",
+		"-p", "line1\nline2\nline3",
+		"--output-format", "stream-json",
+		"--yolo",
+		"--workspace", `C:\some\workspace`,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	gotExec, gotArgs, ok := platformCursorInvocation(cmdPath, args, logger)
+	if !ok {
+		t.Fatalf("expected platform rewrite to be applied, got ok=false")
+	}
+	if gotExec != fakePS {
+		t.Errorf("argv0: got %q want %q", gotExec, fakePS)
+	}
+
+	wantArgs := append([]string{
+		"-NoProfile",
+		"-ExecutionPolicy", "Bypass",
+		"-File", ps1Path,
+	}, args...)
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Errorf("argv mismatch:\n got  %#v\n want %#v", gotArgs, wantArgs)
+	}
+}
+
+// TestPlatformCursorInvocation_SkipsWhenNotCmdOrBat ensures we leave argv
+// alone when the user explicitly resolved cursor-agent to something that
+// isn't a batch launcher (e.g. a real binary or a node script).
+func TestPlatformCursorInvocation_SkipsWhenNotCmdOrBat(t *testing.T) {
+	dir := t.TempDir()
+	exePath := filepath.Join(dir, "cursor-agent.exe")
+	writeFile(t, exePath, "")
+	// A sibling .ps1 must not trick us into rewriting a non-launcher exec.
+	writeFile(t, filepath.Join(dir, "cursor-agent.ps1"), "")
+
+	stubPowerShell(t, filepath.Join(dir, "powershell.exe"), true)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if _, _, ok := platformCursorInvocation(exePath, []string{"chat"}, logger); ok {
+		t.Fatalf("expected ok=false for non-.cmd/.bat launcher")
+	}
+}
+
+// TestPlatformCursorInvocation_SkipsWhenPS1Missing covers the rare case where
+// a .cmd was found but its companion .ps1 is missing (e.g. a partial install).
+// We must fall back to the original launcher rather than synthesising an
+// invalid powershell -File invocation.
+func TestPlatformCursorInvocation_SkipsWhenPS1Missing(t *testing.T) {
+	dir := t.TempDir()
+	cmdPath := filepath.Join(dir, "cursor-agent.cmd")
+	writeFile(t, cmdPath, "@echo off\r\n")
+
+	stubPowerShell(t, filepath.Join(dir, "powershell.exe"), true)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if _, _, ok := platformCursorInvocation(cmdPath, []string{"chat"}, logger); ok {
+		t.Fatalf("expected ok=false when cursor-agent.ps1 is missing")
+	}
+}
+
+// TestPlatformCursorInvocation_SkipsWhenPowerShellMissing covers a stripped
+// down environment in which neither pwsh.exe nor powershell.exe can be
+// resolved. We must not fabricate an empty-string argv[0].
+func TestPlatformCursorInvocation_SkipsWhenPowerShellMissing(t *testing.T) {
+	dir := t.TempDir()
+	cmdPath := filepath.Join(dir, "cursor-agent.cmd")
+	ps1Path := filepath.Join(dir, "cursor-agent.ps1")
+	writeFile(t, cmdPath, "@echo off\r\n")
+	writeFile(t, ps1Path, "# fake\r\n")
+
+	stubPowerShell(t, "", false)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if _, _, ok := platformCursorInvocation(cmdPath, []string{"chat"}, logger); ok {
+		t.Fatalf("expected ok=false when no powershell host is available")
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes Multica-spawned `cursor-agent` always exiting 1 on Windows when the
prompt contains newlines (i.e. nearly every real task).

**Root cause.** The official `cursor-agent` installer ships
`cursor-agent.cmd`, whose body is

    powershell ... -File cursor-agent.ps1 %*

`CreateProcess` for a `.cmd` file routes through `cmd.exe`, and `%*` in a
batch file is expanded by **re-tokenising the original command line**.
That re-tokenisation mangles any argument containing newlines or other
whitespace — most notably a long, multi-line `-p <prompt>`. The agent
ends up seeing a truncated prompt and either reports `Workspace Trust
Required` or exits with status 1 before producing a session id.

Manually pasting an equivalent command into PowerShell works because
PowerShell tokenises the user input itself instead of recovering tokens
from the command-line string — exactly what we want Go's `os/exec` to do
for us.

**Fix.** When `LookPath` resolves `cursor-agent` to a `.cmd` / `.bat`
launcher and a sibling `cursor-agent.ps1` exists, the daemon now invokes
PowerShell directly:

    powershell -NoProfile -ExecutionPolicy Bypass -File <ps1> <args...>

This is exactly what the `.cmd` does internally; we simply skip the
`cmd.exe` re-tokenisation step. Each `argv` is passed as a discrete
token, so multi-line prompts and other whitespace-heavy values survive
intact. macOS / Linux behaviour is unchanged (the path is gated by
`//go:build windows`); the official cursor-agent launch chain is
preserved (no `node.exe` shortcut, no prompt mutation, no extra flags).

PowerShell host resolution prefers `pwsh.exe` (PS 7) on PATH, then
`powershell.exe` on PATH, then falls back to
`%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`. The
lookup is a package-level variable so it can be stubbed in tests.

## Related Issue

Closes #1297

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/cursor.go` — call `chooseCursorInvocation(...)` to
  pick `argv[0]` and the full argv just before `exec.CommandContext`.
- `server/pkg/agent/cursor_invocation.go` — shared
  `chooseCursorInvocation` entry point with a doc-comment that explains
  the cmd `%*` trap, so future maintainers don't "optimise" the rewrite
  away.
- `server/pkg/agent/cursor_invocation_other.go` (`//go:build !windows`)
  — no-op passthrough, keeps non-Windows builds free of any
  Windows-only dependency.
- `server/pkg/agent/cursor_invocation_windows.go` (`//go:build windows`)
  — detect `.cmd`/`.bat` + sibling `cursor-agent.ps1`, build the
  PowerShell argv, log a structured `Info` line on activation. Exports
  `powerShellLookup` as a package variable for test injection.
- `server/pkg/agent/cursor_invocation_test.go` — passthrough behaviour
  for non-launcher targets (runs on every platform).
- `server/pkg/agent/cursor_invocation_windows_test.go`
  (`//go:build windows`) — four tests covering: successful rewrite with
  a multi-line prompt, `.exe` direct launch (skip), missing `.ps1`
  (skip), missing PowerShell host (skip). All paths use a stubbed
  `powerShellLookup` so the suite never spawns real PowerShell.
- `server/pkg/agent/exec_fixture_windows_test.go` — restored Windows
  test helper `writeTestExecutable`. Required for the `pkg/agent` test
  binary to compile on Windows (consumed by existing
  `claude_test.go` / `codex_test.go` / `kimi_test.go`); without it the
  whole test package can't build on Windows and the new cursor tests
  can't run either.

## How to Test

1. **Unit tests (any platform):**

   ```
   cd server
   go test ./pkg/agent/ -run "Cursor" -count=1 -v
   ```

   Expected: all `TestChooseCursorInvocation_*` and
   `TestPlatformCursorInvocation_*` cases pass on Windows; the
   passthrough case also passes on macOS / Linux.

2. **End-to-end on Windows** (reproduces the issue from #1297):

   - Stop the existing daemon.
   - Build & start the daemon from this branch (`make daemon` / your
     usual launch).
   - Assign a Cursor agent task with a real, multi-line prompt
     (anything ≥ a few hundred characters with newlines is enough; the
     reported failure trigger is a typical Multica system prompt).
   - Before the fix: task fails almost immediately with
     `cursor-agent exited with error: exit status 1` and the stderr
     tail mentions `Workspace Trust Required`.
   - After the fix: task runs to completion. The daemon log shows a
     new line:

         cursor-agent: routing through powershell -File to preserve argv tokens
         powershell=...\powershell.exe ps1=...\cursor-agent.ps1
         original=...\cursor-agent.cmd

     and the subsequent `agent command` line lists `argv[0]` as
     PowerShell with `-NoProfile -ExecutionPolicy Bypass -File ...
     cursor-agent.ps1` followed by the original cursor-agent argv.

3. **Sanity on non-Windows:** behaviour is unchanged (the new code path
   is gated by `//go:build windows`); `go test ./pkg/agent/...` should
   pass exactly as on `main`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — daemon-only)
- [x] I have updated relevant documentation to reflect my changes (doc-comments in new files explain the `cmd %*` trap)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Risks considered

- **PowerShell ExecutionPolicy.** We pass `-ExecutionPolicy Bypass`, the
  same flag the official `cursor-agent.cmd` already uses, so we don't
  weaken policy beyond what the upstream installer does.
- **PS profile side effects.** `-NoProfile` matches the `.cmd`,
  guaranteeing identical environment.
- **Locked-down hosts without PowerShell.** Both `pwsh.exe` and
  `powershell.exe` are missing → `chooseCursorInvocation` falls back to
  the original `.cmd` invocation (the test
  `TestPlatformCursorInvocation_SkipsWhenPowerShellMissing` pins this
  behaviour). Worst case is the pre-existing behaviour, never worse.
- **`cursor-agent` shipped without `.ps1`.** Same fallback —
  `TestPlatformCursorInvocation_SkipsWhenPS1Missing` pins it.
- **Future installer changes the launcher layout.** We only rewrite
  when we actually see a sibling `.ps1`; other layouts hit the
  passthrough and behave exactly as today.

## AI Disclosure

**AI tool used:** Cursor

**Prompt / approach:**
Reproduced #1297 locally with a small `go run`-able harness that drives
`backend.Execute` with both a short prompt and an embedded production
long prompt, confirming the failure mode and bisecting the cause to the
`.cmd` `%*` re-tokenisation. Iterated on the fix in chat: started from a
prompt-normalisation hypothesis (rejected — masks the root cause and
silently rewrites user content), then moved to invoking PowerShell
directly with `-File` so we stay on the official launch chain while
sidestepping `cmd.exe`. Refactored the platform-specific bits behind a
build-tag boundary, exposed the PowerShell lookup as an injectable
variable, and wrote a Windows-only unit suite that exercises every
fallback branch without spawning real PowerShell. Final state validated
with `go vet ./...`, `go build ./...`, and `go test ./pkg/agent/...` on
Windows.

## Screenshots (optional)

N/A — daemon-only change.
