### PR TITLE
fix(server): include resources in project get response

### DIFF
--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -28,8 +28,9 @@ type ProjectResponse struct {
 	LeadID      *string `json:"lead_id"`
 	CreatedAt   string  `json:"created_at"`
 	UpdatedAt   string  `json:"updated_at"`
-	IssueCount  int64   `json:"issue_count"`
-	DoneCount   int64   `json:"done_count"`
+	IssueCount  int64                     `json:"issue_count"`
+	DoneCount   int64                     `json:"done_count"`
+	Resources   []ProjectResourceResponse  `json:"resources,omitempty"`
 }
 
 func projectToResponse(p db.Project) ProjectResponse {
@@ -157,6 +158,12 @@ func (h *Handler) GetProject(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := projectToResponse(project)
 	resp.IssueCount, resp.DoneCount = h.loadProjectIssueStats(r.Context(), project.ID)
+	if resources, err := h.Queries.ListProjectResources(r.Context(), project.ID); err == nil && len(resources) > 0 {
+		resp.Resources = make([]ProjectResourceResponse, len(resources))
+		for i, r := range resources {
+			resp.Resources[i] = projectResourceToResponse(r)
+		}
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 


### PR DESCRIPTION
## Problem

`multica project get <id>` returns project details without its attached resources (#2087). Agents using the CLI cannot discover project resources unless explicitly told to read `project/resources.json` — a file path they have no way to know about.

## Fix

Add a `resources` field to the `GetProject` API response. When a project has attached resources, they are now included inline in the response from `GET /api/projects/{id}`.

### Changes

- **`ProjectResponse`**: Added `Resources []ProjectResourceResponse \`json:"resources,omitempty"\`` field
- **`GetProject` handler**: After loading the project, calls `ListProjectResources` and includes results in the response

The field uses `omitempty` so projects with no resources return the same shape as before — no breaking change for existing consumers.

### Before
```json
{"id": "...", "title": "my-project", "status": "planned", ...}
```

### After
```json
{"id": "...", "title": "my-project", "status": "planned", ..., "resources": [{"id": "...", "resource_type": "github_repo", "resource_ref": {"url": "https://github.com/..."}}]}
```

## Verification

- `go vet ./internal/handler/...` passes clean
- 1 file changed, +9/-2 lines (alignment adjustments on existing fields)
- `ListProjectResources` is the same query used by the existing `GET /api/projects/{id}/resources` endpoint

Closes #2087