### PR TITLE
fix(execenv): make agent always read comment history on assignment

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -207,8 +207,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		// Assignment-triggered: defer to agent Skills for workflow specifics.
 		b.WriteString("You are responsible for managing the issue status throughout your work.\n\n")
 		fmt.Fprintf(&b, "1. Run `multica issue get %s --output json` to understand your task\n", ctx.IssueID)
-		fmt.Fprintf(&b, "2. Run `multica issue status %s in_progress`\n", ctx.IssueID)
-		b.WriteString("3. Read comments for additional context or human instructions\n")
+		fmt.Fprintf(&b, "2. Run `multica issue comment list %s --output json` to read the full comment history — this is mandatory, not optional. Earlier comments often carry context the issue body lacks (e.g. which repo to work in, the prior agent's findings, the reason the issue was reassigned to you). Skipping this step is the most common cause of agents acting on stale or incomplete instructions.\n", ctx.IssueID)
+		fmt.Fprintf(&b, "   - If the output is very large or truncated, use pagination: `--limit 30` to get the latest 30 comments, or `--since <timestamp>` to fetch only recent ones\n")
+		fmt.Fprintf(&b, "3. Run `multica issue status %s in_progress`\n", ctx.IssueID)
 		b.WriteString("4. Follow your Skills and Agent Identity to complete the task (write code, investigate, etc.)\n")
 		fmt.Fprintf(&b, "5. **Post your final results as a comment — this step is mandatory**: `multica issue comment add %s --content \"...\"`. Your results are only visible to the user if posted via this CLI call; text in your terminal or run logs is NOT delivered.\n", ctx.IssueID)
 		fmt.Fprintf(&b, "6. When done, run `multica issue status %s in_review`\n", ctx.IssueID)


### PR DESCRIPTION
## Summary

Fixes GitHub #1839 — when an issue is reassigned (e.g. from agent A to agent B), the new agent often only reads the issue body and misses context that was added in comments (which repo to use, prior agent's findings, etc.).

The assignment-triggered workflow in `runtime_config.go` told the agent:

> 3. Read comments for additional context or human instructions

That phrasing was vague and easy to skip. The comment-triggered branch right above it already mandates an explicit `multica issue comment list <id> --output json` call, so behavior between the two trigger types had diverged.

## Change

- Promote "read comments" to step 2 with a concrete CLI invocation, matching the comment-triggered branch.
- Mark it as mandatory and call out the most common failure mode (stale instructions on reassignment) so the agent recognizes when it matters.
- Reorder so the agent reads comments *before* flipping status to `in_progress` — closer to how a human catches up on a thread before claiming work.

## Test plan

- [x] `go build ./internal/daemon/...`
- [x] `go test ./internal/daemon/...`
- [ ] Verify by reassigning an issue with comments to a fresh agent and checking that it reads the thread before acting