### PR TITLE
fix(auth): add Retry-After header to send-code 429 response

### DIFF
--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -258,6 +259,11 @@ func (h *Handler) SendCode(w http.ResponseWriter, r *http.Request) {
 	// Rate limit: max 1 code per 60 seconds per email
 	latest, err := h.Queries.GetLatestCodeByEmail(r.Context(), email)
 	if err == nil && time.Since(latest.CreatedAt.Time) < 60*time.Second {
+		remaining := 60 - int(math.Ceil(time.Since(latest.CreatedAt.Time).Seconds()))
+		if remaining < 1 {
+			remaining = 1
+		}
+		w.Header().Set("Retry-After", fmt.Sprintf("%d", remaining))
 		writeError(w, http.StatusTooManyRequests, "please wait before requesting another code")
 		return
 	}


### PR DESCRIPTION
## Problem

When `/auth/send-code` rate-limits a client (1 code per 60s per email), the 429 response does not include a `Retry-After` header. Clients cannot determine how long to wait before retrying.

## Fix

Compute the remaining seconds until the rate-limit window expires and set `Retry-After: <seconds>` on the 429 response. The header value is always ≥ 1 (clamped).

## Changes

- `server/internal/handler/auth.go`: Add `Retry-After` header before the existing `writeError` call in the rate-limit branch (+6 lines)

## Testing

- `go vet ./internal/handler/...` — passes clean
- No behavioral change to existing rate limiting — the 429 status and error message are unchanged

Closes #1666