### PR TITLE
feat(inbox): add one-click Done button to inbox items

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -2,7 +2,7 @@
 
 import { StatusIcon } from "../../issues/components";
 import { ActorAvatar } from "../../common/actor-avatar";
-import { Archive } from "lucide-react";
+import { Archive, CircleCheck } from "lucide-react";
 import type { InboxItem } from "@multica/core/types";
 import { InboxDetailLabel } from "./inbox-detail-label";
 import { getInboxDisplayTitle } from "./inbox-display";
@@ -25,11 +25,13 @@ export function InboxListItem({
   isSelected,
   onClick,
   onArchive,
+  onDone,
 }: {
   item: InboxItem;
   isSelected: boolean;
   onClick: () => void;
   onArchive: () => void;
+  onDone?: () => void;
 }) {
   const displayTitle = getInboxDisplayTitle(item);
 
@@ -59,6 +61,26 @@ export function InboxListItem({
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-1">
+            {onDone && (
+              <span
+                role="button"
+                tabIndex={-1}
+                title="Mark as done"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDone();
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.stopPropagation();
+                    onDone();
+                  }
+                }}
+                className="hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-info group-hover:inline-flex"
+              >
+                <CircleCheck className="h-3.5 w-3.5" />
+              </span>
+            )}
             <span
               role="button"
               tabIndex={-1}

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -20,6 +20,7 @@ import {
   useArchiveAllReadInbox,
   useArchiveCompletedInbox,
 } from "@multica/core/inbox/mutations";
+import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { IssueDetail } from "../../issues/components";
 import { useNavigation } from "../../navigation";
 import { toast } from "sonner";
@@ -117,6 +118,7 @@ export function InboxPage() {
   const archiveAllMutation = useArchiveAllInbox();
   const archiveAllReadMutation = useArchiveAllReadInbox();
   const archiveCompletedMutation = useArchiveCompletedInbox();
+  const updateIssueMutation = useUpdateIssue();
 
   // Auto-mark-read whenever a selected item is unread — covers both click-
   // to-select and URL-param-select (e.g. OS notification click on desktop).
@@ -141,6 +143,18 @@ export function InboxPage() {
     const archived = items.find((i) => i.id === id);
     if (archived && (archived.issue_id ?? archived.id) === selectedKey) setSelectedKey("");
     archiveMutation.mutate(id, {
+      onError: () => toast.error("Failed to archive"),
+    });
+  };
+
+  const handleDone = (item: InboxItem) => {
+    if (!item.issue_id) return;
+    setSelectedKey("");
+    updateIssueMutation.mutate(
+      { id: item.issue_id, status: "done" },
+      { onError: () => toast.error("Failed to mark as done") },
+    );
+    archiveMutation.mutate(item.id, {
       onError: () => toast.error("Failed to archive"),
     });
   };
@@ -235,6 +249,11 @@ export function InboxPage() {
           isSelected={(item.issue_id ?? item.id) === selectedKey}
           onClick={() => handleSelect(item)}
           onArchive={() => handleArchive(item.id)}
+          onDone={
+            item.issue_id && item.issue_status !== "done" && item.issue_status !== "cancelled"
+              ? () => handleDone(item)
+              : undefined
+          }
         />
       ))}
     </div>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -9,6 +9,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  CircleCheck,
   MoreHorizontal,
   PanelRight,
   Pin,
@@ -511,6 +512,23 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
             </span>
           </div>
           <div className="flex items-center gap-1 shrink-0">
+            {issue.status !== "done" && issue.status !== "cancelled" && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="text-muted-foreground"
+                      onClick={() => handleUpdateField({ status: "done" })}
+                    >
+                      <CircleCheck />
+                    </Button>
+                  }
+                />
+                <TooltipContent side="bottom">Mark as done</TooltipContent>
+              </Tooltip>
+            )}
             <Tooltip>
               <TooltipTrigger
                 render={


### PR DESCRIPTION
## Summary

- Adds a hover-visible "Mark as done" button (CircleCheck icon) to each inbox list item
- Button only appears for items with an associated issue that isn't already done/cancelled
- Clicking it sets the issue status to "done" and archives the inbox notification in one action
- Uses the project's `text-info` semantic color (matching the Done status icon color) on hover

Closes MUL-1589

## Test plan

- [ ] Hover over an inbox item with a non-done issue → verify CircleCheck button appears to the left of the Archive button
- [ ] Click the Done button → verify issue status changes to "done" and item is archived from inbox
- [ ] Verify Done button does NOT appear for items already in done/cancelled status
- [ ] Verify Done button does NOT appear for non-issue inbox notifications
- [ ] Verify typecheck passes (`pnpm --filter @multica/views exec tsc --noEmit`)
- [ ] Verify existing inbox tests pass (`pnpm --filter @multica/views exec vitest run inbox/`)