### PR TITLE
feat(daemon): inject peer agents into the agent's runtime context

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1332,6 +1332,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		ProjectID:               task.ProjectID,
 		ProjectTitle:            task.ProjectTitle,
 		ProjectResources:        convertProjectResourcesForEnv(task.ProjectResources),
+		PeerAgents:              convertPeerAgentsForEnv(task.PeerAgents),
 		ChatSessionID:           task.ChatSessionID,
 		AutopilotRunID:          task.AutopilotRunID,
 		AutopilotID:             task.AutopilotID,
@@ -1905,6 +1906,21 @@ func convertProjectResourcesForEnv(resources []ProjectResourceData) []execenv.Pr
 			ResourceType: r.ResourceType,
 			ResourceRef:  r.ResourceRef,
 			Label:        r.Label,
+		}
+	}
+	return result
+}
+
+func convertPeerAgentsForEnv(peers []PeerAgentData) []execenv.PeerAgentForEnv {
+	if len(peers) == 0 {
+		return nil
+	}
+	result := make([]execenv.PeerAgentForEnv, len(peers))
+	for i, p := range peers {
+		result[i] = execenv.PeerAgentForEnv{
+			ID:           p.ID,
+			Name:         p.Name,
+			Instructions: p.Instructions,
 		}
 	}
 	return result

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -29,6 +29,17 @@ type ProjectResourceForEnv struct {
 	Label        string          // optional user-supplied label
 }
 
+// PeerAgentForEnv describes another non-archived agent in the same workspace
+// as the claiming agent. The runtime config renders a "Peer Agents" section
+// listing them by name and id, so orchestrators that select an assignee
+// (e.g. via `multica issue assign --to <name>`) can resolve a real peer
+// instead of self-assigning because they don't know other agents exist.
+type PeerAgentForEnv struct {
+	ID           string
+	Name         string
+	Instructions string // short description / role; surfaced as a one-liner
+}
+
 // PrepareParams holds all inputs needed to set up an execution environment.
 type PrepareParams struct {
 	WorkspacesRoot string            // base path for all envs (e.g., ~/multica_workspaces)
@@ -52,6 +63,7 @@ type TaskContextForEnv struct {
 	ProjectID               string                  // issue's project, when present
 	ProjectTitle            string                  // human-readable project title
 	ProjectResources        []ProjectResourceForEnv // resources attached to the project
+	PeerAgents              []PeerAgentForEnv       // other non-archived agents in this workspace, surfaced to orchestrators so they can route by name
 	ChatSessionID           string                  // non-empty for chat tasks
 	AutopilotRunID          string              // non-empty for autopilot run_only tasks
 	AutopilotID             string

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -219,6 +219,108 @@ func TestPrepareWithProjectResources(t *testing.T) {
 	}
 }
 
+// TestPrepareWithPeerAgents covers the orchestrator-routing fix: when the
+// claiming agent has peers in the same workspace, runtime_config.md
+// surfaces them by name + id so an orchestrator-style agent (e.g. one that
+// delegates coding work) can route to a peer instead of self-assigning
+// because it doesn't know other agents exist.
+func TestPrepareWithPeerAgents(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+
+	taskCtx := TaskContextForEnv{
+		IssueID: "44444444-5555-6666-7777-888888888888",
+		PeerAgents: []PeerAgentForEnv{
+			{
+				ID:           "aaaa1111-bbbb-2222-cccc-333344445555",
+				Name:         "Claude Code",
+				Instructions: "Coding agent. Implements features and fixes bugs in code.\nUse for any task that involves writing or modifying source files.",
+			},
+			{
+				ID:   "bbbb2222-cccc-3333-dddd-444455556666",
+				Name: "Reviewer",
+			},
+		},
+	}
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-peer-agents",
+		TaskID:         "44444444-5555-6666-7777-888888888888",
+		AgentName:      "Test Orchestrator",
+		Provider:       "claude",
+		Task:           taskCtx,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if err := InjectRuntimeConfig(env.WorkDir, "claude", taskCtx); err != nil {
+		t.Fatalf("InjectRuntimeConfig: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(env.WorkDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	s := string(content)
+	for _, want := range []string{
+		"## Peer Agents in this Workspace",
+		"**Claude Code**",
+		"aaaa1111-bbbb-2222-cccc-333344445555",
+		// First non-empty line of multi-line instructions only — proves
+		// we're surfacing the role one-liner, not pasting the whole
+		// instruction block.
+		"Coding agent. Implements features and fixes bugs in code.",
+		"**Reviewer**",
+		// Reassignment hint — the actionable next step for an
+		// orchestrator that just decided to route to a peer.
+		"multica issue assign",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("CLAUDE.md missing %q", want)
+		}
+	}
+	// Must NOT bleed the second line of the multi-line peer instructions.
+	if strings.Contains(s, "Use for any task that involves writing or modifying source files.") {
+		t.Errorf("CLAUDE.md leaked second line of peer instructions; should only show first line")
+	}
+}
+
+// TestPrepareWithoutPeerAgents covers the negative path: a single-agent
+// workspace renders no Peer Agents section so we don't pollute the prompt
+// with an empty heading.
+func TestPrepareWithoutPeerAgents(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+	taskCtx := TaskContextForEnv{
+		IssueID:    "55555555-6666-7777-8888-999999999999",
+		PeerAgents: nil,
+	}
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-no-peers",
+		TaskID:         "55555555-6666-7777-8888-999999999999",
+		AgentName:      "Solo Agent",
+		Provider:       "claude",
+		Task:           taskCtx,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if err := InjectRuntimeConfig(env.WorkDir, "claude", taskCtx); err != nil {
+		t.Fatalf("InjectRuntimeConfig: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(env.WorkDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if strings.Contains(string(content), "Peer Agents in this Workspace") {
+		t.Errorf("CLAUDE.md unexpectedly rendered Peer Agents section with no peers")
+	}
+}
+
 // When the issue's project has its own github_repo resources, those should be
 // the only repos rendered in the meta-skill — workspace-level repos must not
 // leak into the agent prompt to avoid confusing it about which repo to use.

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -101,6 +101,31 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("\n\n")
 	}
 
+	// Inject peer agents — every other non-archived agent in the workspace.
+	// Orchestrator-style agents (the picker, Hermes, etc.) need to know who
+	// the other agents are so they can route work by name (`multica issue
+	// assign --to <name>` or `--assignee <name>` on create) instead of self-
+	// assigning because they don't realise other agents exist. The block is
+	// agent-name-agnostic — it lists peers as data, never hardcodes which
+	// peer to pick; the agent's own instructions decide the routing policy.
+	if len(ctx.PeerAgents) > 0 {
+		b.WriteString("## Peer Agents in this Workspace\n\n")
+		b.WriteString("Other agents are available in this workspace. When delegating work (creating issues for others, reassigning, picking an assignee), refer to them by name. Do not assume you are the only agent — if a task is outside your role, route it to a peer instead of self-assigning.\n\n")
+		for _, p := range ctx.PeerAgents {
+			fmt.Fprintf(&b, "- **%s** (id: `%s`)", p.Name, p.ID)
+			if trimmed := strings.TrimSpace(p.Instructions); trimmed != "" {
+				// First non-empty line of the peer's instructions —
+				// usually their role/persona one-liner.
+				if idx := strings.IndexByte(trimmed, '\n'); idx > 0 {
+					trimmed = trimmed[:idx]
+				}
+				fmt.Fprintf(&b, " — %s", trimmed)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\nUse `multica issue assign <issue-id> --to <name>` to reassign, or `--assignee <name>` on `multica issue create` to dispatch a new issue to a peer.\n\n")
+	}
+
 	b.WriteString("## Available Commands\n\n")
 	b.WriteString("**Always use `--output json` for all read commands** to get structured data with full IDs.\n\n")
 	b.WriteString("### Read\n")

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -30,6 +30,16 @@ type ProjectResourceData struct {
 	Label        string          `json:"label,omitempty"`
 }
 
+// PeerAgentData mirrors handler.PeerAgentData — a non-archived peer agent
+// in the same workspace as the claiming agent. Sent so orchestrator agents
+// can route work by name instead of self-assigning because they don't know
+// what other agents exist.
+type PeerAgentData struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Instructions string `json:"instructions,omitempty"`
+}
+
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
@@ -43,6 +53,7 @@ type Task struct {
 	ProjectID               string                `json:"project_id,omitempty"`        // issue's project, when present
 	ProjectTitle            string                `json:"project_title,omitempty"`     // human-readable project title for context injection
 	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"` // project-scoped resources to expose to the agent
+	PeerAgents              []PeerAgentData       `json:"peer_agents,omitempty"`       // other non-archived agents in the same workspace, for orchestrator routing
 	PriorSessionID          string          `json:"prior_session_id,omitempty"`          // Claude session ID from a previous task on this issue
 	PriorWorkDir            string          `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on this issue
 	TriggerCommentID        string          `json:"trigger_comment_id,omitempty"`        // comment that triggered this task

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -155,6 +155,7 @@ type AgentTaskResponse struct {
 	ProjectID               string                `json:"project_id,omitempty"`         // issue's project, when present
 	ProjectTitle            string                `json:"project_title,omitempty"`      // for surfacing in agent context
 	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"`  // resources attached to the project
+	PeerAgents              []PeerAgentData       `json:"peer_agents,omitempty"`        // other agents in the same workspace (excluding the claiming agent), so orchestrators can route to peers by name/id
 	CreatedAt               string          `json:"created_at"`
 	PriorSessionID          string          `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
 	PriorWorkDir            string          `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
@@ -186,6 +187,15 @@ type TaskAgentData struct {
 	CustomArgs   []string                 `json:"custom_args,omitempty"`
 	McpConfig    json.RawMessage          `json:"mcp_config,omitempty"`
 	Model        string                   `json:"model,omitempty"`
+}
+
+// PeerAgentData is a lightweight projection of another agent in the same
+// workspace, sent to the claiming agent so orchestrators can route work to
+// peers by name. Excludes the claiming agent itself and archived agents.
+type PeerAgentData struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Instructions string `json:"instructions,omitempty"` // short description / role; useful for orchestrators picking the right peer
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1133,7 +1133,34 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("task claimed by runtime", "task_id", uuidToString(task.ID), "runtime_id", runtimeID, "agent_id", uuidToString(task.AgentID), "prior_session", resp.PriorSessionID)
+	// Inject peer agents — every other non-archived agent in the workspace.
+	// Orchestrator agents (Hermes, picker patterns, etc.) need to know which
+	// peers exist so they can route work by name instead of self-assigning
+	// because they don't realise a coding agent is available. Best-effort:
+	// failure to list logs and continues with an empty list rather than
+	// failing the claim.
+	if workspaceUUID, err := util.ParseUUID(resp.WorkspaceID); err == nil {
+		if peers, err := h.Queries.ListAgents(r.Context(), workspaceUUID); err == nil {
+			out := make([]PeerAgentData, 0, len(peers))
+			for _, p := range peers {
+				if uuidToString(p.ID) == uuidToString(task.AgentID) {
+					continue // exclude the claiming agent
+				}
+				out = append(out, PeerAgentData{
+					ID:           uuidToString(p.ID),
+					Name:         p.Name,
+					Instructions: p.Instructions,
+				})
+			}
+			if len(out) > 0 {
+				resp.PeerAgents = out
+			}
+		} else {
+			slog.Warn("task claim: failed to list peer agents (continuing without)", "workspace_id", resp.WorkspaceID, "error", err)
+		}
+	}
+
+	slog.Info("task claimed by runtime", "task_id", uuidToString(task.ID), "runtime_id", runtimeID, "agent_id", uuidToString(task.AgentID), "prior_session", resp.PriorSessionID, "peer_agents", len(resp.PeerAgents))
 	writeJSON(w, http.StatusOK, map[string]any{"task": resp})
 }
 


### PR DESCRIPTION
## Summary

When an orchestrator-style agent (one that decides who an issue should go to) doesn't know what other agents exist in the workspace, it routes work to itself by default and the actual coding agent never gets dispatched. The agent's runtime context (CLAUDE.md / AGENTS.md) carries detailed instructions and project resources, but no list of peer agents — so any "pick the right assignee" logic the agent runs is operating without the inputs it needs.

Reproducible failure: a workspace with two agents — one orchestrator (e.g. Hermes), one coding agent (e.g. Claude Code). The orchestrator creates an issue and self-assigns because it has no awareness that a coding agent exists in the same workspace.

This PR injects peers into the runtime context as data — listed by name and id, with each peer's role one-liner — and lets the agent's own instructions (or workspace policy) decide routing. **The block is agent-name-agnostic on purpose**: it never tells a specific agent which peer to pick.

## What changes

| Layer | File | Change |
|---|---|---|
| Server claim response | `server/internal/handler/agent.go` | Add `PeerAgents []PeerAgentData` next to existing `ProjectResources`. New `PeerAgentData` struct: `id`, `name`, optional `instructions` (the role one-liner). |
| Server claim handler | `server/internal/handler/daemon.go` | After the workspace id is verified, call `Queries.ListAgents` (already filters archived) and exclude the claiming agent. Best-effort — a failed list logs and continues with no peers rather than failing the claim. |
| Daemon types | `server/internal/daemon/types.go` | Mirror `PeerAgentData` on `Task`. |
| Daemon → execenv | `server/internal/daemon/daemon.go` | New `convertPeerAgentsForEnv` parallels `convertProjectResourcesForEnv`. Threads `task.PeerAgents` into `TaskContextForEnv`. |
| Execenv ctx | `server/internal/daemon/execenv/execenv.go` | New `PeerAgentForEnv` struct + `PeerAgents` field on `TaskContextForEnv`. |
| Runtime config render | `server/internal/daemon/execenv/runtime_config.go` | New "Peer Agents in this Workspace" section directly after Agent Identity. Each peer is listed by name + id; the **first non-empty line** of their instructions is appended after an em-dash. Section is omitted entirely when there are no peers — single-agent workspaces don't get a stub heading. |

## Rendered output (example)

```markdown
## Peer Agents in this Workspace

Other agents are available in this workspace. When delegating work
(creating issues for others, reassigning, picking an assignee), refer
to them by name. Do not assume you are the only agent — if a task is
outside your role, route it to a peer instead of self-assigning.

- **Claude Code** (id: `aaaa1111-bbbb-2222-cccc-333344445555`) — Coding agent. Implements features and fixes bugs in code.
- **Reviewer** (id: `bbbb2222-cccc-3333-dddd-444455556666`)

Use `multica issue assign <issue-id> --to <name>` to reassign, or
`--assignee <name>` on `multica issue create` to dispatch a new issue
to a peer.
```

## Test plan

- [x] `go test ./server/internal/daemon/...` — all green, including two new cases:
  - `TestPrepareWithPeerAgents` — section renders, peer name + id present, role one-liner included, second line of multi-line instructions NOT bled into the prompt, reassignment hint present.
  - `TestPrepareWithoutPeerAgents` — no peers → no section (no stub heading).
- [x] `go test ./server/internal/handler/...` — all green; existing claim flow unaffected.
- [x] `pnpm typecheck` — clean.
- [x] Manual repro on a self-hosted install: orchestrator agent's CLAUDE.md now includes the Peer Agents section listing the workspace's coding agent; reassignment via `multica issue assign --to <name>` resolves the peer correctly.

## Compatibility

- No schema change.
- Existing `Queries.ListAgents` is the same query the workspace agent list page already uses — no new SQL.
- Single-agent workspaces see no behavior change (no peers → no section).
- Pre-existing claim response is a strict superset (the new `peer_agents` field is `omitempty`).

## Out of scope

- Workspace-level "orchestrator agent" setting + comment-trigger routing — separate, larger PR (the second of the four bugs/features in our internal triage).
- Per-issue repo override / repo dropdown on the issue-create dialog — separate PR. The project picker already exists in `create-issue.tsx` (`packages/views/modals/create-issue.tsx:398`).
- A "default repo per project" affordance — coming in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
