### PR TITLE
fix(desktop): disable RPM build-id symlinks to avoid Slack conflict

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -37,6 +37,14 @@ linux:
     - deb
     - rpm
   artifactName: multica-desktop-${version}-linux-${arch}.${ext}
+rpm:
+  # Disable RPM build-id symlinks. Electron apps embed the upstream Electron
+  # binary, whose GNU build-id is identical across every app shipping the same
+  # Electron version (Slack, VS Code, Discord, ...). Without this, our RPM
+  # would own /usr/lib/.build-id/<hash> paths and collide with any other
+  # Electron RPM already installed, breaking `dnf install` on Fedora/RHEL.
+  fpm:
+    - "--rpm-rpmbuild-define=_build_id_links none"
 win:
   target:
     - nsis


### PR DESCRIPTION
## Summary

- Adds an `rpm.fpm` override in `apps/desktop/electron-builder.yml` that passes `--rpm-rpmbuild-define=_build_id_links none` through to rpmbuild, so the Multica desktop RPM no longer ships `/usr/lib/.build-id/<hash>` symlinks.

## Context

Fixes #1723.

Every Electron app embeds the same upstream `electron` binary, so its GNU build-id is **byte-identical** across every Electron-based RPM (Slack, VS Code, Discord, Signal Desktop, ...). With electron-builder's defaults, fpm/rpmbuild auto-generates `/usr/lib/.build-id/<hash>` symlinks for each ELF and packs them into the RPM. RPM does not allow two installed packages to own the same path, so `dnf install` fails as soon as any other Electron app is present:

```
file /usr/lib/.build-id/be/ffc50b8076e4eac5a913fca05e8f10eb93fa0b
from install of Multica-0.2.17-1.x86_64
conflicts with file from package slack-4.47.69-0.1.el8.x86_64
```

Setting the rpmbuild macro `_build_id_links` to `none` tells `find-debuginfo.sh` not to generate those symlinks at all. The actual binaries (and their embedded build-ids) are unchanged — only the file-tree decoration is suppressed. Electron apps don't ship separate debuginfo packages, so nothing depends on these links.

## Test plan

- [ ] Build a linux-x86_64 RPM via the release workflow (or `pnpm --filter @multica/desktop package -- --linux rpm`).
- [ ] `rpm -qpl multica-desktop-*.rpm | grep '\.build-id'` returns no output.
- [ ] On a Fedora machine with the Slack RPM installed, `sudo dnf install multica-desktop-*.rpm` succeeds.
- [ ] Installed app launches normally; uninstall (`sudo dnf remove multica`) leaves no orphan files.