### PR TITLE
fix: validate csrf request origins

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -101,7 +101,8 @@ func NewRouter(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus, analytics
 	r.Use(middleware.ContentSecurityPolicy)
 	origins := allowedOrigins()
 
-	// Share allowed origins with WebSocket origin checker.
+	// Share allowed origins with browser request origin checkers.
+	auth.SetAllowedCSRFOrigins(origins)
 	realtime.SetAllowedOrigins(origins)
 
 	r.Use(cors.Handler(cors.Options{

--- a/server/internal/auth/cookie.go
+++ b/server/internal/auth/cookie.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -22,6 +23,34 @@ const (
 )
 
 var ipCookieDomainWarnOnce sync.Once
+
+var defaultCSRFOrigins = []string{
+	"http://localhost:3000",
+	"http://localhost:5173",
+	"http://localhost:5174",
+}
+
+var allowedCSRFOrigins atomic.Value // holds []string
+
+func init() {
+	allowedCSRFOrigins.Store(defaultCSRFOrigins)
+}
+
+// SetAllowedCSRFOrigins configures the trusted browser origins for CSRF
+// origin checks. Empty values fall back to the local development defaults.
+func SetAllowedCSRFOrigins(origins []string) {
+	cleaned := make([]string, 0, len(origins))
+	for _, origin := range origins {
+		origin = strings.TrimSpace(origin)
+		if origin != "" {
+			cleaned = append(cleaned, origin)
+		}
+	}
+	if len(cleaned) == 0 {
+		cleaned = defaultCSRFOrigins
+	}
+	allowedCSRFOrigins.Store(cleaned)
+}
 
 // cookieDomain returns the trimmed COOKIE_DOMAIN env value, or "" if it looks
 // like an IP address. RFC 6265 §4.1.2.3 forbids IP literals in the cookie
@@ -147,7 +176,7 @@ func ClearAuthCookies(w http.ResponseWriter) {
 	})
 }
 
-// ValidateCSRF checks the X-CSRF-Token header against the auth cookie.
+// ValidateCSRF checks the request origin and X-CSRF-Token header against the auth cookie.
 // The CSRF token is HMAC-signed with the auth token, so the server verifies
 // the signature rather than simply comparing cookie == header.
 // Returns true if validation passes (including for safe methods that don't need CSRF).
@@ -155,6 +184,10 @@ func ValidateCSRF(r *http.Request) bool {
 	switch r.Method {
 	case http.MethodGet, http.MethodHead, http.MethodOptions:
 		return true
+	}
+
+	if !validateCSRFOrigin(r) {
+		return false
 	}
 
 	csrfHeader := r.Header.Get("X-CSRF-Token")
@@ -185,4 +218,35 @@ func ValidateCSRF(r *http.Request) bool {
 	mac := hmac.New(sha256.New, []byte(authCookie.Value))
 	mac.Write(nonce)
 	return hmac.Equal(mac.Sum(nil), expectedSig)
+}
+
+func validateCSRFOrigin(r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		referer := strings.TrimSpace(r.Header.Get("Referer"))
+		if referer == "" {
+			return true
+		}
+		var ok bool
+		origin, ok = originFromReferer(referer)
+		if !ok {
+			return false
+		}
+	}
+
+	origins := allowedCSRFOrigins.Load().([]string)
+	for _, allowed := range origins {
+		if origin == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func originFromReferer(raw string) (string, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", false
+	}
+	return u.Scheme + "://" + u.Host, true
 }

--- a/server/internal/auth/cookie_test.go
+++ b/server/internal/auth/cookie_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 )
@@ -98,4 +99,104 @@ func TestSetAuthCookies_HTTPSProduction(t *testing.T) {
 			t.Errorf("cookie %q Domain = %q, want %q", c.Name, c.Domain, "app.example.com")
 		}
 	}
+}
+
+func TestValidateCSRFOriginChecks(t *testing.T) {
+	t.Cleanup(func() {
+		SetAllowedCSRFOrigins(defaultCSRFOrigins)
+	})
+	SetAllowedCSRFOrigins([]string{"https://app.example.com", "http://localhost:3000"})
+
+	cases := []struct {
+		name    string
+		origin  string
+		referer string
+		want    bool
+	}{
+		{
+			name: "missing origin and referer passes",
+			want: true,
+		},
+		{
+			name:   "matching origin passes",
+			origin: "https://app.example.com",
+			want:   true,
+		},
+		{
+			name:   "matching origin from allowlist passes",
+			origin: "http://localhost:3000",
+			want:   true,
+		},
+		{
+			name:   "mismatched origin fails",
+			origin: "https://evil.example.com",
+			want:   false,
+		},
+		{
+			name:    "matching referer fallback passes",
+			referer: "https://app.example.com/issues/123",
+			want:    true,
+		},
+		{
+			name:    "mismatched referer fallback fails",
+			referer: "https://evil.example.com/issues/123",
+			want:    false,
+		},
+		{
+			name:    "malformed referer fallback fails",
+			referer: "://not-a-url",
+			want:    false,
+		},
+		{
+			name:    "origin mismatch takes precedence over matching referer",
+			origin:  "https://evil.example.com",
+			referer: "https://app.example.com/issues/123",
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := validCSRFRequest(t, http.MethodPost)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			if tc.referer != "" {
+				req.Header.Set("Referer", tc.referer)
+			}
+
+			if got := ValidateCSRF(req); got != tc.want {
+				t.Fatalf("ValidateCSRF() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateCSRFSkipsOriginCheckForSafeMethods(t *testing.T) {
+	t.Cleanup(func() {
+		SetAllowedCSRFOrigins(defaultCSRFOrigins)
+	})
+	SetAllowedCSRFOrigins([]string{"https://app.example.com"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+
+	if !ValidateCSRF(req) {
+		t.Fatal("ValidateCSRF() rejected a safe method")
+	}
+}
+
+func validCSRFRequest(t *testing.T, method string) *http.Request {
+	t.Helper()
+
+	authToken := "test-auth-token"
+	csrfToken, err := generateCSRFToken(authToken)
+	if err != nil {
+		t.Fatalf("generateCSRFToken: %v", err)
+	}
+
+	req := httptest.NewRequest(method, "/api/issues", nil)
+	req.AddCookie(&http.Cookie{Name: AuthCookieName, Value: authToken})
+	req.Header.Set("X-CSRF-Token", csrfToken)
+	return req
 }


### PR DESCRIPTION
## Summary
- reject state-changing cookie-auth requests when Origin is present and not in the configured CORS allowlist
- fall back to Referer only when Origin is missing, while allowing requests with neither header for non-browser clients
- share the router CORS allowlist with CSRF validation and cover the behavior with table-driven tests

Fixes https://github.com/multica-ai/multica/issues/1667

## Testing
- go test ./...
