### PR TITLE
fix(inbox): jump instantly to targeted comments

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -273,7 +273,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
     if (el) {
       didHighlightRef.current = highlightCommentId;
       requestAnimationFrame(() => {
-        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        el.scrollIntoView({ behavior: "instant", block: "center" });
         setHighlightedId(highlightCommentId);
         const timer = setTimeout(() => setHighlightedId(null), 2000);
         return () => clearTimeout(timer);


### PR DESCRIPTION
## Summary

Fixes #1749.

Inbox comment targeting currently uses smooth scrolling when `highlightCommentId` is passed into `IssueDetail`. That creates unnecessary motion when users switch between multiple agent updates from the Inbox.

This changes the target-comment navigation to jump instantly while keeping the existing highlight effect so the destination remains visible.

## Validation

- `corepack pnpm --filter @multica/views typecheck`
- `git diff --check`
