### PR TITLE
refactor(issues): flatten status group headers in list/board

### DIFF
--- a/packages/core/issues/config/status.ts
+++ b/packages/core/issues/config/status.ts
@@ -37,16 +37,14 @@ export const STATUS_CONFIG: Record<
     iconColor: string;
     hoverBg: string;
     dividerColor: string;
-    badgeBg: string;
-    badgeText: string;
     columnBg: string;
   }
 > = {
-  backlog: { label: "Backlog", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", badgeBg: "bg-muted", badgeText: "text-muted-foreground", columnBg: "bg-muted/40" },
-  todo: { label: "Todo", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", badgeBg: "bg-muted", badgeText: "text-muted-foreground", columnBg: "bg-muted/40" },
-  in_progress: { label: "In Progress", iconColor: "text-warning", hoverBg: "hover:bg-warning/10", dividerColor: "bg-warning", badgeBg: "bg-warning", badgeText: "text-white", columnBg: "bg-warning/5" },
-  in_review: { label: "In Review", iconColor: "text-success", hoverBg: "hover:bg-success/10", dividerColor: "bg-success", badgeBg: "bg-success", badgeText: "text-white", columnBg: "bg-success/5" },
-  done: { label: "Done", iconColor: "text-info", hoverBg: "hover:bg-info/10", dividerColor: "bg-info", badgeBg: "bg-info", badgeText: "text-white", columnBg: "bg-info/5" },
-  blocked: { label: "Blocked", iconColor: "text-destructive", hoverBg: "hover:bg-destructive/10", dividerColor: "bg-destructive", badgeBg: "bg-destructive", badgeText: "text-white", columnBg: "bg-destructive/5" },
-  cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", badgeBg: "bg-muted", badgeText: "text-muted-foreground", columnBg: "bg-muted/40" },
+  backlog: { label: "Backlog", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", columnBg: "bg-muted/40" },
+  todo: { label: "Todo", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", columnBg: "bg-muted/40" },
+  in_progress: { label: "In Progress", iconColor: "text-warning", hoverBg: "hover:bg-warning/10", dividerColor: "bg-warning", columnBg: "bg-warning/5" },
+  in_review: { label: "In Review", iconColor: "text-success", hoverBg: "hover:bg-success/10", dividerColor: "bg-success", columnBg: "bg-success/5" },
+  done: { label: "Done", iconColor: "text-info", hoverBg: "hover:bg-info/10", dividerColor: "bg-info", columnBg: "bg-info/5" },
+  blocked: { label: "Blocked", iconColor: "text-destructive", hoverBg: "hover:bg-destructive/10", dividerColor: "bg-destructive", columnBg: "bg-destructive/5" },
+  cancelled: { label: "Cancelled", iconColor: "text-muted-foreground", hoverBg: "hover:bg-accent", dividerColor: "bg-muted-foreground/40", columnBg: "bg-muted/40" },
 };

--- a/packages/views/issues/components/board-column.tsx
+++ b/packages/views/issues/components/board-column.tsx
@@ -16,7 +16,7 @@ import {
 import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { useModalStore } from "@multica/core/modals";
 import { useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
-import { StatusIcon } from "./status-icon";
+import { StatusHeading } from "./status-heading";
 import { DraggableBoardCard } from "./board-card";
 import type { ChildProgress } from "./list-row";
 
@@ -52,16 +52,7 @@ export function BoardColumn({
   return (
     <div className={`flex w-[280px] shrink-0 flex-col rounded-xl ${cfg.columnBg} p-2`}>
       <div className="mb-2 flex items-center justify-between px-1.5">
-        {/* Left: status badge + count */}
-        <div className="flex items-center gap-2">
-          <span className={`inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-semibold ${cfg.badgeBg} ${cfg.badgeText}`}>
-            <StatusIcon status={status} className="h-3 w-3" inheritColor />
-            {cfg.label}
-          </span>
-          <span className="text-xs text-muted-foreground">
-            {totalCount ?? issueIds.length}
-          </span>
-        </div>
+        <StatusHeading status={status} count={totalCount ?? issueIds.length} />
 
         {/* Right: add + menu */}
         <div className="flex items-center gap-1">

--- a/packages/views/issues/components/index.ts
+++ b/packages/views/issues/components/index.ts
@@ -1,4 +1,5 @@
 export { StatusIcon } from "./status-icon";
+export { StatusHeading } from "./status-heading";
 export { PriorityIcon } from "./priority-icon";
 export { StatusPicker, PriorityPicker, AssigneePicker, canAssignAgent, DueDatePicker, LabelPicker } from "./pickers";
 export { IssueDetail } from "./issue-detail";

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -8,12 +8,11 @@ import { Button } from "@multica/ui/components/ui/button";
 import type { Issue, IssueStatus } from "@multica/core/types";
 import { useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { MyIssuesFilter } from "@multica/core/issues/queries";
-import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { useModalStore } from "@multica/core/modals";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { sortIssues } from "../utils/sort";
-import { StatusIcon } from "./status-icon";
+import { StatusHeading } from "./status-heading";
 import { ListRow, type ChildProgress } from "./list-row";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 
@@ -104,7 +103,6 @@ function StatusAccordionItem({
   childProgressMap: Map<string, ChildProgress>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
 }) {
-  const cfg = STATUS_CONFIG[status];
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
   const select = useIssueSelectionStore((s) => s.select);
   const deselect = useIssueSelectionStore((s) => s.deselect);
@@ -140,11 +138,7 @@ function StatusAccordionItem({
         </div>
         <Accordion.Trigger className="group/trigger flex flex-1 items-center gap-2 px-2 h-full text-left outline-none">
           <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-aria-expanded/trigger:rotate-90" />
-          <span className={`inline-flex items-center gap-1.5 rounded px-2 py-0.5 text-xs font-semibold ${cfg.badgeBg} ${cfg.badgeText}`}>
-            <StatusIcon status={status} className="h-3 w-3" inheritColor />
-            {cfg.label}
-          </span>
-          <span className="text-xs text-muted-foreground">{total}</span>
+          <StatusHeading status={status} count={total} />
         </Accordion.Trigger>
         <div className="pr-2">
           <Tooltip>

--- a/packages/views/issues/components/status-heading.tsx
+++ b/packages/views/issues/components/status-heading.tsx
@@ -1,0 +1,22 @@
+import type { IssueStatus } from "@multica/core/types";
+import { STATUS_CONFIG } from "@multica/core/issues/config";
+import { StatusIcon } from "./status-icon";
+
+export function StatusHeading({
+  status,
+  count,
+}: {
+  status: IssueStatus;
+  count: number;
+}) {
+  const cfg = STATUS_CONFIG[status];
+  return (
+    <div className="flex items-center gap-2">
+      <span className="inline-flex items-center gap-1.5 text-xs font-semibold">
+        <StatusIcon status={status} className="h-3 w-3" />
+        {cfg.label}
+      </span>
+      <span className="text-xs text-muted-foreground">{count}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Drop the filled status chip (`bg-warning text-white` and friends) from list/board column headers — `StatusIcon` already carries the semantic color, so the chip duplicated it on the text background; for `bg-muted` variants the chip was nearly invisible against the row's `bg-muted/40` background anyway.
- Extract a shared `StatusHeading` component (icon + bold label + muted count) consumed by both `list-view.tsx` and `board-column.tsx`.
- Drop the now-unused `badgeBg` / `badgeText` fields from `STATUS_CONFIG`.

The board column's `cfg.columnBg` (per-column tint) is intentionally **not** touched in this PR.

## Test plan
- [ ] Issues → List view: column headers render icon + bold label + muted count, no filled pill; `In Progress` shows a yellow icon + black bold text instead of yellow pill + white text.
- [ ] Issues → Board view: same flat treatment in column headers.
- [ ] All status colors still distinguishable via the icon (yellow / blue / green / red / muted).
- [ ] No TS errors (`pnpm typecheck` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)