### PR TITLE
docs(changelog): publish v0.2.19 release notes

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -286,12 +286,12 @@ export function createEnDict(allowSignup: boolean): LandingDict {
       {
         version: "0.2.19",
         date: "2026-04-28",
-        title: "Desktop Notifications, Realtime Daemon Wakeups & Issue Label Filter",
+        title: "Kiro CLI Runtime, Desktop Notifications & Issue Label Filter",
         changes: [],
         features: [
+          "Kiro CLI added as a local agent runtime option",
           "macOS dock badge for unread issues, plus a native notification when the window is unfocused — click to jump straight to the issue",
           "Issue list now supports filtering by label, combinable with status / priority / assignee",
-          "Create-issue dialog remembers the last assignee you picked",
           "Daemon receives task wakeups over WebSocket — task startup latency drops noticeably",
         ],
         improvements: [

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -284,6 +284,30 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.19",
+        date: "2026-04-28",
+        title: "Desktop Notifications, Realtime Daemon Wakeups & Issue Label Filter",
+        changes: [],
+        features: [
+          "macOS dock badge for unread issues, plus a native notification when the window is unfocused — click to jump straight to the issue",
+          "Issue list now supports filtering by label, combinable with status / priority / assignee",
+          "Create-issue dialog remembers the last assignee you picked",
+          "Daemon receives task wakeups over WebSocket — task startup latency drops noticeably",
+        ],
+        improvements: [
+          "List and board status group headers are simpler, with clearer color cues",
+          "Author-written markdown links are preserved through linkify",
+          "Label attach now applies optimistically, no server round-trip wait",
+          "Mention picker's issue search refreshes as you type",
+        ],
+        fixes: [
+          "Deleting a comment now cancels any agent task it triggered — no more ghost runs",
+          "Stalled Codex turns now time out instead of holding the slot",
+          "Windows daemon no longer dies when the parent shell closes",
+          "Agent-to-agent mention threads no longer cause feedback loops",
+        ],
+      },
+      {
         version: "0.2.18",
         date: "2026-04-27",
         title: "Issue Labels, Labs Tab & Sidebar Invite Dot",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -284,6 +284,30 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.19",
+        date: "2026-04-28",
+        title: "桌面通知红点、Daemon 实时唤醒与 Issue 标签过滤",
+        changes: [],
+        features: [
+          "macOS Dock 显示未读 Issue 红点；窗口失焦时弹出原生通知，点击直达对应 Issue",
+          "Issue 列表新增 Label 过滤，可与状态、优先级、Assignee 等组合使用",
+          "创建 Issue 时默认沿用上次选择的 Assignee",
+          "Daemon 通过 WebSocket 接收任务唤醒，任务起跑延迟显著降低",
+        ],
+        improvements: [
+          "List/Board 视图的状态分组 header 更简洁，颜色提示更清晰",
+          "评论中作者手写的 Markdown 链接不再被自动 linkify 替换",
+          "添加 Label 现在乐观更新，无需等待服务端往返",
+          "Mention 输入时的 Issue 搜索结果会随着输入实时刷新",
+        ],
+        fixes: [
+          "Comment 被删除时会取消已触发的 Agent 任务，不再有幽灵 run",
+          "Codex 卡住的对话回合会超时退出，避免占用配额",
+          "Windows Daemon 不再随父 shell 关闭被一同杀掉",
+          "Agent 之间的 mention 不再相互触发，避免死循环",
+        ],
+      },
+      {
         version: "0.2.18",
         date: "2026-04-27",
         title: "Issue 标签、Labs 设置页与邀请红点",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -286,12 +286,12 @@ export function createZhDict(allowSignup: boolean): LandingDict {
       {
         version: "0.2.19",
         date: "2026-04-28",
-        title: "桌面通知红点、Daemon 实时唤醒与 Issue 标签过滤",
+        title: "Kiro CLI Runtime、桌面通知红点与 Issue 标签过滤",
         changes: [],
         features: [
+          "新增 Kiro CLI 作为本地 Agent runtime 选项",
           "macOS Dock 显示未读 Issue 红点；窗口失焦时弹出原生通知，点击直达对应 Issue",
           "Issue 列表新增 Label 过滤，可与状态、优先级、Assignee 等组合使用",
-          "创建 Issue 时默认沿用上次选择的 Assignee",
           "Daemon 通过 WebSocket 接收任务唤醒，任务起跑延迟显著降低",
         ],
         improvements: [


### PR DESCRIPTION
## Summary

Adds the v0.2.19 changelog entry (2026-04-28) to both `apps/web/features/landing/i18n/zh.ts` and `apps/web/features/landing/i18n/en.ts`, mirroring the structure of the v0.2.18 entry from #1745.

23 commits land since v0.2.18. The entry surfaces only the user-visible items, with implementation detail trimmed per the convention established in #1745.

### Spotlight (features)
- Kiro CLI added as a local agent runtime option (#1780, icon update #1787)
- macOS dock unread badge + focus-gated inbox notifications (#1445)
- Client-side label filter on the issues list (#1782)
- Daemon WebSocket task wakeups, polling fallback (#1772)

### Notes
- The "create-issue remembers last assignee" line was intentionally dropped from features to keep the spotlight to four items per release sign-off.
- Kiro ships together with the chat-mode fix; the changelog assumes the fix lands before tag.

## Test plan
- [ ] Open `/changelog` on the staging landing site and confirm the v0.2.19 entry renders correctly in both `en` and `zh`.
- [ ] Verify the JSON-shaped entries are syntactically valid (`pnpm --filter @multica/web typecheck`).
- [ ] Confirm the entry order: v0.2.19 above v0.2.18.