### PR TITLE
fix(ci): restore frontend checks

### DIFF
--- a/apps/desktop/test/setup.ts
+++ b/apps/desktop/test/setup.ts
@@ -1,1 +1,38 @@
 import "@testing-library/jest-dom/vitest";
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+}
+
+const localStorageIsUsable =
+  typeof globalThis.localStorage?.getItem === "function" &&
+  typeof globalThis.localStorage?.setItem === "function" &&
+  typeof globalThis.localStorage?.removeItem === "function" &&
+  typeof globalThis.localStorage?.clear === "function";
+
+if (!localStorageIsUsable) {
+  const storage = createMemoryStorage();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}

--- a/packages/views/agents/components/inspector/model-picker.tsx
+++ b/packages/views/agents/components/inspector/model-picker.tsx
@@ -41,13 +41,12 @@ export function ModelPicker({
   );
   const supported = modelsQuery.data?.supported ?? true;
   // Memoise the model list so every downstream useMemo gets a stable
-  // reference — `?? []` would mint a fresh array on every render and
-  // invalidate filters / defaultModel needlessly.
+  // reference; `?? []` would mint a fresh array on every render and
+  // invalidate filters needlessly.
   const models = useMemo(
     () => modelsQuery.data?.models ?? [],
     [modelsQuery.data],
   );
-  const defaultModel = useMemo(() => models.find((m) => m.default), [models]);
 
   const filtered = useMemo(() => {
     const s = search.trim().toLowerCase();

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["src/**", "app/**", "**/*.ts", "**/*.tsx", "**/*.css"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", "out/**"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
- remove the stale `defaultModel` computation left behind by the default model display change so `@multica/views` typecheck passes
- add a memory `localStorage` shim for desktop Vitest setup so Zustand persisted tab tests can run in jsdom
- include desktop `out/**` artifacts in turbo build outputs so the desktop build task no longer warns about missing outputs

## Verification
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/desktop test`
- `pnpm exec turbo build typecheck test --filter='!@multica/docs'`

Context: MUL-1581
