### PR TITLE
feat(views): add left sidebar collapse option for desktop

### DIFF
--- a/packages/ui/components/ui/sidebar.tsx
+++ b/packages/ui/components/ui/sidebar.tsx
@@ -112,6 +112,8 @@ function SidebarProvider({
   }, [isMobile, setOpen, setOpenMobile])
 
   // Toggle sidebar with keyboard shortcut (Cmd+B / Ctrl+B).
+  // Skip when focus is inside editable content so the shortcut doesn't
+  // steal Cmd+B (bold) from TipTap / contentEditable / inputs.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
@@ -120,6 +122,13 @@ function SidebarProvider({
         !event.shiftKey &&
         !event.altKey
       ) {
+        const tag = (event.target as HTMLElement)?.tagName
+        const isEditable =
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          (event.target as HTMLElement)?.isContentEditable
+        if (isEditable) return
         event.preventDefault()
         toggleSidebar()
       }

--- a/packages/ui/components/ui/sidebar.tsx
+++ b/packages/ui/components/ui/sidebar.tsx
@@ -111,32 +111,6 @@ function SidebarProvider({
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
 
-  // Toggle sidebar with keyboard shortcut (Cmd+B / Ctrl+B).
-  // Skip when focus is inside editable content so the shortcut doesn't
-  // steal Cmd+B (bold) from TipTap / contentEditable / inputs.
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.key === "b" &&
-        (event.metaKey || event.ctrlKey) &&
-        !event.shiftKey &&
-        !event.altKey
-      ) {
-        const tag = (event.target as HTMLElement)?.tagName
-        const isEditable =
-          tag === "INPUT" ||
-          tag === "TEXTAREA" ||
-          tag === "SELECT" ||
-          (event.target as HTMLElement)?.isContentEditable
-        if (isEditable) return
-        event.preventDefault()
-        toggleSidebar()
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [toggleSidebar])
-
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? "expanded" : "collapsed"

--- a/packages/ui/components/ui/sidebar.tsx
+++ b/packages/ui/components/ui/sidebar.tsx
@@ -111,6 +111,23 @@ function SidebarProvider({
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
 
+  // Toggle sidebar with keyboard shortcut (Cmd+B / Ctrl+B).
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === "b" &&
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey &&
+        !event.altKey
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? "expanded" : "collapsed"

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -51,6 +51,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  SidebarTrigger,
 } from "@multica/ui/components/ui/sidebar";
 import {
   DropdownMenu,
@@ -691,7 +692,8 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
         </SidebarContent>
 
         <SidebarFooter className="p-2">
-          <div className="flex justify-end">
+          <div className="flex items-center justify-between">
+            <SidebarTrigger />
             <HelpLauncher />
           </div>
         </SidebarFooter>

--- a/packages/views/layout/page-header.tsx
+++ b/packages/views/layout/page-header.tsx
@@ -3,13 +3,14 @@
 import { cn } from "@multica/ui/lib/utils";
 import { SidebarTrigger, useSidebar } from "@multica/ui/components/ui/sidebar";
 
-function MobileSidebarTrigger() {
+function SidebarToggle() {
   try {
-    useSidebar();
+    const { state } = useSidebar();
+    // On mobile: always show (hamburger). On desktop: only when sidebar is collapsed.
+    return <SidebarTrigger className={cn("mr-2", state === "expanded" && "md:hidden")} />;
   } catch {
     return null;
   }
-  return <SidebarTrigger className="mr-2 md:hidden" />;
 }
 
 interface PageHeaderProps {
@@ -20,7 +21,7 @@ interface PageHeaderProps {
 export function PageHeader({ children, className }: PageHeaderProps) {
   return (
     <div className={cn("flex h-12 shrink-0 items-center border-b px-4", className)}>
-      <MobileSidebarTrigger />
+      <SidebarToggle />
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- Show a sidebar toggle button (PanelLeft icon) in the page header when the sidebar is collapsed on desktop, so users can re-expand it
- Add a toggle button to the sidebar footer for collapsing the sidebar from within
- Add `Cmd+B` / `Ctrl+B` keyboard shortcut to toggle the sidebar (standard convention used by VS Code, Linear, etc.)

Closes #1967

## Changes
- **`packages/ui/components/ui/sidebar.tsx`** — Added keyboard shortcut handler in `SidebarProvider`
- **`packages/views/layout/page-header.tsx`** — Made `SidebarTrigger` visible on desktop when sidebar is collapsed (was `md:hidden`)
- **`packages/views/layout/app-sidebar.tsx`** — Added `SidebarTrigger` to sidebar footer next to help button

## Test plan
- [ ] Open the web app, verify the sidebar toggle button appears at bottom-left of the sidebar
- [ ] Click the toggle button — sidebar should collapse (slide offscreen)
- [ ] When collapsed, a toggle button should appear in the page header — click to re-expand
- [ ] Press `Cmd+B` (Mac) / `Ctrl+B` (Windows/Linux) to toggle sidebar
- [ ] On mobile, behavior should remain unchanged (hamburger menu)
- [ ] Desktop app should continue working as before (it already had its own collapse trigger)