### PR TITLE
feat(daemon): expose concurrent task slot env

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -886,7 +886,7 @@ func (d *Daemon) triggerRestart() {
 }
 
 func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan struct{}) error {
-	sem := make(chan struct{}, d.cfg.MaxConcurrentTasks)
+	sem := newTaskSlotSemaphore(d.cfg.MaxConcurrentTasks)
 	var wg sync.WaitGroup
 
 	pollOffset := 0
@@ -919,8 +919,9 @@ func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan struct{}) erro
 		n := len(runtimeIDs)
 		for i := 0; i < n; i++ {
 			// Check if we have capacity before claiming.
+			var slot int
 			select {
-			case sem <- struct{}{}:
+			case slot = <-sem:
 				// Acquired a slot.
 			default:
 				// All slots occupied, stop trying to claim.
@@ -931,7 +932,7 @@ func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan struct{}) erro
 			rid := runtimeIDs[(pollOffset+i)%n]
 			task, err := d.client.ClaimTask(ctx, rid)
 			if err != nil {
-				<-sem // Release the slot.
+				sem <- slot // Release the slot.
 				d.logger.Warn("claim task failed", "runtime_id", rid, "error", err)
 				continue
 			}
@@ -943,18 +944,18 @@ func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan struct{}) erro
 				d.logger.Info("task received", "task", shortID(task.ID), "target", taskTarget)
 				wg.Add(1)
 				d.activeTasks.Add(1)
-				go func(t Task) {
+				go func(t Task, slot int) {
 					defer wg.Done()
 					defer d.activeTasks.Add(-1)
-					defer func() { <-sem }()
-					d.handleTask(ctx, t)
-				}(*task)
+					defer func() { sem <- slot }()
+					d.handleTask(ctx, t, slot)
+				}(*task, slot)
 				claimed = true
 				pollOffset = (pollOffset + i + 1) % n
 				break
 			}
 			// No task for this runtime, release the slot and try next.
-			<-sem
+			sem <- slot
 		}
 
 	sleep:
@@ -974,7 +975,15 @@ func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan struct{}) erro
 	}
 }
 
-func (d *Daemon) handleTask(ctx context.Context, task Task) {
+func newTaskSlotSemaphore(maxConcurrentTasks int) chan int {
+	sem := make(chan int, maxConcurrentTasks)
+	for i := 0; i < maxConcurrentTasks; i++ {
+		sem <- i
+	}
+	return sem
+}
+
+func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	d.mu.Lock()
 	rt := d.runtimeIndex[task.RuntimeID]
 	d.mu.Unlock()
@@ -1027,7 +1036,7 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 		}
 	}()
 
-	result, err := d.runTask(runCtx, task, provider, taskLog)
+	result, err := d.runTask(runCtx, task, provider, slot, taskLog)
 
 	// Check if we were cancelled by the polling goroutine.
 	select {
@@ -1097,7 +1106,7 @@ func (d *Daemon) handleTask(ctx context.Context, task Task) {
 	}
 }
 
-func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLog *slog.Logger) (TaskResult, error) {
+func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot int, taskLog *slog.Logger) (TaskResult, error) {
 	// Refuse to spawn an agent without a workspace. An empty workspace_id
 	// here would make MULTICA_WORKSPACE_ID empty in the agent env, and the
 	// CLI would otherwise silently fall back to the user-global config — a
@@ -1186,6 +1195,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, taskLo
 		"MULTICA_AGENT_NAME":   agentName,
 		"MULTICA_AGENT_ID":     task.AgentID,
 		"MULTICA_TASK_ID":      task.ID,
+		"MULTICA_TASK_SLOT":    fmt.Sprintf("%d", slot),
 	}
 	if task.AutopilotRunID != "" {
 		agentEnv["MULTICA_AUTOPILOT_RUN_ID"] = task.AutopilotRunID

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -975,6 +976,9 @@ func (d *Daemon) pollLoop(ctx context.Context, taskWakeups <-chan struct{}) erro
 	}
 }
 
+// newTaskSlotSemaphore returns a buffered channel pre-populated with stable
+// slot indices [0, n). Receive to acquire a slot, send the same slot back to
+// release. Used by pollLoop to expose MULTICA_TASK_SLOT to spawned tasks.
 func newTaskSlotSemaphore(maxConcurrentTasks int) chan int {
 	sem := make(chan int, maxConcurrentTasks)
 	for i := 0; i < maxConcurrentTasks; i++ {
@@ -1187,6 +1191,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 	// Pass the daemon's auth credentials and context so the spawned agent CLI
 	// can call the Multica API and the local daemon (e.g. `multica repo checkout`).
+	// MULTICA_TASK_SLOT is allocated from the daemon-wide concurrency pool, not
+	// per-agent. When one daemon hosts multiple agents, slots index shared
+	// daemon-level resources such as GPUs.
 	agentEnv := map[string]string{
 		"MULTICA_TOKEN":        d.client.Token(),
 		"MULTICA_SERVER_URL":   d.cfg.ServerBaseURL,
@@ -1195,7 +1202,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"MULTICA_AGENT_NAME":   agentName,
 		"MULTICA_AGENT_ID":     task.AgentID,
 		"MULTICA_TASK_ID":      task.ID,
-		"MULTICA_TASK_SLOT":    fmt.Sprintf("%d", slot),
+		"MULTICA_TASK_SLOT":    strconv.Itoa(slot),
 	}
 	if task.AutopilotRunID != "" {
 		agentEnv["MULTICA_AUTOPILOT_RUN_ID"] = task.AutopilotRunID

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -52,6 +52,43 @@ func TestNormalizeServerBaseURL(t *testing.T) {
 	}
 }
 
+func TestNewTaskSlotSemaphoreReturnsStableSlotIndexes(t *testing.T) {
+	t.Parallel()
+
+	sem := newTaskSlotSemaphore(4)
+	seen := make(map[int]bool)
+	for i := 0; i < 4; i++ {
+		select {
+		case slot := <-sem:
+			if slot < 0 || slot > 3 {
+				t.Fatalf("slot out of range: %d", slot)
+			}
+			if seen[slot] {
+				t.Fatalf("duplicate slot: %d", slot)
+			}
+			seen[slot] = true
+		default:
+			t.Fatalf("expected slot %d to be available", i)
+		}
+	}
+
+	select {
+	case slot := <-sem:
+		t.Fatalf("expected semaphore to be empty, got slot %d", slot)
+	default:
+	}
+
+	sem <- 2
+	select {
+	case slot := <-sem:
+		if slot != 2 {
+			t.Fatalf("expected released slot 2, got %d", slot)
+		}
+	default:
+		t.Fatal("expected released slot to be available")
+	}
+}
+
 func TestBuildPromptContainsIssueID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #1750.

Adds a stable `MULTICA_TASK_SLOT` environment variable for daemon-launched agent tasks.

When the daemon runs with `max_concurrent_tasks > 1`, each in-flight task now receives the slot index it acquired from the daemon concurrency semaphore:

```bash
MULTICA_TASK_SLOT=0
MULTICA_TASK_SLOT=1
MULTICA_TASK_SLOT=2
```

This lets self-hosted users map concurrent agent tasks to isolated resources without creating duplicate agents. For example:

```bash
export CUDA_VISIBLE_DEVICES=$MULTICA_TASK_SLOT
```

## Implementation notes

- Changes the daemon poll-loop semaphore from anonymous `struct{}` capacity tokens to stable integer slot tokens.
- Slots are returned to the semaphore when a task completes, claim fails, or no task is available.
- Injects the slot into the spawned agent environment as `MULTICA_TASK_SLOT`.
- Adds a unit test for stable slot allocation and release behavior.

## Validation

- `GOCACHE=/tmp/gocache go test ./internal/daemon -run TestNewTaskSlotSemaphoreReturnsStableSlotIndexes`
- `GOCACHE=/tmp/gocache go test ./internal/daemon`
- `git diff --check`
