### PR TITLE
Add labs settings tab

### DIFF
--- a/packages/views/settings/components/labs-tab.tsx
+++ b/packages/views/settings/components/labs-tab.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { FlaskConical } from "lucide-react";
+import { Card, CardContent } from "@multica/ui/components/ui/card";
+
+export function LabsTab() {
+  return (
+    <div className="space-y-4">
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold">Labs</h2>
+
+        <Card>
+          <CardContent>
+            <div className="flex items-start gap-3">
+              <div className="rounded-md border bg-muted/50 p-2 text-muted-foreground">
+                <FlaskConical className="h-4 w-4" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-medium">No experimental features yet</p>
+                <p className="text-sm text-muted-foreground">
+                  Beta features that require manual opt-in will appear here.
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/packages/views/settings/components/settings-page.tsx
+++ b/packages/views/settings/components/settings-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { User, Palette, Key, Settings, Users, FolderGit2 } from "lucide-react";
+import { User, Palette, Key, Settings, Users, FolderGit2, FlaskConical } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@multica/ui/components/ui/tabs";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { AccountTab } from "./account-tab";
@@ -10,6 +10,7 @@ import { TokensTab } from "./tokens-tab";
 import { WorkspaceTab } from "./workspace-tab";
 import { MembersTab } from "./members-tab";
 import { RepositoriesTab } from "./repositories-tab";
+import { LabsTab } from "./labs-tab";
 
 const accountTabs = [
   { value: "profile", label: "Profile", icon: User },
@@ -20,6 +21,7 @@ const accountTabs = [
 const workspaceTabs = [
   { value: "workspace", label: "General", icon: Settings },
   { value: "repositories", label: "Repositories", icon: FolderGit2 },
+  { value: "labs", label: "Labs", icon: FlaskConical },
   { value: "members", label: "Members", icon: Users },
 ];
 
@@ -82,6 +84,7 @@ export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
           <TabsContent value="tokens"><TokensTab /></TabsContent>
           <TabsContent value="workspace"><WorkspaceTab /></TabsContent>
           <TabsContent value="repositories"><RepositoriesTab /></TabsContent>
+          <TabsContent value="labs"><LabsTab /></TabsContent>
           <TabsContent value="members"><MembersTab /></TabsContent>
           {extraAccountTabs?.map((tab) => (
             <TabsContent key={tab.value} value={tab.value}>{tab.content}</TabsContent>


### PR DESCRIPTION
## Summary
- Add a Labs tab to workspace settings for future beta feature opt-ins.
- Add an empty-state Labs panel until experimental feature toggles are available.

## Verification
- `pnpm --filter @multica/views typecheck`
- `pnpm exec eslint settings/components/settings-page.tsx settings/components/labs-tab.tsx` from `packages/views`

Note: full `pnpm --filter @multica/views lint` is currently blocked by unrelated existing lint errors in `agents/components/tabs/custom-args-tab.tsx` and `workspace/no-access-page.tsx`.