### PR TITLE
fix(daemon): drain background repo syncs before test teardown

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -69,6 +69,13 @@ type Daemon struct {
 
 	activeEnvRootsMu sync.Mutex
 	activeEnvRoots   map[string]int // env root path -> reference count (handles reuse paths marked twice)
+
+	// bgSyncs tracks background goroutines started by registerTaskRepos so
+	// callers (notably tests using t.TempDir-backed cache roots) can wait for
+	// them to drain before tearing the daemon down. Without this the bg
+	// goroutine can race against t.TempDir cleanup, leaving a partially
+	// deleted bare clone and an unrelated `not empty` cleanup failure.
+	bgSyncs sync.WaitGroup
 }
 
 // New creates a new Daemon instance.
@@ -454,8 +461,21 @@ func (d *Daemon) registerTaskRepos(workspaceID string, repos []RepoData) {
 		// `ensureRepoReady` reports a meaningful error if the cache isn't ready
 		// yet, so the agent's first checkout will surface a sync failure
 		// without silently treating it as a config bug.
-		go d.syncWorkspaceRepos(workspaceID, toSync)
+		d.bgSyncs.Add(1)
+		go func() {
+			defer d.bgSyncs.Done()
+			d.syncWorkspaceRepos(workspaceID, toSync)
+		}()
 	}
+}
+
+// waitBackgroundSyncs blocks until every background sync started by
+// registerTaskRepos has finished. Intended for test teardown: tests that
+// hand the daemon a t.TempDir-backed repo cache must call this before
+// returning, otherwise an in-flight clone/fetch can race against TempDir
+// cleanup and surface as an unrelated "directory not empty" failure.
+func (d *Daemon) waitBackgroundSyncs() {
+	d.bgSyncs.Wait()
 }
 
 func (d *Daemon) syncWorkspaceRepos(workspaceID string, repos []RepoData) {

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -368,13 +368,19 @@ func newRepoReadyTestDaemon(t *testing.T, handler http.HandlerFunc) *Daemon {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	return &Daemon{
+	d := &Daemon{
 		client:       NewClient(srv.URL),
 		repoCache:    repocache.New(t.TempDir(), slog.Default()),
 		logger:       slog.Default(),
 		workspaces:   make(map[string]*workspaceState),
 		runtimeIndex: make(map[string]Runtime),
 	}
+	// Drain background syncs (started by registerTaskRepos) before the
+	// t.TempDir cache root is cleaned up, otherwise an in-flight clone/fetch
+	// races against the deletion and the test fails with a misleading
+	// "directory not empty" cleanup error.
+	t.Cleanup(d.waitBackgroundSyncs)
+	return d
 }
 
 func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestRegisterTaskReposSurvivesWorkspaceRefresh` started flaking on `main` after merging #2024 — but the failure is not in the agent code that PR touched, it's a latent race in the daemon test that #1988 (`feat: support repo checkout ref selection`) made much more likely to lose.

`registerTaskRepos` fires `go syncWorkspaceRepos(...)` to clone a repo into the cache root, which in tests is `t.TempDir()`. The test waits on `repoCache.Lookup` returning a path, then exits. Meanwhile the bg goroutine is still inside `ensureRemoteTrackingLayout` running `git fetch` on the clone dir. `t.TempDir`'s cleanup races with those git commands and surfaces as either:

- `TempDir RemoveAll cleanup: unlinkat .../ws-1/<sanitized>.git: directory not empty`, or
- `git fetch: fatal: cannot change to '...' : No such file or directory`.

Either way the failure looks unrelated to what the test is asserting. Reproduces locally within ~10 iterations of `-count=30`.

### Fix

- Track the background goroutine on the `Daemon` via a `sync.WaitGroup` and expose a private `waitBackgroundSyncs()`.
- `newRepoReadyTestDaemon` registers a `t.Cleanup` that calls it, so every test using the helper drains in-flight syncs before `t.TempDir` cleanup runs.
- No production-behavior change — `registerTaskRepos` still fires-and-forgets from the caller's perspective. The WaitGroup just makes the lifecycle observable for callers that explicitly want to drain (i.e. tests today, graceful shutdown tomorrow).

## Test plan

- [x] `cd server && go test ./internal/daemon -run TestRegisterTaskReposSurvivesWorkspaceRefresh -count=30` (30 green; previously failed within ~10).
- [x] `cd server && go test ./internal/daemon/...` (full daemon suite green).
- [ ] CI on this PR also exercises the same code path.