### PR TITLE
feat(quick-create): cache agent prompt draft across navigation

### DIFF
--- a/packages/core/issues/stores/quick-create-store.test.ts
+++ b/packages/core/issues/stores/quick-create-store.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useQuickCreateStore } from "./quick-create-store";
+
+const RESET_STATE = {
+  lastAgentId: null,
+  prompt: "",
+  keepOpen: false,
+};
+
+describe("quick create store", () => {
+  beforeEach(() => {
+    useQuickCreateStore.setState(RESET_STATE);
+  });
+
+  it("persists the agent prompt draft until explicitly cleared", () => {
+    const { setPrompt, clearPrompt } = useQuickCreateStore.getState();
+
+    setPrompt("Investigate the inbox loading regression");
+    expect(useQuickCreateStore.getState().prompt).toBe(
+      "Investigate the inbox loading regression",
+    );
+
+    clearPrompt();
+    expect(useQuickCreateStore.getState().prompt).toBe("");
+  });
+});

--- a/packages/core/issues/stores/quick-create-store.ts
+++ b/packages/core/issues/stores/quick-create-store.ts
@@ -15,6 +15,9 @@ import { defaultStorage } from "../../platform/storage";
 interface QuickCreateState {
   lastAgentId: string | null;
   setLastAgentId: (id: string | null) => void;
+  prompt: string;
+  setPrompt: (prompt: string) => void;
+  clearPrompt: () => void;
   keepOpen: boolean;
   setKeepOpen: (v: boolean) => void;
 }
@@ -24,6 +27,9 @@ export const useQuickCreateStore = create<QuickCreateState>()(
     (set) => ({
       lastAgentId: null,
       setLastAgentId: (id) => set({ lastAgentId: id }),
+      prompt: "",
+      setPrompt: (prompt) => set({ prompt }),
+      clearPrompt: () => set({ prompt: "" }),
       keepOpen: false,
       setKeepOpen: (v) => set({ keepOpen: v }),
     }),

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -1,0 +1,247 @@
+import { forwardRef, useImperativeHandle, useRef, useState, type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockQuickCreateIssue = vi.hoisted(() => vi.fn());
+const mockSetLastAgentId = vi.hoisted(() => vi.fn());
+const mockSetPrompt = vi.hoisted(() => vi.fn());
+const mockClearPrompt = vi.hoisted(() => vi.fn());
+const mockSetKeepOpen = vi.hoisted(() => vi.fn());
+const mockSetLastMode = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
+
+const mockQuickCreateStore = {
+  lastAgentId: null as string | null,
+  setLastAgentId: mockSetLastAgentId,
+  prompt: "Persisted draft prompt",
+  setPrompt: mockSetPrompt,
+  clearPrompt: mockClearPrompt,
+  keepOpen: false,
+  setKeepOpen: mockSetKeepOpen,
+};
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: string[] }) => {
+    switch (queryKey[0]) {
+      case "members":
+        return { data: [{ user_id: "user-1", role: "admin" }] };
+      case "agents":
+        return {
+          data: [{ id: "agent-1", name: "Bohan", archived_at: null, runtime_id: "runtime-1" }],
+        };
+      case "runtimes":
+        return { data: [{ id: "runtime-1", metadata: { cli_version: "1.2.3" } }] };
+      default:
+        return { data: [] };
+    }
+  },
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    quickCreateIssue: mockQuickCreateIssue,
+  },
+  ApiError: class ApiError extends Error {
+    body?: unknown;
+  },
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-test",
+}));
+
+vi.mock("@multica/core/paths", () => ({
+  useCurrentWorkspace: () => ({ name: "Test Workspace" }),
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  agentListOptions: () => ({ queryKey: ["agents"] }),
+  memberListOptions: () => ({ queryKey: ["members"] }),
+}));
+
+vi.mock("@multica/core/issues/stores/quick-create-store", () => ({
+  useQuickCreateStore: (selector?: (state: typeof mockQuickCreateStore) => unknown) =>
+    (selector ? selector(mockQuickCreateStore) : mockQuickCreateStore),
+}));
+
+vi.mock("@multica/core/issues/stores/create-mode-store", () => ({
+  useCreateModeStore: (selector?: (state: { setLastMode: typeof mockSetLastMode }) => unknown) =>
+    (selector ? selector({ setLastMode: mockSetLastMode }) : { setLastMode: mockSetLastMode }),
+}));
+
+vi.mock("@multica/core/auth", () => ({
+  useAuthStore: (selector?: (state: { user: { id: string } }) => unknown) =>
+    (selector ? selector({ user: { id: "user-1" } }) : { user: { id: "user-1" } }),
+}));
+
+vi.mock("@multica/core/runtimes", () => ({
+  runtimeListOptions: () => ({ queryKey: ["runtimes"] }),
+  checkQuickCreateCliVersion: () => ({ state: "ok", min: "1.0.0" }),
+  readRuntimeCliVersion: () => "1.2.3",
+  MIN_QUICK_CREATE_CLI_VERSION: "1.0.0",
+}));
+
+vi.mock("@multica/core/hooks/use-file-upload", () => ({
+  useFileUpload: () => ({ uploadWithToast: vi.fn(), uploading: false }),
+}));
+
+vi.mock("../issues/components/pickers/assignee-picker", () => ({
+  canAssignAgent: () => true,
+}));
+
+vi.mock("../common/actor-avatar", () => ({
+  ActorAvatar: () => <span data-testid="actor-avatar" />,
+}));
+
+vi.mock("../issues/components", () => ({
+  PriorityPicker: () => <div data-testid="priority-picker" />,
+  DueDatePicker: () => <div data-testid="due-date-picker" />,
+}));
+
+vi.mock("../projects/components/project-picker", () => ({
+  ProjectPicker: () => <div data-testid="project-picker" />,
+}));
+
+vi.mock("../common/pill-button", () => ({
+  PillButton: () => <div data-testid="pill-button" />,
+}));
+
+vi.mock("../editor", () => {
+  const ContentEditor = forwardRef(({ defaultValue, onUpdate, onSubmit, placeholder }: any, ref: any) => {
+    const valueRef = useRef(defaultValue || "");
+    const [value, setValue] = useState(defaultValue || "");
+
+    useImperativeHandle(ref, () => ({
+      getMarkdown: () => valueRef.current,
+      clearContent: () => {
+        valueRef.current = "";
+        setValue("");
+      },
+      uploadFile: vi.fn(),
+      focus: vi.fn(),
+    }));
+
+    return (
+      <textarea
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => {
+          valueRef.current = e.target.value;
+          setValue(e.target.value);
+          onUpdate?.(e.target.value);
+        }}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            onSubmit?.();
+          }
+        }}
+      />
+    );
+  });
+  ContentEditor.displayName = "ContentEditor";
+
+  return {
+    ContentEditor,
+    useFileDropZone: () => ({ isDragOver: false, dropZoneProps: {} }),
+    FileDropOverlay: () => null,
+  };
+});
+
+vi.mock("@multica/ui/components/ui/dialog", () => ({
+  DialogTitle: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ render }: { render: ReactNode }) => <>{render}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>{children}</button>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/button", () => ({
+  Button: ({ children, disabled, onClick }: { children: ReactNode; disabled?: boolean; onClick?: () => void }) => (
+    <button type="button" disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@multica/ui/components/ui/switch", () => ({
+  Switch: ({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: (v: boolean) => void }) => (
+    <input
+      aria-label="Create another"
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange(e.target.checked)}
+    />
+  ),
+}));
+
+vi.mock("@multica/ui/components/common/file-upload-button", () => ({
+  FileUploadButton: () => <button type="button">Upload file</button>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mockToastSuccess,
+  },
+}));
+
+import { AgentCreatePanel } from "./quick-create-issue";
+
+describe("AgentCreatePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuickCreateStore.lastAgentId = null;
+    mockQuickCreateStore.prompt = "Persisted draft prompt";
+    mockQuickCreateStore.keepOpen = false;
+    mockQuickCreateIssue.mockResolvedValue(undefined);
+    mockSetKeepOpen.mockImplementation((value: boolean) => {
+      mockQuickCreateStore.keepOpen = value;
+    });
+  });
+
+  it("loads the persisted prompt draft when no transient prompt is provided", () => {
+    render(<AgentCreatePanel onClose={vi.fn()} />);
+
+    expect(
+      screen.getByPlaceholderText(
+        'Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"',
+      ),
+    ).toHaveValue("Persisted draft prompt");
+  });
+
+  it("writes prompt changes back to the draft store and clears them after submit", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(<AgentCreatePanel onClose={onClose} />);
+
+    const editor = screen.getByPlaceholderText(
+      'Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"',
+    );
+
+    await user.clear(editor);
+    await user.type(editor, "New agent prompt");
+    expect(mockSetPrompt).toHaveBeenLastCalledWith("New agent prompt");
+
+    await user.click(screen.getByRole("button", { name: /Create \(⌘↵\)/i }));
+
+    await waitFor(() => {
+      expect(mockQuickCreateIssue).toHaveBeenCalledWith({
+        agent_id: "agent-1",
+        prompt: "New agent prompt",
+      });
+    });
+
+    expect(mockSetLastAgentId).toHaveBeenCalledWith("agent-1");
+    expect(mockClearPrompt).toHaveBeenCalled();
+    expect(mockSetLastMode).toHaveBeenCalledWith("agent");
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -82,6 +82,9 @@ export function AgentCreatePanel({
 
   const lastAgentId = useQuickCreateStore((s) => s.lastAgentId);
   const setLastAgentId = useQuickCreateStore((s) => s.setLastAgentId);
+  const promptDraft = useQuickCreateStore((s) => s.prompt);
+  const setPrompt = useQuickCreateStore((s) => s.setPrompt);
+  const clearPrompt = useQuickCreateStore((s) => s.clearPrompt);
   const keepOpen = useQuickCreateStore((s) => s.keepOpen);
   const setKeepOpen = useQuickCreateStore((s) => s.setKeepOpen);
   const setLastMode = useCreateModeStore((s) => s.setLastMode);
@@ -129,7 +132,7 @@ export function AgentCreatePanel({
   );
   const versionBlocked = versionCheck.state !== "ok";
 
-  const initialPrompt = (data?.prompt as string) || "";
+  const initialPrompt = (data?.prompt as string) || promptDraft;
   // The editor is uncontrolled — we read the latest markdown via the ref at
   // submit/switch time. `hasContent` mirrors emptiness so the Create button
   // can disable correctly without a controlled-input rerender on every keystroke.
@@ -177,6 +180,7 @@ export function AgentCreatePanel({
         ...(projectId ? { project_id: projectId } : {}),
       });
       setLastAgentId(agentId);
+      clearPrompt();
       setLastMode("agent");
       toast.success("Sent to agent — you'll get an inbox notification when it's done", {
         duration: 4000,
@@ -374,7 +378,10 @@ export function AgentCreatePanel({
             ref={editorRef}
             defaultValue={initialPrompt}
             placeholder='Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"'
-            onUpdate={(md) => setHasContent(md.trim().length > 0)}
+            onUpdate={(md) => {
+              setHasContent(md.trim().length > 0);
+              setPrompt(md);
+            }}
             onUploadFile={handleUploadFile}
             onSubmit={submit}
             debounceMs={150}


### PR DESCRIPTION
## Summary

When creating an issue with agent, the input content was lost when navigating away (e.g., to view a ticket) and returning. Manual create already persisted its draft - now agent create does too.

## Changes

- **packages/core/issues/stores/quick-create-store.ts**: Added `prompt` field to `QuickCreateState` interface with `setPrompt` and `clearPrompt` methods
- **packages/views/modals/quick-create-issue.tsx**:
  - `AgentCreatePanel` now reads `initialPrompt` from the draft store if no transient `data?.prompt` is provided
  - `onUpdate` callback now saves prompt to draft store (not just updating `hasContent`)
  - `clearPrompt()` is called after successful submit

## Testing

- Added unit tests for the draft store behavior
- Added integration tests for `AgentCreatePanel` prompt caching
- All 251 @multica/views tests pass
- All 83 @multica/desktop tests pass
- All 20 @multica/web tests pass

Fixes: #1957