### PR TITLE
feat(issues): add board column move to done action

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -238,19 +238,40 @@ export function useBatchUpdateIssues() {
     onMutate: async ({ ids, updates }) => {
       await qc.cancelQueries({ queryKey: issueKeys.list(wsId) });
       const prevList = qc.getQueryData<ListIssuesCache>(issueKeys.list(wsId));
+      const parentIssueIds = new Set<string>();
+      if (prevList) {
+        for (const id of ids) {
+          const loc = findIssueLocation(prevList, id);
+          if (loc?.issue.parent_issue_id) parentIssueIds.add(loc.issue.parent_issue_id);
+        }
+      }
       qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) => {
         if (!old) return old;
         let next = old;
         for (const id of ids) next = patchIssueInBuckets(next, id, updates);
         return next;
       });
-      return { prevList };
+      return { prevList, parentIssueIds };
     },
     onError: (_err, _vars, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
     },
-    onSettled: () => {
+    onSettled: (_data, _err, vars, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
+      for (const id of vars.ids) {
+        qc.invalidateQueries({ queryKey: issueKeys.detail(wsId, id) });
+      }
+      if (
+        ctx?.parentIssueIds &&
+        ctx.parentIssueIds.size > 0 &&
+        (vars.updates.status !== undefined || vars.updates.parent_issue_id !== undefined)
+      ) {
+        for (const parentId of ctx.parentIssueIds) {
+          qc.invalidateQueries({ queryKey: issueKeys.children(wsId, parentId) });
+        }
+        qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+      }
     },
   });
 }

--- a/packages/views/issues/components/board-column.tsx
+++ b/packages/views/issues/components/board-column.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, type ReactNode } from "react";
-import { EyeOff, MoreHorizontal, Plus } from "lucide-react";
+import { CheckCircle2, EyeOff, MoreHorizontal, Plus } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
@@ -12,6 +12,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { useModalStore } from "@multica/core/modals";
@@ -27,6 +28,8 @@ export function BoardColumn({
   childProgressMap,
   totalCount,
   footer,
+  movingToDone = false,
+  onMoveVisibleToDone,
 }: {
   status: IssueStatus;
   issueIds: string[];
@@ -34,6 +37,8 @@ export function BoardColumn({
   childProgressMap?: Map<string, ChildProgress>;
   totalCount?: number;
   footer?: ReactNode;
+  movingToDone?: boolean;
+  onMoveVisibleToDone?: (status: IssueStatus, issueIds: string[]) => void;
 }) {
   const cfg = STATUS_CONFIG[status];
   const { setNodeRef, isOver } = useDroppable({ id: status });
@@ -65,6 +70,18 @@ export function BoardColumn({
               }
             />
             <DropdownMenuContent align="end">
+              {status !== "done" && (
+                <>
+                  <DropdownMenuItem
+                    disabled={issueIds.length === 0 || movingToDone}
+                    onClick={() => onMoveVisibleToDone?.(status, issueIds)}
+                  >
+                    <CheckCircle2 className="size-3.5" />
+                    Move visible to Done
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </>
+              )}
               <DropdownMenuItem onClick={() => viewStoreApi.getState().hideStatus(status)}>
                 <EyeOff className="size-3.5" />
                 Hide column

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -16,9 +16,10 @@ import {
 } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { Eye, MoreHorizontal } from "lucide-react";
+import { toast } from "sonner";
 import type { Issue, IssueStatus } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
-import { useLoadMoreByStatus } from "@multica/core/issues/mutations";
+import { useBatchUpdateIssues, useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { MyIssuesFilter } from "@multica/core/issues/queries";
 import {
   DropdownMenu,
@@ -124,6 +125,7 @@ export function BoardView({
   const myIssuesOpts = myIssuesScope
     ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
     : undefined;
+  const moveVisibleToDone = useBatchUpdateIssues();
 
   // --- Drag state ---
   const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
@@ -271,6 +273,25 @@ export function BoardView({
     [issues, visibleStatuses, sortBy, sortDirection, onMoveIssue],
   );
 
+  const handleMoveVisibleToDone = useCallback(
+    async (status: IssueStatus, issueIds: string[]) => {
+      if (status === "done" || issueIds.length === 0 || moveVisibleToDone.isPending) return;
+
+      try {
+        await moveVisibleToDone.mutateAsync({
+          ids: issueIds,
+          updates: { status: "done" },
+        });
+        toast.success(
+          `Moved ${issueIds.length} visible issue${issueIds.length === 1 ? "" : "s"} to Done`,
+        );
+      } catch {
+        toast.error("Failed to move issues to Done");
+      }
+    },
+    [moveVisibleToDone],
+  );
+
   return (
     <DndContext
       sensors={sensors}
@@ -288,6 +309,8 @@ export function BoardView({
             issueMap={issueMapRef.current}
             childProgressMap={childProgressMap}
             myIssuesOpts={myIssuesOpts}
+            movingToDone={moveVisibleToDone.isPending}
+            onMoveVisibleToDone={handleMoveVisibleToDone}
           />
         ))}
 
@@ -316,12 +339,16 @@ function PaginatedBoardColumn({
   issueMap,
   childProgressMap,
   myIssuesOpts,
+  movingToDone,
+  onMoveVisibleToDone,
 }: {
   status: IssueStatus;
   issueIds: string[];
   issueMap: Map<string, Issue>;
   childProgressMap?: Map<string, ChildProgress>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  movingToDone?: boolean;
+  onMoveVisibleToDone?: (status: IssueStatus, issueIds: string[]) => void;
 }) {
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByStatus(
     status,
@@ -334,6 +361,8 @@ function PaginatedBoardColumn({
       issueMap={issueMap}
       childProgressMap={childProgressMap}
       totalCount={total}
+      movingToDone={movingToDone}
+      onMoveVisibleToDone={onMoveVisibleToDone}
       footer={
         hasMore ? (
           <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />


### PR DESCRIPTION
## Summary
- add a board column menu action to move the currently visible issues in that column to Done
- disable the action for empty columns and omit it from the Done column
- refresh issue list, scoped issue lists, details, and child progress after batch updates

## Testing
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/core test
- pnpm --filter @multica/views test

Note: `make check` was not runnable locally because `.env` is missing in this checkout.