### PR TITLE
refactor(server): error-returning ParseUUID to prevent silent data loss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,17 @@ make start-worktree     # Start using .env.worktree
 - Avoid broad refactors unless required by the task.
 - New global (pre-workspace) routes MUST use a single word (`/login`, `/inbox`) or a `/{noun}/{verb}` pair (`/workspaces/new`). NEVER add hyphenated word-group root routes (`/new-workspace`, `/create-team`) — they collide with common user workspace names and force endless reserved-slug audits. Reserving the noun (`workspaces`) automatically protects the entire `/workspaces/*` subtree.
 
+### Backend Handler UUID Parsing Convention
+
+Every Go handler in `server/internal/handler/` follows these rules. The convention exists because `util.ParseUUID` used to silently return a zero UUID on invalid input, which caused #1661 — a `DELETE` returning 204 success while the SQL `DELETE` matched zero rows.
+
+- **Resource path params that accept either a UUID or a human-readable identifier** (e.g. `chi.URLParam(r, "id")` for an issue, which accepts both `MUL-123` and a UUID) MUST be resolved through the dedicated loader (`loadIssueForUser` / `loadSkillForUser` / `loadAgentForUser` / `requireDaemonRuntimeAccess`). After resolution, all subsequent DB calls — especially `Queries.Delete*` / `Queries.Update*` — MUST use `entity.ID` from the resolved object. Never round-trip the raw URL string through `parseUUID` for a write query.
+- **Pure-UUID inputs from request boundaries** (URL params that are always UUIDs, request body fields, query params, headers) MUST be validated with `parseUUIDOrBadRequest(w, s, fieldName)`. On invalid input it writes a 400 and returns `ok=false` — return immediately.
+- **Trusted UUID round-trips** (sqlc-returned UUIDs being passed back into queries, test fixtures) use `parseUUID(s)` which calls `util.MustParseUUID` and panics on invalid input. A panic here means an unguarded user-input string slipped in — that is a real bug. `chi`'s `middleware.Recoverer` translates the panic into a 500 so the process keeps running.
+- **`util.ParseUUID(s) (pgtype.UUID, error)`** is the only safe variant outside the handler package. Always check the error.
+
+When adding a `Queries.Delete*` or `Queries.Update*` call, ask: "Where did this UUID come from?" If the answer is "raw user input that hasn't been validated," route it through `parseUUIDOrBadRequest` or a loader first.
+
 ### Package Boundary Rules
 
 These are hard constraints. Violating them breaks the cross-platform architecture:

--- a/server/cmd/server/activity_listeners_test.go
+++ b/server/cmd/server/activity_listeners_test.go
@@ -16,7 +16,7 @@ import (
 func listActivitiesForIssue(t *testing.T, queries *db.Queries, issueID string) []db.ActivityLog {
 	t.Helper()
 	activities, err := queries.ListActivities(context.Background(), db.ListActivitiesParams{
-		IssueID: util.ParseUUID(issueID),
+		IssueID: util.MustParseUUID(issueID),
 		Limit:   100,
 		Offset:  0,
 	})

--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -18,9 +18,9 @@ import (
 func inboxItemsForRecipient(t *testing.T, queries *db.Queries, recipientID string) []db.ListInboxItemsRow {
 	t.Helper()
 	items, err := queries.ListInboxItems(context.Background(), db.ListInboxItemsParams{
-		WorkspaceID:   util.ParseUUID(testWorkspaceID),
+		WorkspaceID:   util.MustParseUUID(testWorkspaceID),
 		RecipientType: "member",
-		RecipientID:   util.ParseUUID(recipientID),
+		RecipientID:   util.MustParseUUID(recipientID),
 	})
 	if err != nil {
 		t.Fatalf("ListInboxItems: %v", err)

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -469,12 +469,11 @@ func (pr *patResolver) ResolveToken(ctx context.Context, token string) (string, 
 	return util.UUIDToString(pat.UserID), true
 }
 
+// parseUUID is a thin alias for util.MustParseUUID. Call sites here are all
+// internal round-trips of DB-sourced UUIDs (e.g. issue.ID, e.ActorID), so an
+// invalid value indicates a programming error and should panic loudly.
 func parseUUID(s string) pgtype.UUID {
-	var u pgtype.UUID
-	if err := u.Scan(s); err != nil {
-		return pgtype.UUID{}
-	}
-	return u
+	return util.MustParseUUID(s)
 }
 
 func splitAndTrim(s string) []string {

--- a/server/cmd/server/scope_authorizer.go
+++ b/server/cmd/server/scope_authorizer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/realtime"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -31,9 +32,12 @@ func (a *dbScopeAuthorizer) AuthorizeScope(ctx context.Context, userID, workspac
 	if workspaceID == "" || scopeID == "" {
 		return false, nil
 	}
-	wsUUID := parseUUID(workspaceID)
-	idUUID := parseUUID(scopeID)
-	if !wsUUID.Valid || !idUUID.Valid {
+	wsUUID, err := util.ParseUUID(workspaceID)
+	if err != nil {
+		return false, nil
+	}
+	idUUID, err := util.ParseUUID(scopeID)
+	if err != nil {
 		return false, nil
 	}
 	switch scopeType {
@@ -60,8 +64,8 @@ func (a *dbScopeAuthorizer) AuthorizeScope(ctx context.Context, userID, workspac
 			if sess.WorkspaceID != wsUUID {
 				return false, nil
 			}
-			uidUUID := parseUUID(userID)
-			if !uidUUID.Valid || sess.CreatorID != uidUUID {
+			uidUUID, err := util.ParseUUID(userID)
+			if err != nil || sess.CreatorID != uidUUID {
 				return false, nil
 			}
 			return true, nil
@@ -81,8 +85,8 @@ func (a *dbScopeAuthorizer) AuthorizeScope(ctx context.Context, userID, workspac
 		// otherwise any workspace member who learns a session_id could
 		// subscribe to chat:message / chat:done / chat:session_read for a
 		// peer's private chat.
-		uidUUID := parseUUID(userID)
-		if !uidUUID.Valid || sess.CreatorID != uidUUID {
+		uidUUID, err := util.ParseUUID(userID)
+		if err != nil || sess.CreatorID != uidUUID {
 			return false, nil
 		}
 		return true, nil

--- a/server/cmd/server/subscriber_listeners_test.go
+++ b/server/cmd/server/subscriber_listeners_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/handler"
 	"github.com/multica-ai/multica/server/internal/util"
@@ -64,9 +63,9 @@ func cleanupTestUser(t *testing.T, email string) {
 func isSubscribed(t *testing.T, queries *db.Queries, issueID, userType, userID string) bool {
 	t.Helper()
 	subscribed, err := queries.IsIssueSubscriber(context.Background(), db.IsIssueSubscriberParams{
-		IssueID:  util.ParseUUID(issueID),
+		IssueID:  util.MustParseUUID(issueID),
 		UserType: userType,
-		UserID:   util.ParseUUID(userID),
+		UserID:   util.MustParseUUID(userID),
 	})
 	if err != nil {
 		t.Fatalf("IsIssueSubscriber: %v", err)
@@ -76,7 +75,7 @@ func isSubscribed(t *testing.T, queries *db.Queries, issueID, userType, userID s
 
 func subscriberCount(t *testing.T, queries *db.Queries, issueID string) int {
 	t.Helper()
-	subs, err := queries.ListIssueSubscribers(context.Background(), util.ParseUUID(issueID))
+	subs, err := queries.ListIssueSubscribers(context.Background(), util.MustParseUUID(issueID))
 	if err != nil {
 		t.Fatalf("ListIssueSubscribers: %v", err)
 	}
@@ -394,11 +393,13 @@ func TestSubscriberIssueCreated_AutopilotMapPayload(t *testing.T) {
 	}
 }
 
-// Verify parseUUID is consistent — pgtype.UUID from our local helper should match util.ParseUUID
+// Verify parseUUID is consistent — the local helper should agree with util.MustParseUUID
+// for valid input, and panic on invalid input (the silent-zero behavior was removed
+// after #1661 to prevent silent SQL writes against a zero UUID).
 func TestParseUUIDConsistency(t *testing.T) {
 	uuid := "550e8400-e29b-41d4-a716-446655440000"
 	local := parseUUID(uuid)
-	utilResult := util.ParseUUID(uuid)
+	utilResult := util.MustParseUUID(uuid)
 	if local != utilResult {
 		t.Fatalf("parseUUID inconsistency: local=%v, util=%v", local, utilResult)
 	}
@@ -406,9 +407,11 @@ func TestParseUUIDConsistency(t *testing.T) {
 		t.Fatal("expected valid UUID")
 	}
 
-	// Empty string should produce invalid UUID
-	empty := parseUUID("")
-	if empty != (pgtype.UUID{}) {
-		t.Fatalf("expected zero UUID for empty string, got %v", empty)
-	}
+	// Invalid input (empty string) must panic now — never silently return a zero UUID.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected parseUUID(\"\") to panic, but it returned normally")
+		}
+	}()
+	_ = parseUUID("")
 }

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -354,9 +354,18 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		req.MaxConcurrentTasks = 6
 	}
 
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, req.RuntimeID, "runtime_id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
 	runtime, err := h.Queries.GetAgentRuntimeForWorkspace(r.Context(), db.GetAgentRuntimeForWorkspaceParams{
-		ID:          parseUUID(req.RuntimeID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          runtimeUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid runtime_id")
@@ -369,7 +378,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	// list fails we fall through with isFirstAgent=false rather than
 	// blocking creation, since the primary DB operation is the insert.
 	isFirstAgent := false
-	if existing, listErr := h.Queries.ListAgents(r.Context(), parseUUID(workspaceID)); listErr == nil {
+	if existing, listErr := h.Queries.ListAgents(r.Context(), wsUUID); listErr == nil {
 		isFirstAgent = len(existing) == 0
 	}
 
@@ -394,7 +403,7 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	agent, err := h.Queries.CreateAgent(r.Context(), db.CreateAgentParams{
-		WorkspaceID:        parseUUID(workspaceID),
+		WorkspaceID:        wsUUID,
 		Name:               req.Name,
 		Description:        req.Description,
 		Instructions:       req.Instructions,
@@ -529,7 +538,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := db.UpdateAgentParams{
-		ID: parseUUID(id),
+		ID: agent.ID,
 	}
 	if req.Name != nil {
 		params.Name = pgtype.Text{String: *req.Name, Valid: true}
@@ -561,8 +570,12 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 		params.McpConfig = append([]byte(nil), rawMcpConfig...)
 	}
 	if req.RuntimeID != nil {
+		runtimeUUID, ok := parseUUIDOrBadRequest(w, *req.RuntimeID, "runtime_id")
+		if !ok {
+			return
+		}
 		runtime, err := h.Queries.GetAgentRuntimeForWorkspace(r.Context(), db.GetAgentRuntimeForWorkspaceParams{
-			ID:          parseUUID(*req.RuntimeID),
+			ID:          runtimeUUID,
 			WorkspaceID: agent.WorkspaceID,
 		})
 		if err != nil {
@@ -595,7 +608,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	// mcp_config: null in the request means explicitly clear the field.
 	// COALESCE in UpdateAgent cannot set a column to NULL, so we use a dedicated query.
 	if shouldClearMcpConfig {
-		agent, err = h.Queries.ClearAgentMcpConfig(r.Context(), parseUUID(id))
+		agent, err = h.Queries.ClearAgentMcpConfig(r.Context(), agent.ID)
 		if err != nil {
 			slog.Warn("clear agent mcp_config failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 			writeError(w, http.StatusInternalServerError, "failed to clear mcp_config: "+err.Error())
@@ -627,7 +640,7 @@ func (h *Handler) ArchiveAgent(w http.ResponseWriter, r *http.Request) {
 
 	userID := requestUserID(r)
 	archived, err := h.Queries.ArchiveAgent(r.Context(), db.ArchiveAgentParams{
-		ID:         parseUUID(id),
+		ID:         agent.ID,
 		ArchivedBy: parseUUID(userID),
 	})
 	if err != nil {
@@ -637,7 +650,7 @@ func (h *Handler) ArchiveAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cancel all pending/active tasks for this agent.
-	if err := h.Queries.CancelAgentTasksByAgent(r.Context(), parseUUID(id)); err != nil {
+	if err := h.Queries.CancelAgentTasksByAgent(r.Context(), agent.ID); err != nil {
 		slog.Warn("cancel agent tasks on archive failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 	}
 
@@ -663,7 +676,7 @@ func (h *Handler) RestoreAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restored, err := h.Queries.RestoreAgent(r.Context(), parseUUID(id))
+	restored, err := h.Queries.RestoreAgent(r.Context(), agent.ID)
 	if err != nil {
 		slog.Warn("restore agent failed", append(logger.RequestAttrs(r), "error", err, "agent_id", id)...)
 		writeError(w, http.StatusInternalServerError, "failed to restore agent")
@@ -681,11 +694,12 @@ func (h *Handler) RestoreAgent(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) ListAgentTasks(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if _, ok := h.loadAgentForUser(w, r, id); !ok {
+	agent, ok := h.loadAgentForUser(w, r, id)
+	if !ok {
 		return
 	}
 
-	tasks, err := h.Queries.ListAgentTasks(r.Context(), parseUUID(id))
+	tasks, err := h.Queries.ListAgentTasks(r.Context(), agent.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list agent tasks")
 		return

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -194,12 +194,8 @@ func (h *Handler) GetAutopilot(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
 
-	autopilot, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
-		ID:          parseUUID(id),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "autopilot not found")
+	autopilot, ok := h.loadAutopilotInWorkspace(w, r, id, workspaceID)
+	if !ok {
 		return
 	}
 
@@ -219,6 +215,27 @@ func (h *Handler) GetAutopilot(w http.ResponseWriter, r *http.Request) {
 		"autopilot": resp,
 		"triggers":  triggerResp,
 	})
+}
+
+func (h *Handler) loadAutopilotInWorkspace(w http.ResponseWriter, r *http.Request, autopilotID, workspaceID string) (db.Autopilot, bool) {
+	autopilotUUID, ok := parseUUIDOrBadRequest(w, autopilotID, "autopilot id")
+	if !ok {
+		return db.Autopilot{}, false
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return db.Autopilot{}, false
+	}
+
+	autopilot, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
+		ID:          autopilotUUID,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "autopilot not found")
+		return db.Autopilot{}, false
+	}
+	return autopilot, true
 }
 
 func (h *Handler) CreateAutopilot(w http.ResponseWriter, r *http.Request) {
@@ -250,10 +267,19 @@ func (h *Handler) CreateAutopilot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	assigneeUUID, ok := parseUUIDOrBadRequest(w, req.AssigneeID, "assignee_id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
 	// Validate assignee is an agent in the workspace.
 	_, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
-		ID:          parseUUID(req.AssigneeID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          assigneeUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "assignee must be a valid agent in this workspace")
@@ -261,9 +287,9 @@ func (h *Handler) CreateAutopilot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	autopilot, err := h.Queries.CreateAutopilot(r.Context(), db.CreateAutopilotParams{
-		WorkspaceID:        parseUUID(workspaceID),
+		WorkspaceID:        wsUUID,
 		Title:              req.Title,
-		AssigneeID:         parseUUID(req.AssigneeID),
+		AssigneeID:         assigneeUUID,
 		Status:             "active",
 		ExecutionMode:      req.ExecutionMode,
 		CreatedByType:      "member",
@@ -285,12 +311,8 @@ func (h *Handler) UpdateAutopilot(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
 
-	prev, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
-		ID:          parseUUID(id),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "autopilot not found")
+	prev, ok := h.loadAutopilotInWorkspace(w, r, id, workspaceID)
+	if !ok {
 		return
 	}
 
@@ -335,14 +357,18 @@ func (h *Handler) UpdateAutopilot(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, ok := rawFields["assignee_id"]; ok {
 		if req.AssigneeID != nil {
+			assigneeUUID, ok := parseUUIDOrBadRequest(w, *req.AssigneeID, "assignee_id")
+			if !ok {
+				return
+			}
 			if _, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
-				ID:          parseUUID(*req.AssigneeID),
-				WorkspaceID: parseUUID(workspaceID),
+				ID:          assigneeUUID,
+				WorkspaceID: prev.WorkspaceID,
 			}); err != nil {
 				writeError(w, http.StatusBadRequest, "assignee must be a valid agent in this workspace")
 				return
 			}
-			params.AssigneeID = parseUUID(*req.AssigneeID)
+			params.AssigneeID = assigneeUUID
 		}
 	}
 
@@ -398,12 +424,8 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	autopilotID := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
 
-	ap, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
-		ID:          parseUUID(autopilotID),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "autopilot not found")
+	ap, ok := h.loadAutopilotInWorkspace(w, r, autopilotID, workspaceID)
+	if !ok {
 		return
 	}
 
@@ -463,7 +485,7 @@ func (h *Handler) CreateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	resp := triggerToResponse(trigger)
 	userID, _ := requireUserID(w, r)
 	h.publish(protocol.EventAutopilotUpdated, workspaceID, "member", userID, map[string]any{
-		"autopilot_id": autopilotID,
+		"autopilot_id": uuidToString(ap.ID),
 		"trigger":      resp,
 	})
 	writeJSON(w, http.StatusCreated, resp)
@@ -474,17 +496,18 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	triggerID := chi.URLParam(r, "triggerId")
 	workspaceID := h.resolveWorkspaceID(r)
 
-	// Verify autopilot belongs to workspace.
-	if _, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
-		ID:          parseUUID(autopilotID),
-		WorkspaceID: parseUUID(workspaceID),
-	}); err != nil {
-		writeError(w, http.StatusNotFound, "autopilot not found")
+	ap, ok := h.loadAutopilotInWorkspace(w, r, autopilotID, workspaceID)
+	if !ok {
 		return
 	}
 
-	prev, err := h.Queries.GetAutopilotTrigger(r.Context(), parseUUID(triggerID))
-	if err != nil || uuidToString(prev.AutopilotID) != autopilotID {
+	triggerUUID, ok := parseUUIDOrBadRequest(w, triggerID, "trigger id")
+	if !ok {
+		return
+	}
+
+	prev, err := h.Queries.GetAutopilotTrigger(r.Context(), triggerUUID)
+	if err != nil || uuidToString(prev.AutopilotID) != uuidToString(ap.ID) {
 		writeError(w, http.StatusNotFound, "trigger not found")
 		return
 	}
@@ -551,7 +574,7 @@ func (h *Handler) UpdateAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	resp := triggerToResponse(trigger)
 	userID, _ := requireUserID(w, r)
 	h.publish(protocol.EventAutopilotUpdated, workspaceID, "member", userID, map[string]any{
-		"autopilot_id": autopilotID,
+		"autopilot_id": uuidToString(ap.ID),
 		"trigger":      resp,
 	})
 	writeJSON(w, http.StatusOK, resp)
@@ -612,11 +635,8 @@ func (h *Handler) ListAutopilotRuns(w http.ResponseWriter, r *http.Request) {
 	autopilotID := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
 
-	if _, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
-		ID:          parseUUID(autopilotID),
-		WorkspaceID: parseUUID(workspaceID),
-	}); err != nil {
-		writeError(w, http.StatusNotFound, "autopilot not found")
+	autopilot, ok := h.loadAutopilotInWorkspace(w, r, autopilotID, workspaceID)
+	if !ok {
 		return
 	}
 
@@ -637,7 +657,7 @@ func (h *Handler) ListAutopilotRuns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	runs, err := h.Queries.ListAutopilotRuns(r.Context(), db.ListAutopilotRunsParams{
-		AutopilotID: parseUUID(autopilotID),
+		AutopilotID: autopilot.ID,
 		Limit:       limit,
 		Offset:      offset,
 	})
@@ -659,12 +679,8 @@ func (h *Handler) TriggerAutopilot(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
 
-	autopilot, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
-		ID:          parseUUID(id),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "autopilot not found")
+	autopilot, ok := h.loadAutopilotInWorkspace(w, r, id, workspaceID)
+	if !ok {
 		return
 	}
 	if autopilot.Status != "active" {

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -361,9 +361,18 @@ func (h *Handler) DeleteAutopilot(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
 
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "autopilot id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
 	if _, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
-		ID:          parseUUID(id),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          idUUID,
+		WorkspaceID: wsUUID,
 	}); err != nil {
 		writeError(w, http.StatusNotFound, "autopilot not found")
 		return
@@ -374,12 +383,12 @@ func (h *Handler) DeleteAutopilot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.Queries.DeleteAutopilot(r.Context(), parseUUID(id)); err != nil {
+	if err := h.Queries.DeleteAutopilot(r.Context(), idUUID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete autopilot")
 		return
 	}
 
-	h.publish(protocol.EventAutopilotDeleted, workspaceID, "member", userID, map[string]any{"autopilot_id": id})
+	h.publish(protocol.EventAutopilotDeleted, workspaceID, "member", userID, map[string]any{"autopilot_id": uuidToString(idUUID)})
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -553,16 +562,29 @@ func (h *Handler) DeleteAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 	triggerID := chi.URLParam(r, "triggerId")
 	workspaceID := h.resolveWorkspaceID(r)
 
+	autopilotUUID, ok := parseUUIDOrBadRequest(w, autopilotID, "autopilot id")
+	if !ok {
+		return
+	}
+	triggerUUID, ok := parseUUIDOrBadRequest(w, triggerID, "trigger id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
 	if _, err := h.Queries.GetAutopilotInWorkspace(r.Context(), db.GetAutopilotInWorkspaceParams{
-		ID:          parseUUID(autopilotID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          autopilotUUID,
+		WorkspaceID: wsUUID,
 	}); err != nil {
 		writeError(w, http.StatusNotFound, "autopilot not found")
 		return
 	}
 
-	trigger, err := h.Queries.GetAutopilotTrigger(r.Context(), parseUUID(triggerID))
-	if err != nil || uuidToString(trigger.AutopilotID) != autopilotID {
+	trigger, err := h.Queries.GetAutopilotTrigger(r.Context(), triggerUUID)
+	if err != nil || uuidToString(trigger.AutopilotID) != uuidToString(autopilotUUID) {
 		writeError(w, http.StatusNotFound, "trigger not found")
 		return
 	}
@@ -572,14 +594,14 @@ func (h *Handler) DeleteAutopilotTrigger(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err := h.Queries.DeleteAutopilotTrigger(r.Context(), parseUUID(triggerID)); err != nil {
+	if err := h.Queries.DeleteAutopilotTrigger(r.Context(), triggerUUID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete trigger")
 		return
 	}
 
 	h.publish(protocol.EventAutopilotUpdated, workspaceID, "member", userID, map[string]any{
-		"autopilot_id": autopilotID,
-		"trigger_id":   triggerID,
+		"autopilot_id": uuidToString(autopilotUUID),
+		"trigger_id":   uuidToString(triggerUUID),
 	})
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -35,11 +35,19 @@ func (h *Handler) CreateChatSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "agent_id is required")
 		return
 	}
+	agentID, ok := parseUUIDOrBadRequest(w, req.AgentID, "agent_id")
+	if !ok {
+		return
+	}
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
 	// Verify agent exists in workspace.
 	agent, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
-		ID:          parseUUID(req.AgentID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          agentID,
+		WorkspaceID: workspaceUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "agent not found")
@@ -51,8 +59,8 @@ func (h *Handler) CreateChatSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	session, err := h.Queries.CreateChatSession(r.Context(), db.CreateChatSessionParams{
-		WorkspaceID: parseUUID(workspaceID),
-		AgentID:     parseUUID(req.AgentID),
+		WorkspaceID: workspaceUUID,
+		AgentID:     agentID,
 		CreatorID:   parseUUID(userID),
 		Title:       req.Title,
 	})
@@ -126,6 +134,30 @@ func (h *Handler) ListChatSessions(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+func (h *Handler) loadChatSessionForUser(w http.ResponseWriter, r *http.Request, userID, workspaceID, sessionID string) (db.ChatSession, bool) {
+	sessionUUID, ok := parseUUIDOrBadRequest(w, sessionID, "chat session id")
+	if !ok {
+		return db.ChatSession{}, false
+	}
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return db.ChatSession{}, false
+	}
+	session, err := h.Queries.GetChatSessionInWorkspace(r.Context(), db.GetChatSessionInWorkspaceParams{
+		ID:          sessionUUID,
+		WorkspaceID: workspaceUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "chat session not found")
+		return db.ChatSession{}, false
+	}
+	if uuidToString(session.CreatorID) != userID {
+		writeError(w, http.StatusForbidden, "not your chat session")
+		return db.ChatSession{}, false
+	}
+	return session, true
+}
+
 func (h *Handler) GetChatSession(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(w, r)
 	if !ok {
@@ -134,16 +166,8 @@ func (h *Handler) GetChatSession(w http.ResponseWriter, r *http.Request) {
 	workspaceID := ctxWorkspaceID(r.Context())
 	sessionID := chi.URLParam(r, "sessionId")
 
-	session, err := h.Queries.GetChatSessionInWorkspace(r.Context(), db.GetChatSessionInWorkspaceParams{
-		ID:          parseUUID(sessionID),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "chat session not found")
-		return
-	}
-	if uuidToString(session.CreatorID) != userID {
-		writeError(w, http.StatusForbidden, "not your chat session")
+	session, ok := h.loadChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
 		return
 	}
 
@@ -158,20 +182,12 @@ func (h *Handler) ArchiveChatSession(w http.ResponseWriter, r *http.Request) {
 	workspaceID := ctxWorkspaceID(r.Context())
 	sessionID := chi.URLParam(r, "sessionId")
 
-	session, err := h.Queries.GetChatSessionInWorkspace(r.Context(), db.GetChatSessionInWorkspaceParams{
-		ID:          parseUUID(sessionID),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "chat session not found")
-		return
-	}
-	if uuidToString(session.CreatorID) != userID {
-		writeError(w, http.StatusForbidden, "not your chat session")
+	session, ok := h.loadChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
 		return
 	}
 
-	if err := h.Queries.ArchiveChatSession(r.Context(), parseUUID(sessionID)); err != nil {
+	if err := h.Queries.ArchiveChatSession(r.Context(), session.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to archive chat session")
 		return
 	}
@@ -211,20 +227,12 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Load chat session.
-	session, err := h.Queries.GetChatSessionInWorkspace(r.Context(), db.GetChatSessionInWorkspaceParams{
-		ID:          parseUUID(sessionID),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "chat session not found")
+	session, ok := h.loadChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
 		return
 	}
 	if session.Status != "active" {
 		writeError(w, http.StatusBadRequest, "chat session is archived")
-		return
-	}
-	if uuidToString(session.CreatorID) != userID {
-		writeError(w, http.StatusForbidden, "not your chat session")
 		return
 	}
 
@@ -252,8 +260,9 @@ func (h *Handler) SendChatMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Broadcast the user message.
-	h.publishChat(protocol.EventChatMessage, workspaceID, "member", userID, sessionID, protocol.ChatMessagePayload{
-		ChatSessionID: sessionID,
+	resolvedSessionID := uuidToString(session.ID)
+	h.publishChat(protocol.EventChatMessage, workspaceID, "member", userID, resolvedSessionID, protocol.ChatMessagePayload{
+		ChatSessionID: resolvedSessionID,
 		MessageID:     uuidToString(msg.ID),
 		Role:          "user",
 		Content:       req.Content,
@@ -275,20 +284,12 @@ func (h *Handler) ListChatMessages(w http.ResponseWriter, r *http.Request) {
 	workspaceID := ctxWorkspaceID(r.Context())
 	sessionID := chi.URLParam(r, "sessionId")
 
-	session, err := h.Queries.GetChatSessionInWorkspace(r.Context(), db.GetChatSessionInWorkspaceParams{
-		ID:          parseUUID(sessionID),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "chat session not found")
-		return
-	}
-	if uuidToString(session.CreatorID) != userID {
-		writeError(w, http.StatusForbidden, "not your chat session")
+	session, ok := h.loadChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
 		return
 	}
 
-	messages, err := h.Queries.ListChatMessages(r.Context(), parseUUID(sessionID))
+	messages, err := h.Queries.ListChatMessages(r.Context(), session.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list chat messages")
 		return
@@ -319,26 +320,19 @@ func (h *Handler) MarkChatSessionRead(w http.ResponseWriter, r *http.Request) {
 	workspaceID := ctxWorkspaceID(r.Context())
 	sessionID := chi.URLParam(r, "sessionId")
 
-	session, err := h.Queries.GetChatSessionInWorkspace(r.Context(), db.GetChatSessionInWorkspaceParams{
-		ID:          parseUUID(sessionID),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "chat session not found")
-		return
-	}
-	if uuidToString(session.CreatorID) != userID {
-		writeError(w, http.StatusForbidden, "not your chat session")
+	session, ok := h.loadChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
 		return
 	}
 
-	if err := h.Queries.MarkChatSessionRead(r.Context(), parseUUID(sessionID)); err != nil {
+	if err := h.Queries.MarkChatSessionRead(r.Context(), session.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to mark session read")
 		return
 	}
 
-	h.publishChat(protocol.EventChatSessionRead, workspaceID, "member", userID, sessionID, protocol.ChatSessionReadPayload{
-		ChatSessionID: sessionID,
+	resolvedSessionID := uuidToString(session.ID)
+	h.publishChat(protocol.EventChatSessionRead, workspaceID, "member", userID, resolvedSessionID, protocol.ChatSessionReadPayload{
+		ChatSessionID: resolvedSessionID,
 	})
 
 	w.WriteHeader(http.StatusNoContent)
@@ -396,20 +390,12 @@ func (h *Handler) GetPendingChatTask(w http.ResponseWriter, r *http.Request) {
 	workspaceID := ctxWorkspaceID(r.Context())
 	sessionID := chi.URLParam(r, "sessionId")
 
-	session, err := h.Queries.GetChatSessionInWorkspace(r.Context(), db.GetChatSessionInWorkspaceParams{
-		ID:          parseUUID(sessionID),
-		WorkspaceID: parseUUID(workspaceID),
-	})
-	if err != nil {
-		writeError(w, http.StatusNotFound, "chat session not found")
-		return
-	}
-	if uuidToString(session.CreatorID) != userID {
-		writeError(w, http.StatusForbidden, "not your chat session")
+	session, ok := h.loadChatSessionForUser(w, r, userID, workspaceID, sessionID)
+	if !ok {
 		return
 	}
 
-	task, err := h.Queries.GetPendingChatTask(r.Context(), parseUUID(sessionID))
+	task, err := h.Queries.GetPendingChatTask(r.Context(), session.ID)
 	if err != nil {
 		// No in-flight task — return an empty object, not an error.
 		writeJSON(w, http.StatusOK, PendingChatTaskResponse{})
@@ -435,8 +421,12 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 	}
 	workspaceID := ctxWorkspaceID(r.Context())
 	taskID := chi.URLParam(r, "taskId")
+	taskUUID, ok := parseUUIDOrBadRequest(w, taskID, "task id")
+	if !ok {
+		return
+	}
 
-	task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "task not found")
 		return
@@ -468,7 +458,7 @@ func (h *Handler) CancelTaskByUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cancelled, err := h.TaskService.CancelTask(r.Context(), parseUUID(taskID))
+	cancelled, err := h.TaskService.CancelTask(r.Context(), taskUUID)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -474,12 +474,20 @@ func (h *Handler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	commentUUID, ok := parseUUIDOrBadRequest(w, commentId, "comment id")
+	if !ok {
+		return
+	}
 
 	// Load comment scoped to current workspace.
 	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	existing, err := h.Queries.GetCommentInWorkspace(r.Context(), db.GetCommentInWorkspaceParams{
-		ID:          parseUUID(commentId),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          commentUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "comment not found")
@@ -514,7 +522,7 @@ func (h *Handler) UpdateComment(w http.ResponseWriter, r *http.Request) {
 	// NOTE: See CreateComment — Markdown is sanitized at render/edit time, not here.
 
 	comment, err := h.Queries.UpdateComment(r.Context(), db.UpdateCommentParams{
-		ID:      parseUUID(commentId),
+		ID:      commentUUID,
 		Content: req.Content,
 	})
 	if err != nil {

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -203,13 +203,23 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	var parentID pgtype.UUID
 	var parentComment *db.Comment
 	if req.ParentID != nil {
-		parentID = parseUUID(*req.ParentID)
+		var parsed pgtype.UUID
+		parsed, ok = parseUUIDOrBadRequest(w, *req.ParentID, "parent_id")
+		if !ok {
+			return
+		}
+		parentID = parsed
 		parent, err := h.Queries.GetComment(r.Context(), parentID)
-		if err != nil || uuidToString(parent.IssueID) != issueID {
+		if err != nil || uuidToString(parent.IssueID) != uuidToString(issue.ID) {
 			writeError(w, http.StatusBadRequest, "invalid parent comment")
 			return
 		}
 		parentComment = &parent
+	}
+
+	attachmentIDs, ok := parseUUIDSliceOrBadRequest(w, req.AttachmentIDs, "attachment_ids")
+	if !ok {
+		return
 	}
 
 	// Determine author identity: agent (via X-Agent-ID header) or member.
@@ -227,12 +237,15 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	// tasks (no TriggerCommentID) are also unaffected.
 	if authorType == "agent" {
 		if taskIDHeader := r.Header.Get("X-Task-ID"); taskIDHeader != "" {
-			task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskIDHeader))
-			if err == nil && task.TriggerCommentID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
-				if uuidToString(parentID) != uuidToString(task.TriggerCommentID) {
-					writeError(w, http.StatusConflict,
-						"parent_id must equal this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+")")
-					return
+			taskUUID, parseErr := util.ParseUUID(taskIDHeader)
+			if parseErr == nil {
+				task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
+				if err == nil && task.TriggerCommentID.Valid && uuidToString(task.IssueID) == uuidToString(issue.ID) {
+					if uuidToString(parentID) != uuidToString(task.TriggerCommentID) {
+						writeError(w, http.StatusConflict,
+							"parent_id must equal this task's trigger comment id ("+uuidToString(task.TriggerCommentID)+")")
+						return
+					}
 				}
 			}
 		}
@@ -263,8 +276,8 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Link uploaded attachments to this comment.
-	if len(req.AttachmentIDs) > 0 {
-		h.linkAttachmentsByIDs(r.Context(), comment.ID, issue.ID, req.AttachmentIDs)
+	if len(attachmentIDs) > 0 {
+		h.linkAttachmentsByIDs(r.Context(), comment.ID, issue.ID, attachmentIDs)
 	}
 
 	// Fetch linked attachments so the response includes them.

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -528,11 +528,20 @@ func (h *Handler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	commentUUID, ok := parseUUIDOrBadRequest(w, commentId, "comment id")
+	if !ok {
+		return
+	}
+
 	// Load comment scoped to current workspace.
 	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	comment, err := h.Queries.GetCommentInWorkspace(r.Context(), db.GetCommentInWorkspaceParams{
-		ID:          parseUUID(commentId),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          commentUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "comment not found")
@@ -553,9 +562,9 @@ func (h *Handler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Collect attachment URLs before CASCADE delete removes them.
-	attachmentURLs, _ := h.Queries.ListAttachmentURLsByCommentID(r.Context(), parseUUID(commentId))
+	attachmentURLs, _ := h.Queries.ListAttachmentURLsByCommentID(r.Context(), comment.ID)
 
-	if err := h.Queries.DeleteComment(r.Context(), parseUUID(commentId)); err != nil {
+	if err := h.Queries.DeleteComment(r.Context(), comment.ID); err != nil {
 		slog.Warn("delete comment failed", append(logger.RequestAttrs(r), "error", err, "comment_id", commentId)...)
 		writeError(w, http.StatusInternalServerError, "failed to delete comment")
 		return
@@ -564,7 +573,7 @@ func (h *Handler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 	h.deleteS3Objects(r.Context(), attachmentURLs)
 	slog.Info("comment deleted", append(logger.RequestAttrs(r), "comment_id", commentId, "issue_id", uuidToString(comment.IssueID))...)
 	h.publish(protocol.EventCommentDeleted, workspaceID, actorType, actorID, map[string]any{
-		"comment_id": commentId,
+		"comment_id": uuidToString(comment.ID),
 		"issue_id":   uuidToString(comment.IssueID),
 	})
 	w.WriteHeader(http.StatusNoContent)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -457,13 +457,17 @@ func (h *Handler) DaemonDeregister(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "runtime_ids is required")
 		return
 	}
+	runtimeUUIDs, ok := parseUUIDSliceOrBadRequest(w, req.RuntimeIDs, "runtime_ids")
+	if !ok {
+		return
+	}
 
 	// Track affected workspaces for WS notifications.
 	affectedWorkspaces := make(map[string]bool)
 
-	for _, rid := range req.RuntimeIDs {
+	for i, rid := range req.RuntimeIDs {
 		// Look up the runtime and verify ownership.
-		rt, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(rid))
+		rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUIDs[i])
 		if err != nil {
 			slog.Warn("deregister: runtime not found", "runtime_id", rid, "error", err)
 			continue
@@ -475,7 +479,7 @@ func (h *Handler) DaemonDeregister(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		if err := h.Queries.SetAgentRuntimeOffline(r.Context(), parseUUID(rid)); err != nil {
+		if err := h.Queries.SetAgentRuntimeOffline(r.Context(), rt.ID); err != nil {
 			slog.Warn("deregister: failed to set offline", "runtime_id", rid, "error", err)
 			continue
 		}
@@ -1463,7 +1467,11 @@ func (h *Handler) GetIssueUsage(w http.ResponseWriter, r *http.Request) {
 // read issue metadata from workspace B via UUID enumeration.
 func (h *Handler) GetIssueGCCheck(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "issueId")
-	issue, err := h.Queries.GetIssue(r.Context(), parseUUID(issueID))
+	issueUUID, ok := parseUUIDOrBadRequest(w, issueID, "issue_id")
+	if !ok {
+		return
+	}
+	issue, err := h.Queries.GetIssue(r.Context(), issueUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "issue not found")
 		return

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -218,6 +218,11 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "at least one runtime is required")
 		return
 	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, req.WorkspaceID, "workspace_id")
+	if !ok {
+		return
+	}
+	req.WorkspaceID = uuidToString(wsUUID)
 
 	// Verify workspace access and resolve owner.
 	// Daemon tokens (mdt_) prove workspace access directly; OwnerID will be zero
@@ -238,7 +243,7 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 		ownerID = member.UserID
 	}
 
-	ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(req.WorkspaceID))
+	ws, err := h.Queries.GetWorkspace(r.Context(), wsUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "workspace not found")
 		return
@@ -274,7 +279,7 @@ func (h *Handler) DaemonRegister(w http.ResponseWriter, r *http.Request) {
 		})
 
 		row, err := h.Queries.UpsertAgentRuntime(r.Context(), db.UpsertAgentRuntimeParams{
-			WorkspaceID: parseUUID(req.WorkspaceID),
+			WorkspaceID: wsUUID,
 			DaemonID:    strToText(req.DaemonID),
 			Name:        name,
 			RuntimeMode: "local",

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -52,7 +52,11 @@ func (h *Handler) requireDaemonWorkspaceAccess(w http.ResponseWriter, r *http.Re
 
 // requireDaemonRuntimeAccess looks up a runtime and verifies the caller owns its workspace.
 func (h *Handler) requireDaemonRuntimeAccess(w http.ResponseWriter, r *http.Request, runtimeID string) (db.AgentRuntime, bool) {
-	rt, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(runtimeID))
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return db.AgentRuntime{}, false
+	}
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "runtime not found")
 		return db.AgentRuntime{}, false
@@ -65,7 +69,11 @@ func (h *Handler) requireDaemonRuntimeAccess(w http.ResponseWriter, r *http.Requ
 
 // requireDaemonTaskAccess looks up a task and verifies the caller owns its workspace.
 func (h *Handler) requireDaemonTaskAccess(w http.ResponseWriter, r *http.Request, taskID string) (db.AgentTaskQueue, bool) {
-	task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	taskUUID, ok := parseUUIDOrBadRequest(w, taskID, "task_id")
+	if !ok {
+		return db.AgentTaskQueue{}, false
+	}
+	task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "task not found")
 		return db.AgentTaskQueue{}, false
@@ -524,13 +532,14 @@ func (h *Handler) DaemonHeartbeat(w http.ResponseWriter, r *http.Request) {
 	runtimeID = req.RuntimeID
 
 	// Verify the caller owns this runtime's workspace.
-	if _, ok := h.requireDaemonRuntimeAccess(w, r, req.RuntimeID); !ok {
+	rt, ok := h.requireDaemonRuntimeAccess(w, r, req.RuntimeID)
+	if !ok {
 		return
 	}
 	authMs = time.Since(start).Milliseconds()
 
 	updateStart := time.Now()
-	_, err := h.Queries.UpdateAgentRuntimeHeartbeat(r.Context(), parseUUID(req.RuntimeID))
+	_, err := h.Queries.UpdateAgentRuntimeHeartbeat(r.Context(), rt.ID)
 	updateMs = time.Since(updateStart).Milliseconds()
 	if err != nil {
 		outcome = "error_update"

--- a/server/internal/handler/feedback.go
+++ b/server/internal/handler/feedback.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/logger"
 	"github.com/multica-ai/multica/server/internal/middleware"
@@ -93,9 +94,13 @@ func (h *Handler) CreateFeedback(w http.ResponseWriter, r *http.Request) {
 		metaBytes = []byte("{}")
 	}
 
-	var workspaceID = parseUUID("")
+	var workspaceID pgtype.UUID
 	if req.WorkspaceID != nil && *req.WorkspaceID != "" {
-		workspaceID = parseUUID(*req.WorkspaceID)
+		ws, ok := parseUUIDOrBadRequest(w, *req.WorkspaceID, "workspace_id")
+		if !ok {
+			return
+		}
+		workspaceID = ws
 	}
 
 	fb, err := h.Queries.CreateFeedback(r.Context(), db.CreateFeedbackParams{

--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -188,8 +188,12 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if issueID := r.FormValue("issue_id"); issueID != "" {
+			issueUUID, ok := parseUUIDOrBadRequest(w, issueID, "issue_id")
+			if !ok {
+				return
+			}
 			issue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
-				ID:          parseUUID(issueID),
+				ID:          issueUUID,
 				WorkspaceID: parseUUID(workspaceID),
 			})
 			if err != nil {
@@ -199,7 +203,11 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 			params.IssueID = issue.ID
 		}
 		if commentID := r.FormValue("comment_id"); commentID != "" {
-			comment, err := h.Queries.GetComment(r.Context(), parseUUID(commentID))
+			commentUUID, ok := parseUUIDOrBadRequest(w, commentID, "comment_id")
+			if !ok {
+				return
+			}
+			comment, err := h.Queries.GetComment(r.Context(), commentUUID)
 			if err != nil || uuidToString(comment.WorkspaceID) != workspaceID {
 				writeError(w, http.StatusForbidden, "invalid comment_id")
 				return
@@ -285,9 +293,18 @@ func (h *Handler) GetAttachmentByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	attUUID, ok := parseUUIDOrBadRequest(w, attachmentID, "attachment id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
 	att, err := h.Queries.GetAttachment(r.Context(), db.GetAttachmentParams{
-		ID:          parseUUID(attachmentID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          attUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "attachment not found")
@@ -362,15 +379,11 @@ func (h *Handler) DeleteAttachment(w http.ResponseWriter, r *http.Request) {
 
 // linkAttachmentsByIssueIDs links the given attachment IDs to an issue.
 // Only updates attachments that have no issue_id yet.
-func (h *Handler) linkAttachmentsByIssueIDs(ctx context.Context, issueID, workspaceID pgtype.UUID, ids []string) {
-	uuids := make([]pgtype.UUID, len(ids))
-	for i, id := range ids {
-		uuids[i] = parseUUID(id)
-	}
+func (h *Handler) linkAttachmentsByIssueIDs(ctx context.Context, issueID, workspaceID pgtype.UUID, ids []pgtype.UUID) {
 	if err := h.Queries.LinkAttachmentsToIssue(ctx, db.LinkAttachmentsToIssueParams{
 		IssueID:     issueID,
 		WorkspaceID: workspaceID,
-		Column3:     uuids,
+		Column3:     ids,
 	}); err != nil {
 		slog.Error("failed to link attachments to issue", "error", err)
 	}
@@ -378,15 +391,11 @@ func (h *Handler) linkAttachmentsByIssueIDs(ctx context.Context, issueID, worksp
 
 // linkAttachmentsByIDs links the given attachment IDs to a comment.
 // Only updates attachments that belong to the same issue and have no comment_id yet.
-func (h *Handler) linkAttachmentsByIDs(ctx context.Context, commentID, issueID pgtype.UUID, ids []string) {
-	uuids := make([]pgtype.UUID, len(ids))
-	for i, id := range ids {
-		uuids[i] = parseUUID(id)
-	}
+func (h *Handler) linkAttachmentsByIDs(ctx context.Context, commentID, issueID pgtype.UUID, ids []pgtype.UUID) {
 	if err := h.Queries.LinkAttachmentsToComment(ctx, db.LinkAttachmentsToCommentParams{
 		CommentID: commentID,
 		IssueID:   issueID,
-		Column3:   uuids,
+		Column3:   ids,
 	}); err != nil {
 		slog.Error("failed to link attachments to comment", "error", err)
 	}

--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -314,9 +314,18 @@ func (h *Handler) DeleteAttachment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	attUUID, ok := parseUUIDOrBadRequest(w, attachmentID, "attachment id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
 	att, err := h.Queries.GetAttachment(r.Context(), db.GetAttachmentParams{
-		ID:          parseUUID(attachmentID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          attUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "attachment not found")

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -145,6 +145,19 @@ func parseUUIDOrBadRequest(w http.ResponseWriter, s, fieldName string) (pgtype.U
 	return u, true
 }
 
+func parseUUIDSliceOrBadRequest(w http.ResponseWriter, ids []string, fieldName string) ([]pgtype.UUID, bool) {
+	uuids := make([]pgtype.UUID, len(ids))
+	for i, id := range ids {
+		u, err := util.ParseUUID(id)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid "+fieldName)
+			return nil, false
+		}
+		uuids[i] = u
+	}
+	return uuids, true
+}
+
 // publish sends a domain event through the event bus.
 func (h *Handler) publish(eventType, workspaceID, actorType, actorID string, payload any) {
 	h.Bus.Publish(events.Event{

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -369,9 +369,17 @@ func (h *Handler) isWorkspaceEntity(ctx context.Context, userType, userID, works
 		_, err := h.getWorkspaceMember(ctx, userID, workspaceID)
 		return err == nil
 	case "agent":
-		_, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
-			ID:          parseUUID(userID),
-			WorkspaceID: parseUUID(workspaceID),
+		userUUID, err := util.ParseUUID(userID)
+		if err != nil {
+			return false
+		}
+		wsUUID, err := util.ParseUUID(workspaceID)
+		if err != nil {
+			return false
+		}
+		_, err = h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+			ID:          userUUID,
+			WorkspaceID: wsUUID,
 		})
 		return err == nil
 	default:
@@ -530,9 +538,18 @@ func (h *Handler) loadInboxItemForUser(w http.ResponseWriter, r *http.Request, i
 		return db.InboxItem{}, false
 	}
 
+	itemUUID, ok := parseUUIDOrBadRequest(w, itemID, "inbox item id")
+	if !ok {
+		return db.InboxItem{}, false
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return db.InboxItem{}, false
+	}
+
 	item, err := h.Queries.GetInboxItemInWorkspace(r.Context(), db.GetInboxItemInWorkspaceParams{
-		ID:          parseUUID(itemID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          itemUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "inbox item not found")

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -498,9 +498,18 @@ func (h *Handler) loadAgentForUser(w http.ResponseWriter, r *http.Request, agent
 		return db.Agent{}, false
 	}
 
+	agentUUID, ok := parseUUIDOrBadRequest(w, agentID, "agent id")
+	if !ok {
+		return db.Agent{}, false
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return db.Agent{}, false
+	}
+
 	agent, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
-		ID:          parseUUID(agentID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          agentUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "agent not found")

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -206,8 +206,13 @@ func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (act
 		return "member", userID
 	}
 
+	agentUUID, err := util.ParseUUID(agentID)
+	if err != nil {
+		slog.Debug("resolveActor: X-Agent-ID is not a valid UUID, falling back to member", "agent_id", agentID)
+		return "member", userID
+	}
 	// Validate the agent exists in the target workspace.
-	agent, err := h.Queries.GetAgent(r.Context(), parseUUID(agentID))
+	agent, err := h.Queries.GetAgent(r.Context(), agentUUID)
 	if err != nil || uuidToString(agent.WorkspaceID) != workspaceID {
 		slog.Debug("resolveActor: X-Agent-ID rejected, agent not found or workspace mismatch", "agent_id", agentID, "workspace_id", workspaceID)
 		return "member", userID
@@ -215,7 +220,12 @@ func (h *Handler) resolveActor(r *http.Request, userID, workspaceID string) (act
 
 	// When X-Task-ID is provided, cross-check that the task belongs to this agent.
 	if taskID := r.Header.Get("X-Task-ID"); taskID != "" {
-		task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+		taskUUID, err := util.ParseUUID(taskID)
+		if err != nil {
+			slog.Debug("resolveActor: X-Task-ID is not a valid UUID, falling back to member", "task_id", taskID)
+			return "member", userID
+		}
+		task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 		if err != nil || uuidToString(task.AgentID) != agentID {
 			slog.Debug("resolveActor: X-Task-ID rejected, task not found or agent mismatch", "agent_id", agentID, "task_id", taskID)
 			return "member", userID

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -108,8 +108,19 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
 }
 
-// Thin wrappers around util functions (preserve existing handler code unchanged).
-func parseUUID(s string) pgtype.UUID                { return util.ParseUUID(s) }
+// Thin wrappers around util functions.
+//
+// parseUUID is intentionally the panicking variant: any handler call site
+// reachable here is expected to feed a UUID that is either (a) a sqlc round-trip
+// of a DB-sourced value, or (b) a raw request input that has already been
+// validated upstream. A panic here means an unguarded user-input string slipped
+// in — that is a real bug we want surfaced loudly (chi's middleware.Recoverer
+// converts it to a 500) instead of silently corrupting data via a zero UUID.
+//
+// For unvalidated user input at request boundaries, use parseUUIDOrBadRequest
+// (writes 400) — never feed raw chi.URLParam / request-body strings into
+// parseUUID directly when the call writes to the database.
+func parseUUID(s string) pgtype.UUID                { return util.MustParseUUID(s) }
 func uuidToString(u pgtype.UUID) string             { return util.UUIDToString(u) }
 func textToPtr(t pgtype.Text) *string               { return util.TextToPtr(t) }
 func ptrToText(s *string) pgtype.Text               { return util.PtrToText(s) }
@@ -117,6 +128,22 @@ func strToText(s string) pgtype.Text                { return util.StrToText(s) }
 func timestampToString(t pgtype.Timestamptz) string { return util.TimestampToString(t) }
 func timestampToPtr(t pgtype.Timestamptz) *string   { return util.TimestampToPtr(t) }
 func uuidToPtr(u pgtype.UUID) *string               { return util.UUIDToPtr(u) }
+
+// parseUUIDOrBadRequest validates a UUID string sourced from user input
+// (URL params, request body, headers). On invalid input it writes a 400
+// response and returns ok=false; callers must return immediately.
+//
+// Use this anywhere a malformed UUID would otherwise reach a write query
+// (DELETE / UPDATE) — the silent zero-UUID behavior of the old ParseUUID
+// caused real silent-data-loss bugs (#1661).
+func parseUUIDOrBadRequest(w http.ResponseWriter, s, fieldName string) (pgtype.UUID, bool) {
+	u, err := util.ParseUUID(s)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid "+fieldName)
+		return pgtype.UUID{}, false
+	}
+	return u, true
+}
 
 // publish sends a domain event through the event bus.
 func (h *Handler) publish(eventType, workspaceID, actorType, actorID string, payload any) {
@@ -265,9 +292,17 @@ func countOwners(members []db.Member) int {
 }
 
 func (h *Handler) getWorkspaceMember(ctx context.Context, userID, workspaceID string) (db.Member, error) {
+	userUUID, err := util.ParseUUID(userID)
+	if err != nil {
+		return db.Member{}, err
+	}
+	wsUUID, err := util.ParseUUID(workspaceID)
+	if err != nil {
+		return db.Member{}, err
+	}
 	return h.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
-		UserID:      parseUUID(userID),
-		WorkspaceID: parseUUID(workspaceID),
+		UserID:      userUUID,
+		WorkspaceID: wsUUID,
 	})
 }
 
@@ -332,14 +367,28 @@ func (h *Handler) loadIssueForUser(w http.ResponseWriter, r *http.Request, issue
 		return db.Issue{}, false
 	}
 
-	// Try identifier format first (e.g., "JIA-42").
+	// Try identifier format first (e.g., "JIA-42"). resolveIssueByIdentifier
+	// silently returns false for non-identifier strings, falling through to
+	// the UUID path below.
 	if issue, ok := h.resolveIssueByIdentifier(r.Context(), issueID, workspaceID); ok {
 		return issue, true
 	}
 
+	issueUUID, err := util.ParseUUID(issueID)
+	if err != nil {
+		// Not a valid UUID and didn't match identifier format → 404 (consistent
+		// with previous silent-zero behavior, which would also have produced 404).
+		writeError(w, http.StatusNotFound, "issue not found")
+		return db.Issue{}, false
+	}
+	wsUUID, err := util.ParseUUID(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid workspace_id")
+		return db.Issue{}, false
+	}
 	issue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
-		ID:          parseUUID(issueID),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          issueUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "issue not found")
@@ -357,8 +406,12 @@ func (h *Handler) resolveIssueByIdentifier(ctx context.Context, id, workspaceID 
 	if workspaceID == "" {
 		return db.Issue{}, false
 	}
+	wsUUID, err := util.ParseUUID(workspaceID)
+	if err != nil {
+		return db.Issue{}, false
+	}
 	issue, err := h.Queries.GetIssueByNumber(ctx, db.GetIssueByNumberParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		Number:      parts.number,
 	})
 	if err != nil {

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1016,6 +1016,94 @@ func TestCreatePinRejectsMalformedItemID(t *testing.T) {
 	}
 }
 
+func TestUpdateWorkspaceRejectsMalformedID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/workspaces/not-a-uuid", map[string]any{
+		"name": "Malformed workspace id",
+	})
+	req = withURLParam(req, "id", "not-a-uuid")
+	testHandler.UpdateWorkspace(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateWorkspace: expected 400 for malformed id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateMemberRejectsMalformedMemberID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/members/not-a-uuid", map[string]any{
+		"role": "member",
+	})
+	req = withURLParams(req, "id", testWorkspaceID, "memberId", "not-a-uuid")
+	testHandler.UpdateMember(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateMember: expected 400 for malformed memberId, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRevokeInvitationRejectsMalformedInvitationID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/invitations/not-a-uuid", nil)
+	req = withURLParams(req, "id", testWorkspaceID, "invitationId", "not-a-uuid")
+	testHandler.RevokeInvitation(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("RevokeInvitation: expected 400 for malformed invitationId, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMyInvitationRejectsMalformedID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/invitations/not-a-uuid", nil)
+	req = withURLParam(req, "id", "not-a-uuid")
+	testHandler.GetMyInvitation(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("GetMyInvitation: expected 400 for malformed id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAddReactionRejectsMalformedCommentID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/comments/not-a-uuid/reactions", map[string]any{
+		"emoji": "thumbs_up",
+	})
+	req = withURLParam(req, "commentId", "not-a-uuid")
+	testHandler.AddReaction(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("AddReaction: expected 400 for malformed commentId, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateCommentRejectsMalformedCommentID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/comments/not-a-uuid", map[string]any{
+		"content": "updated",
+	})
+	req = withURLParam(req, "commentId", "not-a-uuid")
+	testHandler.UpdateComment(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateComment: expected 400 for malformed commentId, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMarkInboxReadRejectsMalformedItemID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/inbox/not-a-uuid/read", nil)
+	req = withURLParam(req, "id", "not-a-uuid")
+	testHandler.MarkInboxRead(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("MarkInboxRead: expected 400 for malformed id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRevokePersonalAccessTokenRejectsMalformedID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/tokens/not-a-uuid", nil)
+	req = withURLParam(req, "id", "not-a-uuid")
+	testHandler.RevokePersonalAccessToken(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("RevokePersonalAccessToken: expected 400 for malformed id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAgentCRUD(t *testing.T) {
 	// List agents
 	w := httptest.NewRecorder()

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -729,6 +729,31 @@ func TestCreateIssueRejectsMalformedAssigneeID(t *testing.T) {
 	}
 }
 
+func TestCreateIssueRejectsMalformedAttachmentIDBeforeWrite(t *testing.T) {
+	var before int
+	if err := testPool.QueryRow(context.Background(), `SELECT count(*) FROM issue WHERE workspace_id = $1`, testWorkspaceID).Scan(&before); err != nil {
+		t.Fatalf("count issues before: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":          "Malformed attachment issue",
+		"attachment_ids": []string{"not-a-uuid"},
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CreateIssue: expected 400 for malformed attachment_ids, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var after int
+	if err := testPool.QueryRow(context.Background(), `SELECT count(*) FROM issue WHERE workspace_id = $1`, testWorkspaceID).Scan(&after); err != nil {
+		t.Fatalf("count issues after: %v", err)
+	}
+	if after != before {
+		t.Fatalf("CreateIssue: malformed attachment_ids should not create issue, count before=%d after=%d", before, after)
+	}
+}
+
 // TestUpdateIssueRejectsMalformedAssigneeID is the equivalent for the update
 // path, where the same parseUUID-shaped gap existed on a previously-unassigned
 // issue.
@@ -875,6 +900,45 @@ func TestCommentCRUD(t *testing.T) {
 	req = newRequest("DELETE", "/api/issues/"+issueID, nil)
 	req = withURLParam(req, "id", issueID)
 	testHandler.DeleteIssue(w, req)
+}
+
+func TestCreateCommentRejectsMalformedParentID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Comment malformed parent issue",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var issue IssueResponse
+	json.NewDecoder(w.Body).Decode(&issue)
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/issues/"+issue.ID+"/comments", map[string]any{
+		"content":   "bad parent",
+		"parent_id": "not-a-uuid",
+	})
+	req = withURLParam(req, "id", issue.ID)
+	testHandler.CreateComment(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CreateComment: expected 400 for malformed parent_id, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("DELETE", "/api/issues/"+issue.ID, nil)
+	req = withURLParam(req, "id", issue.ID)
+	testHandler.DeleteIssue(w, req)
+}
+
+func TestGetChatSessionRejectsMalformedSessionID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/chat/sessions/not-a-uuid", nil)
+	req = withURLParam(req, "sessionId", "not-a-uuid")
+	testHandler.GetChatSession(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("GetChatSession: expected 400 for malformed sessionId, got %d: %s", w.Code, w.Body.String())
+	}
 }
 
 func TestAgentCRUD(t *testing.T) {
@@ -1126,7 +1190,7 @@ func TestSendCodeDbError(t *testing.T) {
 	// We can't easily mock the DB here without changing architecture,
 	// but we can simulate a DB error by closing the pool temporarily or
 	// using a cancelled context if the query respects it.
-	
+
 	// Create a handler with a "broken" queries object is hard because it's a struct.
 	// Instead, let's use a context that is already cancelled.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1141,13 +1205,13 @@ func TestSendCodeDbError(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	testHandler.SendCode(w, req)
-	
+
 	// If the DB query respects the cancelled context, it should return an error.
 	// pgx usually returns context.Canceled which is not what isNotFound checks for.
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("SendCode (db error): expected 500, got %d: %s", w.Code, w.Body.String())
 	}
-	
+
 	var resp map[string]string
 	json.NewDecoder(w.Body).Decode(&resp)
 	if resp["error"] != "failed to lookup user" {

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -941,6 +941,81 @@ func TestGetChatSessionRejectsMalformedSessionID(t *testing.T) {
 	}
 }
 
+func TestCreateAutopilotRejectsMalformedAssigneeID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/autopilots", map[string]any{
+		"title":          "Malformed assignee autopilot",
+		"assignee_id":    "not-a-uuid",
+		"execution_mode": "run_only",
+	})
+	testHandler.CreateAutopilot(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CreateAutopilot: expected 400 for malformed assignee_id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAutopilotRejectsMalformedID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/autopilots/not-a-uuid", map[string]any{
+		"title": "Malformed autopilot id",
+	})
+	req = withURLParam(req, "id", "not-a-uuid")
+	testHandler.UpdateAutopilot(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateAutopilot: expected 400 for malformed id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAgentRejectsMalformedAgentID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/agents/not-a-uuid", map[string]any{
+		"name": "Malformed agent id",
+	})
+	req = withURLParam(req, "id", "not-a-uuid")
+	testHandler.UpdateAgent(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateAgent: expected 400 for malformed id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateAgentRejectsMalformedRuntimeID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents", map[string]any{
+		"name":       "Malformed runtime agent",
+		"runtime_id": "not-a-uuid",
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CreateAgent: expected 400 for malformed runtime_id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateAgentRejectsMalformedRuntimeID(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "Handler Malformed Runtime Update", nil)
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/agents/"+agentID, map[string]any{
+		"runtime_id": "not-a-uuid",
+	})
+	req = withURLParam(req, "id", agentID)
+	testHandler.UpdateAgent(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("UpdateAgent: expected 400 for malformed runtime_id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreatePinRejectsMalformedItemID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/pins", map[string]any{
+		"item_type": "issue",
+		"item_id":   "not-a-uuid",
+	})
+	testHandler.CreatePin(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CreatePin: expected 400 for malformed item_id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAgentCRUD(t *testing.T) {
 	// List agents
 	w := httptest.NewRecorder()

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -18,6 +19,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/realtime"
 	"github.com/multica-ai/multica/server/internal/service"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
+	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
 var testHandler *Handler
@@ -335,6 +337,10 @@ func TestIssueCRUD(t *testing.T) {
 // identifier ("HAN-42") rather than a UUID. Before the PR #1680 + MUL-1410
 // refactor, parseUUID(rawString) silently produced a zero UUID, the SQL
 // DELETE matched nothing, and the handler still returned 204.
+//
+// Also asserts the issue:deleted WS event payload carries the resolved UUID,
+// not the raw identifier — frontend caches key by UUID and would otherwise
+// leave stale entries on other clients after an identifier-path delete.
 func TestDeleteIssueByIdentifier(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
@@ -351,6 +357,17 @@ func TestDeleteIssueByIdentifier(t *testing.T) {
 	if created.Identifier == "" {
 		t.Fatalf("CreateIssue: expected identifier to be populated, got empty")
 	}
+
+	// Capture the issue:deleted event payload via the bus.
+	gotPayload := make(chan map[string]any, 1)
+	testHandler.Bus.Subscribe(protocol.EventIssueDeleted, func(e events.Event) {
+		if payload, ok := e.Payload.(map[string]any); ok {
+			select {
+			case gotPayload <- payload:
+			default:
+			}
+		}
+	})
 
 	// Delete using the human-readable identifier (e.g. "HAN-1") rather than the UUID.
 	w = httptest.NewRecorder()
@@ -371,6 +388,17 @@ func TestDeleteIssueByIdentifier(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("DeleteIssue by identifier returned 204 but row still exists (count=%d) — silent-data-loss regression", count)
+	}
+
+	// Event payload must carry the resolved UUID, not the identifier string.
+	select {
+	case payload := <-gotPayload:
+		issueID, _ := payload["issue_id"].(string)
+		if issueID != created.ID {
+			t.Fatalf("issue:deleted event payload issue_id = %q; want resolved UUID %q (must not leak identifier %q)", issueID, created.ID, created.Identifier)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive issue:deleted event within timeout")
 	}
 }
 

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1144,6 +1144,41 @@ func TestRequestBodyUUIDFieldsRejectMalformed(t *testing.T) {
 	}
 }
 
+func TestDaemonDeregisterRejectsMalformedRuntimeID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/daemon/deregister", map[string]any{
+		"runtime_ids": []string{"not-a-uuid"},
+	})
+	testHandler.DaemonDeregister(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("DaemonDeregister: expected 400 for malformed runtime_ids, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetIssueGCCheckRejectsMalformedIssueID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/daemon/issues/not-a-uuid/gc-check", nil)
+	req = withURLParam(req, "issueId", "not-a-uuid")
+	testHandler.GetIssueGCCheck(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("GetIssueGCCheck: expected 400 for malformed issueId, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSetAgentSkillsRejectsMalformedSkillID(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "Handler Malformed Skill Assignment", nil)
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/agents/"+agentID+"/skills", map[string]any{
+		"skill_ids": []string{"not-a-uuid"},
+	})
+	req = withURLParam(req, "id", agentID)
+	testHandler.SetAgentSkills(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("SetAgentSkills: expected 400 for malformed skill_ids, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestAgentCRUD(t *testing.T) {
 	// List agents
 	w := httptest.NewRecorder()

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -330,6 +330,66 @@ func TestIssueCRUD(t *testing.T) {
 	}
 }
 
+// TestDeleteIssueByIdentifier guards against #1661 — DELETE /api/issues/{id}
+// must actually delete the row when the path segment is a human-readable
+// identifier ("HAN-42") rather than a UUID. Before the PR #1680 + MUL-1410
+// refactor, parseUUID(rawString) silently produced a zero UUID, the SQL
+// DELETE matched nothing, and the handler still returned 204.
+func TestDeleteIssueByIdentifier(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":    "Issue to delete by identifier",
+		"status":   "todo",
+		"priority": "medium",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+	if created.Identifier == "" {
+		t.Fatalf("CreateIssue: expected identifier to be populated, got empty")
+	}
+
+	// Delete using the human-readable identifier (e.g. "HAN-1") rather than the UUID.
+	w = httptest.NewRecorder()
+	req = newRequest("DELETE", "/api/issues/"+created.Identifier, nil)
+	req = withURLParam(req, "id", created.Identifier)
+	testHandler.DeleteIssue(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DeleteIssue by identifier: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the row is actually gone — the silent-data-loss bug would have
+	// returned 204 here too, but the row would still exist.
+	var count int
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM issue WHERE id = $1`, created.ID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("DeleteIssue by identifier returned 204 but row still exists (count=%d) — silent-data-loss regression", count)
+	}
+}
+
+// TestDeleteIssueRejectsInvalidUUID verifies that a path segment that is
+// neither a valid UUID nor a valid identifier returns 404 (not 204) — the
+// handler must never silently succeed on malformed input.
+func TestDeleteIssueRejectsInvalidUUID(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/issues/not-a-uuid-or-identifier", nil)
+	req = withURLParam(req, "id", "not-a-uuid-or-identifier")
+	testHandler.DeleteIssue(w, req)
+	if w.Code == http.StatusNoContent {
+		t.Fatalf("DeleteIssue with invalid id: must not return 204; got %d", w.Code)
+	}
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("DeleteIssue with invalid id: expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestCreateIssueDefaultStatusIsTodo verifies that issues created without an
 // explicit status default to "todo" so the daemon picks them up immediately.
 // Before this fix the default was "backlog", which daemons ignore.

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1104,6 +1104,46 @@ func TestRevokePersonalAccessTokenRejectsMalformedID(t *testing.T) {
 	}
 }
 
+func TestRequestBodyUUIDFieldsRejectMalformed(t *testing.T) {
+	tests := []struct {
+		name   string
+		req    *http.Request
+		handle func(http.ResponseWriter, *http.Request)
+	}{
+		{
+			name: "daemon register workspace_id",
+			req: newRequest("POST", "/api/daemon/register", map[string]any{
+				"workspace_id": "not-a-uuid",
+				"daemon_id":    "daemon-malformed-workspace",
+				"runtimes": []map[string]any{
+					{"name": "codex", "type": "codex", "status": "online"},
+				},
+			}),
+			handle: testHandler.DaemonRegister,
+		},
+		{
+			name: "import starter content workspace_id",
+			req: newRequest("POST", "/api/onboarding/starter-content/import", map[string]any{
+				"workspace_id": "not-a-uuid",
+				"project": map[string]any{
+					"title": "Getting Started",
+				},
+			}),
+			handle: testHandler.ImportStarterContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			tt.handle(w, tt.req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("%s: expected 400 for malformed body UUID, got %d: %s", tt.name, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestAgentCRUD(t *testing.T) {
 	// List agents
 	w := httptest.NewRecorder()

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -91,9 +91,13 @@ func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaceID := ctxWorkspaceID(r.Context())
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
 	items, err := h.Queries.ListInboxItems(r.Context(), db.ListInboxItemsParams{
-		WorkspaceID:   parseUUID(workspaceID),
+		WorkspaceID:   wsUUID,
 		RecipientType: "member",
 		RecipientID:   parseUUID(userID),
 	})
@@ -112,10 +116,11 @@ func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) MarkInboxRead(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if _, ok := h.loadInboxItemForUser(w, r, id); !ok {
+	prev, ok := h.loadInboxItemForUser(w, r, id)
+	if !ok {
 		return
 	}
-	item, err := h.Queries.MarkInboxRead(r.Context(), parseUUID(id))
+	item, err := h.Queries.MarkInboxRead(r.Context(), prev.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to mark read")
 		return
@@ -134,10 +139,11 @@ func (h *Handler) MarkInboxRead(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) ArchiveInboxItem(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	if _, ok := h.loadInboxItemForUser(w, r, id); !ok {
+	prev, ok := h.loadInboxItemForUser(w, r, id)
+	if !ok {
 		return
 	}
-	item, err := h.Queries.ArchiveInboxItem(r.Context(), parseUUID(id))
+	item, err := h.Queries.ArchiveInboxItem(r.Context(), prev.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to archive")
 		return
@@ -171,9 +177,13 @@ func (h *Handler) CountUnreadInbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaceID := ctxWorkspaceID(r.Context())
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
 	count, err := h.Queries.CountUnreadInbox(r.Context(), db.CountUnreadInboxParams{
-		WorkspaceID:   parseUUID(workspaceID),
+		WorkspaceID:   wsUUID,
 		RecipientType: "member",
 		RecipientID:   parseUUID(userID),
 	})
@@ -191,9 +201,13 @@ func (h *Handler) MarkAllInboxRead(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaceID := ctxWorkspaceID(r.Context())
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
 	count, err := h.Queries.MarkAllInboxRead(r.Context(), db.MarkAllInboxReadParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		RecipientID: parseUUID(userID),
 	})
 	if err != nil {
@@ -216,9 +230,13 @@ func (h *Handler) ArchiveAllInbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaceID := ctxWorkspaceID(r.Context())
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
 	count, err := h.Queries.ArchiveAllInbox(r.Context(), db.ArchiveAllInboxParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		RecipientID: parseUUID(userID),
 	})
 	if err != nil {
@@ -241,9 +259,13 @@ func (h *Handler) ArchiveAllReadInbox(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	workspaceID := ctxWorkspaceID(r.Context())
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
 	count, err := h.Queries.ArchiveAllReadInbox(r.Context(), db.ArchiveAllReadInboxParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		RecipientID: parseUUID(userID),
 	})
 	if err != nil {
@@ -266,9 +288,13 @@ func (h *Handler) ArchiveCompletedInbox(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	workspaceID := ctxWorkspaceID(r.Context())
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
 	count, err := h.Queries.ArchiveCompletedInbox(r.Context(), db.ArchiveCompletedInboxParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		RecipientID: parseUUID(userID),
 	})
 	if err != nil {

--- a/server/internal/handler/invitation.go
+++ b/server/internal/handler/invitation.go
@@ -87,7 +87,7 @@ func (h *Handler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		_, memberErr := h.Queries.GetMemberByUserAndWorkspace(r.Context(), db.GetMemberByUserAndWorkspaceParams{
 			UserID:      existingUser.ID,
-			WorkspaceID: parseUUID(workspaceID),
+			WorkspaceID: requester.WorkspaceID,
 		})
 		if memberErr == nil {
 			writeError(w, http.StatusConflict, "user is already a member")
@@ -97,7 +97,7 @@ func (h *Handler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 
 	// Check if there is already a pending invitation.
 	_, err = h.Queries.GetPendingInvitationByEmail(r.Context(), db.GetPendingInvitationByEmailParams{
-		WorkspaceID:  parseUUID(workspaceID),
+		WorkspaceID:  requester.WorkspaceID,
 		InviteeEmail: email,
 	})
 	if err == nil {
@@ -112,7 +112,7 @@ func (h *Handler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	inv, err := h.Queries.CreateInvitation(r.Context(), db.CreateInvitationParams{
-		WorkspaceID:   parseUUID(workspaceID),
+		WorkspaceID:   requester.WorkspaceID,
 		InviterID:     requester.UserID,
 		InviteeEmail:  email,
 		InviteeUserID: inviteeUserID,
@@ -136,15 +136,15 @@ func (h *Handler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 	userID := requestUserID(r)
 	eventPayload := map[string]any{"invitation": resp}
 	var workspaceName string
-	if ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(workspaceID)); err == nil {
+	if ws, err := h.Queries.GetWorkspace(r.Context(), requester.WorkspaceID); err == nil {
 		workspaceName = ws.Name
 		eventPayload["workspace_name"] = ws.Name
 	}
-	h.publish(protocol.EventInvitationCreated, workspaceID, "member", userID, eventPayload)
+	h.publish(protocol.EventInvitationCreated, uuidToString(requester.WorkspaceID), "member", userID, eventPayload)
 
 	h.Analytics.Capture(analytics.TeamInviteSent(
 		uuidToString(requester.UserID),
-		workspaceID,
+		uuidToString(requester.WorkspaceID),
 		email,
 		"email",
 	))
@@ -173,8 +173,12 @@ func (h *Handler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) ListWorkspaceInvitations(w http.ResponseWriter, r *http.Request) {
 	workspaceID := workspaceIDFromURL(r, "id")
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
-	rows, err := h.Queries.ListPendingInvitationsByWorkspace(r.Context(), parseUUID(workspaceID))
+	rows, err := h.Queries.ListPendingInvitationsByWorkspace(r.Context(), workspaceUUID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list invitations")
 		return
@@ -209,9 +213,17 @@ func (h *Handler) ListWorkspaceInvitations(w http.ResponseWriter, r *http.Reques
 func (h *Handler) RevokeInvitation(w http.ResponseWriter, r *http.Request) {
 	workspaceID := workspaceIDFromURL(r, "id")
 	invitationID := chi.URLParam(r, "invitationId")
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+	invitationUUID, ok := parseUUIDOrBadRequest(w, invitationID, "invitation id")
+	if !ok {
+		return
+	}
 
-	inv, err := h.Queries.GetInvitation(r.Context(), parseUUID(invitationID))
-	if err != nil || uuidToString(inv.WorkspaceID) != workspaceID || inv.Status != "pending" {
+	inv, err := h.Queries.GetInvitation(r.Context(), invitationUUID)
+	if err != nil || uuidToString(inv.WorkspaceID) != uuidToString(workspaceUUID) || inv.Status != "pending" {
 		writeError(w, http.StatusNotFound, "invitation not found")
 		return
 	}
@@ -224,8 +236,8 @@ func (h *Handler) RevokeInvitation(w http.ResponseWriter, r *http.Request) {
 	slog.Info("invitation revoked", "invitation_id", invitationID, "workspace_id", workspaceID)
 
 	userID := requestUserID(r)
-	h.publish(protocol.EventInvitationRevoked, workspaceID, "member", userID, map[string]any{
-		"invitation_id":   invitationID,
+	h.publish(protocol.EventInvitationRevoked, uuidToString(workspaceUUID), "member", userID, map[string]any{
+		"invitation_id":   uuidToString(inv.ID),
 		"invitee_email":   inv.InviteeEmail,
 		"invitee_user_id": uuidToPtr(inv.InviteeUserID),
 	})
@@ -245,7 +257,11 @@ func (h *Handler) GetMyInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	invitationID := chi.URLParam(r, "id")
-	inv, err := h.Queries.GetInvitation(r.Context(), parseUUID(invitationID))
+	invitationUUID, ok := parseUUIDOrBadRequest(w, invitationID, "invitation id")
+	if !ok {
+		return
+	}
+	inv, err := h.Queries.GetInvitation(r.Context(), invitationUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "invitation not found")
 		return
@@ -336,7 +352,11 @@ func (h *Handler) AcceptInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	invitationID := chi.URLParam(r, "id")
-	inv, err := h.Queries.GetInvitation(r.Context(), parseUUID(invitationID))
+	invitationUUID, ok := parseUUIDOrBadRequest(w, invitationID, "invitation id")
+	if !ok {
+		return
+	}
+	inv, err := h.Queries.GetInvitation(r.Context(), invitationUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "invitation not found")
 		return
@@ -413,7 +433,7 @@ func (h *Handler) AcceptInvitation(w http.ResponseWriter, r *http.Request) {
 
 	// Notify the workspace about the acceptance.
 	h.publish(protocol.EventInvitationAccepted, wsID, "member", userID, map[string]any{
-		"invitation_id": invitationID,
+		"invitation_id": uuidToString(accepted.ID),
 		"member":        memberResp,
 	})
 
@@ -445,7 +465,11 @@ func (h *Handler) DeclineInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	invitationID := chi.URLParam(r, "id")
-	inv, err := h.Queries.GetInvitation(r.Context(), parseUUID(invitationID))
+	invitationUUID, ok := parseUUIDOrBadRequest(w, invitationID, "invitation id")
+	if !ok {
+		return
+	}
+	inv, err := h.Queries.GetInvitation(r.Context(), invitationUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "invitation not found")
 		return
@@ -477,7 +501,7 @@ func (h *Handler) DeclineInvitation(w http.ResponseWriter, r *http.Request) {
 
 	wsID := uuidToString(declined.WorkspaceID)
 	h.publish(protocol.EventInvitationDeclined, wsID, "member", userID, map[string]any{
-		"invitation_id": invitationID,
+		"invitation_id": uuidToString(declined.ID),
 		"invitee_email": declined.InviteeEmail,
 	})
 

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -941,6 +941,11 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	attachmentIDs, ok := parseUUIDSliceOrBadRequest(w, req.AttachmentIDs, "attachment_ids")
+	if !ok {
+		return
+	}
+
 	var dueDate pgtype.Timestamptz
 	if req.DueDate != nil && *req.DueDate != "" {
 		t, err := time.Parse(time.RFC3339, *req.DueDate)
@@ -999,15 +1004,15 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Link any pre-uploaded attachments to this issue.
-	if len(req.AttachmentIDs) > 0 {
-		h.linkAttachmentsByIssueIDs(r.Context(), issue.ID, issue.WorkspaceID, req.AttachmentIDs)
+	if len(attachmentIDs) > 0 {
+		h.linkAttachmentsByIssueIDs(r.Context(), issue.ID, issue.WorkspaceID, attachmentIDs)
 	}
 
 	prefix := h.getIssuePrefix(r.Context(), issue.WorkspaceID)
 	resp := issueToResponse(issue, prefix)
 
 	// Fetch linked attachments so they appear in the response.
-	if len(req.AttachmentIDs) > 0 {
+	if len(attachmentIDs) > 0 {
 		attachments, err := h.Queries.ListAttachmentsByIssue(r.Context(), db.ListAttachmentsByIssueParams{
 			IssueID:     issue.ID,
 			WorkspaceID: issue.WorkspaceID,

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -510,7 +511,10 @@ func (h *Handler) SearchIssues(w http.ResponseWriter, r *http.Request) {
 
 	includeClosed := r.URL.Query().Get("include_closed") == "true"
 
-	wsUUID := parseUUID(workspaceID)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
 	terms := splitSearchTerms(q)
 	queryNum, hasNum := parseQueryNumber(q)
 
@@ -597,32 +601,53 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	workspaceID := h.resolveWorkspaceID(r)
-	wsUUID := parseUUID(workspaceID)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
 
-	// Parse optional filter params
+	// Parse optional filter params. Malformed UUIDs in filters return 400 —
+	// silently coercing them to a zero UUID would mask a client bug and let
+	// the query return an empty result set (or worse, match a NULL row).
 	var priorityFilter pgtype.Text
 	if p := r.URL.Query().Get("priority"); p != "" {
 		priorityFilter = pgtype.Text{String: p, Valid: true}
 	}
 	var assigneeFilter pgtype.UUID
 	if a := r.URL.Query().Get("assignee_id"); a != "" {
-		assigneeFilter = parseUUID(a)
+		id, ok := parseUUIDOrBadRequest(w, a, "assignee_id")
+		if !ok {
+			return
+		}
+		assigneeFilter = id
 	}
 	var assigneeIdsFilter []pgtype.UUID
 	if ids := r.URL.Query().Get("assignee_ids"); ids != "" {
 		for _, raw := range strings.Split(ids, ",") {
 			if s := strings.TrimSpace(raw); s != "" {
-				assigneeIdsFilter = append(assigneeIdsFilter, parseUUID(s))
+				id, ok := parseUUIDOrBadRequest(w, s, "assignee_ids")
+				if !ok {
+					return
+				}
+				assigneeIdsFilter = append(assigneeIdsFilter, id)
 			}
 		}
 	}
 	var creatorFilter pgtype.UUID
 	if c := r.URL.Query().Get("creator_id"); c != "" {
-		creatorFilter = parseUUID(c)
+		id, ok := parseUUIDOrBadRequest(w, c, "creator_id")
+		if !ok {
+			return
+		}
+		creatorFilter = id
 	}
 	var projectFilter pgtype.UUID
 	if p := r.URL.Query().Get("project_id"); p != "" {
-		projectFilter = parseUUID(p)
+		id, ok := parseUUIDOrBadRequest(w, p, "project_id")
+		if !ok {
+			return
+		}
+		projectFilter = id
 	}
 
 	// open_only=true returns all non-done/cancelled issues (no limit).
@@ -794,7 +819,10 @@ func (h *Handler) ListChildIssues(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) ChildIssueProgress(w http.ResponseWriter, r *http.Request) {
 	wsID := h.resolveWorkspaceID(r)
-	wsUUID := parseUUID(wsID)
+	wsUUID, ok := parseUUIDOrBadRequest(w, wsID, "workspace_id")
+	if !ok {
+		return
+	}
 
 	rows, err := h.Queries.ChildIssueProgress(r.Context(), wsUUID)
 	if err != nil {
@@ -846,6 +874,10 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
 
 	// Get creator from context (set by auth middleware)
 	creatorID, ok := requireUserID(w, r)
@@ -883,14 +915,22 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	var parentIssueID pgtype.UUID
 	var projectID pgtype.UUID
 	if req.ProjectID != nil {
-		projectID = parseUUID(*req.ProjectID)
+		id, ok := parseUUIDOrBadRequest(w, *req.ProjectID, "project_id")
+		if !ok {
+			return
+		}
+		projectID = id
 	}
 	if req.ParentIssueID != nil {
-		parentIssueID = parseUUID(*req.ParentIssueID)
+		id, ok := parseUUIDOrBadRequest(w, *req.ParentIssueID, "parent_issue_id")
+		if !ok {
+			return
+		}
+		parentIssueID = id
 		// Validate parent exists in the same workspace.
 		parent, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
 			ID:          parentIssueID,
-			WorkspaceID: parseUUID(workspaceID),
+			WorkspaceID: wsUUID,
 		})
 		if err != nil || !parent.ID.Valid {
 			writeError(w, http.StatusBadRequest, "parent issue not found in this workspace")
@@ -921,7 +961,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	defer tx.Rollback(r.Context())
 
 	qtx := h.Queries.WithTx(tx)
-	issueNumber, err := qtx.IncrementIssueCounter(r.Context(), parseUUID(workspaceID))
+	issueNumber, err := qtx.IncrementIssueCounter(r.Context(), wsUUID)
 	if err != nil {
 		slog.Warn("increment issue counter failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID)...)
 		writeError(w, http.StatusInternalServerError, "failed to create issue")
@@ -932,7 +972,7 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	creatorType, actualCreatorID := h.resolveActor(r, creatorID, workspaceID)
 
 	issue, err := qtx.CreateIssue(r.Context(), db.CreateIssueParams{
-		WorkspaceID:        parseUUID(workspaceID),
+		WorkspaceID:        wsUUID,
 		Title:              req.Title,
 		Description:        ptrToText(req.Description),
 		Status:             status,
@@ -1091,9 +1131,14 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, ok := rawFields["parent_issue_id"]; ok {
 		if req.ParentIssueID != nil {
-			newParentID := parseUUID(*req.ParentIssueID)
-			// Cannot set self as parent.
-			if uuidToString(newParentID) == id {
+			newParentID, ok := parseUUIDOrBadRequest(w, *req.ParentIssueID, "parent_issue_id")
+			if !ok {
+				return
+			}
+			// Cannot set self as parent. Compare against prevIssue.ID (the
+			// resolved entity), not the raw URL string — `id` may be an
+			// identifier like "MUL-7".
+			if newParentID == prevIssue.ID {
 				writeError(w, http.StatusBadRequest, "an issue cannot be its own parent")
 				return
 			}
@@ -1112,7 +1157,7 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 				if err != nil || !ancestor.ParentIssueID.Valid {
 					break
 				}
-				if uuidToString(ancestor.ParentIssueID) == id {
+				if ancestor.ParentIssueID == prevIssue.ID {
 					writeError(w, http.StatusBadRequest, "circular parent relationship detected")
 					return
 				}
@@ -1125,7 +1170,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, ok := rawFields["project_id"]; ok {
 		if req.ProjectID != nil {
-			params.ProjectID = parseUUID(*req.ProjectID)
+			projectUUID, ok := parseUUIDOrBadRequest(w, *req.ProjectID, "project_id")
+			if !ok {
+				return
+			}
+			params.ProjectID = projectUUID
 		} else {
 			params.ProjectID = pgtype.UUID{Valid: false}
 		}
@@ -1232,11 +1281,15 @@ func (h *Handler) validateAssigneePair(ctx context.Context, r *http.Request, wor
 	if assigneeType.Valid != assigneeID.Valid {
 		return http.StatusBadRequest, "assignee_type and assignee_id must be provided together"
 	}
+	wsUUID, err := util.ParseUUID(workspaceID)
+	if err != nil {
+		return http.StatusBadRequest, "invalid workspace_id"
+	}
 	switch assigneeType.String {
 	case "member":
 		if _, err := h.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
 			UserID:      assigneeID,
-			WorkspaceID: parseUUID(workspaceID),
+			WorkspaceID: wsUUID,
 		}); err != nil {
 			return http.StatusBadRequest, "assignee_id does not refer to a member of this workspace"
 		}
@@ -1244,7 +1297,7 @@ func (h *Handler) validateAssigneePair(ctx context.Context, r *http.Request, wor
 	case "agent":
 		agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
 			ID:          assigneeID,
-			WorkspaceID: parseUUID(workspaceID),
+			WorkspaceID: wsUUID,
 		})
 		if err != nil {
 			return http.StatusBadRequest, "assignee_id does not refer to an agent of this workspace"
@@ -1338,8 +1391,12 @@ func (h *Handler) DeleteIssue(w http.ResponseWriter, r *http.Request) {
 	h.deleteS3Objects(r.Context(), attachmentURLs)
 	userID := requestUserID(r)
 	actorType, actorID := h.resolveActor(r, userID, uuidToString(issue.WorkspaceID))
-	h.publish(protocol.EventIssueDeleted, uuidToString(issue.WorkspaceID), actorType, actorID, map[string]any{"issue_id": id})
-	slog.Info("issue deleted", append(logger.RequestAttrs(r), "issue_id", id, "workspace_id", uuidToString(issue.WorkspaceID))...)
+	// Always emit the resolved UUID — frontend caches key by UUID, so an
+	// identifier-style payload ("MUL-123") would leave stale entries on
+	// other clients after an identifier-path delete.
+	resolvedID := uuidToString(issue.ID)
+	h.publish(protocol.EventIssueDeleted, uuidToString(issue.WorkspaceID), actorType, actorID, map[string]any{"issue_id": resolvedID})
+	slog.Info("issue deleted", append(logger.RequestAttrs(r), "issue_id", resolvedID, "workspace_id", uuidToString(issue.WorkspaceID))...)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -1384,11 +1441,19 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
 	updated := 0
 	for _, issueID := range req.IssueIDs {
+		issueUUID, err := util.ParseUUID(issueID)
+		if err != nil {
+			continue
+		}
 		prevIssue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
-			ID:          parseUUID(issueID),
-			WorkspaceID: parseUUID(workspaceID),
+			ID:          issueUUID,
+			WorkspaceID: wsUUID,
 		})
 		if err != nil {
 			continue
@@ -1427,10 +1492,11 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		}
 		if _, ok := rawUpdates["assignee_id"]; ok {
 			if req.Updates.AssigneeID != nil {
-				params.AssigneeID = parseUUID(*req.Updates.AssigneeID)
-				if !params.AssigneeID.Valid {
+				assigneeUUID, err := util.ParseUUID(*req.Updates.AssigneeID)
+				if err != nil {
 					continue
 				}
+				params.AssigneeID = assigneeUUID
 			} else {
 				params.AssigneeID = pgtype.UUID{Valid: false}
 			}
@@ -1449,9 +1515,12 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 
 		if _, ok := rawUpdates["parent_issue_id"]; ok {
 			if req.Updates.ParentIssueID != nil {
-				newParentID := parseUUID(*req.Updates.ParentIssueID)
+				newParentID, err := util.ParseUUID(*req.Updates.ParentIssueID)
+				if err != nil {
+					continue
+				}
 				// Cannot set self as parent.
-				if uuidToString(newParentID) == issueID {
+				if newParentID == prevIssue.ID {
 					continue
 				}
 				// Validate parent exists in the same workspace.
@@ -1469,7 +1538,7 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 					if err != nil || !ancestor.ParentIssueID.Valid {
 						break
 					}
-					if uuidToString(ancestor.ParentIssueID) == issueID {
+					if ancestor.ParentIssueID == prevIssue.ID {
 						cycleDetected = true
 						break
 					}
@@ -1485,7 +1554,11 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		}
 		if _, ok := rawUpdates["project_id"]; ok {
 			if req.Updates.ProjectID != nil {
-				params.ProjectID = parseUUID(*req.Updates.ProjectID)
+				projectUUID, err := util.ParseUUID(*req.Updates.ProjectID)
+				if err != nil {
+					continue
+				}
+				params.ProjectID = projectUUID
 			} else {
 				params.ProjectID = pgtype.UUID{Valid: false}
 			}
@@ -1572,11 +1645,19 @@ func (h *Handler) BatchDeleteIssues(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
 	deleted := 0
 	for _, issueID := range req.IssueIDs {
+		issueUUID, err := util.ParseUUID(issueID)
+		if err != nil {
+			continue
+		}
 		issue, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
-			ID:          parseUUID(issueID),
-			WorkspaceID: parseUUID(workspaceID),
+			ID:          issueUUID,
+			WorkspaceID: wsUUID,
 		})
 		if err != nil {
 			continue
@@ -1595,8 +1676,9 @@ func (h *Handler) BatchDeleteIssues(w http.ResponseWriter, r *http.Request) {
 
 		h.deleteS3Objects(r.Context(), attachmentURLs)
 
+		// Always emit the resolved UUID — frontend caches key by UUID.
 		actorType, actorID := h.resolveActor(r, userID, workspaceID)
-		h.publish(protocol.EventIssueDeleted, workspaceID, actorType, actorID, map[string]any{"issue_id": issueID})
+		h.publish(protocol.EventIssueDeleted, workspaceID, actorType, actorID, map[string]any{"issue_id": uuidToString(issue.ID)})
 		deleted++
 	}
 

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -868,14 +868,11 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		assigneeType = pgtype.Text{String: *req.AssigneeType, Valid: true}
 	}
 	if req.AssigneeID != nil {
-		assigneeID = parseUUID(*req.AssigneeID)
-		// parseUUID silently returns an invalid pgtype.UUID for malformed input.
-		// Reject explicitly so the validator below cannot mistake "type unset
-		// + id unparseable" for "no assignee" and accept the request.
-		if !assigneeID.Valid {
-			writeError(w, http.StatusBadRequest, "assignee_id is not a valid UUID")
+		id, ok := parseUUIDOrBadRequest(w, *req.AssigneeID, "assignee_id")
+		if !ok {
 			return
 		}
+		assigneeID = id
 	}
 
 	if status, msg := h.validateAssigneePair(r.Context(), r, workspaceID, assigneeType, assigneeID); status != 0 {
@@ -1071,11 +1068,11 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, ok := rawFields["assignee_id"]; ok {
 		if req.AssigneeID != nil {
-			params.AssigneeID = parseUUID(*req.AssigneeID)
-			if !params.AssigneeID.Valid {
-				writeError(w, http.StatusBadRequest, "assignee_id is not a valid UUID")
+			id, ok := parseUUIDOrBadRequest(w, *req.AssigneeID, "assignee_id")
+			if !ok {
 				return
 			}
+			params.AssigneeID = id
 		} else {
 			params.AssigneeID = pgtype.UUID{Valid: false} // explicit null = unassign
 		}

--- a/server/internal/handler/label.go
+++ b/server/internal/handler/label.go
@@ -115,8 +115,16 @@ func (h *Handler) ListLabels(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) GetLabel(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "label id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	label, err := h.Queries.GetLabel(r.Context(), db.GetLabelParams{
-		ID: parseUUID(id), WorkspaceID: parseUUID(workspaceID),
+		ID: idUUID, WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -265,7 +273,7 @@ func (h *Handler) DeleteLabel(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to delete label")
 		return
 	}
-	h.publish(protocol.EventLabelDeleted, workspaceID, "member", userID, map[string]any{"label_id": id})
+	h.publish(protocol.EventLabelDeleted, workspaceID, "member", userID, map[string]any{"label_id": uuidToString(idUUID)})
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -283,13 +291,13 @@ type AttachLabelRequest struct {
 // nil → clients refetch via query invalidation, and we skip broadcasting an
 // empty list that would incorrectly overwrite every subscriber's optimistic
 // state.
-func (h *Handler) listLabelsForIssueSafe(r *http.Request, issueID, workspaceID string) ([]db.IssueLabel, bool) {
+func (h *Handler) listLabelsForIssueSafe(r *http.Request, issueID, workspaceID pgtype.UUID) ([]db.IssueLabel, bool) {
 	labels, err := h.Queries.ListLabelsByIssue(r.Context(), db.ListLabelsByIssueParams{
-		IssueID:     parseUUID(issueID),
-		WorkspaceID: parseUUID(workspaceID),
+		IssueID:     issueID,
+		WorkspaceID: workspaceID,
 	})
 	if err != nil {
-		slog.Warn("ListLabelsByIssue failed after mutation", append(logger.RequestAttrs(r), "error", err, "issue_id", issueID)...)
+		slog.Warn("ListLabelsByIssue failed after mutation", append(logger.RequestAttrs(r), "error", err, "issue_id", uuidToString(issueID))...)
 		return nil, false
 	}
 	return labels, true
@@ -298,17 +306,15 @@ func (h *Handler) listLabelsForIssueSafe(r *http.Request, issueID, workspaceID s
 // ListLabelsForIssue returns the labels currently attached to an issue.
 func (h *Handler) ListLabelsForIssue(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "id")
-	workspaceID := h.resolveWorkspaceID(r)
 	// Authorize via the issue — if it's not in this workspace, the caller
 	// shouldn't see its labels.
-	issue, err := h.Queries.GetIssue(r.Context(), parseUUID(issueID))
-	if err != nil || uuidToString(issue.WorkspaceID) != workspaceID {
-		writeError(w, http.StatusNotFound, "issue not found")
+	issue, ok := h.loadIssueForUser(w, r, issueID)
+	if !ok {
 		return
 	}
 	labels, err := h.Queries.ListLabelsByIssue(r.Context(), db.ListLabelsByIssueParams{
-		IssueID:     parseUUID(issueID),
-		WorkspaceID: parseUUID(workspaceID),
+		IssueID:     issue.ID,
+		WorkspaceID: issue.WorkspaceID,
 	})
 	if err != nil {
 		slog.Warn("ListLabelsForIssue failed", append(logger.RequestAttrs(r), "error", err)...)
@@ -321,7 +327,6 @@ func (h *Handler) ListLabelsForIssue(w http.ResponseWriter, r *http.Request) {
 // AttachLabel attaches a label to an issue.
 func (h *Handler) AttachLabel(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "id")
-	workspaceID := h.resolveWorkspaceID(r)
 	userID, ok := requireUserID(w, r)
 	if !ok {
 		return
@@ -338,13 +343,16 @@ func (h *Handler) AttachLabel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Both the issue and label must belong to this workspace.
-	issue, err := h.Queries.GetIssue(r.Context(), parseUUID(issueID))
-	if err != nil || uuidToString(issue.WorkspaceID) != workspaceID {
-		writeError(w, http.StatusNotFound, "issue not found")
+	issue, ok := h.loadIssueForUser(w, r, issueID)
+	if !ok {
+		return
+	}
+	labelID, ok := parseUUIDOrBadRequest(w, req.LabelID, "label_id")
+	if !ok {
 		return
 	}
 	if _, err := h.Queries.GetLabel(r.Context(), db.GetLabelParams{
-		ID: parseUUID(req.LabelID), WorkspaceID: parseUUID(workspaceID),
+		ID: labelID, WorkspaceID: issue.WorkspaceID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			writeError(w, http.StatusNotFound, "label not found")
@@ -356,9 +364,9 @@ func (h *Handler) AttachLabel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.Queries.AttachLabelToIssue(r.Context(), db.AttachLabelToIssueParams{
-		IssueID:     parseUUID(issueID),
-		LabelID:     parseUUID(req.LabelID),
-		WorkspaceID: parseUUID(workspaceID),
+		IssueID:     issue.ID,
+		LabelID:     labelID,
+		WorkspaceID: issue.WorkspaceID,
 	}); err != nil {
 		slog.Warn("AttachLabelToIssue failed", append(logger.RequestAttrs(r), "error", err)...)
 		writeError(w, http.StatusInternalServerError, "failed to attach label")
@@ -369,14 +377,14 @@ func (h *Handler) AttachLabel(w http.ResponseWriter, r *http.Request) {
 	// committed — return success without a labels body (clients refetch via
 	// query invalidation) and skip the broadcast so we don't overwrite every
 	// subscriber's optimistic state with an incorrect empty list.
-	labels, ok2 := h.listLabelsForIssueSafe(r, issueID, workspaceID)
+	labels, ok2 := h.listLabelsForIssueSafe(r, issue.ID, issue.WorkspaceID)
 	if !ok2 {
 		writeJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
 	resp := labelsToResponse(labels)
-	h.publish(protocol.EventIssueLabelsChanged, workspaceID, "member", userID, map[string]any{
-		"issue_id": issueID,
+	h.publish(protocol.EventIssueLabelsChanged, uuidToString(issue.WorkspaceID), "member", userID, map[string]any{
+		"issue_id": uuidToString(issue.ID),
 		"labels":   resp,
 	})
 	writeJSON(w, http.StatusOK, map[string]any{"labels": resp})
@@ -386,7 +394,6 @@ func (h *Handler) AttachLabel(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) DetachLabel(w http.ResponseWriter, r *http.Request) {
 	issueID := chi.URLParam(r, "id")
 	labelID := chi.URLParam(r, "labelId")
-	workspaceID := h.resolveWorkspaceID(r)
 	userID, ok := requireUserID(w, r)
 	if !ok {
 		return
@@ -396,13 +403,16 @@ func (h *Handler) DetachLabel(w http.ResponseWriter, r *http.Request) {
 	// (mirror of AttachLabel). Without this, a crafted request with a foreign
 	// labelID would no-op and return 200 — "silent success" is worse than an
 	// explicit 404.
-	issue, err := h.Queries.GetIssue(r.Context(), parseUUID(issueID))
-	if err != nil || uuidToString(issue.WorkspaceID) != workspaceID {
-		writeError(w, http.StatusNotFound, "issue not found")
+	issue, ok := h.loadIssueForUser(w, r, issueID)
+	if !ok {
+		return
+	}
+	labelUUID, ok := parseUUIDOrBadRequest(w, labelID, "label id")
+	if !ok {
 		return
 	}
 	if _, err := h.Queries.GetLabel(r.Context(), db.GetLabelParams{
-		ID: parseUUID(labelID), WorkspaceID: parseUUID(workspaceID),
+		ID: labelUUID, WorkspaceID: issue.WorkspaceID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			writeError(w, http.StatusNotFound, "label not found")
@@ -414,23 +424,23 @@ func (h *Handler) DetachLabel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.Queries.DetachLabelFromIssue(r.Context(), db.DetachLabelFromIssueParams{
-		IssueID:     parseUUID(issueID),
-		LabelID:     parseUUID(labelID),
-		WorkspaceID: parseUUID(workspaceID),
+		IssueID:     issue.ID,
+		LabelID:     labelUUID,
+		WorkspaceID: issue.WorkspaceID,
 	}); err != nil {
 		slog.Warn("DetachLabelFromIssue failed", append(logger.RequestAttrs(r), "error", err)...)
 		writeError(w, http.StatusInternalServerError, "failed to detach label")
 		return
 	}
 
-	labels, ok2 := h.listLabelsForIssueSafe(r, issueID, workspaceID)
+	labels, ok2 := h.listLabelsForIssueSafe(r, issue.ID, issue.WorkspaceID)
 	if !ok2 {
 		writeJSON(w, http.StatusOK, map[string]any{})
 		return
 	}
 	resp := labelsToResponse(labels)
-	h.publish(protocol.EventIssueLabelsChanged, workspaceID, "member", userID, map[string]any{
-		"issue_id": issueID,
+	h.publish(protocol.EventIssueLabelsChanged, uuidToString(issue.WorkspaceID), "member", userID, map[string]any{
+		"issue_id": uuidToString(issue.ID),
 		"labels":   resp,
 	})
 	writeJSON(w, http.StatusOK, map[string]any{"labels": resp})

--- a/server/internal/handler/label.go
+++ b/server/internal/handler/label.go
@@ -185,9 +185,17 @@ func (h *Handler) UpdateLabel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "label id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	params := db.UpdateLabelParams{
-		ID:          parseUUID(id),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          idUUID,
+		WorkspaceID: wsUUID,
 	}
 	if req.Name != nil {
 		name, err := validateLabelName(*req.Name)
@@ -236,10 +244,18 @@ func (h *Handler) DeleteLabel(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "label id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	// DeleteLabel is :one RETURNING id — ErrNoRows means the label wasn't in
 	// this workspace (404). Any other error is a real 500.
 	if _, err := h.Queries.DeleteLabel(r.Context(), db.DeleteLabelParams{
-		ID: parseUUID(id), WorkspaceID: parseUUID(workspaceID),
+		ID: idUUID, WorkspaceID: wsUUID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			writeError(w, http.StatusNotFound, "label not found")

--- a/server/internal/handler/onboarding.go
+++ b/server/internal/handler/onboarding.go
@@ -7,11 +7,11 @@ import (
 	"net/mail"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -356,16 +356,14 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "workspace_id is required")
 		return
 	}
-	// Reject malformed UUIDs up front. Without this, `parseUUID` below
-	// silently returns a zero-UUID and the membership check fails with
-	// a misleading 403 "not a member of this workspace" instead of the
-	// true 400. Defense-in-depth: even if the membership check is ever
-	// refactored, a garbage workspace_id never reaches CreateProject /
+	// Reject malformed UUIDs up front and reuse the parsed value for every
+	// write below so a garbage workspace_id never reaches CreateProject /
 	// CreateIssue.
-	if _, err := uuid.Parse(req.WorkspaceID); err != nil {
-		writeError(w, http.StatusBadRequest, "workspace_id is invalid")
+	wsUUID, ok := parseUUIDOrBadRequest(w, req.WorkspaceID, "workspace_id")
+	if !ok {
 		return
 	}
+	req.WorkspaceID = uuidToString(wsUUID)
 	if req.Project.Title == "" {
 		writeError(w, http.StatusBadRequest, "project.title is required")
 		return
@@ -406,7 +404,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 	// since members are looked up by `user_id`.
 	if _, err := qtx.GetMemberByUserAndWorkspace(r.Context(), db.GetMemberByUserAndWorkspaceParams{
 		UserID:      parseUUID(userID),
-		WorkspaceID: parseUUID(req.WorkspaceID),
+		WorkspaceID: wsUUID,
 	}); err != nil {
 		writeError(w, http.StatusForbidden, "not a member of this workspace")
 		return
@@ -418,7 +416,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 	// workspace. `ListAgents` orders by created_at ASC, so "agents[0]"
 	// is deterministically the earliest-created agent. This replaces
 	// the old client-supplied `welcome_issue.agent_id` trust chain.
-	agents, err := qtx.ListAgents(r.Context(), parseUUID(req.WorkspaceID))
+	agents, err := qtx.ListAgents(r.Context(), wsUUID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list agents")
 		return
@@ -435,7 +433,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 
 	// --- Create project ---
 	project, err := qtx.CreateProject(r.Context(), db.CreateProjectParams{
-		WorkspaceID: parseUUID(req.WorkspaceID),
+		WorkspaceID: wsUUID,
 		Title:       req.Project.Title,
 		Description: strOrNullText(req.Project.Description),
 		Icon:        strOrNullText(req.Project.Icon),
@@ -452,7 +450,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 	var welcomeIssueID *string
 	var welcomeIssueForEvent *db.Issue
 	if hasAgent && req.WelcomeIssueTemplate.Title != "" {
-		welcomeNumber, err := qtx.IncrementIssueCounter(r.Context(), parseUUID(req.WorkspaceID))
+		welcomeNumber, err := qtx.IncrementIssueCounter(r.Context(), wsUUID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to allocate issue number")
 			return
@@ -462,7 +460,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 			priority = "high"
 		}
 		welcome, err := qtx.CreateIssue(r.Context(), db.CreateIssueParams{
-			WorkspaceID:  parseUUID(req.WorkspaceID),
+			WorkspaceID:  wsUUID,
 			Title:        req.WelcomeIssueTemplate.Title,
 			Description:  strOrNullText(req.WelcomeIssueTemplate.Description),
 			Status:       "todo",
@@ -490,7 +488,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 		if sub.Title == "" {
 			continue
 		}
-		number, err := qtx.IncrementIssueCounter(r.Context(), parseUUID(req.WorkspaceID))
+		number, err := qtx.IncrementIssueCounter(r.Context(), wsUUID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to allocate issue number")
 			return
@@ -510,7 +508,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 			priority = "none"
 		}
 		issue, err := qtx.CreateIssue(r.Context(), db.CreateIssueParams{
-			WorkspaceID:  parseUUID(req.WorkspaceID),
+			WorkspaceID:  wsUUID,
 			Title:        sub.Title,
 			Description:  strOrNullText(sub.Description),
 			Status:       status,
@@ -538,7 +536,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 	pinnedProjectPos := float64(1)
 	var pinProjectForEvent *db.PinnedItem
 	pinProject, err := qtx.CreatePinnedItem(r.Context(), db.CreatePinnedItemParams{
-		WorkspaceID: parseUUID(req.WorkspaceID),
+		WorkspaceID: wsUUID,
 		UserID:      parseUUID(userID),
 		ItemType:    "project",
 		ItemID:      project.ID,
@@ -552,7 +550,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 	var pinWelcomeIssueForEvent *db.PinnedItem
 	if welcomeIssueForEvent != nil {
 		pinWelcome, err := qtx.CreatePinnedItem(r.Context(), db.CreatePinnedItemParams{
-			WorkspaceID: parseUUID(req.WorkspaceID),
+			WorkspaceID: wsUUID,
 			UserID:      parseUUID(userID),
 			ItemType:    "issue",
 			ItemID:      welcomeIssueForEvent.ID,
@@ -587,7 +585,7 @@ func (h *Handler) ImportStarterContent(w http.ResponseWriter, r *http.Request) {
 	projectResp := projectToResponse(project)
 	h.publish(protocol.EventProjectCreated, req.WorkspaceID, "member", userID, map[string]any{"project": projectResp})
 
-	workspacePrefix := h.getIssuePrefix(r.Context(), parseUUID(req.WorkspaceID))
+	workspacePrefix := h.getIssuePrefix(r.Context(), wsUUID)
 	if welcomeIssueForEvent != nil {
 		welcomeResp := issueToResponse(*welcomeIssueForEvent, workspacePrefix)
 		h.publish(protocol.EventIssueCreated, req.WorkspaceID, "member", userID, map[string]any{"issue": welcomeResp})
@@ -675,12 +673,13 @@ func (h *Handler) DismissStarterContent(w http.ResponseWriter, r *http.Request) 
 	// ListAgents returns empty.
 	branch := analytics.StarterContentBranchSelfServe
 	if req.WorkspaceID != "" {
-		if _, err := uuid.Parse(req.WorkspaceID); err == nil {
+		if wsUUID, err := util.ParseUUID(req.WorkspaceID); err == nil {
+			req.WorkspaceID = uuidToString(wsUUID)
 			if _, err := h.Queries.GetMemberByUserAndWorkspace(r.Context(), db.GetMemberByUserAndWorkspaceParams{
 				UserID:      parseUUID(userID),
-				WorkspaceID: parseUUID(req.WorkspaceID),
+				WorkspaceID: wsUUID,
 			}); err == nil {
-				agents, err := h.Queries.ListAgents(r.Context(), parseUUID(req.WorkspaceID))
+				agents, err := h.Queries.ListAgents(r.Context(), wsUUID)
 				if err == nil && len(agents) > 0 {
 					branch = analytics.StarterContentBranchAgentGuided
 				}

--- a/server/internal/handler/personal_access_token.go
+++ b/server/internal/handler/personal_access_token.go
@@ -37,8 +37,8 @@ func patToResponse(pat db.PersonalAccessToken) PersonalAccessTokenResponse {
 }
 
 type CreatePATRequest struct {
-	Name         string `json:"name"`
-	ExpiresInDays *int  `json:"expires_in_days"`
+	Name          string `json:"name"`
+	ExpiresInDays *int   `json:"expires_in_days"`
 }
 
 func (h *Handler) CreatePersonalAccessToken(w http.ResponseWriter, r *http.Request) {
@@ -77,11 +77,11 @@ func (h *Handler) CreatePersonalAccessToken(w http.ResponseWriter, r *http.Reque
 	}
 
 	pat, err := h.Queries.CreatePersonalAccessToken(r.Context(), db.CreatePersonalAccessTokenParams{
-		UserID:    parseUUID(userID),
-		Name:      req.Name,
-		TokenHash: auth.HashToken(rawToken),
+		UserID:      parseUUID(userID),
+		Name:        req.Name,
+		TokenHash:   auth.HashToken(rawToken),
 		TokenPrefix: prefix,
-		ExpiresAt: expiresAt,
+		ExpiresAt:   expiresAt,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create token")
@@ -120,8 +120,12 @@ func (h *Handler) RevokePersonalAccessToken(w http.ResponseWriter, r *http.Reque
 	}
 
 	id := chi.URLParam(r, "id")
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "token id")
+	if !ok {
+		return
+	}
 	if err := h.Queries.RevokePersonalAccessToken(r.Context(), db.RevokePersonalAccessTokenParams{
-		ID:     parseUUID(id),
+		ID:     idUUID,
 		UserID: parseUUID(userID),
 	}); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to revoke token")

--- a/server/internal/handler/pin.go
+++ b/server/internal/handler/pin.go
@@ -93,18 +93,27 @@ func (h *Handler) CreatePin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	itemUUID, ok := parseUUIDOrBadRequest(w, req.ItemID, "item_id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
 	// Verify the item exists in this workspace
 	switch req.ItemType {
 	case "issue":
 		if _, err := h.Queries.GetIssueInWorkspace(r.Context(), db.GetIssueInWorkspaceParams{
-			ID: parseUUID(req.ItemID), WorkspaceID: parseUUID(workspaceID),
+			ID: itemUUID, WorkspaceID: wsUUID,
 		}); err != nil {
 			writeError(w, http.StatusNotFound, "issue not found")
 			return
 		}
 	case "project":
 		if _, err := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
-			ID: parseUUID(req.ItemID), WorkspaceID: parseUUID(workspaceID),
+			ID: itemUUID, WorkspaceID: wsUUID,
 		}); err != nil {
 			writeError(w, http.StatusNotFound, "project not found")
 			return
@@ -113,7 +122,7 @@ func (h *Handler) CreatePin(w http.ResponseWriter, r *http.Request) {
 
 	// Get max position to append at end
 	maxPos, err := h.Queries.GetMaxPinnedItemPosition(r.Context(), db.GetMaxPinnedItemPositionParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		UserID:      parseUUID(userID),
 	})
 	if err != nil {
@@ -122,10 +131,10 @@ func (h *Handler) CreatePin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pin, err := h.Queries.CreatePinnedItem(r.Context(), db.CreatePinnedItemParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		UserID:      parseUUID(userID),
 		ItemType:    req.ItemType,
-		ItemID:      parseUUID(req.ItemID),
+		ItemID:      itemUUID,
 		Position:    maxPos + 1,
 	})
 	if err != nil {

--- a/server/internal/handler/pin.go
+++ b/server/internal/handler/pin.go
@@ -151,11 +151,20 @@ func (h *Handler) DeletePin(w http.ResponseWriter, r *http.Request) {
 	itemType := chi.URLParam(r, "itemType")
 	itemID := chi.URLParam(r, "itemId")
 
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+	itemUUID, ok := parseUUIDOrBadRequest(w, itemID, "item id")
+	if !ok {
+		return
+	}
+
 	err := h.Queries.DeletePinnedItem(r.Context(), db.DeletePinnedItemParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		UserID:      parseUUID(userID),
 		ItemType:    itemType,
-		ItemID:      parseUUID(itemID),
+		ItemID:      itemUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete pin")
@@ -182,11 +191,20 @@ func (h *Handler) ReorderPins(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+
 	for _, item := range req.Items {
+		itemUUID, ok := parseUUIDOrBadRequest(w, item.ID, "items[].id")
+		if !ok {
+			return
+		}
 		if err := h.Queries.UpdatePinnedItemPosition(r.Context(), db.UpdatePinnedItemPositionParams{
 			Position:    item.Position,
-			ID:          parseUUID(item.ID),
-			WorkspaceID: parseUUID(workspaceID),
+			ID:          itemUUID,
+			WorkspaceID: wsUUID,
 			UserID:      parseUUID(userID),
 		}); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to reorder pins")

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -78,6 +78,10 @@ type UpdateProjectRequest struct {
 
 func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
 	var statusFilter pgtype.Text
 	if s := r.URL.Query().Get("status"); s != "" {
 		statusFilter = pgtype.Text{String: s, Valid: true}
@@ -87,7 +91,7 @@ func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 		priorityFilter = pgtype.Text{String: p, Valid: true}
 	}
 	projects, err := h.Queries.ListProjects(r.Context(), db.ListProjectsParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		Status:      statusFilter,
 		Priority:    priorityFilter,
 	})
@@ -125,8 +129,16 @@ func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) GetProject(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "project id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	project, err := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
-		ID: parseUUID(id), WorkspaceID: parseUUID(workspaceID),
+		ID: idUUID, WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "project not found")
@@ -166,10 +178,18 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		leadType = pgtype.Text{String: *req.LeadType, Valid: true}
 	}
 	if req.LeadID != nil {
-		leadID = parseUUID(*req.LeadID)
+		id, ok := parseUUIDOrBadRequest(w, *req.LeadID, "lead_id")
+		if !ok {
+			return
+		}
+		leadID = id
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
 	}
 	project, err := h.Queries.CreateProject(r.Context(), db.CreateProjectParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		Title:       req.Title,
 		Description: ptrToText(req.Description),
 		Icon:        ptrToText(req.Icon),
@@ -190,8 +210,16 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "project id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	prevProject, err := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
-		ID: parseUUID(id), WorkspaceID: parseUUID(workspaceID),
+		ID: idUUID, WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "project not found")
@@ -253,7 +281,11 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, ok := rawFields["lead_id"]; ok {
 		if req.LeadID != nil {
-			params.LeadID = parseUUID(*req.LeadID)
+			leadUUID, ok := parseUUIDOrBadRequest(w, *req.LeadID, "lead_id")
+			if !ok {
+				return
+			}
+			params.LeadID = leadUUID
 		} else {
 			params.LeadID = pgtype.UUID{Valid: false}
 		}
@@ -462,7 +494,10 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 
 	includeClosed := r.URL.Query().Get("include_closed") == "true"
 
-	wsUUID := parseUUID(workspaceID)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
 	terms := splitSearchTerms(q)
 
 	sqlQuery, args := buildProjectSearchQuery(q, terms, includeClosed)

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -271,9 +271,18 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	workspaceID := h.resolveWorkspaceID(r)
-	if _, err := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
-		ID: parseUUID(id), WorkspaceID: parseUUID(workspaceID),
-	}); err != nil {
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "project id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+	project, err := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
+		ID: idUUID, WorkspaceID: wsUUID,
+	})
+	if err != nil {
 		writeError(w, http.StatusNotFound, "project not found")
 		return
 	}
@@ -281,11 +290,11 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := h.Queries.DeleteProject(r.Context(), parseUUID(id)); err != nil {
+	if err := h.Queries.DeleteProject(r.Context(), project.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete project")
 		return
 	}
-	h.publish(protocol.EventProjectDeleted, workspaceID, "member", userID, map[string]any{"project_id": id})
+	h.publish(protocol.EventProjectDeleted, workspaceID, "member", userID, map[string]any{"project_id": uuidToString(project.ID)})
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/server/internal/handler/reaction.go
+++ b/server/internal/handler/reaction.go
@@ -41,9 +41,17 @@ func (h *Handler) AddReaction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspaceID := h.resolveWorkspaceID(r)
+	commentUUID, ok := parseUUIDOrBadRequest(w, commentId, "comment id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	comment, err := h.Queries.GetCommentInWorkspace(r.Context(), db.GetCommentInWorkspaceParams{
-		ID:          parseUUID(commentId),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          commentUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "comment not found")
@@ -66,7 +74,7 @@ func (h *Handler) AddReaction(w http.ResponseWriter, r *http.Request) {
 
 	reaction, err := h.Queries.AddReaction(r.Context(), db.AddReactionParams{
 		CommentID:   comment.ID,
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: wsUUID,
 		ActorType:   actorType,
 		ActorID:     parseUUID(actorID),
 		Emoji:       req.Emoji,
@@ -108,9 +116,17 @@ func (h *Handler) RemoveReaction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	workspaceID := h.resolveWorkspaceID(r)
+	commentUUID, ok := parseUUIDOrBadRequest(w, commentId, "comment id")
+	if !ok {
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 	comment, err := h.Queries.GetCommentInWorkspace(r.Context(), db.GetCommentInWorkspaceParams{
-		ID:          parseUUID(commentId),
-		WorkspaceID: parseUUID(workspaceID),
+		ID:          commentUUID,
+		WorkspaceID: wsUUID,
 	})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "comment not found")
@@ -143,7 +159,7 @@ func (h *Handler) RemoveReaction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.publish(protocol.EventReactionRemoved, workspaceID, actorType, actorID, map[string]any{
-		"comment_id": commentId,
+		"comment_id": uuidToString(comment.ID),
 		"issue_id":   uuidToString(comment.IssueID),
 		"emoji":      req.Emoji,
 		"actor_type": actorType,

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -79,8 +79,12 @@ type RuntimeUsageResponse struct {
 // same tool).
 func (h *Handler) GetRuntimeUsage(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return
+	}
 
-	rt, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(runtimeID))
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "runtime not found")
 		return
@@ -93,7 +97,7 @@ func (h *Handler) GetRuntimeUsage(w http.ResponseWriter, r *http.Request) {
 	since := parseSinceParam(r, 90)
 
 	rows, err := h.Queries.ListRuntimeUsage(r.Context(), db.ListRuntimeUsageParams{
-		RuntimeID: parseUUID(runtimeID),
+		RuntimeID: rt.ID,
 		Since:     since,
 	})
 	if err != nil {
@@ -102,9 +106,10 @@ func (h *Handler) GetRuntimeUsage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := make([]RuntimeUsageResponse, len(rows))
+	resolvedRuntimeID := uuidToString(rt.ID)
 	for i, row := range rows {
 		resp[i] = RuntimeUsageResponse{
-			RuntimeID:        runtimeID,
+			RuntimeID:        resolvedRuntimeID,
 			Date:             row.Date.Time.Format("2006-01-02"),
 			Provider:         row.Provider,
 			Model:            row.Model,
@@ -121,8 +126,12 @@ func (h *Handler) GetRuntimeUsage(w http.ResponseWriter, r *http.Request) {
 // GetRuntimeTaskActivity returns hourly task activity distribution for a runtime.
 func (h *Handler) GetRuntimeTaskActivity(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return
+	}
 
-	rt, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(runtimeID))
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "runtime not found")
 		return
@@ -132,7 +141,7 @@ func (h *Handler) GetRuntimeTaskActivity(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	rows, err := h.Queries.GetRuntimeTaskHourlyActivity(r.Context(), parseUUID(runtimeID))
+	rows, err := h.Queries.GetRuntimeTaskHourlyActivity(r.Context(), rt.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to get task activity")
 		return
@@ -276,8 +285,12 @@ func (h *Handler) ListAgentRuntimes(w http.ResponseWriter, r *http.Request) {
 // DeleteAgentRuntime deletes a runtime after permission and dependency checks.
 func (h *Handler) DeleteAgentRuntime(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return
+	}
 
-	rt, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(runtimeID))
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "runtime not found")
 		return
@@ -320,7 +333,7 @@ func (h *Handler) DeleteAgentRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("runtime deleted", "runtime_id", runtimeID, "deleted_by", userID)
+	slog.Info("runtime deleted", "runtime_id", uuidToString(rt.ID), "deleted_by", userID)
 
 	// Notify frontend to refresh runtime list.
 	h.publish(protocol.EventDaemonRegister, wsID, "member", userID, map[string]any{

--- a/server/internal/handler/runtime_local_skills.go
+++ b/server/internal/handler/runtime_local_skills.go
@@ -388,7 +388,12 @@ func runtimeLocalSkillRequestTerminal(status RuntimeLocalSkillRequestStatus) boo
 }
 
 func (h *Handler) requireRuntimeLocalSkillAccess(w http.ResponseWriter, r *http.Request, runtimeID string) (runtimeIDAndWorkspace, bool) {
-	rt, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(runtimeID))
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return runtimeIDAndWorkspace{}, false
+	}
+
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "runtime not found")
 		return runtimeIDAndWorkspace{}, false
@@ -402,7 +407,7 @@ func (h *Handler) requireRuntimeLocalSkillAccess(w http.ResponseWriter, r *http.
 
 	if rt.OwnerID.Valid && uuidToString(rt.OwnerID) == uuidToString(member.UserID) {
 		return runtimeIDAndWorkspace{
-			runtimeID:   runtimeID,
+			runtimeID:   uuidToString(rt.ID),
 			workspaceID: wsID,
 			provider:    rt.Provider,
 			status:      rt.Status,
@@ -431,7 +436,7 @@ func (h *Handler) InitiateListLocalSkills(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	req, err := h.LocalSkillListStore.Create(r.Context(), runtimeID)
+	req, err := h.LocalSkillListStore.Create(r.Context(), rt.runtimeID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to enqueue local skills request: "+err.Error())
 		return
@@ -441,7 +446,8 @@ func (h *Handler) InitiateListLocalSkills(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) GetLocalSkillListRequest(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
-	if _, ok := h.requireRuntimeLocalSkillAccess(w, r, runtimeID); !ok {
+	rt, ok := h.requireRuntimeLocalSkillAccess(w, r, runtimeID)
+	if !ok {
 		return
 	}
 
@@ -451,7 +457,7 @@ func (h *Handler) GetLocalSkillListRequest(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusInternalServerError, "failed to load request: "+err.Error())
 		return
 	}
-	if req == nil || req.RuntimeID != runtimeID {
+	if req == nil || req.RuntimeID != rt.runtimeID {
 		writeError(w, http.StatusNotFound, "request not found")
 		return
 	}
@@ -487,7 +493,7 @@ func (h *Handler) InitiateImportLocalSkill(w http.ResponseWriter, r *http.Reques
 
 	importReq, err := h.LocalSkillImportStore.Create(
 		r.Context(),
-		runtimeID,
+		rt.runtimeID,
 		creatorID,
 		strings.TrimSpace(req.SkillKey),
 		cleanOptionalString(req.Name),
@@ -502,7 +508,8 @@ func (h *Handler) InitiateImportLocalSkill(w http.ResponseWriter, r *http.Reques
 
 func (h *Handler) GetLocalSkillImportRequest(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
-	if _, ok := h.requireRuntimeLocalSkillAccess(w, r, runtimeID); !ok {
+	rt, ok := h.requireRuntimeLocalSkillAccess(w, r, runtimeID)
+	if !ok {
 		return
 	}
 
@@ -512,7 +519,7 @@ func (h *Handler) GetLocalSkillImportRequest(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, "failed to load request: "+err.Error())
 		return
 	}
-	if req == nil || req.RuntimeID != runtimeID {
+	if req == nil || req.RuntimeID != rt.runtimeID {
 		writeError(w, http.StatusNotFound, "request not found")
 		return
 	}

--- a/server/internal/handler/runtime_local_skills.go
+++ b/server/internal/handler/runtime_local_skills.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/multica-ai/multica/server/internal/util"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
@@ -629,6 +630,15 @@ func (h *Handler) ReportLocalSkillImportResult(w http.ResponseWriter, r *http.Re
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 		return
 	}
+	creatorUUID, err := util.ParseUUID(req.CreatorID)
+	if err != nil {
+		failMsg := "stored local skill import creator_id is invalid"
+		if ferr := h.LocalSkillImportStore.Fail(r.Context(), requestID, failMsg); ferr != nil {
+			slog.Error("local skill import Fail failed", "error", ferr, "request_id", requestID)
+		}
+		writeError(w, http.StatusInternalServerError, failMsg)
+		return
+	}
 
 	name := body.Skill.Name
 	if req.Name != nil {
@@ -648,8 +658,8 @@ func (h *Handler) ReportLocalSkillImportResult(w http.ResponseWriter, r *http.Re
 	}
 
 	resp, err := h.createSkillWithFiles(r.Context(), skillCreateInput{
-		WorkspaceID: uuidToString(rt.WorkspaceID),
-		CreatorID:   req.CreatorID,
+		WorkspaceID: rt.WorkspaceID,
+		CreatorID:   creatorUUID,
 		Name:        name,
 		Description: description,
 		Content:     body.Skill.Content,

--- a/server/internal/handler/runtime_models.go
+++ b/server/internal/handler/runtime_models.go
@@ -193,8 +193,12 @@ func (s *ModelListStore) Fail(id string, errMsg string) {
 // Called by the frontend; the daemon picks it up on its next heartbeat.
 func (h *Handler) InitiateListModels(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return
+	}
 
-	rt, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(runtimeID))
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "runtime not found")
 		return
@@ -207,7 +211,7 @@ func (h *Handler) InitiateListModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req := h.ModelListStore.Create(runtimeID)
+	req := h.ModelListStore.Create(uuidToString(rt.ID))
 	writeJSON(w, http.StatusOK, req)
 }
 

--- a/server/internal/handler/runtime_test.go
+++ b/server/internal/handler/runtime_test.go
@@ -9,6 +9,64 @@ import (
 	"time"
 )
 
+func TestRuntimeHandlersRejectMalformedRuntimeID(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		handle func(http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:   "usage",
+			method: "GET",
+			path:   "/api/runtimes/not-a-uuid/usage",
+			handle: testHandler.GetRuntimeUsage,
+		},
+		{
+			name:   "task activity",
+			method: "GET",
+			path:   "/api/runtimes/not-a-uuid/task-activity",
+			handle: testHandler.GetRuntimeTaskActivity,
+		},
+		{
+			name:   "delete",
+			method: "DELETE",
+			path:   "/api/runtimes/not-a-uuid",
+			handle: testHandler.DeleteAgentRuntime,
+		},
+		{
+			name:   "models",
+			method: "POST",
+			path:   "/api/runtimes/not-a-uuid/models",
+			handle: testHandler.InitiateListModels,
+		},
+		{
+			name:   "update",
+			method: "POST",
+			path:   "/api/runtimes/not-a-uuid/update",
+			handle: testHandler.InitiateUpdate,
+		},
+		{
+			name:   "local skills",
+			method: "POST",
+			path:   "/api/runtimes/not-a-uuid/local-skills",
+			handle: testHandler.InitiateListLocalSkills,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newRequest(tt.method, tt.path, nil)
+			req = withURLParam(req, "runtimeId", "not-a-uuid")
+			tt.handle(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("%s: expected 400 for malformed runtimeId, got %d: %s", tt.name, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 // TestGetRuntimeUsage_BucketsByUsageTime ensures a task that was enqueued on
 // one calendar day but whose tokens were reported the next day (e.g. execution
 // crossed midnight, or the task sat in the queue) is attributed to the day
@@ -78,7 +136,7 @@ func TestGetRuntimeUsage_BucketsByUsageTime(t *testing.T) {
 		return taskID
 	}
 
-	insertTaskWithUsage(yesterdayLate, todayEarly, 1000)     // cross-midnight
+	insertTaskWithUsage(yesterdayLate, todayEarly, 1000)          // cross-midnight
 	insertTaskWithUsage(yesterdayMorning, yesterdayMorning, 2000) // full-day yesterday
 
 	// Call the handler with ?days=1 at whatever "now" is. That should include

--- a/server/internal/handler/runtime_update.go
+++ b/server/internal/handler/runtime_update.go
@@ -144,8 +144,12 @@ func (s *UpdateStore) Fail(id string, errMsg string) {
 // InitiateUpdate creates a new CLI update request (protected route, called by frontend).
 func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return
+	}
 
-	rt, err := h.Queries.GetAgentRuntime(r.Context(), parseUUID(runtimeID))
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "runtime not found")
 		return
@@ -167,7 +171,7 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	update, err := h.UpdateStore.Create(runtimeID, req.TargetVersion)
+	update, err := h.UpdateStore.Create(uuidToString(rt.ID), req.TargetVersion)
 	if err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -190,6 +190,11 @@ func (h *Handler) CreateSkill(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
+	creatorUUID := parseUUID(creatorID)
 
 	var req CreateSkillRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -210,8 +215,8 @@ func (h *Handler) CreateSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, err := h.createSkillWithFiles(r.Context(), skillCreateInput{
-		WorkspaceID: workspaceID,
-		CreatorID:   creatorID,
+		WorkspaceID: workspaceUUID,
+		CreatorID:   creatorUUID,
 		Name:        req.Name,
 		Description: req.Description,
 		Content:     req.Content,
@@ -1073,6 +1078,11 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
+	creatorUUID := parseUUID(creatorID)
 
 	var req ImportSkillRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1112,8 +1122,8 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp, err := h.createSkillWithFiles(r.Context(), skillCreateInput{
-		WorkspaceID: workspaceID,
-		CreatorID:   creatorID,
+		WorkspaceID: workspaceUUID,
+		CreatorID:   creatorUUID,
 		Name:        imported.name,
 		Description: imported.description,
 		Content:     imported.content,

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -1265,6 +1265,10 @@ func (h *Handler) SetAgentSkills(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
+	skillUUIDs, ok := parseUUIDSliceOrBadRequest(w, req.SkillIDs, "skill_ids")
+	if !ok {
+		return
+	}
 
 	tx, err := h.TxStarter.Begin(r.Context())
 	if err != nil {
@@ -1280,10 +1284,10 @@ func (h *Handler) SetAgentSkills(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for _, skillID := range req.SkillIDs {
+	for _, skillID := range skillUUIDs {
 		if err := qtx.AddAgentSkill(r.Context(), db.AddAgentSkillParams{
 			AgentID: agent.ID,
-			SkillID: parseUUID(skillID),
+			SkillID: skillID,
 		}); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to add agent skill: "+err.Error())
 			return

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -360,12 +360,12 @@ func (h *Handler) DeleteSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.Queries.DeleteSkill(r.Context(), parseUUID(id)); err != nil {
+	if err := h.Queries.DeleteSkill(r.Context(), skill.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete skill")
 		return
 	}
 	actorType, actorID := h.resolveActor(r, requestUserID(r), uuidToString(skill.WorkspaceID))
-	h.publish(protocol.EventSkillDeleted, uuidToString(skill.WorkspaceID), actorType, actorID, map[string]any{"skill_id": id})
+	h.publish(protocol.EventSkillDeleted, uuidToString(skill.WorkspaceID), actorType, actorID, map[string]any{"skill_id": uuidToString(skill.ID)})
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -1200,7 +1200,18 @@ func (h *Handler) DeleteSkillFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fileID := chi.URLParam(r, "fileId")
-	if err := h.Queries.DeleteSkillFile(r.Context(), parseUUID(fileID)); err != nil {
+	fileUUID, ok := parseUUIDOrBadRequest(w, fileID, "file id")
+	if !ok {
+		return
+	}
+	// Verify the file belongs to the parent skill we just authorized — guards
+	// against deleting a file owned by a different skill via the URL param.
+	file, err := h.Queries.GetSkillFile(r.Context(), fileUUID)
+	if err != nil || uuidToString(file.SkillID) != uuidToString(skill.ID) {
+		writeError(w, http.StatusNotFound, "skill file not found")
+		return
+	}
+	if err := h.Queries.DeleteSkillFile(r.Context(), file.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to delete skill file")
 		return
 	}

--- a/server/internal/handler/skill_create.go
+++ b/server/internal/handler/skill_create.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 type skillCreateInput struct {
-	WorkspaceID string
-	CreatorID   string
+	WorkspaceID pgtype.UUID
+	CreatorID   pgtype.UUID
 	Name        string
 	Description string
 	Content     string
@@ -35,12 +36,12 @@ func (h *Handler) createSkillWithFiles(ctx context.Context, input skillCreateInp
 	qtx := h.Queries.WithTx(tx)
 
 	skill, err := qtx.CreateSkill(ctx, db.CreateSkillParams{
-		WorkspaceID: parseUUID(input.WorkspaceID),
+		WorkspaceID: input.WorkspaceID,
 		Name:        input.Name,
 		Description: input.Description,
 		Content:     input.Content,
 		Config:      config,
-		CreatedBy:   parseUUID(input.CreatorID),
+		CreatedBy:   input.CreatorID,
 	})
 	if err != nil {
 		return SkillWithFilesResponse{}, err

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -114,8 +114,12 @@ func (h *Handler) ListWorkspaces(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) GetWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := workspaceIDFromURL(r, "id")
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "workspace id")
+	if !ok {
+		return
+	}
 
-	ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(id))
+	ws, err := h.Queries.GetWorkspace(r.Context(), idUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "workspace not found")
 		return
@@ -223,6 +227,10 @@ type UpdateWorkspaceRequest struct {
 
 func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := workspaceIDFromURL(r, "id")
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "workspace id")
+	if !ok {
+		return
+	}
 
 	var req UpdateWorkspaceRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -231,7 +239,7 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := db.UpdateWorkspaceParams{
-		ID: parseUUID(id),
+		ID: idUUID,
 	}
 	if req.Name != nil {
 		name := strings.TrimSpace(*req.Name)
@@ -271,18 +279,19 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("workspace updated", append(logger.RequestAttrs(r), "workspace_id", id)...)
 	userID := requestUserID(r)
-	h.publish(protocol.EventWorkspaceUpdated, id, "member", userID, map[string]any{"workspace": workspaceToResponse(ws)})
+	h.publish(protocol.EventWorkspaceUpdated, uuidToString(ws.ID), "member", userID, map[string]any{"workspace": workspaceToResponse(ws)})
 
 	writeJSON(w, http.StatusOK, workspaceToResponse(ws))
 }
 
 func (h *Handler) ListMembers(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "id")
-	if _, ok := h.requireWorkspaceMember(w, r, workspaceID, "workspace not found"); !ok {
+	member, ok := h.requireWorkspaceMember(w, r, workspaceID, "workspace not found")
+	if !ok {
 		return
 	}
 
-	members, err := h.Queries.ListMembers(r.Context(), parseUUID(workspaceID))
+	members, err := h.Queries.ListMembers(r.Context(), member.WorkspaceID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list members")
 		return
@@ -309,8 +318,12 @@ type MemberWithUserResponse struct {
 
 func (h *Handler) ListMembersWithUser(w http.ResponseWriter, r *http.Request) {
 	workspaceID := workspaceIDFromURL(r, "id")
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
 
-	members, err := h.Queries.ListMembersWithUser(r.Context(), parseUUID(workspaceID))
+	members, err := h.Queries.ListMembersWithUser(r.Context(), wsUUID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list members")
 		return
@@ -413,7 +426,7 @@ func (h *Handler) CreateMember(w http.ResponseWriter, r *http.Request) {
 	}
 
 	member, err := h.Queries.CreateMember(r.Context(), db.CreateMemberParams{
-		WorkspaceID: parseUUID(workspaceID),
+		WorkspaceID: requester.WorkspaceID,
 		UserID:      user.ID,
 		Role:        role,
 	})
@@ -430,10 +443,10 @@ func (h *Handler) CreateMember(w http.ResponseWriter, r *http.Request) {
 	slog.Info("member added", append(logger.RequestAttrs(r), "member_id", uuidToString(member.ID), "workspace_id", workspaceID, "email", email, "role", role)...)
 	userID := requestUserID(r)
 	eventPayload := map[string]any{"member": memberWithUserResponse(member, user)}
-	if ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(workspaceID)); err == nil {
+	if ws, err := h.Queries.GetWorkspace(r.Context(), requester.WorkspaceID); err == nil {
 		eventPayload["workspace_name"] = ws.Name
 	}
-	h.publish(protocol.EventMemberAdded, workspaceID, "member", userID, eventPayload)
+	h.publish(protocol.EventMemberAdded, uuidToString(requester.WorkspaceID), "member", userID, eventPayload)
 
 	writeJSON(w, http.StatusCreated, memberWithUserResponse(member, user))
 }
@@ -450,8 +463,12 @@ func (h *Handler) UpdateMember(w http.ResponseWriter, r *http.Request) {
 	}
 
 	memberID := chi.URLParam(r, "memberId")
-	target, err := h.Queries.GetMember(r.Context(), parseUUID(memberID))
-	if err != nil || uuidToString(target.WorkspaceID) != workspaceID {
+	memberUUID, ok := parseUUIDOrBadRequest(w, memberID, "member id")
+	if !ok {
+		return
+	}
+	target, err := h.Queries.GetMember(r.Context(), memberUUID)
+	if err != nil || uuidToString(target.WorkspaceID) != uuidToString(requester.WorkspaceID) {
 		writeError(w, http.StatusNotFound, "member not found")
 		return
 	}
@@ -505,7 +522,7 @@ func (h *Handler) UpdateMember(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := requestUserID(r)
-	h.publish(protocol.EventMemberUpdated, workspaceID, "member", userID, map[string]any{
+	h.publish(protocol.EventMemberUpdated, uuidToString(requester.WorkspaceID), "member", userID, map[string]any{
 		"member": memberWithUserResponse(updatedMember, user),
 	})
 
@@ -520,8 +537,12 @@ func (h *Handler) DeleteMember(w http.ResponseWriter, r *http.Request) {
 	}
 
 	memberID := chi.URLParam(r, "memberId")
-	target, err := h.Queries.GetMember(r.Context(), parseUUID(memberID))
-	if err != nil || uuidToString(target.WorkspaceID) != workspaceID {
+	memberUUID, ok := parseUUIDOrBadRequest(w, memberID, "member id")
+	if !ok {
+		return
+	}
+	target, err := h.Queries.GetMember(r.Context(), memberUUID)
+	if err != nil || uuidToString(target.WorkspaceID) != uuidToString(requester.WorkspaceID) {
 		writeError(w, http.StatusNotFound, "member not found")
 		return
 	}
@@ -551,9 +572,9 @@ func (h *Handler) DeleteMember(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("member removed", append(logger.RequestAttrs(r), "member_id", uuidToString(target.ID), "workspace_id", workspaceID, "user_id", uuidToString(target.UserID))...)
 	userID := requestUserID(r)
-	h.publish(protocol.EventMemberRemoved, workspaceID, "member", userID, map[string]any{
+	h.publish(protocol.EventMemberRemoved, uuidToString(requester.WorkspaceID), "member", userID, map[string]any{
 		"member_id":    uuidToString(target.ID),
-		"workspace_id": workspaceID,
+		"workspace_id": uuidToString(requester.WorkspaceID),
 		"user_id":      uuidToString(target.UserID),
 	})
 

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -612,7 +612,9 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.Queries.DeleteWorkspace(r.Context(), parseUUID(workspaceID)); err != nil {
+	// At this point workspaceMember has resolved → workspaceID is a valid UUID
+	// (the lookup would have errored otherwise), so reuse the resolved value.
+	if err := h.Queries.DeleteWorkspace(r.Context(), requester.WorkspaceID); err != nil {
 		slog.Warn("delete workspace failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID)...)
 		writeError(w, http.StatusInternalServerError, "failed to delete workspace")
 		return

--- a/server/internal/middleware/workspace.go
+++ b/server/internal/middleware/workspace.go
@@ -186,9 +186,19 @@ func buildMiddleware(queries *db.Queries, resolve workspaceResolver, roles []str
 				return
 			}
 
+			userUUID, err := util.ParseUUID(userID)
+			if err != nil {
+				writeError(w, http.StatusUnauthorized, "user not authenticated")
+				return
+			}
+			wsUUID, err := util.ParseUUID(workspaceID)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "invalid workspace_id")
+				return
+			}
 			member, err := queries.GetMemberByUserAndWorkspace(r.Context(), db.GetMemberByUserAndWorkspaceParams{
-				UserID:      util.ParseUUID(userID),
-				WorkspaceID: util.ParseUUID(workspaceID),
+				UserID:      userUUID,
+				WorkspaceID: wsUUID,
 			})
 			if err != nil {
 				writeError(w, http.StatusNotFound, "workspace not found")

--- a/server/internal/util/pgx.go
+++ b/server/internal/util/pgx.go
@@ -2,14 +2,39 @@ package util
 
 import (
 	"encoding/hex"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-func ParseUUID(s string) pgtype.UUID {
+// ParseUUID parses s into a pgtype.UUID. Invalid input returns an error
+// instead of a zero-valued UUID — silently dropping bad input has caused
+// data-loss bugs (e.g. DELETE matching no rows, returning 204 success).
+//
+// Use this at any boundary where s comes from user input (URL params,
+// request bodies, headers) and pair it with a 4xx response on error.
+// For trusted, already-validated UUID strings (sqlc round-trips, fixtures),
+// use MustParseUUID instead.
+func ParseUUID(s string) (pgtype.UUID, error) {
 	var u pgtype.UUID
-	_ = u.Scan(s)
+	if err := u.Scan(s); err != nil {
+		return u, fmt.Errorf("invalid UUID %q: %w", s, err)
+	}
+	if !u.Valid {
+		return u, fmt.Errorf("invalid UUID: %q", s)
+	}
+	return u, nil
+}
+
+// MustParseUUID parses s into a pgtype.UUID and panics on invalid input.
+// Reserve for trusted callers (already-validated round-trips, test fixtures).
+// At a request boundary, use ParseUUID and surface a 4xx instead.
+func MustParseUUID(s string) pgtype.UUID {
+	u, err := ParseUUID(s)
+	if err != nil {
+		panic(err)
+	}
 	return u
 }
 

--- a/server/internal/util/pgx_test.go
+++ b/server/internal/util/pgx_test.go
@@ -1,0 +1,47 @@
+package util
+
+import "testing"
+
+func TestParseUUID_Valid(t *testing.T) {
+	u, err := ParseUUID("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !u.Valid {
+		t.Fatalf("expected u.Valid = true")
+	}
+}
+
+func TestParseUUID_InvalidReturnsError(t *testing.T) {
+	cases := []string{"", "not-a-uuid", "MUL-123", "12345"}
+	for _, s := range cases {
+		t.Run(s, func(t *testing.T) {
+			u, err := ParseUUID(s)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil (u.Valid=%v)", s, u.Valid)
+			}
+			if u.Valid {
+				// Critical invariant: invalid input must NOT yield a valid UUID.
+				// Returning a valid zero-UUID was the root cause of #1661.
+				t.Fatalf("expected u.Valid = false for %q, got true", s)
+			}
+		})
+	}
+}
+
+func TestMustParseUUID_PanicsOnInvalid(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected MustParseUUID to panic on invalid input")
+		}
+	}()
+	MustParseUUID("not-a-uuid")
+}
+
+func TestMustParseUUID_RoundTrip(t *testing.T) {
+	const s = "550e8400-e29b-41d4-a716-446655440000"
+	u := MustParseUUID(s)
+	if got := UUIDToString(u); got != s {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, s)
+	}
+}


### PR DESCRIPTION
## Summary

`util.ParseUUID` previously swallowed errors and returned a zero `pgtype.UUID` on invalid input. When that zero UUID reached a write query (`Queries.Delete*` / `Queries.Update*`), the SQL matched zero rows and the handler returned `2xx` success — silent data corruption. #1661 (`DELETE /api/issues/MUL-123` returning 204 without deleting) was the visible symptom; PR #1680 patched that one site, this PR closes the **class** of bug.

## What changed

### `util.ParseUUID` API change

- `ParseUUID(s) → (pgtype.UUID, error)` — errors on invalid input
- `MustParseUUID(s) → pgtype.UUID` — panics on invalid input (use only for trusted round-trips: sqlc-returned UUIDs, test fixtures)

### `handler/handler.go`

- `parseUUID(s) pgtype.UUID` wrapper now calls `MustParseUUID` — any unguarded user-input string surfaces as a recovered panic (chi `middleware.Recoverer` → 500) instead of silently corrupting data via a zero UUID
- New `parseUUIDOrBadRequest(w, s, fieldName) (pgtype.UUID, bool)` helper — validates user input and writes a 400 on failure

### Audit of write-query call sites

Converted every `Queries.Delete*` / `Queries.Update*` site reachable from raw user input to validate UUIDs explicitly:

- `autopilot.go` — `DeleteAutopilot`, `DeleteAutopilotTrigger`
- `comment.go` — `DeleteComment`
- `daemon.go` — `requireDaemonRuntimeAccess`, `requireDaemonTaskAccess` (validate up front; heartbeat reuses the resolved `rt.ID`)
- `feedback.go` — `CreateFeedback` workspace_id (was relying on silent-zero for "no workspace")
- `file.go` — `DeleteAttachment`
- `issue.go` — Create/Update assignee_id (now go through `parseUUIDOrBadRequest`)
- `label.go` — `UpdateLabel`, `DeleteLabel`
- `pin.go` — `DeletePin`, `ReorderPins`
- `project.go` — `DeleteProject`
- `skill.go` — `DeleteSkill`, `DeleteSkillFile` (also now verifies the file belongs to the parent skill)
- `workspace.go` — `DeleteWorkspace` reuses `requester.WorkspaceID`

Where a resolved `entity.ID` was already in scope, write queries now use it directly instead of re-parsing the URL string. WS event payloads similarly emit `uuidToString(entity.ID)` instead of leaking raw input strings to subscribers.

### Other callers

`util.ParseUUID` callers outside `handler/`:
- `middleware/workspace.go` — checks errors, returns 401/400
- `cmd/server/scope_authorizer.go` — returns `false, nil` on invalid UUID (matches existing failure semantics)
- `cmd/server/router.go` — local `parseUUID` switched to `MustParseUUID`
- Test helpers in `cmd/server/*_test.go` — switched to `MustParseUUID` (test fixtures are trusted)

### Tests

- `server/internal/util/pgx_test.go` — covers valid/invalid input and the `MustParseUUID` panic contract
- `TestDeleteIssueByIdentifier` — regression for #1661 (DELETE by `MUL-N`-style identifier must actually remove the row, verified by a count query)
- `TestDeleteIssueRejectsInvalidUUID` — DELETE with a malformed id must NOT return 204
- Existing `TestParseUUIDConsistency` updated to assert `parseUUID("")` panics (the silent-zero behavior is gone)

### Docs

`CLAUDE.md` gains a "Backend Handler UUID Parsing Convention" section documenting the rule for future PR review:
- Resource params that accept UUID-or-identifier MUST go through a loader; subsequent writes use `entity.ID`
- Pure-UUID inputs MUST be validated with `parseUUIDOrBadRequest`
- Trusted round-trips use `parseUUID` / `util.MustParseUUID` and panic on bad input (Recoverer turns it into 500, never silent corruption)

## Test plan

- [x] `go test ./...` — all server tests green (handler, util, cmd/server, middleware)
- [x] New regression tests pass: `TestDeleteIssueByIdentifier`, `TestDeleteIssueRejectsInvalidUUID`
- [x] `util.ParseUUID` unit tests cover empty string, malformed string, identifier-format string, valid UUID, and `MustParseUUID` panic
- [ ] Manual: hit `DELETE /api/autopilots/not-a-uuid` and verify 400 (was 500/silent-204 paths previously)
- [ ] Manual: hit `DELETE /api/issues/MUL-1` and confirm 204 + row actually removed (covered by automated test, worth a smoke check too)