### PR TITLE
fix(views): prevent unresponsive page on mobile project detail

### DIFF
--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -224,12 +224,17 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
     id: "multica_project_detail_layout",
   });
   const sidebarRef = usePanelRef();
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  // Desktop and mobile sidebar state must be separate. A single state defaulting
+  // to `true` made the mobile <Sheet> mount in the open position on first render
+  // (after `useIsMobile()` flipped from false→true), briefly covering the page
+  // with its modal backdrop and locking scroll — leaving the page unresponsive.
+  const [desktopSidebarOpen, setDesktopSidebarOpen] = useState(true);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const sidebarOpen = isMobile ? mobileSidebarOpen : desktopSidebarOpen;
 
   useEffect(() => {
     if (isMobile) {
-      setSidebarOpen(false);
-      sidebarRef.current?.collapse();
+      setMobileSidebarOpen(false);
     }
   }, [isMobile]);
 
@@ -560,7 +565,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
                       className={sidebarOpen ? "" : "text-muted-foreground"}
                       onClick={() => {
                         if (isMobile) {
-                          setSidebarOpen(!sidebarOpen);
+                          setMobileSidebarOpen((open) => !open);
                         } else {
                           const panel = sidebarRef.current;
                           if (!panel) return;
@@ -593,13 +598,13 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
         {!isMobile && (
         <ResizablePanel
           id="sidebar"
-          defaultSize={sidebarOpen ? 320 : 0}
+          defaultSize={desktopSidebarOpen ? 320 : 0}
           minSize={260}
           maxSize={420}
           collapsible
           groupResizeBehavior="preserve-pixel-size"
           panelRef={sidebarRef}
-          onResize={(size) => setSidebarOpen(size.inPixels > 0)}
+          onResize={(size) => setDesktopSidebarOpen(size.inPixels > 0)}
         >
           <div className="overflow-y-auto border-l h-full">
             <div className="p-4">
@@ -609,7 +614,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
         </ResizablePanel>
         )}
         {isMobile && (
-          <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+          <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
             <SheetContent side="right" showCloseButton={false} className="w-[320px] overflow-y-auto p-4">
               {sidebarContent}
             </SheetContent>


### PR DESCRIPTION
## Summary

- On mobile web, navigating to a project detail page (from the sidebar pin or the projects list) left the page frozen — taps and scroll were blocked from the moment it mounted.
- Splits the project-detail sidebar state into separate `desktopSidebarOpen` / `mobileSidebarOpen`, mirroring `issue-detail.tsx`. The mobile `<Sheet>` now binds to `mobileSidebarOpen` only, so it never mounts in the open position.

## Root Cause

`packages/views/projects/components/project-detail.tsx:227` used a single `sidebarOpen` state defaulting to `true`. `useIsMobile()` returns `false` on the first render and flips to `true` on the next; on that second render the mobile branch mounted `<Sheet open={true}>`, drawing a `fixed inset-0 z-50` backdrop and locking scroll. A trailing `useEffect` immediately set it to `false`, but the open→close flip inside one animation cycle left Base UI Dialog's `pointer-events` / `inert` / scroll-lock state stuck on mobile — the user-visible result was an unresponsive page.

The sibling page `packages/views/issues/components/issue-detail.tsx:181-189` already avoids this by keeping `desktopSidebarOpen` (default `true`) and `mobileSidebarOpen` (default `false`) as separate states. The mobile `<Sheet>` there is bound only to `mobileSidebarOpen`, so it never mounts open. Converging on the same shape fixes the bug here. The divergence dates back to #1087, where issue-detail and project-detail received mobile-Sheet support together but only issue-detail used split state.

## Test plan

- [x] Manual: mobile viewport (< 768px) → open the left drawer → tap a pinned project → page is interactive, scroll works.
- [x] Manual: mobile viewport → `/<workspace>/projects` → tap a project card → page is interactive, scroll works.
- [x] Manual: desktop → user-set sidebar width and open/closed state still persist across reloads (`useDefaultLayout` unaffected).
- [x] Manual: desktop → resize down to mobile width → the mobile drawer stays closed (regression guard for the `useEffect` path).
- [ ] `pnpm --filter @multica/views typecheck` (recommended before merge)

Fixes #2066