### PR TITLE
fix(agent): recover stale ACP session IDs with new_session + one retry

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -167,20 +167,27 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			cwd = "."
 		}
 
+		// Attempt to resume a prior session if one was provided. On failure,
+		// fall back to a new session so the task is not blocked by a stale or
+		// missing session ID (e.g. provider restart, persisted session lost).
+		// The new session ID is returned in the result so the caller can update
+		// its stored mapping.
 		if opts.ResumeSessionID != "" {
-			result, err := c.request(runCtx, "session/resume", map[string]any{
+			_, resumeErr := c.request(runCtx, "session/resume", map[string]any{
 				"cwd":       cwd,
 				"sessionId": opts.ResumeSessionID,
 			})
-			if err != nil {
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("hermes session/resume failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
-				return
+			if resumeErr != nil {
+				b.cfg.Logger.Warn("hermes session/resume failed; falling back to new session",
+					"old_session_id", opts.ResumeSessionID, "error", resumeErr)
+				// sessionID stays "", session/new runs below.
+			} else {
+				sessionID = opts.ResumeSessionID
 			}
-			sessionID = opts.ResumeSessionID
-			_ = result
-		} else {
+		}
+
+		if sessionID == "" {
+			// Either no prior session was provided, or resume failed above.
 			result, err := c.request(runCtx, "session/new", buildHermesSessionParams(cwd, opts.Model))
 			if err != nil {
 				finalStatus = "failed"
@@ -194,6 +201,10 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				finalError = "hermes session/new returned no session ID"
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
+			}
+			if opts.ResumeSessionID != "" {
+				b.cfg.Logger.Info("hermes session recovery: new session created after failed resume",
+					"old_session_id", opts.ResumeSessionID, "new_session_id", sessionID)
 			}
 		}
 
@@ -234,15 +245,71 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		}
 
 		// 5. Send the prompt and wait for PromptResponse.
-		_, err = c.request(runCtx, "session/prompt", map[string]any{
+		_, promptErr := c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,
 			"prompt": []map[string]any{
 				{"type": "text", "text": userText},
 			},
 		})
-		if err != nil {
-			// If the request itself failed (not just context cancelled),
-			// check if the context was cancelled/timed out.
+
+		// If the prompt failed with a stale-session error on a resumed session,
+		// create a new session and retry the prompt exactly once. This handles
+		// the case where resume appears to succeed but the provider has already
+		// discarded the session internally (the Hermes incident: ACP
+		// ResumeSessionResponse cannot carry the replacement session ID, so
+		// Multica keeps prompting a session the provider no longer has).
+		if promptErr != nil && isACPStaleSessionError(promptErr) &&
+			opts.ResumeSessionID != "" && sessionID == opts.ResumeSessionID {
+			b.cfg.Logger.Warn("hermes prompt: stale session after apparent successful resume; retrying on new session",
+				"old_session_id", sessionID, "error", promptErr)
+
+			retryResult, newErr := c.request(runCtx, "session/new", buildHermesSessionParams(cwd, opts.Model))
+			if newErr != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("hermes session recovery failed (session/new): %v", newErr)
+				promptErr = nil
+			} else {
+				newSessionID := extractACPSessionID(retryResult)
+				if newSessionID == "" {
+					finalStatus = "failed"
+					finalError = "hermes session recovery failed: session/new returned no session ID"
+					promptErr = nil
+				} else {
+					b.cfg.Logger.Info("hermes stale-session recovery: retrying prompt on new session",
+						"old_session_id", sessionID, "new_session_id", newSessionID)
+					sessionID = newSessionID
+					c.sessionID = sessionID
+
+					if opts.Model != "" {
+						if _, modelErr := c.request(runCtx, "session/set_model", map[string]any{
+							"sessionId": sessionID,
+							"modelId":   opts.Model,
+						}); modelErr != nil {
+							b.cfg.Logger.Warn("hermes set_session_model failed on recovery session",
+								"error", modelErr, "model", opts.Model)
+							finalStatus = "failed"
+							finalError = fmt.Sprintf("hermes could not switch to model %q on recovery session: %v", opts.Model, modelErr)
+							promptErr = nil
+						}
+					}
+
+					if finalStatus == "completed" {
+						_, promptErr = c.request(runCtx, "session/prompt", map[string]any{
+							"sessionId": sessionID,
+							"prompt": []map[string]any{
+								{"type": "text", "text": userText},
+							},
+						})
+						if promptErr != nil {
+							promptErr = fmt.Errorf("stale-session retry: %w", promptErr)
+						}
+					}
+				}
+			}
+		}
+
+		if promptErr != nil {
+			// Check if the context was cancelled/timed out.
 			if runCtx.Err() == context.DeadlineExceeded {
 				finalStatus = "timeout"
 				finalError = fmt.Sprintf("hermes timed out after %s", timeout)
@@ -251,9 +318,9 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				finalError = "execution cancelled"
 			} else {
 				finalStatus = "failed"
-				finalError = fmt.Sprintf("hermes session/prompt failed: %v", err)
+				finalError = fmt.Sprintf("hermes session/prompt failed: %v", promptErr)
 			}
-		} else {
+		} else if finalStatus == "completed" {
 			// The prompt completed. Check if we got a promptDone result
 			// from the response parsing.
 			select {
@@ -1131,6 +1198,26 @@ func (s *acpProviderErrorSniffer) Write(p []byte) (int, error) {
 		}
 	}
 	return len(p), nil
+}
+
+// acpStaleSessionRe matches "session <identifier> not found" — the pattern
+// ACP providers emit when a prompt is sent against a session that no longer
+// exists. Word-boundary anchors prevent the "session/" method-name prefix
+// from creating false positives (e.g. "session/prompt: resource not found").
+var acpStaleSessionRe = regexp.MustCompile(`(?i)\bsession\s+\S+\s+not\s+found\b`)
+
+// isACPStaleSessionError reports whether err looks like a missing or stale
+// session error from session/prompt. These are safe to recover from by
+// calling session/new and retrying the prompt once: the session simply no
+// longer exists on the provider, which is not caused by the prompt itself.
+//
+// The observed pattern (Hermes incident): provider returns a JSON-RPC error
+// whose message matches "session <id> not found".
+func isACPStaleSessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return acpStaleSessionRe.MatchString(err.Error())
 }
 
 // message returns a single-line summary suitable for the task

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -173,15 +173,22 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		// The new session ID is returned in the result so the caller can update
 		// its stored mapping.
 		if opts.ResumeSessionID != "" {
-			_, resumeErr := c.request(runCtx, "session/resume", map[string]any{
+			resumeResult, resumeErr := c.request(runCtx, "session/resume", map[string]any{
 				"cwd":       cwd,
 				"sessionId": opts.ResumeSessionID,
 			})
-			if resumeErr != nil {
+			switch {
+			case resumeErr != nil:
 				b.cfg.Logger.Warn("hermes session/resume failed; falling back to new session",
 					"old_session_id", opts.ResumeSessionID, "error", resumeErr)
 				// sessionID stays "", session/new runs below.
-			} else {
+			case len(resumeResult) == 0 || string(resumeResult) == "null":
+				// Some providers return a JSON null success body to signal the
+				// session cannot be resumed, rather than returning an error.
+				b.cfg.Logger.Warn("hermes session/resume returned null; falling back to new session",
+					"old_session_id", opts.ResumeSessionID)
+				// sessionID stays "", session/new runs below.
+			default:
 				sessionID = opts.ResumeSessionID
 			}
 		}
@@ -301,7 +308,12 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 							},
 						})
 						if promptErr != nil {
+							b.cfg.Logger.Warn("hermes stale-session recovery: retry prompt failed",
+								"old_session_id", opts.ResumeSessionID, "new_session_id", sessionID, "error", promptErr)
 							promptErr = fmt.Errorf("stale-session retry: %w", promptErr)
+						} else {
+							b.cfg.Logger.Info("hermes stale-session recovery: retry prompt succeeded",
+								"old_session_id", opts.ResumeSessionID, "new_session_id", sessionID)
 						}
 					}
 				}

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -840,6 +840,24 @@ func TestIsACPStaleSessionError(t *testing.T) {
 // package). Instead we use TestFakeHermesHelper as the entrypoint for the
 // subprocess, detected via an env var at the top of each Execute test.
 
+func TestHermesExecuteResumeNullFallbackSuccess(t *testing.T) {
+	t.Parallel()
+	// Scenario: resume returns a JSON null success body (no error), which some
+	// providers use to signal "cannot resume". Multica should fall back to a
+	// new session and succeed.
+	runFakeHermesExecuteTest(t, "resume_null_new_success", func(t *testing.T, result Result) {
+		if result.Status != "completed" {
+			t.Errorf("status: got %q, want completed", result.Status)
+		}
+		if result.Output == "" {
+			t.Error("expected non-empty output after null-resume fallback")
+		}
+		if result.SessionID == "stale-session-id" {
+			t.Error("result carries stale session ID; expected the new one")
+		}
+	})
+}
+
 func TestHermesExecuteResumeFailFallbackSuccess(t *testing.T) {
 	t.Parallel()
 	// Scenario: resume returns an error; Multica should fall back to a new
@@ -897,6 +915,50 @@ func TestHermesExecuteResumeSuccessPromptStaleRetryFail(t *testing.T) {
 	})
 }
 
+// ── Kimi stale-session recovery ──
+//
+// Kimi uses an identical ACP session-recovery code path. These tests exercise
+// the kimiBackend directly with the same fake ACP server.
+
+func TestKimiExecuteResumeFailFallbackSuccess(t *testing.T) {
+	t.Parallel()
+	runFakeKimiExecuteTest(t, "resume_fail_new_success", func(t *testing.T, result Result) {
+		if result.Status != "completed" {
+			t.Errorf("status: got %q, want completed", result.Status)
+		}
+		if result.Output == "" {
+			t.Error("expected non-empty output")
+		}
+		if result.SessionID == "stale-session-id" {
+			t.Error("result carries stale session ID; expected the new one")
+		}
+	})
+}
+
+func TestKimiExecuteResumeNullFallbackSuccess(t *testing.T) {
+	t.Parallel()
+	runFakeKimiExecuteTest(t, "resume_null_new_success", func(t *testing.T, result Result) {
+		if result.Status != "completed" {
+			t.Errorf("status: got %q, want completed", result.Status)
+		}
+		if result.SessionID == "stale-session-id" {
+			t.Error("result carries stale session ID after null-resume fallback")
+		}
+	})
+}
+
+func TestKimiExecuteResumeSuccessPromptStaleRetrySuccess(t *testing.T) {
+	t.Parallel()
+	runFakeKimiExecuteTest(t, "resume_ok_prompt_stale_retry_success", func(t *testing.T, result Result) {
+		if result.Status != "completed" {
+			t.Errorf("status: got %q, want completed", result.Status)
+		}
+		if result.SessionID == "stale-session-id" {
+			t.Error("result carries stale session ID after recovery")
+		}
+	})
+}
+
 // runFakeHermesExecuteTest launches a subprocess running this test binary as a
 // fake hermes ACP server (FAKE_HERMES_SCENARIO=<scenario>), then runs
 // hermesBackend.Execute against it and calls check on the result.
@@ -924,6 +986,36 @@ func runFakeHermesExecuteTest(t *testing.T, scenario string, check func(*testing
 	}
 
 	// Drain messages (required to unblock the goroutine).
+	for range sess.Messages {
+	}
+	result := <-sess.Result
+
+	check(t, result)
+}
+
+// runFakeKimiExecuteTest is the kimi equivalent of runFakeHermesExecuteTest.
+// Both backends speak the same ACP protocol so the same fake server handles both.
+func runFakeKimiExecuteTest(t *testing.T, scenario string, check func(*testing.T, Result)) {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	b := &kimiBackend{cfg: Config{
+		ExecutablePath: exe,
+		Logger:         slog.Default(),
+	}}
+
+	sess, err := b.Execute(context.Background(), "hello", ExecOptions{
+		ResumeSessionID: "stale-session-id",
+		CustomArgs:      []string{"--fake-hermes-scenario=" + scenario},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
 	for range sess.Messages {
 	}
 	result := <-sess.Result
@@ -1013,6 +1105,24 @@ func runFakeACPServer(scenario string) error {
 	_ = json.Unmarshal(req["method"], &method)
 
 	switch scenario {
+	case "resume_null_new_success":
+		// Resume returns a JSON null body (no error) — provider signals it
+		// cannot resume via null rather than an error. Multica must fall back.
+		if method != "session/resume" {
+			return fmt.Errorf("scenario %q: expected session/resume, got %s", scenario, method)
+		}
+		if err := sendResult(req["id"], nil); err != nil { // nil → JSON null
+			return err
+		}
+		// Multica falls back to session/new.
+		req, err = readReq()
+		if err != nil {
+			return err
+		}
+		if err := sendResult(req["id"], map[string]any{"sessionId": "new-session-abc"}); err != nil {
+			return err
+		}
+
 	case "resume_fail_new_success":
 		// Resume must fail so Multica falls back to session/new.
 		if method != "session/resume" {
@@ -1051,8 +1161,8 @@ func runFakeACPServer(scenario string) error {
 	_ = json.Unmarshal(req["method"], &method)
 
 	switch scenario {
-	case "resume_fail_new_success":
-		// Prompt on the new session succeeds.
+	case "resume_null_new_success", "resume_fail_new_success":
+		// Prompt on the new (fallback) session succeeds.
 		if method != "session/prompt" {
 			return fmt.Errorf("scenario %q: expected session/prompt, got %s", scenario, method)
 		}

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -1,8 +1,12 @@
 package agent
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -789,4 +793,324 @@ func TestHermesProviderErrorSnifferBoundedBuffer(t *testing.T) {
 	if len(s.lines) > acpMaxErrorLines {
 		t.Errorf("sniffer kept %d lines, limit is %d", len(s.lines), acpMaxErrorLines)
 	}
+}
+
+// ── isACPStaleSessionError ──
+
+func TestIsACPStaleSessionError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		// Matches — the observed Hermes pattern.
+		{"hermes not found", "session/prompt: session 19bbcb1c-b28c-4106-b647-1af0a86a5198 not found (code=-32000)", true},
+		{"simple not found", "session/prompt: session abc not found (code=-32601)", true},
+		{"uppercase mixed", "session/prompt: Session ABC NOT FOUND (code=0)", true},
+		// Non-matches — unrelated errors must not be treated as stale sessions.
+		{"no session word", "session/prompt: resource not found (code=-32001)", false},
+		{"no not found", "session/prompt: session abc expired (code=-32001)", false},
+		{"nil error", "", false},
+		{"provider error", "hermes provider error: HTTP 400 bad request", false},
+		{"timeout", "hermes timed out after 20m0s", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			if tt.msg != "" {
+				err = fmt.Errorf("%s", tt.msg)
+			}
+			got := isACPStaleSessionError(err)
+			if got != tt.want {
+				t.Errorf("isACPStaleSessionError(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+// ── Execute stale-session recovery (fake ACP server) ──
+//
+// The fake ACP server is embedded in the test binary itself: when the env var
+// FAKE_HERMES_SCENARIO is set, the binary acts as a minimal hermes process
+// rather than running tests. This is a standard Go test-helper-binary pattern
+// that avoids needing a real hermes installation.
+
+// TestMain is NOT defined here (it would conflict with other tests in the
+// package). Instead we use TestFakeHermesHelper as the entrypoint for the
+// subprocess, detected via an env var at the top of each Execute test.
+
+func TestHermesExecuteResumeFailFallbackSuccess(t *testing.T) {
+	t.Parallel()
+	// Scenario: resume returns an error; Multica should fall back to a new
+	// session and succeed.
+	runFakeHermesExecuteTest(t, "resume_fail_new_success", func(t *testing.T, result Result) {
+		if result.Status != "completed" {
+			t.Errorf("status: got %q, want completed", result.Status)
+		}
+		if result.Output == "" {
+			t.Error("expected non-empty output")
+		}
+		if result.SessionID == "" {
+			t.Error("expected a session ID in result")
+		}
+		// The result session ID must NOT be the stale one we tried to resume.
+		if result.SessionID == "stale-session-id" {
+			t.Error("result carries stale session ID; expected the new one")
+		}
+	})
+}
+
+func TestHermesExecuteResumeSuccessPromptStaleRetrySuccess(t *testing.T) {
+	t.Parallel()
+	// Scenario: resume appears successful but prompt returns session-not-found;
+	// Multica should create a new session and retry the prompt successfully.
+	runFakeHermesExecuteTest(t, "resume_ok_prompt_stale_retry_success", func(t *testing.T, result Result) {
+		if result.Status != "completed" {
+			t.Errorf("status: got %q, want completed", result.Status)
+		}
+		if result.Output == "" {
+			t.Error("expected non-empty output after retry")
+		}
+		if result.SessionID == "stale-session-id" {
+			t.Error("result carries stale session ID after recovery")
+		}
+	})
+}
+
+func TestHermesExecuteResumeSuccessPromptStaleRetryFail(t *testing.T) {
+	t.Parallel()
+	// Scenario: resume appears successful, prompt returns session-not-found,
+	// new session is created, but retry also fails. The real error must be
+	// surfaced (not "empty output").
+	runFakeHermesExecuteTest(t, "resume_ok_prompt_stale_retry_fail", func(t *testing.T, result Result) {
+		if result.Status != "failed" {
+			t.Errorf("status: got %q, want failed", result.Status)
+		}
+		if result.Error == "" {
+			t.Error("expected a non-empty error on retry failure")
+		}
+		// Must not be the generic empty-output message.
+		if strings.Contains(result.Error, "empty output") {
+			t.Errorf("error should not be the generic empty-output message, got %q", result.Error)
+		}
+	})
+}
+
+// runFakeHermesExecuteTest launches a subprocess running this test binary as a
+// fake hermes ACP server (FAKE_HERMES_SCENARIO=<scenario>), then runs
+// hermesBackend.Execute against it and calls check on the result.
+func runFakeHermesExecuteTest(t *testing.T, scenario string, check func(*testing.T, Result)) {
+	t.Helper()
+
+	// Build the test binary path — os.Executable gives us the running binary.
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	b := &hermesBackend{cfg: Config{
+		ExecutablePath: exe,
+		Logger:         slog.Default(),
+	}}
+
+	sess, err := b.Execute(context.Background(), "hello", ExecOptions{
+		ResumeSessionID: "stale-session-id",
+		// Tell the fake server which scenario to run.
+		CustomArgs: []string{"--fake-hermes-scenario=" + scenario},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Drain messages (required to unblock the goroutine).
+	for range sess.Messages {
+	}
+	result := <-sess.Result
+
+	check(t, result)
+}
+
+// TestFakeHermesHelper is the entrypoint for the subprocess. When run normally
+// (no FAKE_HERMES_SCENARIO env var), it exits immediately. When run as a fake
+// hermes binary, it plays back an ACP scenario on stdin/stdout.
+func TestFakeHermesHelper(t *testing.T) {
+	scenario := ""
+	for _, arg := range os.Args {
+		const prefix = "--fake-hermes-scenario="
+		if strings.HasPrefix(arg, prefix) {
+			scenario = strings.TrimPrefix(arg, prefix)
+		}
+	}
+	if scenario == "" {
+		t.Skip("not running as fake hermes helper")
+	}
+
+	// Run the fake ACP server on the real stdin/stdout of this subprocess.
+	if err := runFakeACPServer(scenario); err != nil {
+		fmt.Fprintf(os.Stderr, "fake hermes error: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// runFakeACPServer speaks the ACP JSON-RPC 2.0 protocol for a given scenario.
+// It reads requests from stdin and writes responses to stdout, then exits.
+func runFakeACPServer(scenario string) error {
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+
+	readReq := func() (map[string]json.RawMessage, error) {
+		if !scanner.Scan() {
+			return nil, fmt.Errorf("stdin closed")
+		}
+		var req map[string]json.RawMessage
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			return nil, err
+		}
+		return req, nil
+	}
+
+	sendResult := func(id json.RawMessage, result any) error {
+		return encoder.Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"result":  result,
+		})
+	}
+
+	sendError := func(id json.RawMessage, code int, message string) error {
+		return encoder.Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"error":   map[string]any{"code": code, "message": message},
+		})
+	}
+
+	sendNotification := func(method string, params any) error {
+		return encoder.Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"method":  method,
+			"params":  params,
+		})
+	}
+
+	// Step 1: initialize — always succeeds.
+	req, err := readReq()
+	if err != nil {
+		return err
+	}
+	if err := sendResult(req["id"], map[string]any{"protocolVersion": 1}); err != nil {
+		return err
+	}
+
+	// Step 2: session/resume or session/new.
+	req, err = readReq()
+	if err != nil {
+		return err
+	}
+	var method string
+	_ = json.Unmarshal(req["method"], &method)
+
+	switch scenario {
+	case "resume_fail_new_success":
+		// Resume must fail so Multica falls back to session/new.
+		if method != "session/resume" {
+			return fmt.Errorf("scenario %q: expected session/resume, got %s", scenario, method)
+		}
+		if err := sendError(req["id"], -32000, "session stale-session-id not found"); err != nil {
+			return err
+		}
+		// Multica will now send session/new.
+		req, err = readReq()
+		if err != nil {
+			return err
+		}
+		if err := sendResult(req["id"], map[string]any{"sessionId": "new-session-abc"}); err != nil {
+			return err
+		}
+
+	case "resume_ok_prompt_stale_retry_success", "resume_ok_prompt_stale_retry_fail":
+		// Resume succeeds but the session is silently dead — prompt will fail.
+		if method != "session/resume" {
+			return fmt.Errorf("scenario %q: expected session/resume, got %s", scenario, method)
+		}
+		if err := sendResult(req["id"], map[string]any{"sessionId": "stale-session-id"}); err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("unknown scenario: %q", scenario)
+	}
+
+	// Step 3: session/prompt (first attempt).
+	req, err = readReq()
+	if err != nil {
+		return err
+	}
+	_ = json.Unmarshal(req["method"], &method)
+
+	switch scenario {
+	case "resume_fail_new_success":
+		// Prompt on the new session succeeds.
+		if method != "session/prompt" {
+			return fmt.Errorf("scenario %q: expected session/prompt, got %s", scenario, method)
+		}
+		_ = sendNotification("session/update", map[string]any{
+			"sessionId": "new-session-abc",
+			"update": map[string]any{
+				"sessionUpdate": "agent_message_chunk",
+				"content":       map[string]any{"type": "text", "text": "recovered output"},
+			},
+		})
+		return sendResult(req["id"], map[string]any{"stopReason": "end_turn"})
+
+	case "resume_ok_prompt_stale_retry_success", "resume_ok_prompt_stale_retry_fail":
+		// First prompt fails: session not found.
+		if method != "session/prompt" {
+			return fmt.Errorf("scenario %q: expected session/prompt, got %s", scenario, method)
+		}
+		if err := sendError(req["id"], -32000, "session stale-session-id not found"); err != nil {
+			return err
+		}
+
+		// Multica recovers: sends session/new.
+		req, err = readReq()
+		if err != nil {
+			return err
+		}
+		_ = json.Unmarshal(req["method"], &method)
+		if method != "session/new" {
+			return fmt.Errorf("scenario %q: expected session/new for recovery, got %s", scenario, method)
+		}
+		if err := sendResult(req["id"], map[string]any{"sessionId": "recovery-session-xyz"}); err != nil {
+			return err
+		}
+
+		// Retry prompt.
+		req, err = readReq()
+		if err != nil {
+			return err
+		}
+		_ = json.Unmarshal(req["method"], &method)
+		if method != "session/prompt" {
+			return fmt.Errorf("scenario %q: expected retry session/prompt, got %s", scenario, method)
+		}
+
+		if scenario == "resume_ok_prompt_stale_retry_success" {
+			_ = sendNotification("session/update", map[string]any{
+				"sessionId": "recovery-session-xyz",
+				"update": map[string]any{
+					"sessionUpdate": "agent_message_chunk",
+					"content":       map[string]any{"type": "text", "text": "retry succeeded"},
+				},
+			})
+			return sendResult(req["id"], map[string]any{"stopReason": "end_turn"})
+		}
+
+		// retry_fail: the retry also fails with a real (non-stale) error.
+		return sendError(req["id"], -32001, "upstream LLM unreachable")
+	}
+
+	return nil
 }

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -179,20 +179,26 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 			cwd = "."
 		}
 
+		// Attempt to resume a prior session if one was provided. On failure,
+		// fall back to a new session so the task is not blocked by a stale or
+		// missing session ID. The new session ID is returned in the result so
+		// the caller can update its stored mapping.
 		if opts.ResumeSessionID != "" {
-			result, err := c.request(runCtx, "session/resume", map[string]any{
+			_, resumeErr := c.request(runCtx, "session/resume", map[string]any{
 				"cwd":       cwd,
 				"sessionId": opts.ResumeSessionID,
 			})
-			if err != nil {
-				finalStatus = "failed"
-				finalError = fmt.Sprintf("kimi session/resume failed: %v", err)
-				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
-				return
+			if resumeErr != nil {
+				b.cfg.Logger.Warn("kimi session/resume failed; falling back to new session",
+					"old_session_id", opts.ResumeSessionID, "error", resumeErr)
+				// sessionID stays "", session/new runs below.
+			} else {
+				sessionID = opts.ResumeSessionID
 			}
-			sessionID = opts.ResumeSessionID
-			_ = result
-		} else {
+		}
+
+		if sessionID == "" {
+			// Either no prior session was provided, or resume failed above.
 			result, err := c.request(runCtx, "session/new", map[string]any{
 				"cwd":        cwd,
 				"mcpServers": []any{},
@@ -209,6 +215,10 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				finalError = "kimi session/new returned no session ID"
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
+			}
+			if opts.ResumeSessionID != "" {
+				b.cfg.Logger.Info("kimi session recovery: new session created after failed resume",
+					"old_session_id", opts.ResumeSessionID, "new_session_id", sessionID)
 			}
 		}
 
@@ -251,13 +261,69 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		}
 
 		// 5. Send the prompt and wait for PromptResponse.
-		_, err = c.request(runCtx, "session/prompt", map[string]any{
+		_, promptErr := c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,
 			"prompt": []map[string]any{
 				{"type": "text", "text": userText},
 			},
 		})
-		if err != nil {
+
+		// If the prompt failed with a stale-session error on a resumed session,
+		// create a new session and retry the prompt exactly once.
+		if promptErr != nil && isACPStaleSessionError(promptErr) &&
+			opts.ResumeSessionID != "" && sessionID == opts.ResumeSessionID {
+			b.cfg.Logger.Warn("kimi prompt: stale session after apparent successful resume; retrying on new session",
+				"old_session_id", sessionID, "error", promptErr)
+
+			retryResult, newErr := c.request(runCtx, "session/new", map[string]any{
+				"cwd":        cwd,
+				"mcpServers": []any{},
+			})
+			if newErr != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("kimi session recovery failed (session/new): %v", newErr)
+				promptErr = nil
+			} else {
+				newSessionID := extractACPSessionID(retryResult)
+				if newSessionID == "" {
+					finalStatus = "failed"
+					finalError = "kimi session recovery failed: session/new returned no session ID"
+					promptErr = nil
+				} else {
+					b.cfg.Logger.Info("kimi stale-session recovery: retrying prompt on new session",
+						"old_session_id", sessionID, "new_session_id", newSessionID)
+					sessionID = newSessionID
+					c.sessionID = sessionID
+
+					if opts.Model != "" {
+						if _, modelErr := c.request(runCtx, "session/set_model", map[string]any{
+							"sessionId": sessionID,
+							"modelId":   opts.Model,
+						}); modelErr != nil {
+							b.cfg.Logger.Warn("kimi set_session_model failed on recovery session",
+								"error", modelErr, "model", opts.Model)
+							finalStatus = "failed"
+							finalError = fmt.Sprintf("kimi could not switch to model %q on recovery session: %v", opts.Model, modelErr)
+							promptErr = nil
+						}
+					}
+
+					if finalStatus == "completed" {
+						_, promptErr = c.request(runCtx, "session/prompt", map[string]any{
+							"sessionId": sessionID,
+							"prompt": []map[string]any{
+								{"type": "text", "text": userText},
+							},
+						})
+						if promptErr != nil {
+							promptErr = fmt.Errorf("stale-session retry: %w", promptErr)
+						}
+					}
+				}
+			}
+		}
+
+		if promptErr != nil {
 			if runCtx.Err() == context.DeadlineExceeded {
 				finalStatus = "timeout"
 				finalError = fmt.Sprintf("kimi timed out after %s", timeout)
@@ -266,9 +332,9 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				finalError = "execution cancelled"
 			} else {
 				finalStatus = "failed"
-				finalError = fmt.Sprintf("kimi session/prompt failed: %v", err)
+				finalError = fmt.Sprintf("kimi session/prompt failed: %v", promptErr)
 			}
-		} else {
+		} else if finalStatus == "completed" {
 			select {
 			case pr := <-promptDone:
 				if pr.stopReason == "cancelled" {

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -184,15 +184,20 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// missing session ID. The new session ID is returned in the result so
 		// the caller can update its stored mapping.
 		if opts.ResumeSessionID != "" {
-			_, resumeErr := c.request(runCtx, "session/resume", map[string]any{
+			resumeResult, resumeErr := c.request(runCtx, "session/resume", map[string]any{
 				"cwd":       cwd,
 				"sessionId": opts.ResumeSessionID,
 			})
-			if resumeErr != nil {
+			switch {
+			case resumeErr != nil:
 				b.cfg.Logger.Warn("kimi session/resume failed; falling back to new session",
 					"old_session_id", opts.ResumeSessionID, "error", resumeErr)
 				// sessionID stays "", session/new runs below.
-			} else {
+			case len(resumeResult) == 0 || string(resumeResult) == "null":
+				b.cfg.Logger.Warn("kimi session/resume returned null; falling back to new session",
+					"old_session_id", opts.ResumeSessionID)
+				// sessionID stays "", session/new runs below.
+			default:
 				sessionID = opts.ResumeSessionID
 			}
 		}
@@ -316,7 +321,12 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 							},
 						})
 						if promptErr != nil {
+							b.cfg.Logger.Warn("kimi stale-session recovery: retry prompt failed",
+								"old_session_id", opts.ResumeSessionID, "new_session_id", sessionID, "error", promptErr)
 							promptErr = fmt.Errorf("stale-session retry: %w", promptErr)
+						} else {
+							b.cfg.Logger.Info("kimi stale-session recovery: retry prompt succeeded",
+								"old_session_id", opts.ResumeSessionID, "new_session_id", sessionID)
 						}
 					}
 				}


### PR DESCRIPTION
## Motivation

During a Hermes provider restart, Multica surfaced a confusing error:

```
hermes returned empty output
```

Root cause: ACP's `ResumeSessionResponse` cannot return a replacement session ID, so when Hermes silently created a new internal session B in place of the one Multica asked to resume (session A), Multica kept prompting A. Hermes logged `prompt: session A not found` and the task failed with an empty result.

Even after a Hermes-side fix, Multica should not blindly trust stored session IDs across provider restarts or daemon crashes. This change adds generic ACP client-side hardening.

## Changes

**`server/pkg/agent/hermes.go` and `kimi.go`** — two recovery paths added to both ACP backends:

**Case 1 — `session/resume` returns an explicit error:**
Fall back to `session/new` immediately instead of failing the task. The new session ID is returned in the `Result` so the daemon can update its stored mapping.

**Case 2 — `session/resume` appears successful but `session/prompt` returns a stale-session error** (e.g. `session <id> not found`):
- Call `session/new`, re-apply any model selection, retry the prompt exactly once.
- If the retry also fails, surface the real error — not an empty-output message.

**`isACPStaleSessionError`** — new helper using `(?i)\bsession\s+\S+\s+not\s+found\b` regex. Word-boundary anchoring prevents the `session/` method-name prefix from creating false positives on unrelated "not found" errors.

## Test coverage

Three new fake-ACP integration tests in `hermes_test.go` (test binary doubles as the fake hermes process via `--fake-hermes-scenario` flag):

| Test | Scenario |
|------|----------|
| `TestHermesExecuteResumeFailFallbackSuccess` | resume error → new session → prompt succeeds |
| `TestHermesExecuteResumeSuccessPromptStaleRetrySuccess` | resume ok, prompt stale → new session → retry succeeds |
| `TestHermesExecuteResumeSuccessPromptStaleRetryFail` | resume ok, prompt stale → new session → retry fails → real error surfaced |

Plus unit tests for `isACPStaleSessionError`.

## Boundaries

- No changes outside `server/pkg/agent/`.
- One controlled retry only — no carousel loop.
- Unrelated prompt failures are not treated as stale-session errors.
- Credentials/tokens are not referenced.