### PR TITLE
Improve quick create inbox previews

### DIFF
--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -4,6 +4,7 @@ import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { StatusIcon, PriorityIcon } from "../../issues/components";
 import type { InboxItem, InboxItemType, IssueStatus, IssuePriority } from "@multica/core/types";
+import { getQuickCreateFailureDetail } from "./inbox-display";
 
 const typeLabels: Record<InboxItemType, string> = {
   issue_assigned: "Assigned",
@@ -20,8 +21,8 @@ const typeLabels: Record<InboxItemType, string> = {
   agent_blocked: "Agent blocked",
   agent_completed: "Agent completed",
   reaction_added: "Reacted",
-  quick_create_done: "Quick create done",
-  quick_create_failed: "Quick create failed",
+  quick_create_done: "Created with agent",
+  quick_create_failed: "Create with agent failed",
 };
 
 export { typeLabels };
@@ -90,7 +91,12 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
     }
     case "quick_create_done": {
       const identifier = details.identifier;
-      if (identifier) return <span>Created {identifier}</span>;
+      if (identifier) return <span>Created with agent: {identifier}</span>;
+      return <span>{typeLabels[item.type]}</span>;
+    }
+    case "quick_create_failed": {
+      const detail = getQuickCreateFailureDetail(item);
+      if (detail) return <span>Failed: {detail}</span>;
       return <span>{typeLabels[item.type]}</span>;
     }
     default:

--- a/packages/views/inbox/components/inbox-display.test.ts
+++ b/packages/views/inbox/components/inbox-display.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { InboxItem } from "@multica/core/types";
+import {
+  getInboxDisplayTitle,
+  getQuickCreateFailureDetail,
+  stripQuickCreatePrefix,
+} from "./inbox-display";
+
+function item(overrides: Partial<InboxItem>): InboxItem {
+  return {
+    id: "inbox-1",
+    workspace_id: "workspace-1",
+    recipient_type: "member",
+    recipient_id: "member-1",
+    actor_type: "agent",
+    actor_id: "agent-1",
+    type: "new_comment",
+    severity: "info",
+    issue_id: "issue-1",
+    title: "Issue title",
+    body: null,
+    issue_status: null,
+    read: false,
+    archived: false,
+    created_at: "2026-04-29T12:00:00Z",
+    details: null,
+    ...overrides,
+  };
+}
+
+describe("inbox display helpers", () => {
+  it("removes legacy quick-create created prefixes from list titles", () => {
+    expect(
+      stripQuickCreatePrefix(
+        "Created MUL-1583: Fix agent list column widths",
+        "MUL-1583",
+      ),
+    ).toBe("Fix agent list column widths");
+  });
+
+  it("cleans quick-create success titles before rendering the inbox row", () => {
+    const quickCreateItem = item({
+      type: "quick_create_done",
+      title: "Created MUL-1583: Fix agent list column widths",
+      details: { identifier: "MUL-1583" },
+    });
+
+    expect(getInboxDisplayTitle(quickCreateItem)).toBe(
+      "Fix agent list column widths",
+    );
+  });
+
+  it("uses the original prompt as the failed quick-create row title", () => {
+    const failedItem = item({
+      type: "quick_create_failed",
+      title: "Quick create failed",
+      body: "agent finished without creating an issue",
+      issue_id: null,
+      details: {
+        original_prompt: "Optimize QuickCapture UI\nand attached screenshot",
+      },
+    });
+
+    expect(getInboxDisplayTitle(failedItem)).toBe(
+      "Optimize QuickCapture UI and attached screenshot",
+    );
+  });
+
+  it("uses the redacted failure detail for failed quick-create subtitles", () => {
+    const failedItem = item({
+      type: "quick_create_failed",
+      body: "fallback body",
+      details: { error: "CLI failed\nwith exit status 1" },
+    });
+
+    expect(getQuickCreateFailureDetail(failedItem)).toBe(
+      "CLI failed with exit status 1",
+    );
+  });
+});

--- a/packages/views/inbox/components/inbox-display.ts
+++ b/packages/views/inbox/components/inbox-display.ts
@@ -1,0 +1,49 @@
+import type { InboxItem } from "@multica/core/types";
+
+function singleLine(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function stripQuickCreatePrefix(title: string, identifier?: string): string {
+  const normalized = singleLine(title);
+  if (!normalized) return "";
+
+  if (identifier) {
+    const exactPrefix = new RegExp(
+      `^Created\\s+${escapeRegExp(identifier)}:\\s*`,
+      "i",
+    );
+    const withoutExactPrefix = normalized.replace(exactPrefix, "");
+    if (withoutExactPrefix !== normalized) return withoutExactPrefix.trim();
+  }
+
+  return normalized.replace(/^Created\s+[A-Z][A-Z0-9]*-\d+:\s*/i, "").trim();
+}
+
+export function getInboxDisplayTitle(item: InboxItem): string {
+  const details = item.details ?? {};
+
+  if (item.type === "quick_create_done") {
+    const cleanedTitle = stripQuickCreatePrefix(item.title, details.identifier);
+    if (cleanedTitle) return cleanedTitle;
+
+    const prompt = singleLine(details.original_prompt);
+    if (prompt) return prompt;
+  }
+
+  if (item.type === "quick_create_failed") {
+    const prompt = singleLine(details.original_prompt);
+    if (prompt) return prompt;
+  }
+
+  return item.title;
+}
+
+export function getQuickCreateFailureDetail(item: InboxItem): string {
+  const details = item.details ?? {};
+  return singleLine(details.error) || singleLine(item.body);
+}

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -5,6 +5,7 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import { Archive } from "lucide-react";
 import type { InboxItem } from "@multica/core/types";
 import { InboxDetailLabel } from "./inbox-detail-label";
+import { getInboxDisplayTitle } from "./inbox-display";
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -30,6 +31,8 @@ export function InboxListItem({
   onClick: () => void;
   onArchive: () => void;
 }) {
+  const displayTitle = getInboxDisplayTitle(item);
+
   return (
     <button
       onClick={onClick}
@@ -52,7 +55,7 @@ export function InboxListItem({
             <span
               className={`truncate text-sm ${!item.read ? "font-medium" : "text-muted-foreground"}`}
             >
-              {item.title}
+              {displayTitle}
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-1">

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -51,6 +51,7 @@ import { useIsMobile } from "@multica/ui/hooks/use-mobile";
 import { PageHeader } from "../../layout/page-header";
 import { InboxListItem, timeAgo } from "./inbox-list-item";
 import { typeLabels } from "./inbox-detail-label";
+import { getInboxDisplayTitle } from "./inbox-display";
 
 export function InboxPage() {
   const { searchParams, replace } = useNavigation();
@@ -260,7 +261,7 @@ export function InboxPage() {
     />
   ) : selected ? (
     <div className="p-6">
-      <h2 className="text-lg font-semibold">{selected.title}</h2>
+      <h2 className="text-lg font-semibold">{getInboxDisplayTitle(selected)}</h2>
       <p className="mt-1 text-sm text-muted-foreground">
         {typeLabels[selected.type]} · {timeAgo(selected.created_at)}
       </p>

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1424,10 +1424,11 @@ func (s *TaskService) notifyQuickCreateCompleted(ctx context.Context, task db.Ag
 	prefix := s.getIssuePrefix(workspaceID)
 	identifier := fmt.Sprintf("%s-%d", prefix, issue.Number)
 	details, _ := json.Marshal(map[string]any{
-		"task_id":    util.UUIDToString(task.ID),
-		"agent_id":   util.UUIDToString(task.AgentID),
-		"issue_id":   util.UUIDToString(issue.ID),
-		"identifier": identifier,
+		"task_id":         util.UUIDToString(task.ID),
+		"agent_id":        util.UUIDToString(task.AgentID),
+		"issue_id":        util.UUIDToString(issue.ID),
+		"identifier":      identifier,
+		"original_prompt": qc.Prompt,
 	})
 	item, err := s.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
 		WorkspaceID:   workspaceID,


### PR DESCRIPTION
## Summary
- Show clearer quick-create inbox row titles by stripping legacy `Created MUL-123:` prefixes and using the original prompt for failed quick-create notifications.
- Update quick-create subtitles to show agent-created identifiers or failure details instead of repeating generic labels.
- Include the original quick-create prompt in future successful inbox notification details.

## Verification
- `pnpm --filter @multica/views test -- inbox-display` (passes; runs 32 views test files / 231 tests)
- `pnpm --filter @multica/views exec eslint inbox/components/inbox-display.ts inbox/components/inbox-display.test.ts inbox/components/inbox-list-item.tsx inbox/components/inbox-detail-label.tsx inbox/components/inbox-page.tsx`
- `go test ./internal/service` from `server/`

Full-package checks currently fail on unrelated existing issues:
- `pnpm --filter @multica/views typecheck`: `agents/components/inspector/model-picker.tsx(50,9)` unused `defaultModel`
- `pnpm --filter @multica/views lint`: existing `react/no-unescaped-entities` errors in `workspace/no-access-page.tsx` plus hook warnings
