### PR TITLE
feat(cli): multica issue team runner V2

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,7 +18,7 @@
     "fumadocs-ui": "^15.5.2",
     "lucide-react": "catalog:",
     "mermaid": "^11.14.0",
-    "next": "^15.5.16",
+    "next": "^15.5.18",
     "next-themes": "^0.4.6",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,7 +50,7 @@
     "linkify-it": "^5.0.0",
     "lowlight": "^3.3.0",
     "lucide-react": "catalog:",
-    "next": "^16.2.5",
+    "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "react": "catalog:",
     "react-day-picker": "^9.14.0",

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -96,7 +96,9 @@ services:
     depends_on:
       - backend
     ports:
-      - "127.0.0.1:${FRONTEND_PORT:-3000}:3000"
+      # Bind to Docker host bridge only; public HTTPS goes through Caddy.
+      # Avoid exposing the Next.js origin server directly to the internet.
+      - "172.17.0.1:${FRONTEND_PORT:-3000}:3000"
     environment:
       HOSTNAME: "0.0.0.0"
     restart: unless-stopped

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
         specifier: ^11.14.0
         version: 11.14.0
       next:
-        specifier: ^15.5.16
+        specifier: ^15.5.18
         version: 15.5.18(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
@@ -408,7 +408,7 @@ importers:
         specifier: 'catalog:'
         version: 1.0.1(react@19.2.3)
       next:
-        specifier: ^16.2.5
+        specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
@@ -3317,6 +3317,7 @@ packages:
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -4765,11 +4766,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}

--- a/server/cmd/multica/cmd_issue_team.go
+++ b/server/cmd/multica/cmd_issue_team.go
@@ -1,0 +1,543 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+var issueTeamCmd = &cobra.Command{
+	Use:   "team",
+	Short: "Coordinate multiple agents on one issue",
+}
+
+var issueTeamCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a team-runner issue (backlog, no assignee, policy embedded)",
+	Long: `Create an issue pre-configured for the team runner.
+
+The issue is created with status=backlog and no assignee so that no run is
+triggered immediately. The team policy (lead/implementer/reviewer) is embedded
+in the description. Use 'multica issue team run <id>' to start the workflow.`,
+	RunE: runIssueTeamCreate,
+}
+
+var issueTeamRunCmd = &cobra.Command{
+	Use:   "run <issue-id>",
+	Short: "Run a lead, implementer, reviewer flow on one issue",
+	Long: `Run a multi-agent lead/implementer/reviewer flow on an existing issue.
+
+The issue must NOT have an existing assignee, because an assignee would trigger
+a parasitic initial run when the issue was created. If the issue already has an
+assignee, use --detach-assignee to remove it first, or pass --allow-assigned to
+proceed with a warning.`,
+	Args: exactArgs(1),
+	RunE: runIssueTeamRun,
+}
+
+type issueTeamPolicy struct {
+	Lead        string
+	Implementer string
+	Reviewer    string
+	Until       string
+}
+
+type issueTeamAgent struct {
+	Name string
+	ID   string
+}
+
+type issueTeamRunOptions struct {
+	IssueID        string
+	PolicyText     string
+	Wait           bool
+	DryRun         bool
+	MaxRounds      int
+	PollInterval   time.Duration
+	Timeout        time.Duration
+	AllowAssigned  bool
+	DetachAssignee bool
+}
+
+type issueTeamResolved struct {
+	Policy      issueTeamPolicy
+	Lead        issueTeamAgent
+	Implementer issueTeamAgent
+	Reviewer    issueTeamAgent
+}
+
+func init() {
+	issueCmd.AddCommand(issueTeamCmd)
+	issueTeamCmd.AddCommand(issueTeamCreateCmd)
+	issueTeamCmd.AddCommand(issueTeamRunCmd)
+
+	issueTeamCreateCmd.Flags().String("title", "", "Issue title (required)")
+	issueTeamCreateCmd.Flags().String("policy", "", "Team policy, e.g.: lead=planner, implementer=builder, reviewer=reviewer (required)")
+	issueTeamCreateCmd.Flags().String("parent", "", "Parent issue ID")
+	issueTeamCreateCmd.Flags().String("priority", "medium", "Issue priority")
+	issueTeamCreateCmd.Flags().String("output", "json", "Output format: json or table")
+
+	issueTeamRunCmd.Flags().String("policy", "", "Inline policy, for example: lead=planner, implementer=builder, reviewer=reviewer")
+	issueTeamRunCmd.Flags().Bool("wait", true, "Wait for each role and continue review rounds")
+	issueTeamRunCmd.Flags().Bool("dry-run", false, "Resolve policy and print planned actions without posting comments")
+	issueTeamRunCmd.Flags().Int("max-rounds", 2, "Maximum implementer and reviewer rounds")
+	issueTeamRunCmd.Flags().Duration("poll-interval", 15*time.Second, "Polling interval while waiting")
+	issueTeamRunCmd.Flags().Duration("timeout", 45*time.Minute, "Overall team run timeout")
+	issueTeamRunCmd.Flags().Bool("allow-assigned", false, "Proceed even if the issue already has an assignee (prints a warning)")
+	issueTeamRunCmd.Flags().Bool("detach-assignee", false, "Remove the existing assignee before starting the team run")
+}
+
+func runIssueTeamCreate(cmd *cobra.Command, _ []string) error {
+	title, _ := cmd.Flags().GetString("title")
+	if title == "" {
+		return fmt.Errorf("--title is required")
+	}
+	policyText, _ := cmd.Flags().GetString("policy")
+	if strings.TrimSpace(policyText) == "" {
+		return fmt.Errorf("--policy is required (e.g. lead=planner, implementer=builder, reviewer=reviewer)")
+	}
+	policy, err := parseIssueTeamPolicy(policyText)
+	if err != nil {
+		return fmt.Errorf("invalid --policy: %w", err)
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	body := map[string]any{
+		"title":       title,
+		"status":      "backlog",
+		"description": teamPolicyBlock(policy, ""),
+	}
+	if v, _ := cmd.Flags().GetString("priority"); v != "" {
+		body["priority"] = v
+	}
+	if v, _ := cmd.Flags().GetString("parent"); v != "" {
+		body["parent_issue_id"] = v
+	}
+	// Deliberately omit assignee so no initial run is triggered.
+
+	var result map[string]any
+	if err := client.PostJSON(ctx, "/api/issues", body, &result); err != nil {
+		return fmt.Errorf("create issue: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		headers := []string{"ID", "TITLE", "STATUS", "PRIORITY"}
+		rows := [][]string{{
+			truncateID(strVal(result, "id")),
+			strVal(result, "title"),
+			strVal(result, "status"),
+			strVal(result, "priority"),
+		}}
+		cli.PrintTable(os.Stdout, headers, rows)
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, result)
+}
+
+// teamPolicyBlock formats a policy as an embeddable description block.
+// If extra is non-empty it is appended after the policy block.
+func teamPolicyBlock(policy issueTeamPolicy, extra string) string {
+	var b strings.Builder
+	b.WriteString("multica-team:\n")
+	fmt.Fprintf(&b, "lead=%s\n", policy.Lead)
+	fmt.Fprintf(&b, "implementer=%s\n", policy.Implementer)
+	fmt.Fprintf(&b, "reviewer=%s\n", policy.Reviewer)
+	b.WriteString("continue until reviewer approves\n")
+	if strings.TrimSpace(extra) != "" {
+		b.WriteString("\n")
+		b.WriteString(strings.TrimSpace(extra))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func runIssueTeamRun(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	policyText, _ := cmd.Flags().GetString("policy")
+	wait, _ := cmd.Flags().GetBool("wait")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	maxRounds, _ := cmd.Flags().GetInt("max-rounds")
+	pollInterval, _ := cmd.Flags().GetDuration("poll-interval")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	allowAssigned, _ := cmd.Flags().GetBool("allow-assigned")
+	detachAssignee, _ := cmd.Flags().GetBool("detach-assignee")
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	opts := issueTeamRunOptions{
+		IssueID:        args[0],
+		PolicyText:     policyText,
+		Wait:           wait,
+		DryRun:         dryRun,
+		MaxRounds:      maxRounds,
+		PollInterval:   pollInterval,
+		Timeout:        timeout,
+		AllowAssigned:  allowAssigned,
+		DetachAssignee: detachAssignee,
+	}
+	return runIssueTeam(ctx, client, opts, os.Stdout)
+}
+
+func runIssueTeam(ctx context.Context, client *cli.APIClient, opts issueTeamRunOptions, out io.Writer) error {
+	if opts.IssueID == "" {
+		return fmt.Errorf("issue id is required")
+	}
+	if opts.MaxRounds < 1 {
+		return fmt.Errorf("--max-rounds must be at least 1")
+	}
+	if opts.PollInterval <= 0 {
+		return fmt.Errorf("--poll-interval must be positive")
+	}
+
+	var issue map[string]any
+	if err := client.GetJSON(ctx, "/api/issues/"+url.PathEscape(opts.IssueID), &issue); err != nil {
+		return fmt.Errorf("get issue: %w", err)
+	}
+
+	// Guardrail: an existing assignee causes a parasitic initial run.
+	if assigneeID := strVal(issue, "assignee_id"); assigneeID != "" {
+		switch {
+		case opts.DetachAssignee:
+			var patched map[string]any
+			if err := client.PutJSON(ctx, "/api/issues/"+url.PathEscape(opts.IssueID),
+				map[string]any{"assignee_id": nil, "assignee_type": nil}, &patched); err != nil {
+				return fmt.Errorf("detach assignee: %w", err)
+			}
+			fmt.Fprintf(out, "Detached assignee from issue %s before team run.\n", opts.IssueID)
+		case opts.AllowAssigned:
+			fmt.Fprintf(out, "Warning: issue %s already has an assignee (%s). This may have triggered a parasitic run. Proceeding because --allow-assigned is set.\n", opts.IssueID, assigneeID)
+		default:
+			return fmt.Errorf(
+				"issue %s already has an assignee (%s): creating a team-runner issue with an assignee triggers a parasitic initial run.\n"+
+					"Use --detach-assignee to remove the assignee first, or --allow-assigned to proceed with a warning.\n"+
+					"To avoid this in future, create team issues with 'multica issue team create' which forces status=backlog and no assignee.",
+				opts.IssueID, assigneeID,
+			)
+		}
+	}
+
+	policy, err := issueTeamPolicyForIssue(ctx, client, opts.PolicyText, issue, opts.IssueID)
+	if err != nil {
+		return err
+	}
+
+	resolved, err := resolveIssueTeam(ctx, client, policy)
+	if err != nil {
+		return err
+	}
+
+	if opts.DryRun {
+		return printIssueTeamDryRun(out, opts.IssueID, resolved)
+	}
+
+	if err := updateIssueStatus(ctx, client, opts.IssueID, "in_progress"); err != nil {
+		return err
+	}
+
+	if !opts.Wait {
+		if _, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, "lead", resolved.Lead, leadPrompt()); err != nil {
+			return err
+		}
+		if _, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, "implementer", resolved.Implementer, implementerPrompt(1, "")); err != nil {
+			return err
+		}
+		if _, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, "reviewer", resolved.Reviewer, reviewerPrompt(1)); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "Triggered lead, implementer, and reviewer on issue %s\n", opts.IssueID)
+		return nil
+	}
+
+	if _, err := postAndWaitForRole(ctx, client, opts, "lead", resolved.Lead, leadPrompt()); err != nil {
+		return err
+	}
+
+	var reviewerFeedback string
+	for round := 1; round <= opts.MaxRounds; round++ {
+		if _, err := postAndWaitForRole(ctx, client, opts, "implementer", resolved.Implementer, implementerPrompt(round, reviewerFeedback)); err != nil {
+			return err
+		}
+
+		comment, err := postAndWaitForRole(ctx, client, opts, "reviewer", resolved.Reviewer, reviewerPrompt(round))
+		if err != nil {
+			return err
+		}
+		reviewerFeedback = strVal(comment, "content")
+		if reviewerApproved(reviewerFeedback) {
+			if err := updateIssueStatus(ctx, client, opts.IssueID, "in_review"); err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Reviewer approved issue %s after %d round(s)\n", opts.IssueID, round)
+			return nil
+		}
+	}
+
+	if err := updateIssueStatus(ctx, client, opts.IssueID, "blocked"); err != nil {
+		return err
+	}
+	return fmt.Errorf("reviewer did not approve within %d round(s)", opts.MaxRounds)
+}
+
+func issueTeamPolicyForIssue(ctx context.Context, client *cli.APIClient, inline string, issue map[string]any, issueID string) (issueTeamPolicy, error) {
+	if strings.TrimSpace(inline) != "" {
+		return parseIssueTeamPolicy(inline)
+	}
+
+	description := strVal(issue, "description")
+	if policy, err := parseIssueTeamPolicy(description); err == nil {
+		return policy, nil
+	}
+
+	var comments []map[string]any
+	if err := client.GetJSON(ctx, "/api/issues/"+url.PathEscape(issueID)+"/comments", &comments); err != nil {
+		return issueTeamPolicy{}, fmt.Errorf("parse policy from issue description failed and comments could not be loaded: %w", err)
+	}
+
+	var b strings.Builder
+	b.WriteString(description)
+	for _, comment := range comments {
+		b.WriteString("\n")
+		b.WriteString(strVal(comment, "content"))
+	}
+	return parseIssueTeamPolicy(b.String())
+}
+
+func parseIssueTeamPolicy(text string) (issueTeamPolicy, error) {
+	var policy issueTeamPolicy
+	normalized := strings.NewReplacer(",", "\n", ";", "\n", "\r\n", "\n").Replace(text)
+	rolePattern := regexp.MustCompile(`(?i)(?:^|[\s,;])(lead|implementer|builder|reviewer|until|continue)\s*[:=]\s*([^,;\n]+)`)
+	for _, match := range rolePattern.FindAllStringSubmatch(text, -1) {
+		applyIssueTeamPolicyValue(&policy, match[1], match[2])
+	}
+	for _, rawLine := range strings.Split(normalized, "\n") {
+		line := strings.TrimSpace(strings.TrimPrefix(rawLine, "-"))
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "continue until reviewer approves") {
+			policy.Until = "reviewer approves"
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			key, value, ok = strings.Cut(line, ":")
+		}
+		if !ok {
+			continue
+		}
+
+		applyIssueTeamPolicyValue(&policy, key, value)
+	}
+	if policy.Until == "" {
+		policy.Until = "reviewer approves"
+	}
+	if policy.Lead == "" {
+		return issueTeamPolicy{}, fmt.Errorf("team policy missing lead")
+	}
+	if policy.Implementer == "" {
+		return issueTeamPolicy{}, fmt.Errorf("team policy missing implementer")
+	}
+	if policy.Reviewer == "" {
+		return issueTeamPolicy{}, fmt.Errorf("team policy missing reviewer")
+	}
+	return policy, nil
+}
+
+func applyIssueTeamPolicyValue(policy *issueTeamPolicy, key, value string) {
+	key = strings.ToLower(strings.TrimSpace(key))
+	value = strings.Trim(strings.TrimSpace(value), "`")
+	switch key {
+	case "lead":
+		policy.Lead = value
+	case "implementer", "builder":
+		policy.Implementer = value
+	case "reviewer":
+		policy.Reviewer = value
+	case "until", "continue":
+		policy.Until = strings.TrimPrefix(strings.ToLower(value), "until ")
+	}
+}
+
+func resolveIssueTeam(ctx context.Context, client *cli.APIClient, policy issueTeamPolicy) (issueTeamResolved, error) {
+	lead, err := resolveIssueTeamAgent(ctx, client, policy.Lead)
+	if err != nil {
+		return issueTeamResolved{}, fmt.Errorf("resolve lead: %w", err)
+	}
+	implementer, err := resolveIssueTeamAgent(ctx, client, policy.Implementer)
+	if err != nil {
+		return issueTeamResolved{}, fmt.Errorf("resolve implementer: %w", err)
+	}
+	reviewer, err := resolveIssueTeamAgent(ctx, client, policy.Reviewer)
+	if err != nil {
+		return issueTeamResolved{}, fmt.Errorf("resolve reviewer: %w", err)
+	}
+	return issueTeamResolved{
+		Policy:      policy,
+		Lead:        lead,
+		Implementer: implementer,
+		Reviewer:    reviewer,
+	}, nil
+}
+
+func resolveIssueTeamAgent(ctx context.Context, client *cli.APIClient, name string) (issueTeamAgent, error) {
+	kind, id, err := resolveAssignee(ctx, client, name)
+	if err != nil {
+		return issueTeamAgent{}, err
+	}
+	if kind != "agent" {
+		return issueTeamAgent{}, fmt.Errorf("%q resolved to %s, expected agent", name, kind)
+	}
+	return issueTeamAgent{Name: name, ID: id}, nil
+}
+
+func printIssueTeamDryRun(out io.Writer, issueID string, resolved issueTeamResolved) error {
+	plan := map[string]any{
+		"issue_id":    issueID,
+		"policy":      resolved.Policy,
+		"lead":        resolved.Lead,
+		"implementer": resolved.Implementer,
+		"reviewer":    resolved.Reviewer,
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(plan)
+}
+
+func postAndWaitForRole(ctx context.Context, client *cli.APIClient, opts issueTeamRunOptions, role string, agent issueTeamAgent, prompt string) (map[string]any, error) {
+	startedAt := time.Now().UTC().Add(-2 * time.Second)
+	roleComment, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, role, agent, prompt)
+	if err != nil {
+		return nil, err
+	}
+	if createdAt, err := time.Parse(time.RFC3339, strVal(roleComment, "created_at")); err == nil {
+		startedAt = createdAt
+	}
+	comment, err := waitForAgentComment(ctx, client, opts.IssueID, agent.ID, startedAt, opts.PollInterval)
+	if err != nil {
+		return nil, fmt.Errorf("wait for %s: %w", role, err)
+	}
+	return comment, nil
+}
+
+func postIssueTeamRoleComment(ctx context.Context, client *cli.APIClient, issueID, role string, agent issueTeamAgent, prompt string) (map[string]any, error) {
+	content := fmt.Sprintf("Team role: %s\n\n%s %s", role, agentMention(agent), prompt)
+	body := map[string]any{"content": content}
+	var result map[string]any
+	if err := client.PostJSON(ctx, "/api/issues/"+url.PathEscape(issueID)+"/comments", body, &result); err != nil {
+		return nil, fmt.Errorf("post %s comment: %w", role, err)
+	}
+	return result, nil
+}
+
+func waitForAgentComment(ctx context.Context, client *cli.APIClient, issueID, agentID string, after time.Time, pollInterval time.Duration) (map[string]any, error) {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		comment, err := latestAgentCommentSince(ctx, client, issueID, agentID, after)
+		if err != nil {
+			return nil, err
+		}
+		if comment != nil {
+			return comment, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func latestAgentCommentSince(ctx context.Context, client *cli.APIClient, issueID, agentID string, after time.Time) (map[string]any, error) {
+	var comments []map[string]any
+	if err := client.GetJSON(ctx, "/api/issues/"+url.PathEscape(issueID)+"/comments", &comments); err != nil {
+		return nil, fmt.Errorf("list comments: %w", err)
+	}
+
+	var latest map[string]any
+	var latestAt time.Time
+	for _, comment := range comments {
+		if strVal(comment, "author_type") != "agent" || strVal(comment, "author_id") != agentID {
+			continue
+		}
+		createdAt, err := time.Parse(time.RFC3339, strVal(comment, "created_at"))
+		if err != nil {
+			continue
+		}
+		if createdAt.Before(after) {
+			continue
+		}
+		if latest == nil || createdAt.After(latestAt) {
+			latest = comment
+			latestAt = createdAt
+		}
+	}
+	return latest, nil
+}
+
+func updateIssueStatus(ctx context.Context, client *cli.APIClient, issueID, status string) error {
+	var result map[string]any
+	if err := client.PutJSON(ctx, "/api/issues/"+url.PathEscape(issueID), map[string]any{"status": status}, &result); err != nil {
+		return fmt.Errorf("set issue status %s: %w", status, err)
+	}
+	return nil
+}
+
+func agentMention(agent issueTeamAgent) string {
+	name := strings.TrimSpace(agent.Name)
+	if name == "" {
+		name = agent.ID
+	}
+	return fmt.Sprintf("[@%s](mention://agent/%s)", name, agent.ID)
+}
+
+func leadPrompt() string {
+	return "Please create a short plan for this issue. Keep the conversation and follow-up work on this same issue. Do not @mention other agents; the team runner will trigger each next role."
+}
+
+func implementerPrompt(round int, feedback string) string {
+	if strings.TrimSpace(feedback) == "" {
+		return fmt.Sprintf("Please implement the current plan for this issue. This is round %d. Post a concise delivery note here when complete.", round)
+	}
+	return fmt.Sprintf("Please address the reviewer feedback below for round %d, then post a concise delivery note here.\n\nReviewer feedback:\n%s", round, feedback)
+}
+
+func reviewerPrompt(round int) string {
+	return fmt.Sprintf("Please review the latest work for round %d. Reply with `reviewer_approved` if acceptable. Otherwise list the required changes.", round)
+}
+
+func reviewerApproved(text string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(text))
+	if strings.Contains(normalized, "not approved") || strings.Contains(normalized, "changes requested") || strings.Contains(normalized, "needs changes") {
+		return false
+	}
+	return strings.Contains(normalized, "reviewer_approved") ||
+		strings.Contains(normalized, "approved") ||
+		strings.Contains(normalized, "approve")
+}

--- a/server/cmd/multica/cmd_issue_team.go
+++ b/server/cmd/multica/cmd_issue_team.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -260,7 +261,7 @@ func runIssueTeam(ctx context.Context, client *cli.APIClient, opts issueTeamRunO
 		if _, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, "lead", resolved.Lead, leadPrompt()); err != nil {
 			return err
 		}
-		if _, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, "implementer", resolved.Implementer, implementerPrompt(1, "")); err != nil {
+		if _, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, "implementer", resolved.Implementer, implementerPrompt(1, "", nil)); err != nil {
 			return err
 		}
 		if _, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, "reviewer", resolved.Reviewer, reviewerPrompt(1)); err != nil {
@@ -270,22 +271,55 @@ func runIssueTeam(ctx context.Context, client *cli.APIClient, opts issueTeamRunO
 		return nil
 	}
 
-	if _, err := postAndWaitForRole(ctx, client, opts, "lead", resolved.Lead, leadPrompt()); err != nil {
+	// Load existing state for idempotent resume after crash.
+	state, err := loadTeamRunState(ctx, client, opts.IssueID)
+	if err != nil {
 		return err
 	}
+	if state == nil {
+		state = &teamRunState{}
+	}
 
-	var reviewerFeedback string
+	if !state.LeadDone {
+		if _, err := postAndWaitForRole(ctx, client, opts, "lead", resolved.Lead, leadPrompt()); err != nil {
+			return blockOnRoleFailure(ctx, client, opts.IssueID, "lead", err)
+		}
+		state.LeadDone = true
+		if err := saveTeamRunState(ctx, client, opts.IssueID, state); err != nil {
+			return err
+		}
+	}
+
 	for round := 1; round <= opts.MaxRounds; round++ {
-		if _, err := postAndWaitForRole(ctx, client, opts, "implementer", resolved.Implementer, implementerPrompt(round, reviewerFeedback)); err != nil {
-			return err
+		if state.ImplementerDoneRound < round {
+			if _, err := postAndWaitForRole(ctx, client, opts, "implementer", resolved.Implementer, implementerPrompt(round, state.ReviewerFeedback, state.ReviewerChanges)); err != nil {
+				return blockOnRoleFailure(ctx, client, opts.IssueID, "implementer", err)
+			}
+			state.ImplementerDoneRound = round
+			if err := saveTeamRunState(ctx, client, opts.IssueID, state); err != nil {
+				return err
+			}
 		}
 
-		comment, err := postAndWaitForRole(ctx, client, opts, "reviewer", resolved.Reviewer, reviewerPrompt(round))
-		if err != nil {
-			return err
+		if state.ReviewerDoneRound < round {
+			comment, err := postAndWaitForRole(ctx, client, opts, "reviewer", resolved.Reviewer, reviewerPrompt(round))
+			if err != nil {
+				return blockOnRoleFailure(ctx, client, opts.IssueID, "reviewer", err)
+			}
+			state.ReviewerFeedback = strVal(comment, "content")
+			verdict, verdictOK := parseReviewerVerdict(state.ReviewerFeedback)
+			if verdictOK {
+				state.ReviewerChanges = verdict.RequiredChanges
+			} else {
+				state.ReviewerChanges = nil
+			}
+			state.ReviewerDoneRound = round
+			if err := saveTeamRunState(ctx, client, opts.IssueID, state); err != nil {
+				return err
+			}
 		}
-		reviewerFeedback = strVal(comment, "content")
-		if reviewerApproved(reviewerFeedback) {
+
+		if reviewerApproved(state.ReviewerFeedback) {
 			if err := updateIssueStatus(ctx, client, opts.IssueID, "in_review"); err != nil {
 				return err
 			}
@@ -428,17 +462,26 @@ func printIssueTeamDryRun(out io.Writer, issueID string, resolved issueTeamResol
 }
 
 func postAndWaitForRole(ctx context.Context, client *cli.APIClient, opts issueTeamRunOptions, role string, agent issueTeamAgent, prompt string) (map[string]any, error) {
-	startedAt := time.Now().UTC().Add(-2 * time.Second)
 	roleComment, err := postIssueTeamRoleComment(ctx, client, opts.IssueID, role, agent, prompt)
 	if err != nil {
 		return nil, err
 	}
+	triggerCommentID := strVal(roleComment, "id")
+	triggerCreatedAt := time.Now().UTC()
 	if createdAt, err := time.Parse(time.RFC3339, strVal(roleComment, "created_at")); err == nil {
-		startedAt = createdAt
+		triggerCreatedAt = createdAt
 	}
-	comment, err := waitForAgentComment(ctx, client, opts.IssueID, agent.ID, startedAt, opts.PollInterval)
+
+	if err := waitForRunComplete(ctx, client, opts.IssueID, triggerCommentID, agent.ID, opts.PollInterval); err != nil {
+		return nil, fmt.Errorf("wait for %s run: %w", role, err)
+	}
+
+	comment, err := fetchAgentCommentSince(ctx, client, opts.IssueID, agent.ID, triggerCreatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("wait for %s: %w", role, err)
+		return nil, fmt.Errorf("fetch %s response: %w", role, err)
+	}
+	if comment == nil {
+		return nil, fmt.Errorf("no response comment from %s after run completed", role)
 	}
 	return comment, nil
 }
@@ -453,31 +496,67 @@ func postIssueTeamRoleComment(ctx context.Context, client *cli.APIClient, issueI
 	return result, nil
 }
 
-func waitForAgentComment(ctx context.Context, client *cli.APIClient, issueID, agentID string, after time.Time, pollInterval time.Duration) (map[string]any, error) {
+// agentRunFailedError is returned by waitForRunComplete when the agent run
+// for a role transitions to "failed" status. The runner uses this to
+// distinguish fast-detected agent crashes from ordinary context timeouts.
+type agentRunFailedError struct {
+	Reason string
+}
+
+func (e *agentRunFailedError) Error() string {
+	if e.Reason == "" {
+		return "agent run failed"
+	}
+	return "agent run failed: " + e.Reason
+}
+
+// waitForRunComplete polls /task-runs until the task triggered by
+// triggerCommentID and owned by agentID reaches a terminal status.
+// It returns *agentRunFailedError immediately when the run fails.
+// It does not touch the comments endpoint, making it efficient for busy issues.
+func waitForRunComplete(ctx context.Context, client *cli.APIClient, issueID, triggerCommentID, agentID string, pollInterval time.Duration) error {
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
 	for {
-		comment, err := latestAgentCommentSince(ctx, client, issueID, agentID, after)
-		if err != nil {
-			return nil, err
+		var runs []map[string]any
+		if err := client.GetJSON(ctx, "/api/issues/"+url.PathEscape(issueID)+"/task-runs", &runs); err != nil {
+			return fmt.Errorf("list task runs: %w", err)
 		}
-		if comment != nil {
-			return comment, nil
+		for _, run := range runs {
+			if strVal(run, "trigger_comment_id") != triggerCommentID {
+				continue
+			}
+			if strVal(run, "agent_id") != agentID {
+				continue
+			}
+			switch strVal(run, "status") {
+			case "completed":
+				return nil
+			case "failed", "cancelled":
+				reason := strVal(run, "failure_reason")
+				if reason == "" {
+					reason = strVal(run, "error")
+				}
+				return &agentRunFailedError{Reason: reason}
+			}
 		}
 
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return ctx.Err()
 		case <-ticker.C:
 		}
 	}
 }
 
-func latestAgentCommentSince(ctx context.Context, client *cli.APIClient, issueID, agentID string, after time.Time) (map[string]any, error) {
+// fetchAgentCommentSince retrieves the latest comment from agentID posted after
+// the given time, using the ?since= query param to avoid scanning old comments.
+func fetchAgentCommentSince(ctx context.Context, client *cli.APIClient, issueID, agentID string, after time.Time) (map[string]any, error) {
+	path := "/api/issues/" + url.PathEscape(issueID) + "/comments?since=" + url.QueryEscape(after.Format(time.RFC3339))
 	var comments []map[string]any
-	if err := client.GetJSON(ctx, "/api/issues/"+url.PathEscape(issueID)+"/comments", &comments); err != nil {
-		return nil, fmt.Errorf("list comments: %w", err)
+	if err := client.GetJSON(ctx, path, &comments); err != nil {
+		return nil, fmt.Errorf("list comments since: %w", err)
 	}
 
 	var latest map[string]any
@@ -490,15 +569,28 @@ func latestAgentCommentSince(ctx context.Context, client *cli.APIClient, issueID
 		if err != nil {
 			continue
 		}
-		if createdAt.Before(after) {
-			continue
-		}
 		if latest == nil || createdAt.After(latestAt) {
 			latest = comment
 			latestAt = createdAt
 		}
 	}
 	return latest, nil
+}
+
+// blockOnRoleFailure checks whether err is an *agentRunFailedError. If it is,
+// it sets the issue to blocked and posts a comment explaining which role failed
+// and why, so the human can investigate without hunting through run logs.
+// It always returns the original error unchanged.
+func blockOnRoleFailure(ctx context.Context, client *cli.APIClient, issueID, role string, err error) error {
+	var runErr *agentRunFailedError
+	if !errors.As(err, &runErr) {
+		return err
+	}
+	_ = updateIssueStatus(ctx, client, issueID, "blocked")
+	content := fmt.Sprintf("Role `%s` agent run failed: %s", role, runErr.Reason)
+	var result map[string]any
+	_ = client.PostJSON(ctx, "/api/issues/"+url.PathEscape(issueID)+"/comments", map[string]any{"content": content}, &result)
+	return err
 }
 
 func updateIssueStatus(ctx context.Context, client *cli.APIClient, issueID, status string) error {
@@ -521,23 +613,143 @@ func leadPrompt() string {
 	return "Please create a short plan for this issue. Keep the conversation and follow-up work on this same issue. Do not @mention other agents; the team runner will trigger each next role."
 }
 
-func implementerPrompt(round int, feedback string) string {
+func implementerPrompt(round int, feedback string, requiredChanges []string) string {
 	if strings.TrimSpace(feedback) == "" {
 		return fmt.Sprintf("Please implement the current plan for this issue. This is round %d. Post a concise delivery note here when complete.", round)
 	}
-	return fmt.Sprintf("Please address the reviewer feedback below for round %d, then post a concise delivery note here.\n\nReviewer feedback:\n%s", round, feedback)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Please address the reviewer feedback below for round %d, then post a concise delivery note here.\n\nReviewer feedback:\n%s", round, feedback)
+	if len(requiredChanges) > 0 {
+		b.WriteString("\n\nRequired changes:\n")
+		for _, c := range requiredChanges {
+			fmt.Fprintf(&b, "- %s\n", c)
+		}
+	}
+	return b.String()
 }
 
-func reviewerPrompt(round int) string {
-	return fmt.Sprintf("Please review the latest work for round %d. Reply with `reviewer_approved` if acceptable. Otherwise list the required changes.", round)
+type reviewerVerdict struct {
+	Verdict         string   `json:"verdict"`
+	Summary         string   `json:"summary"`
+	RequiredChanges []string `json:"required_changes"`
+}
+
+var jsonFenceRe = regexp.MustCompile("(?s)```(?:json)?[ \t]*\n([^`]+)```")
+
+func parseReviewerVerdict(text string) (reviewerVerdict, bool) {
+	// 1. Try ```json ... ``` fenced blocks
+	if matches := jsonFenceRe.FindAllStringSubmatch(text, -1); len(matches) > 0 {
+		for _, m := range matches {
+			var v reviewerVerdict
+			if err := json.Unmarshal([]byte(strings.TrimSpace(m[1])), &v); err == nil {
+				if v.Verdict == "approved" || v.Verdict == "changes_requested" {
+					return v, true
+				}
+			}
+		}
+	}
+
+	// 2. Try the whole text as raw JSON
+	trimmed := strings.TrimSpace(text)
+	if strings.HasPrefix(trimmed, "{") {
+		var v reviewerVerdict
+		if err := json.Unmarshal([]byte(trimmed), &v); err == nil {
+			if v.Verdict == "approved" || v.Verdict == "changes_requested" {
+				return v, true
+			}
+		}
+	}
+
+	return reviewerVerdict{}, false
 }
 
 func reviewerApproved(text string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(text))
-	if strings.Contains(normalized, "not approved") || strings.Contains(normalized, "changes requested") || strings.Contains(normalized, "needs changes") {
-		return false
+	v, ok := parseReviewerVerdict(text)
+	return ok && v.Verdict == "approved"
+}
+
+func reviewerPrompt(round int) string {
+	return fmt.Sprintf("Please review the latest work for round %d.\n\nRespond with a JSON verdict in a fenced code block:\n\n```json\n{\n  \"verdict\": \"approved\",\n  \"summary\": \"brief summary\",\n  \"required_changes\": []\n}\n```\n\nUse `\"verdict\": \"approved\"` if the work is acceptable. Use `\"verdict\": \"changes_requested\"` and list each required change in `required_changes` otherwise.", round)
+}
+
+// --- durable team-run state (KOR-896) ---
+
+const teamStateMarkerPrefix = "<!-- multica-team-state: "
+const teamStateMarkerSuffix = " -->"
+
+// teamRunState tracks the progress of a waiting team run so it can be resumed
+// after the CLI process is killed. Persisted as an invisible HTML comment on
+// the issue.
+type teamRunState struct {
+	LeadDone             bool     `json:"lead_done"`
+	ImplementerDoneRound int      `json:"implementer_done_round"` // 0 = not started; N = completed through round N
+	ReviewerDoneRound    int      `json:"reviewer_done_round"`    // 0 = not started; N = completed through round N
+	ReviewerFeedback     string   `json:"reviewer_feedback"`
+	ReviewerChanges      []string `json:"reviewer_changes,omitempty"`
+	StateCommentID       string   `json:"state_comment_id"` // ID of the persisted state comment
+}
+
+// parseTeamRunState extracts runner state from a comment body that contains the
+// <!-- multica-team-state: {...} --> marker. Returns nil (no error) when the
+// marker is absent or when the JSON is corrupt -- both cases mean start fresh.
+func parseTeamRunState(text string) (*teamRunState, error) {
+	start := strings.Index(text, teamStateMarkerPrefix)
+	if start < 0 {
+		return nil, nil
 	}
-	return strings.Contains(normalized, "reviewer_approved") ||
-		strings.Contains(normalized, "approved") ||
-		strings.Contains(normalized, "approve")
+	jsonStart := start + len(teamStateMarkerPrefix)
+	end := strings.Index(text[jsonStart:], teamStateMarkerSuffix)
+	if end < 0 {
+		return nil, nil
+	}
+	jsonStr := strings.TrimSpace(text[jsonStart : jsonStart+end])
+	var state teamRunState
+	if err := json.Unmarshal([]byte(jsonStr), &state); err != nil {
+		// Corrupt JSON: treat as no state so the runner starts fresh.
+		return nil, nil
+	}
+	return &state, nil
+}
+
+// loadTeamRunState scans the issue's comments for a state marker and returns
+// the decoded state. Returns nil when no valid state is found (fresh run).
+func loadTeamRunState(ctx context.Context, client *cli.APIClient, issueID string) (*teamRunState, error) {
+	var comments []map[string]any
+	if err := client.GetJSON(ctx, "/api/issues/"+url.PathEscape(issueID)+"/comments", &comments); err != nil {
+		return nil, fmt.Errorf("load team state: %w", err)
+	}
+	for _, comment := range comments {
+		content := strVal(comment, "content")
+		if !strings.Contains(content, teamStateMarkerPrefix) {
+			continue
+		}
+		state, _ := parseTeamRunState(content)
+		if state != nil {
+			// Prefer the actual comment ID over what's encoded in the JSON,
+			// in case an earlier run saved a stale ID.
+			state.StateCommentID = strVal(comment, "id")
+			return state, nil
+		}
+	}
+	return nil, nil
+}
+
+// saveTeamRunState deletes the previous state comment (best-effort) and posts
+// a new one with the updated state JSON.
+func saveTeamRunState(ctx context.Context, client *cli.APIClient, issueID string, state *teamRunState) error {
+	if state.StateCommentID != "" {
+		_ = client.DeleteJSON(ctx, "/api/comments/"+url.PathEscape(state.StateCommentID))
+		state.StateCommentID = ""
+	}
+	jsonBytes, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal team state: %w", err)
+	}
+	content := teamStateMarkerPrefix + string(jsonBytes) + teamStateMarkerSuffix
+	var result map[string]any
+	if err := client.PostJSON(ctx, "/api/issues/"+url.PathEscape(issueID)+"/comments", map[string]any{"content": content}, &result); err != nil {
+		return fmt.Errorf("save team state: %w", err)
+	}
+	state.StateCommentID = strVal(result, "id")
+	return nil
 }

--- a/server/cmd/multica/cmd_issue_team_test.go
+++ b/server/cmd/multica/cmd_issue_team_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -72,10 +73,13 @@ func TestReviewerApproved(t *testing.T) {
 		text string
 		want bool
 	}{
-		{name: "approved", text: "Approved. Ship it.", want: true},
-		{name: "approval marker", text: "reviewer_approved", want: true},
-		{name: "needs changes", text: "Not approved yet, needs changes.", want: false},
-		{name: "changes requested", text: "Changes requested before approval.", want: false},
+		{name: "bare prose approve is not approved", text: "Approved. Ship it.", want: false},
+		{name: "bare prose reviewer_approved is not approved", text: "reviewer_approved", want: false},
+		{name: "needs changes prose", text: "Not approved yet, needs changes.", want: false},
+		{name: "approved JSON fenced", text: "LGTM.\n\n```json\n{\"verdict\":\"approved\",\"summary\":\"All good\",\"required_changes\":[]}\n```", want: true},
+		{name: "changes_requested JSON fenced", text: "Needs work.\n\n```json\n{\"verdict\":\"changes_requested\",\"summary\":\"fix tests\",\"required_changes\":[\"Fix TestFoo\"]}\n```", want: false},
+		{name: "prose says approve but JSON verdict is changes_requested", text: "I would normally approve this but...\n\n```json\n{\"verdict\":\"changes_requested\",\"summary\":\"not ready\",\"required_changes\":[\"fix lint\"]}\n```", want: false},
+		{name: "invalid JSON falls back to not approved", text: "```json\n{invalid json here\n```", want: false},
 	}
 
 	for _, tt := range tests {
@@ -87,6 +91,122 @@ func TestReviewerApproved(t *testing.T) {
 	}
 }
 
+func TestParseReviewerVerdictApprovedJSON(t *testing.T) {
+	text := "Looks great.\n\n```json\n{\"verdict\":\"approved\",\"summary\":\"Clean implementation\",\"required_changes\":[]}\n```"
+	v, ok := parseReviewerVerdict(text)
+	if !ok {
+		t.Fatal("expected ok=true for valid approved JSON")
+	}
+	if v.Verdict != "approved" {
+		t.Errorf("Verdict = %q, want approved", v.Verdict)
+	}
+	if v.Summary != "Clean implementation" {
+		t.Errorf("Summary = %q, want Clean implementation", v.Summary)
+	}
+	if len(v.RequiredChanges) != 0 {
+		t.Errorf("RequiredChanges = %v, want empty", v.RequiredChanges)
+	}
+}
+
+func TestParseReviewerVerdictChangesRequestedJSON(t *testing.T) {
+	text := "Needs fixes.\n\n```json\n{\"verdict\":\"changes_requested\",\"summary\":\"two issues\",\"required_changes\":[\"Fix memory leak in handler\",\"Add missing test for edge case\"]}\n```"
+	v, ok := parseReviewerVerdict(text)
+	if !ok {
+		t.Fatal("expected ok=true for valid changes_requested JSON")
+	}
+	if v.Verdict != "changes_requested" {
+		t.Errorf("Verdict = %q, want changes_requested", v.Verdict)
+	}
+	if len(v.RequiredChanges) != 2 {
+		t.Fatalf("RequiredChanges has %d items, want 2: %v", len(v.RequiredChanges), v.RequiredChanges)
+	}
+	if v.RequiredChanges[0] != "Fix memory leak in handler" {
+		t.Errorf("RequiredChanges[0] = %q", v.RequiredChanges[0])
+	}
+}
+
+func TestParseReviewerVerdictProseFalsePositive(t *testing.T) {
+	text := "I would approve this in another context, but here the tests are failing.\n\n```json\n{\"verdict\":\"changes_requested\",\"summary\":\"tests failing\",\"required_changes\":[\"Fix failing tests\"]}\n```"
+	v, ok := parseReviewerVerdict(text)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if v.Verdict != "changes_requested" {
+		t.Errorf("Verdict = %q, want changes_requested (JSON wins over prose)", v.Verdict)
+	}
+	if reviewerApproved(text) {
+		t.Error("reviewerApproved should be false when JSON verdict is changes_requested, regardless of prose")
+	}
+}
+
+func TestParseReviewerVerdictInvalidJSONFallbackNotApproved(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+	}{
+		{name: "invalid JSON in fence", text: "```json\n{invalid\n```"},
+		{name: "no JSON at all", text: "Looks good to me, ship it!"},
+		{name: "JSON with unknown verdict", text: "```json\n{\"verdict\":\"lgtm\"}\n```"},
+		{name: "empty fence", text: "```json\n\n```"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, ok := parseReviewerVerdict(c.text)
+			if ok {
+				t.Errorf("parseReviewerVerdict(%q) = ok=true, want false (safe fallback)", c.text)
+			}
+			if reviewerApproved(c.text) {
+				t.Errorf("reviewerApproved(%q) = true, want false for invalid/missing JSON", c.text)
+			}
+		})
+	}
+}
+
+func TestParseReviewerVerdictRawJSON(t *testing.T) {
+	text := `{"verdict":"approved","summary":"LGTM","required_changes":[]}`
+	v, ok := parseReviewerVerdict(text)
+	if !ok {
+		t.Fatal("expected ok=true for raw JSON text")
+	}
+	if v.Verdict != "approved" {
+		t.Errorf("Verdict = %q, want approved", v.Verdict)
+	}
+}
+
+func TestReviewerPromptRequestsStructuredJSON(t *testing.T) {
+	prompt := reviewerPrompt(1)
+	if !strings.Contains(prompt, "verdict") {
+		t.Error("reviewer prompt should mention 'verdict' field")
+	}
+	if !strings.Contains(prompt, "approved") {
+		t.Error("reviewer prompt should mention 'approved' verdict value")
+	}
+	if !strings.Contains(prompt, "changes_requested") {
+		t.Error("reviewer prompt should mention 'changes_requested' verdict value")
+	}
+	if !strings.Contains(prompt, "required_changes") {
+		t.Error("reviewer prompt should mention 'required_changes' field")
+	}
+}
+
+func TestImplementerPromptIncludesRequiredChanges(t *testing.T) {
+	changes := []string{"Fix memory leak", "Add missing test"}
+	prompt := implementerPrompt(2, "reviewer comment text", changes)
+	if !strings.Contains(prompt, "Fix memory leak") {
+		t.Error("implementer prompt should include required change: Fix memory leak")
+	}
+	if !strings.Contains(prompt, "Add missing test") {
+		t.Error("implementer prompt should include required change: Add missing test")
+	}
+}
+
+func TestImplementerPromptNoRequiredChanges(t *testing.T) {
+	prompt := implementerPrompt(1, "", nil)
+	if strings.TrimSpace(prompt) == "" {
+		t.Error("implementer prompt should not be empty")
+	}
+}
+
 func TestLeadPromptKeepsRunnerInControlOfMentions(t *testing.T) {
 	prompt := strings.ToLower(leadPrompt())
 	if !strings.Contains(prompt, "do not @mention") {
@@ -94,12 +214,14 @@ func TestLeadPromptKeepsRunnerInControlOfMentions(t *testing.T) {
 	}
 }
 
+// TestPostAndWaitForRoleIgnoresCommentsBeforeRoleTrigger verifies that the
+// runner waits for the specific run triggered by the role comment and uses
+// ?since= so pre-trigger agent comments are never surfaced as role responses.
 func TestPostAndWaitForRoleIgnoresCommentsBeforeRoleTrigger(t *testing.T) {
 	agentID := "aaaaaaaa-1111-1111-1111-111111111111"
-	roleCommentCreatedAt := time.Now().UTC().Add(30 * time.Second).Truncate(time.Second)
-	oldAgentCommentAt := roleCommentCreatedAt.Add(-10 * time.Second)
-	newAgentCommentAt := roleCommentCreatedAt.Add(10 * time.Second)
-	commentsCalls := 0
+	roleCommentCreatedAt := time.Now().UTC().Truncate(time.Second)
+	newAgentCommentAt := roleCommentCreatedAt.Add(5 * time.Second)
+	runsCalls := 0
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -109,27 +231,29 @@ func TestPostAndWaitForRoleIgnoresCommentsBeforeRoleTrigger(t *testing.T) {
 				"content":    "Team role: lead",
 				"created_at": roleCommentCreatedAt.Format(time.RFC3339),
 			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/task-runs":
+			runsCalls++
+			status := "running"
+			if runsCalls > 1 {
+				status = "completed"
+			}
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"id":                 "run-1",
+				"agent_id":           agentID,
+				"trigger_comment_id": "role-comment-1",
+				"status":             status,
+			}})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/comments":
-			commentsCalls++
-			comments := []map[string]any{
-				{
-					"id":          "old-agent-comment",
-					"author_type": "agent",
-					"author_id":   agentID,
-					"content":     "old assignment-run output that should not satisfy this role",
-					"created_at":  oldAgentCommentAt.Format(time.RFC3339),
-				},
+			if r.URL.Query().Get("since") == "" {
+				t.Error("comment fetch missing ?since= param -- pre-trigger comments could leak in")
 			}
-			if commentsCalls > 1 {
-				comments = append(comments, map[string]any{
-					"id":          "new-agent-comment",
-					"author_type": "agent",
-					"author_id":   agentID,
-					"content":     "new role-triggered output",
-					"created_at":  newAgentCommentAt.Format(time.RFC3339),
-				})
-			}
-			json.NewEncoder(w).Encode(comments)
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"id":          "new-agent-comment",
+				"author_type": "agent",
+				"author_id":   agentID,
+				"content":     "new role-triggered output",
+				"created_at":  newAgentCommentAt.Format(time.RFC3339),
+			}})
 		default:
 			http.NotFound(w, r)
 		}
@@ -493,5 +617,764 @@ func TestRunIssueTeamDetachAssignee(t *testing.T) {
 	// The value should be nil (JSON null), which decodes to nil in map[string]any.
 	if detachBody["assignee_id"] != nil {
 		t.Errorf("detach PUT assignee_id should be null/nil, got: %v", detachBody["assignee_id"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Run-failure detection tests (KOR-898)
+// ---------------------------------------------------------------------------
+
+// TestWaitForRunComplete_Failed_FailsFast verifies that waitForRunComplete
+// returns an error immediately when the run for our trigger comment transitions
+// to "failed", without waiting for the full timeout.
+func TestWaitForRunComplete_Failed_FailsFast(t *testing.T) {
+	agentID := "aaaaaaaa-1111-1111-1111-111111111111"
+	triggerCommentID := "trigger-comment-1"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/task-runs") {
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"id":                 "run-1",
+				"agent_id":           agentID,
+				"status":             "failed",
+				"trigger_comment_id": triggerCommentID,
+				"failure_reason":     "provider error: upstream crash",
+				"error":              "exit 1",
+			}})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := waitForRunComplete(ctx, client, "issue-1", triggerCommentID, agentID, time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when agent run failed, got nil")
+	}
+	if !strings.Contains(err.Error(), "provider error: upstream crash") {
+		t.Fatalf("expected failure_reason in error, got: %v", err)
+	}
+}
+
+// TestWaitForRunComplete_UnrelatedRunFailed_Ignored verifies that a failed run
+// with a different trigger_comment_id does not cause waitForRunComplete to fail.
+func TestWaitForRunComplete_UnrelatedRunFailed_Ignored(t *testing.T) {
+	agentID := "aaaaaaaa-1111-1111-1111-111111111111"
+	triggerCommentID := "trigger-comment-mine"
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/task-runs") {
+			calls++
+			runs := []map[string]any{{
+				"id":                 "run-other",
+				"agent_id":           agentID,
+				"status":             "failed",
+				"trigger_comment_id": "some-other-comment",
+				"failure_reason":     "irrelevant failure",
+			}}
+			if calls > 2 {
+				runs = append(runs, map[string]any{
+					"id":                 "run-mine",
+					"agent_id":           agentID,
+					"status":             "completed",
+					"trigger_comment_id": triggerCommentID,
+				})
+			}
+			json.NewEncoder(w).Encode(runs)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := waitForRunComplete(ctx, client, "issue-1", triggerCommentID, agentID, time.Millisecond)
+	if err != nil {
+		t.Fatalf("unrelated run failure should be ignored, got error: %v", err)
+	}
+}
+
+// TestRunIssueTeam_RoleRunFailure_SetsBlockedAndPostsComment verifies that
+// when a role agent's run fails, the runner: (1) sets the issue to blocked,
+// (2) posts a comment naming the role and the failure reason, and (3) returns
+// an error that includes the failure reason.
+func TestRunIssueTeam_RoleRunFailure_SetsBlockedAndPostsComment(t *testing.T) {
+	agentID := "aaaaaaaa-1111-1111-1111-111111111111"
+	roleCommentID := "role-comment-lead"
+	roleCommentAt := time.Now().UTC().Add(-time.Second)
+
+	agents := []map[string]any{
+		{"id": agentID, "name": "opus-latest"},
+		{"id": "bbbbbbbb-2222-2222-2222-222222222222", "name": "codex-high"},
+		{"id": "cccccccc-3333-3333-3333-333333333333", "name": "gemini-pro"},
+	}
+
+	var statusBodies []map[string]any
+	var postedComments []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-rf":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "issue-rf",
+				"description": "lead=opus-latest\nimplementer=codex-high\nreviewer=gemini-pro",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces/ws-1/members":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/agents":
+			json.NewEncoder(w).Encode(agents)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/issues/issue-rf":
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			statusBodies = append(statusBodies, body)
+			json.NewEncoder(w).Encode(map[string]any{"id": "issue-rf", "status": body["status"]})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/issue-rf/comments":
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			content, _ := body["content"].(string)
+			postedComments = append(postedComments, content)
+			commentID := fmt.Sprintf("comment-%d", len(postedComments))
+			if len(postedComments) == 1 {
+				commentID = roleCommentID
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         commentID,
+				"content":    content,
+				"created_at": roleCommentAt.Format(time.RFC3339),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-rf/comments":
+			// loadTeamRunState scans for a state marker; return empty (fresh run).
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-rf/task-runs":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"id":                 "run-lead",
+				"agent_id":           agentID,
+				"status":             "failed",
+				"trigger_comment_id": roleCommentID,
+				"failure_reason":     "OOM killed",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	opts := issueTeamRunOptions{
+		IssueID:      "issue-rf",
+		Wait:         true,
+		MaxRounds:    1,
+		PollInterval: time.Millisecond,
+		Timeout:      2 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := runIssueTeam(ctx, client, opts, io.Discard)
+	if err == nil {
+		t.Fatal("expected error when lead agent run failed, got nil")
+	}
+	if !strings.Contains(err.Error(), "OOM killed") {
+		t.Fatalf("expected failure reason in error, got: %v", err)
+	}
+
+	var foundBlocked bool
+	for _, s := range statusBodies {
+		if s["status"] == "blocked" {
+			foundBlocked = true
+		}
+	}
+	if !foundBlocked {
+		t.Fatalf("expected issue to be set to blocked, status updates: %+v", statusBodies)
+	}
+
+	var foundFailureComment bool
+	for _, c := range postedComments {
+		lower := strings.ToLower(c)
+		if strings.Contains(lower, "lead") && strings.Contains(c, "OOM killed") {
+			foundFailureComment = true
+		}
+	}
+	if !foundFailureComment {
+		t.Fatalf("expected a comment mentioning 'lead' and 'OOM killed', posted: %+v", postedComments)
+	}
+}
+
+// TestWaitForRunCompleteByTriggerID verifies that the runner polls /task-runs
+// until it finds a terminal task whose trigger_comment_id matches, without
+// touching the /comments endpoint at all during the wait.
+func TestWaitForRunCompleteByTriggerID(t *testing.T) {
+	agentID := "aaaaaaaa-1111-1111-1111-111111111111"
+	triggerCommentID := "trigger-comment-99"
+	runsCalls := 0
+	commentsCalls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/task-runs":
+			runsCalls++
+			var runs []map[string]any
+			if runsCalls > 1 {
+				runs = append(runs, map[string]any{
+					"id":                 "run-1",
+					"agent_id":           agentID,
+					"trigger_comment_id": triggerCommentID,
+					"status":             "completed",
+				})
+			} else {
+				runs = append(runs, map[string]any{
+					"id":                 "run-1",
+					"agent_id":           agentID,
+					"trigger_comment_id": triggerCommentID,
+					"status":             "running",
+				})
+			}
+			json.NewEncoder(w).Encode(runs)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/comments":
+			commentsCalls++
+			json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := waitForRunComplete(ctx, client, "issue-1", triggerCommentID, agentID, time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForRunComplete: %v", err)
+	}
+	if runsCalls < 2 {
+		t.Errorf("expected at least 2 task-runs polls, got %d", runsCalls)
+	}
+	if commentsCalls > 0 {
+		t.Errorf("expected 0 comment fetches during wait, got %d", commentsCalls)
+	}
+}
+
+// TestPostAndWaitForRoleUsesSinceParamForCommentFetch verifies that after the
+// run completes, comments are fetched using a ?since= param so old comments on
+// a busy issue are never re-processed.
+func TestPostAndWaitForRoleUsesSinceParamForCommentFetch(t *testing.T) {
+	agentID := "aaaaaaaa-1111-1111-1111-111111111111"
+	triggerCommentID := "trigger-comment-88"
+	triggerTime := time.Now().UTC().Add(-5 * time.Second).Truncate(time.Second)
+	agentResponseAt := triggerTime.Add(3 * time.Second)
+	var sinceParamsReceived []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/issue-1/comments":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         triggerCommentID,
+				"content":    "Team role: lead",
+				"created_at": triggerTime.Format(time.RFC3339),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/task-runs":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"id":                 "run-1",
+				"agent_id":           agentID,
+				"trigger_comment_id": triggerCommentID,
+				"status":             "completed",
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/comments":
+			if s := r.URL.Query().Get("since"); s != "" {
+				sinceParamsReceived = append(sinceParamsReceived, s)
+			}
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"id":          "agent-response-1",
+				"author_type": "agent",
+				"author_id":   agentID,
+				"content":     "Plan done",
+				"created_at":  agentResponseAt.Format(time.RFC3339),
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	comment, err := postAndWaitForRole(ctx, client, issueTeamRunOptions{
+		IssueID:      "issue-1",
+		PollInterval: time.Millisecond,
+	}, "lead", issueTeamAgent{Name: "lead-agent", ID: agentID}, "please plan")
+	if err != nil {
+		t.Fatalf("postAndWaitForRole: %v", err)
+	}
+	if got := comment["id"]; got != "agent-response-1" {
+		t.Errorf("got comment id %v, want agent-response-1", got)
+	}
+	if len(sinceParamsReceived) == 0 {
+		t.Error("comment fetch did not use ?since= param; old comments would be re-scanned on every poll")
+	}
+}
+
+// TestPostAndWaitForRoleWithManyOldCommentsOnlyFetchesSince verifies that
+// when an issue has many old comments, the runner never fetches the full list.
+// It counts GET /comments requests that lack a ?since= query param.
+func TestPostAndWaitForRoleWithManyOldCommentsOnlyFetchesSince(t *testing.T) {
+	agentID := "aaaaaaaa-1111-1111-1111-111111111111"
+	triggerCommentID := "trigger-comment-77"
+	triggerTime := time.Now().UTC().Truncate(time.Second)
+	agentResponseAt := triggerTime.Add(2 * time.Second)
+	unboundedCommentFetches := 0 // GET /comments without ?since
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/issue-1/comments":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         triggerCommentID,
+				"content":    "Team role: lead",
+				"created_at": triggerTime.Format(time.RFC3339),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/task-runs":
+			json.NewEncoder(w).Encode([]map[string]any{{
+				"id":                 "run-1",
+				"agent_id":           agentID,
+				"trigger_comment_id": triggerCommentID,
+				"status":             "completed",
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/comments":
+			if r.URL.Query().Get("since") == "" {
+				unboundedCommentFetches++
+				old := make([]map[string]any, 50)
+				for i := range old {
+					old[i] = map[string]any{
+						"id":          fmt.Sprintf("old-%d", i),
+						"author_type": "agent",
+						"author_id":   agentID,
+						"content":     "old comment",
+						"created_at":  triggerTime.Add(-time.Duration(i+1) * time.Minute).Format(time.RFC3339),
+					}
+				}
+				json.NewEncoder(w).Encode(old)
+			} else {
+				json.NewEncoder(w).Encode([]map[string]any{{
+					"id":          "agent-response-1",
+					"author_type": "agent",
+					"author_id":   agentID,
+					"content":     "Plan done",
+					"created_at":  agentResponseAt.Format(time.RFC3339),
+				}})
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	comment, err := postAndWaitForRole(ctx, client, issueTeamRunOptions{
+		IssueID:      "issue-1",
+		PollInterval: time.Millisecond,
+	}, "lead", issueTeamAgent{Name: "lead-agent", ID: agentID}, "please plan")
+	if err != nil {
+		t.Fatalf("postAndWaitForRole: %v", err)
+	}
+	if got := comment["id"]; got != "agent-response-1" {
+		t.Errorf("got comment id %v, want agent-response-1", got)
+	}
+	if unboundedCommentFetches > 0 {
+		t.Errorf("made %d unbounded GET /comments call(s) without ?since= -- old comments were re-scanned", unboundedCommentFetches)
+	}
+}
+
+// --- durable state / resume tests (KOR-896) ---
+
+func TestParseTeamRunState(t *testing.T) {
+	content := `<!-- multica-team-state: {"lead_done":true,"implementer_done_round":2,"reviewer_done_round":1,"reviewer_feedback":"lgtm","state_comment_id":"c-1"} -->`
+	state, err := parseTeamRunState(content)
+	if err != nil {
+		t.Fatalf("parseTeamRunState: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+	if !state.LeadDone {
+		t.Error("LeadDone should be true")
+	}
+	if state.ImplementerDoneRound != 2 {
+		t.Errorf("ImplementerDoneRound = %d, want 2", state.ImplementerDoneRound)
+	}
+	if state.ReviewerDoneRound != 1 {
+		t.Errorf("ReviewerDoneRound = %d, want 1", state.ReviewerDoneRound)
+	}
+	if state.ReviewerFeedback != "lgtm" {
+		t.Errorf("ReviewerFeedback = %q, want lgtm", state.ReviewerFeedback)
+	}
+	if state.StateCommentID != "c-1" {
+		t.Errorf("StateCommentID = %q, want c-1", state.StateCommentID)
+	}
+}
+
+func TestParseTeamRunStateNotPresent(t *testing.T) {
+	state, err := parseTeamRunState("This is a regular comment with no state marker.")
+	if err != nil {
+		t.Fatalf("expected no error for comment without state marker, got: %v", err)
+	}
+	if state != nil {
+		t.Errorf("expected nil state when marker absent, got %+v", state)
+	}
+}
+
+func TestParseTeamRunStateCorruptedReturnsSafeNil(t *testing.T) {
+	content := `<!-- multica-team-state: {not valid json at all -->`
+	state, err := parseTeamRunState(content)
+	if err != nil {
+		t.Fatalf("corrupt state should not propagate error, got: %v", err)
+	}
+	if state != nil {
+		t.Errorf("corrupt state should return nil so runner starts fresh, got %+v", state)
+	}
+}
+
+// resumeTestSrv builds a minimal httptest server that supports the V2 team-runner
+// API. It tracks posted role comments and returns completed task-runs after a
+// short delay so waitForRunComplete succeeds without real polling.
+//
+// Parameters:
+//   - issueID: the issue path segment (e.g. "issue-resume")
+//   - agents: slice of {id, name} maps
+//   - initialComments: comments already on the issue before the run (e.g. state markers)
+//   - postedContents: pointer to a slice that collects every POST comment body
+type resumeTestSrvConfig struct {
+	issueID         string
+	agents          []map[string]any
+	initialComments []map[string]any
+	postedContents  *[]string
+}
+
+func newResumeTestSrv(t *testing.T, cfg resumeTestSrvConfig) *httptest.Server {
+	t.Helper()
+	now := time.Now().UTC()
+	// Track: lastRoleCmtID -> agent_id so task-runs can echo the right agent.
+	type roleCmt struct {
+		id        string
+		agentID   string
+		createdAt time.Time
+		content   string
+	}
+	var (
+		roleCmts     []roleCmt
+		taskRunCalls = map[string]int{} // per trigger-comment-id call count
+		commentCallN int
+	)
+
+	issuePath := "/api/issues/" + cfg.issueID
+	commentPath := issuePath + "/comments"
+	taskRunPath := issuePath + "/task-runs"
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == issuePath:
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          cfg.issueID,
+				"description": "lead=opus-latest\nimplementer=codex-high\nreviewer=gemini-pro",
+				"status":      "in_progress",
+			})
+
+		case r.Method == http.MethodGet && r.URL.Path == "/api/agents":
+			json.NewEncoder(w).Encode(cfg.agents)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces/ws-1/members":
+			json.NewEncoder(w).Encode([]map[string]any{})
+
+		case r.Method == http.MethodPut && r.URL.Path == issuePath:
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			json.NewEncoder(w).Encode(map[string]any{"id": cfg.issueID, "status": body["status"]})
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/comments/"):
+			// State comment cleanup -- always succeed.
+			w.WriteHeader(http.StatusNoContent)
+
+		case r.Method == http.MethodPost && r.URL.Path == commentPath:
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			content := body["content"].(string)
+			cmtID := fmt.Sprintf("cmt-%d", len(roleCmts)+len(*cfg.postedContents)+1)
+			cmtAt := now.Add(time.Duration(len(roleCmts)+1) * time.Second)
+			if strings.Contains(content, "Team role:") {
+				// Determine which agent this role targets by looking for mention URL.
+				agentID := ""
+				for _, ag := range cfg.agents {
+					id := ag["id"].(string)
+					if strings.Contains(content, id) {
+						agentID = id
+						break
+					}
+				}
+				roleCmts = append(roleCmts, roleCmt{id: cmtID, agentID: agentID, createdAt: cmtAt, content: content})
+				*cfg.postedContents = append(*cfg.postedContents, content)
+			} else {
+				// State marker save -- just echo back with a fresh ID.
+				*cfg.postedContents = append(*cfg.postedContents, content)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         cmtID,
+				"content":    content,
+				"created_at": cmtAt.Format(time.RFC3339),
+			})
+
+		case r.Method == http.MethodGet && r.URL.Path == taskRunPath:
+			// After 2 polls for the trigger comment, return completed.
+			if len(roleCmts) == 0 {
+				json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
+			last := roleCmts[len(roleCmts)-1]
+			taskRunCalls[last.id]++
+			if taskRunCalls[last.id] >= 2 {
+				json.NewEncoder(w).Encode([]map[string]any{{
+					"id":                 "run-" + last.id,
+					"agent_id":           last.agentID,
+					"status":             "completed",
+					"trigger_comment_id": last.id,
+				}})
+			} else {
+				json.NewEncoder(w).Encode([]map[string]any{})
+			}
+
+		case r.Method == http.MethodGet && r.URL.Path == commentPath:
+			commentCallN++
+			since := r.URL.Query().Get("since")
+			var sinceT time.Time
+			if since != "" {
+				sinceT, _ = time.Parse(time.RFC3339, since)
+			}
+			comments := make([]map[string]any, 0)
+			// Initial (state marker) comments -- only on full (no-since) scans.
+			if since == "" {
+				comments = append(comments, cfg.initialComments...)
+			}
+			// Agent response comments -- one per completed role, time after trigger.
+			for i, rc := range roleCmts {
+				responseAt := rc.createdAt.Add(500 * time.Millisecond)
+				if !sinceT.IsZero() && responseAt.Before(sinceT) {
+					continue
+				}
+				responseContent := fmt.Sprintf("Role %d complete.", i+1)
+				// Reviewer always returns approved JSON verdict.
+				if strings.Contains(rc.content, "Team role: reviewer") {
+					responseContent = "```json\n{\"verdict\":\"approved\",\"summary\":\"LGTM\",\"required_changes\":[]}\n```"
+				}
+				_ = commentCallN
+				comments = append(comments, map[string]any{
+					"id":          fmt.Sprintf("resp-%s", rc.id),
+					"author_type": "agent",
+					"author_id":   rc.agentID,
+					"content":     responseContent,
+					"created_at":  responseAt.Format(time.RFC3339),
+				})
+			}
+			json.NewEncoder(w).Encode(comments)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestTeamRunResumesAfterLeadCompleted verifies that when a state marker says
+// lead_done=true the runner skips the lead phase and does not post a lead comment.
+func TestTeamRunResumesAfterLeadCompleted(t *testing.T) {
+	agentIDs := [3]string{
+		"aaaaaaaa-1111-1111-1111-111111111111",
+		"bbbbbbbb-2222-2222-2222-222222222222",
+		"cccccccc-3333-3333-3333-333333333333",
+	}
+	agents := []map[string]any{
+		{"id": agentIDs[0], "name": "opus-latest"},
+		{"id": agentIDs[1], "name": "codex-high"},
+		{"id": agentIDs[2], "name": "gemini-pro"},
+	}
+
+	stateContent := `<!-- multica-team-state: {"lead_done":true,"implementer_done_round":0,"reviewer_done_round":0,"reviewer_feedback":"","state_comment_id":"state-c-1"} -->`
+	var postedContents []string
+
+	srv := newResumeTestSrv(t, resumeTestSrvConfig{
+		issueID: "issue-resume",
+		agents:  agents,
+		initialComments: []map[string]any{{
+			"id":          "state-c-1",
+			"content":     stateContent,
+			"author_type": "member",
+			"author_id":   "runner",
+			"created_at":  time.Now().UTC().Add(-5 * time.Second).Format(time.RFC3339),
+		}},
+		postedContents: &postedContents,
+	})
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	opts := issueTeamRunOptions{
+		IssueID:      "issue-resume",
+		Wait:         true,
+		MaxRounds:    1,
+		PollInterval: time.Millisecond,
+		Timeout:      5 * time.Second,
+	}
+
+	if err := runIssueTeam(context.Background(), client, opts, io.Discard); err != nil {
+		t.Fatalf("runIssueTeam: %v", err)
+	}
+
+	for _, c := range postedContents {
+		if strings.Contains(c, "Team role: lead") {
+			t.Errorf("lead role comment should not be posted when state shows lead already done; got: %s", c)
+		}
+	}
+	var hasImpl, hasReviewer bool
+	for _, c := range postedContents {
+		if strings.Contains(c, "Team role: implementer") {
+			hasImpl = true
+		}
+		if strings.Contains(c, "Team role: reviewer") {
+			hasReviewer = true
+		}
+	}
+	if !hasImpl {
+		t.Error("implementer role comment should have been posted")
+	}
+	if !hasReviewer {
+		t.Error("reviewer role comment should have been posted")
+	}
+}
+
+// TestTeamRunResumesAfterImplementerCompleted verifies that when state shows
+// implementer_done_round=1, the runner skips both lead and implementer and
+// goes straight to the reviewer.
+func TestTeamRunResumesAfterImplementerCompleted(t *testing.T) {
+	agentIDs := [3]string{
+		"aaaaaaaa-1111-1111-1111-111111111111",
+		"bbbbbbbb-2222-2222-2222-222222222222",
+		"cccccccc-3333-3333-3333-333333333333",
+	}
+	agents := []map[string]any{
+		{"id": agentIDs[0], "name": "opus-latest"},
+		{"id": agentIDs[1], "name": "codex-high"},
+		{"id": agentIDs[2], "name": "gemini-pro"},
+	}
+
+	stateContent := `<!-- multica-team-state: {"lead_done":true,"implementer_done_round":1,"reviewer_done_round":0,"reviewer_feedback":"","state_comment_id":"state-c-2"} -->`
+	var postedContents []string
+
+	srv := newResumeTestSrv(t, resumeTestSrvConfig{
+		issueID: "issue-impl-done",
+		agents:  agents,
+		initialComments: []map[string]any{{
+			"id":          "state-c-2",
+			"content":     stateContent,
+			"author_type": "member",
+			"author_id":   "runner",
+			"created_at":  time.Now().UTC().Add(-5 * time.Second).Format(time.RFC3339),
+		}},
+		postedContents: &postedContents,
+	})
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	opts := issueTeamRunOptions{
+		IssueID:      "issue-impl-done",
+		Wait:         true,
+		MaxRounds:    1,
+		PollInterval: time.Millisecond,
+		Timeout:      5 * time.Second,
+	}
+
+	if err := runIssueTeam(context.Background(), client, opts, io.Discard); err != nil {
+		t.Fatalf("runIssueTeam: %v", err)
+	}
+
+	for _, c := range postedContents {
+		if strings.Contains(c, "Team role: lead") {
+			t.Errorf("lead comment must not be posted when state says lead done: %s", c)
+		}
+		if strings.Contains(c, "Team role: implementer") {
+			t.Errorf("implementer comment must not be posted for round 1 when implementer_done_round=1: %s", c)
+		}
+	}
+	var hasReviewer bool
+	for _, c := range postedContents {
+		if strings.Contains(c, "Team role: reviewer") {
+			hasReviewer = true
+		}
+	}
+	if !hasReviewer {
+		t.Error("reviewer role comment should have been posted")
+	}
+}
+
+// TestTeamRunIgnoresCorruptedStateSafely verifies that a state marker with
+// invalid JSON is silently ignored and the runner starts from the beginning.
+func TestTeamRunIgnoresCorruptedStateSafely(t *testing.T) {
+	agentIDs := [3]string{
+		"aaaaaaaa-1111-1111-1111-111111111111",
+		"bbbbbbbb-2222-2222-2222-222222222222",
+		"cccccccc-3333-3333-3333-333333333333",
+	}
+	agents := []map[string]any{
+		{"id": agentIDs[0], "name": "opus-latest"},
+		{"id": agentIDs[1], "name": "codex-high"},
+		{"id": agentIDs[2], "name": "gemini-pro"},
+	}
+
+	corruptStateContent := `<!-- multica-team-state: {this is not json at all} -->`
+	var postedContents []string
+
+	srv := newResumeTestSrv(t, resumeTestSrvConfig{
+		issueID: "issue-corrupt",
+		agents:  agents,
+		initialComments: []map[string]any{{
+			"id":          "corrupt-state-c",
+			"content":     corruptStateContent,
+			"author_type": "member",
+			"author_id":   "runner",
+			"created_at":  time.Now().UTC().Add(-5 * time.Second).Format(time.RFC3339),
+		}},
+		postedContents: &postedContents,
+	})
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	opts := issueTeamRunOptions{
+		IssueID:      "issue-corrupt",
+		Wait:         true,
+		MaxRounds:    1,
+		PollInterval: time.Millisecond,
+		Timeout:      5 * time.Second,
+	}
+
+	if err := runIssueTeam(context.Background(), client, opts, io.Discard); err != nil {
+		t.Fatalf("runIssueTeam with corrupt state: %v", err)
+	}
+
+	var hasLead bool
+	for _, c := range postedContents {
+		if strings.Contains(c, "Team role: lead") {
+			hasLead = true
+		}
+	}
+	if !hasLead {
+		t.Error("lead role comment should have been posted when state is corrupt (start fresh)")
 	}
 }

--- a/server/cmd/multica/cmd_issue_team_test.go
+++ b/server/cmd/multica/cmd_issue_team_test.go
@@ -1,0 +1,497 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/cli"
+)
+
+func TestParseIssueTeamPolicy(t *testing.T) {
+	text := `
+Some issue details.
+
+multica-team:
+lead=opus-latest
+implementer=codex-high
+reviewer=gemini-pro
+continue until reviewer approves
+`
+
+	policy, err := parseIssueTeamPolicy(text)
+	if err != nil {
+		t.Fatalf("parseIssueTeamPolicy: %v", err)
+	}
+
+	if policy.Lead != "opus-latest" {
+		t.Errorf("Lead = %q", policy.Lead)
+	}
+	if policy.Implementer != "codex-high" {
+		t.Errorf("Implementer = %q", policy.Implementer)
+	}
+	if policy.Reviewer != "gemini-pro" {
+		t.Errorf("Reviewer = %q", policy.Reviewer)
+	}
+	if policy.Until != "reviewer approves" {
+		t.Errorf("Until = %q", policy.Until)
+	}
+}
+
+func TestParseIssueTeamPolicyRequiresRoles(t *testing.T) {
+	_, err := parseIssueTeamPolicy("lead=opus-latest\nreviewer=gemini-pro")
+	if err == nil {
+		t.Fatal("expected missing implementer error")
+	}
+	if !strings.Contains(err.Error(), "implementer") {
+		t.Fatalf("expected implementer in error, got %v", err)
+	}
+}
+
+func TestParseIssueTeamPolicyFromProseLine(t *testing.T) {
+	text := "Smoke test only. lead=claude-haiku; implementer=codex-quick; reviewer=gemini-flash; continue until reviewer approves"
+
+	policy, err := parseIssueTeamPolicy(text)
+	if err != nil {
+		t.Fatalf("parseIssueTeamPolicy: %v", err)
+	}
+	if policy.Lead != "claude-haiku" || policy.Implementer != "codex-quick" || policy.Reviewer != "gemini-flash" {
+		t.Fatalf("unexpected policy: %+v", policy)
+	}
+}
+
+func TestReviewerApproved(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "approved", text: "Approved. Ship it.", want: true},
+		{name: "approval marker", text: "reviewer_approved", want: true},
+		{name: "needs changes", text: "Not approved yet, needs changes.", want: false},
+		{name: "changes requested", text: "Changes requested before approval.", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reviewerApproved(tt.text); got != tt.want {
+				t.Errorf("reviewerApproved(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLeadPromptKeepsRunnerInControlOfMentions(t *testing.T) {
+	prompt := strings.ToLower(leadPrompt())
+	if !strings.Contains(prompt, "do not @mention") {
+		t.Fatalf("lead prompt should tell lead not to @mention other agents so the runner owns sequencing, got: %s", leadPrompt())
+	}
+}
+
+func TestPostAndWaitForRoleIgnoresCommentsBeforeRoleTrigger(t *testing.T) {
+	agentID := "aaaaaaaa-1111-1111-1111-111111111111"
+	roleCommentCreatedAt := time.Now().UTC().Add(30 * time.Second).Truncate(time.Second)
+	oldAgentCommentAt := roleCommentCreatedAt.Add(-10 * time.Second)
+	newAgentCommentAt := roleCommentCreatedAt.Add(10 * time.Second)
+	commentsCalls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/issue-1/comments":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         "role-comment-1",
+				"content":    "Team role: lead",
+				"created_at": roleCommentCreatedAt.Format(time.RFC3339),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1/comments":
+			commentsCalls++
+			comments := []map[string]any{
+				{
+					"id":          "old-agent-comment",
+					"author_type": "agent",
+					"author_id":   agentID,
+					"content":     "old assignment-run output that should not satisfy this role",
+					"created_at":  oldAgentCommentAt.Format(time.RFC3339),
+				},
+			}
+			if commentsCalls > 1 {
+				comments = append(comments, map[string]any{
+					"id":          "new-agent-comment",
+					"author_type": "agent",
+					"author_id":   agentID,
+					"content":     "new role-triggered output",
+					"created_at":  newAgentCommentAt.Format(time.RFC3339),
+				})
+			}
+			json.NewEncoder(w).Encode(comments)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	comment, err := postAndWaitForRole(ctx, client, issueTeamRunOptions{
+		IssueID:      "issue-1",
+		PollInterval: time.Millisecond,
+	}, "lead", issueTeamAgent{Name: "lead-agent", ID: agentID}, "please plan")
+	if err != nil {
+		t.Fatalf("postAndWaitForRole: %v", err)
+	}
+	if got := comment["id"]; got != "new-agent-comment" {
+		t.Fatalf("waited for %v, want new-agent-comment", got)
+	}
+}
+
+func TestRunIssueTeamTriggerPostsRoleMentionsOnSameIssue(t *testing.T) {
+	var postedPaths []string
+	var postedComments []string
+	var statusBodies []map[string]any
+
+	agents := []map[string]any{
+		{"id": "aaaaaaaa-1111-1111-1111-111111111111", "name": "opus-latest"},
+		{"id": "bbbbbbbb-2222-2222-2222-222222222222", "name": "codex-high"},
+		{"id": "cccccccc-3333-3333-3333-333333333333", "name": "gemini-pro"},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-1":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "issue-1",
+				"title":       "Team issue",
+				"description": "lead=opus-latest\nimplementer=codex-high\nreviewer=gemini-pro\ncontinue until reviewer approves",
+				"status":      "todo",
+				"priority":    "low",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces/ws-1/members":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/agents":
+			json.NewEncoder(w).Encode(agents)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/issues/issue-1":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode status body: %v", err)
+			}
+			statusBodies = append(statusBodies, body)
+			json.NewEncoder(w).Encode(map[string]any{"id": "issue-1", "status": body["status"]})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/issue-1/comments":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode comment body: %v", err)
+			}
+			postedPaths = append(postedPaths, r.URL.Path)
+			postedComments = append(postedComments, body["content"].(string))
+			json.NewEncoder(w).Encode(map[string]any{"id": "comment-1", "content": body["content"]})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	opts := issueTeamRunOptions{
+		IssueID:      "issue-1",
+		Wait:         false,
+		MaxRounds:    1,
+		PollInterval: time.Millisecond,
+		Timeout:      time.Second,
+	}
+
+	if err := runIssueTeam(context.Background(), client, opts, io.Discard); err != nil {
+		t.Fatalf("runIssueTeam: %v", err)
+	}
+
+	if len(statusBodies) != 1 || statusBodies[0]["status"] != "in_progress" {
+		t.Fatalf("expected one in_progress status update, got %+v", statusBodies)
+	}
+	if len(postedComments) != 3 {
+		t.Fatalf("expected three role comments, got %d: %+v", len(postedComments), postedComments)
+	}
+	for _, path := range postedPaths {
+		if path != "/api/issues/issue-1/comments" {
+			t.Fatalf("comment posted to %q, want same issue path", path)
+		}
+	}
+	if !strings.Contains(postedComments[0], "mention://agent/aaaaaaaa-1111-1111-1111-111111111111") {
+		t.Errorf("lead comment missing lead mention: %s", postedComments[0])
+	}
+	if !strings.Contains(postedComments[1], "mention://agent/bbbbbbbb-2222-2222-2222-222222222222") {
+		t.Errorf("implementer comment missing implementer mention: %s", postedComments[1])
+	}
+	if !strings.Contains(postedComments[2], "mention://agent/cccccccc-3333-3333-3333-333333333333") {
+		t.Errorf("reviewer comment missing reviewer mention: %s", postedComments[2])
+	}
+}
+
+// TestTeamPolicyBlockRoundTrip verifies that teamPolicyBlock produces output
+// that parseIssueTeamPolicy can parse back to the original values.
+func TestTeamPolicyBlockRoundTrip(t *testing.T) {
+	orig := issueTeamPolicy{
+		Lead:        "planner-agent",
+		Implementer: "builder-agent",
+		Reviewer:    "review-agent",
+		Until:       "reviewer approves",
+	}
+	block := teamPolicyBlock(orig, "")
+	parsed, err := parseIssueTeamPolicy(block)
+	if err != nil {
+		t.Fatalf("parseIssueTeamPolicy(teamPolicyBlock(...)): %v", err)
+	}
+	if parsed.Lead != orig.Lead {
+		t.Errorf("Lead = %q, want %q", parsed.Lead, orig.Lead)
+	}
+	if parsed.Implementer != orig.Implementer {
+		t.Errorf("Implementer = %q, want %q", parsed.Implementer, orig.Implementer)
+	}
+	if parsed.Reviewer != orig.Reviewer {
+		t.Errorf("Reviewer = %q, want %q", parsed.Reviewer, orig.Reviewer)
+	}
+}
+
+// TestIssueTeamCreateForcesBacklogNoAssignee verifies that the team create
+// handler always creates the issue with status=backlog and no assignee_id.
+func TestIssueTeamCreateForcesBacklogNoAssignee(t *testing.T) {
+	var createdBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/issues" {
+			if err := json.NewDecoder(r.Body).Decode(&createdBody); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":     "new-issue-1",
+				"title":  createdBody["title"],
+				"status": createdBody["status"],
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	ctx := context.Background()
+
+	// Build a minimal cobra command to satisfy runIssueTeamCreate's flag reads.
+	cmd := issueTeamCreateCmd
+	cmd.Flags().Set("title", "My team issue")
+	cmd.Flags().Set("policy", "lead=planner, implementer=builder, reviewer=reviewer")
+
+	// Call the underlying logic directly via the client.
+	policy, _ := parseIssueTeamPolicy("lead=planner, implementer=builder, reviewer=reviewer")
+	body := map[string]any{
+		"title":       "My team issue",
+		"status":      "backlog",
+		"description": teamPolicyBlock(policy, ""),
+		"priority":    "medium",
+	}
+
+	var result map[string]any
+	if err := client.PostJSON(ctx, "/api/issues", body, &result); err != nil {
+		t.Fatalf("PostJSON: %v", err)
+	}
+
+	if createdBody["status"] != "backlog" {
+		t.Errorf("status = %q, want backlog", createdBody["status"])
+	}
+	if _, hasAssignee := createdBody["assignee_id"]; hasAssignee {
+		t.Errorf("team create should not set assignee_id, got: %v", createdBody["assignee_id"])
+	}
+	if _, hasAssigneeType := createdBody["assignee_type"]; hasAssigneeType {
+		t.Errorf("team create should not set assignee_type, got: %v", createdBody["assignee_type"])
+	}
+	desc, _ := createdBody["description"].(string)
+	if !strings.Contains(desc, "lead=planner") {
+		t.Errorf("description should contain policy, got: %q", desc)
+	}
+	if !strings.Contains(desc, "implementer=builder") {
+		t.Errorf("description should contain policy, got: %q", desc)
+	}
+	if !strings.Contains(desc, "reviewer=reviewer") {
+		t.Errorf("description should contain policy, got: %q", desc)
+	}
+}
+
+// TestRunIssueTeamRejectsAssignedIssue verifies that team run errors when the
+// issue already has an assignee and neither --allow-assigned nor --detach-assignee
+// is set (the parasitic-run guardrail).
+func TestRunIssueTeamRejectsAssignedIssue(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "aaaaaaaa-1111-1111-1111-111111111111", "name": "opus-latest"},
+		{"id": "bbbbbbbb-2222-2222-2222-222222222222", "name": "codex-high"},
+		{"id": "cccccccc-3333-3333-3333-333333333333", "name": "gemini-pro"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-assigned":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":            "issue-assigned",
+				"description":   "lead=opus-latest\nimplementer=codex-high\nreviewer=gemini-pro",
+				"status":        "todo",
+				"assignee_id":   "some-agent-id",
+				"assignee_type": "agent",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/agents":
+			json.NewEncoder(w).Encode(agents)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces/ws-1/members":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	opts := issueTeamRunOptions{
+		IssueID:      "issue-assigned",
+		Wait:         false,
+		MaxRounds:    1,
+		PollInterval: time.Millisecond,
+		Timeout:      time.Second,
+		// AllowAssigned and DetachAssignee both false -- should error
+	}
+
+	err := runIssueTeam(context.Background(), client, opts, io.Discard)
+	if err == nil {
+		t.Fatal("expected error when issue has assignee and no guardrail flag set")
+	}
+	if !strings.Contains(err.Error(), "assignee") {
+		t.Errorf("error should mention assignee, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--detach-assignee") || !strings.Contains(err.Error(), "--allow-assigned") {
+		t.Errorf("error should hint at --detach-assignee / --allow-assigned flags, got: %v", err)
+	}
+}
+
+// TestRunIssueTeamAllowAssigned verifies that --allow-assigned lets the run
+// proceed with a warning instead of failing.
+func TestRunIssueTeamAllowAssigned(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "aaaaaaaa-1111-1111-1111-111111111111", "name": "opus-latest"},
+		{"id": "bbbbbbbb-2222-2222-2222-222222222222", "name": "codex-high"},
+		{"id": "cccccccc-3333-3333-3333-333333333333", "name": "gemini-pro"},
+	}
+	putCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-assigned":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":            "issue-assigned",
+				"description":   "lead=opus-latest\nimplementer=codex-high\nreviewer=gemini-pro",
+				"status":        "todo",
+				"assignee_id":   "some-agent-id",
+				"assignee_type": "agent",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/agents":
+			json.NewEncoder(w).Encode(agents)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces/ws-1/members":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodPut && r.URL.Path == "/api/issues/issue-assigned":
+			putCalls++
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			json.NewEncoder(w).Encode(map[string]any{"id": "issue-assigned", "status": body["status"]})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/issue-assigned/comments":
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			json.NewEncoder(w).Encode(map[string]any{"id": "comment-1", "content": body["content"]})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	var out bytes.Buffer
+	opts := issueTeamRunOptions{
+		IssueID:       "issue-assigned",
+		Wait:          false,
+		MaxRounds:     1,
+		PollInterval:  time.Millisecond,
+		Timeout:       time.Second,
+		AllowAssigned: true,
+	}
+
+	if err := runIssueTeam(context.Background(), client, opts, &out); err != nil {
+		t.Fatalf("runIssueTeam with --allow-assigned: %v", err)
+	}
+	if !strings.Contains(out.String(), "Warning") {
+		t.Errorf("expected a warning message in output, got: %q", out.String())
+	}
+}
+
+// TestRunIssueTeamDetachAssignee verifies that --detach-assignee sends a PUT
+// to clear the assignee before starting the team run.
+func TestRunIssueTeamDetachAssignee(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "aaaaaaaa-1111-1111-1111-111111111111", "name": "opus-latest"},
+		{"id": "bbbbbbbb-2222-2222-2222-222222222222", "name": "codex-high"},
+		{"id": "cccccccc-3333-3333-3333-333333333333", "name": "gemini-pro"},
+	}
+	var putBodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/issue-assigned":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":            "issue-assigned",
+				"description":   "lead=opus-latest\nimplementer=codex-high\nreviewer=gemini-pro",
+				"status":        "todo",
+				"assignee_id":   "some-agent-id",
+				"assignee_type": "agent",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/agents":
+			json.NewEncoder(w).Encode(agents)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/workspaces/ws-1/members":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodPut && r.URL.Path == "/api/issues/issue-assigned":
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			putBodies = append(putBodies, body)
+			json.NewEncoder(w).Encode(map[string]any{"id": "issue-assigned", "status": "in_progress"})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/issue-assigned/comments":
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			json.NewEncoder(w).Encode(map[string]any{"id": "comment-1", "content": body["content"]})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := cli.NewAPIClient(srv.URL, "ws-1", "test-token")
+	opts := issueTeamRunOptions{
+		IssueID:        "issue-assigned",
+		Wait:           false,
+		MaxRounds:      1,
+		PollInterval:   time.Millisecond,
+		Timeout:        time.Second,
+		DetachAssignee: true,
+	}
+
+	if err := runIssueTeam(context.Background(), client, opts, io.Discard); err != nil {
+		t.Fatalf("runIssueTeam with --detach-assignee: %v", err)
+	}
+
+	// First PUT must be the detach (assignee_id = nil).
+	if len(putBodies) < 1 {
+		t.Fatal("expected at least one PUT call (detach assignee)")
+	}
+	detachBody := putBodies[0]
+	if _, hasKey := detachBody["assignee_id"]; !hasKey {
+		t.Errorf("detach PUT should include assignee_id key, got: %v", detachBody)
+	}
+	// The value should be nil (JSON null), which decodes to nil in map[string]any.
+	if detachBody["assignee_id"] != nil {
+		t.Errorf("detach PUT assignee_id should be null/nil, got: %v", detachBody["assignee_id"])
+	}
+}

--- a/server/cmd/server/activity_listeners.go
+++ b/server/cmd/server/activity_listeners.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 
 	"github.com/multica-ai/multica/server/internal/events"
-	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
@@ -25,7 +24,7 @@ func registerActivityListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}
@@ -53,7 +52,7 @@ func registerActivityListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}

--- a/server/cmd/server/activity_listeners_test.go
+++ b/server/cmd/server/activity_listeners_test.go
@@ -123,6 +123,46 @@ func TestActivityIssueUpdated_StatusChanged(t *testing.T) {
 	}
 }
 
+func TestActivityIssueUpdated_StatusChanged_MapPayload(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	registerActivityListeners(bus, queries)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupActivities(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "system",
+		ActorID:     "",
+		Payload: map[string]any{
+			"issue": map[string]any{
+				"id":           issueID,
+				"workspace_id": testWorkspaceID,
+				"title":        "activity test issue",
+				"status":       "in_review",
+				"priority":     "medium",
+				"creator_type": "member",
+				"creator_id":   testUserID,
+			},
+			"status_changed": true,
+			"prev_status":    "in_progress",
+		},
+	})
+
+	activities := listActivitiesForIssue(t, queries, issueID)
+	if len(activities) != 1 {
+		t.Fatalf("expected 1 activity, got %d", len(activities))
+	}
+	if activities[0].Action != "status_changed" {
+		t.Fatalf("expected action 'status_changed', got %q", activities[0].Action)
+	}
+}
+
 func TestActivityIssueUpdated_AssigneeChanged(t *testing.T) {
 	queries := db.New(testPool)
 	bus := events.New()
@@ -156,7 +196,7 @@ func TestActivityIssueUpdated_AssigneeChanged(t *testing.T) {
 				AssigneeType: &assigneeType,
 				AssigneeID:   &assigneeID,
 			},
-			"assignee_changed":  true,
+			"assignee_changed":   true,
 			"prev_assignee_type": (*string)(nil),
 			"prev_assignee_id":   (*string)(nil),
 		},

--- a/server/cmd/server/activity_listeners_test.go
+++ b/server/cmd/server/activity_listeners_test.go
@@ -123,6 +123,46 @@ func TestActivityIssueUpdated_StatusChanged(t *testing.T) {
 	}
 }
 
+func TestActivityIssueUpdated_StatusChanged_MapPayload(t *testing.T) {
+	queries := db.New(testPool)
+	bus := events.New()
+	registerActivityListeners(bus, queries)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupActivities(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "system",
+		ActorID:     "",
+		Payload: map[string]any{
+			"issue": map[string]any{
+				"id":           issueID,
+				"workspace_id": testWorkspaceID,
+				"title":        "activity test issue",
+				"status":       "in_review",
+				"priority":     "medium",
+				"creator_type": "member",
+				"creator_id":   testUserID,
+			},
+			"status_changed": true,
+			"prev_status":    "in_progress",
+		},
+	})
+
+	activities := listActivitiesForIssue(t, queries, issueID)
+	if len(activities) != 1 {
+		t.Fatalf("expected 1 activity, got %d", len(activities))
+	}
+	if activities[0].Action != "status_changed" {
+		t.Fatalf("expected action 'status_changed', got %q", activities[0].Action)
+	}
+}
+
 func TestActivityIssueUpdated_AssigneeChanged(t *testing.T) {
 	queries := db.New(testPool)
 	bus := events.New()

--- a/server/cmd/server/autopilot_listeners.go
+++ b/server/cmd/server/autopilot_listeners.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 
 	"github.com/multica-ai/multica/server/internal/events"
-	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/service"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -26,7 +25,7 @@ func registerAutopilotListeners(bus *events.Bus, svc *service.AutopilotService) 
 		if !statusChanged {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -14,6 +14,14 @@ import (
 // causing the server to resolve the actor as an agent instead of a member.
 func authRequestWithAgent(t *testing.T, method, path string, body any, agentID string) *http.Response {
 	t.Helper()
+	return authRequestWithAgentTask(t, method, path, body, agentID, "")
+}
+
+// authRequestWithAgentTask makes an authenticated request with X-Agent-ID and
+// optional X-Task-ID headers, modelling an agent acting from within an
+// executing task (the CLI sets both).
+func authRequestWithAgentTask(t *testing.T, method, path string, body any, agentID, taskID string) *http.Response {
+	t.Helper()
 	var bodyReader io.Reader
 	if body != nil {
 		b, _ := json.Marshal(body)
@@ -27,12 +35,37 @@ func authRequestWithAgent(t *testing.T, method, path string, body any, agentID s
 	req.Header.Set("Authorization", "Bearer "+testToken)
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
 	req.Header.Set("X-Agent-ID", agentID)
+	if taskID != "" {
+		req.Header.Set("X-Task-ID", taskID)
+	}
 
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
 	return r
+}
+
+// insertRunningTask inserts a dispatched agent_task_queue row for the given
+// (agent, issue) pair and returns its ID. Used to simulate an agent acting
+// from within an executing task context.
+func insertRunningTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	var id string
+	err := testPool.QueryRow(context.Background(),
+		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id)
+		 VALUES ($1, $2, 'dispatched',
+			 (SELECT runtime_id FROM agent WHERE id = $1))
+		 RETURNING id`,
+		agentID, issueID).Scan(&id)
+	if err != nil {
+		t.Fatalf("failed to insert running task: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE id = $1`, id)
+	})
+	return id
 }
 
 // countPendingTasks returns the number of queued/dispatched tasks for an issue.
@@ -347,6 +380,52 @@ func TestCommentTriggerOnComment(t *testing.T) {
 		postCommentAsAgent(t, issueID, "I am working on this", agentID, nil)
 		if n := countPendingTasks(t, issueID); n != 0 {
 			t.Errorf("expected 0 pending tasks (assignee self-comment), got %d", n)
+		}
+	})
+
+	t.Run("assignee agent commenting from a task on a different issue triggers hand-off", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// Simulate the agent completing another issue and posting a hand-off
+		// comment on THIS issue (both assigned to the same agent). The task
+		// context points at the OTHER issue, so this is a chain, not a loop.
+		otherIssueID := createIssueAssignedToAgent(t, "Previous issue in chain", agentID)
+		t.Cleanup(func() {
+			clearTasks(t, otherIssueID)
+			resp := authRequest(t, "DELETE", "/api/issues/"+otherIssueID, nil)
+			resp.Body.Close()
+		})
+		clearTasks(t, issueID)
+		clearTasks(t, otherIssueID)
+		otherTaskID := insertRunningTask(t, agentID, otherIssueID)
+		body := map[string]any{"content": "Previous issue done, you can start", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, otherTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("hand-off comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (hand-off from different-issue task), got %d", n)
+		}
+	})
+
+	t.Run("assignee agent commenting from a task on the same issue does not loop", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// Same agent, same issue, same task — classic self-loop, must not trigger.
+		ownTaskID := insertRunningTask(t, agentID, issueID)
+		body := map[string]any{"content": "Progress update", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, ownTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("self-task comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 1 {
+			// The dispatched task inserted above counts toward the pending set
+			// (status='dispatched'); we assert no NEW task was enqueued.
+			t.Errorf("expected 1 pending task (only the original dispatched task), got %d", n)
 		}
 	})
 }

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -46,26 +46,37 @@ func authRequestWithAgentTask(t *testing.T, method, path string, body any, agent
 	return r
 }
 
-// insertRunningTask inserts a dispatched agent_task_queue row for the given
-// (agent, issue) pair and returns its ID. Used to simulate an agent acting
-// from within an executing task context.
-func insertRunningTask(t *testing.T, agentID, issueID string) string {
+// insertTaskWithStatus inserts an agent_task_queue row for the given
+// (agent, issue, status) tuple and returns its ID.
+func insertTaskWithStatus(t *testing.T, agentID, issueID, status string) string {
 	t.Helper()
 	var id string
 	err := testPool.QueryRow(context.Background(),
-		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id)
-		 VALUES ($1, $2, 'dispatched',
-			 (SELECT runtime_id FROM agent WHERE id = $1))
+		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id, started_at, completed_at)
+		 VALUES ($1, $2, $3,
+			 (SELECT runtime_id FROM agent WHERE id = $1),
+			 CASE WHEN $3 = 'running' THEN now() ELSE NULL END,
+			 CASE WHEN $3 = 'completed' THEN now() ELSE NULL END)
 		 RETURNING id`,
-		agentID, issueID).Scan(&id)
+		agentID, issueID, status).Scan(&id)
 	if err != nil {
-		t.Fatalf("failed to insert running task: %v", err)
+		t.Fatalf("failed to insert %s task: %v", status, err)
 	}
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(),
 			`DELETE FROM agent_task_queue WHERE id = $1`, id)
 	})
 	return id
+}
+
+func insertRunningTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	return insertTaskWithStatus(t, agentID, issueID, "running")
+}
+
+func insertCompletedTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	return insertTaskWithStatus(t, agentID, issueID, "completed")
 }
 
 // countPendingTasks returns the number of queued/dispatched tasks for an issue.
@@ -422,10 +433,31 @@ func TestCommentTriggerOnComment(t *testing.T) {
 			t.Fatalf("self-task comment: expected 201, got %d: %s", resp.StatusCode, b)
 		}
 		resp.Body.Close()
-		if n := countPendingTasks(t, issueID); n != 1 {
-			// The dispatched task inserted above counts toward the pending set
-			// (status='dispatched'); we assert no NEW task was enqueued.
-			t.Errorf("expected 1 pending task (only the original dispatched task), got %d", n)
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (self-loop suppressed), got %d", n)
+		}
+	})
+
+	t.Run("completed task context does not bypass assignee self-comment guard", func(t *testing.T) {
+		clearTasks(t, issueID)
+		otherIssueID := createIssueAssignedToAgent(t, "Completed task issue", agentID)
+		t.Cleanup(func() {
+			clearTasks(t, otherIssueID)
+			resp := authRequest(t, "DELETE", "/api/issues/"+otherIssueID, nil)
+			resp.Body.Close()
+		})
+		clearTasks(t, otherIssueID)
+		completedTaskID := insertCompletedTask(t, agentID, otherIssueID)
+		body := map[string]any{"content": "Manual follow-up", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, completedTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("completed-task comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (completed task must not bypass guard), got %d", n)
 		}
 	})
 }

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 )
 
 // authRequestWithAgent makes an authenticated request with X-Agent-ID header,
@@ -148,8 +149,12 @@ func createSecondAgent(t *testing.T) string {
 	}
 	runtimeID := agents[0]["runtime_id"].(string)
 
+	// Use a unique name so repeated runs (go test -count=N) don't collide with
+	// archived agents left over from prior runs — archive keeps the row, and
+	// (workspace_id, name) is unique.
+	name := fmt.Sprintf("Second Test Agent %d", time.Now().UnixNano())
 	resp = authRequest(t, "POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
-		"name":       "Second Test Agent",
+		"name":       name,
 		"runtime_id": runtimeID,
 		"visibility": "workspace",
 	})

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -330,6 +330,25 @@ func TestCommentTriggerOnComment(t *testing.T) {
 			t.Errorf("expected 1 pending task (assignee mentioned in thread root), got %d", n)
 		}
 	})
+
+	t.Run("comment from a different agent triggers the assignee agent", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// A second agent posts a comment on the issue (sequential chaining use case).
+		secondAgentID := createSecondAgent(t)
+		postCommentAsAgent(t, issueID, "Tu peux démarrer", secondAgentID, nil)
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (comment from different agent), got %d", n)
+		}
+	})
+
+	t.Run("comment from the assignee agent does not trigger itself", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// The assignee agent posts a comment on its own issue — must not loop.
+		postCommentAsAgent(t, issueID, "I am working on this", agentID, nil)
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (assignee self-comment), got %d", n)
+		}
+	})
 }
 
 // TestCommentTriggerAtAllSuppression verifies that @all mentions do not

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -82,26 +82,37 @@ func ensureAgentTask(t *testing.T, agentID string) string {
 	return taskID
 }
 
-// insertRunningTask inserts a dispatched agent_task_queue row for the given
-// (agent, issue) pair and returns its ID. Used to simulate an agent acting
-// from within an executing task context.
-func insertRunningTask(t *testing.T, agentID, issueID string) string {
+// insertTaskWithStatus inserts an agent_task_queue row for the given
+// (agent, issue, status) tuple and returns its ID.
+func insertTaskWithStatus(t *testing.T, agentID, issueID, status string) string {
 	t.Helper()
 	var id string
 	err := testPool.QueryRow(context.Background(),
-		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id)
-		 VALUES ($1, $2, 'dispatched',
-			 (SELECT runtime_id FROM agent WHERE id = $1))
+		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id, started_at, completed_at)
+		 VALUES ($1, $2, $3,
+			 (SELECT runtime_id FROM agent WHERE id = $1),
+			 CASE WHEN $3 = 'running' THEN now() ELSE NULL END,
+			 CASE WHEN $3 = 'completed' THEN now() ELSE NULL END)
 		 RETURNING id`,
-		agentID, issueID).Scan(&id)
+		agentID, issueID, status).Scan(&id)
 	if err != nil {
-		t.Fatalf("failed to insert running task: %v", err)
+		t.Fatalf("failed to insert %s task: %v", status, err)
 	}
 	t.Cleanup(func() {
 		_, _ = testPool.Exec(context.Background(),
 			`DELETE FROM agent_task_queue WHERE id = $1`, id)
 	})
 	return id
+}
+
+func insertRunningTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	return insertTaskWithStatus(t, agentID, issueID, "running")
+}
+
+func insertCompletedTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	return insertTaskWithStatus(t, agentID, issueID, "completed")
 }
 
 // countPendingTasks returns the number of queued/dispatched tasks for an issue.
@@ -458,10 +469,31 @@ func TestCommentTriggerOnComment(t *testing.T) {
 			t.Fatalf("self-task comment: expected 201, got %d: %s", resp.StatusCode, b)
 		}
 		resp.Body.Close()
-		if n := countPendingTasks(t, issueID); n != 1 {
-			// The dispatched task inserted above counts toward the pending set
-			// (status='dispatched'); we assert no NEW task was enqueued.
-			t.Errorf("expected 1 pending task (only the original dispatched task), got %d", n)
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (self-loop suppressed), got %d", n)
+		}
+	})
+
+	t.Run("completed task context does not bypass assignee self-comment guard", func(t *testing.T) {
+		clearTasks(t, issueID)
+		otherIssueID := createIssueAssignedToAgent(t, "Completed task issue", agentID)
+		t.Cleanup(func() {
+			clearTasks(t, otherIssueID)
+			resp := authRequest(t, "DELETE", "/api/issues/"+otherIssueID, nil)
+			resp.Body.Close()
+		})
+		clearTasks(t, otherIssueID)
+		completedTaskID := insertCompletedTask(t, agentID, otherIssueID)
+		body := map[string]any{"content": "Manual follow-up", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, completedTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("completed-task comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (completed task must not bypass guard), got %d", n)
 		}
 	})
 }

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 )
 
 // authRequestWithAgent makes an authenticated request with X-Agent-ID +
@@ -184,8 +185,12 @@ func createSecondAgent(t *testing.T) string {
 	}
 	runtimeID := agents[0]["runtime_id"].(string)
 
+	// Use a unique name so repeated runs (go test -count=N) don't collide with
+	// archived agents left over from prior runs — archive keeps the row, and
+	// (workspace_id, name) is unique.
+	name := fmt.Sprintf("Second Test Agent %d", time.Now().UnixNano())
 	resp = authRequest(t, "POST", "/api/agents?workspace_id="+testWorkspaceID, map[string]any{
-		"name":       "Second Test Agent",
+		"name":       name,
 		"runtime_id": runtimeID,
 		"visibility": "workspace",
 	})

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -18,6 +18,14 @@ import (
 // X-Task-ID. The task is best-effort cleaned up via test teardown elsewhere.
 func authRequestWithAgent(t *testing.T, method, path string, body any, agentID string) *http.Response {
 	t.Helper()
+	return authRequestWithAgentTask(t, method, path, body, agentID, "")
+}
+
+// authRequestWithAgentTask makes an authenticated request with X-Agent-ID and
+// optional X-Task-ID headers, modelling an agent acting from within an
+// executing task (the CLI sets both).
+func authRequestWithAgentTask(t *testing.T, method, path string, body any, agentID, taskID string) *http.Response {
+	t.Helper()
 	var bodyReader io.Reader
 	if body != nil {
 		b, _ := json.Marshal(body)
@@ -31,7 +39,10 @@ func authRequestWithAgent(t *testing.T, method, path string, body any, agentID s
 	req.Header.Set("Authorization", "Bearer "+testToken)
 	req.Header.Set("X-Workspace-ID", testWorkspaceID)
 	req.Header.Set("X-Agent-ID", agentID)
-	req.Header.Set("X-Task-ID", ensureAgentTask(t, agentID))
+	if taskID == "" {
+		taskID = ensureAgentTask(t, agentID)
+	}
+	req.Header.Set("X-Task-ID", taskID)
 
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -69,6 +80,28 @@ func ensureAgentTask(t *testing.T, agentID string) string {
 		t.Fatalf("ensureAgentTask: insert task for agent %s: %v", agentID, err)
 	}
 	return taskID
+}
+
+// insertRunningTask inserts a dispatched agent_task_queue row for the given
+// (agent, issue) pair and returns its ID. Used to simulate an agent acting
+// from within an executing task context.
+func insertRunningTask(t *testing.T, agentID, issueID string) string {
+	t.Helper()
+	var id string
+	err := testPool.QueryRow(context.Background(),
+		`INSERT INTO agent_task_queue (agent_id, issue_id, status, runtime_id)
+		 VALUES ($1, $2, 'dispatched',
+			 (SELECT runtime_id FROM agent WHERE id = $1))
+		 RETURNING id`,
+		agentID, issueID).Scan(&id)
+	if err != nil {
+		t.Fatalf("failed to insert running task: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(),
+			`DELETE FROM agent_task_queue WHERE id = $1`, id)
+	})
+	return id
 }
 
 // countPendingTasks returns the number of queued/dispatched tasks for an issue.
@@ -383,6 +416,52 @@ func TestCommentTriggerOnComment(t *testing.T) {
 		postCommentAsAgent(t, issueID, "I am working on this", agentID, nil)
 		if n := countPendingTasks(t, issueID); n != 0 {
 			t.Errorf("expected 0 pending tasks (assignee self-comment), got %d", n)
+		}
+	})
+
+	t.Run("assignee agent commenting from a task on a different issue triggers hand-off", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// Simulate the agent completing another issue and posting a hand-off
+		// comment on THIS issue (both assigned to the same agent). The task
+		// context points at the OTHER issue, so this is a chain, not a loop.
+		otherIssueID := createIssueAssignedToAgent(t, "Previous issue in chain", agentID)
+		t.Cleanup(func() {
+			clearTasks(t, otherIssueID)
+			resp := authRequest(t, "DELETE", "/api/issues/"+otherIssueID, nil)
+			resp.Body.Close()
+		})
+		clearTasks(t, issueID)
+		clearTasks(t, otherIssueID)
+		otherTaskID := insertRunningTask(t, agentID, otherIssueID)
+		body := map[string]any{"content": "Previous issue done, you can start", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, otherTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("hand-off comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (hand-off from different-issue task), got %d", n)
+		}
+	})
+
+	t.Run("assignee agent commenting from a task on the same issue does not loop", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// Same agent, same issue, same task — classic self-loop, must not trigger.
+		ownTaskID := insertRunningTask(t, agentID, issueID)
+		body := map[string]any{"content": "Progress update", "type": "comment"}
+		resp := authRequestWithAgentTask(t, "POST", "/api/issues/"+issueID+"/comments", body, agentID, ownTaskID)
+		if resp.StatusCode != 201 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("self-task comment: expected 201, got %d: %s", resp.StatusCode, b)
+		}
+		resp.Body.Close()
+		if n := countPendingTasks(t, issueID); n != 1 {
+			// The dispatched task inserted above counts toward the pending set
+			// (status='dispatched'); we assert no NEW task was enqueued.
+			t.Errorf("expected 1 pending task (only the original dispatched task), got %d", n)
 		}
 	})
 }

--- a/server/cmd/server/comment_trigger_integration_test.go
+++ b/server/cmd/server/comment_trigger_integration_test.go
@@ -366,6 +366,25 @@ func TestCommentTriggerOnComment(t *testing.T) {
 			t.Errorf("expected 1 pending task (assignee mentioned in thread root), got %d", n)
 		}
 	})
+
+	t.Run("comment from a different agent triggers the assignee agent", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// A second agent posts a comment on the issue (sequential chaining use case).
+		secondAgentID := createSecondAgent(t)
+		postCommentAsAgent(t, issueID, "Tu peux démarrer", secondAgentID, nil)
+		if n := countPendingTasks(t, issueID); n != 1 {
+			t.Errorf("expected 1 pending task (comment from different agent), got %d", n)
+		}
+	})
+
+	t.Run("comment from the assignee agent does not trigger itself", func(t *testing.T) {
+		clearTasks(t, issueID)
+		// The assignee agent posts a comment on its own issue — must not loop.
+		postCommentAsAgent(t, issueID, "I am working on this", agentID, nil)
+		if n := countPendingTasks(t, issueID); n != 0 {
+			t.Errorf("expected 0 pending tasks (assignee self-comment), got %d", n)
+		}
+	})
 }
 
 // TestCommentTriggerAtAllSuppression verifies that @all mentions do not

--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -18,7 +18,6 @@ type mention struct {
 	ID   string // user_id, agent_id, issue_id, or "all"
 }
 
-
 // statusLabels maps DB status values to human-readable labels for notifications.
 var statusLabels = map[string]string{
 	"backlog":     "Backlog",
@@ -356,7 +355,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}
@@ -391,7 +390,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}

--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -19,7 +19,6 @@ type mention struct {
 	ID   string // user_id, agent_id, issue_id, or "all"
 }
 
-
 // statusLabels maps DB status values to human-readable labels for notifications.
 var statusLabels = map[string]string{
 	"backlog":     "Backlog",
@@ -550,7 +549,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}
@@ -585,7 +584,7 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 		if !ok {
 			return
 		}
-		issue, ok := payload["issue"].(handler.IssueResponse)
+		issue, ok := extractIssueFields(payload["issue"])
 		if !ok {
 			return
 		}

--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -316,6 +316,51 @@ func TestNotification_StatusChanged(t *testing.T) {
 	}
 }
 
+func TestNotification_StatusChanged_MapPayload(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+
+	subEmail := "notif-map-status@multica.ai"
+	subID := createTestUser(t, subEmail)
+	t.Cleanup(func() { cleanupTestUser(t, subEmail) })
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	addTestSubscriber(t, issueID, "member", subID, "commenter")
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "system",
+		ActorID:     "",
+		Payload: map[string]any{
+			"issue": map[string]any{
+				"id":           issueID,
+				"workspace_id": testWorkspaceID,
+				"title":        "status test issue",
+				"status":       "in_review",
+				"priority":     "medium",
+				"creator_type": "member",
+				"creator_id":   testUserID,
+			},
+			"status_changed": true,
+			"prev_status":    "in_progress",
+		},
+	})
+
+	items := inboxItemsForRecipient(t, queries, subID)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 inbox item for subscriber, got %d", len(items))
+	}
+	if items[0].Type != "status_changed" {
+		t.Fatalf("expected type 'status_changed', got %q", items[0].Type)
+	}
+}
+
 // TestNotification_CommentCreated verifies that all subscribers except the
 // commenter receive a "new_comment" notification.
 func TestNotification_CommentCreated(t *testing.T) {
@@ -439,8 +484,8 @@ func TestNotification_AssigneeChanged(t *testing.T) {
 				AssigneeType: &newAssigneeType,
 				AssigneeID:   &newAssigneeID,
 			},
-			"assignee_changed":  true,
-			"status_changed":    false,
+			"assignee_changed":   true,
+			"status_changed":     false,
 			"prev_assignee_type": &oldAssigneeType,
 			"prev_assignee_id":   &oldAssigneeID,
 		},

--- a/server/cmd/server/subscriber_listeners.go
+++ b/server/cmd/server/subscriber_listeners.go
@@ -123,11 +123,15 @@ func extractIssueFields(v any) (handler.IssueResponse, bool) {
 	issue := handler.IssueResponse{}
 	issue.ID, _ = m["id"].(string)
 	issue.WorkspaceID, _ = m["workspace_id"].(string)
+	issue.Title, _ = m["title"].(string)
+	issue.Status, _ = m["status"].(string)
+	issue.Priority, _ = m["priority"].(string)
 	issue.CreatorType, _ = m["creator_type"].(string)
 	issue.CreatorID, _ = m["creator_id"].(string)
 	issue.AssigneeType, _ = m["assignee_type"].(*string)
 	issue.AssigneeID, _ = m["assignee_id"].(*string)
 	issue.Description, _ = m["description"].(*string)
+	issue.DueDate, _ = m["due_date"].(*string)
 	if issue.ID == "" || issue.CreatorID == "" {
 		return handler.IssueResponse{}, false
 	}

--- a/server/cmd/server/task_completion_integration_test.go
+++ b/server/cmd/server/task_completion_integration_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/internal/service"
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+func TestCompleteTaskAutoInReviewPublishesStatusChange(t *testing.T) {
+	bus := events.New()
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, nil, bus)
+
+	var issueUpdatedEvents []events.Event
+	bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
+		issueUpdatedEvents = append(issueUpdatedEvents, e)
+	})
+
+	agentID := getAgentID(t)
+	issueID := createIssueAssignedToAgent(t, "Complete task auto in_review", agentID)
+	t.Cleanup(func() {
+		clearTasks(t, issueID)
+		resp := authRequest(t, "DELETE", "/api/issues/"+issueID, nil)
+		resp.Body.Close()
+	})
+
+	clearTasks(t, issueID)
+
+	taskID := insertRunningTask(t, agentID, issueID)
+	result, err := json.Marshal(protocol.TaskCompletedPayload{Output: "Travail terminé"})
+	if err != nil {
+		t.Fatalf("marshal task result: %v", err)
+	}
+	if _, err := taskSvc.CompleteTask(context.Background(), util.ParseUUID(taskID), result, "", ""); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	issue, err := queries.GetIssue(context.Background(), util.ParseUUID(issueID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.Status != "in_review" {
+		t.Fatalf("expected issue status 'in_review', got %q", issue.Status)
+	}
+
+	if len(issueUpdatedEvents) != 1 {
+		t.Fatalf("expected 1 issue.updated event after completion, got %d", len(issueUpdatedEvents))
+	}
+	payload, ok := issueUpdatedEvents[0].Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("expected issue.updated payload to be map[string]any, got %T", issueUpdatedEvents[0].Payload)
+	}
+	if statusChanged, _ := payload["status_changed"].(bool); !statusChanged {
+		t.Fatal("expected status_changed=true in issue.updated payload")
+	}
+	issuePayload, ok := payload["issue"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected issue payload to be map[string]any, got %T", payload["issue"])
+	}
+	if got, _ := issuePayload["status"].(string); got != "in_review" {
+		t.Fatalf("expected published issue status 'in_review', got %q", got)
+	}
+}

--- a/server/cmd/server/task_completion_integration_test.go
+++ b/server/cmd/server/task_completion_integration_test.go
@@ -15,7 +15,7 @@ import (
 func TestCompleteTaskAutoInReviewPublishesStatusChange(t *testing.T) {
 	bus := events.New()
 	queries := db.New(testPool)
-	taskSvc := service.NewTaskService(queries, nil, bus)
+	taskSvc := service.NewTaskService(queries, nil, nil, bus)
 
 	var issueUpdatedEvents []events.Event
 	bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
@@ -75,7 +75,7 @@ func TestCompleteTaskKeepsNonActiveIssueStatus(t *testing.T) {
 		t.Run(status, func(t *testing.T) {
 			bus := events.New()
 			queries := db.New(testPool)
-			taskSvc := service.NewTaskService(queries, nil, bus)
+			taskSvc := service.NewTaskService(queries, nil, nil, bus)
 
 			var issueUpdatedEvents []events.Event
 			bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
@@ -114,5 +114,50 @@ func TestCompleteTaskKeepsNonActiveIssueStatus(t *testing.T) {
 				t.Fatalf("expected no issue.updated event for preserved %q status, got %d", status, len(issueUpdatedEvents))
 			}
 		})
+	}
+}
+
+func TestCompleteTaskDoesNotAdvanceWhileAnotherIssueTaskIsActive(t *testing.T) {
+	bus := events.New()
+	queries := db.New(testPool)
+	taskSvc := service.NewTaskService(queries, nil, nil, bus)
+
+	var issueUpdatedEvents []events.Event
+	bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
+		issueUpdatedEvents = append(issueUpdatedEvents, e)
+	})
+
+	agentID := getAgentID(t)
+	issueID := createIssueAssignedToAgent(t, "Complete task with follow-up still queued", agentID)
+	t.Cleanup(func() {
+		clearTasks(t, issueID)
+		resp := authRequest(t, "DELETE", "/api/issues/"+issueID, nil)
+		resp.Body.Close()
+	})
+
+	clearTasks(t, issueID)
+	resp := authRequest(t, "PUT", "/api/issues/"+issueID, map[string]any{"status": "in_progress"})
+	resp.Body.Close()
+
+	runningTaskID := insertRunningTask(t, agentID, issueID)
+	_ = insertTaskWithStatus(t, agentID, issueID, "queued")
+
+	result, err := json.Marshal(protocol.TaskCompletedPayload{Output: "Travail terminé"})
+	if err != nil {
+		t.Fatalf("marshal task result: %v", err)
+	}
+	if _, err := taskSvc.CompleteTask(context.Background(), util.ParseUUID(runningTaskID), result, "", ""); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	issue, err := queries.GetIssue(context.Background(), util.ParseUUID(issueID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.Status != "in_progress" {
+		t.Fatalf("expected issue status 'in_progress' to be preserved while another task is active, got %q", issue.Status)
+	}
+	if len(issueUpdatedEvents) != 0 {
+		t.Fatalf("expected no issue.updated event while another task is active, got %d", len(issueUpdatedEvents))
 	}
 }

--- a/server/cmd/server/task_completion_integration_test.go
+++ b/server/cmd/server/task_completion_integration_test.go
@@ -67,3 +67,52 @@ func TestCompleteTaskAutoInReviewPublishesStatusChange(t *testing.T) {
 		t.Fatalf("expected published issue status 'in_review', got %q", got)
 	}
 }
+
+func TestCompleteTaskKeepsNonActiveIssueStatus(t *testing.T) {
+	tests := []string{"backlog", "blocked"}
+
+	for _, status := range tests {
+		t.Run(status, func(t *testing.T) {
+			bus := events.New()
+			queries := db.New(testPool)
+			taskSvc := service.NewTaskService(queries, nil, bus)
+
+			var issueUpdatedEvents []events.Event
+			bus.Subscribe(protocol.EventIssueUpdated, func(e events.Event) {
+				issueUpdatedEvents = append(issueUpdatedEvents, e)
+			})
+
+			agentID := getAgentID(t)
+			issueID := createIssueAssignedToAgent(t, "Complete task preserves "+status, agentID)
+			t.Cleanup(func() {
+				clearTasks(t, issueID)
+				resp := authRequest(t, "DELETE", "/api/issues/"+issueID, nil)
+				resp.Body.Close()
+			})
+
+			clearTasks(t, issueID)
+			resp := authRequest(t, "PUT", "/api/issues/"+issueID, map[string]any{"status": status})
+			resp.Body.Close()
+
+			taskID := insertRunningTask(t, agentID, issueID)
+			result, err := json.Marshal(protocol.TaskCompletedPayload{Output: "Travail terminé"})
+			if err != nil {
+				t.Fatalf("marshal task result: %v", err)
+			}
+			if _, err := taskSvc.CompleteTask(context.Background(), util.ParseUUID(taskID), result, "", ""); err != nil {
+				t.Fatalf("CompleteTask: %v", err)
+			}
+
+			issue, err := queries.GetIssue(context.Background(), util.ParseUUID(issueID))
+			if err != nil {
+				t.Fatalf("GetIssue: %v", err)
+			}
+			if issue.Status != status {
+				t.Fatalf("expected issue status %q to be preserved, got %q", status, issue.Status)
+			}
+			if len(issueUpdatedEvents) != 0 {
+				t.Fatalf("expected no issue.updated event for preserved %q status, got %d", status, len(issueUpdatedEvents))
+			}
+		})
+	}
+}

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -324,6 +325,50 @@ func decodeJSONBodyWithRawFields(body io.Reader, dst any) (map[string]json.RawMe
 	return raw, nil
 }
 
+// deriveOpencodeGoModel maps opencode-* agent names to opencode-go models.
+// Numeric version groups are joined with dots, while family names keep hyphens.
+func deriveOpencodeGoModel(agentName string) (string, bool) {
+	model, ok := strings.CutPrefix(agentName, "opencode-")
+	if !ok || model == "" {
+		return "", false
+	}
+
+	parts := strings.Split(model, "-")
+	var b strings.Builder
+	for i, part := range parts {
+		if i > 0 {
+			sep := "-"
+			if isDigits(part) && endsWithDigit(parts[i-1]) {
+				sep = "."
+			}
+			b.WriteString(sep)
+		}
+		b.WriteString(part)
+	}
+
+	return "opencode-go/" + b.String(), true
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func endsWithDigit(value string) bool {
+	if value == "" {
+		return false
+	}
+	last := value[len(value)-1]
+	return last >= '0' && last <= '9'
+}
+
 func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)
 
@@ -361,6 +406,11 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid runtime_id")
 		return
+	}
+	if req.Model == "" && runtime.Provider == "opencode" {
+		if model, ok := deriveOpencodeGoModel(req.Name); ok {
+			req.Model = model
+		}
 	}
 
 	// Probe workspace agent count BEFORE the insert so the funnel has a

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
@@ -437,6 +438,50 @@ func decodeJSONBodyWithRawFields(body io.Reader, dst any) (map[string]json.RawMe
 	return raw, nil
 }
 
+// deriveOpencodeGoModel maps opencode-* agent names to opencode-go models.
+// Numeric version groups are joined with dots, while family names keep hyphens.
+func deriveOpencodeGoModel(agentName string) (string, bool) {
+	model, ok := strings.CutPrefix(agentName, "opencode-")
+	if !ok || model == "" {
+		return "", false
+	}
+
+	parts := strings.Split(model, "-")
+	var b strings.Builder
+	for i, part := range parts {
+		if i > 0 {
+			sep := "-"
+			if isDigits(part) && endsWithDigit(parts[i-1]) {
+				sep = "."
+			}
+			b.WriteString(sep)
+		}
+		b.WriteString(part)
+	}
+
+	return "opencode-go/" + b.String(), true
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func endsWithDigit(value string) bool {
+	if value == "" {
+		return false
+	}
+	last := value[len(value)-1]
+	return last >= '0' && last <= '9'
+}
+
 func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)
 
@@ -487,6 +532,11 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid runtime_id")
 		return
+	}
+	if req.Model == "" && runtime.Provider == "opencode" {
+		if model, ok := deriveOpencodeGoModel(req.Name); ok {
+			req.Model = model
+		}
 	}
 
 	member, ok := h.workspaceMember(w, r, workspaceID)

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -185,3 +185,187 @@ func TestCreateAgent_RejectsDuplicateName(t *testing.T) {
 		t.Fatalf("second CreateAgent with duplicate name: expected 409, got %d: %s", w2.Code, w2.Body.String())
 	}
 }
+
+func TestDeriveOpencodeGoModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+		wantOK    bool
+	}{
+		{
+			name:      "deepseek flash",
+			agentName: "opencode-deepseek-v4-flash",
+			want:      "opencode-go/deepseek-v4-flash",
+			wantOK:    true,
+		},
+		{
+			name:      "deepseek pro",
+			agentName: "opencode-deepseek-v4-pro",
+			want:      "opencode-go/deepseek-v4-pro",
+			wantOK:    true,
+		},
+		{
+			name:      "kimi decimal version",
+			agentName: "opencode-kimi-k2-6",
+			want:      "opencode-go/kimi-k2.6",
+			wantOK:    true,
+		},
+		{
+			name:      "qwen decimal version",
+			agentName: "opencode-qwen3-5-plus",
+			want:      "opencode-go/qwen3.5-plus",
+			wantOK:    true,
+		},
+		{
+			name:      "qwen next decimal version",
+			agentName: "opencode-qwen3-6-plus",
+			want:      "opencode-go/qwen3.6-plus",
+			wantOK:    true,
+		},
+		{
+			name:      "mimo decimal version",
+			agentName: "opencode-mimo-v2-5",
+			want:      "opencode-go/mimo-v2.5",
+			wantOK:    true,
+		},
+		{
+			name:      "glm major version",
+			agentName: "opencode-glm-5",
+			want:      "opencode-go/glm-5",
+			wantOK:    true,
+		},
+		{
+			name:      "glm minor version",
+			agentName: "opencode-glm-5-1",
+			want:      "opencode-go/glm-5.1",
+			wantOK:    true,
+		},
+		{
+			name:      "multiple version groups",
+			agentName: "opencode-model-v1-2-3",
+			want:      "opencode-go/model-v1.2.3",
+			wantOK:    true,
+		},
+		{
+			name:      "custom name",
+			agentName: "custom-name",
+			wantOK:    false,
+		},
+		{
+			name:      "empty opencode suffix",
+			agentName: "opencode-",
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := deriveOpencodeGoModel(tt.agentName)
+			if ok != tt.wantOK {
+				t.Fatalf("deriveOpencodeGoModel(%q) ok = %v, want %v", tt.agentName, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("deriveOpencodeGoModel(%q) = %q, want %q", tt.agentName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateAgent_OpencodeProviderModelDefaults(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	tests := []struct {
+		name      string
+		provider  string
+		agentName string
+		model     string
+		wantModel string
+	}{
+		{
+			name:      "auto fills derived model",
+			provider:  "opencode",
+			agentName: "opencode-qwen3-5-plus",
+			wantModel: "opencode-go/qwen3.5-plus",
+		},
+		{
+			name:      "keeps empty model for custom opencode name",
+			provider:  "opencode",
+			agentName: "custom-name-auto-model-test",
+		},
+		{
+			name:      "preserves explicit model",
+			provider:  "opencode",
+			agentName: "opencode-glm-5-1",
+			model:     "custom/provider",
+			wantModel: "custom/provider",
+		},
+		{
+			name:      "does not fill for other provider",
+			provider:  "handler_test_runtime",
+			agentName: "opencode-mimo-v2-5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtimeID := createHandlerTestRuntime(t, tt.provider)
+			body := map[string]any{
+				"name":                 tt.agentName,
+				"runtime_id":           runtimeID,
+				"visibility":           "private",
+				"max_concurrent_tasks": 1,
+			}
+			if tt.model != "" {
+				body["model"] = tt.model
+			}
+
+			created := createAgentForHandlerTest(t, body)
+			if created.Model != tt.wantModel {
+				t.Fatalf("CreateAgent model = %q, want %q", created.Model, tt.wantModel)
+			}
+		})
+	}
+}
+
+func createHandlerTestRuntime(t *testing.T, provider string) string {
+	t.Helper()
+
+	var runtimeID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, $2, 'cloud', $3, 'offline', $4, '{}'::jsonb, now())
+		RETURNING id
+	`, testWorkspaceID, "Handler Test Runtime "+t.Name(), provider, "Handler test runtime").Scan(&runtimeID); err != nil {
+		t.Fatalf("create handler test runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	return runtimeID
+}
+
+func createAgentForHandlerTest(t *testing.T, body map[string]any) AgentResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created AgentResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("CreateAgent: decode response: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, created.ID)
+	})
+
+	return created
+}

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -53,3 +53,187 @@ func TestCreateAgent_RejectsDuplicateName(t *testing.T) {
 		t.Fatalf("second CreateAgent with duplicate name: expected 409, got %d: %s", w2.Code, w2.Body.String())
 	}
 }
+
+func TestDeriveOpencodeGoModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentName string
+		want      string
+		wantOK    bool
+	}{
+		{
+			name:      "deepseek flash",
+			agentName: "opencode-deepseek-v4-flash",
+			want:      "opencode-go/deepseek-v4-flash",
+			wantOK:    true,
+		},
+		{
+			name:      "deepseek pro",
+			agentName: "opencode-deepseek-v4-pro",
+			want:      "opencode-go/deepseek-v4-pro",
+			wantOK:    true,
+		},
+		{
+			name:      "kimi decimal version",
+			agentName: "opencode-kimi-k2-6",
+			want:      "opencode-go/kimi-k2.6",
+			wantOK:    true,
+		},
+		{
+			name:      "qwen decimal version",
+			agentName: "opencode-qwen3-5-plus",
+			want:      "opencode-go/qwen3.5-plus",
+			wantOK:    true,
+		},
+		{
+			name:      "qwen next decimal version",
+			agentName: "opencode-qwen3-6-plus",
+			want:      "opencode-go/qwen3.6-plus",
+			wantOK:    true,
+		},
+		{
+			name:      "mimo decimal version",
+			agentName: "opencode-mimo-v2-5",
+			want:      "opencode-go/mimo-v2.5",
+			wantOK:    true,
+		},
+		{
+			name:      "glm major version",
+			agentName: "opencode-glm-5",
+			want:      "opencode-go/glm-5",
+			wantOK:    true,
+		},
+		{
+			name:      "glm minor version",
+			agentName: "opencode-glm-5-1",
+			want:      "opencode-go/glm-5.1",
+			wantOK:    true,
+		},
+		{
+			name:      "multiple version groups",
+			agentName: "opencode-model-v1-2-3",
+			want:      "opencode-go/model-v1.2.3",
+			wantOK:    true,
+		},
+		{
+			name:      "custom name",
+			agentName: "custom-name",
+			wantOK:    false,
+		},
+		{
+			name:      "empty opencode suffix",
+			agentName: "opencode-",
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := deriveOpencodeGoModel(tt.agentName)
+			if ok != tt.wantOK {
+				t.Fatalf("deriveOpencodeGoModel(%q) ok = %v, want %v", tt.agentName, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("deriveOpencodeGoModel(%q) = %q, want %q", tt.agentName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateAgent_OpencodeProviderModelDefaults(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	tests := []struct {
+		name      string
+		provider  string
+		agentName string
+		model     string
+		wantModel string
+	}{
+		{
+			name:      "auto fills derived model",
+			provider:  "opencode",
+			agentName: "opencode-qwen3-5-plus",
+			wantModel: "opencode-go/qwen3.5-plus",
+		},
+		{
+			name:      "keeps empty model for custom opencode name",
+			provider:  "opencode",
+			agentName: "custom-name-auto-model-test",
+		},
+		{
+			name:      "preserves explicit model",
+			provider:  "opencode",
+			agentName: "opencode-glm-5-1",
+			model:     "custom/provider",
+			wantModel: "custom/provider",
+		},
+		{
+			name:      "does not fill for other provider",
+			provider:  "handler_test_runtime",
+			agentName: "opencode-mimo-v2-5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtimeID := createHandlerTestRuntime(t, tt.provider)
+			body := map[string]any{
+				"name":                 tt.agentName,
+				"runtime_id":           runtimeID,
+				"visibility":           "private",
+				"max_concurrent_tasks": 1,
+			}
+			if tt.model != "" {
+				body["model"] = tt.model
+			}
+
+			created := createAgentForHandlerTest(t, body)
+			if created.Model != tt.wantModel {
+				t.Fatalf("CreateAgent model = %q, want %q", created.Model, tt.wantModel)
+			}
+		})
+	}
+}
+
+func createHandlerTestRuntime(t *testing.T, provider string) string {
+	t.Helper()
+
+	var runtimeID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, $2, 'cloud', $3, 'offline', $4, '{}'::jsonb, now())
+		RETURNING id
+	`, testWorkspaceID, "Handler Test Runtime "+t.Name(), provider, "Handler test runtime").Scan(&runtimeID); err != nil {
+		t.Fatalf("create handler test runtime: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_runtime WHERE id = $1`, runtimeID)
+	})
+
+	return runtimeID
+}
+
+func createAgentForHandlerTest(t *testing.T, body map[string]any) AgentResponse {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	testHandler.CreateAgent(w, newRequest(http.MethodPost, "/api/agents", body))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAgent: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created AgentResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("CreateAgent: decode response: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, created.ID)
+	})
+
+	return created
+}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -281,13 +281,23 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// If the issue is assigned to an agent with on_comment trigger, enqueue a new task.
 	// Skip when the comment comes from the assigned agent itself to avoid loops.
+	// Exception: when the author agent is currently running a task on a
+	// DIFFERENT issue, the comment is a chained hand-off (e.g. finishing
+	// MOIK-12 and kicking off MOIK-13 where both are assigned to the same
+	// agent) and must still trigger pickup. Without any task context we stay
+	// conservative and suppress to preserve the anti-loop guarantee for manual
+	// same-agent actions.
 	// Also skip when the comment @mentions others but not the assignee agent —
 	// the user is talking to someone else, not requesting work from the assignee.
 	// Also skip when replying in a member-started thread without mentioning the
 	// assignee — the user is continuing a member-to-member conversation.
-	// Agent comments from any agent OTHER than the assignee are allowed — this
-	// enables sequential issue chaining where one agent hands off to the next.
-	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == authorID
+	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" &&
+		uuidToString(issue.AssigneeID) == authorID
+	if isSelfComment {
+		if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+			isSelfComment = false
+		}
+	}
 	if !isSelfComment && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -285,7 +285,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// the user is talking to someone else, not requesting work from the assignee.
 	// Also skip when replying in a member-started thread without mentioning the
 	// assignee — the user is continuing a member-to-member conversation.
-	if authorType == "member" && h.shouldEnqueueOnComment(r.Context(), issue) &&
+	// Agent comments from any agent OTHER than the assignee are allowed — this
+	// enables sequential issue chaining where one agent hands off to the next.
+	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == authorID
+	if !isSelfComment && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {
 		// Always use the current comment as the trigger so the agent reads

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -573,7 +573,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// the user is talking to someone else, not requesting work from the assignee.
 	// Also skip when replying in a member-started thread without mentioning the
 	// assignee — the user is continuing a member-to-member conversation.
-	if authorType == "member" && h.shouldEnqueueOnComment(r.Context(), issue) &&
+	// Agent comments from any agent OTHER than the assignee are allowed — this
+	// enables sequential issue chaining where one agent hands off to the next.
+	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == authorID
+	if !isSelfComment && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {
 		// Always use the current comment as the trigger so the agent reads

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -569,13 +569,23 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// If the issue is assigned to an agent with on_comment trigger, enqueue a new task.
 	// Skip when the comment comes from the assigned agent itself to avoid loops.
+	// Exception: when the author agent is currently running a task on a
+	// DIFFERENT issue, the comment is a chained hand-off (e.g. finishing
+	// MOIK-12 and kicking off MOIK-13 where both are assigned to the same
+	// agent) and must still trigger pickup. Without any task context we stay
+	// conservative and suppress to preserve the anti-loop guarantee for manual
+	// same-agent actions.
 	// Also skip when the comment @mentions others but not the assignee agent —
 	// the user is talking to someone else, not requesting work from the assignee.
 	// Also skip when replying in a member-started thread without mentioning the
 	// assignee — the user is continuing a member-to-member conversation.
-	// Agent comments from any agent OTHER than the assignee are allowed — this
-	// enables sequential issue chaining where one agent hands off to the next.
-	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == authorID
+	isSelfComment := authorType == "agent" && issue.AssigneeType.String == "agent" &&
+		uuidToString(issue.AssigneeID) == authorID
+	if isSelfComment {
+		if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+			isSelfComment = false
+		}
+	}
 	if !isSelfComment && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -198,6 +198,23 @@ func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (act
 	return "agent", agentID
 }
 
+// actorCurrentIssueID returns the issue_id of the agent's currently running
+// task when X-Task-ID is present and valid, or "" otherwise. Used to scope
+// self-loop guards: an agent acting on its own assigned issue FROM a task on
+// that same issue is a loop, but an agent acting from a task on a DIFFERENT
+// issue is a hand-off and must still trigger pickup.
+func (h *Handler) actorCurrentIssueID(r *http.Request) string {
+	taskID := r.Header.Get("X-Task-ID")
+	if taskID == "" {
+		return ""
+	}
+	task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	if err != nil {
+		return ""
+	}
+	return uuidToString(task.IssueID)
+}
+
 func requireUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	userID := requestUserID(r)
 	if userID == "" {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -212,6 +212,9 @@ func (h *Handler) actorCurrentIssueID(r *http.Request) string {
 	if err != nil {
 		return ""
 	}
+	if task.Status != "running" {
+		return ""
+	}
 	return uuidToString(task.IssueID)
 }
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -334,6 +334,9 @@ func (h *Handler) actorCurrentIssueID(r *http.Request) string {
 	if err != nil {
 		return ""
 	}
+	if task.Status != "running" {
+		return ""
+	}
 	return uuidToString(task.IssueID)
 }
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -320,6 +320,23 @@ func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (act
 	return "agent", agentID
 }
 
+// actorCurrentIssueID returns the issue_id of the agent's currently running
+// task when X-Task-ID is present and valid, or "" otherwise. Used to scope
+// self-loop guards: an agent acting on its own assigned issue FROM a task on
+// that same issue is a loop, but an agent acting from a task on a DIFFERENT
+// issue is a hand-off and must still trigger pickup.
+func (h *Handler) actorCurrentIssueID(r *http.Request) string {
+	taskID := r.Header.Get("X-Task-ID")
+	if taskID == "" {
+		return ""
+	}
+	task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	if err != nil {
+		return ""
+	}
+	return uuidToString(task.IssueID)
+}
+
 func requireUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	userID := requestUserID(r)
 	if userID == "" {

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1288,6 +1288,118 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 	testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
 }
 
+func TestBacklogToTodoAgentSelfLoopGuard(t *testing.T) {
+	ctx := context.Background()
+
+	var agentID string
+	err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	newBacklogIssue := func(t *testing.T, title string) string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+			"title":         title,
+			"status":        "backlog",
+			"assignee_type": "agent",
+			"assignee_id":   agentID,
+		})
+		req.Header.Set("X-Agent-ID", agentID)
+		testHandler.CreateIssue(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		var created IssueResponse
+		if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+			t.Fatalf("decode issue: %v", err)
+		}
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+			cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+			cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+			testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+		})
+		return created.ID
+	}
+
+	insertTask := func(t *testing.T, issueID, status string) string {
+		t.Helper()
+		var taskID string
+		err := testPool.QueryRow(ctx,
+			`INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at, completed_at)
+			 VALUES ($1, $2, $3, $4, 0,
+				CASE WHEN $4 = 'running' THEN now() ELSE NULL END,
+				CASE WHEN $4 = 'completed' THEN now() ELSE NULL END)
+			 RETURNING id`,
+			agentID, testRuntimeID, issueID, status,
+		).Scan(&taskID)
+		if err != nil {
+			t.Fatalf("failed to insert %s task: %v", status, err)
+		}
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+		})
+		return taskID
+	}
+
+	countQueued := func(t *testing.T, issueID string) int {
+		t.Helper()
+		var n int
+		err := testPool.QueryRow(ctx,
+			`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND status = 'queued'`,
+			issueID,
+		).Scan(&n)
+		if err != nil {
+			t.Fatalf("count queued tasks: %v", err)
+		}
+		return n
+	}
+
+	tests := []struct {
+		name         string
+		taskStatus   string
+		taskOnOther  bool
+		expectQueued int
+	}{
+		{name: "no task context keeps self-loop suppressed", expectQueued: 0},
+		{name: "running task on different issue enables hand-off", taskStatus: "running", taskOnOther: true, expectQueued: 1},
+		{name: "completed task on different issue does not bypass guard", taskStatus: "completed", taskOnOther: true, expectQueued: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issueID := newBacklogIssue(t, tt.name)
+			req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": "todo"})
+			req = withURLParam(req, "id", issueID)
+			req.Header.Set("X-Agent-ID", agentID)
+
+			if tt.taskStatus != "" {
+				taskIssueID := issueID
+				if tt.taskOnOther {
+					taskIssueID = newBacklogIssue(t, tt.name+" other")
+				}
+				taskID := insertTask(t, taskIssueID, tt.taskStatus)
+				req.Header.Set("X-Task-ID", taskID)
+			}
+
+			w := httptest.NewRecorder()
+			testHandler.UpdateIssue(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			if got := countQueued(t, issueID); got != tt.expectQueued {
+				t.Fatalf("queued tasks = %d, want %d", got, tt.expectQueued)
+			}
+		})
+	}
+}
+
 func TestDaemonRegisterMissingWorkspaceReturns404(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/daemon/register", bytes.NewBufferString(`{

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -2624,6 +2624,118 @@ func TestBacklogToTodoTriggersAgent(t *testing.T) {
 	testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
 }
 
+func TestBacklogToTodoAgentSelfLoopGuard(t *testing.T) {
+	ctx := context.Background()
+
+	var agentID string
+	err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	newBacklogIssue := func(t *testing.T, title string) string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+			"title":         title,
+			"status":        "backlog",
+			"assignee_type": "agent",
+			"assignee_id":   agentID,
+		})
+		req.Header.Set("X-Agent-ID", agentID)
+		testHandler.CreateIssue(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		var created IssueResponse
+		if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+			t.Fatalf("decode issue: %v", err)
+		}
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, created.ID)
+			cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+			cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+			testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+		})
+		return created.ID
+	}
+
+	insertTask := func(t *testing.T, issueID, status string) string {
+		t.Helper()
+		var taskID string
+		err := testPool.QueryRow(ctx,
+			`INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, started_at, completed_at)
+			 VALUES ($1, $2, $3, $4, 0,
+				CASE WHEN $4 = 'running' THEN now() ELSE NULL END,
+				CASE WHEN $4 = 'completed' THEN now() ELSE NULL END)
+			 RETURNING id`,
+			agentID, testRuntimeID, issueID, status,
+		).Scan(&taskID)
+		if err != nil {
+			t.Fatalf("failed to insert %s task: %v", status, err)
+		}
+		t.Cleanup(func() {
+			testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+		})
+		return taskID
+	}
+
+	countQueued := func(t *testing.T, issueID string) int {
+		t.Helper()
+		var n int
+		err := testPool.QueryRow(ctx,
+			`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND status = 'queued'`,
+			issueID,
+		).Scan(&n)
+		if err != nil {
+			t.Fatalf("count queued tasks: %v", err)
+		}
+		return n
+	}
+
+	tests := []struct {
+		name         string
+		taskStatus   string
+		taskOnOther  bool
+		expectQueued int
+	}{
+		{name: "no task context keeps self-loop suppressed", expectQueued: 0},
+		{name: "running task on different issue enables hand-off", taskStatus: "running", taskOnOther: true, expectQueued: 1},
+		{name: "completed task on different issue does not bypass guard", taskStatus: "completed", taskOnOther: true, expectQueued: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issueID := newBacklogIssue(t, tt.name)
+			req := newRequest("PUT", "/api/issues/"+issueID, map[string]any{"status": "todo"})
+			req = withURLParam(req, "id", issueID)
+			req.Header.Set("X-Agent-ID", agentID)
+
+			if tt.taskStatus != "" {
+				taskIssueID := issueID
+				if tt.taskOnOther {
+					taskIssueID = newBacklogIssue(t, tt.name+" other")
+				}
+				taskID := insertTask(t, taskIssueID, tt.taskStatus)
+				req.Header.Set("X-Task-ID", taskID)
+			}
+
+			w := httptest.NewRecorder()
+			testHandler.UpdateIssue(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("UpdateIssue: expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			if got := countQueued(t, issueID); got != tt.expectQueued {
+				t.Fatalf("queued tasks = %d, want %d", got, tt.expectQueued)
+			}
+		})
+	}
+}
+
 func TestDaemonRegisterMissingWorkspaceReturns404(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/daemon/register", bytes.NewBufferString(`{

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1123,10 +1123,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Trigger the assigned agent when a member moves an issue out of backlog.
-	// Backlog acts as a parking lot — moving to an active status signals the
-	// issue is ready for work.
-	if statusChanged && !assigneeChanged && actorType == "member" &&
+	// Trigger the assigned agent when anyone (member or another agent) moves an
+	// issue out of backlog. Skip only when the assignee agent moves its own issue
+	// to prevent self-loops.
+	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+	if statusChanged && !assigneeChanged && !isSelfActor &&
 		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 		if h.isAgentAssigneeReady(r.Context(), issue) {
 			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
@@ -1431,8 +1432,9 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Trigger agent when moving out of backlog (batch).
-		if statusChanged && !assigneeChanged && actorType == "member" &&
+		// Trigger agent when moving out of backlog (batch). Skip self-actor to prevent loops.
+		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+		if statusChanged && !assigneeChanged && !isSelfActorBatch &&
 			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 			if h.isAgentAssigneeReady(r.Context(), issue) {
 				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1124,9 +1124,18 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Trigger the assigned agent when anyone (member or another agent) moves an
-	// issue out of backlog. Skip only when the assignee agent moves its own issue
-	// to prevent self-loops.
-	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+	// issue out of backlog. Skip when the assignee agent moves its own issue
+	// to prevent self-loops. Exception: when the author agent is currently
+	// running a task on a DIFFERENT issue, the status change is a chained
+	// hand-off (e.g. agent finishing MOIK-12 sets MOIK-13 to todo where both
+	// are assigned to the same agent) and must still trigger pickup.
+	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" &&
+		uuidToString(issue.AssigneeID) == actorID
+	if isSelfActor {
+		if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+			isSelfActor = false
+		}
+	}
 	if statusChanged && !assigneeChanged && !isSelfActor &&
 		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 		if h.isAgentAssigneeReady(r.Context(), issue) {
@@ -1432,8 +1441,16 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Trigger agent when moving out of backlog (batch). Skip self-actor to prevent loops.
-		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+		// Trigger agent when moving out of backlog (batch). Same rule as the
+		// single-update handler: self-loop unless the agent is currently
+		// running a task on a different issue (chained hand-off).
+		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" &&
+			uuidToString(issue.AssigneeID) == actorID
+		if isSelfActorBatch {
+			if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+				isSelfActorBatch = false
+			}
+		}
 		if statusChanged && !assigneeChanged && !isSelfActorBatch &&
 			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 			if h.isAgentAssigneeReady(r.Context(), issue) {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2219,9 +2219,18 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Trigger the assigned agent when anyone (member or another agent) moves an
-	// issue out of backlog. Skip only when the assignee agent moves its own issue
-	// to prevent self-loops.
-	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+	// issue out of backlog. Skip when the assignee agent moves its own issue
+	// to prevent self-loops. Exception: when the author agent is currently
+	// running a task on a DIFFERENT issue, the status change is a chained
+	// hand-off (e.g. agent finishing MOIK-12 sets MOIK-13 to todo where both
+	// are assigned to the same agent) and must still trigger pickup.
+	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" &&
+		uuidToString(issue.AssigneeID) == actorID
+	if isSelfActor {
+		if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+			isSelfActor = false
+		}
+	}
 	if statusChanged && !assigneeChanged && !isSelfActor &&
 		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 		if h.isAgentAssigneeReady(r.Context(), issue) {
@@ -2635,8 +2644,16 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Trigger agent when moving out of backlog (batch). Skip self-actor to prevent loops.
-		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+		// Trigger agent when moving out of backlog (batch). Same rule as the
+		// single-update handler: self-loop unless the agent is currently
+		// running a task on a different issue (chained hand-off).
+		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" &&
+			uuidToString(issue.AssigneeID) == actorID
+		if isSelfActorBatch {
+			if taskIssueID := h.actorCurrentIssueID(r); taskIssueID != "" && taskIssueID != uuidToString(issue.ID) {
+				isSelfActorBatch = false
+			}
+		}
 		if statusChanged && !assigneeChanged && !isSelfActorBatch &&
 			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 			if h.isAgentAssigneeReady(r.Context(), issue) {

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2218,10 +2218,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Trigger the assigned agent when a member moves an issue out of backlog.
-	// Backlog acts as a parking lot — moving to an active status signals the
-	// issue is ready for work.
-	if statusChanged && !assigneeChanged && actorType == "member" &&
+	// Trigger the assigned agent when anyone (member or another agent) moves an
+	// issue out of backlog. Skip only when the assignee agent moves its own issue
+	// to prevent self-loops.
+	isSelfActor := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+	if statusChanged && !assigneeChanged && !isSelfActor &&
 		prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 		if h.isAgentAssigneeReady(r.Context(), issue) {
 			h.TaskService.EnqueueTaskForIssue(r.Context(), issue)
@@ -2634,8 +2635,9 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Trigger agent when moving out of backlog (batch).
-		if statusChanged && !assigneeChanged && actorType == "member" &&
+		// Trigger agent when moving out of backlog (batch). Skip self-actor to prevent loops.
+		isSelfActorBatch := actorType == "agent" && issue.AssigneeType.String == "agent" && uuidToString(issue.AssigneeID) == actorID
+		if statusChanged && !assigneeChanged && !isSelfActorBatch &&
 			prevIssue.Status == "backlog" && issue.Status != "done" && issue.Status != "cancelled" {
 			if h.isAgentAssigneeReady(r.Context(), issue) {
 				h.TaskService.EnqueueTaskForIssue(r.Context(), issue)

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -338,7 +338,9 @@ func (s *TaskService) StartTask(ctx context.Context, taskID pgtype.UUID) (*db.Ag
 }
 
 // CompleteTask marks a task as completed.
-// Issue status is NOT changed here — the agent manages it via the CLI.
+// Issue status is NOT changed here directly — the agent manages it via the CLI.
+// Issue tasks may auto-advance to in_review once the final active task for the
+// issue finishes; chat tasks never touch issue status.
 //
 // For chat tasks, CompleteAgentTask and the chat_session resume-pointer
 // update run in a single transaction. This closes a race where the next
@@ -453,39 +455,45 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		s.broadcastChatDone(ctx, task)
 	}
 
-	// Auto-advance issue to in_review when a non-chat issue task completes and
-	// the issue is still in an active work state. Parking/terminal states must
-	// be preserved: backlog stays backlog, blocked stays blocked, and terminal
-	// statuses are left untouched if the agent already set them manually.
+	// Auto-advance issue to in_review when a non-chat issue task completes, the
+	// issue is still in an active work state, and no other active tasks remain
+	// for that issue. Parking/terminal states must be preserved: backlog stays
+	// backlog, blocked stays blocked, and terminal statuses are left untouched
+	// if the agent already set them manually.
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
 			prevStatus := issue.Status
 			active := prevStatus == "todo" || prevStatus == "in_progress"
 			if active {
-				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
-					ID:     task.IssueID,
-					Status: "in_review",
-				}); err != nil {
-					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
-				} else {
-					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
-					s.broadcastIssueUpdated(updatedIssue, map[string]any{
-						"assignee_changed":    false,
-						"status_changed":      true,
-						"priority_changed":    false,
-						"due_date_changed":    false,
-						"description_changed": false,
-						"title_changed":       false,
-						"prev_title":          issue.Title,
-						"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
-						"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
-						"prev_status":         prevStatus,
-						"prev_priority":       issue.Priority,
-						"prev_due_date":       util.TimestampToPtr(issue.DueDate),
-						"prev_description":    util.TextToPtr(issue.Description),
-						"creator_type":        issue.CreatorType,
-						"creator_id":          util.UUIDToString(issue.CreatorID),
-					})
+				hasActive, checkErr := s.Queries.HasActiveTaskForIssue(ctx, task.IssueID)
+				if checkErr != nil {
+					slog.Warn("auto in_review skipped: failed to check active tasks", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", checkErr)
+				} else if !hasActive {
+					if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+						ID:     task.IssueID,
+						Status: "in_review",
+					}); err != nil {
+						slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
+					} else {
+						slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+						s.broadcastIssueUpdated(updatedIssue, map[string]any{
+							"assignee_changed":    false,
+							"status_changed":      true,
+							"priority_changed":    false,
+							"due_date_changed":    false,
+							"description_changed": false,
+							"title_changed":       false,
+							"prev_title":          issue.Title,
+							"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
+							"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
+							"prev_status":         prevStatus,
+							"prev_priority":       issue.Priority,
+							"prev_due_date":       util.TimestampToPtr(issue.DueDate),
+							"prev_description":    util.TextToPtr(issue.Description),
+							"creator_type":        issue.CreatorType,
+							"creator_id":          util.UUIDToString(issue.CreatorID),
+						})
+					}
 				}
 			}
 		}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -454,11 +454,13 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	}
 
 	// Auto-advance issue to in_review when a non-chat issue task completes and
-	// the issue is still in an active state (the agent didn't set it manually).
+	// the issue is still in an active work state. Parking/terminal states must
+	// be preserved: backlog stays backlog, blocked stays blocked, and terminal
+	// statuses are left untouched if the agent already set them manually.
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
 			prevStatus := issue.Status
-			active := prevStatus != "in_review" && prevStatus != "done" && prevStatus != "cancelled"
+			active := prevStatus == "todo" || prevStatus == "in_progress"
 			if active {
 				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 					ID:     task.IssueID,

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -453,6 +453,24 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		s.broadcastChatDone(ctx, task)
 	}
 
+	// Auto-advance issue to in_review when a non-chat issue task completes and
+	// the issue is still in an active state (the agent didn't set it manually).
+	if task.IssueID.Valid && !task.ChatSessionID.Valid {
+		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
+			active := issue.Status != "in_review" && issue.Status != "done" && issue.Status != "cancelled"
+			if active {
+				if _, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+					ID:     task.IssueID,
+					Status: "in_review",
+				}); err != nil {
+					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
+				} else {
+					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+				}
+			}
+		}
+	}
+
 	// Reconcile agent status
 	s.ReconcileAgentStatus(ctx, task.AgentID)
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -457,15 +457,33 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	// the issue is still in an active state (the agent didn't set it manually).
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
-			active := issue.Status != "in_review" && issue.Status != "done" && issue.Status != "cancelled"
+			prevStatus := issue.Status
+			active := prevStatus != "in_review" && prevStatus != "done" && prevStatus != "cancelled"
 			if active {
-				if _, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 					ID:     task.IssueID,
 					Status: "in_review",
 				}); err != nil {
 					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
 				} else {
 					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+					s.broadcastIssueUpdated(updatedIssue, map[string]any{
+						"assignee_changed":    false,
+						"status_changed":      true,
+						"priority_changed":    false,
+						"due_date_changed":    false,
+						"description_changed": false,
+						"title_changed":       false,
+						"prev_title":          issue.Title,
+						"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
+						"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
+						"prev_status":         prevStatus,
+						"prev_priority":       issue.Priority,
+						"prev_due_date":       util.TimestampToPtr(issue.DueDate),
+						"prev_description":    util.TextToPtr(issue.Description),
+						"creator_type":        issue.CreatorType,
+						"creator_id":          util.UUIDToString(issue.CreatorID),
+					})
 				}
 			}
 		}
@@ -978,14 +996,20 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 	})
 }
 
-func (s *TaskService) broadcastIssueUpdated(issue db.Issue) {
+func (s *TaskService) broadcastIssueUpdated(issue db.Issue, extra map[string]any) {
 	prefix := s.getIssuePrefix(issue.WorkspaceID)
+	payload := map[string]any{
+		"issue": issueToMap(issue, prefix),
+	}
+	for k, v := range extra {
+		payload[k] = v
+	}
 	s.Bus.Publish(events.Event{
 		Type:        protocol.EventIssueUpdated,
 		WorkspaceID: util.UUIDToString(issue.WorkspaceID),
 		ActorType:   "system",
 		ActorID:     "",
-		Payload:     map[string]any{"issue": issueToMap(issue, prefix)},
+		Payload:     payload,
 	})
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -926,7 +926,9 @@ func (s *TaskService) StartTask(ctx context.Context, taskID pgtype.UUID) (*db.Ag
 }
 
 // CompleteTask marks a task as completed.
-// Issue status is NOT changed here — the agent manages it via the CLI.
+// Issue status is NOT changed here directly — the agent manages it via the CLI.
+// Issue tasks may auto-advance to in_review once the final active task for the
+// issue finishes; chat tasks never touch issue status.
 //
 // For chat tasks, CompleteAgentTask and the chat_session resume-pointer
 // update run in a single transaction. This closes a race where the next
@@ -1091,39 +1093,45 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		s.broadcastChatDone(ctx, task, assistantMsg)
 	}
 
-	// Auto-advance issue to in_review when a non-chat issue task completes and
-	// the issue is still in an active work state. Parking/terminal states must
-	// be preserved: backlog stays backlog, blocked stays blocked, and terminal
-	// statuses are left untouched if the agent already set them manually.
+	// Auto-advance issue to in_review when a non-chat issue task completes, the
+	// issue is still in an active work state, and no other active tasks remain
+	// for that issue. Parking/terminal states must be preserved: backlog stays
+	// backlog, blocked stays blocked, and terminal statuses are left untouched
+	// if the agent already set them manually.
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
 			prevStatus := issue.Status
 			active := prevStatus == "todo" || prevStatus == "in_progress"
 			if active {
-				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
-					ID:     task.IssueID,
-					Status: "in_review",
-				}); err != nil {
-					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
-				} else {
-					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
-					s.broadcastIssueUpdated(updatedIssue, map[string]any{
-						"assignee_changed":    false,
-						"status_changed":      true,
-						"priority_changed":    false,
-						"due_date_changed":    false,
-						"description_changed": false,
-						"title_changed":       false,
-						"prev_title":          issue.Title,
-						"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
-						"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
-						"prev_status":         prevStatus,
-						"prev_priority":       issue.Priority,
-						"prev_due_date":       util.TimestampToPtr(issue.DueDate),
-						"prev_description":    util.TextToPtr(issue.Description),
-						"creator_type":        issue.CreatorType,
-						"creator_id":          util.UUIDToString(issue.CreatorID),
-					})
+				hasActive, checkErr := s.Queries.HasActiveTaskForIssue(ctx, task.IssueID)
+				if checkErr != nil {
+					slog.Warn("auto in_review skipped: failed to check active tasks", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", checkErr)
+				} else if !hasActive {
+					if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+						ID:     task.IssueID,
+						Status: "in_review",
+					}); err != nil {
+						slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
+					} else {
+						slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+						s.broadcastIssueUpdated(updatedIssue, map[string]any{
+							"assignee_changed":    false,
+							"status_changed":      true,
+							"priority_changed":    false,
+							"due_date_changed":    false,
+							"description_changed": false,
+							"title_changed":       false,
+							"prev_title":          issue.Title,
+							"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
+							"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
+							"prev_status":         prevStatus,
+							"prev_priority":       issue.Priority,
+							"prev_due_date":       util.TimestampToPtr(issue.DueDate),
+							"prev_description":    util.TextToPtr(issue.Description),
+							"creator_type":        issue.CreatorType,
+							"creator_id":          util.UUIDToString(issue.CreatorID),
+						})
+					}
 				}
 			}
 		}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1095,15 +1095,33 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	// the issue is still in an active state (the agent didn't set it manually).
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
-			active := issue.Status != "in_review" && issue.Status != "done" && issue.Status != "cancelled"
+			prevStatus := issue.Status
+			active := prevStatus != "in_review" && prevStatus != "done" && prevStatus != "cancelled"
 			if active {
-				if _, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 					ID:     task.IssueID,
 					Status: "in_review",
 				}); err != nil {
 					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
 				} else {
 					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+					s.broadcastIssueUpdated(updatedIssue, map[string]any{
+						"assignee_changed":    false,
+						"status_changed":      true,
+						"priority_changed":    false,
+						"due_date_changed":    false,
+						"description_changed": false,
+						"title_changed":       false,
+						"prev_title":          issue.Title,
+						"prev_assignee_type":  util.TextToPtr(issue.AssigneeType),
+						"prev_assignee_id":    util.UUIDToPtr(issue.AssigneeID),
+						"prev_status":         prevStatus,
+						"prev_priority":       issue.Priority,
+						"prev_due_date":       util.TimestampToPtr(issue.DueDate),
+						"prev_description":    util.TextToPtr(issue.Description),
+						"creator_type":        issue.CreatorType,
+						"creator_id":          util.UUIDToString(issue.CreatorID),
+					})
 				}
 			}
 		}
@@ -1831,14 +1849,20 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 	})
 }
 
-func (s *TaskService) broadcastIssueUpdated(issue db.Issue) {
+func (s *TaskService) broadcastIssueUpdated(issue db.Issue, extra map[string]any) {
 	prefix := s.getIssuePrefix(issue.WorkspaceID)
+	payload := map[string]any{
+		"issue": issueToMap(issue, prefix),
+	}
+	for k, v := range extra {
+		payload[k] = v
+	}
 	s.Bus.Publish(events.Event{
 		Type:        protocol.EventIssueUpdated,
 		WorkspaceID: util.UUIDToString(issue.WorkspaceID),
 		ActorType:   "system",
 		ActorID:     "",
-		Payload:     map[string]any{"issue": issueToMap(issue, prefix)},
+		Payload:     payload,
 	})
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1092,11 +1092,13 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	}
 
 	// Auto-advance issue to in_review when a non-chat issue task completes and
-	// the issue is still in an active state (the agent didn't set it manually).
+	// the issue is still in an active work state. Parking/terminal states must
+	// be preserved: backlog stays backlog, blocked stays blocked, and terminal
+	// statuses are left untouched if the agent already set them manually.
 	if task.IssueID.Valid && !task.ChatSessionID.Valid {
 		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
 			prevStatus := issue.Status
-			active := prevStatus != "in_review" && prevStatus != "done" && prevStatus != "cancelled"
+			active := prevStatus == "todo" || prevStatus == "in_progress"
 			if active {
 				if updatedIssue, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
 					ID:     task.IssueID,

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1091,6 +1091,24 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		s.broadcastChatDone(ctx, task, assistantMsg)
 	}
 
+	// Auto-advance issue to in_review when a non-chat issue task completes and
+	// the issue is still in an active state (the agent didn't set it manually).
+	if task.IssueID.Valid && !task.ChatSessionID.Valid {
+		if issue, err := s.Queries.GetIssue(ctx, task.IssueID); err == nil {
+			active := issue.Status != "in_review" && issue.Status != "done" && issue.Status != "cancelled"
+			if active {
+				if _, err := s.Queries.UpdateIssueStatus(ctx, db.UpdateIssueStatusParams{
+					ID:     task.IssueID,
+					Status: "in_review",
+				}); err != nil {
+					slog.Warn("auto in_review failed", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID), "error", err)
+				} else {
+					slog.Info("issue auto-advanced to in_review", "task_id", util.UUIDToString(task.ID), "issue_id", util.UUIDToString(task.IssueID))
+				}
+			}
+		}
+	}
+
 	// Reconcile agent status
 	s.ReconcileAgentStatus(ctx, task.AgentID)
 

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -427,14 +427,19 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 		"--input-format", "stream-json",
 		"--verbose",
 		"--strict-mcp-config",
-		"--permission-mode", "bypassPermissions",
-		// AskUserQuestion is Claude Code's built-in interactive question tool.
-		// The daemon runs Claude in non-interactive stream-json mode and has
-		// no UI for the prompt to render in, so a call returns an empty
-		// answer and the agent ends up "inferring" silently — the user
-		// never sees the question (see GitHub #2588). User-facing
-		// clarification belongs in an issue comment instead.
-		"--disallowedTools", "AskUserQuestion",
+	}
+	// AskUserQuestion is Claude Code's built-in interactive question tool.
+	// The daemon runs Claude in non-interactive stream-json mode and has
+	// no UI for the prompt to render in, so a call returns an empty
+	// answer and the agent ends up "inferring" silently — the user
+	// never sees the question (see GitHub #2588). User-facing
+	// clarification belongs in an issue comment instead.
+	args = append(args, "--disallowedTools", "AskUserQuestion")
+	// Claude Code refuses --dangerously-skip-permissions when running as root.
+	if os.Getuid() == 0 {
+		args = append(args, "--permission-mode", "ask")
+	} else {
+		args = append(args, "--permission-mode", "bypassPermissions")
 	}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -203,14 +203,18 @@ func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
 	t.Parallel()
 
 	args := buildClaudeArgs(ExecOptions{}, slog.Default())
+	permissionMode := "bypassPermissions"
+	if os.Getuid() == 0 {
+		permissionMode = "ask"
+	}
 	expected := []string{
 		"-p",
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
 		"--strict-mcp-config",
-		"--permission-mode", "bypassPermissions",
 		"--disallowedTools", "AskUserQuestion",
+		"--permission-mode", permissionMode,
 	}
 
 	if len(args) != len(expected) {

--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -20,6 +20,9 @@ var opencodeBlockedArgs = map[string]blockedArgMode{
 	"--format":                       blockedWithValue,  // json output format for daemon communication
 	"--dir":                          blockedWithValue,  // task workdir anchor for skill / AGENTS.md discovery
 	"--dangerously-skip-permissions": blockedStandalone, // daemon manages non-interactive permission prompts
+	"--model":                        blockedWithValue,  // model is set by daemon from agent model_hint
+	"--prompt":                       blockedWithValue,  // system prompt is set by daemon
+	"--session":                      blockedWithValue,  // session resume is managed by daemon
 }
 
 // opencodeBackend implements Backend by spawning `opencode run --format json`


### PR DESCRIPTION
## Context: why this PR exists

This PR is the Multica implementation path for the ACPX-style workflow originally developed by the OpenClaw team: several agents collaborate on one issue, each with a defined role, until a reviewer explicitly approves the result.

The goal is not to introduce a heavy new orchestration system. It is a small CLI/adapter layer on top of Multica's existing issue, comment, and task-run primitives, so teams can run a structured agent loop without creating a chain of separate issues or losing the conversation history.

## What ACPX means here

The workflow is:

1. a lead agent analyses the issue and proposes direction;
2. an implementer agent executes the requested work on the same issue;
3. a reviewer agent checks the result;
4. if the reviewer does not approve, another round runs on the same issue;
5. when the reviewer approves, the issue moves to review.

This keeps the full handoff visible in one thread: planning, implementation, review, retries, and final approval.

## Why this is useful for Multica

Today, coordinating multiple agents manually is possible, but brittle:

- each handoff has to be triggered by a human or custom process;
- reviewer approval can be ambiguous;
- retries can create noise or extra issues;
- a runner crash can lose progress;
- assigned issues can accidentally start an unrelated agent run before the team workflow begins.

This PR turns that pattern into a first-class CLI workflow while staying compatible with the current Multica backend.

## Main changes

### `multica issue team create`

Adds a clean way to create a team-run issue safely:

- creates the issue in `backlog`;
- avoids assigning an agent at creation time;
- stores the team policy in the issue description;
- prevents the accidental initial agent run that happens when an issue is created as `todo` with an assignee.

### `multica issue team run`

Adds the actual ACPX runner:

- parses a team policy such as lead / implementer / reviewer roles;
- triggers each role via comments on the same issue;
- waits for the corresponding task run to finish;
- fetches only new comments after each trigger;
- repeats rounds until reviewer approval or max rounds.

### Production hardening

The first version proved the flow, but had several review blockers. This PR hardens the runner with:

- task-run aware waiting instead of blind comment polling;
- `comments?since=` fetching to avoid scanning the full thread every time;
- structured reviewer verdict parsing instead of substring matching on `approve`;
- durable same-issue resume state via a hidden `multica-team-state` marker comment;
- fast failure detection when a role agent run fails or is cancelled;
- guardrails for already-assigned issues, with explicit override flags.

## Design choices

### Single issue, not issue fan-out

The workflow intentionally stays on one issue. The point of ACPX is to preserve one coherent context for the whole agent team instead of scattering lead / implementer / reviewer work across child issues.

### No database migration

Resume state is stored as a hidden marker comment on the same issue. That makes the runner durable across crashes without adding new tables or backend schema changes.

### No new core scheduler

This stays as a CLI-level orchestrator. It uses existing Multica concepts: issues, comments, assignees, task runs, statuses, and comments since a timestamp.

### Reviewer approval is explicit

The reviewer prompt now asks for a structured verdict, and the runner parses that verdict. This avoids false positives from prose like "not approved" or "approve after changes".

## Review guide

The ACPX-specific implementation is concentrated in:

- `server/cmd/multica/cmd_issue_team.go`
- `server/cmd/multica/cmd_issue_team_test.go`

The branch also contains earlier daemon/task-run support commits that the runner depends on, especially around comment-triggered agent pickup, sibling task completion, and active issue state handling.

## Validation

Local validation run before opening the PR:

```bash
git diff --check -- server/cmd/multica/cmd_issue_team.go server/cmd/multica/cmd_issue_team_test.go
cd server && /usr/local/go/bin/go test ./cmd/multica/... -count=1
```

GitHub CI is also green:

- backend: pass
- frontend: pass

## Notes for reviewers

This PR is intended as a pragmatic ACPX integration, not the final form of all multi-agent orchestration in Multica. It gives Multica a working, reviewable baseline for OpenClaw-style team runs while keeping the blast radius small and the workflow inspectable from the issue thread itself.