### PR TITLE
feat(driver-plane): verdict routing state machine without mention-pong

### DIFF
--- a/docs/reviewer-verdict-routing-v1.md
+++ b/docs/reviewer-verdict-routing-v1.md
@@ -1,0 +1,240 @@
+# Reviewer Verdict Routing — Driver-Plane State Machine v1
+
+Related: [DRV-78](mention://issue/68455f33-73d7-4a56-aad5-fb2eccfd0734) · [DRV-79](mention://issue/3ea0dab1-52ff-4b1a-942c-64eeeb38c0bd) · [DRV-80](mention://issue/0a2dcef5-5ed1-4965-b876-b4b039fc66d7)
+
+## Problem
+
+Review verdicts (REQUEST_CHANGES / BLOCKER) currently require a human `@mention` to wake the implementing agent. This doc specifies the driver-plane state machine that routes verdicts to fix tasks automatically — no mention-pong, no polling.
+
+---
+
+## 1. States
+
+| State | Issue status | Meaning |
+|---|---|---|
+| `IMPLEMENTING` | `in_progress` | Implementer writing/fixing code |
+| `AWAITING_REVIEW` | `in_review` | PR open, reviewer agent running or queued |
+| `FIX_IN_PROGRESS` | `in_review` | Fix task created; implementer working on changes |
+| `ESCALATED` | `blocked` | Exceeded max fix cycles, or BLOCKER on scope/auth/human-decision |
+| `MERGE_READY` | `in_review` | APPROVED; waiting for merge gate |
+| `DONE` | `done` | Merged and closed |
+
+`in_review` covers both AWAITING_REVIEW and FIX_IN_PROGRESS because the parent issue is still under review in both cases. `blocked` is reserved for cases where a human must unblock.
+
+---
+
+## 2. Transitions
+
+```
+IMPLEMENTING ──(push PR + request review)──▶ AWAITING_REVIEW
+
+AWAITING_REVIEW ──(APPROVED)──────────────▶ MERGE_READY
+AWAITING_REVIEW ──(WARNING)───────────────▶ MERGE_READY        (non-blocking; audit trail only)
+AWAITING_REVIEW ──(REQUEST_CHANGES)───────▶ FIX_IN_PROGRESS    (create/reuse fix task)
+AWAITING_REVIEW ──(BLOCKER)───────────────▶ ESCALATED          (if scope/auth/human-decision)
+AWAITING_REVIEW ──(BLOCKER, code fix ok)──▶ FIX_IN_PROGRESS    (create/reuse fix task)
+
+FIX_IN_PROGRESS ──(implementer pushes)────▶ AWAITING_REVIEW    (re-request review)
+FIX_IN_PROGRESS ──(N ≥ 3 failed cycles)──▶ ESCALATED
+
+MERGE_READY ──(merge succeeds)────────────▶ DONE
+MERGE_READY ──(merge fails / CI red)──────▶ FIX_IN_PROGRESS
+
+ESCALATED ──(human resolves + reassigns)──▶ IMPLEMENTING
+```
+
+---
+
+## 3. Idempotency Keys
+
+Fix tasks are keyed by `{head_sha}:{verdict_id}` to prevent duplicates.
+
+| Scenario | Driver behavior |
+|---|---|
+| Same verdict re-posted (same `verdict_id`) | Look up task by idempotency key → reuse existing; do NOT create second task |
+| Same HEAD SHA, new verdict ID | New idempotency key → create new fix task (reviewer ran again on same commit) |
+| New HEAD SHA, new verdict ID | New idempotency key → new fix task (implementer pushed; new review cycle) |
+| New HEAD SHA, stale verdict ID re-used | Should not happen; `verdict_id` is UUID per emission — treat as duplicate of old verdict |
+
+**Storage:** idempotency key is written to the fix task description as a machine-readable tag:
+
+```
+<!-- multica:fix-task-key {head_sha}:{verdict_id} -->
+```
+
+Driver scans existing child issues for this tag before creating a new task.
+
+---
+
+## 4. BLOCKER Routing Decision Tree
+
+Not all BLOCKERs warrant a fix task. Driver must classify before routing:
+
+```
+BLOCKER finding
+├── check = "scope-change" | "product-ambiguity"  → ESCALATED (no fix task)
+├── check = "destructive-operation"                → ESCALATED (no fix task)
+├── check = "auth-failure" | "permission-denied"  → ESCALATED (no fix task)
+├── finding.required_action contains "human"      → ESCALATED (no fix task)
+└── otherwise                                      → FIX_IN_PROGRESS (fix task)
+```
+
+Escalated BLOCKERs set issue to `blocked` and post an audit comment with the human escalation reason. No agent mention link — human discovers it via issue status change.
+
+---
+
+## 5. Fix Task Shape
+
+When the driver creates a fix task:
+
+```
+Title:       fix(scope): address {VERDICT} from review {verdict_id[:8]}
+Parent:      parent issue ID (same as the issue under review)
+Status:      todo
+Priority:    inherit from parent
+Assigned to: implementer agent ID (same agent that opened the PR)
+Project:     same project as parent
+Description:
+  Parent review: {parent_issue_identifier} PR: {pr_url} @ {head_sha[:7]}
+
+  <!-- multica:fix-task-key {head_sha}:{verdict_id} -->
+
+  ## Findings to address
+
+  {for each finding with severity >= high:}
+  - [{severity}] `{check}` — {rationale}
+    File: {location.file}:{location.line}
+    Fix: {required_action}
+
+  {if truncated:}
+  … plus {N} lower-severity findings. See verdict comment for full list.
+
+  ## Verifications that must pass before re-review
+
+  {for each verification that failed:}
+  - [ ] {verification.name}
+
+  Re-push when fixed. No @mention needed — assignment wakes this task automatically.
+```
+
+Assignment (not mention) wakes the implementer. The issue `Wakeup` mechanism already fires a task on assignment to an agent.
+
+---
+
+## 6. Audit Comment Format
+
+Driver posts exactly ONE comment per review iteration. Contents:
+
+```
+**Review iteration {N}** · verdict `{VERDICT}` · {verdict_id[:8]}
+
+{if APPROVED:}
+All checks passed. Routing to merge gate.
+
+{if WARNING:}
+{M} low/medium finding(s). Non-blocking — proceeding to merge gate.
+{finding list: "- [{severity}] {check}: {rationale[:120]}"}
+
+{if REQUEST_CHANGES:}
+{M} high finding(s) require fixes. Fix task: [{fix_task_identifier}](mention://issue/{fix_task_id}).
+Implementer will push when done; reviewer will be re-requested automatically.
+
+{if BLOCKER (fix task created):}
+{M} critical finding(s) block merge. Fix task: [{fix_task_identifier}](mention://issue/{fix_task_id}).
+
+{if BLOCKER (escalated):}
+Escalated: {escalation_reason}. Human decision required before this can proceed.
+
+{if cycle >= 3:}
+⚠ {N} fix cycles completed without resolution. Escalating for human review.
+```
+
+**No `mention://agent` link in this comment.** Issue-mention links (`mention://issue/...`) are safe (no side effect).
+
+---
+
+## 7. Cycle Counter and Escalation
+
+The driver tracks `review_cycle` as an integer in the issue description or a label:
+
+```
+<!-- multica:review-cycle {N} -->
+```
+
+Increment on each AWAITING_REVIEW → FIX_IN_PROGRESS transition. On `N ≥ 3` REQUEST_CHANGES/BLOCKER: skip fix task, post escalation comment, set issue to `blocked`.
+
+Label `review-escalated` is attached when escalated so humans can filter.
+
+---
+
+## 8. Malformed Verdict Handling
+
+Per DRV-79 §6 — driver behavior when envelope parse fails:
+
+| Failure | Derived verdict | Driver action |
+|---|---|---|
+| JSON parse fails | WARNING | Log `malformed-envelope` finding; do NOT create fix task; post audit comment |
+| Unknown `schema_version` | WARNING | Log `unsupported-schema-version`; treat as prose fallback |
+| `verdict` inconsistent with `max(severity)` | Derived from findings | Override; log `verdict-severity-mismatch` |
+| Missing required fields | BLOCKER | Escalate; log `incomplete-envelope` |
+| Findings exceed cap | — | Trim to cap; add `cap-exceeded` info finding |
+
+Driver never auto-retriggers reviewer on malformed verdict (loop risk). Post one audit comment; stop.
+
+---
+
+## 9. No-Mention Wake Protocol
+
+The platform wakes an agent when a task is assigned to it (see `EnqueueTaskForIssue` / `ClaimTask`). Driver exploits this:
+
+1. Create fix task assigned to implementer agent → platform enqueues a run.
+2. Implementer runs, fixes, pushes, then updates fix task status to `done`.
+3. Implementer also transitions parent issue back to `in_review`.
+4. Platform wake on parent issue `in_review` + reviewer autopilot → reviewer runs.
+5. Reviewer posts new verdict comment → driver processes it (driver is the assignee of the parent issue → new comment triggers new run).
+
+No `mention://agent` at any step. Assignment + status change + comment on assigned issue are sufficient triggers.
+
+---
+
+## 10. Test Plan
+
+### 10.1 Unit tests (`packages/core/verdict-router.test.ts`)
+
+| Test | Input | Expected |
+|---|---|---|
+| Parse valid APPROVED envelope | Comment with fenced `multica:reviewer-verdict v1` block | Returns parsed `VerdictEnvelope` with verdict=APPROVED |
+| Parse valid REQUEST_CHANGES envelope | Same | verdict=REQUEST_CHANGES, findings non-empty |
+| Parse valid BLOCKER envelope | Same | verdict=BLOCKER, findings with critical severity |
+| Parse valid WARNING envelope | Same | verdict=WARNING |
+| Prose-only comment (no envelope) | Plain text "LGTM" | Returns `null` envelope; fallback WARNING decision |
+| Malformed JSON in envelope | Garbled JSON | `ParseResult.error = 'malformed-envelope'` |
+| Unknown schema version | `schema_version: "99"` | `ParseResult.error = 'unsupported-schema-version'` |
+| Verdict/severity mismatch | verdict=APPROVED but finding.severity=critical | Derived verdict=BLOCKER; `mismatch` flag set |
+| Missing required fields | Envelope without `verdict_id` | `ParseResult.error = 'incomplete-envelope'`; treated as BLOCKER |
+| Cap exceeded | 25 findings | Trimmed to 20; `cap-exceeded` info finding appended |
+| Derive idempotency key | head_sha="abc123", verdict_id="uuid-1" | `abc123:uuid-1` |
+
+### 10.2 Routing tests (`packages/core/verdict-router.test.ts`)
+
+| Test | Scenario | Expected |
+|---|---|---|
+| Duplicate verdict — same idempotency key | `routeVerdict` called twice with same head_sha+verdict_id, existing fix task present | Returns `action=REUSE_TASK`, same task ID |
+| Moved head SHA — new commit, new verdict | New head_sha, new verdict_id; no existing task with key | Returns `action=CREATE_TASK` |
+| New verdict on same SHA | Same head_sha, new verdict_id (reviewer ran again) | Returns `action=CREATE_TASK` (new verdict cycle) |
+| APPROVED routing | verdict=APPROVED | Returns `action=MERGE_GATE` |
+| WARNING routing | verdict=WARNING | Returns `action=MERGE_GATE` + findings surfaced |
+| BLOCKER scope-change check | BLOCKER with `check=scope-change` | Returns `action=ESCALATE` |
+| BLOCKER code fix | BLOCKER with `check=p0-cancellation-rethrow` | Returns `action=CREATE_TASK` |
+| Cycle limit reached | `reviewCycle=3`, verdict=REQUEST_CHANGES | Returns `action=ESCALATE` |
+| Malformed verdict | Parse error | Returns `action=AUDIT_ONLY` (no task, no escalation) |
+
+### 10.3 Integration / manual test plan
+
+1. **Happy path APPROVED**: open PR → reviewer posts APPROVED envelope → driver creates no fix task, transitions issue to merge-ready, posts audit comment with iteration + verdict_id.
+2. **REQUEST_CHANGES cycle**: reviewer posts REQUEST_CHANGES → fix task created, assignee = implementer → implementer pushes → fix task marked done → reviewer re-runs → APPROVED.
+3. **Duplicate verdict idempotency**: same verdict comment posted twice (e.g., accidental re-trigger) → second run finds existing fix task by key → no duplicate task created.
+4. **Moved head SHA**: implementer pushes new commit → reviewer posts new verdict for new SHA → new fix task with new key → old fix task not touched.
+5. **Escalation after 3 cycles**: 3 × REQUEST_CHANGES with no resolution → issue set to `blocked`, `review-escalated` label, no new fix task, audit comment says "escalating".
+6. **BLOCKER scope-change**: reviewer posts BLOCKER with check=scope-change → no fix task, issue blocked, human escalation comment.
+7. **Malformed envelope**: reviewer posts garbled JSON in fenced block → audit comment only, no fix task, no loop.

--- a/packages/core/verdict-router.test.ts
+++ b/packages/core/verdict-router.test.ts
@@ -1,0 +1,650 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseVerdictFromComment,
+  routeVerdict,
+  routeMalformedVerdict,
+  buildIdempotencyKey,
+  extractFixTaskKey,
+  buildFixTaskKeyTag,
+  buildFixTaskDraft,
+  buildAuditComment,
+  type VerdictEnvelope,
+  type RoutingContext,
+  type ExistingFixTask,
+} from "./verdict-router";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeEnvelope(overrides: Partial<VerdictEnvelope> = {}): VerdictEnvelope {
+  return {
+    schema_version: "1",
+    verdict: "APPROVED",
+    verdict_id: "aaaaaaaa-0000-0000-0000-000000000001",
+    pr: { url: "https://github.com/multica-ai/multica/pull/1", head_sha: "abc1234", base_sha: "f0e9d8c" },
+    reviewer: { agent_id: "rev-001", agent_name: "codex-reviewer" },
+    issued_at: "2026-05-05T10:00:00Z",
+    findings: [],
+    verifications: [{ name: "pnpm test", status: "passed", evidence: "all green" }],
+    summary: "Looks good.",
+    next_review_required: false,
+    ...overrides,
+  };
+}
+
+function wrapInComment(envelope: VerdictEnvelope): string {
+  return `Some prose before.\n\n<!-- multica:reviewer-verdict v1 -->\n\`\`\`json\n${JSON.stringify(envelope, null, 2)}\n\`\`\`\n\nSome prose after.`;
+}
+
+function makeContext(overrides: Partial<RoutingContext> = {}): RoutingContext {
+  return { reviewCycle: 1, existingFixTasks: [], ...overrides };
+}
+
+function makeFixTask(idempotencyKey: string): ExistingFixTask {
+  return { id: "task-001", identifier: "DRV-99", idempotencyKey };
+}
+
+// ── Parse tests ───────────────────────────────────────────────────────────────
+
+describe("parseVerdictFromComment", () => {
+  it("parses a valid APPROVED envelope", () => {
+    const env = makeEnvelope({ verdict: "APPROVED" });
+    const result = parseVerdictFromComment(wrapInComment(env));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.envelope.verdict).toBe("APPROVED");
+    expect(result.envelope.verdict_id).toBe(env.verdict_id);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("parses a valid REQUEST_CHANGES envelope with findings", () => {
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      findings: [
+        {
+          id: "sha256:abc",
+          severity: "high",
+          check: "missing-test",
+          rationale: "Branch without coverage.",
+          required_action: "Add test.",
+          location: { file: "src/foo.ts", line: 10, range: null, commit_sha: "abc1234" },
+          tags: ["tests"],
+        },
+      ],
+    });
+    const result = parseVerdictFromComment(wrapInComment(env));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.envelope.verdict).toBe("REQUEST_CHANGES");
+    expect(result.envelope.findings).toHaveLength(1);
+  });
+
+  it("parses a valid BLOCKER envelope", () => {
+    const env = makeEnvelope({
+      verdict: "BLOCKER",
+      findings: [
+        {
+          id: "sha256:def",
+          severity: "critical",
+          check: "p0-cancellation-rethrow",
+          rationale: "Silent deadlock risk.",
+          required_action: "Re-throw CancellationException.",
+          location: { file: "src/dispatcher.ts", line: 57, range: null, commit_sha: "abc1234" },
+          tags: ["concurrency", "p0"],
+        },
+      ],
+    });
+    const result = parseVerdictFromComment(wrapInComment(env));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.envelope.verdict).toBe("BLOCKER");
+  });
+
+  it("parses a valid WARNING envelope", () => {
+    const env = makeEnvelope({
+      verdict: "WARNING",
+      findings: [
+        {
+          id: "sha256:ghi",
+          severity: "low",
+          check: "naming-convention",
+          rationale: "Unclear name.",
+          required_action: "Rename.",
+          location: { file: null, line: null, range: null, commit_sha: "abc1234" },
+          tags: ["style"],
+        },
+      ],
+    });
+    const result = parseVerdictFromComment(wrapInComment(env));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.envelope.verdict).toBe("WARNING");
+  });
+
+  it("returns malformed-envelope for prose-only comment", () => {
+    const result = parseVerdictFromComment("LGTM, looks great!");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("malformed-envelope");
+  });
+
+  it("returns malformed-envelope for garbled JSON", () => {
+    const comment = `<!-- multica:reviewer-verdict v1 -->\n\`\`\`json\n{ not valid json }\n\`\`\``;
+    const result = parseVerdictFromComment(comment);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("malformed-envelope");
+  });
+
+  it("returns unsupported-schema-version for unknown version", () => {
+    const env = makeEnvelope({ schema_version: "99" } as Partial<VerdictEnvelope>);
+    const result = parseVerdictFromComment(wrapInComment(env));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("unsupported-schema-version");
+  });
+
+  it("corrects verdict/severity mismatch and emits warning", () => {
+    // Reviewer claims APPROVED but findings include critical — should derive BLOCKER
+    const env = makeEnvelope({
+      verdict: "APPROVED",
+      findings: [
+        {
+          id: "sha256:mismatch",
+          severity: "critical",
+          check: "sql-injection",
+          rationale: "SQL injection.",
+          required_action: "Use parameterized query.",
+          location: { file: "db.ts", line: 5, range: null, commit_sha: "abc1234" },
+          tags: ["security"],
+        },
+      ],
+    });
+    const result = parseVerdictFromComment(wrapInComment(env));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.envelope.verdict).toBe("BLOCKER"); // overridden
+    expect(result.warnings).toContain("verdict-severity-mismatch");
+  });
+
+  it("returns incomplete-envelope when required fields missing", () => {
+    const env = makeEnvelope();
+    const broken = { ...env } as Record<string, unknown>;
+    delete broken["verdict_id"];
+    const comment = `<!-- multica:reviewer-verdict v1 -->\n\`\`\`json\n${JSON.stringify(broken)}\n\`\`\``;
+    const result = parseVerdictFromComment(comment);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("incomplete-envelope");
+  });
+
+  it("trims findings to cap and adds cap-exceeded marker", () => {
+    const findings = Array.from({ length: 25 }, (_, i) => ({
+      id: `sha256:f${i}`,
+      severity: "high" as const,
+      check: `check-${i}`,
+      rationale: `Rationale ${i}`,
+      required_action: `Fix ${i}`,
+      location: { file: `file${i}.ts`, line: i + 1, range: null, commit_sha: "abc1234" },
+      tags: [],
+    }));
+    const env = makeEnvelope({ verdict: "REQUEST_CHANGES", findings });
+    const result = parseVerdictFromComment(wrapInComment(env));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const success = result;
+    expect(success.envelope.findings).toHaveLength(20);
+    expect(success.envelope.findings[19]!.check).toBe("cap-exceeded");
+    expect(success.warnings).toContain("cap-exceeded");
+  });
+});
+
+// ── Idempotency key tests ─────────────────────────────────────────────────────
+
+describe("buildIdempotencyKey", () => {
+  it("combines head_sha and verdict_id", () => {
+    expect(buildIdempotencyKey("abc1234", "uuid-1")).toBe("abc1234:uuid-1");
+  });
+});
+
+describe("extractFixTaskKey", () => {
+  it("extracts key from description tag", () => {
+    const desc = `Some text\n${buildFixTaskKeyTag("abc1234:uuid-1")}\nMore text`;
+    expect(extractFixTaskKey(desc)).toBe("abc1234:uuid-1");
+  });
+
+  it("returns null when no tag present", () => {
+    expect(extractFixTaskKey("No tag here")).toBeNull();
+  });
+});
+
+// ── Routing tests ─────────────────────────────────────────────────────────────
+
+describe("routeVerdict", () => {
+  it("routes APPROVED to MERGE_GATE", () => {
+    const env = makeEnvelope({ verdict: "APPROVED" });
+    const decision = routeVerdict(env, makeContext());
+    expect(decision.action).toBe("MERGE_GATE");
+  });
+
+  it("routes WARNING to MERGE_GATE", () => {
+    const env = makeEnvelope({
+      verdict: "WARNING",
+      findings: [
+        {
+          id: "sha256:w1",
+          severity: "low",
+          check: "style",
+          rationale: "Minor.",
+          required_action: "Rename.",
+          location: { file: null, line: null, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    const decision = routeVerdict(env, makeContext());
+    expect(decision.action).toBe("MERGE_GATE");
+  });
+
+  it("routes REQUEST_CHANGES to CREATE_TASK when no existing task", () => {
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      findings: [
+        {
+          id: "sha256:rc1",
+          severity: "high",
+          check: "missing-test",
+          rationale: "Missing test.",
+          required_action: "Add test.",
+          location: { file: "foo.ts", line: 1, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    const decision = routeVerdict(env, makeContext());
+    expect(decision.action).toBe("CREATE_TASK");
+    expect(decision.idempotencyKey).toBe(
+      buildIdempotencyKey(env.pr.head_sha, env.verdict_id)
+    );
+  });
+
+  it("routes duplicate verdict (same idempotency key) to REUSE_TASK", () => {
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      findings: [
+        {
+          id: "sha256:rc1",
+          severity: "high",
+          check: "missing-test",
+          rationale: "Missing test.",
+          required_action: "Add test.",
+          location: { file: "foo.ts", line: 1, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    const key = buildIdempotencyKey(env.pr.head_sha, env.verdict_id);
+    const ctx = makeContext({ existingFixTasks: [makeFixTask(key)] });
+    const decision = routeVerdict(env, ctx);
+    expect(decision.action).toBe("REUSE_TASK");
+    expect(decision.fixTaskId).toBe("task-001");
+  });
+
+  it("creates new task when head SHA moved (new commit, same verdict struct)", () => {
+    // New head SHA = new idempotency key even if verdict_id is different
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      pr: { url: "https://...", head_sha: "newsha99", base_sha: "f0e9d8c" },
+      verdict_id: "bbbbbbbb-0000-0000-0000-000000000002",
+      findings: [
+        {
+          id: "sha256:rc2",
+          severity: "high",
+          check: "missing-test",
+          rationale: "Missing test.",
+          required_action: "Add test.",
+          location: { file: "foo.ts", line: 1, range: null, commit_sha: "newsha99" },
+          tags: [],
+        },
+      ],
+    });
+    // Old task has old key (different sha + verdict_id)
+    const oldKey = buildIdempotencyKey("abc1234", "aaaaaaaa-0000-0000-0000-000000000001");
+    const ctx = makeContext({ existingFixTasks: [makeFixTask(oldKey)] });
+    const decision = routeVerdict(env, ctx);
+    expect(decision.action).toBe("CREATE_TASK");
+    expect(decision.idempotencyKey).toBe("newsha99:bbbbbbbb-0000-0000-0000-000000000002");
+  });
+
+  it("routes BLOCKER with code fix to CREATE_TASK", () => {
+    const env = makeEnvelope({
+      verdict: "BLOCKER",
+      findings: [
+        {
+          id: "sha256:bl1",
+          severity: "critical",
+          check: "p0-cancellation-rethrow",
+          rationale: "Silent deadlock.",
+          required_action: "Re-throw CancellationException.",
+          location: { file: "dispatcher.ts", line: 57, range: null, commit_sha: "abc1234" },
+          tags: ["p0"],
+        },
+      ],
+    });
+    const decision = routeVerdict(env, makeContext());
+    expect(decision.action).toBe("CREATE_TASK");
+  });
+
+  it("escalates BLOCKER with scope-change check", () => {
+    const env = makeEnvelope({
+      verdict: "BLOCKER",
+      findings: [
+        {
+          id: "sha256:sc1",
+          severity: "critical",
+          check: "scope-change",
+          rationale: "This PR changes product scope beyond the issue.",
+          required_action: "Human must decide whether to proceed.",
+          location: { file: null, line: null, range: null, commit_sha: "abc1234" },
+          tags: ["scope"],
+        },
+      ],
+    });
+    const decision = routeVerdict(env, makeContext());
+    expect(decision.action).toBe("ESCALATE");
+  });
+
+  it("escalates BLOCKER with destructive-operation check", () => {
+    const env = makeEnvelope({
+      verdict: "BLOCKER",
+      findings: [
+        {
+          id: "sha256:do1",
+          severity: "critical",
+          check: "destructive-operation",
+          rationale: "Drops production table.",
+          required_action: "Human approval required.",
+          location: { file: "migration.sql", line: 1, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    const decision = routeVerdict(env, makeContext());
+    expect(decision.action).toBe("ESCALATE");
+  });
+
+  it("escalates when cycle limit reached on REQUEST_CHANGES", () => {
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      findings: [
+        {
+          id: "sha256:cl1",
+          severity: "high",
+          check: "missing-test",
+          rationale: "Still missing.",
+          required_action: "Add test.",
+          location: { file: "foo.ts", line: 1, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    const ctx = makeContext({ reviewCycle: 3 });
+    const decision = routeVerdict(env, ctx);
+    expect(decision.action).toBe("ESCALATE");
+    expect(decision.reason).toContain("fix cycle");
+  });
+
+  it("respects custom maxCycles", () => {
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      findings: [
+        {
+          id: "sha256:mc1",
+          severity: "high",
+          check: "missing-test",
+          rationale: "Still.",
+          required_action: "Add test.",
+          location: { file: "foo.ts", line: 1, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    // maxCycles=5, cycle=3 → should still CREATE_TASK
+    const ctx = makeContext({ reviewCycle: 3, maxCycles: 5 });
+    const decision = routeVerdict(env, ctx);
+    expect(decision.action).toBe("CREATE_TASK");
+
+    // At cycle 5 → ESCALATE
+    const ctx5 = makeContext({ reviewCycle: 5, maxCycles: 5 });
+    const decision5 = routeVerdict(env, ctx5);
+    expect(decision5.action).toBe("ESCALATE");
+  });
+});
+
+describe("routeMalformedVerdict", () => {
+  it("returns AUDIT_ONLY for malformed-envelope", () => {
+    const result = routeMalformedVerdict({ ok: false, error: "malformed-envelope", rawContent: "" });
+    expect(result.action).toBe("AUDIT_ONLY");
+  });
+
+  it("returns ESCALATE for incomplete-envelope (fail closed)", () => {
+    const result = routeMalformedVerdict({ ok: false, error: "incomplete-envelope", rawContent: "" });
+    expect(result.action).toBe("ESCALATE");
+  });
+});
+
+// ── Fix task draft tests ──────────────────────────────────────────────────────
+
+describe("buildFixTaskDraft", () => {
+  it("title contains verdict type and short verdict_id", () => {
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      verdict_id: "aaaaaaaa-1234-0000-0000-000000000001",
+      findings: [
+        {
+          id: "sha256:f1",
+          severity: "high",
+          check: "missing-test",
+          rationale: "No test.",
+          required_action: "Add test.",
+          location: { file: "foo.ts", line: 1, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    const key = buildIdempotencyKey(env.pr.head_sha, env.verdict_id);
+    const draft = buildFixTaskDraft(env, "DRV-80", key);
+    expect(draft.title).toContain("REQUEST_CHANGES");
+    expect(draft.title).toContain("aaaaaaaa");
+  });
+
+  it("description embeds idempotency key tag", () => {
+    const env = makeEnvelope({ verdict: "REQUEST_CHANGES" });
+    const key = buildIdempotencyKey(env.pr.head_sha, env.verdict_id);
+    const draft = buildFixTaskDraft(env, "DRV-80", key);
+    expect(draft.description).toContain(`<!-- multica:fix-task-key ${key} -->`);
+  });
+
+  it("description includes high/critical findings", () => {
+    const env = makeEnvelope({
+      verdict: "BLOCKER",
+      findings: [
+        {
+          id: "sha256:bl1",
+          severity: "critical",
+          check: "sql-injection",
+          rationale: "SQL injection risk.",
+          required_action: "Parameterize query.",
+          location: { file: "db.ts", line: 10, range: null, commit_sha: "abc1234" },
+          tags: ["security"],
+        },
+      ],
+    });
+    const key = buildIdempotencyKey(env.pr.head_sha, env.verdict_id);
+    const draft = buildFixTaskDraft(env, "DRV-80", key);
+    expect(draft.description).toContain("sql-injection");
+    expect(draft.description).toContain("Parameterize query");
+  });
+
+  it("description omits low findings but counts them", () => {
+    const findings = [
+      {
+        id: "sha256:h1",
+        severity: "high" as const,
+        check: "high-check",
+        rationale: "High issue.",
+        required_action: "Fix high.",
+        location: { file: "a.ts", line: 1, range: null, commit_sha: "abc1234" },
+        tags: [],
+      },
+      {
+        id: "sha256:l1",
+        severity: "low" as const,
+        check: "style",
+        rationale: "Minor style.",
+        required_action: "Rename.",
+        location: { file: "b.ts", line: 2, range: null, commit_sha: "abc1234" },
+        tags: [],
+      },
+    ];
+    const env = makeEnvelope({ verdict: "REQUEST_CHANGES", findings });
+    const key = buildIdempotencyKey(env.pr.head_sha, env.verdict_id);
+    const draft = buildFixTaskDraft(env, "DRV-80", key);
+    expect(draft.description).toContain("high-check");
+    expect(draft.description).toContain("1 lower-severity finding");
+    expect(draft.description).not.toContain("style\n");
+  });
+
+  it("includes failed verifications checklist", () => {
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      findings: [
+        {
+          id: "sha256:f1",
+          severity: "high",
+          check: "c",
+          rationale: "r",
+          required_action: "f",
+          location: { file: null, line: null, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+      verifications: [
+        { name: "pnpm test", status: "failed", evidence: "3 failures" },
+        { name: "pnpm typecheck", status: "passed", evidence: "ok" },
+      ],
+    });
+    const key = buildIdempotencyKey(env.pr.head_sha, env.verdict_id);
+    const draft = buildFixTaskDraft(env, "DRV-80", key);
+    expect(draft.description).toContain("pnpm test");
+    expect(draft.description).not.toContain("pnpm typecheck");
+  });
+});
+
+// ── Audit comment tests ───────────────────────────────────────────────────────
+
+describe("buildAuditComment", () => {
+  it("APPROVED: mentions iteration + verdict + routing to merge gate", () => {
+    const env = makeEnvelope({ verdict: "APPROVED" });
+    const decision = routeVerdict(env, makeContext());
+    const comment = buildAuditComment({ iterationNumber: 1, envelope: env, decision });
+    expect(comment).toContain("Review iteration 1");
+    expect(comment).toContain("APPROVED");
+    expect(comment).toContain("merge gate");
+    expect(comment).not.toMatch(/mention:\/\/agent/);
+  });
+
+  it("REQUEST_CHANGES with task: contains fix task issue-mention link", () => {
+    const env = makeEnvelope({
+      verdict: "REQUEST_CHANGES",
+      findings: [
+        {
+          id: "sha256:f1",
+          severity: "high",
+          check: "c",
+          rationale: "r",
+          required_action: "f",
+          location: { file: null, line: null, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    const decision = routeVerdict(env, makeContext());
+    const comment = buildAuditComment({
+      iterationNumber: 2,
+      envelope: env,
+      decision,
+      fixTaskIdentifier: "DRV-99",
+      fixTaskId: "task-001-uuid",
+    });
+    expect(comment).toContain("[DRV-99](mention://issue/task-001-uuid)");
+    expect(comment).not.toMatch(/mention:\/\/agent/);
+  });
+
+  it("ESCALATE: contains escalation reason", () => {
+    const env = makeEnvelope({
+      verdict: "BLOCKER",
+      findings: [
+        {
+          id: "sha256:sc1",
+          severity: "critical",
+          check: "scope-change",
+          rationale: "Scope change.",
+          required_action: "Human must decide.",
+          location: { file: null, line: null, range: null, commit_sha: "abc1234" },
+          tags: [],
+        },
+      ],
+    });
+    const decision = routeVerdict(env, makeContext());
+    const comment = buildAuditComment({ iterationNumber: 1, envelope: env, decision });
+    expect(comment).toContain("Escalated");
+    expect(comment).toContain("Human decision required");
+    expect(comment).not.toMatch(/mention:\/\/agent/);
+  });
+
+  it("no agent mention links in any audit comment", () => {
+    const scenarios: Array<[ReturnType<typeof makeEnvelope>, RoutingContext]> = [
+      [makeEnvelope({ verdict: "APPROVED" }), makeContext()],
+      [makeEnvelope({ verdict: "WARNING" }), makeContext()],
+      [
+        makeEnvelope({
+          verdict: "REQUEST_CHANGES",
+          findings: [
+            {
+              id: "sha256:f",
+              severity: "high",
+              check: "c",
+              rationale: "r",
+              required_action: "f",
+              location: { file: null, line: null, range: null, commit_sha: "abc1234" },
+              tags: [],
+            },
+          ],
+        }),
+        makeContext(),
+      ],
+      [
+        makeEnvelope({
+          verdict: "BLOCKER",
+          findings: [
+            {
+              id: "sha256:sc",
+              severity: "critical",
+              check: "scope-change",
+              rationale: ".",
+              required_action: "Human.",
+              location: { file: null, line: null, range: null, commit_sha: "abc1234" },
+              tags: [],
+            },
+          ],
+        }),
+        makeContext(),
+      ],
+    ];
+    for (const [env, ctx] of scenarios) {
+      const decision = routeVerdict(env, ctx);
+      const comment = buildAuditComment({ iterationNumber: 1, envelope: env, decision });
+      expect(comment).not.toMatch(/mention:\/\/agent/);
+    }
+  });
+});

--- a/packages/core/verdict-router.ts
+++ b/packages/core/verdict-router.ts
@@ -1,0 +1,534 @@
+/**
+ * Reviewer Verdict Router — Driver-plane state machine v1
+ *
+ * Parses structured reviewer-verdict envelopes from issue comments and
+ * produces routing decisions (create fix task, escalate, merge gate, etc.)
+ * without requiring agent @mention links.
+ *
+ * Spec: docs/reviewer-verdict-routing-v1.md
+ * Schema: docs/reviewer-verdict-v1.md (DRV-79)
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type VerdictValue = "APPROVED" | "WARNING" | "REQUEST_CHANGES" | "BLOCKER";
+
+export type FindingSeverity = "info" | "low" | "medium" | "high" | "critical";
+
+export interface FindingLocation {
+  file: string | null;
+  line: number | null;
+  range: { start: number; end: number } | null;
+  commit_sha: string;
+}
+
+export interface Finding {
+  id: string;
+  severity: FindingSeverity;
+  check: string;
+  rationale: string;
+  required_action: string;
+  location: FindingLocation;
+  tags: string[];
+}
+
+export interface Verification {
+  name: string;
+  status: "passed" | "failed" | "skipped";
+  evidence: string;
+}
+
+export interface VerdictEnvelope {
+  schema_version: string;
+  verdict: VerdictValue;
+  verdict_id: string;
+  pr: {
+    url: string;
+    head_sha: string;
+    base_sha: string;
+  };
+  reviewer: {
+    agent_id: string;
+    agent_name: string;
+    model?: string;
+  };
+  issued_at: string;
+  findings: Finding[];
+  verifications: Verification[];
+  summary: string;
+  next_review_required: boolean;
+}
+
+export type ParseErrorKind =
+  | "malformed-envelope"
+  | "unsupported-schema-version"
+  | "verdict-severity-mismatch"
+  | "incomplete-envelope"
+  | "cap-exceeded";
+
+export interface ParseSuccess {
+  ok: true;
+  envelope: VerdictEnvelope;
+  warnings: ParseErrorKind[];
+}
+
+export interface ParseFailure {
+  ok: false;
+  error: ParseErrorKind;
+  rawContent: string;
+}
+
+export type ParseResult = ParseSuccess | ParseFailure;
+
+export type RoutingAction =
+  | "MERGE_GATE"       // APPROVED or WARNING — proceed to merge
+  | "CREATE_TASK"      // Create new fix task
+  | "REUSE_TASK"       // Idempotent — existing task already covers this verdict
+  | "ESCALATE"         // Human required
+  | "AUDIT_ONLY";      // Log finding, no task, no escalation (malformed etc.)
+
+export interface ExistingFixTask {
+  id: string;
+  identifier: string;
+  idempotencyKey: string;
+}
+
+export interface RoutingContext {
+  /** Current review iteration count (1-based, incremented after each FIX_IN_PROGRESS). */
+  reviewCycle: number;
+  /** Max fix cycles before escalating. Default 3. */
+  maxCycles?: number;
+  /** Existing child fix tasks for this issue (used for idempotency lookup). */
+  existingFixTasks: ExistingFixTask[];
+}
+
+export interface RoutingDecision {
+  action: RoutingAction;
+  /** Set when action=CREATE_TASK or REUSE_TASK. */
+  fixTaskId?: string;
+  /** Idempotency key used for lookup/creation. */
+  idempotencyKey?: string;
+  /** Human-readable reason, used in audit comment. */
+  reason: string;
+  /** Escalation reason when action=ESCALATE. */
+  escalationReason?: string;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const VERDICT_MARKER = "<!-- multica:reviewer-verdict v1 -->";
+const FIX_TASK_KEY_PATTERN = /<!--\s*multica:fix-task-key\s+(\S+)\s*-->/;
+const FINDING_CAP = 20;
+const SUPPORTED_SCHEMA_VERSIONS = new Set(["1"]);
+const SEVERITY_RANK: Record<FindingSeverity, number> = {
+  info: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+/** Checks that escalate to human instead of creating a fix task. */
+const ESCALATE_CHECKS = new Set([
+  "scope-change",
+  "product-ambiguity",
+  "destructive-operation",
+  "auth-failure",
+  "permission-denied",
+]);
+
+// ── Parsing ───────────────────────────────────────────────────────────────────
+
+/**
+ * Derive the correct verdict from findings — overrides claimed verdict when
+ * inconsistent (prevents reviewer from saying APPROVED while listing critical).
+ */
+function deriveVerdictFromFindings(findings: Finding[]): VerdictValue {
+  if (findings.length === 0) return "APPROVED";
+  const max = findings.reduce((best, f) => {
+    return SEVERITY_RANK[f.severity] > SEVERITY_RANK[best] ? f.severity : best;
+  }, "info" as FindingSeverity);
+  if (max === "critical") return "BLOCKER";
+  if (max === "high") return "REQUEST_CHANGES";
+  if (max === "medium" || max === "low") return "WARNING";
+  return "APPROVED";
+}
+
+/**
+ * Extract and validate the fenced verdict envelope from a comment string.
+ * Returns ParseSuccess with any warnings, or ParseFailure on hard errors.
+ */
+export function parseVerdictFromComment(content: string): ParseResult {
+  const markerIdx = content.indexOf(VERDICT_MARKER);
+  if (markerIdx === -1) {
+    // No structured envelope — driver falls back to prose heuristics upstream
+    return { ok: false, error: "malformed-envelope", rawContent: content };
+  }
+
+  // Extract JSON from fenced block after marker
+  const afterMarker = content.slice(markerIdx + VERDICT_MARKER.length);
+  const fenceMatch = afterMarker.match(/```(?:json)?\s*\n([\s\S]*?)```/);
+  if (!fenceMatch) {
+    return { ok: false, error: "malformed-envelope", rawContent: content };
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fenceMatch[1] ?? "");
+  } catch {
+    return { ok: false, error: "malformed-envelope", rawContent: content };
+  }
+
+  if (typeof raw !== "object" || raw === null) {
+    return { ok: false, error: "malformed-envelope", rawContent: content };
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const warnings: ParseErrorKind[] = [];
+
+  // schema_version check
+  const schemaVersion = String(obj["schema_version"] ?? "");
+  if (!SUPPORTED_SCHEMA_VERSIONS.has(schemaVersion)) {
+    return { ok: false, error: "unsupported-schema-version", rawContent: content };
+  }
+
+  // Required fields
+  const requiredFields = ["verdict", "verdict_id", "pr", "reviewer", "issued_at", "findings"] as const;
+  for (const field of requiredFields) {
+    if (!(field in obj) || obj[field] === null || obj[field] === undefined) {
+      return { ok: false, error: "incomplete-envelope", rawContent: content };
+    }
+  }
+
+  const pr = obj["pr"] as Record<string, unknown>;
+  if (!pr["head_sha"] || !pr["url"] || !pr["base_sha"]) {
+    return { ok: false, error: "incomplete-envelope", rawContent: content };
+  }
+
+  const reviewer = obj["reviewer"] as Record<string, unknown>;
+  if (!reviewer["agent_id"] || !reviewer["agent_name"]) {
+    return { ok: false, error: "incomplete-envelope", rawContent: content };
+  }
+
+  // Findings — cap at FINDING_CAP
+  let findings = (obj["findings"] as Finding[]) ?? [];
+  if (findings.length > FINDING_CAP) {
+    const omittedCount = findings.length - (FINDING_CAP - 1);
+    findings = findings.slice(0, FINDING_CAP - 1);
+    findings.push({
+      id: "truncation-marker",
+      severity: "info",
+      check: "cap-exceeded",
+      rationale: `${omittedCount} additional findings omitted`,
+      required_action: "Review full finding list in the reviewer's session output.",
+      location: { file: null, line: null, range: null, commit_sha: String(pr["head_sha"]) },
+      tags: ["meta"],
+    });
+    warnings.push("cap-exceeded");
+  }
+
+  // Verdict/severity consistency
+  const claimedVerdict = String(obj["verdict"]) as VerdictValue;
+  const derivedVerdict = deriveVerdictFromFindings(findings);
+  const resolvedVerdict =
+    claimedVerdict === derivedVerdict ? claimedVerdict : derivedVerdict;
+  if (claimedVerdict !== derivedVerdict) {
+    warnings.push("verdict-severity-mismatch");
+  }
+
+  const envelope: VerdictEnvelope = {
+    schema_version: schemaVersion,
+    verdict: resolvedVerdict,
+    verdict_id: String(obj["verdict_id"]),
+    pr: {
+      url: String(pr["url"]),
+      head_sha: String(pr["head_sha"]),
+      base_sha: String(pr["base_sha"]),
+    },
+    reviewer: {
+      agent_id: String(reviewer["agent_id"]),
+      agent_name: String(reviewer["agent_name"]),
+      model: reviewer["model"] ? String(reviewer["model"]) : undefined,
+    },
+    issued_at: String(obj["issued_at"]),
+    findings,
+    verifications: (obj["verifications"] as Verification[]) ?? [],
+    summary: String(obj["summary"] ?? ""),
+    next_review_required: Boolean(obj["next_review_required"]),
+  };
+
+  return { ok: true, envelope, warnings };
+}
+
+// ── Idempotency ───────────────────────────────────────────────────────────────
+
+/** Returns the idempotency key for a verdict: `{head_sha}:{verdict_id}` */
+export function buildIdempotencyKey(headSha: string, verdictId: string): string {
+  return `${headSha}:${verdictId}`;
+}
+
+/** Extracts the fix-task idempotency key tag from a task description. */
+export function extractFixTaskKey(description: string): string | null {
+  const m = description.match(FIX_TASK_KEY_PATTERN);
+  return m?.[1] ?? null;
+}
+
+/** Builds the idempotency tag to embed in a fix task description. */
+export function buildFixTaskKeyTag(key: string): string {
+  return `<!-- multica:fix-task-key ${key} -->`;
+}
+
+// ── Escalation classification ─────────────────────────────────────────────────
+
+function shouldEscalateBlocker(findings: Finding[]): { escalate: boolean; reason: string } {
+  for (const f of findings) {
+    if (ESCALATE_CHECKS.has(f.check)) {
+      return {
+        escalate: true,
+        reason: `BLOCKER finding \`${f.check}\` requires human decision: ${f.rationale.slice(0, 200)}`,
+      };
+    }
+    if (f.required_action.toLowerCase().includes("human")) {
+      return {
+        escalate: true,
+        reason: `BLOCKER finding \`${f.check}\` requires human action: ${f.required_action.slice(0, 200)}`,
+      };
+    }
+  }
+  return { escalate: false, reason: "" };
+}
+
+// ── Routing ───────────────────────────────────────────────────────────────────
+
+/**
+ * Given a parsed VerdictEnvelope and the current routing context, returns a
+ * RoutingDecision describing what the driver should do next.
+ *
+ * Does NOT perform any side effects — caller is responsible for creating tasks,
+ * updating issue status, and posting audit comments.
+ */
+export function routeVerdict(
+  envelope: VerdictEnvelope,
+  context: RoutingContext
+): RoutingDecision {
+  const maxCycles = context.maxCycles ?? 3;
+  const { verdict, pr, verdict_id } = envelope;
+  const idempotencyKey = buildIdempotencyKey(pr.head_sha, verdict_id);
+
+  switch (verdict) {
+    case "APPROVED":
+    case "WARNING": {
+      return {
+        action: "MERGE_GATE",
+        idempotencyKey,
+        reason:
+          verdict === "APPROVED"
+            ? "All checks passed. Routing to merge gate."
+            : `${envelope.findings.filter((f) => ["low", "medium"].includes(f.severity)).length} low/medium finding(s). Non-blocking — routing to merge gate.`,
+      };
+    }
+
+    case "REQUEST_CHANGES":
+    case "BLOCKER": {
+      // Check cycle limit first
+      if (context.reviewCycle >= maxCycles) {
+        return {
+          action: "ESCALATE",
+          idempotencyKey,
+          reason: `${context.reviewCycle} fix cycle(s) completed without resolution. Escalating for human review.`,
+          escalationReason: `Exceeded max fix cycles (${maxCycles}).`,
+        };
+      }
+
+      // For BLOCKERs: classify findings to decide escalate vs fix task
+      if (verdict === "BLOCKER") {
+        const { escalate, reason } = shouldEscalateBlocker(envelope.findings);
+        if (escalate) {
+          return {
+            action: "ESCALATE",
+            idempotencyKey,
+            reason,
+            escalationReason: reason,
+          };
+        }
+      }
+
+      // Idempotency: check if fix task for this key already exists
+      const existing = context.existingFixTasks.find(
+        (t) => t.idempotencyKey === idempotencyKey
+      );
+      if (existing) {
+        return {
+          action: "REUSE_TASK",
+          fixTaskId: existing.id,
+          idempotencyKey,
+          reason: `Fix task ${existing.identifier} already covers verdict ${verdict_id.slice(0, 8)}.`,
+        };
+      }
+
+      return {
+        action: "CREATE_TASK",
+        idempotencyKey,
+        reason:
+          verdict === "BLOCKER"
+            ? `BLOCKER: ${envelope.findings.filter((f) => f.severity === "critical").length} critical finding(s) must be fixed before merge.`
+            : `REQUEST_CHANGES: ${envelope.findings.filter((f) => f.severity === "high").length} high finding(s) require fixes.`,
+      };
+    }
+  }
+}
+
+/**
+ * Build a routing decision for a failed parse result.
+ * Malformed envelopes produce AUDIT_ONLY or ESCALATE (incomplete-envelope = fail closed).
+ */
+export function routeMalformedVerdict(failure: ParseFailure): RoutingDecision {
+  if (failure.error === "incomplete-envelope") {
+    return {
+      action: "ESCALATE",
+      reason: "Reviewer envelope missing required fields — failing closed. Human review needed.",
+      escalationReason: `Malformed reviewer envelope: ${failure.error}`,
+    };
+  }
+  return {
+    action: "AUDIT_ONLY",
+    reason: `Reviewer envelope could not be parsed (${failure.error}). No task created.`,
+  };
+}
+
+// ── Fix task content helpers ──────────────────────────────────────────────────
+
+export interface FixTaskDraft {
+  title: string;
+  description: string;
+}
+
+/**
+ * Build the title and description for a new fix task.
+ * Caller is responsible for setting assignee, parent, project, etc.
+ */
+export function buildFixTaskDraft(
+  envelope: VerdictEnvelope,
+  parentIdentifier: string,
+  idempotencyKey: string
+): FixTaskDraft {
+  const { verdict, verdict_id, pr, findings, verifications } = envelope;
+  const shortVerdictId = verdict_id.slice(0, 8);
+  const shortSha = pr.head_sha.slice(0, 7);
+
+  const scope = parentIdentifier.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+  const title = `fix(${scope}): address ${verdict} from review ${shortVerdictId}`;
+
+  const actionableFindings = findings
+    .filter((f) => SEVERITY_RANK[f.severity] >= SEVERITY_RANK["high"])
+    .slice(0, 10);
+
+  const findingLines = actionableFindings
+    .map((f) => {
+      const loc = f.location.file ? `\n    File: ${f.location.file}${f.location.line ? `:${f.location.line}` : ""}` : "";
+      return `- [${f.severity}] \`${f.check}\` — ${f.rationale}\n    Fix: ${f.required_action}${loc}`;
+    })
+    .join("\n\n");
+
+  const lowerFindingCount = findings.filter(
+    (f) => SEVERITY_RANK[f.severity] < SEVERITY_RANK["high"]
+  ).length;
+
+  const failedVerifications = verifications.filter((v) => v.status === "failed");
+  const verificationLines = failedVerifications.length > 0
+    ? "\n\n## Verifications that must pass before re-review\n\n" +
+      failedVerifications.map((v) => `- [ ] ${v.name}`).join("\n")
+    : "";
+
+  const truncationNote =
+    lowerFindingCount > 0
+      ? `\n\n… plus ${lowerFindingCount} lower-severity finding(s). See verdict comment for full list.`
+      : "";
+
+  const description = [
+    `Parent review: ${parentIdentifier} · PR: ${pr.url} @ \`${shortSha}\``,
+    "",
+    buildFixTaskKeyTag(idempotencyKey),
+    "",
+    "## Findings to address",
+    "",
+    findingLines || "_No high/critical findings listed — check full verdict comment._",
+    truncationNote,
+    verificationLines,
+    "",
+    "Re-push when fixed. No @mention needed — assignment wakes this task automatically.",
+  ]
+    .join("\n")
+    .trim();
+
+  return { title, description };
+}
+
+// ── Audit comment helpers ─────────────────────────────────────────────────────
+
+export interface AuditCommentContext {
+  iterationNumber: number;
+  envelope: VerdictEnvelope;
+  decision: RoutingDecision;
+  fixTaskIdentifier?: string;
+  fixTaskId?: string;
+}
+
+/**
+ * Build the single audit comment the driver posts per review iteration.
+ * No agent @mention links — issue-mention links only.
+ */
+export function buildAuditComment(ctx: AuditCommentContext): string {
+  const { iterationNumber, envelope, decision, fixTaskIdentifier, fixTaskId } = ctx;
+  const { verdict, verdict_id } = envelope;
+  const shortId = verdict_id.slice(0, 8);
+
+  const header = `**Review iteration ${iterationNumber}** · verdict \`${verdict}\` · ${shortId}`;
+
+  let body: string;
+  switch (decision.action) {
+    case "MERGE_GATE":
+      if (verdict === "APPROVED") {
+        body = "All checks passed. Routing to merge gate.";
+      } else {
+        const count = envelope.findings.filter((f) =>
+          ["low", "medium"].includes(f.severity)
+        ).length;
+        const lines = envelope.findings
+          .filter((f) => ["low", "medium"].includes(f.severity))
+          .slice(0, 5)
+          .map((f) => `- [${f.severity}] \`${f.check}\`: ${f.rationale.slice(0, 120)}`)
+          .join("\n");
+        body = `${count} low/medium finding(s). Non-blocking — proceeding to merge gate.\n\n${lines}`;
+      }
+      break;
+
+    case "CREATE_TASK":
+    case "REUSE_TASK": {
+      const taskRef =
+        fixTaskIdentifier && fixTaskId
+          ? `[${fixTaskIdentifier}](mention://issue/${fixTaskId})`
+          : "_fix task_";
+      const count =
+        verdict === "BLOCKER"
+          ? envelope.findings.filter((f) => f.severity === "critical").length
+          : envelope.findings.filter((f) => f.severity === "high").length;
+      const severity = verdict === "BLOCKER" ? "critical" : "high";
+      body =
+        decision.action === "REUSE_TASK"
+          ? `${count} ${severity} finding(s) require fixes. Fix task ${taskRef} already exists — no duplicate created.`
+          : `${count} ${severity} finding(s) require fixes. Fix task: ${taskRef}.\nImplementer will push when done; reviewer will be re-requested automatically.`;
+      break;
+    }
+
+    case "ESCALATE":
+      body = `Escalated: ${decision.escalationReason ?? decision.reason}\n\nHuman decision required before this can proceed.`;
+      break;
+
+    case "AUDIT_ONLY":
+      body = `⚠ ${decision.reason}`;
+      break;
+  }
+
+  return `${header}\n\n${body}`;
+}


### PR DESCRIPTION
## Summary

Implements [DRV-80](https://github.com/multica-ai/multica): driver-plane state machine routing REQUEST_CHANGES/BLOCKER review verdicts to fix tasks without agent `@mention` links.

- **`docs/reviewer-verdict-routing-v1.md`** — Full spec: states, transitions, idempotency keys (`{head_sha}:{verdict_id}`), BLOCKER classification tree (escalate vs fix), fix task shape with embedded key tag, one-audit-comment-per-iteration format, cycle counter + escalation after N=3, malformed verdict handling, and integration test plan
- **`packages/core/verdict-router.ts`** — TypeScript implementation:
  - `parseVerdictFromComment` — extracts + validates structured envelope, corrects verdict/severity mismatch, caps findings at 20
  - `routeVerdict` — returns `MERGE_GATE / CREATE_TASK / REUSE_TASK / ESCALATE / AUDIT_ONLY`
  - `buildIdempotencyKey / extractFixTaskKey / buildFixTaskKeyTag` — idempotency helpers
  - `buildFixTaskDraft` — generates fix task title + description with embedded key tag
  - `buildAuditComment` — one comment per iteration; guaranteed no `mention://agent` links
- **`packages/core/verdict-router.test.ts`** — 34 tests: parse (all 4 verdicts, prose-only, malformed JSON, unknown schema, mismatch, missing fields, cap), routing (duplicate verdict, moved SHA, BLOCKER code-fix vs escalate, cycle limit, custom maxCycles), fix task draft, audit comment no-mention guarantee

## Test plan

- [x] `pnpm --filter @multica/core typecheck` — clean
- [x] `pnpm --filter @multica/core test` — 211/211 passing