### PR TITLE
fix(cli): accept token value directly in `login --token <value>`

### DIFF
--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -92,9 +92,9 @@ func openBrowser(url string) error {
 }
 
 func runAuthLogin(cmd *cobra.Command, _ []string) error {
-	useToken, _ := cmd.Flags().GetBool("token")
-	if useToken {
-		return runAuthLoginToken(cmd)
+	if cmd.Flags().Changed("token") {
+		tokenVal, _ := cmd.Flags().GetString("token")
+		return runAuthLoginToken(cmd, tokenVal)
 	}
 	return runAuthLoginBrowser(cmd)
 }
@@ -320,13 +320,18 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	return nil
 }
 
-func runAuthLoginToken(cmd *cobra.Command) error {
-	fmt.Print("Enter your personal access token: ")
-	scanner := bufio.NewScanner(os.Stdin)
-	if !scanner.Scan() {
-		return fmt.Errorf("no input")
+func runAuthLoginToken(cmd *cobra.Command, providedToken string) error {
+	var token string
+	if providedToken != "" && providedToken != "__prompt__" {
+		token = strings.TrimSpace(providedToken)
+	} else {
+		fmt.Print("Enter your personal access token: ")
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() {
+			return fmt.Errorf("no input")
+		}
+		token = strings.TrimSpace(scanner.Text())
 	}
-	token := strings.TrimSpace(scanner.Text())
 	if token == "" {
 		return fmt.Errorf("token is required")
 	}

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -119,6 +119,53 @@ func TestResolveCallbackBinding(t *testing.T) {
 	}
 }
 
+func TestLoginTokenFlag(t *testing.T) {
+	t.Run("--token with value uses it directly", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.PersistentFlags().String("profile", "", "")
+		cmd.Flags().String("token", "", "")
+		cmd.Flag("token").NoOptDefVal = "__prompt__"
+
+		// Simulate: multica login --token mul_test123
+		cmd.Flags().Set("token", "mul_test123")
+
+		if !cmd.Flags().Changed("token") {
+			t.Fatal("expected token flag to be changed")
+		}
+		val, _ := cmd.Flags().GetString("token")
+		if val != "mul_test123" {
+			t.Fatalf("expected %q, got %q", "mul_test123", val)
+		}
+	})
+
+	t.Run("--token without value gets NoOptDefVal", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.PersistentFlags().String("profile", "", "")
+		cmd.Flags().String("token", "", "")
+		cmd.Flag("token").NoOptDefVal = "__prompt__"
+
+		// Simulate: multica login --token (no value)
+		cmd.Flags().Set("token", "__prompt__")
+
+		val, _ := cmd.Flags().GetString("token")
+		if val != "__prompt__" {
+			t.Fatalf("expected %q, got %q", "__prompt__", val)
+		}
+	})
+
+	t.Run("no --token flag means browser login", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.PersistentFlags().String("profile", "", "")
+		cmd.Flags().String("token", "", "")
+		cmd.Flag("token").NoOptDefVal = "__prompt__"
+
+		// Don't set the flag — simulates: multica login
+		if cmd.Flags().Changed("token") {
+			t.Fatal("expected token flag to NOT be changed")
+		}
+	})
+}
+
 func TestNormalizeAPIBaseURL(t *testing.T) {
 	t.Run("converts websocket base URL", func(t *testing.T) {
 		if got := normalizeAPIBaseURL("ws://localhost:18106/ws"); got != "http://localhost:18106" {

--- a/server/cmd/multica/cmd_login.go
+++ b/server/cmd/multica/cmd_login.go
@@ -36,7 +36,8 @@ var loginCmd = &cobra.Command{
 }
 
 func init() {
-	loginCmd.Flags().Bool("token", false, "Authenticate by pasting a personal access token")
+	loginCmd.Flags().String("token", "", "Authenticate with a personal access token (omit value to be prompted)")
+	loginCmd.Flag("token").NoOptDefVal = "__prompt__"
 	loginCmd.Flags().String(callbackHostFlag, "", "Host the OAuth callback URL points at (auto-detected from the server's route when empty). Use this for reverse-proxy / FQDN setups where auto-detection picks the wrong interface.")
 }
 


### PR DESCRIPTION
## Summary

Fixes #1994.

The `--token` flag on `multica login` was defined as a `Bool` flag, so running:

```sh
multica login --token "mul_xxx"
```

silently discarded the token value and always prompted for interactive input — contradicting the guided setup steps shown in the web UI.

## Changes

- **`cmd_login.go`**: Change `--token` from `Bool` to `String` with `NoOptDefVal` so that:
  - `multica login --token mul_xxx` → uses the token directly (no prompt)
  - `multica login --token` (no value) → prompts interactively (backward-compatible)
  - `multica login` → browser OAuth (unchanged)
- **`cmd_auth.go`**: Update `runAuthLogin` / `runAuthLoginToken` to accept the optional pre-provided value
- **`cmd_auth_test.go`**: Add `TestLoginTokenFlag` covering all three modes

## Testing

```sh
cd server/cmd/multica && go test -run TestLoginTokenFlag -v
# PASS (3/3 subtests)
go build .
# clean
```