### PR TITLE
fix(views): stop showing hardcoded model name in default model display

### DIFF
--- a/packages/views/agents/components/inspector/model-picker.tsx
+++ b/packages/views/agents/components/inspector/model-picker.tsx
@@ -78,9 +78,7 @@ export function ModelPicker({
     );
   }
 
-  const triggerLabel =
-    value ||
-    (defaultModel ? `Default — ${defaultModel.label}` : "Default");
+  const triggerLabel = value || "Default";
   const triggerTitle = `Model · ${triggerLabel}`;
 
   return (

--- a/packages/views/agents/components/model-dropdown.tsx
+++ b/packages/views/agents/components/model-dropdown.tsx
@@ -42,7 +42,6 @@ export function ModelDropdown({
 
   const supported = modelsQuery.data?.supported ?? true;
   const models = modelsQuery.data?.models ?? [];
-  const defaultModel = useMemo(() => models.find((m) => m.default), [models]);
   const grouped = useMemo(() => groupByProvider(models), [models]);
 
   // When the selected runtime reports it doesn't support per-agent
@@ -86,9 +85,7 @@ export function ModelDropdown({
     (disabled
       ? "Select a runtime first"
       : runtimeOnline
-        ? defaultModel
-          ? `Default — ${defaultModel.label}`
-          : "Default (provider)"
+        ? "Default (provider)"
         : "Runtime offline — enter manually");
 
   if (!supported && !modelsQuery.isLoading) {


### PR DESCRIPTION
## Summary
- When no model is explicitly selected for an agent, the model dropdown previously showed "Default — Claude Sonnet 4.6" (hardcoded from `claudeStaticModels()`). This could mislead users when the actual CLI default differs.
- Now shows "Default (provider)" in the create-agent dialog and "Default" in the inspector picker — no specific model name.
- The "default" badge on individual model entries inside the dropdown list is preserved.

## Changes
- `packages/views/agents/components/model-dropdown.tsx` — removed `defaultModel` variable and simplified trigger label
- `packages/views/agents/components/inspector/model-picker.tsx` — simplified trigger label

Closes MUL-1580