### PR TITLE
fix(inbox): improve quick-create notification to show issue title prominently

### DIFF
--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -88,6 +88,11 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
       if (emoji) return <span>Reacted {emoji} to your comment</span>;
       return <span>{typeLabels[item.type]}</span>;
     }
+    case "quick_create_done": {
+      const identifier = details.identifier;
+      if (identifier) return <span>Created {identifier}</span>;
+      return <span>{typeLabels[item.type]}</span>;
+    }
     default:
       return <span>{typeLabels[item.type] ?? item.type}</span>;
   }

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1436,7 +1436,7 @@ func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.Ag
 		Type:          "quick_create_done",
 		Severity:      "info",
 		IssueID:       issue.ID,
-		Title:         fmt.Sprintf("Created %s: %s", identifier, issue.Title),
+		Title:         issue.Title,
 		Body:          pgtype.Text{},
 		ActorType:     pgtype.Text{String: "agent", Valid: true},
 		ActorID:       task.AgentID,


### PR DESCRIPTION
## Summary
- **Title** now shows just the issue title (e.g. "Fix login redirect") instead of "Created MUL-1577: Fix login redirect" — prevents truncation from hiding the most useful information
- **Detail label** now shows "Created MUL-1577" instead of generic "Quick create done" — gives the identifier context below the title

Fixes [MUL-1578](mention://issue/5f3ba123-be6f-40c8-828f-c626c49c94da)

## Changes
- `server/internal/service/task.go`: Inbox item title set to `issue.Title` instead of `fmt.Sprintf("Created %s: %s", identifier, issue.Title)`
- `packages/views/inbox/components/inbox-detail-label.tsx`: Added `quick_create_done` case to show "Created MUL-XXXX" from `details.identifier`

## Test plan
- [ ] Quick-create an issue and verify the inbox notification shows the issue title as the main text
- [ ] Verify the detail label below shows "Created MUL-XXXX" with the correct identifier
- [ ] Verify clicking the notification still navigates to the correct issue