### PR TITLE
fix: harden Windows CLI architecture detection

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -88,6 +88,75 @@ function Pull-OfficialSelfHostImages {
     exit 1
 }
 
+function Convert-ToCliArch {
+    param([object]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $normalized = "$Value".Trim().ToUpperInvariant()
+    switch ($normalized) {
+        "9"      { return "amd64" }
+        "AMD64"  { return "amd64" }
+        "X64"    { return "amd64" }
+        "X86_64" { return "amd64" }
+        "12"     { return "arm64" }
+        "ARM64"  { return "arm64" }
+        "AARCH64" { return "arm64" }
+        default  { return $null }
+    }
+}
+
+function Get-WindowsCliArch {
+    $signals = @()
+
+    # Prefer the native processor architecture over the current PowerShell
+    # process architecture. This keeps Windows on ARM from being misdetected
+    # when PowerShell is running through x64/x86 emulation.
+    try {
+        if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
+            $processorArch = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop |
+                Select-Object -First 1 -ExpandProperty Architecture
+            $signals += [pscustomobject]@{ Source = "Win32_Processor.Architecture"; Value = $processorArch }
+        }
+    } catch {}
+
+    try {
+        if (Get-Command Get-WmiObject -ErrorAction SilentlyContinue) {
+            $processorArch = Get-WmiObject -Class Win32_Processor -ErrorAction Stop |
+                Select-Object -First 1 -ExpandProperty Architecture
+            $signals += [pscustomobject]@{ Source = "Win32_Processor.Architecture"; Value = $processorArch }
+        }
+    } catch {}
+
+    try {
+        $signals += [pscustomobject]@{
+            Source = "RuntimeInformation.OSArchitecture"
+            Value = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+        }
+    } catch {}
+
+    $signals += [pscustomobject]@{ Source = "PROCESSOR_ARCHITEW6432"; Value = $env:PROCESSOR_ARCHITEW6432 }
+    $signals += [pscustomobject]@{ Source = "PROCESSOR_ARCHITECTURE"; Value = $env:PROCESSOR_ARCHITECTURE }
+
+    foreach ($signal in $signals) {
+        $arch = Convert-ToCliArch $signal.Value
+        if ($arch) {
+            return $arch
+        }
+    }
+
+    $details = ($signals |
+        Where-Object { $null -ne $_.Value -and "$($_.Value)".Trim() -ne "" } |
+        ForEach-Object { "$($_.Source)=$($_.Value)" }) -join ", "
+    if (-not $details) {
+        $details = "no architecture signals available"
+    }
+
+    Write-Fail "Unsupported Windows architecture ($details). Only x64 and ARM64 are supported."
+}
+
 # ---------------------------------------------------------------------------
 # CLI Installation
 # ---------------------------------------------------------------------------
@@ -98,35 +167,7 @@ function Install-CliBinary {
         Write-Fail "Multica requires a 64-bit Windows installation."
     }
 
-    # Distinguish amd64 vs arm64 — Is64BitOperatingSystem is true for both.
-    # Use multiple detection methods for robustness
-    $osArch = $null
-    
-    # Method 1: RuntimeInformation (primary)
-    try {
-        $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    } catch {}
-    
-    # Method 2: PROCESSOR_ARCHITECTURE environment variable
-    if (-not $osArch) {
-        $envArch = $env:PROCESSOR_ARCHITECTURE
-        if ($envArch -eq "AMD64") { $osArch = 'X64' }
-        elseif ($envArch -eq "ARM64") { $osArch = 'Arm64' }
-    }
-    
-    # Method 3: PROCESSOR_ARCHITEW6432 (for 32-bit PowerShell on 64-bit Windows)
-    if (-not $osArch) {
-        $envArch = $env:PROCESSOR_ARCHITEW6432
-        if ($envArch -eq "AMD64") { $osArch = 'X64' }
-        elseif ($envArch -eq "ARM64") { $osArch = 'Arm64' }
-    }
-    
-    # Determine architecture
-    switch ($osArch) {
-        'X64'   { $arch = "amd64" }
-        'Arm64' { $arch = "arm64" }
-        default { Write-Fail "Unsupported Windows architecture: $osArch (only X64 and Arm64 are supported)." }
-    }
+    $arch = Get-WindowsCliArch
 
     $latest = Get-LatestVersion
     if (-not $latest) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -110,6 +110,7 @@ function Convert-ToCliArch {
 
 function Get-WindowsCliArch {
     $signals = @()
+    $nativeArchSignalFound = $false
 
     # Prefer the native processor architecture over the current PowerShell
     # process architecture. This keeps Windows on ARM from being misdetected
@@ -119,14 +120,16 @@ function Get-WindowsCliArch {
             $processorArch = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop |
                 Select-Object -First 1 -ExpandProperty Architecture
             $signals += [pscustomobject]@{ Source = "Win32_Processor.Architecture"; Value = $processorArch }
+            $nativeArchSignalFound = $true
         }
     } catch {}
 
     try {
-        if (Get-Command Get-WmiObject -ErrorAction SilentlyContinue) {
+        if (-not $nativeArchSignalFound -and (Get-Command Get-WmiObject -ErrorAction SilentlyContinue)) {
             $processorArch = Get-WmiObject -Class Win32_Processor -ErrorAction Stop |
                 Select-Object -First 1 -ExpandProperty Architecture
             $signals += [pscustomobject]@{ Source = "Win32_Processor.Architecture"; Value = $processorArch }
+            $nativeArchSignalFound = $true
         }
     } catch {}
 


### PR DESCRIPTION
## Summary
- Detect Windows native processor architecture via Win32_Processor before falling back to RuntimeInformation and environment variables.
- Normalize common x64 and ARM64 signals to the CLI release asset architecture names.
- Include detected architecture signals in the unsupported-architecture error for easier diagnosis.

Fixes #1654

## Testing
- git diff --check
- Not run: Windows PowerShell installer execution; PowerShell is not available on this macOS runner.