### PR TITLE
feat(projects): add setup hooks for agent workdirs

### DIFF
--- a/apps/docs/content/docs/project-resources.mdx
+++ b/apps/docs/content/docs/project-resources.mdx
@@ -111,6 +111,18 @@ The text is intentionally minimal. The full payload is on disk; the prompt only 
 
 Resource fetch is **best-effort**. If the API call fails, the project section is omitted from the prompt and the file is not written, but the task still starts. Agents never block on missing project context.
 
+## Project setup hooks
+
+Workspace owners and admins can add a project setup hook at `settings.hooks.after_create`. The daemon runs this shell script once for each fresh project-scoped task workdir, after creating `workdir/`, `output/`, and `logs/`, but before writing Multica context files, provider config, skills, or starting the provider.
+
+The hook runs from the task `workdir` with the same Multica task environment the agent receives, including `MULTICA_WORKDIR`, `MULTICA_ENV_ROOT`, `MULTICA_WORKSPACE_ID`, `MULTICA_PROJECT_ID`, and the local daemon/API variables needed by `multica repo checkout`. On Unix, hooks run with `/bin/sh -c`; on Windows, they run with `cmd /C`.
+
+Output is written to `logs/after_create.log` inside the task environment. Stdout/stderr are capped so a broken hook cannot grow the log indefinitely, while the task error still includes a short output tail. The default timeout is 30 minutes and can be changed by setting `MULTICA_PROJECT_AFTER_CREATE_TIMEOUT` to a Go duration such as `10m`.
+
+If the hook exits non-zero or times out, Multica marks the task as blocked before provider startup and preserves the environment paths for debugging. When a later task reuses an existing workdir, the hook does not run again.
+
+Treat setup hooks like code running on the daemon host. Only configure hooks from projects and scripts you trust.
+
 ## Adding a new resource type
 
 The whole point of the abstraction is that new types are cheap. The full path:

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1,6 +1,7 @@
 import type {
   Issue,
   CreateIssueRequest,
+  QuickCreateIssueRequest,
   UpdateIssueRequest,
   ListIssuesResponse,
   SearchIssuesResponse,
@@ -426,7 +427,7 @@ export class ApiClient {
     });
   }
 
-  async quickCreateIssue(data: { agent_id: string; prompt: string }): Promise<{ task_id: string }> {
+  async quickCreateIssue(data: QuickCreateIssueRequest): Promise<{ task_id: string }> {
     return this.fetch("/api/issues/quick-create", {
       method: "POST",
       body: JSON.stringify(data),

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -16,6 +16,12 @@ export interface CreateIssueRequest {
   attachment_ids?: string[];
 }
 
+export interface QuickCreateIssueRequest {
+  agent_id: string;
+  prompt: string;
+  project_id?: string;
+}
+
 export interface UpdateIssueRequest {
   title?: string;
   description?: string;

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -50,6 +50,7 @@ export type { ChatSession, ChatMessage, ChatPendingTask, PendingChatTaskItem, Pe
 export type { StorageAdapter } from "./storage";
 export type {
   Project,
+  ProjectSettings,
   ProjectStatus,
   ProjectPriority,
   CreateProjectRequest,

--- a/packages/core/types/project.ts
+++ b/packages/core/types/project.ts
@@ -2,6 +2,13 @@ export type ProjectStatus = "planned" | "in_progress" | "paused" | "completed" |
 
 export type ProjectPriority = "urgent" | "high" | "medium" | "low" | "none";
 
+export interface ProjectSettings {
+  hooks?: {
+    after_create?: string;
+  };
+  [key: string]: unknown;
+}
+
 export interface Project {
   id: string;
   workspace_id: string;
@@ -10,6 +17,7 @@ export interface Project {
   icon: string | null;
   status: ProjectStatus;
   priority: ProjectPriority;
+  settings: ProjectSettings;
   lead_type: "member" | "agent" | null;
   lead_id: string | null;
   created_at: string;
@@ -24,6 +32,7 @@ export interface CreateProjectRequest {
   icon?: string;
   status?: ProjectStatus;
   priority?: ProjectPriority;
+  settings?: ProjectSettings;
   lead_type?: "member" | "agent";
   lead_id?: string;
   // Resources to attach in the same transaction as the project. Server returns
@@ -37,6 +46,7 @@ export interface UpdateProjectRequest {
   icon?: string | null;
   status?: ProjectStatus;
   priority?: ProjectPriority;
+  settings?: ProjectSettings;
   lead_type?: "member" | "agent" | null;
   lead_id?: string | null;
 }

--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Issue, Project } from "@multica/core/types";
+import type { Issue } from "@multica/core/types";
 
 // ---------------------------------------------------------------------------
 // Mocks — same pattern as the issue-detail test suite.
@@ -42,31 +42,6 @@ vi.mock("@multica/core/workspace/queries", () => ({
   agentListOptions: () => ({
     queryKey: ["workspaces", "ws-1", "agents"],
     queryFn: () => Promise.resolve([]),
-  }),
-}));
-
-vi.mock("@multica/core/projects/queries", () => ({
-  projectListOptions: () => ({
-    queryKey: ["projects", "ws-1", "list"],
-    queryFn: () =>
-      Promise.resolve([
-        {
-          id: "project-1",
-          workspace_id: "ws-1",
-          title: "Launch work",
-          description: null,
-          icon: "🚀",
-          status: "in_progress",
-          priority: "medium",
-          settings: {},
-          lead_type: null,
-          lead_id: null,
-          created_at: "2026-01-01T00:00:00Z",
-          updated_at: "2026-01-01T00:00:00Z",
-          issue_count: 1,
-          done_count: 0,
-        },
-      ]),
   }),
 }));
 
@@ -115,10 +90,6 @@ vi.mock("../../../common/actor-avatar", () => ({
 // Import after mocks.
 import { IssueActionsDropdown } from "../issue-actions-dropdown";
 import { IssueActionsContextMenu } from "../issue-actions-context-menu";
-import {
-  IssueActionsMenuItems,
-  type MenuPrimitives,
-} from "../issue-actions-menu-items";
 
 const mockIssue: Issue = {
   id: "issue-1",
@@ -168,7 +139,6 @@ describe("IssueActionsDropdown", () => {
     expect(await screen.findByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Priority")).toBeInTheDocument();
     expect(screen.getByText("Assignee")).toBeInTheDocument();
-    expect(screen.getByText("Project")).toBeInTheDocument();
     expect(screen.getByText("Due date")).toBeInTheDocument();
     expect(screen.getByText("Copy link")).toBeInTheDocument();
     expect(screen.getByText("More")).toBeInTheDocument();
@@ -215,66 +185,6 @@ describe("IssueActionsContextMenu", () => {
     fireEvent.contextMenu(screen.getByTestId("row"));
 
     expect(await screen.findByText("Status")).toBeInTheDocument();
-    expect(screen.getByText("Project")).toBeInTheDocument();
     expect(screen.getByText("Delete issue")).toBeInTheDocument();
-  });
-});
-
-const testPrimitives = {
-  Item: ({ children, onClick, disabled }: any) => (
-    <button disabled={disabled} onClick={onClick} type="button">
-      {children}
-    </button>
-  ),
-  Sub: ({ children }: any) => <div>{children}</div>,
-  SubTrigger: ({ children }: any) => <div>{children}</div>,
-  SubContent: ({ children }: any) => <div>{children}</div>,
-  Separator: () => <hr />,
-} as unknown as MenuPrimitives;
-
-const project: Project = {
-  id: "project-1",
-  workspace_id: "ws-1",
-  title: "Launch work",
-  description: null,
-  icon: "🚀",
-  status: "in_progress",
-  priority: "medium",
-  settings: {},
-  lead_type: null,
-  lead_id: null,
-  created_at: "2026-01-01T00:00:00Z",
-  updated_at: "2026-01-01T00:00:00Z",
-  issue_count: 1,
-  done_count: 0,
-};
-
-describe("IssueActionsMenuItems", () => {
-  it("updates the issue project from the shared action menu", () => {
-    const updateField = vi.fn();
-
-    render(
-      <IssueActionsMenuItems
-        issue={mockIssue}
-        primitives={testPrimitives}
-        actions={{
-          members: [],
-          agents: [],
-          projects: [project],
-          isPinned: false,
-          updateField,
-          togglePin: vi.fn(),
-          copyLink: vi.fn(),
-          openCreateSubIssue: vi.fn(),
-          openSetParent: vi.fn(),
-          openAddChild: vi.fn(),
-          openDeleteConfirm: vi.fn(),
-        }}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /launch work/i }));
-
-    expect(updateField).toHaveBeenCalledWith({ project_id: "project-1" });
   });
 });

--- a/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
+++ b/packages/views/issues/actions/__tests__/issue-actions-menu.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Issue } from "@multica/core/types";
+import type { Issue, Project } from "@multica/core/types";
 
 // ---------------------------------------------------------------------------
 // Mocks — same pattern as the issue-detail test suite.
@@ -42,6 +42,31 @@ vi.mock("@multica/core/workspace/queries", () => ({
   agentListOptions: () => ({
     queryKey: ["workspaces", "ws-1", "agents"],
     queryFn: () => Promise.resolve([]),
+  }),
+}));
+
+vi.mock("@multica/core/projects/queries", () => ({
+  projectListOptions: () => ({
+    queryKey: ["projects", "ws-1", "list"],
+    queryFn: () =>
+      Promise.resolve([
+        {
+          id: "project-1",
+          workspace_id: "ws-1",
+          title: "Launch work",
+          description: null,
+          icon: "🚀",
+          status: "in_progress",
+          priority: "medium",
+          settings: {},
+          lead_type: null,
+          lead_id: null,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          issue_count: 1,
+          done_count: 0,
+        },
+      ]),
   }),
 }));
 
@@ -90,6 +115,10 @@ vi.mock("../../../common/actor-avatar", () => ({
 // Import after mocks.
 import { IssueActionsDropdown } from "../issue-actions-dropdown";
 import { IssueActionsContextMenu } from "../issue-actions-context-menu";
+import {
+  IssueActionsMenuItems,
+  type MenuPrimitives,
+} from "../issue-actions-menu-items";
 
 const mockIssue: Issue = {
   id: "issue-1",
@@ -139,6 +168,7 @@ describe("IssueActionsDropdown", () => {
     expect(await screen.findByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Priority")).toBeInTheDocument();
     expect(screen.getByText("Assignee")).toBeInTheDocument();
+    expect(screen.getByText("Project")).toBeInTheDocument();
     expect(screen.getByText("Due date")).toBeInTheDocument();
     expect(screen.getByText("Copy link")).toBeInTheDocument();
     expect(screen.getByText("More")).toBeInTheDocument();
@@ -185,6 +215,66 @@ describe("IssueActionsContextMenu", () => {
     fireEvent.contextMenu(screen.getByTestId("row"));
 
     expect(await screen.findByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Project")).toBeInTheDocument();
     expect(screen.getByText("Delete issue")).toBeInTheDocument();
+  });
+});
+
+const testPrimitives = {
+  Item: ({ children, onClick, disabled }: any) => (
+    <button disabled={disabled} onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+  Sub: ({ children }: any) => <div>{children}</div>,
+  SubTrigger: ({ children }: any) => <div>{children}</div>,
+  SubContent: ({ children }: any) => <div>{children}</div>,
+  Separator: () => <hr />,
+} as unknown as MenuPrimitives;
+
+const project: Project = {
+  id: "project-1",
+  workspace_id: "ws-1",
+  title: "Launch work",
+  description: null,
+  icon: "🚀",
+  status: "in_progress",
+  priority: "medium",
+  settings: {},
+  lead_type: null,
+  lead_id: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  issue_count: 1,
+  done_count: 0,
+};
+
+describe("IssueActionsMenuItems", () => {
+  it("updates the issue project from the shared action menu", () => {
+    const updateField = vi.fn();
+
+    render(
+      <IssueActionsMenuItems
+        issue={mockIssue}
+        primitives={testPrimitives}
+        actions={{
+          members: [],
+          agents: [],
+          projects: [project],
+          isPinned: false,
+          updateField,
+          togglePin: vi.fn(),
+          copyLink: vi.fn(),
+          openCreateSubIssue: vi.fn(),
+          openSetParent: vi.fn(),
+          openAddChild: vi.fn(),
+          openDeleteConfirm: vi.fn(),
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /launch work/i }));
+
+    expect(updateField).toHaveBeenCalledWith({ project_id: "project-1" });
   });
 });

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -414,14 +414,13 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
       if (useModalStore.getState().modal) return;
       e.preventDefault();
       const lastMode = useCreateModeStore.getState().lastMode;
+      const projectMatch = pathname.match(/^\/[^/]+\/projects\/([^/]+)$/);
+      const data = projectMatch ? { project_id: projectMatch[1] } : undefined;
       if (lastMode === "manual") {
-        // Auto-fill project when on a project detail page (manual form only —
-        // agent mode lets the agent infer project from the prompt).
-        const projectMatch = pathname.match(/^\/[^/]+\/projects\/([^/]+)$/);
-        const data = projectMatch ? { project_id: projectMatch[1] } : undefined;
+        // Auto-fill project when on a project detail page.
         useModalStore.getState().open("create-issue", data);
       } else {
-        useModalStore.getState().open("quick-create-issue");
+        useModalStore.getState().open("quick-create-issue", data);
       }
     };
     document.addEventListener("keydown", handleKeyDown);
@@ -560,7 +559,15 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
             <SidebarMenuItem>
               <SidebarMenuButton
                 className="text-muted-foreground"
-                onClick={() => useModalStore.getState().open("quick-create-issue")}
+                onClick={() => {
+                  const projectMatch = pathname.match(
+                    /^\/[^/]+\/projects\/([^/]+)$/,
+                  );
+                  const data = projectMatch
+                    ? { project_id: projectMatch[1] }
+                    : undefined;
+                  useModalStore.getState().open("quick-create-issue", data);
+                }}
               >
                 <span className="relative">
                   <SquarePen />

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -263,6 +263,7 @@ export function ManualCreatePanel({
     setLastMode("agent");
     onSwitchMode?.({
       prompt,
+      ...(projectId ? { project_id: projectId } : {}),
       ...(assigneeType === "agent" && assigneeId
         ? { agent_id: assigneeId }
         : {}),

--- a/packages/views/modals/quick-create-issue.test.tsx
+++ b/packages/views/modals/quick-create-issue.test.tsx
@@ -100,7 +100,20 @@ vi.mock("../issues/components", () => ({
 }));
 
 vi.mock("../projects/components/project-picker", () => ({
-  ProjectPicker: () => <div data-testid="project-picker" />,
+  ProjectPicker: ({
+    projectId,
+    onUpdate,
+  }: {
+    projectId: string | null;
+    onUpdate: (updates: { project_id?: string | null }) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => onUpdate({ project_id: projectId ? null : "project-1" })}
+    >
+      Project {projectId ?? "none"}
+    </button>
+  ),
 }));
 
 vi.mock("../common/pill-button", () => ({
@@ -243,5 +256,27 @@ describe("AgentCreatePanel", () => {
     expect(mockClearPrompt).toHaveBeenCalled();
     expect(mockSetLastMode).toHaveBeenCalledWith("agent");
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("submits the selected project id", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentCreatePanel onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "Project none" }));
+    const editor = screen.getByPlaceholderText(
+      'Tell the agent what to do, e.g. "let Bohan fix the inbox loading slowness in the Web project"',
+    );
+    await user.clear(editor);
+    await user.type(editor, "Create this in the selected project");
+    await user.click(screen.getByRole("button", { name: /^Create \(/i }));
+
+    await waitFor(() => {
+      expect(mockQuickCreateIssue).toHaveBeenCalledWith({
+        agent_id: "agent-1",
+        prompt: "Create this in the selected project",
+        project_id: "project-1",
+      });
+    });
   });
 });

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -40,6 +40,7 @@ import {
   FileDropOverlay,
 } from "../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
+import { ProjectPicker } from "../projects/components/project-picker";
 
 // AgentCreatePanel — agent-mode body of the create-issue dialog. Renders
 // only the inner content; the surrounding `<Dialog>` AND `<DialogContent>`
@@ -56,7 +57,7 @@ export function AgentCreatePanel({
   data,
 }: {
   onClose: () => void;
-  onSwitchMode?: () => void;
+  onSwitchMode?: (carry?: Record<string, unknown> | null) => void;
   data?: Record<string, unknown> | null;
 }) {
   const workspaceName = useCurrentWorkspace()?.name;
@@ -92,6 +93,10 @@ export function AgentCreatePanel({
     const seed = (data?.agent_id as string) || lastAgentId || undefined;
     if (seed && visibleAgents.some((a) => a.id === seed)) return seed;
     return visibleAgents[0]?.id;
+  });
+  const [projectId, setProjectId] = useState<string | undefined>(() => {
+    const seed = data?.project_id;
+    return typeof seed === "string" && seed ? seed : undefined;
   });
 
   // Re-seed once visible list resolves (queries may be empty on first render).
@@ -168,7 +173,11 @@ export function AgentCreatePanel({
     setSubmitting(true);
     setError(null);
     try {
-      await api.quickCreateIssue({ agent_id: agentId, prompt: md });
+      await api.quickCreateIssue({
+        agent_id: agentId,
+        prompt: md,
+        ...(projectId ? { project_id: projectId } : {}),
+      });
       setLastAgentId(agentId);
       clearPrompt();
       setLastMode("agent");
@@ -238,7 +247,7 @@ export function AgentCreatePanel({
         : {}),
     });
     setLastMode("manual");
-    onSwitchMode?.();
+    onSwitchMode?.(projectId ? { project_id: projectId } : null);
   };
 
   return (
@@ -267,8 +276,8 @@ export function AgentCreatePanel({
           </button>
         </div>
 
-        {/* Agent picker */}
-        <div className="px-5 pt-1 pb-2 shrink-0">
+        {/* Agent and project pickers */}
+        <div className="px-5 pt-1 pb-2 shrink-0 flex flex-wrap items-center gap-x-4 gap-y-1">
           <DropdownMenu>
             <DropdownMenuTrigger
               render={
@@ -322,6 +331,16 @@ export function AgentCreatePanel({
               )}
             </DropdownMenuContent>
           </DropdownMenu>
+          <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+            <span>Project</span>
+            <ProjectPicker
+              projectId={projectId ?? null}
+              onUpdate={(updates) => {
+                setProjectId(updates.project_id ?? undefined);
+                setError(null);
+              }}
+            />
+          </div>
         </div>
 
         {selectedAgent && versionBlocked && (

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -279,7 +279,7 @@ function BashScriptEditor({
   return (
     <div className="h-64 overflow-hidden rounded-lg border border-input bg-muted/50 transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50">
       <div className="flex h-8 items-center justify-between border-b border-border/60 px-2.5">
-        <span className="font-mono text-xs text-muted-foreground">bash</span>
+        <span className="font-mono text-xs text-muted-foreground">sh</span>
         <Button
           type="button"
           variant="ghost"
@@ -309,7 +309,7 @@ function BashScriptEditor({
           disabled={disabled}
           spellCheck={false}
           wrap="off"
-          aria-label="Project setup bash script"
+          aria-label="Project setup shell script"
           placeholder="git clone https://github.com/org/repo.git ."
           className="absolute inset-0 h-full w-full resize-none overflow-auto border-0 bg-transparent p-3 font-mono text-[13px] leading-5 text-transparent caret-foreground outline-none placeholder:text-muted-foreground selection:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
         />

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useCallback, useRef, useEffect } from "react";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
-import { Check, ChevronRight, Link2, ListTodo, MoreHorizontal, PanelRight, Pin, PinOff, Trash2, UserMinus } from "lucide-react";
+import { Check, ChevronRight, Copy, Link2, ListTodo, MoreHorizontal, PanelRight, Pin, PinOff, Trash2, UserMinus } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { cn } from "@multica/ui/lib/utils";
 import { toast } from "sonner";
@@ -67,6 +67,256 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@multica/ui/components/ui/alert-dialog";
+
+function getAfterCreateHook(settings: unknown): string {
+  if (!settings || typeof settings !== "object") return "";
+  const hooks = (settings as { hooks?: unknown }).hooks;
+  if (!hooks || typeof hooks !== "object") return "";
+  const value = (hooks as { after_create?: unknown }).after_create;
+  return typeof value === "string" ? value : "";
+}
+
+function settingsWithAfterCreateHook(settings: unknown, script: string) {
+  const base =
+    settings && typeof settings === "object" && !Array.isArray(settings)
+      ? { ...(settings as Record<string, unknown>) }
+      : {};
+  const hooks =
+    base.hooks && typeof base.hooks === "object" && !Array.isArray(base.hooks)
+      ? { ...(base.hooks as Record<string, unknown>) }
+      : {};
+
+  if (script) {
+    hooks.after_create = script;
+    base.hooks = hooks;
+    return base;
+  }
+
+  delete hooks.after_create;
+  if (Object.keys(hooks).length > 0) {
+    base.hooks = hooks;
+  } else {
+    delete base.hooks;
+  }
+  return base;
+}
+
+const BASH_WORDS = new Set([
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "until",
+  "do",
+  "done",
+  "case",
+  "esac",
+  "in",
+  "function",
+  "select",
+  "set",
+  "export",
+  "local",
+  "readonly",
+  "return",
+  "exit",
+  "source",
+  "cd",
+  "echo",
+  "test",
+  "bash",
+  "git",
+  "pnpm",
+  "npm",
+  "node",
+  "mkdir",
+  "cp",
+  "rm",
+  "mv",
+]);
+
+function renderBashPlain(text: string, keyPrefix: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  const wordRe = /[A-Za-z_][A-Za-z0-9_-]*/g;
+  for (const match of text.matchAll(wordRe)) {
+    const index = match.index ?? 0;
+    const word = match[0];
+    if (index > cursor) nodes.push(text.slice(cursor, index));
+    if (BASH_WORDS.has(word)) {
+      nodes.push(
+        <span key={`${keyPrefix}-${index}`} className="text-amber-600 dark:text-amber-400">
+          {word}
+        </span>,
+      );
+    } else {
+      nodes.push(word);
+    }
+    cursor = index + word.length;
+  }
+  if (cursor < text.length) nodes.push(text.slice(cursor));
+  return nodes;
+}
+
+function renderBashLine(line: string, lineIndex: number): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let i = 0;
+  let plain = "";
+
+  const flushPlain = () => {
+    if (!plain) return;
+    nodes.push(...renderBashPlain(plain, `plain-${lineIndex}-${i}`));
+    plain = "";
+  };
+
+  while (i < line.length) {
+    const char = line[i];
+    if (char === "#" && (i === 0 || /\s/.test(line[i - 1] ?? ""))) {
+      flushPlain();
+      nodes.push(
+        <span key={`comment-${lineIndex}-${i}`} className="text-muted-foreground">
+          {line.slice(i)}
+        </span>,
+      );
+      return nodes;
+    }
+
+    if (char === "'" || char === '"') {
+      flushPlain();
+      const quote = char;
+      let end = i + 1;
+      while (end < line.length) {
+        if (line[end] === "\\" && quote === '"') {
+          end += 2;
+          continue;
+        }
+        if (line[end] === quote) {
+          end += 1;
+          break;
+        }
+        end += 1;
+      }
+      nodes.push(
+        <span key={`string-${lineIndex}-${i}`} className="text-emerald-700 dark:text-emerald-400">
+          {line.slice(i, end)}
+        </span>,
+      );
+      i = end;
+      continue;
+    }
+
+    if (char === "$") {
+      flushPlain();
+      let end = i + 1;
+      if (line[end] === "{") {
+        end += 1;
+        while (end < line.length && line[end] !== "}") end += 1;
+        if (line[end] === "}") end += 1;
+      } else if (line[end] === "(") {
+        end += 1;
+        while (end < line.length && line[end] !== ")") end += 1;
+        if (line[end] === ")") end += 1;
+      } else {
+        while (end < line.length && /[A-Za-z0-9_]/.test(line[end] ?? "")) end += 1;
+      }
+      nodes.push(
+        <span key={`var-${lineIndex}-${i}`} className="text-sky-700 dark:text-sky-400">
+          {line.slice(i, end)}
+        </span>,
+      );
+      i = end;
+      continue;
+    }
+
+    plain += char;
+    i += 1;
+  }
+
+  flushPlain();
+  return nodes;
+}
+
+function renderBashScript(script: string): React.ReactNode[] {
+  return script.split("\n").flatMap((line, index, lines) => [
+    ...renderBashLine(line, index),
+    ...(index < lines.length - 1 ? ["\n"] : []),
+  ]);
+}
+
+function BashScriptEditor({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}) {
+  const highlightRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLTextAreaElement>) => {
+    const target = e.currentTarget;
+    if (!highlightRef.current) return;
+    highlightRef.current.scrollTop = target.scrollTop;
+    highlightRef.current.scrollLeft = target.scrollLeft;
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      toast.error("Failed to copy setup script");
+    }
+  }, [value]);
+
+  return (
+    <div className="h-64 overflow-hidden rounded-lg border border-input bg-muted/50 transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50">
+      <div className="flex h-8 items-center justify-between border-b border-border/60 px-2.5">
+        <span className="font-mono text-xs text-muted-foreground">bash</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="text-muted-foreground hover:text-foreground"
+          disabled={!value}
+          onClick={handleCopy}
+          aria-label="Copy setup script"
+        >
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </Button>
+      </div>
+      <div className="relative h-[calc(100%-2rem)]">
+        <pre
+          ref={highlightRef}
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 m-0 overflow-hidden p-3 font-mono text-[13px] leading-5 text-foreground"
+        >
+          <code className="block min-w-max whitespace-pre">
+            {value ? renderBashScript(value) : null}
+          </code>
+        </pre>
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onScroll={handleScroll}
+          disabled={disabled}
+          spellCheck={false}
+          wrap="off"
+          aria-label="Project setup bash script"
+          placeholder="git clone https://github.com/org/repo.git ."
+          className="absolute inset-0 h-full w-full resize-none overflow-auto border-0 bg-transparent p-3 font-mono text-[13px] leading-5 text-transparent caret-foreground outline-none placeholder:text-muted-foreground selection:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      </div>
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Property row — sidebar property display
@@ -218,6 +468,8 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
   const [propertiesOpen, setPropertiesOpen] = useState(true);
   const [progressOpen, setProgressOpen] = useState(true);
   const [descriptionOpen, setDescriptionOpen] = useState(true);
+  const [setupOpen, setSetupOpen] = useState(true);
+  const [afterCreateDraft, setAfterCreateDraft] = useState("");
 
   // Sidebar panel
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
@@ -232,6 +484,10 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
       sidebarRef.current?.collapse();
     }
   }, [isMobile]);
+
+  useEffect(() => {
+    setAfterCreateDraft(getAfterCreateHook(project?.settings));
+  }, [project?.id, project?.settings]);
 
   // Lead popover
   const [leadOpen, setLeadOpen] = useState(false);
@@ -257,6 +513,43 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
       },
     });
   }, [project, deleteProject, router, wsPaths]);
+
+  const currentAfterCreate = getAfterCreateHook(project?.settings);
+  const saveAfterCreateHook = useCallback(() => {
+    if (!project) return;
+    updateProject.mutate(
+      {
+        id: project.id,
+        settings: settingsWithAfterCreateHook(
+          project.settings,
+          afterCreateDraft,
+        ),
+      },
+      {
+        onSuccess: () => toast.success("Project setup hook saved"),
+        onError: () => toast.error("Failed to save setup hook"),
+      },
+    );
+  }, [afterCreateDraft, project, updateProject]);
+  const clearAfterCreateHook = useCallback(() => {
+    if (!project) {
+      setAfterCreateDraft("");
+      return;
+    }
+    updateProject.mutate(
+      {
+        id: project.id,
+        settings: settingsWithAfterCreateHook(project.settings, ""),
+      },
+      {
+        onSuccess: () => {
+          setAfterCreateDraft("");
+          toast.success("Project setup hook cleared");
+        },
+        onError: () => toast.error("Failed to clear setup hook"),
+      },
+    );
+  }, [project, updateProject]);
 
   if (isLoading) {
     return (
@@ -492,6 +785,44 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
       </div>
 
       {/* Resources */}
+      <div>
+        <button
+          className={`flex w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors mb-2 hover:bg-accent/70 ${setupOpen ? "" : "text-muted-foreground hover:text-foreground"}`}
+          onClick={() => setSetupOpen(!setupOpen)}
+        >
+          Setup
+          <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${setupOpen ? "rotate-90" : ""}`} />
+        </button>
+        {setupOpen && (
+          <div className="space-y-2 pl-2">
+            <BashScriptEditor
+              value={afterCreateDraft}
+              onChange={setAfterCreateDraft}
+              disabled={updateProject.isPending}
+            />
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={(!afterCreateDraft && !currentAfterCreate) || updateProject.isPending}
+                onClick={clearAfterCreateHook}
+              >
+                Clear
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={afterCreateDraft === currentAfterCreate || updateProject.isPending}
+                onClick={saveAfterCreateHook}
+              >
+                Save
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
       <ProjectResourcesSection projectId={projectId} />
     </div>
   );

--- a/server/cmd/server/quick_create_subscriber_test.go
+++ b/server/cmd/server/quick_create_subscriber_test.go
@@ -34,6 +34,7 @@ func TestQuickCreateCompletion_SubscribesRequester(t *testing.T) {
 		parseUUID(testWorkspaceID),
 		parseUUID(testUserID),
 		parseUUID(agentID),
+		pgtype.UUID{},
 		"please file a bug",
 	)
 	if err != nil {
@@ -105,6 +106,7 @@ func TestQuickCreateFailure_DoesNotSubscribeRequester(t *testing.T) {
 		parseUUID(testWorkspaceID),
 		parseUUID(testUserID),
 		parseUUID(agentID),
+		pgtype.UUID{},
 		"another bug",
 	)
 	if err != nil {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1343,6 +1343,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	}
 
 	agentEnv := d.taskAgentEnv(task, agentName, agentID, slot)
+	// Ensure the multica CLI is on PATH for both project setup hooks and the
+	// provider process. Some runtimes (e.g. Codex) run in an isolated sandbox
+	// that may not inherit the daemon's PATH. Prepend the directory of the
+	// running multica binary so `multica` commands resolve consistently.
+	if selfBin, err := os.Executable(); err == nil {
+		binDir := filepath.Dir(selfBin)
+		agentEnv["PATH"] = binDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	}
 
 	// Mark candidate env roots as active before any env work so the GC loop
 	// can't reclaim artifacts inside them mid-execution. We mark both the
@@ -1409,14 +1417,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 	prompt := BuildPrompt(task)
 
-	// Ensure the multica CLI is on PATH inside the agent's environment.
-	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not
-	// inherit the daemon's PATH. Prepend the directory of the running
-	// multica binary so that `multica` commands in the agent always resolve.
-	if selfBin, err := os.Executable(); err == nil {
-		binDir := filepath.Dir(selfBin)
-		agentEnv["PATH"] = binDir + string(os.PathListSeparator) + os.Getenv("PATH")
-	}
 	// Point Codex to the per-task CODEX_HOME so it discovers skills natively
 	// without polluting the system ~/.codex/skills/.
 	if env.CodexHome != "" {

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1308,7 +1308,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	}
 
 	agentName := "agent"
-	var agentID string
+	agentID := task.AgentID
 	var skills []SkillData
 	var instructions string
 	if task.Agent != nil {
@@ -1342,6 +1342,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		QuickCreatePrompt:       task.QuickCreatePrompt,
 	}
 
+	agentEnv := d.taskAgentEnv(task, agentName, agentID, slot)
+
 	// Mark candidate env roots as active before any env work so the GC loop
 	// can't reclaim artifacts inside them mid-execution. We mark both the
 	// predicted root for a fresh Prepare and the prior root for Reuse — they
@@ -1372,9 +1374,21 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			AgentName:      agentName,
 			Provider:       provider,
 			CodexVersion:   codexVersion,
+			Context:        ctx,
+			AfterCreate:    projectAfterCreateHook(task, agentEnv),
 			Task:           taskCtx,
 		}, d.logger)
 		if err != nil {
+			var hookErr *execenv.AfterCreateHookError
+			if errors.As(err, &hookErr) {
+				return TaskResult{
+					Status:        "blocked",
+					Comment:       hookErr.Error(),
+					WorkDir:       hookErr.WorkDir,
+					EnvRoot:       hookErr.EnvRoot,
+					FailureReason: "agent_error",
+				}, nil
+			}
 			return TaskResult{}, fmt.Errorf("prepare execution environment: %w", err)
 		}
 	}
@@ -1395,34 +1409,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 	prompt := BuildPrompt(task)
 
-	// Pass the daemon's auth credentials and context so the spawned agent CLI
-	// can call the Multica API and the local daemon (e.g. `multica repo checkout`).
-	// MULTICA_TASK_SLOT is allocated from the daemon-wide concurrency pool, not
-	// per-agent. When one daemon hosts multiple agents, slots index shared
-	// daemon-level resources such as GPUs.
-	agentEnv := map[string]string{
-		"MULTICA_TOKEN":        d.client.Token(),
-		"MULTICA_SERVER_URL":   d.cfg.ServerBaseURL,
-		"MULTICA_DAEMON_PORT":  fmt.Sprintf("%d", d.cfg.HealthPort),
-		"MULTICA_WORKSPACE_ID": task.WorkspaceID,
-		"MULTICA_AGENT_NAME":   agentName,
-		"MULTICA_AGENT_ID":     task.AgentID,
-		"MULTICA_TASK_ID":      task.ID,
-		"MULTICA_TASK_SLOT":    strconv.Itoa(slot),
-	}
-	if task.AutopilotRunID != "" {
-		agentEnv["MULTICA_AUTOPILOT_RUN_ID"] = task.AutopilotRunID
-	}
-	if task.AutopilotID != "" {
-		agentEnv["MULTICA_AUTOPILOT_ID"] = task.AutopilotID
-	}
-	// Quick-create marker — when set, the multica CLI's `issue create`
-	// command stamps the new issue with origin_type=quick_create +
-	// origin_id=<task_id> so the completion handler can find it
-	// deterministically (see GetIssueByOrigin).
-	if task.QuickCreatePrompt != "" {
-		agentEnv["MULTICA_QUICK_CREATE_TASK_ID"] = task.ID
-	}
 	// Ensure the multica CLI is on PATH inside the agent's environment.
 	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not
 	// inherit the daemon's PATH. Prepend the directory of the running
@@ -1908,6 +1894,51 @@ func convertProjectResourcesForEnv(resources []ProjectResourceData) []execenv.Pr
 		}
 	}
 	return result
+}
+
+func (d *Daemon) taskAgentEnv(task Task, agentName, agentID string, slot int) map[string]string {
+	// Pass the daemon's auth credentials and context so the spawned agent CLI
+	// can call the Multica API and the local daemon (e.g. `multica repo checkout`).
+	// MULTICA_TASK_SLOT is allocated from the daemon-wide concurrency pool, not
+	// per-agent. When one daemon hosts multiple agents, slots index shared
+	// daemon-level resources such as GPUs.
+	agentEnv := map[string]string{
+		"MULTICA_TOKEN":        d.client.Token(),
+		"MULTICA_SERVER_URL":   d.cfg.ServerBaseURL,
+		"MULTICA_DAEMON_PORT":  fmt.Sprintf("%d", d.cfg.HealthPort),
+		"MULTICA_WORKSPACE_ID": task.WorkspaceID,
+		"MULTICA_AGENT_NAME":   agentName,
+		"MULTICA_AGENT_ID":     agentID,
+		"MULTICA_TASK_ID":      task.ID,
+		"MULTICA_TASK_SLOT":    strconv.Itoa(slot),
+	}
+	if task.ProjectID != "" {
+		agentEnv["MULTICA_PROJECT_ID"] = task.ProjectID
+	}
+	if task.AutopilotRunID != "" {
+		agentEnv["MULTICA_AUTOPILOT_RUN_ID"] = task.AutopilotRunID
+	}
+	if task.AutopilotID != "" {
+		agentEnv["MULTICA_AUTOPILOT_ID"] = task.AutopilotID
+	}
+	// Quick-create marker — when set, the multica CLI's `issue create`
+	// command stamps the new issue with origin_type=quick_create +
+	// origin_id=<task_id> so the completion handler can find it
+	// deterministically (see GetIssueByOrigin).
+	if task.QuickCreatePrompt != "" {
+		agentEnv["MULTICA_QUICK_CREATE_TASK_ID"] = task.ID
+	}
+	return agentEnv
+}
+
+func projectAfterCreateHook(task Task, env map[string]string) *execenv.AfterCreateHook {
+	if task.ProjectHooks == nil || strings.TrimSpace(task.ProjectHooks.AfterCreate) == "" {
+		return nil
+	}
+	return &execenv.AfterCreateHook{
+		Script: task.ProjectHooks.AfterCreate,
+		Env:    env,
+	}
 }
 
 // markActiveEnvRoot records that a task is currently using the given env root,

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -466,6 +466,56 @@ func TestExecuteAndDrain_NoRetryWhenSessionEstablished(t *testing.T) {
 	}
 }
 
+func TestRunTaskAfterCreateFailureBlocksBeforeProviderStart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell hook fixture is POSIX-only")
+	}
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	d.cfg = Config{
+		WorkspacesRoot: t.TempDir(),
+		HealthPort:     19514,
+		Agents: map[string]AgentEntry{
+			"codex": {Path: "/definitely/not/executed"},
+		},
+	}
+	d.activeEnvRoots = make(map[string]int)
+
+	result, err := d.runTask(context.Background(), Task{
+		ID:          "44444444-5555-6666-7777-888888888888",
+		AgentID:     "agent-1",
+		WorkspaceID: "ws-hook-run",
+		Agent: &AgentData{
+			ID:   "agent-1",
+			Name: "Hook Agent",
+		},
+		ProjectID: "project-1",
+		ProjectHooks: &ProjectHooksData{
+			AfterCreate: `echo "setup failed before provider"; exit 13`,
+		},
+	}, "codex", 0, slog.Default())
+	if err != nil {
+		t.Fatalf("runTask returned error: %v", err)
+	}
+	if result.Status != "blocked" {
+		t.Fatalf("expected blocked result, got %+v", result)
+	}
+	if !strings.Contains(result.Comment, "setup failed before provider") {
+		t.Fatalf("result comment missing hook output: %q", result.Comment)
+	}
+	if result.EnvRoot == "" || result.WorkDir == "" {
+		t.Fatalf("result missing env paths: %+v", result)
+	}
+	logPath := filepath.Join(result.EnvRoot, "logs", "after_create.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("after_create log missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(result.WorkDir, ".agent_context")); !os.IsNotExist(err) {
+		t.Fatalf("context files should not be written after hook failure, stat err=%v", err)
+	}
+}
+
 func TestExecuteAndDrain_CodexInactivityReportsToolResultTranscript(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-script fixture is POSIX-only")

--- a/server/internal/daemon/execenv/after_create.go
+++ b/server/internal/daemon/execenv/after_create.go
@@ -1,0 +1,187 @@
+package execenv
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultAfterCreateHookTimeout is intentionally long enough for dependency
+	// installs while still bounding a stuck setup script before provider launch.
+	DefaultAfterCreateHookTimeout = 30 * time.Minute
+	AfterCreateHookTimeoutEnv     = "MULTICA_PROJECT_AFTER_CREATE_TIMEOUT"
+	afterCreateLogName            = "after_create.log"
+	afterCreateOutputTailBytes    = 8 * 1024
+)
+
+// AfterCreateHook describes a project-scoped setup script to run in a fresh
+// task workdir before Multica context files and provider runtime config exist.
+type AfterCreateHook struct {
+	Script  string
+	Env     map[string]string
+	Timeout time.Duration
+}
+
+// AfterCreateHookError includes enough context for the daemon to block the task
+// while preserving the workdir and log location for debugging.
+type AfterCreateHookError struct {
+	EnvRoot    string
+	WorkDir    string
+	LogPath    string
+	OutputTail string
+	TimedOut   bool
+	Err        error
+}
+
+func (e *AfterCreateHookError) Error() string {
+	if e == nil {
+		return ""
+	}
+	status := "failed"
+	if e.TimedOut {
+		status = "timed out"
+	}
+	msg := fmt.Sprintf("project after_create hook %s", status)
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	if e.LogPath != "" {
+		msg += fmt.Sprintf("\n\nLog: %s", e.LogPath)
+	}
+	tail := strings.TrimSpace(e.OutputTail)
+	if tail != "" {
+		msg += "\n\nOutput:\n" + tail
+	}
+	return msg
+}
+
+func (e *AfterCreateHookError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func resolveAfterCreateHookTimeout(override time.Duration) (time.Duration, error) {
+	if override > 0 {
+		return override, nil
+	}
+	raw := strings.TrimSpace(os.Getenv(AfterCreateHookTimeoutEnv))
+	if raw == "" {
+		return DefaultAfterCreateHookTimeout, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s: invalid duration %q: %w", AfterCreateHookTimeoutEnv, raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s: duration must be positive", AfterCreateHookTimeoutEnv)
+	}
+	return d, nil
+}
+
+func runAfterCreateHook(ctx context.Context, envRoot, workDir string, hook AfterCreateHook, logger *slog.Logger) error {
+	script := hook.Script
+	if strings.TrimSpace(script) == "" {
+		return nil
+	}
+	timeout, err := resolveAfterCreateHookTimeout(hook.Timeout)
+	logPath := filepath.Join(envRoot, "logs", afterCreateLogName)
+	if err != nil {
+		return &AfterCreateHookError{
+			EnvRoot: envRoot,
+			WorkDir: workDir,
+			LogPath: logPath,
+			Err:     err,
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return fmt.Errorf("after_create hook: create log dir: %w", err)
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("after_create hook: open log: %w", err)
+	}
+	defer logFile.Close()
+
+	fmt.Fprintf(logFile, "multica project after_create hook\ncwd: %s\ntimeout: %s\n\n", workDir, timeout)
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := shellCommand(runCtx, script)
+	cmd.Dir = workDir
+	cmd.Env = hookEnv(hook.Env, workDir, envRoot)
+
+	tail := &tailWriter{max: afterCreateOutputTailBytes}
+	writer := io.MultiWriter(logFile, tail)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+
+	if logger != nil {
+		logger.Info("execenv: running project after_create hook", "workdir", workDir, "log", logPath, "timeout", timeout.String())
+	}
+	err = cmd.Run()
+	timedOut := runCtx.Err() == context.DeadlineExceeded
+	if err != nil {
+		fmt.Fprintf(logFile, "\n\nhook exit: %v\n", err)
+		return &AfterCreateHookError{
+			EnvRoot:    envRoot,
+			WorkDir:    workDir,
+			LogPath:    logPath,
+			OutputTail: tail.String(),
+			TimedOut:   timedOut,
+			Err:        err,
+		}
+	}
+	fmt.Fprintln(logFile, "\n\nhook exit: 0")
+	return nil
+}
+
+func shellCommand(ctx context.Context, script string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "cmd", "/C", script)
+	}
+	return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+}
+
+func hookEnv(extra map[string]string, workDir, envRoot string) []string {
+	env := os.Environ()
+	for k, v := range extra {
+		env = append(env, k+"="+v)
+	}
+	env = append(env,
+		"MULTICA_WORKDIR="+workDir,
+		"MULTICA_ENV_ROOT="+envRoot,
+	)
+	return env
+}
+
+type tailWriter struct {
+	max int
+	buf []byte
+}
+
+func (w *tailWriter) Write(p []byte) (int, error) {
+	if w.max <= 0 {
+		return len(p), nil
+	}
+	w.buf = append(w.buf, p...)
+	if len(w.buf) > w.max {
+		w.buf = append([]byte(nil), w.buf[len(w.buf)-w.max:]...)
+	}
+	return len(p), nil
+}
+
+func (w *tailWriter) String() string {
+	return string(w.buf)
+}

--- a/server/internal/daemon/execenv/after_create.go
+++ b/server/internal/daemon/execenv/after_create.go
@@ -20,6 +20,7 @@ const (
 	AfterCreateHookTimeoutEnv     = "MULTICA_PROJECT_AFTER_CREATE_TIMEOUT"
 	afterCreateLogName            = "after_create.log"
 	afterCreateOutputTailBytes    = 8 * 1024
+	afterCreateLogOutputMaxBytes  = 1024 * 1024
 )
 
 // AfterCreateHook describes a project-scoped setup script to run in a fresh
@@ -123,7 +124,8 @@ func runAfterCreateHook(ctx context.Context, envRoot, workDir string, hook After
 	cmd.Env = hookEnv(hook.Env, workDir, envRoot)
 
 	tail := &tailWriter{max: afterCreateOutputTailBytes}
-	writer := io.MultiWriter(logFile, tail)
+	logOutput := &cappedWriter{w: logFile, max: afterCreateLogOutputMaxBytes}
+	writer := io.MultiWriter(logOutput, tail)
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 
@@ -184,4 +186,36 @@ func (w *tailWriter) Write(p []byte) (int, error) {
 
 func (w *tailWriter) String() string {
 	return string(w.buf)
+}
+
+type cappedWriter struct {
+	w         io.Writer
+	max       int
+	written   int
+	truncated bool
+}
+
+func (w *cappedWriter) Write(p []byte) (int, error) {
+	if w.max <= 0 || w.w == nil {
+		return len(p), nil
+	}
+	remaining := w.max - w.written
+	if remaining > 0 {
+		chunk := p
+		if len(chunk) > remaining {
+			chunk = chunk[:remaining]
+		}
+		n, err := w.w.Write(chunk)
+		w.written += n
+		if err != nil {
+			return n, err
+		}
+	}
+	if len(p) > remaining && !w.truncated {
+		w.truncated = true
+		if _, err := io.WriteString(w.w, "\n\n[after_create log truncated]\n"); err != nil {
+			return len(p), err
+		}
+	}
+	return len(p), nil
 }

--- a/server/internal/daemon/execenv/codex_trust.go
+++ b/server/internal/daemon/execenv/codex_trust.go
@@ -1,0 +1,113 @@
+package execenv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ensureCodexTrustedProjectConfig marks the daemon-managed workdir as trusted
+// in the per-task CODEX_HOME/config.toml. This allows Codex to load
+// project-local .codex config/hooks/exec policies from repositories prepared by
+// the after_create hook without mutating the user's global ~/.codex/config.toml.
+func ensureCodexTrustedProjectConfig(configPath, projectDir string) error {
+	if strings.TrimSpace(projectDir) == "" {
+		return nil
+	}
+	absProjectDir, err := filepath.Abs(projectDir)
+	if err == nil {
+		projectDir = absProjectDir
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read config.toml: %w", err)
+	}
+	existing := string(data)
+	quotedProjectDir := tomlBasicString(projectDir)
+	projectHeader := "[projects." + quotedProjectDir + "]"
+
+	lines := strings.Split(existing, "\n")
+	headerRe := regexp.MustCompile(`^\s*\[\s*projects\s*\.\s*` + regexp.QuoteMeta(quotedProjectDir) + `\s*\]\s*(?:#.*)?$`)
+	trustLineRe := regexp.MustCompile(`^\s*trust_level\s*=`)
+
+	headerIndex := -1
+	for i, line := range lines {
+		if headerRe.MatchString(line) {
+			headerIndex = i
+			break
+		}
+	}
+
+	var updated string
+	if headerIndex >= 0 {
+		endIndex := len(lines)
+		for i := headerIndex + 1; i < len(lines); i++ {
+			trimmed := strings.TrimSpace(lines[i])
+			if strings.HasPrefix(trimmed, "[") {
+				endIndex = i
+				break
+			}
+		}
+		for i := headerIndex + 1; i < endIndex; i++ {
+			if !trustLineRe.MatchString(lines[i]) {
+				continue
+			}
+			if strings.TrimSpace(lines[i]) == `trust_level = "trusted"` {
+				return nil
+			}
+			lines[i] = `trust_level = "trusted"`
+			updated = strings.Join(lines, "\n")
+			break
+		}
+		if updated == "" {
+			out := make([]string, 0, len(lines)+1)
+			out = append(out, lines[:headerIndex+1]...)
+			out = append(out, `trust_level = "trusted"`)
+			out = append(out, lines[headerIndex+1:]...)
+			updated = strings.Join(out, "\n")
+		}
+	} else {
+		updated = strings.TrimRight(existing, "\n")
+		if updated != "" {
+			updated += "\n\n"
+		}
+		updated += projectHeader + "\ntrust_level = \"trusted\"\n"
+	}
+
+	if updated == existing {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.WriteFile(configPath, []byte(updated), 0o644); err != nil {
+		return fmt.Errorf("write config.toml: %w", err)
+	}
+	return nil
+}
+
+func tomlBasicString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/server/internal/daemon/execenv/codex_trust_test.go
+++ b/server/internal/daemon/execenv/codex_trust_test.go
@@ -1,0 +1,122 @@
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func assertValidTOML(t *testing.T, content string) {
+	t.Helper()
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("config should parse as TOML: %v\n%s", err, content)
+	}
+}
+
+func TestEnsureCodexTrustedProjectConfigAddsWorkdir(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	workDir := filepath.Join(dir, "workdir")
+	if err := os.WriteFile(configPath, []byte("model = \"gpt-5\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := ensureCodexTrustedProjectConfig(configPath, workDir); err != nil {
+		t.Fatalf("ensure trusted project: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	content := string(data)
+	assertValidTOML(t, content)
+	if !strings.Contains(content, "[projects."+tomlBasicString(workDir)+"]") {
+		t.Fatalf("config missing trusted project table:\n%s", content)
+	}
+	if !strings.Contains(content, `trust_level = "trusted"`) {
+		t.Fatalf("config missing trusted trust_level:\n%s", content)
+	}
+}
+
+func TestEnsureCodexTrustedProjectConfigIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	workDir := filepath.Join(dir, "workdir")
+
+	if err := ensureCodexTrustedProjectConfig(configPath, workDir); err != nil {
+		t.Fatalf("first ensure trusted project: %v", err)
+	}
+	if err := ensureCodexTrustedProjectConfig(configPath, workDir); err != nil {
+		t.Fatalf("second ensure trusted project: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	content := string(data)
+	assertValidTOML(t, content)
+	if count := strings.Count(content, "[projects."+tomlBasicString(workDir)+"]"); count != 1 {
+		t.Fatalf("expected one project table, got %d:\n%s", count, content)
+	}
+}
+
+func TestEnsureCodexTrustedProjectConfigUpdatesExistingProjectTable(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	workDir := filepath.Join(dir, "workdir")
+	content := "[projects." + tomlBasicString(workDir) + "]\ntrust_level = \"untrusted\"\nextra = true\n"
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := ensureCodexTrustedProjectConfig(configPath, workDir); err != nil {
+		t.Fatalf("ensure trusted project: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	updated := string(data)
+	assertValidTOML(t, updated)
+	if strings.Count(updated, "[projects."+tomlBasicString(workDir)+"]") != 1 {
+		t.Fatalf("expected one project table:\n%s", updated)
+	}
+	if !strings.Contains(updated, "trust_level = \"trusted\"") || !strings.Contains(updated, "extra = true") {
+		t.Fatalf("expected trust_level update with table contents preserved:\n%s", updated)
+	}
+}
+
+func TestPrepareCodexHomeTrustsFreshWorkdir(t *testing.T) {
+	sharedHome := t.TempDir()
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: filepath.Join(t.TempDir(), "workspaces"),
+		WorkspaceID:    "workspace-1",
+		TaskID:         "task-12345678",
+		Provider:       "codex",
+		Task: TaskContextForEnv{
+			IssueID: "issue-1",
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(env.CodexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read codex config: %v", err)
+	}
+	content := string(data)
+	assertValidTOML(t, content)
+	if !strings.Contains(content, "[projects."+tomlBasicString(env.WorkDir)+"]") {
+		t.Fatalf("config missing fresh workdir trust entry:\n%s", content)
+	}
+}

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -4,6 +4,7 @@
 package execenv
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -37,6 +38,8 @@ type PrepareParams struct {
 	AgentName      string            // for git branch naming only
 	Provider       string            // agent provider (determines runtime config and skill injection paths)
 	CodexVersion   string            // detected Codex CLI version (only used when Provider == "codex")
+	Context        context.Context   // optional task context for cancellable setup hooks
+	AfterCreate    *AfterCreateHook  // optional project hook run only for fresh env creation
 	Task           TaskContextForEnv // context data for writing files
 }
 
@@ -53,7 +56,7 @@ type TaskContextForEnv struct {
 	ProjectTitle            string                  // human-readable project title
 	ProjectResources        []ProjectResourceForEnv // resources attached to the project
 	ChatSessionID           string                  // non-empty for chat tasks
-	AutopilotRunID          string              // non-empty for autopilot run_only tasks
+	AutopilotRunID          string                  // non-empty for autopilot run_only tasks
 	AutopilotID             string
 	AutopilotTitle          string
 	AutopilotDescription    string
@@ -134,6 +137,16 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		logger:  logger,
 	}
 
+	if params.AfterCreate != nil {
+		ctx := params.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		if err := runAfterCreateHook(ctx, envRoot, workDir, *params.AfterCreate, logger); err != nil {
+			return nil, err
+		}
+	}
+
 	// Write context files into workdir (skills go to provider-native paths).
 	if err := writeContextFiles(workDir, params.Provider, params.Task); err != nil {
 		return nil, fmt.Errorf("execenv: write context files: %w", err)
@@ -147,6 +160,9 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		}
 		if err := writeCodexWorkspaceSkills(codexHome, params.Task.AgentSkills); err != nil {
 			return nil, fmt.Errorf("execenv: write codex skills: %w", err)
+		}
+		if err := ensureCodexTrustedProjectConfig(filepath.Join(codexHome, "config.toml"), workDir); err != nil {
+			return nil, fmt.Errorf("execenv: trust codex workdir: %w", err)
 		}
 		env.CodexHome = codexHome
 	}
@@ -188,6 +204,9 @@ func Reuse(workDir, provider, codexVersion string, task TaskContextForEnv, logge
 			env.CodexHome = codexHome
 			if err := writeCodexWorkspaceSkills(codexHome, task.AgentSkills); err != nil {
 				logger.Warn("execenv: refresh codex skills failed", "error", err)
+			}
+			if err := ensureCodexTrustedProjectConfig(filepath.Join(codexHome, "config.toml"), workDir); err != nil {
+				logger.Warn("execenv: refresh codex trusted workdir failed", "error", err)
 			}
 		}
 	}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2,6 +2,7 @@ package execenv
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -216,6 +217,118 @@ func TestPrepareWithProjectResources(t *testing.T) {
 		if !strings.Contains(s, want) {
 			t.Errorf("CLAUDE.md missing %q", want)
 		}
+	}
+}
+
+func TestPrepareAfterCreateHookRunsBeforeContextFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell hook fixture is POSIX-only")
+	}
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-hook-order",
+		TaskID:         "11111111-2222-3333-4444-555555555555",
+		AgentName:      "Hook Agent",
+		Provider:       "claude",
+		AfterCreate: &AfterCreateHook{
+			Script: `
+if [ -e ".agent_context" ] || [ -e "CLAUDE.md" ]; then
+  echo "context files should not exist before after_create"
+  exit 7
+fi
+printf "ready" > hook_marker
+`,
+		},
+		Task: TaskContextForEnv{
+			IssueID:   "11111111-2222-3333-4444-555555555555",
+			AgentName: "Hook Agent",
+		},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	marker, err := os.ReadFile(filepath.Join(env.WorkDir, "hook_marker"))
+	if err != nil {
+		t.Fatalf("hook marker missing: %v", err)
+	}
+	if string(marker) != "ready" {
+		t.Fatalf("hook marker = %q, want ready", marker)
+	}
+	if _, err := os.Stat(filepath.Join(env.WorkDir, ".agent_context", "issue_context.md")); err != nil {
+		t.Fatalf("context file should be written after hook: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(env.RootDir, "logs", afterCreateLogName)); err != nil {
+		t.Fatalf("after_create log missing: %v", err)
+	}
+}
+
+func TestPrepareAfterCreateHookFailureReturnsLogContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell hook fixture is POSIX-only")
+	}
+
+	_, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-hook-fail",
+		TaskID:         "22222222-3333-4444-5555-666666666666",
+		AgentName:      "Hook Agent",
+		Provider:       "claude",
+		AfterCreate: &AfterCreateHook{
+			Script: `echo "setup failed"; exit 42`,
+		},
+		Task: TaskContextForEnv{IssueID: "22222222-3333-4444-5555-666666666666"},
+	}, testLogger())
+	if err == nil {
+		t.Fatal("expected Prepare to fail")
+	}
+	var hookErr *AfterCreateHookError
+	if !errors.As(err, &hookErr) {
+		t.Fatalf("expected AfterCreateHookError, got %T: %v", err, err)
+	}
+	if hookErr.WorkDir == "" || hookErr.EnvRoot == "" || hookErr.LogPath == "" {
+		t.Fatalf("hook error missing path context: %+v", hookErr)
+	}
+	if !strings.Contains(hookErr.OutputTail, "setup failed") {
+		t.Fatalf("output tail missing hook output: %q", hookErr.OutputTail)
+	}
+	data, readErr := os.ReadFile(hookErr.LogPath)
+	if readErr != nil {
+		t.Fatalf("read hook log: %v", readErr)
+	}
+	if !strings.Contains(string(data), "setup failed") {
+		t.Fatalf("hook log missing output:\n%s", data)
+	}
+}
+
+func TestPrepareAfterCreateHookTimeoutUsesEnvOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell hook fixture is POSIX-only")
+	}
+	t.Setenv(AfterCreateHookTimeoutEnv, "10ms")
+
+	_, err := Prepare(PrepareParams{
+		WorkspacesRoot: t.TempDir(),
+		WorkspaceID:    "ws-hook-timeout",
+		TaskID:         "33333333-4444-5555-6666-777777777777",
+		AgentName:      "Hook Agent",
+		Provider:       "claude",
+		AfterCreate: &AfterCreateHook{
+			Script: `sleep 1`,
+		},
+		Task: TaskContextForEnv{IssueID: "33333333-4444-5555-6666-777777777777"},
+	}, testLogger())
+	if err == nil {
+		t.Fatal("expected Prepare to time out")
+	}
+	var hookErr *AfterCreateHookError
+	if !errors.As(err, &hookErr) {
+		t.Fatalf("expected AfterCreateHookError, got %T: %v", err, err)
+	}
+	if !hookErr.TimedOut {
+		t.Fatalf("expected timeout classification, got %+v", hookErr)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -303,6 +303,37 @@ func TestPrepareAfterCreateHookFailureReturnsLogContext(t *testing.T) {
 	}
 }
 
+func TestCappedWriterLimitsOutput(t *testing.T) {
+	var b strings.Builder
+	w := &cappedWriter{w: &b, max: 5}
+
+	n, err := w.Write([]byte("123456789"))
+	if err != nil {
+		t.Fatalf("first write failed: %v", err)
+	}
+	if n != 9 {
+		t.Fatalf("first write n = %d, want 9", n)
+	}
+	n, err = w.Write([]byte("abcdef"))
+	if err != nil {
+		t.Fatalf("second write failed: %v", err)
+	}
+	if n != 6 {
+		t.Fatalf("second write n = %d, want 6", n)
+	}
+
+	got := b.String()
+	if !strings.HasPrefix(got, "12345") {
+		t.Fatalf("output prefix = %q, want capped payload", got)
+	}
+	if strings.Count(got, "after_create log truncated") != 1 {
+		t.Fatalf("expected one truncation marker, got %q", got)
+	}
+	if strings.Contains(got, "6789") || strings.Contains(got, "abcdef") {
+		t.Fatalf("output included bytes past cap: %q", got)
+	}
+}
+
 func TestPrepareAfterCreateHookTimeoutUsesEnvOverride(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell hook fixture is POSIX-only")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -173,7 +173,11 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	if ctx.ProjectID != "" || len(ctx.ProjectResources) > 0 {
 		b.WriteString("## Project Context\n\n")
 		if ctx.ProjectTitle != "" {
-			fmt.Fprintf(&b, "This issue belongs to **%s**.\n\n", ctx.ProjectTitle)
+			if ctx.QuickCreatePrompt != "" {
+				fmt.Fprintf(&b, "The issue you create must belong to **%s**.\n\n", ctx.ProjectTitle)
+			} else {
+				fmt.Fprintf(&b, "This issue belongs to **%s**.\n\n", ctx.ProjectTitle)
+			}
 		}
 		if len(ctx.ProjectResources) > 0 {
 			b.WriteString("Project resources (also written to `.multica/project/resources.json`):\n\n")
@@ -211,6 +215,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("**This task was triggered by quick-create.** There is NO existing Multica issue. Follow the field and output rules in the user message you just received; ignore the default assignment-task workflow.\n\n")
 		b.WriteString("Hard guardrails (apply even if the user message is missing):\n")
 		b.WriteString("- Run exactly one `multica issue create` invocation, then exit.\n")
+		if ctx.ProjectID != "" {
+			fmt.Fprintf(&b, "- Include `--project %q` on the `multica issue create` invocation.\n", ctx.ProjectID)
+		}
 		b.WriteString("- Do NOT call `multica issue get`, `multica issue status`, or `multica issue comment add` for this task — there is no issue to query, transition, or comment on. The platform writes the user's success/failure inbox notification automatically based on whether `multica issue create` succeeded.\n")
 		b.WriteString("- If the CLI returns an error, exit with that error as the only output. Do not retry.\n\n")
 	} else if ctx.AutopilotRunID != "" {

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -76,8 +76,18 @@ func buildQuickCreatePrompt(task Task) string {
 		b.WriteString("    - When the user did NOT name an assignee, default to YOURSELF (the picker agent): pass `--assignee <your agent name>`. Never leave the issue unassigned.\n\n")
 	}
 
+	// project
+	if task.ProjectID != "" {
+		if task.ProjectTitle != "" {
+			fmt.Fprintf(&b, "- **project**: selected project is %q. Pass `--project %q` exactly; do not substitute the project title.\n", task.ProjectTitle, task.ProjectID)
+		} else {
+			fmt.Fprintf(&b, "- **project**: pass `--project %q` exactly.\n", task.ProjectID)
+		}
+	} else {
+		b.WriteString("- **project**: omit. No project was selected for this quick-create request.\n")
+	}
+
 	// fields to omit
-	b.WriteString("- **project**: omit. The platform will route the issue to the workspace default.\n")
 	b.WriteString("- **status**: omit (defaults to `todo`).\n")
 	b.WriteString("- **attachments**: do NOT pass `--attachment`. The flag only accepts LOCAL file paths. Any image URL in the user input is already markdown — keep it inline in `--description` instead.\n\n")
 

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -1,0 +1,38 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildQuickCreatePromptUsesSelectedProject(t *testing.T) {
+	prompt := BuildPrompt(Task{
+		QuickCreatePrompt: "file the follow-up",
+		ProjectID:         "22222222-3333-4444-5555-666666666666",
+		ProjectTitle:      "Project Alpha",
+	})
+
+	for _, want := range []string{
+		`selected project is "Project Alpha"`,
+		`--project "22222222-3333-4444-5555-666666666666"`,
+		"do not substitute the project title",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("quick-create prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "project**: omit") {
+		t.Fatalf("quick-create prompt should not omit project when selected\n---\n%s", prompt)
+	}
+}
+
+func TestBuildQuickCreatePromptOmitsProjectWhenUnselected(t *testing.T) {
+	prompt := BuildPrompt(Task{QuickCreatePrompt: "file the follow-up"})
+
+	if !strings.Contains(prompt, "No project was selected") {
+		t.Fatalf("quick-create prompt should explain no project was selected\n---\n%s", prompt)
+	}
+	if strings.Contains(prompt, "--project") {
+		t.Fatalf("quick-create prompt should not include --project without a selected project\n---\n%s", prompt)
+	}
+}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -30,34 +30,40 @@ type ProjectResourceData struct {
 	Label        string          `json:"label,omitempty"`
 }
 
+// ProjectHooksData carries project-scoped setup hooks included in a task claim.
+type ProjectHooksData struct {
+	AfterCreate string `json:"after_create,omitempty"`
+}
+
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID                      string          `json:"id"`
-	AgentID                 string          `json:"agent_id"`
-	RuntimeID               string          `json:"runtime_id"`
-	IssueID                 string          `json:"issue_id"`
-	WorkspaceID             string          `json:"workspace_id"`
-	Agent                   *AgentData      `json:"agent,omitempty"`
+	ID                      string                `json:"id"`
+	AgentID                 string                `json:"agent_id"`
+	RuntimeID               string                `json:"runtime_id"`
+	IssueID                 string                `json:"issue_id"`
+	WorkspaceID             string                `json:"workspace_id"`
+	Agent                   *AgentData            `json:"agent,omitempty"`
 	Repos                   []RepoData            `json:"repos,omitempty"`
-	ProjectID               string                `json:"project_id,omitempty"`        // issue's project, when present
-	ProjectTitle            string                `json:"project_title,omitempty"`     // human-readable project title for context injection
-	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"` // project-scoped resources to expose to the agent
-	PriorSessionID          string          `json:"prior_session_id,omitempty"`          // Claude session ID from a previous task on this issue
-	PriorWorkDir            string          `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on this issue
-	TriggerCommentID        string          `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
-	TriggerCommentContent   string          `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
-	TriggerAuthorType       string          `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind for the triggering comment
-	TriggerAuthorName       string          `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
-	ChatSessionID           string          `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
-	ChatMessage             string          `json:"chat_message,omitempty"`              // user message content for chat tasks
-	AutopilotRunID          string          `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot run_only tasks
-	AutopilotID             string          `json:"autopilot_id,omitempty"`              // autopilot that spawned this run
-	AutopilotTitle          string          `json:"autopilot_title,omitempty"`           // autopilot title used as task context
-	AutopilotDescription    string          `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
-	AutopilotSource         string          `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
-	AutopilotTriggerPayload json.RawMessage `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
-	QuickCreatePrompt       string          `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
+	ProjectID               string                `json:"project_id,omitempty"`                // task project, when present
+	ProjectTitle            string                `json:"project_title,omitempty"`             // human-readable project title for context injection
+	ProjectHooks            *ProjectHooksData     `json:"project_hooks,omitempty"`             // project-scoped setup hooks
+	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"`         // project-scoped resources to expose to the agent
+	PriorSessionID          string                `json:"prior_session_id,omitempty"`          // Claude session ID from a previous task on this issue
+	PriorWorkDir            string                `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on this issue
+	TriggerCommentID        string                `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
+	TriggerCommentContent   string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
+	TriggerAuthorType       string                `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind for the triggering comment
+	TriggerAuthorName       string                `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
+	ChatSessionID           string                `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
+	ChatMessage             string                `json:"chat_message,omitempty"`              // user message content for chat tasks
+	AutopilotRunID          string                `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot run_only tasks
+	AutopilotID             string                `json:"autopilot_id,omitempty"`              // autopilot that spawned this run
+	AutopilotTitle          string                `json:"autopilot_title,omitempty"`           // autopilot title used as task context
+	AutopilotDescription    string                `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
+	AutopilotSource         string                `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
+	AutopilotTriggerPayload json.RawMessage       `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
+	QuickCreatePrompt       string                `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
 }
 
 // AgentData holds agent details returned by the claim endpoint.

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -134,45 +134,46 @@ type ProjectResourceData struct {
 }
 
 type AgentTaskResponse struct {
-	ID                      string          `json:"id"`
-	AgentID                 string          `json:"agent_id"`
-	RuntimeID               string          `json:"runtime_id"`
-	IssueID                 string          `json:"issue_id"`
-	WorkspaceID             string          `json:"workspace_id"`
-	Status                  string          `json:"status"`
-	Priority                int32           `json:"priority"`
-	DispatchedAt            *string         `json:"dispatched_at"`
-	StartedAt               *string         `json:"started_at"`
-	CompletedAt             *string         `json:"completed_at"`
-	Result                  any             `json:"result"`
-	Error                   *string         `json:"error"`
-	FailureReason           string          `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
-	Attempt                 int32           `json:"attempt"`
-	MaxAttempts             int32           `json:"max_attempts"`
-	ParentTaskID            *string         `json:"parent_task_id,omitempty"`
-	Agent                   *TaskAgentData  `json:"agent,omitempty"`
+	ID                      string                `json:"id"`
+	AgentID                 string                `json:"agent_id"`
+	RuntimeID               string                `json:"runtime_id"`
+	IssueID                 string                `json:"issue_id"`
+	WorkspaceID             string                `json:"workspace_id"`
+	Status                  string                `json:"status"`
+	Priority                int32                 `json:"priority"`
+	DispatchedAt            *string               `json:"dispatched_at"`
+	StartedAt               *string               `json:"started_at"`
+	CompletedAt             *string               `json:"completed_at"`
+	Result                  any                   `json:"result"`
+	Error                   *string               `json:"error"`
+	FailureReason           string                `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
+	Attempt                 int32                 `json:"attempt"`
+	MaxAttempts             int32                 `json:"max_attempts"`
+	ParentTaskID            *string               `json:"parent_task_id,omitempty"`
+	Agent                   *TaskAgentData        `json:"agent,omitempty"`
 	Repos                   []RepoData            `json:"repos,omitempty"`
-	ProjectID               string                `json:"project_id,omitempty"`         // issue's project, when present
-	ProjectTitle            string                `json:"project_title,omitempty"`      // for surfacing in agent context
-	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"`  // resources attached to the project
-	CreatedAt               string          `json:"created_at"`
-	PriorSessionID          string          `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
-	PriorWorkDir            string          `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
-	TriggerCommentID        *string         `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
-	TriggerCommentContent   string          `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
-	TriggerSummary          *string         `json:"trigger_summary,omitempty"`           // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
-	TriggerAuthorType       string          `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind of the triggering comment
-	TriggerAuthorName       string          `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
-	ChatSessionID           string          `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
-	ChatMessage             string          `json:"chat_message,omitempty"`              // user message for chat tasks
-	AutopilotRunID          string          `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot-spawned tasks
-	AutopilotID             string          `json:"autopilot_id,omitempty"`              // autopilot that spawned this task
-	AutopilotTitle          string          `json:"autopilot_title,omitempty"`           // autopilot title used as task context
-	AutopilotDescription    string          `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
-	AutopilotSource         string          `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
-	AutopilotTriggerPayload json.RawMessage `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
-	QuickCreatePrompt       string          `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
-	Kind                    string          `json:"kind"`                                // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
+	ProjectID               string                `json:"project_id,omitempty"`        // task project, when present
+	ProjectTitle            string                `json:"project_title,omitempty"`     // for surfacing in agent context
+	ProjectHooks            *projectHooksWire     `json:"project_hooks,omitempty"`     // project-scoped setup hooks for daemon execution
+	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"` // resources attached to the project
+	CreatedAt               string                `json:"created_at"`
+	PriorSessionID          string                `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
+	PriorWorkDir            string                `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
+	TriggerCommentID        *string               `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
+	TriggerCommentContent   string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
+	TriggerSummary          *string               `json:"trigger_summary,omitempty"`           // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
+	TriggerAuthorType       string                `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind of the triggering comment
+	TriggerAuthorName       string                `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
+	ChatSessionID           string                `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
+	ChatMessage             string                `json:"chat_message,omitempty"`              // user message for chat tasks
+	AutopilotRunID          string                `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot-spawned tasks
+	AutopilotID             string                `json:"autopilot_id,omitempty"`              // autopilot that spawned this task
+	AutopilotTitle          string                `json:"autopilot_title,omitempty"`           // autopilot title used as task context
+	AutopilotDescription    string                `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
+	AutopilotSource         string                `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
+	AutopilotTriggerPayload json.RawMessage       `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
+	QuickCreatePrompt       string                `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
+	Kind                    string                `json:"kind"`                                // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
 }
 
 // TaskAgentData holds agent info included in claim responses so the daemon

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -186,6 +186,57 @@ func parseWorkspaceRepos(raw []byte) []RepoData {
 	return normalizeWorkspaceRepos(repos)
 }
 
+func projectResourcesForClaim(rows []db.ProjectResource) ([]ProjectResourceData, []RepoData) {
+	resources := make([]ProjectResourceData, 0, len(rows))
+	projectRepos := make([]RepoData, 0)
+	for _, row := range rows {
+		label := ""
+		if row.Label.Valid {
+			label = row.Label.String
+		}
+		ref := json.RawMessage(row.ResourceRef)
+		if len(ref) == 0 {
+			ref = json.RawMessage("{}")
+		}
+		resources = append(resources, ProjectResourceData{
+			ID:           uuidToString(row.ID),
+			ResourceType: row.ResourceType,
+			ResourceRef:  ref,
+			Label:        label,
+		})
+
+		// Lift github_repo resources into the daemon's repo list so `multica
+		// repo checkout` and the meta-skill render them as the task's repos.
+		if row.ResourceType == "github_repo" {
+			var payload struct {
+				URL string `json:"url"`
+			}
+			if json.Unmarshal(row.ResourceRef, &payload) == nil && payload.URL != "" {
+				projectRepos = append(projectRepos, RepoData{URL: payload.URL})
+			}
+		}
+	}
+	return resources, projectRepos
+}
+
+func (h *Handler) applyProjectContextToClaim(ctx context.Context, resp *AgentTaskResponse, projectID pgtype.UUID) []RepoData {
+	if !projectID.Valid {
+		return nil
+	}
+	resp.ProjectID = uuidToString(projectID)
+	if proj, err := h.Queries.GetProject(ctx, projectID); err == nil {
+		resp.ProjectTitle = proj.Title
+		resp.ProjectHooks = projectHooksFromSettings(proj.Settings)
+	}
+	rows := h.listProjectResourcesForProject(ctx, projectID)
+	if len(rows) == 0 {
+		return nil
+	}
+	resources, projectRepos := projectResourcesForClaim(rows)
+	resp.ProjectResources = resources
+	return projectRepos
+}
+
 func workspaceReposResponse(workspaceID string, raw []byte) daemonWorkspaceReposResponse {
 	repos := parseWorkspaceRepos(raw)
 	return daemonWorkspaceReposResponse{
@@ -912,41 +963,7 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 
 			var projectRepos []RepoData
 			if issue.ProjectID.Valid {
-				resp.ProjectID = uuidToString(issue.ProjectID)
-				if proj, err := h.Queries.GetProject(r.Context(), issue.ProjectID); err == nil {
-					resp.ProjectTitle = proj.Title
-				}
-				if rows := h.listProjectResourcesForProject(r.Context(), issue.ProjectID); len(rows) > 0 {
-					out := make([]ProjectResourceData, 0, len(rows))
-					for _, row := range rows {
-						label := ""
-						if row.Label.Valid {
-							label = row.Label.String
-						}
-						ref := json.RawMessage(row.ResourceRef)
-						if len(ref) == 0 {
-							ref = json.RawMessage("{}")
-						}
-						out = append(out, ProjectResourceData{
-							ID:           uuidToString(row.ID),
-							ResourceType: row.ResourceType,
-							ResourceRef:  ref,
-							Label:        label,
-						})
-						// Lift github_repo resources into the daemon's repo list
-						// so `multica repo checkout` and the meta-skill render
-						// them as the issue's repos.
-						if row.ResourceType == "github_repo" {
-							var payload struct {
-								URL string `json:"url"`
-							}
-							if json.Unmarshal(row.ResourceRef, &payload) == nil && payload.URL != "" {
-								projectRepos = append(projectRepos, RepoData{URL: payload.URL})
-							}
-						}
-					}
-					resp.ProjectResources = out
-				}
+				projectRepos = h.applyProjectContextToClaim(r.Context(), &resp, issue.ProjectID)
 			}
 
 			if len(projectRepos) > 0 {
@@ -1096,7 +1113,21 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 			hasQuickCreate = true
 			resp.QuickCreatePrompt = qc.Prompt
 			resp.WorkspaceID = qc.WorkspaceID
-			if ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(qc.WorkspaceID)); err == nil && ws.Repos != nil {
+			var projectRepos []RepoData
+			if qc.ProjectID != "" {
+				if projectID, err := util.ParseUUID(qc.ProjectID); err == nil && projectID.Valid {
+					projectRepos = h.applyProjectContextToClaim(r.Context(), &resp, projectID)
+				} else {
+					slog.Warn("quick-create claim: invalid project_id in context",
+						"task_id", uuidToString(task.ID),
+						"project_id", qc.ProjectID,
+						"error", err,
+					)
+				}
+			}
+			if len(projectRepos) > 0 {
+				resp.Repos = projectRepos
+			} else if ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(qc.WorkspaceID)); err == nil && ws.Repos != nil {
 				var repos []RepoData
 				if json.Unmarshal(ws.Repos, &repos) == nil && len(repos) > 0 {
 					resp.Repos = repos

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/multica-ai/multica/server/internal/middleware"
+	"github.com/multica-ai/multica/server/internal/service"
 )
 
 // slowProbeLocalSkillListStore wraps a LocalSkillListStore but blocks inside
@@ -1283,8 +1284,10 @@ func TestClaimTask_ProjectGithubReposOverrideWorkspaceRepos(t *testing.T) {
 	// workspace's repos list.
 	var projectID string
 	if err := testPool.QueryRow(ctx, `
-		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
-	`, testWorkspaceID, "Claim project repo override").Scan(&projectID); err != nil {
+		INSERT INTO project (workspace_id, title, settings)
+		VALUES ($1, $2, $3::jsonb)
+		RETURNING id
+	`, testWorkspaceID, "Claim project repo override", `{"hooks":{"after_create":"echo project setup"}}`).Scan(&projectID); err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
@@ -1341,6 +1344,7 @@ func TestClaimTask_ProjectGithubReposOverrideWorkspaceRepos(t *testing.T) {
 		Task *struct {
 			Repos            []RepoData            `json:"repos"`
 			ProjectID        string                `json:"project_id"`
+			ProjectHooks     *projectHooksWire     `json:"project_hooks"`
 			ProjectResources []ProjectResourceData `json:"project_resources"`
 		} `json:"task"`
 	}
@@ -1355,6 +1359,9 @@ func TestClaimTask_ProjectGithubReposOverrideWorkspaceRepos(t *testing.T) {
 	}
 	if len(resp.Task.Repos) != 1 || resp.Task.Repos[0].URL != projectRepoURL {
 		t.Fatalf("expected resp.Repos to contain only the project repo URL, got %+v", resp.Task.Repos)
+	}
+	if resp.Task.ProjectHooks == nil || resp.Task.ProjectHooks.AfterCreate != "echo project setup" {
+		t.Fatalf("expected project after_create hook in claim response, got %+v", resp.Task.ProjectHooks)
 	}
 	for _, r := range resp.Task.Repos {
 		if strings.HasSuffix(r.URL, "workspace-repo-a") || strings.HasSuffix(r.URL, "workspace-repo-b") {
@@ -1438,6 +1445,109 @@ func TestClaimTask_ProjectWithoutRepos_FallsBackToWorkspaceRepos(t *testing.T) {
 	}
 	if len(resp.Task.Repos) != 1 || !strings.HasSuffix(resp.Task.Repos[0].URL, "workspace-fallback") {
 		t.Fatalf("expected workspace fallback repo, got %+v", resp.Task.Repos)
+	}
+}
+
+func TestClaimTask_QuickCreateProjectContext(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+	setHandlerTestWorkspaceRepos(t, []map[string]string{
+		{"url": "https://github.com/example/workspace-quick-create", "description": "ws"},
+	})
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title, settings)
+		VALUES ($1, $2, $3::jsonb)
+		RETURNING id
+	`, testWorkspaceID, "Quick Create Project", `{"hooks":{"after_create":"echo quick project setup"}}`).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+
+	const projectRepoURL = "https://github.com/example/quick-create-project-repo"
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO project_resource (
+			project_id, workspace_id, resource_type, resource_ref, position
+		) VALUES ($1, $2, 'github_repo', $3::jsonb, 0)
+	`, projectID, testWorkspaceID, `{"url":"`+projectRepoURL+`"}`); err != nil {
+		t.Fatalf("create project_resource: %v", err)
+	}
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text, runtime_id::text FROM agent WHERE workspace_id = $1 LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+
+	contextJSON, err := json.Marshal(map[string]string{
+		"type":         service.QuickCreateContextType,
+		"prompt":       "create a scoped issue",
+		"requester_id": testUserID,
+		"workspace_id": testWorkspaceID,
+		"project_id":   projectID,
+	})
+	if err != nil {
+		t.Fatalf("marshal context: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority, context
+		) VALUES ($1, $2, NULL, 'queued', 999, $3::jsonb)
+		RETURNING id
+	`, agentID, runtimeID, contextJSON).Scan(&taskID); err != nil {
+		t.Fatalf("create quick-create task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "test-claim-quick-project")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: %d %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Task *struct {
+			QuickCreatePrompt string                `json:"quick_create_prompt"`
+			Repos             []RepoData            `json:"repos"`
+			ProjectID         string                `json:"project_id"`
+			ProjectTitle      string                `json:"project_title"`
+			ProjectHooks      *projectHooksWire     `json:"project_hooks"`
+			ProjectResources  []ProjectResourceData `json:"project_resources"`
+		} `json:"task"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task == nil {
+		t.Fatal("expected task in response")
+	}
+	if resp.Task.QuickCreatePrompt != "create a scoped issue" {
+		t.Fatalf("quick_create_prompt = %q", resp.Task.QuickCreatePrompt)
+	}
+	if resp.Task.ProjectID != projectID {
+		t.Fatalf("project_id = %q, want %q", resp.Task.ProjectID, projectID)
+	}
+	if resp.Task.ProjectTitle != "Quick Create Project" {
+		t.Fatalf("project_title = %q", resp.Task.ProjectTitle)
+	}
+	if resp.Task.ProjectHooks == nil || resp.Task.ProjectHooks.AfterCreate != "echo quick project setup" {
+		t.Fatalf("expected project after_create hook in claim response, got %+v", resp.Task.ProjectHooks)
+	}
+	if len(resp.Task.ProjectResources) != 1 {
+		t.Fatalf("expected 1 project resource, got %d", len(resp.Task.ProjectResources))
+	}
+	if len(resp.Task.Repos) != 1 || resp.Task.Repos[0].URL != projectRepoURL {
+		t.Fatalf("expected project repo override, got %+v", resp.Task.Repos)
 	}
 }
 

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -198,6 +198,27 @@ func createHandlerTestAgent(t *testing.T, name string, mcpConfig []byte) string 
 	return agentID
 }
 
+func enableQuickCreateForRuntime(t *testing.T, runtimeID string) {
+	t.Helper()
+
+	var previous []byte
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT metadata FROM agent_runtime WHERE id = $1`,
+		runtimeID,
+	).Scan(&previous); err != nil {
+		t.Fatalf("load runtime metadata: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE agent_runtime SET metadata = '{"cli_version":"0.2.20"}'::jsonb WHERE id = $1`,
+		runtimeID,
+	); err != nil {
+		t.Fatalf("set runtime cli_version: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `UPDATE agent_runtime SET metadata = $2::jsonb WHERE id = $1`, runtimeID, previous)
+	})
+}
+
 func fetchAgentMcpConfig(t *testing.T, agentID string) []byte {
 	t.Helper()
 
@@ -615,6 +636,115 @@ func TestCreateSubIssueUsesExplicitProjectOverParentProject(t *testing.T) {
 	}
 	if child.ProjectID == nil || *child.ProjectID != childProjectID {
 		t.Fatalf("CreateIssue child: expected explicit project_id %q, got %v", childProjectID, child.ProjectID)
+	}
+}
+
+func TestQuickCreateIssueStoresProjectID(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text, runtime_id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+	enableQuickCreateForRuntime(t, runtimeID)
+
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, 'Quick create selected project')
+		RETURNING id
+	`, testWorkspaceID).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() {
+		req := newRequest("DELETE", "/api/projects/"+projectID, nil)
+		req = withURLParam(req, "id", projectID)
+		testHandler.DeleteProject(httptest.NewRecorder(), req)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/quick-create?workspace_id="+testWorkspaceID, map[string]any{
+		"agent_id":   agentID,
+		"prompt":     "Create this in the selected project",
+		"project_id": projectID,
+	})
+	testHandler.QuickCreateIssue(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("QuickCreateIssue: expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp QuickCreateIssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, resp.TaskID)
+	})
+
+	var rawContext []byte
+	if err := testPool.QueryRow(ctx,
+		`SELECT context FROM agent_task_queue WHERE id = $1`,
+		resp.TaskID,
+	).Scan(&rawContext); err != nil {
+		t.Fatalf("load queued task context: %v", err)
+	}
+	var qc service.QuickCreateContext
+	if err := json.Unmarshal(rawContext, &qc); err != nil {
+		t.Fatalf("unmarshal quick-create context: %v", err)
+	}
+	if qc.ProjectID != projectID {
+		t.Fatalf("context project_id = %q, want %q; context=%s", qc.ProjectID, projectID, string(rawContext))
+	}
+}
+
+func TestQuickCreateIssueRejectsProjectOutsideWorkspace(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id::text, runtime_id::text FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("load fixture agent: %v", err)
+	}
+	enableQuickCreateForRuntime(t, runtimeID)
+
+	var foreignWorkspaceID, foreignProjectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, issue_prefix)
+		VALUES ('Quick Create Foreign', 'quick-create-foreign-workspace', 'QCF')
+		RETURNING id
+	`).Scan(&foreignWorkspaceID); err != nil {
+		t.Fatalf("create foreign workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID)
+	})
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, 'Foreign project')
+		RETURNING id
+	`, foreignWorkspaceID).Scan(&foreignProjectID); err != nil {
+		t.Fatalf("create foreign project: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/quick-create?workspace_id="+testWorkspaceID, map[string]any{
+		"agent_id":   agentID,
+		"prompt":     "Should not enqueue",
+		"project_id": foreignProjectID,
+	})
+	testHandler.QuickCreateIssue(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("QuickCreateIssue with foreign project: expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -26,33 +26,33 @@ import (
 
 // IssueResponse is the JSON response for an issue.
 type IssueResponse struct {
-	ID                 string                  `json:"id"`
-	WorkspaceID        string                  `json:"workspace_id"`
-	Number             int32                   `json:"number"`
-	Identifier         string                  `json:"identifier"`
-	Title              string                  `json:"title"`
-	Description        *string                 `json:"description"`
-	Status             string                  `json:"status"`
-	Priority           string                  `json:"priority"`
-	AssigneeType       *string                 `json:"assignee_type"`
-	AssigneeID         *string                 `json:"assignee_id"`
-	CreatorType        string                  `json:"creator_type"`
-	CreatorID          string                  `json:"creator_id"`
-	ParentIssueID      *string                 `json:"parent_issue_id"`
-	ProjectID          *string                 `json:"project_id"`
-	Position           float64                 `json:"position"`
-	DueDate            *string                 `json:"due_date"`
-	CreatedAt          string                  `json:"created_at"`
-	UpdatedAt          string                  `json:"updated_at"`
-	Reactions          []IssueReactionResponse `json:"reactions,omitempty"`
-	Attachments        []AttachmentResponse    `json:"attachments,omitempty"`
+	ID            string                  `json:"id"`
+	WorkspaceID   string                  `json:"workspace_id"`
+	Number        int32                   `json:"number"`
+	Identifier    string                  `json:"identifier"`
+	Title         string                  `json:"title"`
+	Description   *string                 `json:"description"`
+	Status        string                  `json:"status"`
+	Priority      string                  `json:"priority"`
+	AssigneeType  *string                 `json:"assignee_type"`
+	AssigneeID    *string                 `json:"assignee_id"`
+	CreatorType   string                  `json:"creator_type"`
+	CreatorID     string                  `json:"creator_id"`
+	ParentIssueID *string                 `json:"parent_issue_id"`
+	ProjectID     *string                 `json:"project_id"`
+	Position      float64                 `json:"position"`
+	DueDate       *string                 `json:"due_date"`
+	CreatedAt     string                  `json:"created_at"`
+	UpdatedAt     string                  `json:"updated_at"`
+	Reactions     []IssueReactionResponse `json:"reactions,omitempty"`
+	Attachments   []AttachmentResponse    `json:"attachments,omitempty"`
 	// Labels are bulk-attached by list/detail endpoints so the client can render
 	// chips without an N+1 round-trip per row. Pointer + omitempty so paths that
 	// don't load labels (e.g. UpdateIssue, batch UpdateIssues, the issue:updated
 	// WS broadcast) emit no `labels` field at all — the client merge then
 	// preserves whatever labels are already in cache. nil pointer = "field
 	// absent, do not touch"; non-nil (incl. empty slice) = authoritative list.
-	Labels             *[]LabelResponse        `json:"labels,omitempty"`
+	Labels *[]LabelResponse `json:"labels,omitempty"`
 }
 
 func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
@@ -286,7 +286,7 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 	}
 
 	escapedPhrase := escapeLike(phrase)
-	phraseParam := nextArg(escapedPhrase)               // $1
+	phraseParam := nextArg(escapedPhrase) // $1
 	phraseContains := "'%' || " + phraseParam + " || '%'"
 	phraseStartsWith := phraseParam + " || '%'"
 
@@ -858,8 +858,9 @@ func (h *Handler) ChildIssueProgress(w http.ResponseWriter, r *http.Request) {
 // into a `multica issue create` invocation in the background; success and
 // failure both surface as inbox notifications to the requester.
 type QuickCreateIssueRequest struct {
-	AgentID string `json:"agent_id"`
-	Prompt  string `json:"prompt"`
+	AgentID   string  `json:"agent_id"`
+	Prompt    string  `json:"prompt"`
+	ProjectID *string `json:"project_id,omitempty"`
 }
 
 // QuickCreateIssueResponse echoes the queued task id so the frontend can
@@ -932,6 +933,27 @@ func (h *Handler) QuickCreateIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var projectID pgtype.UUID
+	if req.ProjectID != nil {
+		rawProjectID := strings.TrimSpace(*req.ProjectID)
+		if rawProjectID == "" {
+			writeError(w, http.StatusBadRequest, "project_id must not be empty")
+			return
+		}
+		id, ok := parseUUIDOrBadRequest(w, rawProjectID, "project_id")
+		if !ok {
+			return
+		}
+		if _, err := h.Queries.GetProjectInWorkspace(r.Context(), db.GetProjectInWorkspaceParams{
+			ID:          id,
+			WorkspaceID: wsUUID,
+		}); err != nil {
+			writeError(w, http.StatusBadRequest, "project not found in this workspace")
+			return
+		}
+		projectID = id
+	}
+
 	// Daemon CLI version gate. The agent-side prompt + create-flow rely on
 	// behaviors introduced in MinQuickCreateCLIVersion (URL attachment
 	// handling, no-retry on partial failure). Older daemons either
@@ -943,7 +965,7 @@ func (h *Handler) QuickCreateIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := h.TaskService.EnqueueQuickCreateTask(r.Context(), wsUUID, requesterUUID, agentUUID, prompt)
+	task, err := h.TaskService.EnqueueQuickCreateTask(r.Context(), wsUUID, requesterUUID, agentUUID, projectID, prompt)
 	if err != nil {
 		slog.Warn("quick-create enqueue failed", append(logger.RequestAttrs(r), "error", err)...)
 		writeError(w, http.StatusInternalServerError, "failed to enqueue quick-create task")
@@ -1042,16 +1064,16 @@ func readRuntimeCLIVersion(metadata []byte) string {
 }
 
 type CreateIssueRequest struct {
-	Title              string   `json:"title"`
-	Description        *string  `json:"description"`
-	Status             string   `json:"status"`
-	Priority           string   `json:"priority"`
-	AssigneeType       *string  `json:"assignee_type"`
-	AssigneeID         *string  `json:"assignee_id"`
-	ParentIssueID      *string  `json:"parent_issue_id"`
-	ProjectID          *string  `json:"project_id"`
-	DueDate            *string  `json:"due_date"`
-	AttachmentIDs      []string `json:"attachment_ids,omitempty"`
+	Title         string   `json:"title"`
+	Description   *string  `json:"description"`
+	Status        string   `json:"status"`
+	Priority      string   `json:"priority"`
+	AssigneeType  *string  `json:"assignee_type"`
+	AssigneeID    *string  `json:"assignee_id"`
+	ParentIssueID *string  `json:"parent_issue_id"`
+	ProjectID     *string  `json:"project_id"`
+	DueDate       *string  `json:"due_date"`
+	AttachmentIDs []string `json:"attachment_ids,omitempty"`
 	// OriginType / OriginID stamp the new issue with its provenance so
 	// platform-internal flows can deterministically locate it later. Only
 	// trusted callers should set these — currently the daemon CLI passes
@@ -1287,16 +1309,16 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 }
 
 type UpdateIssueRequest struct {
-	Title              *string  `json:"title"`
-	Description        *string  `json:"description"`
-	Status             *string  `json:"status"`
-	Priority           *string  `json:"priority"`
-	AssigneeType       *string  `json:"assignee_type"`
-	AssigneeID         *string  `json:"assignee_id"`
-	Position           *float64 `json:"position"`
-	DueDate            *string  `json:"due_date"`
-	ParentIssueID      *string  `json:"parent_issue_id"`
-	ProjectID          *string  `json:"project_id"`
+	Title         *string  `json:"title"`
+	Description   *string  `json:"description"`
+	Status        *string  `json:"status"`
+	Priority      *string  `json:"priority"`
+	AssigneeType  *string  `json:"assignee_type"`
+	AssigneeID    *string  `json:"assignee_id"`
+	Position      *float64 `json:"position"`
+	DueDate       *string  `json:"due_date"`
+	ParentIssueID *string  `json:"parent_issue_id"`
+	ProjectID     *string  `json:"project_id"`
 }
 
 func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -24,6 +25,7 @@ type ProjectResponse struct {
 	Icon        *string `json:"icon"`
 	Status      string  `json:"status"`
 	Priority    string  `json:"priority"`
+	Settings    any     `json:"settings"`
 	LeadType    *string `json:"lead_type"`
 	LeadID      *string `json:"lead_id"`
 	CreatedAt   string  `json:"created_at"`
@@ -33,6 +35,13 @@ type ProjectResponse struct {
 }
 
 func projectToResponse(p db.Project) ProjectResponse {
+	var settings any
+	if p.Settings != nil {
+		json.Unmarshal(p.Settings, &settings)
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
 	return ProjectResponse{
 		ID:          uuidToString(p.ID),
 		WorkspaceID: uuidToString(p.WorkspaceID),
@@ -41,6 +50,7 @@ func projectToResponse(p db.Project) ProjectResponse {
 		Icon:        textToPtr(p.Icon),
 		Status:      p.Status,
 		Priority:    p.Priority,
+		Settings:    settings,
 		LeadType:    textToPtr(p.LeadType),
 		LeadID:      uuidToPtr(p.LeadID),
 		CreatedAt:   timestampToString(p.CreatedAt),
@@ -62,6 +72,7 @@ type CreateProjectRequest struct {
 	Icon        *string                               `json:"icon"`
 	Status      string                                `json:"status"`
 	Priority    string                                `json:"priority"`
+	Settings    any                                   `json:"settings"`
 	LeadType    *string                               `json:"lead_type"`
 	LeadID      *string                               `json:"lead_id"`
 	Resources   []CreateProjectResourceRequestPayload `json:"resources,omitempty"`
@@ -83,8 +94,57 @@ type UpdateProjectRequest struct {
 	Icon        *string `json:"icon"`
 	Status      *string `json:"status"`
 	Priority    *string `json:"priority"`
+	Settings    any     `json:"settings"`
 	LeadType    *string `json:"lead_type"`
 	LeadID      *string `json:"lead_id"`
+}
+
+type projectHooksWire struct {
+	AfterCreate string `json:"after_create,omitempty"`
+}
+
+func marshalProjectSettingsForWrite(settings any) ([]byte, error) {
+	if settings == nil {
+		return []byte("{}"), nil
+	}
+	obj, ok := settings.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("settings must be an object")
+	}
+	if hooksRaw, exists := obj["hooks"]; exists {
+		hooks, ok := hooksRaw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("settings.hooks must be an object")
+		}
+		if afterCreateRaw, exists := hooks["after_create"]; exists {
+			if _, ok := afterCreateRaw.(string); !ok {
+				return nil, fmt.Errorf("settings.hooks.after_create must be a string")
+			}
+		}
+	}
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("settings must be valid JSON: %w", err)
+	}
+	return data, nil
+}
+
+func projectHooksFromSettings(settings []byte) *projectHooksWire {
+	if len(settings) == 0 {
+		return nil
+	}
+	var payload struct {
+		Hooks struct {
+			AfterCreate string `json:"after_create"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(settings, &payload); err != nil {
+		return nil
+	}
+	if payload.Hooks.AfterCreate == "" {
+		return nil
+	}
+	return &projectHooksWire{AfterCreate: payload.Hooks.AfterCreate}
 }
 
 func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
@@ -162,7 +222,8 @@ func (h *Handler) GetProject(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	var req CreateProjectRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	rawFields, err := decodeJSONBodyWithRawFields(r.Body, &req)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
@@ -182,6 +243,15 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	priority := req.Priority
 	if priority == "" {
 		priority = "none"
+	}
+	if raw, ok := rawFields["settings"]; ok && bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		writeError(w, http.StatusBadRequest, "settings must be an object")
+		return
+	}
+	settingsJSON, err := marshalProjectSettingsForWrite(req.Settings)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 	var leadType pgtype.Text
 	var leadID pgtype.UUID
@@ -226,6 +296,7 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		LeadType:    leadType,
 		LeadID:      leadID,
 		Priority:    priority,
+		Settings:    settingsJSON,
 	}
 
 	// Without resources, keep the simple non-tx path.
@@ -311,6 +382,7 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		"icon":         resp.Icon,
 		"status":       resp.Status,
 		"priority":     resp.Priority,
+		"settings":     resp.Settings,
 		"lead_type":    resp.LeadType,
 		"lead_id":      resp.LeadID,
 		"created_at":   resp.CreatedAt,
@@ -371,6 +443,18 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Priority != nil {
 		params.Priority = pgtype.Text{String: *req.Priority, Valid: true}
+	}
+	if _, ok := rawFields["settings"]; ok {
+		if bytes.Equal(bytes.TrimSpace(rawFields["settings"]), []byte("null")) {
+			writeError(w, http.StatusBadRequest, "settings must be an object")
+			return
+		}
+		settingsJSON, err := marshalProjectSettingsForWrite(req.Settings)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		params.Settings = settingsJSON
 	}
 	if _, ok := rawFields["description"]; ok {
 		if req.Description != nil {
@@ -562,7 +646,7 @@ func buildProjectSearchQuery(phrase string, terms []string, includeClosed bool) 
 
 	query := fmt.Sprintf(`SELECT p.id, p.workspace_id, p.title, p.description, p.icon,
 		p.status, p.priority, p.lead_type, p.lead_id,
-		p.created_at, p.updated_at,
+		p.created_at, p.updated_at, p.settings,
 		COUNT(*) OVER() AS total_count,
 		%s AS match_source
 	FROM project p
@@ -648,6 +732,7 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 			&row.project.LeadID,
 			&row.project.CreatedAt,
 			&row.project.UpdatedAt,
+			&row.project.Settings,
 			&row.totalCount,
 			&row.matchSource,
 		); err != nil {

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -103,6 +103,35 @@ type projectHooksWire struct {
 	AfterCreate string `json:"after_create,omitempty"`
 }
 
+func projectSettingsMentionsAfterCreateHook(settings any) bool {
+	obj, ok := settings.(map[string]any)
+	if !ok {
+		return false
+	}
+	hooksRaw, ok := obj["hooks"]
+	if !ok {
+		return false
+	}
+	hooks, ok := hooksRaw.(map[string]any)
+	if !ok {
+		return false
+	}
+	_, exists := hooks["after_create"]
+	return exists
+}
+
+func (h *Handler) requireProjectHookManager(w http.ResponseWriter, r *http.Request, workspaceID string) bool {
+	member, ok := h.workspaceMember(w, r, workspaceID)
+	if !ok {
+		return false
+	}
+	if !roleAllowed(member.Role, "owner", "admin") {
+		writeError(w, http.StatusForbidden, "only workspace owners and admins can configure project setup hooks")
+		return false
+	}
+	return true
+}
+
 func marshalProjectSettingsForWrite(settings any) ([]byte, error) {
 	if settings == nil {
 		return []byte("{}"), nil
@@ -251,6 +280,9 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	settingsJSON, err := marshalProjectSettingsForWrite(req.Settings)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if projectSettingsMentionsAfterCreateHook(req.Settings) && !h.requireProjectHookManager(w, r, workspaceID) {
 		return
 	}
 	var leadType pgtype.Text
@@ -452,6 +484,11 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		settingsJSON, err := marshalProjectSettingsForWrite(req.Settings)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if (projectSettingsMentionsAfterCreateHook(req.Settings) ||
+			projectHooksFromSettings(prevProject.Settings) != nil) &&
+			!h.requireProjectHookManager(w, r, workspaceID) {
 			return
 		}
 		params.Settings = settingsJSON

--- a/server/internal/handler/project_resource_test.go
+++ b/server/internal/handler/project_resource_test.go
@@ -162,6 +162,71 @@ func TestProjectSettingsRejectMalformedHooks(t *testing.T) {
 	}
 }
 
+func TestProjectSettingsHooksRequireAdminRole(t *testing.T) {
+	memberUserID := createRuntimeLocalSkillTestMember(t, "member")
+
+	w := httptest.NewRecorder()
+	req := newRequestAsUser(memberUserID, http.MethodPost, "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Member hook project",
+		"settings": map[string]any{
+			"hooks": map[string]any{
+				"after_create": "echo no",
+			},
+		},
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("CreateProject with hook as member: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Owner-created hook target",
+		"settings": map[string]any{
+			"hooks": map[string]any{
+				"after_create": "echo yes",
+			},
+		},
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateProject: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+		t.Fatalf("decode CreateProject: %v", err)
+	}
+	defer func() {
+		req := newRequest("DELETE", "/api/projects/"+project.ID, nil)
+		req = withURLParam(req, "id", project.ID)
+		testHandler.DeleteProject(httptest.NewRecorder(), req)
+	}()
+
+	w = httptest.NewRecorder()
+	req = newRequestAsUser(memberUserID, http.MethodPut, "/api/projects/"+project.ID, map[string]any{
+		"settings": map[string]any{},
+	})
+	req = withURLParam(req, "id", project.ID)
+	testHandler.UpdateProject(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("UpdateProject clearing hook as member: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequestAsUser(memberUserID, http.MethodPut, "/api/projects/"+project.ID, map[string]any{
+		"settings": map[string]any{
+			"hooks": map[string]any{
+				"after_create": "echo no",
+			},
+		},
+	})
+	req = withURLParam(req, "id", project.ID)
+	testHandler.UpdateProject(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("UpdateProject with hook as member: expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestProjectResourceLifecycle(t *testing.T) {
 	// Create a project to attach resources to.
 	w := httptest.NewRecorder()

--- a/server/internal/handler/project_resource_test.go
+++ b/server/internal/handler/project_resource_test.go
@@ -7,6 +7,161 @@ import (
 	"testing"
 )
 
+func TestProjectSettingsHooksAfterCreateRoundTrip(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Settings hook project",
+		"settings": map[string]any{
+			"hooks": map[string]any{
+				"after_create": "git clone https://github.com/example/repo.git .",
+			},
+		},
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateProject: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+		t.Fatalf("decode CreateProject: %v", err)
+	}
+	defer func() {
+		req := newRequest("DELETE", "/api/projects/"+project.ID, nil)
+		req = withURLParam(req, "id", project.ID)
+		testHandler.DeleteProject(httptest.NewRecorder(), req)
+	}()
+
+	settings := project.Settings.(map[string]any)
+	hooks := settings["hooks"].(map[string]any)
+	if got := hooks["after_create"]; got != "git clone https://github.com/example/repo.git ." {
+		t.Fatalf("create settings hooks.after_create = %q", got)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("PUT", "/api/projects/"+project.ID, map[string]any{
+		"settings": map[string]any{
+			"hooks": map[string]any{
+				"after_create": "corepack pnpm install --frozen-lockfile",
+			},
+		},
+	})
+	req = withURLParam(req, "id", project.ID)
+	testHandler.UpdateProject(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateProject: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var updated ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode UpdateProject: %v", err)
+	}
+	settings = updated.Settings.(map[string]any)
+	hooks = settings["hooks"].(map[string]any)
+	if got := hooks["after_create"]; got != "corepack pnpm install --frozen-lockfile" {
+		t.Fatalf("updated settings hooks.after_create = %q", got)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/projects/"+project.ID, nil)
+	req = withURLParam(req, "id", project.ID)
+	testHandler.GetProject(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetProject: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var fetched ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&fetched); err != nil {
+		t.Fatalf("decode GetProject: %v", err)
+	}
+	settings = fetched.Settings.(map[string]any)
+	hooks = settings["hooks"].(map[string]any)
+	if got := hooks["after_create"]; got != "corepack pnpm install --frozen-lockfile" {
+		t.Fatalf("fetched settings hooks.after_create = %q", got)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/projects?workspace_id="+testWorkspaceID, nil)
+	testHandler.ListProjects(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListProjects: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var listed struct {
+		Projects []ProjectResponse `json:"projects"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode ListProjects: %v", err)
+	}
+	found := false
+	for _, p := range listed.Projects {
+		if p.ID != project.ID {
+			continue
+		}
+		found = true
+		settings = p.Settings.(map[string]any)
+		hooks = settings["hooks"].(map[string]any)
+		if got := hooks["after_create"]; got != "corepack pnpm install --frozen-lockfile" {
+			t.Fatalf("listed settings hooks.after_create = %q", got)
+		}
+	}
+	if !found {
+		t.Fatalf("project %s missing from list response", project.ID)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/search/projects?workspace_id="+testWorkspaceID+"&q=Settings", nil)
+	testHandler.SearchProjects(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("SearchProjects: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var searched struct {
+		Projects []SearchProjectResponse `json:"projects"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&searched); err != nil {
+		t.Fatalf("decode SearchProjects: %v", err)
+	}
+	found = false
+	for _, p := range searched.Projects {
+		if p.ID != project.ID {
+			continue
+		}
+		found = true
+		settings = p.Settings.(map[string]any)
+		hooks = settings["hooks"].(map[string]any)
+		if got := hooks["after_create"]; got != "corepack pnpm install --frozen-lockfile" {
+			t.Fatalf("searched settings hooks.after_create = %q", got)
+		}
+	}
+	if !found {
+		t.Fatalf("project %s missing from search response", project.ID)
+	}
+}
+
+func TestProjectSettingsRejectMalformedHooks(t *testing.T) {
+	for name, body := range map[string]map[string]any{
+		"settings array": {
+			"title":    "Bad settings",
+			"settings": []any{"not", "object"},
+		},
+		"hooks string": {
+			"title":    "Bad hooks",
+			"settings": map[string]any{"hooks": "nope"},
+		},
+		"after_create number": {
+			"title": "Bad after_create",
+			"settings": map[string]any{
+				"hooks": map[string]any{"after_create": 42},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, body)
+			testHandler.CreateProject(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("CreateProject: expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestProjectResourceLifecycle(t *testing.T) {
 	// Create a project to attach resources to.
 	w := httptest.NewRecorder()
@@ -204,4 +359,3 @@ func TestCreateProjectRollsBackOnInvalidResource(t *testing.T) {
 		}
 	}
 }
-

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -212,6 +212,7 @@ type QuickCreateContext struct {
 	Prompt      string `json:"prompt"`
 	RequesterID string `json:"requester_id"`
 	WorkspaceID string `json:"workspace_id"`
+	ProjectID   string `json:"project_id,omitempty"`
 }
 
 // QuickCreateContextType marks a task as a quick-create job.
@@ -223,7 +224,7 @@ const QuickCreateContextType = "quick_create"
 // `multica issue create` call. Pre-validates that the agent is reachable
 // (not archived, has a runtime) so the API can reject up-front rather than
 // queue a task no one will ever claim.
-func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, requesterID pgtype.UUID, agentID pgtype.UUID, prompt string) (db.AgentTaskQueue, error) {
+func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, requesterID pgtype.UUID, agentID pgtype.UUID, projectID pgtype.UUID, prompt string) (db.AgentTaskQueue, error) {
 	agent, err := s.Queries.GetAgent(ctx, agentID)
 	if err != nil {
 		return db.AgentTaskQueue{}, fmt.Errorf("load agent: %w", err)
@@ -240,6 +241,9 @@ func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, r
 		Prompt:      prompt,
 		RequesterID: util.UUIDToString(requesterID),
 		WorkspaceID: util.UUIDToString(workspaceID),
+	}
+	if projectID.Valid {
+		payload.ProjectID = util.UUIDToString(projectID)
 	}
 	contextJSON, err := json.Marshal(payload)
 	if err != nil {

--- a/server/migrations/068_project_settings.down.sql
+++ b/server/migrations/068_project_settings.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project
+  DROP COLUMN settings;

--- a/server/migrations/068_project_settings.up.sql
+++ b/server/migrations/068_project_settings.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project
+  ADD COLUMN settings JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1450,7 +1450,7 @@ func (q *Queries) ListPendingTasksByRuntime(ctx context.Context, runtimeID pgtyp
 }
 
 const listQueuedClaimCandidatesByRuntime = `-- name: ListQueuedClaimCandidatesByRuntime :many
-SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, trigger_summary FROM agent_task_queue
+SELECT id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, last_heartbeat_at, trigger_summary, force_fresh_session FROM agent_task_queue
 WHERE runtime_id = $1 AND status = 'queued'
 ORDER BY priority DESC, created_at ASC
 `
@@ -1497,6 +1497,7 @@ func (q *Queries) ListQueuedClaimCandidatesByRuntime(ctx context.Context, runtim
 			&i.FailureReason,
 			&i.LastHeartbeatAt,
 			&i.TriggerSummary,
+			&i.ForceFreshSession,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -365,6 +365,7 @@ type Project struct {
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 	Priority    string             `json:"priority"`
+	Settings    []byte             `json:"settings"`
 }
 
 type ProjectResource struct {

--- a/server/pkg/db/generated/project.sql.go
+++ b/server/pkg/db/generated/project.sql.go
@@ -26,10 +26,11 @@ func (q *Queries) CountIssuesByProject(ctx context.Context, projectID pgtype.UUI
 const createProject = `-- name: CreateProject :one
 INSERT INTO project (
     workspace_id, title, description, icon, status,
-    lead_type, lead_id, priority
+    lead_type, lead_id, priority, settings
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
-) RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority
+    $1, $2, $3, $4, $5, $6, $7, $8,
+    COALESCE($9::jsonb, '{}'::jsonb)
+) RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, settings
 `
 
 type CreateProjectParams struct {
@@ -41,6 +42,7 @@ type CreateProjectParams struct {
 	LeadType    pgtype.Text `json:"lead_type"`
 	LeadID      pgtype.UUID `json:"lead_id"`
 	Priority    string      `json:"priority"`
+	Settings    []byte      `json:"settings"`
 }
 
 func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (Project, error) {
@@ -53,6 +55,7 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 		arg.LeadType,
 		arg.LeadID,
 		arg.Priority,
+		arg.Settings,
 	)
 	var i Project
 	err := row.Scan(
@@ -67,6 +70,7 @@ func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (P
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Priority,
+		&i.Settings,
 	)
 	return i, err
 }
@@ -81,7 +85,7 @@ func (q *Queries) DeleteProject(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getProject = `-- name: GetProject :one
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, settings FROM project
 WHERE id = $1
 `
 
@@ -100,12 +104,13 @@ func (q *Queries) GetProject(ctx context.Context, id pgtype.UUID) (Project, erro
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Priority,
+		&i.Settings,
 	)
 	return i, err
 }
 
 const getProjectInWorkspace = `-- name: GetProjectInWorkspace :one
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, settings FROM project
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -129,6 +134,7 @@ func (q *Queries) GetProjectInWorkspace(ctx context.Context, arg GetProjectInWor
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Priority,
+		&i.Settings,
 	)
 	return i, err
 }
@@ -169,7 +175,7 @@ func (q *Queries) GetProjectIssueStats(ctx context.Context, projectIds []pgtype.
 }
 
 const listProjects = `-- name: ListProjects :many
-SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority FROM project
+SELECT id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, settings FROM project
 WHERE workspace_id = $1
   AND ($2::text IS NULL OR status = $2)
   AND ($3::text IS NULL OR priority = $3)
@@ -203,6 +209,7 @@ func (q *Queries) ListProjects(ctx context.Context, arg ListProjectsParams) ([]P
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.Priority,
+			&i.Settings,
 		); err != nil {
 			return nil, err
 		}
@@ -221,11 +228,12 @@ UPDATE project SET
     icon = $4,
     status = COALESCE($5, status),
     priority = COALESCE($6, priority),
-    lead_type = $7,
-    lead_id = $8,
+    settings = COALESCE($7::jsonb, settings),
+    lead_type = $8,
+    lead_id = $9,
     updated_at = now()
 WHERE id = $1
-RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority
+RETURNING id, workspace_id, title, description, icon, status, lead_type, lead_id, created_at, updated_at, priority, settings
 `
 
 type UpdateProjectParams struct {
@@ -235,6 +243,7 @@ type UpdateProjectParams struct {
 	Icon        pgtype.Text `json:"icon"`
 	Status      pgtype.Text `json:"status"`
 	Priority    pgtype.Text `json:"priority"`
+	Settings    []byte      `json:"settings"`
 	LeadType    pgtype.Text `json:"lead_type"`
 	LeadID      pgtype.UUID `json:"lead_id"`
 }
@@ -247,6 +256,7 @@ func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (P
 		arg.Icon,
 		arg.Status,
 		arg.Priority,
+		arg.Settings,
 		arg.LeadType,
 		arg.LeadID,
 	)
@@ -263,6 +273,7 @@ func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) (P
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Priority,
+		&i.Settings,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/project.sql
+++ b/server/pkg/db/queries/project.sql
@@ -16,9 +16,10 @@ WHERE id = $1 AND workspace_id = $2;
 -- name: CreateProject :one
 INSERT INTO project (
     workspace_id, title, description, icon, status,
-    lead_type, lead_id, priority
+    lead_type, lead_id, priority, settings
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8,
+    COALESCE(sqlc.narg('settings')::jsonb, '{}'::jsonb)
 ) RETURNING *;
 
 -- name: UpdateProject :one
@@ -28,6 +29,7 @@ UPDATE project SET
     icon = sqlc.narg('icon'),
     status = COALESCE(sqlc.narg('status'), status),
     priority = COALESCE(sqlc.narg('priority'), priority),
+    settings = COALESCE(sqlc.narg('settings')::jsonb, settings),
     lead_type = sqlc.narg('lead_type'),
     lead_id = sqlc.narg('lead_id'),
     updated_at = now()


### PR DESCRIPTION
## Summary

Adds project-scoped setup hooks for agent execution environments.

Projects can store `settings.hooks.after_create`. When an agent task is claimed for an issue or quick-create flow scoped to that project, the daemon receives the hook through the claim payload and runs it once for a fresh task workdir before writing Multica context files, provider config, skills, or starting the provider.

## What changed

- Add `project.settings` JSONB storage and API validation.
- Add project settings UI for editing the setup hook.
- Include project hooks and project resources in daemon claim payloads.
- Run `hooks.after_create` in fresh execenv workdirs and block provider startup if setup fails.
- Capture hook output in `logs/after_create.log` with bounded stdout/stderr growth.
- Add Codex per-task trusted project config for generated workdirs.
- Allow quick-create tasks to be scoped to a project.
- Restrict project setup-hook configuration to workspace owners/admins.
- Document setup-hook runtime behavior in project resources docs.

## Trust model

Setup hooks execute shell on the daemon host. This draft gates hook configuration to workspace owners/admins, caps hook log output, labels the shell contract as `sh`, and gives hooks the same `multica` CLI `PATH` guarantee as provider processes. Maintainer review should still confirm whether this trust boundary is sufficient for upstream.

## Validation

- `pnpm --filter @multica/views exec vitest run modals/quick-create-issue.test.tsx`
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/docs typecheck`
- `git diff --check upstream/main...HEAD`

Not run: Go tests. This local worktree does not have `go` or `gofmt` on `PATH`.
