### PR TITLE
fix(projects): add New Issue button to empty project state and URL tooltips to resources

### DIFF
--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState, useCallback, useRef, useEffect } from "react";
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels";
-import { Check, ChevronRight, Link2, ListTodo, MoreHorizontal, PanelRight, Pin, PinOff, Trash2, UserMinus } from "lucide-react";
+import { Check, ChevronRight, Link2, ListTodo, MoreHorizontal, PanelRight, Pin, PinOff, Plus, Trash2, UserMinus } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { cn } from "@multica/ui/lib/utils";
 import { toast } from "sonner";
@@ -14,6 +14,7 @@ import { pinListOptions } from "@multica/core/pins";
 import { useCreatePin, useDeletePin } from "@multica/core/pins";
 import { myIssueListOptions, childIssueProgressOptions, type MyIssuesFilter } from "@multica/core/issues/queries";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
+import { useModalStore } from "@multica/core/modals";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
@@ -146,10 +147,23 @@ function ProjectIssuesContent({
 
   if (projectIssues.length === 0) {
     return (
-      <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-2 text-muted-foreground">
+      <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 text-muted-foreground">
         <ListTodo className="h-10 w-10 text-muted-foreground/40" />
         <p className="text-sm">No issues linked</p>
-        <p className="text-xs">Assign issues to this project from the issue detail page.</p>
+        <p className="text-xs">Create a new issue or assign existing ones to this project.</p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-1"
+          onClick={() =>
+            useModalStore
+              .getState()
+              .open("create-issue", { project_id: scope.replace("project:", "") })
+          }
+        >
+          <Plus className="size-3.5 mr-1.5" />
+          New Issue
+        </Button>
       </div>
     );
   }

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -21,6 +21,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@multica/ui/components/ui/popover";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@multica/ui/components/ui/tooltip";
 
 // Project Resources sidebar section.
 //
@@ -125,7 +130,14 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
                         className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-left hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <FolderGit className="size-3.5" />
-                        <span className="truncate flex-1">{repo.url}</span>
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <span className="truncate flex-1">{repo.url}</span>
+                            }
+                          />
+                          <TooltipContent side="top">{repo.url}</TooltipContent>
+                        </Tooltip>
                         {isAttached && (
                           <span className="text-[10px] text-muted-foreground">
                             attached
@@ -162,14 +174,21 @@ function ResourceRow({
     return (
       <div className="flex items-center gap-2 text-xs group">
         <FolderGit className="size-3.5 text-muted-foreground shrink-0" />
-        <a
-          href={ref.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="truncate flex-1 hover:underline"
-        >
-          {resource.label || ref.url}
-        </a>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <a
+                href={ref.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="truncate flex-1 hover:underline"
+              >
+                {resource.label || ref.url}
+              </a>
+            }
+          />
+          <TooltipContent side="top">{ref.url}</TooltipContent>
+        </Tooltip>
         <button
           type="button"
           onClick={onRemove}


### PR DESCRIPTION
## What

When a project has no issues, the empty state only shows static text telling users to assign issues from elsewhere. This PR adds a **`+ New Issue`** button that opens the create-issue dialog with the project pre-selected, making it easy to create the first issue directly.

Also adds **tooltips** to repository URLs in the Resources section so truncated URLs can be read in full on hover — both for attached resources and in the repo selection popover.

## Changes

- **`project-detail.tsx`**: Added `+ New Issue` button to the empty project issues state, using `useModalStore.open("create-issue", { project_id })` to pre-select the project
- **`project-resources-section.tsx`**: Wrapped resource URLs and repo picker URLs with `Tooltip` components to show full URLs on hover

## Testing

- TypeScript compiles cleanly (only pre-existing `motion/react` error in unrelated file)
- Follows existing patterns: `useModalStore.open("create-issue", { project_id })` matches the pattern used in `board-column.tsx` and `list-view.tsx`

Closes #2078