### PR TITLE
refactor(repos): drop unused description + tighten create-project layout

### DIFF
--- a/packages/core/types/workspace.ts
+++ b/packages/core/types/workspace.ts
@@ -2,7 +2,6 @@ export type MemberRole = "owner" | "admin" | "member";
 
 export interface WorkspaceRepo {
   url: string;
-  description: string;
 }
 
 export interface Workspace {

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -1,7 +1,26 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { ChevronRight, FolderGit, Maximize2, Minimize2, X as XIcon, UserMinus } from "lucide-react";
+import { ChevronRight, Maximize2, Minimize2, X as XIcon, UserMinus } from "lucide-react";
+
+/**
+ * GitHub mark — lucide-react v1 dropped brand icons, so we inline the
+ * Octicon-style mark here (24×24 viewBox, currentColor fill so it inherits
+ * the parent's text color). Stays in this file because there's only one
+ * caller; promote to packages/ui if a second use crops up.
+ */
+function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M12 .5C5.73.5.66 5.57.66 11.84c0 5.01 3.25 9.26 7.76 10.76.57.1.78-.25.78-.55 0-.27-.01-1.17-.02-2.13-3.16.69-3.83-1.34-3.83-1.34-.52-1.31-1.27-1.66-1.27-1.66-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.75 2.68 1.24 3.34.95.1-.74.4-1.24.72-1.53-2.52-.29-5.18-1.26-5.18-5.62 0-1.24.45-2.26 1.18-3.06-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.17a10.93 10.93 0 0 1 5.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.57.23 2.73.11 3.02.74.8 1.18 1.82 1.18 3.06 0 4.37-2.67 5.32-5.21 5.61.41.35.78 1.04.78 2.1 0 1.52-.01 2.74-.01 3.11 0 .3.21.66.79.55 4.51-1.5 7.76-5.75 7.76-10.76C23.34 5.57 18.27.5 12 .5Z" />
+    </svg>
+  );
+}
 import { useQuery } from "@tanstack/react-query";
 import { useCreateProject } from "@multica/core/projects/mutations";
 import { useProjectDraftStore } from "@multica/core/projects";
@@ -247,7 +266,14 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
           />
         </div>
 
-        <div className="flex items-center gap-1.5 px-4 py-2 shrink-0 flex-wrap">
+        {/* Footer: properties (left, wrap) + Create button (right). Single row
+            so the modal stays compact — Linear-style.
+            Repos lives here alongside the property pills for now. Once we
+            support more resource types (Linear / Notion / Figma / Slack), pull
+            them out into a dedicated Resources strip above this footer — a
+            single Repos pill on its own row looked too sparse. */}
+        <div className="flex items-center justify-between gap-2 px-4 py-3 border-t shrink-0">
+          <div className="flex items-center gap-1.5 flex-wrap min-w-0">
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -386,7 +412,7 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
             <PopoverTrigger
               render={
                 <PillButton>
-                  <FolderGit className="size-3" />
+                  <GithubIcon className="size-3" />
                   <span>
                     {selectedRepos.length === 0
                       ? "Repos"
@@ -419,7 +445,7 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
                           readOnly
                           className="size-3.5"
                         />
-                        <FolderGit className="size-3.5" />
+                        <GithubIcon className="size-3.5" />
                         <span className="truncate flex-1 text-left">{repo.url}</span>
                       </button>
                     );
@@ -465,7 +491,7 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
                       key={url}
                       className="flex items-center gap-2 text-xs"
                     >
-                      <FolderGit className="size-3 text-muted-foreground" />
+                      <GithubIcon className="size-3 text-muted-foreground" />
                       <span className="truncate flex-1">{url}</span>
                       <button
                         type="button"
@@ -480,10 +506,14 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
               )}
             </PopoverContent>
           </Popover>
-        </div>
+          </div>
 
-        <div className="flex items-center justify-end px-4 py-3 border-t shrink-0">
-          <Button size="sm" onClick={handleSubmit} disabled={!title.trim() || submitting}>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!title.trim() || submitting}
+            className="shrink-0"
+          >
             {submitting ? "Creating..." : "Create Project"}
           </Button>
         </div>

--- a/packages/views/settings/components/repositories-tab.tsx
+++ b/packages/views/settings/components/repositories-tab.tsx
@@ -48,15 +48,15 @@ export function RepositoriesTab() {
   };
 
   const handleAddRepo = () => {
-    setRepos([...repos, { url: "", description: "" }]);
+    setRepos([...repos, { url: "" }]);
   };
 
   const handleRemoveRepo = (index: number) => {
     setRepos(repos.filter((_, i) => i !== index));
   };
 
-  const handleRepoChange = (index: number, field: keyof WorkspaceRepo, value: string) => {
-    setRepos(repos.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+  const handleRepoChange = (index: number, value: string) => {
+    setRepos(repos.map((r, i) => (i === index ? { ...r, url: value } : r)));
   };
 
   if (!workspace) return null;
@@ -74,24 +74,14 @@ export function RepositoriesTab() {
 
             {repos.map((repo, index) => (
               <div key={index} className="flex gap-2">
-                <div className="flex-1 space-y-1.5">
-                  <Input
-                    type="url"
-                    value={repo.url}
-                    onChange={(e) => handleRepoChange(index, "url", e.target.value)}
-                    disabled={!canManageWorkspace}
-                    placeholder="https://git.example.com/org/repo.git"
-                    className="text-sm"
-                  />
-                  <Input
-                    type="text"
-                    value={repo.description}
-                    onChange={(e) => handleRepoChange(index, "description", e.target.value)}
-                    disabled={!canManageWorkspace}
-                    placeholder="Description (e.g. Go backend + Next.js frontend)"
-                    className="text-sm"
-                  />
-                </div>
+                <Input
+                  type="url"
+                  value={repo.url}
+                  onChange={(e) => handleRepoChange(index, e.target.value)}
+                  disabled={!canManageWorkspace}
+                  placeholder="https://git.example.com/org/repo.git"
+                  className="flex-1 text-sm"
+                />
                 {canManageWorkspace && (
                   <Button
                     variant="ghost"

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -441,7 +441,7 @@ func (d *Daemon) registerTaskRepos(workspaceID string, repos []RepoData) {
 			continue
 		}
 		ws.taskRepoURLs[url] = struct{}{}
-		toSync = append(toSync, RepoData{URL: url, Description: repo.Description})
+		toSync = append(toSync, RepoData{URL: url})
 	}
 	d.mu.Unlock()
 

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1766,7 +1766,7 @@ func mergeUsage(a, b map[string]agent.TokenUsage) map[string]agent.TokenUsage {
 func repoDataToInfo(repos []RepoData) []repocache.RepoInfo {
 	info := make([]repocache.RepoInfo, len(repos))
 	for i, r := range repos {
-		info[i] = repocache.RepoInfo{URL: r.URL, Description: r.Description}
+		info[i] = repocache.RepoInfo{URL: r.URL}
 	}
 	return info
 }
@@ -1777,7 +1777,7 @@ func convertReposForEnv(repos []RepoData) []execenv.RepoContextForEnv {
 	}
 	result := make([]execenv.RepoContextForEnv, len(repos))
 	for i, r := range repos {
-		result[i] = execenv.RepoContextForEnv{URL: r.URL, Description: r.Description}
+		result[i] = execenv.RepoContextForEnv{URL: r.URL}
 	}
 	return result
 }

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -677,7 +677,7 @@ func TestRegisterTaskReposAllowsProjectOnlyURL(t *testing.T) {
 	// the only repo URL the agent should be able to check out.
 	d.workspaces["ws-1"] = newWorkspaceState("ws-1", nil, "", nil, nil)
 
-	d.registerTaskRepos("ws-1", []RepoData{{URL: sourceRepo, Description: "project repo"}})
+	d.registerTaskRepos("ws-1", []RepoData{{URL: sourceRepo}})
 
 	// The async clone goroutine in registerTaskRepos may not have finished;
 	// poll briefly until the cache is populated so the test isn't racy.

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -637,7 +637,7 @@ func TestEnsureRepoReadyRefreshesOnMiss(t *testing.T) {
 		refreshCalls.Add(1)
 		json.NewEncoder(w).Encode(WorkspaceReposResponse{
 			WorkspaceID:  "ws-1",
-			Repos:        []RepoData{{URL: sourceRepo, Description: "repo"}},
+			Repos:        []RepoData{{URL: sourceRepo}},
 			ReposVersion: "v2",
 		})
 	})
@@ -762,7 +762,7 @@ func TestEnsureRepoReadyReportsSyncFailure(t *testing.T) {
 	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(WorkspaceReposResponse{
 			WorkspaceID:  "ws-1",
-			Repos:        []RepoData{{URL: missingRepo, Description: "missing"}},
+			Repos:        []RepoData{{URL: missingRepo}},
 			ReposVersion: "v1",
 		})
 	})
@@ -790,7 +790,7 @@ func TestEnsureRepoReadyConcurrentMissRefreshesOnce(t *testing.T) {
 		refreshCalls.Add(1)
 		json.NewEncoder(w).Encode(WorkspaceReposResponse{
 			WorkspaceID:  "ws-1",
-			Repos:        []RepoData{{URL: sourceRepo, Description: "repo"}},
+			Repos:        []RepoData{{URL: sourceRepo}},
 			ReposVersion: "v2",
 		})
 	})

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -14,8 +14,7 @@ import (
 
 // RepoContextForEnv describes a workspace repo available for checkout.
 type RepoContextForEnv struct {
-	URL         string // remote URL
-	Description string // human-readable description
+	URL string // remote URL
 }
 
 // ProjectResourceForEnv describes a single resource attached to the issue's

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -217,7 +217,7 @@ func TestProjectReposReplaceWorkspaceReposInMetaSkill(t *testing.T) {
 		ProjectID:    "22222222-3333-4444-5555-666666666666",
 		ProjectTitle: "Project A",
 		Repos: []RepoContextForEnv{
-			{URL: "https://github.com/org/project-repo", Description: ""},
+			{URL: "https://github.com/org/project-repo"},
 		},
 		ProjectResources: []ProjectResourceForEnv{
 			{

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -261,8 +261,8 @@ func TestPrepareWithRepoContext(t *testing.T) {
 	taskCtx := TaskContextForEnv{
 		IssueID: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
 		Repos: []RepoContextForEnv{
-			{URL: "https://github.com/org/backend", Description: "Go backend"},
-			{URL: "https://github.com/org/frontend", Description: "React frontend"},
+			{URL: "https://github.com/org/backend"},
+			{URL: "https://github.com/org/frontend"},
 		},
 	}
 	env, err := Prepare(PrepareParams{
@@ -304,9 +304,7 @@ func TestPrepareWithRepoContext(t *testing.T) {
 	for _, want := range []string{
 		"multica repo checkout",
 		"https://github.com/org/backend",
-		"Go backend",
 		"https://github.com/org/frontend",
-		"React frontend",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("CLAUDE.md missing %q", want)
@@ -853,7 +851,7 @@ func TestPrepareWithRepoContextOpencode(t *testing.T) {
 	taskCtx := TaskContextForEnv{
 		IssueID: "c3d4e5f6-a7b8-9012-cdef-123456789012",
 		Repos: []RepoContextForEnv{
-			{URL: "https://github.com/org/backend", Description: "Go backend"},
+			{URL: "https://github.com/org/backend"},
 		},
 	}
 	env, err := Prepare(PrepareParams{
@@ -894,7 +892,6 @@ func TestPrepareWithRepoContextOpencode(t *testing.T) {
 	for _, want := range []string{
 		"multica repo checkout",
 		"https://github.com/org/backend",
-		"Go backend",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("AGENTS.md missing %q", want)

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -161,14 +161,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("## Repositories\n\n")
 		b.WriteString("The following code repositories are available in this workspace.\n")
 		b.WriteString("Use `multica repo checkout <url>` to check out a repository into your working directory.\n\n")
-		b.WriteString("| URL | Description |\n")
-		b.WriteString("|-----|-------------|\n")
 		for _, repo := range ctx.Repos {
-			desc := repo.Description
-			if desc == "" {
-				desc = "—"
-			}
-			fmt.Fprintf(&b, "| %s | %s |\n", repo.URL, desc)
+			fmt.Fprintf(&b, "- %s\n", repo.URL)
 		}
 		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed.\n\n")
 	}

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -25,15 +25,13 @@ func gitEnv() []string {
 
 // RepoInfo describes a repository to cache.
 type RepoInfo struct {
-	URL         string
-	Description string
+	URL string
 }
 
 // CachedRepo describes a cached bare clone ready for worktree creation.
 type CachedRepo struct {
-	URL         string // remote URL
-	Description string // human-readable description
-	LocalPath   string // absolute path to the bare clone
+	URL       string // remote URL
+	LocalPath string // absolute path to the bare clone
 }
 
 // Cache manages bare git clones for workspace repositories.

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -185,7 +185,7 @@ func TestSyncAndLookup(t *testing.T) {
 
 	// Sync should clone the repo.
 	err := cache.Sync("ws-123", []RepoInfo{
-		{URL: sourceRepo, Description: "test repo"},
+		{URL: sourceRepo},
 	})
 	if err != nil {
 		t.Fatalf("Sync failed: %v", err)

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -18,8 +18,7 @@ type Runtime struct {
 
 // RepoData holds repository information from the workspace.
 type RepoData struct {
-	URL         string `json:"url"`
-	Description string `json:"description"`
+	URL string `json:"url"`
 }
 
 // ProjectResourceData mirrors handler.ProjectResourceData — a single project

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -116,8 +116,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 // RepoData holds repository information included in claim responses so the
 // daemon can set up worktrees for each workspace repo.
 type RepoData struct {
-	URL         string `json:"url"`
-	Description string `json:"description"`
+	URL string `json:"url"`
 }
 
 // ProjectResourceData is the wire shape for a project resource included in a

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -156,10 +156,7 @@ func normalizeWorkspaceRepos(repos []RepoData) []RepoData {
 			continue
 		}
 		seen[url] = struct{}{}
-		normalized = append(normalized, RepoData{
-			URL:         url,
-			Description: strings.TrimSpace(repo.Description),
-		})
+		normalized = append(normalized, RepoData{URL: url})
 	}
 	return normalized
 }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -911,11 +911,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 								URL string `json:"url"`
 							}
 							if json.Unmarshal(row.ResourceRef, &payload) == nil && payload.URL != "" {
-								desc := ""
-								if row.Label.Valid {
-									desc = row.Label.String
-								}
-								projectRepos = append(projectRepos, RepoData{URL: payload.URL, Description: desc})
+								projectRepos = append(projectRepos, RepoData{URL: payload.URL})
 							}
 						}
 					}


### PR DESCRIPTION
## Summary

Two related changes that both touch the workspace-repos surface, packaged together because they share files and would conflict if landed independently.

### 1. Remove the per-repo `description` field everywhere

The only place this string ever surfaced was a markdown table column the daemon injected into the agent runtime config (`| URL | Description |`), where most rows just rendered `—` because nobody filled it in. Agents already discover project structure by running `multica project` / `multica issue` against the CLI, so the human-readable description carried no real value — just an extra Settings input row to fill out and a six-layer propagation path.

**What's gone**

- Settings → Repositories: dropped the description input; the URL field now spans the whole row.
- `packages/core/types/workspace.ts`: `WorkspaceRepo` loses `description`.
- `server/internal/handler/agent.go`: `RepoData` collapses to `URL` only.
- `server/internal/handler/daemon.go`: normalize / forward paths drop description.
- `server/internal/daemon/types.go`: daemon-side `RepoData` mirror.
- `server/internal/daemon/daemon.go`: both `repoDataToInfo` and `convertReposForEnv` no longer carry it.
- `server/internal/daemon/repocache/cache.go`: `RepoInfo` / `CachedRepo` lose `Description`.
- `server/internal/daemon/execenv/execenv.go`: `RepoContextForEnv` is URL-only.
- `server/internal/daemon/execenv/runtime_config.go`: Repositories block in the agent context renders as a simple bullet list (`- <url>`) instead of the two-column markdown table.
- Tests updated to match.

**No migration needed** — `workspace.repos` is JSONB, `normalizeWorkspaceRepos` quietly drops the residual `description` field on read, so existing rows keep working.

### 2. Tighten the Create Project modal footer

Pull the Status / Priority / Lead / Repos pills onto the same row as the Create Project button (Linear-style single-row footer) instead of stacking them above it. Also swap the Repos pill's `FolderGit` icon for a real GitHub mark — lucide-react v1 dropped its brand icon set, so the mark is inlined as a small `<GithubIcon>` SVG in the modal file.

I prototyped promoting Repos to its own \"Resources\" strip above the footer (resources are a different abstraction from project metadata), but with only a single pill it looked too sparse. Left a TODO in the footer comment so we revisit it when Linear / Notion / Figma / Slack resource types come online.

## Test plan

- [ ] Settings → Repositories: only one URL input per repo, save/load round-trips, existing rows with stale `description` data keep working (it's silently dropped).
- [ ] Create Project modal: Status, Priority, Lead, Repos pills all sit in the same row as the Create button; Repos pill shows the GitHub mark.
- [ ] Open the Repos popover on a workspace that previously had repos with descriptions — items render with URL only, no broken layout.
- [ ] Run a task on an agent: the injected runtime config Repositories block reads as a bullet list, not a `| URL | Description |` table.
- [ ] `go test ./internal/daemon/execenv ./internal/daemon/repocache ./internal/handler` (verified locally).
- [ ] `pnpm --filter @multica/views typecheck` + `@multica/core typecheck` (verified locally).