### PR TITLE
fix(views): preserve kanban display settings when dragging issues

### DIFF
--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -77,13 +77,6 @@ export function IssuesPage() {
   const updateIssueMutation = useUpdateIssue();
   const handleMoveIssue = useCallback(
     (issueId: string, newStatus: IssueStatus, newPosition?: number) => {
-      // Auto-switch to manual sort so drag ordering is preserved
-      const viewState = useIssueViewStore.getState();
-      if (viewState.sortBy !== "position") {
-        viewState.setSortBy("position");
-        viewState.setSortDirection("asc");
-      }
-
       const updates: Partial<{ status: IssueStatus; position: number }> = {
         status: newStatus,
       };

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -102,12 +102,6 @@ export function MyIssuesPage() {
   const updateIssueMutation = useUpdateIssue();
   const handleMoveIssue = useCallback(
     (issueId: string, newStatus: IssueStatus, newPosition?: number) => {
-      const viewState = myIssuesViewStore.getState();
-      if (viewState.sortBy !== "position") {
-        viewState.setSortBy("position");
-        viewState.setSortDirection("asc");
-      }
-
       const updates: Partial<{ status: IssueStatus; position: number }> = {
         status: newStatus,
       };

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -134,11 +134,6 @@ function ProjectIssuesContent({
   const updateIssueMutation = useUpdateIssue();
   const handleMoveIssue = useCallback(
     (issueId: string, newStatus: IssueStatus, newPosition?: number) => {
-      const viewState = projectViewStore.getState();
-      if (viewState.sortBy !== "position") {
-        viewState.setSortBy("position");
-        viewState.setSortDirection("asc");
-      }
       const updates: Partial<{ status: IssueStatus; position: number }> = { status: newStatus };
       if (newPosition !== undefined) updates.position = newPosition;
       updateIssueMutation.mutate(


### PR DESCRIPTION
## Summary

- Remove the auto-switch to "position" (manual) sort that fired every time a user dragged an issue between kanban columns
- This was resetting user-chosen display settings (e.g. sorting by title) on every drag operation
- The fix applies to all three board views: workspace issues, my-issues, and project detail

Fixes https://github.com/multica-ai/multica/issues/1960

## Root Cause

In `handleMoveIssue`, the code checked `if (viewState.sortBy !== "position")` and forcefully switched `sortBy` to `"position"` and `sortDirection` to `"asc"`. This was intended to preserve manual drag ordering, but it had the side effect of resetting the user's chosen sort/display settings whenever they dragged any issue.

## Test plan

- [x] TypeScript typecheck passes (all 6 tasks)
- [x] Unit tests pass (issues-page.test.tsx — 6/6)
- [ ] Manual: Set kanban sort to "Title", drag an issue between columns → sort should remain "Title"