### PR TITLE
Superseded by #1990

### DIFF
--- a/apps/web/app/install.sh/route.test.ts
+++ b/apps/web/app/install.sh/route.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+describe("GET /install.sh", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("serves the hosted install script", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("#!/usr/bin/env bash\necho multica\n", {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/x-shellscript");
+    await expect(response.text()).resolves.toContain("echo multica");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh",
+      expect.objectContaining({
+        next: { revalidate: 300 },
+      }),
+    );
+  });
+
+  it("returns a plain 502 when the upstream installer is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("not found", { status: 404 })),
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.text()).resolves.toContain(
+      "Failed to fetch Multica installer",
+    );
+  });
+});

--- a/apps/web/app/install.sh/route.ts
+++ b/apps/web/app/install.sh/route.ts
@@ -1,0 +1,35 @@
+const INSTALL_SCRIPT_URL =
+  "https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh";
+
+export async function GET() {
+  const upstreamResponse = await fetch(INSTALL_SCRIPT_URL, {
+    headers: {
+      accept: "text/x-shellscript,text/plain,*/*",
+    },
+    next: {
+      revalidate: 300,
+    },
+  });
+
+  if (!upstreamResponse.ok) {
+    return new Response(
+      `Failed to fetch Multica installer from ${INSTALL_SCRIPT_URL}\n`,
+      {
+        status: 502,
+        headers: {
+          "content-type": "text/plain; charset=utf-8",
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  const script = await upstreamResponse.text();
+
+  return new Response(script, {
+    headers: {
+      "content-type": "text/x-shellscript; charset=utf-8",
+      "cache-control": "public, max-age=300, s-maxage=300",
+    },
+  });
+}


### PR DESCRIPTION
Superseded by #1990.

Both PRs were opened for #1984. The other implementation is cleaner because it serves the repository's existing `scripts/install.sh` directly from the web app, instead of fetching the script from GitHub at request time.

Closing this one to keep the issue discussion focused.
