### PR TITLE
feat: add backend default agent args env vars

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -181,8 +181,10 @@ Agent-specific overrides:
 |----------|-------------|
 | `MULTICA_CLAUDE_PATH` | Custom path to the `claude` binary |
 | `MULTICA_CLAUDE_MODEL` | Override the Claude model used |
+| `MULTICA_CLAUDE_ARGS` | Default extra arguments for Claude Code runs |
 | `MULTICA_CODEX_PATH` | Custom path to the `codex` binary |
 | `MULTICA_CODEX_MODEL` | Override the Codex model used |
+| `MULTICA_CODEX_ARGS` | Default extra arguments for Codex runs |
 | `MULTICA_OPENCODE_PATH` | Custom path to the `opencode` binary |
 | `MULTICA_OPENCODE_MODEL` | Override the OpenCode model used |
 | `MULTICA_OPENCLAW_PATH` | Custom path to the `openclaw` binary |
@@ -199,6 +201,8 @@ Agent-specific overrides:
 | `MULTICA_KIMI_MODEL` | Override the Kimi model used |
 | `MULTICA_KIRO_PATH` | Custom path to the `kiro-cli` binary |
 | `MULTICA_KIRO_MODEL` | Override the Kiro model used |
+
+`MULTICA_CLAUDE_ARGS` and `MULTICA_CODEX_ARGS` are parsed with POSIX shellword quoting, so values such as `--model "gpt-5.1 codex" --sandbox read-only` are split like a shell command line. Agent arguments are applied in this order: hardcoded Multica defaults, daemon-wide env defaults, then per-agent `custom_args` from the task.
 
 ### Self-Hosted Server
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/mattn/go-shellwords v1.0.13 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/server/go.mod
+++ b/server/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/lmittmann/tint v1.1.3
+	github.com/mattn/go-shellwords v1.0.13
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
@@ -47,7 +48,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/mattn/go-shellwords v1.0.13 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -87,6 +87,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lmittmann/tint v1.1.3 h1:Hv4EaHWXQr+GTFnOU4VKf8UvAtZgn0VuKT+G0wFlO3I=
 github.com/lmittmann/tint v1.1.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
+github.com/mattn/go-shellwords v1.0.13 h1:DC0OMEpGjm6LfNFU4ckYcvbQKyp2vE8atyFGXNtDcf4=
+github.com/mattn/go-shellwords v1.0.13/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/mattn/go-shellwords"
 )
 
 const (
@@ -48,6 +50,8 @@ type Config struct {
 	HeartbeatInterval              time.Duration
 	AgentTimeout                   time.Duration
 	CodexSemanticInactivityTimeout time.Duration
+	ClaudeArgs                     []string
+	CodexArgs                      []string
 }
 
 // Overrides allows CLI flags to override environment variables and defaults.
@@ -161,6 +165,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	}
 	if len(agents) == 0 {
 		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, or kiro-cli and ensure it is on PATH")
+	}
+
+	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")
+	if err != nil {
+		return Config{}, err
+	}
+	codexArgs, err := shellArgsFromEnv("MULTICA_CODEX_ARGS")
+	if err != nil {
+		return Config{}, err
 	}
 
 	// Host info
@@ -326,6 +339,8 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		HeartbeatInterval:              heartbeatInterval,
 		AgentTimeout:                   agentTimeout,
 		CodexSemanticInactivityTimeout: codexSemanticInactivityTimeout,
+		ClaudeArgs:                     claudeArgs,
+		CodexArgs:                      codexArgs,
 	}, nil
 }
 
@@ -351,4 +366,16 @@ func NormalizeServerBaseURL(raw string) (string, error) {
 	u.RawQuery = ""
 	u.Fragment = ""
 	return strings.TrimRight(u.String(), "/"), nil
+}
+
+func shellArgsFromEnv(name string) ([]string, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return nil, nil
+	}
+	args, err := shellwords.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	return args, nil
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1183,6 +1183,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 	taskStart := time.Now()
 
 	var customArgs []string
+	extraArgs := defaultArgsForProvider(d.cfg, provider)
 	var mcpConfig json.RawMessage
 	if task.Agent != nil {
 		customArgs = task.Agent.CustomArgs
@@ -1210,6 +1211,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		Timeout:                   d.cfg.AgentTimeout,
 		SemanticInactivityTimeout: d.cfg.CodexSemanticInactivityTimeout,
 		ResumeSessionID:           task.PriorSessionID,
+		ExtraArgs:                 extraArgs,
 		CustomArgs:                customArgs,
 		McpConfig:                 mcpConfig,
 	}
@@ -1633,4 +1635,15 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	return false
+}
+
+func defaultArgsForProvider(cfg Config, provider string) []string {
+	switch provider {
+	case "claude":
+		return cfg.ClaudeArgs
+	case "codex":
+		return cfg.CodexArgs
+	default:
+		return nil
+	}
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1638,12 +1638,14 @@ func isBlockedEnvKey(key string) bool {
 }
 
 func defaultArgsForProvider(cfg Config, provider string) []string {
+	var args []string
 	switch provider {
 	case "claude":
-		return cfg.ClaudeArgs
+		args = cfg.ClaudeArgs
 	case "codex":
-		return cfg.CodexArgs
+		args = cfg.CodexArgs
 	default:
 		return nil
 	}
+	return append([]string(nil), args...)
 }

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -700,3 +700,39 @@ func TestEnsureRepoReadyConcurrentMissRefreshesOnce(t *testing.T) {
 		t.Fatalf("expected exactly 1 refresh call, got %d", got)
 	}
 }
+
+func TestShellArgsFromEnv(t *testing.T) {
+	t.Setenv("MULTICA_CLAUDE_ARGS", `--max-turns 60 --append-system-prompt "multi word"`)
+	got, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")
+	if err != nil {
+		t.Fatalf("shellArgsFromEnv: %v", err)
+	}
+	want := []string{"--max-turns", "60", "--append-system-prompt", "multi word"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestShellArgsFromEnvEmptyIsNil(t *testing.T) {
+	t.Setenv("MULTICA_CODEX_ARGS", "   ")
+	got, err := shellArgsFromEnv("MULTICA_CODEX_ARGS")
+	if err != nil {
+		t.Fatalf("shellArgsFromEnv: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for empty env, got %#v", got)
+	}
+}
+
+func TestDefaultArgsForProvider(t *testing.T) {
+	cfg := Config{ClaudeArgs: []string{"--max-turns", "60"}, CodexArgs: []string{"--sandbox", "workspace-write"}}
+	if got := defaultArgsForProvider(cfg, "claude"); strings.Join(got, " ") != "--max-turns 60" {
+		t.Fatalf("unexpected claude args: %#v", got)
+	}
+	if got := defaultArgsForProvider(cfg, "codex"); strings.Join(got, " ") != "--sandbox workspace-write" {
+		t.Fatalf("unexpected codex args: %#v", got)
+	}
+	if got := defaultArgsForProvider(cfg, "gemini"); got != nil {
+		t.Fatalf("expected nil for unsupported provider, got %#v", got)
+	}
+}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -29,7 +29,8 @@ type ExecOptions struct {
 	Timeout                   time.Duration
 	SemanticInactivityTimeout time.Duration
 	ResumeSessionID           string          // if non-empty, resume a previous agent session
-	CustomArgs                []string        // additional CLI arguments appended to the agent command
+	ExtraArgs                 []string        // daemon-wide default CLI arguments appended before CustomArgs
+	CustomArgs                []string        // per-agent CLI arguments appended after ExtraArgs
 	McpConfig                 json.RawMessage // if non-nil, MCP server config to pass via --mcp-config
 }
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -29,7 +29,7 @@ type ExecOptions struct {
 	Timeout                   time.Duration
 	SemanticInactivityTimeout time.Duration
 	ResumeSessionID           string          // if non-empty, resume a previous agent session
-	ExtraArgs                 []string        // daemon-wide default CLI arguments appended before CustomArgs
+	ExtraArgs                 []string        // daemon-wide default CLI arguments appended before CustomArgs; currently read by claude and codex backends only
 	CustomArgs                []string        // per-agent CLI arguments appended after ExtraArgs
 	McpConfig                 json.RawMessage // if non-nil, MCP server config to pass via --mcp-config
 }

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -434,6 +434,7 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 	if opts.ResumeSessionID != "" {
 		args = append(args, "--resume", opts.ResumeSessionID)
 	}
+	args = append(args, filterCustomArgs(opts.ExtraArgs, claudeBlockedArgs, logger)...)
 	args = append(args, filterCustomArgs(opts.CustomArgs, claudeBlockedArgs, logger)...)
 	return args
 }

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -602,3 +602,26 @@ func mustMarshal(t *testing.T, v any) json.RawMessage {
 	}
 	return data
 }
+
+func TestBuildClaudeArgsExtraArgsBeforeCustomArgsAndFiltersBoth(t *testing.T) {
+	args := buildClaudeArgs(ExecOptions{
+		ExtraArgs:  []string{"--output-format", "text", "--max-budget-usd", "1.00"},
+		CustomArgs: []string{"--max-budget-usd", "2.00", "--permission-mode", "plan"},
+	}, slog.Default())
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--output-format text") || strings.Contains(joined, "--permission-mode plan") {
+		t.Fatalf("blocked args should be filtered from both layers: %v", args)
+	}
+	extraIdx, customIdx := -1, -1
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--max-budget-usd" && args[i+1] == "1.00" {
+			extraIdx = i
+		}
+		if args[i] == "--max-budget-usd" && args[i+1] == "2.00" {
+			customIdx = i
+		}
+	}
+	if extraIdx == -1 || customIdx == -1 || extraIdx > customIdx {
+		t.Fatalf("expected extra args before custom args, got %v", args)
+	}
+}

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -36,6 +36,13 @@ type codexBackend struct {
 	cfg Config
 }
 
+func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
+	args := []string{"app-server", "--listen", "stdio://"}
+	args = append(args, filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger)...)
+	args = append(args, filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger)...)
+	return args
+}
+
 func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
 	execPath := b.cfg.ExecutablePath
 	if execPath == "" {
@@ -55,7 +62,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
-	codexArgs := append([]string{"app-server", "--listen", "stdio://"}, filterCustomArgs(opts.CustomArgs, codexBlockedArgs, b.cfg.Logger)...)
+	codexArgs := buildCodexArgs(opts, b.cfg.Logger)
 	cmd := exec.CommandContext(runCtx, execPath, codexArgs...)
 	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", codexArgs)

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1192,3 +1192,26 @@ func TestWithAgentStderrAppendsHint(t *testing.T) {
 		t.Errorf("got %q, want %q", msg, want)
 	}
 }
+
+func TestBuildCodexArgsExtraArgsBeforeCustomArgsAndFiltersBoth(t *testing.T) {
+	args := buildCodexArgs(ExecOptions{
+		ExtraArgs:  []string{"--listen", "tcp://evil", "--sandbox", "read-only"},
+		CustomArgs: []string{"--sandbox", "workspace-write", "--listen=bad"},
+	}, slog.Default())
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "tcp://evil") || strings.Contains(joined, "--listen=bad") {
+		t.Fatalf("blocked args should be filtered from both layers: %v", args)
+	}
+	extraIdx, customIdx := -1, -1
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--sandbox" && args[i+1] == "read-only" {
+			extraIdx = i
+		}
+		if args[i] == "--sandbox" && args[i+1] == "workspace-write" {
+			customIdx = i
+		}
+	}
+	if extraIdx == -1 || customIdx == -1 || extraIdx > customIdx {
+		t.Fatalf("expected extra args before custom args, got %v", args)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1467

Adds fleet-wide backend default arg env vars for the daemon:

- `MULTICA_CLAUDE_ARGS`
- `MULTICA_CODEX_ARGS`

These are parsed with POSIX shellword splitting in `server/internal/daemon/config.go`, stored on daemon `Config`, and passed through `ExecOptions.ExtraArgs` before per-agent `CustomArgs`.

Both `ExtraArgs` and `CustomArgs` go through each backend's existing `filterCustomArgs()` blocked-flag filter.

## Behavior

Ordering is intentionally simple:

1. daemon hardcoded protocol args
2. env-var default args
3. per-agent `custom_args`

If both layers specify the same downstream CLI flag, Multica appends both in that order. Any last-wins behavior is delegated to the downstream CLI argument parser. No daemon-side deduplication is performed.

Unset or empty env vars produce nil args and preserve current behavior.

## Validation

```bash
cd server
go test ./internal/daemon ./pkg/agent
```

Covered cases:

- quoted shellword parsing, including multi-word values
- empty env var no-op behavior
- provider-specific default arg selection
- Claude env args ordered before per-agent custom args
- Codex env args ordered before per-agent custom args
- blocked args filtered from both env and custom layers
