### PR TITLE
fix(selfhost): pass ALLOW_SIGNUP / ALLOWED_EMAILS / ALLOWED_EMAIL_DOMAINS to  backend

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -21,11 +21,6 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
-      APP_ENV: ${APP_ENV:-production}
-        MULTICA_APP_URL: ${MULTICA_APP_URL:-http://localhost:3000}              
-  +     ALLOW_SIGNUP: ${ALLOW_SIGNUP:-true}                                     
-  +     ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}                                     
-  +     ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-} 
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-multica} -d ${POSTGRES_DB:-multica}"]
@@ -61,6 +56,9 @@ services:
       COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
       APP_ENV: ${APP_ENV:-production}
       MULTICA_APP_URL: ${MULTICA_APP_URL:-http://localhost:3000}
+      ALLOW_SIGNUP: ${ALLOW_SIGNUP:-true}                                     
+      ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}                                     
+      ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-} 
     restart: unless-stopped
 
   frontend:

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -21,6 +21,11 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+      APP_ENV: ${APP_ENV:-production}
+        MULTICA_APP_URL: ${MULTICA_APP_URL:-http://localhost:3000}              
+  +     ALLOW_SIGNUP: ${ALLOW_SIGNUP:-true}                                     
+  +     ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}                                     
+  +     ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-} 
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-multica} -d ${POSTGRES_DB:-multica}"]


### PR DESCRIPTION
## What                                                                                                                                                                               
   
  `docker-compose.selfhost.yml` doesn't pass `ALLOW_SIGNUP`,                                                                                                                            
  `ALLOWED_EMAILS`, or `ALLOWED_EMAIL_DOMAINS` into the backend
  container. Self-hosters who configure these in `.env` (as the                                                                                                                         
  `.env.example` documents) get no enforcement at the multica layer —                                                                                                                   
  the backend never sees the variables.                                                                                                                                                 
                                                                                                                                                                                        
  ## Why it matters                                                                                                                                                                     
                                                                                                                                                                                        
  `.env.example` documents these as the way to lock down a private                                                                                                                      
  self-host (under "Self-hosting: Control Signups"). Today they're
  decorative: the only thing actually gating signups on a public                                                                                                                        
  self-host is whatever sits in front of the deployment (reverse                                                                                                                        
  proxy, Cloudflare Access, etc.). A documented allowlist that                                                                                                                          
  doesn't allowlist is a defense-in-depth gap.                                                                                                                                          
                                                                                                                                                                                        
  ## Fix                                                                                                                                                                                
                                                                                                                                                                                        
  Three lines added to `backend.environment` with defaults that                                                                                                                         
  match `.env.example`:
                                                                                                                                                                                        
  ```yaml         
  ALLOW_SIGNUP: ${ALLOW_SIGNUP:-true}
  ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}                                                                                                                                                   
  ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-}
                                                                                                                                                                                        
  Verify          
                                                                                                                                                                                        
  echo 'ALLOWED_EMAILS=alice@example.com' >> .env
  docker compose -f docker-compose.selfhost.yml up -d                                                                                                                                   
  docker exec multica-backend-1 env | grep ALLOWED_EMAILS
  # → ALLOWED_EMAILS=alice@example.com   (was: empty)                                                                                                                                   
                                                                                                                                                                                        
  If the backend doesn't actually read these env vars yet, happy to                                                                                                                     
  drop this and submit on the Go side instead.