### PR TITLE
feat(quick-create): default assignee to picker agent when user didn't name one

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -151,30 +151,17 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("- If the task requires code changes, use `multica repo checkout <url>` to get the code first\n")
 		b.WriteString("- Keep responses concise and direct\n\n")
 	} else if ctx.QuickCreatePrompt != "" {
-		// Quick-create task: no issue exists yet. The agent's only job is to
-		// translate one line of natural language into a single
-		// `multica issue create` call. Suppress the default assignment
-		// workflow that would tell the agent to call `multica issue get` /
-		// `multica issue status` / `multica issue comment add` against an
-		// empty IssueID — those would either error or silently target the
-		// wrong issue.
-		b.WriteString("**This task was triggered by quick-create.** There is NO existing Multica issue. Translate the user's input into a single `multica issue create` invocation and exit.\n\n")
-		fmt.Fprintf(&b, "User input:\n> %s\n\n", ctx.QuickCreatePrompt)
-		b.WriteString("Field rules:\n")
-		b.WriteString("- title: required, short imperative summary extracted from the user input.\n")
-		b.WriteString("- description: optional; only include if the user supplied detail beyond the title.\n")
-		b.WriteString("- priority: one of `urgent`, `high`, `medium`, `low`, or omit. Map P0/P1 → urgent/high; \"asap\"/\"紧急\" → urgent; \"低优先级\" → low.\n")
-		b.WriteString("- assignee:\n")
-		b.WriteString("    - When the user names someone (\"分给 X\" / \"assign to X\" / \"@X\"), call `multica workspace members --output json` and find the matching member. On clean match, pass `--assignee <name>`. On no/ambiguous match, OMIT `--assignee` and append a final line to the description: `未识别 assignee: X`.\n")
-		if ctx.AgentName != "" {
-			fmt.Fprintf(&b, "    - When the user did NOT name an assignee, default to YOURSELF: pass `--assignee %q`. The picker agent is the expected owner because the user opened quick-create with you selected — never leave the issue unassigned.\n", ctx.AgentName)
-		} else {
-			b.WriteString("    - When the user did NOT name an assignee, default to YOURSELF (the picker agent): pass `--assignee <your agent name>`. Never leave the issue unassigned.\n")
-		}
-		b.WriteString("- project / status: omit (defaults apply).\n\n")
-		b.WriteString("Output rules:\n")
-		b.WriteString("- Run exactly one `multica issue create` invocation.\n")
-		b.WriteString("- After it succeeds, print exactly one line: `Created MUL-<n>: <title>` and exit.\n")
+		// Quick-create task: detailed field / output rules live in the
+		// per-turn prompt (BuildPrompt → buildQuickCreatePrompt) so they
+		// have a single source of truth. Quick-create is one-shot, so the
+		// per-turn message is always present and the agent reads the rules
+		// from there. We only keep the hard guardrails here so a provider
+		// that doesn't propagate the user message into its working context
+		// (or a resumed session) still avoids the assignment-task workflow
+		// pointing at an empty issue id.
+		b.WriteString("**This task was triggered by quick-create.** There is NO existing Multica issue. Follow the field and output rules in the user message you just received; ignore the default assignment-task workflow.\n\n")
+		b.WriteString("Hard guardrails (apply even if the user message is missing):\n")
+		b.WriteString("- Run exactly one `multica issue create` invocation, then exit.\n")
 		b.WriteString("- Do NOT call `multica issue get`, `multica issue status`, or `multica issue comment add` for this task — there is no issue to query, transition, or comment on. The platform writes the user's success/failure inbox notification automatically based on whether `multica issue create` succeeded.\n")
 		b.WriteString("- If the CLI returns an error, exit with that error as the only output. Do not retry.\n\n")
 	} else if ctx.AutopilotRunID != "" {

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -164,7 +164,13 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("- title: required, short imperative summary extracted from the user input.\n")
 		b.WriteString("- description: optional; only include if the user supplied detail beyond the title.\n")
 		b.WriteString("- priority: one of `urgent`, `high`, `medium`, `low`, or omit. Map P0/P1 → urgent/high; \"asap\"/\"紧急\" → urgent; \"低优先级\" → low.\n")
-		b.WriteString("- assignee: when the user says \"分给 X\" / \"assign to X\" / \"@X\", call `multica workspace members --output json` and find the matching member. On clean match, pass `--assignee <name>`. On no/ambiguous match, OMIT `--assignee` and append a final line to the description: `未识别 assignee: X`.\n")
+		b.WriteString("- assignee:\n")
+		b.WriteString("    - When the user names someone (\"分给 X\" / \"assign to X\" / \"@X\"), call `multica workspace members --output json` and find the matching member. On clean match, pass `--assignee <name>`. On no/ambiguous match, OMIT `--assignee` and append a final line to the description: `未识别 assignee: X`.\n")
+		if ctx.AgentName != "" {
+			fmt.Fprintf(&b, "    - When the user did NOT name an assignee, default to YOURSELF: pass `--assignee %q`. The picker agent is the expected owner because the user opened quick-create with you selected — never leave the issue unassigned.\n", ctx.AgentName)
+		} else {
+			b.WriteString("    - When the user did NOT name an assignee, default to YOURSELF (the picker agent): pass `--assignee <your agent name>`. Never leave the issue unassigned.\n")
+		}
 		b.WriteString("- project / status: omit (defaults apply).\n\n")
 		b.WriteString("Output rules:\n")
 		b.WriteString("- Run exactly one `multica issue create` invocation.\n")

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -45,7 +45,17 @@ func buildQuickCreatePrompt(task Task) string {
 	b.WriteString("- title: required. A short, imperative summary extracted from the user input (e.g. \"fix inbox loading\"). Strip filler words.\n")
 	b.WriteString("- description: optional. Include only if the user supplied detail beyond the title; otherwise omit. Never echo the title here.\n")
 	b.WriteString("- priority: one of `urgent`, `high`, `medium`, `low`, or omit. Map P0/P1 → urgent/high; \"asap\"/\"紧急\" → urgent; \"低优先级\" → low. If unspecified, omit.\n")
-	b.WriteString("- assignee: when the user says \"分给 X\" / \"assign to X\" / \"@X\", call `multica workspace members --output json` and find the matching member by display name (case-insensitive substring match is fine). On a clean match, pass `--assignee <name>`. On no match or ambiguous match, do NOT pass `--assignee` — instead append a final line to the description: `未识别 assignee: X`.\n")
+	b.WriteString("- assignee:\n")
+	b.WriteString("    - When the user names someone (\"分给 X\" / \"assign to X\" / \"@X\"), call `multica workspace members --output json` and find the matching member by display name (case-insensitive substring match is fine). On a clean match, pass `--assignee <name>`. On no match or ambiguous match, do NOT pass `--assignee` — instead append a final line to the description: `未识别 assignee: X`.\n")
+	agentName := ""
+	if task.Agent != nil {
+		agentName = task.Agent.Name
+	}
+	if agentName != "" {
+		fmt.Fprintf(&b, "    - When the user did NOT name an assignee, default to YOURSELF: pass `--assignee %q`. The picker agent is the expected owner because the user opened quick-create with you selected — never leave the issue unassigned.\n", agentName)
+	} else {
+		b.WriteString("    - When the user did NOT name an assignee, default to YOURSELF (the picker agent): pass `--assignee <your agent name>`. Never leave the issue unassigned.\n")
+	}
 	b.WriteString("- project: omit. The platform will route the issue to the workspace default.\n")
 	b.WriteString("- status: omit (defaults to `todo`).\n\n")
 	b.WriteString("Output format:\n")


### PR DESCRIPTION
## Summary

Two related changes to the quick-create prompt path:

### 1. Default assignee to the picker agent when the user didn't name one

The previous prompt told the agent to OMIT `--assignee` whenever the user's input didn't explicitly name a person. Result: almost every quick-created issue landed unassigned, which doesn't match intent — the user opened quick-create with a specific agent picked, and that agent is the obvious default owner.

Both prompt surfaces now have a two-bullet assignee rule:

- User named someone → resolve via `multica workspace members` (unchanged).
- User did NOT name anyone → default to YOURSELF: `--assignee "<picker agent's name>"`.

The picker agent's name is interpolated at task-build time (`task.Agent.Name` in `prompt.go`) so the agent gets a literal string to use rather than having to guess its own name.

### 2. Single source of truth for quick-create rules

The quick-create field / output rules used to live in **two places** — the per-turn user message built by `BuildPrompt` (`prompt.go`), and the workflow block injected into `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` by `buildMetaSkillContent` (`runtime_config.go`). Same content, two sources — exactly the failure mode this PR's first commit hit (the assignee-default change had to be made in both files in lockstep).

Quick-create is one-shot, so the per-turn user message is always present and is the natural single source of truth. The injected file's quick-create section now keeps only the **hard guardrails**:

- Run exactly one `multica issue create` and exit
- Do NOT call `multica issue get` / `multica issue status` / `multica issue comment add`
- On CLI error, exit with that error as the only output

Those guardrails stay in BOTH surfaces because they're the safety net for providers / resumed-session contexts that don't propagate the user message. Detailed field rules now live only in the prompt.

`renderQuickCreateContext` (`issue_context.md`) was already guardrails-only — no change needed there.

## Files

- `server/internal/daemon/prompt.go` — assignee rule split into two branches; picker agent's name interpolated.
- `server/internal/daemon/execenv/runtime_config.go` — quick-create workflow block trimmed to guardrails + a "see the user message" pointer; assignee rule (and other field rules) removed.

## Test plan

- [x] `go build ./... && go test ./internal/daemon/...`
- [ ] Manual: quick-create `"fix inbox loading"` (no assignee mentioned) → new issue's assignee is the picker agent.
- [ ] Manual (regression): quick-create `"fix inbox loading, 分给 naiyuan"` → assignee is naiyuan, not the picker agent.
- [ ] Manual (ambiguous): quick-create `"fix inbox loading, 分给 zzz-not-a-member"` → assignee is the picker agent (defaulted) AND description ends with `未识别 assignee: zzz-not-a-member`. (Slight semantic shift from before — see note below.)

### Note on the ambiguous-name case

Before this PR: ambiguous → unassigned + `未识别 assignee: X` in description.
After: ambiguous → picker agent + `未识别 assignee: X` in description (because the "no clean match" branch falls through to "user didn't name anyone").

If you'd rather keep ambiguous matches unassigned, the rule can be split into three branches (named-and-matched / named-but-no-match / not-named).