### PR TITLE
fix(core): invalidate byIssue label cache on WS label change

### DIFF
--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { onIssueLabelsChanged } from "./ws-updaters";
+import { issueKeys } from "./queries";
+import { labelKeys } from "../labels/queries";
+import type {
+  Issue,
+  IssueLabelsResponse,
+  Label,
+  ListIssuesCache,
+} from "../types";
+
+const WS_ID = "ws-1";
+const ISSUE_ID = "issue-1";
+
+const labelA: Label = {
+  id: "label-a",
+  workspace_id: WS_ID,
+  name: "bug",
+  color: "#ef4444",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+const labelB: Label = {
+  id: "label-b",
+  workspace_id: WS_ID,
+  name: "feature",
+  color: "#22c55e",
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+const baseIssue: Issue = {
+  id: ISSUE_ID,
+  workspace_id: WS_ID,
+  number: 1,
+  identifier: "MUL-1",
+  title: "Test",
+  description: null,
+  status: "todo",
+  priority: "none",
+  assignee_type: null,
+  assignee_id: null,
+  creator_type: "member",
+  creator_id: "user-1",
+  parent_issue_id: null,
+  project_id: null,
+  position: 0,
+  due_date: null,
+  labels: [labelA],
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+describe("onIssueLabelsChanged", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+  });
+
+  it("patches the per-issue label cache when present (LabelPicker source)", () => {
+    qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(WS_ID, ISSUE_ID), {
+      labels: [labelA],
+    });
+
+    onIssueLabelsChanged(qc, WS_ID, ISSUE_ID, [labelB]);
+
+    expect(
+      qc.getQueryData<IssueLabelsResponse>(labelKeys.byIssue(WS_ID, ISSUE_ID)),
+    ).toEqual({ labels: [labelB] });
+  });
+
+  it("leaves the per-issue label cache untouched when the picker has not fetched", () => {
+    onIssueLabelsChanged(qc, WS_ID, ISSUE_ID, [labelB]);
+
+    expect(qc.getQueryData(labelKeys.byIssue(WS_ID, ISSUE_ID))).toBeUndefined();
+  });
+
+  it("still patches the list and detail caches", () => {
+    qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), {
+      byStatus: { todo: { issues: [baseIssue], total: 1 } },
+    });
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
+
+    onIssueLabelsChanged(qc, WS_ID, ISSUE_ID, [labelB]);
+
+    const list = qc.getQueryData<ListIssuesCache>(issueKeys.list(WS_ID));
+    expect(list?.byStatus.todo?.issues[0]?.labels).toEqual([labelB]);
+
+    const detail = qc.getQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID));
+    expect(detail?.labels).toEqual([labelB]);
+  });
+});

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -1,12 +1,13 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { issueKeys } from "./queries";
+import { labelKeys } from "../labels/queries";
 import {
   addIssueToBuckets,
   findIssueLocation,
   patchIssueInBuckets,
   removeIssueFromBuckets,
 } from "./cache-helpers";
-import type { Issue, Label } from "../types";
+import type { Issue, IssueLabelsResponse, Label } from "../types";
 import type { ListIssuesCache } from "../types";
 
 export function onIssueCreated(
@@ -73,9 +74,15 @@ export function onIssueUpdated(
 }
 
 /**
- * Patch an issue's `labels` field in-place across the list cache, my-issues
- * caches, and the detail cache. Triggered by the `issue_labels:changed` WS
- * event after attach/detach so list/board chips update without a refetch.
+ * Patch an issue's labels in-place across the list cache, my-issues caches,
+ * the detail cache, and the per-issue label cache. Triggered by the
+ * `issue_labels:changed` WS event after attach/detach so list/board chips
+ * and the issue-detail Properties LabelPicker update without a refetch.
+ *
+ * The byIssue cache backs `LabelPicker`; without patching it, externally
+ * driven label changes (agents, other tabs) leave the picker stale until it
+ * remounts — `staleTime: Infinity` + `refetchOnWindowFocus: false` (see
+ * `query-client.ts`) means focus changes won't recover it.
  */
 export function onIssueLabelsChanged(
   qc: QueryClient,
@@ -87,6 +94,9 @@ export function onIssueLabelsChanged(
     old ? patchIssueInBuckets(old, issueId, { labels }) : old,
   );
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issueId), (old) =>
+    old ? { ...old, labels } : old,
+  );
+  qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), (old) =>
     old ? { ...old, labels } : old,
   );
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });


### PR DESCRIPTION
## Summary
- `onIssueLabelsChanged` now also writes the fresh label set into `labelKeys.byIssue(wsId, issueId)`, alongside the existing list/detail patches. Mirrors the actor-side mutation flow in `useAttachLabel` / `useDetachLabel`, which already touched all three caches.

## Root Cause
`packages/core/issues/ws-updaters.ts` patched the embedded `labels` field in `issueKeys.list` and `issueKeys.detail`, but never touched `labelKeys.byIssue` — the cache backing the issue-detail Properties sidebar `LabelPicker` (`packages/views/issues/components/pickers/label-picker.tsx:85`). When the actor themself changed a label, the mutation handlers covered all three caches; when an agent or another tab changed it, only the WS handler ran, so the open issue's sidebar showed stale labels. The default `staleTime: Infinity` + `refetchOnWindowFocus: false` (`packages/core/query-client.ts:7-9`) means the picker stays stale until it remounts (closing/reopening the issue).

## Test plan
- [x] `pnpm --filter @multica/core typecheck`
- [x] `pnpm --filter @multica/core test` (173 passed, 22 files)
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views test` (251 passed, 36 files)
- [x] Regression test added: `packages/core/issues/ws-updaters.test.ts` covers the `byIssue` cache patch and the existing list/detail patches
- [ ] Manual: open issue X in tab A; have an agent (or use the CLI / a second tab) change its labels; the LabelPicker chips in tab A's Properties sidebar update without reopening the issue

Fixes #2049