### PR TITLE
fix(skill): strip null bytes from imported file content

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -604,9 +604,9 @@ func fetchFromClawHub(httpClient *http.Client, rawURL string) (*importedSkill, e
 			continue
 		}
 		if fp == "SKILL.md" {
-			result.content = string(body)
+			result.content = nullSafeString(body)
 		} else {
-			result.files = append(result.files, importedFile{path: fp, content: string(body)})
+			result.files = append(result.files, importedFile{path: fp, content: nullSafeString(body)})
 		}
 	}
 
@@ -692,7 +692,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	result := &importedSkill{
 		name:        name,
 		description: description,
-		content:     string(skillMdBody),
+		content:     nullSafeString(skillMdBody),
 	}
 
 	// 2. List supporting files via GitHub API
@@ -735,7 +735,7 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 		}
 		// Convert absolute GitHub path to relative path within skill
 		relPath := strings.TrimPrefix(entry.Path, basePath)
-		result.files = append(result.files, importedFile{path: relPath, content: string(body)})
+		result.files = append(result.files, importedFile{path: relPath, content: nullSafeString(body)})
 	}
 
 	return result, nil
@@ -1027,6 +1027,14 @@ func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
 		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+}
+
+// nullSafeString converts bytes to string, stripping null bytes (0x00) that
+// PostgreSQL TEXT columns reject with error 22021. Binary files such as PDFs
+// embedded in skill packages contain null bytes, which must be removed before
+// any database write.
+func nullSafeString(b []byte) string {
+	return strings.ReplaceAll(string(b), "\x00", "")
 }
 
 func buildRawGitHubURL(rawPrefix, repoPath string) string {


### PR DESCRIPTION
## Problem

When importing a skill that includes binary files (e.g. PDF templates), the raw bytes are converted to Go strings and written to a PostgreSQL `TEXT` column. PostgreSQL rejects null bytes (`0x00`) in TEXT with:

```
ERROR: invalid byte sequence for encoding "UTF8": 0x00 (SQLSTATE 22021)
```

The `business-document-generator` skill on skills.sh includes PDF templates under `assets/templates/` that contain 100+ null bytes each.

## Fix

Add a `nullSafeString(b []byte) string` helper that strips null bytes before converting to string. Apply it at all four places where file content from external sources is assigned in both import paths (ClawHub and skills.sh).

The fix does not change the schema — binary files continue to be stored as text with null bytes removed. No data is lost for text-based skill files (SKILL.md, scripts, config), which should never contain null bytes legitimately.

## Testing

After this fix, `multica skill import --url https://skills.sh/ailabs-393/ai-labs-claude-skills/business-document-generator` should succeed instead of returning a 500 error.