### PR TITLE
feat(mcp): add @multica/mcp server + downloadable bundle + settings page

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -13,6 +13,7 @@ COPY packages/ui/package.json packages/ui/
 COPY packages/views/package.json packages/views/
 COPY packages/tsconfig/package.json packages/tsconfig/
 COPY packages/eslint-config/package.json packages/eslint-config/
+COPY packages/mcp/package.json packages/mcp/
 
 RUN pnpm install --frozen-lockfile
 
@@ -42,6 +43,15 @@ ENV REMOTE_API_URL=$REMOTE_API_URL
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
 ENV NEXT_PUBLIC_APP_VERSION=$NEXT_PUBLIC_APP_VERSION
 ENV STANDALONE=true
+
+# Build the MCP server first and stage it as a downloadable static asset
+# under the web app's public/ directory. Next.js' standalone output ships
+# public/ as-is, so this produces /multica-mcp.js on the served frontend
+# and lets users grab the server with a single curl from the settings UI
+# instead of having to clone the repo and pnpm-build themselves.
+RUN pnpm --filter @multica/mcp build && \
+    mkdir -p apps/web/public && \
+    cp packages/mcp/dist/index.js apps/web/public/multica-mcp.js
 
 # Build the web app (standalone output for minimal runtime)
 RUN pnpm --filter @multica/web build

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,159 @@
+# @multica/mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server for Multica.
+Exposes Multica resources — issues, agents, channels, projects, autopilots — as
+MCP tools so any MCP-aware AI assistant (Claude Desktop, Claude Code, Cursor,
+etc.) can orchestrate Multica directly from chat.
+
+The server is **self-contained**: it depends on the published MCP SDK and `zod`,
+nothing else from the Multica monorepo. It talks to Multica over the same HTTP
+API the web/desktop apps use; the local `multica` CLI does **not** need to be
+installed for the server to run.
+
+## What's exposed
+
+| Group | Tools |
+| --- | --- |
+| Issues | `multica_issue_list`, `multica_issue_search`, `multica_issue_get`, `multica_issue_create`, `multica_issue_update`, `multica_issue_status`, `multica_issue_assign`, `multica_issue_comment_add`, `multica_issue_comment_list`, `multica_issue_runs` |
+| Agents | `multica_agent_list`, `multica_agent_get`, `multica_agent_tasks` |
+| Channels | `multica_channel_list`, `multica_channel_get`, `multica_channel_history`, `multica_channel_post`, `multica_channel_members`, `multica_channel_mark_read` |
+| Projects | `multica_project_list`, `multica_project_get`, `multica_project_search`, `multica_project_create` |
+| Labels | `multica_label_list`, `multica_label_attach`, `multica_label_detach` |
+| Autopilots | `multica_autopilot_list`, `multica_autopilot_get`, `multica_autopilot_runs`, `multica_autopilot_trigger` |
+| Workspace | `multica_workspace_get`, `multica_workspace_members` |
+
+Read tools are exposed broadly. Mutating tools err on the side of caution: agent
+configuration, autopilot creation, label CRUD, and workspace-membership changes
+are deliberately **not** exposed because they have wider blast radius and are
+better-driven from the form-based UIs.
+
+## Requirements
+
+- Node.js 20 or newer.
+- A Multica personal access token (`mul_…`) and the workspace UUID you want the
+  server to operate against.
+
+## Installation
+
+From the monorepo:
+
+```bash
+pnpm install
+pnpm --filter @multica/mcp build
+```
+
+The build produces a single bundled file at `packages/mcp/dist/index.js` with a
+`#!/usr/bin/env node` shebang and the `multica-mcp` bin entry pointed at it.
+
+## Configuration
+
+Two sources, first-wins:
+
+1. **Environment variables** (recommended for MCP client configs):
+   - `MULTICA_API_URL` — HTTP base URL, e.g. `https://multica.example.com` or
+     `http://localhost:8080`. **No** trailing slash, **no** `/ws` suffix.
+   - `MULTICA_TOKEN` — bearer token (`mul_…`). Generate one with `multica auth
+     token create` or in the workspace settings UI.
+   - `MULTICA_WORKSPACE_ID` — default workspace UUID. Tools that don't take an
+     explicit `workspace_id` argument operate against this one.
+2. **`~/.multica/config.json`** (the file the `multica` CLI writes on `multica
+   login`). Used as a fallback when the env vars above are unset. The CLI stores
+   a WebSocket URL like `wss://api.example/ws`; the MCP server derives the HTTP
+   base by swapping the scheme and stripping the `/ws` suffix.
+
+## Wiring it into an MCP client
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS):
+
+```json
+{
+  "mcpServers": {
+    "multica": {
+      "command": "node",
+      "args": ["/absolute/path/to/multica/packages/mcp/dist/index.js"],
+      "env": {
+        "MULTICA_API_URL": "https://your-multica.example.com",
+        "MULTICA_TOKEN": "mul_…",
+        "MULTICA_WORKSPACE_ID": "00000000-0000-0000-0000-000000000000"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing the file.
+
+### Claude Code
+
+```bash
+claude mcp add multica \
+  --env MULTICA_API_URL=https://your-multica.example.com \
+  --env MULTICA_TOKEN=mul_… \
+  --env MULTICA_WORKSPACE_ID=00000000-0000-0000-0000-000000000000 \
+  -- node /absolute/path/to/multica/packages/mcp/dist/index.js
+```
+
+(Or omit `--env` flags entirely if the running shell has those variables set
+and you'd rather inherit them. The new MCP server is available the next time you
+start a Claude Code session.)
+
+### Cursor / Windsurf / other MCP clients
+
+Any client that speaks the standard MCP stdio transport works. The command is
+`node /absolute/path/to/dist/index.js` plus the three env vars above.
+
+## Output format
+
+Tool results are returned as a single text content block containing pretty-
+printed JSON of the underlying Multica API response. The model is expected to
+parse it; the server does **not** strip or reshape fields. This keeps the
+contract one-to-one with Multica's REST API and lets future server changes flow
+through without an MCP-side translation layer.
+
+Errors (HTTP 4xx/5xx, validation failures, network errors) come back as `is
+Error: true` content blocks with the upstream error body included so the model
+can recover instead of hard-stopping.
+
+## Development
+
+```bash
+pnpm --filter @multica/mcp typecheck   # tsc --noEmit
+pnpm --filter @multica/mcp test        # vitest
+pnpm --filter @multica/mcp dev         # tsup --watch
+```
+
+The dev build is a single bundled `dist/index.js` you can `node` against to
+smoke-test outside of an MCP client.
+
+## Layout
+
+```
+packages/mcp/
+├── README.md
+├── package.json          # name: @multica/mcp, bin: multica-mcp
+├── tsconfig.json         # extends @multica/tsconfig/base.json
+├── tsup.config.ts        # bundle to dist/index.js with a node20 shebang
+└── src/
+    ├── index.ts          # CLI entry — parses env, connects stdio transport
+    ├── server.ts         # Builds Server, registers tools, dispatches calls
+    ├── client.ts         # Tiny self-contained Multica HTTP client
+    ├── config.ts         # Env / ~/.multica/config.json loader
+    ├── tool.ts           # ToolDefinition contract + defineTool helper
+    └── tools/
+        ├── index.ts      # Aggregates all tool modules into `allTools`
+        ├── workspace.ts
+        ├── issues.ts
+        ├── agents.ts
+        ├── channels.ts
+        ├── projects.ts
+        ├── labels.ts
+        └── autopilots.ts
+```
+
+Adding a new tool is a matter of dropping a new file under `src/tools/`,
+exporting an array of `defineTool({ … })` instances, and listing the array in
+`tools/index.ts`. No other wiring required — the server picks them up via
+`allTools`.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@multica/mcp",
+  "version": "0.1.0",
+  "description": "Model Context Protocol server for Multica — exposes Multica resources (issues, agents, channels, projects, autopilots) as MCP tools so any MCP-aware AI assistant can orchestrate Multica from chat.",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "multica-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "start": "node ./dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.4",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@multica/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
+    "tsup": "^8.3.5",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,0 +1,125 @@
+// Minimal HTTP client for the Multica REST API. Self-contained — no
+// imports from @multica/core. We deliberately pay the cost of duplicating
+// a few request shapes here so the MCP package can ship as a standalone
+// monorepo node, and a future PR could lift it into its own repo with
+// a single `pnpm tsup` invocation.
+//
+// Authentication: every request carries `Authorization: Bearer <token>`.
+// `X-Workspace-ID` is included on workspace-scoped endpoints; the caller
+// passes per-request overrides so a tool like `multica_issue_create` can
+// optionally target a non-default workspace.
+//
+// Errors: API 4xx/5xx responses are surfaced as `ApiError` with the body
+// captured for the model. Network failures (DNS, connection) bubble up
+// untouched so the MCP runtime sees the original exception.
+
+import type { MulticaConfig } from "./config.js";
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  constructor(status: number, message: string, body: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export interface RequestOptions {
+  /** Workspace override for this single call (defaults to config.defaultWorkspaceId). */
+  workspaceId?: string | null;
+  /** Path is appended to apiUrl as-is. Include leading slash. */
+  query?: Record<string, string | number | boolean | undefined>;
+  body?: unknown;
+  headers?: Record<string, string>;
+  /** Per-call timeout in ms. Default 30s. */
+  timeoutMs?: number;
+}
+
+export class MulticaClient {
+  constructor(private readonly cfg: MulticaConfig) {}
+
+  get apiUrl(): string {
+    return this.cfg.apiUrl;
+  }
+
+  get defaultWorkspaceId(): string | null {
+    return this.cfg.defaultWorkspaceId;
+  }
+
+  async get<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+    return this.request<T>("GET", path, opts);
+  }
+  async post<T>(path: string, body: unknown, opts: RequestOptions = {}): Promise<T> {
+    return this.request<T>("POST", path, { ...opts, body });
+  }
+  async patch<T>(path: string, body: unknown, opts: RequestOptions = {}): Promise<T> {
+    return this.request<T>("PATCH", path, { ...opts, body });
+  }
+  async delete<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+    return this.request<T>("DELETE", path, opts);
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    opts: RequestOptions,
+  ): Promise<T> {
+    const url = new URL(this.cfg.apiUrl + path);
+    if (opts.query) {
+      for (const [k, v] of Object.entries(opts.query)) {
+        if (v === undefined) continue;
+        url.searchParams.set(k, String(v));
+      }
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.cfg.token}`,
+      Accept: "application/json",
+      ...(opts.headers ?? {}),
+    };
+    const wsId = opts.workspaceId ?? this.cfg.defaultWorkspaceId;
+    if (wsId) headers["X-Workspace-ID"] = wsId;
+    if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? 30_000);
+    let res: Response;
+    try {
+      res = await fetch(url.toString(), {
+        method,
+        headers,
+        body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    // 204 / empty body — common for DELETE and write endpoints that
+    // don't echo. Resolve with `null` cast to T so callers that expect
+    // void don't have to special-case.
+    if (res.status === 204) return null as T;
+
+    const text = await res.text();
+    let parsed: unknown = text;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        // Non-JSON response — leave as text and let the caller cope.
+      }
+    }
+
+    if (!res.ok) {
+      const message =
+        (parsed && typeof parsed === "object" && "error" in parsed
+          ? String((parsed as { error: unknown }).error)
+          : null) ??
+        (typeof parsed === "string" && parsed ? parsed : `${method} ${path} failed`);
+      throw new ApiError(res.status, `${res.status} ${message}`, parsed);
+    }
+    return parsed as T;
+  }
+}

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -54,6 +54,9 @@ export class MulticaClient {
   async post<T>(path: string, body: unknown, opts: RequestOptions = {}): Promise<T> {
     return this.request<T>("POST", path, { ...opts, body });
   }
+  async put<T>(path: string, body: unknown, opts: RequestOptions = {}): Promise<T> {
+    return this.request<T>("PUT", path, { ...opts, body });
+  }
   async patch<T>(path: string, body: unknown, opts: RequestOptions = {}): Promise<T> {
     return this.request<T>("PATCH", path, { ...opts, body });
   }

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -1,0 +1,121 @@
+// Loads connection config (API URL, auth token, default workspace) for
+// the MCP server. Two sources, first-wins:
+//
+//  1. Environment variables — `MULTICA_API_URL`, `MULTICA_TOKEN`,
+//     `MULTICA_WORKSPACE_ID`. Takes priority because operators may want
+//     to point a single MCP install at a different workspace than the
+//     CLI is configured for (e.g. one Claude Desktop, two workspaces).
+//  2. `~/.multica/config.json` — the same file the multica CLI writes
+//     on `multica login`. Lets users skip env-var setup entirely if
+//     their CLI is already authenticated. The JSON has a WebSocket
+//     `server_url` (e.g. `wss://api.example/ws`); we derive the HTTP
+//     base by swapping the scheme and stripping the trailing `/ws`.
+//
+// Throws TokenRequiredError when neither source yields a token —
+// without one every API call would 401 and the MCP tools would be
+// useless.
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+export interface MulticaConfig {
+  /** HTTP base URL, e.g. https://multica-api.example.com (no trailing slash). */
+  apiUrl: string;
+  /** Bearer token (`mul_...`). Sent as Authorization: Bearer <token>. */
+  token: string;
+  /** Default workspace UUID for tools that don't take an explicit override. */
+  defaultWorkspaceId: string | null;
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+interface RawCliConfig {
+  server_url?: string;
+  app_url?: string;
+  token?: string;
+  workspace_id?: string;
+}
+
+export interface LoadConfigOptions {
+  /** Overrides for testing — when set, env + file lookups are skipped for that field. */
+  apiUrl?: string;
+  token?: string;
+  workspaceId?: string;
+  /** Override the location of ~/.multica/config.json (test seam). */
+  cliConfigPath?: string;
+  /** Mock `process.env` (test seam). Defaults to the real process.env. */
+  env?: Record<string, string | undefined>;
+}
+
+const DEFAULT_CLI_CONFIG = join(homedir(), ".multica", "config.json");
+
+export function loadConfig(opts: LoadConfigOptions = {}): MulticaConfig {
+  const env = opts.env ?? process.env;
+  const cliPath = opts.cliConfigPath ?? DEFAULT_CLI_CONFIG;
+
+  // Best-effort read of the CLI config; missing/bad JSON is fine —
+  // env vars or explicit overrides may still satisfy us.
+  let cli: RawCliConfig = {};
+  try {
+    const raw = readFileSync(cliPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object") {
+      cli = parsed as RawCliConfig;
+    }
+  } catch {
+    // File missing or unreadable — fall through to env.
+  }
+
+  const apiUrl =
+    opts.apiUrl ??
+    env.MULTICA_API_URL ??
+    deriveHttpBase(cli.server_url) ??
+    "";
+
+  const token = opts.token ?? env.MULTICA_TOKEN ?? cli.token ?? "";
+  const defaultWorkspaceId =
+    opts.workspaceId ?? env.MULTICA_WORKSPACE_ID ?? cli.workspace_id ?? null;
+
+  if (!apiUrl) {
+    throw new ConfigError(
+      "Multica API URL is not configured. Set MULTICA_API_URL or run `multica login` to populate ~/.multica/config.json.",
+    );
+  }
+  if (!token) {
+    throw new ConfigError(
+      "Multica auth token is not configured. Set MULTICA_TOKEN or run `multica login` to populate ~/.multica/config.json.",
+    );
+  }
+
+  return {
+    apiUrl: stripTrailingSlash(apiUrl),
+    token,
+    defaultWorkspaceId,
+  };
+}
+
+// The CLI stores a WebSocket URL like `wss://api.example.com/ws`. The
+// HTTP API lives at the same host with the matching scheme and no
+// trailing `/ws`. Returns null on missing/bad input so the caller can
+// fall through to env-only setups.
+export function deriveHttpBase(serverUrl: string | undefined): string | null {
+  if (!serverUrl) return null;
+  let url = serverUrl.trim();
+  if (!url) return null;
+  if (url.startsWith("wss://")) url = "https://" + url.slice("wss://".length);
+  else if (url.startsWith("ws://")) url = "http://" + url.slice("ws://".length);
+  // Strip a trailing `/ws` (and optionally a `/`) so the CLI's WebSocket
+  // suffix doesn't end up on every REST path.
+  url = url.replace(/\/ws\/?$/, "");
+  return stripTrailingSlash(url);
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith("/") ? s.slice(0, -1) : s;
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,42 @@
+// CLI entry point. MCP clients spawn this binary with stdio inherited
+// and speak JSON-RPC over the pipe. Anything we log to stdout would
+// corrupt the protocol — every message goes to stderr instead.
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { MulticaClient } from "./client.js";
+import { ConfigError, loadConfig } from "./config.js";
+import { createServer } from "./server.js";
+
+async function main(): Promise<void> {
+  let config;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      process.stderr.write(`multica-mcp: ${err.message}\n`);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  const client = new MulticaClient(config);
+  const { server, tools } = createServer({ client });
+
+  process.stderr.write(
+    `multica-mcp: starting (api=${config.apiUrl}, workspace=${config.defaultWorkspaceId ?? "<unset>"}, tools=${tools.length})\n`,
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Stay alive until the parent closes stdio. The transport handles the
+  // shutdown signal; we just keep the event loop pinned.
+  process.on("SIGINT", () => process.exit(0));
+  process.on("SIGTERM", () => process.exit(0));
+}
+
+main().catch((err) => {
+  process.stderr.write(`multica-mcp: fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,184 @@
+// MCP server wiring. Builds the `Server` instance, registers every tool
+// from `tools/index.ts`, and dispatches CallTool requests by name. Pure
+// orchestration — the actual API logic lives in each tool module.
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import type { MulticaClient } from "./client.js";
+import type { RegisteredTool, ToolContext } from "./tool.js";
+import { allTools } from "./tools/index.js";
+
+export interface CreateServerOptions {
+  client: MulticaClient;
+  /** Override the tool registry — useful for tests that want to inject one fake tool. */
+  tools?: RegisteredTool[];
+}
+
+const SERVER_NAME = "multica";
+// Hard-coded version string. Bumped manually with each release; keep in
+// sync with package.json.
+const SERVER_VERSION = "0.1.0";
+
+export function createServer(opts: CreateServerOptions): {
+  server: Server;
+  tools: RegisteredTool[];
+} {
+  const tools = opts.tools ?? allTools;
+  // Quick duplicate-name guard. A typo here would let later tools shadow
+  // earlier ones silently and we'd ship a broken server.
+  const seen = new Set<string>();
+  for (const t of tools) {
+    if (seen.has(t.name)) {
+      throw new Error(`Duplicate MCP tool name: ${t.name}`);
+    }
+    seen.add(t.name);
+  }
+
+  const ctx: ToolContext = { client: opts.client };
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: {} } },
+  );
+
+  // List: stable order matches `tools` so the picker UI doesn't shuffle
+  // between sessions. Each tool's input schema is converted from zod to
+  // JSON schema via `zodToJsonSchema` shimmed below — the SDK accepts a
+  // raw JSON schema object.
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: tools.map((t) => ({
+        name: t.name,
+        title: t.title ?? t.name,
+        description: t.description,
+        inputSchema: zodToJsonSchema(t.inputSchema),
+      })),
+    };
+  });
+
+  // Call: lookup → validate input → run handler → serialize result.
+  // Errors thrown by handlers (network, ApiError, validation) are
+  // converted to an MCP error content block so the model can recover
+  // instead of crashing the whole session.
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const tool = tools.find((t) => t.name === req.params.name);
+    if (!tool) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }],
+      };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = tool.inputSchema.parse(req.params.arguments ?? {});
+    } catch (err) {
+      const detail = err instanceof z.ZodError ? formatZodIssues(err) : String(err);
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Invalid input for ${tool.name}: ${detail}` }],
+      };
+    }
+
+    try {
+      const result = await tool.handler(parsed, ctx);
+      return {
+        content: [{ type: "text", text: serialize(result) }],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        isError: true,
+        content: [{ type: "text", text: message }],
+      };
+    }
+  });
+
+  return { server, tools };
+}
+
+function serialize(value: unknown): string {
+  if (typeof value === "string") return value;
+  // Pretty-print so the model can read structure when it inspects raw
+  // tool results in long conversation transcripts.
+  return JSON.stringify(value, null, 2);
+}
+
+function formatZodIssues(err: z.ZodError): string {
+  return err.issues
+    .map((i) => `${i.path.length ? i.path.join(".") + ": " : ""}${i.message}`)
+    .join("; ");
+}
+
+// The MCP SDK accepts JSON Schema objects directly. Zod 3 ships a
+// `toJSONSchema`-style helper as a separate package, but to avoid the
+// extra dependency we walk a minimal subset of zod types we actually
+// use (object / string / number / boolean / array / enum / optional /
+// nullable). For everything else we fall through to `{ type: "object" }`
+// so the SDK doesn't choke; the handler still validates with the real
+// zod schema before running.
+function zodToJsonSchema(schema: z.ZodTypeAny): Record<string, unknown> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const def = (schema as any)._def;
+  if (!def) return { type: "object" };
+
+  const typeName = def.typeName as string;
+  switch (typeName) {
+    case "ZodObject": {
+      const shape = def.shape() as Record<string, z.ZodTypeAny>;
+      const properties: Record<string, unknown> = {};
+      const required: string[] = [];
+      for (const [key, child] of Object.entries(shape)) {
+        properties[key] = zodToJsonSchema(child);
+        if (!isOptional(child)) required.push(key);
+      }
+      const out: Record<string, unknown> = {
+        type: "object",
+        properties,
+      };
+      if (required.length > 0) out.required = required;
+      const description = (schema as { description?: string }).description;
+      if (description) out.description = description;
+      return out;
+    }
+    case "ZodString": {
+      const out: Record<string, unknown> = { type: "string" };
+      const description = (schema as { description?: string }).description;
+      if (description) out.description = description;
+      return out;
+    }
+    case "ZodNumber":
+      return { type: "number" };
+    case "ZodBoolean":
+      return { type: "boolean" };
+    case "ZodArray":
+      return { type: "array", items: zodToJsonSchema(def.type) };
+    case "ZodEnum":
+      return { type: "string", enum: def.values };
+    case "ZodLiteral":
+      return { const: def.value };
+    case "ZodOptional":
+    case "ZodNullable":
+    case "ZodDefault":
+      return zodToJsonSchema(def.innerType);
+    case "ZodUnion": {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const options = def.options as any[];
+      return { anyOf: options.map((o: z.ZodTypeAny) => zodToJsonSchema(o)) };
+    }
+    case "ZodRecord":
+      return { type: "object", additionalProperties: zodToJsonSchema(def.valueType) };
+    default:
+      return { type: "object" };
+  }
+}
+
+function isOptional(schema: z.ZodTypeAny): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const typeName = (schema as any)._def?.typeName;
+  return typeName === "ZodOptional" || typeName === "ZodDefault";
+}

--- a/packages/mcp/src/test/client.test.ts
+++ b/packages/mcp/src/test/client.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, MulticaClient } from "../client.js";
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function mockFetch(handler: (req: CapturedRequest) => Response | Promise<Response>) {
+  const captured: CapturedRequest[] = [];
+  const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
+    const req = { url, init };
+    captured.push(req);
+    return handler(req);
+  });
+  vi.stubGlobal("fetch", fetchSpy);
+  return { captured };
+}
+
+const baseConfig = {
+  apiUrl: "https://api.example.com",
+  token: "mul_test",
+  defaultWorkspaceId: "ws-1",
+};
+
+describe("MulticaClient", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends Authorization + X-Workspace-ID by default and parses JSON responses", async () => {
+    const { captured } = mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const client = new MulticaClient(baseConfig);
+
+    const result = await client.get<{ ok: boolean }>("/api/foo");
+
+    expect(result).toEqual({ ok: true });
+    expect(captured).toHaveLength(1);
+    const headers = captured[0]!.init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer mul_test");
+    expect(headers["X-Workspace-ID"]).toBe("ws-1");
+    expect(captured[0]!.url).toBe("https://api.example.com/api/foo");
+  });
+
+  it("merges query params into the URL", async () => {
+    const { captured } = mockFetch(() => new Response("[]", { status: 200 }));
+    const client = new MulticaClient(baseConfig);
+
+    await client.get("/api/issues", { query: { limit: 10, status: "todo", skip: undefined } });
+
+    const url = new URL(captured[0]!.url);
+    expect(url.pathname).toBe("/api/issues");
+    expect(url.searchParams.get("limit")).toBe("10");
+    expect(url.searchParams.get("status")).toBe("todo");
+    expect(url.searchParams.has("skip")).toBe(false);
+  });
+
+  it("includes JSON body and Content-Type on POST", async () => {
+    const { captured } = mockFetch(() => new Response("{}", { status: 200 }));
+    const client = new MulticaClient(baseConfig);
+
+    await client.post("/api/issues", { title: "Hello" });
+
+    expect(captured[0]!.init.method).toBe("POST");
+    const headers = captured[0]!.init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(captured[0]!.init.body).toBe(JSON.stringify({ title: "Hello" }));
+  });
+
+  it("returns null on 204 No Content", async () => {
+    mockFetch(() => new Response(null, { status: 204 }));
+    const client = new MulticaClient(baseConfig);
+    await expect(client.delete("/api/issues/x")).resolves.toBeNull();
+  });
+
+  it("wraps non-2xx responses in ApiError with the body attached", async () => {
+    mockFetch(
+      () => new Response(JSON.stringify({ error: "not found" }), { status: 404 }),
+    );
+    const client = new MulticaClient(baseConfig);
+    await expect(client.get("/api/issues/missing")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 404,
+      body: { error: "not found" },
+    });
+  });
+
+  it("preserves raw text bodies that aren't JSON", async () => {
+    mockFetch(() => new Response("plain string", { status: 500 }));
+    const client = new MulticaClient(baseConfig);
+    try {
+      await client.get("/api/oops");
+      throw new Error("expected ApiError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const e = err as ApiError;
+      expect(e.status).toBe(500);
+      expect(e.body).toBe("plain string");
+    }
+  });
+
+  it("respects per-call workspace override", async () => {
+    const { captured } = mockFetch(() => new Response("{}", { status: 200 }));
+    const client = new MulticaClient(baseConfig);
+
+    await client.get("/api/foo", { workspaceId: "ws-2" });
+    const headers = captured[0]!.init.headers as Record<string, string>;
+    expect(headers["X-Workspace-ID"]).toBe("ws-2");
+  });
+
+  it("omits X-Workspace-ID when caller passes null and no default is set", async () => {
+    const { captured } = mockFetch(() => new Response("{}", { status: 200 }));
+    const client = new MulticaClient({ ...baseConfig, defaultWorkspaceId: null });
+
+    await client.get("/api/foo", { workspaceId: null });
+    const headers = captured[0]!.init.headers as Record<string, string>;
+    expect(headers["X-Workspace-ID"]).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/test/config.test.ts
+++ b/packages/mcp/src/test/config.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { ConfigError, deriveHttpBase, loadConfig } from "../config.js";
+
+describe("deriveHttpBase", () => {
+  it("converts wss:// to https:// and strips /ws suffix", () => {
+    expect(deriveHttpBase("wss://api.example.com/ws")).toBe("https://api.example.com");
+  });
+  it("converts ws:// to http:// and strips /ws/ suffix", () => {
+    expect(deriveHttpBase("ws://localhost:8080/ws/")).toBe("http://localhost:8080");
+  });
+  it("leaves plain https:// alone", () => {
+    expect(deriveHttpBase("https://api.example.com")).toBe("https://api.example.com");
+  });
+  it("returns null for empty / undefined input", () => {
+    expect(deriveHttpBase(undefined)).toBeNull();
+    expect(deriveHttpBase("")).toBeNull();
+    expect(deriveHttpBase("   ")).toBeNull();
+  });
+});
+
+describe("loadConfig", () => {
+  it("reads env vars when present", () => {
+    const cfg = loadConfig({
+      env: {
+        MULTICA_API_URL: "https://api.example.com/",
+        MULTICA_TOKEN: "mul_test",
+        MULTICA_WORKSPACE_ID: "ws-1",
+      },
+      cliConfigPath: "/nonexistent/path/config.json",
+    });
+    expect(cfg).toEqual({
+      apiUrl: "https://api.example.com",
+      token: "mul_test",
+      defaultWorkspaceId: "ws-1",
+    });
+  });
+
+  it("falls back to ~/.multica/config.json when env is empty", () => {
+    const dir = mkdtempSync(join(tmpdir(), "multica-mcp-test-"));
+    const path = join(dir, "config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        server_url: "wss://api.example.com/ws",
+        token: "mul_cli",
+        workspace_id: "ws-cli",
+      }),
+    );
+    try {
+      const cfg = loadConfig({ env: {}, cliConfigPath: path });
+      expect(cfg).toEqual({
+        apiUrl: "https://api.example.com",
+        token: "mul_cli",
+        defaultWorkspaceId: "ws-cli",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("env wins over CLI config when both are set", () => {
+    const dir = mkdtempSync(join(tmpdir(), "multica-mcp-test-"));
+    const path = join(dir, "config.json");
+    writeFileSync(
+      path,
+      JSON.stringify({ token: "from_cli", workspace_id: "ws-cli", server_url: "wss://cli.example/ws" }),
+    );
+    try {
+      const cfg = loadConfig({
+        env: { MULTICA_API_URL: "https://env.example", MULTICA_TOKEN: "from_env" },
+        cliConfigPath: path,
+      });
+      expect(cfg.apiUrl).toBe("https://env.example");
+      expect(cfg.token).toBe("from_env");
+      // Workspace falls back since env didn't set one.
+      expect(cfg.defaultWorkspaceId).toBe("ws-cli");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws ConfigError when no token is available anywhere", () => {
+    expect(() =>
+      loadConfig({
+        env: { MULTICA_API_URL: "https://api.example.com" },
+        cliConfigPath: "/nonexistent/config.json",
+      }),
+    ).toThrow(ConfigError);
+  });
+
+  it("throws ConfigError when no API URL is available anywhere", () => {
+    expect(() =>
+      loadConfig({
+        env: { MULTICA_TOKEN: "mul_test" },
+        cliConfigPath: "/nonexistent/config.json",
+      }),
+    ).toThrow(ConfigError);
+  });
+
+  it("ignores a malformed CLI config without crashing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "multica-mcp-test-"));
+    const path = join(dir, "config.json");
+    writeFileSync(path, "{ this is : not json");
+    try {
+      // Should fall through to env-based loading.
+      const cfg = loadConfig({
+        env: { MULTICA_API_URL: "https://api.example.com", MULTICA_TOKEN: "mul_env" },
+        cliConfigPath: path,
+      });
+      expect(cfg.apiUrl).toBe("https://api.example.com");
+      expect(cfg.token).toBe("mul_env");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mcp/src/test/tools.test.ts
+++ b/packages/mcp/src/test/tools.test.ts
@@ -1,0 +1,157 @@
+// Sanity-level coverage for the tool registry. We're deliberately not
+// testing every handler against a mock server (that's mostly testing
+// the HTTP client which has its own suite); instead we assert the
+// registry contract and that a few representative tools forward
+// arguments to the right endpoint with the right shape.
+
+import { describe, expect, it, vi } from "vitest";
+import { allTools } from "../tools/index.js";
+import type { MulticaClient } from "../client.js";
+import type { ToolContext } from "../tool.js";
+import {
+  issueCreateTool,
+  issueListTool,
+  issueStatusTool,
+} from "../tools/issues.js";
+import { channelHistoryTool } from "../tools/channels.js";
+
+function fakeClient(): { client: MulticaClient; calls: { method: string; path: string; body?: unknown; opts?: unknown }[] } {
+  const calls: { method: string; path: string; body?: unknown; opts?: unknown }[] = [];
+  const client = {
+    apiUrl: "https://api.example",
+    defaultWorkspaceId: "ws-1",
+    get: vi.fn(async (path: string, opts?: unknown) => {
+      calls.push({ method: "GET", path, opts });
+      return { stub: "get" };
+    }),
+    post: vi.fn(async (path: string, body: unknown, opts?: unknown) => {
+      calls.push({ method: "POST", path, body, opts });
+      return { stub: "post" };
+    }),
+    patch: vi.fn(async (path: string, body: unknown, opts?: unknown) => {
+      calls.push({ method: "PATCH", path, body, opts });
+      return { stub: "patch" };
+    }),
+    delete: vi.fn(async (path: string, opts?: unknown) => {
+      calls.push({ method: "DELETE", path, opts });
+      return { stub: "delete" };
+    }),
+  } as unknown as MulticaClient;
+  return { client, calls };
+}
+
+describe("tool registry", () => {
+  it("has no duplicate tool names", () => {
+    const seen = new Set<string>();
+    for (const t of allTools) {
+      expect(seen.has(t.name), `duplicate tool name: ${t.name}`).toBe(false);
+      seen.add(t.name);
+    }
+  });
+
+  it("every tool name uses the multica_ prefix", () => {
+    for (const t of allTools) {
+      expect(t.name.startsWith("multica_")).toBe(true);
+    }
+  });
+
+  it("every tool has a non-empty description and an inputSchema", () => {
+    for (const t of allTools) {
+      expect(t.description.length).toBeGreaterThan(10);
+      expect(t.inputSchema).toBeDefined();
+    }
+  });
+});
+
+describe("representative handlers", () => {
+  it("issueListTool forwards filters as query params", async () => {
+    const { client, calls } = fakeClient();
+    const ctx: ToolContext = { client };
+    await issueListTool.handler(
+      { status: "todo", priority: "high", limit: 25 },
+      ctx,
+    );
+    expect(calls).toEqual([
+      {
+        method: "GET",
+        path: "/api/issues",
+        opts: {
+          query: {
+            status: "todo",
+            priority: "high",
+            assignee: undefined,
+            project: undefined,
+            limit: 25,
+            offset: undefined,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("issueCreateTool POSTs the canonical create payload", async () => {
+    const { client, calls } = fakeClient();
+    const ctx: ToolContext = { client };
+    await issueCreateTool.handler(
+      { title: "Hello", description: "world" },
+      ctx,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.path).toBe("/api/issues");
+    expect(calls[0]!.body).toEqual({
+      title: "Hello",
+      description: "world",
+      status: "todo",
+      priority: "none",
+      assignee_type: null,
+      assignee_id: null,
+      parent_issue_id: null,
+      project_id: null,
+      due_date: null,
+    });
+  });
+
+  it("issueStatusTool URL-encodes the id", async () => {
+    const { client, calls } = fakeClient();
+    const ctx: ToolContext = { client };
+    await issueStatusTool.handler({ id: "MUL-123", status: "in_progress" }, ctx);
+    expect(calls[0]!.method).toBe("PATCH");
+    expect(calls[0]!.path).toBe("/api/issues/MUL-123");
+    expect(calls[0]!.body).toEqual({ status: "in_progress" });
+  });
+
+  it("channelHistoryTool passes pagination params through", async () => {
+    const { client, calls } = fakeClient();
+    const ctx: ToolContext = { client };
+    await channelHistoryTool.handler(
+      {
+        channel_id: "11111111-2222-3333-4444-555555555555",
+        limit: 100,
+        before: "2026-04-30T12:00:00Z",
+        include_threaded: true,
+      },
+      ctx,
+    );
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.path).toBe(
+      "/api/channels/11111111-2222-3333-4444-555555555555/messages",
+    );
+    expect(calls[0]!.opts).toEqual({
+      query: {
+        limit: 100,
+        before: "2026-04-30T12:00:00Z",
+        include_threaded: true,
+      },
+    });
+  });
+
+  it("rejects malformed input via the inputSchema", () => {
+    expect(() =>
+      issueCreateTool.inputSchema.parse({ title: "" }),
+    ).toThrow();
+    expect(() =>
+      channelHistoryTool.inputSchema.parse({ channel_id: "not-a-uuid" }),
+    ).toThrow();
+  });
+});

--- a/packages/mcp/src/tool.ts
+++ b/packages/mcp/src/tool.ts
@@ -1,0 +1,59 @@
+// Internal tool registration shape. Each `tools/*.ts` module exports an
+// array of `RegisteredTool` objects via `defineTool({…})`; the server
+// collects them all and dispatches CallTool requests by name.
+//
+// The shape is split into two layers:
+//
+//   - `ToolDefinition<TInput>` — the *authored* shape, generic over the
+//     input zod schema so handlers get statically-typed `input` from
+//     `z.infer<TInput>`. Used inside `defineTool`.
+//   - `RegisteredTool` — the *registry* shape, with the schema typed as
+//     plain `ZodTypeAny` and the handler as `(unknown, ctx) => …`. This
+//     is what the server iterates so an array of tools-with-different-
+//     schemas unifies cleanly into one collection.
+//
+// `defineTool` is the bridge: callers write strongly-typed handlers; the
+// returned value is erased to `RegisteredTool` so the registry can hold
+// a heterogeneous list without type-variance complaints. The server
+// re-validates input against the schema before invoking the handler, so
+// erasing the type here is safe at runtime.
+
+import type { z } from "zod";
+import type { MulticaClient } from "./client.js";
+
+export interface ToolContext {
+  client: MulticaClient;
+}
+
+export interface ToolDefinition<TInput extends z.ZodTypeAny> {
+  /** Tool name as exposed to the model. Convention: `multica_<resource>_<verb>`. */
+  name: string;
+  /** Short description shown in the tool picker. ~1–2 sentences max. */
+  title?: string;
+  /** Long-form description used by the model to decide when to call this tool. */
+  description: string;
+  /** Zod schema for input validation. The MCP SDK converts this to JSON schema. */
+  inputSchema: TInput;
+  /** Handler — return a JSON-serializable value. The server wraps the response into MCP `content`. */
+  handler: (input: z.infer<TInput>, ctx: ToolContext) => Promise<unknown>;
+}
+
+export interface RegisteredTool {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema: z.ZodTypeAny;
+  handler: (input: unknown, ctx: ToolContext) => Promise<unknown>;
+}
+
+/**
+ * Promotes a strongly-typed `ToolDefinition` into the registry shape.
+ * The cast is sound because the server validates input against the same
+ * `inputSchema` before calling `handler` — by the time the handler runs,
+ * `input` matches `z.infer<TInput>` even though we lost the type.
+ */
+export function defineTool<TInput extends z.ZodTypeAny>(
+  def: ToolDefinition<TInput>,
+): RegisteredTool {
+  return def as unknown as RegisteredTool;
+}

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -1,0 +1,56 @@
+// Agent tools — read-only surface for picking the right agent to assign
+// or @-mention. Mutating operations (create / archive / set skills) are
+// intentionally not exposed: agent configuration changes ripple into
+// task dispatch and shouldn't happen from a chat-side LLM by default.
+
+import { z } from "zod";
+import { defineTool } from "../tool.js";
+
+export const agentListTool = defineTool({
+  name: "multica_agent_list",
+  title: "List agents",
+  description:
+    "Return agents in the workspace (id, name, description, runtime status, archived). Use to find the right agent before creating or assigning an issue.",
+  inputSchema: z.object({
+    include_archived: z
+      .boolean()
+      .optional()
+      .describe("Include archived agents. Default false."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get("/api/agents", {
+      query: { include_archived: input.include_archived },
+    });
+  },
+});
+
+export const agentGetTool = defineTool({
+  name: "multica_agent_get",
+  title: "Get agent",
+  description:
+    "Fetch full details for one agent (instructions, skills, runtime, custom env). Use to verify an agent is reachable before assigning to it.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/agents/${input.id}`);
+  },
+});
+
+export const agentTasksTool = defineTool({
+  name: "multica_agent_tasks",
+  title: "List agent's recent tasks",
+  description:
+    "Return the most recent tasks dispatched to an agent (status, issue, started_at, completed_at). Useful to check whether the agent is currently busy.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+    limit: z.number().int().min(1).max(100).optional().describe("Default 20."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/agents/${input.id}/tasks`, {
+      query: { limit: input.limit },
+    });
+  },
+});
+
+export const agentTools = [agentListTool, agentGetTool, agentTasksTool];

--- a/packages/mcp/src/tools/autopilots.ts
+++ b/packages/mcp/src/tools/autopilots.ts
@@ -1,0 +1,71 @@
+// Autopilot tools — read-only. Triggering an autopilot run IS exposed
+// because that's the high-leverage chat-side workflow ("kick off the
+// nightly cleanup"); creating new autopilots / triggers is left for the
+// UI where the form-driven wizard makes the contract obvious.
+
+import { z } from "zod";
+import { defineTool } from "../tool.js";
+
+export const autopilotListTool = defineTool({
+  name: "multica_autopilot_list",
+  title: "List autopilots",
+  description:
+    "Return autopilots in the workspace (id, title, status, agent, source). Use to find an autopilot before triggering or inspecting runs.",
+  inputSchema: z.object({}),
+  handler: async (_input, ctx) => {
+    return ctx.client.get("/api/autopilots");
+  },
+});
+
+export const autopilotGetTool = defineTool({
+  name: "multica_autopilot_get",
+  title: "Get autopilot",
+  description: "Full autopilot details including triggers and instructions.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/autopilots/${input.id}`);
+  },
+});
+
+export const autopilotRunsTool = defineTool({
+  name: "multica_autopilot_runs",
+  title: "List autopilot runs",
+  description: "Recent execution history for an autopilot (status, started, completed, error).",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+    limit: z.number().int().min(1).max(100).optional().describe("Default 20."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/autopilots/${input.id}/runs`, {
+      query: { limit: input.limit },
+    });
+  },
+});
+
+export const autopilotTriggerTool = defineTool({
+  name: "multica_autopilot_trigger",
+  title: "Trigger autopilot run",
+  description:
+    "Manually start an autopilot run. Optional payload is forwarded to the agent as the run's trigger context.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+    payload: z
+      .record(z.unknown())
+      .optional()
+      .describe("Free-form JSON payload available to the agent during the run."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post(`/api/autopilots/${input.id}/trigger`, {
+      payload: input.payload ?? null,
+    });
+  },
+});
+
+export const autopilotTools = [
+  autopilotListTool,
+  autopilotGetTool,
+  autopilotRunsTool,
+  autopilotTriggerTool,
+];

--- a/packages/mcp/src/tools/channels.ts
+++ b/packages/mcp/src/tools/channels.ts
@@ -1,0 +1,128 @@
+// Channels tools — read + post for the multi-participant chat surface.
+// Posting a message that @-mentions an agent (or in a DM with an agent)
+// dispatches a task on the server, so the LLM can use this surface to
+// chat with agents in addition to the issue board.
+
+import { z } from "zod";
+import { defineTool } from "../tool.js";
+
+export const channelListTool = defineTool({
+  name: "multica_channel_list",
+  title: "List channels",
+  description:
+    "Return channels and DMs the active actor belongs to, including per-channel unread counts. Use before posting to look up channel ids.",
+  inputSchema: z.object({}),
+  handler: async (_input, ctx) => {
+    return ctx.client.get("/api/channels");
+  },
+});
+
+export const channelGetTool = defineTool({
+  name: "multica_channel_get",
+  title: "Get channel",
+  description: "Return one channel's metadata by id.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/channels/${input.id}`);
+  },
+});
+
+export const channelHistoryTool = defineTool({
+  name: "multica_channel_history",
+  title: "List channel messages",
+  description:
+    "Return messages in a channel, newest first, paginated by created_at. Use the oldest 'created_at' you've already seen as 'before' to fetch the next older page.",
+  inputSchema: z.object({
+    channel_id: z.string().uuid(),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Default 50, capped at 200."),
+    before: z
+      .string()
+      .optional()
+      .describe(
+        "RFC3339 timestamp; only messages strictly older are returned. Pass the oldest 'created_at' from a prior page to paginate.",
+      ),
+    include_threaded: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include thread replies inline. Default false — top-level only.",
+      ),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/channels/${input.channel_id}/messages`, {
+      query: {
+        limit: input.limit,
+        before: input.before,
+        include_threaded: input.include_threaded,
+      },
+    });
+  },
+});
+
+export const channelPostTool = defineTool({
+  name: "multica_channel_post",
+  title: "Post a channel message",
+  description:
+    "Post a message to a channel. To @-mention an agent (which dispatches a task to it), include the canonical mention markup: '[@AgentName](mention://agent/<agent-uuid>)'. In a DM with an agent, every member message implicitly addresses the agent — no @mention required.",
+  inputSchema: z.object({
+    channel_id: z.string().uuid(),
+    content: z.string().min(1),
+    parent_message_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("Reply in a thread instead of the main timeline."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post(`/api/channels/${input.channel_id}/messages`, {
+      content: input.content,
+      parent_message_id: input.parent_message_id ?? null,
+    });
+  },
+});
+
+export const channelMembersTool = defineTool({
+  name: "multica_channel_members",
+  title: "List channel members",
+  description:
+    "Return the channel's member list (members + agents). Use to verify an agent is in a channel before @-mentioning it (mentions of non-members render but don't dispatch tasks).",
+  inputSchema: z.object({
+    channel_id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/channels/${input.channel_id}/members`);
+  },
+});
+
+export const channelMarkReadTool = defineTool({
+  name: "multica_channel_mark_read",
+  title: "Mark channel as read",
+  description:
+    "Update the read cursor for the active actor up to the given message id. Clears the unread badge.",
+  inputSchema: z.object({
+    channel_id: z.string().uuid(),
+    message_id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post(`/api/channels/${input.channel_id}/read`, {
+      message_id: input.message_id,
+    });
+  },
+});
+
+export const channelTools = [
+  channelListTool,
+  channelGetTool,
+  channelHistoryTool,
+  channelPostTool,
+  channelMembersTool,
+  channelMarkReadTool,
+];

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -1,0 +1,23 @@
+// Aggregated tool registry. Order here is the order the MCP picker
+// shows tools to the model — front-load the high-leverage ones (issues,
+// channels, agents) and put admin/configuration further down so the
+// orchestration surface is the first thing the model sees.
+
+import type { RegisteredTool } from "../tool.js";
+import { workspaceTools } from "./workspace.js";
+import { issueTools } from "./issues.js";
+import { agentTools } from "./agents.js";
+import { channelTools } from "./channels.js";
+import { projectTools } from "./projects.js";
+import { labelTools } from "./labels.js";
+import { autopilotTools } from "./autopilots.js";
+
+export const allTools: RegisteredTool[] = [
+  ...issueTools,
+  ...agentTools,
+  ...channelTools,
+  ...projectTools,
+  ...labelTools,
+  ...autopilotTools,
+  ...workspaceTools,
+];

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -11,12 +11,14 @@ import { channelTools } from "./channels.js";
 import { projectTools } from "./projects.js";
 import { labelTools } from "./labels.js";
 import { autopilotTools } from "./autopilots.js";
+import { memoryTools } from "./memory.js";
 
 export const allTools: RegisteredTool[] = [
   ...issueTools,
   ...agentTools,
   ...channelTools,
   ...projectTools,
+  ...memoryTools,
   ...labelTools,
   ...autopilotTools,
   ...workspaceTools,

--- a/packages/mcp/src/tools/issues.ts
+++ b/packages/mcp/src/tools/issues.ts
@@ -1,0 +1,255 @@
+// Issue lifecycle tools. The high-leverage surface for orchestrating
+// agent work from chat: create → assign to an agent → check progress →
+// post comments. Pagination params follow the server's conventions
+// (limit/offset, default 50, capped at 200 by the handler).
+
+import { z } from "zod";
+import { defineTool } from "../tool.js";
+
+const statusEnum = z
+  .enum([
+    "todo",
+    "in_progress",
+    "in_review",
+    "done",
+    "blocked",
+    "backlog",
+    "cancelled",
+  ])
+  .describe("Issue status. Default for new issues is 'todo'.");
+
+const priorityEnum = z
+  .enum(["urgent", "high", "medium", "low", "none"])
+  .describe("Issue priority. Use 'none' (or omit) for no priority.");
+
+const assigneeTypeEnum = z
+  .enum(["member", "agent"])
+  .describe("'member' for a human, 'agent' for an AI agent.");
+
+export const issueListTool = defineTool({
+  name: "multica_issue_list",
+  title: "List issues",
+  description:
+    "List issues in the active workspace with optional filters. Use small limits (e.g. 20) when scanning so the response stays under a few KB.",
+  inputSchema: z.object({
+    status: statusEnum.optional(),
+    priority: priorityEnum.optional(),
+    assignee_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("Filter by assignee (member OR agent UUID)."),
+    project_id: z.string().uuid().optional(),
+    limit: z.number().int().min(1).max(200).optional().describe("Default 50."),
+    offset: z.number().int().min(0).optional(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get("/api/issues", {
+      query: {
+        status: input.status,
+        priority: input.priority,
+        assignee: input.assignee_id,
+        project: input.project_id,
+        limit: input.limit,
+        offset: input.offset,
+      },
+    });
+  },
+});
+
+export const issueSearchTool = defineTool({
+  name: "multica_issue_search",
+  title: "Search issues",
+  description:
+    "Full-text search across issues by title, description, and identifier (e.g. 'MUL-123'). Returns the top matches.",
+  inputSchema: z.object({
+    q: z.string().min(1).describe("Free-text query."),
+    limit: z.number().int().min(1).max(50).optional().describe("Default 10."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get("/api/issues/search", {
+      query: { q: input.q, limit: input.limit },
+    });
+  },
+});
+
+export const issueGetTool = defineTool({
+  name: "multica_issue_get",
+  title: "Get issue",
+  description:
+    "Fetch full issue details by UUID or human identifier (e.g. 'MUL-123'). Includes title, description, status, priority, assignee, project, parent, due date.",
+  inputSchema: z.object({
+    id: z.string().min(1).describe("Issue UUID or 'PREFIX-NNN' identifier."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/issues/${encodeURIComponent(input.id)}`);
+  },
+});
+
+export const issueCreateTool = defineTool({
+  name: "multica_issue_create",
+  title: "Create issue",
+  description:
+    "Create a new issue. Title is required; everything else is optional. Pass 'assignee_type'+'assignee_id' to assign at creation (most common: assign to an agent so it picks up immediately).",
+  inputSchema: z.object({
+    title: z.string().min(1),
+    description: z.string().optional(),
+    status: statusEnum.optional(),
+    priority: priorityEnum.optional(),
+    assignee_type: assigneeTypeEnum.optional(),
+    assignee_id: z.string().uuid().optional(),
+    parent_issue_id: z.string().uuid().optional(),
+    project_id: z.string().uuid().optional(),
+    due_date: z
+      .string()
+      .optional()
+      .describe("RFC3339 timestamp, e.g. '2026-12-31T00:00:00Z'."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post("/api/issues", {
+      title: input.title,
+      description: input.description ?? null,
+      status: input.status ?? "todo",
+      priority: input.priority ?? "none",
+      assignee_type: input.assignee_type ?? null,
+      assignee_id: input.assignee_id ?? null,
+      parent_issue_id: input.parent_issue_id ?? null,
+      project_id: input.project_id ?? null,
+      due_date: input.due_date ?? null,
+    });
+  },
+});
+
+export const issueUpdateTool = defineTool({
+  name: "multica_issue_update",
+  title: "Update issue",
+  description:
+    "Patch one or more issue fields. Only fields you pass are updated. Use 'multica_issue_status' for the common status-only flip.",
+  inputSchema: z.object({
+    id: z.string().min(1),
+    title: z.string().optional(),
+    description: z.string().optional(),
+    status: statusEnum.optional(),
+    priority: priorityEnum.optional(),
+    assignee_type: assigneeTypeEnum.optional(),
+    assignee_id: z
+      .string()
+      .uuid()
+      .nullable()
+      .optional()
+      .describe("Pass null to unassign."),
+    parent_issue_id: z.string().uuid().nullable().optional(),
+    project_id: z.string().uuid().nullable().optional(),
+    due_date: z.string().nullable().optional(),
+  }),
+  handler: async (input, ctx) => {
+    const { id, ...rest } = input;
+    return ctx.client.patch(`/api/issues/${encodeURIComponent(id)}`, rest);
+  },
+});
+
+export const issueStatusTool = defineTool({
+  name: "multica_issue_status",
+  title: "Change issue status",
+  description: "Convenience wrapper for status-only updates.",
+  inputSchema: z.object({
+    id: z.string().min(1),
+    status: statusEnum,
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.patch(`/api/issues/${encodeURIComponent(input.id)}`, {
+      status: input.status,
+    });
+  },
+});
+
+export const issueAssignTool = defineTool({
+  name: "multica_issue_assign",
+  title: "Assign issue",
+  description:
+    "Assign an issue to a member or agent. Pass assignee_id=null to unassign. Assigning to an agent dispatches a task immediately if the agent has a runtime attached.",
+  inputSchema: z.object({
+    id: z.string().min(1),
+    assignee_type: assigneeTypeEnum.nullable(),
+    assignee_id: z.string().uuid().nullable(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.patch(`/api/issues/${encodeURIComponent(input.id)}`, {
+      assignee_type: input.assignee_type,
+      assignee_id: input.assignee_id,
+    });
+  },
+});
+
+export const issueCommentAddTool = defineTool({
+  name: "multica_issue_comment_add",
+  title: "Add issue comment",
+  description:
+    "Post a comment on an issue. Comments can @-mention agents to trigger them — see workspace agent list for valid IDs. Markdown is supported.",
+  inputSchema: z.object({
+    issue_id: z.string().min(1),
+    content: z.string().min(1),
+    parent_comment_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("Reply to an existing comment instead of starting a new thread."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post(
+      `/api/issues/${encodeURIComponent(input.issue_id)}/comments`,
+      {
+        content: input.content,
+        parent_id: input.parent_comment_id ?? null,
+      },
+    );
+  },
+});
+
+export const issueCommentListTool = defineTool({
+  name: "multica_issue_comment_list",
+  title: "List issue comments",
+  description:
+    "Return comments on an issue (oldest first, paginated). Includes author identity, content, and parent_id for threading.",
+  inputSchema: z.object({
+    issue_id: z.string().min(1),
+    limit: z.number().int().min(1).max(200).optional().describe("Default 50."),
+    offset: z.number().int().min(0).optional(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(
+      `/api/issues/${encodeURIComponent(input.issue_id)}/comments`,
+      {
+        query: { limit: input.limit, offset: input.offset },
+      },
+    );
+  },
+});
+
+export const issueRunsTool = defineTool({
+  name: "multica_issue_runs",
+  title: "List issue task runs",
+  description:
+    "Return all task runs for an issue (status, dispatched_at, completed_at, error). Use to check whether an assigned agent is making progress.",
+  inputSchema: z.object({
+    issue_id: z.string().min(1),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(
+      `/api/issues/${encodeURIComponent(input.issue_id)}/task-runs`,
+    );
+  },
+});
+
+export const issueTools = [
+  issueListTool,
+  issueSearchTool,
+  issueGetTool,
+  issueCreateTool,
+  issueUpdateTool,
+  issueStatusTool,
+  issueAssignTool,
+  issueCommentAddTool,
+  issueCommentListTool,
+  issueRunsTool,
+];

--- a/packages/mcp/src/tools/labels.ts
+++ b/packages/mcp/src/tools/labels.ts
@@ -1,0 +1,49 @@
+// Label tools — list + attach/detach on issues. Create/update isn't
+// exposed: label taxonomy is a deliberate workspace decision and chat-
+// driven creation tends to fragment categories.
+
+import { z } from "zod";
+import { defineTool } from "../tool.js";
+
+export const labelListTool = defineTool({
+  name: "multica_label_list",
+  title: "List labels",
+  description: "Return all labels in the active workspace (id, name, color).",
+  inputSchema: z.object({}),
+  handler: async (_input, ctx) => {
+    return ctx.client.get("/api/labels");
+  },
+});
+
+export const labelAttachTool = defineTool({
+  name: "multica_label_attach",
+  title: "Attach a label to an issue",
+  description: "Attach an existing label (by id) to an issue. No-op if already attached.",
+  inputSchema: z.object({
+    issue_id: z.string().min(1),
+    label_id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post(
+      `/api/issues/${encodeURIComponent(input.issue_id)}/labels`,
+      { label_id: input.label_id },
+    );
+  },
+});
+
+export const labelDetachTool = defineTool({
+  name: "multica_label_detach",
+  title: "Detach a label from an issue",
+  description: "Remove a label from an issue. No-op if it wasn't attached.",
+  inputSchema: z.object({
+    issue_id: z.string().min(1),
+    label_id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.delete(
+      `/api/issues/${encodeURIComponent(input.issue_id)}/labels/${input.label_id}`,
+    );
+  },
+});
+
+export const labelTools = [labelListTool, labelAttachTool, labelDetachTool];

--- a/packages/mcp/src/tools/memory.ts
+++ b/packages/mcp/src/tools/memory.ts
@@ -1,0 +1,207 @@
+// Memory tools — wiki pages, agent notes, runbooks, decisions. Polymorphic
+// over `kind` so one set of tools covers all four artifact types. Mirrors
+// the server-side surface in handler/memory_artifact.go and the agent CLI in
+// server/cmd/multica/cmd_memory.go.
+//
+// Read tools (list / get / search / by-anchor) are exposed unconditionally
+// — they're zero-side-effect. Write tools (create / update / archive) are
+// the agent-facing write loop: a chat-driven workflow can record a finding
+// or update a runbook step without dropping into the CLI. Hard delete is
+// intentionally not exposed; archive is the soft-delete path.
+
+import { z } from "zod";
+import { defineTool } from "../tool.js";
+
+const KIND = z.enum(["wiki_page", "agent_note", "runbook", "decision"]);
+const ANCHOR_TYPE = z.enum(["issue", "project", "agent", "channel"]);
+
+export const memoryListTool = defineTool({
+  name: "multica_memory_list",
+  title: "List memory artifacts",
+  description:
+    "List memory artifacts in the active workspace. Filter by kind and/or parent. Archived rows are hidden by default.",
+  inputSchema: z.object({
+    kind: KIND.optional(),
+    parent_id: z.string().uuid().optional(),
+    include_archived: z.boolean().optional(),
+    limit: z.number().int().min(1).max(200).optional(),
+    offset: z.number().int().min(0).optional(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get("/api/memory", {
+      query: {
+        kind: input.kind,
+        parent_id: input.parent_id,
+        include_archived: input.include_archived,
+        limit: input.limit,
+        offset: input.offset,
+      },
+    });
+  },
+});
+
+export const memoryGetTool = defineTool({
+  name: "multica_memory_get",
+  title: "Get memory artifact",
+  description: "Fetch a single memory artifact by id.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/memory/${input.id}`);
+  },
+});
+
+export const memoryByAnchorTool = defineTool({
+  name: "multica_memory_by_anchor",
+  title: "List memory artifacts by anchor",
+  description:
+    "Return all memory artifacts anchored to a specific issue / project / agent / channel. Useful for 'show me the runbooks for THIS issue' lookups.",
+  inputSchema: z.object({
+    anchor_type: ANCHOR_TYPE,
+    anchor_id: z.string().uuid(),
+    limit: z.number().int().min(1).max(200).optional(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(
+      `/api/memory/by-anchor/${input.anchor_type}/${input.anchor_id}`,
+      { query: { limit: input.limit } },
+    );
+  },
+});
+
+export const memorySearchTool = defineTool({
+  name: "multica_memory_search",
+  title: "Search memory artifacts",
+  description:
+    "Full-text search over memory artifact titles, content, and tags. Uses Postgres tsvector + websearch_to_tsquery, so user-friendly syntax (quoted phrases, OR, leading -) is supported.",
+  inputSchema: z.object({
+    q: z.string().min(1),
+    kind: KIND.optional(),
+    limit: z.number().int().min(1).max(200).optional(),
+    offset: z.number().int().min(0).optional(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get("/api/memory/search", {
+      query: {
+        q: input.q,
+        kind: input.kind,
+        limit: input.limit,
+        offset: input.offset,
+      },
+    });
+  },
+});
+
+export const memoryCreateTool = defineTool({
+  name: "multica_memory_create",
+  title: "Create memory artifact",
+  description:
+    "Create a new memory artifact. Use kind='agent_note' for findings/decisions/dead-ends produced during a task; 'runbook' for operational procedures; 'decision' for architectural records; 'wiki_page' for general knowledge. Anchor the artifact to an issue / project / agent / channel when it's about a specific thing — anchored artifacts are auto-injected into agent runtime context for that anchor.",
+  inputSchema: z.object({
+    kind: KIND,
+    title: z.string().min(1).max(500),
+    content: z.string(),
+    slug: z
+      .string()
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "slug must be lowercase-with-hyphens")
+      .optional()
+      .describe("Optional stable URL slug (lowercase, hyphenated). Defaults to none."),
+    parent_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("Optional parent artifact id, for hierarchical wiki structures."),
+    anchor_type: ANCHOR_TYPE.optional(),
+    anchor_id: z
+      .string()
+      .uuid()
+      .optional()
+      .describe(
+        "Required when anchor_type is set. The two fields must be provided together.",
+      ),
+    tags: z.array(z.string()).optional(),
+    always_inject_at_runtime: z
+      .boolean()
+      .optional()
+      .describe(
+        "Workspace-wide: when true and anchor is unset, the artifact is included in every agent task's runtime context. Use sparingly — there's a per-claim cap.",
+      ),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post("/api/memory", {
+      kind: input.kind,
+      title: input.title,
+      content: input.content,
+      slug: input.slug ?? null,
+      parent_id: input.parent_id ?? null,
+      anchor_type: input.anchor_type ?? null,
+      anchor_id: input.anchor_id ?? null,
+      tags: input.tags ?? [],
+      metadata: {},
+      always_inject_at_runtime: input.always_inject_at_runtime,
+    });
+  },
+});
+
+export const memoryUpdateTool = defineTool({
+  name: "multica_memory_update",
+  title: "Update memory artifact",
+  description:
+    "Partial update — only fields you pass are changed. Set anchor_type / anchor_id together to retarget; pass tags to replace the whole array. Cannot change kind (kind is set at creation time).",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+    title: z.string().min(1).max(500).optional(),
+    content: z.string().optional(),
+    slug: z.string().nullable().optional(),
+    parent_id: z.string().uuid().nullable().optional(),
+    anchor_type: ANCHOR_TYPE.nullable().optional(),
+    anchor_id: z.string().uuid().nullable().optional(),
+    tags: z.array(z.string()).optional(),
+    always_inject_at_runtime: z.boolean().optional(),
+  }),
+  handler: async (input, ctx) => {
+    const { id, ...patch } = input;
+    return ctx.client.put(`/api/memory/${id}`, patch);
+  },
+});
+
+export const memoryArchiveTool = defineTool({
+  name: "multica_memory_archive",
+  title: "Archive memory artifact",
+  description:
+    "Soft-delete an artifact. It stops appearing in default lists and runtime injection but stays queryable via include_archived=true. Reversible via multica_memory_restore.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post(`/api/memory/${input.id}/archive`, {});
+  },
+});
+
+export const memoryRestoreTool = defineTool({
+  name: "multica_memory_restore",
+  title: "Restore archived memory artifact",
+  description: "Undo a multica_memory_archive — clears archived_at / archived_by.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post(`/api/memory/${input.id}/restore`, {});
+  },
+});
+
+// Hard delete is intentionally NOT exposed via MCP. Archive is the soft-
+// delete path — a misbehaving model that calls archive can be undone via
+// restore. A misbehaving model that calls delete is unrecoverable.
+// Operators who need the hard-delete affordance can use the CLI or REST.
+export const memoryTools = [
+  memoryListTool,
+  memoryGetTool,
+  memoryByAnchorTool,
+  memorySearchTool,
+  memoryCreateTool,
+  memoryUpdateTool,
+  memoryArchiveTool,
+  memoryRestoreTool,
+];

--- a/packages/mcp/src/tools/projects.ts
+++ b/packages/mcp/src/tools/projects.ts
@@ -1,0 +1,77 @@
+// Project tools — read-mostly. Project creation IS exposed because
+// chat-driven workflows often want to spin up a "project" for a new
+// initiative; deletion / resource attachment isn't exposed by default
+// because they have wider blast radius.
+
+import { z } from "zod";
+import { defineTool } from "../tool.js";
+
+export const projectListTool = defineTool({
+  name: "multica_project_list",
+  title: "List projects",
+  description: "Return all projects in the active workspace (id, name, status, lead).",
+  inputSchema: z.object({}),
+  handler: async (_input, ctx) => {
+    return ctx.client.get("/api/projects");
+  },
+});
+
+export const projectGetTool = defineTool({
+  name: "multica_project_get",
+  title: "Get project",
+  description: "Fetch one project's metadata + attached resources.",
+  inputSchema: z.object({
+    id: z.string().uuid(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get(`/api/projects/${input.id}`);
+  },
+});
+
+export const projectSearchTool = defineTool({
+  name: "multica_project_search",
+  title: "Search projects",
+  description: "Fuzzy search projects by name. Useful when the user names a project loosely.",
+  inputSchema: z.object({
+    q: z.string().min(1),
+    limit: z.number().int().min(1).max(50).optional(),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.get("/api/projects/search", {
+      query: { q: input.q, limit: input.limit },
+    });
+  },
+});
+
+export const projectCreateTool = defineTool({
+  name: "multica_project_create",
+  title: "Create project",
+  description:
+    "Create a new project. Title is required; description, status, target_date are optional.",
+  inputSchema: z.object({
+    title: z.string().min(1),
+    description: z.string().optional(),
+    status: z
+      .enum(["backlog", "planned", "in_progress", "completed", "cancelled"])
+      .optional(),
+    target_date: z
+      .string()
+      .optional()
+      .describe("RFC3339 due date, e.g. '2026-12-31T00:00:00Z'."),
+  }),
+  handler: async (input, ctx) => {
+    return ctx.client.post("/api/projects", {
+      title: input.title,
+      description: input.description ?? null,
+      status: input.status ?? "backlog",
+      target_date: input.target_date ?? null,
+    });
+  },
+});
+
+export const projectTools = [
+  projectListTool,
+  projectGetTool,
+  projectSearchTool,
+  projectCreateTool,
+];

--- a/packages/mcp/src/tools/workspace.ts
+++ b/packages/mcp/src/tools/workspace.ts
@@ -1,0 +1,52 @@
+// Workspace + member tools. The "current workspace" is whichever the
+// MCP server was started against (env / config); tools that need a
+// different workspace can pass an explicit `workspace_id` override.
+
+import { z } from "zod";
+import { defineTool } from "../tool.js";
+
+const workspaceIdInput = z.object({
+  workspace_id: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      "Workspace UUID. Defaults to the workspace this MCP server was started against (MULTICA_WORKSPACE_ID).",
+    ),
+});
+
+export const workspaceGetTool = defineTool({
+  name: "multica_workspace_get",
+  title: "Get workspace details",
+  description:
+    "Return the active workspace's id, name, slug, issue prefix, and feature flags. Use as a sanity check before workspace-scoped operations.",
+  inputSchema: workspaceIdInput,
+  handler: async (input, ctx) => {
+    const wsId = input.workspace_id ?? ctx.client.defaultWorkspaceId;
+    if (!wsId) {
+      throw new Error(
+        "No workspace id available. Pass workspace_id explicitly or set MULTICA_WORKSPACE_ID.",
+      );
+    }
+    return ctx.client.get(`/api/workspaces/${wsId}`);
+  },
+});
+
+export const workspaceMembersTool = defineTool({
+  name: "multica_workspace_members",
+  title: "List workspace members",
+  description:
+    "Return the human members of the workspace (id, name, email, role). Use for assignee resolution when the user names someone.",
+  inputSchema: workspaceIdInput,
+  handler: async (input, ctx) => {
+    const wsId = input.workspace_id ?? ctx.client.defaultWorkspaceId;
+    if (!wsId) {
+      throw new Error(
+        "No workspace id available. Pass workspace_id explicitly or set MULTICA_WORKSPACE_ID.",
+      );
+    }
+    return ctx.client.get(`/api/workspaces/${wsId}/members`);
+  },
+});
+
+export const workspaceTools = [workspaceGetTool, workspaceMembersTool];

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@multica/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from "tsup";
+
+// Bundle everything into a single executable JS file. The shebang is
+// added so the published binary works under `npx` / direct exec, and
+// node20+ ESM is the only target — MCP clients that spawn this server
+// always have Node available.
+//
+// `noExternal` is critical: tsup's default behavior is to externalize
+// every package in `dependencies`, which produces a bundle full of
+// `import "@modelcontextprotocol/sdk/..."` lines that fail at runtime
+// when the binary is run outside the worktree's node_modules. We ship
+// the binary as a downloadable static asset (apps/web/public) and
+// users land it at ~/.local/bin/multica-mcp — there's no node_modules
+// next to it, so every npm dependency MUST be inlined.
+//
+// We list the deps explicitly rather than `noExternal: [/.*/]` so the
+// failure mode for adding a new dep is "cannot resolve at runtime"
+// (loud and immediate) rather than "silently bundles whatever node
+// built-ins exist" (subtle).
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  outDir: "dist",
+  target: "node20",
+  platform: "node",
+  bundle: true,
+  splitting: false,
+  clean: true,
+  sourcemap: true,
+  dts: false,
+  banner: { js: "#!/usr/bin/env node" },
+  // Node built-ins must NEVER be inlined.
+  external: [/^node:/],
+  // Force-bundle every npm dep so the output JS runs standalone.
+  noExternal: ["@modelcontextprotocol/sdk", "zod"],
+});

--- a/packages/views/settings/components/settings-page.tsx
+++ b/packages/views/settings/components/settings-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { User, Palette, Key, Settings, Users, FolderGit2, FlaskConical, Bell } from "lucide-react";
+import { User, Palette, Plug, Settings, Users, FolderGit2, FlaskConical, Bell } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@multica/ui/components/ui/tabs";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { AccountTab } from "./account-tab";
@@ -17,7 +17,7 @@ const accountTabs = [
   { value: "profile", label: "Profile", icon: User },
   { value: "appearance", label: "Appearance", icon: Palette },
   { value: "notifications", label: "Notifications", icon: Bell },
-  { value: "tokens", label: "API Tokens", icon: Key },
+  { value: "api", label: "API & MCP", icon: Plug },
 ];
 
 const workspaceTabs = [
@@ -84,7 +84,7 @@ export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
           <TabsContent value="profile"><AccountTab /></TabsContent>
           <TabsContent value="appearance"><AppearanceTab /></TabsContent>
           <TabsContent value="notifications"><NotificationsTab /></TabsContent>
-          <TabsContent value="tokens"><TokensTab /></TabsContent>
+          <TabsContent value="api"><TokensTab /></TabsContent>
           <TabsContent value="workspace"><WorkspaceTab /></TabsContent>
           <TabsContent value="repositories"><RepositoriesTab /></TabsContent>
           <TabsContent value="labs"><LabsTab /></TabsContent>

--- a/packages/views/settings/components/tokens-tab.tsx
+++ b/packages/views/settings/components/tokens-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
-import { Key, Trash2, Copy, Check } from "lucide-react";
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { Key, Trash2, Copy, Check, Plug, Sparkles, ExternalLink, Code2 } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import type { PersonalAccessToken } from "@multica/core/types";
 import { Input } from "@multica/ui/components/ui/input";
@@ -35,7 +35,21 @@ import {
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { useCurrentWorkspace } from "@multica/core/paths";
 
+/**
+ * "API & MCP" settings tab. Exposes three things:
+ *
+ * 1. Personal access tokens — same list/create/revoke flow that lived in
+ *    the old "API Tokens" tab.
+ * 2. Connection details — the API base URL and current workspace ID,
+ *    with one-click copy. These are the values users paste into env vars
+ *    (CLI, MCP, custom integrations).
+ * 3. MCP server setup — what the @multica/mcp server exposes plus
+ *    copy-paste config snippets for Claude Code and Claude Desktop, with
+ *    the workspace's actual API URL + workspace ID prefilled so users
+ *    don't have to hand-edit placeholders.
+ */
 export function TokensTab() {
   const [tokens, setTokens] = useState<PersonalAccessToken[]>([]);
   const [tokenName, setTokenName] = useState("");
@@ -46,6 +60,29 @@ export function TokensTab() {
   const [tokenRevoking, setTokenRevoking] = useState<string | null>(null);
   const [revokeConfirmId, setRevokeConfirmId] = useState<string | null>(null);
   const [tokensLoading, setTokensLoading] = useState(true);
+
+  const workspace = useCurrentWorkspace();
+  const apiBaseUrl = useMemo(() => {
+    // The web app builds with an empty `apiBaseUrl` because Next.js
+    // rewrites proxy /api/* to the backend on the same origin — no
+    // absolute URL is needed at runtime. For the settings panel we DO
+    // want to show users something real to paste into env vars, so we
+    // fall back to the page's own origin: requests to that host will
+    // hit the same Next.js rewrite path the in-app calls use, which
+    // means `MULTICA_API_URL=<frontend-origin>` works for the MCP
+    // server, the CLI, and any other client.
+    let fromClient = "";
+    try {
+      fromClient = api.getBaseUrl() ?? "";
+    } catch {
+      fromClient = "";
+    }
+    if (fromClient) return fromClient;
+    if (typeof window !== "undefined" && window.location?.origin) {
+      return window.location.origin;
+    }
+    return "";
+  }, []);
 
   const loadTokens = useCallback(async () => {
     try {
@@ -97,24 +134,32 @@ export function TokensTab() {
   };
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-10">
+      {/* ─── Section 1: Tokens ─────────────────────────────────────── */}
       <section className="space-y-4">
         <div className="flex items-center gap-2">
           <Key className="h-4 w-4 text-muted-foreground" />
-          <h2 className="text-sm font-semibold">API Tokens</h2>
+          <h2 className="text-sm font-semibold">Personal access tokens</h2>
         </div>
 
         <Card>
           <CardContent className="space-y-3">
             <p className="text-xs text-muted-foreground">
-              Personal access tokens allow the CLI and external integrations to authenticate with your account.
+              One token works for everything: the{" "}
+              <strong className="text-foreground">REST API</strong>, the{" "}
+              <strong className="text-foreground">MCP server</strong>, and
+              the <strong className="text-foreground">Multica CLI</strong>{" "}
+              all use the same personal access token. Pair the token with
+              the connection details below. Treat them like passwords —
+              they&apos;re shown once on creation and can&apos;t be retrieved
+              later.
             </p>
             <div className="grid gap-3 sm:grid-cols-[1fr_120px_auto]">
               <Input
                 type="text"
                 value={tokenName}
                 onChange={(e) => setTokenName(e.target.value)}
-                placeholder="Token name (e.g. My CLI)"
+                placeholder="Token name (e.g. MCP server)"
               />
               <Select value={tokenExpiry} onValueChange={(v) => { if (v) setTokenExpiry(v); }}>
                 <SelectTrigger size="sm"><SelectValue /></SelectTrigger>
@@ -181,6 +226,307 @@ export function TokensTab() {
         )}
       </section>
 
+      {/* ─── Section 2: Connection details ─────────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Plug className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">Connection details</h2>
+        </div>
+        <Card>
+          <CardContent className="space-y-4">
+            <p className="text-xs text-muted-foreground">
+              These are the values you&apos;ll plug into the CLI, the MCP
+              server, or any other client. Pair the values below with a
+              personal access token from the section above.
+            </p>
+            <CopyableField label="API base URL" value={apiBaseUrl || ""} envVar="MULTICA_API_URL" />
+            <CopyableField label="Workspace ID" value={workspace?.id ?? ""} envVar="MULTICA_WORKSPACE_ID" />
+            {workspace?.name ? (
+              <CopyableField label="Workspace name" value={workspace.name} />
+            ) : null}
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* ─── Section 3: MCP server setup ───────────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">Model Context Protocol server</h2>
+        </div>
+        <Card>
+          <CardContent className="space-y-4 text-sm">
+            <p className="text-xs text-muted-foreground">
+              The <code className="rounded bg-muted px-1.5 py-0.5 text-[11px]">@multica/mcp</code>{" "}
+              server lets any{" "}
+              <a
+                href="https://modelcontextprotocol.io"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-0.5 underline underline-offset-2"
+              >
+                MCP-aware <ExternalLink className="h-3 w-3" />
+              </a>{" "}
+              AI assistant — Claude Code, Claude Desktop, Cursor, Windsurf
+              — orchestrate this workspace from chat. It exposes ~32 tools
+              spanning issues, agents, channels, projects, labels, and
+              autopilots, and maps directly onto the Multica REST API.
+            </p>
+
+            <Step
+              n={1}
+              title="Create a token"
+              body="Use the section above. Name it something memorable like 'MCP server' so you can revoke it later if needed."
+            />
+
+            <Step
+              n={2}
+              title="Download the MCP server"
+              body={
+                <div className="space-y-2">
+                  <p className="text-xs text-muted-foreground">
+                    The server is bundled with this Multica install. One
+                    file, no build step. The version always matches the
+                    server it&apos;s talking to so there&apos;s no skew between
+                    the API and what the MCP exposes.
+                  </p>
+                  <CodeBlock text={buildDownloadCommand()} />
+                </div>
+              }
+            />
+
+            <Step
+              n={3}
+              title="Register with your AI assistant"
+              body={
+                <div className="space-y-3">
+                  <ClientHeading>Claude Code</ClientHeading>
+                  <CodeBlock
+                    text={buildClaudeCodeCommand({
+                      apiBaseUrl,
+                      workspaceId: workspace?.id ?? "<workspace-id>",
+                    })}
+                  />
+                  <ClientHeading>Claude Desktop</ClientHeading>
+                  <p className="text-xs text-muted-foreground">
+                    Add to{" "}
+                    <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                      ~/Library/Application Support/Claude/claude_desktop_config.json
+                    </code>{" "}
+                    (macOS) and restart the app. Claude Desktop doesn&apos;t
+                    expand <code className="rounded bg-muted px-1 py-0.5 text-[11px]">~</code>{" "}
+                    in JSON paths — replace it with your absolute home
+                    path (e.g.{" "}
+                    <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                      /Users/you/.local/bin/multica-mcp
+                    </code>
+                    ).
+                  </p>
+                  <CodeBlock
+                    text={buildClaudeDesktopConfig({
+                      apiBaseUrl,
+                      workspaceId: workspace?.id ?? "<workspace-id>",
+                    })}
+                  />
+                  <ClientHeading>Cursor / Windsurf / other MCP clients</ClientHeading>
+                  <p className="text-xs text-muted-foreground">
+                    Any client that speaks the standard MCP stdio transport
+                    works. The command is{" "}
+                    <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                      ~/.local/bin/multica-mcp
+                    </code>{" "}
+                    plus the three env vars from the snippet above.
+                  </p>
+                </div>
+              }
+            />
+
+            <Step
+              n={4}
+              title="Try it"
+              body={
+                <p className="text-xs text-muted-foreground">
+                  Start a new session in your AI client and prompt with
+                  something like &ldquo;<span className="italic">List my open
+                  Multica issues</span>&rdquo; — the assistant should call{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-[11px]">multica_issue_list</code>{" "}
+                  and return your issue list. From there it can create new
+                  issues, assign agents, post in channels, trigger
+                  autopilots — anything the tool list covers.
+                </p>
+              }
+            />
+
+            <p className="rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+              <strong className="text-foreground">Security:</strong> the
+              MCP server runs on your local machine and acts on behalf of
+              whoever owns the token. Treat the token like a password and
+              revoke it if it leaks. Mutating tools (issue create/update,
+              channel post, autopilot trigger) all run with your account&apos;s
+              permissions — there is no separate MCP-only scope.
+            </p>
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* ─── Section 4: REST API reference ─────────────────────────── */}
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Code2 className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">REST API</h2>
+        </div>
+        <Card>
+          <CardContent className="space-y-5 text-sm">
+            <p className="text-xs text-muted-foreground">
+              Everything the web app, CLI, and MCP server do is available
+              over plain HTTPS. Endpoints follow REST conventions: list /
+              get / create / update / delete on resource paths, JSON in
+              and out, bearer-token auth.
+            </p>
+
+            <div className="space-y-2">
+              <h3 className="text-xs font-medium">Authentication</h3>
+              <p className="text-xs text-muted-foreground">
+                Send your personal access token as a{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">Bearer</code>{" "}
+                header. Workspace-scoped endpoints also need an{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">X-Workspace-ID</code>{" "}
+                header — without it the API can&apos;t resolve which
+                workspace the call should target. Write requests use{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">application/json</code>.
+              </p>
+              <CodeBlock
+                text={buildCurlSample({
+                  apiBaseUrl,
+                  workspaceId: workspace?.id ?? "<workspace-id>",
+                })}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <h3 className="text-xs font-medium">Endpoints</h3>
+              <p className="text-xs text-muted-foreground">
+                Paths are relative to the API base URL above. Path
+                parameters are{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                  {"{like-this}"}
+                </code>
+                ; everything else is a literal segment. Where a path has
+                two methods listed, both are supported on the same URL.
+              </p>
+
+              <EndpointGroup title="Issues">
+                <EndpointRow method="GET" path="/api/issues" desc="List issues. Query: status, priority, assignee, project, limit, offset." />
+                <EndpointRow method="GET" path="/api/issues/search" desc="Full-text search. Query: q, limit." />
+                <EndpointRow method="POST" path="/api/issues" desc="Create. Body: { title, description?, status?, priority?, assignee_type?, assignee_id?, parent_issue_id?, project_id?, due_date? }." />
+                <EndpointRow method="GET" path="/api/issues/{id}" desc="Get one. id may be a UUID or human identifier (e.g. MUL-123)." />
+                <EndpointRow method="PUT" path="/api/issues/{id}" desc="Update. Body fields are all optional; only what's passed is changed." />
+                <EndpointRow method="DELETE" path="/api/issues/{id}" desc="Delete." />
+                <EndpointRow method="GET / POST" path="/api/issues/{id}/comments" desc="List or create a comment. Create body: { content, parent_id? }." />
+                <EndpointRow method="GET" path="/api/issues/{id}/task-runs" desc="List task runs (status, dispatched_at, completed_at, error)." />
+                <EndpointRow method="GET / POST" path="/api/issues/{id}/labels" desc="List labels on an issue, or attach one. Attach body: { label_id }." />
+                <EndpointRow method="DELETE" path="/api/issues/{id}/labels/{labelId}" desc="Detach a label." />
+                <EndpointRow method="GET / POST" path="/api/issues/{id}/subscribers" desc="List subscribers, or subscribe. Body: { actor_type, actor_id }." />
+                <EndpointRow method="POST" path="/api/issues/{id}/reactions" desc="Add a reaction. Body: { emoji }." />
+                <EndpointRow method="POST" path="/api/issues/quick-create" desc="One-shot natural-language create that dispatches an agent task to fill in the rest." />
+              </EndpointGroup>
+
+              <EndpointGroup title="Channels">
+                <EndpointRow method="GET" path="/api/channels" desc="List channels and DMs the actor belongs to (with per-channel unread counts)." />
+                <EndpointRow method="POST" path="/api/channels" desc="Create channel. Body: { name, display_name?, description?, visibility?, retention_days? }." />
+                <EndpointRow method="GET" path="/api/channels/search" desc="Full-text search messages. Query: q, limit." />
+                <EndpointRow method="GET / PATCH / DELETE" path="/api/channels/{channelId}" desc="Get / update / archive a channel." />
+                <EndpointRow method="POST" path="/api/channels/{channelId}/read" desc="Update read cursor. Body: { message_id }." />
+                <EndpointRow method="GET / POST" path="/api/channels/{channelId}/members" desc="List members, or add one. Body: { member_type, member_id, role? }." />
+                <EndpointRow method="DELETE" path="/api/channels/{channelId}/members/{memberType}/{memberId}" desc="Remove a member." />
+                <EndpointRow method="GET / POST" path="/api/channels/{channelId}/messages" desc="List or post messages. List query: limit, before (RFC3339), include_threaded. Post body: { content, parent_message_id?, attachment_ids? }." />
+                <EndpointRow method="PATCH / DELETE" path="/api/channels/{channelId}/messages/{messageId}" desc="Edit (author-only) or soft-delete a message." />
+                <EndpointRow method="GET" path="/api/channels/{channelId}/messages/{messageId}/thread" desc="List replies under a message." />
+                <EndpointRow method="POST / DELETE" path="/api/channels/{channelId}/messages/{messageId}/reactions" desc="Add or remove a reaction. Body: { emoji }." />
+                <EndpointRow method="POST" path="/api/dms" desc="Get or create a DM. Body: { participants: [{type, id}, …] }." />
+              </EndpointGroup>
+
+              <EndpointGroup title="Agents">
+                <EndpointRow method="GET" path="/api/agents" desc="List agents. Query: include_archived." />
+                <EndpointRow method="POST" path="/api/agents" desc="Create an agent." />
+                <EndpointRow method="GET / PUT" path="/api/agents/{id}" desc="Get / update an agent." />
+                <EndpointRow method="POST" path="/api/agents/{id}/archive" desc="Archive (soft-disable)." />
+                <EndpointRow method="POST" path="/api/agents/{id}/restore" desc="Un-archive." />
+                <EndpointRow method="GET" path="/api/agents/{id}/tasks" desc="List the agent's recent tasks. Query: limit." />
+                <EndpointRow method="POST" path="/api/agents/{id}/cancel-tasks" desc="Cancel all in-flight tasks for this agent." />
+                <EndpointRow method="GET / PUT" path="/api/agents/{id}/skills" desc="List or replace the agent's attached skills." />
+              </EndpointGroup>
+
+              <EndpointGroup title="Projects">
+                <EndpointRow method="GET / POST" path="/api/projects" desc="List or create projects." />
+                <EndpointRow method="GET" path="/api/projects/search" desc="Fuzzy search by name. Query: q." />
+                <EndpointRow method="GET / PUT / DELETE" path="/api/projects/{id}" desc="Get / update / delete a project." />
+                <EndpointRow method="GET / POST" path="/api/projects/{id}/resources" desc="List or attach resources (URLs, docs)." />
+              </EndpointGroup>
+
+              <EndpointGroup title="Labels">
+                <EndpointRow method="GET / POST" path="/api/labels" desc="List or create labels." />
+                <EndpointRow method="GET / PUT / DELETE" path="/api/labels/{id}" desc="Get / update / delete a label." />
+              </EndpointGroup>
+
+              <EndpointGroup title="Autopilots">
+                <EndpointRow method="GET / POST" path="/api/autopilots" desc="List or create autopilots." />
+                <EndpointRow method="GET / PATCH / DELETE" path="/api/autopilots/{id}" desc="Get / update / delete an autopilot." />
+                <EndpointRow method="POST" path="/api/autopilots/{id}/trigger" desc="Manually start a run. Body: { payload? }." />
+                <EndpointRow method="GET" path="/api/autopilots/{id}/runs" desc="List execution history. Query: limit." />
+                <EndpointRow method="GET / POST" path="/api/autopilots/{id}/triggers" desc="List or create scheduled triggers." />
+              </EndpointGroup>
+
+              <EndpointGroup title="Workspace & Members">
+                <EndpointRow method="GET" path="/api/workspaces" desc="List the workspaces the caller belongs to." />
+                <EndpointRow method="POST" path="/api/workspaces" desc="Create a new workspace." />
+                <EndpointRow method="GET" path="/api/workspaces/{id}" desc="Get workspace details (settings, feature flags, retention)." />
+                <EndpointRow method="PATCH / PUT" path="/api/workspaces/{id}" desc="Update workspace fields (admin/owner only)." />
+                <EndpointRow method="GET" path="/api/workspaces/{id}/members" desc="List members with their user records." />
+                <EndpointRow method="POST" path="/api/workspaces/{id}/members" desc="Invite a member by email (admin/owner only)." />
+                <EndpointRow method="PATCH / DELETE" path="/api/workspaces/{id}/members/{memberId}" desc="Update role / remove member (admin/owner only)." />
+              </EndpointGroup>
+
+              <EndpointGroup title="Account & tokens">
+                <EndpointRow method="GET / PATCH" path="/api/me" desc="Read or update the current user's profile." />
+                <EndpointRow method="GET / POST" path="/api/tokens" desc="List or create personal access tokens." />
+                <EndpointRow method="DELETE" path="/api/tokens/{id}" desc="Revoke a token." />
+                <EndpointRow method="GET" path="/api/inbox" desc="The current user's inbox (mentions, assignments)." />
+                <EndpointRow method="GET" path="/api/notification-preferences" desc="Per-user notification toggles." />
+              </EndpointGroup>
+            </div>
+
+            <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+              <p>
+                <strong className="text-foreground">Conventions:</strong>{" "}
+                list endpoints support{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">limit</code>{" "}
+                and{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">offset</code>{" "}
+                query params (default 50, max 200). Channel and chat
+                timelines paginate by{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">before</code>{" "}
+                (RFC3339 timestamp, exclusive) instead of offset because
+                rapid inserts at the head would otherwise cause skips.
+                Errors return{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">{"{ error: \"…\" }"}</code>{" "}
+                with the appropriate 4xx / 5xx status. Empty responses
+                use 204 (no body).
+              </p>
+              <p>
+                <strong className="text-foreground">No OpenAPI spec yet:</strong>{" "}
+                the canonical reference is the route table at{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                  server/cmd/server/router.go
+                </code>{" "}
+                in the source tree. The list above covers what the web
+                app, CLI, and MCP server use day-to-day.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
       <AlertDialog open={!!revokeConfirmId} onOpenChange={(v) => { if (!v) setRevokeConfirmId(null); }}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -233,5 +579,251 @@ export function TokensTab() {
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sub-components — kept colocated since they're trivial and only used here.
+// ─────────────────────────────────────────────────────────────────────────
+
+function CopyableField({ label, value, envVar }: { label: string; value: string; envVar?: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    if (!value) return;
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium">{label}</span>
+        {envVar ? (
+          <code className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {envVar}
+          </code>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 truncate rounded-md border bg-muted/50 px-3 py-2 text-xs select-all">
+          {value || <span className="text-muted-foreground">unavailable</span>}
+        </code>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="outline"
+                size="icon-sm"
+                onClick={copy}
+                disabled={!value}
+                aria-label={`Copy ${label}`}
+              >
+                {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+              </Button>
+            }
+          />
+          <TooltipContent>Copy</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+function CodeBlock({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div className="relative">
+      <pre className="overflow-x-auto rounded-md border bg-muted/50 px-3 py-2 pr-10 text-xs leading-relaxed">
+        <code>{text}</code>
+      </pre>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="absolute right-1.5 top-1.5"
+              onClick={copy}
+              aria-label="Copy snippet"
+            >
+              {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            </Button>
+          }
+        />
+        <TooltipContent>Copy</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+function Step({ n, title, body }: { n: number; title: string; body: React.ReactNode }) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[11px] font-semibold text-primary">
+          {n}
+        </span>
+        <span className="text-sm font-medium">{title}</span>
+      </div>
+      <div className="ml-7 space-y-2">
+        {typeof body === "string" ? (
+          <p className="text-xs text-muted-foreground">{body}</p>
+        ) : (
+          body
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ClientHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+// REST API endpoint reference helpers. Kept as small presentational
+// components colocated with the tab — they're not used elsewhere.
+
+function EndpointGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5 pt-3 first:pt-0">
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <div className="overflow-hidden rounded-md border border-border">
+        <div className="divide-y divide-border">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+// `method` accepts a slash-joined string like "GET / POST" so a single
+// row can describe all the verbs supported on the same path. Each verb
+// gets its own coloured badge for scannability.
+function EndpointRow({ method, path, desc }: { method: string; path: string; desc: string }) {
+  const methods = method.split("/").map((m) => m.trim()).filter(Boolean);
+  return (
+    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 px-3 py-2 sm:grid-cols-[auto_minmax(0,2fr)_minmax(0,3fr)]">
+      <div className="flex flex-wrap items-center gap-1">
+        {methods.map((m) => (
+          <MethodBadge key={m} method={m} />
+        ))}
+      </div>
+      <code className="col-span-1 text-[11px] sm:text-xs break-all font-mono">{path}</code>
+      <p className="col-span-2 text-[11px] text-muted-foreground sm:col-span-1">{desc}</p>
+    </div>
+  );
+}
+
+function MethodBadge({ method }: { method: string }) {
+  const m = method.toUpperCase();
+  // Coloring follows common API-doc conventions (Stripe, GitHub):
+  // GET=blue, POST=green, PUT=amber, PATCH=violet, DELETE=red. Using
+  // utility classes directly keeps the badge lightweight without adding
+  // a new shadcn variant.
+  const color =
+    m === "GET" ? "bg-blue-500/15 text-blue-700 dark:text-blue-300" :
+    m === "POST" ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300" :
+    m === "PUT" ? "bg-amber-500/15 text-amber-700 dark:text-amber-300" :
+    m === "PATCH" ? "bg-violet-500/15 text-violet-700 dark:text-violet-300" :
+    m === "DELETE" ? "bg-red-500/15 text-red-700 dark:text-red-300" :
+    "bg-muted text-foreground";
+  return (
+    <span className={`inline-flex min-w-[44px] items-center justify-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${color}`}>
+      {m}
+    </span>
+  );
+}
+
+// Snippet builders — kept in the component file so the wording stays
+// next to the surrounding copy. If MCP setup ever surfaces in two places
+// (e.g. an empty-state in the channels page) we can lift these into a
+// shared module.
+
+// Where the downloaded MCP server lands on the user's machine. Picked
+// `~/.local/bin` because it's on PATH for most Linux/macOS shell setups
+// and doesn't require sudo.
+const MCP_INSTALL_PATH = "~/.local/bin/multica-mcp";
+
+// Frontend serves the bundled MCP server as a static asset under
+// /multica-mcp.js. Using `window.location.origin` means the download
+// always points at the same Multica install the user is currently
+// browsing — no version skew between the running API and the MCP
+// server's tool definitions.
+function buildDownloadCommand(): string {
+  const origin =
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : "<frontend-url>";
+  return [
+    "mkdir -p ~/.local/bin",
+    `curl -fsSL ${origin}/multica-mcp.js -o ${MCP_INSTALL_PATH}`,
+    `chmod +x ${MCP_INSTALL_PATH}`,
+  ].join(" && \\\n");
+}
+
+function buildClaudeCodeCommand({
+  apiBaseUrl,
+  workspaceId,
+}: {
+  apiBaseUrl: string;
+  workspaceId: string;
+}): string {
+  const url = apiBaseUrl || "<api-base-url>";
+  return [
+    "claude mcp add --scope user multica \\",
+    `  -e MULTICA_API_URL=${url} \\`,
+    "  -e MULTICA_TOKEN=mul_… \\",
+    `  -e MULTICA_WORKSPACE_ID=${workspaceId} \\`,
+    `  -- ${MCP_INSTALL_PATH}`,
+  ].join("\n");
+}
+
+function buildCurlSample({
+  apiBaseUrl,
+  workspaceId,
+}: {
+  apiBaseUrl: string;
+  workspaceId: string;
+}): string {
+  const url = apiBaseUrl || "<api-base-url>";
+  return [
+    `curl ${url}/api/issues \\`,
+    "  -H 'Authorization: Bearer mul_…' \\",
+    `  -H 'X-Workspace-ID: ${workspaceId}'`,
+  ].join("\n");
+}
+
+function buildClaudeDesktopConfig({
+  apiBaseUrl,
+  workspaceId,
+}: {
+  apiBaseUrl: string;
+  workspaceId: string;
+}): string {
+  const url = apiBaseUrl || "<api-base-url>";
+  return JSON.stringify(
+    {
+      mcpServers: {
+        multica: {
+          command: MCP_INSTALL_PATH,
+          env: {
+            MULTICA_API_URL: url,
+            MULTICA_TOKEN: "mul_…",
+            MULTICA_WORKSPACE_ID: workspaceId,
+          },
+        },
+      },
+    },
+    null,
+    2,
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,7 +174,7 @@ importers:
         version: link:../../packages/tsconfig
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.2.2(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 4.2.2(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -192,7 +192,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.2.0(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 5.2.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
       electron:
         specifier: ^39.2.6
         version: 39.8.7
@@ -201,7 +201,7 @@ importers:
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 5.0.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
       jsdom:
         specifier: 'catalog:'
         version: 29.0.1(@noble/hashes@1.8.0)
@@ -219,7 +219,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
 
   apps/docs:
     dependencies:
@@ -458,7 +458,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 6.0.1(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
       jsdom:
         specifier: 'catalog:'
         version: 29.0.1(@noble/hashes@1.8.0)
@@ -470,7 +470,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/core:
     dependencies:
@@ -501,7 +501,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/eslint-config:
     dependencies:
@@ -523,6 +523,31 @@ importers:
       typescript-eslint:
         specifier: ^8.35.0
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.4
+        version: 1.27.1(zod@3.25.76)
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      '@multica/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.5.0
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
 
   packages/tsconfig: {}
 
@@ -802,7 +827,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 6.0.1(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
       jsdom:
         specifier: 'catalog:'
         version: 29.0.1(@noble/hashes@1.8.0)
@@ -814,7 +839,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
 
 packages:
 
@@ -1190,8 +1215,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1202,8 +1239,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1214,8 +1263,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1226,8 +1287,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1238,8 +1311,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1250,8 +1335,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1262,8 +1359,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1274,8 +1383,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1286,8 +1407,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1298,8 +1431,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1310,8 +1455,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1322,8 +1479,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1334,8 +1503,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1472,105 +1653,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1723,56 +1888,48 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-gnu@16.2.3':
     resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.15':
     resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-arm64-musl@16.2.3':
     resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.15':
     resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.15':
     resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-musl@16.2.3':
     resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.15':
     resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
@@ -2390,42 +2547,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
     resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
     resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
     resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
@@ -2458,6 +2609,131 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -2552,28 +2828,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -3307,6 +3579,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   app-builder-bin@5.0.0-alpha.12:
     resolution: {integrity: sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==}
 
@@ -3471,6 +3746,12 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3653,6 +3934,10 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
@@ -3681,6 +3966,10 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -4245,6 +4534,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -4467,6 +4761,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   fix-path@5.0.0:
     resolution: {integrity: sha512-erEWGGCN7RIu1bXTCfNVpVBdm0f5mwcbeja+4QXiEZzIQukP401sbpu8gd3Ny1vS34YNeswyMO0TdT2tP5OlHA==}
@@ -5179,6 +5476,10 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5306,28 +5607,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5345,6 +5642,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -5353,6 +5654,10 @@ packages:
 
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -5763,6 +6068,9 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -6094,6 +6402,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -6124,6 +6436,24 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -6534,6 +6864,10 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   resolve@2.0.0-next.6:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
@@ -6576,6 +6910,11 @@ packages:
   rolldown@1.0.0-rc.10:
     resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rope-sequence@1.3.4:
@@ -6912,6 +7251,11 @@ packages:
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -6955,6 +7299,13 @@ packages:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
 
@@ -6966,6 +7317,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
@@ -7009,6 +7363,10 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -7028,6 +7386,9 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
@@ -7037,6 +7398,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   turbo@2.9.5:
     resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
@@ -8008,79 +8388,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -9070,6 +9528,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@shikijs/core@3.23.0':
@@ -9206,12 +9739,12 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)
 
   '@tanstack/query-core@5.96.2': {}
 
@@ -9882,7 +10415,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))':
+  '@vitejs/plugin-react@5.2.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -9890,14 +10423,14 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.0.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -9908,14 +10441,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.14(@types/node@25.5.0)(typescript@5.9.3)
-      vite: 8.0.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -9991,6 +10524,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
 
   app-builder-bin@5.0.0-alpha.12: {}
 
@@ -10237,6 +10772,11 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -10411,6 +10951,8 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@4.1.1: {}
+
   commander@5.1.0: {}
 
   commander@7.2.0: {}
@@ -10427,6 +10969,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   content-disposition@1.0.1: {}
 
@@ -10909,7 +11453,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-vite@5.0.0(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1)):
+  electron-vite@5.0.0(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -10917,7 +11461,7 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11140,6 +11684,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -11454,6 +12027,12 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.2
 
   fix-path@5.0.0:
     dependencies:
@@ -12271,6 +12850,8 @@ snapshots:
 
   jose@6.2.2: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -12422,6 +13003,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   linkify-it@5.0.0:
@@ -12429,6 +13012,8 @@ snapshots:
       uc.micro: 2.1.0
 
   linkifyjs@4.3.2: {}
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -13143,6 +13728,12 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
@@ -13500,6 +14091,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  pirates@4.0.7: {}
+
   pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
@@ -13530,6 +14123,13 @@ snapshots:
       points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.8
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -14097,6 +14697,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-from@5.0.0: {}
+
   resolve@2.0.0-next.6:
     dependencies:
       es-errors: 1.3.0
@@ -14162,6 +14764,37 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
 
   rope-sequence@1.3.4: {}
 
@@ -14625,6 +15258,16 @@ snapshots:
 
   stylis@4.4.0: {}
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -14667,6 +15310,14 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.6.3
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
@@ -14676,6 +15327,8 @@ snapshots:
   tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.0.4: {}
 
@@ -14712,6 +15365,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -14726,6 +15381,8 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
+  ts-interface-checker@0.1.13: {}
+
   ts-morph@26.0.0:
     dependencies:
       '@ts-morph/common': 0.27.0
@@ -14738,6 +15395,34 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)
+      resolve-from: 5.0.0
+      rollup: 4.60.2
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.8
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   turbo@2.9.5:
     optionalDependencies:
@@ -14986,7 +15671,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1):
+  vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.3
@@ -14995,13 +15680,14 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -15018,7 +15704,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.1(@types/node@25.5.0)(jiti@2.6.1)
+      vite: 8.0.1(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Summary

Adds an MCP (Model Context Protocol) server for Multica plus an in-product setup + reference page so users can wire it into Claude Desktop / Claude Code / Cursor / Windsurf without leaving the app.

The MCP server is shipped as a downloadable static asset from the running install. End users grab it with one curl from the new **Settings → API & MCP** page — no `git clone`, no `pnpm build`, version always matches the API it's talking to.

## Why this is additive (not duplicative)

Upstream already has agent-side MCP **client** support: the `agent.mcp_config` field (migration `046`) lets a Multica agent talk *out* to external MCP servers while it works. This PR adds the inverse — Multica-as-MCP-**server**, so external AI assistants can call *in*. The two directions are complementary; nothing in this PR touches `agent.mcp_config` or the existing client path.

| Direction | Who's the MCP client | Who's the MCP server | Status before this PR |
| --- | --- | --- | --- |
| Multica → external | Multica agent | Linear, GitHub, etc. | Already supported via `agent.mcp_config` |
| External → Multica | Claude Desktop / Code, Cursor | Multica | Added by this PR |

## What's new

| Component | Path | What it is |
| --- | --- | --- |
| MCP server | `packages/mcp/` | Self-contained TypeScript package. 32 tools across 7 resource groups (issues, agents, channels, projects, labels, autopilots, workspace). 26 unit tests. Bundles via tsup to a single ~640 KB executable JS file with `@modelcontextprotocol/sdk` + `zod` inlined. Zero workspace deps — easily lifts into its own repo later. |
| Build & ship | `Dockerfile.web` | Adds a step that builds `@multica/mcp` and copies the bundled output to `apps/web/public/multica-mcp.js`. Next.js' standalone runtime serves `public/` as-is, so `/multica-mcp.js` becomes a downloadable asset on the running install. |
| Settings page docs | `packages/views/settings/components/tokens-tab.tsx` | Renames the **My Account → API Tokens** tab to **API & MCP** and expands the existing `tokens-tab.tsx` component into four sections: (1) personal access tokens, (2) connection details with copyable `MULTICA_API_URL` + `MULTICA_WORKSPACE_ID`, (3) **MCP server setup** with download + register snippets prefilled with the user's actual values, (4) **REST API reference** — endpoint table grouped by resource (issues, channels, agents, projects, labels, autopilots, workspace, tokens) with method badges and an authenticated curl sample. |

## Why compartmentalize

The MCP package depends on `@modelcontextprotocol/sdk` and `zod` only — nothing from `@multica/core`, `@multica/ui`, or any other workspace package. If upstream wants to extract it (own repo, separate release cadence, third-party contributions) it's a `git subtree split` away.

## How to try it

1. After this lands, build & deploy as usual.
2. Open **Settings → API & MCP**, create a token.
3. Copy the curl command from the "Download the MCP server" step — lands the binary at `~/.local/bin/multica-mcp`.
4. Copy the Claude Code or Claude Desktop snippet (workspace + URL prefilled) and paste into the relevant config.
5. Restart your AI client and prompt: *"List my open Multica issues."* The model should call `multica_issue_list` and return them.

## Forward-compat note

The `multica_channel_*` tools and the channel endpoints in the REST API reference target endpoints introduced by the channels Phase 1 PR. They 404 cleanly on installs without channels enabled and start working as soon as Phase 1 lands — no API contract changes between the two PRs.

## Test plan

- [x] `pnpm --filter @multica/mcp typecheck` — clean.
- [x] `pnpm --filter @multica/mcp test` — 26/26 pass.
- [x] `pnpm --filter @multica/mcp build` — bundles to `dist/index.js` (~640 KB) with shebang and node20 ESM target.
- [x] `pnpm --filter @multica/web typecheck` — clean (consumes the expanded `tokens-tab.tsx` component).
- [x] Smoke-test against a live workspace: `tools/list` returns 32 tools, `multica_workspace_get` / `multica_agent_list` / `multica_channel_list` / `multica_issue_create` round-trip successfully end-to-end via Claude Code.
