### PR TITLE
fix(realtime): add SSE fallback for blocked WebSockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ _features/
 
 # runtime
 *.pid
+backups/
+deploy/certs/
 
 # platform specific
 *.dmg

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -237,6 +237,19 @@ server {
         proxy_set_header Host $host;
         proxy_read_timeout 86400;
     }
+
+    # SSE fallback for clients/proxies that cannot use WebSocket Upgrade
+    location /sse {
+        proxy_pass http://localhost:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400;
+    }
 }
 ```
 
@@ -271,9 +284,9 @@ docker compose -f docker-compose.selfhost.yml up -d
 
 ### WebSocket for LAN / Non-localhost Access
 
-HTTP requests (issues, comments, uploads) work on LAN out of the box — Next.js rewrites proxy `/api`, `/auth`, and `/uploads` to the backend. **WebSockets do not**: Next.js rewrites only forward HTTP requests, not the `Upgrade` handshake a WebSocket needs. If you open the app on `http://<lan-ip>:3000`, real-time features (chat streaming, live issue updates, notifications) will fail to connect until you do one of the following:
+HTTP requests (issues, comments, uploads) work on LAN out of the box — Next.js rewrites proxy `/api`, `/auth`, `/uploads`, and the HTTP `/sse` fallback to the backend. **WebSockets do not**: Next.js rewrites only forward HTTP requests, not the `Upgrade` handshake a WebSocket needs. If you open the app on `http://<lan-ip>:3000`, real-time features (chat streaming, live issue updates, notifications) will fail to connect until you do one of the following:
 
-1. **Put a reverse proxy in front of the stack (recommended).** Nginx or Caddy terminates the WebSocket upgrade and forwards it to the backend on port 8080. See the [Reverse Proxy](#reverse-proxy) section above — the Nginx example already includes a `location /ws { ... }` block with the correct `Upgrade` / `Connection` headers. Once a proxy is in place the browser connects directly through it, so no frontend rebuild is needed.
+1. **Put a reverse proxy in front of the stack (recommended).** Nginx or Caddy terminates the WebSocket upgrade and forwards it to the backend on port 8080. See the [Reverse Proxy](#reverse-proxy) section above — the Nginx example already includes a `location /ws { ... }` block with the correct `Upgrade` / `Connection` headers. If a client-side network blocks WebSocket Upgrade entirely, the web client automatically falls back to the backend's HTTP Server-Sent Events stream at `/sse`; reverse proxies should forward `/sse` to the backend with buffering disabled (`proxy_buffering off` in Nginx) so events are delivered promptly. The fallback is receive-only: it receives the same workspace/user event stream as the current browser UI, but browser-to-server realtime control frames still require WebSocket. Once a proxy is in place the browser connects directly through it, so no frontend rebuild is needed.
 
 2. **Bake a WebSocket URL into the web image.** If you are not running a reverse proxy, rebuild the web image with `NEXT_PUBLIC_WS_URL` pointing straight at the backend (port 8080 must be reachable from the browser):
 

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -11,6 +11,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: [
           "/api/",
           "/ws",
+          "/sse",
           "/auth/",
           "/issues",
           "/board",

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -56,6 +56,10 @@ const nextConfig: NextConfig = {
           destination: `${remoteApiUrl}/ws`,
         },
         {
+          source: "/sse",
+          destination: `${remoteApiUrl}/sse`,
+        },
+        {
           source: "/auth/:path*",
           destination: `${remoteApiUrl}/auth/:path*`,
         },

--- a/apps/web/robots.test.ts
+++ b/apps/web/robots.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import robots from "./app/robots";
+
+describe("robots", () => {
+  it("disallows realtime transport endpoints", () => {
+    const config = robots();
+    const rules = Array.isArray(config.rules) ? config.rules[0] : config.rules;
+    expect(rules?.disallow).toEqual(expect.arrayContaining(["/ws", "/sse"]));
+  });
+});

--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -6,6 +6,7 @@ import { WSClient } from "./ws-client";
 // upgrade URL construction, which is what carries client identity.
 class FakeWebSocket {
   static lastUrl: string | null = null;
+  static instances: FakeWebSocket[] = [];
   // Fields read by WSClient.connect()/disconnect(), all no-op here.
   onopen: (() => void) | null = null;
   onmessage: ((ev: { data: string }) => void) | null = null;
@@ -14,6 +15,7 @@ class FakeWebSocket {
   readyState = 0;
   constructor(url: string) {
     FakeWebSocket.lastUrl = url;
+    FakeWebSocket.instances.push(this);
   }
   close() {}
   send() {}
@@ -22,6 +24,7 @@ class FakeWebSocket {
 describe("WSClient", () => {
   beforeEach(() => {
     FakeWebSocket.lastUrl = null;
+    FakeWebSocket.instances = [];
     vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
   });
 
@@ -68,5 +71,89 @@ describe("WSClient", () => {
     expect(url.searchParams.get("client_platform")).toBe("cli");
     expect(url.searchParams.has("client_version")).toBe(false);
     expect(url.searchParams.has("client_os")).toBe(false);
+  });
+
+  it("falls back to an authenticated HTTP SSE stream when the initial WebSocket closes before auth", async () => {
+    const fetchMock = vi.fn(() => new Promise<Response>(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ws = new WSClient("wss://api.example.test/ws", {
+      identity: { platform: "web" },
+    });
+    ws.setAuth("secret-token", "acme");
+    ws.connect();
+
+    FakeWebSocket.instances[0]!.onclose?.();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0]! as unknown as [
+      string,
+      RequestInit,
+    ];
+    const sseURL = new URL(url);
+    expect(sseURL.protocol).toBe("https:");
+    expect(sseURL.pathname).toBe("/sse");
+    expect(sseURL.searchParams.get("workspace_slug")).toBe("acme");
+    expect(sseURL.searchParams.get("client_platform")).toBe("web");
+    expect(init.headers).toMatchObject({
+      Accept: "text/event-stream",
+      Authorization: "Bearer secret-token",
+    });
+    expect(init.credentials).toBe("same-origin");
+
+    ws.disconnect();
+  });
+
+  it("uses cookie credentials for the SSE fallback in cookie-auth mode", async () => {
+    const fetchMock = vi.fn(() => new Promise<Response>(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ws = new WSClient("ws://api.example.test/ws", { cookieAuth: true });
+    ws.setAuth(null, "acme");
+    ws.connect();
+
+    FakeWebSocket.instances[0]!.onclose?.();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0]! as unknown as [
+      string,
+      RequestInit,
+    ];
+    const sseURL = new URL(url);
+    expect(sseURL.protocol).toBe("http:");
+    expect(sseURL.pathname).toBe("/sse");
+    expect(init.headers).toMatchObject({ Accept: "text/event-stream" });
+    expect(init.headers).not.toHaveProperty("Authorization");
+    expect(init.credentials).toBe("include");
+
+    ws.disconnect();
+  });
+
+  it("warns instead of silently dropping sends while using receive-only SSE", async () => {
+    const fetchMock = vi.fn(() => new Promise<Response>(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+    const warn = vi.fn();
+
+    const ws = new WSClient("wss://api.example.test/ws", {
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn,
+        error: vi.fn(),
+      },
+    });
+    ws.setAuth("secret-token", "acme");
+    ws.connect();
+
+    FakeWebSocket.instances[0]!.onclose?.();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    ws.send({ type: "subscribe", payload: {} } as never);
+    expect(warn).toHaveBeenCalledWith(
+      "cannot send realtime frame while using receive-only SSE fallback",
+      "subscribe",
+    );
+
+    ws.disconnect();
   });
 });

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -15,6 +15,7 @@ export interface WSClientIdentity {
 
 export class WSClient {
   private ws: WebSocket | null = null;
+  private sseAbort: AbortController | null = null;
   private baseUrl: string;
   private token: string | null = null;
   private workspaceSlug: string | null = null;
@@ -23,6 +24,8 @@ export class WSClient {
   private handlers = new Map<WSEventType, Set<EventHandler>>();
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private hasConnectedBefore = false;
+  private closed = false;
+  private usingEventStream = false;
   private onReconnectCallbacks = new Set<() => void>();
   private anyHandlers = new Set<(msg: WSMessage) => void>();
   private logger: Logger;
@@ -47,6 +50,11 @@ export class WSClient {
   }
 
   connect() {
+    this.closed = false;
+    this.connectWebSocket();
+  }
+
+  private websocketURL() {
     const url = new URL(this.baseUrl);
     // Token is never sent as a URL query parameter — it would be logged by
     // proxies, CDNs, and browser history.  In cookie mode the HttpOnly cookie
@@ -60,8 +68,32 @@ export class WSClient {
       url.searchParams.set("client_version", this.identity.version);
     if (this.identity?.os)
       url.searchParams.set("client_os", this.identity.os);
+    return url;
+  }
 
-    this.ws = new WebSocket(url.toString());
+  private eventStreamURL() {
+    const url = this.websocketURL();
+    url.protocol = url.protocol === "wss:" ? "https:" : "http:";
+    if (url.pathname.endsWith("/ws")) {
+      url.pathname = url.pathname.slice(0, -"/ws".length) + "/sse";
+    } else {
+      url.pathname = url.pathname.replace(/\/$/, "") + "/sse";
+    }
+    return url;
+  }
+
+  private connectWebSocket() {
+    if (this.closed) return;
+    this.usingEventStream = false;
+    const url = this.websocketURL();
+
+    try {
+      this.ws = new WebSocket(url.toString());
+    } catch (error) {
+      this.logger.warn("websocket unavailable, falling back to SSE", error);
+      this.connectEventStream();
+      return;
+    }
 
     this.ws.onopen = () => {
       if (!this.cookieAuth && this.token) {
@@ -76,31 +108,117 @@ export class WSClient {
 
     this.ws.onmessage = (event) => {
       const msg = JSON.parse(event.data as string) as WSMessage;
-      if ((msg as any).type === "auth_ack") {
-        this.onAuthenticated();
-        return;
-      }
-      this.logger.debug("received", msg.type);
-      const eventHandlers = this.handlers.get(msg.type);
-      if (eventHandlers) {
-        for (const handler of eventHandlers) {
-          handler(msg.payload, msg.actor_id);
-        }
-      }
-      for (const handler of this.anyHandlers) {
-        handler(msg);
-      }
+      this.handleMessage(msg);
     };
 
     this.ws.onclose = () => {
+      this.ws = null;
+      if (this.closed) return;
+      if (!this.hasConnectedBefore) {
+        this.logger.warn("websocket unavailable, falling back to SSE");
+        this.connectEventStream();
+        return;
+      }
       this.logger.warn("disconnected, reconnecting in 3s");
-      this.reconnectTimer = setTimeout(() => this.connect(), 3000);
+      this.reconnectTimer = setTimeout(() => this.connectWebSocket(), 3000);
     };
 
     this.ws.onerror = () => {
-      // Suppress — onclose handles reconnect; errors during StrictMode
+      // Suppress — onclose handles reconnect/fallback; errors during StrictMode
       // double-fire are expected in dev and harmless.
     };
+  }
+
+  private connectEventStream() {
+    if (this.closed) return;
+    if (!this.cookieAuth && !this.token) return;
+
+    const controller = new AbortController();
+    this.sseAbort = controller;
+    this.usingEventStream = true;
+
+    const headers: Record<string, string> = { Accept: "text/event-stream" };
+    if (!this.cookieAuth && this.token) {
+      headers.Authorization = `Bearer ${this.token}`;
+    }
+
+    fetch(this.eventStreamURL().toString(), {
+      method: "GET",
+      headers,
+      credentials: this.cookieAuth ? "include" : "same-origin",
+      signal: controller.signal,
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`SSE connection failed with ${response.status}`);
+        }
+        if (!response.body) {
+          throw new Error("SSE response body is empty");
+        }
+        return this.readEventStream(response.body);
+      })
+      .catch((error) => {
+        if (this.closed || controller.signal.aborted) return;
+        this.logger.warn("SSE disconnected, reconnecting in 3s", error);
+        this.reconnectTimer = setTimeout(() => this.connectEventStream(), 3000);
+      });
+  }
+
+  private async readEventStream(body: ReadableStream<Uint8Array>) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        let boundary = buffer.indexOf("\n\n");
+        while (boundary !== -1) {
+          const rawEvent = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+          this.handleEventStreamFrame(rawEvent);
+          boundary = buffer.indexOf("\n\n");
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    if (!this.closed) {
+      throw new Error("SSE stream ended");
+    }
+  }
+
+  private handleEventStreamFrame(rawEvent: string) {
+    const data = rawEvent
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice("data:".length).trimStart())
+      .join("\n");
+
+    if (!data) return;
+    const msg = JSON.parse(data) as WSMessage;
+    this.handleMessage(msg);
+  }
+
+  private handleMessage(msg: WSMessage) {
+    if ((msg as any).type === "auth_ack") {
+      this.onAuthenticated();
+      return;
+    }
+    this.logger.debug("received", msg.type);
+    const eventHandlers = this.handlers.get(msg.type);
+    if (eventHandlers) {
+      for (const handler of eventHandlers) {
+        handler(msg.payload, msg.actor_id);
+      }
+    }
+    for (const handler of this.anyHandlers) {
+      handler(msg);
+    }
   }
 
   private onAuthenticated() {
@@ -118,9 +236,14 @@ export class WSClient {
   }
 
   disconnect() {
+    this.closed = true;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+    if (this.sseAbort) {
+      this.sseAbort.abort();
+      this.sseAbort = null;
     }
     if (this.ws) {
       // Remove handlers before close to prevent onclose from scheduling a reconnect
@@ -130,6 +253,7 @@ export class WSClient {
       this.ws = null;
     }
     this.hasConnectedBefore = false;
+    this.usingEventStream = false;
     this.handlers.clear();
     this.anyHandlers.clear();
     this.onReconnectCallbacks.clear();
@@ -160,8 +284,16 @@ export class WSClient {
   }
 
   send(message: WSMessage) {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(message));
+    const ws = this.ws;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(message));
+      return;
+    }
+    if (this.usingEventStream) {
+      this.logger.warn(
+        "cannot send realtime frame while using receive-only SSE fallback",
+        message.type,
+      );
     }
   }
 }

--- a/packages/core/paths/reserved-slugs.ts
+++ b/packages/core/paths/reserved-slugs.ts
@@ -85,7 +85,7 @@ export const RESERVED_SLUGS = new Set([
   "tokens",
   "cli",
 
-  // Backend ops / observability. `/health`, `/readyz`, `/healthz`, and `/ws`
+  // Backend ops / observability. `/health`, `/readyz`, `/healthz`, `/ws`, and `/sse`
   // exist on the backend
   // host; reserving them on the workspace slug space prevents naming
   // confusion if/when these paths are ever proxied through the web origin.
@@ -93,6 +93,7 @@ export const RESERVED_SLUGS = new Set([
   "readyz",
   "healthz",
   "ws",
+  "sse",
   "metrics",
   "ping",
 

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -163,6 +163,10 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	r.Get("/ws", func(w http.ResponseWriter, r *http.Request) {
 		realtime.HandleWebSocket(hub, mc, pr, slugResolver, w, r)
 	})
+	// HTTP streaming fallback for clients behind proxies that block WebSocket Upgrade.
+	r.Get("/sse", func(w http.ResponseWriter, r *http.Request) {
+		realtime.HandleEventStream(hub, mc, pr, slugResolver, w, r)
+	})
 
 	// Local file serving (when using local storage)
 	if local, ok := store.(*storage.LocalStorage); ok {

--- a/server/internal/handler/workspace_reserved_slugs.go
+++ b/server/internal/handler/workspace_reserved_slugs.go
@@ -84,7 +84,7 @@ var reservedSlugs = map[string]bool{
 	"tokens":   true,
 	"cli":      true,
 
-	// Backend ops / observability. `/health`, `/readyz`, `/healthz`, and `/ws`
+	// Backend ops / observability. `/health`, `/readyz`, `/healthz`, `/ws`, and `/sse`
 	// exist on the backend
 	// host; reserving them on the workspace slug space prevents naming
 	// confusion if/when these paths are ever proxied through the web origin.
@@ -92,6 +92,7 @@ var reservedSlugs = map[string]bool{
 	"readyz":  true,
 	"healthz": true,
 	"ws":      true,
+	"sse":     true,
 	"metrics": true,
 	"ping":    true,
 

--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -601,6 +601,35 @@ func authenticateToken(tokenStr string, pr PATResolver, ctx context.Context) (st
 	return uid, ""
 }
 
+func bearerToken(r *http.Request) string {
+	authz := strings.TrimSpace(r.Header.Get("Authorization"))
+	if authz == "" {
+		return ""
+	}
+	parts := strings.SplitN(authz, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+func resolveWorkspaceID(r *http.Request, resolveSlug SlugResolver) (string, int, string) {
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if workspaceID == "" {
+		if slug := r.URL.Query().Get("workspace_slug"); slug != "" && resolveSlug != nil {
+			resolved, err := resolveSlug(r.Context(), slug)
+			if err != nil {
+				return "", http.StatusNotFound, `{"error":"workspace not found"}`
+			}
+			workspaceID = resolved
+		}
+	}
+	if workspaceID == "" {
+		return "", http.StatusBadRequest, `{"error":"workspace_id or workspace_slug required"}`
+	}
+	return workspaceID, 0, ""
+}
+
 // firstMessageAuth reads the first WebSocket message expecting an auth payload.
 func firstMessageAuth(conn *websocket.Conn) (string, string) {
 	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
@@ -624,22 +653,117 @@ func firstMessageAuth(conn *websocket.Conn) (string, string) {
 	return msg.Payload.Token, ""
 }
 
+// HandleEventStream opens an HTTP Server-Sent Events stream for clients that
+// cannot use WebSocket upgrades. It mirrors the WebSocket connection model:
+// cookie or Authorization Bearer auth, membership check, and automatic
+// workspace/user scope subscriptions.
+func HandleEventStream(hub *Hub, mc MembershipChecker, pr PATResolver, resolveSlug SlugResolver, w http.ResponseWriter, r *http.Request) {
+	workspaceID, status, errMsg := resolveWorkspaceID(r, resolveSlug)
+	if errMsg != "" {
+		http.Error(w, errMsg, status)
+		return
+	}
+
+	var tokenStr string
+	if cookie, err := r.Cookie(auth.AuthCookieName); err == nil && cookie.Value != "" {
+		tokenStr = cookie.Value
+	} else {
+		tokenStr = bearerToken(r)
+	}
+	if tokenStr == "" {
+		http.Error(w, `{"error":"missing token"}`, http.StatusUnauthorized)
+		return
+	}
+
+	userID, errMsg := authenticateToken(tokenStr, pr, r.Context())
+	if errMsg != "" {
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		return
+	}
+	if !mc.IsMember(r.Context(), userID, workspaceID) {
+		http.Error(w, `{"error":"not a member of this workspace"}`, http.StatusForbidden)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, `{"error":"streaming unsupported"}`, http.StatusInternalServerError)
+		return
+	}
+
+	header := w.Header()
+	header.Set("Content-Type", "text/event-stream; charset=utf-8")
+	header.Set("Cache-Control", "no-cache, no-transform")
+	header.Set("Connection", "keep-alive")
+	header.Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	client := &Client{
+		hub:         hub,
+		send:        make(chan []byte, 256),
+		userID:      userID,
+		workspaceID: workspaceID,
+	}
+	hub.register <- client
+	defer func() { hub.unregister <- client }()
+
+	clientPlatform := r.URL.Query().Get("client_platform")
+	clientVersion := r.URL.Query().Get("client_version")
+	clientOS := r.URL.Query().Get("client_os")
+	slog.Info("sse client connected",
+		"user_id", userID,
+		"workspace_id", workspaceID,
+		"client_platform", clientPlatform,
+		"client_version", clientVersion,
+		"client_os", clientOS,
+	)
+
+	writeSSE := func(data []byte) bool {
+		if _, err := w.Write([]byte("data: ")); err != nil {
+			return false
+		}
+		if _, err := w.Write(data); err != nil {
+			return false
+		}
+		if _, err := w.Write([]byte("\n\n")); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	if !writeSSE([]byte(`{"type":"auth_ack"}`)) {
+		return
+	}
+
+	keepalive := time.NewTicker(25 * time.Second)
+	defer keepalive.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case msg, ok := <-client.send:
+			if !ok {
+				return
+			}
+			if !writeSSE(msg) {
+				return
+			}
+		case <-keepalive.C:
+			if _, err := w.Write([]byte(": keepalive\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
 // HandleWebSocket upgrades an HTTP connection to WebSocket with cookie or
 // first-message auth.
 func HandleWebSocket(hub *Hub, mc MembershipChecker, pr PATResolver, resolveSlug SlugResolver, w http.ResponseWriter, r *http.Request) {
-	workspaceID := r.URL.Query().Get("workspace_id")
-	if workspaceID == "" {
-		if slug := r.URL.Query().Get("workspace_slug"); slug != "" && resolveSlug != nil {
-			resolved, err := resolveSlug(r.Context(), slug)
-			if err != nil {
-				http.Error(w, `{"error":"workspace not found"}`, http.StatusNotFound)
-				return
-			}
-			workspaceID = resolved
-		}
-	}
-	if workspaceID == "" {
-		http.Error(w, `{"error":"workspace_id or workspace_slug required"}`, http.StatusBadRequest)
+	workspaceID, status, errMsg := resolveWorkspaceID(r, resolveSlug)
+	if errMsg != "" {
+		http.Error(w, errMsg, status)
 		return
 	}
 

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -1,6 +1,7 @@
 package realtime
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -49,6 +50,9 @@ func newTestHub(t *testing.T) (*Hub, *httptest.Server) {
 	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		HandleWebSocket(hub, mc, nil, nil, w, r)
 	})
+	mux.HandleFunc("/sse", func(w http.ResponseWriter, r *http.Request) {
+		HandleEventStream(hub, mc, nil, nil, w, r)
+	})
 	server := httptest.NewServer(mux)
 	return hub, server
 }
@@ -86,6 +90,81 @@ func totalClients(hub *Hub) int {
 	hub.mu.RLock()
 	defer hub.mu.RUnlock()
 	return len(hub.clients)
+}
+
+func connectSSE(t *testing.T, server *httptest.Server) (*http.Response, *bufio.Reader) {
+	t.Helper()
+	token := makeTestToken(t)
+	sseURL := server.URL + "/sse?workspace_id=" + testWorkspaceID
+	req, err := http.NewRequest(http.MethodGet, sseURL, nil)
+	if err != nil {
+		t.Fatalf("new SSE request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("connect SSE: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		t.Fatalf("SSE status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		resp.Body.Close()
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	return resp, bufio.NewReader(resp.Body)
+}
+
+func readSSEData(t *testing.T, reader *bufio.Reader) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read SSE line: %v", err)
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "data: ") {
+			return strings.TrimPrefix(line, "data: ")
+		}
+	}
+	t.Fatalf("timed out waiting for SSE data")
+	return ""
+}
+
+func TestHub_EventStreamBroadcastToWorkspace(t *testing.T) {
+	hub, server := newTestHub(t)
+	defer server.Close()
+
+	resp, reader := connectSSE(t, server)
+	defer resp.Body.Close()
+
+	if data := readSSEData(t, reader); !strings.Contains(data, "auth_ack") {
+		t.Fatalf("expected initial auth_ack event, got %s", data)
+	}
+
+	msg := []byte(`{"type":"issue:created","data":"test"}`)
+	hub.BroadcastToWorkspace(testWorkspaceID, msg)
+
+	if data := readSSEData(t, reader); data != string(msg) {
+		t.Fatalf("expected SSE message %s, got %s", msg, data)
+	}
+}
+
+func TestHub_EventStreamRequiresAuth(t *testing.T) {
+	_, server := newTestHub(t)
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/sse?workspace_id=" + testWorkspaceID)
+	if err != nil {
+		t.Fatalf("GET /sse: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
 }
 
 func TestHub_ClientRegistration(t *testing.T) {
@@ -228,86 +307,86 @@ func TestHub_MultipleBroadcasts(t *testing.T) {
 // headers on WS upgrades, so this query-param channel is the only way to
 // preserve the same observability dimensions HTTP clients get via X-Client-*.
 func TestHandleWebSocket_ClientIdentityFromQuery(t *testing.T) {
-var buf bytes.Buffer
-var mu sync.Mutex
-handler := slog.NewJSONHandler(&lockedWriter{w: &buf, mu: &mu}, &slog.HandlerOptions{Level: slog.LevelDebug})
-prevDefault := slog.Default()
-slog.SetDefault(slog.New(handler))
-t.Cleanup(func() { slog.SetDefault(prevDefault) })
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	handler := slog.NewJSONHandler(&lockedWriter{w: &buf, mu: &mu}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
 
-_, server := newTestHub(t)
-defer server.Close()
+	_, server := newTestHub(t)
+	defer server.Close()
 
-token := makeTestToken(t)
-wsURL := "ws" + strings.TrimPrefix(server.URL, "http") +
-"/ws?workspace_id=" + testWorkspaceID +
-"&client_platform=desktop&client_version=1.2.3&client_os=macos"
-conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
-if err != nil {
-t.Fatalf("dial: %v", err)
-}
-defer conn.Close()
+	token := makeTestToken(t)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/ws?workspace_id=" + testWorkspaceID +
+		"&client_platform=desktop&client_version=1.2.3&client_os=macos"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
 
-authMsg, _ := json.Marshal(map[string]any{
-"type":    "auth",
-"payload": map[string]string{"token": token},
-})
-if err := conn.WriteMessage(websocket.TextMessage, authMsg); err != nil {
-t.Fatalf("write auth: %v", err)
-}
-conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-if _, _, err := conn.ReadMessage(); err != nil {
-t.Fatalf("read auth_ack: %v", err)
-}
+	authMsg, _ := json.Marshal(map[string]any{
+		"type":    "auth",
+		"payload": map[string]string{"token": token},
+	})
+	if err := conn.WriteMessage(websocket.TextMessage, authMsg); err != nil {
+		t.Fatalf("write auth: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read auth_ack: %v", err)
+	}
 
-// Wait briefly for the "websocket connected" log line to be flushed.
-deadline := time.Now().Add(2 * time.Second)
-var found map[string]any
-for time.Now().Before(deadline) {
-mu.Lock()
-raw := buf.String()
-mu.Unlock()
-for _, line := range strings.Split(raw, "\n") {
-if line == "" {
-continue
-}
-var entry map[string]any
-if err := json.Unmarshal([]byte(line), &entry); err != nil {
-continue
-}
-if msg, _ := entry["msg"].(string); msg == "websocket connected" {
-found = entry
-break
-}
-}
-if found != nil {
-break
-}
-time.Sleep(20 * time.Millisecond)
-}
+	// Wait briefly for the "websocket connected" log line to be flushed.
+	deadline := time.Now().Add(2 * time.Second)
+	var found map[string]any
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		raw := buf.String()
+		mu.Unlock()
+		for _, line := range strings.Split(raw, "\n") {
+			if line == "" {
+				continue
+			}
+			var entry map[string]any
+			if err := json.Unmarshal([]byte(line), &entry); err != nil {
+				continue
+			}
+			if msg, _ := entry["msg"].(string); msg == "websocket connected" {
+				found = entry
+				break
+			}
+		}
+		if found != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 
-if found == nil {
-t.Fatalf("did not observe \"websocket connected\" log entry; buffered logs:\n%s", buf.String())
-}
-if got, _ := found["client_platform"].(string); got != "desktop" {
-t.Errorf("client_platform = %q, want %q", got, "desktop")
-}
-if got, _ := found["client_version"].(string); got != "1.2.3" {
-t.Errorf("client_version = %q, want %q", got, "1.2.3")
-}
-if got, _ := found["client_os"].(string); got != "macos" {
-t.Errorf("client_os = %q, want %q", got, "macos")
-}
+	if found == nil {
+		t.Fatalf("did not observe \"websocket connected\" log entry; buffered logs:\n%s", buf.String())
+	}
+	if got, _ := found["client_platform"].(string); got != "desktop" {
+		t.Errorf("client_platform = %q, want %q", got, "desktop")
+	}
+	if got, _ := found["client_version"].(string); got != "1.2.3" {
+		t.Errorf("client_version = %q, want %q", got, "1.2.3")
+	}
+	if got, _ := found["client_os"].(string); got != "macos" {
+		t.Errorf("client_os = %q, want %q", got, "macos")
+	}
 }
 
 // lockedWriter is a thread-safe writer used to capture concurrent slog output.
 type lockedWriter struct {
-w  *bytes.Buffer
-mu *sync.Mutex
+	w  *bytes.Buffer
+	mu *sync.Mutex
 }
 
 func (l *lockedWriter) Write(p []byte) (int, error) {
-l.mu.Lock()
-defer l.mu.Unlock()
-return l.w.Write(p)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
 }


### PR DESCRIPTION
## Summary
- Add authenticated `/sse` endpoint as a receive-only fallback for clients/proxies that block WebSocket Upgrade
- Make the web realtime client fall back from the initial WebSocket connection to fetch-based SSE with bearer/cookie auth
- Reserve and proxy `/sse`, disallow it in robots.txt, and document reverse-proxy buffering requirements

## Test Plan
- `git diff --check`
- `pnpm --filter @multica/core test -- api/ws-client.test.ts`
- `pnpm --filter @multica/web test -- robots.test.ts`
- `docker run --rm -v "$PWD/server:/src" -w /src golang:1.26-alpine sh -lc 'test -z "$(/usr/local/go/bin/gofmt -l cmd/server/router.go internal/handler/workspace_reserved_slugs.go internal/realtime/hub.go internal/realtime/hub_test.go)"'`
- `docker run --rm -v "$PWD/server:/src" -w /src golang:1.26-alpine sh -lc '/usr/local/go/bin/go test ./internal/realtime -count=1'`