### PR TITLE
Refine Quick Create agent modal

### DIFF
--- a/packages/ui/components/common/file-upload-button.tsx
+++ b/packages/ui/components/common/file-upload-button.tsx
@@ -36,6 +36,8 @@ function FileUploadButton({
         type="button"
         onClick={() => inputRef.current?.click()}
         disabled={disabled}
+        aria-label="Attach file"
+        title="Attach file"
         className={cn(
           "inline-flex items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-50 disabled:pointer-events-none",
           btnSize,

--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -9,6 +9,7 @@ const mockCreateIssue = vi.hoisted(() => vi.fn());
 const mockSetDraft = vi.hoisted(() => vi.fn());
 const mockClearDraft = vi.hoisted(() => vi.fn());
 const mockSetLastAssignee = vi.hoisted(() => vi.fn());
+const mockSetKeepOpen = vi.hoisted(() => vi.fn());
 const mockToastCustom = vi.hoisted(() => vi.fn());
 const mockToastDismiss = vi.hoisted(() => vi.fn());
 const mockToastError = vi.hoisted(() => vi.fn());
@@ -28,6 +29,11 @@ const mockDraftStore = {
   setDraft: mockSetDraft,
   clearDraft: mockClearDraft,
   setLastAssignee: mockSetLastAssignee,
+};
+
+const mockQuickCreateStore = {
+  keepOpen: false,
+  setKeepOpen: mockSetKeepOpen,
 };
 
 vi.mock("../navigation", () => ({
@@ -60,6 +66,11 @@ vi.mock("@multica/core/issues/stores/draft-store", () => ({
   ),
 }));
 
+vi.mock("@multica/core/issues/stores/quick-create-store", () => ({
+  useQuickCreateStore: (selector?: (state: typeof mockQuickCreateStore) => unknown) =>
+    (selector ? selector(mockQuickCreateStore) : mockQuickCreateStore),
+}));
+
 vi.mock("@multica/core/issues/mutations", () => ({
   useCreateIssue: () => ({ mutateAsync: mockCreateIssue }),
   useUpdateIssue: () => ({ mutate: vi.fn() }),
@@ -79,6 +90,10 @@ vi.mock("../editor", () => {
     const [value, setValue] = useState(defaultValue || "");
     useImperativeHandle(ref, () => ({
       getMarkdown: () => valueRef.current,
+      clearContent: () => {
+        valueRef.current = "";
+        setValue("");
+      },
       uploadFile: vi.fn(),
     }));
     return (
@@ -178,6 +193,23 @@ vi.mock("@multica/ui/components/ui/button", () => ({
   ),
 }));
 
+vi.mock("@multica/ui/components/ui/switch", () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+  }: {
+    checked: boolean;
+    onCheckedChange: (v: boolean) => void;
+  }) => (
+    <input
+      aria-label="Create another"
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange(e.target.checked)}
+    />
+  ),
+}));
+
 vi.mock("@multica/ui/components/common/file-upload-button", () => ({
   FileUploadButton: ({ onSelect }: { onSelect: (file: File) => void }) => (
     <button type="button" onClick={() => onSelect(new File(["test"], "test.txt"))}>
@@ -210,6 +242,10 @@ function renderModal(element: React.ReactElement) {
 describe("CreateIssueModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockQuickCreateStore.keepOpen = false;
+    mockSetKeepOpen.mockImplementation((v: boolean) => {
+      mockQuickCreateStore.keepOpen = v;
+    });
     mockCreateIssue.mockResolvedValue({
       id: "issue-123",
       identifier: "TES-123",
@@ -260,5 +296,45 @@ describe("CreateIssueModal", () => {
 
     expect(mockPush).toHaveBeenCalledWith("/ws-test/issues/issue-123");
     expect(mockToastDismiss).toHaveBeenCalledWith("toast-1");
+  });
+
+  it("keeps manual mode open and clears content when create another is enabled", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    mockQuickCreateStore.keepOpen = true;
+
+    renderModal(<CreateIssueModal onClose={onClose} />);
+
+    await user.type(screen.getByPlaceholderText("Issue title"), "First follow-up issue");
+    await user.type(screen.getByPlaceholderText("Add description..."), "Description to clear");
+    await user.click(screen.getByRole("button", { name: "Create Issue" }));
+
+    await waitFor(() => {
+      expect(mockCreateIssue).toHaveBeenCalledWith({
+        title: "First follow-up issue",
+        description: "Description to clear",
+        status: "todo",
+        priority: "none",
+        assignee_type: undefined,
+        assignee_id: undefined,
+        due_date: undefined,
+        attachment_ids: undefined,
+        parent_issue_id: undefined,
+        project_id: undefined,
+      });
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText("Issue title")).toHaveValue("");
+    expect(screen.getByPlaceholderText("Add description...")).toHaveValue("");
+    expect(mockSetDraft).toHaveBeenCalledWith({
+      title: "",
+      description: "",
+      status: "todo",
+      priority: "none",
+      assigneeType: undefined,
+      assigneeId: undefined,
+      dueDate: null,
+    });
   });
 });

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -30,6 +30,7 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
+import { Switch } from "@multica/ui/components/ui/switch";
 import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../editor";
 import { StatusIcon, StatusPicker, PriorityPicker, AssigneePicker, DueDatePicker } from "../issues/components";
 import { BacklogAgentHintContent } from "../issues/components/backlog-agent-hint-dialog";
@@ -38,6 +39,7 @@ import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import { useCreateModeStore } from "@multica/core/issues/stores/create-mode-store";
+import { useQuickCreateStore } from "@multica/core/issues/stores/quick-create-store";
 import { issueDetailOptions } from "@multica/core/issues/queries";
 import { useCreateIssue, useUpdateIssue } from "@multica/core/issues/mutations";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
@@ -84,8 +86,11 @@ export function ManualCreatePanel({
   const clearDraft = useIssueDraftStore((s) => s.clearDraft);
   const setLastAssignee = useIssueDraftStore((s) => s.setLastAssignee);
   const setLastMode = useCreateModeStore((s) => s.setLastMode);
+  const keepOpen = useQuickCreateStore((s) => s.keepOpen);
+  const setKeepOpen = useQuickCreateStore((s) => s.setKeepOpen);
 
   const [title, setTitle] = useState(draft.title);
+  const [formResetKey, setFormResetKey] = useState(0);
   const descEditorRef = useRef<ContentEditorRef>(null);
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => descEditorRef.current?.uploadFile(f)),
@@ -138,6 +143,28 @@ export function ManualCreatePanel({
 
   const createIssueMutation = useCreateIssue();
   const updateIssueMutation = useUpdateIssue();
+  const resetForNextIssue = () => {
+    setTitle("");
+    setStatus("todo");
+    setPriority("none");
+    setDueDate(null);
+    setProjectId(undefined);
+    setParentIssueId(undefined);
+    setChildIssues([]);
+    setAttachmentIds([]);
+    setDraft({
+      title: "",
+      description: "",
+      status: "todo",
+      priority: "none",
+      assigneeType,
+      assigneeId,
+      dueDate: null,
+    });
+    descEditorRef.current?.clearContent();
+    setFormResetKey((key) => key + 1);
+  };
+
   const handleSubmit = async () => {
     if (!title.trim() || submitting) return;
     setSubmitting(true);
@@ -186,6 +213,8 @@ export function ManualCreatePanel({
 
       if (shouldShowBacklogHint) {
         setBacklogHintIssueId(issue.id);
+      } else if (keepOpen) {
+        resetForNextIssue();
       } else {
         onClose();
       }
@@ -304,6 +333,7 @@ export function ManualCreatePanel({
             {/* Title */}
             <div className="px-5 pb-2 shrink-0">
               <TitleEditor
+                key={formResetKey}
                 autoFocus
                 defaultValue={draft.title}
                 placeholder="Issue title"
@@ -494,20 +524,30 @@ export function ManualCreatePanel({
             />
 
             {/* Footer */}
-            <div className="flex items-center justify-between px-4 py-3 border-t shrink-0">
-              <FileUploadButton
-                onSelect={(file) => descEditorRef.current?.uploadFile(file)}
-              />
-              <div className="flex items-center gap-2">
+            <div className="flex flex-col gap-2 border-t px-4 py-3 shrink-0 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex min-h-7 items-center gap-2">
+                <FileUploadButton
+                  onSelect={(file) => descEditorRef.current?.uploadFile(file)}
+                />
+              </div>
+              <div className="flex flex-wrap items-center justify-end gap-2">
                 <button
                   type="button"
                   onClick={switchToAgent}
                   title="Switch to create with agent — describe in one line and let the agent file it"
-                  className="flex items-center gap-1.5 text-xs px-2 py-1 rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
+                  className="flex shrink-0 items-center gap-1.5 text-xs px-2 py-1 rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
                 >
                   <ArrowLeftRight className="size-3.5" />
-                  Switch to agent
+                  Switch to Agent
                 </button>
+                <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
+                  <Switch
+                    size="sm"
+                    checked={keepOpen}
+                    onCheckedChange={setKeepOpen}
+                  />
+                  Create another
+                </label>
                 <Button size="sm" onClick={handleSubmit} disabled={!title.trim() || submitting}>
                   {submitting ? "Creating..." : "Create Issue"}
                 </Button>

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -376,7 +376,7 @@ export function AgentCreatePanel({
               className="flex shrink-0 items-center gap-1.5 text-xs px-2 py-1 rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
             >
               <ArrowLeftRight className="size-3.5" />
-              Manual
+              Switch to Manual
             </button>
             <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
               <Switch

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -241,7 +241,7 @@ export function AgentCreatePanel({
         <DialogTitle className="sr-only">Quick create issue</DialogTitle>
 
         {/* Header */}
-        <div className="flex items-center justify-between px-5 pt-4 pb-2 shrink-0">
+        <div className="flex items-center justify-between px-5 pt-3 pb-2 shrink-0">
           <div className="flex items-center gap-1.5 text-xs">
             <span className="text-muted-foreground">{workspaceName}</span>
             <ChevronRight className="size-3 text-muted-foreground/50" />
@@ -263,24 +263,24 @@ export function AgentCreatePanel({
         </div>
 
         {/* Agent picker */}
-        <div className="px-5 pt-1 pb-3 shrink-0">
+        <div className="px-5 pt-1 pb-2 shrink-0">
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
                 <button
                   type="button"
                   aria-label="Select agent"
-                  className="inline-flex max-w-full items-center gap-2 rounded-md border bg-muted/20 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground cursor-pointer"
+                  className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer rounded-sm px-1.5 py-1 -ml-1.5 hover:bg-accent/60"
                 >
-                  <span className="shrink-0">Created by</span>
+                  <span>Created by</span>
                   {selectedAgent ? (
-                    <span className="flex min-w-0 items-center gap-1.5 text-foreground">
+                    <span className="flex items-center gap-1.5 text-foreground">
                       <ActorAvatar
                         actorType="agent"
                         actorId={selectedAgent.id}
                         size={16}
                       />
-                      <span className="truncate">{selectedAgent.name}</span>
+                      {selectedAgent.name}
                     </span>
                   ) : (
                     <span>Pick an agent…</span>
@@ -336,12 +336,12 @@ export function AgentCreatePanel({
             editor unbounded and pushed the modal past the viewport. */}
         <div
           {...dropZoneProps}
-          className="relative mx-5 mb-4 flex-1 min-h-[11rem] max-h-[42vh] overflow-y-auto rounded-lg border bg-background px-3 py-2.5 transition-[border-color,box-shadow] focus-within:border-ring/50 focus-within:ring-[3px] focus-within:ring-ring/15"
+          className="relative px-5 pb-3 flex-1 min-h-[140px] overflow-y-auto"
         >
           <ContentEditor
             ref={editorRef}
             defaultValue={initialPrompt}
-            placeholder="Describe the task for this agent..."
+            placeholder='Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"'
             onUpdate={(md) => setHasContent(md.trim().length > 0)}
             onUploadFile={handleUploadFile}
             onSubmit={submit}
@@ -376,7 +376,7 @@ export function AgentCreatePanel({
               className="flex shrink-0 items-center gap-1.5 text-xs px-2 py-1 rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
             >
               <ArrowLeftRight className="size-3.5" />
-              Switch to manual
+              Manual
             </button>
             <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
               <Switch
@@ -395,11 +395,11 @@ export function AgentCreatePanel({
                   ? `Daemon CLI must be ≥ ${versionCheck.min}`
                   : undefined
               }
-              className={justSent ? "min-w-20 !bg-emerald-600 !text-white" : "min-w-20"}
+              className={justSent ? "min-w-28 !bg-emerald-600 !text-white" : "min-w-28"}
             >
               {submitting ? "Sending…" : uploading ? "Uploading…" : justSent ? (
                 <span className="flex items-center gap-1"><Check className="size-3.5" />Sent</span>
-              ) : "Create"}
+              ) : "Create (⌘↵)"}
             </Button>
           </div>
         </div>

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -241,7 +241,7 @@ export function AgentCreatePanel({
         <DialogTitle className="sr-only">Quick create issue</DialogTitle>
 
         {/* Header */}
-        <div className="flex items-center justify-between px-5 pt-3 pb-2 shrink-0">
+        <div className="flex items-center justify-between px-5 pt-4 pb-2 shrink-0">
           <div className="flex items-center gap-1.5 text-xs">
             <span className="text-muted-foreground">{workspaceName}</span>
             <ChevronRight className="size-3 text-muted-foreground/50" />
@@ -252,6 +252,7 @@ export function AgentCreatePanel({
               on the first focusable element on mount, causing the tooltip to
               auto-pop every open. */}
           <button
+            type="button"
             onClick={onClose}
             title="Close"
             aria-label="Close"
@@ -262,23 +263,24 @@ export function AgentCreatePanel({
         </div>
 
         {/* Agent picker */}
-        <div className="px-5 pt-1 pb-2 shrink-0">
+        <div className="px-5 pt-1 pb-3 shrink-0">
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
                 <button
                   type="button"
-                  className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer rounded-sm px-1.5 py-1 -ml-1.5 hover:bg-accent/60"
+                  aria-label="Select agent"
+                  className="inline-flex max-w-full items-center gap-2 rounded-md border bg-muted/20 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground cursor-pointer"
                 >
-                  <span>Created by</span>
+                  <span className="shrink-0">Created by</span>
                   {selectedAgent ? (
-                    <span className="flex items-center gap-1.5 text-foreground">
+                    <span className="flex min-w-0 items-center gap-1.5 text-foreground">
                       <ActorAvatar
                         actorType="agent"
                         actorId={selectedAgent.id}
                         size={16}
                       />
-                      {selectedAgent.name}
+                      <span className="truncate">{selectedAgent.name}</span>
                     </span>
                   ) : (
                     <span>Pick an agent…</span>
@@ -307,6 +309,9 @@ export function AgentCreatePanel({
                       size={16}
                     />
                     <span className="flex-1 truncate">{a.name}</span>
+                    {agentId === a.id && (
+                      <Check className="size-3.5 text-muted-foreground" />
+                    )}
                   </DropdownMenuItem>
                 ))
               )}
@@ -331,12 +336,12 @@ export function AgentCreatePanel({
             editor unbounded and pushed the modal past the viewport. */}
         <div
           {...dropZoneProps}
-          className="relative px-5 pb-3 flex-1 min-h-[140px] overflow-y-auto"
+          className="relative mx-5 mb-4 flex-1 min-h-[11rem] max-h-[42vh] overflow-y-auto rounded-lg border bg-background px-3 py-2.5 transition-[border-color,box-shadow] focus-within:border-ring/50 focus-within:ring-[3px] focus-within:ring-ring/15"
         >
           <ContentEditor
             ref={editorRef}
             defaultValue={initialPrompt}
-            placeholder='Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"'
+            placeholder="Describe the task for this agent..."
             onUpdate={(md) => setHasContent(md.trim().length > 0)}
             onUploadFile={handleUploadFile}
             onSubmit={submit}
@@ -350,30 +355,30 @@ export function AgentCreatePanel({
         )}
 
         {/* Footer */}
-        <div className="flex items-center justify-between px-4 py-3 border-t shrink-0">
-          <div className="flex items-center gap-1.5">
+        <div className="flex flex-col gap-2 border-t px-4 py-3 shrink-0 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-h-7 items-center gap-2">
             <FileUploadButton
               size="sm"
+              disabled={uploading}
               onSelect={(file) => editorRef.current?.uploadFile(file)}
             />
-            <span className="text-xs text-muted-foreground">
-              {keepOpen && sentCount > 0 && (
-                <span className="text-emerald-600 dark:text-emerald-400">{sentCount} sent · </span>
-              )}
-              ⌘↵ to submit
-            </span>
+            {keepOpen && sentCount > 0 && (
+              <span className="text-xs text-emerald-600 dark:text-emerald-400">
+                {sentCount} sent
+              </span>
+            )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <button
               type="button"
               onClick={switchToManual}
               title="Switch to manual create — fill the fields yourself"
-              className="flex items-center gap-1.5 text-xs px-2 py-1 rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
+              className="flex shrink-0 items-center gap-1.5 text-xs px-2 py-1 rounded-sm text-muted-foreground hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
             >
               <ArrowLeftRight className="size-3.5" />
               Switch to manual
             </button>
-            <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
+            <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
               <Switch
                 size="sm"
                 checked={keepOpen}
@@ -390,7 +395,7 @@ export function AgentCreatePanel({
                   ? `Daemon CLI must be ≥ ${versionCheck.min}`
                   : undefined
               }
-              className={justSent ? "!bg-emerald-600 !text-white" : undefined}
+              className={justSent ? "min-w-20 !bg-emerald-600 !text-white" : "min-w-20"}
             >
               {submitting ? "Sending…" : uploading ? "Uploading…" : justSent ? (
                 <span className="flex items-center gap-1"><Check className="size-3.5" />Sent</span>


### PR DESCRIPTION
## Summary
- Refine the Quick Create agent footer toolbar while keeping the prompt area visually unchanged.
- Keep the agent/manual mode switch labels symmetric as `Switch to Manual` and `Switch to Agent`.
- Remove the standalone shortcut hint and move the shortcut into the primary button label as `Create (⌘↵)`.
- Keep the attachment action as a borderless icon button, restore the clearer `Create another` label, and add the same `Create another` option to manual mode.
- In manual mode, `Create another` now keeps the dialog open after submit and clears the transient title/description/attachment/relationship fields for the next issue.
- Add accessible label/title text to the shared file upload icon button.

## Verification
- `pnpm --filter @multica/views exec vitest run modals/create-issue.test.tsx`
- `pnpm --filter @multica/views exec eslint modals/quick-create-issue.tsx modals/create-issue.tsx modals/create-issue.test.tsx`
- `pnpm --filter @multica/views exec tsc --noEmit --noUnusedLocals false`
- `pnpm --filter @multica/ui typecheck`

Note: regular `pnpm --filter @multica/views typecheck` still fails on an unrelated existing unused local in `agents/components/inspector/model-picker.tsx` (`defaultModel`).
