### PR TITLE
fix: update Kiro runtime icon

### DIFF
--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Monitor } from "lucide-react";
 
 // Claude (Anthropic) — official mark, sourced from Bootstrap Icons (bi-claude)
@@ -125,13 +126,41 @@ function KimiLogo({ className }: { className: string }) {
   );
 }
 
-// Kiro CLI — compact "K" mark for runtime rows.
+// Kiro CLI — official icon sourced from kiro.dev/icon.svg.
 function KiroLogo({ className }: { className: string }) {
+  const maskId = `kiro-logo-mask-${useId().replace(/:/g, "")}`;
+
   return (
-    <svg viewBox="0 0 24 24" fill="none" className={className}>
-      <rect width="24" height="24" rx="5" fill="#0F172A" />
-      <path d="M6.5 5.5h3v5.1l4.7-5.1h3.5l-5.1 5.4 5.4 7.6h-3.6l-3.8-5.5-1.1 1.2v4.3h-3V5.5Z" fill="#38BDF8" />
-      <path d="M9.5 14.2 14.2 9l1.8 2.2-4.7 5.1-1.8-2.1Z" fill="#A7F3D0" opacity="0.9" />
+    <svg viewBox="0 0 1200 1200" fill="none" className={className}>
+      <rect width="1200" height="1200" rx="260" fill="#9046FF" />
+      <mask
+        id={maskId}
+        style={{ maskType: "luminance" }}
+        maskUnits="userSpaceOnUse"
+        x="272"
+        y="202"
+        width="655"
+        height="796"
+      >
+        <path
+          d="M926.578 202.793H272.637V997.857H926.578V202.793Z"
+          fill="white"
+        />
+      </mask>
+      <g mask={`url(#${maskId})`}>
+        <path
+          d="M398.554 818.914C316.315 1001.03 491.477 1046.74 620.672 940.156C658.687 1059.66 801.052 970.473 852.234 877.795C964.787 673.567 919.318 465.357 907.64 422.374C827.637 129.443 427.623 128.946 358.8 423.865C342.651 475.544 342.402 534.18 333.458 595.051C328.986 625.86 325.507 645.488 313.83 677.785C306.873 696.424 297.68 712.819 282.773 740.645C259.915 783.881 269.604 867.113 387.87 823.883L399.051 818.914H398.554Z"
+          fill="white"
+        />
+        <path
+          d="M636.123 549.353C603.328 549.353 598.359 510.097 598.359 486.742C598.359 465.623 602.086 448.977 609.293 438.293C615.504 428.852 624.697 424.131 636.123 424.131C647.555 424.131 657.492 428.852 664.447 438.541C672.398 449.474 676.623 466.12 676.623 486.742C676.623 525.998 661.471 549.353 636.375 549.353H636.123Z"
+          fill="black"
+        />
+        <path
+          d="M771.24 549.353C738.445 549.353 733.477 510.097 733.477 486.742C733.477 465.623 737.203 448.977 744.41 438.293C750.621 428.852 759.814 424.131 771.24 424.131C782.672 424.131 792.609 428.852 799.564 438.541C807.516 449.474 811.74 466.12 811.74 486.742C811.74 525.998 796.588 549.353 771.492 549.353H771.24Z"
+          fill="black"
+        />
+      </g>
     </svg>
   );
 }


### PR DESCRIPTION
Summary: Replaced the handmade Kiro runtime mark with the official SVG from https://kiro.dev/icon.svg, keeping the existing ProviderLogo sizing API and adding a unique mask id per render. Testing: pnpm --filter @multica/views typecheck; pnpm --dir packages/views exec eslint runtimes/components/provider-logo.tsx. Note: full pnpm --filter @multica/views lint is still blocked by unrelated existing react/no-unescaped-entities errors in model-dropdown/no-access-page/custom-args-tab plus existing hook dependency warnings.