### PR TITLE
fix(quick-create): bound dialog height + scroll editor when content overflows

### DIFF
--- a/packages/views/modals/create-issue-dialog.tsx
+++ b/packages/views/modals/create-issue-dialog.tsx
@@ -57,7 +57,10 @@ export function CreateIssueDialog({
       ? cn(
           "p-0 gap-0 flex flex-col overflow-hidden",
           "!top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2",
-          "!max-w-xl !w-full",
+          // Width is capped; height is content-driven up to 80vh so a
+          // pasted screenshot can't push the dialog past the viewport
+          // (the inner editor area scrolls instead).
+          "!max-w-xl !w-full !max-h-[80vh]",
           // Smooth size transition when switching modes — the manual mode
           // uses the same easing.
           "!transition-all !duration-300 !ease-out",

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -257,9 +257,13 @@ export function AgentCreatePanel({
         {/* Prompt — same rich editor Advanced uses, so paste/drop images,
             mentions, and formatting all work. The dropZone wrapper enables
             drag-and-drop file uploads alongside paste. */}
+        {/* `flex-1 min-h-0 overflow-y-auto` so the editor area absorbs the
+            remaining vertical space inside the (now max-bounded) DialogContent
+            and scrolls internally. Without it, pasting an image expanded the
+            editor unbounded and pushed the modal past the viewport. */}
         <div
           {...dropZoneProps}
-          className="relative px-5 pb-3 min-h-[140px]"
+          className="relative px-5 pb-3 flex-1 min-h-[140px] overflow-y-auto"
         >
           <ContentEditor
             ref={editorRef}


### PR DESCRIPTION
## Summary

Pasting a screenshot into the agent-create prompt expanded the editor unbounded, dragging the whole DialogContent past the viewport. Manual mode was unaffected because `manualDialogContentClass` pins `!h-96`; agent mode had no max-height.

- Cap agent-mode DialogContent at `!max-h-[80vh]` (width stays `!max-w-xl`). Short prompts still render compact (height is content-driven), tall content stops at 80% of the viewport.
- Switch the editor wrapper to `flex-1 min-h-[140px] overflow-y-auto` so it absorbs the remaining vertical space inside the now-bounded DialogContent and scrolls internally instead of pushing the dialog.

## Test plan
- [x] Open agent-create, paste a small image → modal stays compact, image visible.
- [x] Paste a tall screenshot → modal hits ~80% of viewport height; image scrolls inside the editor area; header, agent picker, footer (Switch to manual / Create) all stay visible.
- [x] Type a long multi-line prompt without an image → editor scrolls inside the bounded modal.
- [x] Switch to manual and back → no regression in either mode's layout.