### PR TITLE
fix(api): batch-update no-op responses report updated=0 (#1660)

### DIFF
--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1386,6 +1386,32 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 		json.Unmarshal(raw, &rawUpdates)
 	}
 
+	// Short-circuit when no mutation field is present in `updates`. Without
+	// this, the loop below runs N no-op UPDATEs (every if-guard skips, every
+	// COALESCE preserves the existing value) and reports `{"updated": N}` —
+	// the response cheerfully claims success while nothing changed. Most
+	// real-world cases that hit this path are caller mistakes (status placed
+	// at the top level, "update" misspelled as singular). Telling the truth
+	// here — `{"updated": 0}` — keeps the wire shape stable while making the
+	// count match reality. See multica-ai/multica#1660.
+	hasMutation := req.Updates.Title != nil ||
+		req.Updates.Description != nil ||
+		req.Updates.Status != nil ||
+		req.Updates.Priority != nil ||
+		req.Updates.Position != nil
+	if !hasMutation {
+		for _, k := range []string{"assignee_type", "assignee_id", "due_date", "parent_issue_id", "project_id"} {
+			if _, ok := rawUpdates[k]; ok {
+				hasMutation = true
+				break
+			}
+		}
+	}
+	if !hasMutation {
+		writeJSON(w, http.StatusOK, map[string]any{"updated": 0})
+		return
+	}
+
 	workspaceID := h.resolveWorkspaceID(r)
 	updated := 0
 	for _, issueID := range req.IssueIDs {

--- a/server/internal/handler/issue_batch_test.go
+++ b/server/internal/handler/issue_batch_test.go
@@ -1,0 +1,149 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestBatchUpdateNoMutationReturnsZero — regression for #1660.
+//
+// When the request payload has valid issue_ids but the "updates" field
+// is empty, missing, or doesn't decode any known mutation field, the
+// handler used to walk every issue, run a no-op UPDATE, and increment
+// `updated` for each one — returning {"updated": N} despite changing
+// nothing. Reporters saw 200 + a positive count and assumed the call
+// worked, then chased a phantom persistence bug.
+//
+// The fix is "tell the truth": when no mutation field is present, return
+// {"updated": 0} immediately so the count matches reality.
+func TestBatchUpdateNoMutationReturnsZero(t *testing.T) {
+	// Two fresh issues so we can also assert no fields actually changed.
+	a := createTestIssue(t, "BU-no-mut A", "todo", "low")
+	b := createTestIssue(t, "BU-no-mut B", "todo", "low")
+	t.Cleanup(func() { deleteTestIssue(t, a) })
+	t.Cleanup(func() { deleteTestIssue(t, b) })
+
+	cases := []struct {
+		desc string
+		body map[string]any
+	}{
+		{
+			desc: "updates_missing",
+			// Most common reporter pattern: status at top level.
+			body: map[string]any{"issue_ids": []string{a, b}, "status": "in_progress"},
+		},
+		{
+			desc: "updates_empty_object",
+			body: map[string]any{"issue_ids": []string{a, b}, "updates": map[string]any{}},
+		},
+		{
+			desc: "updates_misnamed",
+			// Singular "update" instead of plural "updates".
+			body: map[string]any{"issue_ids": []string{a, b}, "update": map[string]any{"status": "done"}},
+		},
+		{
+			desc: "updates_unknown_field_only",
+			// Payload IS nested correctly, but every key inside `updates` is
+			// unknown to the handler — same class of caller mistake as the
+			// shapes above. hasMutation must stay false; behavior is already
+			// correct, this case locks it in against future regressions.
+			body: map[string]any{"issue_ids": []string{a, b}, "updates": map[string]any{"foo": "bar"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newRequest("POST", "/api/issues/batch-update", tc.body)
+			testHandler.BatchUpdateIssues(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			var resp struct {
+				Updated int `json:"updated"`
+			}
+			json.NewDecoder(w.Body).Decode(&resp)
+			if resp.Updated != 0 {
+				t.Errorf("expected updated=0 when no mutation field present, got %d", resp.Updated)
+			}
+
+			// Belt and braces: confirm the issues weren't touched.
+			for _, id := range []string{a, b} {
+				gw := httptest.NewRecorder()
+				gr := newRequest("GET", "/api/issues/"+id, nil)
+				gr = withURLParam(gr, "id", id)
+				testHandler.GetIssue(gw, gr)
+				var got IssueResponse
+				json.NewDecoder(gw.Body).Decode(&got)
+				if got.Status != "todo" {
+					t.Errorf("issue %s: status changed to %q despite no-mutation request", id, got.Status)
+				}
+			}
+		})
+	}
+}
+
+// TestBatchUpdateValidUpdatesPersistAndCount — positive case to lock in
+// happy-path behavior alongside the regression test above.
+func TestBatchUpdateValidUpdatesPersistAndCount(t *testing.T) {
+	a := createTestIssue(t, "BU-ok A", "todo", "low")
+	b := createTestIssue(t, "BU-ok B", "todo", "low")
+	t.Cleanup(func() { deleteTestIssue(t, a) })
+	t.Cleanup(func() { deleteTestIssue(t, b) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/batch-update", map[string]any{
+		"issue_ids": []string{a, b},
+		"updates":   map[string]any{"status": "in_progress"},
+	})
+	testHandler.BatchUpdateIssues(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Updated int `json:"updated"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Updated != 2 {
+		t.Errorf("expected updated=2, got %d", resp.Updated)
+	}
+	for _, id := range []string{a, b} {
+		gw := httptest.NewRecorder()
+		gr := newRequest("GET", "/api/issues/"+id, nil)
+		gr = withURLParam(gr, "id", id)
+		testHandler.GetIssue(gw, gr)
+		var got IssueResponse
+		json.NewDecoder(gw.Body).Decode(&got)
+		if got.Status != "in_progress" {
+			t.Errorf("issue %s: expected status=in_progress, got %q", id, got.Status)
+		}
+	}
+}
+
+// createTestIssue is a small helper to keep the table-driven cases clean.
+// Returns the new issue's id; caller is responsible for cleanup.
+func createTestIssue(t *testing.T, title, status, priority string) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":    title,
+		"status":   status,
+		"priority": priority,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue %q: expected 201, got %d: %s", title, w.Code, w.Body.String())
+	}
+	var issue IssueResponse
+	json.NewDecoder(w.Body).Decode(&issue)
+	return issue.ID
+}
+
+func deleteTestIssue(t *testing.T, id string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/issues/"+id, nil)
+	req = withURLParam(req, "id", id)
+	testHandler.DeleteIssue(w, req)
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #1660 — the `POST /api/issues/batch-update` endpoint cheerfully returned `{"updated": N}` even when none of the requested field changes had landed.

The handler walked every issue ID and incremented `updated` regardless of whether the iteration carried a recognized mutation. When the caller's payload had no recognized field in `updates` (status placed at the top level instead of nested, `update` misspelled as singular, `updates: {}`, or unknown keys only), the loop ran N no-op `UPDATE` statements and the response reported `{"updated": N}` while nothing changed. Reporters mistook the positive count for success and chased a phantom persistence bug.

The fix detects at the top of the handler whether any known mutation field is present in the parsed `updates` payload. If none is, short-circuit with `{"updated": 0}` so the count matches reality.

## Related Issue

Closes #1660.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

**Backend** (Go):

- `server/internal/handler/issue.go` — `BatchUpdateIssues` now checks whether any of the 10 fields it would write (5 typed pointers on `req.Updates` + 5 nullable fields detected via `rawUpdates` presence) is set. When none is, returns `{"updated": 0}` and skips the loop entirely. Wire shape stays identical (still 200, still `{updated}` body).

**Tests** (`server/internal/handler/issue_batch_test.go`, new):

- `TestBatchUpdateNoMutationReturnsZero` — table-driven, four sub-tests covering the no-mutation request shapes:
  - `updates_missing` — caller put `status` at the top level instead of inside `updates` (the reporter's pattern).
  - `updates_empty_object` — `"updates": {}`.
  - `updates_misnamed` — singular `"update"` instead of plural `"updates"`.
  - `updates_unknown_field_only` — `"updates"` is present but every key inside is unknown to the handler.
- `TestBatchUpdateValidUpdatesPersistAndCount` — positive case locking the happy path: `updates: {status: "in_progress"}` returns `{"updated": 2}` and the change actually persists on both issues.

## Behavior change risk

The wire shape is unchanged: same HTTP 200, same `{"updated": ...}` body. The only difference is the count value when the request carries no mutation — previously `len(issue_ids)`, now `0`.

There is one theoretical caller this could affect: anyone using batch-update purely to bump `updated_at` on a set of rows without changing any field. The schema doesn't document a "touch" semantic, no in-repo client uses it that way, and the original behavior was already misleading to anyone treating the counter as a success signal. If a touch-style endpoint is ever needed, it can be added explicitly as a separate verb without conflating it with the mutation path.

## How to Test

### Backend (auto)

```bash
DATABASE_URL=postgres://multica:multica@localhost:5432/multica?sslmode=disable \
  go test ./server/internal/handler/ -run TestBatchUpdate -v
```

Expect: 4 negative sub-cases + 1 positive case all pass.

### Manual reproduction (matches the issue report)

```bash
# Create two issues and capture their UUIDs.
A=$(curl -s -X POST "$SERVER/api/issues?workspace_id=$WS" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"title":"A","status":"todo","priority":"low"}' | jq -r .id)
B=$(curl -s -X POST "$SERVER/api/issues?workspace_id=$WS" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d '{"title":"B","status":"todo","priority":"low"}' | jq -r .id)

# 1. Caller mistake — status at top level (the reporter's shape).
#    Before this PR: 200 + {"updated":2}  ← lying
#    After  this PR: 200 + {"updated":0}
curl -s -X POST "$SERVER/api/issues/batch-update?workspace_id=$WS" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d "{\"issue_ids\":[\"$A\",\"$B\"],\"status\":\"in_progress\"}"

# 2. Correctly nested update — unchanged behavior.
#    Returns: 200 + {"updated":2}  AND status actually flips to in_progress.
curl -s -X POST "$SERVER/api/issues/batch-update?workspace_id=$WS" \
  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
  -d "{\"issue_ids\":[\"$A\",\"$B\"],\"updates\":{\"status\":\"in_progress\"}}"
```

## Checklist

- [x] I have included a thinking path that traces from project context to this change (PR description above)
- [x] I have run tests locally and they pass (4 new sub-cases + 1 positive case + full handler suite green)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, backend-only fix
- [ ] I have updated relevant documentation to reflect my changes — no documented contract for the response counter; CHANGELOG entry to follow on the next release commit
- [x] I have considered and documented any risks above (see *Behavior change risk*)
- [x] I will address all reviewer comments before requesting merge
