### PR TITLE
fix(editor): keep blank-line paste inside the code block

### DIFF
--- a/packages/views/editor/extensions/markdown-paste.test.ts
+++ b/packages/views/editor/extensions/markdown-paste.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { Markdown } from "@tiptap/markdown";
+import { createMarkdownPasteExtension } from "./markdown-paste";
+
+interface FakeClipboard {
+  files: never[];
+  getData: (type: string) => string;
+}
+
+function fakePasteEvent(text: string, html?: string) {
+  const data: FakeClipboard = {
+    files: [],
+    getData: (type) =>
+      type === "text/plain" ? text : type === "text/html" ? (html ?? "") : "",
+  };
+  return {
+    clipboardData: data,
+    preventDefault: () => {},
+  } as unknown as ClipboardEvent;
+}
+
+function makeEditor(content: object) {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+  return new Editor({
+    element,
+    extensions: [StarterKit, Markdown, createMarkdownPasteExtension()],
+    content,
+  });
+}
+
+function paste(editor: Editor, text: string, html?: string): boolean {
+  const event = fakePasteEvent(text, html);
+  return (
+    editor.view.someProp("handlePaste", (handler) =>
+      handler(editor.view, event, editor.view.state.selection.content()),
+    ) === true
+  );
+}
+
+interface JsonNode {
+  type: string;
+  text?: string;
+  content?: JsonNode[];
+}
+
+function findFirst(json: JsonNode, type: string): JsonNode | undefined {
+  if (json.type === type) return json;
+  for (const child of json.content ?? []) {
+    const hit = findFirst(child, type);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+function nodeText(node: JsonNode): string {
+  if (node.text !== undefined) return node.text;
+  return (node.content ?? []).map(nodeText).join("");
+}
+
+describe("markdownPaste — code block context", () => {
+  let editor: Editor | null = null;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = null;
+    document.body.innerHTML = "";
+  });
+
+  it("preserves blank lines when pasting into a code block (#1982)", () => {
+    editor = makeEditor({
+      type: "doc",
+      content: [{ type: "codeBlock", content: [{ type: "text", text: "x" }] }],
+    });
+
+    // Place caret after "x" inside the code block.
+    editor.commands.setTextSelection(2);
+    expect(editor.state.selection.$from.parent.type.name).toBe("codeBlock");
+
+    const handled = paste(editor, "line1\n\nline2");
+    expect(handled).toBe(true);
+
+    const json = editor.getJSON() as JsonNode;
+    const codeBlock = findFirst(json, "codeBlock");
+    expect(codeBlock).toBeDefined();
+    // Code block content is preserved verbatim — blank line stays inside.
+    expect(nodeText(codeBlock!)).toBe("xline1\n\nline2");
+    // No paragraph leaked out carrying any of the pasted text.
+    const leakedParagraph = (json.content ?? []).find(
+      (n) => n.type === "paragraph" && nodeText(n).length > 0,
+    );
+    expect(leakedParagraph).toBeUndefined();
+  });
+
+  it("preserves fence characters pasted into a code block", () => {
+    editor = makeEditor({
+      type: "doc",
+      content: [{ type: "codeBlock", content: [] }],
+    });
+
+    editor.commands.setTextSelection(1);
+    expect(editor.state.selection.$from.parent.type.name).toBe("codeBlock");
+
+    paste(editor, "```\nhello\n```");
+
+    const json = editor.getJSON() as JsonNode;
+    const codeBlock = findFirst(json, "codeBlock");
+    expect(codeBlock).toBeDefined();
+    expect(nodeText(codeBlock!)).toBe("```\nhello\n```");
+  });
+
+  it("still parses Markdown when pasting into a regular paragraph", () => {
+    editor = makeEditor({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
+
+    editor.commands.setTextSelection(1);
+    expect(editor.state.selection.$from.parent.type.name).toBe("paragraph");
+
+    paste(editor, "# Heading\n\nbody");
+
+    const json = editor.getJSON() as JsonNode;
+    const types = (json.content ?? []).map((n) => n.type);
+    // Markdown parsing produced a heading at the top.
+    expect(types).toContain("heading");
+  });
+});

--- a/packages/views/editor/extensions/markdown-paste.ts
+++ b/packages/views/editor/extensions/markdown-paste.ts
@@ -46,6 +46,16 @@ export function createMarkdownPasteExtension() {
               const text = clipboard.getData("text/plain");
               if (!text) return false;
 
+              // If the caret is inside a code block, insert the text as-is.
+              // Code blocks must keep newlines literal; running Markdown
+              // parsing here would split a blank line (\n\n) into two
+              // paragraphs and tear the code block open. (#1982)
+              const { $from } = view.state.selection;
+              if ($from.parent.type.name === "codeBlock") {
+                view.dispatch(view.state.tr.insertText(text));
+                return true;
+              }
+
               const html = clipboard.getData("text/html");
 
               // If HTML contains data-pm-slice, the source is another


### PR DESCRIPTION
## Summary

- When the caret is inside a code block, paste the clipboard text verbatim instead of running it through the Markdown parser. The parser was splitting on `\n\n`, tearing the code block open and dropping the trailing content into a sibling paragraph.
- Code blocks have `code: true`, so newlines stay literal — matches what users expect from GitHub / Linear when pasting code or logs.

Closes #1982

## Test plan

- [x] New `packages/views/editor/extensions/markdown-paste.test.ts` covers three cases:
  - blank-line paste inside a code block stays inside (regression for #1982)
  - fence characters (` ``` `) pasted inside a code block are preserved verbatim
  - a regular paragraph still goes through the Markdown parser (heading is produced)
- [x] `pnpm --filter @multica/views test` — 38 files / 255 tests pass
- [x] `pnpm typecheck` — clean across all packages
- [x] Stash-revert verified: without the fix the two new code-block tests fail; with the fix they pass