### PR TITLE
feat(quick-create): add file upload button to Quick Capture dialog

### DIFF
--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -37,6 +37,7 @@ import {
   useFileDropZone,
   FileDropOverlay,
 } from "../editor";
+import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 
 // AgentCreatePanel — agent-mode body of the create-issue dialog. Renders
 // only the inner content; the surrounding `<Dialog>` AND `<DialogContent>`
@@ -334,7 +335,13 @@ export function AgentCreatePanel({
 
         {/* Footer */}
         <div className="flex items-center justify-between px-4 py-3 border-t shrink-0">
-          <span className="text-xs text-muted-foreground">⌘↵ to submit</span>
+          <div className="flex items-center gap-1.5">
+            <FileUploadButton
+              size="sm"
+              onSelect={(file) => editorRef.current?.uploadFile(file)}
+            />
+            <span className="text-xs text-muted-foreground">⌘↵ to submit</span>
+          </div>
           <div className="flex items-center gap-2">
             <button
               type="button"


### PR DESCRIPTION
## Summary

- Adds a `FileUploadButton` (paperclip icon) to the agent-mode Quick Capture dialog footer
- The dialog already supported image paste and drag-drop via the ContentEditor, but lacked a visible attachment button — this made the feature undiscoverable
- Matches the pattern used by the manual create panel and comment input

Closes MUL-1557

## Test plan

- [x] `pnpm typecheck` passes (all 6 tasks)
- [x] `pnpm --filter @multica/views exec vitest run` passes (228 tests)
- [ ] Manual: open Quick Capture (Cmd+K), verify paperclip button appears in footer
- [ ] Manual: click paperclip → select image → image uploads and appears in editor
- [ ] Manual: paste image (Cmd+V) → image uploads and appears in editor (existing behavior, unchanged)
- [ ] Manual: drag-drop file → file uploads (existing behavior, unchanged)