### PR TITLE
fix(labels): apply label attach optimistically

### DIFF
--- a/packages/core/labels/mutations.ts
+++ b/packages/core/labels/mutations.ts
@@ -101,15 +101,37 @@ export function useAttachLabel(issueId: string) {
   const wsId = useWorkspaceId();
   return useMutation({
     mutationFn: (labelId: string) => api.attachLabel(issueId, labelId),
+    onMutate: async (labelId) => {
+      await qc.cancelQueries({ queryKey: labelKeys.byIssue(wsId, issueId) });
+      const prev = qc.getQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId));
+      // Resolve the full label from the workspace list cache so the chip
+      // can render immediately with the right name + color. If it isn't
+      // cached we skip the optimistic patch and rely on onSettled refetch.
+      const list = qc.getQueryData<ListLabelsResponse>(labelKeys.list(wsId));
+      const label = list?.labels.find((l) => l.id === labelId);
+      if (label && !prev?.labels.some((l) => l.id === labelId)) {
+        const next: IssueLabelsResponse = {
+          ...prev,
+          labels: [...(prev?.labels ?? []), label],
+        };
+        qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), next);
+        onIssueLabelsChanged(qc, wsId, issueId, next.labels);
+      }
+      return { prev };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.prev) {
+        qc.setQueryData(labelKeys.byIssue(wsId, issueId), ctx.prev);
+        onIssueLabelsChanged(qc, wsId, issueId, ctx.prev.labels);
+      }
+    },
     onSuccess: (data: IssueLabelsResponse) => {
       // Backend may return an empty object when the post-mutation read fails
-      // (it logs a warning and skips the broadcast). We only apply the list
-      // when the backend gave us one — otherwise rely on onSettled's
-      // invalidation to refetch.
+      // (it logs a warning and skips the broadcast). Only apply the list
+      // when the backend gave us one — otherwise the optimistic patch from
+      // onMutate stands until onSettled's invalidation refetches.
       if (data && Array.isArray(data.labels)) {
         qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), data);
-        // Mirror into the issues list / detail caches so list/board chips
-        // update immediately for the actor without waiting for the WS event.
         onIssueLabelsChanged(qc, wsId, issueId, data.labels);
       }
     },

--- a/packages/core/labels/mutations.ts
+++ b/packages/core/labels/mutations.ts
@@ -104,19 +104,19 @@ export function useAttachLabel(issueId: string) {
     onMutate: async (labelId) => {
       await qc.cancelQueries({ queryKey: labelKeys.byIssue(wsId, issueId) });
       const prev = qc.getQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId));
-      // Resolve the full label from the workspace list cache so the chip
-      // can render immediately with the right name + color. If it isn't
-      // cached we skip the optimistic patch and rely on onSettled refetch.
+      // Only patch when we already know the current label set — otherwise
+      // appending `[label]` to an empty array would wipe denormalized
+      // labels in issue list/detail caches and rollback couldn't restore
+      // them. If byIssue isn't cached yet (user clicked before the picker
+      // fetched), skip the optimistic patch and rely on onSettled refetch.
+      if (!prev) return { prev };
+      if (prev.labels.some((l) => l.id === labelId)) return { prev };
       const list = qc.getQueryData<ListLabelsResponse>(labelKeys.list(wsId));
       const label = list?.labels.find((l) => l.id === labelId);
-      if (label && !prev?.labels.some((l) => l.id === labelId)) {
-        const next: IssueLabelsResponse = {
-          ...prev,
-          labels: [...(prev?.labels ?? []), label],
-        };
-        qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), next);
-        onIssueLabelsChanged(qc, wsId, issueId, next.labels);
-      }
+      if (!label) return { prev };
+      const next: IssueLabelsResponse = { ...prev, labels: [...prev.labels, label] };
+      qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), next);
+      onIssueLabelsChanged(qc, wsId, issueId, next.labels);
       return { prev };
     },
     onError: (_err, _id, ctx) => {


### PR DESCRIPTION
## Summary
- `useAttachLabel` now patches the byIssue + issue list/detail caches in `onMutate`, so the chip appears the moment the user clicks instead of after the round-trip.
- Mirrors the existing `useDetachLabel` pattern: snapshot prev, optimistic update via `onIssueLabelsChanged`, rollback in `onError`, reconcile in `onSuccess`, invalidate in `onSettled`.
- Same optimistic guarantee that status / assignee / priority pickers already have through `useUpdateIssue`.

The full label is resolved from the cached workspace label list (`labelKeys.list`) so the chip renders with the correct name + color immediately. If the list isn't cached we skip the patch and fall back to the existing post-success reconcile.

## Test plan
- [x] `pnpm --filter @multica/core typecheck`
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/core test` (88 passed)
- [x] `pnpm --filter @multica/views test` (219 passed)
- [ ] Manual: open an issue, click a label in the picker — chip appears instantly; turn on devtools network throttling to confirm no waiting on the API; force the request to fail to confirm rollback.
- [ ] Manual: type a new label name and press Enter — create + attach still work (create populates the label list cache, attach picks it up optimistically).