### PR TITLE
fix(agent/opencode): bypass npm .cmd shim on Windows to preserve multi-line prompts

### DIFF
--- a/server/pkg/agent/exec_fixture_windows_test.go
+++ b/server/pkg/agent/exec_fixture_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package agent
+
+import (
+	"os"
+	"testing"
+)
+
+// writeTestExecutable is the Windows counterpart to the //go:build unix
+// implementation in exec_fixture_unix_test.go. ETXTBSY is a Linux/Unix
+// fork-exec race; Windows doesn't have that pathology, so a plain
+// os.WriteFile is sufficient.
+//
+// The helper is referenced by claude_test.go / codex_test.go /
+// kimi_test.go, so the absence of a Windows impl made
+// `go test ./pkg/agent` fail to build on Windows. Lifted from #1719
+// (Codex) with attribution.
+func writeTestExecutable(tb testing.TB, path string, content []byte) {
+	tb.Helper()
+	if err := os.WriteFile(path, content, 0o755); err != nil {
+		tb.Fatalf("write test executable %s: %v", path, err)
+	}
+}

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -289,7 +289,8 @@ func (b *opencodeBackend) handleErrorEvent(event opencodeEvent, ch chan<- Messag
 // resolveOpenCodeNativeFromShim returns the path to the native OpenCode
 // executable bundled inside the npm package, given the path to the npm
 // `opencode.cmd` shim that PATH lookup found on Windows. Returns "" if shim
-// doesn't end in `.cmd` or the expected native binary isn't present.
+// doesn't end in `.cmd` or no candidate npm platform package has a bundled
+// native binary present.
 //
 // Windows batch argument forwarding via `%*` does not preserve newlines, so
 // multi-line positional argv is truncated at the first newline before the
@@ -299,8 +300,13 @@ func (b *opencodeBackend) handleErrorEvent(event opencodeEvent, ch chan<- Messag
 //
 // Layout when installed via `npm install -g opencode-ai`:
 //
-//	<prefix>\opencode.cmd                                                  (shim)
-//	<prefix>\node_modules\opencode-ai\node_modules\opencode-windows-x64\bin\opencode.exe (native)
+//	<prefix>\opencode.cmd                                                                       (shim)
+//	<prefix>\node_modules\opencode-ai\node_modules\opencode-windows-{x64,x64-baseline,arm64}\bin\opencode.exe (native)
+//
+// `opencode-windows-x64-baseline` ships for older CPUs without AVX2;
+// `opencode-windows-arm64` ships for Surface / Copilot+ PC hosts.
+// Candidates are tried in GOARCH-preferred order so the most likely match
+// for the current host comes first.
 //
 // statFn is injected so this is testable on non-Windows hosts.
 func resolveOpenCodeNativeFromShim(shimPath string, statFn func(string) (os.FileInfo, error)) string {
@@ -308,11 +314,29 @@ func resolveOpenCodeNativeFromShim(shimPath string, statFn func(string) (os.File
 		return ""
 	}
 	prefix := filepath.Dir(shimPath)
-	candidate := filepath.Join(prefix, "node_modules", "opencode-ai", "node_modules", "opencode-windows-x64", "bin", "opencode.exe")
-	if _, err := statFn(candidate); err != nil {
-		return ""
+	for _, pkg := range opencodeWindowsPackageCandidates(runtime.GOARCH) {
+		candidate := filepath.Join(prefix, "node_modules", "opencode-ai", "node_modules", pkg, "bin", "opencode.exe")
+		if _, err := statFn(candidate); err == nil {
+			return candidate
+		}
 	}
-	return candidate
+	return ""
+}
+
+// opencodeWindowsPackageCandidates returns the npm platform package names
+// that may host the bundled `opencode.exe` on Windows, ordered so the most
+// likely match for the given GOARCH comes first. ARM64 hosts try the arm64
+// build first; everything else tries x64, then the baseline x64 build for
+// older CPUs without AVX2, then arm64 as a final fallback. Cost is one
+// extra statFn call per miss when the GOARCH-preferred package isn't
+// installed.
+func opencodeWindowsPackageCandidates(goarch string) []string {
+	switch goarch {
+	case "arm64":
+		return []string{"opencode-windows-arm64", "opencode-windows-x64", "opencode-windows-x64-baseline"}
+	default:
+		return []string{"opencode-windows-x64", "opencode-windows-x64-baseline", "opencode-windows-arm64"}
+	}
 }
 
 // extractToolOutput converts the tool state output (which may be a string or
@@ -368,8 +392,8 @@ type opencodeEventPart struct {
 
 // opencodeTokens represents token usage in a step_finish event.
 type opencodeTokens struct {
-	Input  int64              `json:"input"`
-	Output int64              `json:"output"`
+	Input  int64                `json:"input"`
+	Output int64                `json:"output"`
 	Cache  *opencodeCacheTokens `json:"cache,omitempty"`
 }
 

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -28,9 +31,17 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	if execPath == "" {
 		execPath = "opencode"
 	}
-	if _, err := exec.LookPath(execPath); err != nil {
+	resolved, err := exec.LookPath(execPath)
+	if err != nil {
 		return nil, fmt.Errorf("opencode executable not found at %q: %w", execPath, err)
 	}
+	if runtime.GOOS == "windows" {
+		if native := resolveOpenCodeNativeFromShim(resolved, os.Stat); native != "" {
+			b.cfg.Logger.Info("opencode resolved to native binary to avoid .cmd shim argv truncation", "shim", resolved, "native", native)
+			resolved = native
+		}
+	}
+	execPath = resolved
 
 	timeout := opts.Timeout
 	if timeout == 0 {
@@ -273,6 +284,35 @@ func (b *opencodeBackend) handleErrorEvent(event opencodeEvent, ch chan<- Messag
 
 	*finalStatus = "failed"
 	*finalError = errMsg
+}
+
+// resolveOpenCodeNativeFromShim returns the path to the native OpenCode
+// executable bundled inside the npm package, given the path to the npm
+// `opencode.cmd` shim that PATH lookup found on Windows. Returns "" if shim
+// doesn't end in `.cmd` or the expected native binary isn't present.
+//
+// Windows batch argument forwarding via `%*` does not preserve newlines, so
+// multi-line positional argv is truncated at the first newline before the
+// shim hands off to the JS entrypoint. Daemon prompts can include literal
+// newlines (system prompt + user message), which makes the agent see only
+// the first line. Native binary spawn skips the cmd.exe layer entirely.
+//
+// Layout when installed via `npm install -g opencode-ai`:
+//
+//	<prefix>\opencode.cmd                                                  (shim)
+//	<prefix>\node_modules\opencode-ai\node_modules\opencode-windows-x64\bin\opencode.exe (native)
+//
+// statFn is injected so this is testable on non-Windows hosts.
+func resolveOpenCodeNativeFromShim(shimPath string, statFn func(string) (os.FileInfo, error)) string {
+	if !strings.EqualFold(filepath.Ext(shimPath), ".cmd") {
+		return ""
+	}
+	prefix := filepath.Dir(shimPath)
+	candidate := filepath.Join(prefix, "node_modules", "opencode-ai", "node_modules", "opencode-windows-x64", "bin", "opencode.exe")
+	if _, err := statFn(candidate); err != nil {
+		return ""
+	}
+	return candidate
 }
 
 // extractToolOutput converts the tool state output (which may be a string or

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -2,8 +2,11 @@ package agent
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -708,4 +711,81 @@ func TestOpencodeProcessEventsErrorDoesNotRevertToCompleted(t *testing.T) {
 	}
 
 	close(ch)
+}
+
+// ── Windows native-binary resolution tests ──
+
+// fakeStat returns a statFn that reports any path in `present` as existing
+// and every other path as not-found. The returned os.FileInfo is a stub
+// because resolveOpenCodeNativeFromShim only inspects the error.
+func fakeStat(present ...string) func(string) (os.FileInfo, error) {
+	set := make(map[string]struct{}, len(present))
+	for _, p := range present {
+		set[p] = struct{}{}
+	}
+	return func(path string) (os.FileInfo, error) {
+		if _, ok := set[path]; ok {
+			return nil, nil
+		}
+		return nil, errors.New("not found")
+	}
+}
+
+func TestResolveOpenCodeNativeFromShimResolvesNpmShim(t *testing.T) {
+	t.Parallel()
+
+	// Reporter's exact layout from multica#1717.
+	shim := filepath.Join("C:\\nvm4w", "nodejs", "opencode.cmd")
+	native := filepath.Join("C:\\nvm4w", "nodejs", "node_modules", "opencode-ai", "node_modules", "opencode-windows-x64", "bin", "opencode.exe")
+
+	got := resolveOpenCodeNativeFromShim(shim, fakeStat(native))
+	if got != native {
+		t.Errorf("got %q, want %q", got, native)
+	}
+}
+
+func TestResolveOpenCodeNativeFromShimReturnsEmptyWhenNativeMissing(t *testing.T) {
+	t.Parallel()
+
+	// Shim ends in .cmd but the bundled native binary isn't present (e.g.
+	// platform package didn't install or layout changed). Caller must keep
+	// the original shim path so PATH lookup still wins.
+	shim := filepath.Join("C:\\nvm4w", "nodejs", "opencode.cmd")
+
+	got := resolveOpenCodeNativeFromShim(shim, fakeStat())
+	if got != "" {
+		t.Errorf("got %q, want empty (missing native binary)", got)
+	}
+}
+
+func TestResolveOpenCodeNativeFromShimSkipsNonCmdPath(t *testing.T) {
+	t.Parallel()
+
+	// On macOS/Linux the path returned by exec.LookPath is the native
+	// binary itself, with no .cmd extension. Helper should signal "no
+	// rewrite needed" by returning empty.
+	cases := []string{
+		"/usr/local/bin/opencode",
+		"C:\\nvm4w\\nodejs\\opencode.exe",
+		"",
+	}
+	for _, p := range cases {
+		if got := resolveOpenCodeNativeFromShim(p, fakeStat("anything")); got != "" {
+			t.Errorf("path %q: got %q, want empty", p, got)
+		}
+	}
+}
+
+func TestResolveOpenCodeNativeFromShimAcceptsUppercaseExtension(t *testing.T) {
+	t.Parallel()
+
+	// Windows is case-insensitive on filesystem extensions. PATHEXT tokens
+	// are commonly uppercase, and exec.LookPath can return either case.
+	shim := filepath.Join("C:\\nvm4w", "nodejs", "opencode.CMD")
+	native := filepath.Join("C:\\nvm4w", "nodejs", "node_modules", "opencode-ai", "node_modules", "opencode-windows-x64", "bin", "opencode.exe")
+
+	got := resolveOpenCodeNativeFromShim(shim, fakeStat(native))
+	if got != native {
+		t.Errorf("got %q, want %q", got, native)
+	}
 }

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -789,3 +789,56 @@ func TestResolveOpenCodeNativeFromShimAcceptsUppercaseExtension(t *testing.T) {
 		t.Errorf("got %q, want %q", got, native)
 	}
 }
+
+func TestResolveOpenCodeNativeFromShimFallsBackToBaseline(t *testing.T) {
+	t.Parallel()
+
+	// Older CPUs without AVX2 get `opencode-windows-x64-baseline` instead of
+	// the default x64 build. Resolver should fall through and find it when
+	// the primary x64 package isn't installed.
+	shim := filepath.Join("C:\\nvm4w", "nodejs", "opencode.cmd")
+	baseline := filepath.Join("C:\\nvm4w", "nodejs", "node_modules", "opencode-ai", "node_modules", "opencode-windows-x64-baseline", "bin", "opencode.exe")
+
+	got := resolveOpenCodeNativeFromShim(shim, fakeStat(baseline))
+	if got != baseline {
+		t.Errorf("got %q, want %q", got, baseline)
+	}
+}
+
+func TestOpencodeWindowsPackageCandidatesArm64(t *testing.T) {
+	t.Parallel()
+
+	// ARM64 hosts (Surface, Copilot+ PC) should try arm64 first so the
+	// resolver doesn't accidentally pick up a leftover x64 install when
+	// the matching arm64 package is present.
+	got := opencodeWindowsPackageCandidates("arm64")
+	want := []string{"opencode-windows-arm64", "opencode-windows-x64", "opencode-windows-x64-baseline"}
+	if !equalStringSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestOpencodeWindowsPackageCandidatesAmd64(t *testing.T) {
+	t.Parallel()
+
+	// amd64 (and any non-arm64) hosts try x64 → baseline → arm64. The arm64
+	// fallback at the end covers the unusual case where only the arm64
+	// package is installed; resolution still succeeds.
+	got := opencodeWindowsPackageCandidates("amd64")
+	want := []string{"opencode-windows-x64", "opencode-windows-x64-baseline", "opencode-windows-arm64"}
+	if !equalStringSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Problem

Closes #1717. On Windows, when the daemon launches OpenCode through the npm-generated `opencode.cmd` shim, multi-line prompts are truncated at the first newline before they reach the agent. The user-facing symptom: chat messages like `test` or `你的模型是什么` are dropped from the prompt and OpenCode replies generically as if it never received them.

The daemon log shows the full multi-line prompt is in argv:

```
agent command exec=opencode args="[run --format json --model ... You are running as a chat assistant for a Multica workspace.\nA user is chatting with you directly. Respond to their message.\n\nUser message:\ntest\n]"
```

But OpenCode's own SQLite DB only records the first line. The reporter confirmed that invoking the bundled native `opencode.exe` directly preserves the full prompt.

## Root cause

The npm shim forwards arguments using Windows batch `%*`:

```bat
"%_prog%" "%dp0%\node_modules\opencode-ai\bin\opencode" %*
```

Windows batch argument forwarding does not preserve newlines inside positional arguments. The shim hands a truncated argv to the JS entrypoint before OpenCode ever runs.

## Fix

When `runtime.GOOS == "windows"` and `exec.LookPath` returned a `.cmd` shim, walk to the native binary npm bundles next to the shim:

```
<prefix>\opencode.cmd                                                                       (shim found by PATH)
<prefix>\node_modules\opencode-ai\node_modules\opencode-windows-x64\bin\opencode.exe        (native target)
```

If the native binary isn't there (unusual install layout, opted-out platform package), the resolver returns empty and the existing shim path is kept so behavior is unchanged for non-npm installs.

Resolution is a pure helper with an injected `statFn`, so the layout walk is testable on Linux without spawning anything.

## Why scoped to opencode

Other agent backends (codex, claude, openclaw, hermes, kimi, copilot, gemini, cursor, pi) use the same `exec.LookPath(execPath)` pattern, so they could exhibit the same `.cmd` truncation if their distribution similarly relies on a Windows npm shim. I've kept this PR narrow to OpenCode because that's where the repro lives, the npm package layout is OpenCode-specific, and the fix shape needs the path walk validated against an actual installed layout. Happy to extend or split out a generic Windows-shim-aware resolver if you'd prefer to land that pattern across the agent package in a follow-up.

## Tests

Four cases in `opencode_test.go`, all run on Linux via `fakeStat`:

- `TestResolveOpenCodeNativeFromShimResolvesNpmShim` — the reporter's exact `C:\nvm4w\nodejs\opencode.cmd` layout resolves to the bundled `opencode.exe`.
- `TestResolveOpenCodeNativeFromShimReturnsEmptyWhenNativeMissing` — shim is `.cmd` but native binary is absent, helper returns "" and the caller keeps the original path.
- `TestResolveOpenCodeNativeFromShimSkipsNonCmdPath` — Linux/Mac binary, direct `.exe`, and empty input all skip resolution unchanged.
- `TestResolveOpenCodeNativeFromShimAcceptsUppercaseExtension` — uppercase `.CMD` (Windows is case-insensitive on extensions, PATHEXT can return either case) resolves the same way.

```
=== RUN   TestResolveOpenCodeNativeFromShimResolvesNpmShim
--- PASS: TestResolveOpenCodeNativeFromShimResolvesNpmShim (0.00s)
=== RUN   TestResolveOpenCodeNativeFromShimReturnsEmptyWhenNativeMissing
--- PASS: TestResolveOpenCodeNativeFromShimReturnsEmptyWhenNativeMissing (0.00s)
=== RUN   TestResolveOpenCodeNativeFromShimSkipsNonCmdPath
--- PASS: TestResolveOpenCodeNativeFromShimSkipsNonCmdPath (0.00s)
=== RUN   TestResolveOpenCodeNativeFromShimAcceptsUppercaseExtension
--- PASS: TestResolveOpenCodeNativeFromShimAcceptsUppercaseExtension (0.00s)
PASS
ok  	github.com/multica-ai/multica/server/pkg/agent	0.003s
```

Full `go test ./pkg/agent/` stays green.

## Notes

- I don't have a Windows host to validate end-to-end at the daemon level. The shim-truncation pathology is well-characterized in node-windows / npm tracker history and the reporter's repro pins it explicitly. The path walk itself matches the layout described in the issue and what `npm install -g opencode-ai` produces today; if you'd prefer the resolver gated by an env flag or a config opt-in for the first release, happy to add that.
- Logging the rewrite (`opencode resolved to native binary to avoid .cmd shim argv truncation`) gives operators visibility when the daemon swaps shim → native, in case the npm layout changes in a future OpenCode release and the resolver starts missing.