### PR TITLE
fix(issues): show attachment indicator on board / list cards

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -21,6 +21,7 @@ export interface CardProperties {
   project: boolean;
   childProgress: boolean;
   labels: boolean;
+  attachments: boolean;
 }
 
 export interface ActorFilterValue {
@@ -43,6 +44,7 @@ export const CARD_PROPERTY_OPTIONS: { key: keyof CardProperties; label: string }
   { key: "dueDate", label: "Due date" },
   { key: "project", label: "Project" },
   { key: "labels", label: "Labels" },
+  { key: "attachments", label: "Attachments" },
   { key: "childProgress", label: "Sub-issue progress" },
 ];
 
@@ -98,6 +100,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
     project: true,
     childProgress: true,
     labels: true,
+    attachments: true,
   },
   listCollapsedStatuses: [],
 

--- a/packages/core/types/issue.ts
+++ b/packages/core/types/issue.ts
@@ -41,6 +41,7 @@ export interface Issue {
   due_date: string | null;
   reactions?: IssueReaction[];
   labels?: Label[];
+  attachment_count?: number;
   created_at: string;
   updated_at: string;
 }

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -7,7 +7,7 @@ import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { toast } from "sonner";
 import type { Issue, UpdateIssueRequest } from "@multica/core/types";
-import { CalendarDays } from "lucide-react";
+import { CalendarDays, Paperclip } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
@@ -62,6 +62,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   });
   const project = issue.project_id ? projects.find((p) => p.id === issue.project_id) : undefined;
   const labels = issue.labels ?? [];
+  const attachmentCount = issue.attachment_count ?? 0;
 
   const updateIssueMutation = useUpdateIssue();
   const handleUpdate = useCallback(
@@ -81,6 +82,7 @@ export const BoardCardContent = memo(function BoardCardContent({
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
   const showLabels = storeProperties.labels && labels.length > 0;
+  const showAttachments = storeProperties.attachments && attachmentCount > 0;
 
   return (
     <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-colors group-hover/card:border-accent group-hover/card:bg-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
@@ -92,8 +94,8 @@ export const BoardCardContent = memo(function BoardCardContent({
         {issue.title}
       </p>
 
-      {/* Sub-issue progress + project + labels */}
-      {(showChildProgress || showProject || showLabels) && (
+      {/* Sub-issue progress + project + labels + attachments */}
+      {(showChildProgress || showProject || showLabels || showAttachments) && (
         <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
           {showChildProgress && (
             <div className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5">
@@ -112,6 +114,15 @@ export const BoardCardContent = memo(function BoardCardContent({
           {showLabels && labels.map((label) => (
             <LabelChip key={label.id} label={label} />
           ))}
+          {showAttachments && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground tabular-nums"
+              aria-label={`${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"}`}
+            >
+              <Paperclip className="size-3" />
+              {attachmentCount}
+            </span>
+          )}
         </div>
       )}
 

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -109,7 +109,7 @@ const mockViewState = {
   labelFilters: [] as string[],
   sortBy: "position" as const,
   sortDirection: "asc" as const,
-  cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
+  cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true, attachments: true },
   listCollapsedStatuses: [] as string[],
   setViewMode: vi.fn(),
   toggleStatusFilter: vi.fn(),

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -2,6 +2,7 @@
 
 import { memo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Paperclip } from "lucide-react";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -46,12 +47,14 @@ export const ListRow = memo(function ListRow({
   });
   const project = issue.project_id ? projects.find((pr) => pr.id === issue.project_id) : undefined;
   const labels = issue.labels ?? [];
+  const attachmentCount = issue.attachment_count ?? 0;
 
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
   const showAssignee = storeProperties.assignee && issue.assignee_type && issue.assignee_id;
   const showDueDate = storeProperties.dueDate && issue.due_date;
   const showLabels = storeProperties.labels && labels.length > 0;
+  const showAttachments = storeProperties.attachments && attachmentCount > 0;
 
   return (
     <IssueActionsContextMenu issue={issue}>
@@ -101,6 +104,15 @@ export const ListRow = memo(function ListRow({
                     +{labels.length - 3}
                   </span>
                 )}
+              </span>
+            )}
+            {showAttachments && (
+              <span
+                className="ml-1.5 inline-flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground tabular-nums"
+                aria-label={`${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"}`}
+              >
+                <Paperclip className="size-3" />
+                {attachmentCount}
               </span>
             )}
           </span>

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -43,6 +43,12 @@ type IssueResponse struct {
 	UpdatedAt          string                  `json:"updated_at"`
 	Reactions          []IssueReactionResponse `json:"reactions,omitempty"`
 	Attachments        []AttachmentResponse    `json:"attachments,omitempty"`
+	// AttachmentCount is bulk-attached by list/detail endpoints so the board /
+	// list cards can render a paperclip indicator without an N+1 fetch per row.
+	// Pointer + omitempty so paths that don't load it (UpdateIssue, batch
+	// UpdateIssues, the issue:updated WS broadcast) emit no field at all and
+	// the client cache merge preserves whatever value is already present.
+	AttachmentCount    *int64                  `json:"attachment_count,omitempty"`
 	// Labels are bulk-attached by list/detail endpoints so the client can render
 	// chips without an N+1 round-trip per row. Pointer + omitempty so paths that
 	// don't load labels (e.g. UpdateIssue, batch UpdateIssues, the issue:updated
@@ -99,6 +105,30 @@ func issueListRowToResponse(i db.ListIssuesRow, issuePrefix string) IssueRespons
 		CreatedAt:     timestampToString(i.CreatedAt),
 		UpdatedAt:     timestampToString(i.UpdatedAt),
 	}
+}
+
+// attachmentCountByIssue bulk-loads attachment counts for the given issue IDs
+// and returns a map keyed by issue UUID string. Issues with no attachments are
+// absent from the map; callers should treat absent as zero. On error or empty
+// input, returns an empty map — the indicator is non-critical and we'd rather
+// serve issues without it than fail the whole list call.
+func (h *Handler) attachmentCountByIssue(ctx context.Context, wsUUID pgtype.UUID, issueIDs []pgtype.UUID) map[string]int64 {
+	out := map[string]int64{}
+	if len(issueIDs) == 0 {
+		return out
+	}
+	rows, err := h.Queries.CountAttachmentsForIssues(ctx, db.CountAttachmentsForIssuesParams{
+		IssueIds:    issueIDs,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		slog.Warn("CountAttachmentsForIssues failed", "error", err)
+		return out
+	}
+	for _, r := range rows {
+		out[uuidToString(r.IssueID)] = r.Count
+	}
+	return out
 }
 
 // labelsByIssue bulk-loads labels for the given issue IDs and returns a map
@@ -671,6 +701,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 			ids[i] = issue.ID
 		}
 		labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
+		attachmentCounts := h.attachmentCountByIssue(ctx, wsUUID, ids)
 		resp := make([]IssueResponse, len(issues))
 		for i, issue := range issues {
 			resp[i] = openIssueRowToResponse(issue, prefix)
@@ -679,6 +710,8 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 				labels = []LabelResponse{}
 			}
 			resp[i].Labels = &labels
+			count := attachmentCounts[resp[i].ID]
+			resp[i].AttachmentCount = &count
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{
@@ -742,6 +775,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		ids[i] = issue.ID
 	}
 	labelsMap := h.labelsByIssue(ctx, wsUUID, ids)
+	attachmentCounts := h.attachmentCountByIssue(ctx, wsUUID, ids)
 	resp := make([]IssueResponse, len(issues))
 	for i, issue := range issues {
 		resp[i] = issueListRowToResponse(issue, prefix)
@@ -750,6 +784,8 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 			labels = []LabelResponse{}
 		}
 		resp[i].Labels = &labels
+		count := attachmentCounts[resp[i].ID]
+		resp[i].AttachmentCount = &count
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -786,12 +822,15 @@ func (h *Handler) GetIssue(w http.ResponseWriter, r *http.Request) {
 		IssueID:     issue.ID,
 		WorkspaceID: issue.WorkspaceID,
 	})
+	count := int64(0)
 	if err == nil && len(attachments) > 0 {
 		resp.Attachments = make([]AttachmentResponse, len(attachments))
 		for i, a := range attachments {
 			resp.Attachments[i] = h.attachmentToResponse(a)
 		}
+		count = int64(len(attachments))
 	}
+	resp.AttachmentCount = &count
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/server/pkg/db/generated/attachment.sql.go
+++ b/server/pkg/db/generated/attachment.sql.go
@@ -60,6 +60,48 @@ func (q *Queries) CreateAttachment(ctx context.Context, arg CreateAttachmentPara
 	return i, err
 }
 
+const countAttachmentsForIssues = `-- name: CountAttachmentsForIssues :many
+SELECT issue_id, COUNT(*)::bigint AS count
+FROM attachment
+WHERE issue_id = ANY($1::uuid[])
+  AND workspace_id = $2::uuid
+GROUP BY issue_id
+`
+
+type CountAttachmentsForIssuesParams struct {
+	IssueIds    []pgtype.UUID `json:"issue_ids"`
+	WorkspaceID pgtype.UUID   `json:"workspace_id"`
+}
+
+type CountAttachmentsForIssuesRow struct {
+	IssueID pgtype.UUID `json:"issue_id"`
+	Count   int64       `json:"count"`
+}
+
+// Bulk variant: returns (issue_id, count) for each issue that has at least one
+// attachment, so the issue list endpoints can fold an attachment indicator into
+// each row without N+1 queries from the client. Workspace-guarded the same way
+// as ListAttachmentsByIssue.
+func (q *Queries) CountAttachmentsForIssues(ctx context.Context, arg CountAttachmentsForIssuesParams) ([]CountAttachmentsForIssuesRow, error) {
+	rows, err := q.db.Query(ctx, countAttachmentsForIssues, arg.IssueIds, arg.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CountAttachmentsForIssuesRow{}
+	for rows.Next() {
+		var i CountAttachmentsForIssuesRow
+		if err := rows.Scan(&i.IssueID, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const deleteAttachment = `-- name: DeleteAttachment :exec
 DELETE FROM attachment WHERE id = $1 AND workspace_id = $2
 `

--- a/server/pkg/db/queries/attachment.sql
+++ b/server/pkg/db/queries/attachment.sql
@@ -8,6 +8,17 @@ SELECT * FROM attachment
 WHERE issue_id = $1 AND workspace_id = $2
 ORDER BY created_at ASC;
 
+-- name: CountAttachmentsForIssues :many
+-- Bulk variant: returns (issue_id, count) for each issue that has at least one
+-- attachment, so the issue list endpoints can fold an attachment indicator into
+-- each row without N+1 queries from the client. Workspace-guarded the same way
+-- as ListAttachmentsByIssue.
+SELECT issue_id, COUNT(*)::bigint AS count
+FROM attachment
+WHERE issue_id = ANY(sqlc.arg('issue_ids')::uuid[])
+  AND workspace_id = sqlc.arg('workspace_id')::uuid
+GROUP BY issue_id;
+
 -- name: ListAttachmentsByComment :many
 SELECT * FROM attachment
 WHERE comment_id = $1 AND workspace_id = $2


### PR DESCRIPTION
## Problem

Issue-level attachments uploaded via the CLI (`multica attachment …`) are never surfaced on the issues board view. The cards on the kanban board show identifier, title, labels, due-date, etc., but no signal that an issue has files associated with it. The same is true on the list view. Users have to click into each issue's detail to know whether attachments exist — and even there, only comment-level attachments render today.

The root cause: `ListIssues` (and its `open_only` branch) returns no attachment information at all, and the `Issue` interface on the client doesn't model attachment data, so even if a card *wanted* to show an indicator the data is unreachable.

This mirrors the description fix in #1377 and the labels rollout in #1741 — same pattern: bulk-fetch on the server, fold into the row response, gate on a `cardProperties` toggle.

## Fix

- **Backend**
  - New SQL query `CountAttachmentsForIssues(issue_ids, workspace_id)` returning `(issue_id, count)` so the list endpoints get all counts in one round-trip instead of N per-row lookups (`server/pkg/db/queries/attachment.sql`, generated code in `server/pkg/db/generated/attachment.sql.go`).
  - New `(h *Handler).attachmentCountByIssue` helper in `server/internal/handler/issue.go`, modelled on the existing `labelsByIssue` helper — non-fatal on error, returns an empty map and serves issues without the indicator.
  - `ListIssues` (paginated branch) and the `open_only` branch now populate `attachment_count` on each row. `GetIssue` populates it from the existing `ListAttachmentsByIssue` result so the count and the full attachment list stay consistent.
  - `IssueResponse.AttachmentCount` is `*int64` + `omitempty` so paths that don't load it (UpdateIssue, batch updates, the `issue:updated` WS broadcast) emit no field at all and the client cache merge preserves whatever is already in cache. Same convention as `Labels`.

- **Frontend**
  - Added `attachment_count?: number` to the `Issue` type (`packages/core/types/issue.ts`).
  - Added `attachments: boolean` to `CardProperties` and a corresponding `"Attachments"` entry in `CARD_PROPERTY_OPTIONS`, defaulting on. The deep-merge in `viewStorePersistOptions` (added in #1741) already migrates persisted snapshots that predate the new key.
  - Updated the test mock in `issues-page.test.tsx` to include the new toggle.
  - Board card and list row render a `📎 N` chip when the toggle is on and `attachment_count > 0`. List-row chip mirrors the existing label-chip placement.

## Why a count, not the full list

Showing the full attachment list per row means an N-attachment payload per issue × N issues per board column. A single tagged count gives users the indicator they need on the board ("this issue has files") at a fraction of the payload, and the detail page already loads the full list on click-through. If a use case for thumbnails on cards comes up later, the count field stays useful and the bulk query can be swapped without touching the frontend toggle/UI plumbing.

## Validation

Per [CONTRIBUTING.md → Validate Before Pushing](https://github.com/multica-ai/multica/blob/main/CONTRIBUTING.md#validate-before-pushing), the prescribed command for a main checkout is `make check-main`, which runs:

1. **TypeScript typecheck** — ✅ verified locally (`pnpm typecheck` clean across all 6 packages: `core`, `views`, `ui`, `web`, `desktop`, `docs`).
2. **TypeScript unit tests** — ✅ verified via CI on Node 22 (local Node v20.11.0 hits a pre-existing rolldown/`node:util` `styleText` incompat that's fixed in 20.12+; the contributing guide says Node `v20+` so this is environmental, not a regression from this PR).
3. **Go tests** — ✅ verified locally (`go build ./...`, `go vet ./...`, `go test ./internal/handler/...` all clean).
4. **Playwright E2E** — relied on CI; no E2E spec touches the new card chip (existing specs still pass).

Both CI jobs (`frontend` and `backend`) are green on this PR.

## Manual test plan

- [ ] Open an issue that has CLI-uploaded attachments → board card shows `📎 N` chip with the correct count.
- [ ] Toggle "Attachments" off in the board display dropdown → chip disappears on board *and* list views.
- [ ] Issue with no attachments → no chip, regardless of toggle state.
- [ ] DevTools Network: list paint issues a single `/api/issues` call with `attachment_count` populated (no per-row attachment fetch).
- [ ] Existing user with a persisted view-store snapshot from before this change → "Attachments" toggle defaults on (deep-merge migration).

## Files

```
packages/core/issues/stores/view-store.ts          |  3 ++
packages/core/types/issue.ts                       |  1 +
packages/views/issues/components/board-card.tsx    | 17 +++++++--
packages/views/issues/components/issues-page.test.tsx |  2 +-
packages/views/issues/components/list-row.tsx      | 12 +++++++
server/internal/handler/issue.go                   | 39 ++++++++++++++++++++
server/pkg/db/generated/attachment.sql.go          | 42 ++++++++++++++++++++
server/pkg/db/queries/attachment.sql               | 11 ++++++
8 files changed, 123 insertions(+), 4 deletions(-)
```
