### PR TITLE
fix(issues): show labels in my-issues view + reposition chips after title

### DIFF
--- a/packages/core/issues/stores/my-issues-view-store.ts
+++ b/packages/core/issues/stores/my-issues-view-store.ts
@@ -6,6 +6,7 @@ import {
   type IssueViewState,
   viewStoreSlice,
   viewStorePersistOptions,
+  mergeViewStatePersisted,
 } from "./view-store";
 import { registerForWorkspaceRehydration } from "../../platform/workspace-storage";
 
@@ -32,6 +33,11 @@ const _myIssuesViewStore = createStore<MyIssuesViewState>()(
         ...basePersist.partialize(state),
         scope: state.scope,
       }),
+      // Reuse the same deep-merge as the base view store so newly added
+      // cardProperties toggles inherit defaults for existing users. Without
+      // this, the my-issues page renders no labels because the persisted
+      // snapshot predates the `labels` key and shallow-merge wins.
+      merge: mergeViewStatePersisted<MyIssuesViewState>,
     },
   ),
 );

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -212,18 +212,28 @@ export const viewStorePersistOptions = (name: string) => ({
   // missing — the dropdown switch then reads `undefined` and renders unchecked
   // even though defaults treat it as on. Deep-merge `cardProperties` so newly
   // added toggles inherit their default value for existing users.
-  merge: (persisted: unknown, current: IssueViewState): IssueViewState => {
-    const p = (persisted ?? {}) as Partial<IssueViewState>;
-    return {
-      ...current,
-      ...p,
-      cardProperties: {
-        ...current.cardProperties,
-        ...(p.cardProperties ?? {}),
-      },
-    };
-  },
+  merge: mergeViewStatePersisted,
 });
+
+/**
+ * Reusable persist `merge` for view-state stores. Generic over T so the same
+ * deep-merge for `cardProperties` works for both the issues view store and
+ * the my-issues view store (which extends IssueViewState).
+ */
+export function mergeViewStatePersisted<T extends IssueViewState>(
+  persisted: unknown,
+  current: T,
+): T {
+  const p = (persisted ?? {}) as Partial<T>;
+  return {
+    ...current,
+    ...p,
+    cardProperties: {
+      ...current.cardProperties,
+      ...(p.cardProperties ?? {}),
+    },
+  };
+}
 
 /** Factory: creates a vanilla StoreApi for use with React Context. */
 export function createIssueViewStore(persistKey: string): StoreApi<IssueViewState> {

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -130,6 +130,7 @@ const mockViewState = {
 vi.mock("@multica/core/issues/stores/view-store", () => ({
   useClearFiltersOnWorkspaceChange: () => {},
   viewStorePersistOptions: () => ({ name: "test", storage: undefined, partialize: (s: any) => s }),
+  mergeViewStatePersisted: (_p: unknown, c: any) => c,
   viewStoreSlice: vi.fn(),
   useIssueViewStore: Object.assign(
     (selector?: any) => (selector ? selector(mockViewState) : mockViewState),
@@ -153,6 +154,7 @@ vi.mock("@multica/core/issues/stores/view-store", () => ({
     { key: "assignee", label: "Assignee" },
     { key: "dueDate", label: "Due date" },
     { key: "project", label: "Project" },
+    { key: "labels", label: "Labels" },
     { key: "childProgress", label: "Sub-issue progress" },
   ],
 }));

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -91,19 +91,19 @@ export const ListRow = memo(function ListRow({
                 </span>
               </span>
             )}
+            {showLabels && (
+              <span className="ml-1.5 hidden md:inline-flex shrink-0 items-center gap-1 max-w-[260px] overflow-hidden">
+                {labels.slice(0, 3).map((label) => (
+                  <LabelChip key={label.id} label={label} />
+                ))}
+                {labels.length > 3 && (
+                  <span className="text-[11px] text-muted-foreground">
+                    +{labels.length - 3}
+                  </span>
+                )}
+              </span>
+            )}
           </span>
-          {showLabels && (
-            <span className="hidden md:inline-flex shrink-0 items-center gap-1 max-w-[260px] overflow-hidden">
-              {labels.slice(0, 3).map((label) => (
-                <LabelChip key={label.id} label={label} />
-              ))}
-              {labels.length > 3 && (
-                <span className="text-[11px] text-muted-foreground">
-                  +{labels.length - 3}
-                </span>
-              )}
-            </span>
-          )}
           {showProject && (
             <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground max-w-[140px]">
               <ProjectIcon project={project} size="sm" />


### PR DESCRIPTION
## Summary

Two follow-ups on #1741:

- **My-issues page wasn't rendering labels.** `myIssuesViewStore` cherry-picked `name/storage/partialize` from `viewStorePersistOptions`, which dropped the `cardProperties`-aware `merge` introduced in #1741. Existing users' persisted snapshots predate the `labels` toggle, so the shallow default merge left `cardProperties.labels === undefined`, which short-circuited `showLabels` to falsy. Extracted `mergeViewStatePersisted` as a reusable generic and wired it into both stores.
- **List-view label placement.** Moved chips from the right-aligned cluster (next to project / due date / assignee) to immediately after the title, with a small `ml-1.5` for breathing room. Matches Linear's layout and keeps the right cluster reserved for metadata-style chips.

## Test plan
- [ ] `/my-issues` — labels render as chips on each row (same toggle off → chips disappear).
- [ ] `/list` — chips now appear right after the issue title rather than on the right side; project / due date / assignee stay right-aligned.
- [ ] Existing user (persisted `cardProperties` from before #1741) sees the "Labels" switch in the display dropdown as on by default and chips render.
- [ ] Toggle "Labels" off → chips disappear in both /list and /my-issues; toggle back on → reappear.
- [ ] Typecheck + unit tests green (verified locally).