### PR TITLE
fix(quick-create): unstick queued tasks (workspace resolution + WS wakeup)

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -180,6 +180,12 @@ func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, r
 		"requester_id", util.UUIDToString(requesterID),
 		"workspace_id", util.UUIDToString(workspaceID),
 	)
+	// Match every other Enqueue* path: kick the daemon WS so the task
+	// gets claimed promptly instead of waiting for the next 30 s poll
+	// cycle. Without this the user perceives "quick create never
+	// triggered" because the modal closes immediately and the task
+	// sits in 'queued' until the next sleepWithContextOrWakeup tick.
+	s.notifyTaskAvailable(task)
 	return task, nil
 }
 
@@ -1095,6 +1101,14 @@ func (s *TaskService) ResolveTaskWorkspaceID(ctx context.Context, task db.AgentT
 				return util.UUIDToString(ap.WorkspaceID)
 			}
 		}
+	}
+	// Quick-create tasks have no issue / chat / autopilot link — workspace
+	// lives in the context JSONB. Returning "" here is what blocked
+	// requireDaemonTaskAccess (404 on /start, /progress, /complete, /fail
+	// for the daemon) and silently dropped task:dispatch / task:completed
+	// broadcasts, which is why quick-create tasks appeared stuck queued.
+	if qc, ok := s.parseQuickCreateContext(task); ok {
+		return qc.WorkspaceID
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

Two related bugs combined to leave every quick-create task in `queued` from the user's POV. Fixes both:

### 1. `ResolveTaskWorkspaceID` returned `""` for quick-create tasks

The helper only knew about `issue_id` / `chat_session_id` / `autopilot_run_id` — all NULL on a quick-create task. So:

- `requireDaemonTaskAccess` 404'd on the daemon's `/start`, `/progress`, `/complete`, `/fail` endpoints. Even when the claim succeeded, the daemon couldn't transition the task forward.
- `broadcastTaskEvent` silently dropped `task:dispatch` and `task:completed` events because it bails when workspace resolves to `""`.

Fix: read the workspace from the `QuickCreateContext` JSONB stored on `task.context`. Same source the daemon claim handler already uses for the workspace-isolation check.

### 2. `EnqueueQuickCreateTask` never called `notifyTaskAvailable`

Every other Enqueue* path (issue / mention / chat / autopilot retry) signals the daemon WS wakeup so the task is claimed within milliseconds. Quick-create skipped this, so the task waited up to 30s for the next `pollLoop` tick. Combined with #1 above, "stuck in queued, never triggered" became the dominant user experience.

Fix: call `s.notifyTaskAvailable(task)` after the insert.

## Test plan

- [x] `go build ./... && go test ./internal/service/... ./internal/handler/...`
- [ ] CI green
- [ ] Manual: press `c` → submit a quick-create → task transitions queued → dispatched → running → completed within seconds; inbox `quick_create_done` lands.
- [ ] Manual (regression): kill the daemon WS connection (`pkill -STOP multica-daemon`); fire a quick-create; resume daemon and confirm the next poll picks it up.