### PR TITLE
fix(daemon): add safe.directory=* to gitEnv to fix CI dubious ownership errors

### DIFF
--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,11 +27,26 @@ import (
 // and breaks CI environments where the runner UID differs from the
 // directory owner.
 func gitEnv() []string {
-	return append(os.Environ(),
+	base := os.Environ()
+
+	// Find the existing GIT_CONFIG_COUNT so we append at the next index
+	// rather than overwriting any env-scoped git config (auth, URL
+	// rewrites, extra headers, etc.).
+	existing := 0
+	for _, e := range base {
+		if strings.HasPrefix(e, "GIT_CONFIG_COUNT=") {
+			if n, err := strconv.Atoi(strings.TrimPrefix(e, "GIT_CONFIG_COUNT=")); err == nil {
+				existing = n
+			}
+		}
+	}
+
+	idx := strconv.Itoa(existing)
+	return append(base,
 		"GIT_TERMINAL_PROMPT=0",
-		"GIT_CONFIG_COUNT=1",
-		"GIT_CONFIG_KEY_0=safe.directory",
-		"GIT_CONFIG_VALUE_0=*",
+		"GIT_CONFIG_COUNT="+strconv.Itoa(existing+1),
+		"GIT_CONFIG_KEY_"+idx+"=safe.directory",
+		"GIT_CONFIG_VALUE_"+idx+"=*",
 	)
 }
 

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -19,8 +19,19 @@ import (
 // It passes the full daemon environment so credential helpers (e.g. gh) can
 // locate their config, and disables TTY prompting so auth failures produce
 // clear errors instead of blocking on a non-existent terminal.
+//
+// safe.directory=* is set via GIT_CONFIG_* env vars so git trusts all
+// directories regardless of ownership. The daemon manages its own bare
+// caches and worktrees, so the ownership check adds no security value
+// and breaks CI environments where the runner UID differs from the
+// directory owner.
 func gitEnv() []string {
-	return append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	return append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=safe.directory",
+		"GIT_CONFIG_VALUE_0=*",
+	)
 }
 
 // RepoInfo describes a repository to cache.

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -44,6 +44,23 @@ func TestGitEnv(t *testing.T) {
 	if !foundHome {
 		t.Error("gitEnv() must include HOME from os.Environ()")
 	}
+
+	// Must set safe.directory=* via GIT_CONFIG env vars.
+	want := map[string]bool{
+		"GIT_CONFIG_COUNT=1":              false,
+		"GIT_CONFIG_KEY_0=safe.directory": false,
+		"GIT_CONFIG_VALUE_0=*":            false,
+	}
+	for _, entry := range env {
+		if _, ok := want[entry]; ok {
+			want[entry] = true
+		}
+	}
+	for k, found := range want {
+		if !found {
+			t.Errorf("gitEnv() must include %s", k)
+		}
+	}
 }
 
 func TestBareDirName(t *testing.T) {

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -46,20 +46,62 @@ func TestGitEnv(t *testing.T) {
 	}
 
 	// Must set safe.directory=* via GIT_CONFIG env vars.
-	want := map[string]bool{
-		"GIT_CONFIG_COUNT=1":              false,
-		"GIT_CONFIG_KEY_0=safe.directory": false,
-		"GIT_CONFIG_VALUE_0=*":            false,
-	}
-	for _, entry := range env {
-		if _, ok := want[entry]; ok {
-			want[entry] = true
+	envHas := func(env []string, want string) bool {
+		for _, e := range env {
+			if e == want {
+				return true
+			}
 		}
+		return false
 	}
-	for k, found := range want {
-		if !found {
-			t.Errorf("gitEnv() must include %s", k)
+	if !envHas(env, "GIT_CONFIG_KEY_0=safe.directory") {
+		t.Error("gitEnv() must include GIT_CONFIG_KEY_0=safe.directory (no pre-existing config)")
+	}
+	if !envHas(env, "GIT_CONFIG_VALUE_0=*") {
+		t.Error("gitEnv() must include GIT_CONFIG_VALUE_0=*")
+	}
+}
+
+func TestGitEnvPreservesExistingConfig(t *testing.T) {
+	// GIT_CONFIG_COUNT env vars are process-wide; cannot use t.Setenv in
+	// parallel tests, so run sequentially.
+	t.Setenv("GIT_CONFIG_COUNT", "2")
+	t.Setenv("GIT_CONFIG_KEY_0", "url.https://github.com/.insteadOf")
+	t.Setenv("GIT_CONFIG_VALUE_0", "gh:")
+	t.Setenv("GIT_CONFIG_KEY_1", "http.extraHeader")
+	t.Setenv("GIT_CONFIG_VALUE_1", "Authorization: Bearer tok")
+
+	env := gitEnv()
+
+	envHas := func(want string) bool {
+		for _, e := range env {
+			if e == want {
+				return true
+			}
 		}
+		return false
+	}
+
+	// safe.directory must be appended at index 2 (next available).
+	if !envHas("GIT_CONFIG_COUNT=3") {
+		t.Error("expected GIT_CONFIG_COUNT=3")
+	}
+	if !envHas("GIT_CONFIG_KEY_2=safe.directory") {
+		t.Error("expected GIT_CONFIG_KEY_2=safe.directory")
+	}
+	if !envHas("GIT_CONFIG_VALUE_2=*") {
+		t.Error("expected GIT_CONFIG_VALUE_2=*")
+	}
+
+	// Original entries must still be present.
+	if !envHas("GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf") {
+		t.Error("existing GIT_CONFIG_KEY_0 was lost")
+	}
+	if !envHas("GIT_CONFIG_VALUE_0=gh:") {
+		t.Error("existing GIT_CONFIG_VALUE_0 was lost")
+	}
+	if !envHas("GIT_CONFIG_KEY_1=http.extraHeader") {
+		t.Error("existing GIT_CONFIG_KEY_1 was lost")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `safe.directory=*` via `GIT_CONFIG_*` env vars to `gitEnv()` in `repocache/cache.go`
- Fixes `TestRegisterTaskReposAllowsProjectOnlyURL` and `TestRegisterTaskReposSurvivesWorkspaceRefresh` failures on CI where git's ownership check rejects temp directories owned by a different UID
- Updates `TestGitEnv` to verify the new env vars

## Context

The backend CI (`go test ./...`) has been intermittently failing on main due to git's `safe.directory` ownership check (introduced in Git 2.35.2). When tests create local git repos via `t.TempDir()` and the daemon's repo cache clones from them, `git clone --bare` fails with "dubious ownership" because the CI runner UID differs from the directory owner.

The daemon manages its own bare caches and worktrees, so the ownership check provides no security value here.

## Test plan

- [x] `go test ./internal/daemon/repocache/...` passes
- [x] `go test ./internal/daemon/...` passes
- [x] `go build ./...` succeeds
- [x] Full `go test ./...` passes