### PR TITLE
feat(desktop): add Intel Mac (x86_64) support

### DIFF
--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -16,6 +16,8 @@ jobs:
             target: linux
           - os: windows-latest
             target: win
+          - os: macos-latest
+            target: mac
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -64,6 +64,7 @@ const ARCH_FLAGS = new Map([
 const SUPPORTED_CLI_ARCHS = new Set(["x64", "arm64"]);
 const MAC_ALL_PLATFORM_TARGETS = [
   { platform: "mac", arch: "arm64" },
+  { platform: "mac", arch: "x64" },
   { platform: "win", arch: "x64" },
   { platform: "win", arch: "arm64" },
   { platform: "linux", arch: "x64" },

--- a/apps/desktop/scripts/package.test.mjs
+++ b/apps/desktop/scripts/package.test.mjs
@@ -134,6 +134,7 @@ describe("resolveBuildMatrix", () => {
       ),
     ).toEqual([
       { platform: "mac", arch: "arm64" },
+      { platform: "mac", arch: "x64" },
       { platform: "win", arch: "x64" },
       { platform: "win", arch: "arm64" },
       { platform: "linux", arch: "x64" },


### PR DESCRIPTION
## What does this PR do?

Adds Intel Mac (x86_64) build support for the Desktop app. Previously, the cross-platform build matrix only included macOS ARM64, excluding Intel Mac users.

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/scripts/package.mjs`: Added `{platform: "mac", arch: "x64"}` to `MAC_ALL_PLATFORM_TARGETS`
- `apps/desktop/scripts/package.test.mjs`: Updated test expectation for all-platforms macOS build matrix
- `.github/workflows/desktop-smoke.yml`: Added `macos-latest` runner to smoke-test macOS builds in CI

## How to Test

1. `cd apps/desktop && node scripts/package.mjs --mac --x64`
2. Verify `dist/mac/Multica.app/Contents/MacOS/Multica` is `Mach-O 64-bit executable x86_64`

## Checklist

- [x] I have run tests locally and they pass (TS unit tests + Go core tests)
- [x] Build verified: DMG and ZIP artifacts produced successfully for mac/x64

## AI Disclosure

**AI tool used:** Claude Code
**Prompt / approach:** AI agent analyzed the codebase to identify why Intel Mac was excluded, made minimal targeted changes to the build matrix and tests, then built and verified the x86_64 artifact locally.