### PR TITLE
fix(issues): scroll body on mobile by adding min-h-0 to flex container

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -584,7 +584,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
         </PageHeader>
 
         {/* Content — scrollable */}
-        <div ref={scrollContainerRef} className="relative flex-1 overflow-y-auto">
+        <div ref={scrollContainerRef} className="relative flex-1 min-h-0 overflow-y-auto">
         <div className="mx-auto w-full max-w-4xl px-8 py-8">
           <TitleEditor
             key={`title-${id}`}


### PR DESCRIPTION
## What

Fixes #1756. On Android Chrome, the issue detail page (`/<workspace>/<issue-id>`)
body content cannot be scrolled with single-finger touch when the body
overflows the viewport.

## Why

The scroll container at `packages/views/issues/components/issue-detail.tsx`
relied on `flex-1 overflow-y-auto` but was missing `min-h-0`. Flex items
default to `min-height: auto`, which means they refuse to shrink below
their content's intrinsic height. As a result, `flex-1` never produces a
constrained height when content exceeds viewport: the container grows
with its content and there's nothing for `overflow-y: auto` to scroll.

On desktop this is masked because `react-resizable-panels` provides its
own inline height constraints between sibling panels. On mobile the
sibling sidebar panel is conditionally hidden (rendered as a `Sheet`
instead via `isMobile`), so the constraint is gone and scroll breaks.

## Fix

```diff
- <div ref={scrollContainerRef} className="relative flex-1 overflow-y-auto">
+ <div ref={scrollContainerRef} className="relative flex-1 min-h-0 overflow-y-auto">
```

One line, no behavior change on desktop (where flex-1 was already being
honored), restores scroll on mobile.

## Verification

Before: open any issue with body content longer than the viewport on
Android Chrome. Cannot scroll the body. Content below the fold is
unreachable.

After: scrolls normally with single-finger touch.

`pnpm --filter @multica/views typecheck` passes.

## Notes

- Atomic single-line change. No test added because this is purely a CSS
  layout fix (would require Playwright with mobile viewport emulation
  to assert against, which doesn't seem to exist in the e2e suite yet).
- Did not touch the loading-state scroll container (line 329) because
  its parent already provides the `min-h-0` constraint in that branch.