### PR TITLE
fix(desktop): use themed Toaster wrapper instead of bare sonner

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -7,7 +7,7 @@ import { api } from "@multica/core/api";
 import { useHasOnboarded } from "@multica/core/paths";
 import { ThemeProvider } from "@multica/ui/components/common/theme-provider";
 import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
-import { Toaster } from "sonner";
+import { Toaster } from "@multica/ui/components/ui/sonner";
 import { DesktopLoginPage } from "./pages/login";
 import { DesktopShell } from "./components/desktop-layout";
 import { PageviewTracker } from "./components/pageview-tracker";


### PR DESCRIPTION
## Summary

#1831 fixed the `Toaster` wrapper in `@multica/ui/components/ui/sonner` to follow next-themes' `resolvedTheme`, so toasts pick up dark/light correctly. But the desktop renderer was importing `Toaster` directly from `sonner`, bypassing that wrapper entirely — so the agent-create success toast still rendered light on a dark UI on desktop. Web (`apps/web/app/layout.tsx`) already imports through the wrapper.

Switching the desktop import path also picks up the wrapper's icon overrides (lucide icons matching the rest of the app's iconography), which were previously the raw sonner defaults on desktop.

## Test plan
- [ ] Submit a quick-create from agent mode in desktop → success toast renders dark.
- [ ] Same in web → unchanged (already worked).