### PR TITLE
refactor(server): polish runtime-guard nits from PR #1905 review

### DIFF
--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -992,8 +992,13 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			// Resume chat sessions only when the stored pointer was produced
-			// by the same runtime as the claiming task. Legacy rows with no
-			// chat_session.runtime_id fall back to the task-row lookup below.
+			// by the same runtime as the claiming task. When the chat_session
+			// pointer is missing (legacy NULL runtime_id), stale (last task
+			// failed before reporting completion), or runtime-mismatched, fall
+			// back to the most recent task row that recorded a session_id —
+			// otherwise a single failed turn would silently drop the entire
+			// conversation memory on the next message. The fallback also
+			// requires runtime to match.
 			if cs.SessionID.Valid && cs.RuntimeID.Valid && cs.RuntimeID == task.RuntimeID {
 				resp.PriorSessionID = cs.SessionID.String
 			}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -2183,3 +2183,58 @@ func TestClaimTask_ChatPriorSessionRuntimeGuard(t *testing.T) {
 		t.Fatalf("chat runtime match: expected PriorWorkDir='/tmp/same-chat-workdir', got %q", task.PriorWorkDir)
 	}
 }
+
+// Locks the legacy-row fallback: chat_session.runtime_id IS NULL (e.g. a row
+// the migration left untouched because no prior task matched the cs pointer)
+// but a completed task on the claiming runtime exists. ClaimTaskByRuntime
+// must recover the session from the task row, not start a fresh conversation.
+func TestClaimTask_ChatLegacyNullRuntimeFallsBackToTaskRow(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	agentID, runtimeID, daemonID := createRuntimeGuardAgent(t, ctx)
+
+	var legacySessionID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO chat_session (
+			workspace_id, agent_id, creator_id, title,
+			session_id, work_dir, runtime_id
+		)
+		VALUES ($1, $2, $3, 'runtime guard legacy chat', NULL, NULL, NULL)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&legacySessionID); err != nil {
+		t.Fatalf("setup: create legacy chat session: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM chat_session WHERE id = $1`, legacySessionID) })
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority, started_at, completed_at,
+			session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'completed', 0, now(), now(), 'legacy-fallback-session', '/tmp/legacy-fallback-workdir')
+	`, agentID, runtimeID, legacySessionID); err != nil {
+		t.Fatalf("setup: create matching-runtime prior task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, chat_session_id,
+			status, priority
+		)
+		VALUES ($1, $2, $3, 'queued', 0)
+	`, agentID, runtimeID, legacySessionID); err != nil {
+		t.Fatalf("setup: create current chat task: %v", err)
+	}
+
+	task := claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "legacy-fallback-session" {
+		t.Fatalf("legacy fallback: expected PriorSessionID='legacy-fallback-session', got %q", task.PriorSessionID)
+	}
+	if task.PriorWorkDir != "/tmp/legacy-fallback-workdir" {
+		t.Fatalf("legacy fallback: expected PriorWorkDir='/tmp/legacy-fallback-workdir', got %q", task.PriorWorkDir)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -605,8 +605,14 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 		task = t
 
 		if t.ChatSessionID.Valid {
-			sessionRuntimeID := t.RuntimeID
-			sessionRuntimeID.Valid = sessionID != ""
+			// Pin the chat_session's runtime_id alongside the session_id so the
+			// next claim can apply the runtime-guard. Both fields move together:
+			// when there's no session_id to record, leave runtime_id untouched
+			// (NULL → COALESCE keeps the existing value).
+			var sessionRuntimeID pgtype.UUID
+			if sessionID != "" {
+				sessionRuntimeID = t.RuntimeID
+			}
 			// COALESCE in SQL guarantees empty inputs don't wipe the
 			// existing resume pointer; we still surface DB errors.
 			if err := qtx.UpdateChatSessionSession(ctx, db.UpdateChatSessionSessionParams{
@@ -757,8 +763,14 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 		task = t
 
 		if t.ChatSessionID.Valid {
-			sessionRuntimeID := t.RuntimeID
-			sessionRuntimeID.Valid = sessionID != ""
+			// Pin the chat_session's runtime_id alongside the session_id so the
+			// next claim can apply the runtime-guard. Both fields move together:
+			// when there's no session_id to record, leave runtime_id untouched
+			// (NULL → COALESCE keeps the existing value).
+			var sessionRuntimeID pgtype.UUID
+			if sessionID != "" {
+				sessionRuntimeID = t.RuntimeID
+			}
 			if err := qtx.UpdateChatSessionSession(ctx, db.UpdateChatSessionSessionParams{
 				ID:        t.ChatSessionID,
 				SessionID: pgtype.Text{String: sessionID, Valid: sessionID != ""},


### PR DESCRIPTION
## Summary

Follow-up to #1905 — applies the four review nits without changing runtime-guard semantics.

- **`server/internal/handler/daemon.go`** — expanded the chat-resume comment so the *why* of the task-row fallback (single failed turn must not drop chat memory) is preserved, and so the comment doesn't read as if it only applies to legacy NULL rows (it also covers stale / runtime-mismatched cs pointers).
- **`server/internal/service/task.go`** — replaced the \"clever\" `sessionRuntimeID := t.RuntimeID; sessionRuntimeID.Valid = sessionID != \"\"` pattern in both `CompleteTask` and `FailTask` with a `var sessionRuntimeID pgtype.UUID; if sessionID != \"\" { sessionRuntimeID = t.RuntimeID }` form. Same wire output to `UpdateChatSessionSession` (zero UUID + Valid=false → NULL → COALESCE keeps existing), but the coupling `no session_id ⇒ leave runtime_id alone` is now obvious from one read.
- **`server/internal/handler/daemon_test.go`** — added `TestClaimTask_ChatLegacyNullRuntimeFallsBackToTaskRow`. PR #1905 tested cs/runtime-match (resume) and cs/runtime-mismatch (skip) for chat, plus a migration-level backfill regression. The legacy-NULL-cs + matching-runtime-task case (the dominant post-migration shape) was only covered transitively. New test seeds `chat_session.runtime_id IS NULL` plus a completed task on the claiming runtime and asserts the daemon resumes from the task row.

## Dependency

Touches files introduced/modified by #1905 (`chat_session.runtime_id` column, runtime-guard branches in `ClaimTaskByRuntime`, runtime_id wiring in `Complete/FailTask`). Should land **after** #1905 merges; the diff against `main` will then collapse to just this cleanup.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/handler/ ./internal/service/\` clean
- [x] \`gofmt -l\` clean on changed files
- [x] Test package compiles (\`go test -run '^\$' ./internal/handler/ ./internal/service/\`)
- [ ] CI: full backend test suite on the merged base (will run against the post-#1905 main once that lands)