### PR TITLE
feat(projects): surface the project's primary repo to agents and in the UI

### DIFF
--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -85,13 +85,26 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
               No resources attached.
             </p>
           )}
-          {resources.map((resource) => (
-            <ResourceRow
-              key={resource.id}
-              resource={resource}
-              onRemove={() => handleRemove(resource)}
-            />
-          ))}
+          {resources.map((resource, idx) => {
+            // The first `github_repo` (lowest position; resources arrive
+            // pre-sorted from the server) is the project's primary /
+            // default repo. The agent's runtime context renders it as
+            // the "Primary repo" callout, so we surface the same status
+            // here for the user. To change the primary, remove and re-add
+            // the resources in the desired order — explicit reordering
+            // is a follow-up.
+            const isPrimaryRepo =
+              resource.resource_type === "github_repo" &&
+              resources.findIndex((r) => r.resource_type === "github_repo") === idx;
+            return (
+              <ResourceRow
+                key={resource.id}
+                resource={resource}
+                isPrimary={isPrimaryRepo}
+                onRemove={() => handleRemove(resource)}
+              />
+            );
+          })}
           <Popover open={addOpen} onOpenChange={setAddOpen}>
             <PopoverTrigger
               render={
@@ -152,9 +165,11 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
 
 function ResourceRow({
   resource,
+  isPrimary = false,
   onRemove,
 }: {
   resource: ProjectResource;
+  isPrimary?: boolean;
   onRemove: () => void;
 }) {
   if (resource.resource_type === "github_repo") {
@@ -170,6 +185,14 @@ function ResourceRow({
         >
           {resource.label || ref.url}
         </a>
+        {isPrimary && (
+          <span
+            className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary"
+            title="Primary repo — issues in this project default to working in this repo. To change, remove and re-add resources in the desired order."
+          >
+            Primary
+          </span>
+        )}
         <button
           type="button"
           onClick={onRemove}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1332,6 +1332,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		ProjectID:               task.ProjectID,
 		ProjectTitle:            task.ProjectTitle,
 		ProjectResources:        convertProjectResourcesForEnv(task.ProjectResources),
+		PeerAgents:              convertPeerAgentsForEnv(task.PeerAgents),
 		ChatSessionID:           task.ChatSessionID,
 		AutopilotRunID:          task.AutopilotRunID,
 		AutopilotID:             task.AutopilotID,
@@ -1905,6 +1906,21 @@ func convertProjectResourcesForEnv(resources []ProjectResourceData) []execenv.Pr
 			ResourceType: r.ResourceType,
 			ResourceRef:  r.ResourceRef,
 			Label:        r.Label,
+		}
+	}
+	return result
+}
+
+func convertPeerAgentsForEnv(peers []PeerAgentData) []execenv.PeerAgentForEnv {
+	if len(peers) == 0 {
+		return nil
+	}
+	result := make([]execenv.PeerAgentForEnv, len(peers))
+	for i, p := range peers {
+		result[i] = execenv.PeerAgentForEnv{
+			ID:           p.ID,
+			Name:         p.Name,
+			Instructions: p.Instructions,
 		}
 	}
 	return result

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -29,6 +29,17 @@ type ProjectResourceForEnv struct {
 	Label        string          // optional user-supplied label
 }
 
+// PeerAgentForEnv describes another non-archived agent in the same workspace
+// as the claiming agent. The runtime config renders a "Peer Agents" section
+// listing them by name and id, so orchestrators that select an assignee
+// (e.g. via `multica issue assign --to <name>`) can resolve a real peer
+// instead of self-assigning because they don't know other agents exist.
+type PeerAgentForEnv struct {
+	ID           string
+	Name         string
+	Instructions string // short description / role; surfaced as a one-liner
+}
+
 // PrepareParams holds all inputs needed to set up an execution environment.
 type PrepareParams struct {
 	WorkspacesRoot string            // base path for all envs (e.g., ~/multica_workspaces)
@@ -52,6 +63,7 @@ type TaskContextForEnv struct {
 	ProjectID               string                  // issue's project, when present
 	ProjectTitle            string                  // human-readable project title
 	ProjectResources        []ProjectResourceForEnv // resources attached to the project
+	PeerAgents              []PeerAgentForEnv       // other non-archived agents in this workspace, surfaced to orchestrators so they can route by name
 	ChatSessionID           string                  // non-empty for chat tasks
 	AutopilotRunID          string              // non-empty for autopilot run_only tasks
 	AutopilotID             string

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -219,6 +219,108 @@ func TestPrepareWithProjectResources(t *testing.T) {
 	}
 }
 
+// TestPrepareWithPeerAgents covers the orchestrator-routing fix: when the
+// claiming agent has peers in the same workspace, runtime_config.md
+// surfaces them by name + id so an orchestrator-style agent (e.g. one that
+// delegates coding work) can route to a peer instead of self-assigning
+// because it doesn't know other agents exist.
+func TestPrepareWithPeerAgents(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+
+	taskCtx := TaskContextForEnv{
+		IssueID: "44444444-5555-6666-7777-888888888888",
+		PeerAgents: []PeerAgentForEnv{
+			{
+				ID:           "aaaa1111-bbbb-2222-cccc-333344445555",
+				Name:         "Claude Code",
+				Instructions: "Coding agent. Implements features and fixes bugs in code.\nUse for any task that involves writing or modifying source files.",
+			},
+			{
+				ID:   "bbbb2222-cccc-3333-dddd-444455556666",
+				Name: "Reviewer",
+			},
+		},
+	}
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-peer-agents",
+		TaskID:         "44444444-5555-6666-7777-888888888888",
+		AgentName:      "Test Orchestrator",
+		Provider:       "claude",
+		Task:           taskCtx,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if err := InjectRuntimeConfig(env.WorkDir, "claude", taskCtx); err != nil {
+		t.Fatalf("InjectRuntimeConfig: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(env.WorkDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	s := string(content)
+	for _, want := range []string{
+		"## Peer Agents in this Workspace",
+		"**Claude Code**",
+		"aaaa1111-bbbb-2222-cccc-333344445555",
+		// First non-empty line of multi-line instructions only — proves
+		// we're surfacing the role one-liner, not pasting the whole
+		// instruction block.
+		"Coding agent. Implements features and fixes bugs in code.",
+		"**Reviewer**",
+		// Reassignment hint — the actionable next step for an
+		// orchestrator that just decided to route to a peer.
+		"multica issue assign",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("CLAUDE.md missing %q", want)
+		}
+	}
+	// Must NOT bleed the second line of the multi-line peer instructions.
+	if strings.Contains(s, "Use for any task that involves writing or modifying source files.") {
+		t.Errorf("CLAUDE.md leaked second line of peer instructions; should only show first line")
+	}
+}
+
+// TestPrepareWithoutPeerAgents covers the negative path: a single-agent
+// workspace renders no Peer Agents section so we don't pollute the prompt
+// with an empty heading.
+func TestPrepareWithoutPeerAgents(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+	taskCtx := TaskContextForEnv{
+		IssueID:    "55555555-6666-7777-8888-999999999999",
+		PeerAgents: nil,
+	}
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-no-peers",
+		TaskID:         "55555555-6666-7777-8888-999999999999",
+		AgentName:      "Solo Agent",
+		Provider:       "claude",
+		Task:           taskCtx,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if err := InjectRuntimeConfig(env.WorkDir, "claude", taskCtx); err != nil {
+		t.Fatalf("InjectRuntimeConfig: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(env.WorkDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	if strings.Contains(string(content), "Peer Agents in this Workspace") {
+		t.Errorf("CLAUDE.md unexpectedly rendered Peer Agents section with no peers")
+	}
+}
+
 // When the issue's project has its own github_repo resources, those should be
 // the only repos rendered in the meta-skill — workspace-level repos must not
 // leak into the agent prompt to avoid confusing it about which repo to use.

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -286,6 +286,128 @@ func TestPrepareWithPeerAgents(t *testing.T) {
 	}
 }
 
+// TestPrimaryProjectRepoURL covers the helper that picks the project's
+// default repo for the runtime config "Primary repo" callout.
+func TestPrimaryProjectRepoURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		resources []ProjectResourceForEnv
+		want      string
+	}{
+		{
+			name:      "empty",
+			resources: nil,
+			want:      "",
+		},
+		{
+			name: "no github_repo (only docs)",
+			resources: []ProjectResourceForEnv{
+				{ResourceType: "notion_page", ResourceRef: json.RawMessage(`{"url":"https://notion.so/x"}`)},
+			},
+			want: "",
+		},
+		{
+			name: "first by position wins",
+			resources: []ProjectResourceForEnv{
+				{ResourceType: "github_repo", ResourceRef: json.RawMessage(`{"url":"https://github.com/owner/primary"}`)},
+				{ResourceType: "github_repo", ResourceRef: json.RawMessage(`{"url":"https://github.com/owner/secondary"}`)},
+			},
+			want: "https://github.com/owner/primary",
+		},
+		{
+			name: "non-repo resources before the first github_repo are skipped",
+			resources: []ProjectResourceForEnv{
+				{ResourceType: "notion_page", ResourceRef: json.RawMessage(`{"url":"https://notion.so/y"}`)},
+				{ResourceType: "github_repo", ResourceRef: json.RawMessage(`{"url":"https://github.com/owner/primary"}`)},
+			},
+			want: "https://github.com/owner/primary",
+		},
+		{
+			name: "malformed json falls through to next github_repo",
+			resources: []ProjectResourceForEnv{
+				{ResourceType: "github_repo", ResourceRef: json.RawMessage(`not json`)},
+				{ResourceType: "github_repo", ResourceRef: json.RawMessage(`{"url":"https://github.com/owner/fallback"}`)},
+			},
+			want: "https://github.com/owner/fallback",
+		},
+		{
+			name: "empty url skipped",
+			resources: []ProjectResourceForEnv{
+				{ResourceType: "github_repo", ResourceRef: json.RawMessage(`{"url":""}`)},
+				{ResourceType: "github_repo", ResourceRef: json.RawMessage(`{"url":"https://github.com/owner/real"}`)},
+			},
+			want: "https://github.com/owner/real",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := primaryProjectRepoURL(tc.resources)
+			if got != tc.want {
+				t.Errorf("primaryProjectRepoURL: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPrepareWithPrimaryProjectRepo — runtime_config.md should surface the
+// project's primary repo as a deterministic callout above the resource list.
+func TestPrepareWithPrimaryProjectRepo(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+
+	taskCtx := TaskContextForEnv{
+		IssueID:      "66666666-7777-8888-9999-aaaaaaaaaaaa",
+		ProjectID:    "77777777-8888-9999-aaaa-bbbbbbbbbbbb",
+		ProjectTitle: "Multi-repo project",
+		ProjectResources: []ProjectResourceForEnv{
+			{
+				ID:           "88888888-9999-aaaa-bbbb-cccccccccccc",
+				ResourceType: "github_repo",
+				ResourceRef:  json.RawMessage(`{"url":"https://github.com/owner/primary-app"}`),
+			},
+			{
+				ID:           "99999999-aaaa-bbbb-cccc-dddddddddddd",
+				ResourceType: "github_repo",
+				ResourceRef:  json.RawMessage(`{"url":"https://github.com/owner/secondary-lib"}`),
+			},
+		},
+	}
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-primary-repo",
+		TaskID:         "66666666-7777-8888-9999-aaaaaaaaaaaa",
+		AgentName:      "Test Agent",
+		Provider:       "claude",
+		Task:           taskCtx,
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if err := InjectRuntimeConfig(env.WorkDir, "claude", taskCtx); err != nil {
+		t.Fatalf("InjectRuntimeConfig: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(env.WorkDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	s := string(content)
+	if !strings.Contains(s, "**Primary repo:** https://github.com/owner/primary-app") {
+		t.Errorf("CLAUDE.md missing primary repo callout for primary-app")
+	}
+	// Both repos should still appear in the resource list — the primary
+	// callout is additive context, not a filter.
+	if !strings.Contains(s, "https://github.com/owner/primary-app") ||
+		!strings.Contains(s, "https://github.com/owner/secondary-lib") {
+		t.Errorf("CLAUDE.md missing one of the resource bullet entries")
+	}
+}
+
 // TestPrepareWithoutPeerAgents covers the negative path: a single-agent
 // workspace renders no Peer Agents section so we don't pollute the prompt
 // with an empty heading.

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -101,6 +101,31 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("\n\n")
 	}
 
+	// Inject peer agents — every other non-archived agent in the workspace.
+	// Orchestrator-style agents (the picker, Hermes, etc.) need to know who
+	// the other agents are so they can route work by name (`multica issue
+	// assign --to <name>` or `--assignee <name>` on create) instead of self-
+	// assigning because they don't realise other agents exist. The block is
+	// agent-name-agnostic — it lists peers as data, never hardcodes which
+	// peer to pick; the agent's own instructions decide the routing policy.
+	if len(ctx.PeerAgents) > 0 {
+		b.WriteString("## Peer Agents in this Workspace\n\n")
+		b.WriteString("Other agents are available in this workspace. When delegating work (creating issues for others, reassigning, picking an assignee), refer to them by name. Do not assume you are the only agent — if a task is outside your role, route it to a peer instead of self-assigning.\n\n")
+		for _, p := range ctx.PeerAgents {
+			fmt.Fprintf(&b, "- **%s** (id: `%s`)", p.Name, p.ID)
+			if trimmed := strings.TrimSpace(p.Instructions); trimmed != "" {
+				// First non-empty line of the peer's instructions —
+				// usually their role/persona one-liner.
+				if idx := strings.IndexByte(trimmed, '\n'); idx > 0 {
+					trimmed = trimmed[:idx]
+				}
+				fmt.Fprintf(&b, " — %s", trimmed)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\nUse `multica issue assign <issue-id> --to <name>` to reassign, or `--assignee <name>` on `multica issue create` to dispatch a new issue to a peer.\n\n")
+	}
+
 	b.WriteString("## Available Commands\n\n")
 	b.WriteString("**Always use `--output json` for all read commands** to get structured data with full IDs.\n\n")
 	b.WriteString("### Read\n")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -8,6 +8,29 @@ import (
 	"strings"
 )
 
+// primaryProjectRepoURL returns the URL of the first `github_repo` resource
+// in the list — by convention, the project's primary / default repo. The
+// daemon receives resources already ordered by the server's `position ASC,
+// created_at ASC`, so "first" is deterministic. Returns "" when the project
+// has no github_repo resources (e.g. it only attaches docs or notion pages).
+func primaryProjectRepoURL(resources []ProjectResourceForEnv) string {
+	for _, r := range resources {
+		if r.ResourceType != "github_repo" {
+			continue
+		}
+		var payload struct {
+			URL string `json:"url"`
+		}
+		if err := json.Unmarshal(r.ResourceRef, &payload); err != nil {
+			continue
+		}
+		if payload.URL != "" {
+			return payload.URL
+		}
+	}
+	return ""
+}
+
 // formatProjectResource renders a single resource as a human-readable bullet.
 // Unknown resource types fall back to a JSON-encoded ref so the agent can
 // still read what the user attached. New resource types should add a case
@@ -201,6 +224,15 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 			fmt.Fprintf(&b, "This issue belongs to **%s**.\n\n", ctx.ProjectTitle)
 		}
 		if len(ctx.ProjectResources) > 0 {
+			// The first `github_repo` resource (lowest position) is the project's
+			// primary / default repo. Surface it explicitly so the agent has a
+			// deterministic answer to "which repo do I work in?" instead of having
+			// to guess from the issue description. Falls back to no callout when
+			// the project has no github_repo resources at all (e.g. only docs or
+			// notion pages attached).
+			if primaryRepo := primaryProjectRepoURL(ctx.ProjectResources); primaryRepo != "" {
+				fmt.Fprintf(&b, "**Primary repo:** %s — when an issue under this project doesn't say otherwise, work in this repo. Use `multica repo checkout %s` to fetch it.\n\n", primaryRepo, primaryRepo)
+			}
 			b.WriteString("Project resources (also written to `.multica/project/resources.json`):\n\n")
 			for _, r := range ctx.ProjectResources {
 				fmt.Fprintf(&b, "- %s\n", formatProjectResource(r))

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -30,6 +30,16 @@ type ProjectResourceData struct {
 	Label        string          `json:"label,omitempty"`
 }
 
+// PeerAgentData mirrors handler.PeerAgentData — a non-archived peer agent
+// in the same workspace as the claiming agent. Sent so orchestrator agents
+// can route work by name instead of self-assigning because they don't know
+// what other agents exist.
+type PeerAgentData struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Instructions string `json:"instructions,omitempty"`
+}
+
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
@@ -43,6 +53,7 @@ type Task struct {
 	ProjectID               string                `json:"project_id,omitempty"`        // issue's project, when present
 	ProjectTitle            string                `json:"project_title,omitempty"`     // human-readable project title for context injection
 	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"` // project-scoped resources to expose to the agent
+	PeerAgents              []PeerAgentData       `json:"peer_agents,omitempty"`       // other non-archived agents in the same workspace, for orchestrator routing
 	PriorSessionID          string          `json:"prior_session_id,omitempty"`          // Claude session ID from a previous task on this issue
 	PriorWorkDir            string          `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on this issue
 	TriggerCommentID        string          `json:"trigger_comment_id,omitempty"`        // comment that triggered this task

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -155,6 +155,7 @@ type AgentTaskResponse struct {
 	ProjectID               string                `json:"project_id,omitempty"`         // issue's project, when present
 	ProjectTitle            string                `json:"project_title,omitempty"`      // for surfacing in agent context
 	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"`  // resources attached to the project
+	PeerAgents              []PeerAgentData       `json:"peer_agents,omitempty"`        // other agents in the same workspace (excluding the claiming agent), so orchestrators can route to peers by name/id
 	CreatedAt               string          `json:"created_at"`
 	PriorSessionID          string          `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
 	PriorWorkDir            string          `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
@@ -186,6 +187,15 @@ type TaskAgentData struct {
 	CustomArgs   []string                 `json:"custom_args,omitempty"`
 	McpConfig    json.RawMessage          `json:"mcp_config,omitempty"`
 	Model        string                   `json:"model,omitempty"`
+}
+
+// PeerAgentData is a lightweight projection of another agent in the same
+// workspace, sent to the claiming agent so orchestrators can route work to
+// peers by name. Excludes the claiming agent itself and archived agents.
+type PeerAgentData struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Instructions string `json:"instructions,omitempty"` // short description / role; useful for orchestrators picking the right peer
 }
 
 func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1133,7 +1133,34 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("task claimed by runtime", "task_id", uuidToString(task.ID), "runtime_id", runtimeID, "agent_id", uuidToString(task.AgentID), "prior_session", resp.PriorSessionID)
+	// Inject peer agents — every other non-archived agent in the workspace.
+	// Orchestrator agents (Hermes, picker patterns, etc.) need to know which
+	// peers exist so they can route work by name instead of self-assigning
+	// because they don't realise a coding agent is available. Best-effort:
+	// failure to list logs and continues with an empty list rather than
+	// failing the claim.
+	if workspaceUUID, err := util.ParseUUID(resp.WorkspaceID); err == nil {
+		if peers, err := h.Queries.ListAgents(r.Context(), workspaceUUID); err == nil {
+			out := make([]PeerAgentData, 0, len(peers))
+			for _, p := range peers {
+				if uuidToString(p.ID) == uuidToString(task.AgentID) {
+					continue // exclude the claiming agent
+				}
+				out = append(out, PeerAgentData{
+					ID:           uuidToString(p.ID),
+					Name:         p.Name,
+					Instructions: p.Instructions,
+				})
+			}
+			if len(out) > 0 {
+				resp.PeerAgents = out
+			}
+		} else {
+			slog.Warn("task claim: failed to list peer agents (continuing without)", "workspace_id", resp.WorkspaceID, "error", err)
+		}
+	}
+
+	slog.Info("task claimed by runtime", "task_id", uuidToString(task.ID), "runtime_id", runtimeID, "agent_id", uuidToString(task.AgentID), "prior_session", resp.PriorSessionID, "peer_agents", len(resp.PeerAgents))
 	writeJSON(w, http.StatusOK, map[string]any{"task": resp})
 }
 


### PR DESCRIPTION
## Summary

Projects can attach multiple `github_repo` resources, but the agent's runtime context lists them as an unordered set — leaving the agent to guess which one to clone for an issue tied to that project. The `project_resource` table already orders by `position ASC, created_at ASC`, so "first" is deterministic; this PR teaches the runtime context and the project sidebar to treat the first `github_repo` as the project's primary / default repo.

> **Note**: this PR is **stacked on top of #2071** (peer agents in runtime context). Reviewing #2071 first lets you see this PR's diff in isolation.

## Why no schema change

[`server/pkg/db/queries/project_resource.sql`](https://github.com/multica-ai/multica/blob/main/server/pkg/db/queries/project_resource.sql):

```sql
-- name: ListProjectResources :many
SELECT * FROM project_resource
WHERE project_id = $1
ORDER BY position ASC, created_at ASC;
```

The ordering is already deterministic. This PR uses it as the source of truth: **the first `github_repo` is primary**. To change the primary, remove and re-add resources in the desired order — explicit drag-to-reorder is a follow-up.

## What changes

| File | Δ | What |
|---|---|---|
| `server/internal/daemon/execenv/runtime_config.go` | +28 | New `primaryProjectRepoURL([]ProjectResourceForEnv) string` helper picks the first github_repo from the (pre-ordered) resource list. The "Project Context" section now prepends a `**Primary repo:** <url> — when an issue under this project doesn't say otherwise, work in this repo.` callout. Bullet list is unchanged — primary is additive, not a filter. |
| `server/internal/daemon/execenv/execenv_test.go` | +99 | Two new test cases (see below). |
| `packages/views/projects/components/project-resources-section.tsx` | +20 | First `github_repo` row gets a small "Primary" badge (`bg-primary/10 text-primary`). Tooltip on the badge explains how to change the primary. |

## Rendered output for the agent

```markdown
## Project Context

This issue belongs to **Multi-repo project**.

**Primary repo:** https://github.com/owner/primary-app — when an issue
under this project doesn't say otherwise, work in this repo. Use
`multica repo checkout https://github.com/owner/primary-app` to fetch it.

Project resources (also written to `.multica/project/resources.json`):

- **GitHub repo**: https://github.com/owner/primary-app
- **GitHub repo**: https://github.com/owner/secondary-lib

Resources are pointers — open them only when relevant to the task. ...
```

## Test plan

- [x] `go test ./server/internal/daemon/execenv/` — green:
  - `TestPrimaryProjectRepoURL` — table-driven: empty list, no github_repo, first-wins, non-repo before first repo, malformed JSON falls through to next repo, empty url skipped.
  - `TestPrepareWithPrimaryProjectRepo` — runtime_config.md renders the Primary repo callout for the first github_repo and keeps both repos in the bullet list (no filtering).
- [x] `pnpm --filter @multica/views typecheck` — clean.
- [x] Manual smoke: a project with two repos shows the Primary badge on the first; runtime context callout matches.

## Compatibility

- No schema change.
- No API change.
- Single-repo projects: the badge appears (correctly) on the only repo.
- Projects with no `github_repo`: no callout, no badge, current behavior.

## Out of scope

- Drag-to-reorder UI for promoting a non-primary to primary — happy to ship as a follow-up; needs a small `UpdateProjectResourcePosition` SQL + handler + mutation hook + DnD wiring. The MVP here ships the rendering + badge benefit without that surface.
- A boolean `is_default` column on `project_resource` — nice if reviewers prefer it, but it's redundant with the existing `position` and would require a migration. Happy to switch if requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
