### PR TITLE
feat(issues): render labels on list/board with bulk server-side fetch

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -207,6 +207,22 @@ export const viewStorePersistOptions = (name: string) => ({
     cardProperties: state.cardProperties,
     listCollapsedStatuses: state.listCollapsedStatuses,
   }),
+  // Default Zustand merge is shallow, so a persisted `cardProperties` snapshot
+  // saved before a new toggle was introduced wins entirely and the new key is
+  // missing — the dropdown switch then reads `undefined` and renders unchecked
+  // even though defaults treat it as on. Deep-merge `cardProperties` so newly
+  // added toggles inherit their default value for existing users.
+  merge: (persisted: unknown, current: IssueViewState): IssueViewState => {
+    const p = (persisted ?? {}) as Partial<IssueViewState>;
+    return {
+      ...current,
+      ...p,
+      cardProperties: {
+        ...current.cardProperties,
+        ...(p.cardProperties ?? {}),
+      },
+    };
+  },
 });
 
 /** Factory: creates a vanilla StoreApi for use with React Context. */

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -20,6 +20,7 @@ export interface CardProperties {
   dueDate: boolean;
   project: boolean;
   childProgress: boolean;
+  labels: boolean;
 }
 
 export interface ActorFilterValue {
@@ -41,6 +42,7 @@ export const CARD_PROPERTY_OPTIONS: { key: keyof CardProperties; label: string }
   { key: "assignee", label: "Assignee" },
   { key: "dueDate", label: "Due date" },
   { key: "project", label: "Project" },
+  { key: "labels", label: "Labels" },
   { key: "childProgress", label: "Sub-issue progress" },
 ];
 
@@ -92,6 +94,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
     dueDate: true,
     project: true,
     childProgress: true,
+    labels: true,
   },
   listCollapsedStatuses: [],
 

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -6,7 +6,7 @@ import {
   patchIssueInBuckets,
   removeIssueFromBuckets,
 } from "./cache-helpers";
-import type { Issue } from "../types";
+import type { Issue, Label } from "../types";
 import type { ListIssuesCache } from "../types";
 
 export function onIssueCreated(
@@ -70,6 +70,26 @@ export function onIssueUpdated(
       qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
     }
   }
+}
+
+/**
+ * Patch an issue's `labels` field in-place across the list cache, my-issues
+ * caches, and the detail cache. Triggered by the `issue_labels:changed` WS
+ * event after attach/detach so list/board chips update without a refetch.
+ */
+export function onIssueLabelsChanged(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+  labels: Label[],
+) {
+  qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
+    old ? patchIssueInBuckets(old, issueId, { labels }) : old,
+  );
+  qc.setQueryData<Issue>(issueKeys.detail(wsId, issueId), (old) =>
+    old ? { ...old, labels } : old,
+  );
+  qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
 }
 
 export function onIssueDeleted(

--- a/packages/core/labels/mutations.ts
+++ b/packages/core/labels/mutations.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { labelKeys } from "./queries";
 import { useWorkspaceId } from "../hooks";
+import { onIssueLabelsChanged } from "../issues/ws-updaters";
 import type {
   Label,
   CreateLabelRequest,
@@ -100,6 +101,9 @@ export function useAttachLabel(issueId: string) {
       // invalidation to refetch.
       if (data && Array.isArray(data.labels)) {
         qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), data);
+        // Mirror into the issues list / detail caches so list/board chips
+        // update immediately for the actor without waiting for the WS event.
+        onIssueLabelsChanged(qc, wsId, issueId, data.labels);
       }
     },
     onSettled: () => {
@@ -116,13 +120,20 @@ export function useDetachLabel(issueId: string) {
     onMutate: async (labelId) => {
       await qc.cancelQueries({ queryKey: labelKeys.byIssue(wsId, issueId) });
       const prev = qc.getQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId));
-      qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), (old) =>
-        old ? { ...old, labels: old.labels.filter((l: Label) => l.id !== labelId) } : old,
-      );
+      const next = prev
+        ? { ...prev, labels: prev.labels.filter((l: Label) => l.id !== labelId) }
+        : undefined;
+      if (next) {
+        qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), next);
+        onIssueLabelsChanged(qc, wsId, issueId, next.labels);
+      }
       return { prev };
     },
     onError: (_err, _id, ctx) => {
-      if (ctx?.prev) qc.setQueryData(labelKeys.byIssue(wsId, issueId), ctx.prev);
+      if (ctx?.prev) {
+        qc.setQueryData(labelKeys.byIssue(wsId, issueId), ctx.prev);
+        onIssueLabelsChanged(qc, wsId, issueId, ctx.prev.labels);
+      }
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: labelKeys.byIssue(wsId, issueId) });

--- a/packages/core/labels/mutations.ts
+++ b/packages/core/labels/mutations.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { labelKeys } from "./queries";
 import { useWorkspaceId } from "../hooks";
+import { issueKeys } from "../issues/queries";
 import { onIssueLabelsChanged } from "../issues/ws-updaters";
 import type {
   Label,
@@ -61,6 +62,9 @@ export function useUpdateLabel() {
       // stale copy of this label is refetched. The list cache is the source
       // of truth; byIssue views will re-render with the fresh data.
       qc.invalidateQueries({ queryKey: labelKeys.all(wsId) });
+      // Issues now embed labels (denormalized snapshot), so a rename/recolor
+      // also has to refresh the issues caches that hold those snapshots.
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }
@@ -85,6 +89,9 @@ export function useDeleteLabel() {
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: labelKeys.all(wsId) });
+      // A deleted label still lives in cached issue.labels arrays until we
+      // refetch — invalidate so list/board chips drop the orphan.
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
     },
   });
 }

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -18,6 +18,7 @@ import {
   onIssueCreated,
   onIssueUpdated,
   onIssueDeleted,
+  onIssueLabelsChanged,
 } from "../issues/ws-updaters";
 import { onInboxNew, onInboxInvalidate, onInboxIssueStatusChanged, onInboxIssueDeleted } from "../inbox/ws-updaters";
 import { inboxKeys } from "../inbox/queries";
@@ -31,6 +32,7 @@ import type {
   IssueUpdatedPayload,
   IssueCreatedPayload,
   IssueDeletedPayload,
+  IssueLabelsChangedPayload,
   InboxNewPayload,
   CommentCreatedPayload,
   CommentUpdatedPayload,
@@ -147,7 +149,7 @@ export function useRealtimeSync(
 
     // Event types handled by specific handlers below -- skip generic refresh
     const specificEvents = new Set([
-      "issue:updated", "issue:created", "issue:deleted", "inbox:new",
+      "issue:updated", "issue:created", "issue:deleted", "issue_labels:changed", "inbox:new",
       "comment:created", "comment:updated", "comment:deleted",
       "activity:created",
       "reaction:added", "reaction:removed",
@@ -198,6 +200,13 @@ export function useRealtimeSync(
         onIssueDeleted(qc, wsId, issue_id);
         onInboxIssueDeleted(qc, wsId, issue_id);
       }
+    });
+
+    const unsubIssueLabelsChanged = ws.on("issue_labels:changed", (p) => {
+      const { issue_id, labels } = p as IssueLabelsChangedPayload;
+      if (!issue_id) return;
+      const wsId = getCurrentWsId();
+      if (wsId) onIssueLabelsChanged(qc, wsId, issue_id, labels ?? []);
     });
 
     const unsubInboxNew = ws.on("inbox:new", (p) => {
@@ -464,6 +473,7 @@ export function useRealtimeSync(
       unsubIssueUpdated();
       unsubIssueCreated();
       unsubIssueDeleted();
+      unsubIssueLabelsChanged();
       unsubInboxNew();
       unsubCommentCreated();
       unsubCommentUpdated();

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -119,6 +119,17 @@ export function useRealtimeSync(
         const wsId = getCurrentWsId();
         if (wsId) qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
       },
+      label: () => {
+        // label:created/updated/deleted — also refresh issues, since each
+        // issue carries a denormalized snapshot of its labels (rename/recolor
+        // /delete on a label needs to flush the chips on every issue showing
+        // it).
+        const wsId = getCurrentWsId();
+        if (wsId) {
+          qc.invalidateQueries({ queryKey: ["labels", wsId] });
+          qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
+        }
+      },
       pin: () => {
         const wsId = getCurrentWsId();
         const userId = authStore.getState().user?.id;

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -5,6 +5,7 @@ import type { Comment, Reaction } from "./comment";
 import type { TimelineEntry } from "./activity";
 import type { Workspace, MemberWithUser, Invitation } from "./workspace";
 import type { Project } from "./project";
+import type { Label } from "./label";
 
 // WebSocket event types (matching Go server protocol/events.go)
 export type WSEventType =
@@ -80,6 +81,11 @@ export interface IssueUpdatedPayload {
 
 export interface IssueDeletedPayload {
   issue_id: string;
+}
+
+export interface IssueLabelsChangedPayload {
+  issue_id: string;
+  labels: Label[];
 }
 
 export interface AgentStatusPayload {

--- a/packages/core/types/issue.ts
+++ b/packages/core/types/issue.ts
@@ -1,3 +1,5 @@
+import type { Label } from "./label";
+
 export type IssueStatus =
   | "backlog"
   | "todo"
@@ -38,6 +40,7 @@ export interface Issue {
   position: number;
   due_date: string | null;
   reactions?: IssueReaction[];
+  labels?: Label[];
   created_at: string;
   updated_at: string;
 }

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -55,7 +55,6 @@ export const BoardCardContent = memo(function BoardCardContent({
   const storeProperties = useViewStore((s) => s.cardProperties);
   const priorityCfg = PRIORITY_CONFIG[issue.priority];
   const wsId = useWorkspaceId();
-  const showLabelsToggle = storeProperties.labels ?? true;
   const { data: projects = [] } = useQuery({
     ...projectListOptions(wsId),
     enabled: storeProperties.project && !!issue.project_id,
@@ -80,7 +79,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showDueDate = storeProperties.dueDate && issue.due_date;
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
-  const showLabels = showLabelsToggle && labels.length > 0;
+  const showLabels = storeProperties.labels && labels.length > 0;
 
   return (
     <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-colors group-hover/card:border-accent group-hover/card:bg-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -21,6 +21,7 @@ import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { ProgressRing } from "./progress-ring";
 import type { ChildProgress } from "./list-row";
 import { IssueActionsContextMenu } from "../actions";
+import { LabelChip } from "../../labels/label-chip";
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleDateString("en-US", {
@@ -54,11 +55,13 @@ export const BoardCardContent = memo(function BoardCardContent({
   const storeProperties = useViewStore((s) => s.cardProperties);
   const priorityCfg = PRIORITY_CONFIG[issue.priority];
   const wsId = useWorkspaceId();
+  const showLabelsToggle = storeProperties.labels ?? true;
   const { data: projects = [] } = useQuery({
     ...projectListOptions(wsId),
     enabled: storeProperties.project && !!issue.project_id,
   });
   const project = issue.project_id ? projects.find((p) => p.id === issue.project_id) : undefined;
+  const labels = issue.labels ?? [];
 
   const updateIssueMutation = useUpdateIssue();
   const handleUpdate = useCallback(
@@ -77,6 +80,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showDueDate = storeProperties.dueDate && issue.due_date;
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
+  const showLabels = showLabelsToggle && labels.length > 0;
 
   return (
     <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-colors group-hover/card:border-accent group-hover/card:bg-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
@@ -88,8 +92,8 @@ export const BoardCardContent = memo(function BoardCardContent({
         {issue.title}
       </p>
 
-      {/* Sub-issue progress + project */}
-      {(showChildProgress || showProject) && (
+      {/* Sub-issue progress + project + labels */}
+      {(showChildProgress || showProject || showLabels) && (
         <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
           {showChildProgress && (
             <div className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
@@ -105,6 +109,9 @@ export const BoardCardContent = memo(function BoardCardContent({
               <span className="truncate">{project!.title}</span>
             </span>
           )}
+          {showLabels && labels.map((label) => (
+            <LabelChip key={label.id} label={label} />
+          ))}
         </div>
       )}
 

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -108,7 +108,7 @@ const mockViewState = {
   includeNoProject: false,
   sortBy: "position" as const,
   sortDirection: "asc" as const,
-  cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true },
+  cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
   listCollapsedStatuses: [] as string[],
   setViewMode: vi.fn(),
   toggleStatusFilter: vi.fn(),

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -39,7 +39,6 @@ export const ListRow = memo(function ListRow({
   const p = useWorkspacePaths();
   const storeProperties = useViewStore((s) => s.cardProperties);
   const wsId = useWorkspaceId();
-  const showLabelsToggle = storeProperties.labels ?? true;
   const { data: projects = [] } = useQuery({
     ...projectListOptions(wsId),
     enabled: storeProperties.project && !!issue.project_id,
@@ -51,7 +50,7 @@ export const ListRow = memo(function ListRow({
   const showChildProgress = storeProperties.childProgress && childProgress;
   const showAssignee = storeProperties.assignee && issue.assignee_type && issue.assignee_id;
   const showDueDate = storeProperties.dueDate && issue.due_date;
-  const showLabels = showLabelsToggle && labels.length > 0;
+  const showLabels = storeProperties.labels && labels.length > 0;
 
   return (
     <IssueActionsContextMenu issue={issue}>

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -13,6 +13,7 @@ import { projectListOptions } from "@multica/core/projects/queries";
 import { PriorityIcon } from "./priority-icon";
 import { ProgressRing } from "./progress-ring";
 import { IssueActionsContextMenu } from "../actions";
+import { LabelChip } from "../../labels/label-chip";
 
 export interface ChildProgress {
   done: number;
@@ -38,16 +39,19 @@ export const ListRow = memo(function ListRow({
   const p = useWorkspacePaths();
   const storeProperties = useViewStore((s) => s.cardProperties);
   const wsId = useWorkspaceId();
+  const showLabelsToggle = storeProperties.labels ?? true;
   const { data: projects = [] } = useQuery({
     ...projectListOptions(wsId),
     enabled: storeProperties.project && !!issue.project_id,
   });
   const project = issue.project_id ? projects.find((pr) => pr.id === issue.project_id) : undefined;
+  const labels = issue.labels ?? [];
 
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
   const showAssignee = storeProperties.assignee && issue.assignee_type && issue.assignee_id;
   const showDueDate = storeProperties.dueDate && issue.due_date;
+  const showLabels = showLabelsToggle && labels.length > 0;
 
   return (
     <IssueActionsContextMenu issue={issue}>
@@ -88,6 +92,18 @@ export const ListRow = memo(function ListRow({
               </span>
             )}
           </span>
+          {showLabels && (
+            <span className="hidden md:inline-flex shrink-0 items-center gap-1 max-w-[260px] overflow-hidden">
+              {labels.slice(0, 3).map((label) => (
+                <LabelChip key={label.id} label={label} />
+              ))}
+              {labels.length > 3 && (
+                <span className="text-[11px] text-muted-foreground">
+                  +{labels.length - 3}
+                </span>
+              )}
+            </span>
+          )}
           {showProject && (
             <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground max-w-[140px]">
               <span aria-hidden="true" className="shrink-0">{project!.icon || "📁"}</span>

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -42,6 +42,10 @@ type IssueResponse struct {
 	UpdatedAt          string                  `json:"updated_at"`
 	Reactions          []IssueReactionResponse `json:"reactions,omitempty"`
 	Attachments        []AttachmentResponse    `json:"attachments,omitempty"`
+	// Labels are bulk-attached by list endpoints so the client can render chips
+	// without an N+1 round-trip per row. Always serialized (never omitempty) so
+	// the frontend can distinguish "no labels" from "field absent".
+	Labels             []LabelResponse         `json:"labels"`
 }
 
 func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
@@ -91,6 +95,37 @@ func issueListRowToResponse(i db.ListIssuesRow, issuePrefix string) IssueRespons
 		CreatedAt:     timestampToString(i.CreatedAt),
 		UpdatedAt:     timestampToString(i.UpdatedAt),
 	}
+}
+
+// labelsByIssue bulk-loads labels for the given issue IDs and returns a map
+// keyed by issue UUID string. On error or empty input, returns an empty map —
+// label rendering is non-critical and we'd rather serve issues without labels
+// than fail the whole list call.
+func (h *Handler) labelsByIssue(ctx context.Context, wsUUID pgtype.UUID, issueIDs []pgtype.UUID) map[string][]LabelResponse {
+	out := map[string][]LabelResponse{}
+	if len(issueIDs) == 0 {
+		return out
+	}
+	rows, err := h.Queries.ListLabelsForIssues(ctx, db.ListLabelsForIssuesParams{
+		IssueIds:    issueIDs,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		slog.Warn("ListLabelsForIssues failed", "error", err)
+		return out
+	}
+	for _, r := range rows {
+		issueID := uuidToString(r.IssueID)
+		out[issueID] = append(out[issueID], LabelResponse{
+			ID:          uuidToString(r.ID),
+			WorkspaceID: uuidToString(r.WorkspaceID),
+			Name:        r.Name,
+			Color:       r.Color,
+			CreatedAt:   timestampToString(r.CreatedAt),
+			UpdatedAt:   timestampToString(r.UpdatedAt),
+		})
+	}
+	return out
 }
 
 func openIssueRowToResponse(i db.ListOpenIssuesRow, issuePrefix string) IssueResponse {
@@ -603,9 +638,15 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		}
 
 		prefix := h.getIssuePrefix(ctx, wsUUID)
+		ids := make([]pgtype.UUID, len(issues))
+		for i, issue := range issues {
+			ids[i] = issue.ID
+		}
+		labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
 		resp := make([]IssueResponse, len(issues))
 		for i, issue := range issues {
 			resp[i] = openIssueRowToResponse(issue, prefix)
+			resp[i].Labels = labelsMap[resp[i].ID]
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{
@@ -664,9 +705,15 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	prefix := h.getIssuePrefix(ctx, wsUUID)
+	ids := make([]pgtype.UUID, len(issues))
+	for i, issue := range issues {
+		ids[i] = issue.ID
+	}
+	labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
 	resp := make([]IssueResponse, len(issues))
 	for i, issue := range issues {
 		resp[i] = issueListRowToResponse(issue, prefix)
+		resp[i].Labels = labelsMap[resp[i].ID]
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -683,6 +730,7 @@ func (h *Handler) GetIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 	resp := issueToResponse(issue, prefix)
+	resp.Labels = h.labelsByIssue(r.Context(), issue.WorkspaceID, []pgtype.UUID{issue.ID})[uuidToString(issue.ID)]
 
 	// Fetch issue reactions.
 	reactions, err := h.Queries.ListIssueReactions(r.Context(), issue.ID)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -42,10 +42,13 @@ type IssueResponse struct {
 	UpdatedAt          string                  `json:"updated_at"`
 	Reactions          []IssueReactionResponse `json:"reactions,omitempty"`
 	Attachments        []AttachmentResponse    `json:"attachments,omitempty"`
-	// Labels are bulk-attached by list endpoints so the client can render chips
-	// without an N+1 round-trip per row. Always serialized (never omitempty) so
-	// the frontend can distinguish "no labels" from "field absent".
-	Labels             []LabelResponse         `json:"labels"`
+	// Labels are bulk-attached by list/detail endpoints so the client can render
+	// chips without an N+1 round-trip per row. Pointer + omitempty so paths that
+	// don't load labels (e.g. UpdateIssue, batch UpdateIssues, the issue:updated
+	// WS broadcast) emit no `labels` field at all — the client merge then
+	// preserves whatever labels are already in cache. nil pointer = "field
+	// absent, do not touch"; non-nil (incl. empty slice) = authoritative list.
+	Labels             *[]LabelResponse        `json:"labels,omitempty"`
 }
 
 func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
@@ -646,7 +649,11 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		resp := make([]IssueResponse, len(issues))
 		for i, issue := range issues {
 			resp[i] = openIssueRowToResponse(issue, prefix)
-			resp[i].Labels = labelsMap[resp[i].ID]
+			labels := labelsMap[resp[i].ID]
+			if labels == nil {
+				labels = []LabelResponse{}
+			}
+			resp[i].Labels = &labels
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{
@@ -713,7 +720,11 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	resp := make([]IssueResponse, len(issues))
 	for i, issue := range issues {
 		resp[i] = issueListRowToResponse(issue, prefix)
-		resp[i].Labels = labelsMap[resp[i].ID]
+		labels := labelsMap[resp[i].ID]
+		if labels == nil {
+			labels = []LabelResponse{}
+		}
+		resp[i].Labels = &labels
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -730,7 +741,11 @@ func (h *Handler) GetIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 	resp := issueToResponse(issue, prefix)
-	resp.Labels = h.labelsByIssue(r.Context(), issue.WorkspaceID, []pgtype.UUID{issue.ID})[uuidToString(issue.ID)]
+	detailLabels := h.labelsByIssue(r.Context(), issue.WorkspaceID, []pgtype.UUID{issue.ID})[uuidToString(issue.ID)]
+	if detailLabels == nil {
+		detailLabels = []LabelResponse{}
+	}
+	resp.Labels = &detailLabels
 
 	// Fetch issue reactions.
 	reactions, err := h.Queries.ListIssueReactions(r.Context(), issue.ID)

--- a/server/pkg/db/generated/issue_label.sql.go
+++ b/server/pkg/db/generated/issue_label.sql.go
@@ -211,6 +211,61 @@ func (q *Queries) ListLabelsByIssue(ctx context.Context, arg ListLabelsByIssuePa
 	return items, nil
 }
 
+const listLabelsForIssues = `-- name: ListLabelsForIssues :many
+SELECT il.issue_id, l.id, l.workspace_id, l.name, l.color, l.created_at, l.updated_at
+FROM issue_label l
+JOIN issue_to_label il ON il.label_id = l.id
+WHERE il.issue_id = ANY($1::uuid[])
+  AND l.workspace_id = $2::uuid
+ORDER BY il.issue_id, LOWER(l.name) ASC
+`
+
+type ListLabelsForIssuesParams struct {
+	IssueIds    []pgtype.UUID `json:"issue_ids"`
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+}
+
+type ListLabelsForIssuesRow struct {
+	IssueID     pgtype.UUID        `json:"issue_id"`
+	ID          pgtype.UUID        `json:"id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	Name        string             `json:"name"`
+	Color       string             `json:"color"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+}
+
+// Bulk variant: fetch labels for many issues in one round-trip so the issue
+// list endpoints can fold labels into each row without N+1 queries from the
+// client. Workspace-guarded the same way as ListLabelsByIssue.
+func (q *Queries) ListLabelsForIssues(ctx context.Context, arg ListLabelsForIssuesParams) ([]ListLabelsForIssuesRow, error) {
+	rows, err := q.db.Query(ctx, listLabelsForIssues, arg.IssueIds, arg.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListLabelsForIssuesRow{}
+	for rows.Next() {
+		var i ListLabelsForIssuesRow
+		if err := rows.Scan(
+			&i.IssueID,
+			&i.ID,
+			&i.WorkspaceID,
+			&i.Name,
+			&i.Color,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateLabel = `-- name: UpdateLabel :one
 UPDATE issue_label SET
     name = COALESCE($3, name),

--- a/server/pkg/db/queries/issue_label.sql
+++ b/server/pkg/db/queries/issue_label.sql
@@ -66,3 +66,14 @@ JOIN issue_to_label il ON il.label_id = l.id
 WHERE il.issue_id = sqlc.arg('issue_id')::uuid
   AND l.workspace_id = sqlc.arg('workspace_id')::uuid
 ORDER BY LOWER(l.name) ASC;
+
+-- name: ListLabelsForIssues :many
+-- Bulk variant: fetch labels for many issues in one round-trip so the issue
+-- list endpoints can fold labels into each row without N+1 queries from the
+-- client. Workspace-guarded the same way as ListLabelsByIssue.
+SELECT il.issue_id, l.*
+FROM issue_label l
+JOIN issue_to_label il ON il.label_id = l.id
+WHERE il.issue_id = ANY(sqlc.arg('issue_ids')::uuid[])
+  AND l.workspace_id = sqlc.arg('workspace_id')::uuid
+ORDER BY il.issue_id, LOWER(l.name) ASC;


### PR DESCRIPTION
## Summary

- Issue list / open-issue / detail responses now include `labels: Label[]`, populated by a single bulk `ListLabelsForIssues(workspace_id, issue_ids)` query — one DB round-trip per page instead of N HTTP requests per visible issue.
- `list-row` and `board-card` read `issue.labels` directly. A new "Labels" toggle in the card-properties dropdown lets users hide them (defaults on).
- Cache stays live: `issue_labels:changed` WS handler patches the bucketed list cache and detail cache via a new `onIssueLabelsChanged` updater; `useAttachLabel` / `useDetachLabel` mirror their result into the same caches so the actor's tab updates instantly without waiting for the WS roundtrip.

## Why

After #1233 shipped labels, they only rendered on the issue detail page — list view and board view had no chips. The first cut used a per-row `useQuery(issueLabelsOptions)`, but that fires N parallel requests on every list paint. This change moves the join to the server.

## Test plan
- [ ] Open `/list` — labels render as chips on each row (max 3 + `+N` overflow on list view; full wrap on board cards).
- [ ] Toggle "Labels" off in the display dropdown → chips disappear in both views.
- [ ] Attach a label via the issue detail picker → list/board chip updates immediately in same tab; second tab updates via WS within ~1s.
- [ ] Detach a label → same as above; rollback path also reverts the list cache on mutation error.
- [ ] DevTools Network tab: list paint issues a single `/api/issues` call with `labels` populated (no `/api/issues/:id/labels` per row).
- [ ] `make check` passes.