### PR TITLE
feat(wiki): add wiki route and sidebar navigation entry

### DIFF
--- a/apps/web/app/[workspaceSlug]/(dashboard)/wiki/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(dashboard)/wiki/page.tsx
@@ -1,0 +1,1 @@
+export { WikiPage as default } from "@multica/views/wiki";

--- a/packages/core/paths/paths.ts
+++ b/packages/core/paths/paths.ts
@@ -33,6 +33,7 @@ function workspaceScoped(slug: string) {
     skills: () => `${ws}/skills`,
     skillDetail: (id: string) => `${ws}/skills/${encode(id)}`,
     settings: () => `${ws}/settings`,
+    wiki: () => `${ws}/wiki`,
   };
 }
 

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -107,6 +107,7 @@ type NavKey =
   | "agents"
   | "runtimes"
   | "skills"
+  | "wiki"
   | "settings";
 
 const personalNav: { key: NavKey; label: string; icon: typeof Inbox }[] = [
@@ -119,6 +120,7 @@ const workspaceNav: { key: NavKey; label: string; icon: typeof Inbox }[] = [
   { key: "projects", label: "Projects", icon: FolderKanban },
   { key: "autopilots", label: "Autopilot", icon: Zap },
   { key: "agents", label: "Agents", icon: Bot },
+  { key: "wiki", label: "Wiki", icon: BookOpenText },
 ];
 
 const configureNav: { key: NavKey; label: string; icon: typeof Inbox }[] = [

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -24,6 +24,7 @@
     "./modals/create-issue": "./modals/create-issue.tsx",
     "./my-issues": "./my-issues/index.ts",
     "./skills": "./skills/index.ts",
+    "./wiki": "./wiki/index.ts",
     "./agents": "./agents/index.ts",
     "./inbox": "./inbox/index.ts",
     "./runtimes": "./runtimes/index.ts",

--- a/packages/views/wiki/index.ts
+++ b/packages/views/wiki/index.ts
@@ -1,0 +1,1 @@
+export { WikiPage } from "./wiki-page";

--- a/packages/views/wiki/wiki-page.tsx
+++ b/packages/views/wiki/wiki-page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { BookOpenText } from "lucide-react";
+import { PageHeader } from "../layout/page-header";
+
+export function WikiPage() {
+  return (
+    <div className="flex flex-1 min-h-0 flex-col">
+      <PageHeader className="px-5">
+        <div className="flex items-center gap-2">
+          <BookOpenText className="h-4 w-4 text-muted-foreground" />
+          <h1 className="text-sm font-medium">Wiki</h1>
+        </div>
+      </PageHeader>
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+          <BookOpenText className="h-6 w-6 text-muted-foreground" />
+        </div>
+        <h2 className="text-base font-semibold">Wiki coming soon</h2>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          A shared knowledge base for your workspace. Stay tuned.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Wires up the wiki section as described in NR-16.

## Changes
- Added `wiki()` path builder to `packages/core/paths/paths.ts`
- Created Next.js page at `apps/web/app/[workspaceSlug]/(dashboard)/wiki/page.tsx`
- Added 'Wiki' entry to the Workspace nav section in `app-sidebar.tsx`
- Created placeholder `WikiPage` component in `packages/views/wiki/`
- Added `./wiki` export to `packages/views/package.json`