### PR TITLE
feat(autopilots): duplicate existing autopilots

### DIFF
--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Zap, Play, Clock, Plus, Trash2, CheckCircle2, XCircle, Loader2, Pencil } from "lucide-react";
+import { CheckCircle2, Clock, Copy, Loader2, Pencil, Play, Plus, Trash2, XCircle, Zap } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { autopilotDetailOptions, autopilotRunsOptions } from "@multica/core/autopilots/queries";
 import {
@@ -46,6 +46,7 @@ import type { TriggerConfig } from "./trigger-config";
 import type { AutopilotExecutionMode, AutopilotRun, AutopilotTrigger } from "@multica/core/types";
 import { ReadonlyContent } from "../../editor";
 import { AutopilotDialog } from "./autopilot-dialog";
+import { buildAutopilotDuplicatePreset } from "./autopilot-duplicate";
 
 function formatDate(date: string): string {
   return new Date(date).toLocaleString(undefined, {
@@ -253,6 +254,7 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
 
   const [triggerDialogOpen, setTriggerDialogOpen] = useState(false);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -304,6 +306,7 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
   }
 
   const { autopilot, triggers } = data;
+  const duplicatePreset = buildAutopilotDuplicatePreset(autopilot, triggers);
 
   const handleRunNow = async () => {
     try {
@@ -359,6 +362,10 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={() => setDuplicateDialogOpen(true)}>
+            <Copy className="h-3.5 w-3.5 mr-1" />
+            Duplicate
+          </Button>
           <Button size="sm" variant="outline" onClick={() => setEditDialogOpen(true)}>
             <Pencil className="h-3.5 w-3.5 mr-1" />
             Edit
@@ -473,6 +480,16 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
             execution_mode: autopilot.execution_mode as AutopilotExecutionMode,
           }}
           triggers={triggers}
+        />
+      )}
+      {duplicateDialogOpen && (
+        <AutopilotDialog
+          mode="create"
+          open={duplicateDialogOpen}
+          onOpenChange={setDuplicateDialogOpen}
+          initial={duplicatePreset.initial}
+          initialTriggerConfig={duplicatePreset.initialTriggerConfig}
+          intent="duplicate"
         />
       )}
       <AlertDialog

--- a/packages/views/autopilots/components/autopilot-dialog.tsx
+++ b/packages/views/autopilots/components/autopilot-dialog.tsx
@@ -76,6 +76,7 @@ export type AutopilotDialogProps =
       onOpenChange: (v: boolean) => void;
       initial?: Partial<AutopilotInitial>;
       initialTriggerConfig?: Partial<TriggerConfig>;
+      intent?: "create" | "duplicate";
     }
   | {
       mode: "edit";
@@ -248,6 +249,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const isCreate = props.mode === "create";
+  const isDuplicate = isCreate && props.intent === "duplicate";
   const initial: Partial<AutopilotInitial> = isCreate
     ? props.initial ?? {}
     : props.initial;
@@ -322,7 +324,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
           scheduleOk = false;
         }
         onOpenChange(false);
-        if (scheduleOk) toast.success("Autopilot created");
+        if (scheduleOk) toast.success(isDuplicate ? "Autopilot copied" : "Autopilot created");
         else toast.error("Autopilot created, but schedule failed to save");
       } else {
         await updateAutopilot.mutateAsync({
@@ -382,7 +384,7 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
         )}
       >
         <DialogTitle className="sr-only">
-          {isCreate ? "New Autopilot" : "Edit Autopilot"}
+          {isCreate ? (isDuplicate ? "Duplicate Autopilot" : "New Autopilot") : "Edit Autopilot"}
         </DialogTitle>
 
         {/* Header */}
@@ -393,11 +395,13 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
                 <Rocket className="size-3" />
               </span>
               <span className="font-medium text-foreground">
-                {isCreate ? "New autopilot" : "Edit autopilot"}
+                {isCreate ? (isDuplicate ? "Duplicate autopilot" : "New autopilot") : "Edit autopilot"}
               </span>
             </div>
             <span className="text-muted-foreground/60">·</span>
-            <span className="text-muted-foreground">A recurring AI task</span>
+            <span className="text-muted-foreground">
+              {isDuplicate ? "Review copied settings before saving" : "A recurring AI task"}
+            </span>
             {workspaceName && (
               <>
                 <ChevronRight className="size-3 text-muted-foreground/40" />
@@ -514,10 +518,14 @@ export function AutopilotDialog(props: AutopilotDialogProps) {
             <Button size="sm" onClick={handleSubmit} disabled={!canSubmit}>
               {submitting
                 ? isCreate
-                  ? "Creating..."
+                  ? isDuplicate
+                    ? "Copying..."
+                    : "Creating..."
                   : "Saving..."
                 : isCreate
-                ? "Create autopilot"
+                ? isDuplicate
+                  ? "Create copy"
+                  : "Create autopilot"
                 : "Save"}
             </Button>
           </div>

--- a/packages/views/autopilots/components/autopilot-duplicate.test.ts
+++ b/packages/views/autopilots/components/autopilot-duplicate.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { Autopilot, AutopilotTrigger } from "@multica/core/types";
+import { buildAutopilotDuplicatePreset } from "./autopilot-duplicate";
+
+function autopilotFixture(overrides: Partial<Autopilot> = {}): Autopilot {
+  return {
+    id: "ap-1",
+    workspace_id: "ws-1",
+    title: "Daily digest",
+    description: "Summarize the day",
+    assignee_id: "agent-1",
+    status: "paused",
+    execution_mode: "run_only",
+    issue_title_template: null,
+    created_by_type: "member",
+    created_by_id: "user-1",
+    last_run_at: "2026-04-30T08:00:00Z",
+    created_at: "2026-04-29T08:00:00Z",
+    updated_at: "2026-04-30T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function triggerFixture(overrides: Partial<AutopilotTrigger> = {}): AutopilotTrigger {
+  return {
+    id: "trigger-1",
+    autopilot_id: "ap-1",
+    kind: "schedule",
+    enabled: true,
+    cron_expression: "30 9 * * 1-5",
+    timezone: "Asia/Shanghai",
+    next_run_at: null,
+    webhook_token: null,
+    label: null,
+    last_fired_at: null,
+    created_at: "2026-04-29T08:00:00Z",
+    updated_at: "2026-04-30T08:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("buildAutopilotDuplicatePreset", () => {
+  it("copies editable fields and appends copy suffix", () => {
+    const preset = buildAutopilotDuplicatePreset(autopilotFixture(), []);
+
+    expect(preset.initial).toEqual({
+      title: "Daily digest (Copy)",
+      description: "Summarize the day",
+      assignee_id: "agent-1",
+      execution_mode: "run_only",
+    });
+  });
+
+  it("uses an empty prompt when the source description is null", () => {
+    const preset = buildAutopilotDuplicatePreset(
+      autopilotFixture({ description: null }),
+      [],
+    );
+
+    expect(preset.initial.description).toBe("");
+  });
+
+  it("copies only the first schedule trigger as the main schedule", () => {
+    const preset = buildAutopilotDuplicatePreset(autopilotFixture(), [
+      triggerFixture({ id: "webhook-1", kind: "webhook", cron_expression: null }),
+      triggerFixture({ id: "schedule-1", cron_expression: "30 9 * * 1-5" }),
+      triggerFixture({ id: "schedule-2", cron_expression: "0 17 * * *" }),
+    ]);
+
+    expect(preset.initialTriggerConfig).toMatchObject({
+      frequency: "weekdays",
+      time: "09:30",
+      timezone: "Asia/Shanghai",
+    });
+  });
+
+  it("leaves schedule undefined when no schedule trigger can be copied", () => {
+    const preset = buildAutopilotDuplicatePreset(autopilotFixture(), [
+      triggerFixture({ kind: "api", cron_expression: null }),
+      triggerFixture({ kind: "schedule", cron_expression: null }),
+    ]);
+
+    expect(preset.initialTriggerConfig).toBeUndefined();
+  });
+});

--- a/packages/views/autopilots/components/autopilot-duplicate.ts
+++ b/packages/views/autopilots/components/autopilot-duplicate.ts
@@ -1,0 +1,33 @@
+import type { Autopilot, AutopilotExecutionMode, AutopilotTrigger } from "@multica/core/types";
+import { parseCronExpression, type TriggerConfig } from "./trigger-config";
+
+export interface AutopilotDuplicatePreset {
+  initial: {
+    title: string;
+    description: string;
+    assignee_id: string;
+    execution_mode: AutopilotExecutionMode;
+  };
+  initialTriggerConfig?: TriggerConfig;
+}
+
+export function buildAutopilotDuplicatePreset(
+  autopilot: Autopilot,
+  triggers: AutopilotTrigger[],
+): AutopilotDuplicatePreset {
+  const primarySchedule = triggers.find(
+    (trigger) => trigger.kind === "schedule" && !!trigger.cron_expression,
+  );
+
+  return {
+    initial: {
+      title: `${autopilot.title} (Copy)`,
+      description: autopilot.description ?? "",
+      assignee_id: autopilot.assignee_id,
+      execution_mode: autopilot.execution_mode,
+    },
+    initialTriggerConfig: primarySchedule?.cron_expression
+      ? parseCronExpression(primarySchedule.cron_expression, primarySchedule.timezone ?? "UTC")
+      : undefined,
+  };
+}

--- a/packages/views/autopilots/components/autopilots-page.tsx
+++ b/packages/views/autopilots/components/autopilots-page.tsx
@@ -1,21 +1,23 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, Zap, Play, Pause, AlertCircle, Newspaper, GitPullRequest, Bug, BarChart3, Shield, FileSearch } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
-import { autopilotListOptions } from "@multica/core/autopilots/queries";
+import { AlertCircle, BarChart3, Bug, Copy, FileSearch, GitPullRequest, Newspaper, Pause, Play, Plus, Shield, Zap } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { autopilotDetailOptions, autopilotListOptions } from "@multica/core/autopilots/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useActorName } from "@multica/core/workspace/hooks";
+import { toast } from "sonner";
 import { AppLink } from "../../navigation";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { PageHeader } from "../../layout/page-header";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { Button } from "@multica/ui/components/ui/button";
 import { cn } from "@multica/ui/lib/utils";
-import { AutopilotDialog } from "./autopilot-dialog";
+import { AutopilotDialog, type AutopilotInitial } from "./autopilot-dialog";
+import { buildAutopilotDuplicatePreset } from "./autopilot-duplicate";
 import type { Autopilot } from "@multica/core/types";
-import type { TriggerFrequency } from "./trigger-config";
+import type { TriggerConfig, TriggerFrequency } from "./trigger-config";
 
 interface AutopilotTemplate {
   title: string;
@@ -123,7 +125,15 @@ const EXECUTION_MODE_LABELS: Record<string, string> = {
   run_only: "Run Only",
 };
 
-function AutopilotRow({ autopilot }: { autopilot: Autopilot }) {
+function AutopilotRow({
+  autopilot,
+  duplicating,
+  onDuplicate,
+}: {
+  autopilot: Autopilot;
+  duplicating: boolean;
+  onDuplicate: (autopilot: Autopilot) => void;
+}) {
   const { getActorName } = useActorName();
   const wsPaths = useWorkspacePaths();
   const statusCfg = (STATUS_CONFIG[autopilot.status] ?? STATUS_CONFIG["active"])!;
@@ -162,19 +172,62 @@ function AutopilotRow({ autopilot }: { autopilot: Autopilot }) {
       <span className="w-20 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
         {autopilot.last_run_at ? formatRelativeDate(autopilot.last_run_at) : "--"}
       </span>
+
+      <Button
+        type="button"
+        size="icon-xs"
+        variant="ghost"
+        aria-label={`Duplicate ${autopilot.title}`}
+        title="Duplicate"
+        disabled={duplicating}
+        className="shrink-0 opacity-60 transition-opacity hover:opacity-100 focus-visible:opacity-100 sm:opacity-0 sm:group-hover/row:opacity-100"
+        onClick={() => onDuplicate(autopilot)}
+      >
+        <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+      </Button>
     </div>
   );
 }
 
 export function AutopilotsPage() {
   const wsId = useWorkspaceId();
+  const qc = useQueryClient();
   const { data: autopilots = [], isLoading } = useQuery(autopilotListOptions(wsId));
   const [createOpen, setCreateOpen] = useState(false);
-  const [selectedTemplate, setSelectedTemplate] = useState<AutopilotTemplate | null>(null);
+  const [createIntent, setCreateIntent] = useState<"create" | "duplicate">("create");
+  const [createInitial, setCreateInitial] = useState<Partial<AutopilotInitial> | undefined>();
+  const [createTriggerConfig, setCreateTriggerConfig] = useState<Partial<TriggerConfig> | undefined>();
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
 
   const openCreate = (template?: AutopilotTemplate) => {
-    setSelectedTemplate(template ?? null);
+    setCreateIntent("create");
+    setCreateInitial(
+      template
+        ? { title: template.title, description: template.prompt }
+        : undefined,
+    );
+    setCreateTriggerConfig(
+      template
+        ? { frequency: template.frequency, time: template.time }
+        : undefined,
+    );
     setCreateOpen(true);
+  };
+
+  const handleDuplicate = async (autopilot: Autopilot) => {
+    setDuplicatingId(autopilot.id);
+    try {
+      const detail = await qc.fetchQuery(autopilotDetailOptions(wsId, autopilot.id));
+      const preset = buildAutopilotDuplicatePreset(detail.autopilot, detail.triggers);
+      setCreateIntent("duplicate");
+      setCreateInitial(preset.initial);
+      setCreateTriggerConfig(preset.initialTriggerConfig);
+      setCreateOpen(true);
+    } catch {
+      toast.error("Failed to load autopilot for copying");
+    } finally {
+      setDuplicatingId(null);
+    }
   };
 
   return (
@@ -253,9 +306,15 @@ export function AutopilotsPage() {
               <span className="w-24 text-center shrink-0">Mode</span>
               <span className="w-20 text-center shrink-0">Status</span>
               <span className="w-20 text-right shrink-0">Last run</span>
+              <span className="w-6 shrink-0" />
             </div>
             {autopilots.map((autopilot) => (
-              <AutopilotRow key={autopilot.id} autopilot={autopilot} />
+              <AutopilotRow
+                key={autopilot.id}
+                autopilot={autopilot}
+                duplicating={duplicatingId === autopilot.id}
+                onDuplicate={handleDuplicate}
+              />
             ))}
           </>
         )}
@@ -266,16 +325,9 @@ export function AutopilotsPage() {
           mode="create"
           open={createOpen}
           onOpenChange={setCreateOpen}
-          initial={
-            selectedTemplate
-              ? { title: selectedTemplate.title, description: selectedTemplate.prompt }
-              : undefined
-          }
-          initialTriggerConfig={
-            selectedTemplate
-              ? { frequency: selectedTemplate.frequency, time: selectedTemplate.time }
-              : undefined
-          }
+          initial={createInitial}
+          initialTriggerConfig={createTriggerConfig}
+          intent={createIntent}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- add duplicate actions for Autopilots list rows and detail pages
- open the existing create dialog with copied title, prompt, agent, output mode, and primary schedule
- keep duplicate creation explicit so users can review edits before saving

## Tests
- pnpm --filter @multica/views exec vitest run autopilots/components
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views exec eslint autopilots/components/autopilots-page.tsx autopilots/components/autopilot-detail-page.tsx autopilots/components/autopilot-dialog.tsx autopilots/components/autopilot-duplicate.ts autopilots/components/autopilot-duplicate.test.ts