### PR TITLE
fix(views): only show "Mark as Done" button on Inbox page

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -532,7 +532,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             </span>
           </div>
           <div className="flex items-center gap-1 shrink-0">
-            {issue.status !== "done" && issue.status !== "cancelled" && (
+            {onDone && issue.status !== "done" && issue.status !== "cancelled" && (
               <Tooltip>
                 <TooltipTrigger
                   render={


### PR DESCRIPTION
## Summary

- Gate the "Mark as Done" toolbar button in `IssueDetail` on the `onDone` prop, so it only renders when viewed from the Inbox page
- Previously, the button appeared on all issue detail views (standalone issue page, desktop issue page, etc.)

Closes MUL-1646

## Test plan

- [x] TypeScript typecheck passes (all 6 tasks)
- [x] `issue-detail.test.tsx` passes (11/11 tests)
- [ ] Manually verify "Mark as Done" button appears in Inbox issue detail
- [ ] Manually verify "Mark as Done" button does NOT appear on standalone issue detail page