### PR TITLE
fix(views): remove redundant issue ID from breadcrumb

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -506,9 +506,6 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                 <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
               </>
             )}
-            <span className="shrink-0 text-muted-foreground">
-              {issue.identifier}
-            </span>
             <span className="truncate font-medium text-foreground">
               {issue.title}
             </span>


### PR DESCRIPTION
## Summary

- Removed the redundant `issue.identifier` span from the breadcrumb in the issue detail page
- Previously the breadcrumb showed: `Workspace > MUL-1562 > MUL-1567 Title` — the issue ID appeared as a separate element before the title
- Now it shows: `Workspace > MUL-1562 > Title` — cleaner, no duplication

Fixes MUL-1577.

## Test plan

- [ ] Open an issue detail page and verify the breadcrumb no longer shows the issue ID separately
- [ ] Verify sub-issues still show the parent issue ID as a link in the breadcrumb