### PR TITLE
fix(views): coalesce repeated task_completed/task_failed activity entries

### DIFF
--- a/packages/core/types/activity.ts
+++ b/packages/core/types/activity.ts
@@ -23,4 +23,6 @@ export interface TimelineEntry {
   comment_type?: string;
   reactions?: Reaction[];
   attachments?: Attachment[];
+  /** Set by frontend coalescing when consecutive identical activities are merged. */
+  coalesced_count?: number;
 }

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -113,10 +113,14 @@ function formatActivity(
       return `renamed this issue from "${details.from ?? "?"}" to "${details.to ?? "?"}"`;
     case "description_updated":
       return "updated the description";
-    case "task_completed":
-      return "completed the task";
-    case "task_failed":
-      return "task failed";
+    case "task_completed": {
+      const n = entry.coalesced_count ?? 1;
+      return n > 1 ? `completed the task (${n} times)` : "completed the task";
+    }
+    case "task_failed": {
+      const n = entry.coalesced_count ?? 1;
+      return n > 1 ? `task failed (${n} times)` : "task failed";
+    }
     default:
       return entry.action ?? "";
   }
@@ -259,8 +263,11 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       }
     }
 
-    // Coalesce: same actor + same action within 2 min → keep last only
+    // Coalesce consecutive activities from the same actor + action.
+    // - task_completed / task_failed: no time limit (these repeat across runs)
+    // - all other actions: within a 2-minute window
     const COALESCE_MS = 2 * 60 * 1000;
+    const NO_TIME_LIMIT_ACTIONS = new Set(["task_completed", "task_failed"]);
     const coalesced: TimelineEntry[] = [];
     for (const entry of topLevel) {
       if (entry.type === "activity") {
@@ -270,9 +277,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           prev.action === entry.action &&
           prev.actor_type === entry.actor_type &&
           prev.actor_id === entry.actor_id &&
-          Math.abs(new Date(entry.created_at).getTime() - new Date(prev.created_at).getTime()) <= COALESCE_MS
+          (NO_TIME_LIMIT_ACTIONS.has(entry.action!) ||
+            Math.abs(new Date(entry.created_at).getTime() - new Date(prev.created_at).getTime()) <= COALESCE_MS)
         ) {
-          coalesced[coalesced.length - 1] = entry;
+          coalesced[coalesced.length - 1] = { ...entry, coalesced_count: (prev.coalesced_count ?? 1) + 1 };
           continue;
         }
       }


### PR DESCRIPTION
## Summary

- Consecutive "completed the task" / "task failed" activity entries from the same agent are now merged into a single line with a count (e.g. "completed the task (7 times)"), regardless of time gap between entries
- Other activity types retain the existing 2-minute coalescing window
- Added `coalesced_count` field to `TimelineEntry` type to track merged entry counts

Closes MUL-1709

## Test plan

- [ ] Verify typecheck passes (`pnpm typecheck`) — confirmed
- [ ] Verify all unit tests pass (`pnpm test`) — confirmed (249/249)
- [ ] Open an issue with multiple consecutive `task_completed` activities and confirm they collapse into a single "completed the task (N times)" entry
- [ ] Confirm non-consecutive `task_completed` entries (separated by other activity types like comments) remain separate
- [ ] Confirm other activity types (status_changed, etc.) still coalesce only within 2-minute window