### PR TITLE
fix(issues): wrap Details/Token usage in grid for PropRow subgrid

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -436,7 +436,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           Details
           <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${detailsOpen ? "rotate-90" : ""}`} />
         </button>
-        {detailsOpen && <div className="space-y-0.5 pl-2">
+        {detailsOpen && <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 pl-2">
           <PropRow label="Created by">
             <ActorAvatar actorType={issue.creator_type} actorId={issue.creator_id} size={18} enableHoverCard />
             <span className="cursor-pointer truncate">{getActorName(issue.creator_type, issue.creator_id)}</span>
@@ -465,7 +465,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             Token usage
             <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${tokenUsageOpen ? "rotate-90" : ""}`} />
           </button>
-          {tokenUsageOpen && <div className="space-y-0.5 pl-2">
+          {tokenUsageOpen && <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 pl-2">
             <PropRow label="Input">
               <span className="text-muted-foreground">{formatTokenCount(usage.total_input_tokens)}</span>
             </PropRow>


### PR DESCRIPTION
## Summary
- `PropRow` switched to CSS subgrid in #1919, which requires its parent to declare `grid grid-cols-[auto_1fr]`
- The Properties section's wrapper was updated, but Details and Token usage in the same file were missed — their PropRows collapsed to a single column, stacking label and value vertically (Created by / avatar / name on three lines)
- Add the same grid wrapper used by Properties so all three sections render consistently

## Test plan
- [ ] Open any issue's detail panel and expand the Details section — Created by / Created / Updated should render label-on-left, value-on-right with proper spacing
- [ ] Open an issue with token usage data and expand Token usage — Input / Output / Cache / Runs should render the same way
- [ ] Properties section unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)