### PR TITLE
docs(views): explain min-h-[60vh] mobile fallback in agent overview pane

### DIFF
--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -108,6 +108,10 @@ export function AgentOverviewPane({
   };
 
   return (
+    // On mobile the parent stacks the inspector and overview and scrolls the
+    // page itself, so this pane has no inherited height. `min-h-[60vh]` keeps
+    // the tab content area usably tall when content is short; `md:` restores
+    // the grid-driven full-height behavior on tablet and up.
     <div className="flex min-h-[60vh] flex-col overflow-hidden rounded-lg border bg-background md:h-full md:min-h-0">
       <div className="flex shrink-0 items-center gap-0 overflow-x-auto border-b px-2 md:px-4">
         {detailTabs.map((tab) => (


### PR DESCRIPTION
## Summary
- Add a short comment next to `min-h-[60vh]` in `agent-overview-pane.tsx` explaining why the magic number exists (mobile parent stacks inspector + overview and scrolls the page, so this pane needs an explicit minimum height) and why `md:h-full md:min-h-0` overrides it on tablet+.

## Why
Follow-up to PR #2036 review. The 60vh fallback was correct but unannotated, so it was hard to tell whether the value could be safely tweaked. A short comment makes the constraint self-documenting.

## Validation
- `pnpm --filter @multica/views typecheck`
- `pnpm exec eslint agents/components/agent-overview-pane.tsx` from `packages/views`

No behavioral change — comment-only.