### PR TITLE
fix(cli): add --to flag to issue status (preserve positional form)

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -127,10 +127,13 @@ var issueAssignCmd = &cobra.Command{
 }
 
 var issueStatusCmd = &cobra.Command{
-	Use:   "status <id> <status>",
+	Use:   "status <id> [<status>]",
 	Short: "Change issue status",
-	Args:  exactArgs(2),
-	RunE:  runIssueStatus,
+	// Accept either:
+	//   multica issue status <id> <status>     (positional, original form)
+	//   multica issue status <id> --to <status> (flag form, consistent with `issue assign --to`)
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runIssueStatus,
 }
 
 // Comment subcommands.
@@ -283,6 +286,7 @@ func init() {
 	issueUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 
 	// issue status
+	issueStatusCmd.Flags().String("to", "", "New status (alternative to positional argument; see `multica issue status --help`)")
 	issueStatusCmd.Flags().String("output", "table", "Output format: table or json")
 
 	// issue assign
@@ -683,7 +687,23 @@ func runIssueAssign(cmd *cobra.Command, args []string) error {
 
 func runIssueStatus(cmd *cobra.Command, args []string) error {
 	id := args[0]
-	status := args[1]
+
+	// Accept the new status from either the positional argument or the --to flag.
+	// Positional takes precedence when both are provided; this preserves the
+	// original behavior verbatim and makes `multica issue status <id> done` work
+	// identically to before.
+	var status string
+	if len(args) >= 2 {
+		status = args[1]
+	}
+	if flagVal, _ := cmd.Flags().GetString("to"); flagVal != "" {
+		if status == "" {
+			status = flagVal
+		}
+	}
+	if status == "" {
+		return fmt.Errorf("status required: pass as positional argument or via --to")
+	}
 
 	valid := false
 	for _, s := range validIssueStatuses {

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -548,6 +548,94 @@ func TestIssueSubscriberMutationBody(t *testing.T) {
 	}
 }
 
+// TestIssueStatusBothForms verifies that `multica issue status <id> <status>`
+// (positional, original form) and `multica issue status <id> --to <status>`
+// (flag form, consistent with `issue assign --to`) both produce the same
+// PUT /api/issues/<id> body and that positional takes precedence when both are
+// supplied. Also covers the error case (status missing entirely).
+func TestIssueStatusBothForms(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStatus string
+		wantErr    bool
+	}{
+		{
+			name:       "positional only (original form)",
+			args:       []string{"issue-abc", "done"},
+			wantStatus: "done",
+		},
+		{
+			name:       "--to flag only (new form)",
+			args:       []string{"issue-abc", "--to", "in_review"},
+			wantStatus: "in_review",
+		},
+		{
+			name:       "both supplied — positional wins",
+			args:       []string{"issue-abc", "done", "--to", "in_review"},
+			wantStatus: "done",
+		},
+		{
+			name:    "neither supplied — error",
+			args:    []string{"issue-abc"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid status — error",
+			args:    []string{"issue-abc", "--to", "not-a-status"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				_ = json.NewEncoder(w).Encode(map[string]any{"id": "issue-abc", "status": gotBody["status"]})
+			}))
+			defer srv.Close()
+
+			t.Setenv("MULTICA_SERVER_URL", srv.URL)
+			t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+			t.Setenv("MULTICA_TOKEN", "test-token")
+
+			// Build a fresh command tree per test to avoid stale flag state
+			// between test cases.
+			cmd := &cobra.Command{
+				Use:  "status <id> [<status>]",
+				Args: cobra.RangeArgs(1, 2),
+				RunE: runIssueStatus,
+			}
+			cmd.Flags().String("to", "", "New status (alternative to positional argument)")
+			cmd.Flags().String("output", "table", "Output format")
+			cmd.SetArgs(tt.args)
+			cmd.SetOut(new(strings.Builder))
+			cmd.SetErr(new(strings.Builder))
+
+			err := cmd.Execute()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil; gotBody=%+v", gotBody)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotPath != "/api/issues/issue-abc" {
+				t.Errorf("path = %q, want /api/issues/issue-abc", gotPath)
+			}
+			if gotBody["status"] != tt.wantStatus {
+				t.Errorf("body.status = %v, want %v", gotBody["status"], tt.wantStatus)
+			}
+		})
+	}
+}
+
 func TestValidIssueStatuses(t *testing.T) {
 	expected := map[string]bool{
 		"backlog":     true,


### PR DESCRIPTION
## Summary

Adds a `--to` flag to `multica issue status`, mirroring the shape of `multica issue assign --to`. The original positional form continues to work unchanged.

## Why

`multica issue status` is currently the only CLI verb taking a target status that uses positional-only args. Every other surface uses a flag:

- `multica issue assign --to <name>`
- `multica issue update --status <s>`
- `multica issue list --status <s>`
- `multica issue create --status <s>`

Users hitting that inconsistency naturally try `multica issue status <id> --to cancelled` and get `Error: unknown flag: --to` rather than just having it work. Caught while scripting against the CLI for end-to-end agent flow testing on a self-host install.

## What changes

- `Args: exactArgs(2)` → `Args: cobra.RangeArgs(1, 2)` (relaxes positional)
- Adds `--to` flag that's resolved as a fallback to positional
- Errors cleanly when neither positional nor `--to` is supplied
- **Positional takes precedence** when both are supplied — preserves the original behavior byte-for-byte

## Tests

New `TestIssueStatusBothForms` in `cmd_issue_test.go` covers all five paths (positional-only, --to-only, both, neither, invalid status). Existing tests unaffected.

```
$ go test ./cmd/multica/ -run TestIssueStatus -v
=== RUN   TestIssueStatusBothForms
=== RUN   TestIssueStatusBothForms/positional_only_(original_form)
=== RUN   TestIssueStatusBothForms/--to_flag_only_(new_form)
=== RUN   TestIssueStatusBothForms/both_supplied_—_positional_wins
=== RUN   TestIssueStatusBothForms/neither_supplied_—_error
=== RUN   TestIssueStatusBothForms/invalid_status_—_error
--- PASS: TestIssueStatusBothForms (0.00s)
PASS
ok  	github.com/multica-ai/multica/server/cmd/multica	0.379s
```

`go vet` clean. `gofmt -l` clean on changed files.

## Backward compatibility

Fully backward-compatible. Every existing invocation continues to work identically. The `Use:` string changes from `status <id> <status>` to `status <id> [<status>]`, which `--help` reflects but doesn't affect tab completion or runtime behavior.