### PR TITLE
docs: ADR 0001 — cross-workspace meta view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ server/server
 data/
 .kilo
 .idea
+.env
+docker-compose.production.yml

--- a/docs/adrs/0001-cross-workspace-meta-view-techspec.md
+++ b/docs/adrs/0001-cross-workspace-meta-view-techspec.md
@@ -1,0 +1,285 @@
+# Tech Spec: Cross-Workspace Meta View
+
+- Companion to: `0001-cross-workspace-meta-view.md`
+- Date: 2026-04-28
+- Author: Ultron CTO
+
+This document is the implementation contract. Read the ADR first for the
+"why"; this document is for "what exactly to build".
+
+## 1. Backend — `GET /api/issues/cross-workspace`
+
+### 1.1. Path & auth
+
+- Path: `GET /api/issues/cross-workspace`
+- Auth: standard session auth (the same `middleware.Auth(queries)` chain that
+  protects every authenticated route).
+- **Not** under the `RequireWorkspaceMember` group, because there is no
+  workspace ID in the URL. Membership is enforced inside the SQL query.
+
+### 1.2. Query parameters
+
+| Param           | Type     | Default        | Notes |
+|-----------------|----------|----------------|-------|
+| `status`        | string   | (none)         | Comma-separated list. Allowed: `backlog`, `todo`, `in_progress`, `in_review`, `done`. Multiple = OR. |
+| `priority`      | string   | (none)         | Comma-separated. `low` `medium` `high` `urgent`. |
+| `assignee_id`   | uuid     | (none)         | Single assignee. |
+| `assignee_ids`  | string   | (none)         | Comma-separated UUIDs. |
+| `workspace_ids` | string   | (none)         | Comma-separated workspace UUIDs. Server intersects with membership; unknown IDs are silently dropped. |
+| `limit`         | int      | `50`           | Hard cap `100`. Values above are clamped, not rejected. |
+| `after`         | string   | (none)         | Opaque cursor; base64-encoded `created_at|id`. |
+| `open_only`     | bool     | `false`        | If `true`, ignores `status` and returns everything except `done` and `cancelled`. |
+
+### 1.3. Response shape
+
+200 OK:
+
+```json
+{
+  "issues": [
+    {
+      "id": "uuid",
+      "identifier": "MUL-3",
+      "number": 3,
+      "title": "Design cross-workspace meta view",
+      "description": "...",
+      "status": "in_progress",
+      "priority": "high",
+      "assignee_id": "uuid",
+      "assignee_type": "agent",
+      "creator_id": "uuid",
+      "creator_type": "member",
+      "parent_issue_id": null,
+      "project_id": null,
+      "position": 0,
+      "due_date": null,
+      "created_at": "2026-04-28T02:43:32Z",
+      "updated_at": "2026-04-28T02:43:32Z",
+      "labels": [],
+      "workspace": {
+        "id": "uuid",
+        "name": "Multica Fork",
+        "slug": "multica-fork",
+        "issue_prefix": "MUL",
+        "color": "#7c3aed"
+      }
+    }
+  ],
+  "next_cursor": "eyJjcmVhdGVkX2F0Ijoi..." ,
+  "has_more": true,
+  "total_returned": 50
+}
+```
+
+- `next_cursor` is `null` when there are no more results.
+- `total_returned` is the count of items in `issues` (not a global total — we
+  intentionally do NOT compute a global `COUNT(*)` for the cross-workspace
+  query because of cost; the global view shows "showing N issues" instead of
+  "N of M").
+
+### 1.4. Error cases
+
+| Status | When | Body |
+|--------|------|------|
+| `401`  | unauthenticated | `{"error":"unauthorized"}` |
+| `400`  | malformed `after` cursor or unknown `status` value | `{"error":"<detail>"}` |
+| `500`  | DB error | `{"error":"failed to list cross-workspace issues"}` (logs include trace ID) |
+
+A user with **zero** workspaces returns `200 { issues: [], next_cursor: null,
+has_more: false }` — empty, not 404.
+
+### 1.5. SQL (sqlc)
+
+A new query `ListCrossWorkspaceIssues` in `server/internal/queries/issue.sql`:
+
+```sql
+-- name: ListCrossWorkspaceIssues :many
+SELECT i.*, w.id   AS w_id,
+            w.name AS w_name,
+            w.slug AS w_slug,
+            w.issue_prefix AS w_prefix
+FROM issue i
+JOIN workspace w ON w.id = i.workspace_id
+JOIN member    m ON m.workspace_id = i.workspace_id
+WHERE m.user_id = $1
+  AND ($2::uuid[]   IS NULL OR i.workspace_id = ANY($2))
+  AND ($3::text[]   IS NULL OR i.status       = ANY($3))
+  AND ($4::text[]   IS NULL OR i.priority     = ANY($4))
+  AND ($5::uuid[]   IS NULL OR i.assignee_id  = ANY($5))
+  AND ($6::timestamptz IS NULL OR (i.created_at, i.id) < ($6, $7))
+ORDER BY i.created_at DESC, i.id DESC
+LIMIT $8;
+```
+
+The cursor `($6, $7)` uses `(created_at, id)` keyset semantics. We request
+`limit + 1` rows internally; if we get back `limit + 1` we set
+`has_more = true` and drop the last one.
+
+### 1.6. Color derivation
+
+`server/internal/util/wscolor.go`:
+
+```go
+var palette = []string{
+  "#ef4444", "#f97316", "#f59e0b", "#eab308",
+  "#84cc16", "#22c55e", "#10b981", "#14b8a6",
+  "#06b6d4", "#3b82f6", "#8b5cf6", "#ec4899",
+}
+
+func WorkspaceColor(id uuid.UUID) string {
+  // FNV-1a 32-bit hash over the UUID bytes, modulo palette length.
+  ...
+}
+```
+
+### 1.7. Tests (Tony)
+
+- Happy path: user with 3 workspaces, ~50 issues each. Response merges all,
+  sorted by `created_at DESC`. Pagination across the boundary is consistent
+  (no duplicates, no skips).
+- Empty path: user with zero workspaces returns `[]`.
+- Filter intersection: caller passes `workspace_ids` containing one workspace
+  they belong to and one they do not. Result includes only issues from the
+  one they belong to. Status code is `200`, not `403`.
+- Auth: unauthenticated returns `401`.
+- Cursor: malformed `after` returns `400`.
+
+## 2. Frontend
+
+### 2.1. Routes
+
+```
+apps/web/app/
+├── global/
+│   ├── layout.tsx       <- WorkspaceRail + page content (no workspace dropdown)
+│   └── page.tsx         <- Cross-workspace Kanban
+└── [workspaceSlug]/
+    └── (dashboard)/
+        └── layout.tsx   <- WorkspaceRail + workspace-scoped sidebar (existing)
+```
+
+- The `<WorkspaceRail />` is hoisted into both layouts so it is always
+  visible.
+- `apps/web/app/global/page.tsx` is a client component that reads filters
+  from URL search params (`?status=...&priority=...`).
+- Add `global` to `workspaceReservedSlugs` so a workspace can never have the
+  slug `global`.
+
+### 2.2. Component tree
+
+```
+<WorkspaceRail />
+├── <RailItem href="/global" icon={GlobeIcon} label="All workspaces" />
+├── <RailItem href="/<slug>" avatar={ws.avatar_url|color} label={ws.name} /> * N
+└── <RailItem onClick={openCreateWorkspaceModal} icon={PlusIcon} label="New" />
+
+<GlobalKanbanPage />
+├── <GlobalKanbanFilters />          <- workspace multi-select, assignee, priority, status
+├── <GlobalKanbanBoard>
+│   ├── <KanbanColumn status="backlog">
+│   │   └── <CrossWorkspaceIssueCard /> * N
+│   ├── <KanbanColumn status="todo"> ...
+│   └── ... (5 columns)
+└── <GlobalKanbanFooter />           <- "Showing N issues. Load more"
+```
+
+### 2.3. Reused vs new components
+
+- **Reused:** `<KanbanColumn />`, `<IssueCard />` (extended via prop, see
+  below), the existing filter primitives (`<MultiSelect />`, etc.).
+- **New:**
+  - `packages/views/workspace/workspace-rail.tsx`
+  - `packages/views/issues/components/workspace-badge.tsx` — small chip
+    rendering `{color, prefix}`. Used only inside the cross-workspace card.
+  - `packages/views/issues/global-kanban/index.tsx` — orchestrates the
+    cross-workspace view. Reuses `<KanbanColumn />`.
+
+The existing `<IssueCard />` gains an optional `workspaceBadge?: ReactNode`
+prop. Default-undefined keeps existing call sites unchanged.
+
+### 2.4. State management
+
+- React Query key: `["issues", "cross-workspace", normalizedFilters]`.
+- Mutations from anywhere in the app that touch issues already invalidate
+  per-workspace keys. We extend the invalidator in
+  `packages/core/issues/mutations.ts` to also invalidate the
+  `["issues", "cross-workspace"]` key family.
+- `useCrossWorkspaceIssues(filters)` in `packages/core/issues/queries.ts`
+  wraps the new endpoint, mirroring `useIssues(workspaceId, filters)`.
+
+### 2.5. Realtime
+
+- The realtime hub already publishes per-workspace channels. The global page
+  subscribes to every channel for workspaces in the user's
+  `listWorkspaces()` response.
+- On any `issue.updated` / `issue.created` / `issue.deleted` event from any
+  of those channels, invalidate
+  `["issues", "cross-workspace"]`.
+
+### 2.6. Filters
+
+- **Workspace multi-select:** the user can narrow the global view to a
+  subset of their workspaces. Selected IDs feed into `?workspace_ids=`.
+- **Assignee:** people + agents. Server filters via `assignee_ids`. Workspace
+  agents do not span workspaces, so the dropdown lists members + agents
+  across the union of selected workspaces (or all workspaces if none
+  selected).
+- **Priority, Status:** identical to the per-workspace page.
+- All filter state is mirrored into URL search params for shareable links.
+
+### 2.7. Empty / loading / error UX
+
+- Loading: skeleton columns (existing `<KanbanSkeleton />`).
+- Empty: a polite "No issues across your workspaces yet" with a button to
+  create an issue (which opens the existing modal scoped to a workspace
+  picker).
+- Error: existing `<ErrorBoundary />` with a "Retry" button.
+
+## 3. Migrations / DB
+
+**None in v1.** The endpoint is read-only over existing tables (`issue`,
+`workspace`, `member`). The deterministic color helper requires no schema
+change.
+
+If a v2 ever needs persistent colors:
+
+```sql
+ALTER TABLE workspace ADD COLUMN color TEXT;
+```
+
+— and the helper falls back to the deterministic value when the column is
+NULL. Out of scope for v1.
+
+## 4. Telemetry / observability
+
+- Structured log per request:
+  - `endpoint=/api/issues/cross-workspace`
+  - `user_id=...`
+  - `workspace_count=...` (how many workspaces the user belongs to)
+  - `filter_workspace_ids=...`
+  - `result_count=...`
+  - `duration_ms=...`
+- Prometheus histogram `multica_cross_workspace_issues_duration_ms`.
+- Alert (JARVIS, sub-issue #6): page if p95 over 5 minutes > 250ms.
+- The frontend reports a single analytics event `cross_workspace_view` with
+  the filter set (workspace count, status filter active y/n) on first paint.
+
+## 5. Rollout & flags
+
+- v1 ships behind a feature flag `feature.cross_workspace` (config), default
+  `true` for self-host (where Cuong is the only user that matters), default
+  `false` for cloud until we have load numbers from self-host.
+- The feature flag gates both the rail and the route. When off, `/global`
+  returns 404 and `<WorkspaceRail />` renders as a no-op (the existing
+  workspace dropdown stays the only switcher).
+
+## 6. Acceptance checklist (for the parent issue MUL-3)
+
+- [ ] ADR `0001-cross-workspace-meta-view.md` merged.
+- [ ] Companion tech spec merged in the same PR.
+- [ ] 5 sub-issues created and parent-linked to MUL-3.
+- [ ] Sub-issue #2 (Tony) has the API contract above as its description.
+- [ ] Sub-issue #3 (Peter) has the rail component contract.
+- [ ] Sub-issue #4 (Peter) has the global Kanban contract.
+- [ ] Sub-issue #5 (Bruce) has the E2E coverage list.
+- [ ] Sub-issue #6 (JARVIS) has the deploy + observability contract.

--- a/docs/adrs/0001-cross-workspace-meta-view.md
+++ b/docs/adrs/0001-cross-workspace-meta-view.md
@@ -1,0 +1,303 @@
+# ADR 0001: Cross-Workspace Meta View
+
+- Status: Proposed
+- Date: 2026-04-28
+- Author: Ultron CTO
+- Driver: Cuong (owner, multi-business operator)
+
+## Context
+
+Multica self-host (`team.cuongpho.com`) is being used to pilot AI agents across
+multiple businesses. The owner currently belongs to 6 active workspaces:
+
+| Workspace            | ID                                     |
+| -------------------- | -------------------------------------- |
+| Fuchsia B2B          | `42a4a362-b06c-4e64-b6a2-f9e73c67af63` |
+| Fuchsia B2C          | `43725562-2f1e-45e7-aa21-5d79c7a8f5d5` |
+| Business             | `facace57-fbeb-4839-a070-918e29a482cb` |
+| The Institut Academy | `34225cad-856f-4212-b87a-aeca9c4ea002` |
+| Tiny Little Space    | `0f5f7dc3-a221-4d61-9e2c-05ba2926ed68` |
+| Multica Fork         | `6940266a-b0d5-43e2-b63c-d0f9b091e11f` |
+
+Today the only way to switch context is the workspace dropdown in the existing
+sidebar. There is no place where the operator can see, in one glance, what
+every agent across every business is currently working on.
+
+The product goal is a **cross-workspace meta view**:
+
+1. A persistent thin left rail (`~56px`) listing every workspace the user is a
+   member of, plus a special "All workspaces" entry pinned at the top.
+2. A new top-level route showing a giant Kanban that aggregates issues from
+   every workspace the user belongs to, in the standard 5 columns
+   (Backlog / Todo / In Progress / In Review / Done).
+3. Each issue card shows a workspace badge so the source workspace is visible
+   at a glance.
+4. Filters: workspace (multi-select), assignee, priority, status.
+
+This ADR captures the architecture decisions; the companion document
+`0001-cross-workspace-meta-view-techspec.md` captures the concrete contracts.
+
+## Decision summary
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Aggregation strategy | New backend endpoint `GET /api/issues/cross-workspace` |
+| D2 | Permissions model | Server-side filter to workspaces where the caller is a `member` row |
+| D3 | Data shape | Existing `IssueResponse` enriched with embedded `workspace` object |
+| D4 | Pagination | Keyset pagination on `(created_at DESC, id DESC)`, page size 50, hard cap 100 |
+| D5 | URL routing | `/global` (top-level, outside `[workspaceSlug]`) |
+| D6 | Sidebar layout | New `<WorkspaceRail />` always-visible thin rail. Existing dropdown stays inside the workspace-scoped sidebar |
+| D7 | Workspace color | Derived deterministically from workspace ID (no DB migration in v1) |
+| D8 | Group-by | `status` only in v1. `workspace` group-by deferred to v2 |
+| D9 | Cache & realtime | Reuse the existing realtime hub; tag query keys per-workspace so a single workspace mutation invalidates only its slice |
+
+## Decisions in detail
+
+### D1. Aggregation strategy — backend endpoint
+
+**Choice:** add a new `GET /api/issues/cross-workspace` handler that
+aggregates issues across all workspaces the caller is a member of, in a single
+SQL query.
+
+**Why:**
+
+- One round-trip instead of N (N = number of workspaces the user is a member
+  of). With 6 workspaces today, the frontend would otherwise issue 6 parallel
+  `ListIssues` requests; with growth this will not scale.
+- Auth check runs once on the server using the same `member` table that the
+  rest of the app already uses. No risk of "I forgot to filter" leaks on the
+  client.
+- Pagination becomes a single problem (one cursor) instead of N interleaved
+  problems on the frontend.
+- Server can apply the workspace, assignee, priority, status filters in SQL
+  with one composable query — much cheaper than fan-out + merge in JS.
+- We can add cross-workspace ordering (created_at DESC) consistently. With the
+  per-workspace approach the frontend would have to re-sort the merged list
+  every time more pages stream in.
+
+**Rejected alternative — frontend fan-out:** issuing N parallel calls to the
+existing `ListIssues` endpoint and merging client-side. Wins: zero backend
+work. Loses: chatty, awkward pagination, sort merging, no single source of
+truth for "across my workspaces".
+
+### D2. Permissions model
+
+**Rule:** the cross-workspace endpoint returns issues only from workspaces
+where the authenticated user has a row in `member` (any role: `owner`, `admin`,
+`member`). Same membership semantics as the rest of the app.
+
+- The existing `RequireWorkspaceMember` middleware does not apply here (it
+  takes a workspace ID from the URL and checks membership for that one
+  workspace).
+- Instead, the new handler will resolve the caller's workspace IDs from the
+  `member` table inside the SQL query itself (`WHERE workspace_id IN (SELECT
+  workspace_id FROM member WHERE user_id = $1)`), so there is no round-trip
+  between auth resolution and the data query.
+- The `?workspace_ids=...` filter, when supplied, is intersected with that
+  membership set on the server. A user passing a workspace ID they do not
+  belong to silently gets it filtered out (no 403 — we don't want to leak
+  whether a workspace exists).
+
+### D3. Data shape
+
+Each issue in the response uses the existing `IssueResponse` enriched with an
+embedded `workspace` block:
+
+```json
+{
+  "id": "uuid",
+  "identifier": "MUL-3",
+  "title": "Design cross-workspace meta view",
+  "status": "in_progress",
+  "priority": "high",
+  "assignee_id": "uuid",
+  "assignee_type": "agent",
+  "created_at": "2026-04-28T02:43:32Z",
+  "updated_at": "2026-04-28T02:43:32Z",
+  "workspace": {
+    "id": "6940266a-b0d5-43e2-b63c-d0f9b091e11f",
+    "name": "Multica Fork",
+    "slug": "multica-fork",
+    "issue_prefix": "MUL",
+    "color": "#7c3aed"
+  }
+}
+```
+
+Notes:
+
+- `workspace.color` is derived server-side from the workspace UUID using a
+  deterministic hash (HSL palette of 12 colors). No DB migration in v1 — see
+  D7.
+- The rest of the issue fields stay byte-identical to `IssueResponse` so the
+  frontend can reuse existing card components.
+
+### D4. Pagination & performance
+
+- Default page size: `50`. Hard server cap: `100`.
+- Default sort: `created_at DESC, id DESC` (stable tie-breaker).
+- Cursor: `?after=<base64(created_at|id)>`. Keyset, not offset — keeps query
+  cost flat as the user scrolls.
+- Response shape: `{ issues: [...], next_cursor: "..." | null, has_more: bool }`.
+- Existing per-workspace `ListIssues` already takes ~50ms for ~200 issues; the
+  cross-workspace variant adds one extra `WHERE workspace_id IN (...)` clause.
+  Expected p95 < 100ms for the workspace counts we see today (≤ 6 workspaces,
+  ≤ ~2k issues total).
+- The existing `(workspace_id, created_at)` index already covers the access
+  pattern; no new indexes needed in v1. JARVIS adds a slow-query alert if p95
+  drifts past 250ms.
+
+### D5. URL routing
+
+**Choice:** `/global`.
+
+- Short, single-word, no collision with existing `[workspaceSlug]` segment
+  because `global` is reserved.
+- `/all` is too generic and could be misread as "all of something inside one
+  workspace".
+- `/workspaces/all` reads like a workspaces admin page; the meta view is about
+  issues, not workspaces.
+
+The route lives outside the `[workspaceSlug]` Next.js segment, in
+`apps/web/app/global/`, so it has its own layout that hosts the workspace rail
+without the per-workspace sidebar.
+
+The reserved-slug list (`apps/web/app/[workspaceSlug]` already excludes
+`auth`, `landing`, etc. via `workspaceReservedSlugs`) gets `global` added.
+
+### D6. Sidebar layout impact
+
+Two surfaces, side by side:
+
+```
++----+--------------------------+----------------------------------+
+| WR | Workspace sidebar (slug) | Page content                     |
+| .. | (issues / chat / ...)    |                                  |
+| WR |                          |                                  |
+| WR |                          |                                  |
++----+--------------------------+----------------------------------+
+```
+
+- `WR` = `<WorkspaceRail />`, ~56px wide, always visible (including on the
+  global view).
+- The existing workspace-scoped sidebar (Inbox, Chat, My Issues, Issues, ...)
+  stays as is — it is workspace-local and only renders inside the
+  `[workspaceSlug]` segment.
+- On the global view, only the rail + the global page render. The
+  workspace-scoped sidebar is absent.
+
+The rail entries (top to bottom):
+
+1. "All" — links to `/global`. Active when pathname starts with `/global`.
+2. One avatar per workspace the user is a member of. Active when the current
+   pathname's first segment matches that workspace slug.
+3. A `+` button at the bottom — opens the existing "create workspace" modal.
+
+The rail replaces the *workspace switching* role of the dropdown that lives
+inside the existing sidebar header. The dropdown stays for now but becomes
+secondary; we will revisit removing it in a follow-up once the rail proves
+itself.
+
+ASCII reference:
+
+```
++---+
+| A |  <- "All workspaces" button (filled when on /global)
+|---|
+| F |  <- Fuchsia B2B avatar
+|   |
+| F |  <- Fuchsia B2C
+|   |
+| B |  <- Business
+|   |
+| T |  <- The Institut Academy
+|   |
+| T |  <- Tiny Little Space
+|   |
+| M |  <- Multica Fork
+|---|
+| + |
++---+
+```
+
+### D7. Workspace color
+
+The `workspace` table has no `color` column today. Two options:
+
+- **(a) Add a column** via a migration. Wins: persistent, user-customizable.
+  Loses: schema change, migration coordination, one more thing to seed.
+- **(b) Derive deterministically** from the workspace UUID using a 12-entry
+  HSL palette. Wins: zero migration, zero seeding, immediate. Loses: not
+  user-customizable.
+
+**Choice for v1: (b) deterministic derivation, server-side.** Customization
+becomes a v2 concern; do (a) only if Cuong asks for it.
+
+The derivation lives in a small `internal/util/wscolor.go` helper so backend
+and any future server-rendered surface stay consistent. The frontend trusts
+the server-provided `color` field; no client-side recomputation.
+
+### D8. Group-by
+
+- v1: `status` group-by only. Five columns Backlog / Todo / In Progress /
+  In Review / Done — exactly the columns of the existing per-workspace board.
+- v2 (deferred, not in this ADR's scope): a toggle to group by `workspace`
+  (one column per business). Useful when the operator wants to see "what's
+  Tiny Little Space currently doing" in isolation, without leaving the meta
+  view. Document this as a future enhancement; do not build it yet.
+
+### D9. Cache & realtime
+
+- The frontend already keys React Query cache by workspace ID. We add a new
+  key `["issues", "cross-workspace", filters]` for the global view.
+- On any issue mutation (create/update/delete) we already publish to the
+  realtime hub on a workspace-scoped channel. The global view subscribes to
+  every workspace channel the user is a member of and invalidates the
+  cross-workspace query key on any event.
+- No new database triggers, no new event types. The cost is one additional
+  websocket subscription per workspace on this single page — negligible.
+
+## Consequences
+
+### Positive
+
+- Single round-trip for the meta view. Predictable performance.
+- Strict server-side membership filter — no risk of leaking issues across
+  tenant boundaries.
+- The data shape is a strict superset of `IssueResponse`, so existing card
+  components reuse cleanly.
+- No DB migration in v1; the change is purely additive (new endpoint, new
+  routes, new components).
+
+### Negative / costs
+
+- The deterministic color (D7) means workspaces cannot pick a custom color
+  until v2.
+- The workspace rail adds ~56px of permanent horizontal chrome. We accept
+  this; the existing dropdown is going to feel redundant for a while.
+- Realtime invalidation on the global view subscribes to N workspace channels
+  in parallel. With 6 workspaces this is fine; if a user belongs to dozens we
+  will need to revisit.
+
+### Out of scope
+
+- Editing or rearranging issues from the global view (drag between columns,
+  drag between workspaces). v1 is read + filter only. Clicking a card
+  navigates to that issue inside its workspace.
+- Per-user persisted filter state (saved views, bookmarked filters).
+- Bulk actions across workspaces.
+
+## Open questions
+
+1. Should "All workspaces" appear at the top or bottom of the rail? Choosing
+   top in v1 because that mirrors the natural "overview-then-detail" reading
+   order; revisit if Cuong's muscle memory disagrees.
+2. Should the global Kanban paginate per column, or globally? Going with
+   globally for simplicity; per-column pagination is a v2 stretch.
+
+## References
+
+- Companion tech spec: `0001-cross-workspace-meta-view-techspec.md`
+- Existing per-workspace endpoint: `server/internal/handler/issue.go::ListIssues`
+- Existing sidebar: `packages/views/layout/app-sidebar.tsx`
+- Reserved slug list: `server/internal/handler/workspace_reserved_slugs.go`

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# sync-upstream.sh — sync bonjourcuong/multica `main` with upstream multica-ai/multica
+#
+# Contract (see PKM-CUONG/GROWTH/PROJECTS/multica-fork/adrs/2026-04-28-upstream-sync-strategy.md):
+#   - Idempotent. Safe to re-run.
+#   - Dry-run by default. Reports diff and exits without merging.
+#   - --apply prompts for explicit y/N confirmation before merging.
+#   - --push only valid with --apply. Pushes to origin/main after a clean merge.
+#   - --report-only is cron-friendly: fetch + report, exit 0, no prompt.
+#   - Never rebases. Never force-pushes. Never amends.
+#   - Aborts cleanly on conflict via `git merge --abort`.
+#
+# Usage:
+#   ./scripts/sync-upstream.sh                  # dry-run, prints report
+#   ./scripts/sync-upstream.sh --apply          # interactive merge after prompt
+#   ./scripts/sync-upstream.sh --apply --push   # merge + push to origin/main
+#   ./scripts/sync-upstream.sh --report-only    # cron mode, report and exit
+#   ./scripts/sync-upstream.sh --help
+#
+# Exit codes:
+#   0  ok (or up-to-date, or dry-run completed, or user said no)
+#   1  user aborted at prompt
+#   2  dirty working tree
+#   3  not on main branch (or detached HEAD)
+#   4  merge conflict (aborted cleanly)
+#   5  no upstream remote configured
+#   6  invalid arguments
+# =============================================================================
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- color helpers (only when stdout is a tty) -------------------------------
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'
+  C_BLUE=$'\033[34m'; C_BOLD=$'\033[1m'; C_RESET=$'\033[0m'
+else
+  C_RED=""; C_GREEN=""; C_YELLOW=""; C_BLUE=""; C_BOLD=""; C_RESET=""
+fi
+
+info()  { printf "%s[info]%s  %s\n" "$C_BLUE"   "$C_RESET" "$*"; }
+ok()    { printf "%s[ok]%s    %s\n" "$C_GREEN"  "$C_RESET" "$*"; }
+warn()  { printf "%s[warn]%s  %s\n" "$C_YELLOW" "$C_RESET" "$*"; }
+fail()  { printf "%s[fail]%s  %s\n" "$C_RED"    "$C_RESET" "$*" >&2; }
+hr()    { printf -- "----------------------------------------------------------------\n"; }
+
+usage() {
+  sed -n '4,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# --- arg parsing -------------------------------------------------------------
+APPLY=0
+PUSH=0
+REPORT_ONLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply)        APPLY=1 ;;
+    --push)         PUSH=1 ;;
+    --report-only)  REPORT_ONLY=1 ;;
+    -h|--help)      usage; exit 0 ;;
+    *)              fail "unknown argument: $1"; usage; exit 6 ;;
+  esac
+  shift
+done
+
+if [ "$PUSH" = 1 ] && [ "$APPLY" = 0 ]; then
+  fail "--push requires --apply"
+  exit 6
+fi
+if [ "$REPORT_ONLY" = 1 ] && [ "$APPLY" = 1 ]; then
+  fail "--report-only and --apply are mutually exclusive"
+  exit 6
+fi
+
+# --- preflight ---------------------------------------------------------------
+UPSTREAM_REMOTE="upstream"
+UPSTREAM_BRANCH="main"
+ORIGIN_REMOTE="origin"
+LOCAL_BRANCH="main"
+
+info "repo: $REPO_ROOT"
+
+if ! git remote get-url "$UPSTREAM_REMOTE" >/dev/null 2>&1; then
+  fail "no '$UPSTREAM_REMOTE' remote configured. Add it: git remote add upstream https://github.com/multica-ai/multica.git"
+  exit 5
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" != "$LOCAL_BRANCH" ]; then
+  fail "current branch is '$CURRENT_BRANCH', expected '$LOCAL_BRANCH'. Switch first: git checkout $LOCAL_BRANCH"
+  exit 3
+fi
+
+if ! git diff --quiet --ignore-submodules HEAD -- || ! git diff --cached --quiet --ignore-submodules HEAD --; then
+  fail "working tree is dirty. Commit or stash before syncing:"
+  git status --short
+  exit 2
+fi
+
+# --- fetch -------------------------------------------------------------------
+info "fetching $UPSTREAM_REMOTE/$UPSTREAM_BRANCH..."
+git fetch --quiet "$UPSTREAM_REMOTE" "$UPSTREAM_BRANCH"
+
+LOCAL_HEAD="$(git rev-parse "$LOCAL_BRANCH")"
+UPSTREAM_HEAD="$(git rev-parse "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH")"
+MERGE_BASE="$(git merge-base "$LOCAL_HEAD" "$UPSTREAM_HEAD")"
+
+BEHIND="$(git rev-list --count "$LOCAL_HEAD..$UPSTREAM_HEAD")"
+AHEAD="$(git rev-list --count "$UPSTREAM_HEAD..$LOCAL_HEAD")"
+
+# --- report ------------------------------------------------------------------
+hr
+printf "%sUpstream sync report%s — %s\n" "$C_BOLD" "$C_RESET" "$(date -Iseconds)"
+hr
+printf "  local  %s @ %s\n" "$LOCAL_BRANCH"           "${LOCAL_HEAD:0:12}"
+printf "  upstr  %s/%s @ %s\n" "$UPSTREAM_REMOTE" "$UPSTREAM_BRANCH" "${UPSTREAM_HEAD:0:12}"
+printf "  base   %s\n"                                "${MERGE_BASE:0:12}"
+printf "  behind %s commits | ahead %s commits\n"     "$BEHIND" "$AHEAD"
+hr
+
+if [ "$BEHIND" = "0" ]; then
+  ok "already up to date with $UPSTREAM_REMOTE/$UPSTREAM_BRANCH. Nothing to do."
+  exit 0
+fi
+
+printf "\n%sCommits to merge (%s):%s\n" "$C_BOLD" "$BEHIND" "$C_RESET"
+git log --oneline --no-decorate "$LOCAL_HEAD..$UPSTREAM_HEAD"
+
+printf "\n%sFile diffstat:%s\n" "$C_BOLD" "$C_RESET"
+git diff --stat "$LOCAL_HEAD..$UPSTREAM_HEAD" | tail -n 40
+
+printf "\n%sChange categories:%s\n" "$C_BOLD" "$C_RESET"
+git diff --name-only "$LOCAL_HEAD..$UPSTREAM_HEAD" | awk '
+  /^server\//                                                      { back++;  next }
+  /^(apps\/(web|desktop)|packages)\//                              { front++; next }
+  /^Dockerfile|^docker-compose|^\.github\/workflows\/|^scripts\/|^Makefile$|package\.json$|pnpm-lock\.yaml$|^\.env\.example$/ { infra++; next }
+  /\.md$|^docs\//                                                  { docs++;  next }
+  { other++ }
+  END {
+    printf "  back:  %d (server/)\n  front: %d (apps/web,desktop + packages/)\n  infra: %d (docker, ci, scripts, build)\n  docs:  %d (markdown)\n  other: %d\n", back+0, front+0, infra+0, docs+0, other+0
+  }
+'
+hr
+
+# --- report-only mode (cron) -------------------------------------------------
+if [ "$REPORT_ONLY" = 1 ]; then
+  ok "report-only mode. Not merging. Exit 0."
+  exit 0
+fi
+
+# --- dry-run (default) -------------------------------------------------------
+if [ "$APPLY" = 0 ]; then
+  warn "dry-run. To merge, re-run with --apply (you will be prompted to confirm)."
+  exit 0
+fi
+
+# --- apply: prompt for confirmation ------------------------------------------
+printf "\n%sYou are about to merge %s commits from %s/%s into %s.%s\n" \
+  "$C_BOLD" "$BEHIND" "$UPSTREAM_REMOTE" "$UPSTREAM_BRANCH" "$LOCAL_BRANCH" "$C_RESET"
+if [ "$PUSH" = 1 ]; then
+  printf "%sAfter merge, this script will push to %s/%s.%s\n" \
+    "$C_YELLOW" "$ORIGIN_REMOTE" "$LOCAL_BRANCH" "$C_RESET"
+fi
+printf "Type %sy%s to proceed, anything else to abort: " "$C_GREEN" "$C_RESET"
+
+if ! [ -t 0 ]; then
+  fail "stdin is not a tty. --apply requires an interactive terminal. Use --report-only for cron."
+  exit 1
+fi
+read -r ANSWER
+if [ "$ANSWER" != "y" ] && [ "$ANSWER" != "Y" ]; then
+  warn "aborted by user."
+  exit 1
+fi
+
+# --- merge -------------------------------------------------------------------
+SYNC_TS="$(date +%Y-%m-%d)"
+MERGE_MSG="chore: sync upstream multica-ai/multica $SYNC_TS
+
+Sync $BEHIND commits from upstream/main into bonjourcuong/main.
+Base: ${MERGE_BASE:0:12}
+Upstream HEAD: ${UPSTREAM_HEAD:0:12}
+"
+
+info "merging (no fast-forward to keep a clear sync commit)..."
+if ! git merge --no-ff --no-edit -m "$MERGE_MSG" "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH"; then
+  fail "merge produced conflicts. Aborting cleanly."
+  printf "\n%sConflicting paths:%s\n" "$C_BOLD" "$C_RESET"
+  git diff --name-only --diff-filter=U || true
+  git merge --abort
+  warn "tree restored. Open a sub-issue per conflict scope (back / front / infra / cross-cutting)."
+  exit 4
+fi
+ok "merge complete."
+
+# --- push (optional) ---------------------------------------------------------
+if [ "$PUSH" = 1 ]; then
+  info "pushing to $ORIGIN_REMOTE/$LOCAL_BRANCH..."
+  git push "$ORIGIN_REMOTE" "$LOCAL_BRANCH"
+  ok "pushed."
+else
+  warn "merged locally. Not pushed. To publish: git push $ORIGIN_REMOTE $LOCAL_BRANCH"
+fi
+
+ok "sync done."


### PR DESCRIPTION
## Summary

Architecture Decision Record + tech spec for the cross-workspace meta view feature requested in [MUL-3](mention://issue/bfdc1e65-f54c-46d5-9e26-cccda94bdd9a).

This PR is **docs only** — no production code. It captures:

- A new backend endpoint `GET /api/issues/cross-workspace` that aggregates issues across every workspace the caller is a member of, with strict server-side membership filtering.
- A thin left rail (`<WorkspaceRail />`) listing every workspace + an "All" entry that links to the new `/global` route.
- A global Kanban view with the standard 5 columns (Backlog / Todo / In Progress / In Review / Done), workspace badge per card, and filters for workspace, assignee, priority, status.
- Concrete contracts (API signature, component tree, query shape, telemetry) so Tony, Peter, Bruce, and JARVIS can pick up implementation in parallel.

## Files

- `docs/adrs/0001-cross-workspace-meta-view.md` — the ADR (decisions + reasoning).
- `docs/adrs/0001-cross-workspace-meta-view-techspec.md` — the implementation contract.

## Decisions at a glance

| Topic | Choice |
|---|---|
| Aggregation | Backend endpoint, single round-trip |
| Permissions | Server-side filter on `member` table, no 403 leak |
| Pagination | Keyset on `(created_at, id)`, page 50, cap 100 |
| URL | `/global` (top-level, outside `[workspaceSlug]`) |
| Sidebar | New always-visible thin rail; existing dropdown stays for now |
| Workspace color | Deterministic from UUID (no DB migration in v1) |
| Group-by | `status` only in v1; group-by `workspace` deferred to v2 |
| Migration | None in v1 |

## Sub-issues created in Multica Fork

To be linked once created — see the comment on MUL-3.

## Test plan

- [ ] Cuong reads the ADR and either approves or requests changes.
- [ ] Once approved, Tony picks up sub-issue #2 (backend endpoint).
- [ ] Peter picks up sub-issues #3 and #4 in parallel.
- [ ] Bruce wires up E2E in sub-issue #5.
- [ ] JARVIS deploys to `team.cuongpho.com` in sub-issue #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)