### PR TITLE
fix(views): remove unused defaultModel declaration in model-picker

### DIFF
--- a/packages/views/agents/components/inspector/model-picker.tsx
+++ b/packages/views/agents/components/inspector/model-picker.tsx
@@ -42,12 +42,11 @@ export function ModelPicker({
   const supported = modelsQuery.data?.supported ?? true;
   // Memoise the model list so every downstream useMemo gets a stable
   // reference — `?? []` would mint a fresh array on every render and
-  // invalidate filters / defaultModel needlessly.
+  // invalidate `filtered` needlessly.
   const models = useMemo(
     () => modelsQuery.data?.models ?? [],
     [modelsQuery.data],
   );
-  const defaultModel = useMemo(() => models.find((m) => m.default), [models]);
 
   const filtered = useMemo(() => {
     const s = search.trim().toLowerCase();


### PR DESCRIPTION
## What does this PR do?

Removes a now-unused `defaultModel` `useMemo` declaration in `packages/views/agents/components/inspector/model-picker.tsx` that was orphaned by #1875. Restores `tsc --noEmit` (and CI) to green.

## Related Issue

Caused by #1875. Surfaced as a CI failure on #1880; fixing here unblocks both `main` and any open PR that gets the merged tree.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests
- [ ] CI / infrastructure

## Changes Made

- `packages/views/agents/components/inspector/model-picker.tsx` — drop the orphaned `const defaultModel = useMemo(...)`. The sibling change in #1875 already deleted the declaration in `model-dropdown.tsx`; this is the missing half. Updated the adjacent comment so it no longer references the removed binding.

## How to Test

```bash
pnpm install
pnpm --filter @multica/views typecheck
```

Should exit cleanly. Before this change it fails with:

```
agents/components/inspector/model-picker.tsx(50,9): error TS6133: 'defaultModel' is declared but its value is never read.
```

No runtime behavior change — `defaultModel` was already unused after #1875.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass (`pnpm --filter @multica/views typecheck` clean)
- [ ] I have added or updated tests where applicable (N/A — pure dead-code removal)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [ ] I have updated relevant documentation to reflect my changes (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code (Opus 4.7).

**Prompt / approach:** Diagnosed CI failure on #1880, traced the unused-variable error to commit 55b7e2e9 which removed the consumer (`triggerLabel`) but left the declaration. Removed the declaration and refreshed the surrounding comment.

## Screenshots (optional)

N/A.