### PR TITLE
fix(skill): sanitize null bytes to prevent PostgreSQL UTF8 encoding error

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -17,6 +17,13 @@ import (
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
 
+// sanitizeNullBytes removes null bytes (0x00) from strings.
+// PostgreSQL rejects null bytes in text columns with
+// "invalid byte sequence for encoding UTF8: 0x00 (SQLSTATE 22021)".
+func sanitizeNullBytes(s string) string {
+	return strings.ReplaceAll(s, "\x00", "")
+}
+
 // --- Response structs ---
 
 type SkillResponse struct {
@@ -289,13 +296,13 @@ func (h *Handler) UpdateSkill(w http.ResponseWriter, r *http.Request) {
 		ID: parseUUID(id),
 	}
 	if req.Name != nil {
-		params.Name = pgtype.Text{String: *req.Name, Valid: true}
+		params.Name = pgtype.Text{String: sanitizeNullBytes(*req.Name), Valid: true}
 	}
 	if req.Description != nil {
-		params.Description = pgtype.Text{String: *req.Description, Valid: true}
+		params.Description = pgtype.Text{String: sanitizeNullBytes(*req.Description), Valid: true}
 	}
 	if req.Content != nil {
-		params.Content = pgtype.Text{String: *req.Content, Valid: true}
+		params.Content = pgtype.Text{String: sanitizeNullBytes(*req.Content), Valid: true}
 	}
 	if req.Config != nil {
 		config, _ := json.Marshal(req.Config)
@@ -323,8 +330,8 @@ func (h *Handler) UpdateSkill(w http.ResponseWriter, r *http.Request) {
 		for _, f := range req.Files {
 			sf, err := qtx.UpsertSkillFile(r.Context(), db.UpsertSkillFileParams{
 				SkillID: skill.ID,
-				Path:    f.Path,
-				Content: f.Content,
+				Path:    sanitizeNullBytes(f.Path),
+				Content: sanitizeNullBytes(f.Content),
 			})
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to upsert skill file: "+err.Error())
@@ -1188,8 +1195,8 @@ func (h *Handler) UpsertSkillFile(w http.ResponseWriter, r *http.Request) {
 
 	sf, err := h.Queries.UpsertSkillFile(r.Context(), db.UpsertSkillFileParams{
 		SkillID: skill.ID,
-		Path:    req.Path,
-		Content: req.Content,
+		Path:    sanitizeNullBytes(req.Path),
+		Content: sanitizeNullBytes(req.Content),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to upsert skill file: "+err.Error())

--- a/server/internal/handler/skill_create.go
+++ b/server/internal/handler/skill_create.go
@@ -37,9 +37,9 @@ func (h *Handler) createSkillWithFiles(ctx context.Context, input skillCreateInp
 
 	skill, err := qtx.CreateSkill(ctx, db.CreateSkillParams{
 		WorkspaceID: input.WorkspaceID,
-		Name:        input.Name,
-		Description: input.Description,
-		Content:     input.Content,
+		Name:        sanitizeNullBytes(input.Name),
+		Description: sanitizeNullBytes(input.Description),
+		Content:     sanitizeNullBytes(input.Content),
 		Config:      config,
 		CreatedBy:   input.CreatorID,
 	})
@@ -51,8 +51,8 @@ func (h *Handler) createSkillWithFiles(ctx context.Context, input skillCreateInp
 	for _, f := range input.Files {
 		sf, err := qtx.UpsertSkillFile(ctx, db.UpsertSkillFileParams{
 			SkillID: skill.ID,
-			Path:    f.Path,
-			Content: f.Content,
+			Path:    sanitizeNullBytes(f.Path),
+			Content: sanitizeNullBytes(f.Content),
 		})
 		if err != nil {
 			return SkillWithFilesResponse{}, err


### PR DESCRIPTION
## Bug

When importing a skill from skills.sh (or other sources), the operation fails with:

```
ERROR: invalid byte sequence for encoding "UTF8": 0x00 (SQLSTATE 22021)
```

This occurs because skill content fetched from external sources (like GitHub raw files) can contain null bytes (0x00), which PostgreSQL rejects in text columns.

## Root Cause

The `sanitizeNullBytes` helper function was already defined in `handler/skill.go` and was being used in `skill_create.go` for the create path. However, several other code paths that write skill data to the database were missing this sanitization:

1. **UpdateSkill**: Name, Description, and Content fields were not sanitized.
2. **UpsertSkillFile (in UpdateSkill)**: File Path and Content were not sanitized.
3. **UpsertSkillFile handler**: File Path and Content were not sanitized.

## Fix

Added `sanitizeNullBytes()` calls to all locations where user/request data is passed to the database:

- `handler/skill.go`: Updated `UpdateSkill` and `UpsertSkillFile` to sanitize all text inputs.
- The `sanitizeNullBytes` function (already present in the file) strips `\x00` characters using `strings.ReplaceAll`.

This ensures null bytes are removed before any database insertion, preventing the PostgreSQL UTF8 encoding error.

Closes #1955.