### PR TITLE
fix(inbox): auto-archive inbox item when marking done from issue detail

### DIFF
--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -277,6 +277,12 @@ export function InboxPage() {
         // longer exists.
         setSelectedKey("");
       }}
+      onDone={() => {
+        setSelectedKey("");
+        archiveMutation.mutate(selected.id, {
+          onError: () => toast.error("Failed to archive"),
+        });
+      }}
     />
   ) : selected ? (
     <div className="p-6">

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -139,6 +139,8 @@ function formatTokenCount(n: number): string {
 interface IssueDetailProps {
   issueId: string;
   onDelete?: () => void;
+  /** Called after the issue is marked as done via the toolbar button. */
+  onDone?: () => void;
   defaultSidebarOpen?: boolean;
   layoutId?: string;
   /** When set, the issue detail will auto-scroll to this comment and briefly highlight it. */
@@ -149,7 +151,7 @@ interface IssueDetailProps {
 // IssueDetail
 // ---------------------------------------------------------------------------
 
-export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
+export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
   const id = issueId;
   const router = useNavigation();
   const user = useAuthStore((s) => s.user);
@@ -520,7 +522,7 @@ export function IssueDetail({ issueId, onDelete, defaultSidebarOpen = true, layo
                       variant="ghost"
                       size="icon-sm"
                       className="text-muted-foreground"
-                      onClick={() => handleUpdateField({ status: "done" })}
+                      onClick={() => { handleUpdateField({ status: "done" }); onDone?.(); }}
                     >
                       <CircleCheck />
                     </Button>


### PR DESCRIPTION
## Summary
- When viewing an inbox notification and clicking "Mark as done" in the issue detail toolbar, the inbox item is now automatically archived alongside the status update
- Adds an `onDone` callback prop to `IssueDetail`, wired in the inbox page to archive the notification
- Matches the existing behavior of the list-item Done button (CircleCheck on hover)

Closes MUL-1594
## Test plan
- [ ] Open Inbox, select a notification with an active issue
- [ ] Click "Mark as done" (CircleCheck) in the issue detail toolbar
- [ ] Verify the issue status changes to "done" AND the inbox item is archived (removed from list)
- [ ] Verify the list-item "Mark as done" button still works as before