### PR TITLE
feat(issues): add project action menu

### DIFF
--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Issue } from "@multica/core/types";
+import type { Issue, Project } from "@multica/core/types";
 
 // ---------------------------------------------------------------------------
 // Mocks — same pattern as the issue-detail test suite.
@@ -42,6 +42,30 @@ vi.mock("@multica/core/workspace/queries", () => ({
   agentListOptions: () => ({
     queryKey: ["workspaces", "ws-1", "agents"],
     queryFn: () => Promise.resolve([]),
+  }),
+}));
+
+vi.mock("@multica/core/projects/queries", () => ({
+  projectListOptions: () => ({
+    queryKey: ["projects", "ws-1", "list"],
+    queryFn: () =>
+      Promise.resolve([
+        {
+          id: "project-1",
+          workspace_id: "ws-1",
+          title: "Launch work",
+          description: null,
+          icon: "🚀",
+          status: "in_progress",
+          priority: "medium",
+          lead_type: null,
+          lead_id: null,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          issue_count: 1,
+          done_count: 0,
+        },
+      ]),
   }),
 }));
 
@@ -90,6 +114,10 @@ vi.mock("../../../common/actor-avatar", () => ({
 // Import after mocks.
 import { IssueActionsDropdown } from "../issue-actions-dropdown";
 import { IssueActionsContextMenu } from "../issue-actions-context-menu";
+import {
+  IssueActionsMenuItems,
+  type MenuPrimitives,
+} from "../issue-actions-menu-items";
 
 const mockIssue: Issue = {
   id: "issue-1",
@@ -139,6 +167,7 @@ describe("IssueActionsDropdown", () => {
     expect(await screen.findByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Priority")).toBeInTheDocument();
     expect(screen.getByText("Assignee")).toBeInTheDocument();
+    expect(screen.getByText("Project")).toBeInTheDocument();
     expect(screen.getByText("Due date")).toBeInTheDocument();
     expect(screen.getByText("Copy link")).toBeInTheDocument();
     expect(screen.getByText("More")).toBeInTheDocument();
@@ -185,6 +214,65 @@ describe("IssueActionsContextMenu", () => {
     fireEvent.contextMenu(screen.getByTestId("row"));
 
     expect(await screen.findByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Project")).toBeInTheDocument();
     expect(screen.getByText("Delete issue")).toBeInTheDocument();
+  });
+});
+
+const testPrimitives = {
+  Item: ({ children, onClick, disabled }: any) => (
+    <button disabled={disabled} onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+  Sub: ({ children }: any) => <div>{children}</div>,
+  SubTrigger: ({ children }: any) => <div>{children}</div>,
+  SubContent: ({ children }: any) => <div>{children}</div>,
+  Separator: () => <hr />,
+} as unknown as MenuPrimitives;
+
+const project: Project = {
+  id: "project-1",
+  workspace_id: "ws-1",
+  title: "Launch work",
+  description: null,
+  icon: "🚀",
+  status: "in_progress",
+  priority: "medium",
+  lead_type: null,
+  lead_id: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  issue_count: 1,
+  done_count: 0,
+};
+
+describe("IssueActionsMenuItems", () => {
+  it("updates the issue project from the shared action menu", () => {
+    const updateField = vi.fn();
+
+    render(
+      <IssueActionsMenuItems
+        issue={mockIssue}
+        primitives={testPrimitives}
+        actions={{
+          members: [],
+          agents: [],
+          projects: [project],
+          isPinned: false,
+          updateField,
+          togglePin: vi.fn(),
+          copyLink: vi.fn(),
+          openCreateSubIssue: vi.fn(),
+          openSetParent: vi.fn(),
+          openAddChild: vi.fn(),
+          openDeleteConfirm: vi.fn(),
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /launch work/i }));
+
+    expect(updateField).toHaveBeenCalledWith({ project_id: "project-1" });
   });
 });

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -4,6 +4,8 @@ import {
   ArrowDown,
   ArrowUp,
   Calendar,
+  Check,
+  FolderKanban,
   Link2,
   MoreHorizontal,
   Pin,
@@ -22,6 +24,7 @@ import {
 import { StatusIcon } from "../components/status-icon";
 import { PriorityIcon } from "../components/priority-icon";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { ProjectIcon } from "../../projects/components/project-icon";
 import {
   DropdownMenuItem,
   DropdownMenuSub,
@@ -85,6 +88,7 @@ export function IssueActionsMenuItems({
   const {
     members,
     agents,
+    projects,
     isPinned,
     updateField,
     togglePin,
@@ -101,6 +105,9 @@ export function IssueActionsMenuItems({
     d.setDate(d.getDate() + days);
     return d.toISOString();
   };
+  const currentProject = issue.project_id
+    ? projects.find((project) => project.id === issue.project_id)
+    : null;
 
   return (
     <>
@@ -193,6 +200,43 @@ export function IssueActionsMenuItems({
               )}
             </P.Item>
           ))}
+        </P.SubContent>
+      </P.Sub>
+
+      {/* Project */}
+      <P.Sub>
+        <P.SubTrigger>
+          {currentProject ? (
+            <ProjectIcon project={currentProject} size="sm" />
+          ) : (
+            <FolderKanban className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+          Project
+        </P.SubTrigger>
+        <P.SubContent className="max-h-72 min-w-56 overflow-y-auto">
+          <P.Item onClick={() => updateField({ project_id: null })}>
+            <FolderKanban className="h-3.5 w-3.5 text-muted-foreground" />
+            No project
+            {!issue.project_id && (
+              <Check className="ml-auto h-3.5 w-3.5 text-muted-foreground" />
+            )}
+          </P.Item>
+          {projects.length > 0 && <P.Separator />}
+          {projects.map((project) => (
+            <P.Item
+              key={project.id}
+              onClick={() => updateField({ project_id: project.id })}
+            >
+              <ProjectIcon project={project} size="md" />
+              <span className="truncate">{project.title}</span>
+              {issue.project_id === project.id && (
+                <Check className="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              )}
+            </P.Item>
+          ))}
+          {projects.length === 0 && (
+            <P.Item disabled>No projects yet</P.Item>
+          )}
         </P.SubContent>
       </P.Sub>
 

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -7,6 +7,7 @@ import type {
   Issue,
   MemberWithUser,
   Agent,
+  Project,
   UpdateIssueRequest,
 } from "@multica/core/types";
 import { useAuthStore } from "@multica/core/auth";
@@ -18,6 +19,7 @@ import {
   memberListOptions,
   agentListOptions,
 } from "@multica/core/workspace/queries";
+import { projectListOptions } from "@multica/core/projects/queries";
 import { pinListOptions, useCreatePin, useDeletePin } from "@multica/core/pins";
 import { canAssignAgent } from "../components/pickers";
 import { useNavigation } from "../../navigation";
@@ -28,6 +30,7 @@ export interface UseIssueActionsResult {
   // Derived data for rendering menu rows
   members: MemberWithUser[];
   agents: Agent[];
+  projects: Project[];
   isPinned: boolean;
   // Handlers
   updateField: (updates: Partial<UpdateIssueRequest>) => void;
@@ -53,6 +56,7 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
 
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const { data: projects = [] } = useQuery(projectListOptions(wsId));
   const { data: pinnedItems = [] } = useQuery({
     ...pinListOptions(wsId, userId ?? ""),
     enabled: !!userId,
@@ -164,6 +168,7 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
   return {
     members,
     agents: filteredAgents,
+    projects,
     isPinned,
     updateField,
     togglePin,

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -227,7 +227,7 @@ function PageHeaderBar({
         <p className="ml-2 hidden text-xs text-muted-foreground md:block">
           Machines and cloud workers running CLI sessions for your agents.{" "}
           <a
-            href="https://multica.ai/docs/runtimes"
+            href="https://multica.ai/docs/daemon-runtimes"
             target="_blank"
             rel="noopener noreferrer"
             className="underline decoration-muted-foreground/30 underline-offset-4 transition-colors hover:text-foreground"


### PR DESCRIPTION
## Summary

- Add a project action menu to issue action handling, with focused coverage for menu rendering and actions.
- Point the runtimes page Learn more link at the daemon-runtimes documentation.

## Commit provenance

Cherry-picked from private fork commits:

- 234f3bd04c8a5b160715821b6e3c50174bb3f90d
- 2b7dea3ced27d7d1ff27fc70c52af2ed5a7f1664

## Validation

- `pnpm --filter @multica/views exec vitest run issues/actions/__tests__/issue-actions-menu.test.tsx`
- `pnpm typecheck`
