### PR TITLE
fix(server): default_assignee fallback in CreateIssue (ALI-121)

### DIFF
--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -25,6 +25,7 @@ var testPool *pgxpool.Pool
 var testUserID string
 var testWorkspaceID string
 var testRuntimeID string
+var testAgentID string
 
 const (
 	handlerTestEmail         = "handler-test@multica.ai"
@@ -118,15 +119,18 @@ func setupHandlerTestFixture(ctx context.Context, pool *pgxpool.Pool) (string, s
 	}
 	testRuntimeID = runtimeID
 
-	if _, err := pool.Exec(ctx, `
+	var agentID string
+	if err := pool.QueryRow(ctx, `
 		INSERT INTO agent (
 			workspace_id, name, description, runtime_mode, runtime_config,
 			runtime_id, visibility, max_concurrent_tasks, owner_id
 		)
 		VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4)
-	`, workspaceID, "Handler Test Agent", runtimeID, userID); err != nil {
+		RETURNING id
+	`, workspaceID, "Handler Test Agent", runtimeID, userID).Scan(&agentID); err != nil {
 		return "", "", err
 	}
+	testAgentID = agentID
 
 	return userID, workspaceID, nil
 }

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -877,6 +877,13 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if req.AssigneeType == nil && req.AssigneeID == nil {
+		defaultAssigneeType, defaultAssigneeID, ok := h.workspaceDefaultAssignee(r.Context(), workspaceID)
+		if ok {
+			assigneeType = defaultAssigneeType
+			assigneeID = defaultAssigneeID
+		}
+	}
 
 	if status, msg := h.validateAssigneePair(r.Context(), r, workspaceID, assigneeType, assigneeID); status != 0 {
 		writeError(w, status, msg)
@@ -994,6 +1001,63 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (h *Handler) workspaceDefaultAssignee(ctx context.Context, workspaceID string) (pgtype.Text, pgtype.UUID, bool) {
+	workspace, err := h.Queries.GetWorkspace(ctx, parseUUID(workspaceID))
+	if err != nil {
+		slog.Warn("load workspace default assignee failed", "error", err, "workspace_id", workspaceID)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+
+	var settings struct {
+		DefaultAssigneeID   string `json:"default_assignee_id"`
+		DefaultAssigneeType string `json:"default_assignee_type"`
+	}
+	if len(workspace.Settings) == 0 {
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	if err := json.Unmarshal(workspace.Settings, &settings); err != nil {
+		slog.Warn("parse workspace default assignee settings failed", "error", err, "workspace_id", workspaceID)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+
+	assigneeType := strings.TrimSpace(settings.DefaultAssigneeType)
+	assigneeID := strings.TrimSpace(settings.DefaultAssigneeID)
+	if assigneeType == "" || assigneeID == "" {
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+
+	assigneeUUID := parseUUID(assigneeID)
+	if !assigneeUUID.Valid {
+		slog.Warn("workspace default assignee id is invalid", "workspace_id", workspaceID, "default_assignee_type", assigneeType, "default_assignee_id", assigneeID)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+
+	switch assigneeType {
+	case "agent":
+		agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+			ID:          assigneeUUID,
+			WorkspaceID: parseUUID(workspaceID),
+		})
+		if err != nil || agent.ArchivedAt.Valid {
+			slog.Warn("workspace default agent assignee is not available", "error", err, "workspace_id", workspaceID, "default_assignee_id", assigneeID)
+			return pgtype.Text{}, pgtype.UUID{}, false
+		}
+	case "member":
+		if _, err := h.Queries.GetMemberByUserAndWorkspace(ctx, db.GetMemberByUserAndWorkspaceParams{
+			UserID:      assigneeUUID,
+			WorkspaceID: parseUUID(workspaceID),
+		}); err != nil {
+			slog.Warn("workspace default member assignee is not available", "error", err, "workspace_id", workspaceID, "default_assignee_id", assigneeID)
+			return pgtype.Text{}, pgtype.UUID{}, false
+		}
+	default:
+		slog.Warn("workspace default assignee type is unsupported", "workspace_id", workspaceID, "default_assignee_type", assigneeType)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+
+	return pgtype.Text{String: assigneeType, Valid: true}, assigneeUUID, true
 }
 
 type UpdateIssueRequest struct {

--- a/server/internal/handler/issue_default_assignee_test.go
+++ b/server/internal/handler/issue_default_assignee_test.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateIssue_DefaultAssigneeFallback(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name             string
+		settings         map[string]string
+		body             map[string]any
+		wantAssigneeType *string
+		wantAssigneeID   *string
+	}{
+		{
+			name: "uses workspace default when request has no assignee",
+			settings: map[string]string{
+				"default_assignee_type": "agent",
+				"default_assignee_id":   testAgentID,
+			},
+			body: map[string]any{
+				"title": "Default assignee fallback issue",
+			},
+			wantAssigneeType: ptr("agent"),
+			wantAssigneeID:   &testAgentID,
+		},
+		{
+			name: "explicit request assignee wins over workspace default",
+			settings: map[string]string{
+				"default_assignee_type": "agent",
+				"default_assignee_id":   testAgentID,
+			},
+			body: map[string]any{
+				"title":         "Explicit assignee issue",
+				"assignee_type": "member",
+				"assignee_id":   testUserID,
+			},
+			wantAssigneeType: ptr("member"),
+			wantAssigneeID:   &testUserID,
+		},
+		{
+			name:     "empty workspace settings leaves issue unassigned",
+			settings: map[string]string{},
+			body: map[string]any{
+				"title": "Unassigned issue",
+			},
+			wantAssigneeType: nil,
+			wantAssigneeID:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setWorkspaceSettings(t, tt.settings)
+			t.Cleanup(func() {
+				setWorkspaceSettings(t, map[string]string{})
+			})
+
+			w := httptest.NewRecorder()
+			req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, tt.body)
+			testHandler.CreateIssue(w, req)
+			if w.Code != http.StatusCreated {
+				t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+			}
+
+			var created IssueResponse
+			if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+				t.Fatalf("decode CreateIssue response: %v", err)
+			}
+			t.Cleanup(func() {
+				req := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+				req = withURLParam(req, "id", created.ID)
+				testHandler.DeleteIssue(httptest.NewRecorder(), req)
+			})
+
+			assertOptionalString(t, "assignee_type", created.AssigneeType, tt.wantAssigneeType)
+			assertOptionalString(t, "assignee_id", created.AssigneeID, tt.wantAssigneeID)
+		})
+	}
+}
+
+func setWorkspaceSettings(t *testing.T, settings map[string]string) {
+	t.Helper()
+
+	rawSettings, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatalf("marshal workspace settings: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(), `
+		UPDATE workspace
+		SET settings = $1::jsonb
+		WHERE id = $2
+	`, string(rawSettings), testWorkspaceID); err != nil {
+		t.Fatalf("update workspace settings: %v", err)
+	}
+}
+
+func assertOptionalString(t *testing.T, field string, got, want *string) {
+	t.Helper()
+
+	if want == nil {
+		if got != nil {
+			t.Fatalf("expected %s to be nil, got %q", field, *got)
+		}
+		return
+	}
+	if got == nil {
+		t.Fatalf("expected %s %q, got nil", field, *want)
+	}
+	if *got != *want {
+		t.Fatalf("expected %s %q, got %q", field, *want, *got)
+	}
+}


### PR DESCRIPTION
## Bug

When creating an issue without specifying `assignee_type`/`assignee_id`, the workspace `settings.default_assignee_id` (e.g. ARIA Orchestrator) was ignored. Issues landed unassigned even when the workspace had configured a default. Tracked in Multica issue **ALI-121** (`196632c1-4b8d-449c-82f1-230d891c3133`).

## Fix

`server/internal/handler/issue.go` — `CreateIssue` now consults `workspaceDefaultAssignee()` whenever **both** `req.AssigneeType` and `req.AssigneeID` are nil:
- Reads `default_assignee_type` + `default_assignee_id` from `workspace.settings` JSON.
- For `agent`: validates the agent exists in the workspace and is not archived.
- For `member`: validates membership.
- Any error/missing/invalid case → graceful fall-through to unassigned with `slog.Warn`.
- Explicit assignees in the request always win — fallback never overrides.

Server-only change. No migration. No CLI/UI changes.

## Acceptance criteria

- [x] Default applied when request body has no assignee
- [x] Explicit `assignee_type`/`assignee_id` in request override the workspace default
- [x] Empty workspace settings → issue stays unassigned (no error)
- [x] Archived agent default → fall through to unassigned (logged)
- [x] Invalid UUID in settings → fall through to unassigned (logged)
- [x] No migration required

## Tests

`server/internal/handler/issue_default_assignee_test.go` (new, 119 lines) — `TestCreateIssue_DefaultAssigneeFallback` with 3 sub-cases:
1. `uses workspace default when request has no assignee`
2. `explicit request assignee wins over workspace default`
3. `empty workspace settings leaves issue unassigned`

Antigravity ran the targeted test and the full handler package green:
- `go test ./internal/handler/ -run TestCreateIssue_DefaultAssigneeFallback -count=1 -v` ✅
- `go test ./internal/handler/ -count=1` ✅
- `go vet ./internal/handler/...` ✅
- `go build ./...` ✅

E2E pipeline had pre-existing auth/navigation/comment failures (`send-code 429`, selector timeouts) unrelated to this change.

## Provenance

Server-side fix delivered by Antigravity on branch `agent/antigravity/cdc6fbbb` (based on `feat/hermes-cloud-runtime`, which is unrelated to ALI-121). The changes were extracted as a patch and applied as a single atomic commit on top of `main` to keep the unrelated Hermes commits out of this PR.

See ALI-121 comments for the original delivery report:
- `a2075888-0fd9-41e4-a234-61b1d9df3410`
- `9831632b-e9e4-464d-a91a-1b981b2b88f4`

Closes ALI-121. Also resolves duplicate **ALI-120** (BMad Dev's filing of the same bug).

cc @Ayavuzer for review.