### PR TITLE
fix(agent): preserve OpenCode multiline prompts on Windows

### DIFF
--- a/server/pkg/agent/exec_fixture_windows_test.go
+++ b/server/pkg/agent/exec_fixture_windows_test.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package agent
+
+import (
+	"os"
+	"testing"
+)
+
+func writeTestExecutable(tb testing.TB, path string, content []byte) {
+	tb.Helper()
+	if err := os.WriteFile(path, content, 0o755); err != nil {
+		tb.Fatalf("write test executable %s: %v", path, err)
+	}
+}

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -24,12 +27,9 @@ type opencodeBackend struct {
 }
 
 func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
-	execPath := b.cfg.ExecutablePath
-	if execPath == "" {
-		execPath = "opencode"
-	}
-	if _, err := exec.LookPath(execPath); err != nil {
-		return nil, fmt.Errorf("opencode executable not found at %q: %w", execPath, err)
+	execPath, err := resolveOpenCodeExecPath(b.cfg.ExecutablePath)
+	if err != nil {
+		return nil, err
 	}
 
 	timeout := opts.Timeout
@@ -138,6 +138,52 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func resolveOpenCodeExecPath(execPath string) (string, error) {
+	if execPath == "" {
+		execPath = "opencode"
+	}
+	resolved, err := exec.LookPath(execPath)
+	if err != nil {
+		return "", fmt.Errorf("opencode executable not found at %q: %w", execPath, err)
+	}
+	if runtime.GOOS == "windows" {
+		if native := resolveOpenCodeWindowsNativeBinary(resolved); native != "" {
+			return native, nil
+		}
+	}
+	return resolved, nil
+}
+
+func resolveOpenCodeWindowsNativeBinary(shimPath string) string {
+	for _, packageRoot := range openCodePackageRoots(shimPath) {
+		for _, pkg := range openCodeWindowsPackageCandidates() {
+			candidate := filepath.Join(packageRoot, "node_modules", pkg, "bin", "opencode.exe")
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate
+			}
+		}
+	}
+	return ""
+}
+
+func openCodePackageRoots(shimPath string) []string {
+	dir := filepath.Dir(shimPath)
+	roots := []string{filepath.Join(dir, "node_modules", "opencode-ai")}
+	if filepath.Base(dir) == "bin" && filepath.Base(filepath.Dir(dir)) == "opencode-ai" {
+		roots = append(roots, filepath.Dir(dir))
+	}
+	return roots
+}
+
+func openCodeWindowsPackageCandidates() []string {
+	switch runtime.GOARCH {
+	case "arm64":
+		return []string{"opencode-windows-arm64", "opencode-windows-x64", "opencode-windows-x64-baseline"}
+	default:
+		return []string{"opencode-windows-x64", "opencode-windows-x64-baseline", "opencode-windows-arm64"}
+	}
 }
 
 // ── Event handlers ──
@@ -328,8 +374,8 @@ type opencodeEventPart struct {
 
 // opencodeTokens represents token usage in a step_finish event.
 type opencodeTokens struct {
-	Input  int64              `json:"input"`
-	Output int64              `json:"output"`
+	Input  int64                `json:"input"`
+	Output int64                `json:"output"`
 	Cache  *opencodeCacheTokens `json:"cache,omitempty"`
 }
 

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -17,6 +20,120 @@ func TestNewReturnsOpencodeBackend(t *testing.T) {
 	if _, ok := b.(*opencodeBackend); !ok {
 		t.Fatalf("expected *opencodeBackend, got %T", b)
 	}
+}
+
+func TestResolveOpenCodeWindowsNativeBinaryPrefersNativeExe(t *testing.T) {
+	t.Parallel()
+
+	shimDir := t.TempDir()
+	native := filepath.Join(shimDir, "node_modules", "opencode-ai", "node_modules", "opencode-windows-x64", "bin", "opencode.exe")
+	if err := os.MkdirAll(filepath.Dir(native), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(native, []byte("fake exe"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveOpenCodeWindowsNativeBinary(filepath.Join(shimDir, "opencode.cmd"))
+	if got != native {
+		t.Fatalf("native path: got %q, want %q", got, native)
+	}
+}
+
+func TestResolveOpenCodeWindowsNativeBinaryFallsBackToBaseline(t *testing.T) {
+	t.Parallel()
+
+	shimDir := t.TempDir()
+	native := filepath.Join(shimDir, "node_modules", "opencode-ai", "node_modules", "opencode-windows-x64-baseline", "bin", "opencode.exe")
+	if err := os.MkdirAll(filepath.Dir(native), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(native, []byte("fake exe"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveOpenCodeWindowsNativeBinary(filepath.Join(shimDir, "opencode.cmd"))
+	if got != native {
+		t.Fatalf("native path: got %q, want %q", got, native)
+	}
+}
+
+func TestResolveOpenCodeWindowsNativeBinaryFromPackageBin(t *testing.T) {
+	t.Parallel()
+
+	packageRoot := filepath.Join(t.TempDir(), "node_modules", "opencode-ai")
+	native := filepath.Join(packageRoot, "node_modules", "opencode-windows-x64", "bin", "opencode.exe")
+	if err := os.MkdirAll(filepath.Dir(native), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(native, []byte("fake exe"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveOpenCodeWindowsNativeBinary(filepath.Join(packageRoot, "bin", "opencode"))
+	if got != native {
+		t.Fatalf("native path: got %q, want %q", got, native)
+	}
+}
+
+func TestResolveOpenCodeExecPathWindowsPrefersNativeBinary(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific executable substitution")
+	}
+
+	shimDir := t.TempDir()
+	shim := filepath.Join(shimDir, "opencode.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	native := filepath.Join(shimDir, "node_modules", "opencode-ai", "node_modules", "opencode-windows-x64", "bin", "opencode.exe")
+	if err := os.MkdirAll(filepath.Dir(native), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(native, []byte("fake exe"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveOpenCodeExecPath(shim)
+	if err != nil {
+		t.Fatalf("resolve executable: %v", err)
+	}
+	if got != native {
+		t.Fatalf("exec path: got %q, want %q", got, native)
+	}
+}
+
+func TestResolveOpenCodeExecPathFallsBackToResolvedExecutable(t *testing.T) {
+	t.Parallel()
+
+	execPath := writeOpenCodeTestExecutable(t)
+	got, err := resolveOpenCodeExecPath(execPath)
+	if err != nil {
+		t.Fatalf("resolve executable: %v", err)
+	}
+	if got != execPath {
+		t.Fatalf("exec path: got %q, want %q", got, execPath)
+	}
+}
+
+func writeOpenCodeTestExecutable(tb testing.TB) string {
+	tb.Helper()
+
+	dir := tb.TempDir()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "opencode.cmd")
+		if err := os.WriteFile(path, []byte("@echo off\r\n"), 0o755); err != nil {
+			tb.Fatal(err)
+		}
+		return path
+	}
+
+	path := filepath.Join(dir, "opencode")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	return path
 }
 
 // ── Text event tests ──


### PR DESCRIPTION
## What does this PR do?

Fixes Windows OpenCode daemon execution when `opencode` resolves to the npm-generated `.cmd` shim. The shim forwards arguments through Windows batch `%*`, which truncates newline-containing positional prompts before OpenCode receives them. The daemon now resolves OpenCode on Windows and prefers the bundled native `opencode.exe` when it is available, preserving the full multiline prompt.

This keeps prompt construction and non-Windows execution behavior unchanged.

## Related Issue

Closes #1717

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `server/pkg/agent/opencode.go` to resolve the OpenCode executable before launch and prefer bundled native Windows binaries over npm shims.
- Added Windows package candidate fallback coverage for `opencode-windows-x64`, `opencode-windows-x64-baseline`, and `opencode-windows-arm64`.
- Added focused resolver tests in `server/pkg/agent/opencode_test.go`.
- Added `server/pkg/agent/exec_fixture_windows_test.go` so existing package tests have a Windows implementation of the test executable helper.

## How to Test

1. Reproduce the bug on Windows by comparing a multiline positional prompt through `opencode.cmd` versus the native `opencode.exe`.
2. Run `go test ./pkg/agent -run "TestResolveOpenCode|TestOpencode" -count=1`.
3. Run `GOOS=linux GOARCH=amd64 go test -c ./pkg/agent`.
4. Run `GOOS=darwin GOARCH=amd64 go test -c ./pkg/agent`.
5. Start the modified daemon and send an OpenCode chat task with a multiline/user-message prompt.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Investigated a Windows-specific OpenCode daemon bug where Multica logs showed the full prompt but OpenCode's SQLite DB only recorded the first prompt line. Verified that `opencode.cmd` truncates multiline positional argv while the native `opencode.exe` preserves it, then implemented a Windows resolver that prefers the native bundled binary and added focused Go tests.

## Screenshots (optional)

N/A
