### PR TITLE
fix(daemon): unify workspaces root across Desktop/Web/CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -499,7 +499,7 @@ Nothing in this flow touches the system-installed `multica` or the default
 | Config | `~/.multica/config.json` | `~/.multica/profiles/dev-<slug>-<hash>/config.json` |
 | Daemon PID | `~/.multica/daemon.pid` | `~/.multica/profiles/dev-<slug>-<hash>/daemon.pid` |
 | Health port | `19514` | `19514 + 1 + (name_hash % 1000)` |
-| Workspaces dir | `~/multica_workspaces/` | `~/multica_workspaces_dev-<slug>-<hash>/` |
+| Workspaces dir | `~/multica_workspaces/` | `~/multica_workspaces/` (shared; set `MULTICA_WORKSPACES_ROOT` to isolate per worktree) |
 | Database | remote / production | local Docker: `multica_<slug>_<hash>` |
 | Desktop profile | `desktop-api.multica.ai` | `desktop-localhost-<port>` |
 

--- a/apps/docs/content/docs/cli/reference.zh.mdx
+++ b/apps/docs/content/docs/cli/reference.zh.mdx
@@ -181,7 +181,7 @@ multica daemon start --profile staging
 multica daemon start
 ```
 
-Each profile gets its own config directory (`~/.multica/profiles/<name>/`), daemon state, health port, and workspace root.
+Each profile gets its own config directory (`~/.multica/profiles/<name>/`), daemon state, and health port. All profiles share the same workspaces root (`~/multica_workspaces/`) so the same workspace's local files are reachable from any client (Desktop, Web, CLI). Override with `MULTICA_WORKSPACES_ROOT` if you need per-profile isolation.
 
 ## Workspaces
 

--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -325,6 +325,10 @@ func runDaemonForeground(cmd *cobra.Command) error {
 	defer stop()
 
 	logger := logger_pkg.NewLogger("daemon")
+	// One-shot migration: relocate pre-change `~/multica_workspaces_<profile>/`
+	// contents into the unified `~/multica_workspaces/` so Desktop, Web, and
+	// CLI share the same local files. Best-effort; never blocks startup.
+	daemon.MigrateLegacyWorkspacesRoot(cfg, logger)
 	d := daemon.New(cfg, logger)
 
 	// Write PID file so "daemon stop" can find us.

--- a/server/cmd/multica/main.go
+++ b/server/cmd/multica/main.go
@@ -34,7 +34,7 @@ func init() {
 
 	rootCmd.PersistentFlags().String("server-url", "", "Multica server URL (env: MULTICA_SERVER_URL)")
 	rootCmd.PersistentFlags().String("workspace-id", "", "Workspace ID (env: MULTICA_WORKSPACE_ID)")
-	rootCmd.PersistentFlags().String("profile", "", "Configuration profile name (e.g. dev) — isolates config, daemon state, and workspaces")
+	rootCmd.PersistentFlags().String("profile", "", "Configuration profile name (e.g. dev) — isolates config, daemon state, and health port (workspaces are shared across profiles; set MULTICA_WORKSPACES_ROOT to override)")
 
 	// Core commands
 	issueCmd.GroupID = groupCore

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -258,7 +258,10 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		runtimeName = overrides.RuntimeName
 	}
 
-	// Workspaces root: override > env > default (~/multica_workspaces or ~/multica_workspaces_<profile>)
+	// Workspaces root: override > env > default (~/multica_workspaces).
+	// Profile no longer affects the default — Desktop, Web, and CLI all share
+	// ~/multica_workspaces/ so a workspace's local files don't fork by client.
+	// MigrateLegacyWorkspacesRoot relocates pre-change profile-suffixed dirs.
 	workspacesRoot := strings.TrimSpace(os.Getenv("MULTICA_WORKSPACES_ROOT"))
 	if overrides.WorkspacesRoot != "" {
 		workspacesRoot = overrides.WorkspacesRoot
@@ -268,11 +271,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		if err != nil {
 			return Config{}, fmt.Errorf("resolve home directory: %w (set MULTICA_WORKSPACES_ROOT to override)", err)
 		}
-		if profile != "" {
-			workspacesRoot = filepath.Join(home, "multica_workspaces_"+profile)
-		} else {
-			workspacesRoot = filepath.Join(home, "multica_workspaces")
-		}
+		workspacesRoot = filepath.Join(home, "multica_workspaces")
 	}
 	workspacesRoot, err = filepath.Abs(workspacesRoot)
 	if err != nil {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -56,9 +56,23 @@ type Daemon struct {
 	activeTasks   atomic.Int64       // number of tasks currently in handleTask; exposed via /health
 }
 
+// repoCacheRoot returns the bare-clone cache directory for the daemon. It is
+// per-profile so two daemons running side-by-side (e.g. Desktop's
+// profile=desktop-<host> daemon + a user-managed CLI daemon on the default
+// profile) don't fight over git lockfiles in the same `.git/`.
+// repocache.repoLocks is process-local and would not protect concurrent
+// fetch/worktree-add across processes if they shared a path.
+func repoCacheRoot(cfg Config) string {
+	dir := ".repos"
+	if cfg.Profile != "" {
+		dir = ".repos-" + cfg.Profile
+	}
+	return filepath.Join(cfg.WorkspacesRoot, dir)
+}
+
 // New creates a new Daemon instance.
 func New(cfg Config, logger *slog.Logger) *Daemon {
-	cacheRoot := filepath.Join(cfg.WorkspacesRoot, ".repos")
+	cacheRoot := repoCacheRoot(cfg)
 	client := NewClient(cfg.ServerBaseURL)
 	// Tag every daemon HTTP request with the daemon's CLI version so the
 	// server can split logs/metrics by client version (parallel to the CLI).

--- a/server/internal/daemon/workspaces_migrate.go
+++ b/server/internal/daemon/workspaces_migrate.go
@@ -1,0 +1,110 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MigrateLegacyWorkspacesRoot relocates per-profile workspace dirs (the
+// pre-change layout `~/multica_workspaces_<profile>/`) into the unified
+// `~/multica_workspaces/` directory, so Desktop, Web, and CLI all see the
+// same local workspace files for the same workspace_id.
+//
+// The migration is a one-time best-effort op invoked at daemon startup. It is
+// silently skipped when:
+//   - cfg.Profile is empty (default profile already used the unified path);
+//   - MULTICA_WORKSPACES_ROOT is set (user opted out of the default layout —
+//     local-dev worktrees rely on this);
+//   - cfg.WorkspacesRoot is not the default `~/multica_workspaces` (user
+//     pointed it elsewhere via Overrides);
+//   - the legacy directory does not exist.
+//
+// Failures (permission, EXDEV, etc.) are logged at warn level but never block
+// daemon startup — the daemon falls back to the default unified path and the
+// stale legacy dir stays in place.
+func MigrateLegacyWorkspacesRoot(cfg Config, logger *slog.Logger) {
+	if cfg.Profile == "" {
+		return
+	}
+	if strings.TrimSpace(os.Getenv("MULTICA_WORKSPACES_ROOT")) != "" {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	defaultRoot, err := filepath.Abs(filepath.Join(home, "multica_workspaces"))
+	if err != nil {
+		return
+	}
+	if cfg.WorkspacesRoot != defaultRoot {
+		return
+	}
+	legacyRoot := filepath.Join(home, "multica_workspaces_"+cfg.Profile)
+	info, err := os.Stat(legacyRoot)
+	if err != nil || !info.IsDir() {
+		return
+	}
+
+	if err := migrateWorkspacesRoot(legacyRoot, defaultRoot); err != nil {
+		logger.Warn("migrate legacy workspaces root failed; legacy dir kept in place",
+			"legacy", legacyRoot, "target", defaultRoot, "error", err)
+		return
+	}
+	logger.Info("migrated legacy workspaces root",
+		"legacy", legacyRoot, "target", defaultRoot)
+}
+
+// migrateWorkspacesRoot moves every immediate child of legacyRoot into
+// targetRoot. Children whose name already exists at the target are left
+// untouched in legacyRoot (we never overwrite). If, after the move pass,
+// legacyRoot is empty, it is removed; otherwise it is kept so the user can
+// reconcile the leftovers manually.
+func migrateWorkspacesRoot(legacyRoot, targetRoot string) error {
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		return fmt.Errorf("ensure target root: %w", err)
+	}
+
+	entries, err := os.ReadDir(legacyRoot)
+	if err != nil {
+		return fmt.Errorf("read legacy root: %w", err)
+	}
+
+	var firstErr error
+	for _, e := range entries {
+		src := filepath.Join(legacyRoot, e.Name())
+		dst := filepath.Join(targetRoot, e.Name())
+
+		if _, err := os.Lstat(dst); err == nil {
+			// Target already exists — leave src in place to avoid clobbering.
+			continue
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("stat target %s: %w", dst, err)
+			}
+			continue
+		}
+
+		if err := os.Rename(src, dst); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("rename %s -> %s: %w", src, dst, err)
+			}
+		}
+	}
+
+	if firstErr != nil {
+		return firstErr
+	}
+
+	// If everything was relocated cleanly, prune the empty legacy root.
+	remaining, err := os.ReadDir(legacyRoot)
+	if err == nil && len(remaining) == 0 {
+		_ = os.Remove(legacyRoot)
+	}
+	return nil
+}

--- a/server/internal/daemon/workspaces_migrate.go
+++ b/server/internal/daemon/workspaces_migrate.go
@@ -51,7 +51,7 @@ func MigrateLegacyWorkspacesRoot(cfg Config, logger *slog.Logger) {
 		return
 	}
 
-	if err := migrateWorkspacesRoot(legacyRoot, defaultRoot); err != nil {
+	if err := migrateWorkspacesRoot(legacyRoot, defaultRoot, cfg.Profile); err != nil {
 		logger.Warn("migrate legacy workspaces root failed; legacy dir kept in place",
 			"legacy", legacyRoot, "target", defaultRoot, "error", err)
 		return
@@ -65,22 +65,32 @@ func MigrateLegacyWorkspacesRoot(cfg Config, logger *slog.Logger) {
 // The on-disk layout is `<root>/<workspace_id>/<task_short>/...`, so when a
 // `<workspace_id>` directory already exists at the target (because Web/CLI
 // has run a task there) we still want to relocate the per-task subdirs from
-// the legacy `<workspace_id>` rather than abandon them. The walk therefore
-// merges one level deep:
+// the legacy `<workspace_id>` rather than abandon them. The walk merges one
+// level deep for workspace_id-shaped entries.
+//
+// The legacy `.repos` bare-clone cache gets special treatment: it is renamed
+// to `.repos-<profile>` at the target. Two profiled daemons must not share a
+// single `.repos/` (repocache.repoLocks is process-local and won't protect
+// concurrent git mutations across processes).
 //
 //   - If the legacy entry name does not exist at the target, the whole entry
-//     is renamed in one syscall (fast path; covers fresh workspaces and the
-//     `.repos` cache).
+//     is renamed in one syscall (fast path; covers fresh workspaces).
+//   - For `.repos`, the rename target is always `.repos-<profile>` regardless
+//     of whether `.repos` already exists at the target — they belong to
+//     different daemons. If `.repos-<profile>` already exists at the target,
+//     the legacy `.repos` is left in place (we don't overwrite a previously
+//     migrated cache).
 //   - Otherwise, if both sides are directories AND the entry name does not
-//     start with `.` (i.e. it looks like a workspace_id, not a hidden file
-//     like `.repos`), recurse and rename each task_short subdir whose name
-//     is free at the target. Conflicting task_short subdirs stay in legacy
-//     for manual reconciliation.
-//   - Other conflicts (file vs dir, dotfiles, non-dirs) are left untouched.
+//     start with `.` (i.e. it looks like a workspace_id, not a hidden file),
+//     recurse and rename each task_short subdir whose name is free at the
+//     target. Conflicting task_short subdirs stay in legacy for manual
+//     reconciliation.
+//   - Other conflicts (file vs dir, non-`.repos` dotfiles, non-dirs) are
+//     left untouched.
 //
 // If, after the pass, legacyRoot is empty, it is removed; otherwise it stays
 // so the user can reconcile leftovers.
-func migrateWorkspacesRoot(legacyRoot, targetRoot string) error {
+func migrateWorkspacesRoot(legacyRoot, targetRoot, profile string) error {
 	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
 		return fmt.Errorf("ensure target root: %w", err)
 	}
@@ -99,8 +109,26 @@ func migrateWorkspacesRoot(legacyRoot, targetRoot string) error {
 
 	for _, e := range entries {
 		src := filepath.Join(legacyRoot, e.Name())
-		dst := filepath.Join(targetRoot, e.Name())
 
+		// Special-case the bare-repo cache: relocate to a per-profile path so
+		// the unified workspaces root doesn't put two daemons on the same
+		// .git/.
+		if e.Name() == ".repos" && profile != "" {
+			dst := filepath.Join(targetRoot, ".repos-"+profile)
+			if _, err := os.Lstat(dst); err == nil {
+				// Already migrated — leave legacy in place.
+				continue
+			} else if !errors.Is(err, fs.ErrNotExist) {
+				recordErr(fmt.Errorf("stat target %s: %w", dst, err))
+				continue
+			}
+			if err := os.Rename(src, dst); err != nil {
+				recordErr(fmt.Errorf("rename %s -> %s: %w", src, dst, err))
+			}
+			continue
+		}
+
+		dst := filepath.Join(targetRoot, e.Name())
 		dstInfo, err := os.Lstat(dst)
 		if errors.Is(err, fs.ErrNotExist) {
 			if err := os.Rename(src, dst); err != nil {
@@ -114,7 +142,7 @@ func migrateWorkspacesRoot(legacyRoot, targetRoot string) error {
 		}
 
 		// Only merge into existing workspace_id-shaped dirs (skip dotfiles
-		// like `.repos` to avoid stomping shared cache state).
+		// to avoid stomping shared cache state).
 		if !e.IsDir() || !dstInfo.IsDir() || strings.HasPrefix(e.Name(), ".") {
 			continue
 		}

--- a/server/internal/daemon/workspaces_migrate.go
+++ b/server/internal/daemon/workspaces_migrate.go
@@ -60,11 +60,26 @@ func MigrateLegacyWorkspacesRoot(cfg Config, logger *slog.Logger) {
 		"legacy", legacyRoot, "target", defaultRoot)
 }
 
-// migrateWorkspacesRoot moves every immediate child of legacyRoot into
-// targetRoot. Children whose name already exists at the target are left
-// untouched in legacyRoot (we never overwrite). If, after the move pass,
-// legacyRoot is empty, it is removed; otherwise it is kept so the user can
-// reconcile the leftovers manually.
+// migrateWorkspacesRoot moves the contents of legacyRoot into targetRoot.
+//
+// The on-disk layout is `<root>/<workspace_id>/<task_short>/...`, so when a
+// `<workspace_id>` directory already exists at the target (because Web/CLI
+// has run a task there) we still want to relocate the per-task subdirs from
+// the legacy `<workspace_id>` rather than abandon them. The walk therefore
+// merges one level deep:
+//
+//   - If the legacy entry name does not exist at the target, the whole entry
+//     is renamed in one syscall (fast path; covers fresh workspaces and the
+//     `.repos` cache).
+//   - Otherwise, if both sides are directories AND the entry name does not
+//     start with `.` (i.e. it looks like a workspace_id, not a hidden file
+//     like `.repos`), recurse and rename each task_short subdir whose name
+//     is free at the target. Conflicting task_short subdirs stay in legacy
+//     for manual reconciliation.
+//   - Other conflicts (file vs dir, dotfiles, non-dirs) are left untouched.
+//
+// If, after the pass, legacyRoot is empty, it is removed; otherwise it stays
+// so the user can reconcile leftovers.
 func migrateWorkspacesRoot(legacyRoot, targetRoot string) error {
 	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
 		return fmt.Errorf("ensure target root: %w", err)
@@ -76,24 +91,36 @@ func migrateWorkspacesRoot(legacyRoot, targetRoot string) error {
 	}
 
 	var firstErr error
+	recordErr := func(err error) {
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
 	for _, e := range entries {
 		src := filepath.Join(legacyRoot, e.Name())
 		dst := filepath.Join(targetRoot, e.Name())
 
-		if _, err := os.Lstat(dst); err == nil {
-			// Target already exists — leave src in place to avoid clobbering.
-			continue
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("stat target %s: %w", dst, err)
+		dstInfo, err := os.Lstat(dst)
+		if errors.Is(err, fs.ErrNotExist) {
+			if err := os.Rename(src, dst); err != nil {
+				recordErr(fmt.Errorf("rename %s -> %s: %w", src, dst, err))
 			}
 			continue
 		}
+		if err != nil {
+			recordErr(fmt.Errorf("stat target %s: %w", dst, err))
+			continue
+		}
 
-		if err := os.Rename(src, dst); err != nil {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("rename %s -> %s: %w", src, dst, err)
-			}
+		// Only merge into existing workspace_id-shaped dirs (skip dotfiles
+		// like `.repos` to avoid stomping shared cache state).
+		if !e.IsDir() || !dstInfo.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+
+		if err := mergeTaskDirs(src, dst); err != nil {
+			recordErr(err)
 		}
 	}
 
@@ -107,4 +134,36 @@ func migrateWorkspacesRoot(legacyRoot, targetRoot string) error {
 		_ = os.Remove(legacyRoot)
 	}
 	return nil
+}
+
+// mergeTaskDirs renames every task_short subdir in legacyWS into targetWS,
+// skipping (leaving in legacyWS) any subdir whose name already exists at the
+// target. Removes legacyWS afterwards if it ends up empty.
+func mergeTaskDirs(legacyWS, targetWS string) error {
+	subs, err := os.ReadDir(legacyWS)
+	if err != nil {
+		return fmt.Errorf("read legacy workspace dir %s: %w", legacyWS, err)
+	}
+	var firstErr error
+	for _, sub := range subs {
+		src := filepath.Join(legacyWS, sub.Name())
+		dst := filepath.Join(targetWS, sub.Name())
+		if _, err := os.Lstat(dst); err == nil {
+			continue
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("stat target %s: %w", dst, err)
+			}
+			continue
+		}
+		if err := os.Rename(src, dst); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("rename %s -> %s: %w", src, dst, err)
+			}
+		}
+	}
+	if remaining, err := os.ReadDir(legacyWS); err == nil && len(remaining) == 0 {
+		_ = os.Remove(legacyWS)
+	}
+	return firstErr
 }

--- a/server/internal/daemon/workspaces_migrate_test.go
+++ b/server/internal/daemon/workspaces_migrate_test.go
@@ -56,8 +56,8 @@ func TestMigrateLegacyWorkspacesRoot_MovesContentsAndRemovesLegacyDir(t *testing
 	if b, err := os.ReadFile(moved); err != nil || string(b) != "hello" {
 		t.Fatalf("expected moved file with content 'hello', got %q err=%v", string(b), err)
 	}
-	if _, err := os.Stat(filepath.Join(target, ".repos", "github.com", "foo", "bar", "HEAD")); err != nil {
-		t.Fatalf("expected .repos cache to be moved, got err=%v", err)
+	if _, err := os.Stat(filepath.Join(target, ".repos-"+profile, "github.com", "foo", "bar", "HEAD")); err != nil {
+		t.Fatalf("expected legacy .repos to be relocated to .repos-<profile>, got err=%v", err)
 	}
 }
 
@@ -210,15 +210,17 @@ func TestMigrateLegacyWorkspacesRoot_PreservesConflictingTaskShort(t *testing.T)
 	}
 }
 
-func TestMigrateLegacyWorkspacesRoot_LeavesDotfileConflictAlone(t *testing.T) {
+func TestMigrateLegacyWorkspacesRoot_RelocatesReposNextToExistingTargetCache(t *testing.T) {
 	home := withFakeHome(t)
 	profile := "desktop-foo"
 
 	legacy := filepath.Join(home, "multica_workspaces_"+profile)
 	target := filepath.Join(home, "multica_workspaces")
 
-	// Both have a `.repos` cache. Don't merge into existing cache (just
-	// leave the legacy copy; the daemon will lazily repopulate target).
+	// Both daemons have populated bare-repo caches. Each must keep its own.
+	// Legacy `.repos` belongs to the profiled daemon and is relocated to
+	// `.repos-<profile>`; the default-profile daemon's existing `.repos` at
+	// the target stays untouched.
 	mustWriteFile(t, filepath.Join(legacy, ".repos", "github.com", "foo", "HEAD"), "legacy")
 	mustWriteFile(t, filepath.Join(target, ".repos", "github.com", "bar", "HEAD"), "target")
 
@@ -228,13 +230,70 @@ func TestMigrateLegacyWorkspacesRoot_LeavesDotfileConflictAlone(t *testing.T) {
 	}
 	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
 
-	if _, err := os.Stat(filepath.Join(legacy, ".repos", "github.com", "foo", "HEAD")); err != nil {
-		t.Fatalf("legacy dotfile dir should be left in place when target dotfile exists: %v", err)
+	if _, err := os.Stat(filepath.Join(target, ".repos-"+profile, "github.com", "foo", "HEAD")); err != nil {
+		t.Fatalf("legacy .repos should land at .repos-<profile>, got err=%v", err)
 	}
 	if _, err := os.Stat(filepath.Join(target, ".repos", "github.com", "bar", "HEAD")); err != nil {
-		t.Fatalf("target dotfile dir should be untouched: %v", err)
+		t.Fatalf("default-profile .repos should be untouched, got err=%v", err)
 	}
+	// Target's default .repos must not have absorbed any legacy entries.
 	if _, err := os.Stat(filepath.Join(target, ".repos", "github.com", "foo")); !os.IsNotExist(err) {
-		t.Fatalf("target dotfile dir should not be merged into, err=%v", err)
+		t.Fatalf("legacy entries must not leak into target .repos, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(legacy, ".repos")); !os.IsNotExist(err) {
+		t.Fatalf("legacy .repos should be moved, err=%v", err)
+	}
+}
+
+func TestRepoCacheRoot_PerProfile(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantDir string
+	}{
+		{
+			name:    "default profile",
+			cfg:     Config{WorkspacesRoot: "/ws", Profile: ""},
+			wantDir: filepath.Join("/ws", ".repos"),
+		},
+		{
+			name:    "named profile",
+			cfg:     Config{WorkspacesRoot: "/ws", Profile: "desktop-api.multica.ai"},
+			wantDir: filepath.Join("/ws", ".repos-desktop-api.multica.ai"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := repoCacheRoot(tc.cfg); got != tc.wantDir {
+				t.Fatalf("repoCacheRoot = %q, want %q", got, tc.wantDir)
+			}
+		})
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_DoesNotOverwriteExistingPerProfileRepos(t *testing.T) {
+	home := withFakeHome(t)
+	profile := "desktop-foo"
+
+	legacy := filepath.Join(home, "multica_workspaces_"+profile)
+	target := filepath.Join(home, "multica_workspaces")
+
+	// A previous migration already populated .repos-<profile>. The new
+	// migration must not clobber it; the residual legacy .repos stays put
+	// for manual reconciliation.
+	mustWriteFile(t, filepath.Join(legacy, ".repos", "github.com", "foo", "HEAD"), "legacy")
+	mustWriteFile(t, filepath.Join(target, ".repos-"+profile, "github.com", "old", "HEAD"), "already-migrated")
+
+	cfg := Config{
+		Profile:        profile,
+		WorkspacesRoot: target,
+	}
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	if b, err := os.ReadFile(filepath.Join(target, ".repos-"+profile, "github.com", "old", "HEAD")); err != nil || string(b) != "already-migrated" {
+		t.Fatalf("existing per-profile cache must be preserved, got %q err=%v", string(b), err)
+	}
+	if _, err := os.Stat(filepath.Join(legacy, ".repos", "github.com", "foo", "HEAD")); err != nil {
+		t.Fatalf("legacy .repos should remain when per-profile cache already exists, err=%v", err)
 	}
 }

--- a/server/internal/daemon/workspaces_migrate_test.go
+++ b/server/internal/daemon/workspaces_migrate_test.go
@@ -1,0 +1,171 @@
+package daemon
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newSilentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// withFakeHome points os.UserHomeDir() at a temp dir for the duration of the
+// subtest by setting HOME (Unix) and USERPROFILE (Windows).
+func withFakeHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	// MULTICA_WORKSPACES_ROOT must be unset for the migration to run.
+	t.Setenv("MULTICA_WORKSPACES_ROOT", "")
+	return dir
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_MovesContentsAndRemovesLegacyDir(t *testing.T) {
+	home := withFakeHome(t)
+	profile := "desktop-api.multica.ai"
+
+	legacy := filepath.Join(home, "multica_workspaces_"+profile)
+	target := filepath.Join(home, "multica_workspaces")
+	mustWriteFile(t, filepath.Join(legacy, "ws-uuid-1", "task-abc", "workdir", "file.txt"), "hello")
+	mustWriteFile(t, filepath.Join(legacy, ".repos", "github.com", "foo", "bar", "HEAD"), "ref: x")
+
+	cfg := Config{
+		Profile:        profile,
+		WorkspacesRoot: target, // matches what LoadConfig would produce when no env/override
+	}
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy dir to be removed, got err=%v", err)
+	}
+	moved := filepath.Join(target, "ws-uuid-1", "task-abc", "workdir", "file.txt")
+	if b, err := os.ReadFile(moved); err != nil || string(b) != "hello" {
+		t.Fatalf("expected moved file with content 'hello', got %q err=%v", string(b), err)
+	}
+	if _, err := os.Stat(filepath.Join(target, ".repos", "github.com", "foo", "bar", "HEAD")); err != nil {
+		t.Fatalf("expected .repos cache to be moved, got err=%v", err)
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_SkipsWhenProfileEmpty(t *testing.T) {
+	home := withFakeHome(t)
+	// A "_" suffix file shouldn't be touched when no profile is in play.
+	stray := filepath.Join(home, "multica_workspaces_some-profile", "ws", "task", "marker")
+	mustWriteFile(t, stray, "x")
+
+	cfg := Config{
+		Profile:        "",
+		WorkspacesRoot: filepath.Join(home, "multica_workspaces"),
+	}
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	if _, err := os.Stat(stray); err != nil {
+		t.Fatalf("legacy file should be untouched when profile is empty: %v", err)
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_SkipsWhenEnvOverrideSet(t *testing.T) {
+	home := withFakeHome(t)
+	t.Setenv("MULTICA_WORKSPACES_ROOT", filepath.Join(home, "custom"))
+
+	legacy := filepath.Join(home, "multica_workspaces_dev-foo")
+	mustWriteFile(t, filepath.Join(legacy, "ws", "task", "marker"), "x")
+
+	cfg := Config{
+		Profile:        "dev-foo",
+		WorkspacesRoot: filepath.Join(home, "custom"),
+	}
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	if _, err := os.Stat(legacy); err != nil {
+		t.Fatalf("legacy dir should be untouched when env override is set: %v", err)
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_SkipsWhenWorkspacesRootIsNotDefault(t *testing.T) {
+	home := withFakeHome(t)
+
+	legacy := filepath.Join(home, "multica_workspaces_desktop-foo")
+	mustWriteFile(t, filepath.Join(legacy, "ws", "task", "marker"), "x")
+
+	cfg := Config{
+		Profile:        "desktop-foo",
+		WorkspacesRoot: filepath.Join(home, "elsewhere"),
+	}
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	if _, err := os.Stat(legacy); err != nil {
+		t.Fatalf("legacy dir should be untouched when workspaces root is overridden: %v", err)
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_NoLegacyDirNoop(t *testing.T) {
+	home := withFakeHome(t)
+
+	cfg := Config{
+		Profile:        "desktop-foo",
+		WorkspacesRoot: filepath.Join(home, "multica_workspaces"),
+	}
+	// Should not panic, should not create the target dir.
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	if _, err := os.Stat(filepath.Join(home, "multica_workspaces")); !os.IsNotExist(err) {
+		t.Fatalf("target dir should not be eagerly created when nothing to migrate, err=%v", err)
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_PreservesExistingTargetEntry(t *testing.T) {
+	home := withFakeHome(t)
+	profile := "desktop-foo"
+
+	legacy := filepath.Join(home, "multica_workspaces_"+profile)
+	target := filepath.Join(home, "multica_workspaces")
+
+	// Same workspace UUID exists in both. The migration must not overwrite the
+	// target — it must leave the legacy copy in place for manual reconciliation.
+	mustWriteFile(t, filepath.Join(legacy, "ws-uuid", "task-x", "marker"), "from-legacy")
+	mustWriteFile(t, filepath.Join(target, "ws-uuid", "task-y", "marker"), "from-target")
+	// Distinct entry that should be moved cleanly.
+	mustWriteFile(t, filepath.Join(legacy, "ws-uuid-other", "task-z", "marker"), "moved")
+
+	cfg := Config{
+		Profile:        profile,
+		WorkspacesRoot: target,
+	}
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	// Conflicting entry stays in legacy; target version preserved.
+	if b, err := os.ReadFile(filepath.Join(target, "ws-uuid", "task-y", "marker")); err != nil || string(b) != "from-target" {
+		t.Fatalf("target entry should be preserved, got %q err=%v", string(b), err)
+	}
+	if b, err := os.ReadFile(filepath.Join(legacy, "ws-uuid", "task-x", "marker")); err != nil || string(b) != "from-legacy" {
+		t.Fatalf("conflicting legacy entry should remain in place, got %q err=%v", string(b), err)
+	}
+
+	// Distinct entry was moved.
+	if _, err := os.Stat(filepath.Join(legacy, "ws-uuid-other")); !os.IsNotExist(err) {
+		t.Fatalf("non-conflicting legacy entry should be moved, err=%v", err)
+	}
+	if b, err := os.ReadFile(filepath.Join(target, "ws-uuid-other", "task-z", "marker")); err != nil || string(b) != "moved" {
+		t.Fatalf("non-conflicting entry should arrive at target, got %q err=%v", string(b), err)
+	}
+
+	// Legacy root retained because it still has a residual entry.
+	if _, err := os.Stat(legacy); err != nil {
+		t.Fatalf("legacy root should be retained when residual entries exist: %v", err)
+	}
+}

--- a/server/internal/daemon/workspaces_migrate_test.go
+++ b/server/internal/daemon/workspaces_migrate_test.go
@@ -128,18 +128,50 @@ func TestMigrateLegacyWorkspacesRoot_NoLegacyDirNoop(t *testing.T) {
 	}
 }
 
-func TestMigrateLegacyWorkspacesRoot_PreservesExistingTargetEntry(t *testing.T) {
+func TestMigrateLegacyWorkspacesRoot_MergesNonConflictingTasksUnderSameWorkspace(t *testing.T) {
+	home := withFakeHome(t)
+	profile := "desktop-api.multica.ai"
+
+	legacy := filepath.Join(home, "multica_workspaces_"+profile)
+	target := filepath.Join(home, "multica_workspaces")
+
+	// Same workspace_id present in both roots, but different task_short subdirs.
+	// This is the realistic case: Web/CLI created task-web at the new path, the
+	// Desktop daemon created task-desktop at the old per-profile path. Both
+	// must end up under target/<ws>/.
+	mustWriteFile(t, filepath.Join(target, "ws-uuid", "task-web", "marker"), "from-web")
+	mustWriteFile(t, filepath.Join(legacy, "ws-uuid", "task-desktop", "marker"), "from-desktop")
+
+	cfg := Config{
+		Profile:        profile,
+		WorkspacesRoot: target,
+	}
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	if b, err := os.ReadFile(filepath.Join(target, "ws-uuid", "task-web", "marker")); err != nil || string(b) != "from-web" {
+		t.Fatalf("pre-existing target task should be preserved, got %q err=%v", string(b), err)
+	}
+	if b, err := os.ReadFile(filepath.Join(target, "ws-uuid", "task-desktop", "marker")); err != nil || string(b) != "from-desktop" {
+		t.Fatalf("legacy task should be merged into target, got %q err=%v", string(b), err)
+	}
+	// Legacy root and its workspace dir should be cleaned up since everything migrated.
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("legacy root should be removed after full migration, err=%v", err)
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_PreservesConflictingTaskShort(t *testing.T) {
 	home := withFakeHome(t)
 	profile := "desktop-foo"
 
 	legacy := filepath.Join(home, "multica_workspaces_"+profile)
 	target := filepath.Join(home, "multica_workspaces")
 
-	// Same workspace UUID exists in both. The migration must not overwrite the
-	// target — it must leave the legacy copy in place for manual reconciliation.
+	// Same workspace AND same task_short on both sides. We must not overwrite.
 	mustWriteFile(t, filepath.Join(legacy, "ws-uuid", "task-x", "marker"), "from-legacy")
-	mustWriteFile(t, filepath.Join(target, "ws-uuid", "task-y", "marker"), "from-target")
-	// Distinct entry that should be moved cleanly.
+	mustWriteFile(t, filepath.Join(target, "ws-uuid", "task-x", "marker"), "from-target")
+	// Plus a non-conflicting task_short under the same workspace and a fresh workspace.
+	mustWriteFile(t, filepath.Join(legacy, "ws-uuid", "task-y", "marker"), "merged")
 	mustWriteFile(t, filepath.Join(legacy, "ws-uuid-other", "task-z", "marker"), "moved")
 
 	cfg := Config{
@@ -148,24 +180,61 @@ func TestMigrateLegacyWorkspacesRoot_PreservesExistingTargetEntry(t *testing.T) 
 	}
 	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
 
-	// Conflicting entry stays in legacy; target version preserved.
-	if b, err := os.ReadFile(filepath.Join(target, "ws-uuid", "task-y", "marker")); err != nil || string(b) != "from-target" {
-		t.Fatalf("target entry should be preserved, got %q err=%v", string(b), err)
+	// Same task_short on both sides → target wins, legacy copy stays put.
+	if b, err := os.ReadFile(filepath.Join(target, "ws-uuid", "task-x", "marker")); err != nil || string(b) != "from-target" {
+		t.Fatalf("target task_short should be preserved, got %q err=%v", string(b), err)
 	}
 	if b, err := os.ReadFile(filepath.Join(legacy, "ws-uuid", "task-x", "marker")); err != nil || string(b) != "from-legacy" {
-		t.Fatalf("conflicting legacy entry should remain in place, got %q err=%v", string(b), err)
+		t.Fatalf("conflicting legacy task_short should remain in place, got %q err=%v", string(b), err)
 	}
 
-	// Distinct entry was moved.
+	// Non-conflicting task_short under same workspace was merged.
+	if b, err := os.ReadFile(filepath.Join(target, "ws-uuid", "task-y", "marker")); err != nil || string(b) != "merged" {
+		t.Fatalf("non-conflicting task_short should be merged into target, got %q err=%v", string(b), err)
+	}
+
+	// Fresh workspace was renamed wholesale.
 	if _, err := os.Stat(filepath.Join(legacy, "ws-uuid-other")); !os.IsNotExist(err) {
-		t.Fatalf("non-conflicting legacy entry should be moved, err=%v", err)
+		t.Fatalf("fresh legacy workspace should be moved, err=%v", err)
 	}
 	if b, err := os.ReadFile(filepath.Join(target, "ws-uuid-other", "task-z", "marker")); err != nil || string(b) != "moved" {
-		t.Fatalf("non-conflicting entry should arrive at target, got %q err=%v", string(b), err)
+		t.Fatalf("fresh workspace should arrive at target, got %q err=%v", string(b), err)
 	}
 
-	// Legacy root retained because it still has a residual entry.
+	// Legacy root retained because the conflicting task_short still lives there.
+	if _, err := os.Stat(filepath.Join(legacy, "ws-uuid", "task-x")); err != nil {
+		t.Fatalf("legacy conflicting task_short should remain, err=%v", err)
+	}
 	if _, err := os.Stat(legacy); err != nil {
 		t.Fatalf("legacy root should be retained when residual entries exist: %v", err)
+	}
+}
+
+func TestMigrateLegacyWorkspacesRoot_LeavesDotfileConflictAlone(t *testing.T) {
+	home := withFakeHome(t)
+	profile := "desktop-foo"
+
+	legacy := filepath.Join(home, "multica_workspaces_"+profile)
+	target := filepath.Join(home, "multica_workspaces")
+
+	// Both have a `.repos` cache. Don't merge into existing cache (just
+	// leave the legacy copy; the daemon will lazily repopulate target).
+	mustWriteFile(t, filepath.Join(legacy, ".repos", "github.com", "foo", "HEAD"), "legacy")
+	mustWriteFile(t, filepath.Join(target, ".repos", "github.com", "bar", "HEAD"), "target")
+
+	cfg := Config{
+		Profile:        profile,
+		WorkspacesRoot: target,
+	}
+	MigrateLegacyWorkspacesRoot(cfg, newSilentLogger())
+
+	if _, err := os.Stat(filepath.Join(legacy, ".repos", "github.com", "foo", "HEAD")); err != nil {
+		t.Fatalf("legacy dotfile dir should be left in place when target dotfile exists: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, ".repos", "github.com", "bar", "HEAD")); err != nil {
+		t.Fatalf("target dotfile dir should be untouched: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, ".repos", "github.com", "foo")); !os.IsNotExist(err) {
+		t.Fatalf("target dotfile dir should not be merged into, err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Default the daemon's workspaces root to `~/multica_workspaces/` for every profile (instead of `~/multica_workspaces_<profile>/`) so Desktop, Web, and CLI all see the same per-task workdir for the same workspace.
- Keep the bare-repo cache per-profile (`<root>/.repos` for the default profile, `<root>/.repos-<profile>` for named profiles). Profile still isolates the daemon's own state (`~/.multica/profiles/<name>/`, PID, health port, repo cache).
- Add a one-shot, best-effort startup migration that relocates any pre-existing `~/multica_workspaces_<profile>/` contents into the unified workspaces dir, including renaming legacy `.repos` to `.repos-<profile>`.

## Why

A user reported that the same workspace forks into two local directories on their machine — Desktop writes to `~/multica_workspaces_desktop-api.multica.ai/` while Web/CLI use `~/multica_workspaces/` — splitting their task workdirs across two trees. Root cause: Desktop spawns its own daemon with a profile derived from the API host (`desktop-<host>`), and `daemon.LoadConfig` previously used `multica_workspaces_<profile>` as the default root.

Bare-repo caches are kept per-profile because `repocache.repoLocks` is a process-local `sync.Map` and cannot serialize git's lockfiles across two simultaneously running daemons (Desktop daemon + user CLI daemon).

## Behavior change

| Scenario | Before | After |
|---|---|---|
| `multica daemon start` (no profile) | workspaces `~/multica_workspaces/`, cache `~/multica_workspaces/.repos/` | unchanged |
| `multica daemon start --profile X` | workspaces `~/multica_workspaces_X/`, cache `~/multica_workspaces_X/.repos/` | workspaces `~/multica_workspaces/`, cache `~/multica_workspaces/.repos-X/` |
| Desktop-managed daemon | workspaces `~/multica_workspaces_desktop-<host>/`, cache `~/multica_workspaces_desktop-<host>/.repos/` | workspaces `~/multica_workspaces/`, cache `~/multica_workspaces/.repos-desktop-<host>/` |
| `MULTICA_WORKSPACES_ROOT=...` set | honored | honored (migration skipped) |

The migration runs once at daemon startup; failures are logged at warn level and never block the daemon. Layout details:
- Top-level legacy entries (workspace_id dirs) move into the unified dir; if the target already has the same `<workspace_id>`, it merges per `task_short` rather than dropping the whole legacy workspace, so a `target ws/task-web + legacy ws/task-desktop` mix correctly ends up under `target/<ws>/{task-web,task-desktop}`.
- A truly conflicting `<workspace_id>/<task_short>` (same task on both sides) is left in legacy for manual reconciliation rather than overwritten.
- The legacy `.repos` cache is renamed to `.repos-<profile>` at the target so the migration preserves the cache without pulling it onto the default-profile daemon's path. If `.repos-<profile>` already exists (re-migration), the legacy copy stays.

## Test plan
- [x] `go test ./server/internal/daemon/...` — covers: end-to-end migration; per-task merge under shared workspace; conflict-stays-in-legacy; legacy `.repos` → `.repos-<profile>` relocation; no-overwrite when `.repos-<profile>` already exists; `repoCacheRoot` derivation by profile; skips when profile empty / env override set / workspaces root overridden / legacy dir absent
- [x] `go vet ./...`
- [x] `go build ./...`
- [ ] Manual: launch Desktop with a populated `~/multica_workspaces_desktop-api.multica.ai/`, confirm task dirs are transparently moved to `~/multica_workspaces/` and the bare-repo cache lands at `~/multica_workspaces/.repos-desktop-api.multica.ai/` on first daemon start
- [ ] Manual: confirm `MULTICA_WORKSPACES_ROOT=...` (worktree dev path) still skips the migration