### PR TITLE
fix(cli,quick-create): no duplicate issue when --attachment fails post-create

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -465,6 +465,15 @@ func runIssueGet(cmd *cobra.Command, args []string) error {
 	return cli.PrintJSON(os.Stdout, issue)
 }
 
+// isHTTPURL reports whether path is an http:// or https:// URL.
+// Used to skip URL-shaped values passed to --attachment, which only
+// accepts local file paths. Trims surrounding whitespace because
+// agent-generated commands sometimes copy URLs with stray spaces.
+func isHTTPURL(path string) bool {
+	p := strings.TrimSpace(path)
+	return strings.HasPrefix(p, "http://") || strings.HasPrefix(p, "https://")
+}
+
 func runIssueCreate(cmd *cobra.Command, _ []string) error {
 	title, _ := cmd.Flags().GetString("title")
 	if title == "" {
@@ -529,22 +538,53 @@ func runIssueCreate(cmd *cobra.Command, _ []string) error {
 		body["origin_id"] = taskID
 	}
 
+	// Pre-validate attachments BEFORE creating the issue so a bad path
+	// can never produce a half-created issue (which would otherwise
+	// trigger callers — especially the agent doing quick-create — to
+	// retry the whole `issue create` and end up with duplicates).
+	//
+	//   - http(s) URLs are not local files; the API only accepts local
+	//     paths here. Warn and skip rather than fail — a markdown image
+	//     URL embedded in the prompt should never be re-attached, and
+	//     skipping is the safest outcome for that case.
+	//   - Anything else is treated as a local path and read upfront.
+	//     A read failure here is a real user/agent mistake (typo,
+	//     missing file) and we surface it pre-create so the issue
+	//     never lands.
+	type pendingAttachment struct {
+		path string
+		data []byte
+	}
+	pending := make([]pendingAttachment, 0, len(attachments))
+	for _, filePath := range attachments {
+		if isHTTPURL(filePath) {
+			fmt.Fprintf(os.Stderr, "Skipping --attachment %q: URLs are not supported here, only local file paths.\n", filePath)
+			continue
+		}
+		data, readErr := os.ReadFile(filePath)
+		if readErr != nil {
+			return fmt.Errorf("read attachment %s: %w", filePath, readErr)
+		}
+		pending = append(pending, pendingAttachment{path: filePath, data: data})
+	}
+
 	var result map[string]any
 	if err := client.PostJSON(ctx, "/api/issues", body, &result); err != nil {
 		return fmt.Errorf("create issue: %w", err)
 	}
 
 	// Upload attachments and link them to the newly created issue.
+	// Failures here are partial-success: the issue exists already, so
+	// turning a non-zero exit on the caller would invite a retry that
+	// duplicates the issue. Warn on stderr and continue.
 	issueID := strVal(result, "id")
-	for _, filePath := range attachments {
-		data, readErr := os.ReadFile(filePath)
-		if readErr != nil {
-			return fmt.Errorf("read attachment %s: %w", filePath, readErr)
+	for _, att := range pending {
+		if _, uploadErr := client.UploadFile(ctx, att.data, att.path, issueID); uploadErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: upload attachment %s failed (issue already created, %s): %v\n",
+				att.path, strVal(result, "identifier"), uploadErr)
+			continue
 		}
-		if _, uploadErr := client.UploadFile(ctx, data, filePath, issueID); uploadErr != nil {
-			return fmt.Errorf("upload attachment %s: %w", filePath, uploadErr)
-		}
-		fmt.Fprintf(os.Stderr, "Uploaded %s\n", filePath)
+		fmt.Fprintf(os.Stderr, "Uploaded %s\n", att.path)
 	}
 
 	output, _ := cmd.Flags().GetString("output")
@@ -835,9 +875,18 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Upload attachments and collect their IDs.
+	// Upload attachments and collect their IDs. URLs are skipped with a
+	// warning — `--attachment` only accepts local file paths, and a
+	// markdown image URL embedded in agent-supplied content should never
+	// be re-uploaded as if it were a file. Unlike `issue create`, this
+	// path uploads BEFORE posting the comment, so a hard failure on a
+	// real (local) attachment correctly aborts the whole call.
 	var attachmentIDs []string
 	for _, filePath := range attachments {
+		if isHTTPURL(filePath) {
+			fmt.Fprintf(os.Stderr, "Skipping --attachment %q: URLs are not supported here, only local file paths.\n", filePath)
+			continue
+		}
 		data, readErr := os.ReadFile(filePath)
 		if readErr != nil {
 			return fmt.Errorf("read attachment %s: %w", filePath, readErr)

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -57,9 +57,10 @@ func buildQuickCreatePrompt(task Task) string {
 		b.WriteString("    - When the user did NOT name an assignee, default to YOURSELF (the picker agent): pass `--assignee <your agent name>`. Never leave the issue unassigned.\n")
 	}
 	b.WriteString("- project: omit. The platform will route the issue to the workspace default.\n")
-	b.WriteString("- status: omit (defaults to `todo`).\n\n")
+	b.WriteString("- status: omit (defaults to `todo`).\n")
+	b.WriteString("- attachments: do NOT pass `--attachment`. The flag only accepts LOCAL file paths, and any image URL embedded in the user input is already part of the description as markdown — keep it inline in `--description` instead of trying to re-attach it. (Trying to pass `https://…` to `--attachment` will fail and look like a create error to you, but the issue may already exist; never retry `issue create` on that signal.)\n\n")
 	b.WriteString("Output format:\n")
-	b.WriteString("- Run exactly one `multica issue create` invocation.\n")
+	b.WriteString("- Run exactly one `multica issue create` invocation. Do not retry it for any reason — even on a non-zero exit. The issue may already exist; another attempt would create a duplicate.\n")
 	b.WriteString("- After it succeeds, print exactly one line: `Created MUL-<n>: <title>` and exit. No commentary, no follow-up tool calls.\n")
 	b.WriteString("- Do NOT call `multica issue get` or `multica issue comment add` for this task — there is no issue to query or comment on prior to creation.\n")
 	b.WriteString("- If the CLI returns an error, exit with that error as the only output. The platform writes a failure notification automatically; do not retry.\n")


### PR DESCRIPTION
## Summary

Closes the quick-create duplicate-issue bug from [MUL-1496](mention://issue/c30e1216-8bab-4db6-9818-5e0d3ea8a081). Implements the **#1 + #2** plan, with #1 refined to GPT-Boy's recommendation (pre-validate before POST instead of swallowing all errors).

## Repro

1. User pastes an image in the quick-create modal → front-end uploads it and embeds the URL as markdown in the prompt.
2. Agent sees the URL inside `User input:` and runs `multica issue create … --attachment "https://multica-static.copilothub.ai/.../image.png"`.
3. CLI's `runIssueCreate` POSTs the issue first, then loops attachments. `os.ReadFile("https://…")` fails ("no such file"). CLI returns non-zero exit.
4. Issue is **already created** server-side, but agent reads `exit 1 + stderr error` as "create failed" and retries → second issue.

## Fix #1 — CLI (`server/cmd/multica/cmd_issue.go`)

`runIssueCreate` now classifies attachments **before** POSTing:

- `http://` / `https://` URL → stderr warning + skip (never a local file; never re-upload).
- Other path → read upfront. A read error here aborts BEFORE the POST, so we never produce a half-baked issue from a typo.
- POST → only with attachments that successfully pre-loaded.
- Post-POST upload failures → stderr warning per attachment, issue metadata still printed, **exit 0**. The issue exists, partial-success is the correct outcome, and callers no longer see a signal that invites retry.

`runIssueCommentAdd` already uploads attachments **before** posting the comment (so its failure mode is correct), but gets the same URL-skip path for consistency with `issue create`.

`isHTTPURL` lives at the top of the file as a tiny private helper.

## Fix #2 — Quick-create prompt (`buildQuickCreatePrompt`)

Adds a dedicated **attachments** rule to the field list:

- `--attachment` only accepts LOCAL paths.
- Image URLs in the user input are already part of the description as markdown — keep them inline in `--description`, don't try to re-attach.

Also hardens the no-retry rule in the Output section: even on a non-zero exit, **never re-run `multica issue create`** — the issue may already exist and a retry duplicates it. (Belt-and-braces with #1: even if a future code path slips and returns non-zero post-create, the prompt tells the agent not to retry.)

## Why this combination over GPT-Boy's full proposal

GPT-Boy suggested also folding #3 (URL skip) into #1; this PR does that — URL skip is the URL-shaped subset of the new pre-validation step, not a separate change. Net result is the same as their refined #1 + #2.

## Test plan

- [x] `go build ./... && go test ./cmd/multica/... ./internal/daemon/...`
- [ ] Manual: quick-create with a pasted image → exactly one issue lands; CLI stderr shows `Skipping --attachment "https://…": …`.
- [ ] Manual (regression): `multica issue create --title foo --attachment ./real-file.png` → still uploads as before.
- [ ] Manual (regression): `multica issue create --title foo --attachment ./does-not-exist.png` → still fails with `read attachment …: no such file`, but now BEFORE the issue is created (no orphan).
- [ ] Manual: `multica issue create --title foo --attachment ./real-file.png` with a corrupted server-side upload path → issue is created, stderr shows `warning: upload attachment … failed (issue already created, MUL-X): …`, exit code 0.