### PR TITLE
fix: prevent mobile input focus zoom

### DIFF
--- a/packages/ui/styles/base.css
+++ b/packages/ui/styles/base.css
@@ -149,4 +149,14 @@
      * Progressive enhancement: browsers that don't support it simply ignore the rule. */
     text-autospace: ideograph-alpha ideograph-numeric;
   }
+
+  @media (max-width: 767px), (pointer: coarse) {
+    input:not([type="button"]):not([type="checkbox"]):not([type="color"]):not([type="file"]):not([type="hidden"]):not([type="image"]):not([type="radio"]):not([type="range"]):not([type="reset"]):not([type="submit"]),
+    textarea,
+    select,
+    [contenteditable]:not([contenteditable="false"]) {
+      /* iOS Safari zooms the page when focused editable text is below 16px. */
+      font-size: 16px !important;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add a shared mobile/coarse-pointer CSS guard that keeps text-editing controls at 16px to avoid iOS Safari focus zoom.
- Covers native text inputs, textareas, selects, and contenteditable editors while excluding non-text input types.
- Broaden the contenteditable selector to include boolean contenteditable markup while still excluding explicit contenteditable=false.

## Verification
- pnpm --filter @multica/ui lint
- pnpm --filter @multica/ui typecheck
- pnpm --filter @multica/web build

## Notes
- Real iOS Safari/manual device verification was not available in this local runner; this PR enforces the standard 16px focused-editable rule that prevents Safari focus zoom.