### PR TITLE
fix(daemon): trust the agent's session id on resume across ACP backends (hermes, kimi, kiro)

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -194,8 +194,15 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
 			}
-			sessionID = opts.ResumeSessionID
-			_ = result
+			var changed bool
+			sessionID, changed = resolveResumedSessionID(opts.ResumeSessionID, result)
+			if changed {
+				b.cfg.Logger.Warn("agent returned a different session id on resume — original was likely lost; continuing with the new id",
+					"backend", "hermes",
+					"requested", opts.ResumeSessionID,
+					"actual", sessionID,
+				)
+			}
 		} else {
 			result, err := c.request(runCtx, "session/new", buildHermesSessionParams(cwd, opts.Model))
 			if err != nil {
@@ -1072,6 +1079,24 @@ func extractACPSessionID(result json.RawMessage) string {
 		return ""
 	}
 	return r.SessionID
+}
+
+// resolveResumedSessionID picks which session id we should treat as live
+// after a `session/resume` round-trip. Hermes (and other ACP servers)
+// return the canonical sessionId in the response — when the local
+// state.db has been wiped, the server silently creates a brand-new
+// session and returns its new id rather than failing. If we keep using
+// our requested id in that case, every subsequent session/prompt is
+// addressed to a session the server doesn't know about and fails with
+// JSON-RPC -32603. Returns (chosenID, changed). When the response is
+// malformed or omits sessionId we fall back to the requested id so the
+// happy path keeps working against older / non-conforming servers.
+func resolveResumedSessionID(requested string, response json.RawMessage) (string, bool) {
+	got := extractACPSessionID(response)
+	if got == "" {
+		return requested, false
+	}
+	return got, got != requested
 }
 
 // buildHermesSessionParams constructs the params map for the ACP `session/new`

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -48,6 +48,63 @@ func TestExtractACPSessionIDInvalidJSON(t *testing.T) {
 	}
 }
 
+// ── resolveResumedSessionID ──
+
+func TestResolveResumedSessionIDMatching(t *testing.T) {
+	t.Parallel()
+	// Server confirms our requested id — happy resume path. No change.
+	got, changed := resolveResumedSessionID(
+		"ses_alpha",
+		json.RawMessage(`{"sessionId":"ses_alpha"}`),
+	)
+	if got != "ses_alpha" {
+		t.Errorf("got %q, want ses_alpha", got)
+	}
+	if changed {
+		t.Errorf("changed: got true, want false")
+	}
+}
+
+func TestResolveResumedSessionIDDifferent(t *testing.T) {
+	t.Parallel()
+	// Server returned a different id — local state was lost and the
+	// server silently spun up a new session. We trust the server.
+	got, changed := resolveResumedSessionID(
+		"ses_alpha",
+		json.RawMessage(`{"sessionId":"ses_beta_new"}`),
+	)
+	if got != "ses_beta_new" {
+		t.Errorf("got %q, want ses_beta_new", got)
+	}
+	if !changed {
+		t.Errorf("changed: got false, want true")
+	}
+}
+
+func TestResolveResumedSessionIDEmptyResponse(t *testing.T) {
+	t.Parallel()
+	// Older / non-conforming server returns no sessionId — defensive
+	// fallback to the requested id. This preserves the legacy happy
+	// path; a stale id will eventually fail downstream and be retried
+	// via the daemon's session-resume fallback (daemon.go).
+	for _, body := range []string{
+		`{}`,
+		`{"sessionId":""}`,
+		`not json`,
+	} {
+		got, changed := resolveResumedSessionID(
+			"ses_alpha",
+			json.RawMessage(body),
+		)
+		if got != "ses_alpha" {
+			t.Errorf("body=%q: got %q, want ses_alpha", body, got)
+		}
+		if changed {
+			t.Errorf("body=%q: changed: got true, want false", body)
+		}
+	}
+}
+
 // ── buildHermesSessionParams ──
 
 func TestBuildHermesSessionParamsIncludesModel(t *testing.T) {

--- a/server/pkg/agent/kimi.go
+++ b/server/pkg/agent/kimi.go
@@ -190,8 +190,15 @@ func (b *kimiBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
 			}
-			sessionID = opts.ResumeSessionID
-			_ = result
+			var changed bool
+			sessionID, changed = resolveResumedSessionID(opts.ResumeSessionID, result)
+			if changed {
+				b.cfg.Logger.Warn("agent returned a different session id on resume — original was likely lost; continuing with the new id",
+					"backend", "kimi",
+					"requested", opts.ResumeSessionID,
+					"actual", sessionID,
+				)
+			}
 		} else {
 			result, err := c.request(runCtx, "session/new", map[string]any{
 				"cwd":        cwd,

--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -171,7 +171,7 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		}
 
 		if opts.ResumeSessionID != "" {
-			_, err := c.request(runCtx, "session/load", map[string]any{
+			result, err := c.request(runCtx, "session/load", map[string]any{
 				"cwd":        cwd,
 				"sessionId":  opts.ResumeSessionID,
 				"mcpServers": []any{},
@@ -182,7 +182,23 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
 			}
-			sessionID = opts.ResumeSessionID
+			// Apply the same defensive resolution kimi/hermes use: if
+			// kiro echoes a sessionId in the session/load response, prefer
+			// it (the canonical id the backend is committed to). When the
+			// response is empty or doesn't include sessionId — kiro's
+			// current observed shape — the helper falls back to the
+			// requested id, preserving today's behavior. Fixing this here
+			// too means a future kiro that DOES return a different id on
+			// silent state reset is handled the same way as hermes/kimi.
+			var changed bool
+			sessionID, changed = resolveResumedSessionID(opts.ResumeSessionID, result)
+			if changed {
+				b.cfg.Logger.Warn("agent returned a different session id on resume — original was likely lost; continuing with the new id",
+					"backend", "kiro",
+					"requested", opts.ResumeSessionID,
+					"actual", sessionID,
+				)
+			}
 		} else {
 			result, err := c.request(runCtx, "session/new", map[string]any{
 				"cwd":        cwd,


### PR DESCRIPTION
## Summary

When the local `state.db` of an ACP backend (hermes, kimi, kiro) is wiped — crash, config change, manual kill, container reset — the backend's `session/resume` (or `session/load`, for kiro) **silently creates a brand-new session** rather than failing, and returns the new id in the response. Today the daemon ignores the response and stamps `sessionID = opts.ResumeSessionID` across all three backends, so every subsequent `session/prompt` is addressed to a session id the backend has no record of. The task fails with JSON-RPC `-32603 (Internal error)` on the very first turn, with no operator-visible signal that the problem is a session-id mismatch one layer down.

The failure is invisible: the UI shows "started" → "failed" with a generic Internal error. Reproducing in production took repeated runs because nothing in the logs pointed at the silent reset.

## Backends covered

| Backend | Protocol method | Status before this PR | Status after |
|---|---|---|---|
| **hermes** | `session/resume` | confirmed root cause of `-32603` in production | fixed |
| **kimi** | `session/resume` (same response schema as hermes per `extractACPSessionID`) | identical code pattern, same bug, just less commonly hit | fixed |
| **kiro** | `session/load` | same code pattern, different method; current observed response doesn't include `sessionId` | routed through the same helper defensively — today's behavior preserved (helper falls back to requested id when response is empty), and a future kiro release that DOES return a sessionId on silent reset gets the fix automatically |

Backends not affected: claude, codex, copilot, gemini, openclaw, opencode, pi, cursor — they don't use the ACP `session/resume` shape.

## Repro

1. Run an agent task on issue X — backend creates session `ses_alpha`, daemon stores it.
2. Restart the backend (or anything that resets its `state.db`).
3. Trigger a follow-up task on issue X.
4. Daemon sends `session/resume {sessionId: ses_alpha}`. Backend has no record, **returns 200 with `{sessionId: ses_beta_new}`**.
5. Daemon ignores the response, sets `sessionID = ses_alpha`, sends `session/prompt {sessionId: ses_alpha, ...}`.
6. Backend: `-32603 Internal error`.
7. Task fails. Repeat forever until the issue's stored session id is purged manually.

## Why the existing daemon-level fallback doesn't catch it

`server/internal/daemon/daemon.go:1554-1566` already has a fallback that retries with a fresh session when resume fails. **It only triggers when `result.Status == "failed" && result.SessionID == ""`** — but in this failure mode the backend *does* give us a `result.SessionID`, it's just the new one the backend silently committed to. The fallback never fires.

Fixing this inside the ACP backends is the right level — the daemon's contract is "the Backend returns the session id we should reuse next time," and `extractACPSessionID` is already documented in code as shared between `session/new` and `session/resume`:

```go
// extractACPSessionID pulls `sessionId` out of a session/new or
// session/resume response. Shared by all ACP backends (hermes, kimi, kiro,
// and anything else that follows the standard ACP schema).
func extractACPSessionID(result json.RawMessage) string { ... }
```

`session/new` already uses it. `session/resume` (and `session/load`) didn't — until now.

## Fix

Introduces a small `resolveResumedSessionID` helper in `hermes.go` (where the rest of the ACP scaffolding lives) and routes all three backends through it:

```go
sessionID, changed := resolveResumedSessionID(opts.ResumeSessionID, result)
if changed {
    b.cfg.Logger.Warn("agent returned a different session id on resume — original was likely lost; continuing with the new id",
        "backend", "<hermes|kimi|kiro>",
        "requested", opts.ResumeSessionID,
        "actual", sessionID,
    )
}
```

The helper:
- **Prefers the id the backend returned** in its response (the canonical id).
- **Falls back to the requested id** when the response is malformed, empty, or omits `sessionId` — defensive fallback that preserves today's behavior for older / non-conforming backends. This is what makes it safe to apply to kiro's `session/load` even before confirming its response shape.
- **Signals when the id changed** so the caller logs a Warn with `backend=<name>` and operators can grep for silent state resets and correlate them with task failures.

## Test plan

- [x] `go test ./server/pkg/agent/...` — full package green (45 tests).
- [x] New helper tests in `server/pkg/agent/hermes_test.go` (one helper, three backends share it; no per-backend duplication):
  - `TestResolveResumedSessionIDMatching` — backend confirms requested id, no change signaled
  - `TestResolveResumedSessionIDDifferent` — backend returned a new id, caller is told to switch
  - `TestResolveResumedSessionIDEmptyResponse` — older / malformed body; defensive fallback (covers kiro's current shape)
- [x] Manual repro on a self-hosted install: kill the Hermes process between two tasks on the same issue, second task now succeeds (lands on the new sessionId Hermes returned) instead of failing with `-32603`. Same logic now applies to kimi/kiro mechanically.

## Compatibility

- Behavior unchanged on the happy path (backend returns the same id we asked for).
- No schema, API, or wire-protocol change.
- `force_fresh_session` machinery (migration `066`) is unaffected; this is purely about correctly handling the existing response shape.
- kiro's current `session/load` response shape is preserved — defensive fallback means it routes through the helper without changing today's behavior.

## Out of scope

- Surfacing the silent reset in the UI / inbox — happy to add a follow-up that writes a notification when `changed=true`. Held off here to keep the fix small.
- Hermes-side improvement (returning an error instead of silently creating a new session) — would be the cleanest long-term fix but lives outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
