### PR TITLE
feat(inbox): remove redundant mark-as-done hover button, add archive button for done tasks

### DIFF
--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -2,7 +2,7 @@
 
 import { StatusIcon } from "../../issues/components";
 import { ActorAvatar } from "../../common/actor-avatar";
-import { Archive, CircleCheck } from "lucide-react";
+import { Archive } from "lucide-react";
 import type { InboxItem } from "@multica/core/types";
 import { InboxDetailLabel } from "./inbox-detail-label";
 import { getInboxDisplayTitle } from "./inbox-display";
@@ -25,13 +25,11 @@ export function InboxListItem({
   isSelected,
   onClick,
   onArchive,
-  onDone,
 }: {
   item: InboxItem;
   isSelected: boolean;
   onClick: () => void;
   onArchive: () => void;
-  onDone?: () => void;
 }) {
   const displayTitle = getInboxDisplayTitle(item);
 
@@ -61,26 +59,6 @@ export function InboxListItem({
             </span>
           </div>
           <div className="flex shrink-0 items-center gap-1">
-            {onDone && (
-              <span
-                role="button"
-                tabIndex={-1}
-                title="Mark as done"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDone();
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.stopPropagation();
-                    onDone();
-                  }
-                }}
-                className="hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-info group-hover:inline-flex"
-              >
-                <CircleCheck className="h-3.5 w-3.5" />
-              </span>
-            )}
             <span
               role="button"
               tabIndex={-1}

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -20,7 +20,7 @@ import {
   useArchiveAllReadInbox,
   useArchiveCompletedInbox,
 } from "@multica/core/inbox/mutations";
-import { useUpdateIssue } from "@multica/core/issues/mutations";
+
 import { IssueDetail } from "../../issues/components";
 import { useNavigation } from "../../navigation";
 import { toast } from "sonner";
@@ -118,8 +118,6 @@ export function InboxPage() {
   const archiveAllMutation = useArchiveAllInbox();
   const archiveAllReadMutation = useArchiveAllReadInbox();
   const archiveCompletedMutation = useArchiveCompletedInbox();
-  const updateIssueMutation = useUpdateIssue();
-
   // Auto-mark-read whenever a selected item is unread — covers both click-
   // to-select and URL-param-select (e.g. OS notification click on desktop).
   // The mutation flips `read: true` optimistically, so this effect settles
@@ -143,18 +141,6 @@ export function InboxPage() {
     const archived = items.find((i) => i.id === id);
     if (archived && (archived.issue_id ?? archived.id) === selectedKey) setSelectedKey("");
     archiveMutation.mutate(id, {
-      onError: () => toast.error("Failed to archive"),
-    });
-  };
-
-  const handleDone = (item: InboxItem) => {
-    if (!item.issue_id) return;
-    setSelectedKey("");
-    updateIssueMutation.mutate(
-      { id: item.issue_id, status: "done" },
-      { onError: () => toast.error("Failed to mark as done") },
-    );
-    archiveMutation.mutate(item.id, {
       onError: () => toast.error("Failed to archive"),
     });
   };
@@ -249,11 +235,6 @@ export function InboxPage() {
           isSelected={(item.issue_id ?? item.id) === selectedKey}
           onClick={() => handleSelect(item)}
           onArchive={() => handleArchive(item.id)}
-          onDone={
-            item.issue_id && item.issue_status !== "done" && item.issue_status !== "cancelled"
-              ? () => handleDone(item)
-              : undefined
-          }
         />
       ))}
     </div>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -5,6 +5,7 @@ import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { AppLink } from "../../navigation";
 import { useNavigation } from "../../navigation";
 import {
+  Archive,
   Calendar,
   ChevronDown,
   ChevronLeft,
@@ -547,6 +548,23 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                   }
                 />
                 <TooltipContent side="bottom">Mark as done</TooltipContent>
+              </Tooltip>
+            )}
+            {onDone && issue.status === "done" && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="text-muted-foreground"
+                      onClick={() => { onDone(); }}
+                    >
+                      <Archive />
+                    </Button>
+                  }
+                />
+                <TooltipContent side="bottom">Archive</TooltipContent>
               </Tooltip>
             )}
             <Tooltip>


### PR DESCRIPTION
## Summary
- Removed the "mark as done" hover button from inbox list items (redundant with the one in the issue detail header)
- Added an archive button in the issue detail header for tasks already marked as done (archive only, no status change)
- Cleaned up unused `handleDone`, `useUpdateIssue` import, and `onDone` prop from `InboxListItem`

## Test plan
- [ ] Hover over inbox list items — only archive button should appear, no "mark as done" button
- [ ] Open a non-done issue from inbox — "Mark as done" button should still appear in the detail header
- [ ] Open a done issue from inbox — "Archive" button (with archive icon) should appear in the detail header
- [ ] Click the archive button on a done issue — should archive the inbox item