### PR TITLE
fix(daemon/execenv): refuse to write .gc_meta.json when issue_id is empty

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1278,7 +1278,7 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	// can look up the issue later. Written last so that a mid-task crash
 	// leaves the directory as an orphan (cleaned up by GCOrphanTTL).
 	if result.EnvRoot != "" {
-		if err := execenv.WriteGCMeta(result.EnvRoot, task.IssueID, task.WorkspaceID); err != nil {
+		if err := execenv.WriteGCMeta(result.EnvRoot, task.IssueID, task.WorkspaceID, taskLog); err != nil {
 			taskLog.Warn("write gc meta failed (non-fatal)", "error", err)
 		}
 	}

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -53,7 +53,7 @@ type TaskContextForEnv struct {
 	ProjectTitle            string                  // human-readable project title
 	ProjectResources        []ProjectResourceForEnv // resources attached to the project
 	ChatSessionID           string                  // non-empty for chat tasks
-	AutopilotRunID          string              // non-empty for autopilot run_only tasks
+	AutopilotRunID          string                  // non-empty for autopilot run_only tasks
 	AutopilotID             string
 	AutopilotTitle          string
 	AutopilotDescription    string
@@ -214,7 +214,11 @@ type GCMeta struct {
 const gcMetaFile = ".gc_meta.json"
 
 // WriteGCMeta writes GC metadata into the given directory.
-func WriteGCMeta(envRoot, issueID, workspaceID string) error {
+func WriteGCMeta(envRoot, issueID, workspaceID string, logger *slog.Logger) error {
+	if issueID == "" {
+		logger.Warn("execenv: skipping .gc_meta.json write: issue_id is empty", "envRoot", envRoot, "workspaceID", workspaceID)
+		return nil
+	}
 	if envRoot == "" {
 		return nil
 	}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -2,6 +2,7 @@ package execenv
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -12,6 +13,10 @@ import (
 
 func testLogger() *slog.Logger {
 	return slog.Default()
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func TestShortID(t *testing.T) {
@@ -1916,7 +1921,7 @@ func TestWriteReadGCMeta(t *testing.T) {
 	issueID := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 	wsID := "ws-test-001"
 
-	if err := WriteGCMeta(dir, issueID, wsID); err != nil {
+	if err := WriteGCMeta(dir, issueID, wsID, discardLogger()); err != nil {
 		t.Fatalf("WriteGCMeta: %v", err)
 	}
 
@@ -1938,8 +1943,20 @@ func TestWriteReadGCMeta(t *testing.T) {
 
 func TestWriteGCMeta_EmptyRoot(t *testing.T) {
 	t.Parallel()
-	if err := WriteGCMeta("", "issue", "ws"); err != nil {
+	if err := WriteGCMeta("", "issue", "ws", discardLogger()); err != nil {
 		t.Fatalf("expected nil for empty root, got %v", err)
+	}
+}
+
+func TestWriteGCMeta_EmptyIssueID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	if err := WriteGCMeta(dir, "", "ws", discardLogger()); err != nil {
+		t.Fatalf("expected nil for empty issue ID, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, gcMetaFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected gc meta file to be absent, got err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Stops the daemon from writing `.gc_meta.json` files with an empty `issue_id`. A non-trivial fraction (~28% in field reports) of completed task workdirs end up with `issue_id: ""`, which:

1. Defeats the daemon's own GC loop. `gc.go:139` calls `d.client.GetIssueGCCheck(ctx, meta.IssueID)` which can't resolve an empty ID, so the orphan-cleanup decision is wrong.
2. Forces external retention scripts into a "don't know, don't delete" stance, accumulating workdirs over time.

`WriteGCMeta` now returns early with `nil` when `issueID == ""`, emitting a `Warn` log so operators have a starting point for debugging the upstream race (whatever puts `task.IssueID == ""` in `daemon.go:1281` is out of scope for this PR; the right fix at this layer is "stop writing data we know is wrong").

I picked skip-with-warn over the alternative sentinel-marker file. Skip keeps the data invariant clean (every `.gc_meta.json` carries a valid `issue_id`) and matches the repo's CLAUDE.md preference for not preserving dual-state behavior. Happy to swap if you'd rather have a `reason: "no_issue_id"` field for forensics.

## Related Issue

Closes #1913

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/execenv/execenv.go`: `WriteGCMeta` now takes a `*slog.Logger` and returns early when `issueID == ""`. `log/slog` was already imported (used by `Prepare` / `reuseEnv`).
- `server/internal/daemon/daemon.go`: the only production call site at line 1281 now passes `taskLog`, which was already in scope.
- `server/internal/daemon/execenv/execenv_test.go`: existing `TestWriteGCMeta` and `TestWriteGCMeta_EmptyRoot` updated for the signature change (added a `discardLogger()` helper). New `TestWriteGCMeta_EmptyIssueID` asserts the file is absent on disk.

## How to Test

1. `cd server && go test ./internal/daemon/execenv/... -run TestWriteGCMeta -v`. All four test cases pass; `TestWriteGCMeta_EmptyIssueID` would fail against `main`.
2. The race itself (why `task.IssueID == ""` shows up at the call site at all) is left for a separate investigation. Affected workdirs in field reports clustered around early-day timestamps, suggesting autopilot smoke-test paths or pre-assignment task starts.

## Checklist

- [x] I have included relevant tests
- [x] `go vet ./internal/daemon/...` and `go build ./internal/daemon/...` pass
- [x] No backwards-compat shim or sentinel-file path added
- [x] Comments are English-only
