### PR TITLE
fix(execenv): prefer stdin for formatted comment replies

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -878,10 +878,11 @@ func TestInjectRuntimeConfigCodexEmphasizesStdinForFormattedComments(t *testing.
 
 	for _, want := range []string{
 		"Codex-Specific Comment Formatting",
-		"Treat inline `--content \"...\"` examples as short single-line examples only",
-		"`--content-stdin` with a HEREDOC",
-		"keep the same `--parent` value",
-		"Do not compress a multi-paragraph answer",
+		"always use `--content-stdin` with a HEREDOC",
+		"even for short single-line replies",
+		"Never use inline `--content` for agent-authored comments",
+		"Keep the same `--parent` value",
+		"do not rely on `\\n` escapes",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("AGENTS.md missing Codex multiline guidance %q\n---\n%s", want, s)

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -18,15 +18,15 @@ func BuildCommentReplyInstructions(issueID, triggerCommentID string) string {
 	return fmt.Sprintf(
 		"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
 			"do NOT reuse --parent values from previous turns in this session.\n\n"+
-			"For a short single-line reply, use:\n\n"+
-			"    multica issue comment add %s --parent %s --content \"...\"\n\n"+
-			"For multi-line content (paragraphs, bullets, code blocks, backticks, quotes, or anything where formatting matters), "+
-			"do NOT squeeze it into `--content` and do NOT write `\\n` escapes. Pipe via stdin instead, preserving the same issue ID and --parent value:\n\n"+
+			"Always use `--content-stdin` with a HEREDOC for agent-authored issue comments, even when the reply is a single line. "+
+			"Do NOT use inline `--content`; it is easy to lose formatting or accidentally compress a structured reply into one line.\n\n"+
+			"Use this form, preserving the same issue ID and --parent value:\n\n"+
 			"    cat <<'COMMENT' | multica issue comment add %s --parent %s --content-stdin\n"+
 			"    First paragraph.\n"+
 			"\n"+
 			"    Second paragraph.\n"+
-			"    COMMENT\n",
-		issueID, triggerCommentID, issueID, triggerCommentID,
+			"    COMMENT\n\n"+
+			"Do NOT write literal `\\n` escapes to simulate line breaks; the HEREDOC preserves real newlines.\n",
+		issueID, triggerCommentID,
 	)
 }

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -17,15 +17,20 @@ func TestBuildCommentReplyInstructionsIncludesTriggerID(t *testing.T) {
 
 	for _, want := range []string{
 		"multica issue comment add " + issueID + " --parent " + triggerID,
-		"short single-line reply",
+		"Always use `--content-stdin`",
+		"even when the reply is a single line",
 		"--content-stdin",
 		"<<'COMMENT'",
-		"do NOT write `\\n` escapes",
+		"Do NOT write literal `\\n` escapes to simulate line breaks",
 		"do NOT reuse --parent values from previous turns",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("reply instructions missing %q\n---\n%s", want, got)
 		}
+	}
+
+	if strings.Contains(got, "--content \"...\"") {
+		t.Fatalf("reply instructions should not offer inline --content form\n---\n%s", got)
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -95,8 +95,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica issue label remove <issue-id> <label-id>` — Detach a label from an issue\n")
 	b.WriteString("- `multica issue subscriber add <issue-id> [--user <name>]` — Subscribe a member or agent to issue updates (defaults to the caller when `--user` is omitted)\n")
 	b.WriteString("- `multica issue subscriber remove <issue-id> [--user <name>]` — Unsubscribe a member or agent\n")
-	b.WriteString("- `multica issue comment add <issue-id> --content \"...\" [--parent <comment-id>] [--attachment <path>]` — Post a comment (use `--parent` to reply to a specific comment; `--attachment` may be repeated)\n")
-	b.WriteString("  - **For multi-line content (anything with line breaks, paragraphs, code blocks, backticks, or quotes), you MUST pipe via stdin** — bash does NOT expand `\\n` inside double quotes, so writing `--content \"para1\\n\\npara2\"` stores the literal 4-char sequence and the comment renders without line breaks. Use a HEREDOC instead:\n")
+	b.WriteString("- `multica issue comment add <issue-id> --content-stdin [--parent <comment-id>] [--attachment <path>]` — Post a comment. Agent-authored comments should always pipe content via stdin, even for short single-line replies. Use `--parent` to reply to a specific comment; `--attachment` may be repeated.\n")
+	b.WriteString("  - **For comment content, you MUST pipe via stdin; this is mandatory for multi-line content (anything with line breaks, paragraphs, code blocks, backticks, or quotes).** Do not use inline `--content` and do not write `\\n` escapes. Use a HEREDOC instead:\n")
 	b.WriteString("\n")
 	b.WriteString("    ```\n")
 	b.WriteString("    cat <<'COMMENT' | multica issue comment add <issue-id> --content-stdin\n")
@@ -116,9 +116,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 
 	if provider == "codex" {
 		b.WriteString("## Codex-Specific Comment Formatting\n\n")
-		b.WriteString("Codex often follows the per-turn reply command literally. Treat inline `--content \"...\"` examples as short single-line examples only. ")
-		b.WriteString("For paragraphs, bullets, code blocks, backticks, quotes, or any text where line breaks matter, use `--content-stdin` with a HEREDOC and keep the same `--parent` value from the trigger comment. ")
-		b.WriteString("Do not compress a multi-paragraph answer into one `--content` argument and do not rely on `\\n` escapes.\n\n")
+		b.WriteString("Codex often follows the per-turn reply command literally. For issue comments, always use `--content-stdin` with a HEREDOC, even for short single-line replies. ")
+		b.WriteString("Never use inline `--content` for agent-authored comments. Keep the same `--parent` value from the trigger comment when replying. ")
+		b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
 	}
 
 	// Inject available repositories section.


### PR DESCRIPTION
## Summary

- Make `--content-stdin` + HEREDOC the only agent reply path for comment-triggered tasks, including short single-line replies.
- Remove inline `--content` from the canonical reply instructions so models no longer have to choose between two modes.
- Update runtime guidance and tests to require stdin for agent-authored issue comments and prevent regressions back to compressed one-line replies.

## Test plan

- go test ./internal/daemon/execenv
- go test ./internal/daemon/...
- git diff --check
