### PR TITLE
fix: popover click bubble + resilient presence loading

### DIFF
--- a/packages/core/agents/use-agent-presence.ts
+++ b/packages/core/agents/use-agent-presence.ts
@@ -50,36 +50,47 @@ export function useWorkspacePresenceMap(wsId: string | undefined): {
   byAgent: Map<string, AgentPresenceDetail>;
   loading: boolean;
 } {
-  const { data: agents, isPending: agentsPending } = useQuery({
+  const { data: agents, isPending: agentsPending, isError: agentsErr } = useQuery({
     ...agentListOptions(wsId ?? ""),
     enabled: !!wsId,
   });
-  const { data: runtimes, isPending: runtimesPending } = useQuery({
+  const { data: runtimes, isPending: runtimesPending, isError: runtimesErr } = useQuery({
     ...runtimeListOptions(wsId ?? ""),
     enabled: !!wsId,
   });
-  const { data: snapshot, isPending: snapshotPending } = useQuery({
+  const { data: snapshot, isPending: snapshotPending, isError: snapshotErr } = useQuery({
     ...agentTaskSnapshotOptions(wsId ?? ""),
     enabled: !!wsId,
   });
   const tick = usePresenceTick();
 
   const byAgent = useMemo(() => {
-    if (!agents || !runtimes || !snapshot) {
+    // Treat errored queries as empty so the map still builds — a 404 on
+    // the snapshot endpoint shouldn't leave every row's presence blank.
+    const safeAgents = agents ?? (agentsErr ? [] : null);
+    const safeRuntimes = runtimes ?? (runtimesErr ? [] : null);
+    const safeSnapshot = snapshot ?? (snapshotErr ? [] : null);
+    if (!safeAgents || !safeRuntimes || !safeSnapshot) {
       return new Map<string, AgentPresenceDetail>();
     }
     return buildPresenceMap({
-      agents,
-      runtimes,
-      snapshot,
+      agents: safeAgents,
+      runtimes: safeRuntimes,
+      snapshot: safeSnapshot,
       now: Date.now(),
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agents, runtimes, snapshot, tick]);
+  }, [agents, runtimes, snapshot, agentsErr, runtimesErr, snapshotErr, tick]);
 
   return {
     byAgent,
-    loading: agentsPending || runtimesPending || snapshotPending,
+    // "loading" only while the queries are genuinely pending — once they
+    // settle (success OR error), we render with whatever we have. This
+    // matches the detail-version behaviour: don't spin forever on errors.
+    loading:
+      (agentsPending && !agentsErr) ||
+      (runtimesPending && !runtimesErr) ||
+      (snapshotPending && !snapshotErr),
   };
 }
 
@@ -93,19 +104,31 @@ export function useWorkspacePresenceMap(wsId: string | undefined): {
  * Runtime detail), prefer `useWorkspacePresenceMap` to avoid forest of
  * redundant subscriptions.
  */
+// Synthesised fallback shown when we can't resolve a real agent (deleted,
+// archived, or referenced by stale data) but still need to render something
+// next to the avatar. Yields a gray dot + idle last-task — better than a
+// skeleton spinning forever.
+const MISSING_AGENT_DETAIL: AgentPresenceDetail = {
+  availability: "offline",
+  lastTask: "idle",
+  runningCount: 0,
+  queuedCount: 0,
+  capacity: 0,
+};
+
 export function useAgentPresenceDetail(
   wsId: string | undefined,
   agentId: string | undefined,
 ): AgentPresenceDetail | "loading" {
-  const { data: agents } = useQuery({
+  const { data: agents, isError: agentsErr } = useQuery({
     ...agentListOptions(wsId ?? ""),
     enabled: !!wsId,
   });
-  const { data: runtimes } = useQuery({
+  const { data: runtimes, isError: runtimesErr } = useQuery({
     ...runtimeListOptions(wsId ?? ""),
     enabled: !!wsId,
   });
-  const { data: snapshot } = useQuery({
+  const { data: snapshot, isError: snapshotErr } = useQuery({
     ...agentTaskSnapshotOptions(wsId ?? ""),
     enabled: !!wsId,
   });
@@ -113,17 +136,27 @@ export function useAgentPresenceDetail(
 
   return useMemo<AgentPresenceDetail | "loading">(() => {
     if (!wsId || !agentId) return "loading";
-    if (!agents || !runtimes || !snapshot) return "loading";
 
-    const agent = agents.find((a) => a.id === agentId);
-    if (!agent) return "loading";
+    // Treat query errors as "no data" rather than "still loading". A 404 /
+    // 5xx on the snapshot endpoint (e.g. backend hasn't deployed the new
+    // route yet) used to leave the UI spinning forever; now we degrade to
+    // an empty list and the dot still renders based on runtime health.
+    const safeAgents = agents ?? (agentsErr ? [] : null);
+    const safeRuntimes = runtimes ?? (runtimesErr ? [] : null);
+    const safeSnapshot = snapshot ?? (snapshotErr ? [] : null);
+    if (!safeAgents || !safeRuntimes || !safeSnapshot) return "loading";
+
+    const agent = safeAgents.find((a) => a.id === agentId);
+    // Agent referenced but not in the workspace's active list (most often:
+    // archived assignee on an old issue). Render a gray-offline fallback
+    // instead of looping in "loading".
+    if (!agent) return MISSING_AGENT_DETAIL;
     // Missing runtime is a legitimate state (offline) — pass null and let
-    // derive handle it. The previous implementation looped forever in
-    // "loading" when runtime was deleted.
-    const runtime = runtimes.find((r) => r.id === agent.runtime_id) ?? null;
+    // derive handle it.
+    const runtime = safeRuntimes.find((r) => r.id === agent.runtime_id) ?? null;
 
-    const tasks = snapshot.filter((t) => t.agent_id === agentId);
+    const tasks = safeSnapshot.filter((t) => t.agent_id === agentId);
     return deriveAgentPresenceDetail({ agent, runtime, tasks, now: Date.now() });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wsId, agentId, agents, runtimes, snapshot, tick]);
+  }, [wsId, agentId, agents, runtimes, snapshot, agentsErr, runtimesErr, snapshotErr, tick]);
 }

--- a/packages/ui/components/ui/dropdown-menu.tsx
+++ b/packages/ui/components/ui/dropdown-menu.tsx
@@ -24,12 +24,18 @@ function DropdownMenuContent({
   side = "bottom",
   sideOffset = 4,
   className,
+  onClick,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
   >) {
+  // Stop click events from bubbling out of the menu. Base UI portals the
+  // popup so DOM is detached, but React's synthetic event system still
+  // bubbles through the React component tree — without this, clicking a
+  // menu item inside a row that's wrapped in <a> (agent / runtime list
+  // rows) would ALSO fire the row's onClick → unintended navigation.
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
@@ -41,6 +47,10 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
+          onClick={(e) => {
+            e.stopPropagation()
+            onClick?.(e)
+          }}
           className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         />

--- a/packages/ui/components/ui/hover-card.tsx
+++ b/packages/ui/components/ui/hover-card.tsx
@@ -20,12 +20,19 @@ function HoverCardContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 4,
+  onClick,
   ...props
 }: PreviewCardPrimitive.Popup.Props &
   Pick<
     PreviewCardPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
   >) {
+  // Stop click events from bubbling out of the popover. Base UI portals the
+  // popup to <body> so the DOM is detached, but React's synthetic event
+  // system still bubbles through the React component tree — without this,
+  // clicks on links / buttons inside the card would also fire onClick on
+  // any ancestor link the trigger was nested in (e.g. issue list rows).
+  // Consumer-supplied onClick is forwarded after the stop.
   return (
     <PreviewCardPrimitive.Portal data-slot="hover-card-portal">
       <PreviewCardPrimitive.Positioner
@@ -37,6 +44,10 @@ function HoverCardContent({
       >
         <PreviewCardPrimitive.Popup
           data-slot="hover-card-content"
+          onClick={(e) => {
+            e.stopPropagation()
+            onClick?.(e)
+          }}
           className={cn(
             "z-50 w-64 origin-(--transform-origin) rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             className

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -141,7 +141,7 @@ function AutopilotRow({ autopilot }: { autopilot: Autopilot }) {
 
       {/* Agent */}
       <span className="flex w-32 items-center gap-1.5 shrink-0">
-        <ActorAvatar actorType="agent" actorId={autopilot.assignee_id} size={18} enableHoverCard />
+        <ActorAvatar actorType="agent" actorId={autopilot.assignee_id} size={18} enableHoverCard showStatusDot />
         <span className="truncate text-xs text-muted-foreground">
           {getActorName("agent", autopilot.assignee_id)}
         </span>

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -41,6 +41,7 @@ export function InboxListItem({
         actorType={item.actor_type ?? item.recipient_type}
         actorId={item.actor_id ?? item.recipient_id}
         size={28}
+        enableHoverCard
       />
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
## Summary

Two related bugs surfacing on production after #1794, plus an inbox follow-up.

### 1. Click-through inside popovers

Clicking a **Detail** link in an agent hover card, or a **kebab item** in an agents / runtimes list row, also triggered the parent row link's onClick — navigating to the wrong page.

Root cause: Base UI portals popovers (DOM is detached from the trigger), but React synthetic events still bubble through the React component tree. An ancestor \`<a>\` wrapping the trigger therefore still received the click.

Fixed at the primitive level (\`HoverCardContent\` + \`DropdownMenuContent\`) — \`stopPropagation\` on the popup's onClick, with consumer-supplied handlers forwarded after. Every existing and future popover gets the fix automatically.

### 2. Presence indicator loading forever

\`useAgentPresenceDetail\` returned \`"loading"\` whenever any of its three queries had \`data === undefined\`. Two prod scenarios hit this:

- **Backend deploy lag**: the new \`/agent-task-snapshot\` endpoint 404s on backends that haven't picked up #1794 yet → query has \`data: undefined\` forever → indicator spins forever.
- **Archived assignees**: an issue's \`assignee_id\` points to an archived agent that \`ListAgents\` doesn't return → \`agents.find()\` returns undefined → indicator spins forever.

Two fixes:
- Treat query errors as **empty arrays** (degrade gracefully) so the dot still renders based on the data we DO have.
- When the agent is missing from the list, return a **synthesised offline+idle detail** so the dot renders gray and \`<AgentProfileCard>\`'s "Agent unavailable" copy can take over — no more infinite skeleton.

\`useWorkspacePresenceMap\` gets the same isError treatment for consistency.

### 3. Inbox notification hover card

Originally excluded from the hover-card opt-in pass, but inbox notifications are exactly the kind of "who sent me this?" surface where seeing the actor profile on dwell is useful. Click-through to the wrong target is no longer a concern thanks to the popover stop-bubble fix above.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm test --filter @multica/core\` — all 25 derive-presence tests pass
- [ ] Manual: click Detail in an agent hover card hosted inside an issue list row → only navigates to agent, not the issue
- [ ] Manual: click a kebab menu item on an agent / runtime list row → only the menu action runs, no row navigation
- [ ] Manual: backend without the snapshot endpoint → dot still renders (gray for offline runtimes, green for online)
- [ ] Manual: hover an issue assignee that points to an archived agent → gray dot + "Agent unavailable" hover-card copy
- [ ] Manual: hover an inbox notification's actor avatar → profile card appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)