### PR TITLE
Add --ref support to repo checkout

### DIFF
--- a/server/cmd/multica/cmd_repo.go
+++ b/server/cmd/multica/cmd_repo.go
@@ -25,7 +25,10 @@ var repoCheckoutCmd = &cobra.Command{
 	RunE:  runRepoCheckout,
 }
 
+var repoCheckoutRef string
+
 func init() {
+	repoCheckoutCmd.Flags().StringVar(&repoCheckoutRef, "ref", "", "branch, tag, or commit to check out instead of the remote default branch")
 	repoCmd.AddCommand(repoCheckoutCmd)
 }
 
@@ -51,6 +54,7 @@ func runRepoCheckout(cmd *cobra.Command, args []string) error {
 		"url":          repoURL,
 		"workspace_id": workspaceID,
 		"workdir":      workDir,
+		"ref":          repoCheckoutRef,
 		"agent_name":   agentName,
 		"task_id":      taskID,
 	}

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -113,7 +113,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica workspace get --output json` — Get workspace details and context\n")
 	b.WriteString("- `multica workspace members [workspace-id] --output json` — List workspace members (user IDs, names, roles)\n")
 	b.WriteString("- `multica agent list --output json` — List agents in workspace\n")
-	b.WriteString("- `multica repo checkout <url>` — Check out a repository into the working directory (creates a git worktree with a dedicated branch)\n")
+	b.WriteString("- `multica repo checkout <url> [--ref <branch-or-sha>]` — Check out a repository into the working directory (creates a git worktree with a dedicated branch; use `--ref` for review/QA on a specific branch, tag, or commit)\n")
 	b.WriteString("- `multica issue runs <issue-id> --output json` — List all execution runs for an issue (status, timestamps, errors)\n")
 	b.WriteString("- `multica issue run-messages <task-id> [--since <seq>] --output json` — List messages for a specific execution run (supports incremental fetch)\n")
 	b.WriteString("- `multica attachment download <id> [-o <dir>]` — Download an attachment file locally by ID\n")
@@ -160,11 +160,11 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	if len(ctx.Repos) > 0 {
 		b.WriteString("## Repositories\n\n")
 		b.WriteString("The following code repositories are available in this workspace.\n")
-		b.WriteString("Use `multica repo checkout <url>` to check out a repository into your working directory.\n\n")
+		b.WriteString("Use `multica repo checkout <url>` to check out a repository into your working directory. Add `--ref <branch-or-sha>` when you need an exact branch, tag, or commit.\n\n")
 		for _, repo := range ctx.Repos {
 			fmt.Fprintf(&b, "- %s\n", repo.URL)
 		}
-		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed.\n\n")
+		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed, and can pass `--ref` for review/QA on a non-default branch or commit.\n\n")
 	}
 
 	// Inject project-scoped context (resources attached to the issue's project).
@@ -181,7 +181,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 				fmt.Fprintf(&b, "- %s\n", formatProjectResource(r))
 			}
 			b.WriteString("\nResources are pointers — open them only when relevant to the task. ")
-			b.WriteString("For `github_repo` resources, use `multica repo checkout <url>` to fetch the code.\n\n")
+			b.WriteString("For `github_repo` resources, use `multica repo checkout <url>` to fetch the code. Add `--ref <branch-or-sha>` when a task or handoff names an exact revision.\n\n")
 		} else {
 			b.WriteString("This project has no resources attached yet.\n\n")
 		}
@@ -197,7 +197,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("- If asked about issues, use `multica issue list --output json` or `multica issue get <id> --output json`\n")
 		b.WriteString("- If asked about the workspace, use `multica workspace get --output json`\n")
 		b.WriteString("- If asked to perform actions (create issues, update status, etc.), use the appropriate CLI commands\n")
-		b.WriteString("- If the task requires code changes, use `multica repo checkout <url>` to get the code first\n")
+		b.WriteString("- If the task requires code changes, use `multica repo checkout <url>` to get the code first. Use `--ref <branch-or-sha>` when you need an exact revision\n")
 		b.WriteString("- Keep responses concise and direct\n\n")
 	} else if ctx.QuickCreatePrompt != "" {
 		// Quick-create task: detailed field / output rules live in the

--- a/server/internal/daemon/health.go
+++ b/server/internal/daemon/health.go
@@ -48,6 +48,7 @@ type repoCheckoutRequest struct {
 	URL         string `json:"url"`
 	WorkspaceID string `json:"workspace_id"`
 	WorkDir     string `json:"workdir"`
+	Ref         string `json:"ref,omitempty"`
 	AgentName   string `json:"agent_name"`
 	TaskID      string `json:"task_id"`
 }
@@ -158,11 +159,12 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 		}
 
 		result, err := d.repoCache.CreateWorktree(repocache.WorktreeParams{
-			WorkspaceID:        req.WorkspaceID,
-			RepoURL:            req.URL,
-			WorkDir:            req.WorkDir,
-			AgentName:          req.AgentName,
-			TaskID:             req.TaskID,
+			WorkspaceID:         req.WorkspaceID,
+			RepoURL:             req.URL,
+			WorkDir:             req.WorkDir,
+			Ref:                 req.Ref,
+			AgentName:           req.AgentName,
+			TaskID:              req.TaskID,
 			CoAuthoredByEnabled: d.workspaceCoAuthoredByEnabled(req.WorkspaceID),
 		})
 		if err != nil {
@@ -187,4 +189,3 @@ func (d *Daemon) serveHealth(ctx context.Context, ln net.Listener, startedAt tim
 		d.logger.Warn("health server error", "error", err)
 	}
 }
-

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -352,12 +352,13 @@ func setFetchRefspec(barePath, refspec string) error {
 
 // WorktreeParams holds inputs for creating a worktree from a cached bare clone.
 type WorktreeParams struct {
-	WorkspaceID        string // workspace that owns the repo
-	RepoURL            string // remote URL to look up in the cache
-	WorkDir            string // parent directory for the worktree (e.g. task workdir)
-	AgentName          string // for branch naming
-	TaskID             string // for branch naming uniqueness
-	CoAuthoredByEnabled bool  // install prepare-commit-msg hook for Co-authored-by trailer
+	WorkspaceID         string // workspace that owns the repo
+	RepoURL             string // remote URL to look up in the cache
+	WorkDir             string // parent directory for the worktree (e.g. task workdir)
+	Ref                 string // optional branch, tag, or commit to base the worktree on
+	AgentName           string // for branch naming
+	TaskID              string // for branch naming uniqueness
+	CoAuthoredByEnabled bool   // install prepare-commit-msg hook for Co-authored-by trailer
 }
 
 // WorktreeResult describes a successfully created worktree.
@@ -397,13 +398,20 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 		)
 	}
 
-	// Determine the default branch to base the worktree on. getRemoteDefaultBranch
-	// walks origin/HEAD → origin/main, origin/master → bare-HEAD hint into
-	// origin/<same> → single-entry scan of origin/* → bare HEAD (only if
-	// origin/* is empty). Reaching "" here means the cache is in a state we
-	// refuse to guess from (no origin/HEAD, no main/master, bare HEAD doesn't
-	// match any origin/* entry, and origin/* has multiple candidates).
-	baseRef := getRemoteDefaultBranch(barePath)
+	// Determine the ref to base the worktree on. By default this is the remote's
+	// default branch. Callers may request a specific branch, tag, or commit so
+	// review/QA agents can inspect the exact revision without trying to mutate
+	// the daemon-owned worktree metadata themselves.
+	baseRef, err := resolveBaseRef(barePath, params.Ref)
+	if err != nil {
+		return nil, err
+	}
+
+	// getRemoteDefaultBranch walks origin/HEAD → origin/main, origin/master →
+	// bare-HEAD hint into origin/<same> → single-entry scan of origin/* → bare
+	// HEAD (only if origin/* is empty). Reaching "" here means the cache is in a
+	// state we refuse to guess from (no origin/HEAD, no main/master, bare HEAD
+	// doesn't match any origin/* entry, and origin/* has multiple candidates).
 	if baseRef == "" {
 		return nil, fmt.Errorf("cannot resolve default branch for %s: bare cache at %s has no usable refs (origin/* is empty or ambiguous and bare HEAD has no match). The cache may be corrupted; delete it and retry", params.RepoURL, barePath)
 	}
@@ -477,6 +485,32 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 		Path:       worktreePath,
 		BranchName: actualBranch,
 	}, nil
+}
+
+func resolveBaseRef(barePath, requestedRef string) (string, error) {
+	ref := strings.TrimSpace(requestedRef)
+	if ref == "" {
+		return getRemoteDefaultBranch(barePath), nil
+	}
+
+	// Prefer remote-tracking branches for human branch names. Then allow full
+	// local refs, tags, and raw commits that exist in the fetched bare cache.
+	candidates := []string{
+		"refs/remotes/origin/" + ref,
+		"refs/tags/" + ref,
+		ref,
+	}
+	for _, candidate := range candidates {
+		if gitRefExists(barePath, candidate+"^{commit}") {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("cannot resolve requested ref %q in repo cache at %s", ref, barePath)
+}
+
+func gitRefExists(repoPath, ref string) bool {
+	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", ref)
+	return cmd.Run() == nil
 }
 
 // createWorktree creates a git worktree at the given path with a new branch.

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -522,6 +522,99 @@ func TestCreateWorktreeNotCached(t *testing.T) {
 	}
 }
 
+func TestCreateWorktreeWithRequestedBranchRef(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	defaultHead := gitHead(t, sourceRepo)
+
+	runGitAuthored(t, sourceRepo, "checkout", "-b", "review-branch")
+	if err := os.WriteFile(filepath.Join(sourceRepo, "review.txt"), []byte("review\n"), 0o644); err != nil {
+		t.Fatalf("write review file: %v", err)
+	}
+	runGitAuthored(t, sourceRepo, "add", ".")
+	runGitAuthored(t, sourceRepo, "commit", "-m", "review branch commit")
+	reviewHead := gitHead(t, sourceRepo)
+	if reviewHead == defaultHead {
+		t.Fatal("test setup failed: review branch did not advance")
+	}
+
+	cache := New(t.TempDir(), testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		Ref:         "review-branch",
+		AgentName:   "Reviewer",
+		TaskID:      "review-task-id",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	if got := gitHead(t, result.Path); got != reviewHead {
+		t.Fatalf("worktree HEAD = %s, want requested branch head %s", got, reviewHead)
+	}
+	if _, err := os.Stat(filepath.Join(result.Path, "review.txt")); err != nil {
+		t.Fatalf("requested branch file missing: %v", err)
+	}
+}
+
+func TestCreateWorktreeWithRequestedCommitRef(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	firstCommit := gitHead(t, sourceRepo)
+	addEmptyCommit(t, sourceRepo, "second commit")
+
+	cache := New(t.TempDir(), testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	result, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		Ref:         firstCommit,
+		AgentName:   "Reviewer",
+		TaskID:      "commit-task-id",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+
+	if got := gitHead(t, result.Path); got != firstCommit {
+		t.Fatalf("worktree HEAD = %s, want requested commit %s", got, firstCommit)
+	}
+}
+
+func TestCreateWorktreeWithUnknownRequestedRef(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	cache := New(t.TempDir(), testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	_, err := cache.CreateWorktree(WorktreeParams{
+		WorkspaceID: "ws-1",
+		RepoURL:     sourceRepo,
+		WorkDir:     t.TempDir(),
+		Ref:         "missing-ref",
+		AgentName:   "Reviewer",
+		TaskID:      "missing-ref-task-id",
+	})
+	if err == nil {
+		t.Fatal("expected unknown ref error")
+	}
+	if !strings.Contains(err.Error(), "cannot resolve requested ref") {
+		t.Fatalf("expected requested ref error, got: %v", err)
+	}
+}
+
 func trimLine(s string) string {
 	return strings.TrimSpace(s)
 }
@@ -957,11 +1050,11 @@ func TestCreateWorktreeInstallsCoAuthoredByHook(t *testing.T) {
 
 	workDir := t.TempDir()
 	result, err := cache.CreateWorktree(WorktreeParams{
-		WorkspaceID:        "ws-1",
-		RepoURL:            sourceRepo,
-		WorkDir:            workDir,
-		AgentName:          "Test Agent",
-		TaskID:             "a1b2c3d4-0000-0000-0000-000000000000",
+		WorkspaceID:         "ws-1",
+		RepoURL:             sourceRepo,
+		WorkDir:             workDir,
+		AgentName:           "Test Agent",
+		TaskID:              "a1b2c3d4-0000-0000-0000-000000000000",
 		CoAuthoredByEnabled: true,
 	})
 	if err != nil {
@@ -1001,11 +1094,11 @@ func TestCoAuthoredByHookIdempotent(t *testing.T) {
 
 	workDir := t.TempDir()
 	result, err := cache.CreateWorktree(WorktreeParams{
-		WorkspaceID:        "ws-1",
-		RepoURL:            sourceRepo,
-		WorkDir:            workDir,
-		AgentName:          "Test Agent",
-		TaskID:             "b2c3d4e5-0000-0000-0000-000000000000",
+		WorkspaceID:         "ws-1",
+		RepoURL:             sourceRepo,
+		WorkDir:             workDir,
+		AgentName:           "Test Agent",
+		TaskID:              "b2c3d4e5-0000-0000-0000-000000000000",
 		CoAuthoredByEnabled: true,
 	})
 	if err != nil {


### PR DESCRIPTION
This adds an optional `--ref` flag to `multica repo checkout` so an agent can check out a branch, tag, or commit directly instead of always starting from the repo default branch.

That matters for review and QA flows where the target revision is already known. Without this, the agent has to mutate the checked-out worktree after the daemon creates it, which is fragile and can leave the daemon's repo metadata out of sync.

What changed:

- `multica repo checkout <url> --ref <branch-or-sha>` now passes the requested ref to the daemon.
- The repo cache resolves branch names, tags, and commit SHAs before creating the worktree.
- Runtime instructions mention `--ref` for review/QA tasks.
- Added coverage for branch refs, commit refs, and unknown refs.

Fixes #1869.

This also helps #1898 because agents can request the exact branch or commit up front instead of running a separate `git checkout` inside a daemon-owned worktree.

Validation:

```bash
go test ./internal/daemon/repocache ./cmd/multica ./internal/daemon ./internal/daemon/execenv
```
