### PR TITLE
feat(desktop): add 'Take Over Locally' issue action

### DIFF
--- a/apps/desktop/src/main/daemon-manager.ts
+++ b/apps/desktop/src/main/daemon-manager.ts
@@ -237,6 +237,28 @@ function invalidateActiveProfile(): void {
   activeProfile = null;
 }
 
+/**
+ * Resolves a ready-to-run invocation of the bundled `multica` CLI for
+ * features outside the daemon-manager (e.g. `issue:takeOver`). Returns the
+ * binary path, the `--profile <name>` args needed to talk to the same
+ * server the renderer is using, and the env (PATH-fixed + the
+ * MULTICA_LAUNCHED_BY marker). Returns `null` when no CLI binary could be
+ * resolved — the caller surfaces that as a user-visible error.
+ */
+export async function resolveCliInvocation(): Promise<
+  | { bin: string; profileArgs: string[]; env: NodeJS.ProcessEnv }
+  | null
+> {
+  const bin = await resolveCliBinary();
+  if (!bin) return null;
+  const active = await ensureActiveProfile();
+  return {
+    bin,
+    profileArgs: profileArgs(active),
+    env: desktopSpawnEnv(),
+  };
+}
+
 async function fetchHealth(): Promise<DaemonStatus> {
   // While the CLI is being downloaded or has permanently failed, short-circuit
   // polling — there's nothing to probe yet and /health calls would just return

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 import fixPath from "fix-path";
 import { setupAutoUpdater } from "./updater";
 import { setupDaemonManager } from "./daemon-manager";
+import { setupIssueTakeOver } from "./issue-take-over";
 import { openExternalSafely } from "./external-url";
 import { installContextMenu } from "./context-menu";
 import { getAppVersion } from "./app-version";
@@ -277,6 +278,7 @@ if (!gotTheLock) {
 
     setupAutoUpdater(() => mainWindow);
     setupDaemonManager(() => mainWindow);
+    setupIssueTakeOver();
 
     // macOS: deep link arrives via open-url event
     app.on("open-url", (_event, url) => {

--- a/apps/desktop/src/main/issue-take-over.ts
+++ b/apps/desktop/src/main/issue-take-over.ts
@@ -1,0 +1,97 @@
+import { clipboard, ipcMain } from "electron";
+import { execFile } from "child_process";
+import { resolveCliInvocation } from "./daemon-manager";
+
+export interface TakeOverResult {
+  ok: boolean;
+  /** The shell command copied to the clipboard (e.g. `cd '...' && claude --resume sess_abc`). */
+  command?: string;
+  /** Workdir extracted from the `cd '...' && ` prefix, when present. */
+  workDir?: string;
+  /** Set on failure. Surfaced verbatim in the renderer toast. */
+  error?: string;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// MUL-123, ABC-1, etc. — the human-readable identifier accepted by the
+// CLI alongside raw UUIDs.
+const IDENTIFIER_RE = /^[A-Z][A-Z0-9]*-\d+$/;
+
+function isAcceptableIssueId(id: unknown): id is string {
+  if (typeof id !== "string") return false;
+  return UUID_RE.test(id) || IDENTIFIER_RE.test(id);
+}
+
+// Pulls the path out of the `cd '<path>' && ...` prefix the CLI emits. The
+// Go side single-quotes the path with `'\''` for embedded quotes; we just
+// reverse the wrapping here for display purposes — the actual command is
+// already on the clipboard.
+function extractWorkDir(command: string): string | undefined {
+  const match = command.match(/^cd '((?:[^']|'\\'')*)' && /);
+  if (!match) return undefined;
+  return match[1]!.replace(/'\\''/g, "'");
+}
+
+function runCli(
+  bin: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      bin,
+      args,
+      { timeout: 15_000, env, maxBuffer: 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          const e = err as NodeJS.ErrnoException & { stderr?: string };
+          e.stderr = stderr;
+          reject(e);
+          return;
+        }
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+}
+
+async function takeOver(issueId: string): Promise<TakeOverResult> {
+  if (!isAcceptableIssueId(issueId)) {
+    return { ok: false, error: "Invalid issue id" };
+  }
+
+  const cli = await resolveCliInvocation();
+  if (!cli) {
+    return {
+      ok: false,
+      error: "multica CLI is not available. Try restarting the desktop app.",
+    };
+  }
+
+  const args = ["issue", "take", issueId, "--print", ...cli.profileArgs];
+
+  try {
+    const { stdout } = await runCli(cli.bin, args, cli.env);
+    const command = stdout.trim();
+    if (!command) {
+      return { ok: false, error: "CLI returned an empty resume command." };
+    }
+    clipboard.writeText(command);
+    return { ok: true, command, workDir: extractWorkDir(command) };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stderr?: string };
+    // Prefer the CLI's stderr message — it carries the actionable detail
+    // (e.g. "no completed run found", "unsupported provider").
+    const detail = (e.stderr ?? "").trim().split("\n").pop()?.trim();
+    return {
+      ok: false,
+      error: detail && detail.length > 0 ? detail : (e.message ?? "Unknown error"),
+    };
+  }
+}
+
+export function setupIssueTakeOver(): void {
+  ipcMain.handle("issue:takeOver", (_event, issueId: string) =>
+    takeOver(issueId),
+  );
+}

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -32,6 +32,17 @@ interface DesktopAPI {
       issueKey: string;
     }) => void,
   ) => () => void;
+  /**
+   * Resolve and copy the local resume command for an issue. Main runs
+   * `multica issue take <id> --print`, copies stdout to the clipboard,
+   * and returns the command + parsed workdir for the confirmation toast.
+   */
+  takeOverIssue: (issueId: string) => Promise<{
+    ok: boolean;
+    command?: string;
+    workDir?: string;
+    error?: string;
+  }>;
 }
 
 interface DaemonStatus {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -94,6 +94,21 @@ const desktopAPI = {
       ipcRenderer.removeListener("inbox:open", handler);
     };
   },
+  /**
+   * Resolve the local resume command for an issue's most recent agent run
+   * and copy it to the system clipboard. Main runs `multica issue take
+   * <id> --print`, then writes the stdout into the clipboard. Returns the
+   * raw command (and parsed workdir, if the prefix was present) so the
+   * renderer can drop it into a confirmation toast.
+   */
+  takeOverIssue: (
+    issueId: string,
+  ): Promise<{
+    ok: boolean;
+    command?: string;
+    workDir?: string;
+    error?: string;
+  }> => ipcRenderer.invoke("issue:takeOver", issueId),
 };
 
 interface DaemonStatus {

--- a/packages/core/issues/index.ts
+++ b/packages/core/issues/index.ts
@@ -4,3 +4,4 @@ export * from "./mutations";
 export * from "./ws-updaters";
 export * from "./config";
 export * from "./stores";
+export * from "./take-over";

--- a/packages/core/issues/take-over.test.ts
+++ b/packages/core/issues/take-over.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRuntime, AgentTask } from "../types";
+import {
+  TAKE_OVER_PROVIDERS,
+  canTakeOverLocally,
+  findResumableTask,
+  isTakeOverProvider,
+} from "./take-over";
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "t-1",
+    agent_id: "a-1",
+    runtime_id: "rt-1",
+    issue_id: "i-1",
+    status: "completed",
+    priority: 0,
+    dispatched_at: null,
+    started_at: null,
+    completed_at: "2026-04-29T12:00:00Z",
+    result: { session_id: "sess-1", work_dir: "/tmp/work" },
+    error: null,
+    created_at: "2026-04-29T11:55:00Z",
+    ...overrides,
+  };
+}
+
+function makeRuntime(overrides: Partial<AgentRuntime> = {}): AgentRuntime {
+  return {
+    id: "rt-1",
+    workspace_id: "ws-1",
+    daemon_id: null,
+    name: "claude-runtime",
+    runtime_mode: "local",
+    provider: "claude",
+    launch_header: "",
+    status: "online",
+    device_info: "",
+    metadata: {},
+    owner_id: null,
+    last_seen_at: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("isTakeOverProvider", () => {
+  it("matches each canonical provider name (case-insensitive)", () => {
+    for (const p of TAKE_OVER_PROVIDERS) {
+      expect(isTakeOverProvider(p)).toBe(true);
+      expect(isTakeOverProvider(p.toUpperCase())).toBe(true);
+    }
+  });
+
+  it("rejects empty / unknown / null", () => {
+    expect(isTakeOverProvider(null)).toBe(false);
+    expect(isTakeOverProvider(undefined)).toBe(false);
+    expect(isTakeOverProvider("")).toBe(false);
+    expect(isTakeOverProvider("openai")).toBe(false);
+  });
+});
+
+describe("findResumableTask", () => {
+  it("returns the newest completed task with a session id and supported provider", () => {
+    const tasks: AgentTask[] = [
+      makeTask({
+        id: "old",
+        completed_at: "2026-04-29T10:00:00Z",
+        result: { session_id: "old-sess", work_dir: "/old" },
+      }),
+      makeTask({
+        id: "new",
+        completed_at: "2026-04-29T12:00:00Z",
+        result: { session_id: "new-sess", work_dir: "/new" },
+      }),
+    ];
+    const runtimes = [makeRuntime()];
+
+    const found = findResumableTask(tasks, runtimes);
+    expect(found?.task.id).toBe("new");
+    expect(found?.provider).toBe("claude");
+  });
+
+  it("skips non-completed tasks", () => {
+    const tasks: AgentTask[] = [
+      makeTask({ id: "running", status: "running" }),
+      makeTask({
+        id: "old-done",
+        completed_at: "2026-04-29T08:00:00Z",
+        result: { session_id: "sess", work_dir: "/x" },
+      }),
+    ];
+    expect(findResumableTask(tasks, [makeRuntime()])?.task.id).toBe("old-done");
+  });
+
+  it("skips completed tasks without a session_id", () => {
+    const tasks: AgentTask[] = [
+      makeTask({ id: "no-session", result: { work_dir: "/x" } }),
+    ];
+    expect(findResumableTask(tasks, [makeRuntime()])).toBeNull();
+  });
+
+  it("skips tasks whose runtime provider is not supported", () => {
+    const tasks = [makeTask()];
+    const runtimes = [makeRuntime({ provider: "openai" })];
+    expect(findResumableTask(tasks, runtimes)).toBeNull();
+  });
+
+  it("skips tasks whose runtime is missing from the workspace runtimes list", () => {
+    const tasks = [makeTask({ runtime_id: "ghost" })];
+    expect(findResumableTask(tasks, [makeRuntime()])).toBeNull();
+  });
+
+  it("falls back to created_at when completed_at is missing", () => {
+    const tasks: AgentTask[] = [
+      makeTask({
+        id: "older-completed",
+        completed_at: null,
+        created_at: "2026-04-29T09:00:00Z",
+      }),
+      makeTask({
+        id: "newer-completed",
+        completed_at: null,
+        created_at: "2026-04-29T11:00:00Z",
+      }),
+    ];
+    expect(findResumableTask(tasks, [makeRuntime()])?.task.id).toBe(
+      "newer-completed",
+    );
+  });
+});
+
+describe("canTakeOverLocally", () => {
+  const tasks = [makeTask()];
+  const runtimes = [makeRuntime()];
+
+  it("returns true on desktop with a resumable run", () => {
+    expect(canTakeOverLocally({ tasks, runtimes, clientType: "desktop" })).toBe(
+      true,
+    );
+  });
+
+  it("returns false on web even with a resumable run", () => {
+    expect(canTakeOverLocally({ tasks, runtimes, clientType: "web" })).toBe(
+      false,
+    );
+  });
+
+  it("returns false on desktop when there is no resumable run", () => {
+    expect(
+      canTakeOverLocally({ tasks: [], runtimes, clientType: "desktop" }),
+    ).toBe(false);
+  });
+});

--- a/packages/core/issues/take-over.ts
+++ b/packages/core/issues/take-over.ts
@@ -1,0 +1,90 @@
+import type { AgentRuntime, AgentTask } from "../types";
+
+// Providers whose CLI we know how to drive with a `--resume <session>` style
+// invocation. Mirrors `resumeCommandForProvider` in
+// server/cmd/multica/cmd_issue.go — keep the two lists in sync when adding a
+// new provider.
+export const TAKE_OVER_PROVIDERS = [
+  "claude",
+  "codex",
+  "cursor",
+  "gemini",
+  "opencode",
+  "copilot",
+] as const;
+
+export type TakeOverProvider = (typeof TAKE_OVER_PROVIDERS)[number];
+
+export function isTakeOverProvider(p: string | undefined | null): p is TakeOverProvider {
+  if (!p) return false;
+  return (TAKE_OVER_PROVIDERS as readonly string[]).includes(p.toLowerCase());
+}
+
+// Subset of the agent_task.result payload we read for take-over. The Go CLI
+// stores at least these two fields for completed local-runtime runs; the
+// field is `unknown` on AgentTask because other shapes flow through the same
+// column (chat tasks, autopilots, etc.).
+interface TaskRunResult {
+  session_id?: unknown;
+  work_dir?: unknown;
+}
+
+function readResult(task: AgentTask): TaskRunResult {
+  if (task.result && typeof task.result === "object") {
+    return task.result as TaskRunResult;
+  }
+  return {};
+}
+
+function readSessionId(task: AgentTask): string | null {
+  const v = readResult(task).session_id;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/**
+ * Walk tasks newest-first and return the first completed one that carries a
+ * resumable session_id whose runtime maps to a supported provider. Mirrors
+ * `pickResumableRun` + the provider mapping in cmd_issue.go.
+ *
+ * `tasks` does not need to be pre-sorted — this function sorts on a copy to
+ * keep the function pure.
+ */
+export function findResumableTask(
+  tasks: readonly AgentTask[],
+  runtimes: readonly AgentRuntime[],
+): { task: AgentTask; provider: TakeOverProvider } | null {
+  const providerById = new Map(runtimes.map((r) => [r.id, r.provider]));
+
+  const sorted = [...tasks].sort((a, b) => {
+    const at = a.completed_at ?? a.created_at;
+    const bt = b.completed_at ?? b.created_at;
+    return new Date(bt).getTime() - new Date(at).getTime();
+  });
+
+  for (const task of sorted) {
+    if (task.status !== "completed") continue;
+    if (!readSessionId(task)) continue;
+    const provider = providerById.get(task.runtime_id);
+    if (!isTakeOverProvider(provider)) continue;
+    return { task, provider };
+  }
+  return null;
+}
+
+/**
+ * Predicate gating the desktop "Take Over Locally" menu item. Returns true
+ * when the action would actually do something useful — at least one
+ * completed run exists, its runtime is a supported provider, and we're
+ * running in the desktop client.
+ *
+ * `clientType` is passed in (instead of read from `window`) so callers can
+ * unit-test this without DOM globals.
+ */
+export function canTakeOverLocally(args: {
+  tasks: readonly AgentTask[];
+  runtimes: readonly AgentRuntime[];
+  clientType: "desktop" | "web";
+}): boolean {
+  if (args.clientType !== "desktop") return false;
+  return findResumableTask(args.tasks, args.runtimes) !== null;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "./issues/queries": "./issues/queries.ts",
     "./issues/mutations": "./issues/mutations.ts",
     "./issues/ws-updaters": "./issues/ws-updaters.ts",
+    "./issues/take-over": "./issues/take-over.ts",
     "./issues/config": "./issues/config/index.ts",
     "./issues/config/status": "./issues/config/status.ts",
     "./issues/config/priority": "./issues/config/priority.ts",

--- a/packages/views/agents/components/inspector/model-picker.tsx
+++ b/packages/views/agents/components/inspector/model-picker.tsx
@@ -42,12 +42,11 @@ export function ModelPicker({
   const supported = modelsQuery.data?.supported ?? true;
   // Memoise the model list so every downstream useMemo gets a stable
   // reference — `?? []` would mint a fresh array on every render and
-  // invalidate filters / defaultModel needlessly.
+  // invalidate `filtered` needlessly.
   const models = useMemo(
     () => modelsQuery.data?.models ?? [],
     [modelsQuery.data],
   );
-  const defaultModel = useMemo(() => models.find((m) => m.default), [models]);
 
   const filtered = useMemo(() => {
     const s = search.trim().toLowerCase();

--- a/packages/views/issues/actions/__tests__/use-take-over.test.tsx
+++ b/packages/views/issues/actions/__tests__/use-take-over.test.tsx
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { AgentRuntime, AgentTask } from "@multica/core/types";
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+const { mockListTasksByIssue, mockListRuntimes, toastSuccess, toastError } =
+  vi.hoisted(() => ({
+    mockListTasksByIssue: vi.fn<() => Promise<AgentTask[]>>(),
+    mockListRuntimes: vi.fn<() => Promise<AgentRuntime[]>>(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+  }));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    listTasksByIssue: () => mockListTasksByIssue(),
+    listRuntimes: () => mockListRuntimes(),
+  },
+}));
+
+vi.mock("@multica/core/runtimes/queries", async () => {
+  const actual = await vi.importActual<
+    typeof import("@multica/core/runtimes/queries")
+  >("@multica/core/runtimes/queries");
+  return {
+    ...actual,
+    runtimeListOptions: () => ({
+      queryKey: ["runtimes", "ws-1", "list"],
+      queryFn: () => mockListRuntimes(),
+    }),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
+import { useTakeOver } from "../use-take-over";
+
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "t-1",
+    agent_id: "a-1",
+    runtime_id: "rt-1",
+    issue_id: "issue-1",
+    status: "completed",
+    priority: 0,
+    dispatched_at: null,
+    started_at: null,
+    completed_at: "2026-04-29T12:00:00Z",
+    result: { session_id: "sess-1", work_dir: "/tmp/work" },
+    error: null,
+    created_at: "2026-04-29T11:55:00Z",
+    ...overrides,
+  };
+}
+
+function makeRuntime(overrides: Partial<AgentRuntime> = {}): AgentRuntime {
+  return {
+    id: "rt-1",
+    workspace_id: "ws-1",
+    daemon_id: null,
+    name: "claude-runtime",
+    runtime_mode: "local",
+    provider: "claude",
+    launch_header: "",
+    status: "online",
+    device_info: "",
+    metadata: {},
+    owner_id: null,
+    last_seen_at: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const takeOverIssueIPC = vi.fn();
+
+beforeEach(() => {
+  mockListTasksByIssue.mockReset();
+  mockListRuntimes.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+  takeOverIssueIPC.mockReset();
+  mockListTasksByIssue.mockResolvedValue([makeTask()]);
+  mockListRuntimes.mockResolvedValue([makeRuntime()]);
+  (window as unknown as { desktopAPI?: unknown }).desktopAPI = {
+    takeOverIssue: takeOverIssueIPC,
+  };
+});
+
+afterEach(() => {
+  delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
+});
+
+describe("useTakeOver", () => {
+  it("is invisible when running on the web (no desktopAPI)", async () => {
+    delete (window as unknown as { desktopAPI?: unknown }).desktopAPI;
+
+    const { result } = renderHook(
+      () => useTakeOver("issue-1", { enabled: true }),
+      { wrapper },
+    );
+
+    // Without desktopAPI we should not even fire the queries.
+    await waitFor(() => {
+      expect(result.current.visible).toBe(false);
+    });
+    expect(mockListTasksByIssue).not.toHaveBeenCalled();
+    expect(mockListRuntimes).not.toHaveBeenCalled();
+  });
+
+  it("is invisible when disabled, even on desktop", async () => {
+    const { result } = renderHook(
+      () => useTakeOver("issue-1", { enabled: false }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.visible).toBe(false);
+    });
+    expect(mockListTasksByIssue).not.toHaveBeenCalled();
+  });
+
+  it("becomes visible on desktop when a resumable run exists", async () => {
+    const { result } = renderHook(
+      () => useTakeOver("issue-1", { enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.visible).toBe(true);
+    });
+  });
+
+  it("stays invisible when no completed run carries a session id", async () => {
+    mockListTasksByIssue.mockResolvedValue([makeTask({ result: {} })]);
+
+    const { result } = renderHook(
+      () => useTakeOver("issue-1", { enabled: true }),
+      { wrapper },
+    );
+
+    // Wait for the queries to settle.
+    await waitFor(() => {
+      expect(mockListTasksByIssue).toHaveBeenCalled();
+    });
+    expect(result.current.visible).toBe(false);
+  });
+
+  it("stays invisible when the runtime provider isn't supported", async () => {
+    mockListRuntimes.mockResolvedValue([makeRuntime({ provider: "openai" })]);
+
+    const { result } = renderHook(
+      () => useTakeOver("issue-1", { enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(mockListRuntimes).toHaveBeenCalled();
+    });
+    expect(result.current.visible).toBe(false);
+  });
+
+  it("invokes the desktop IPC and shows a success toast with the workdir", async () => {
+    takeOverIssueIPC.mockResolvedValue({
+      ok: true,
+      command: "cd '/Users/x/work' && claude --resume sess-1",
+      workDir: "/Users/x/work",
+    });
+
+    const { result } = renderHook(
+      () => useTakeOver("issue-1", { enabled: true }),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current.visible).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.takeOver();
+    });
+
+    expect(takeOverIssueIPC).toHaveBeenCalledWith("issue-1");
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Command copied. Paste in your terminal to take over.",
+      { description: "/Users/x/work" },
+    );
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast when the IPC call fails", async () => {
+    takeOverIssueIPC.mockResolvedValue({
+      ok: false,
+      error: "no completed run found for issue issue-1",
+    });
+
+    const { result } = renderHook(
+      () => useTakeOver("issue-1", { enabled: true }),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current.visible).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.takeOver();
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Could not prepare take-over command",
+      { description: "no completed run found for issue issue-1" },
+    );
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/issues/actions/issue-actions-dropdown.tsx
+++ b/packages/views/issues/actions/issue-actions-dropdown.tsx
@@ -12,6 +12,7 @@ import {
   IssueActionsMenuItems,
   dropdownPrimitives,
 } from "./issue-actions-menu-items";
+import { useTakeOver } from "./use-take-over";
 
 interface IssueActionsDropdownProps {
   issue: Issue;
@@ -20,6 +21,12 @@ interface IssueActionsDropdownProps {
   align?: "start" | "end" | "center";
   /** If set, navigate here after the issue is deleted. */
   onDeletedNavigateTo?: string;
+  /**
+   * Enable the desktop-only "Take Over Locally" item. The dropdown still
+   * decides per-issue visibility based on the run history; this flag only
+   * gates the data-fetch (board/list rows pass false to skip the round-trip).
+   */
+  enableTakeOver?: boolean;
 }
 
 export function IssueActionsDropdown({
@@ -27,8 +34,10 @@ export function IssueActionsDropdown({
   trigger,
   align = "end",
   onDeletedNavigateTo,
+  enableTakeOver = false,
 }: IssueActionsDropdownProps) {
   const actions = useIssueActions(issue);
+  const takeOver = useTakeOver(issue.id, { enabled: enableTakeOver });
   return (
     <DropdownMenu>
       <DropdownMenuTrigger render={trigger} />
@@ -38,6 +47,7 @@ export function IssueActionsDropdown({
           actions={actions}
           primitives={dropdownPrimitives}
           onDeletedNavigateTo={onDeletedNavigateTo}
+          onTakeOverLocally={takeOver.visible ? takeOver.takeOver : undefined}
         />
       </DropdownMenuContent>
     </DropdownMenu>

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -9,6 +9,7 @@ import {
   Pin,
   PinOff,
   Plus,
+  Terminal,
   Trash2,
   UserMinus,
 } from "lucide-react";
@@ -74,6 +75,13 @@ interface IssueActionsMenuItemsProps {
   primitives: MenuPrimitives;
   /** If set, navigate here after the issue is deleted (used by the detail page). */
   onDeletedNavigateTo?: string;
+  /**
+   * Desktop-only "Take Over Locally" entry. The dropdown wrapper resolves
+   * visibility (desktop + at least one resumable run) and only passes the
+   * handler when the row should appear. Web builds and surfaces that don't
+   * opt in (board/list rows) get `undefined` and skip the row entirely.
+   */
+  onTakeOverLocally?: () => void;
 }
 
 export function IssueActionsMenuItems({
@@ -81,6 +89,7 @@ export function IssueActionsMenuItems({
   actions,
   primitives: P,
   onDeletedNavigateTo,
+  onTakeOverLocally,
 }: IssueActionsMenuItemsProps) {
   const {
     members,
@@ -237,6 +246,12 @@ export function IssueActionsMenuItems({
         <Link2 className="h-3.5 w-3.5" />
         Copy link
       </P.Item>
+      {onTakeOverLocally && (
+        <P.Item onClick={onTakeOverLocally}>
+          <Terminal className="h-3.5 w-3.5" />
+          Take over locally
+        </P.Item>
+      )}
 
       <P.Separator />
 

--- a/packages/views/issues/actions/use-take-over.ts
+++ b/packages/views/issues/actions/use-take-over.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@multica/core/api";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { issueKeys } from "@multica/core/issues/queries";
+import { canTakeOverLocally } from "@multica/core/issues/take-over";
+import { runtimeListOptions } from "@multica/core/runtimes/queries";
+
+interface DesktopAPIWithTakeOver {
+  takeOverIssue?: (
+    issueId: string,
+  ) => Promise<{
+    ok: boolean;
+    command?: string;
+    workDir?: string;
+    error?: string;
+  }>;
+}
+
+function getDesktopAPI(): DesktopAPIWithTakeOver | null {
+  if (typeof window === "undefined") return null;
+  const w = window as unknown as { desktopAPI?: DesktopAPIWithTakeOver };
+  return w.desktopAPI ?? null;
+}
+
+export interface UseTakeOverResult {
+  /** True when the menu item should render (desktop + at least one resumable run). */
+  visible: boolean;
+  /** Triggers the IPC + clipboard copy + toast. No-op when not visible. */
+  takeOver: () => Promise<void>;
+}
+
+/**
+ * Drives the desktop "Take Over Locally" menu item. The hook gates its
+ * own data-fetching on `enabled` so callers in board/list views (where
+ * the action is never offered) don't pay for a runs/runtimes round-trip.
+ *
+ * The visibility decision lives in {@link canTakeOverLocally} so it can
+ * be unit-tested without React.
+ */
+export function useTakeOver(
+  issueId: string | null,
+  opts: { enabled: boolean } = { enabled: true },
+): UseTakeOverResult {
+  const wsId = useWorkspaceId();
+  const desktopAPI = getDesktopAPI();
+
+  // Two short-circuits, in order:
+  //   - the renderer is web (no `desktopAPI`) — the action could never
+  //     execute, so don't fetch.
+  //   - the caller hasn't asked for take-over (`enabled: false`) — the
+  //     dropdown isn't shown on this surface.
+  const queryEnabled = opts.enabled && !!desktopAPI && !!issueId;
+
+  const { data: tasks = [] } = useQuery({
+    queryKey: issueKeys.tasks(issueId ?? ""),
+    queryFn: () => api.listTasksByIssue(issueId!),
+    enabled: queryEnabled,
+    staleTime: 30_000,
+  });
+
+  const { data: runtimes = [] } = useQuery({
+    ...runtimeListOptions(wsId),
+    enabled: queryEnabled,
+  });
+
+  const visible = useMemo(
+    () =>
+      canTakeOverLocally({
+        tasks,
+        runtimes,
+        clientType: desktopAPI ? "desktop" : "web",
+      }),
+    [tasks, runtimes, desktopAPI],
+  );
+
+  const takeOver = useCallback(async () => {
+    if (!issueId || !desktopAPI?.takeOverIssue) return;
+    const result = await desktopAPI.takeOverIssue(issueId);
+    if (!result.ok) {
+      toast.error("Could not prepare take-over command", {
+        description: result.error,
+      });
+      return;
+    }
+    // Workdir is parsed out of the `cd '...' && ` prefix by the main
+    // process. When the worktree was GC'd the CLI omits the prefix, so
+    // workDir is undefined — fall back to the command itself.
+    const description = result.workDir
+      ? result.workDir
+      : (result.command ?? undefined);
+    toast.success("Command copied. Paste in your terminal to take over.", {
+      description,
+    });
+  }, [issueId, desktopAPI]);
+
+  return { visible, takeOver };
+}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -532,6 +532,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
               // When a parent passes `onDelete`, we detect deletion via effect
               // above and skip navigation. Otherwise the modal navigates for us.
               onDeletedNavigateTo={onDelete ? undefined : paths.issues()}
+              enableTakeOver
               trigger={
                 <Button variant="ghost" size="icon-sm" className="text-muted-foreground">
                   <MoreHorizontal />

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -171,6 +173,21 @@ var issueRerunCmd = &cobra.Command{
 	RunE:  runIssueRerun,
 }
 
+var issueTakeCmd = &cobra.Command{
+	Use:   "take <issue-id>",
+	Short: "Resume an agent's last session for an issue locally",
+	Long: `Take over an issue's most recent completed agent run on this machine.
+
+By default this spawns the matching agent CLI inside the worktree the
+agent used, with stdin/stdout/stderr wired through. The agent picks up
+the same session, so prior context is preserved.
+
+Use --print to emit the equivalent shell command for use with eval, or
+--copy to drop it on the system clipboard.`,
+	Args: exactArgs(1),
+	RunE: runIssueTake,
+}
+
 var issueSearchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search issues by title or description",
@@ -194,6 +211,7 @@ func init() {
 	issueCmd.AddCommand(issueRunsCmd)
 	issueCmd.AddCommand(issueRunMessagesCmd)
 	issueCmd.AddCommand(issueRerunCmd)
+	issueCmd.AddCommand(issueTakeCmd)
 	issueCmd.AddCommand(issueSearchCmd)
 
 	issueCommentCmd.AddCommand(issueCommentListCmd)
@@ -260,6 +278,11 @@ func init() {
 
 	// issue rerun
 	issueRerunCmd.Flags().String("output", "json", "Output format: table or json")
+
+	// issue take
+	issueTakeCmd.Flags().String("provider", "", "Force a specific provider (claude, codex, cursor, gemini, opencode, copilot); auto-detected from the latest run when omitted")
+	issueTakeCmd.Flags().Bool("print", false, "Print the shell command to stdout instead of executing it (use with eval)")
+	issueTakeCmd.Flags().Bool("copy", false, "Copy the shell command to the system clipboard instead of executing it")
 
 	// issue run-messages
 	issueRunMessagesCmd.Flags().String("output", "json", "Output format: table or json")
@@ -1022,6 +1045,211 @@ func runIssueRerun(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(os.Stdout, "Re-enqueued task %s on agent %s\n", strVal(task, "id"), strVal(task, "agent_id"))
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Take command — local agent takeover
+// ---------------------------------------------------------------------------
+
+// providerResume describes how to resume a session for a given provider.
+// Captured as a small struct (not just a single string) because the
+// flag-vs-subcommand split varies per CLI: claude uses `--resume <id>`,
+// codex uses a `resume <id>` subcommand, gemini uses `-r <id>`, etc.
+type providerResume struct {
+	Bin  string
+	Args []string
+}
+
+// resumeCommandForProvider maps a runtime provider to the local CLI
+// invocation that resumes the given session. Returns an error for
+// providers we have not mapped — callers translate that into a
+// non-zero exit per the take command spec.
+func resumeCommandForProvider(provider, sessionID string) (providerResume, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "claude":
+		return providerResume{Bin: "claude", Args: []string{"--resume", sessionID}}, nil
+	case "codex":
+		return providerResume{Bin: "codex", Args: []string{"resume", sessionID}}, nil
+	case "cursor":
+		return providerResume{Bin: "cursor-agent", Args: []string{"--resume", sessionID}}, nil
+	case "gemini":
+		return providerResume{Bin: "gemini", Args: []string{"-r", sessionID}}, nil
+	case "opencode":
+		return providerResume{Bin: "opencode", Args: []string{"--session", sessionID}}, nil
+	case "copilot":
+		return providerResume{Bin: "copilot", Args: []string{"--resume", sessionID}}, nil
+	default:
+		return providerResume{}, fmt.Errorf("unsupported provider %q", provider)
+	}
+}
+
+// shellSingleQuote wraps s in POSIX single quotes, escaping any embedded
+// single quotes so the result is safe to paste into bash/zsh. We use
+// single quotes so the workdir path and session id are passed through
+// without any expansion.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// buildShellResumeCommand renders the user-pasteable command line for the
+// given workdir + resume invocation. When workdir is empty, we omit the
+// `cd` prefix so callers can still get a usable command after a GC.
+func buildShellResumeCommand(workDir string, r providerResume) string {
+	parts := make([]string, 0, len(r.Args)+1)
+	parts = append(parts, r.Bin)
+	for _, a := range r.Args {
+		parts = append(parts, shellSingleQuote(a))
+	}
+	cmd := strings.Join(parts, " ")
+	if workDir == "" {
+		return cmd
+	}
+	return "cd " + shellSingleQuote(workDir) + " && " + cmd
+}
+
+// pickResumableRun walks task-runs (newest first) and returns the first
+// completed run that carries a session_id. Returns ok=false when nothing
+// usable exists. work_dir may legitimately be empty and is not required
+// for matching — the agent CLI can still resume a session by id.
+func pickResumableRun(runs []map[string]any) (sessionID, workDir, runtimeID string, ok bool) {
+	for _, r := range runs {
+		if strVal(r, "status") != "completed" {
+			continue
+		}
+		result, _ := r["result"].(map[string]any)
+		sid := strVal(result, "session_id")
+		if sid == "" {
+			continue
+		}
+		return sid, strVal(result, "work_dir"), strVal(r, "runtime_id"), true
+	}
+	return "", "", "", false
+}
+
+// copyToClipboard pipes s into the platform's clipboard utility. macOS
+// has pbcopy in the base system; Linux requires xclip or xsel — we try
+// xclip first then fall back, matching what the take spec lists.
+func copyToClipboard(ctx context.Context, s string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "pbcopy")
+	case "linux":
+		if _, err := exec.LookPath("xclip"); err == nil {
+			cmd = exec.CommandContext(ctx, "xclip", "-selection", "clipboard")
+		} else if _, err := exec.LookPath("xsel"); err == nil {
+			cmd = exec.CommandContext(ctx, "xsel", "--clipboard", "--input")
+		} else {
+			return fmt.Errorf("no clipboard tool found; install xclip or xsel")
+		}
+	default:
+		return fmt.Errorf("clipboard copy not supported on %s", runtime.GOOS)
+	}
+	cmd.Stdin = strings.NewReader(s)
+	return cmd.Run()
+}
+
+func runIssueTake(cmd *cobra.Command, args []string) error {
+	printMode, _ := cmd.Flags().GetBool("print")
+	copyMode, _ := cmd.Flags().GetBool("copy")
+	if printMode && copyMode {
+		return fmt.Errorf("--print and --copy are mutually exclusive")
+	}
+	forceProvider, _ := cmd.Flags().GetString("provider")
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var runs []map[string]any
+	if err := client.GetJSON(ctx, "/api/issues/"+args[0]+"/task-runs", &runs); err != nil {
+		return fmt.Errorf("list runs: %w", err)
+	}
+
+	sessionID, workDir, runtimeID, ok := pickResumableRun(runs)
+	if !ok {
+		return fmt.Errorf("no completed run found for issue %s", args[0])
+	}
+
+	provider := strings.TrimSpace(forceProvider)
+	if provider == "" {
+		var runtimes []map[string]any
+		if err := client.GetJSON(ctx, "/api/runtimes", &runtimes); err != nil {
+			return fmt.Errorf("list runtimes: %w", err)
+		}
+		for _, rt := range runtimes {
+			if strVal(rt, "id") == runtimeID {
+				provider = strVal(rt, "provider")
+				break
+			}
+		}
+		if provider == "" {
+			return fmt.Errorf("runtime %s not found in this workspace; pass --provider explicitly", truncateID(runtimeID))
+		}
+	}
+
+	resume, providerErr := resumeCommandForProvider(provider, sessionID)
+	if providerErr != nil {
+		// Spec: print the raw command via --print style output and exit non-zero.
+		// We have no canonical command for this provider, so surface what we know
+		// (workdir + session id) so the user can assemble it themselves.
+		fmt.Fprintf(os.Stderr, "Provider %q is not in the supported take list. Resume manually with:\n", provider)
+		if workDir != "" {
+			fmt.Fprintf(os.Stderr, "  cd %s\n", shellSingleQuote(workDir))
+		}
+		fmt.Fprintf(os.Stderr, "  session_id: %s\n", sessionID)
+		return providerErr
+	}
+
+	// If the workdir was GC'd we still want the resume to work — most
+	// agent CLIs key off the session id, not the directory. Drop into
+	// the user's current shell cwd (i.e. clear Cmd.Dir) and warn so
+	// they know the file context they had may be gone.
+	workdirUsable := workDir != ""
+	if workdirUsable {
+		if _, statErr := os.Stat(workDir); statErr != nil {
+			workdirUsable = false
+			fmt.Fprintf(os.Stderr, "warning: worktree %s is gone; resuming session from current directory.\n", workDir)
+		}
+	}
+
+	if printMode {
+		effectiveDir := workDir
+		if !workdirUsable {
+			effectiveDir = ""
+		}
+		fmt.Println(buildShellResumeCommand(effectiveDir, resume))
+		return nil
+	}
+	if copyMode {
+		effectiveDir := workDir
+		if !workdirUsable {
+			effectiveDir = ""
+		}
+		if err := copyToClipboard(ctx, buildShellResumeCommand(effectiveDir, resume)); err != nil {
+			return fmt.Errorf("copy to clipboard: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, "Resume command copied to clipboard.")
+		return nil
+	}
+
+	// Default: spawn the agent CLI directly. We do NOT try to change
+	// the parent shell's cwd — that's impossible from a child process.
+	// Setting Cmd.Dir scopes the spawn; the user's shell stays put.
+	// Use a fresh background context so the agent process is not bound
+	// to the 15s API timeout above.
+	exe := exec.Command(resume.Bin, resume.Args...)
+	if workdirUsable {
+		exe.Dir = workDir
+	}
+	exe.Stdin = os.Stdin
+	exe.Stdout = os.Stdout
+	exe.Stderr = os.Stderr
+	return exe.Run()
 }
 
 func runIssueSearch(cmd *cobra.Command, args []string) error {

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -183,7 +183,12 @@ agent used, with stdin/stdout/stderr wired through. The agent picks up
 the same session, so prior context is preserved.
 
 Use --print to emit the equivalent shell command for use with eval, or
---copy to drop it on the system clipboard.`,
+--copy to drop it on the system clipboard.
+
+Local runtimes only. Cloud-runtime tasks do not persist a local
+session_id + work_dir, so the latest run is skipped and the command
+exits with "no completed run found". A future remote-takeover feature
+would need its own attach/exec transport — see the issue tracker.`,
 	Args: exactArgs(1),
 	RunE: runIssueTake,
 }

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -500,6 +501,394 @@ func TestIssueSubscriberMutationBody(t *testing.T) {
 			}
 		})
 	}
+}
+
+// runIssueTakeCmd executes `multica issue take` via the real rootCmd,
+// against a stub server. takeFlags are inserted as `--<k>=<v>` on the
+// command line so cobra parses + marks them Changed. Returns captured
+// stdout and the cobra error.
+//
+// Sequential execution is required: rootCmd is package-global state.
+// We reset the flags this command touches between calls because cobra
+// keeps the previous Set value otherwise.
+func runIssueTakeCmd(t *testing.T, serverURL string, posArgs []string, takeFlags map[string]string) (string, error) {
+	t.Helper()
+
+	for _, name := range []string{"provider", "print", "copy"} {
+		if f := issueTakeCmd.Flags().Lookup(name); f != nil {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		}
+	}
+
+	args := []string{
+		"--server-url=" + serverURL,
+		"--workspace-id=ws-1",
+		"issue", "take",
+	}
+	args = append(args, posArgs...)
+	for k, v := range takeFlags {
+		if v == "true" {
+			args = append(args, "--"+k)
+		} else {
+			args = append(args, "--"+k+"="+v)
+		}
+	}
+
+	origStdout := os.Stdout
+	r, wPipe, _ := os.Pipe()
+	os.Stdout = wPipe
+
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+
+	wPipe.Close()
+	os.Stdout = origStdout
+
+	out, _ := io.ReadAll(r)
+	return string(out), err
+}
+
+// TestResumeCommandForProvider locks the provider→CLI mapping for `issue take`.
+// Drift here breaks the contract documented on the command — these are the
+// commands users would otherwise have to assemble by hand.
+func TestResumeCommandForProvider(t *testing.T) {
+	const sid = "sess-123"
+	cases := []struct {
+		provider string
+		wantBin  string
+		wantArgs []string
+	}{
+		{"claude", "claude", []string{"--resume", sid}},
+		{"codex", "codex", []string{"resume", sid}},
+		{"cursor", "cursor-agent", []string{"--resume", sid}},
+		{"gemini", "gemini", []string{"-r", sid}},
+		{"opencode", "opencode", []string{"--session", sid}},
+		{"copilot", "copilot", []string{"--resume", sid}},
+		{"  Claude  ", "claude", []string{"--resume", sid}}, // case + whitespace tolerant
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			r, err := resumeCommandForProvider(tc.provider, sid)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if r.Bin != tc.wantBin {
+				t.Errorf("bin = %q, want %q", r.Bin, tc.wantBin)
+			}
+			if !equalStringSlice(r.Args, tc.wantArgs) {
+				t.Errorf("args = %#v, want %#v", r.Args, tc.wantArgs)
+			}
+		})
+	}
+
+	t.Run("unknown provider returns error", func(t *testing.T) {
+		if _, err := resumeCommandForProvider("openai-codex-2099", "sid"); err == nil {
+			t.Fatal("expected error for unknown provider")
+		}
+	})
+}
+
+func TestShellSingleQuote(t *testing.T) {
+	cases := map[string]string{
+		"plain":               "'plain'",
+		"":                    "''",
+		"with spaces":         "'with spaces'",
+		"it's-fine":           `'it'\''s-fine'`,
+		"/tmp/multica/wd-1":   "'/tmp/multica/wd-1'",
+		"$HOME/path":          "'$HOME/path'", // single quotes block expansion
+		"a'b'c":               `'a'\''b'\''c'`,
+	}
+	for in, want := range cases {
+		if got := shellSingleQuote(in); got != want {
+			t.Errorf("shellSingleQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildShellResumeCommand(t *testing.T) {
+	resume := providerResume{Bin: "claude", Args: []string{"--resume", "sess-1"}}
+
+	t.Run("with workdir", func(t *testing.T) {
+		got := buildShellResumeCommand("/tmp/wd", resume)
+		want := `cd '/tmp/wd' && claude '--resume' 'sess-1'`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("workdir with quote", func(t *testing.T) {
+		got := buildShellResumeCommand("/tmp/it's/wd", resume)
+		want := `cd '/tmp/it'\''s/wd' && claude '--resume' 'sess-1'`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty workdir omits cd prefix", func(t *testing.T) {
+		got := buildShellResumeCommand("", resume)
+		want := `claude '--resume' 'sess-1'`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestPickResumableRun(t *testing.T) {
+	t.Run("picks first completed with session_id", func(t *testing.T) {
+		runs := []map[string]any{
+			{"status": "in_progress", "runtime_id": "rt-skip", "result": map[string]any{"session_id": "skip"}},
+			{"status": "completed", "runtime_id": "rt-1", "result": map[string]any{"session_id": "sid-1", "work_dir": "/tmp/wd-1"}},
+			{"status": "completed", "runtime_id": "rt-2", "result": map[string]any{"session_id": "sid-2"}},
+		}
+		sid, wd, rid, ok := pickResumableRun(runs)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if sid != "sid-1" || wd != "/tmp/wd-1" || rid != "rt-1" {
+			t.Errorf("got (%q, %q, %q), want (sid-1, /tmp/wd-1, rt-1)", sid, wd, rid)
+		}
+	})
+
+	t.Run("skips completed runs without session_id", func(t *testing.T) {
+		runs := []map[string]any{
+			{"status": "completed", "result": map[string]any{}},
+			{"status": "completed", "runtime_id": "rt-2", "result": map[string]any{"session_id": "sid-2", "work_dir": "/tmp/wd-2"}},
+		}
+		sid, wd, rid, ok := pickResumableRun(runs)
+		if !ok || sid != "sid-2" || wd != "/tmp/wd-2" || rid != "rt-2" {
+			t.Errorf("got (%q, %q, %q, %v), want sid-2 run", sid, wd, rid, ok)
+		}
+	})
+
+	t.Run("no completed runs returns ok=false", func(t *testing.T) {
+		runs := []map[string]any{
+			{"status": "in_progress", "result": map[string]any{"session_id": "s"}},
+			{"status": "failed", "result": map[string]any{"session_id": "s"}},
+		}
+		_, _, _, ok := pickResumableRun(runs)
+		if ok {
+			t.Fatal("expected ok=false")
+		}
+	})
+
+	t.Run("empty list returns ok=false", func(t *testing.T) {
+		_, _, _, ok := pickResumableRun(nil)
+		if ok {
+			t.Fatal("expected ok=false on empty list")
+		}
+	})
+
+	t.Run("missing work_dir is fine", func(t *testing.T) {
+		runs := []map[string]any{
+			{"status": "completed", "runtime_id": "rt-x", "result": map[string]any{"session_id": "sid-x"}},
+		}
+		sid, wd, rid, ok := pickResumableRun(runs)
+		if !ok || sid != "sid-x" || wd != "" || rid != "rt-x" {
+			t.Errorf("got (%q, %q, %q, %v)", sid, wd, rid, ok)
+		}
+	})
+}
+
+// TestIssueTakeProviderAutoDetect exercises the full take flow against a stub
+// server: list runs → list runtimes → render command. --print is used so the
+// test never spawns an actual agent CLI. The work_dir points at a real temp
+// dir so the workdir-existence check does not strip the `cd` prefix.
+func TestIssueTakeProviderAutoDetect(t *testing.T) {
+	wd := t.TempDir()
+	runs := []map[string]any{
+		{
+			"id":         "task-1",
+			"status":     "completed",
+			"runtime_id": "runtime-1",
+			"result":     map[string]any{"session_id": "sid-abc", "work_dir": wd},
+		},
+	}
+	runtimes := []map[string]any{
+		{"id": "runtime-1", "provider": "claude"},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/issues/issue-1/task-runs":
+			json.NewEncoder(w).Encode(runs)
+		case "/api/runtimes":
+			json.NewEncoder(w).Encode(runtimes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	out, err := runIssueTakeCmd(t, srv.URL, []string{"issue-1"}, map[string]string{"print": "true"})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := strings.TrimSpace(out)
+	want := "cd " + shellSingleQuote(wd) + " && claude '--resume' 'sid-abc'"
+	if got != want {
+		t.Errorf("printed command = %q, want %q", got, want)
+	}
+}
+
+// TestIssueTakeNoCompletedRun verifies the spec error when no completed
+// run is available.
+func TestIssueTakeNoCompletedRun(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/issues/issue-1/task-runs":
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"status": "in_progress", "result": map[string]any{"session_id": "x"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := runIssueTakeCmd(t, srv.URL, []string{"issue-1"}, map[string]string{"print": "true"})
+	if err == nil {
+		t.Fatal("expected error when no completed run is available")
+	}
+	if !strings.Contains(err.Error(), "no completed run found") {
+		t.Errorf("error = %v, want 'no completed run found'", err)
+	}
+}
+
+// TestIssueTakePrintAndCopyMutex covers --print and --copy being mutually exclusive.
+func TestIssueTakePrintAndCopyMutex(t *testing.T) {
+	_, err := runIssueTakeCmd(t, "http://unused", []string{"issue-1"}, map[string]string{
+		"print": "true",
+		"copy":  "true",
+	})
+	if err == nil {
+		t.Fatal("expected error when both --print and --copy are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error = %v, want 'mutually exclusive'", err)
+	}
+}
+
+// TestIssueTakeUnsupportedProvider ensures we exit non-zero (with a helpful
+// message) when the runtime's provider is not in the take map.
+func TestIssueTakeUnsupportedProvider(t *testing.T) {
+	runs := []map[string]any{
+		{
+			"id":         "task-1",
+			"status":     "completed",
+			"runtime_id": "runtime-1",
+			"result":     map[string]any{"session_id": "sid-abc", "work_dir": "/tmp/wd"},
+		},
+	}
+	runtimes := []map[string]any{
+		{"id": "runtime-1", "provider": "kimi"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/issues/issue-1/task-runs":
+			json.NewEncoder(w).Encode(runs)
+		case "/api/runtimes":
+			json.NewEncoder(w).Encode(runtimes)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := runIssueTakeCmd(t, srv.URL, []string{"issue-1"}, map[string]string{"print": "true"})
+	if err == nil {
+		t.Fatal("expected error for unsupported provider")
+	}
+	if !strings.Contains(err.Error(), "unsupported provider") {
+		t.Errorf("error = %v, want 'unsupported provider'", err)
+	}
+}
+
+// TestIssueTakeRuntimeNotFound covers the case where the task references a
+// runtime that no longer appears in /api/runtimes.
+func TestIssueTakeRuntimeNotFound(t *testing.T) {
+	runs := []map[string]any{
+		{
+			"id":         "task-1",
+			"status":     "completed",
+			"runtime_id": "runtime-missing",
+			"result":     map[string]any{"session_id": "sid-abc", "work_dir": "/tmp/wd"},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/issues/issue-1/task-runs":
+			json.NewEncoder(w).Encode(runs)
+		case "/api/runtimes":
+			json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := runIssueTakeCmd(t, srv.URL, []string{"issue-1"}, map[string]string{"print": "true"})
+	if err == nil {
+		t.Fatal("expected error when runtime is missing")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %v, want 'not found'", err)
+	}
+}
+
+// TestIssueTakeProviderOverride checks that --provider skips the runtime
+// lookup entirely (and therefore works even when /api/runtimes is broken).
+func TestIssueTakeProviderOverride(t *testing.T) {
+	wd := t.TempDir()
+	runs := []map[string]any{
+		{
+			"id":         "task-1",
+			"status":     "completed",
+			"runtime_id": "runtime-1",
+			"result":     map[string]any{"session_id": "sid-abc", "work_dir": wd},
+		},
+	}
+	hitRuntimes := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/issues/issue-1/task-runs":
+			json.NewEncoder(w).Encode(runs)
+		case "/api/runtimes":
+			hitRuntimes = true
+			http.Error(w, "boom", 500)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	out, err := runIssueTakeCmd(t, srv.URL, []string{"issue-1"}, map[string]string{
+		"provider": "codex",
+		"print":    "true",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if hitRuntimes {
+		t.Error("--provider should bypass /api/runtimes lookup")
+	}
+	got := strings.TrimSpace(out)
+	want := "cd " + shellSingleQuote(wd) + " && codex 'resume' 'sid-abc'"
+	if got != want {
+		t.Errorf("printed command = %q, want %q", got, want)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestValidIssueStatuses(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a desktop-only "Take over locally" entry to the issue overflow menu. Clicking it runs `multica issue take <id> --print` via the bundled CLI in the main process, copies the resolved `cd '<workdir>' && <agent> --resume <session>` command onto the system clipboard, and shows a confirmation toast with the workdir.

Closes [MUL-2](https://desktop-api.multica.ai).

## Visibility rules

- Desktop only — web builds short-circuit and skip the data-fetch, so the menu item never appears.
- The issue has at least one **completed** agent run with a `session_id`.
- That run's runtime `provider` is one we know how to resume: `claude`, `codex`, `cursor`, `gemini`, `opencode`, `copilot`. Mirrors `resumeCommandForProvider` in `server/cmd/multica/cmd_issue.go`.

The visibility predicate (`canTakeOverLocally`, `findResumableTask`) lives in `@multica/core/issues/take-over` so it can be unit-tested without DOM globals — 11 cases pass in `packages/core/issues/take-over.test.ts`.

## How it works

- `apps/desktop/src/main/issue-take-over.ts` — IPC handler `issue:takeOver`. Resolves the bundled CLI + active profile via the existing `daemon-manager` plumbing, runs `multica issue take <id> --print --profile <name>`, parses the workdir out of the `cd '<…>' && ` prefix for the toast, and writes the command to the clipboard with Electron's `clipboard.writeText`.
- `apps/desktop/src/preload/index.ts(.d.ts)` — exposes `desktopAPI.takeOverIssue(issueId)`.
- `packages/views/issues/actions/use-take-over.ts` — React hook that gates queries on `enabled && !!desktopAPI`, derives visibility from the predicate, and triggers the IPC + toast.
- `IssueActionsDropdown` grew an `enableTakeOver` flag (only the issue detail page sets it true). Board / list / context-menu surfaces stay free of the extra round-trip.

## Test plan

- [x] `pnpm typecheck` — green across all packages.
- [x] `pnpm test` — 234 pass (11 new core predicate tests + 7 new hook tests + existing 216).
- [ ] Manual smoke: complete a Claude run on macOS desktop → open the issue → overflow menu shows "Take over locally" → click → command in clipboard → paste in terminal → claude resumes inside the worktree.
- [ ] Manual: `apps/web` build does NOT show the entry (the menu skips it because `desktopAPI` is undefined).
- [ ] Manual: an issue with only cancelled / failed runs hides the entry.
- [ ] Manual: an issue whose latest completed run used an unsupported provider hides the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)