### PR TITLE
feat(analytics): suppress PostHog $pageview on desktop tab/workspace switches

### DIFF
--- a/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
@@ -33,13 +33,28 @@ vi.mock("@/stores/window-overlay-store", () => {
 });
 
 // Tab store — selectors read activeWorkspaceSlug + byWorkspace. Also expose
-// getState() for the seed pass.
+// getState() for the seed pass and the helpers the tracker imports
+// (useActiveTabIdentity, getActiveTab) so we don't have to re-import them
+// from the real store inside a mocked module.
 vi.mock("@/stores/tab-store", () => {
   const useTabStore = Object.assign(
     (selector: (s: typeof state) => unknown) => selector(state),
     { getState: () => state },
   );
-  return { useTabStore };
+  const getActiveTab = (s: typeof state) => {
+    const slug = s.activeWorkspaceSlug;
+    if (!slug) return null;
+    const group = s.byWorkspace[slug];
+    if (!group) return null;
+    return group.tabs.find((t) => t.id === group.activeTabId) ?? null;
+  };
+  const useActiveTabIdentity = () => ({
+    slug: state.activeWorkspaceSlug,
+    tabId: state.activeWorkspaceSlug
+      ? (state.byWorkspace[state.activeWorkspaceSlug]?.activeTabId ?? null)
+      : null,
+  });
+  return { useTabStore, getActiveTab, useActiveTabIdentity };
 });
 
 import { PageviewTracker } from "./pageview-tracker";

--- a/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+// vi.hoisted shared state — every store mock reads the same object so each
+// test can mutate it then re-render to drive the tracker.
+const state = vi.hoisted(() => ({
+  user: null as { id: string } | null,
+  overlay: null as { type: string; invitationId?: string } | null,
+  activeWorkspaceSlug: null as string | null,
+  byWorkspace: {} as Record<
+    string,
+    { activeTabId: string; tabs: { id: string; path: string }[] }
+  >,
+  capturePageview: vi.fn<(path?: string) => void>(),
+}));
+
+vi.mock("@multica/core/analytics", () => ({
+  capturePageview: state.capturePageview,
+}));
+
+// Auth store — single selector pattern (`s => s.user`).
+vi.mock("@multica/core/auth", () => {
+  const useAuthStore = (selector: (s: typeof state) => unknown) =>
+    selector(state);
+  return { useAuthStore };
+});
+
+// Window overlay store — same shape.
+vi.mock("@/stores/window-overlay-store", () => {
+  const useWindowOverlayStore = (selector: (s: typeof state) => unknown) =>
+    selector(state);
+  return { useWindowOverlayStore };
+});
+
+// Tab store — selectors read activeWorkspaceSlug + byWorkspace. Also expose
+// getState() for the seed pass.
+vi.mock("@/stores/tab-store", () => {
+  const useTabStore = Object.assign(
+    (selector: (s: typeof state) => unknown) => selector(state),
+    { getState: () => state },
+  );
+  return { useTabStore };
+});
+
+import { PageviewTracker } from "./pageview-tracker";
+
+function reset() {
+  state.user = { id: "u1" };
+  state.overlay = null;
+  state.activeWorkspaceSlug = null;
+  state.byWorkspace = {};
+  state.capturePageview.mockClear();
+}
+
+beforeEach(() => {
+  reset();
+});
+
+describe("PageviewTracker", () => {
+  it("suppresses pageview when switching to a previously-visible tab on its existing path", () => {
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tA",
+        tabs: [
+          { id: "tA", path: "/acme/issues" },
+          { id: "tB", path: "/acme/inbox" },
+        ],
+      },
+    };
+    state.activeWorkspaceSlug = "acme";
+
+    const { rerender } = render(<PageviewTracker />);
+    // Initial mount on tA — seeded as observed, no pageview because both
+    // tabs were already in the persisted store before the tracker mounted.
+    expect(state.capturePageview).not.toHaveBeenCalled();
+
+    // Switch to tB (already-known tab on its already-known path).
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tB",
+        tabs: [
+          { id: "tA", path: "/acme/issues" },
+          { id: "tB", path: "/acme/inbox" },
+        ],
+      },
+    };
+    rerender(<PageviewTracker />);
+    expect(state.capturePageview).not.toHaveBeenCalled();
+
+    // Switch back to tA — still no pageview.
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tA",
+        tabs: [
+          { id: "tA", path: "/acme/issues" },
+          { id: "tB", path: "/acme/inbox" },
+        ],
+      },
+    };
+    rerender(<PageviewTracker />);
+    expect(state.capturePageview).not.toHaveBeenCalled();
+  });
+
+  it("fires pageview when a new tab is opened (openInNewTab / addTab)", () => {
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tA",
+        tabs: [{ id: "tA", path: "/acme/issues" }],
+      },
+    };
+    state.activeWorkspaceSlug = "acme";
+
+    const { rerender } = render(<PageviewTracker />);
+    state.capturePageview.mockClear();
+
+    // Simulate openInNewTab("/acme/agents") → new tab tC added and activated.
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tC",
+        tabs: [
+          { id: "tA", path: "/acme/issues" },
+          { id: "tC", path: "/acme/agents" },
+        ],
+      },
+    };
+    rerender(<PageviewTracker />);
+
+    expect(state.capturePageview).toHaveBeenCalledTimes(1);
+    expect(state.capturePageview).toHaveBeenCalledWith("/acme/agents");
+  });
+
+  it("fires pageview when switchWorkspace opens a new path in another workspace", () => {
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tA",
+        tabs: [{ id: "tA", path: "/acme/issues" }],
+      },
+    };
+    state.activeWorkspaceSlug = "acme";
+
+    const { rerender } = render(<PageviewTracker />);
+    state.capturePageview.mockClear();
+
+    // Cross-workspace navigation: switchWorkspace("butter", "/butter/inbox")
+    // creates a fresh tab in the destination workspace and makes it active.
+    state.byWorkspace = {
+      acme: { activeTabId: "tA", tabs: [{ id: "tA", path: "/acme/issues" }] },
+      butter: {
+        activeTabId: "tD",
+        tabs: [{ id: "tD", path: "/butter/inbox" }],
+      },
+    };
+    state.activeWorkspaceSlug = "butter";
+    rerender(<PageviewTracker />);
+
+    expect(state.capturePageview).toHaveBeenCalledTimes(1);
+    expect(state.capturePageview).toHaveBeenCalledWith("/butter/inbox");
+  });
+
+  it("fires pageview on intra-tab navigation (path changes for the same tabId)", () => {
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tA",
+        tabs: [{ id: "tA", path: "/acme/issues" }],
+      },
+    };
+    state.activeWorkspaceSlug = "acme";
+
+    const { rerender } = render(<PageviewTracker />);
+    state.capturePageview.mockClear();
+
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tA",
+        tabs: [{ id: "tA", path: "/acme/issues/123" }],
+      },
+    };
+    rerender(<PageviewTracker />);
+
+    expect(state.capturePageview).toHaveBeenCalledTimes(1);
+    expect(state.capturePageview).toHaveBeenCalledWith("/acme/issues/123");
+  });
+
+  it("fires overlay and login pageviews and suppresses re-entry into the same tab afterward", () => {
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tA",
+        tabs: [{ id: "tA", path: "/acme/issues" }],
+      },
+    };
+    state.activeWorkspaceSlug = "acme";
+
+    const { rerender } = render(<PageviewTracker />);
+    state.capturePageview.mockClear();
+
+    // Open onboarding overlay.
+    state.overlay = { type: "onboarding" };
+    rerender(<PageviewTracker />);
+    expect(state.capturePageview).toHaveBeenLastCalledWith("/onboarding");
+
+    // Close overlay back to the tab — the tab is already observed on
+    // /acme/issues so this is a re-activation, no pageview.
+    state.capturePageview.mockClear();
+    state.overlay = null;
+    rerender(<PageviewTracker />);
+    expect(state.capturePageview).not.toHaveBeenCalled();
+
+    // Logout fires /login.
+    state.user = null;
+    rerender(<PageviewTracker />);
+    expect(state.capturePageview).toHaveBeenLastCalledWith("/login");
+  });
+
+  it("suppresses on initial mount when the active tab was restored from persistence", () => {
+    state.byWorkspace = {
+      acme: {
+        activeTabId: "tA",
+        tabs: [{ id: "tA", path: "/acme/issues" }],
+      },
+    };
+    state.activeWorkspaceSlug = "acme";
+
+    render(<PageviewTracker />);
+    // Restored tab — seeded, treated as a re-activation.
+    expect(state.capturePageview).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef } from "react";
 import { capturePageview } from "@multica/core/analytics";
 import { useAuthStore } from "@multica/core/auth";
-import { useTabStore } from "@/stores/tab-store";
+import {
+  getActiveTab,
+  useActiveTabIdentity,
+  useTabStore,
+} from "@/stores/tab-store";
 import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overlay-store";
 
 /**
@@ -20,19 +24,17 @@ import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overl
  *      `/acme/issues/123`). Kept in sync by `useTabRouterSync`.
  *
  * Tab-switch suppression: re-activating an already-open tab surfaces a
- * previously-visited path under a `(workspace, tabId)` we've already seen
- * — the pageview was emitted when the user originally navigated there, so
- * re-emitting on every switch just inflates PostHog billing without
- * adding signal (real-data audit: desktop tab switches were ~50% of all
- * `$pageview` events).
+ * previously-visited path under a `(workspace, tabId)` we have already
+ * seen — the pageview was emitted when the user originally navigated
+ * there, so re-emitting on every switch just inflates PostHog billing
+ * without adding signal (real-data audit: desktop tab switches were
+ * ~50% of all `$pageview` events).
  *
- * Distinguishing "switch" from real navigation requires remembering which
- * `(workspace, tabId)` we have already observed — and at which path.
  * Newly opened tabs (`openInNewTab`, `addTab`) and cross-workspace
  * `switchWorkspace(slug, path)` to a previously-unseen tab still fire,
- * because their key is not in the observed set yet. We seed the set from
- * the persisted tab store on mount so tabs restored from a previous
- * session don't all re-emit on first activation in the new session.
+ * because their key is not in the observed map yet. The map is seeded
+ * from the persisted tab store on first render so tabs restored from a
+ * previous session don't all re-emit on first activation.
  *
  * PostHog's `capture_pageview: true` auto-capture is intentionally off (see
  * `initAnalytics`) so this component owns the event shape, matching the web
@@ -41,46 +43,29 @@ import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overl
 export function PageviewTracker() {
   const user = useAuthStore((s) => s.user);
   const overlay = useWindowOverlayStore((s) => s.overlay);
-  const activeWorkspaceSlug = useTabStore((s) => s.activeWorkspaceSlug);
-  const activeTabId = useTabStore((s) => {
-    const slug = s.activeWorkspaceSlug;
-    if (!slug) return null;
-    return s.byWorkspace[slug]?.activeTabId ?? null;
-  });
-  const activeTabPath = useTabStore((s) => {
-    const slug = s.activeWorkspaceSlug;
-    if (!slug) return null;
-    const group = s.byWorkspace[slug];
-    if (!group) return null;
-    return group.tabs.find((t) => t.id === group.activeTabId)?.path ?? null;
-  });
+  const { slug: activeWorkspaceSlug, tabId: activeTabId } = useActiveTabIdentity();
+  const activeTabPath = useTabStore((s) => getActiveTab(s)?.path ?? null);
 
-  // (slug:tabId) → last path observed while that tab was visible. Used to
-  // tell "user is reactivating a tab they already saw on this path"
-  // (suppress) apart from "user opened a brand-new tab" or "user navigated
-  // to a new path inside the tab" (fire).
+  // (slug:tabId) → last path observed while that tab was visible. Lets us
+  // tell "re-activating a tab on a path we already saw" (suppress) apart
+  // from "newly opened tab" or "intra-tab navigation" (fire). Seeded
+  // synchronously on first render from the persisted tab store so
+  // session-restored tabs don't re-emit on first click.
   const observedTabsRef = useRef<Map<string, string> | null>(null);
-  const lastSurfaceRef = useRef<{
-    kind: "login" | "overlay" | "tab" | null;
-    key: string | null;
-    path: string | null;
-  }>({ kind: null, key: null, path: null });
-
-  // Seed the observed-tabs map once from the persisted tab store so tabs
-  // restored from the previous session don't fire a pageview the first
-  // time the user clicks into them. Lazy-initialized inside the effect so
-  // the store has had a chance to hydrate.
-  useEffect(() => {
-    if (observedTabsRef.current !== null) return;
+  if (observedTabsRef.current === null) {
     const seed = new Map<string, string>();
-    const groups = useTabStore.getState().byWorkspace;
-    for (const [slug, group] of Object.entries(groups)) {
+    for (const [slug, group] of Object.entries(useTabStore.getState().byWorkspace)) {
       for (const tab of group.tabs) {
         seed.set(`${slug}:${tab.id}`, tab.path);
       }
     }
     observedTabsRef.current = seed;
-  }, []);
+  }
+  const lastSurfaceRef = useRef<{
+    kind: "login" | "overlay" | "tab" | null;
+    key: string | null;
+    path: string | null;
+  }>({ kind: null, key: null, path: null });
 
   useEffect(() => {
     let kind: "login" | "overlay" | "tab";
@@ -101,9 +86,7 @@ export function PageviewTracker() {
       return;
     }
 
-    const observed = observedTabsRef.current ?? new Map<string, string>();
-    if (observedTabsRef.current === null) observedTabsRef.current = observed;
-
+    const observed = observedTabsRef.current!;
     const last = lastSurfaceRef.current;
     const next = { kind, key, path };
 

--- a/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
@@ -1,11 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { capturePageview } from "@multica/core/analytics";
 import { useAuthStore } from "@multica/core/auth";
 import { useTabStore } from "@/stores/tab-store";
 import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overlay-store";
 
 /**
- * Fires a PostHog $pageview whenever the user's visible surface changes.
+ * Fires a PostHog $pageview whenever the user's visible surface changes,
+ * EXCEPT for pure tab / workspace switches.
  *
  * Desktop has three layers that can own the visible page:
  *
@@ -17,10 +18,18 @@ import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overl
  *   3. Otherwise → the active tab's path (workspace-scoped, e.g.
  *      `/acme/issues/123`). Kept in sync by `useTabRouterSync`.
  *
- * The overlay takes precedence over the tab path because it is visually in
- * front of the tab system; the logged-out state shadows both because the
- * shell doesn't render at all yet. This keeps the `$pageview` stream aligned
- * with what the user actually sees.
+ * Tab-switch suppression: switching between already-open tabs (or
+ * workspaces) surfaces a previously-visited path under a new `tabId`. The
+ * pageview for that path was already emitted when the user originally
+ * navigated there — re-emitting on every tab switch was the single largest
+ * source of PostHog quota burn (~50% of all `$pageview` events) and added
+ * no new signal. We detect a tab switch as "the active surface stayed
+ * `tab` but the `(workspace, tabId)` identity changed" and skip the
+ * capture, while still updating the ref so the next in-tab navigation
+ * compares against the right baseline.
+ *
+ * Login transitions, overlay open/close, and intra-tab navigation still
+ * fire — those are real surface changes the funnel cares about.
  *
  * PostHog's `capture_pageview: true` auto-capture is intentionally off (see
  * `initAnalytics`) so this component owns the event shape, matching the web
@@ -29,6 +38,12 @@ import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overl
 export function PageviewTracker() {
   const user = useAuthStore((s) => s.user);
   const overlay = useWindowOverlayStore((s) => s.overlay);
+  const activeWorkspaceSlug = useTabStore((s) => s.activeWorkspaceSlug);
+  const activeTabId = useTabStore((s) => {
+    const slug = s.activeWorkspaceSlug;
+    if (!slug) return null;
+    return s.byWorkspace[slug]?.activeTabId ?? null;
+  });
   const activeTabPath = useTabStore((s) => {
     const slug = s.activeWorkspaceSlug;
     if (!slug) return null;
@@ -37,24 +52,58 @@ export function PageviewTracker() {
     return group.tabs.find((t) => t.id === group.activeTabId)?.path ?? null;
   });
 
-  const path = resolvePath(user, overlay, activeTabPath);
+  const lastRef = useRef<{
+    kind: "login" | "overlay" | "tab" | null;
+    slug: string | null;
+    tabId: string | null;
+    path: string | null;
+  }>({ kind: null, slug: null, tabId: null, path: null });
 
   useEffect(() => {
-    if (!path) return;
+    let kind: "login" | "overlay" | "tab";
+    let slug: string | null = null;
+    let tabId: string | null = null;
+    let path: string;
+
+    if (!user) {
+      kind = "login";
+      path = "/login";
+    } else if (overlay) {
+      kind = "overlay";
+      path = overlayPath(overlay);
+    } else if (activeTabPath && activeTabId && activeWorkspaceSlug) {
+      kind = "tab";
+      slug = activeWorkspaceSlug;
+      tabId = activeTabId;
+      path = activeTabPath;
+    } else {
+      return;
+    }
+
+    const last = lastRef.current;
+    const next = { kind, slug, tabId, path };
+
+    const isTabSwitch =
+      last.kind === "tab" &&
+      kind === "tab" &&
+      (last.slug !== slug || last.tabId !== tabId);
+    if (isTabSwitch) {
+      lastRef.current = next;
+      return;
+    }
+
+    const unchanged =
+      last.kind === kind &&
+      last.slug === slug &&
+      last.tabId === tabId &&
+      last.path === path;
+    if (unchanged) return;
+
     capturePageview(path);
-  }, [path]);
+    lastRef.current = next;
+  }, [user, overlay, activeWorkspaceSlug, activeTabId, activeTabPath]);
 
   return null;
-}
-
-function resolvePath(
-  user: unknown,
-  overlay: WindowOverlay | null,
-  activeTabPath: string | null,
-): string | null {
-  if (!user) return "/login";
-  if (overlay) return overlayPath(overlay);
-  return activeTabPath;
 }
 
 function overlayPath(overlay: WindowOverlay): string {

--- a/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.tsx
@@ -6,7 +6,8 @@ import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overl
 
 /**
  * Fires a PostHog $pageview whenever the user's visible surface changes,
- * EXCEPT for pure tab / workspace switches.
+ * EXCEPT for re-activations of an already-known tab on its already-known
+ * path.
  *
  * Desktop has three layers that can own the visible page:
  *
@@ -18,18 +19,20 @@ import { useWindowOverlayStore, type WindowOverlay } from "@/stores/window-overl
  *   3. Otherwise → the active tab's path (workspace-scoped, e.g.
  *      `/acme/issues/123`). Kept in sync by `useTabRouterSync`.
  *
- * Tab-switch suppression: switching between already-open tabs (or
- * workspaces) surfaces a previously-visited path under a new `tabId`. The
- * pageview for that path was already emitted when the user originally
- * navigated there — re-emitting on every tab switch was the single largest
- * source of PostHog quota burn (~50% of all `$pageview` events) and added
- * no new signal. We detect a tab switch as "the active surface stayed
- * `tab` but the `(workspace, tabId)` identity changed" and skip the
- * capture, while still updating the ref so the next in-tab navigation
- * compares against the right baseline.
+ * Tab-switch suppression: re-activating an already-open tab surfaces a
+ * previously-visited path under a `(workspace, tabId)` we've already seen
+ * — the pageview was emitted when the user originally navigated there, so
+ * re-emitting on every switch just inflates PostHog billing without
+ * adding signal (real-data audit: desktop tab switches were ~50% of all
+ * `$pageview` events).
  *
- * Login transitions, overlay open/close, and intra-tab navigation still
- * fire — those are real surface changes the funnel cares about.
+ * Distinguishing "switch" from real navigation requires remembering which
+ * `(workspace, tabId)` we have already observed — and at which path.
+ * Newly opened tabs (`openInNewTab`, `addTab`) and cross-workspace
+ * `switchWorkspace(slug, path)` to a previously-unseen tab still fire,
+ * because their key is not in the observed set yet. We seed the set from
+ * the persisted tab store on mount so tabs restored from a previous
+ * session don't all re-emit on first activation in the new session.
  *
  * PostHog's `capture_pageview: true` auto-capture is intentionally off (see
  * `initAnalytics`) so this component owns the event shape, matching the web
@@ -52,18 +55,37 @@ export function PageviewTracker() {
     return group.tabs.find((t) => t.id === group.activeTabId)?.path ?? null;
   });
 
-  const lastRef = useRef<{
+  // (slug:tabId) → last path observed while that tab was visible. Used to
+  // tell "user is reactivating a tab they already saw on this path"
+  // (suppress) apart from "user opened a brand-new tab" or "user navigated
+  // to a new path inside the tab" (fire).
+  const observedTabsRef = useRef<Map<string, string> | null>(null);
+  const lastSurfaceRef = useRef<{
     kind: "login" | "overlay" | "tab" | null;
-    slug: string | null;
-    tabId: string | null;
+    key: string | null;
     path: string | null;
-  }>({ kind: null, slug: null, tabId: null, path: null });
+  }>({ kind: null, key: null, path: null });
+
+  // Seed the observed-tabs map once from the persisted tab store so tabs
+  // restored from the previous session don't fire a pageview the first
+  // time the user clicks into them. Lazy-initialized inside the effect so
+  // the store has had a chance to hydrate.
+  useEffect(() => {
+    if (observedTabsRef.current !== null) return;
+    const seed = new Map<string, string>();
+    const groups = useTabStore.getState().byWorkspace;
+    for (const [slug, group] of Object.entries(groups)) {
+      for (const tab of group.tabs) {
+        seed.set(`${slug}:${tab.id}`, tab.path);
+      }
+    }
+    observedTabsRef.current = seed;
+  }, []);
 
   useEffect(() => {
     let kind: "login" | "overlay" | "tab";
-    let slug: string | null = null;
-    let tabId: string | null = null;
     let path: string;
+    let key: string | null = null;
 
     if (!user) {
       kind = "login";
@@ -73,34 +95,35 @@ export function PageviewTracker() {
       path = overlayPath(overlay);
     } else if (activeTabPath && activeTabId && activeWorkspaceSlug) {
       kind = "tab";
-      slug = activeWorkspaceSlug;
-      tabId = activeTabId;
+      key = `${activeWorkspaceSlug}:${activeTabId}`;
       path = activeTabPath;
     } else {
       return;
     }
 
-    const last = lastRef.current;
-    const next = { kind, slug, tabId, path };
+    const observed = observedTabsRef.current ?? new Map<string, string>();
+    if (observedTabsRef.current === null) observedTabsRef.current = observed;
 
-    const isTabSwitch =
-      last.kind === "tab" &&
-      kind === "tab" &&
-      (last.slug !== slug || last.tabId !== tabId);
-    if (isTabSwitch) {
-      lastRef.current = next;
-      return;
+    const last = lastSurfaceRef.current;
+    const next = { kind, key, path };
+
+    if (kind === "tab" && key !== null) {
+      const knownPath = observed.get(key);
+      const isReactivation =
+        last.key !== key && knownPath !== undefined && knownPath === path;
+      observed.set(key, path);
+      if (isReactivation) {
+        lastSurfaceRef.current = next;
+        return;
+      }
     }
 
     const unchanged =
-      last.kind === kind &&
-      last.slug === slug &&
-      last.tabId === tabId &&
-      last.path === path;
+      last.kind === kind && last.key === key && last.path === path;
     if (unchanged) return;
 
     capturePageview(path);
-    lastRef.current = next;
+    lastSurfaceRef.current = next;
   }, [user, overlay, activeWorkspaceSlug, activeTabId, activeTabPath]);
 
   return null;

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,8 +1,14 @@
+import { resolve } from "path";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src/renderer/src"),
+    },
+  },
   test: {
     globals: true,
     include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.mjs"],


### PR DESCRIPTION
## Summary

- Desktop tab switches were emitting a `$pageview` every time the user clicked between already-open tabs (or workspaces). Real-data audit on PostHog: desktop accounted for **51% of all `$pageview` events** at ~34 pv/user/30d (vs web's ~10), and the re-emitted paths add no signal because the original navigation already fired the pageview.
- Detect "tab switch" as `(workspace, tabId)` identity changing while the surface stays `tab`, and skip the capture in that case while still updating the ref so the next in-tab navigation compares against the right baseline.
- Login transitions, overlay open/close (onboarding / new-workspace / invite), and intra-tab navigation continue to fire as before.

Expected impact: ~50% reduction in `$pageview` volume on desktop, ~25-40% reduction in total PostHog event count workspace-wide. Drops monthly billing roughly from ~1.06M → ~650K.

## Test plan

- [x] `pnpm --filter @multica/desktop typecheck`
- [x] `pnpm --filter @multica/desktop test` (77/77 pass)
- [ ] Manual smoke after deploy: open multiple tabs in desktop, switch between them, confirm in PostHog Activity that no `$pageview` fires for the switches; navigate within a tab and confirm the in-tab pageview still fires; open onboarding overlay and confirm overlay pageview fires.