### PR TITLE
feat(editor): preserve Markdown source on copy/cut

### DIFF
--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -39,6 +39,7 @@ import { BaseMentionExtension } from "./mention-extension";
 import { createMentionSuggestion } from "./mention-suggestion";
 import { CodeBlockView } from "./code-block-view";
 import { createMarkdownPasteExtension } from "./markdown-paste";
+import { createMarkdownCopyExtension } from "./markdown-copy";
 import { createSubmitExtension } from "./submit-shortcut";
 import { createBlurShortcutExtension } from "./blur-shortcut";
 import { createFileUploadExtension } from "./file-upload";
@@ -129,6 +130,10 @@ export function createEditorExtensions(
     InlineMathExtension,
     // 3-space indent so nested ordered lists survive CommonMark in ReadonlyContent.
     Markdown.configure({ indentation: { style: "space", size: 3 } }),
+    // Make Cmd+C / Cmd+X / drag write Markdown source to clipboard text/plain.
+    // Registered for both editable and readonly so users can copy from rendered
+    // comments and paste the original Markdown elsewhere.
+    createMarkdownCopyExtension(),
     FileCardExtension,
     ...(options.disableMentions
       ? []

--- a/packages/views/editor/extensions/markdown-copy.ts
+++ b/packages/views/editor/extensions/markdown-copy.ts
@@ -1,0 +1,62 @@
+/**
+ * Markdown copy extension — make the clipboard's text/plain channel carry
+ * Markdown source instead of plain textContent.
+ *
+ * Symmetric to markdown-paste.ts:
+ *   paste:  text/plain  →  editor.markdown.parse  →  doc
+ *   copy:   slice       →  editor.markdown.serialize  →  text/plain
+ *
+ * Why: ProseMirror's default clipboardTextSerializer calls Slice.textBetween,
+ * which flattens every node to its inner text. Headings, lists, code blocks,
+ * mentions, file cards — all lose their Markdown markers. Pasting into VS
+ * Code, terminals, or messaging apps then sees only naked text.
+ *
+ * The text/html channel is left at ProseMirror's default so pasting back
+ * into another ProseMirror editor still preserves exact node structure via
+ * data-pm-slice.
+ */
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { Slice } from "@tiptap/pm/model";
+
+// Blob URLs (blob:http://…) are process-local; never let them leave the page.
+const BLOB_IMAGE_RE = /!\[[^\]]*\]\(blob:[^)]*\)\n?/g;
+
+export function createMarkdownCopyExtension() {
+  return Extension.create({
+    name: "markdownCopy",
+    addProseMirrorPlugins() {
+      const { editor } = this;
+
+      const fallback = (slice: Slice) =>
+        slice.content.textBetween(0, slice.content.size, "\n\n");
+
+      return [
+        new Plugin({
+          key: new PluginKey("markdownCopy"),
+          props: {
+            clipboardTextSerializer(slice: Slice) {
+              if (!editor.markdown) return fallback(slice);
+              try {
+                // Wrap slice content in a temp doc so the serializer walks
+                // it like a real document. Inline-only slices auto-wrap
+                // into doc → paragraph; block slices pass through.
+                const doc = editor.schema.topNodeType.create(
+                  null,
+                  slice.content,
+                );
+                const md = editor.markdown.serialize(doc.toJSON());
+                return md.replace(BLOB_IMAGE_RE, "").replace(/\n+$/, "");
+              } catch {
+                // Special selections (e.g. table cellSelection) may fail
+                // schema validation when wrapped in a doc node. Fall back
+                // so copy never breaks.
+                return fallback(slice);
+              }
+            },
+          },
+        }),
+      ];
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Closes [MUL-1552](mention://issue/5a553b9e-3f2c-4d97-b77e-b8c84f00e168) — Cmd+C from the Tiptap editor was dropping Markdown syntax (`##`, `**`, `[]()`, mentions, etc.) when pasted into plain-text targets like VS Code, terminals, or chat apps.
- Adds `markdown-copy` extension symmetric to the existing `markdown-paste`. On copy/cut/drag, the selected `Slice` is routed through `editor.markdown.serialize()` so the clipboard's `text/plain` channel carries Markdown source.
- `text/html` is left at ProseMirror's default → pasting back into another ProseMirror editor still preserves exact node structure via `data-pm-slice`.
- Registered for both editable AND readonly modes — users routinely copy from rendered comments/issue descriptions.

## Why this works

ProseMirror's default `clipboardTextSerializer` calls `Slice.textBetween`, which has no knowledge of Markdown. The `@tiptap/markdown` extension already exposes `editor.markdown.serialize(json)` and every custom node (mention, fileCard, inline/block math) already declares `renderMarkdown` — we just needed to wire the two together at the clipboard seam.

```
paste:  text/plain  →  editor.markdown.parse  →  doc      (existing)
copy:   slice        →  editor.markdown.serialize  →  text/plain   (this PR)
```

A `try/catch` falls back to the default `textBetween` for special selections (e.g. table cell selections, where wrapping the slice content into a doc node can fail schema validation) — copy never breaks.

## Test plan

Run `pnpm dev:web` and open any issue / create a comment.

- [ ] **Heading** — Type `## 你好` into a comment, render it, then select the heading text and Cmd+C. Paste into VS Code → expect `## 你好`. (Before the fix you'd get `你好`.)
- [ ] **Bold + link** — Type `**text** with [a link](https://example.com)`. Select all, Cmd+C, paste into a terminal → expect the markdown source verbatim.
- [ ] **List + nested** — Build a bulleted list with sublists, Cmd+C, paste into VS Code → expect `- ` prefixes preserved.
- [ ] **Code block** — Make a ` ```ts ` fenced code block, select inner code only, Cmd+C, paste into terminal → expect raw code (no fence). Selecting the whole block including the fence should preserve the fence.
- [ ] **Mention** — `@`-mention a member or issue, Cmd+C the mention, paste into VS Code → expect `[@Name](mention://member/<uuid>)` (or `[MUL-N](mention://issue/<uuid>)`).
- [ ] **File card** — Drop a non-image file to insert a fileCard, Cmd+C, paste into VS Code → expect `!file[name](url)`.
- [ ] **Math** — Insert `$E=mc^2$` and `$$\nE=mc^2\n$$`, Cmd+C each, paste into VS Code → expect the markdown source preserved.
- [ ] **Cut** — Same as copy but with Cmd+X. Should write Markdown to clipboard AND remove the selection from the editor.
- [ ] **Round-trip into ProseMirror** — Cmd+C from a comment, then Cmd+V into the new comment composer. Should preserve the rich rendered structure (HTML path, not the markdown-text path).
- [ ] **Readonly source** — Open an existing issue with formatted description (readonly view). Select a heading, Cmd+C, paste into VS Code → expect markdown source. (Validates the readonly registration.)
- [ ] **Table cell selection** — Select cells inside a table, Cmd+C, paste into VS Code → should not throw; gets the cell text content as a fallback.
- [ ] **Drag-drop to external app** — Drag selected text out of the editor into a Slack/Notes/VS Code window → expect markdown.

## Edge cases handled

- Inline-only selection (selecting "你好" out of `## 你好`) → outputs just `你好`, NOT `## 你好`. Wrapping a leaf-only slice into a doc auto-wraps via paragraph, so no spurious heading marker.
- Blob URL leakage — newly-uploaded image placeholders (`blob:http://…`) are stripped from the markdown output before it reaches the clipboard, matching the existing behavior in `getMarkdown()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)