### PR TITLE
fix(agent/hermes): wire streamingCurrentTurn gate to drop history replay

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -90,6 +91,12 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 
 	var outputMu sync.Mutex
 	var output strings.Builder
+	// streamingCurrentTurn gates all session updates so that history
+	// replay (Hermes sends full prior-turn transcripts on session/resume,
+	// and may flush queued chunks before our session/prompt response
+	// streams) is dropped instead of duplicating the previous answer
+	// into output. We flip it to true only after session/prompt is sent.
+	var streamingCurrentTurn atomic.Bool
 
 	promptDone := make(chan hermesPromptResult, 1)
 
@@ -98,7 +105,13 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		stdin:        stdin,
 		pending:      make(map[int]*pendingRPC),
 		pendingTools: make(map[string]*pendingToolCall),
+		acceptNotification: func(string) bool {
+			return streamingCurrentTurn.Load()
+		},
 		onMessage: func(msg Message) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
 			if msg.Type == MessageText {
 				outputMu.Lock()
 				output.WriteString(msg.Content)
@@ -107,6 +120,9 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			trySend(msgCh, msg)
 		},
 		onPromptDone: func(result hermesPromptResult) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
 			select {
 			case promptDone <- result:
 			default:
@@ -233,7 +249,11 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
 		}
 
-		// 5. Send the prompt and wait for PromptResponse.
+		// 5. Send the prompt and wait for PromptResponse. Flip the gate
+		// just before the request so any history replay flushed during
+		// initialize / session setup stays dropped, but every notification
+		// belonging to this turn is processed.
+		streamingCurrentTurn.Store(true)
 		_, err = c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,
 			"prompt": []map[string]any{

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -314,6 +314,48 @@ func TestHermesClientHandleSessionNotificationAgentMessage(t *testing.T) {
 	}
 }
 
+// Regression for #1997: Hermes ACP can flush queued session updates from
+// the previous turn (history replay on session/resume, or chunks queued
+// before our session/prompt response is sent) before the current turn
+// actually starts. Until acceptNotification gates them out, those updates
+// were appended to output and re-sent to the UI, making the previous
+// answer appear duplicated alongside the new one. The Backend wires the
+// gate to a streamingCurrentTurn flag set just before session/prompt; here
+// we exercise the gate directly on hermesClient.
+func TestHermesClientAcceptNotificationGate(t *testing.T) {
+	t.Parallel()
+
+	var (
+		got    []Message
+		accept bool
+	)
+	c := &hermesClient{
+		pending: make(map[int]*pendingRPC),
+		acceptNotification: func(string) bool {
+			return accept
+		},
+		onMessage: func(msg Message) {
+			got = append(got, msg)
+		},
+	}
+
+	replay := `{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_1","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"history should be ignored"}}}}`
+	c.handleLine(replay)
+	if len(got) != 0 {
+		t.Fatalf("expected gate to drop replay before turn starts, got %+v", got)
+	}
+
+	accept = true
+	live := `{"jsonrpc":"2.0","method":"session/notification","params":{"sessionId":"ses_1","update":{"type":"AgentMessageChunk","content":{"type":"text","text":"current"}}}}`
+	c.handleLine(live)
+	if len(got) != 1 {
+		t.Fatalf("expected current-turn update to pass the gate, got %+v", got)
+	}
+	if got[0].Content != "current" {
+		t.Fatalf("got content %q, want \"current\"", got[0].Content)
+	}
+}
+
 func TestHermesClientHandleAgentThought(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Closes #1997.

Hermes ACP can flush queued session updates from the previous turn before the current turn actually starts — both as `session/resume` history replay and as chunks queued before our `session/prompt` response streams. Without a gate those updates were appended to output and re-emitted to the UI, so the previous answer appeared duplicated alongside the new one.

PR #1789 added the `acceptNotification` hook field on `hermesClient` and the call site in `handleNotification`, but never assigned it for Hermes — the guard `c.acceptNotification != nil && !c.acceptNotification(updateType)` short-circuited and every notification was processed. (Note: PR #2000 attempted to fix this but landed an empty commit with no file changes; this PR replaces it with a real patch.)

This change mirrors the working Kiro pattern at `kiro.go:87/97/240`:

- Declare a `streamingCurrentTurn atomic.Bool` in the Hermes backend.
- Assign `acceptNotification`, `onMessage`, and `onPromptDone` gates that all return early when the flag is `false`.
- Flip the flag to `true` immediately before `c.request(runCtx, "session/prompt", ...)`.

## Test plan

- [x] `go test ./pkg/agent` (all package tests pass)
- [x] New regression `TestHermesClientAcceptNotificationGate` asserts that pre-turn notifications are dropped while current-turn notifications pass through.
- [ ] Manual smoke test: add a Hermes runtime, chat across multiple turns, verify the previous answer is no longer duplicated alongside the new one.