### PR TITLE
fix(views): drop disableHoverCard from QuickCreate modal ActorAvatars

### DIFF
--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -218,7 +218,6 @@ export function QuickCreateIssueModal({
                         actorType="agent"
                         actorId={selectedAgent.id}
                         size={16}
-                        disableHoverCard
                       />
                       {selectedAgent.name}
                     </span>
@@ -247,7 +246,6 @@ export function QuickCreateIssueModal({
                       actorType="agent"
                       actorId={a.id}
                       size={16}
-                      disableHoverCard
                     />
                     <span className="flex-1 truncate">{a.name}</span>
                   </DropdownMenuItem>


### PR DESCRIPTION
## Summary

Frontend CI broke on `main` after #1786 merged because the ActorAvatar prop was renamed in #1794 (`disableHoverCard` → `enableHoverCard` with inverted semantics). The QuickCreate modal landed against the old API and trips the views typecheck.

Both avatars already want the default (no hover card), so this just drops the now-stale prop — no behavior change.

```
modals/quick-create-issue.tsx(221,25): error TS2322: Property 'disableHoverCard' does not exist on type 'IntrinsicAttributes & ActorAvatarProps'. Did you mean 'enableHoverCard'?
modals/quick-create-issue.tsx(250,23): error TS2322: Property 'disableHoverCard' does not exist on type 'IntrinsicAttributes & ActorAvatarProps'. Did you mean 'enableHoverCard'?
```

## Test plan

- [x] `pnpm typecheck` passes
- [ ] CI green