### PR TITLE
refactor(landing): replace identical-card grids in how-it-works and open-source

### DIFF
--- a/apps/web/features/landing/components/how-it-works-section.tsx
+++ b/apps/web/features/landing/components/how-it-works-section.tsx
@@ -21,26 +21,78 @@ export function HowItWorksSection() {
           <span className="text-white/40">{t.howItWorks.headlineFaded}</span>
         </h2>
 
-        <div className="mt-20 grid gap-px overflow-hidden rounded-2xl border border-white/10 bg-white/10 sm:grid-cols-2 lg:grid-cols-4">
+        {/* Desktop: horizontal step flow with large serif numerals + connecting rule */}
+        <ol className="mt-20 hidden lg:grid lg:grid-cols-4 lg:gap-10">
           {t.howItWorks.steps.map((step, i) => (
-            <div
-              key={i}
-              className="flex flex-col bg-[#05070b] p-8 lg:p-10"
-            >
-              <span className="text-[13px] font-semibold tabular-nums text-white/28">
-                {String(i + 1).padStart(2, "0")}
+            <li key={i} className="relative flex flex-col">
+              <span className="font-[family-name:var(--font-serif)] text-[5rem] leading-none tracking-[-0.04em] text-white/72">
+                {i + 1}
               </span>
-              <h3 className="mt-4 text-[17px] font-semibold leading-snug text-white sm:text-[18px]">
+              <div className="mt-6 flex items-center gap-3">
+                <span className="h-px flex-1 bg-white/14" />
+                {i < t.howItWorks.steps.length - 1 ? (
+                  <svg
+                    aria-hidden="true"
+                    width="14"
+                    height="10"
+                    viewBox="0 0 14 10"
+                    fill="none"
+                    className="text-white/30"
+                  >
+                    <path
+                      d="M9 1l4 4-4 4M0 5h13"
+                      stroke="currentColor"
+                      strokeWidth="1"
+                      strokeLinecap="square"
+                    />
+                  </svg>
+                ) : (
+                  <span className="size-1.5 shrink-0 rounded-full bg-white/40" />
+                )}
+              </div>
+              <h3 className="mt-6 text-[18px] font-semibold leading-snug text-white">
                 {step.title}
               </h3>
-              <p className="mt-3 text-[14px] leading-[1.7] text-white/50 sm:text-[15px]">
+              <p className="mt-3 text-[15px] leading-[1.7] text-white/56">
                 {step.description}
               </p>
-            </div>
+            </li>
           ))}
-        </div>
+        </ol>
 
-        <div className="mt-14 flex flex-wrap items-center gap-4">
+        {/* Mobile / tablet: vertical timeline with continuous left rail */}
+        <ol className="mt-16 lg:hidden">
+          {t.howItWorks.steps.map((step, i) => {
+            const isLast = i === t.howItWorks.steps.length - 1;
+            return (
+              <li key={i} className="relative grid grid-cols-[3.25rem_1fr] gap-x-5">
+                {/* Left rail + numeral */}
+                <div className="relative flex flex-col items-start">
+                  <span className="font-[family-name:var(--font-serif)] text-[3rem] leading-none tracking-[-0.03em] text-white/80">
+                    {i + 1}
+                  </span>
+                  {!isLast && (
+                    <span
+                      aria-hidden="true"
+                      className="absolute left-[1.05rem] top-[3.5rem] bottom-[-2.5rem] w-px bg-white/14"
+                    />
+                  )}
+                </div>
+                {/* Right content */}
+                <div className={isLast ? "pb-0" : "pb-12"}>
+                  <h3 className="text-[17px] font-semibold leading-snug text-white sm:text-[18px]">
+                    {step.title}
+                  </h3>
+                  <p className="mt-2.5 text-[14px] leading-[1.7] text-white/56 sm:text-[15px]">
+                    {step.description}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+
+        <div className="mt-14 flex flex-wrap items-center gap-4 lg:mt-20">
           <Link href={user ? "/" : "/login"} className={heroButtonClassName("solid")}>
             {user ? t.header.dashboard : t.howItWorks.cta}
           </Link>

--- a/apps/web/features/landing/components/open-source-section.tsx
+++ b/apps/web/features/landing/components/open-source-section.tsx
@@ -54,7 +54,7 @@ export function OpenSourceSection() {
                   <h3
                     className={
                       i === 0
-                        ? "font-[family-name:var(--font-serif)] text-[1.75rem] leading-[1.1] tracking-[-0.02em] text-[#0a0d12] sm:text-[2.05rem] sm:w-[260px] sm:shrink-0"
+                        ? "text-[22px] font-semibold leading-tight tracking-[-0.01em] text-[#0a0d12] sm:text-[24px] sm:w-[260px] sm:shrink-0"
                         : "text-[17px] font-semibold leading-snug text-[#0a0d12] sm:text-[18px] sm:w-[260px] sm:shrink-0"
                     }
                   >

--- a/apps/web/features/landing/components/open-source-section.tsx
+++ b/apps/web/features/landing/components/open-source-section.tsx
@@ -37,21 +37,36 @@ export function OpenSourceSection() {
             </div>
           </div>
 
-          {/* Right column — highlight grid */}
-          <div className="flex-1">
-            <div className="grid gap-px overflow-hidden rounded-2xl border border-[#0a0d12]/8 bg-[#0a0d12]/8 sm:grid-cols-2">
-              {t.openSource.highlights.map((item) => (
-                <div key={item.title} className="bg-white p-8 lg:p-10">
-                  <h3 className="text-[17px] font-semibold leading-snug text-[#0a0d12] sm:text-[18px]">
+          {/* Right column — narrative highlight list */}
+          <ul className="flex-1 divide-y divide-[#0a0d12]/8">
+            {t.openSource.highlights.map((item, i) => (
+              <li
+                key={item.title}
+                className={
+                  i === 0
+                    ? "pb-8 sm:pb-10"
+                    : i === t.openSource.highlights.length - 1
+                      ? "pt-8 sm:pt-10"
+                      : "py-8 sm:py-10"
+                }
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-baseline sm:gap-10">
+                  <h3
+                    className={
+                      i === 0
+                        ? "font-[family-name:var(--font-serif)] text-[1.75rem] leading-[1.1] tracking-[-0.02em] text-[#0a0d12] sm:text-[2.05rem] sm:w-[260px] sm:shrink-0"
+                        : "text-[17px] font-semibold leading-snug text-[#0a0d12] sm:text-[18px] sm:w-[260px] sm:shrink-0"
+                    }
+                  >
                     {item.title}
                   </h3>
-                  <p className="mt-3 text-[14px] leading-[1.7] text-[#0a0d12]/56 sm:text-[15px]">
+                  <p className="text-[14px] leading-[1.7] text-[#0a0d12]/60 sm:text-[15px]">
                     {item.description}
                   </p>
                 </div>
-              ))}
-            </div>
-          </div>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Closes #1939.

Replaces the equal-weight card grids in `how-it-works` and `open-source` with non-grid layouts. Full motivation and the four "before" shots are in the issue; this PR has the implementation and the "after" shots side-by-side.

## How It Works

Desktop — 4 large serif numerals with a horizontal rule (arrow on 1–3, dot on 4):

| Before | After |
|---|---|
| ![](https://raw.githubusercontent.com/fancyboi999/multica/assets/landing-redesign/screenshots/before/how-it-works-desktop.png) | ![](https://raw.githubusercontent.com/fancyboi999/multica/assets/landing-redesign/screenshots/after/how-it-works-desktop.png) |

Mobile — vertical timeline with a continuous left rail and `white/80` numerals (was `white/28`):

| Before | After |
|---|---|
| ![](https://raw.githubusercontent.com/fancyboi999/multica/assets/landing-redesign/screenshots/before/how-it-works-mobile.png) | ![](https://raw.githubusercontent.com/fancyboi999/multica/assets/landing-redesign/screenshots/after/how-it-works-mobile.png) |

## Open Source

Two-column narrative list. The first item ("Self-host anywhere") gets a serif headline — the most concrete differentiator earns more visual weight than the abstract ones. `divide-y` for separation, no card borders:

| Before | After |
|---|---|
| ![](https://raw.githubusercontent.com/fancyboi999/multica/assets/landing-redesign/screenshots/before/open-source-desktop.png) | ![](https://raw.githubusercontent.com/fancyboi999/multica/assets/landing-redesign/screenshots/after/open-source-desktop.png) |

Mobile stacks heading above description per item:

| Before | After |
|---|---|
| ![](https://raw.githubusercontent.com/fancyboi999/multica/assets/landing-redesign/screenshots/before/open-source-mobile.png) | ![](https://raw.githubusercontent.com/fancyboi999/multica/assets/landing-redesign/screenshots/after/open-source-mobile.png) |

## What I did NOT change

- i18n schema, keys, copy — every existing translation entry still resolves.
- Section IDs (`#how-it-works`, `#open-source`) — anchor links still work.
- Shared components, tokens, color values, font config.
- Any other `landing` files or shared packages.

Files touched: 2.

## Validation

```
pnpm --filter @multica/web typecheck  → pass
pnpm --filter @multica/web test       → 20/20 pass
pnpm exec eslint  apps/web/features/landing/components/how-it-works-section.tsx \
                  apps/web/features/landing/components/open-source-section.tsx
                                       → clean
```

`pnpm --filter @multica/web lint` over the whole package reports 7 pre-existing errors in `apps/web/app/not-found.tsx` (`@next/next/no-html-link-for-pages`); they're untouched by this change.

Manually verified at 1440px and 390px against `localhost:3000` with locale forced to `en`. Screenshots above are from those runs.

## Trade-offs

- The horizontal connecting rule on desktop only renders inside each step's column; it visually suggests a connection without me committing to literal cross-column lines (which break ungracefully on narrow viewports). If reviewers want a continuous line across all 4 columns, that's a follow-up — happy to switch the geometry, but it adds a layout dependency I wanted to avoid in the first cut.
- The serif emphasis on "Self-host anywhere" assumes that item stays at index 0. Today both the i18n source and the rendered order make that a safe assumption. If the order ever changes, the emphasis follows position, not item identity. Open to making this explicit (e.g. flagging "primary highlight" in the dict) if you'd prefer.
