### PR TITLE
feat(self-host): add configurable MASTER_LOGIN_CODE

### DIFF
--- a/apps/docs/content/docs/auth-setup.mdx
+++ b/apps/docs/content/docs/auth-setup.mdx
@@ -27,17 +27,21 @@ The user enters an email on the sign-in page → the server sends a 6-digit code
 
 **What happens if you don't set `RESEND_API_KEY`**: the server doesn't error, but **every email that should have been sent is written to the server's stdout only**. Handy for local development (copy the code from the logs); in production it's a black hole.
 
+For private self-host deployments that do not want to set up email delivery, you can optionally set `MASTER_LOGIN_CODE` to a fixed verification code. When set, that code works as a master login code in both development and production. This is intentionally powerful; only use it on trusted/private deployments.
+
 ## The 888888 trap
 
 <Callout type="warning">
-**If `APP_ENV` is not set to `production`, anyone can sign in to any account with the code `888888`.**
+**If `MASTER_LOGIN_CODE` is set, anyone who knows that code can sign in to any account.**
 
-Multica has a development-only master code, `888888` — a backdoor so local development doesn't depend on Resend. The rule is straightforward: when `APP_ENV != "production"`, **any email** plus `888888` passes verification.
+Multica supports an optional fixed master login code via `MASTER_LOGIN_CODE`. When set, that code works in both development and production, which is useful for private self-host deployments that do not want to wire email delivery.
 
-**Production deployments must set `APP_ENV=production`**. If you deploy via `make selfhost` / `docker-compose.selfhost.yml`, this value is already set to `production` by default; but if you deploy from source yourself, write your own Docker config, or redefine environment variables in Kubernetes — you must add `APP_ENV=production` yourself.
+If `MASTER_LOGIN_CODE` is empty and `APP_ENV` is not `production`, Multica falls back to the development-only code `888888` so local development does not depend on Resend.
+
+**Production deployments should either configure real email delivery or treat `MASTER_LOGIN_CODE` like a highly sensitive secret.** If you deploy via `make selfhost` / `docker-compose.selfhost.yml`, `APP_ENV` is already set to `production` by default; if you deploy from source yourself, write your own Docker config, or redefine environment variables in Kubernetes — you must add `APP_ENV=production` yourself.
 </Callout>
 
-To check whether your deployment has this trap: open the sign-in page, enter **any email** to request a code, then enter `888888`. If you get in, your `APP_ENV` is not set to `production`, and **the entire instance is wide open**.
+To check whether your deployment is using a master-code path: open the sign-in page, enter **any email** to request a code, then enter your configured `MASTER_LOGIN_CODE` (or `888888` when intentionally relying on the development fallback). If you get in, your instance is accepting a master code by design.
 
 ## Google OAuth configuration
 

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -16,11 +16,12 @@ These are the five you must think about before deploying — some have defaults 
 | `DATABASE_URL` | `postgres://multica:multica@localhost:5432/multica?sslmode=disable` | **Yes** |
 | `PORT` | `8080` | No (unless you change the port) |
 | `JWT_SECRET` | `multica-dev-secret-change-in-production` | **Yes** (the default is unsafe) |
-| `APP_ENV` | empty | **Yes** (must be `production` — see the next section for the trap) |
+| `APP_ENV` | empty | **Yes** (must be `production` unless you intentionally want the dev `888888` fallback) |
 | `FRONTEND_ORIGIN` | empty | **Yes** (self-host must set its own domain) |
+| `MASTER_LOGIN_CODE` | empty | No (optional fixed master verification code for private self-host deployments) |
 
 <Callout type="warning">
-**If `APP_ENV` is not set to `production`, anyone can sign in to any account using the code `888888`.** Multica has a development-only master code, `888888` — when `APP_ENV != "production"`, **any email** plus `888888` passes verification. The behavior is intentional for local development (no Resend dependency); **in production, failing to set `production` is equivalent to disabling auth entirely**. See [Sign-in and signup configuration → The 888888 trap](/auth-setup#the-888888-trap).
+**If `MASTER_LOGIN_CODE` is set, anyone who knows that code can sign in to any account.** When `MASTER_LOGIN_CODE` is empty and `APP_ENV != "production"`, Multica falls back to the development-only code `888888`. This is intentional for local development (no Resend dependency); in production, set `APP_ENV=production` and only configure `MASTER_LOGIN_CODE` if you explicitly want a fixed master code for a private deployment. See [Sign-in and signup configuration → The 888888 trap](/auth-setup#the-888888-trap).
 </Callout>
 
 ### Database connection pool

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -92,6 +92,10 @@ func generateCode() (string, error) {
 	return fmt.Sprintf("%06d", n), nil
 }
 
+func configuredMasterLoginCode() string {
+	return strings.TrimSpace(os.Getenv("MASTER_LOGIN_CODE"))
+}
+
 func (h *Handler) issueJWT(user db.User) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"sub":   uuidToString(user.ID),
@@ -311,8 +315,10 @@ func (h *Handler) VerifyCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	isMasterCode := code == "888888" && os.Getenv("APP_ENV") != "production"
-	if !isMasterCode && subtle.ConstantTimeCompare([]byte(code), []byte(dbCode.Code)) != 1 {
+	masterCode := configuredMasterLoginCode()
+	isConfiguredMasterCode := masterCode != "" && subtle.ConstantTimeCompare([]byte(code), []byte(masterCode)) == 1
+	isDevFallbackMasterCode := masterCode == "" && code == "888888" && os.Getenv("APP_ENV") != "production"
+	if !isConfiguredMasterCode && !isDevFallbackMasterCode && subtle.ConstantTimeCompare([]byte(code), []byte(dbCode.Code)) != 1 {
 		_ = h.Queries.IncrementVerificationCodeAttempts(r.Context(), dbCode.ID)
 		writeError(w, http.StatusBadRequest, "invalid or expired code")
 		return

--- a/server/internal/handler/auth_signup_test.go
+++ b/server/internal/handler/auth_signup_test.go
@@ -65,6 +65,31 @@ func (m *mockRow) Scan(dest ...interface{}) error {
 	return m.err
 }
 
+func TestConfiguredMasterLoginCode(t *testing.T) {
+	t.Run("configured_master_code_enabled_in_production", func(t *testing.T) {
+		t.Setenv("APP_ENV", "production")
+		t.Setenv("MASTER_LOGIN_CODE", "654321")
+		if got := configuredMasterLoginCode(); got != "654321" {
+			t.Fatalf("configuredMasterLoginCode() = %q, want %q", got, "654321")
+		}
+	})
+
+	t.Run("configured_master_code_trims_spaces", func(t *testing.T) {
+		t.Setenv("MASTER_LOGIN_CODE", " 777777 ")
+		if got := configuredMasterLoginCode(); got != "777777" {
+			t.Fatalf("configuredMasterLoginCode() = %q, want %q", got, "777777")
+		}
+	})
+
+	t.Run("legacy_dev_fallback_still_available_when_env_empty", func(t *testing.T) {
+		t.Setenv("APP_ENV", "development")
+		t.Setenv("MASTER_LOGIN_CODE", "")
+		if got := configuredMasterLoginCode(); got != "" {
+			t.Fatalf("configuredMasterLoginCode() = %q, want empty", got)
+		}
+	})
+}
+
 func TestFindOrCreateUserGating(t *testing.T) {
 	t.Run("new_user_blocked", func(t *testing.T) {
 		cfg := Config{AllowSignup: false}


### PR DESCRIPTION
## Summary
- add optional `MASTER_LOGIN_CODE` env support for self-hosted deployments
- allow the configured master code to work in both `APP_ENV=development` and `APP_ENV=production`
- keep the legacy `888888` fallback only when `MASTER_LOGIN_CODE` is unset and `APP_ENV != production`
- document the new self-host tradeoff and environment variable

## Why
A practical self-hosting use case is operators who want to run Multica in production mode but do **not** want to set up email delivery (Resend or similar) just to sign in.

Today, the only built-in escape hatch is the hardcoded development fallback `888888`, which is tied to non-production mode. That forces a bad tradeoff:
- either stay in dev mode just to keep a fixed login code
- or move to production and lose the simple no-email login path entirely

This PR adds a middle ground for private/self-hosted deployments:
- operators can explicitly set `MASTER_LOGIN_CODE`
- keep `APP_ENV=production`
- avoid complex email configuration when that is overkill for their use case

This came from a real user need: they want to change the secret master code to a value they control, and they do not want to be forced into email setup just to log in to a private self-hosted instance.

## Behavior
- If `MASTER_LOGIN_CODE` is set, that code works as the master login code in both dev and prod.
- If `MASTER_LOGIN_CODE` is empty:
  - `APP_ENV=development` (or non-production) keeps the existing `888888` fallback
  - `APP_ENV=production` disables the fallback, same as today

## Safety note
This is intentionally powerful and should only be used on trusted/private deployments. The docs now call that out more explicitly.

## Testing
- added targeted handler tests for config parsing / fallback behavior
- full local Go test run was blocked in my environment because the host lacked free disk space while pulling the required Go 1.26.1 image for the repos
