### PR TITLE
fix: make workspace table columns resizable

### DIFF
--- a/packages/ui/components/ui/data-table.tsx
+++ b/packages/ui/components/ui/data-table.tsx
@@ -2,10 +2,11 @@
 
 import {
   flexRender,
+  type Header as TanstackHeader,
   type Row,
   type Table as TanstackTable,
 } from "@tanstack/react-table";
-import type * as React from "react";
+import * as React from "react";
 
 // We deliberately use the lower-level shadcn primitives (TableHeader /
 // TableBody / TableRow / TableHead / TableCell) but NOT the wrapping
@@ -48,8 +49,8 @@ interface DataTableProps<TData> extends React.ComponentProps<"div"> {
 //     makes each column's width come from its first row's <th>
 //     inline width. column.size is authoritative for sized columns.
 //   - Columns flagged `meta.grow: true` skip their inline width, so
-//     fixed table-layout assigns them the leftover space (no spacer
-//     column needed).
+//     fixed table-layout assigns them the leftover space until the user
+//     resizes them. Once resized, the explicit width is applied.
 //   - The table's `min-width` is the sum of every column's TanStack
 //     size (`table.getTotalSize()`). That gives grow columns a real
 //     floor — fixed mode ignores cell-level min-width, but it does
@@ -64,6 +65,98 @@ export function DataTable<TData>({
   className,
   ...props
 }: DataTableProps<TData>) {
+  const [resizingColumnId, setResizingColumnId] = React.useState<string | null>(
+    null,
+  );
+
+  const columnSizing = table.getState().columnSizing;
+  const hasExplicitSize = React.useCallback(
+    (columnId: string) =>
+      Object.prototype.hasOwnProperty.call(columnSizing, columnId),
+    [columnSizing],
+  );
+
+  const setColumnWidth = React.useCallback(
+    (header: TanstackHeader<TData, unknown>, width: number) => {
+      const minSize = header.column.columnDef.minSize ?? 48;
+      const maxSize =
+        header.column.columnDef.maxSize ?? Number.MAX_SAFE_INTEGER;
+      const next = Math.min(maxSize, Math.max(minSize, Math.round(width)));
+
+      table.setColumnSizing((old) => ({
+        ...old,
+        [header.column.id]: next,
+      }));
+    },
+    [table],
+  );
+
+  const beginColumnResize = React.useCallback(
+    (
+      header: TanstackHeader<TData, unknown>,
+      event: React.PointerEvent<HTMLDivElement>,
+    ) => {
+      if (!header.column.getCanResize()) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const startX = event.clientX;
+      const headerCell = event.currentTarget.closest("th");
+      const startWidth =
+        headerCell?.getBoundingClientRect().width ?? header.column.getSize();
+
+      setResizingColumnId(header.column.id);
+      setColumnWidth(header, startWidth);
+
+      const originalCursor = document.body.style.cursor;
+      const originalUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+
+      const handlePointerMove = (pointerEvent: PointerEvent) => {
+        setColumnWidth(header, startWidth + pointerEvent.clientX - startX);
+      };
+
+      const stopResize = () => {
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerup", stopResize);
+        window.removeEventListener("pointercancel", stopResize);
+        document.body.style.cursor = originalCursor;
+        document.body.style.userSelect = originalUserSelect;
+        setResizingColumnId(null);
+      };
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", stopResize);
+      window.addEventListener("pointercancel", stopResize);
+    },
+    [setColumnWidth],
+  );
+
+  const handleResizeKeyDown = React.useCallback(
+    (
+      header: TanstackHeader<TData, unknown>,
+      event: React.KeyboardEvent<HTMLDivElement>,
+    ) => {
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const headerCell = event.currentTarget.closest("th");
+      const currentWidth = hasExplicitSize(header.column.id)
+        ? header.column.getSize()
+        : (headerCell?.getBoundingClientRect().width ??
+          header.column.getSize());
+      const direction = event.key === "ArrowRight" ? 1 : -1;
+      const step = event.shiftKey ? 20 : 8;
+
+      setColumnWidth(header, currentWidth + direction * step);
+    },
+    [hasExplicitSize, setColumnWidth],
+  );
+
   return (
     <div
       className={cn("flex min-h-0 flex-1 flex-col", className)}
@@ -79,6 +172,13 @@ export function DataTable<TData>({
               <TableRow key={headerGroup.id} className="hover:bg-transparent">
                 {headerGroup.headers.map((header) => {
                   const isPinned = header.column.getIsPinned();
+                  const columnHasExplicitSize = hasExplicitSize(
+                    header.column.id,
+                  );
+                  const headerLabel =
+                    typeof header.column.columnDef.header === "string"
+                      ? header.column.columnDef.header
+                      : header.column.id;
                   return (
                     <TableHead
                       key={header.id}
@@ -98,10 +198,13 @@ export function DataTable<TData>({
                       // into the header strip rather than appearing as
                       // a white block under sticky scroll.
                       className={cn(
-                        "h-8 overflow-hidden px-4 py-2 text-xs uppercase tracking-wider text-muted-foreground",
+                        "relative h-8 overflow-hidden px-4 py-2 text-xs uppercase tracking-wider text-muted-foreground",
                         isPinned && "bg-muted/30 backdrop-blur",
                       )}
-                      style={getCellStyle(header.column, { withBorder: true })}
+                      style={getCellStyle(header.column, {
+                        withBorder: true,
+                        hasExplicitSize: columnHasExplicitSize,
+                      })}
                     >
                       {header.isPlaceholder
                         ? null
@@ -109,6 +212,33 @@ export function DataTable<TData>({
                             header.column.columnDef.header,
                             header.getContext(),
                           )}
+                      {!header.isPlaceholder &&
+                        header.column.getCanResize() && (
+                          <div
+                            role="separator"
+                            aria-label={`Resize ${headerLabel} column`}
+                            aria-orientation="vertical"
+                            tabIndex={0}
+                            className={cn(
+                              "absolute top-0 right-0 h-full w-2 cursor-col-resize touch-none select-none outline-none",
+                              "after:absolute after:top-1/2 after:right-0 after:h-4 after:w-px after:-translate-y-1/2 after:bg-border after:opacity-0 after:transition-opacity",
+                              "hover:after:opacity-100 focus-visible:after:opacity-100",
+                              resizingColumnId === header.column.id &&
+                                "after:bg-primary after:opacity-100",
+                            )}
+                            onPointerDown={(event) =>
+                              beginColumnResize(header, event)
+                            }
+                            onDoubleClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              header.column.resetSize();
+                            }}
+                            onKeyDown={(event) =>
+                              handleResizeKeyDown(header, event)
+                            }
+                          />
+                        )}
                     </TableHead>
                   );
                 })}
@@ -135,6 +265,9 @@ export function DataTable<TData>({
                 >
                   {row.getVisibleCells().map((cell) => {
                     const isPinned = cell.column.getIsPinned();
+                    const columnHasExplicitSize = hasExplicitSize(
+                      cell.column.id,
+                    );
                     return (
                       <TableCell
                         key={cell.id}
@@ -151,7 +284,10 @@ export function DataTable<TData>({
                           isPinned &&
                             "bg-background group-hover:bg-muted/50",
                         )}
-                        style={getCellStyle(cell.column, { withBorder: true })}
+                        style={getCellStyle(cell.column, {
+                          withBorder: true,
+                          hasExplicitSize: columnHasExplicitSize,
+                        })}
                       >
                         {flexRender(
                           cell.column.columnDef.cell,

--- a/packages/ui/lib/data-table.ts
+++ b/packages/ui/lib/data-table.ts
@@ -4,10 +4,9 @@ import type * as React from "react";
 // Extend TanStack Table's ColumnMeta with a `grow` flag. TanStack merges
 // a default `size: 150` into every columnDef, so "no explicit size" can't
 // be detected by inspecting columnDef.size (it's always a number). Setting
-// `meta: { grow: true }` is the official extension point — DataTable then
-// skips the inline width for these columns and lets fixed table-layout
-// assign them the leftover space (Linear / GitHub-PR-list pattern: title
-// column grows, others stay at their declared widths).
+// `meta: { grow: true }` is the official extension point: DataTable skips
+// the inline width for these columns until the user explicitly resizes them,
+// then the resized width wins.
 declare module "@tanstack/react-table" {
   interface ColumnMeta<TData extends RowData, TValue> {
     grow?: boolean;
@@ -25,10 +24,10 @@ declare module "@tanstack/react-table" {
 // `group-hover:`.
 export function getCellStyle<TData>(
   column: Column<TData>,
-  options?: { withBorder?: boolean },
+  options?: { withBorder?: boolean; hasExplicitSize?: boolean },
 ): React.CSSProperties {
   const grow = column.columnDef.meta?.grow;
-  const width = grow ? undefined : column.columnDef.size;
+  const width = grow && !options?.hasExplicitSize ? undefined : column.getSize();
 
   const isPinned = column.getIsPinned();
   if (!isPinned) {

--- a/packages/views/agents/components/agent-columns.tsx
+++ b/packages/views/agents/components/agent-columns.tsx
@@ -38,18 +38,17 @@ export interface AgentRow {
 // column.size doubles as the cell's effective max-width: truncatable
 // cells with `truncate` inside hit ellipsis at the column edge.
 //
-// The Agent column has `meta.grow: true` so DataTable skips its inline
-// `width` — that lets fixed table-layout assign it the leftover space
-// (= container width − sum of other columns), so the table fills the
-// viewport without an empty spacer column.
+// The Agent and Runtime columns have `meta.grow: true` so DataTable skips
+// their inline widths until the user resizes them. Fixed table-layout splits
+// the leftover space between them, which keeps Agent from monopolising wide
+// viewports while still giving both columns a real floor.
 //
-// The Agent column also keeps `size: 240` even though it isn't used for
-// rendering. TanStack folds this into `table.getTotalSize()`, which
-// DataTable applies as the table's `min-width`. That's how the agent
-// column gets a real 240px floor: when the viewport drops below
-// `sum + 240`, the table refuses to shrink further and the container
-// scrolls instead. (Fixed table-layout ignores cell-level min-width
-// per spec, so the floor has to live on the table itself.)
+// The grow columns also keep their `size` values even though those widths
+// are skipped for initial rendering. TanStack folds them into
+// `table.getTotalSize()`, which DataTable applies as the table's `min-width`.
+// That's how the grow columns get real floors: when the viewport drops below
+// the summed column sizes, the table refuses to shrink further and the
+// container scrolls instead.
 const COL_WIDTHS = {
   agent: 240,
   status: 120,
@@ -102,6 +101,7 @@ export function createAgentColumns({
       id: "runtime",
       header: "Runtime",
       size: COL_WIDTHS.runtime,
+      meta: { grow: true },
       cell: ({ row }) => <RuntimeCell row={row.original} />,
     },
     {
@@ -126,6 +126,7 @@ export function createAgentColumns({
       id: "actions",
       header: () => null,
       size: COL_WIDTHS.actions,
+      enableResizing: false,
       cell: ({ row }) => (
         <div
           className="flex justify-end"

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -334,6 +334,7 @@ export function AgentsPage() {
     data: agentRows,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    enableColumnResizing: true,
     // Pin the kebab column right so it stays accessible during horizontal
     // scroll — matches the pattern in Linear / Notion / GitHub.
     initialState: { columnPinning: { right: ["actions"] } },

--- a/packages/views/runtimes/components/runtime-columns.tsx
+++ b/packages/views/runtimes/components/runtime-columns.tsx
@@ -60,12 +60,10 @@ export interface RuntimeRow {
   canDelete: boolean;
 }
 
-// Column widths in px. The Runtime column has `meta.grow: true` so
-// DataTable skips its inline width — fixed table-layout assigns it the
-// leftover space. Its `size: 240` still flows into table.getTotalSize()
-// to set the table's `min-width`, giving the runtime column a 240px
-// floor below which the container scrolls horizontally instead of
-// shrinking the column further.
+// Column widths in px. Runtime, Health, and CLI grow together until the
+// user resizes them. Their `size` values still flow into table.getTotalSize()
+// to set the table's min-width, giving each grow column a real floor below
+// which the container scrolls horizontally instead of shrinking further.
 const COL_WIDTHS = {
   runtime: 240,
   health: 200,
@@ -105,6 +103,7 @@ export function createRuntimeColumns({
       id: "health",
       header: "Health",
       size: COL_WIDTHS.health,
+      meta: { grow: true },
       cell: ({ row }) => (
         <HealthCell runtime={row.original.runtime} now={now} />
       ),
@@ -164,6 +163,7 @@ export function createRuntimeColumns({
       id: "cli",
       header: "CLI",
       size: COL_WIDTHS.cli,
+      meta: { grow: true },
       cell: ({ row }) => (
         <CliCell
           runtime={row.original.runtime}
@@ -175,6 +175,7 @@ export function createRuntimeColumns({
       id: "actions",
       header: () => null,
       size: COL_WIDTHS.actions,
+      enableResizing: false,
       cell: ({ row }) => (
         <div
           className="flex justify-end"

--- a/packages/views/runtimes/components/runtime-list.tsx
+++ b/packages/views/runtimes/components/runtime-list.tsx
@@ -149,6 +149,7 @@ export function RuntimeList({
     data: rows,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    enableColumnResizing: true,
     // Pin the kebab column right so it stays accessible during horizontal
     // scroll — matches the pattern in Linear / Notion / GitHub.
     initialState: { columnPinning: { right: ["actions"] } },

--- a/packages/views/skills/components/skill-columns.tsx
+++ b/packages/views/skills/components/skill-columns.tsx
@@ -102,6 +102,7 @@ export function createSkillColumns(): ColumnDef<SkillRow>[] {
       id: "_chevron",
       header: () => null,
       size: COL_WIDTHS.chevron,
+      enableResizing: false,
       cell: () => (
         <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/40 transition-colors group-hover:text-muted-foreground" />
       ),

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -288,6 +288,7 @@ export default function SkillsPage() {
     data: skillRows,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    enableColumnResizing: true,
   });
 
   // --- Loading ---


### PR DESCRIPTION
Summary:
- Add shared DataTable column resize handles with pointer, double-click reset, and keyboard arrow support.
- Let resized grow columns keep explicit widths while preserving grow-column floors and pinned action columns.
- Rebalance Agents and Runtimes default grow columns so the first column no longer consumes all extra width; Skills inherits resizable headers and keeps the chevron fixed.

Verification:
- pnpm --filter @multica/ui typecheck
- pnpm --filter @multica/ui lint
- pnpm --filter @multica/views exec eslint agents/components/agent-columns.tsx agents/components/agents-page.tsx runtimes/components/runtime-columns.tsx runtimes/components/runtime-list.tsx skills/components/skill-columns.tsx skills/components/skills-page.tsx
- pnpm --filter @multica/views exec tsc --noEmit --noUnusedLocals false --noUnusedParameters false

Notes:
- The full @multica/views typecheck is currently blocked by an unrelated existing unused variable in agents/components/inspector/model-picker.tsx.
- The full @multica/views lint is currently blocked by unrelated existing issues in workspace/no-access-page.tsx plus warnings in model-dropdown.tsx, issue-detail.tsx, and project-detail.tsx.
