### PR TITLE
fix(daemon): use brew prefix symlink for self-restart so Linux Cellar deletion does not orphan runtimes

### DIFF
--- a/server/internal/cli/update.go
+++ b/server/internal/cli/update.go
@@ -122,6 +122,23 @@ func FetchLatestRelease() (*GitHubRelease, error) {
 	return &release, nil
 }
 
+// knownBrewPrefixes lists the install roots Homebrew uses on each platform.
+// Order is irrelevant — the prefixes do not nest.
+var knownBrewPrefixes = []string{"/opt/homebrew", "/usr/local", "/home/linuxbrew/.linuxbrew"}
+
+// MatchKnownBrewPrefix returns the Homebrew prefix whose Cellar contains path,
+// or "" if path is not under a known Cellar. It is the offline equivalent of
+// `brew --prefix`: callers reach for it when `brew --prefix` is unavailable
+// (brew not on PATH) but the binary's path still betrays its install root.
+func MatchKnownBrewPrefix(path string) string {
+	for _, prefix := range knownBrewPrefixes {
+		if strings.HasPrefix(path, prefix+"/Cellar/") {
+			return prefix
+		}
+	}
+	return ""
+}
+
 // IsBrewInstall checks whether the running multica binary was installed via Homebrew.
 func IsBrewInstall() bool {
 	exePath, err := os.Executable()
@@ -138,12 +155,7 @@ func IsBrewInstall() bool {
 		return true
 	}
 
-	for _, prefix := range []string{"/opt/homebrew", "/usr/local", "/home/linuxbrew/.linuxbrew"} {
-		if strings.HasPrefix(resolved, prefix+"/Cellar/") {
-			return true
-		}
-	}
-	return false
+	return MatchKnownBrewPrefix(resolved) != ""
 }
 
 // GetBrewPrefix returns the Homebrew prefix by running `brew --prefix`, or empty string.

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -25,6 +25,11 @@ import (
 // server refresh.
 var ErrRepoNotConfigured = errors.New("repo is not configured for this workspace")
 
+var (
+	isBrewInstall = cli.IsBrewInstall
+	getBrewPrefix = cli.GetBrewPrefix
+)
+
 // workspaceState tracks registered runtimes for a single workspace.
 //
 // allowedRepoURLs covers the workspace-level repo bindings; it gets rebuilt on
@@ -1043,9 +1048,16 @@ func (d *Daemon) triggerRestart() {
 		d.logger.Error("could not resolve executable path for restart", "error", err)
 		return
 	}
-	// Only resolve symlinks for non-brew installs. Brew uses a symlink that
-	// points to the latest Cellar version, so we must preserve it.
-	if !cli.IsBrewInstall() {
+	if isBrewInstall() {
+		if brewPrefix := getBrewPrefix(); brewPrefix != "" {
+			newBin = filepath.Join(brewPrefix, "bin", "multica")
+		} else {
+			d.logger.Warn("brew install detected but brew prefix was unavailable; falling back to resolved executable path")
+			if resolved, err := filepath.EvalSymlinks(newBin); err == nil {
+				newBin = resolved
+			}
+		}
+	} else {
 		if resolved, err := filepath.EvalSymlinks(newBin); err == nil {
 			newBin = resolved
 		}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -26,8 +26,9 @@ import (
 var ErrRepoNotConfigured = errors.New("repo is not configured for this workspace")
 
 var (
-	isBrewInstall = cli.IsBrewInstall
-	getBrewPrefix = cli.GetBrewPrefix
+	isBrewInstall        = cli.IsBrewInstall
+	getBrewPrefix        = cli.GetBrewPrefix
+	matchKnownBrewPrefix = cli.MatchKnownBrewPrefix
 )
 
 // workspaceState tracks registered runtimes for a single workspace.
@@ -1048,14 +1049,17 @@ func (d *Daemon) triggerRestart() {
 		d.logger.Error("could not resolve executable path for restart", "error", err)
 		return
 	}
+	// On Linux, os.Executable() reads /proc/self/exe, which the kernel resolves
+	// to the Cellar path. brew cleanup deletes that path after upgrade, so we
+	// must use the stable <brew-prefix>/bin/multica symlink instead.
 	if isBrewInstall() {
 		if brewPrefix := getBrewPrefix(); brewPrefix != "" {
 			newBin = filepath.Join(brewPrefix, "bin", "multica")
+		} else if prefix := matchKnownBrewPrefix(newBin); prefix != "" {
+			newBin = filepath.Join(prefix, "bin", "multica")
 		} else {
-			d.logger.Warn("brew install detected but brew prefix was unavailable; falling back to resolved executable path")
-			if resolved, err := filepath.EvalSymlinks(newBin); err == nil {
-				newBin = resolved
-			}
+			d.logger.Warn("brew install detected but prefix could not be resolved; restart may fail",
+				"executable", newBin)
 		}
 	} else {
 		if resolved, err := filepath.EvalSymlinks(newBin); err == nil {

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -49,6 +50,33 @@ func TestNormalizeServerBaseURL(t *testing.T) {
 	}
 	if got != "http://localhost:8080" {
 		t.Fatalf("expected http://localhost:8080, got %s", got)
+	}
+}
+
+func TestTriggerRestart_BrewLinuxCellarDeleted(t *testing.T) {
+	originalIsBrewInstall := isBrewInstall
+	originalGetBrewPrefix := getBrewPrefix
+	t.Cleanup(func() {
+		isBrewInstall = originalIsBrewInstall
+		getBrewPrefix = originalGetBrewPrefix
+	})
+
+	prefix := filepath.Join(t.TempDir(), "home", "linuxbrew", ".linuxbrew")
+	deletedCellarPath := filepath.Join(prefix, "Cellar", "multica", "0.2.9", "bin", "multica")
+	isBrewInstall = func() bool { return true }
+	getBrewPrefix = func() string { return prefix }
+
+	d := &Daemon{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	d.triggerRestart()
+
+	want := filepath.Join(prefix, "bin", "multica")
+	if got := d.RestartBinary(); got != want {
+		t.Fatalf("restart binary = %q, want %q", got, want)
+	}
+	if got := d.RestartBinary(); got == deletedCellarPath {
+		t.Fatalf("restart binary used deleted Cellar path %q", got)
 	}
 }
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -80,6 +80,66 @@ func TestTriggerRestart_BrewLinuxCellarDeleted(t *testing.T) {
 	}
 }
 
+// When `brew --prefix` is unavailable but the executable path is under a
+// known Cellar root, triggerRestart must recover the prefix from the
+// known-prefix list and target <prefix>/bin/multica.
+func TestTriggerRestart_BrewPrefixUnavailable_FallsBackToKnownPrefix(t *testing.T) {
+	originalIsBrewInstall := isBrewInstall
+	originalGetBrewPrefix := getBrewPrefix
+	originalMatchKnownBrewPrefix := matchKnownBrewPrefix
+	t.Cleanup(func() {
+		isBrewInstall = originalIsBrewInstall
+		getBrewPrefix = originalGetBrewPrefix
+		matchKnownBrewPrefix = originalMatchKnownBrewPrefix
+	})
+
+	const knownPrefix = "/home/linuxbrew/.linuxbrew"
+	isBrewInstall = func() bool { return true }
+	getBrewPrefix = func() string { return "" }
+	matchKnownBrewPrefix = func(string) string { return knownPrefix }
+
+	d := &Daemon{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	d.triggerRestart()
+
+	want := filepath.Join(knownPrefix, "bin", "multica")
+	if got := d.RestartBinary(); got != want {
+		t.Fatalf("restart binary = %q, want %q", got, want)
+	}
+}
+
+// When `brew --prefix` is unavailable AND the executable is not under any
+// known Cellar root, triggerRestart logs a warning and keeps the executable
+// path (no fabricated <prefix>/bin/multica path).
+func TestTriggerRestart_BrewPrefixUnavailable_NoKnownPrefix_KeepsExecutable(t *testing.T) {
+	originalIsBrewInstall := isBrewInstall
+	originalGetBrewPrefix := getBrewPrefix
+	originalMatchKnownBrewPrefix := matchKnownBrewPrefix
+	t.Cleanup(func() {
+		isBrewInstall = originalIsBrewInstall
+		getBrewPrefix = originalGetBrewPrefix
+		matchKnownBrewPrefix = originalMatchKnownBrewPrefix
+	})
+
+	isBrewInstall = func() bool { return true }
+	getBrewPrefix = func() string { return "" }
+	matchKnownBrewPrefix = func(string) string { return "" }
+
+	d := &Daemon{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	d.triggerRestart()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	if got := d.RestartBinary(); got != exe {
+		t.Fatalf("restart binary = %q, want unchanged executable %q", got, exe)
+	}
+}
+
 func TestNewTaskSlotSemaphoreReturnsStableSlotIndexes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What does this PR do?

Fixes daemon self-restart on Linux brew installs. After `brew upgrade`, `os.Executable()` returns `.../Cellar/multica/<old-version>/bin/multica` because the Linux kernel resolves `/proc/self/exe` to its real path. `brew cleanup` then deletes that path, so `exec.Command(restartBin, ...)` fails with `no such file or directory` and every runtime stays offline until the user runs `multica daemon start` manually.

The previous `IsBrewInstall()` short-circuit in `triggerRestart()` skipped `EvalSymlinks` to "preserve the symlink", but on Linux there was nothing to preserve. `os.Executable()` had already resolved it. Switch to `cli.GetBrewPrefix()` directly and join `<prefix>/bin/multica` for brew installs, with a `Warn` log + `EvalSymlinks` fallback when the prefix is unavailable.

## Related Issue

Closes #1624

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/daemon.go`: `triggerRestart()` now uses `<brewPrefix>/bin/multica` for brew installs. Added two package-level seams (`isBrewInstall`, `getBrewPrefix`) defaulting to `cli.IsBrewInstall` / `cli.GetBrewPrefix` so the test can override them without touching the `cli` package.
- `server/internal/daemon/daemon_test.go`: added `TestTriggerRestart_BrewLinuxCellarDeleted` that overrides the seams via `t.Cleanup` and asserts `RestartBinary()` returns `<prefix>/bin/multica`, not the deleted Cellar path.

## How to Test

1. `cd server && go test ./internal/daemon/ -run TestTriggerRestart -v`. The new test passes against the fix and would fail against `main` (Cellar path leaks through).
2. On a Linuxbrew-installed daemon, `brew upgrade multica-ai/tap/multica` no longer leaves runtimes offline. `daemon.log` shows `scheduling daemon restart new_binary=/home/linuxbrew/.linuxbrew/bin/multica` (stable symlink) instead of the Cellar path.

## Checklist

- [x] I have included relevant tests
- [x] `go vet ./internal/daemon/...` and `go build ./internal/daemon/...` pass
- [x] No backwards-compat shim or feature flag added
- [x] Comments are English-only and limited to non-obvious WHYs
