### PR TITLE
fix(agent/codex): ignore idle status for turn completion

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -814,11 +814,8 @@ func (c *codexClient) handleRawNotification(method string, params map[string]any
 
 	case "thread/status/changed":
 		statusType := extractNestedString(params, "status", "type")
-		if statusType == "idle" && c.turnStarted {
-			if c.onTurnDone != nil {
-				c.onTurnDone(false)
-			}
-		}
+		threadID, _ := params["threadId"].(string)
+		c.cfg.Logger.Info("codex thread/status changed", "thread_id", threadID, "status", statusType, "turn_started", c.turnStarted)
 
 	default:
 		if strings.HasPrefix(method, "item/") {

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -488,18 +488,42 @@ func TestCodexRawThreadStatusIdle(t *testing.T) {
 	c.notificationProtocol = "raw"
 	c.turnStarted = true
 
-	var turnDone bool
+	var doneCount int
 	c.onTurnDone = func(aborted bool) {
-		turnDone = true
-		if aborted {
-			t.Fatal("expected aborted=false for idle")
-		}
+		doneCount++
 	}
 
 	c.handleLine(`{"jsonrpc":"2.0","method":"thread/status/changed","params":{"status":{"type":"idle"}}}`)
 
-	if !turnDone {
-		t.Fatal("expected onTurnDone for idle status")
+	if doneCount != 0 {
+		t.Fatalf("idle thread status must not complete the turn, got %d calls", doneCount)
+	}
+}
+
+func TestCodexRawThreadStatusIdleWaitsForTurnCompleted(t *testing.T) {
+	t.Parallel()
+
+	c, _, _ := newTestCodexClient(t)
+	c.notificationProtocol = "raw"
+	c.threadID = "thr-main"
+	c.turnStarted = true
+
+	var doneCount int
+	c.onTurnDone = func(aborted bool) {
+		doneCount++
+		if aborted {
+			t.Fatal("expected aborted=false")
+		}
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"thread/status/changed","params":{"threadId":"thr-main","status":{"type":"idle"}}}`)
+	if doneCount != 0 {
+		t.Fatalf("idle thread status must wait for turn/completed, got %d calls", doneCount)
+	}
+
+	c.handleLine(`{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"thr-main","turn":{"id":"turn-main","status":"completed"}}}`)
+	if doneCount != 1 {
+		t.Fatalf("turn/completed should complete exactly once after idle, got %d calls", doneCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop treating Codex `thread/status/changed` idle notifications as turn completion
- keep structured logging for thread status changes
- add regression coverage so idle waits for the authoritative `turn/completed` notification

## Why
Codex app-server can emit thread idle status while work is still in progress, for example after spawning follow-up work before the turn has actually completed. Treating that status as terminal can make Multica close the runner early and mark the task completed before a final answer.

## Tests
- `cd server && go test -count=1 ./pkg/agent`