### PR TITLE
fix(desktop): show git-described version in dev instead of stale 0.1.0

### DIFF
--- a/apps/desktop/src/main/app-version.ts
+++ b/apps/desktop/src/main/app-version.ts
@@ -1,0 +1,33 @@
+import { app } from "electron";
+import { execSync } from "node:child_process";
+
+/**
+ * Resolve the running app version. In packaged builds this is the value
+ * `electron-builder` baked into package.json via `extraMetadata.version`
+ * (driven by `git describe` — see `apps/desktop/scripts/package.mjs`), so
+ * `app.getVersion()` matches the GitHub Release tag exactly.
+ *
+ * In dev (`pnpm dev:desktop`) `app.getVersion()` only sees the static
+ * `apps/desktop/package.json` value, which is "0.1.0" and never bumped —
+ * the Settings → Updates panel and any other UI surfacing the version
+ * would mislead developers into thinking they're running ancient builds.
+ * Fall back to `git describe --tags --always --dirty` (same source the
+ * packager uses) so dev shows e.g. `0.2.19-14-gabcdef-dirty`. If git is
+ * unavailable for whatever reason, we just return the package.json value.
+ */
+export function getAppVersion(): string {
+  if (app.isPackaged) {
+    return app.getVersion();
+  }
+  try {
+    const raw = execSync("git describe --tags --always --dirty", {
+      cwd: app.getAppPath(),
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!raw) return app.getVersion();
+    return raw.replace(/^v/, "");
+  } catch {
+    return app.getVersion();
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
 import { openExternalSafely } from "./external-url";
 import { installContextMenu } from "./context-menu";
+import { getAppVersion } from "./app-version";
 
 // Bundled icon used for dev-mode dock/taskbar branding. In production the
 // app bundle icon (from electron-builder) wins; this path is only consumed
@@ -203,7 +204,7 @@ if (!gotTheLock) {
     ipcMain.on("app:get-info", (event) => {
       const p = process.platform;
       const os = p === "darwin" ? "macos" : p === "win32" ? "windows" : p === "linux" ? "linux" : "unknown";
-      event.returnValue = { version: app.getVersion(), os };
+      event.returnValue = { version: getAppVersion(), os };
     });
 
     // IPC: toggle immersive mode — hides the macOS traffic lights so full-screen


### PR DESCRIPTION
## Summary

Packaged builds are unaffected — `apps/desktop/scripts/package.mjs` already injects `git describe --tags --always --dirty` into electron-builder's `extraMetadata.version`, so the `.app` users download from GitHub Release reports the right version through `app.getVersion()` and the auto-updater's `latest.yml` comparison works correctly.

Dev mode (`pnpm dev:desktop`) didn't go through that path though: `app.getVersion()` only saw the static `"0.1.0"` from `apps/desktop/package.json`, which has never been bumped. After #1861 surfaced the running version in Settings → Updates, that made dev builds look ancient.

Adds a tiny `getAppVersion()` helper that falls back to `git describe` only when `!app.isPackaged`, and uses it for the `app:get-info` IPC. If git is unavailable for any reason, we silently fall back to `app.getVersion()`.

## Test plan
- [ ] Run `pnpm dev:desktop`, open Settings → Updates → "Current version" reads e.g. `v0.2.19-16-gabcdef-dirty`, matching `git describe --tags --always --dirty` from the workspace root.
- [ ] Packaged build (`pnpm --filter @multica/desktop package`) still reports the tag-derived version (no regression — the change is `app.isPackaged`-guarded).
- [ ] Auto-update detection unaffected: `updater.ts` still calls `app.getVersion()` directly (the helper is only wired into the `app:get-info` IPC).