### PR TITLE
Serve install.sh from the web app

### DIFF
--- a/apps/web/app/install.sh/route.test.ts
+++ b/apps/web/app/install.sh/route.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+describe("GET /install.sh", () => {
+  it("serves the Linux installer script directly", async () => {
+    const response = await GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/x-shellscript");
+    expect(body).toContain("#!/usr/bin/env bash");
+    expect(body).toContain("Usage: install.sh");
+  });
+});

--- a/apps/web/app/install.sh/route.ts
+++ b/apps/web/app/install.sh/route.ts
@@ -1,0 +1,18 @@
+import { readFile } from "node:fs/promises";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const script = await readFile(
+    new URL("../../../../scripts/install.sh", import.meta.url),
+    "utf8",
+  );
+
+  return new Response(script, {
+    headers: {
+      "Cache-Control": "public, max-age=300",
+      "Content-Disposition": 'inline; filename="install.sh"',
+      "Content-Type": "text/x-shellscript; charset=utf-8",
+    },
+  });
+}


### PR DESCRIPTION
`https://multica.ai/install.sh` currently returns a 404, even though the repo already has an installer script in `scripts/install.sh`.

This PR serves that existing script from the web app at `/install.sh`, so the published install URL works without adding another copy of the script or depending on a redirect.

What changed:

- Added `apps/web/app/install.sh/route.ts`.
- The route reads `scripts/install.sh` from the repo and returns it as `text/x-shellscript`.
- Added a focused route test that checks the response status, content type, shebang, and usage text.

Closes #1984.

Validation:

```bash
git diff --cached --check
```

I also ran a small Node check to verify the route resolves to `scripts/install.sh`, and that the script starts with `#!/usr/bin/env bash` and includes `Usage: install.sh`.

I attempted the targeted web test as well:

```bash
corepack pnpm --filter @multica/web test -- app/install.sh/route.test.ts
```

That could not run in this checkout because dependencies were not installed, and `corepack pnpm install --frozen-lockfile` failed with `ERR_PNPM_ENOSPC` on the runner filesystem.
