### PR TITLE
fix(views): show Ctrl+K / Ctrl+Enter on non-Mac platforms

### DIFF
--- a/packages/core/platform/index.ts
+++ b/packages/core/platform/index.ts
@@ -5,3 +5,4 @@ export { defaultStorage } from "./storage";
 export { createPersistStorage } from "./persist-storage";
 export { createWorkspaceAwareStorage, setCurrentWorkspace, getCurrentSlug, getCurrentWsId, subscribeToCurrentSlug, registerForWorkspaceRehydration } from "./workspace-storage";
 export { clearWorkspaceStorage } from "./storage-cleanup";
+export { isMac, modKey, enterKey, formatShortcut } from "./keyboard";

--- a/packages/core/platform/keyboard.test.ts
+++ b/packages/core/platform/keyboard.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("keyboard platform helper", () => {
+  it("renders Mac symbols when navigator.platform is MacIntel", async () => {
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+    const mod = await import("./keyboard");
+
+    expect(mod.isMac).toBe(true);
+    expect(mod.modKey).toBe("⌘");
+    expect(mod.enterKey).toBe("↵");
+    expect(mod.formatShortcut(mod.modKey, "K")).toBe("⌘K");
+    expect(mod.formatShortcut(mod.modKey, mod.enterKey)).toBe("⌘↵");
+  });
+
+  it("renders Ctrl/Enter on Windows", async () => {
+    vi.stubGlobal("navigator", { platform: "Win32" });
+    const mod = await import("./keyboard");
+
+    expect(mod.isMac).toBe(false);
+    expect(mod.modKey).toBe("Ctrl");
+    expect(mod.enterKey).toBe("Enter");
+    expect(mod.formatShortcut(mod.modKey, "K")).toBe("Ctrl+K");
+    expect(mod.formatShortcut(mod.modKey, mod.enterKey)).toBe("Ctrl+Enter");
+  });
+
+  it("renders Ctrl/Enter on Linux", async () => {
+    vi.stubGlobal("navigator", { platform: "Linux x86_64" });
+    const mod = await import("./keyboard");
+
+    expect(mod.isMac).toBe(false);
+    expect(mod.modKey).toBe("Ctrl");
+    expect(mod.formatShortcut("Ctrl", "Shift", "P")).toBe("Ctrl+Shift+P");
+  });
+
+  it("falls back to non-Mac when navigator is unavailable (SSR)", async () => {
+    vi.stubGlobal("navigator", undefined);
+    const mod = await import("./keyboard");
+
+    expect(mod.isMac).toBe(false);
+    expect(mod.modKey).toBe("Ctrl");
+  });
+});

--- a/packages/core/platform/keyboard.ts
+++ b/packages/core/platform/keyboard.ts
@@ -1,0 +1,24 @@
+/**
+ * Coarse platform detection for keyboard-shortcut display.
+ *
+ * Eagerly evaluated at module load. On the server (no `navigator`) this
+ * resolves to `false`, so SSR always renders the non-Mac variant; on a
+ * real Mac the value is true after hydration. Acceptable trade-off for
+ * cosmetic shortcut hints — never gate functional behavior on this.
+ */
+export const isMac =
+  typeof navigator !== "undefined" && /Mac/.test(navigator.platform);
+
+/** Modifier key label — ⌘ on Mac, "Ctrl" elsewhere. */
+export const modKey: string = isMac ? "⌘" : "Ctrl";
+
+/** Enter / return key label — ↵ on Mac, "Enter" elsewhere. */
+export const enterKey: string = isMac ? "↵" : "Enter";
+
+/**
+ * Join key labels for display. Mac compresses combos with no separator
+ * ("⌘K", "⌘↵"); other platforms use "+" ("Ctrl+K", "Ctrl+Enter").
+ */
+export function formatShortcut(...keys: string[]): string {
+  return keys.join(isMac ? "" : "+");
+}

--- a/packages/views/editor/bubble-menu.tsx
+++ b/packages/views/editor/bubble-menu.tsx
@@ -34,6 +34,7 @@ import { posToDOMRect } from "@tiptap/core";
 import { NodeSelection } from "@tiptap/pm/state";
 import { toast } from "sonner";
 import { useCreateIssue } from "@multica/core/issues/mutations";
+import { modKey } from "@multica/core/platform";
 import { Toggle } from "@multica/ui/components/ui/toggle";
 import { Separator } from "@multica/ui/components/ui/separator";
 import {
@@ -85,10 +86,6 @@ function shouldShowBubbleMenu(editor: Editor): boolean {
   if ($from.parent.type.name === "codeBlock") return false;
   return true;
 }
-
-const isMac =
-  typeof navigator !== "undefined" && /Mac/.test(navigator.platform);
-const mod = isMac ? "\u2318" : "Ctrl";
 
 // ---------------------------------------------------------------------------
 // Mark Toggle Button
@@ -577,10 +574,10 @@ function EditorBubbleMenu({
       ) : (
         <TooltipProvider delay={300}>
           <div className="bubble-menu">
-            <MarkButton editor={editor} mark="bold" icon={Bold} label="Bold" shortcut={`${mod}+B`} isActive={fmt.bold} />
-            <MarkButton editor={editor} mark="italic" icon={Italic} label="Italic" shortcut={`${mod}+I`} isActive={fmt.italic} />
-            <MarkButton editor={editor} mark="strike" icon={Strikethrough} label="Strikethrough" shortcut={`${mod}+Shift+S`} isActive={fmt.strike} />
-            <MarkButton editor={editor} mark="code" icon={Code} label="Code" shortcut={`${mod}+E`} isActive={fmt.code} />
+            <MarkButton editor={editor} mark="bold" icon={Bold} label="Bold" shortcut={`${modKey}+B`} isActive={fmt.bold} />
+            <MarkButton editor={editor} mark="italic" icon={Italic} label="Italic" shortcut={`${modKey}+I`} isActive={fmt.italic} />
+            <MarkButton editor={editor} mark="strike" icon={Strikethrough} label="Strikethrough" shortcut={`${modKey}+Shift+S`} isActive={fmt.strike} />
+            <MarkButton editor={editor} mark="code" icon={Code} label="Code" shortcut={`${modKey}+E`} isActive={fmt.code} />
             <Separator orientation="vertical" className="mx-0.5 h-5" />
             <Tooltip>
               <TooltipTrigger render={

--- a/packages/views/modals/feedback.tsx
+++ b/packages/views/modals/feedback.tsx
@@ -21,6 +21,7 @@ import { useCurrentWorkspace } from "@multica/core/paths";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import { captureFeedbackOpened } from "@multica/core/analytics";
+import { formatShortcut, modKey, enterKey } from "@multica/core/platform";
 
 const MAX_MESSAGE_LEN = 10000;
 
@@ -120,7 +121,7 @@ export function FeedbackModal({ onClose }: { onClose: () => void }) {
           <Button size="sm" onClick={handleSubmit} disabled={!canSubmit}>
             {mutation.isPending ? "Sending…" : "Send feedback"}
             <kbd className="ml-1 inline-flex h-4 items-center gap-0.5 rounded border border-border/50 bg-background/30 px-1 font-mono text-[10px] leading-none">
-              ⌘↵
+              {formatShortcut(modKey, enterKey)}
             </kbd>
           </Button>
         </div>

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -230,7 +230,7 @@ describe("AgentCreatePanel", () => {
     await user.type(editor, "New agent prompt");
     expect(mockSetPrompt).toHaveBeenLastCalledWith("New agent prompt");
 
-    await user.click(screen.getByRole("button", { name: /Create \(⌘↵\)/i }));
+    await user.click(screen.getByRole("button", { name: /^Create \(/i }));
 
     await waitFor(() => {
       expect(mockQuickCreateIssue).toHaveBeenCalledWith({

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -27,6 +27,7 @@ import {
   MIN_QUICK_CREATE_CLI_VERSION,
 } from "@multica/core/runtimes";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
+import { formatShortcut, modKey, enterKey } from "@multica/core/platform";
 import type { Agent } from "@multica/core/types";
 import { ActorAvatar } from "../common/actor-avatar";
 import { canAssignAgent } from "../issues/components/pickers/assignee-picker";
@@ -406,7 +407,7 @@ export function AgentCreatePanel({
             >
               {submitting ? "Sending…" : uploading ? "Uploading…" : justSent ? (
                 <span className="flex items-center gap-1"><Check className="size-3.5" />Sent</span>
-              ) : "Create (⌘↵)"}
+              ) : `Create (${formatShortcut(modKey, enterKey)})`}
             </Button>
           </div>
         </div>

--- a/packages/views/search/search-trigger.tsx
+++ b/packages/views/search/search-trigger.tsx
@@ -2,6 +2,7 @@
 
 import { Search } from "lucide-react";
 import { SidebarMenuButton } from "@multica/ui/components/ui/sidebar";
+import { isMac, formatShortcut, modKey } from "@multica/core/platform";
 import { useSearchStore } from "./search-store";
 
 export function SearchTrigger() {
@@ -13,7 +14,13 @@ export function SearchTrigger() {
       <Search />
       <span>Search...</span>
       <kbd className="pointer-events-none ml-auto inline-flex h-5 select-none items-center gap-0.5 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-        <span className="text-xs">⌘</span>K
+        {isMac ? (
+          <>
+            <span className="text-xs">{modKey}</span>K
+          </>
+        ) : (
+          formatShortcut(modKey, "K")
+        )}
       </kbd>
     </SidebarMenuButton>
   );


### PR DESCRIPTION
## Summary

The sidebar search trigger, quick-create-issue dialog, and feedback modal hardcoded the Mac glyphs (`⌘`, `↵`) for their keyboard hints, so Windows and Linux users always saw Mac shortcuts even though the actual handlers already accept `metaKey || ctrlKey`. The result was a misleading UI hint, not a broken feature.

## Changes

- New `packages/core/platform/keyboard.ts` exposes a tiny shared helper:
  - `isMac` — eager `navigator.platform` check
  - `modKey` — `⌘` on Mac, `Ctrl` elsewhere
  - `enterKey` — `↵` on Mac, `Enter` elsewhere
  - `formatShortcut(...keys)` — joins with `""` on Mac, `"+"` elsewhere, so combos read naturally on each platform (`⌘K` vs `Ctrl+K`, `⌘↵` vs `Ctrl+Enter`).
- Re-export the helpers from `@multica/core/platform`.
- Update the three hardcoded sites to use the helper:
  - `packages/views/search/search-trigger.tsx`
  - `packages/views/modals/quick-create-issue.tsx`
  - `packages/views/modals/feedback.tsx`
- Migrate the inline `isMac`/`mod` definitions in `packages/views/editor/bubble-menu.tsx` to the shared helper, removing the duplication.

## Behavior after

| Surface | Mac | Windows / Linux |
|---|---|---|
| Sidebar search hint | `⌘K` | `Ctrl+K` |
| Quick-create button | `Create (⌘↵)` | `Create (Ctrl+Enter)` |
| Feedback send hint | `⌘↵` | `Ctrl+Enter` |
| Editor bubble menu tooltips | `⌘+B`, `⌘+I`, … | `Ctrl+B`, `Ctrl+I`, … (already correct, now sourced from the shared helper) |

## Test plan

- [x] `pnpm --filter @multica/core exec vitest run platform/keyboard.test.ts` — 4 new cases (Mac / Windows / Linux / SSR no-navigator) pass
- [x] `pnpm --filter @multica/views exec vitest run modals/quick-create-issue.test.tsx` — existing tests pass; assertion loosened to `^Create \(` to be platform-agnostic
- [x] `pnpm typecheck` — clean across all packages and apps
- [x] `pnpm test` — all 252 view tests + core tests pass
- [ ] Manual verification on Windows browser — visually confirm `Ctrl+K` / `Ctrl+Enter` render in sidebar / quick-create / feedback modals
- [ ] Manual verification on Mac — confirm `⌘K` / `⌘↵` still render

Closes multica-ai/multica#2056