### PR TITLE
fix(daemon): optimize quick-create prompt for high-fidelity descriptions

### DIFF
--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -240,26 +240,19 @@ func renderIssueContext(provider string, ctx TaskContextForEnv) string {
 }
 
 // renderQuickCreateContext renders issue_context.md for quick-create tasks.
-// There is no issue yet, so we explicitly tell the agent NOT to call
-// `multica issue get` / `status` / `comment add` — those would either error
-// (empty IssueID) or silently target an unrelated issue.
+// This file carries only task data (user input, skills). Behavioral rules
+// and guardrails live in AGENTS.md (runtime config) and the per-turn prompt
+// to avoid redundancy and conflicting instructions.
 func renderQuickCreateContext(ctx TaskContextForEnv) string {
 	var b strings.Builder
 	b.WriteString("# Quick Create\n\n")
 	b.WriteString("**Trigger:** Quick-create modal\n\n")
-	b.WriteString("There is NO existing Multica issue for this run. Translate the user input below into a single `multica issue create` invocation, then exit.\n\n")
 	b.WriteString("## User input\n\n")
 	b.WriteString("> ")
 	b.WriteString(ctx.QuickCreatePrompt)
 	b.WriteString("\n\n")
-	b.WriteString("## Rules\n\n")
-	b.WriteString("- Run exactly one `multica issue create` invocation. No retries.\n")
-	b.WriteString("- After it succeeds, print `Created MUL-<n>: <title>` and exit.\n")
-	b.WriteString("- Do NOT run `multica issue get`, `multica issue status`, or `multica issue comment add` — there is nothing to query, transition, or comment on.\n")
-	b.WriteString("- The platform writes the user's success/failure inbox notification automatically based on the CLI exit status.\n\n")
 	if len(ctx.AgentSkills) > 0 {
 		b.WriteString("## Agent Skills\n\n")
-		b.WriteString("The following skills are available, but for quick-create they are usually unnecessary:\n\n")
 		for _, skill := range ctx.AgentSkills {
 			fmt.Fprintf(&b, "- **%s**\n", skill.Name)
 		}

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -40,31 +40,53 @@ func BuildPrompt(task Task) string {
 func buildQuickCreatePrompt(task Task) string {
 	var b strings.Builder
 	b.WriteString("You are running as a quick-create assistant for a Multica workspace.\n\n")
-	b.WriteString("A user pressed the quick-create shortcut and typed a one-line description. There is NO existing issue. Your job is to create a well-formed issue from the user's input with a single `multica issue create` command.\n\n")
+	b.WriteString("A user captured the following input via the quick-create modal. There is NO existing issue. Your job is to create a well-formed issue from this input with a single `multica issue create` command.\n\n")
 	fmt.Fprintf(&b, "User input:\n> %s\n\n", task.QuickCreatePrompt)
-	b.WriteString("Field rules:\n")
-	b.WriteString("- title: required. A concise but semantically rich summary that lets a reader understand what the issue is about at a glance. If the user input references external resources (PRs, issues, URLs, etc.), use your judgment to decide whether fetching the resource would produce a meaningfully better title — if so, fetch it and incorporate the relevant context. For example, \"review PR #123\" is much less useful than \"Review PR #123: Refactor auth module to OAuth2\". Strip filler words but preserve key semantic information.\n")
-	b.WriteString("- description: stay faithful to the user's original input — do NOT invent requirements, design decisions, implementation plans, or constraints that the user did not express. The description should enrich the user's input with factual context only: if the input contains URLs or references (PRs, issues, docs), fetch them and summarize the relevant parts. Restate the user's intent clearly so the executing agent understands the task, but do not expand scope or add made-up details. Keep it concise. Never echo the title here.\n")
-	b.WriteString("- priority: one of `urgent`, `high`, `medium`, `low`, or omit. Map P0/P1 → urgent/high; \"asap\" → urgent. If unspecified, omit.\n")
-	b.WriteString("- assignee:\n")
+
+	b.WriteString("Field rules:\n\n")
+
+	// title
+	b.WriteString("- **title**: required. A concise but semantically rich summary. If the input references external resources (PRs, issues, URLs), use your judgment on whether fetching the resource would produce a meaningfully better title — e.g. \"review PR #123\" → \"Review PR #123: Refactor auth module to OAuth2\". Strip filler words but preserve key semantic information.\n\n")
+
+	// description — the core optimization
+	b.WriteString("- **description**: The description will be the primary context for the executing agent. Your goal is **high fidelity** — the executing agent should understand the user's intent as well as if they had read the original input themselves.\n\n")
+	b.WriteString("  **Structure the description as follows:**\n\n")
+	b.WriteString("  1. **User request** — Faithfully restate what the user wants done, in their own terms. Preserve the user's phrasing, tone, and scope. Do NOT paraphrase into generic language (e.g. don't turn \"把这个按钮改成红色\" into \"UI improvement needed\"). Do NOT add implementation plans, acceptance criteria, design decisions, or constraints the user did not express.\n\n")
+	b.WriteString("  2. **Context** (only if the input contains URLs, references, or image attachments) — Fetch referenced resources (PRs, issues, docs) and summarize the relevant factual content. Keep summaries to verifiable facts only (e.g. \"PR #45 changes the auth middleware to use JWT\" not \"this suggests we should also update the tests\"). Preserve any image URLs or markdown image references inline.\n\n")
+	b.WriteString("  Omit the Context section entirely if there are no external references to enrich.\n\n")
+	b.WriteString("  **Hard rules for description:**\n")
+	b.WriteString("  - NEVER invent requirements, implementation details, acceptance criteria, or scope that the user did not express.\n")
+	b.WriteString("  - NEVER reduce the user's multi-sentence input to a single vague sentence. If the user wrote three sentences, the description should carry at least that much information.\n")
+	b.WriteString("  - Preserve specific names, identifiers, file paths, code snippets, and technical terms from the input verbatim.\n")
+	b.WriteString("  - Never echo the title in the description.\n\n")
+
+	// priority
+	b.WriteString("- **priority**: one of `urgent`, `high`, `medium`, `low`, or omit. Map P0/P1 → urgent/high; \"asap\" → urgent. If unspecified, omit.\n\n")
+
+	// assignee
+	b.WriteString("- **assignee**:\n")
 	b.WriteString("    - When the user names someone (\"assign to X\" / \"@X\"), call `multica workspace members --output json` and find the matching member by display name (case-insensitive substring match is fine). On a clean match, pass `--assignee <name>`. On no match or ambiguous match, do NOT pass `--assignee` — instead append a final line to the description: `Unrecognized assignee: X`.\n")
 	agentName := ""
 	if task.Agent != nil {
 		agentName = task.Agent.Name
 	}
 	if agentName != "" {
-		fmt.Fprintf(&b, "    - When the user did NOT name an assignee, default to YOURSELF: pass `--assignee %q`. The picker agent is the expected owner because the user opened quick-create with you selected — never leave the issue unassigned.\n", agentName)
+		fmt.Fprintf(&b, "    - When the user did NOT name an assignee, default to YOURSELF: pass `--assignee %q`. The picker agent is the expected owner because the user opened quick-create with you selected — never leave the issue unassigned.\n\n", agentName)
 	} else {
-		b.WriteString("    - When the user did NOT name an assignee, default to YOURSELF (the picker agent): pass `--assignee <your agent name>`. Never leave the issue unassigned.\n")
+		b.WriteString("    - When the user did NOT name an assignee, default to YOURSELF (the picker agent): pass `--assignee <your agent name>`. Never leave the issue unassigned.\n\n")
 	}
-	b.WriteString("- project: omit. The platform will route the issue to the workspace default.\n")
-	b.WriteString("- status: omit (defaults to `todo`).\n")
-	b.WriteString("- attachments: do NOT pass `--attachment`. The flag only accepts LOCAL file paths, and any image URL embedded in the user input is already part of the description as markdown — keep it inline in `--description` instead of trying to re-attach it. (Trying to pass `https://…` to `--attachment` will fail and look like a create error to you, but the issue may already exist; never retry `issue create` on that signal.)\n\n")
+
+	// fields to omit
+	b.WriteString("- **project**: omit. The platform will route the issue to the workspace default.\n")
+	b.WriteString("- **status**: omit (defaults to `todo`).\n")
+	b.WriteString("- **attachments**: do NOT pass `--attachment`. The flag only accepts LOCAL file paths. Any image URL in the user input is already markdown — keep it inline in `--description` instead.\n\n")
+
+	// output format
 	b.WriteString("Output format:\n")
-	b.WriteString("- Run exactly one `multica issue create` invocation. Do not retry it for any reason — even on a non-zero exit. The issue may already exist; another attempt would create a duplicate.\n")
-	b.WriteString("- After it succeeds, print exactly one line: `Created MUL-<n>: <title>` and exit. No commentary, no follow-up tool calls.\n")
-	b.WriteString("- Do NOT call `multica issue get` or `multica issue comment add` for this task — there is no issue to query or comment on prior to creation.\n")
-	b.WriteString("- If the CLI returns an error, exit with that error as the only output. The platform writes a failure notification automatically; do not retry.\n")
+	b.WriteString("- Run exactly one `multica issue create` invocation. Do not retry for any reason — even on non-zero exit. The issue may already exist; another attempt would create a duplicate.\n")
+	b.WriteString("- After success, print exactly one line: `Created MUL-<n>: <title>` and exit. No commentary, no follow-up tool calls.\n")
+	b.WriteString("- Do NOT call `multica issue get` or `multica issue comment add` — there is no issue to query or comment on.\n")
+	b.WriteString("- On CLI error, exit with the error as the only output. The platform writes a failure notification automatically.\n")
 	return b.String()
 }
 


### PR DESCRIPTION
## Summary

- Restructured the quick-create description rule from "stay faithful + keep it concise" to a **high-fidelity** two-section format:
  - **User request** — faithful restate preserving the user's phrasing, tone, and scope
  - **Context** — only when there are external references (URLs, PRs), limited to verifiable facts
- Added hard rules against information compression (no reducing multi-sentence input to a vague summary) and semantic downgrading (no turning specific requests into generic language)
- Removed "one-line description" phrasing — UI supports richer input including multiline text and images
- Stripped redundant behavioral rules from `issue_context.md` (`renderQuickCreateContext`) — those are already covered by AGENTS.md hard guardrails and the per-turn prompt

## Motivation

Quick-create descriptions were too terse, causing the executing agent to lose context about the user's intent. The previous `Keep it concise` + `do NOT invent` framing made agents default to very short paraphrases that stripped away the user's original phrasing, background, and references.

## Test plan

- [x] `go build ./internal/daemon/...` — compiles clean
- [ ] Manual testing: verify quick-create with various input lengths produces descriptions that preserve user intent