### PR TITLE
fix(agents): navigate to detail page before invalidating list query

### DIFF
--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -279,10 +279,10 @@ export function AgentsPage() {
         // Surfaced softly; the agent itself is fine.
       }
     }
-    qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
     setShowCreate(false);
     setDuplicateTemplate(null);
     navigation.push(paths.agentDetail(agent.id));
+    qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
   };
 
   const handleDuplicate = useCallback((agent: Agent) => {


### PR DESCRIPTION
## Summary

- Fixes flash where creating an agent from empty state briefly shows the agent list page before landing on the detail page
- Root cause: `qc.invalidateQueries()` triggered a list refetch that re-rendered the agents page (empty → list) before `navigation.push()` completed
- Fix: reorder to navigate first, then invalidate — the list refetch happens in the background after we've already left the page

Closes MUL-1599