### PR TITLE
RFC: agent_workflow engine + issue:resolved event for human-gated workflows

### DIFF
--- a/server/internal/service/workflow.go
+++ b/server/internal/service/workflow.go
@@ -1,0 +1,624 @@
+// Package service: WorkflowEngine — a unified engine that advances both
+// agent workflows and (future) team workflows in response to bus events.
+//
+// # Why one engine
+//
+// Team workflows and agent workflows are the same concept at different
+// granularities: a sequence of steps with explicit handoffs. A team
+// workflow hands off between roles (each role optionally backed by an
+// agent); an agent workflow hands off between steps owned by a single
+// agent, possibly with human gates in between.
+//
+// Both flavors are advanced by the same kinds of events:
+//
+//   - task:completed   — an agent finished a step
+//   - issue:resolved   — a human resolved an approval gate (agent only today)
+//
+// Keeping a single engine means there's one place that owns "what happens
+// next" and one observable surface for status, retries, and audit.
+//
+// # Today's scope
+//
+// This file initially lands the engine subscriber, the agent_workflow run
+// state machine, and a stub for the team-workflow path. Once team
+// workflows have schema + queries to read from, the team-side dispatch
+// fills in alongside the agent-side without changing the engine's
+// surface. See docs/sebai-builder-tax-filing-design.md §8 in the Sebai
+// fork for the full design context this contribution lands.
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// WorkflowEngine listens for task and issue events on the bus and advances
+// any in-flight workflow runs they correspond to.
+//
+// The engine is event-sourced: it never polls. Each Subscribe call below
+// is the engine's only input edge. The output edges are:
+//
+//   - INSERT INTO agent_task_queue   (when dispatching the next agent step)
+//   - UPDATE agent_workflow_run      (status / current_step / state /
+//                                     last_task_id / last_issue_id)
+//   - bus.Publish("team:workflow_blocked")  (team-workflow only;
+//                                            currently a stub)
+type WorkflowEngine struct {
+	Pool        *pgxpool.Pool
+	TaskService *TaskService
+	Bus         *events.Bus
+	Logger      *slog.Logger
+
+	// agentStore is the data-access surface for the agent-workflow path.
+	// Production callers leave this nil and the engine builds a pgxStore
+	// from Pool. Tests may inject a fake via SetAgentStore to drive the
+	// engine without a real database.
+	agentStore agentWorkflowStore
+}
+
+// NewWorkflowEngine constructs the engine and subscribes it to
+// task:completed + issue:resolved events.
+//
+// pool may be nil only in tests that swap in a fake store via
+// SetAgentStore; production callers must pass a connected pgxpool.Pool.
+func NewWorkflowEngine(
+	pool *pgxpool.Pool,
+	taskSvc *TaskService,
+	bus *events.Bus,
+	logger *slog.Logger,
+) *WorkflowEngine {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	engine := &WorkflowEngine{
+		Pool:        pool,
+		TaskService: taskSvc,
+		Bus:         bus,
+		Logger:      logger,
+	}
+	if pool != nil {
+		engine.agentStore = &pgxAgentWorkflowStore{pool: pool}
+	}
+	if bus != nil {
+		bus.Subscribe(protocol.EventTaskCompleted, engine.handleTaskCompleted)
+		bus.Subscribe(protocol.EventIssueResolved, engine.handleIssueResolved)
+	}
+	return engine
+}
+
+// SetAgentStore swaps the agent-workflow data-access surface. Used by
+// tests to inject a fake; production code does not call this.
+func (e *WorkflowEngine) SetAgentStore(s agentWorkflowStore) {
+	e.agentStore = s
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+// handleTaskCompleted dispatches a task:completed event to whichever
+// workflow path applies (team or agent). A single task can only belong to
+// one workflow at a time, so the two paths are mutually exclusive at the
+// per-event level.
+func (e *WorkflowEngine) handleTaskCompleted(evt events.Event) {
+	payload, ok := evt.Payload.(map[string]any)
+	if !ok {
+		return
+	}
+
+	// Team-workflow path: payload carries explicit team_id + role_id. This
+	// is the existing intent of the engine and lands as a stub here — once
+	// team_workflow has schema + queries upstream, fill in advanceTeam
+	// alongside the agent path without changing the engine's interface.
+	teamID, _ := payload["team_id"].(string)
+	roleID, _ := payload["role_id"].(string)
+	if teamID != "" && roleID != "" {
+		e.advanceTeam(context.Background(), evt.WorkspaceID, teamID, roleID)
+		return
+	}
+
+	// Agent-workflow path: lookup by workflow_run_id (preferred) or by
+	// task_id (fall back; correlated via agent_workflow_run.last_task_id).
+	runID, _ := payload["workflow_run_id"].(string)
+	taskID, _ := payload["task_id"].(string)
+	if runID == "" && taskID == "" {
+		return
+	}
+	if e.agentStore == nil {
+		return
+	}
+
+	ctx := context.Background()
+	run, err := e.agentStore.FindRun(ctx, runID, taskID, "")
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Not an agent-workflow task — silent no-op.
+			return
+		}
+		e.Logger.Warn("workflow engine: agent run lookup failed",
+			"task_id", taskID, "run_id", runID, "error", err)
+		return
+	}
+	e.advanceAgent(ctx, run, "")
+}
+
+// handleIssueResolved is the bus handler for issue:resolved events. Only
+// the agent-workflow path consumes these today — team workflows have no
+// human-gate concept yet.
+func (e *WorkflowEngine) handleIssueResolved(evt events.Event) {
+	payload, ok := evt.Payload.(map[string]any)
+	if !ok {
+		return
+	}
+
+	resolution, _ := payload["resolution"].(string)
+	if resolution != "approved" && resolution != "rejected" {
+		return
+	}
+
+	runID, _ := payload["workflow_run_id"].(string)
+	issueID, _ := payload["issue_id"].(string)
+	if runID == "" && issueID == "" {
+		return
+	}
+	if e.agentStore == nil {
+		return
+	}
+
+	ctx := context.Background()
+	run, err := e.agentStore.FindRun(ctx, runID, "", issueID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return
+		}
+		e.Logger.Warn("workflow engine: agent run lookup failed",
+			"issue_id", issueID, "run_id", runID, "error", err)
+		return
+	}
+	e.advanceAgent(ctx, run, resolution)
+}
+
+// ---------------------------------------------------------------------------
+// Agent workflow path
+// ---------------------------------------------------------------------------
+
+// agentWorkflowStore is the data-access surface the engine's agent path
+// needs. The production implementation is pgxAgentWorkflowStore (below);
+// tests substitute a fake to drive the engine without a real database.
+type agentWorkflowStore interface {
+	// FindRun resolves an agent_workflow_run + its workflow definition.
+	// At most one of runID / taskID / issueID is non-empty; the
+	// implementation looks up the run by the first non-empty field.
+	// Returns pgx.ErrNoRows when nothing matches.
+	FindRun(ctx context.Context, runID, taskID, issueID string) (*agentWorkflowRun, error)
+
+	// CreateAgentTask inserts a queued agent_task_queue row for the
+	// run's agent and returns the new task id. The instructions string
+	// is stored in agent_task_queue.context alongside workflow_run_id.
+	CreateAgentTask(ctx context.Context, run *agentWorkflowRun, instructions string) (string, error)
+
+	// UpdateRun persists status / current_step / state.
+	UpdateRun(ctx context.Context, runID, status, step string, state map[string]any) error
+
+	// MarkDone flips the run's status to 'done'.
+	MarkDone(ctx context.Context, runID string) error
+
+	// MarkFailed flips the run's status to 'failed' and stashes the
+	// reason on the row's `error` column.
+	MarkFailed(ctx context.Context, runID, reason string) error
+
+	// SetRunCurrentTask writes the given task id onto last_task_id
+	// (clearing last_issue_id).
+	SetRunCurrentTask(ctx context.Context, runID, taskID string) error
+
+	// SetRunCurrentIssue writes the given issue id onto last_issue_id
+	// (clearing last_task_id). Used by callers that open an approval
+	// issue for the run.
+	SetRunCurrentIssue(ctx context.Context, runID, issueID string) error
+}
+
+// workflowStep mirrors the JSON shape stored under
+// agent_workflow.definition->steps. All fields are optional —
+// actor='agent' steps use tool/skill+next; actor='human' steps use
+// gate+next_on_approve+next_on_reject.
+type workflowStep struct {
+	ID            string `json:"id"`
+	Actor         string `json:"actor"`           // "agent" | "human"
+	Tool          string `json:"tool,omitempty"`  // e.g. "service.fetch_x"
+	Skill         string `json:"skill,omitempty"` // skill name to apply
+	Gate          string `json:"gate,omitempty"`  // e.g. "issue_approval"
+	Next          string `json:"next,omitempty"`  // empty / null = terminal
+	NextOnApprove string `json:"next_on_approve,omitempty"`
+	NextOnReject  string `json:"next_on_reject,omitempty"`
+}
+
+// agentWorkflowRun is the row shape used internally by the engine.
+type agentWorkflowRun struct {
+	ID          string
+	WorkflowID  string
+	WorkspaceID string
+	AgentID     string
+	Status      string
+	CurrentStep string
+	State       map[string]any
+	Definition  map[string]any // raw definition JSON from agent_workflow
+}
+
+// advanceAgent picks the next step (based on the current step + resolution
+// if any) and dispatches it. An empty next pointer marks the run done.
+func (e *WorkflowEngine) advanceAgent(ctx context.Context, run *agentWorkflowRun, resolution string) {
+	steps, err := parseSteps(run.Definition)
+	if err != nil {
+		e.markFailed(ctx, run.ID, fmt.Sprintf("definition parse: %v", err))
+		return
+	}
+
+	current := findStep(steps, run.CurrentStep)
+	if current == nil {
+		e.markFailed(ctx, run.ID, fmt.Sprintf("current step %q not found in definition", run.CurrentStep))
+		return
+	}
+
+	var nextID string
+	switch {
+	case current.Actor == "human" && resolution == "approved":
+		nextID = current.NextOnApprove
+	case current.Actor == "human" && resolution == "rejected":
+		nextID = current.NextOnReject
+	default:
+		nextID = current.Next
+	}
+
+	if nextID == "" {
+		e.markDone(ctx, run.ID)
+		return
+	}
+
+	nextStep := findStep(steps, nextID)
+	if nextStep == nil {
+		e.markFailed(ctx, run.ID, fmt.Sprintf("next step %q not found in definition", nextID))
+		return
+	}
+
+	e.dispatchAgent(ctx, run, nextStep)
+}
+
+// dispatchAgent executes one step. For agent-actor steps it builds an
+// instruction string, creates an agent_task, and updates the run. For
+// human-actor steps (gates) it just parks the run in awaiting_approval —
+// the prior step is expected to have already opened the approval issue
+// via a domain-specific tool and called SetRunCurrentIssue.
+func (e *WorkflowEngine) dispatchAgent(ctx context.Context, run *agentWorkflowRun, step *workflowStep) {
+	if e.agentStore == nil {
+		return
+	}
+	if step.Actor == "human" {
+		// Human gates are pass-through. The step that PRECEDED this one
+		// in the workflow is responsible for opening the approval issue
+		// and calling SetRunCurrentIssue so an inbound issue:resolved
+		// event can be correlated back to this run.
+		if err := e.agentStore.UpdateRun(ctx, run.ID, "awaiting_approval", step.ID, run.State); err != nil {
+			e.Logger.Warn("workflow engine: park failed", "run_id", run.ID, "error", err)
+		}
+		return
+	}
+
+	// actor == "agent" — build instructions, create a task, advance.
+	instructions := buildAgentInstruction(step, run)
+
+	taskID, err := e.agentStore.CreateAgentTask(ctx, run, instructions)
+	if err != nil {
+		e.Logger.Warn("workflow engine: dispatch failed",
+			"run_id", run.ID, "step", step.ID, "error", err)
+		e.markFailed(ctx, run.ID, fmt.Sprintf("dispatch step %s: %v", step.ID, err))
+		return
+	}
+
+	state := cloneState(run.State)
+	if err := e.agentStore.UpdateRun(ctx, run.ID, "running", step.ID, state); err != nil {
+		e.Logger.Warn("workflow engine: state update failed",
+			"run_id", run.ID, "step", step.ID, "error", err)
+	}
+	if err := e.agentStore.SetRunCurrentTask(ctx, run.ID, taskID); err != nil {
+		e.Logger.Warn("workflow engine: last_task_id update failed",
+			"run_id", run.ID, "step", step.ID, "error", err)
+	}
+}
+
+// buildAgentInstruction renders the natural-language instructions the
+// daemon will pipe into the agent runtime for one workflow step.
+//
+// The shape is intentionally generic — domain-specific arguments are
+// pulled from run.State rather than hard-coded so the engine has no
+// knowledge of any particular workflow's semantics.
+func buildAgentInstruction(step *workflowStep, run *agentWorkflowRun) string {
+	switch {
+	case step.Tool != "":
+		return fmt.Sprintf(
+			"Workflow step %q: call MCP tool %s. "+
+				"workflow_run_id=%s. Use the workflow run state for arguments. "+
+				"On completion, the workflow engine will advance to the next step.",
+			step.ID, step.Tool, run.ID,
+		)
+	case step.Skill != "":
+		return fmt.Sprintf(
+			"Workflow step %q: apply skill %s. workflow_run_id=%s.",
+			step.ID, step.Skill, run.ID,
+		)
+	default:
+		return fmt.Sprintf(
+			"Workflow step %q (no tool / skill specified). "+
+				"workflow_run_id=%s. Inspect the run state and decide.",
+			step.ID, run.ID,
+		)
+	}
+}
+
+func (e *WorkflowEngine) markDone(ctx context.Context, runID string) {
+	if e.agentStore == nil {
+		return
+	}
+	if err := e.agentStore.MarkDone(ctx, runID); err != nil {
+		e.Logger.Warn("workflow engine: markDone failed", "run_id", runID, "error", err)
+	}
+}
+
+func (e *WorkflowEngine) markFailed(ctx context.Context, runID, reason string) {
+	e.Logger.Warn("workflow engine: marking run failed", "run_id", runID, "reason", reason)
+	if e.agentStore == nil {
+		return
+	}
+	if err := e.agentStore.MarkFailed(ctx, runID, reason); err != nil {
+		e.Logger.Warn("workflow engine: markFailed update failed", "run_id", runID, "error", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Team workflow path (stub — fills in once team_workflow lands upstream)
+// ---------------------------------------------------------------------------
+
+// advanceTeam is the team-workflow analog of advanceAgent. Today's
+// payload carries team_id + role_id; the engine should:
+//
+//  1. Load the team and its workflow definition.
+//  2. Find the workflow step where FromRole matches the completed role.
+//  3. Check the step condition (always, on_approval, on_finding, manual).
+//  4. If the next role has an assigned agent, create the next task.
+//  5. If the next role is unassigned, emit a team:workflow_blocked event.
+//
+// Until team_workflow has schema + queries upstream, this is a logging
+// stub. The interface is intentionally fixed so the agent path doesn't
+// have to change when teams arrive.
+func (e *WorkflowEngine) advanceTeam(ctx context.Context, workspaceID, teamID, completedRoleID string) {
+	_ = ctx
+	e.Logger.Info("workflow engine: team-advance stub — team workflow schema not yet upstream",
+		"workspace_id", workspaceID,
+		"team_id", teamID,
+		"completed_role_id", completedRoleID,
+	)
+}
+
+// EmitTeamWorkflowBlocked publishes a team:workflow_blocked event when
+// the next role in a team workflow has no assigned agent. Exposed so the
+// future team-workflow advance loop can call it without re-implementing
+// the publish shape.
+func (e *WorkflowEngine) EmitTeamWorkflowBlocked(workspaceID, teamID, roleName, reason string) {
+	if e.Bus == nil {
+		return
+	}
+	e.Bus.Publish(events.Event{
+		Type:        "team:workflow_blocked",
+		WorkspaceID: workspaceID,
+		ActorType:   "system",
+		ActorID:     "",
+		Payload: map[string]any{
+			"team_id":   teamID,
+			"role_name": roleName,
+			"reason":    reason,
+		},
+	})
+	e.Logger.Warn("workflow blocked",
+		"team_id", teamID,
+		"role_name", roleName,
+		"reason", reason,
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — parsing + stepwalking
+// ---------------------------------------------------------------------------
+
+// parseSteps unmarshals the steps[] array out of a workflow definition
+// JSON blob. Returns an error if the shape doesn't look right.
+func parseSteps(definition map[string]any) ([]workflowStep, error) {
+	raw, ok := definition["steps"]
+	if !ok {
+		return nil, errors.New("definition missing 'steps' array")
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal steps: %w", err)
+	}
+	var steps []workflowStep
+	if err := json.Unmarshal(encoded, &steps); err != nil {
+		return nil, fmt.Errorf("unmarshal steps: %w", err)
+	}
+	return steps, nil
+}
+
+func findStep(steps []workflowStep, id string) *workflowStep {
+	for i := range steps {
+		if steps[i].ID == id {
+			return &steps[i]
+		}
+	}
+	return nil
+}
+
+func cloneState(state map[string]any) map[string]any {
+	out := make(map[string]any, len(state))
+	for k, v := range state {
+		out[k] = v
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Production data-access implementation
+// ---------------------------------------------------------------------------
+
+// pgxAgentWorkflowStore is the production implementation of
+// agentWorkflowStore. It uses raw SQL via pgxpool against
+// agent_workflow / agent_workflow_run / agent_task_queue.
+type pgxAgentWorkflowStore struct {
+	pool *pgxpool.Pool
+}
+
+const pgxAgentStoreFindRunSelect = `
+	SELECT r.id::text, r.workflow_id::text, r.workspace_id::text,
+	       w.agent_id::text, r.status, r.current_step, r.state,
+	       w.definition
+	FROM agent_workflow_run r
+	JOIN agent_workflow w ON w.id = r.workflow_id
+`
+
+func (s *pgxAgentWorkflowStore) FindRun(ctx context.Context, runID, taskID, issueID string) (*agentWorkflowRun, error) {
+	// Casts use ::uuid so a caller-supplied UUID-string compares cleanly
+	// against the UUID column.
+	var row pgx.Row
+	switch {
+	case runID != "":
+		row = s.pool.QueryRow(ctx, pgxAgentStoreFindRunSelect+" WHERE r.id = $1::uuid", runID)
+	case taskID != "":
+		row = s.pool.QueryRow(ctx,
+			pgxAgentStoreFindRunSelect+" WHERE r.last_task_id = $1::uuid", taskID)
+	case issueID != "":
+		row = s.pool.QueryRow(ctx,
+			pgxAgentStoreFindRunSelect+" WHERE r.last_issue_id = $1::uuid", issueID)
+	default:
+		return nil, pgx.ErrNoRows
+	}
+
+	var (
+		run        agentWorkflowRun
+		stateBytes []byte
+		defBytes   []byte
+	)
+	if err := row.Scan(
+		&run.ID, &run.WorkflowID, &run.WorkspaceID,
+		&run.AgentID, &run.Status, &run.CurrentStep,
+		&stateBytes, &defBytes,
+	); err != nil {
+		return nil, err
+	}
+
+	run.State = map[string]any{}
+	if len(stateBytes) > 0 {
+		_ = json.Unmarshal(stateBytes, &run.State)
+	}
+	run.Definition = map[string]any{}
+	if len(defBytes) > 0 {
+		_ = json.Unmarshal(defBytes, &run.Definition)
+	}
+	return &run, nil
+}
+
+// CreateAgentTask inserts a row in agent_task_queue for the run's agent.
+// Raw SQL (rather than db.Queries.CreateAgentTask) so the engine can
+// stash workflow_run_id + step instructions in the task.context JSONB in
+// a single statement. Returns the new task id.
+func (s *pgxAgentWorkflowStore) CreateAgentTask(ctx context.Context, run *agentWorkflowRun, instructions string) (string, error) {
+	taskCtx, err := json.Marshal(map[string]any{
+		"workflow_run_id": run.ID,
+		"workflow_id":     run.WorkflowID,
+		"step":            run.CurrentStep,
+		"instructions":    instructions,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal task context: %w", err)
+	}
+
+	const insertSQL = `
+		INSERT INTO agent_task_queue
+		    (agent_id, runtime_id, status, priority, context)
+		SELECT a.id, a.runtime_id, 'queued', 2, $2::jsonb
+		FROM agent a
+		WHERE a.id = $1
+		RETURNING id::text
+	`
+
+	var taskID string
+	if err := s.pool.QueryRow(ctx, insertSQL, run.AgentID, taskCtx).Scan(&taskID); err != nil {
+		return "", fmt.Errorf("insert agent_task_queue: %w", err)
+	}
+	return taskID, nil
+}
+
+func (s *pgxAgentWorkflowStore) UpdateRun(ctx context.Context, runID, status, step string, state map[string]any) error {
+	stateBytes, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+	const sql = `
+		UPDATE agent_workflow_run
+		SET status = $2, current_step = $3, state = $4::jsonb, updated_at = now()
+		WHERE id = $1
+	`
+	_, err = s.pool.Exec(ctx, sql, runID, status, step, stateBytes)
+	return err
+}
+
+func (s *pgxAgentWorkflowStore) MarkDone(ctx context.Context, runID string) error {
+	const sql = `UPDATE agent_workflow_run SET status='done', updated_at=now() WHERE id=$1`
+	_, err := s.pool.Exec(ctx, sql, runID)
+	return err
+}
+
+func (s *pgxAgentWorkflowStore) MarkFailed(ctx context.Context, runID, reason string) error {
+	const sql = `
+		UPDATE agent_workflow_run
+		SET status='failed',
+		    error = $2,
+		    updated_at = now()
+		WHERE id=$1
+	`
+	_, err := s.pool.Exec(ctx, sql, runID, reason)
+	return err
+}
+
+// SetRunCurrentTask writes the given task id onto last_task_id and
+// clears last_issue_id (a run is correlated by exactly one of the two
+// at a time).
+func (s *pgxAgentWorkflowStore) SetRunCurrentTask(ctx context.Context, runID, taskID string) error {
+	const sql = `
+		UPDATE agent_workflow_run
+		SET last_task_id = $2::uuid,
+		    last_issue_id = NULL,
+		    updated_at = now()
+		WHERE id = $1::uuid
+	`
+	_, err := s.pool.Exec(ctx, sql, runID, taskID)
+	return err
+}
+
+// SetRunCurrentIssue writes the given issue id onto last_issue_id and
+// clears last_task_id.
+func (s *pgxAgentWorkflowStore) SetRunCurrentIssue(ctx context.Context, runID, issueID string) error {
+	const sql = `
+		UPDATE agent_workflow_run
+		SET last_issue_id = $2::uuid,
+		    last_task_id = NULL,
+		    updated_at = now()
+		WHERE id = $1::uuid
+	`
+	_, err := s.pool.Exec(ctx, sql, runID, issueID)
+	return err
+}

--- a/server/internal/service/workflow_test.go
+++ b/server/internal/service/workflow_test.go
@@ -1,0 +1,472 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/multica-ai/multica/server/internal/events"
+)
+
+// ---------------------------------------------------------------------------
+// Test fakes
+// ---------------------------------------------------------------------------
+
+// fakeAgentStore is the in-memory agentWorkflowStore implementation used
+// by the agent-path tests. It records every call so assertions can verify
+// that the engine dispatched the right step / parked the run / marked it
+// done.
+type fakeAgentStore struct {
+	// run is what FindRun returns. nil + findErr controls the not-found path.
+	run     *agentWorkflowRun
+	findErr error
+
+	// task id returned by CreateAgentTask.
+	taskIDToReturn string
+
+	// recorded calls
+	createCalls   []agentCreateCall
+	updateCalls   []agentUpdateCall
+	doneCalls     []string
+	failedCalls   []agentFailedCall
+	setTaskCalls  []agentTaskOrIssueCall
+	setIssueCalls []agentTaskOrIssueCall
+}
+
+type agentTaskOrIssueCall struct {
+	runID string
+	id    string
+}
+
+type agentCreateCall struct {
+	runID        string
+	step         string
+	instructions string
+}
+
+type agentUpdateCall struct {
+	runID  string
+	status string
+	step   string
+	state  map[string]any
+}
+
+type agentFailedCall struct {
+	runID  string
+	reason string
+}
+
+func (s *fakeAgentStore) FindRun(_ context.Context, _, _, _ string) (*agentWorkflowRun, error) {
+	if s.findErr != nil {
+		return nil, s.findErr
+	}
+	return s.run, nil
+}
+
+func (s *fakeAgentStore) CreateAgentTask(_ context.Context, run *agentWorkflowRun, instructions string) (string, error) {
+	s.createCalls = append(s.createCalls, agentCreateCall{
+		runID:        run.ID,
+		step:         run.CurrentStep,
+		instructions: instructions,
+	})
+	if s.taskIDToReturn == "" {
+		return "task-new", nil
+	}
+	return s.taskIDToReturn, nil
+}
+
+func (s *fakeAgentStore) UpdateRun(_ context.Context, runID, status, step string, state map[string]any) error {
+	// Defensive copy so later mutations to the engine's state map don't
+	// retroactively mutate the recorded call.
+	stateCopy := make(map[string]any, len(state))
+	for k, v := range state {
+		stateCopy[k] = v
+	}
+	s.updateCalls = append(s.updateCalls, agentUpdateCall{
+		runID:  runID,
+		status: status,
+		step:   step,
+		state:  stateCopy,
+	})
+	return nil
+}
+
+func (s *fakeAgentStore) MarkDone(_ context.Context, runID string) error {
+	s.doneCalls = append(s.doneCalls, runID)
+	return nil
+}
+
+func (s *fakeAgentStore) MarkFailed(_ context.Context, runID, reason string) error {
+	s.failedCalls = append(s.failedCalls, agentFailedCall{runID: runID, reason: reason})
+	return nil
+}
+
+func (s *fakeAgentStore) SetRunCurrentTask(_ context.Context, runID, taskID string) error {
+	s.setTaskCalls = append(s.setTaskCalls, agentTaskOrIssueCall{runID: runID, id: taskID})
+	return nil
+}
+
+func (s *fakeAgentStore) SetRunCurrentIssue(_ context.Context, runID, issueID string) error {
+	s.setIssueCalls = append(s.setIssueCalls, agentTaskOrIssueCall{runID: runID, id: issueID})
+	return nil
+}
+
+// sampleAgentDefinition mirrors a typical six-step approval-gated
+// workflow: ingest → compute → draft → review (human) → file → archive.
+func sampleAgentDefinition() map[string]any {
+	return map[string]any{
+		"steps": []any{
+			map[string]any{"id": "ingest", "actor": "agent", "tool": "service.fetch", "next": "compute"},
+			map[string]any{"id": "compute", "actor": "agent", "skill": "by_kind", "next": "draft"},
+			map[string]any{"id": "draft", "actor": "agent", "tool": "service.draft", "next": "review"},
+			map[string]any{
+				"id": "review", "actor": "human", "gate": "issue_approval",
+				"next_on_approve": "file",
+				"next_on_reject":  "draft",
+			},
+			map[string]any{"id": "file", "actor": "agent", "tool": "service.file", "next": "archive"},
+			map[string]any{"id": "archive", "actor": "agent", "tool": "service.archive"},
+		},
+	}
+}
+
+func newEngineWithStore(s *fakeAgentStore) *WorkflowEngine {
+	e := NewWorkflowEngine(nil, nil, nil, nil)
+	e.SetAgentStore(s)
+	return e
+}
+
+// ---------------------------------------------------------------------------
+// Agent path
+// ---------------------------------------------------------------------------
+
+// task:completed advances to the next agent step.
+func TestWorkflowEngine_Agent_TaskCompleted_AdvancesToNextAgentStep(t *testing.T) {
+	store := &fakeAgentStore{
+		run: &agentWorkflowRun{
+			ID:          "run-1",
+			WorkflowID:  "wf-1",
+			WorkspaceID: "ws-1",
+			AgentID:     "agent-1",
+			Status:      "running",
+			CurrentStep: "ingest",
+			State: map[string]any{
+				"period":    "2024-09",
+				"client_id": "client-1",
+			},
+			Definition: sampleAgentDefinition(),
+		},
+		taskIDToReturn: "task-2",
+	}
+	e := newEngineWithStore(store)
+
+	e.handleTaskCompleted(taskCompletedEvent("task-1"))
+
+	if len(store.createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(store.createCalls))
+	}
+	if got := store.createCalls[0].step; got != "ingest" {
+		// Engine still has run.CurrentStep = "ingest" when CreateAgentTask
+		// is invoked — the run is updated AFTER the task is created.
+		t.Fatalf("create call step = %q, want %q", got, "ingest")
+	}
+	if len(store.updateCalls) != 1 {
+		t.Fatalf("expected 1 update call, got %d", len(store.updateCalls))
+	}
+	upd := store.updateCalls[0]
+	if upd.status != "running" || upd.step != "compute" {
+		t.Fatalf("update = (%s, %s), want (running, compute)", upd.status, upd.step)
+	}
+	if len(store.setTaskCalls) != 1 || store.setTaskCalls[0].id != "task-2" {
+		t.Fatalf("expected SetRunCurrentTask(_, task-2), got %+v", store.setTaskCalls)
+	}
+	if len(store.doneCalls) != 0 {
+		t.Fatalf("did not expect MarkDone, got %d calls", len(store.doneCalls))
+	}
+	if len(store.failedCalls) != 0 {
+		t.Fatalf("did not expect MarkFailed, got %v", store.failedCalls)
+	}
+}
+
+// Task completion at a step whose `next` points at a human-actor step
+// parks the run in awaiting_approval and does NOT enqueue a new task.
+func TestWorkflowEngine_Agent_NextStepIsHumanGate_ParksRun(t *testing.T) {
+	store := &fakeAgentStore{
+		run: &agentWorkflowRun{
+			ID:          "run-park",
+			WorkflowID:  "wf-1",
+			WorkspaceID: "ws-1",
+			AgentID:     "agent-1",
+			Status:      "running",
+			CurrentStep: "draft", // next = "review" (human)
+			State:       map[string]any{},
+			Definition:  sampleAgentDefinition(),
+		},
+	}
+	e := newEngineWithStore(store)
+
+	e.handleTaskCompleted(taskCompletedEvent("task-draft"))
+
+	if len(store.createCalls) != 0 {
+		t.Fatalf("did not expect a new agent task at human gate, got %d", len(store.createCalls))
+	}
+	if len(store.updateCalls) != 1 {
+		t.Fatalf("expected one UpdateRun call, got %d", len(store.updateCalls))
+	}
+	upd := store.updateCalls[0]
+	if upd.status != "awaiting_approval" || upd.step != "review" {
+		t.Fatalf("update = (%s, %s), want (awaiting_approval, review)", upd.status, upd.step)
+	}
+}
+
+// issue:resolved with approved → next_on_approve branch.
+func TestWorkflowEngine_Agent_IssueResolved_Approved_TakesApproveBranch(t *testing.T) {
+	store := &fakeAgentStore{
+		run: &agentWorkflowRun{
+			ID:          "run-2",
+			WorkflowID:  "wf-1",
+			WorkspaceID: "ws-1",
+			AgentID:     "agent-1",
+			Status:      "awaiting_approval",
+			CurrentStep: "review",
+			State:       map[string]any{"period": "2024-09"},
+			Definition:  sampleAgentDefinition(),
+		},
+		taskIDToReturn: "task-file",
+	}
+	e := newEngineWithStore(store)
+
+	e.handleIssueResolved(issueResolvedEvent("issue-7", "approved"))
+
+	if len(store.createCalls) != 1 {
+		t.Fatalf("expected 1 create call after approve, got %d", len(store.createCalls))
+	}
+	upd := lastAgentUpdate(t, store)
+	if upd.step != "file" || upd.status != "running" {
+		t.Fatalf("update = (%s, %s), want (running, file)", upd.status, upd.step)
+	}
+	if len(store.setTaskCalls) != 1 {
+		t.Fatalf("expected exactly one SetRunCurrentTask call, got %+v", store.setTaskCalls)
+	}
+}
+
+// issue:resolved with rejected → next_on_reject branch (loops back to
+// 'draft' which is also an agent step).
+func TestWorkflowEngine_Agent_IssueResolved_Rejected_TakesRejectBranch(t *testing.T) {
+	store := &fakeAgentStore{
+		run: &agentWorkflowRun{
+			ID:          "run-3",
+			WorkflowID:  "wf-1",
+			WorkspaceID: "ws-1",
+			AgentID:     "agent-1",
+			Status:      "awaiting_approval",
+			CurrentStep: "review",
+			State:       map[string]any{},
+			Definition:  sampleAgentDefinition(),
+		},
+		taskIDToReturn: "task-redraft",
+	}
+	e := newEngineWithStore(store)
+
+	e.handleIssueResolved(issueResolvedEvent("issue-9", "rejected"))
+
+	if len(store.createCalls) != 1 {
+		t.Fatalf("expected 1 create call on reject, got %d", len(store.createCalls))
+	}
+	upd := lastAgentUpdate(t, store)
+	if upd.step != "draft" {
+		t.Fatalf("update.step = %q, want draft (reject branch)", upd.step)
+	}
+}
+
+// issue:resolved with an unknown resolution string is a silent no-op.
+func TestWorkflowEngine_Agent_IssueResolved_UnknownResolution_IsNoop(t *testing.T) {
+	store := &fakeAgentStore{
+		run: &agentWorkflowRun{
+			ID:          "run-noop",
+			WorkflowID:  "wf-1",
+			WorkspaceID: "ws-1",
+			AgentID:     "agent-1",
+			Status:      "awaiting_approval",
+			CurrentStep: "review",
+			State:       map[string]any{},
+			Definition:  sampleAgentDefinition(),
+		},
+	}
+	e := newEngineWithStore(store)
+
+	e.handleIssueResolved(issueResolvedEvent("issue-x", "deferred"))
+
+	if total := len(store.createCalls) + len(store.updateCalls) + len(store.doneCalls); total != 0 {
+		t.Fatalf("expected no side effects on unknown resolution, store=%+v", store)
+	}
+}
+
+// Terminal step (next null) marks run done.
+func TestWorkflowEngine_Agent_TerminalStep_MarksRunDone(t *testing.T) {
+	store := &fakeAgentStore{
+		run: &agentWorkflowRun{
+			ID:          "run-4",
+			WorkflowID:  "wf-1",
+			WorkspaceID: "ws-1",
+			AgentID:     "agent-1",
+			Status:      "running",
+			CurrentStep: "archive", // terminal: no `next` in definition
+			State:       map[string]any{},
+			Definition:  sampleAgentDefinition(),
+		},
+	}
+	e := newEngineWithStore(store)
+
+	e.handleTaskCompleted(taskCompletedEvent("task-archive"))
+
+	if len(store.createCalls) != 0 {
+		t.Fatalf("did not expect a new task at terminal step, got %d", len(store.createCalls))
+	}
+	if len(store.doneCalls) != 1 || store.doneCalls[0] != "run-4" {
+		t.Fatalf("expected MarkDone(run-4), got %v", store.doneCalls)
+	}
+}
+
+// Run not found → no-op, no error.
+func TestWorkflowEngine_Agent_RunNotFound_IsNoop(t *testing.T) {
+	store := &fakeAgentStore{findErr: pgx.ErrNoRows}
+	e := newEngineWithStore(store)
+
+	e.handleTaskCompleted(taskCompletedEvent("orphan-task"))
+	e.handleIssueResolved(issueResolvedEvent("orphan-issue", "approved"))
+
+	if total := len(store.createCalls) + len(store.updateCalls) + len(store.doneCalls) + len(store.failedCalls); total != 0 {
+		t.Fatalf("expected no side effects for unknown task/issue, store=%+v", store)
+	}
+}
+
+// Non-pgx errors from FindRun also stay silent (logged but no side
+// effects). Captures the engine's "fail closed, never panic" stance.
+func TestWorkflowEngine_Agent_FindRunGenericError_IsNoop(t *testing.T) {
+	store := &fakeAgentStore{findErr: errors.New("connection reset")}
+	e := newEngineWithStore(store)
+
+	e.handleTaskCompleted(taskCompletedEvent("task-x"))
+
+	if len(store.createCalls) != 0 {
+		t.Fatalf("expected no dispatch on lookup error, got %d", len(store.createCalls))
+	}
+}
+
+// Definition with current_step missing → marks run failed.
+func TestWorkflowEngine_Agent_UnknownCurrentStep_MarksFailed(t *testing.T) {
+	store := &fakeAgentStore{
+		run: &agentWorkflowRun{
+			ID:          "run-fail",
+			WorkflowID:  "wf-1",
+			WorkspaceID: "ws-1",
+			AgentID:     "agent-1",
+			Status:      "running",
+			CurrentStep: "ghost",
+			State:       map[string]any{},
+			Definition:  sampleAgentDefinition(),
+		},
+	}
+	e := newEngineWithStore(store)
+
+	e.handleTaskCompleted(taskCompletedEvent("task-bad"))
+
+	if len(store.failedCalls) != 1 || store.failedCalls[0].runID != "run-fail" {
+		t.Fatalf("expected one MarkFailed for run-fail, got %+v", store.failedCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Team path (stub coverage)
+// ---------------------------------------------------------------------------
+
+// task:completed with team_id + role_id is routed to the team path and
+// must NOT touch the agent store. Until the team-workflow schema lands
+// upstream, the engine logs and returns; the agent store should record
+// zero calls.
+func TestWorkflowEngine_Team_TaskCompletedWithTeamPayload_DoesNotTouchAgentStore(t *testing.T) {
+	store := &fakeAgentStore{
+		run: &agentWorkflowRun{
+			ID:          "should-not-be-touched",
+			WorkflowID:  "wf-1",
+			WorkspaceID: "ws-1",
+			AgentID:     "agent-1",
+			Status:      "running",
+			CurrentStep: "ingest",
+			State:       map[string]any{},
+			Definition:  sampleAgentDefinition(),
+		},
+	}
+	e := newEngineWithStore(store)
+
+	e.handleTaskCompleted(events.Event{
+		Type:        "task:completed",
+		WorkspaceID: "ws-1",
+		Payload: map[string]any{
+			"task_id": "task-team-1",
+			"team_id": "team-7",
+			"role_id": "role-3",
+		},
+	})
+
+	if total := len(store.createCalls) + len(store.updateCalls) + len(store.doneCalls) + len(store.failedCalls); total != 0 {
+		t.Fatalf("team path must not touch agent store, store=%+v", store)
+	}
+}
+
+// EmitTeamWorkflowBlocked publishes a team:workflow_blocked event via the
+// bus when called.
+func TestWorkflowEngine_Team_EmitTeamWorkflowBlocked_PublishesEvent(t *testing.T) {
+	bus := events.New()
+	e := NewWorkflowEngine(nil, nil, bus, nil)
+
+	got := make(chan events.Event, 1)
+	bus.Subscribe("team:workflow_blocked", func(evt events.Event) {
+		got <- evt
+	})
+
+	e.EmitTeamWorkflowBlocked("ws-1", "team-7", "auditor", "no agent assigned")
+
+	select {
+	case evt := <-got:
+		payload, _ := evt.Payload.(map[string]any)
+		if payload["team_id"] != "team-7" || payload["role_name"] != "auditor" {
+			t.Fatalf("unexpected blocked payload: %+v", payload)
+		}
+	default:
+		t.Fatalf("expected team:workflow_blocked event")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func taskCompletedEvent(taskID string) events.Event {
+	return events.Event{
+		Type: "task:completed",
+		Payload: map[string]any{
+			"task_id": taskID,
+		},
+	}
+}
+
+func issueResolvedEvent(issueID, resolution string) events.Event {
+	return events.Event{
+		Type: "issue:resolved",
+		Payload: map[string]any{
+			"issue_id":   issueID,
+			"resolution": resolution,
+		},
+	}
+}
+
+func lastAgentUpdate(t *testing.T, s *fakeAgentStore) agentUpdateCall {
+	t.Helper()
+	if len(s.updateCalls) == 0 {
+		t.Fatalf("expected at least one UpdateRun call")
+	}
+	return s.updateCalls[len(s.updateCalls)-1]
+}

--- a/server/migrations/068_agent_workflow.down.sql
+++ b/server/migrations/068_agent_workflow.down.sql
@@ -1,0 +1,11 @@
+-- Reverse 068: drop agent_workflow_run + agent_workflow. Idempotent.
+DROP INDEX IF EXISTS idx_agent_workflow_run_issue;
+DROP INDEX IF EXISTS idx_agent_workflow_run_task;
+DROP INDEX IF EXISTS idx_agent_workflow_run_status;
+DROP INDEX IF EXISTS idx_agent_workflow_run_workspace;
+DROP INDEX IF EXISTS idx_agent_workflow_run_workflow;
+DROP TABLE IF EXISTS agent_workflow_run;
+
+DROP INDEX IF EXISTS idx_agent_workflow_agent;
+DROP INDEX IF EXISTS idx_agent_workflow_workspace;
+DROP TABLE IF EXISTS agent_workflow;

--- a/server/migrations/068_agent_workflow.up.sql
+++ b/server/migrations/068_agent_workflow.up.sql
@@ -1,0 +1,77 @@
+-- agent_workflow + agent_workflow_run.
+--
+-- Sibling concept to a future team_workflow: an agent_workflow describes
+-- a sequence of steps owned by a single agent. Steps may be 'agent'-actor
+-- (executed by the runtime via a tool / skill / instructions) or
+-- 'human'-actor (gated on an external approval signal — usually an
+-- `issue:resolved` event from an approval-kind issue).
+--
+-- definition JSONB shape (validated by the service layer, not the schema):
+--
+--   {
+--     "steps": [
+--       { "id": "ingest",  "actor": "agent", "tool": "...",  "next": "compute" },
+--       { "id": "compute", "actor": "agent", "skill": "...", "next": "draft"   },
+--       { "id": "review",  "actor": "human", "gate": "issue_approval",
+--         "next_on_approve": "file", "next_on_reject": "draft" },
+--       { "id": "file",    "actor": "agent", "tool": "...",  "next": "archive" },
+--       { "id": "archive", "actor": "agent", "tool": "..." }
+--     ]
+--   }
+--
+-- Snapshot policy: an in-flight run should not be disturbed when the
+-- workflow definition is edited. The recommended pattern is to copy the
+-- definition JSONB onto agent_workflow_run.state.definition at run-create
+-- time. This is enforced by the service layer, not by the schema.
+--
+-- Correlation columns (last_task_id / last_issue_id) let the workflow
+-- engine route inbound `task:completed` and `issue:resolved` events back
+-- to the run that's parked on them, without requiring a payload-schema
+-- change in lockstep with the engine.
+CREATE TABLE IF NOT EXISTS agent_workflow (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    agent_id UUID NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    definition JSONB NOT NULL DEFAULT '{}',
+    archived_at TIMESTAMPTZ NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (workspace_id, agent_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_workflow_workspace
+    ON agent_workflow(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_agent_workflow_agent
+    ON agent_workflow(agent_id);
+
+CREATE TABLE IF NOT EXISTS agent_workflow_run (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workflow_id UUID NOT NULL REFERENCES agent_workflow(id) ON DELETE CASCADE,
+    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    started_by UUID NULL REFERENCES "user"(id) ON DELETE SET NULL,
+    status TEXT NOT NULL DEFAULT 'running'
+        CHECK (status IN ('running', 'awaiting_approval', 'done', 'failed')),
+    current_step TEXT NOT NULL DEFAULT '',
+    state JSONB NOT NULL DEFAULT '{}',
+    -- last_task_id / last_issue_id are the engine's correlation handles.
+    -- Exactly one is non-NULL while the run is parked on a task or an
+    -- approval issue; both are NULL while the run is between steps.
+    last_task_id UUID NULL,
+    last_issue_id UUID NULL REFERENCES issue(id) ON DELETE SET NULL,
+    error TEXT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_workflow_run_workflow
+    ON agent_workflow_run(workflow_id);
+CREATE INDEX IF NOT EXISTS idx_agent_workflow_run_workspace
+    ON agent_workflow_run(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_agent_workflow_run_status
+    ON agent_workflow_run(workspace_id, status);
+CREATE INDEX IF NOT EXISTS idx_agent_workflow_run_task
+    ON agent_workflow_run(last_task_id) WHERE last_task_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_workflow_run_issue
+    ON agent_workflow_run(last_issue_id) WHERE last_issue_id IS NOT NULL;

--- a/server/pkg/protocol/events.go
+++ b/server/pkg/protocol/events.go
@@ -7,6 +7,17 @@ const (
 	EventIssueUpdated = "issue:updated"
 	EventIssueDeleted = "issue:deleted"
 
+	// EventIssueResolved fires when an approval-style issue transitions to
+	// a terminal status. The WorkflowEngine listens for it to advance an
+	// agent_workflow_run that is parked on a human gate.
+	//
+	// Payload:
+	//   { "issue_id": "<uuid>",
+	//     "resolution": "approved" | "rejected",
+	//     "workflow_run_id": "<uuid>" (optional — engine falls back to
+	//                                  agent_workflow_run.last_issue_id) }
+	EventIssueResolved = "issue:resolved"
+
 	// Comment events
 	EventCommentCreated       = "comment:created"
 	EventCommentUpdated       = "comment:updated"


### PR DESCRIPTION
## Summary

This is a draft RFC. It introduces a `WorkflowEngine` that advances **agent workflows** — sequences of steps owned by a single agent, optionally interrupted by human approval gates — in response to existing bus events. Schema is additive (one new migration, two new tables); no existing code paths change.

The PR is filed early so the upstream maintainers can shape the naming, table layout, and event contract before implementation grows further. It comes from work on the [Sebai fork](https://github.com/thesebai/sebai) where this engine drives a Tax Filing Agent end-to-end (see Sebai-fork doc `docs/sebai-builder-tax-filing-design.md` §8 for context).

## Motivation

Single-agent processes with intermediate human approvals are a recurring pattern (tax filings, code review, content moderation, release approvals). Today there's no upstream primitive for sequencing them — every consumer reinvents state on top of `agent_task_queue` plus ad-hoc issue assignments. The proposal:

1. Names the concept (`agent_workflow` / `agent_workflow_run`) so multiple consumers can share one shape.
2. Centralises step transitions in a single engine that subscribes to existing events, so audit / status / retry logic has one home.
3. Lays the groundwork for a unified engine that can also drive team workflows (when team_workflow lands upstream) without duplicating the dispatch loop.

## Design

### One engine, two paths

`WorkflowEngine` subscribes to two events:

- `task:completed` — an agent finished a step. The engine routes by payload:
  - If the payload carries `team_id` + `role_id` → team-workflow path (stub today; fills in when team_workflow has schema upstream).
  - Otherwise → agent-workflow path: lookup the run by `workflow_run_id` (preferred) or `agent_workflow_run.last_task_id`, advance to `next`.
- `issue:resolved` (NEW) — a human approved or rejected an approval gate. Engine looks the run up by `agent_workflow_run.last_issue_id` and follows `next_on_approve` / `next_on_reject`.

The two paths are mutually exclusive at the per-event level, so they live in one engine without coupling.

### Schema (migration 068)

```sql
agent_workflow (
  id, workspace_id, agent_id, name, description,
  definition JSONB,         -- { "steps": [ {id, actor, tool|skill|gate,
                            --     next, next_on_approve, next_on_reject}, ... ] }
  archived_at, created_at, updated_at,
  UNIQUE (workspace_id, agent_id, name)
);

agent_workflow_run (
  id, workflow_id, workspace_id, started_by,
  status,        -- 'running' | 'awaiting_approval' | 'done' | 'failed'
  current_step,
  state JSONB,   -- engine scratch (period, client_id, etc.)
  last_task_id   UUID NULL,  -- correlation handle for task:completed
  last_issue_id  UUID NULL,  -- correlation handle for issue:resolved
  error TEXT NULL,
  created_at, updated_at
);
```

`last_task_id` / `last_issue_id` are the engine's correlation columns. Exactly one is non-NULL while the run is parked; both are NULL between steps. Indexed partially so the lookup stays cheap.

### Step shape

```json
{
  "steps": [
    { "id": "ingest",  "actor": "agent", "tool":  "service.fetch", "next": "compute" },
    { "id": "compute", "actor": "agent", "skill": "by_kind",       "next": "draft" },
    { "id": "draft",   "actor": "agent", "tool":  "service.draft", "next": "review" },
    { "id": "review",  "actor": "human", "gate":  "issue_approval",
      "next_on_approve": "file", "next_on_reject": "draft" },
    { "id": "file",    "actor": "agent", "tool":  "service.file",  "next": "archive" },
    { "id": "archive", "actor": "agent", "tool":  "service.archive" }
  ]
}
```

Empty `next` (or omitted field) marks a terminal step → run flips to `done`.

### Event contract

`EventIssueResolved` (new constant, value `"issue:resolved"`):

```json
{
  "issue_id":        "<uuid>",
  "resolution":      "approved" | "rejected",
  "workflow_run_id": "<uuid>"   // optional; engine falls back to last_issue_id
}
```

This PR adds the constant and the engine's subscription. **The publish site is intentionally not included here** — it requires an `issue.kind = 'approval'` concept on the issue model that doesn't exist upstream yet. The Sebai fork publishes from `handler/issue.go` whenever an approval-kind issue transitions to a terminal status; happy to send that as a follow-up once we agree on the issue-kind shape.

## Backward compatibility

- Strictly additive. New tables, new event constant, new file in `internal/service/`. No existing code paths changed.
- The team-workflow path of the engine is a **logging stub** today. The interface is intentionally fixed so the agent path doesn't have to change when teams arrive.
- The engine writes to `agent_task_queue` via `INSERT ... SELECT` from `agent` so the new dispatch path uses existing daemon claim semantics with no daemon-side changes.
- `agent_task_queue.issue_id` is already nullable post-migration 033 (`033_chat`), so workflow-driven tasks don't need a synthetic issue.

## Testing

`server/internal/service/workflow_test.go` covers the agent path with a fake store:

- `task:completed` advances to the next agent step; persists `last_task_id` via `SetRunCurrentTask`.
- `task:completed` whose `next` points at a human gate parks the run in `awaiting_approval` and does NOT enqueue a new task.
- `issue:resolved` with `approved` follows `next_on_approve`.
- `issue:resolved` with `rejected` follows `next_on_reject`.
- `issue:resolved` with an unknown resolution is a silent no-op.
- Terminal step → `MarkDone`.
- `pgx.ErrNoRows` from `FindRun` → silent no-op (event belongs to a non-workflow task / issue).
- Generic `FindRun` error → silent no-op + warn log.
- Unknown `current_step` → `MarkFailed`.

Plus team-path coverage:

- `task:completed` with `team_id` + `role_id` is routed to the team stub and does NOT touch the agent store (mutual exclusion).
- `EmitTeamWorkflowBlocked` publishes a `team:workflow_blocked` event.

What's NOT covered:

- The `pgxAgentWorkflowStore` SQL itself — needs an integration test against pgvector. Easy follow-up.
- Concurrent advance of the same run (fine today because the engine is event-sourced and pgx serialises per-run UPDATEs, but there's no explicit row lock).

## Future work — explicitly deferred

1. **Workflow versioning.** When the definition changes mid-run, the in-flight run should keep using the snapshot it started with. Recommended: copy `definition` onto `agent_workflow_run.state.definition` at create time. Today the engine just reads from `agent_workflow.definition` every advance — fine for v0, footgun later. Want to land the snapshot helper as a follow-up once we agree on the policy.
2. **Human-actor steps beyond approval.** `actor: "human"` today only models approve/reject gates correlated via `issue:resolved`. Could generalise to other human signals (form submission, manual data entry) via additional gate types.
3. **Idempotent step retries.** A duplicate `task:completed` would dispatch the same next step twice. The engine should grow a generation/etag check so retries become safe; today we rely on pgx serialisation.
4. **Publish site for `issue:resolved`.** Needs an `issue.kind = 'approval'` concept on the issue model. Sebai-fork has it; would land in a separate PR after the model shape is agreed.
5. **Team-workflow path fill-in.** Stubbed here; needs `team_workflow` schema + queries to flesh out. The engine's interface is stable, so this becomes a localised change.

## Open to feedback on

- **Naming.** `agent_workflow` vs `workflow` (with a `kind` discriminator)? `agent_workflow_run` vs `run` vs `workflow_instance`?
- **Table structure.** Single `definition JSONB` blob vs first-class `workflow_step` table? JSONB is faster to ship and matches the runtime shape; a step table opens up indexed step-level analytics later.
- **Event names.** `issue:resolved` reads well but bundles approve / reject / "any other terminal status". Alternatives: `issue:approval_resolved` (narrower) or two events `issue:approved` / `issue:rejected` (split, easier to filter, more boilerplate at the publish site).
- **Correlation columns vs payload field.** Today the engine looks up by `last_task_id` / `last_issue_id` columns rather than requiring `workflow_run_id` on every event payload. This decouples the engine from event-schema changes; the trade-off is two columns per run that need to be kept in sync. Comfortable with this, but happy to switch to payload-only if the project prefers fewer columns.

Happy to iterate on any of the above before going further.