### PR TITLE
fix(auth): route invitees to their workspace instead of forcing /onboarding

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -110,18 +110,19 @@ function AppContent() {
     : undefined;
   useDaemonIPCBridge(activeWsId);
 
-  // Onboarding and zero-workspace both resolve to an overlay, but
-  // onboarding wins: a user who hasn't completed it gets the onboarding
-  // overlay regardless of how many workspaces already exist.
+  // Workspace presence wins over onboarding state: a user invited into an
+  // existing workspace must enter that workspace, not be trapped in the
+  // onboarding overlay just because their personal `onboarded_at` is null.
+  // Onboarding is only the right destination when the account has zero
+  // workspaces AND has never onboarded.
   useEffect(() => {
     if (!user || !workspaceListFetched) return;
     const { overlay, open } = useWindowOverlayStore.getState();
     if (overlay) return;
+    if (wsCount > 0) return;
     if (!hasOnboarded) {
       open({ type: "onboarding" });
-      return;
-    }
-    if (wsCount === 0) {
+    } else {
       open({ type: "new-workspace" });
     }
   }, [user, workspaceListFetched, wsCount, workspaces, hasOnboarded]);

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -72,10 +72,6 @@ function LoginPageContent() {
         });
       return;
     }
-    if (!hasOnboarded) {
-      router.replace(paths.onboarding());
-      return;
-    }
     if (nextUrl) {
       router.replace(nextUrl);
       return;
@@ -89,10 +85,6 @@ function LoginPageContent() {
     // was captured before login completed and would be stale here.
     const currentUser = useAuthStore.getState().user;
     const onboarded = currentUser?.onboarded_at != null;
-    if (!onboarded) {
-      router.push(paths.onboarding());
-      return;
-    }
     if (nextUrl) {
       router.push(nextUrl);
       return;

--- a/apps/web/app/(auth)/onboarding/page.tsx
+++ b/apps/web/app/(auth)/onboarding/page.tsx
@@ -32,20 +32,25 @@ export default function OnboardingPage() {
   const hasOnboarded = useHasOnboarded();
   const { data: workspaces = [], isFetched: workspacesFetched } = useQuery({
     ...workspaceListOptions(),
-    enabled: !!user && hasOnboarded,
+    enabled: !!user,
   });
+  const hasWorkspaces = workspaces.length > 0;
 
   useEffect(() => {
     if (isLoading || !user) {
       if (!isLoading && !user) router.replace(paths.login());
       return;
     }
-    if (hasOnboarded && workspacesFetched) {
+    if (!workspacesFetched) return;
+    // Bounce out if onboarding doesn't apply: either already onboarded, or
+    // the user already has a workspace (e.g. arrived via invitation) — we
+    // never trap an in-workspace user on the onboarding screen.
+    if (hasOnboarded || hasWorkspaces) {
       router.replace(resolvePostAuthDestination(workspaces, hasOnboarded));
     }
-  }, [isLoading, user, hasOnboarded, workspacesFetched, workspaces, router]);
+  }, [isLoading, user, hasOnboarded, workspacesFetched, workspaces, hasWorkspaces, router]);
 
-  if (isLoading || !user || hasOnboarded) return null;
+  if (isLoading || !user || hasOnboarded || hasWorkspaces) return null;
 
   // Layout: page owns its own scroll (root layout sets `body {
   // overflow: hidden }` for the app-shell convention). OnboardingFlow

--- a/apps/web/app/auth/callback/page.test.tsx
+++ b/apps/web/app/auth/callback/page.test.tsx
@@ -61,26 +61,52 @@ import CallbackPage from "./page";
 describe("CallbackPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSearchParams.forEach((_v, k) => mockSearchParams.delete(k));
+    // Snapshot keys before deleting — forEach + delete skips entries because
+    // the iteration index advances while the underlying list shrinks.
+    Array.from(mockSearchParams.keys()).forEach((k) =>
+      mockSearchParams.delete(k),
+    );
     mockSearchParams.set("code", "test-code");
     mockLoginWithGoogle.mockResolvedValue(makeUser());
     mockListWorkspaces.mockResolvedValue([]);
   });
 
-  it("unonboarded user lands on /onboarding regardless of next=", async () => {
+  it("unonboarded user honors a safe next= (e.g. /invite/{id}) so invitees aren't trapped", async () => {
     mockSearchParams.set("state", "next:/invite/abc123");
     render(<CallbackPage />);
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith(paths.onboarding());
+      expect(mockPush).toHaveBeenCalledWith("/invite/abc123");
     });
-    expect(mockPush).not.toHaveBeenCalledWith("/invite/abc123");
+    expect(mockPush).not.toHaveBeenCalledWith(paths.onboarding());
   });
 
-  it("unonboarded user with no next= also lands on /onboarding", async () => {
+  it("unonboarded user with no next= and zero workspaces lands on /onboarding", async () => {
     render(<CallbackPage />);
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(paths.onboarding());
     });
+  });
+
+  it("unonboarded user with existing workspace lands in that workspace, not /onboarding", async () => {
+    mockListWorkspaces.mockResolvedValue([
+      {
+        id: "ws-1",
+        name: "Acme",
+        slug: "acme",
+        description: null,
+        context: null,
+        settings: {},
+        repos: [],
+        issue_prefix: "ACME",
+        created_at: "",
+        updated_at: "",
+      },
+    ]);
+    render(<CallbackPage />);
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(paths.workspace("acme").issues());
+    });
+    expect(mockPush).not.toHaveBeenCalledWith(paths.onboarding());
   });
 
   it("onboarded user ignores unsafe next= targets and lands on the default destination", async () => {

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -66,10 +66,10 @@ function CallbackContent() {
           const wsList = await api.listWorkspaces();
           qc.setQueryData(workspaceKeys.list(), wsList);
           const onboarded = loggedInUser.onboarded_at != null;
-          if (!onboarded) {
-            router.push(paths.onboarding());
-            return;
-          }
+          // Workspace presence beats onboarding state: an invitee with zero
+          // `onboarded_at` but a real workspace must land in that workspace,
+          // not in the new-workspace wizard. A `next=` (e.g. /invite/<id>)
+          // always wins so invite acceptance flows survive auth round-trips.
           router.push(
             nextUrl || resolvePostAuthDestination(wsList, onboarded),
           );

--- a/packages/core/paths/resolve.test.ts
+++ b/packages/core/paths/resolve.test.ts
@@ -19,24 +19,24 @@ function makeWs(slug: string): Workspace {
 }
 
 describe("resolvePostAuthDestination", () => {
-  it("not onboarded → /onboarding regardless of workspaces", () => {
-    expect(resolvePostAuthDestination([], false)).toBe(paths.onboarding());
-    expect(resolvePostAuthDestination([makeWs("acme")], false)).toBe(
-      paths.onboarding(),
-    );
-    expect(
-      resolvePostAuthDestination([makeWs("acme"), makeWs("beta")], false),
-    ).toBe(paths.onboarding());
-  });
-
-  it("onboarded + has workspace → /<first.slug>/issues", () => {
+  it("has workspace → /<first.slug>/issues regardless of onboarded state", () => {
     const ws = [makeWs("acme"), makeWs("beta")];
     expect(resolvePostAuthDestination(ws, true)).toBe(
       paths.workspace("acme").issues(),
     );
+    expect(resolvePostAuthDestination(ws, false)).toBe(
+      paths.workspace("acme").issues(),
+    );
+    expect(resolvePostAuthDestination([makeWs("acme")], false)).toBe(
+      paths.workspace("acme").issues(),
+    );
   });
 
-  it("onboarded + zero workspaces → /workspaces/new", () => {
+  it("zero workspaces + !onboarded → /onboarding", () => {
+    expect(resolvePostAuthDestination([], false)).toBe(paths.onboarding());
+  });
+
+  it("zero workspaces + onboarded → /workspaces/new", () => {
     expect(resolvePostAuthDestination([], true)).toBe(paths.newWorkspace());
   });
 });

--- a/packages/core/paths/resolve.ts
+++ b/packages/core/paths/resolve.ts
@@ -4,19 +4,23 @@ import { paths } from "./paths";
 
 /**
  * Priority:
- *   !hasOnboarded                         → /onboarding
- *   hasOnboarded && has workspace         → /<first.slug>/issues
- *   hasOnboarded && zero workspaces       → /workspaces/new
+ *   has workspace                         → /<first.slug>/issues
+ *   zero workspaces && !hasOnboarded      → /onboarding
+ *   zero workspaces && hasOnboarded       → /workspaces/new
+ *
+ * Workspace presence wins over onboarding state: a user invited into an
+ * existing workspace must NOT be bounced into the new-workspace wizard
+ * just because their personal `onboarded_at` is still null.
  */
 export function resolvePostAuthDestination(
   workspaces: Workspace[],
   hasOnboarded: boolean,
 ): string {
-  if (!hasOnboarded) {
-    return paths.onboarding();
-  }
   const first = workspaces[0];
-  return first ? paths.workspace(first.slug).issues() : paths.newWorkspace();
+  if (first) {
+    return paths.workspace(first.slug).issues();
+  }
+  return hasOnboarded ? paths.newWorkspace() : paths.onboarding();
 }
 
 /**

--- a/packages/views/layout/use-dashboard-guard.ts
+++ b/packages/views/layout/use-dashboard-guard.ts
@@ -21,8 +21,14 @@ import { useNavigation } from "../navigation";
  *  - Not logged in → /login
  *  - Logged in but workspace list not yet loaded → wait (don't bounce prematurely)
  *  - Logged in but URL slug doesn't resolve to any workspace →
- *    `resolvePostAuthDestination(list, hasOnboarded)` — onboarding for
- *    first-timers, /workspaces/new for returning users who deleted out.
+ *    `resolvePostAuthDestination(list, hasOnboarded)` — first workspace if any,
+ *    onboarding for first-timers, /workspaces/new for returning users who
+ *    deleted out.
+ *
+ * Onboarding is NOT a separate gate: a user invited into a workspace can have
+ * `onboarded_at == null` yet legitimately belong inside a workspace, and must
+ * not be bounced to the new-workspace wizard. The onboarding redirect only
+ * fires from the resolver when the user has zero workspaces.
  *
  * We read the workspace list query state directly (rather than relying on
  * useCurrentWorkspace's null return) so we can distinguish "list loading"
@@ -47,10 +53,6 @@ export function useDashboardGuard() {
       return;
     }
     if (!workspaceListFetched) return;
-    if (!hasOnboarded) {
-      replace(paths.onboarding());
-      return;
-    }
     if (!workspace) {
       replace(resolvePostAuthDestination(workspaces, hasOnboarded));
     }


### PR DESCRIPTION
## Summary

Fixes #1837. Workspace presence now wins over `onboarded_at` across every post-auth entry point, so a user invited into an existing workspace lands inside that workspace instead of being trapped in the new-workspace wizard.

The redesigned onboarding flow (#1411) intentionally flipped the priority during frontend development so every login re-entered `/onboarding`; the backend `onboarded_at` field shipped but the flipped priority was never restored.

- `packages/core/paths/resolve.ts` — has-workspace beats `!hasOnboarded`. Onboarding is reachable only when the user has zero workspaces.
- `apps/web/app/auth/callback/page.tsx` — drop the early return on `!onboarded` so a `next=/invite/<id>` survives Google OAuth round-trips.
- `apps/web/app/(auth)/login/page.tsx` — same removal in both the already-authenticated effect and the post-login handler.
- `packages/views/layout/use-dashboard-guard.ts` — stop bouncing in-workspace users to `/onboarding`; rely on the resolver for zero-workspace cases.
- `apps/desktop/src/renderer/src/App.tsx` — window-overlay opens onboarding only when `wsCount === 0 && !hasOnboarded`.
- `apps/web/app/(auth)/onboarding/page.tsx` — defense-in-depth: bounce away if the visitor already has a workspace, even on direct URL access.
- Test fix: `mockSearchParams.forEach + delete` was silently skipping entries (forEach advances index while the underlying list shrinks), letting `state=next:/invite/...` bleed across cases. Snapshot keys via `Array.from` before deleting and rewrite assertions for the new policy.

## Test plan

- [x] `@multica/core` typecheck — clean
- [x] `@multica/views` typecheck — clean
- [x] `apps/web` typecheck — clean
- [x] `apps/desktop` typecheck — clean
- [x] `@multica/core` unit tests — 134/134
- [x] `@multica/views` unit tests — 228/228
- [x] `apps/web` unit tests — 18/18 (incl. 5 callback cases covering: invitee with `next=/invite/...`, unonboarded + zero workspaces → `/onboarding`, unonboarded + has workspace → workspace, onboarded + unsafe `next=` rejected, onboarded + safe `next=` honored)
- [x] `apps/desktop` unit tests — 77/77
- [ ] Manual: invite a brand-new user into an existing workspace and verify they land in that workspace after login (no onboarding detour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)