### PR TITLE
fix(docker): add HTTP_PROXY/HTTPS_PROXY build args for selfhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # --- Build stage ---
 FROM golang:1.26-alpine AS builder
 
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
 RUN apk add --no-cache git
 
 WORKDIR /src

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,10 @@
 # --- Dependencies ---
 FROM node:22-alpine AS deps
 
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+
 RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 
 WORKDIR /app
@@ -18,6 +22,10 @@ RUN pnpm install --frozen-lockfile
 
 # --- Build ---
 FROM node:22-alpine AS builder
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
 
 RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 

--- a/docker-compose.selfhost.build.yml
+++ b/docker-compose.selfhost.build.yml
@@ -7,6 +7,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        HTTP_PROXY: ${HTTP_PROXY:-}
+        HTTPS_PROXY: ${HTTPS_PROXY:-}
+        NO_PROXY: ${NO_PROXY:-}
 
   frontend:
     image: multica-web:dev
@@ -14,6 +18,9 @@ services:
       context: .
       dockerfile: Dockerfile.web
       args:
+        HTTP_PROXY: ${HTTP_PROXY:-}
+        HTTPS_PROXY: ${HTTPS_PROXY:-}
+        NO_PROXY: ${NO_PROXY:-}
         REMOTE_API_URL: http://backend:8080
         NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-}
         NEXT_PUBLIC_APP_VERSION: dev


### PR DESCRIPTION
## Summary
- Add `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` build arguments to `Dockerfile`, `Dockerfile.web`, and `docker-compose.selfhost.build.yml`
- Enables selfhost deployments behind corporate proxies to pass proxy settings at build time

## Test plan
- [ ] Build with `docker compose -f docker-compose.selfhost.build.yml build` without proxy env vars (default behavior unchanged)
- [ ] Build with `HTTP_PROXY`/`HTTPS_PROXY` set and verify args are passed into build stages