### PR TITLE
fix(runtimes): correct install script URL in connect remote dialog

### DIFF
--- a/packages/views/runtimes/components/connect-remote-dialog.tsx
+++ b/packages/views/runtimes/components/connect-remote-dialog.tsx
@@ -115,7 +115,7 @@ export function ConnectRemoteDialog({ onClose }: { onClose: () => void }) {
 // Step 1: Installation instructions
 // ---------------------------------------------------------------------------
 
-const INSTALL_CMD = "curl -fsSL https://multica.ai/install.sh | sh";
+const INSTALL_CMD = "curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash";
 
 const CONFIGURE_CMD = `multica config set server_url https://api.multica.ai
 multica config set app_url https://multica.ai`;


### PR DESCRIPTION
## Summary

- The install command shown in Configure → Runtimes → Connect a remote machine points to `https://multica.ai/install.sh`, which returns 404.
- Fixed to use the actual install script location: `https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh`
- Also changed the shell from `sh` to `bash` to match the script's shebang line.

**Before:**
```
curl -fsSL https://multica.ai/install.sh | sh
```

**After:**
```
curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash
```

## Test plan

- [x] Verified `https://multica.ai/install.sh` returns HTTP 404
- [x] Verified `https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh` returns HTTP 200
- [x] Confirmed the install script file exists at `scripts/install.sh` in the repo