### PR TITLE
fix: guide Codex multiline comments

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -861,6 +861,34 @@ func TestInjectRuntimeConfigDirectsMultiLineWritesToStdin(t *testing.T) {
 	}
 }
 
+func TestInjectRuntimeConfigCodexEmphasizesStdinForFormattedComments(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := InjectRuntimeConfig(dir, "codex", TaskContextForEnv{
+		IssueID:          "issue-1",
+		TriggerCommentID: "comment-1",
+	}); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	s := string(data)
+
+	for _, want := range []string{
+		"Codex-Specific Comment Formatting",
+		"Treat inline `--content \"...\"` examples as short single-line examples only",
+		"`--content-stdin` with a HEREDOC",
+		"keep the same `--parent` value",
+		"Do not compress a multi-paragraph answer",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("AGENTS.md missing Codex multiline guidance %q\n---\n%s", want, s)
+		}
+	}
+}
+
 func TestInjectRuntimeConfigAutopilotRunOnlyNoIssueWorkflow(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -16,9 +16,17 @@ func BuildCommentReplyInstructions(issueID, triggerCommentID string) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"If you decide to reply, post it by running exactly this command — always use the trigger comment ID below, "+
-			"do NOT reuse --parent values from previous turns in this session:\n\n"+
-			"    multica issue comment add %s --parent %s --content \"...\"\n",
-		issueID, triggerCommentID,
+		"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
+			"do NOT reuse --parent values from previous turns in this session.\n\n"+
+			"For a short single-line reply, use:\n\n"+
+			"    multica issue comment add %s --parent %s --content \"...\"\n\n"+
+			"For multi-line content (paragraphs, bullets, code blocks, backticks, quotes, or anything where formatting matters), "+
+			"do NOT squeeze it into `--content` and do NOT write `\\n` escapes. Pipe via stdin instead, preserving the same issue ID and --parent value:\n\n"+
+			"    cat <<'COMMENT' | multica issue comment add %s --parent %s --content-stdin\n"+
+			"    First paragraph.\n"+
+			"\n"+
+			"    Second paragraph.\n"+
+			"    COMMENT\n",
+		issueID, triggerCommentID, issueID, triggerCommentID,
 	)
 }

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -17,6 +17,10 @@ func TestBuildCommentReplyInstructionsIncludesTriggerID(t *testing.T) {
 
 	for _, want := range []string{
 		"multica issue comment add " + issueID + " --parent " + triggerID,
+		"short single-line reply",
+		"--content-stdin",
+		"<<'COMMENT'",
+		"do NOT write `\\n` escapes",
 		"do NOT reuse --parent values from previous turns",
 	} {
 		if !strings.Contains(got, want) {

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -106,6 +106,13 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica autopilot trigger <id>` — Manually trigger an autopilot to run once\n")
 	b.WriteString("- `multica autopilot delete <id>` — Delete an autopilot\n\n")
 
+	if provider == "codex" {
+		b.WriteString("## Codex-Specific Comment Formatting\n\n")
+		b.WriteString("Codex often follows the per-turn reply command literally. Treat inline `--content \"...\"` examples as short single-line examples only. ")
+		b.WriteString("For paragraphs, bullets, code blocks, backticks, quotes, or any text where line breaks matter, use `--content-stdin` with a HEREDOC and keep the same `--parent` value from the trigger comment. ")
+		b.WriteString("Do not compress a multi-paragraph answer into one `--content` argument and do not rely on `\\n` escapes.\n\n")
+	}
+
 	// Inject available repositories section.
 	if len(ctx.Repos) > 0 {
 		b.WriteString("## Repositories\n\n")


### PR DESCRIPTION
## Summary
- clarify comment-trigger reply instructions so multiline replies use --content-stdin with the current --parent ID
- add Codex-specific AGENTS.md guidance to avoid compressing formatted comments into inline --content
- cover the prompt changes with daemon execenv regression tests

## Tests
- go test ./internal/daemon/...