### PR TITLE
fix(agent): expose GPT-5.5 family in Codex runtime model picker

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -150,7 +150,9 @@ func claudeStaticModels() []Model {
 
 func codexStaticModels() []Model {
 	return []Model{
-		{ID: "gpt-5.4", Label: "GPT-5.4", Provider: "openai", Default: true},
+		{ID: "gpt-5.5", Label: "GPT-5.5", Provider: "openai", Default: true},
+		{ID: "gpt-5.5-mini", Label: "GPT-5.5 mini", Provider: "openai"},
+		{ID: "gpt-5.4", Label: "GPT-5.4", Provider: "openai"},
 		{ID: "gpt-5.4-mini", Label: "GPT-5.4 mini", Provider: "openai"},
 		{ID: "gpt-5.3-codex", Label: "GPT-5.3 Codex", Provider: "openai"},
 		{ID: "gpt-5", Label: "GPT-5", Provider: "openai"},

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -58,6 +58,44 @@ func TestGeminiStaticModelsExposesAliasesAndGemini3(t *testing.T) {
 	}
 }
 
+func TestCodexStaticModelsExposesGPT55(t *testing.T) {
+	// Codex CLI has no `models list` subcommand so the catalog is
+	// hand-maintained. Regression guard for multica-ai/multica#2009 —
+	// GPT-5.5 must be selectable, and the badge default must point at
+	// the latest release rather than lagging a version behind.
+	models := codexStaticModels()
+	ids := map[string]Model{}
+	for _, m := range models {
+		ids[m.ID] = m
+	}
+	for _, want := range []string{
+		"gpt-5.5", "gpt-5.5-mini",
+		"gpt-5.4", "gpt-5.4-mini",
+		"gpt-5.3-codex", "gpt-5",
+		"o3", "o3-mini",
+	} {
+		if _, ok := ids[want]; !ok {
+			t.Errorf("missing expected Codex model %q in: %+v", want, models)
+		}
+	}
+	latest, ok := ids["gpt-5.5"]
+	if !ok || !latest.Default {
+		t.Errorf("expected `gpt-5.5` to be the default Codex entry, got %+v", latest)
+	}
+	defaults := 0
+	for _, m := range models {
+		if m.Default {
+			defaults++
+		}
+		if m.Provider != "openai" {
+			t.Errorf("all Codex entries must carry Provider=openai, got %+v", m)
+		}
+	}
+	if defaults != 1 {
+		t.Errorf("expected exactly one default Codex entry, got %d", defaults)
+	}
+}
+
 func TestListModelsHermesWithoutBinary(t *testing.T) {
 	// With no `hermes` binary on PATH the discovery fast-paths to
 	// an empty list (the UI then falls back to creatable manual


### PR DESCRIPTION

## Summary
Fixes #2009 

- Add `gpt-5.5` and `gpt-5.5-mini` to `codexStaticModels()` and promote 5.5 as the default badge.
- Keep `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.3-codex` / `gpt-5` / `o3` / `o3-mini` so users on older Codex CLIs still have working picks.
- Add `TestCodexStaticModelsExposesGPT55` regression guard, mirroring `TestGeminiStaticModelsExposesAliasesAndGemini3` (which was added when Gemini 3 hit the same problem in #1503 / dc8096fb).

## Why

Latest Codex CLI ships GPT-5.5 but Multica's UI picker still tops out at 5.4 — reported in https://github.com/multica-ai/multica/issues/2009. Codex CLI doesn't expose a `models list` subcommand so the catalog is hand-maintained; this is the standard "bump the static list" fix the same as we did for Gemini 3.

The daemon path itself is already model-agnostic — `codexBackend.Execute` passes `opts.Model` straight through to Codex's `thread/start`, so adding to the catalog is sufficient end-to-end.

## Follow-ups (separate PR)

A separate fix is on the way for the cloud-only bug where the picker shows "No models available" because `ModelListStore` is in-memory and Multica Cloud is multi-instance. That's a much bigger refactor and unrelated to the catalog miss.

## Test plan

- [x] `go test ./pkg/agent/ -run 'TestCodex|TestListModelsStaticProviders'`
- [ ] CI green