### PR TITLE
fix(inbox): scroll to activity section immediately to avoid description flash

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -301,7 +301,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   useLayoutEffect(() => {
     if (!highlightCommentId) return;
     activitySectionRef.current?.scrollIntoView({ behavior: "instant", block: "start" });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [highlightCommentId]);
 
   const descEditorRef = useRef<ContentEditorRef>(null);
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from "react";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { AppLink } from "../../navigation";
 import { useNavigation } from "../../navigation";
@@ -194,6 +194,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   const didHighlightRef = useRef<string | null>(null);
+  const activitySectionRef = useRef<HTMLDivElement>(null);
 
   // Issue data from TQ — uses detail query, seeded from list cache if available.
   // Only seed when description is present; list API omits it, and ContentEditor
@@ -292,6 +293,15 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       });
     }
   }, [highlightCommentId, timeline.length]);
+
+  // When opening from inbox with a target comment, scroll past the description
+  // to the activity section before the browser paints, so the user never sees
+  // the description flash. The precise scroll to the specific comment happens
+  // in the useEffect above once the timeline has loaded.
+  useLayoutEffect(() => {
+    if (!highlightCommentId) return;
+    activitySectionRef.current?.scrollIntoView({ behavior: "instant", block: "start" });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const descEditorRef = useRef<ContentEditorRef>(null);
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
@@ -798,7 +808,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           <div className="my-8 border-t" />
 
           {/* Activity / Comments */}
-          <div>
+          <div ref={activitySectionRef}>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <h2 className="text-base font-semibold">Activity</h2>


### PR DESCRIPTION
## Summary
- When clicking an Inbox notification, uses `useLayoutEffect` to scroll the activity section into view before the browser paints, eliminating the flash of issue description
- The existing `useEffect` still handles precise scroll-to-comment once the timeline loads asynchronously

Closes MUL-1669

## Test plan
- [ ] Click an Inbox notification that references a comment
- [ ] Verify the page opens directly at the activity/comment section, not at the description
- [ ] Verify the specific comment is highlighted after a brief moment
- [ ] Verify normal issue detail navigation (without `highlightCommentId`) is unaffected