### PR TITLE
feat(agents): add CodeBuddy Code agent backend support

### DIFF
--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -163,8 +163,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_KIRO_MODEL")),
 		}
 	}
+	codebuddyPath := envOrDefault("MULTICA_CODEBUDDY_PATH", "codebuddy")
+	if _, err := exec.LookPath(codebuddyPath); err == nil {
+		agents["codebuddy"] = AgentEntry{
+			Path:  codebuddyPath,
+			Model: strings.TrimSpace(os.Getenv("MULTICA_CODEBUDDY_MODEL")),
+		}
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, or kiro-cli and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, kiro-cli, or codebuddy and ensure it is on PATH")
 	}
 
 	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -92,8 +92,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCODE_MODEL")),
 		}
 	}
+	codebuddyPath := envOrDefault("MULTICA_CODEBUDDY_PATH", "codebuddy")
+	if _, err := exec.LookPath(codebuddyPath); err == nil {
+		agents["codebuddy"] = AgentEntry{
+			Path:  codebuddyPath,
+			Model: strings.TrimSpace(os.Getenv("MULTICA_CODEBUDDY_MODEL")),
+		}
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, or opencode and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, opencode, or codebuddy and ensure it is on PATH")
 	}
 
 	// Host info

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,6 +1,6 @@
 // Package agent provides a unified interface for executing prompts via
 // coding agents (Claude Code, Codex, Copilot, OpenCode, OpenClaw, Hermes,
-// Gemini, Pi, Cursor, Kimi, Kiro). It mirrors the happy-cli AgentBackend
+// Gemini, Pi, Cursor, Kimi, Kiro, CodeBuddy). It mirrors the happy-cli AgentBackend
 // pattern, translated to idiomatic Go.
 package agent
 
@@ -89,13 +89,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli)
+	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli, codebuddy)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro".
+// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro", "codebuddy".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -124,8 +124,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &kimiBackend{cfg: cfg}, nil
 	case "kiro":
 		return &kiroBackend{cfg: cfg}, nil
+	case "codebuddy":
+		return &codebuddyBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, codebuddy)", agentType)
 	}
 }
 
@@ -141,17 +143,18 @@ func DetectVersion(ctx context.Context, executablePath string) (string, error) {
 // environment variables are deliberately omitted so the string is a hint
 // about *what* users are extending, not a dump of the full command line.
 var launchHeaders = map[string]string{
-	"claude":   "claude (stream-json)",
-	"codex":    "codex app-server",
-	"copilot":  "copilot (json)",
-	"cursor":   "cursor-agent (stream-json)",
-	"gemini":   "gemini (stream-json)",
-	"hermes":   "hermes acp",
-	"openclaw": "openclaw agent (json)",
-	"opencode": "opencode run (json)",
-	"pi":       "pi (json mode)",
-	"kimi":     "kimi acp",
-	"kiro":     "kiro-cli acp",
+	"claude":     "claude (stream-json)",
+	"codex":      "codex app-server",
+	"codebuddy":  "codebuddy (stream-json)",
+	"copilot":    "copilot (json)",
+	"cursor":     "cursor-agent (stream-json)",
+	"gemini":     "gemini (stream-json)",
+	"hermes":     "hermes acp",
+	"openclaw":   "openclaw agent (json)",
+	"opencode":   "opencode run (json)",
+	"pi":         "pi (json mode)",
+	"kimi":       "kimi acp",
+	"kiro":       "kiro-cli acp",
 }
 
 // LaunchHeader returns the user-visible launch skeleton for agentType, or an

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -92,8 +92,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &codexBackend{cfg: cfg}, nil
 	case "opencode":
 		return &opencodeBackend{cfg: cfg}, nil
+	case "codebuddy":
+		return &codebuddyBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, opencode, codebuddy)", agentType)
 	}
 }
 

--- a/server/pkg/agent/codebuddy.go
+++ b/server/pkg/agent/codebuddy.go
@@ -1,0 +1,29 @@
+package agent
+
+import "context"
+
+// codebuddyBackend implements Backend by spawning the CodeBuddy Code CLI
+// with --output-format stream-json. The CLI interface is identical to Claude Code,
+// so this backend reuses the claude streaming protocol.
+type codebuddyBackend struct {
+	cfg Config
+}
+
+// Execute runs a prompt via CodeBuddy Code. The CodeBuddy CLI accepts the same
+// flags as Claude Code (--output-format stream-json, --permission-mode, -p, etc.)
+// and emits the same streaming JSON format, so we delegate directly to the
+// shared claudeBackend implementation with the executable path swapped.
+func (b *codebuddyBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "codebuddy"
+	}
+	delegate := &claudeBackend{
+		cfg: Config{
+			ExecutablePath: execPath,
+			Env:            b.cfg.Env,
+			Logger:         b.cfg.Logger,
+		},
+	}
+	return delegate.Execute(ctx, prompt, opts)
+}


### PR DESCRIPTION
## Summary

Add CodeBuddy Code as a supported agent type alongside claude, codex, and opencode.

## Changes

- **`server/pkg/agent/codebuddy.go`** — New `codebuddyBackend` that delegates to `claudeBackend` with the codebuddy executable path. CodeBuddy Code uses the same CLI interface as Claude Code (`--output-format stream-json`, streaming JSON protocol), so reusing the claude streaming implementation is correct.
- **`server/pkg/agent/agent.go`** — Register `codebuddy` in the `New()` factory function.
- **`server/internal/daemon/config.go`** — Auto-detect codebuddy CLI on startup; support `MULTICA_CODEBUDDY_PATH` and `MULTICA_CODEBUDDY_MODEL` environment variables.

## How it works

The CodeBuddy CLI accepts the same flags as Claude Code and emits the same streaming JSON format, so the codebuddy backend simply wraps claudeBackend with a swapped executable path — zero protocol duplication.

Fixes issue WUX-2.