### PR TITLE
fix(server): allow re-inviting after invitation expires (#2055)

### DIFF
--- a/server/internal/handler/invitation.go
+++ b/server/internal/handler/invitation.go
@@ -95,7 +95,19 @@ func (h *Handler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Check if there is already a pending invitation.
+	// Drop any past-due pending invitations to 'expired' first. The partial unique
+	// index idx_invitation_unique_pending only filters by status = 'pending', so a
+	// stale row would otherwise block CreateInvitation below — see issue #2055.
+	if err := h.Queries.ExpireStalePendingInvitations(r.Context(), db.ExpireStalePendingInvitationsParams{
+		WorkspaceID:  requester.WorkspaceID,
+		InviteeEmail: email,
+	}); err != nil {
+		slog.Warn("expire stale invitations failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", workspaceID, "email", email)...)
+		writeError(w, http.StatusInternalServerError, "failed to create invitation")
+		return
+	}
+
+	// Check if there is still a live pending invitation.
 	_, err = h.Queries.GetPendingInvitationByEmail(r.Context(), db.GetPendingInvitationByEmailParams{
 		WorkspaceID:  requester.WorkspaceID,
 		InviteeEmail: email,

--- a/server/internal/handler/invitation_test.go
+++ b/server/internal/handler/invitation_test.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const invitationTestEmail = "invitation-test@multica.ai"
+
+func clearInvitationsForTestWorkspace(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := testPool.Exec(ctx,
+		`DELETE FROM workspace_invitation WHERE workspace_id = $1`,
+		parseUUID(testWorkspaceID),
+	); err != nil {
+		t.Fatalf("clear invitations: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(),
+			`DELETE FROM workspace_invitation WHERE workspace_id = $1`,
+			parseUUID(testWorkspaceID),
+		)
+	})
+}
+
+// Sanity check: a fresh, live pending invitation must block re-invitation.
+func TestCreateInvitation_BlocksWhilePending(t *testing.T) {
+	clearInvitationsForTestWorkspace(t)
+
+	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/members", CreateMemberRequest{
+		Email: invitationTestEmail,
+		Role:  "member",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	w := httptest.NewRecorder()
+	testHandler.CreateInvitation(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("first invite: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	req2 := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/members", CreateMemberRequest{
+		Email: invitationTestEmail,
+		Role:  "member",
+	})
+	req2 = withURLParam(req2, "id", testWorkspaceID)
+	w2 := httptest.NewRecorder()
+	testHandler.CreateInvitation(w2, req2)
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("second invite: expected 409 while still pending, got %d: %s", w2.Code, w2.Body.String())
+	}
+}
+
+// Regression for issue #2055: an expired pending invitation must NOT block a
+// new invitation to the same email. The stale row should be flipped to
+// 'expired' and a fresh pending row should be created.
+func TestCreateInvitation_AllowsAfterExpiry(t *testing.T) {
+	clearInvitationsForTestWorkspace(t)
+	ctx := context.Background()
+
+	var staleID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace_invitation (
+			workspace_id, inviter_id, invitee_email, role, status, created_at, updated_at, expires_at
+		)
+		VALUES ($1, $2, $3, 'member', 'pending', now() - interval '10 days', now() - interval '10 days', now() - interval '3 days')
+		RETURNING id
+	`, parseUUID(testWorkspaceID), parseUUID(testUserID), invitationTestEmail).Scan(&staleID); err != nil {
+		t.Fatalf("seed expired invitation: %v", err)
+	}
+
+	req := newRequest("POST", "/api/workspaces/"+testWorkspaceID+"/members", CreateMemberRequest{
+		Email: invitationTestEmail,
+		Role:  "member",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	w := httptest.NewRecorder()
+	testHandler.CreateInvitation(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("re-invite after expiry: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp InvitationResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ID == "" || resp.ID == staleID {
+		t.Fatalf("expected a new invitation row, got id=%q (stale=%q)", resp.ID, staleID)
+	}
+
+	var staleStatus string
+	if err := testPool.QueryRow(ctx,
+		`SELECT status FROM workspace_invitation WHERE id = $1`, staleID,
+	).Scan(&staleStatus); err != nil {
+		t.Fatalf("read stale row: %v", err)
+	}
+	if staleStatus != "expired" {
+		t.Fatalf("expected stale row to be 'expired', got %q", staleStatus)
+	}
+
+	var pendingCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM workspace_invitation
+		WHERE workspace_id = $1 AND invitee_email = $2 AND status = 'pending'
+	`, parseUUID(testWorkspaceID), invitationTestEmail).Scan(&pendingCount); err != nil {
+		t.Fatalf("count pending: %v", err)
+	}
+	if pendingCount != 1 {
+		t.Fatalf("expected exactly 1 pending invitation after re-invite, got %d", pendingCount)
+	}
+}

--- a/server/pkg/db/generated/invitation.sql.go
+++ b/server/pkg/db/generated/invitation.sql.go
@@ -99,6 +99,29 @@ func (q *Queries) DeclineInvitation(ctx context.Context, id pgtype.UUID) (Worksp
 	return i, err
 }
 
+const expireStalePendingInvitations = `-- name: ExpireStalePendingInvitations :exec
+UPDATE workspace_invitation
+SET status = 'expired', updated_at = now()
+WHERE workspace_id = $1
+  AND invitee_email = $2
+  AND status = 'pending'
+  AND expires_at <= now()
+`
+
+type ExpireStalePendingInvitationsParams struct {
+	WorkspaceID  pgtype.UUID `json:"workspace_id"`
+	InviteeEmail string      `json:"invitee_email"`
+}
+
+// Mark any past-due pending invitations for (workspace_id, invitee_email) as expired,
+// so the next CreateInvitation does not collide with the partial unique index
+// idx_invitation_unique_pending (which is WHERE status = 'pending' and cannot
+// itself reference now() in its predicate).
+func (q *Queries) ExpireStalePendingInvitations(ctx context.Context, arg ExpireStalePendingInvitationsParams) error {
+	_, err := q.db.Exec(ctx, expireStalePendingInvitations, arg.WorkspaceID, arg.InviteeEmail)
+	return err
+}
+
 const getInvitation = `-- name: GetInvitation :one
 SELECT id, workspace_id, inviter_id, invitee_email, invitee_user_id, role, status, created_at, updated_at, expires_at FROM workspace_invitation
 WHERE id = $1
@@ -124,7 +147,7 @@ func (q *Queries) GetInvitation(ctx context.Context, id pgtype.UUID) (WorkspaceI
 
 const getPendingInvitationByEmail = `-- name: GetPendingInvitationByEmail :one
 SELECT id, workspace_id, inviter_id, invitee_email, invitee_user_id, role, status, created_at, updated_at, expires_at FROM workspace_invitation
-WHERE workspace_id = $1 AND invitee_email = $2 AND status = 'pending'
+WHERE workspace_id = $1 AND invitee_email = $2 AND status = 'pending' AND expires_at > now()
 `
 
 type GetPendingInvitationByEmailParams struct {

--- a/server/pkg/db/queries/invitation.sql
+++ b/server/pkg/db/queries/invitation.sql
@@ -47,4 +47,16 @@ WHERE id = $1 AND status = 'pending';
 
 -- name: GetPendingInvitationByEmail :one
 SELECT * FROM workspace_invitation
-WHERE workspace_id = $1 AND invitee_email = $2 AND status = 'pending';
+WHERE workspace_id = $1 AND invitee_email = $2 AND status = 'pending' AND expires_at > now();
+
+-- name: ExpireStalePendingInvitations :exec
+-- Mark any past-due pending invitations for (workspace_id, invitee_email) as expired,
+-- so the next CreateInvitation does not collide with the partial unique index
+-- idx_invitation_unique_pending (which is WHERE status = 'pending' and cannot
+-- itself reference now() in its predicate).
+UPDATE workspace_invitation
+SET status = 'expired', updated_at = now()
+WHERE workspace_id = $1
+  AND invitee_email = $2
+  AND status = 'pending'
+  AND expires_at <= now();


### PR DESCRIPTION
## Summary

- Fixes [#2055](https://github.com/multica-ai/multica/issues/2055): an expired `workspace_invitation` row with `status = 'pending'` permanently blocked re-inviting the same email.
- Before `CreateInvitation` inserts, flip any past-due pending rows for the same `(workspace_id, invitee_email)` to `status = 'expired'`. This frees the partial unique index `idx_invitation_unique_pending` (which is keyed on `status = 'pending'` only — Postgres does not allow `now()` in a partial-index predicate, so this can't be moved into the index itself).
- Tightens `GetPendingInvitationByEmail` to also require `expires_at > now()`, matching the existing `ListPending*` queries — they were already filtering, only the create path wasn't.

## Why option A from the issue isn't enough on its own

The reporter's "minimal" fix (`AND expires_at > NOW()` in the pending-check) would still let the subsequent `INSERT` collide with the partial unique index, falling through to the duplicate `isUniqueViolation` branch and returning the same 409. The handler must actively expire the stale row first.

## Test plan

- [x] New backend handler tests in `server/internal/handler/invitation_test.go`:
  - `TestCreateInvitation_BlocksWhilePending` — fresh pending row still blocks (regression guard).
  - `TestCreateInvitation_AllowsAfterExpiry` — seeds a stale `expires_at < now()` pending row, calls `CreateInvitation`, asserts 201, asserts old row is now `'expired'`, and asserts exactly one live `'pending'` row remains.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [ ] `make test` — DB integration tests skip locally (no docker), will run in CI.
- [ ] Manual verify on staging: invite a user, manually backdate `expires_at`, re-invite via Settings → success.