### PR TITLE
feat(markdown): add fullscreen lightbox for mermaid diagrams

### DIFF
--- a/packages/views/editor/content-editor.css
+++ b/packages/views/editor/content-editor.css
@@ -208,6 +208,7 @@
   margin: 0.75rem 0;
   overflow-x: auto;
   padding: 1rem;
+  position: relative;
 }
 
 .rich-text-editor .mermaid-diagram-frame {
@@ -226,6 +227,62 @@
 
 .rich-text-editor .mermaid-diagram-error pre {
   margin-bottom: 0;
+}
+
+/* Mermaid toolbar — dark pill, top-right corner, appears on hover */
+.rich-text-editor .mermaid-diagram-toolbar {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  gap: 1px;
+  padding: 0.25rem;
+  background: color-mix(in srgb, black 75%, transparent);
+  backdrop-filter: blur(8px);
+  border-radius: var(--radius);
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 1;
+}
+
+.rich-text-editor .mermaid-diagram:hover .mermaid-diagram-toolbar,
+.rich-text-editor .mermaid-diagram-toolbar:focus-within {
+  opacity: 1;
+}
+
+.rich-text-editor .mermaid-diagram-toolbar button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: calc(var(--radius) - 2px);
+  color: white;
+  transition: background 0.15s;
+}
+
+.rich-text-editor .mermaid-diagram-toolbar button:hover {
+  background: color-mix(in srgb, white 15%, transparent);
+}
+
+/* Mermaid lightbox — full-screen preview (ESC or click backdrop to close) */
+.mermaid-diagram-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, black 80%, transparent);
+  cursor: zoom-out;
+}
+
+.mermaid-diagram-lightbox-frame {
+  border: 0;
+  width: 90vw;
+  height: 90vh;
+  background: transparent;
+  cursor: default;
 }
 
 /* Syntax highlighting — lowlight (hljs) */

--- a/packages/views/editor/readonly-content.test.tsx
+++ b/packages/views/editor/readonly-content.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 
 vi.mock("@multica/core/paths", () => ({
   useWorkspacePaths: () => ({
@@ -137,5 +137,38 @@ describe("ReadonlyContent Mermaid rendering", () => {
         }),
       }),
     );
+  });
+
+  it("opens a fullscreen lightbox when the toolbar button is clicked", async () => {
+    const { container } = render(
+      <ReadonlyContent
+        content={["```mermaid", "graph LR", "  A[Start] --> B[Done]", "```"].join("\n")}
+      />,
+    );
+
+    const button = await waitFor(() => {
+      const found = container.querySelector<HTMLButtonElement>(
+        ".mermaid-diagram-toolbar button",
+      );
+      expect(found).not.toBeNull();
+      return found!;
+    });
+
+    expect(document.querySelector(".mermaid-diagram-lightbox")).toBeNull();
+
+    fireEvent.click(button);
+
+    const lightboxFrame = document.querySelector<HTMLIFrameElement>(
+      ".mermaid-diagram-lightbox-frame",
+    );
+    expect(lightboxFrame).not.toBeNull();
+    expect(lightboxFrame?.getAttribute("sandbox")).toBe("");
+    expect(lightboxFrame?.srcdoc).toContain("mock diagram");
+    expect(lightboxFrame?.srcdoc).toContain("max-height: 100%");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(document.querySelector(".mermaid-diagram-lightbox")).toBeNull();
+    });
   });
 });

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -17,6 +17,7 @@
  */
 
 import { isValidElement, useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import ReactMarkdown, {
   defaultUrlTransform,
   type Components,
@@ -146,6 +147,12 @@ function buildSandboxedMermaidDocument(svg: string, host: HTMLElement | null): s
   const cssVariables = getSandboxCssVariables(host);
 
   return `<!doctype html><html><head><style>:root { ${cssVariables} } body { margin: 0; display: flex; justify-content: center; background: transparent; } svg { max-width: 100%; height: auto; }</style></head><body>${svg}</body></html>`;
+}
+
+function buildExpandedMermaidDocument(svg: string, host: HTMLElement | null): string {
+  const cssVariables = getSandboxCssVariables(host);
+
+  return `<!doctype html><html><head><style>:root { ${cssVariables} } html, body { width: 100%; height: 100%; } body { margin: 0; display: flex; align-items: center; justify-content: center; background: transparent; } svg { max-width: 100%; max-height: 100%; width: auto; height: auto; }</style></head><body>${svg}</body></html>`;
 }
 
 function useThemeVersion() {
@@ -286,6 +293,41 @@ function ReadonlyLink({
   );
 }
 
+function MermaidLightbox({
+  srcDoc,
+  onClose,
+}: {
+  srcDoc: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className="mermaid-diagram-lightbox"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Mermaid diagram fullscreen view"
+      onClick={onClose}
+    >
+      <iframe
+        className="mermaid-diagram-lightbox-frame"
+        sandbox=""
+        srcDoc={srcDoc}
+        title="Mermaid diagram fullscreen"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>,
+    document.body,
+  );
+}
+
 function MermaidDiagram({ chart }: { chart: string }) {
   const reactId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -295,8 +337,10 @@ function MermaidDiagram({ chart }: { chart: string }) {
   );
   const themeVersion = useThemeVersion();
   const [sandboxedDocument, setSandboxedDocument] = useState<string | null>(null);
+  const [expandedDocument, setExpandedDocument] = useState<string | null>(null);
   const [layout, setLayout] = useState<MermaidLayout>({});
   const [error, setError] = useState<string | null>(null);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -305,6 +349,7 @@ function MermaidDiagram({ chart }: { chart: string }) {
       try {
         setError(null);
         setSandboxedDocument(null);
+        setExpandedDocument(null);
         setLayout({});
         const mermaid = await getMermaid();
         mermaid.initialize({
@@ -318,6 +363,9 @@ function MermaidDiagram({ chart }: { chart: string }) {
           setLayout(getMermaidLayout(renderedSvg));
           setSandboxedDocument(
             buildSandboxedMermaidDocument(renderedSvg, containerRef.current),
+          );
+          setExpandedDocument(
+            buildExpandedMermaidDocument(renderedSvg, containerRef.current),
           );
         }
       } catch (err) {
@@ -348,16 +396,34 @@ function MermaidDiagram({ chart }: { chart: string }) {
   return (
     <div ref={containerRef} className="mermaid-diagram" aria-label="Mermaid diagram">
       {sandboxedDocument ? (
-        <iframe
-          className="mermaid-diagram-frame"
-          sandbox=""
-          srcDoc={sandboxedDocument}
-          style={{
-            height: layout.height ? `${layout.height}px` : undefined,
-            width: layout.width ? `${layout.width}px` : undefined,
-          }}
-          title="Mermaid diagram"
-        />
+        <>
+          <iframe
+            className="mermaid-diagram-frame"
+            sandbox=""
+            srcDoc={sandboxedDocument}
+            style={{
+              height: layout.height ? `${layout.height}px` : undefined,
+              width: layout.width ? `${layout.width}px` : undefined,
+            }}
+            title="Mermaid diagram"
+          />
+          <div className="mermaid-diagram-toolbar">
+            <button
+              type="button"
+              onClick={() => setLightboxOpen(true)}
+              title="Open fullscreen"
+              aria-label="Open Mermaid diagram fullscreen"
+            >
+              <Maximize2 className="size-3.5" />
+            </button>
+          </div>
+          {lightboxOpen && expandedDocument && (
+            <MermaidLightbox
+              srcDoc={expandedDocument}
+              onClose={() => setLightboxOpen(false)}
+            />
+          )}
+        </>
       ) : (
         <div className="mermaid-diagram-loading">Rendering diagram…</div>
       )}


### PR DESCRIPTION
## Summary

Follow-up to #1888. Adds a fullscreen viewer for rendered Mermaid diagrams.

The Mermaid renderer landed in #1888 uses a `sandbox=""` iframe to safely embed Mermaid's SVG output. The empty sandbox blocks scripts and (by browser policy) trackpad pinch-zoom, so users could only scroll a clipped or shrunk diagram with no way to inspect detail.

This change adds:

- A hover toolbar (top-right of the diagram, mirroring the existing image toolbar pill) with a single `Maximize2` button.
- A portal-based `MermaidLightbox` rendered into `document.body`, showing the same diagram inside a second `sandbox=""` iframe sized to 90vw × 90vh against a dimmed backdrop.
- A `buildExpandedMermaidDocument` srcDoc variant where the SVG uses `max-width: 100%; max-height: 100%; width: auto; height: auto;` so it fits any viewport.
- ESC key and backdrop click close the lightbox.

Sandbox isolation is preserved end-to-end: both the inline iframe and the lightbox iframe stay `sandbox=""`. No `allow-scripts` or `allow-same-origin` is added.

## Validation

- `corepack pnpm --filter @multica/views typecheck`
- `corepack pnpm --filter @multica/views test` — 236 tests pass, including a new test that:
  - clicks the toolbar button and asserts the lightbox iframe mounts with `sandbox=""` + the expanded srcDoc;
  - presses ESC and asserts the lightbox unmounts.
- `corepack pnpm --filter @multica/views exec eslint editor/readonly-content.tsx editor/readonly-content.test.tsx`