### PR TITLE
fix(codex): handle MCP elicitation server requests correctly

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -649,7 +649,7 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 	case "mcpServer/elicitation/request":
 		c.respond(id, map[string]any{"action": "accept", "content": nil, "_meta": nil})
 	default:
-		slog.Warn("codex: unhandled server request", "method", method, "id", id)
+		c.cfg.Logger.Warn("codex: unhandled server request", "method", method, "id", id)
 		c.respondError(id, -32601, fmt.Sprintf("unhandled server request: %s", method))
 	}
 }

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -552,6 +552,20 @@ func (c *codexClient) respond(id int, result any) {
 	_, _ = c.stdin.Write(data)
 }
 
+func (c *codexClient) respondError(id int, code int, message string) {
+	msg := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	}
+	data, _ := json.Marshal(msg)
+	data = append(data, '\n')
+	_, _ = c.stdin.Write(data)
+}
+
 func (c *codexClient) closeAllPending(err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -632,8 +646,11 @@ func (c *codexClient) handleServerRequest(raw map[string]json.RawMessage) {
 		c.respond(id, map[string]any{"decision": "accept"})
 	case "item/fileChange/requestApproval", "applyPatchApproval":
 		c.respond(id, map[string]any{"decision": "accept"})
+	case "mcpServer/elicitation/request":
+		c.respond(id, map[string]any{"action": "accept", "content": nil, "_meta": nil})
 	default:
-		c.respond(id, map[string]any{})
+		slog.Warn("codex: unhandled server request", "method", method, "id", id)
+		c.respondError(id, -32601, fmt.Sprintf("unhandled server request: %s", method))
 	}
 }
 

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -168,6 +168,68 @@ func TestCodexHandleServerRequestFileChangeApproval(t *testing.T) {
 	}
 }
 
+func TestCodexHandleServerRequestMCPElicitation(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","id":12,"method":"mcpServer/elicitation/request","params":{}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["id"] != float64(12) {
+		t.Fatalf("expected id=12, got %v", resp["id"])
+	}
+	result := resp["result"].(map[string]any)
+	if result["action"] != "accept" {
+		t.Fatalf("expected action=accept, got %v", result["action"])
+	}
+	if _, ok := result["content"]; !ok {
+		t.Fatal("expected content key in response")
+	}
+	if _, ok := result["_meta"]; !ok {
+		t.Fatal("expected _meta key in response")
+	}
+}
+
+func TestCodexHandleServerRequestUnknownReturnsError(t *testing.T) {
+	t.Parallel()
+
+	c, fs, _ := newTestCodexClient(t)
+
+	c.handleLine(`{"jsonrpc":"2.0","id":13,"method":"some/unknown/method","params":{}}`)
+
+	lines := fs.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["id"] != float64(13) {
+		t.Fatalf("expected id=13, got %v", resp["id"])
+	}
+	if resp["result"] != nil {
+		t.Fatalf("expected no result for error response, got %v", resp["result"])
+	}
+	errObj, ok := resp["error"].(map[string]any)
+	if !ok {
+		t.Fatal("expected error object in response")
+	}
+	if errObj["code"] != float64(-32601) {
+		t.Fatalf("expected error code -32601, got %v", errObj["code"])
+	}
+}
+
 func TestCodexLegacyEventTaskStarted(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #1942.

`handleServerRequest()` in the Codex bridge responded with `{}` to all unrecognized server request methods — including `mcpServer/elicitation/request` added in Codex 0.125+. This caused Codex to fail deserializing the response (`missing field 'action'`), which it then interpreted as "user rejected MCP tool call".

## Changes

### `server/pkg/agent/codex.go`
- Add `mcpServer/elicitation/request` case: respond with `{action: "accept", content: null, _meta: null}` per the Codex elicitation response schema
- Add `respondError()` helper for sending JSON-RPC error responses
- Change `default` case from silent `{}` to a proper JSON-RPC method-not-found error (`-32601`) with a warning log — makes future unhandled methods visible instead of silently broken

### `server/pkg/agent/codex_test.go`
- Test MCP elicitation request gets correct response schema
- Test unknown server request method returns JSON-RPC error (not empty object)

## Behavior change

| Server request method | Before | After |
|---|---|---|
| `commandExecution/requestApproval` | ✅ `{decision: accept}` | ✅ No change |
| `fileChange/requestApproval` | ✅ `{decision: accept}` | ✅ No change |
| `mcpServer/elicitation/request` | ❌ `{}` → deserialization error | ✅ `{action: accept, ...}` |
| Unknown methods | `{}` (silent, may break) | JSON-RPC error + warning log |

## How to test

```bash
cd server && go test ./pkg/agent/ -run TestCodexHandleServerRequest -v
```

## Scope note

This PR addresses Phase 1 from the issue (fix protocol errors). Phase 2 (config.toml inheritance sanitization for MCP servers) is a separate concern tracked in the same issue.