### PR TITLE
fix(desktop): prevent Cmd+R / Ctrl+R / F5 from reloading the page

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -111,6 +111,22 @@ function createWindow(): void {
     return { action: "deny" };
   });
 
+  // Prevent Cmd+R / Ctrl+R / Shift+Cmd+R / Shift+Ctrl+R / F5 from
+  // reloading the page. In a desktop app an accidental reload destroys
+  // in-memory state (tabs, drafts, WS connections) with no URL bar to
+  // navigate back. DevTools refresh (via the DevTools UI) still works.
+  mainWindow.webContents.on("before-input-event", (_event, input) => {
+    if (input.type !== "keyDown") return;
+    const cmdOrCtrl =
+      process.platform === "darwin" ? input.meta : input.control;
+    if (
+      (cmdOrCtrl && input.key.toLowerCase() === "r") ||
+      input.key === "F5"
+    ) {
+      _event.preventDefault();
+    }
+  });
+
   installContextMenu(mainWindow.webContents);
 
   if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {


### PR DESCRIPTION
## Summary

- Add a `before-input-event` listener on the main BrowserWindow's webContents that intercepts Cmd+R / Ctrl+R (with or without Shift) and F5, preventing the default page reload
- In a desktop app, accidental reload destroys in-memory state (tabs, drafts, WS connections) with no URL bar to navigate back
- DevTools refresh (via the DevTools UI) still works

Closes MUL-1598

## Test plan

- [ ] Launch the Desktop app
- [ ] Press Cmd+R (macOS) / Ctrl+R (Windows/Linux) — page should NOT reload
- [ ] Press Shift+Cmd+R / Shift+Ctrl+R — page should NOT reload
- [ ] Press F5 — page should NOT reload
- [ ] Open DevTools and use its reload button — should still work