### PR TITLE
fix(cli): make multica login --token accept the PAT as a value

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -70,10 +70,10 @@ Opens your browser for OAuth authentication, creates a 90-day personal access to
 ### Token Login
 
 ```bash
-multica login --token
+multica login --token <mul_...>
 ```
 
-Authenticate by pasting a personal access token directly. Useful for headless environments.
+Authenticate using a personal access token directly. Useful for headless environments. Pass `--token=` with an empty value to be prompted interactively (so the token never lands in shell history).
 
 ### Check Status
 

--- a/CLI_INSTALL.md
+++ b/CLI_INSTALL.md
@@ -140,7 +140,7 @@ multica auth status
 Expected output should show the authenticated user and server URL.
 
 **If login fails:**
-- If no browser is available (headless environment), the user can generate a Personal Access Token at `https://app.multica.ai/settings` and run: `multica login --token`
+- If no browser is available (headless environment), the user can generate a Personal Access Token at `https://app.multica.ai/settings` and run: `multica login --token <mul_...>` (use `--token=` with an empty value to be prompted interactively).
 - If the server URL needs to be customized: `multica config set server_url <url>` before logging in.
 
 ---

--- a/apps/docs/content/docs/cli/reference.zh.mdx
+++ b/apps/docs/content/docs/cli/reference.zh.mdx
@@ -18,10 +18,10 @@ Opens your browser for OAuth authentication, creates a 90-day personal access to
 ### Token Login
 
 ```bash
-multica login --token
+multica login --token <mul_...>
 ```
 
-Authenticate by pasting a personal access token directly. Useful for headless environments.
+Authenticate using a personal access token directly. Useful for headless environments. Pass `--token=` with an empty value to be prompted interactively (so the token never lands in shell history).
 
 ### Check Status
 

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -91,9 +91,16 @@ func openBrowser(url string) error {
 	return exec.Command(cmd, args...).Start()
 }
 
-func runAuthLogin(cmd *cobra.Command, _ []string) error {
+func runAuthLogin(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("token") {
 		tokenFlag, _ := cmd.Flags().GetString("token")
+		// `--token mul_xxx` (space form) is what users actually type — that's
+		// the form from the docs and from #1994. NoOptDefVal prevents pflag
+		// from consuming the next arg as the flag value, so it lands here as
+		// a positional. Promote it to the token value.
+		if tokenFlag == tokenPromptSentinel && len(args) == 1 {
+			tokenFlag = args[0]
+		}
 		return runAuthLoginToken(cmd, tokenFlag)
 	}
 	return runAuthLoginBrowser(cmd)
@@ -321,6 +328,12 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 }
 
 func runAuthLoginToken(cmd *cobra.Command, providedToken string) error {
+	// The prompt sentinel is what pflag substitutes for `--token` with no
+	// value (see loginCmd init); treat it the same as an empty string so we
+	// fall through to the interactive prompt.
+	if providedToken == tokenPromptSentinel {
+		providedToken = ""
+	}
 	token := strings.TrimSpace(providedToken)
 	if token == "" {
 		fmt.Print("Enter your personal access token: ")

--- a/server/cmd/multica/cmd_auth.go
+++ b/server/cmd/multica/cmd_auth.go
@@ -92,9 +92,9 @@ func openBrowser(url string) error {
 }
 
 func runAuthLogin(cmd *cobra.Command, _ []string) error {
-	useToken, _ := cmd.Flags().GetBool("token")
-	if useToken {
-		return runAuthLoginToken(cmd)
+	if cmd.Flags().Changed("token") {
+		tokenFlag, _ := cmd.Flags().GetString("token")
+		return runAuthLoginToken(cmd, tokenFlag)
 	}
 	return runAuthLoginBrowser(cmd)
 }
@@ -320,13 +320,16 @@ func runAuthLoginBrowser(cmd *cobra.Command) error {
 	return nil
 }
 
-func runAuthLoginToken(cmd *cobra.Command) error {
-	fmt.Print("Enter your personal access token: ")
-	scanner := bufio.NewScanner(os.Stdin)
-	if !scanner.Scan() {
-		return fmt.Errorf("no input")
+func runAuthLoginToken(cmd *cobra.Command, providedToken string) error {
+	token := strings.TrimSpace(providedToken)
+	if token == "" {
+		fmt.Print("Enter your personal access token: ")
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() {
+			return fmt.Errorf("no input")
+		}
+		token = strings.TrimSpace(scanner.Text())
 	}
-	token := strings.TrimSpace(scanner.Text())
 	if token == "" {
 		return fmt.Errorf("token is required")
 	}

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -119,34 +119,107 @@ func TestResolveCallbackBinding(t *testing.T) {
 	}
 }
 
-// TestLoginTokenFlagAcceptsValue guards against regressing #1994: the
-// `--token` flag must accept the PAT as a string value (both `--token foo`
-// and `--token=foo`). It used to be a Bool, which silently dropped the
-// supplied value and forced an interactive prompt.
-func TestLoginTokenFlagAcceptsValue(t *testing.T) {
+// TestLoginTokenFlagWiring asserts the production loginCmd flag is registered
+// the way #1994 needs it to be: a String flag (not Bool) with a NoOptDefVal
+// so `--token` (no value) keeps its legacy prompt-mode behavior. This is the
+// load-bearing regression guard — without these asserts a future change that
+// reverts the flag to Bool could pass while a synthetic stand-in test happily
+// keeps testing string-flag parsing.
+func TestLoginTokenFlagWiring(t *testing.T) {
+	tokenFlag := loginCmd.Flags().Lookup("token")
+	if tokenFlag == nil {
+		t.Fatal("loginCmd is missing the --token flag")
+	}
+	if got := tokenFlag.Value.Type(); got != "string" {
+		t.Fatalf("loginCmd --token type = %q, want %q (regressed to bool?)", got, "string")
+	}
+	if tokenFlag.NoOptDefVal != tokenPromptSentinel {
+		t.Fatalf("loginCmd --token NoOptDefVal = %q, want %q (legacy `multica login --token` prompt mode would break)", tokenFlag.NoOptDefVal, tokenPromptSentinel)
+	}
+}
+
+// TestLoginTokenFlagParsing exercises every documented invocation form
+// against a cobra command wired up exactly the same way as the production
+// loginCmd, then runs runAuthLogin's flag-resolution logic to confirm the
+// right downstream branch is taken: `--token mul_xxx` and `--token=mul_xxx`
+// both consume the value (the bug from #1994), `--token` alone falls
+// through to the prompt sentinel (preserves the legacy headless form), and
+// no flag at all leaves the browser flow untouched.
+func TestLoginTokenFlagParsing(t *testing.T) {
+	type want struct {
+		changed         bool
+		resolvedToken   string // empty == "fall through to prompt"
+		expectsPrompted bool
+	}
+
 	cases := []struct {
 		name string
-		args []string
-		want string
+		argv []string
+		want want
 	}{
-		{"space-separated value", []string{"--token", "mul_abc"}, "mul_abc"},
-		{"equals-separated value", []string{"--token=mul_abc"}, "mul_abc"},
-		{"explicit empty value triggers prompt", []string{"--token="}, ""},
+		{
+			name: "space-separated value (the form from #1994)",
+			argv: []string{"--token", "mul_xxx"},
+			want: want{changed: true, resolvedToken: "mul_xxx"},
+		},
+		{
+			name: "equals-separated value",
+			argv: []string{"--token=mul_yyy"},
+			want: want{changed: true, resolvedToken: "mul_yyy"},
+		},
+		{
+			name: "no value falls through to prompt (legacy CLI_INSTALL.md form)",
+			argv: []string{"--token"},
+			want: want{changed: true, expectsPrompted: true},
+		},
+		{
+			name: "explicit empty value also falls through to prompt",
+			argv: []string{"--token="},
+			want: want{changed: true, expectsPrompted: true},
+		},
+		{
+			name: "no flag at all → browser flow",
+			argv: []string{},
+			want: want{changed: false},
+		},
 	}
+
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := &cobra.Command{Use: "login"}
+			// Mirror loginCmd's exact flag wiring. If init() in cmd_login.go
+			// regresses, TestLoginTokenFlagWiring catches that; here we test
+			// the parsing behavior given the documented wiring.
 			cmd.Flags().String("token", "", "")
-			if err := cmd.ParseFlags(tc.args); err != nil {
-				t.Fatalf("ParseFlags(%v) error: %v", tc.args, err)
+			cmd.Flags().Lookup("token").NoOptDefVal = tokenPromptSentinel
+
+			if err := cmd.ParseFlags(tc.argv); err != nil {
+				t.Fatalf("ParseFlags(%v) error: %v", tc.argv, err)
 			}
-			if !cmd.Flags().Changed("token") {
-				t.Fatalf("expected --token flag to be marked Changed for args %v", tc.args)
+			if cmd.Flags().Changed("token") != tc.want.changed {
+				t.Fatalf("Changed(token) = %v, want %v for argv=%v", cmd.Flags().Changed("token"), tc.want.changed, tc.argv)
 			}
-			got, _ := cmd.Flags().GetString("token")
-			if got != tc.want {
-				t.Fatalf("token value = %q, want %q", got, tc.want)
+			if !tc.want.changed {
+				return
+			}
+
+			// Replay runAuthLogin's resolution logic so the test fails if
+			// either the flag wiring OR the space-form recovery breaks.
+			tokenFlag, _ := cmd.Flags().GetString("token")
+			positional := cmd.Flags().Args()
+			if tokenFlag == tokenPromptSentinel && len(positional) == 1 {
+				tokenFlag = positional[0]
+			}
+
+			if tc.want.expectsPrompted {
+				if tokenFlag != tokenPromptSentinel && tokenFlag != "" {
+					t.Fatalf("expected prompt fall-through, got resolved token %q", tokenFlag)
+				}
+			} else {
+				if tokenFlag != tc.want.resolvedToken {
+					t.Fatalf("resolved token = %q, want %q", tokenFlag, tc.want.resolvedToken)
+				}
 			}
 		})
 	}

--- a/server/cmd/multica/cmd_auth_test.go
+++ b/server/cmd/multica/cmd_auth_test.go
@@ -119,6 +119,39 @@ func TestResolveCallbackBinding(t *testing.T) {
 	}
 }
 
+// TestLoginTokenFlagAcceptsValue guards against regressing #1994: the
+// `--token` flag must accept the PAT as a string value (both `--token foo`
+// and `--token=foo`). It used to be a Bool, which silently dropped the
+// supplied value and forced an interactive prompt.
+func TestLoginTokenFlagAcceptsValue(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"space-separated value", []string{"--token", "mul_abc"}, "mul_abc"},
+		{"equals-separated value", []string{"--token=mul_abc"}, "mul_abc"},
+		{"explicit empty value triggers prompt", []string{"--token="}, ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "login"}
+			cmd.Flags().String("token", "", "")
+			if err := cmd.ParseFlags(tc.args); err != nil {
+				t.Fatalf("ParseFlags(%v) error: %v", tc.args, err)
+			}
+			if !cmd.Flags().Changed("token") {
+				t.Fatalf("expected --token flag to be marked Changed for args %v", tc.args)
+			}
+			got, _ := cmd.Flags().GetString("token")
+			if got != tc.want {
+				t.Fatalf("token value = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeAPIBaseURL(t *testing.T) {
 	t.Run("converts websocket base URL", func(t *testing.T) {
 		if got := normalizeAPIBaseURL("ws://localhost:18106/ws"); got != "http://localhost:18106" {

--- a/server/cmd/multica/cmd_login.go
+++ b/server/cmd/multica/cmd_login.go
@@ -36,7 +36,7 @@ var loginCmd = &cobra.Command{
 }
 
 func init() {
-	loginCmd.Flags().Bool("token", false, "Authenticate by pasting a personal access token")
+	loginCmd.Flags().String("token", "", "Authenticate using a personal access token (e.g. --token mul_...). Use --token= without a value to be prompted interactively.")
 	loginCmd.Flags().String(callbackHostFlag, "", "Host the OAuth callback URL points at (auto-detected from the server's route when empty). Use this for reverse-proxy / FQDN setups where auto-detection picks the wrong interface.")
 }
 

--- a/server/cmd/multica/cmd_login.go
+++ b/server/cmd/multica/cmd_login.go
@@ -32,11 +32,23 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Authenticate and set up workspaces",
 	Long:  "Log in to Multica, then automatically discover and watch all your workspaces.",
-	RunE:  runLogin,
+	// Up to one positional is accepted so `--token mul_...` (space form) can
+	// recover the token in runAuthLogin even though pflag won't bind it.
+	Args: cobra.MaximumNArgs(1),
+	RunE: runLogin,
 }
 
+// tokenPromptSentinel is the value pflag assigns to `--token` when the flag
+// is supplied without an explicit value. runAuthLoginToken treats it as
+// "prompt me interactively", preserving the legacy `multica login --token`
+// no-value form alongside the documented `--token mul_...` value form.
+const tokenPromptSentinel = "\x00prompt"
+
 func init() {
-	loginCmd.Flags().String("token", "", "Authenticate using a personal access token (e.g. --token mul_...). Use --token= without a value to be prompted interactively.")
+	loginCmd.Flags().String("token", "", "Authenticate using a personal access token. Pass `--token mul_...` to supply it inline, or `--token` alone to be prompted interactively.")
+	// NoOptDefVal lets `--token` (no value) keep its old prompt-mode behavior
+	// while `--token mul_...` and `--token=mul_...` consume the value normally.
+	loginCmd.Flags().Lookup("token").NoOptDefVal = tokenPromptSentinel
 	loginCmd.Flags().String(callbackHostFlag, "", "Host the OAuth callback URL points at (auto-detected from the server's route when empty). Use this for reverse-proxy / FQDN setups where auto-detection picks the wrong interface.")
 }
 


### PR DESCRIPTION
## Summary

Fixes [#1994](https://github.com/multica-ai/multica/issues/1994) — `multica login --token "$MULTICA_TOKEN"` was ignoring the supplied token and still prompting for one interactively.

The `--token` flag in `cmd_login.go` was registered as a `Bool`, so pflag parsed `--token` as `true` and the actual token fell into the unused positional args, after which `runAuthLoginToken` unconditionally read from stdin. This contradicted the user-facing docs and the in-app `connect-remote-dialog` snippet (`multica login --token <YOUR_TOKEN>`).

## Changes

- `server/cmd/multica/cmd_login.go` — switch `--token` to a `String` flag.
- `server/cmd/multica/cmd_auth.go` — read the string flag via `Flags().Changed("token")` + `GetString`, pass the value into `runAuthLoginToken`, and only prompt when the value is empty.
- `server/cmd/multica/cmd_auth_test.go` — regression test covering `--token mul_…`, `--token=mul_…`, and `--token=` (empty → prompt).
- `CLI_INSTALL.md`, `CLI_AND_DAEMON.md`, `apps/docs/content/docs/cli/reference.zh.mdx` — three remaining docs that showed `multica login --token` (no value) updated to `multica login --token <mul_...>`.

After the fix, all of these work as users expect:

```bash
multica login --token mul_xxxxx       # the form from #1994 — now consumes the value
multica login --token=mul_xxxxx       # explicit equals form
MULTICA_TOKEN=mul_xxxxx multica login --token=""   # empty value → interactive prompt fallback
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./cmd/multica/...` clean
- [x] `go test ./cmd/multica/... -run 'TestLoginTokenFlagAcceptsValue|TestResolveAppURL|TestResolveCallbackBinding|TestNormalizeAPIBaseURL'` — all green, including the new `TestLoginTokenFlagAcceptsValue` cases
- [x] Built CLI and ran `multica login --token "not-a-real-token"` — fails with `invalid token format: must start with mul_` (validation reached, no prompt), confirming the value is now consumed