### PR TITLE
feat(issues): drag-to-move issues in list view

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -60,6 +60,13 @@ export interface IssueViewState {
   sortDirection: SortDirection;
   cardProperties: CardProperties;
   listCollapsedStatuses: IssueStatus[];
+  /**
+   * IDs of parent issues whose sub-issue groups are currently collapsed in
+   * the list view. Default = expanded (matches the IssueDetail page's
+   * sub-issue section). Persisted so the user's open/closed state survives
+   * navigation and reload.
+   */
+  collapsedParentIds: string[];
   setViewMode: (mode: ViewMode) => void;
   toggleStatusFilter: (status: IssueStatus) => void;
   togglePriorityFilter: (priority: IssuePriority) => void;
@@ -76,6 +83,7 @@ export interface IssueViewState {
   setSortDirection: (dir: SortDirection) => void;
   toggleCardProperty: (key: keyof CardProperties) => void;
   toggleListCollapsed: (status: IssueStatus) => void;
+  toggleParentCollapsed: (parentId: string) => void;
 }
 
 export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): IssueViewState => ({
@@ -100,6 +108,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
     labels: true,
   },
   listCollapsedStatuses: [],
+  collapsedParentIds: [],
 
   setViewMode: (mode) => set({ viewMode: mode }),
   toggleStatusFilter: (status) =>
@@ -198,6 +207,12 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
         ? state.listCollapsedStatuses.filter((s) => s !== status)
         : [...state.listCollapsedStatuses, status],
     })),
+  toggleParentCollapsed: (parentId) =>
+    set((state) => ({
+      collapsedParentIds: state.collapsedParentIds.includes(parentId)
+        ? state.collapsedParentIds.filter((id) => id !== parentId)
+        : [...state.collapsedParentIds, parentId],
+    })),
 });
 
 export const viewStorePersistOptions = (name: string) => ({
@@ -217,6 +232,7 @@ export const viewStorePersistOptions = (name: string) => ({
     sortDirection: state.sortDirection,
     cardProperties: state.cardProperties,
     listCollapsedStatuses: state.listCollapsedStatuses,
+    collapsedParentIds: state.collapsedParentIds,
   }),
   // Default Zustand merge is shallow, so a persisted `cardProperties` snapshot
   // saved before a new toggle was introduced wins entirely and the new key is

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -164,7 +164,12 @@ export function IssuesPage() {
                 childProgressMap={childProgressMap}
               />
             ) : (
-              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} />
+              <ListView
+                issues={issues}
+                visibleStatuses={visibleStatuses}
+                childProgressMap={childProgressMap}
+                onMoveIssue={handleMoveIssue}
+              />
             )}
           </div>
         )}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -2,6 +2,7 @@
 
 import { memo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { ChevronRight } from "lucide-react";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -10,6 +11,7 @@ import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { projectListOptions } from "@multica/core/projects/queries";
+import { issueListOptions } from "@multica/core/issues/queries";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { PriorityIcon } from "./priority-icon";
 import { ProgressRing } from "./progress-ring";
@@ -31,9 +33,29 @@ function formatDate(date: string): string {
 export const ListRow = memo(function ListRow({
   issue,
   childProgress,
+  indentLevel = 0,
+  hasChildren = false,
+  collapsed = false,
+  onToggleCollapsed,
+  isOrphan = false,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
+  /** Visual indentation level. 0 = top-level, 1 = nested under a parent. */
+  indentLevel?: number;
+  /** Whether the row has visible sub-issues to expand into. */
+  hasChildren?: boolean;
+  /** When true, the sub-issue group is hidden. */
+  collapsed?: boolean;
+  /** Click handler for the expand/collapse chevron. */
+  onToggleCollapsed?: () => void;
+  /**
+   * True when this row is itself a child whose parent is filtered out of
+   * the current view, so the row appears at the top level. We surface a
+   * subtle "in PARENT-ID" chip so the user understands the relationship
+   * without having to open the issue.
+   */
+  isOrphan?: boolean;
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
@@ -44,8 +66,18 @@ export const ListRow = memo(function ListRow({
     ...projectListOptions(wsId),
     enabled: storeProperties.project && !!issue.project_id,
   });
+  // Used only to resolve the parent's identifier for the orphan chip.
+  // Reads the same cache the page already populated, so no extra fetch.
+  const { data: allIssues = [] } = useQuery({
+    ...issueListOptions(wsId),
+    enabled: isOrphan && !!issue.parent_issue_id,
+  });
   const project = issue.project_id ? projects.find((pr) => pr.id === issue.project_id) : undefined;
   const labels = issue.labels ?? [];
+  const orphanParent =
+    isOrphan && issue.parent_issue_id
+      ? allIssues.find((i) => i.id === issue.parent_issue_id)
+      : undefined;
 
   const showProject = storeProperties.project && project;
   const showChildProgress = storeProperties.childProgress && childProgress;
@@ -53,13 +85,43 @@ export const ListRow = memo(function ListRow({
   const showDueDate = storeProperties.dueDate && issue.due_date;
   const showLabels = storeProperties.labels && labels.length > 0;
 
+  // Indent in pixels per level — keeps alignment with the existing 16px
+  // priority-icon column. 24px per level matches the visual rhythm of the
+  // sub-issues section on the issue detail page.
+  const indentPx = indentLevel * 24;
+
   return (
     <IssueActionsContextMenu issue={issue}>
       <div
         className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
         }`}
+        style={indentPx ? { paddingLeft: `${16 + indentPx}px` } : undefined}
       >
+        {/*
+         * Chevron column.
+         * - Parent with children: visible toggle.
+         * - Anything else: keep the column reserved (so titles align across rows)
+         *   but render an empty spacer.
+         */}
+        {hasChildren && onToggleCollapsed ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleCollapsed();
+            }}
+            className="flex shrink-0 items-center justify-center w-4 h-4 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Expand sub-issues" : "Collapse sub-issues"}
+          >
+            <ChevronRight
+              className={`size-3.5 transition-transform ${collapsed ? "" : "rotate-90"}`}
+            />
+          </button>
+        ) : (
+          <span aria-hidden className="shrink-0 w-4 h-4" />
+        )}
         <div className="relative flex shrink-0 items-center justify-center w-4 h-4">
           <PriorityIcon
             priority={issue.priority}
@@ -89,6 +151,14 @@ export const ListRow = memo(function ListRow({
                 <span className="text-[11px] text-muted-foreground tabular-nums font-medium">
                   {childProgress!.done}/{childProgress!.total}
                 </span>
+              </span>
+            )}
+            {orphanParent && (
+              <span
+                className="inline-flex shrink-0 items-center gap-1 rounded bg-muted/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground"
+                title={`Sub-issue of ${orphanParent.identifier} ${orphanParent.title}`}
+              >
+                in {orphanParent.identifier}
               </span>
             )}
             {showLabels && (

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -2,7 +2,9 @@
 
 import { memo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, GripVertical } from "lucide-react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -38,6 +40,8 @@ export const ListRow = memo(function ListRow({
   collapsed = false,
   onToggleCollapsed,
   isOrphan = false,
+  isSortable = false,
+  isDragOverlay = false,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
@@ -56,6 +60,18 @@ export const ListRow = memo(function ListRow({
    * without having to open the issue.
    */
   isOrphan?: boolean;
+  /**
+   * True when this row participates in the parent SortableContext
+   * (top-level rows in the list view when drag-to-move is enabled).
+   * Sub-issues + orphans are not draggable in v1.
+   */
+  isSortable?: boolean;
+  /**
+   * True when this row is rendered inside a DragOverlay. Skips
+   * useSortable wiring and renders a pointer-events-none clone so it
+   * doesn't intercept drag events while it follows the cursor.
+   */
+  isDragOverlay?: boolean;
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
@@ -90,14 +106,58 @@ export const ListRow = memo(function ListRow({
   // sub-issues section on the issue detail page.
   const indentPx = indentLevel * 24;
 
+  // ----- sortable wiring -----
+  // Hooks must be unconditional, but useSortable is fine to call with
+  // disabled=true; it short-circuits inside dnd-kit. The DragOverlay clone
+  // doesn't participate (rendered via `isDragOverlay`).
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: issue.id, disabled: !isSortable || isDragOverlay });
+
+  const style = isSortable
+    ? {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        paddingLeft: indentPx ? `${16 + indentPx}px` : undefined,
+      }
+    : indentPx
+      ? { paddingLeft: `${16 + indentPx}px` }
+      : undefined;
+
   return (
     <IssueActionsContextMenu issue={issue}>
       <div
+        ref={isSortable && !isDragOverlay ? setNodeRef : undefined}
+        style={style}
         className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
-        }`}
-        style={indentPx ? { paddingLeft: `${16 + indentPx}px` } : undefined}
+        } ${isDragging ? "opacity-40" : ""}`}
       >
+        {/*
+         * Drag handle column. Reserves the same 16px slot whether the row
+         * is draggable or not, so titles align across leaf / parent /
+         * draggable / non-draggable rows.
+         */}
+        {isSortable && !isDragOverlay ? (
+          <span
+            {...attributes}
+            {...listeners}
+            className="flex shrink-0 items-center justify-center w-4 h-4 cursor-grab opacity-0 group-hover/row:opacity-60 hover:opacity-100 active:cursor-grabbing text-muted-foreground"
+            aria-label={`Drag ${issue.identifier}`}
+            // Stop the AppLink's navigation from firing when the user
+            // grabs the handle to start a drag.
+            onClick={(e) => e.preventDefault()}
+          >
+            <GripVertical className="size-3.5" />
+          </span>
+        ) : (
+          <span aria-hidden className="shrink-0 w-4 h-4" />
+        )}
         {/*
          * Chevron column.
          * - Parent with children: visible toggle.

--- a/packages/views/issues/components/list-view.test.tsx
+++ b/packages/views/issues/components/list-view.test.tsx
@@ -165,6 +165,52 @@ vi.mock("@multica/core/issues/mutations", () => ({
   useUpdateIssue: () => ({ mutate: vi.fn() }),
 }));
 
+// Capture the handlers DndContext is mounted with so tests can fire
+// synthetic drag events directly. PointerSensor + jsdom doesn't have
+// real pointer events, and dragging in a unit test is too brittle —
+// invoking onDragEnd with a synthetic event proves the wiring without
+// depending on the sensor.
+type CapturedHandlers = {
+  onDragEnd: ((e: any) => void) | null;
+  onDragStart: ((e: any) => void) | null;
+};
+const dndHandlers: CapturedHandlers = vi.hoisted(() => ({
+  onDragEnd: null,
+  onDragStart: null,
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children, onDragEnd, onDragStart }: any) => {
+    dndHandlers.onDragEnd = onDragEnd ?? null;
+    dndHandlers.onDragStart = onDragStart ?? null;
+    return <div data-testid="dnd-context">{children}</div>;
+  },
+  DragOverlay: ({ children }: any) => <div data-testid="drag-overlay">{children}</div>,
+  PointerSensor: class {},
+  useSensor: () => ({}),
+  useSensors: () => [],
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  pointerWithin: vi.fn(),
+  closestCenter: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: any) => children,
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => undefined } },
+}));
+
 // Render Accordion as plain divs so the panel content always shows
 // (the real impl gates on aria-expanded which depends on real DOM events).
 vi.mock("@base-ui/react/accordion", () => ({
@@ -259,6 +305,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockViewState.collapsedParentIds = [];
   mockViewState.listCollapsedStatuses = [];
+  dndHandlers.onDragEnd = null;
+  dndHandlers.onDragStart = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -335,5 +383,135 @@ describe("ListView — nested sub-issues", () => {
     expect(
       collapseLabels.filter((l) => l && /sub-issues/i.test(l)).length,
     ).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drag-to-move tests
+// ---------------------------------------------------------------------------
+
+const todoIssue: Issue = {
+  ...issueDefaults,
+  id: "issue-todo",
+  number: 10,
+  identifier: "TES-10",
+  title: "Todo item",
+  status: "todo",
+  position: 1,
+};
+
+const inProgressIssue: Issue = {
+  ...issueDefaults,
+  id: "issue-inprog",
+  number: 11,
+  identifier: "TES-11",
+  title: "In progress item",
+  status: "in_progress",
+  position: 1,
+};
+
+describe("ListView — drag to move", () => {
+  it("does NOT mount DndContext when onMoveIssue is not provided (read-only)", () => {
+    renderWithQuery(
+      <ListView issues={[todoIssue]} visibleStatuses={["todo"]} />,
+    );
+    expect(screen.queryByTestId("dnd-context")).not.toBeInTheDocument();
+  });
+
+  it("mounts DndContext when onMoveIssue is provided", () => {
+    const onMove = vi.fn();
+    renderWithQuery(
+      <ListView
+        issues={[todoIssue]}
+        visibleStatuses={["todo"]}
+        onMoveIssue={onMove}
+      />,
+    );
+    expect(screen.getByTestId("dnd-context")).toBeInTheDocument();
+  });
+
+  it("calls onMoveIssue with new status when dropped on another status section", () => {
+    const onMove = vi.fn();
+    renderWithQuery(
+      <ListView
+        issues={[todoIssue, inProgressIssue]}
+        visibleStatuses={["todo", "in_progress"]}
+        onMoveIssue={onMove}
+      />,
+    );
+
+    // Drop the todo issue on the in_progress status section.
+    dndHandlers.onDragEnd?.({
+      active: { id: "issue-todo" },
+      over: { id: "list-status:in_progress" },
+    });
+
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onMove).toHaveBeenCalledWith(
+      "issue-todo",
+      "in_progress",
+      expect.any(Number),
+    );
+  });
+
+  it("calls onMoveIssue with target status when dropped on a row in another status", () => {
+    const onMove = vi.fn();
+    renderWithQuery(
+      <ListView
+        issues={[todoIssue, inProgressIssue]}
+        visibleStatuses={["todo", "in_progress"]}
+        onMoveIssue={onMove}
+      />,
+    );
+
+    // Drop the todo issue ON another row that's in in_progress — target
+    // status is derived from the over-row's status.
+    dndHandlers.onDragEnd?.({
+      active: { id: "issue-todo" },
+      over: { id: "issue-inprog" },
+    });
+
+    expect(onMove).toHaveBeenCalledWith(
+      "issue-todo",
+      "in_progress",
+      expect.any(Number),
+    );
+  });
+
+  it("does NOT call onMoveIssue when status + position would be unchanged", () => {
+    const onMove = vi.fn();
+    renderWithQuery(
+      <ListView
+        issues={[todoIssue]}
+        visibleStatuses={["todo"]}
+        onMoveIssue={onMove}
+      />,
+    );
+
+    // "Drop" on the same item — same status, same position computed.
+    dndHandlers.onDragEnd?.({
+      active: { id: "issue-todo" },
+      over: { id: "issue-todo" },
+    });
+
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onMoveIssue when there's no drop target (drag cancelled)", () => {
+    const onMove = vi.fn();
+    renderWithQuery(
+      <ListView
+        issues={[todoIssue]}
+        visibleStatuses={["todo"]}
+        onMoveIssue={onMove}
+      />,
+    );
+
+    dndHandlers.onDragEnd?.({
+      active: { id: "issue-todo" },
+      over: null,
+    });
+
+    expect(onMove).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/issues/components/list-view.test.tsx
+++ b/packages/views/issues/components/list-view.test.tsx
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Issue } from "@multica/core/types";
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors the pattern in issues-page.test.tsx — see that file's
+// header for the rationale behind each block; copied here so the test is
+// runnable in isolation.)
+// ---------------------------------------------------------------------------
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+vi.mock("@multica/core/auth", () => {
+  const state = {
+    user: { id: "user-1", email: "t@t.com", name: "T" },
+    isAuthenticated: true,
+  };
+  return {
+    useAuthStore: Object.assign(
+      (selector?: any) => (selector ? selector(state) : state),
+      { getState: () => state },
+    ),
+    registerAuthStore: vi.fn(),
+    createAuthStore: vi.fn(),
+  };
+});
+
+vi.mock("@multica/core/paths", async () => {
+  const actual = await vi.importActual<typeof import("@multica/core/paths")>(
+    "@multica/core/paths",
+  );
+  return {
+    ...actual,
+    useCurrentWorkspace: () => ({ id: "ws-1", name: "Test", slug: "test" }),
+    useWorkspacePaths: () => actual.paths.workspace("test"),
+  };
+});
+
+vi.mock("../../navigation", () => ({
+  AppLink: ({ children, href, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+  useNavigation: () => ({ push: vi.fn(), pathname: "/issues" }),
+  NavigationProvider: ({ children }: any) => children,
+}));
+
+const mockListIssues = vi.hoisted(() => vi.fn().mockResolvedValue({ issues: [], total: 0 }));
+vi.mock("@multica/core/api", () => ({
+  api: {
+    listIssues: (...a: any[]) => mockListIssues(...a),
+    listMembers: () => Promise.resolve([]),
+    listAgents: () => Promise.resolve([]),
+    listProjects: () => Promise.resolve({ projects: [], total: 0 }),
+    getChildIssueProgress: () => Promise.resolve({ progress: [] }),
+  },
+  getApi: () => ({
+    listIssues: (...a: any[]) => mockListIssues(...a),
+    listMembers: () => Promise.resolve([]),
+    listAgents: () => Promise.resolve([]),
+    listProjects: () => Promise.resolve({ projects: [], total: 0 }),
+    getChildIssueProgress: () => Promise.resolve({ progress: [] }),
+  }),
+  setApiInstance: vi.fn(),
+}));
+
+vi.mock("@multica/core/issues/config", () => ({
+  ALL_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
+  BOARD_STATUSES: ["backlog", "todo", "in_progress", "in_review", "done", "blocked"],
+  STATUS_CONFIG: {
+    backlog: { label: "Backlog", iconColor: "", hoverBg: "" },
+    todo: { label: "Todo", iconColor: "", hoverBg: "" },
+    in_progress: { label: "In Progress", iconColor: "", hoverBg: "" },
+    in_review: { label: "In Review", iconColor: "", hoverBg: "" },
+    done: { label: "Done", iconColor: "", hoverBg: "" },
+    blocked: { label: "Blocked", iconColor: "", hoverBg: "" },
+    cancelled: { label: "Cancelled", iconColor: "", hoverBg: "" },
+  },
+  PRIORITY_ORDER: ["urgent", "high", "medium", "low", "none"],
+  STATUS_ORDER: ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"],
+  PRIORITY_CONFIG: {
+    urgent: { label: "Urgent", bars: 4, color: "" },
+    high: { label: "High", bars: 3, color: "" },
+    medium: { label: "Medium", bars: 2, color: "" },
+    low: { label: "Low", bars: 1, color: "" },
+    none: { label: "No priority", bars: 0, color: "" },
+  },
+}));
+
+const mockToggleParent = vi.fn();
+const mockViewState = {
+  viewMode: "list" as const,
+  statusFilters: [] as string[],
+  priorityFilters: [] as string[],
+  assigneeFilters: [],
+  includeNoAssignee: false,
+  creatorFilters: [],
+  projectFilters: [],
+  includeNoProject: false,
+  labelFilters: [],
+  sortBy: "position" as const,
+  sortDirection: "asc" as const,
+  cardProperties: {
+    priority: true,
+    description: true,
+    assignee: true,
+    dueDate: true,
+    project: true,
+    childProgress: true,
+    labels: true,
+  },
+  listCollapsedStatuses: [] as string[],
+  collapsedParentIds: [] as string[],
+  toggleListCollapsed: vi.fn(),
+  toggleParentCollapsed: mockToggleParent,
+};
+
+vi.mock("@multica/core/issues/stores/view-store-context", () => ({
+  ViewStoreProvider: ({ children }: any) => children,
+  useViewStore: (selector?: any) => (selector ? selector(mockViewState) : mockViewState),
+  useViewStoreApi: () => ({
+    getState: () => mockViewState,
+    setState: vi.fn(),
+    subscribe: vi.fn(),
+  }),
+}));
+
+vi.mock("@multica/core/issues/stores/selection-store", () => {
+  const state = {
+    selectedIds: new Set<string>(),
+    toggle: vi.fn(),
+    clear: vi.fn(),
+    select: vi.fn(),
+    deselect: vi.fn(),
+  };
+  return {
+    useIssueSelectionStore: Object.assign(
+      (selector?: any) => (selector ? selector(state) : state),
+      { getState: () => state },
+    ),
+  };
+});
+
+vi.mock("@multica/core/modals", () => ({
+  useModalStore: Object.assign(
+    () => ({ open: vi.fn() }),
+    { getState: () => ({ open: vi.fn() }) },
+  ),
+}));
+
+// useLoadMoreByStatus is a TanStack-Query-touching hook that pulls from the
+// real cache; stub it so the component can render without a populated
+// per-status cache.
+vi.mock("@multica/core/issues/mutations", () => ({
+  useLoadMoreByStatus: () => ({
+    loadMore: vi.fn(),
+    hasMore: false,
+    isLoading: false,
+    total: 0,
+  }),
+  useUpdateIssue: () => ({ mutate: vi.fn() }),
+}));
+
+// Render Accordion as plain divs so the panel content always shows
+// (the real impl gates on aria-expanded which depends on real DOM events).
+vi.mock("@base-ui/react/accordion", () => ({
+  Accordion: Object.assign(
+    ({ children }: any) => <div>{children}</div>,
+    {
+      Root: ({ children }: any) => <div>{children}</div>,
+      Item: ({ children }: any) => <div>{children}</div>,
+      Header: ({ children }: any) => <div>{children}</div>,
+      Trigger: ({ children }: any) => <button>{children}</button>,
+      Panel: ({ children }: any) => <div>{children}</div>,
+    },
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const issueDefaults = {
+  workspace_id: "ws-1",
+  description: null,
+  priority: "medium" as const,
+  assignee_type: null,
+  assignee_id: null,
+  creator_type: "member" as const,
+  creator_id: "user-1",
+  due_date: null,
+  project_id: null,
+  parent_issue_id: null,
+  position: 0,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const parent: Issue = {
+  ...issueDefaults,
+  id: "issue-parent",
+  number: 1,
+  identifier: "TES-1",
+  title: "Parent issue",
+  status: "todo",
+};
+
+const child1: Issue = {
+  ...issueDefaults,
+  id: "issue-child-1",
+  number: 2,
+  identifier: "TES-2",
+  title: "First child",
+  status: "todo",
+  parent_issue_id: "issue-parent",
+};
+
+const child2: Issue = {
+  ...issueDefaults,
+  id: "issue-child-2",
+  number: 3,
+  identifier: "TES-3",
+  title: "Second child",
+  status: "todo",
+  parent_issue_id: "issue-parent",
+};
+
+const orphan: Issue = {
+  ...issueDefaults,
+  id: "issue-orphan",
+  number: 4,
+  identifier: "TES-4",
+  title: "Orphan child",
+  status: "todo",
+  parent_issue_id: "issue-not-in-list", // parent excluded by current filters
+};
+
+// ---------------------------------------------------------------------------
+// Imports under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { ListView } from "./list-view";
+
+function renderWithQuery(ui: React.ReactElement) {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockViewState.collapsedParentIds = [];
+  mockViewState.listCollapsedStatuses = [];
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ListView — nested sub-issues", () => {
+  it("renders children indented below their parent and not as siblings", () => {
+    renderWithQuery(
+      <ListView issues={[parent, child1, child2]} visibleStatuses={["todo"]} />,
+    );
+
+    // All three render
+    expect(screen.getByText("Parent issue")).toBeInTheDocument();
+    expect(screen.getByText("First child")).toBeInTheDocument();
+    expect(screen.getByText("Second child")).toBeInTheDocument();
+
+    // Children live inside the parent's role=group container — proves
+    // they are rendered as nested sub-issues, not flat siblings.
+    const subGroup = screen.getByRole("group", { name: /sub-issues of TES-1/i });
+    expect(within(subGroup).getByText("First child")).toBeInTheDocument();
+    expect(within(subGroup).getByText("Second child")).toBeInTheDocument();
+    expect(within(subGroup).queryByText("Parent issue")).not.toBeInTheDocument();
+  });
+
+  it("hides children when the parent is collapsed and toggle calls the store", () => {
+    mockViewState.collapsedParentIds = ["issue-parent"];
+
+    renderWithQuery(
+      <ListView issues={[parent, child1, child2]} visibleStatuses={["todo"]} />,
+    );
+
+    // Parent still visible; children hidden.
+    expect(screen.getByText("Parent issue")).toBeInTheDocument();
+    expect(screen.queryByText("First child")).not.toBeInTheDocument();
+    expect(screen.queryByText("Second child")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("group", { name: /sub-issues of TES-1/i }),
+    ).not.toBeInTheDocument();
+
+    // Click expand chevron — wired to toggleParentCollapsed.
+    const expandBtn = screen.getByRole("button", { name: /expand sub-issues/i });
+    fireEvent.click(expandBtn);
+    expect(mockToggleParent).toHaveBeenCalledWith("issue-parent");
+  });
+
+  it("renders an orphan child at the top level (parent filtered out)", () => {
+    renderWithQuery(
+      <ListView issues={[parent, child1, orphan]} visibleStatuses={["todo"]} />,
+    );
+
+    // Orphan renders even though its parent isn't in the list.
+    expect(screen.getByText("Orphan child")).toBeInTheDocument();
+
+    // Orphan is NOT inside the visible parent's sub-issues group — it's
+    // surfaced at the top level instead.
+    const subGroup = screen.getByRole("group", { name: /sub-issues of TES-1/i });
+    expect(within(subGroup).queryByText("Orphan child")).not.toBeInTheDocument();
+  });
+
+  it("does not show a chevron on rows with no children", () => {
+    renderWithQuery(
+      <ListView issues={[parent, child1]} visibleStatuses={["todo"]} />,
+    );
+
+    // The parent (which has children) should expose a collapse button;
+    // the child should not.
+    const buttons = screen.getAllByRole("button");
+    const collapseLabels = buttons
+      .map((b) => b.getAttribute("aria-label"))
+      .filter(Boolean);
+    expect(collapseLabels).toContain("Collapse sub-issues");
+    // Only one parent → only one such control.
+    expect(
+      collapseLabels.filter((l) => l && /sub-issues/i.test(l)).length,
+    ).toBe(1);
+  });
+});

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -1,8 +1,22 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { ChevronRight, Plus } from "lucide-react";
 import { Accordion } from "@base-ui/react/accordion";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useDroppable,
+  useSensor,
+  useSensors,
+  closestCenter,
+  pointerWithin,
+  type CollisionDetection,
+  type DragStartEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import type { Issue, IssueStatus } from "@multica/core/types";
@@ -11,6 +25,7 @@ import type { MyIssuesFilter } from "@multica/core/issues/queries";
 import { useModalStore } from "@multica/core/modals";
 import { useViewStore } from "@multica/core/issues/stores/view-store-context";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
+import { ALL_STATUSES } from "@multica/core/issues/config";
 import { sortIssues } from "../utils/sort";
 import { StatusHeading } from "./status-heading";
 import { ListRow, type ChildProgress } from "./list-row";
@@ -18,15 +33,64 @@ import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
 
+const STATUS_DROPPABLE_PREFIX = "list-status:";
+
+const STATUS_DROPPABLE_IDS = new Set<string>(
+  ALL_STATUSES.map((s) => `${STATUS_DROPPABLE_PREFIX}${s}`),
+);
+
+/**
+ * Drop targets are either status-section droppables (used when dropping into
+ * an empty / collapsed status, or onto its header) or top-level row
+ * sortables (used when dropping between siblings). Prefer the row over
+ * the section so the user can drop precisely between rows even when their
+ * pointer is technically inside both targets.
+ */
+const listCollision: CollisionDetection = (args) => {
+  const pointer = pointerWithin(args);
+  if (pointer.length > 0) {
+    const rows = pointer.filter((c) => !STATUS_DROPPABLE_IDS.has(c.id as string));
+    if (rows.length > 0) return rows;
+  }
+  return closestCenter(args);
+};
+
+/** Compute float position based on drop neighbors, mirroring board-view. */
+function computePosition(
+  ids: string[],
+  activeId: string,
+  issueMap: Map<string, Issue>,
+): number {
+  const idx = ids.indexOf(activeId);
+  if (idx === -1) return 0;
+  const getPos = (id: string) => issueMap.get(id)?.position ?? 0;
+  if (ids.length === 1) return issueMap.get(activeId)?.position ?? 0;
+  if (idx === 0) return getPos(ids[1]!) - 1;
+  if (idx === ids.length - 1) return getPos(ids[idx - 1]!) + 1;
+  return (getPos(ids[idx - 1]!) + getPos(ids[idx + 1]!)) / 2;
+}
+
 export function ListView({
   issues,
   visibleStatuses,
+  onMoveIssue,
   childProgressMap = EMPTY_PROGRESS_MAP,
   myIssuesScope,
   myIssuesFilter,
 }: {
   issues: Issue[];
   visibleStatuses: IssueStatus[];
+  /**
+   * Optional drag-to-move handler. When set, top-level rows become
+   * draggable; dropping into another status changes `status`, dropping
+   * within the same status sets a fractional `position`. When omitted
+   * (e.g. read-only contexts), drag is disabled.
+   */
+  onMoveIssue?: (
+    issueId: string,
+    newStatus: IssueStatus,
+    newPosition?: number,
+  ) => void;
   childProgressMap?: Map<string, ChildProgress>;
   /** When set, per-status load-more targets the scoped cache instead of the workspace one. */
   myIssuesScope?: string;
@@ -106,36 +170,149 @@ export function ListView({
     ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
     : undefined;
 
+  // ----- drag state -----
+  const dragEnabled = !!onMoveIssue;
+  const [activeIssue, setActiveIssue] = useState<Issue | null>(null);
+
+  // Frozen during drag so child sortables stay referentially stable
+  // even if a TQ refetch lands mid-drag.
+  const issueMap = useMemo(() => {
+    const m = new Map<string, Issue>();
+    for (const i of issues) m.set(i.id, i);
+    return m;
+  }, [issues]);
+  const issueMapRef = useRef(issueMap);
+  if (!activeIssue) issueMapRef.current = issueMap;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const handleDragStart = useCallback(
+    (e: DragStartEvent) => {
+      const issue = issueMapRef.current.get(e.active.id as string);
+      if (issue) setActiveIssue(issue);
+    },
+    [],
+  );
+
+  const handleDragCancel = useCallback(() => setActiveIssue(null), []);
+
+  const handleDragEnd = useCallback(
+    (e: DragEndEvent) => {
+      setActiveIssue(null);
+      const { active, over } = e;
+      if (!over || !onMoveIssue) return;
+
+      const activeId = active.id as string;
+      const overId = over.id as string;
+
+      // Resolve the target status. Dropped on a status section header
+      // → that status. Dropped on a row → that row's status.
+      let targetStatus: IssueStatus | null = null;
+      if (overId.startsWith(STATUS_DROPPABLE_PREFIX)) {
+        targetStatus = overId.slice(STATUS_DROPPABLE_PREFIX.length) as IssueStatus;
+      } else {
+        const overIssue = issueMapRef.current.get(overId);
+        if (overIssue) targetStatus = overIssue.status as IssueStatus;
+      }
+      if (!targetStatus) return;
+
+      const activeIssueObj = issueMapRef.current.get(activeId);
+      if (!activeIssueObj) return;
+
+      // Build the post-drop ID array for the target status, with `activeId`
+      // inserted at the drop position. Used purely to compute the
+      // fractional position from neighbors — server is the source of truth.
+      const sourceIds = (issuesByStatus.get(activeIssueObj.status as IssueStatus) ?? [])
+        .filter((i) => i.id !== activeId)
+        .map((i) => i.id);
+      const destBase =
+        targetStatus === activeIssueObj.status
+          ? sourceIds
+          : (issuesByStatus.get(targetStatus) ?? []).map((i) => i.id);
+
+      let insertIndex = destBase.length;
+      if (!overId.startsWith(STATUS_DROPPABLE_PREFIX)) {
+        const overIdx = destBase.indexOf(overId);
+        if (overIdx !== -1) insertIndex = overIdx;
+      }
+      const finalIds = [...destBase];
+      finalIds.splice(insertIndex, 0, activeId);
+
+      const newPosition = computePosition(finalIds, activeId, issueMapRef.current);
+
+      // No-op guard: same status + same effective position.
+      if (
+        activeIssueObj.status === targetStatus &&
+        activeIssueObj.position === newPosition
+      ) {
+        return;
+      }
+
+      onMoveIssue(activeId, targetStatus, newPosition);
+    },
+    [onMoveIssue, issuesByStatus],
+  );
+
+  const accordion = (
+    <Accordion.Root
+      multiple
+      className="space-y-1"
+      value={expandedStatuses}
+      onValueChange={(value: string[]) => {
+        for (const status of visibleStatuses) {
+          const wasExpanded = expandedStatuses.includes(status);
+          const isExpanded = value.includes(status);
+          if (wasExpanded !== isExpanded) {
+            toggleListCollapsed(status as IssueStatus);
+          }
+        }
+      }}
+    >
+      {visibleStatuses.map((status) => (
+        <StatusAccordionItem
+          key={status}
+          status={status}
+          issues={issuesByStatus.get(status) ?? []}
+          childrenByParent={childrenByParent}
+          collapsedParentIds={collapsedSet}
+          onToggleParent={toggleParentCollapsed}
+          childProgressMap={childProgressMap}
+          orphanedChildIds={orphanedChildIds}
+          dragEnabled={dragEnabled}
+          myIssuesOpts={myIssuesOpts}
+        />
+      ))}
+    </Accordion.Root>
+  );
+
   return (
     <div className="flex-1 min-h-0 overflow-y-auto p-2">
-      <Accordion.Root
-        multiple
-        className="space-y-1"
-        value={expandedStatuses}
-        onValueChange={(value: string[]) => {
-          for (const status of visibleStatuses) {
-            const wasExpanded = expandedStatuses.includes(status);
-            const isExpanded = value.includes(status);
-            if (wasExpanded !== isExpanded) {
-              toggleListCollapsed(status as IssueStatus);
-            }
-          }
-        }}
-      >
-        {visibleStatuses.map((status) => (
-          <StatusAccordionItem
-            key={status}
-            status={status}
-            issues={issuesByStatus.get(status) ?? []}
-            childrenByParent={childrenByParent}
-            collapsedParentIds={collapsedSet}
-            onToggleParent={toggleParentCollapsed}
-            childProgressMap={childProgressMap}
-            orphanedChildIds={orphanedChildIds}
-            myIssuesOpts={myIssuesOpts}
-          />
-        ))}
-      </Accordion.Root>
+      {dragEnabled ? (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={listCollision}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          {accordion}
+          <DragOverlay dropAnimation={null}>
+            {activeIssue ? (
+              <div className="rounded-md bg-card shadow-lg shadow-black/10 ring-1 ring-border/60 opacity-95">
+                <ListRow
+                  issue={activeIssue}
+                  childProgress={childProgressMap.get(activeIssue.id)}
+                  isDragOverlay
+                />
+              </div>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      ) : (
+        accordion
+      )}
     </div>
   );
 }
@@ -148,6 +325,7 @@ function StatusAccordionItem({
   onToggleParent,
   childProgressMap,
   orphanedChildIds,
+  dragEnabled,
   myIssuesOpts,
 }: {
   status: IssueStatus;
@@ -157,6 +335,7 @@ function StatusAccordionItem({
   onToggleParent: (parentId: string) => void;
   childProgressMap: Map<string, ChildProgress>;
   orphanedChildIds: Set<string>;
+  dragEnabled: boolean;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
 }) {
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
@@ -166,6 +345,16 @@ function StatusAccordionItem({
     status,
     myIssuesOpts,
   );
+
+  // Drop target for the whole status section — used when dropping into
+  // an empty status, onto the status header, or below the last row.
+  // The id is namespaced (`list-status:`) so it doesn't collide with
+  // issue ids in collision detection.
+  const droppableId = `${STATUS_DROPPABLE_PREFIX}${status}`;
+  const { setNodeRef: setSectionDroppableRef, isOver: sectionIsOver } = useDroppable({
+    id: droppableId,
+    disabled: !dragEnabled,
+  });
 
   // Selection at the status level covers ALL rows that will render
   // under this status — including currently-visible children — so
@@ -182,13 +371,28 @@ function StatusAccordionItem({
     return ids;
   }, [issues, childrenByParent, collapsedParentIds]);
 
+  // Only top-level non-orphan issues are draggable. Sub-issues stay
+  // anchored to their parent; orphans have a filtered-out parent and
+  // moving them across statuses on their own is confusing UX.
+  const sortableIds = useMemo(
+    () =>
+      issues
+        .filter((i) => !orphanedChildIds.has(i.id))
+        .map((i) => i.id),
+    [issues, orphanedChildIds],
+  );
+
   const selectedCount = visibleRowIds.filter((id) => selectedIds.has(id)).length;
   const allSelected = visibleRowIds.length > 0 && selectedCount === visibleRowIds.length;
   const someSelected = selectedCount > 0;
 
-  return (
+  const sectionContent = (
     <Accordion.Item value={status}>
-      <Accordion.Header className="group/header flex h-10 items-center rounded-lg bg-muted/40 transition-colors hover:bg-accent/30">
+      <Accordion.Header
+        className={`group/header flex h-10 items-center rounded-lg bg-muted/40 transition-colors hover:bg-accent/30 ${
+          dragEnabled && sectionIsOver ? "ring-2 ring-primary/40 bg-primary/5" : ""
+        }`}
+      >
         <div className="pl-3 flex items-center">
           <input
             type="checkbox"
@@ -234,11 +438,12 @@ function StatusAccordionItem({
       </Accordion.Header>
       <Accordion.Panel className="pt-1">
         {issues.length > 0 ? (
-          <>
+          <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
             {issues.map((issue) => {
               const children = childrenByParent.get(issue.id);
               const hasChildren = !!children && children.length > 0;
               const collapsed = collapsedParentIds.has(issue.id);
+              const isOrphan = orphanedChildIds.has(issue.id);
               return (
                 <div key={issue.id}>
                   <ListRow
@@ -249,7 +454,8 @@ function StatusAccordionItem({
                     onToggleCollapsed={
                       hasChildren ? () => onToggleParent(issue.id) : undefined
                     }
-                    isOrphan={orphanedChildIds.has(issue.id)}
+                    isOrphan={isOrphan}
+                    isSortable={dragEnabled && !isOrphan}
                   />
                   {hasChildren && !collapsed && (
                     <div role="group" aria-label={`Sub-issues of ${issue.identifier}`}>
@@ -269,7 +475,7 @@ function StatusAccordionItem({
             {hasMore && (
               <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />
             )}
-          </>
+          </SortableContext>
         ) : (
           <p className="py-6 text-center text-xs text-muted-foreground">
             No issues
@@ -277,5 +483,11 @@ function StatusAccordionItem({
         )}
       </Accordion.Panel>
     </Accordion.Item>
+  );
+
+  return dragEnabled ? (
+    <div ref={setSectionDroppableRef}>{sectionContent}</div>
+  ) : (
+    sectionContent
   );
 }

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -40,15 +40,59 @@ export function ListView({
   const toggleListCollapsed = useViewStore(
     (s) => s.toggleListCollapsed
   );
+  const collapsedParentIds = useViewStore((s) => s.collapsedParentIds);
+  const toggleParentCollapsed = useViewStore((s) => s.toggleParentCollapsed);
 
-  const issuesByStatus = useMemo(() => {
-    const map = new Map<IssueStatus, Issue[]>();
-    for (const status of visibleStatuses) {
-      const filtered = issues.filter((i) => i.status === status);
-      map.set(status, sortIssues(filtered, sortBy, sortDirection));
+  // Build a map from parent_issue_id → child issues, scoped to the issues
+  // currently visible (post-filter, post-scope). A child whose parent is
+  // also in `issues` is treated as nested; a child whose parent has been
+  // filtered out becomes an "orphan" and renders at the top level so it
+  // isn't silently hidden when a status filter excludes the parent.
+  const { issuesByStatus, childrenByParent, orphanedChildIds } = useMemo(() => {
+    const parentIds = new Set<string>();
+    for (const i of issues) parentIds.add(i.id);
+
+    const childrenMap = new Map<string, Issue[]>();
+    const orphans = new Set<string>();
+    for (const i of issues) {
+      if (i.parent_issue_id && parentIds.has(i.parent_issue_id)) {
+        const arr = childrenMap.get(i.parent_issue_id);
+        if (arr) arr.push(i);
+        else childrenMap.set(i.parent_issue_id, [i]);
+      } else if (i.parent_issue_id) {
+        orphans.add(i.id);
+      }
     }
-    return map;
+
+    // Sort children by the same view-level sort (so order is consistent
+    // with siblings at the top level).
+    for (const [pid, arr] of childrenMap) {
+      childrenMap.set(pid, sortIssues(arr, sortBy, sortDirection));
+    }
+
+    // Top-level issues per status: any issue with no parent OR with a
+    // parent that isn't in the visible set (orphans surface here).
+    const byStatus = new Map<IssueStatus, Issue[]>();
+    for (const status of visibleStatuses) {
+      const filtered = issues.filter(
+        (i) =>
+          i.status === status &&
+          (!i.parent_issue_id || !parentIds.has(i.parent_issue_id)),
+      );
+      byStatus.set(status, sortIssues(filtered, sortBy, sortDirection));
+    }
+
+    return {
+      issuesByStatus: byStatus,
+      childrenByParent: childrenMap,
+      orphanedChildIds: orphans,
+    };
   }, [issues, visibleStatuses, sortBy, sortDirection]);
+
+  const collapsedSet = useMemo(
+    () => new Set(collapsedParentIds),
+    [collapsedParentIds],
+  );
 
   const expandedStatuses = useMemo(
     () =>
@@ -83,7 +127,11 @@ export function ListView({
             key={status}
             status={status}
             issues={issuesByStatus.get(status) ?? []}
+            childrenByParent={childrenByParent}
+            collapsedParentIds={collapsedSet}
+            onToggleParent={toggleParentCollapsed}
             childProgressMap={childProgressMap}
+            orphanedChildIds={orphanedChildIds}
             myIssuesOpts={myIssuesOpts}
           />
         ))}
@@ -95,12 +143,20 @@ export function ListView({
 function StatusAccordionItem({
   status,
   issues,
+  childrenByParent,
+  collapsedParentIds,
+  onToggleParent,
   childProgressMap,
+  orphanedChildIds,
   myIssuesOpts,
 }: {
   status: IssueStatus;
   issues: Issue[];
+  childrenByParent: Map<string, Issue[]>;
+  collapsedParentIds: Set<string>;
+  onToggleParent: (parentId: string) => void;
   childProgressMap: Map<string, ChildProgress>;
+  orphanedChildIds: Set<string>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
 }) {
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
@@ -111,9 +167,23 @@ function StatusAccordionItem({
     myIssuesOpts,
   );
 
-  const issueIds = issues.map((i) => i.id);
-  const selectedCount = issueIds.filter((id) => selectedIds.has(id)).length;
-  const allSelected = issues.length > 0 && selectedCount === issues.length;
+  // Selection at the status level covers ALL rows that will render
+  // under this status — including currently-visible children — so
+  // shift-click and "select all" behave the same with or without nesting.
+  const visibleRowIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const issue of issues) {
+      ids.push(issue.id);
+      const children = childrenByParent.get(issue.id);
+      if (children && !collapsedParentIds.has(issue.id)) {
+        for (const c of children) ids.push(c.id);
+      }
+    }
+    return ids;
+  }, [issues, childrenByParent, collapsedParentIds]);
+
+  const selectedCount = visibleRowIds.filter((id) => selectedIds.has(id)).length;
+  const allSelected = visibleRowIds.length > 0 && selectedCount === visibleRowIds.length;
   const someSelected = selectedCount > 0;
 
   return (
@@ -128,9 +198,9 @@ function StatusAccordionItem({
             }}
             onChange={() => {
               if (allSelected) {
-                deselect(issueIds);
+                deselect(visibleRowIds);
               } else {
-                select(issueIds);
+                select(visibleRowIds);
               }
             }}
             className="cursor-pointer accent-primary"
@@ -165,9 +235,37 @@ function StatusAccordionItem({
       <Accordion.Panel className="pt-1">
         {issues.length > 0 ? (
           <>
-            {issues.map((issue) => (
-              <ListRow key={issue.id} issue={issue} childProgress={childProgressMap.get(issue.id)} />
-            ))}
+            {issues.map((issue) => {
+              const children = childrenByParent.get(issue.id);
+              const hasChildren = !!children && children.length > 0;
+              const collapsed = collapsedParentIds.has(issue.id);
+              return (
+                <div key={issue.id}>
+                  <ListRow
+                    issue={issue}
+                    childProgress={childProgressMap.get(issue.id)}
+                    hasChildren={hasChildren}
+                    collapsed={collapsed}
+                    onToggleCollapsed={
+                      hasChildren ? () => onToggleParent(issue.id) : undefined
+                    }
+                    isOrphan={orphanedChildIds.has(issue.id)}
+                  />
+                  {hasChildren && !collapsed && (
+                    <div role="group" aria-label={`Sub-issues of ${issue.identifier}`}>
+                      {children!.map((child) => (
+                        <ListRow
+                          key={child.id}
+                          issue={child}
+                          childProgress={childProgressMap.get(child.id)}
+                          indentLevel={1}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
             {hasMore && (
               <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />
             )}

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -197,6 +197,7 @@ export function MyIssuesPage() {
                 childProgressMap={childProgressMap}
                 myIssuesScope={scope}
                 myIssuesFilter={filter}
+                onMoveIssue={handleMoveIssue}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary

The board view supports drag-to-change-status and drag-to-reorder; the list view (and the My Issues list) didn't. Users on the list view for filtering/density reasons had to either open the issue or use the right-click menu to change status — friction the board never had. This brings parity.

> **Note**: this PR is **stacked on top of #2046** (collapsible sub-issues in list view). The diff against `main` includes both commits; reviewing #2046 first lets you see this PR's diff in isolation.

## What changed

| File | Δ | What |
|---|---|---|
| `packages/views/issues/components/list-view.tsx` | +152 / -27 | Wraps content in `DndContext` (matches `BoardView`). Each status accordion item registers a droppable namespaced `list-status:<status>` so drops on the section header / empty panel route to that status. Each top-level row participates in a per-status `SortableContext`. Drop handler resolves target status from either the section droppable id or the over-row's status, computes a fractional position from neighbors (mirrors `BoardView`'s `computePosition`), no-ops when status + position unchanged. |
| `packages/views/issues/components/list-row.tsx` | +52 / -7 | Hover-revealed `GripVertical` handle on the left of the row is the drag source. Entire row stays the click target for navigation; clicking the grip `preventDefault`s so the `AppLink` doesn't fire mid-drag. New `isSortable` + `isDragOverlay` props. |
| `packages/views/issues/components/issues-page.tsx` | +5 / -1 | Pass the existing `handleMoveIssue` to `<ListView>` (it was already wired for `<BoardView>`). |
| `packages/views/my-issues/components/my-issues-page.tsx` | +1 | Same. |
| `packages/views/issues/components/list-view.test.tsx` | +5 new cases | See "Tests" below. |

## Visual UX

- **Drag handle**: hover-revealed `GripVertical` icon, opacity ramps in on row hover, `cursor-grab` → `cursor-grabbing`.
- **Drag overlay**: clone of the row with `pointer-events: none`, `opacity: 0.95`, ring + shadow.
- **Drop target highlight**: status section header gets `ring-2 ring-primary/40 bg-primary/5` while a drag is over it.
- **Source row**: `opacity-40` while it's the active drag source.

## Scope (deliberately narrow for v1)

- ✅ Top-level rows draggable
- ❌ Sub-issues (nested under a parent) — stay anchored, not draggable
- ❌ Orphan rows (parent filtered out) — not draggable; moving on their own would split them from a hidden parent in confusing ways
- ❌ Re-parenting via drag — separate PR worth
- ❌ Sibling reorder within a parent — follow-up
- ❌ Multi-select drag — board view doesn't support it either
- ❌ Auto-expand collapsed status accordion on hover-during-drag — user can drop on the section header

`onMoveIssue` is **optional** on `<ListView>`. When omitted, drag is entirely disabled and the component renders identically to before — useful for any read-only embedding.

## Why frontend-only

The backend already accepts `(status, position)` updates via the existing `updateIssue` mutation (`handleMoveIssue` in both pages). No new endpoint, no schema change.

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run issues/components/list-view.test.tsx` — 10/10 (5 existing nesting tests + 5 new drag tests):
  - `DndContext` is NOT mounted when `onMoveIssue` is undefined (read-only)
  - `DndContext` IS mounted when `onMoveIssue` is provided
  - drop on `list-status:<status>` section calls `onMoveIssue(id, status, number)`
  - drop on a row in another status uses that row's status as the target
  - no-op guard: dropping back on self produces no `onMoveIssue` call
  - cancelled drag (`over=null`) produces no call
- [x] `pnpm typecheck` — clean across all 6 packages.
- [x] `pnpm test` — 261/261 across views.
- [x] Manual smoke: drag from `Todo` → `In Progress` (status updates), drag within `Todo` to reorder (position updates), cancel via Esc (no call), drop on a `Done` row from another status (target = `Done`).

## Out of scope (deliberate)

- Auto-expand collapsed status accordions when dragging over them — drop on the header works as a workaround. Easy to add later if reviewers want it.
- Sub-issue drag (sibling reorder + re-parenting) — separate PR.
- Multi-select drag — neither view supports it; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
