### PR TITLE
feat(ui): make New Issue button open Quick Capture instead of manual form

### DIFF
--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -560,7 +560,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
             <SidebarMenuItem>
               <SidebarMenuButton
                 className="text-muted-foreground"
-                onClick={() => useModalStore.getState().open("create-issue")}
+                onClick={() => useModalStore.getState().open("quick-create-issue")}
               >
                 <span className="relative">
                   <SquarePen />

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -261,7 +261,7 @@ describe("SearchCommand", () => {
     );
     await user.click(newIssue);
 
-    expect(mockOpenModal).toHaveBeenCalledWith("create-issue");
+    expect(mockOpenModal).toHaveBeenCalledWith("quick-create-issue");
     expect(useSearchStore.getState().open).toBe(false);
   });
 

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -202,7 +202,7 @@ export function SearchCommand() {
         icon: Plus,
         keywords: ["new", "issue", "create", "add"],
         onSelect: () => {
-          useModalStore.getState().open("create-issue");
+          useModalStore.getState().open("quick-create-issue");
           setOpen(false);
         },
       },


### PR DESCRIPTION
## Summary
- Sidebar "New Issue" button now opens Quick Capture (agent-based creation) instead of the manual form
- Search command's "New Issue" action also opens Quick Capture for consistency
- Contextual creation (board columns, list view status groups, sub-issues) still opens the manual form since those pass pre-filled data (status, parent)

Closes MUL-1558

## Test plan
- [ ] Click the "New Issue" button in the sidebar → should open Quick Capture dialog
- [ ] Use search command and select "New Issue" → should open Quick Capture dialog
- [ ] Press "C" keyboard shortcut → should open Quick Capture by default (existing behavior, `lastMode` defaults to `"agent"`)
- [ ] Click "+" on a board column → should still open manual form with status pre-filled
- [ ] Click "Add sub-issue" on an issue → should still open manual form with parent pre-filled