### PR TITLE
feat(issue): add customizable workflow status substrate

### DIFF
--- a/.plans/customizable-issue-workflows.md
+++ b/.plans/customizable-issue-workflows.md
@@ -1,0 +1,40 @@
+# Plan: Customizable Issue Workflows
+Date: 2026-05-05
+Status: IN_PROGRESS
+
+## Problem
+Issue status is currently a hard-coded text lifecycle (`backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`). That blocks richer workflows: status descriptions, valid next actions, transition graphs, graph display, agent guidance, and future per-project/multi-workflow selection.
+
+## Approach
+Ship the smallest server-first v1 substrate:
+
+- Keep `issue.status` as the public stable string key for compatibility.
+- Add project/workspace-scoped workflow tables behind it.
+- Seed the existing lifecycle as the default workflow.
+- Resolve existing API/CLI status strings against the default workflow.
+- Add available-transitions read surface for UI/agents.
+- Avoid full graph editor and multi-workflow selector in this pass.
+
+Important constraints from current code:
+
+- `issue.project_id` is nullable, so workflow resolution must support workspace-level orphan/default workflows or keep issue workflow fields nullable during v1.
+- The current `issue.status` CHECK must be dropped safely by migration.
+- CLI hard-coded status validation must not block custom keys.
+- Handler tests silently skip when Postgres is unavailable; verify with DB when possible and record if unavailable.
+
+## Steps
+- [x] Create follow-up issue for tool-exhaustion/no-final-comment failure.
+- [x] Read DRV-68 and DRV-70 context.
+- [ ] Add RED server tests for workflow seeding / custom status acceptance / available transitions.
+- [ ] Add schema migration for workflows/status definitions/transitions.
+- [ ] Add sqlc queries and generated code for workflow lookups.
+- [ ] Update issue create/update/status path to resolve status key to workflow/status definition.
+- [ ] Add available transitions handler + route + CLI command.
+- [ ] Remove CLI closed-set rejection for issue status.
+- [ ] Run focused Go tests and full check if feasible.
+- [ ] Post concise Multica status with exact landed scope and blockers.
+
+## Open Questions
+- V1 handling for projectless issues: workspace-level orphan workflow vs nullable `workflow_id`/`status_id`. Prefer workspace-level orphan workflow to preserve future invariant.
+- Whether transition enforcement should be enabled immediately or initially read-only. Prefer read-only available transitions first if compatibility risk is high.
+- Whether to include UI read-only graph viewer in this change or split into a frontend follow-up.

--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -92,6 +92,13 @@ var issueStatusCmd = &cobra.Command{
 	RunE:  runIssueStatus,
 }
 
+var issueTransitionsCmd = &cobra.Command{
+	Use:   "transitions <id>",
+	Short: "List available status transitions for an issue",
+	Args:  exactArgs(1),
+	RunE:  runIssueTransitions,
+}
+
 // Comment subcommands.
 
 var issueCommentCmd = &cobra.Command{
@@ -178,10 +185,6 @@ var issueSearchCmd = &cobra.Command{
 	RunE:  runIssueSearch,
 }
 
-var validIssueStatuses = []string{
-	"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled",
-}
-
 func init() {
 	issueCmd.AddCommand(issueListCmd)
 	issueCmd.AddCommand(issueGetCmd)
@@ -189,6 +192,7 @@ func init() {
 	issueCmd.AddCommand(issueUpdateCmd)
 	issueCmd.AddCommand(issueAssignCmd)
 	issueCmd.AddCommand(issueStatusCmd)
+	issueCmd.AddCommand(issueTransitionsCmd)
 	issueCmd.AddCommand(issueCommentCmd)
 	issueCmd.AddCommand(issueSubscriberCmd)
 	issueCmd.AddCommand(issueRunsCmd)
@@ -243,6 +247,9 @@ func init() {
 
 	// issue status
 	issueStatusCmd.Flags().String("output", "table", "Output format: table or json")
+
+	// issue transitions
+	issueTransitionsCmd.Flags().String("output", "table", "Output format: table or json")
 
 	// issue assign
 	issueAssignCmd.Flags().String("to", "", "Assignee name (member or agent)")
@@ -696,17 +703,6 @@ func runIssueStatus(cmd *cobra.Command, args []string) error {
 	id := args[0]
 	status := args[1]
 
-	valid := false
-	for _, s := range validIssueStatuses {
-		if s == status {
-			valid = true
-			break
-		}
-	}
-	if !valid {
-		return fmt.Errorf("invalid status %q; valid values: %s", status, strings.Join(validIssueStatuses, ", "))
-	}
-
 	client, err := newAPIClient(cmd)
 	if err != nil {
 		return err
@@ -727,6 +723,45 @@ func runIssueStatus(cmd *cobra.Command, args []string) error {
 	if output == "json" {
 		return cli.PrintJSON(os.Stdout, result)
 	}
+	return nil
+}
+
+func runIssueTransitions(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var result map[string]any
+	if err := client.GetJSON(ctx, "/api/issues/"+args[0]+"/available-transitions", &result); err != nil {
+		return fmt.Errorf("list transitions: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+
+	current, _ := result["current_status"].(map[string]any)
+	fmt.Fprintf(os.Stdout, "Current status: %s\n", strVal(current, "key"))
+	transitions, _ := result["transitions"].([]any)
+	rows := make([][]string, 0, len(transitions))
+	for _, raw := range transitions {
+		tr, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		rows = append(rows, []string{
+			strVal(tr, "key"),
+			strVal(tr, "name"),
+			strVal(tr, "category"),
+			strVal(tr, "action_label"),
+		})
+	}
+	cli.PrintTable(os.Stdout, []string{"STATUS", "NAME", "CATEGORY", "ACTION"}, rows)
 	return nil
 }
 

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -502,22 +503,40 @@ func TestIssueSubscriberMutationBody(t *testing.T) {
 	}
 }
 
-func TestValidIssueStatuses(t *testing.T) {
-	expected := map[string]bool{
-		"backlog":     true,
-		"todo":        true,
-		"in_progress": true,
-		"in_review":   true,
-		"done":        true,
-		"blocked":     true,
-		"cancelled":   true,
-	}
-	for _, s := range validIssueStatuses {
-		if !expected[s] {
-			t.Errorf("unexpected status in validIssueStatuses: %q", s)
+func TestIssueStatusAllowsCustomStatusKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":     "issue-1",
+			"title":  "Custom status issue",
+			"status": "ready_for_demo",
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	cmd := issueStatusCmd
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := runIssueStatus(cmd, []string{"issue-1", "ready_for_demo"}); err != nil {
+		t.Fatalf("runIssueStatus custom key returned error: %v", err)
 	}
-	if len(validIssueStatuses) != len(expected) {
-		t.Errorf("validIssueStatuses has %d entries, expected %d", len(validIssueStatuses), len(expected))
+	if gotPath != "/api/issues/issue-1" {
+		t.Fatalf("path = %q, want /api/issues/issue-1", gotPath)
+	}
+	if gotBody["status"] != "ready_for_demo" {
+		t.Fatalf("status body = %v, want ready_for_demo", gotBody["status"])
 	}
 }

--- a/server/cmd/multica/cmd_issue_workflow_test.go
+++ b/server/cmd/multica/cmd_issue_workflow_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIssueTransitionsCommandFetchesAvailableTransitions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"issue_id": "issue-1",
+			"current_status": map[string]any{
+				"key": "todo",
+			},
+			"transitions": []map[string]any{
+				{"key": "in_progress", "name": "In progress", "category": "started", "action_label": "Move to in_progress"},
+			},
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+
+	cmd := issueTransitionsCmd
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Flags().Set("output", "json"); err != nil {
+		t.Fatalf("set output flag: %v", err)
+	}
+	if err := runIssueTransitions(cmd, []string{"issue-1"}); err != nil {
+		t.Fatalf("runIssueTransitions returned error: %v", err)
+	}
+	if gotPath != "/api/issues/issue-1/available-transitions" {
+		t.Fatalf("path = %q, want /api/issues/issue-1/available-transitions", gotPath)
+	}
+}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -310,6 +310,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				r.Post("/batch-delete", h.BatchDeleteIssues)
 				r.Route("/{id}", func(r chi.Router) {
 					r.Get("/", h.GetIssue)
+					r.Get("/available-transitions", h.GetIssueAvailableTransitions)
 					r.Put("/", h.UpdateIssue)
 					r.Delete("/", h.DeleteIssue)
 					r.Post("/comments", h.CreateComment)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -26,33 +26,33 @@ import (
 
 // IssueResponse is the JSON response for an issue.
 type IssueResponse struct {
-	ID                 string                  `json:"id"`
-	WorkspaceID        string                  `json:"workspace_id"`
-	Number             int32                   `json:"number"`
-	Identifier         string                  `json:"identifier"`
-	Title              string                  `json:"title"`
-	Description        *string                 `json:"description"`
-	Status             string                  `json:"status"`
-	Priority           string                  `json:"priority"`
-	AssigneeType       *string                 `json:"assignee_type"`
-	AssigneeID         *string                 `json:"assignee_id"`
-	CreatorType        string                  `json:"creator_type"`
-	CreatorID          string                  `json:"creator_id"`
-	ParentIssueID      *string                 `json:"parent_issue_id"`
-	ProjectID          *string                 `json:"project_id"`
-	Position           float64                 `json:"position"`
-	DueDate            *string                 `json:"due_date"`
-	CreatedAt          string                  `json:"created_at"`
-	UpdatedAt          string                  `json:"updated_at"`
-	Reactions          []IssueReactionResponse `json:"reactions,omitempty"`
-	Attachments        []AttachmentResponse    `json:"attachments,omitempty"`
+	ID            string                  `json:"id"`
+	WorkspaceID   string                  `json:"workspace_id"`
+	Number        int32                   `json:"number"`
+	Identifier    string                  `json:"identifier"`
+	Title         string                  `json:"title"`
+	Description   *string                 `json:"description"`
+	Status        string                  `json:"status"`
+	Priority      string                  `json:"priority"`
+	AssigneeType  *string                 `json:"assignee_type"`
+	AssigneeID    *string                 `json:"assignee_id"`
+	CreatorType   string                  `json:"creator_type"`
+	CreatorID     string                  `json:"creator_id"`
+	ParentIssueID *string                 `json:"parent_issue_id"`
+	ProjectID     *string                 `json:"project_id"`
+	Position      float64                 `json:"position"`
+	DueDate       *string                 `json:"due_date"`
+	CreatedAt     string                  `json:"created_at"`
+	UpdatedAt     string                  `json:"updated_at"`
+	Reactions     []IssueReactionResponse `json:"reactions,omitempty"`
+	Attachments   []AttachmentResponse    `json:"attachments,omitempty"`
 	// Labels are bulk-attached by list/detail endpoints so the client can render
 	// chips without an N+1 round-trip per row. Pointer + omitempty so paths that
 	// don't load labels (e.g. UpdateIssue, batch UpdateIssues, the issue:updated
 	// WS broadcast) emit no `labels` field at all — the client merge then
 	// preserves whatever labels are already in cache. nil pointer = "field
 	// absent, do not touch"; non-nil (incl. empty slice) = authoritative list.
-	Labels             *[]LabelResponse        `json:"labels,omitempty"`
+	Labels *[]LabelResponse `json:"labels,omitempty"`
 }
 
 func issueToResponse(i db.Issue, issuePrefix string) IssueResponse {
@@ -286,7 +286,7 @@ func buildSearchQuery(phrase string, terms []string, queryNum int, hasNum bool, 
 	}
 
 	escapedPhrase := escapeLike(phrase)
-	phraseParam := nextArg(escapedPhrase)               // $1
+	phraseParam := nextArg(escapedPhrase) // $1
 	phraseContains := "'%' || " + phraseParam + " || '%'"
 	phraseStartsWith := phraseParam + " || '%'"
 
@@ -1042,16 +1042,16 @@ func readRuntimeCLIVersion(metadata []byte) string {
 }
 
 type CreateIssueRequest struct {
-	Title              string   `json:"title"`
-	Description        *string  `json:"description"`
-	Status             string   `json:"status"`
-	Priority           string   `json:"priority"`
-	AssigneeType       *string  `json:"assignee_type"`
-	AssigneeID         *string  `json:"assignee_id"`
-	ParentIssueID      *string  `json:"parent_issue_id"`
-	ProjectID          *string  `json:"project_id"`
-	DueDate            *string  `json:"due_date"`
-	AttachmentIDs      []string `json:"attachment_ids,omitempty"`
+	Title         string   `json:"title"`
+	Description   *string  `json:"description"`
+	Status        string   `json:"status"`
+	Priority      string   `json:"priority"`
+	AssigneeType  *string  `json:"assignee_type"`
+	AssigneeID    *string  `json:"assignee_id"`
+	ParentIssueID *string  `json:"parent_issue_id"`
+	ProjectID     *string  `json:"project_id"`
+	DueDate       *string  `json:"due_date"`
+	AttachmentIDs []string `json:"attachment_ids,omitempty"`
 	// OriginType / OriginID stamp the new issue with its provenance so
 	// platform-internal flows can deterministically locate it later. Only
 	// trusted callers should set these — currently the daemon CLI passes
@@ -1085,10 +1085,6 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	status := req.Status
-	if status == "" {
-		status = "todo"
-	}
 	priority := req.Priority
 	if priority == "" {
 		priority = "none"
@@ -1139,6 +1135,13 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		if req.ProjectID == nil {
 			projectID = parent.ProjectID
 		}
+	}
+
+	status, err := h.resolveIssueStatusKey(r.Context(), wsUUID, projectID, req.Status)
+	if err != nil {
+		statusCode, msg := issueWorkflowErrorResponse(err)
+		writeError(w, statusCode, msg)
+		return
 	}
 
 	attachmentIDs, ok := parseUUIDSliceOrBadRequest(w, req.AttachmentIDs, "attachment_ids")
@@ -1287,16 +1290,16 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 }
 
 type UpdateIssueRequest struct {
-	Title              *string  `json:"title"`
-	Description        *string  `json:"description"`
-	Status             *string  `json:"status"`
-	Priority           *string  `json:"priority"`
-	AssigneeType       *string  `json:"assignee_type"`
-	AssigneeID         *string  `json:"assignee_id"`
-	Position           *float64 `json:"position"`
-	DueDate            *string  `json:"due_date"`
-	ParentIssueID      *string  `json:"parent_issue_id"`
-	ProjectID          *string  `json:"project_id"`
+	Title         *string  `json:"title"`
+	Description   *string  `json:"description"`
+	Status        *string  `json:"status"`
+	Priority      *string  `json:"priority"`
+	AssigneeType  *string  `json:"assignee_type"`
+	AssigneeID    *string  `json:"assignee_id"`
+	Position      *float64 `json:"position"`
+	DueDate       *string  `json:"due_date"`
+	ParentIssueID *string  `json:"parent_issue_id"`
+	ProjectID     *string  `json:"project_id"`
 }
 
 func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
@@ -1343,7 +1346,13 @@ func (h *Handler) UpdateIssue(w http.ResponseWriter, r *http.Request) {
 		params.Description = pgtype.Text{String: *req.Description, Valid: true}
 	}
 	if req.Status != nil {
-		params.Status = pgtype.Text{String: *req.Status, Valid: true}
+		status, err := h.resolveIssueStatusKey(r.Context(), prevIssue.WorkspaceID, params.ProjectID, *req.Status)
+		if err != nil {
+			statusCode, msg := issueWorkflowErrorResponse(err)
+			writeError(w, statusCode, msg)
+			return
+		}
+		params.Status = pgtype.Text{String: status, Valid: true}
 	}
 	if req.Priority != nil {
 		params.Priority = pgtype.Text{String: *req.Priority, Valid: true}
@@ -1754,7 +1763,11 @@ func (h *Handler) BatchUpdateIssues(w http.ResponseWriter, r *http.Request) {
 			params.Description = pgtype.Text{String: *req.Updates.Description, Valid: true}
 		}
 		if req.Updates.Status != nil {
-			params.Status = pgtype.Text{String: *req.Updates.Status, Valid: true}
+			status, err := h.resolveIssueStatusKey(r.Context(), prevIssue.WorkspaceID, params.ProjectID, *req.Updates.Status)
+			if err != nil {
+				continue
+			}
+			params.Status = pgtype.Text{String: status, Valid: true}
 		}
 		if req.Updates.Priority != nil {
 			params.Priority = pgtype.Text{String: *req.Updates.Priority, Valid: true}

--- a/server/internal/handler/issue_workflow.go
+++ b/server/internal/handler/issue_workflow.go
@@ -1,0 +1,389 @@
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+var defaultIssueWorkflowStatuses = []issueWorkflowSeedStatus{
+	{Key: "backlog", Name: "Backlog", Description: "Parked before the main workflow starts", Category: "backlog", Position: 0, OnMainGraph: false},
+	{Key: "todo", Name: "TODO", Description: "Ready to start", Category: "unstarted", Position: 10, OnMainGraph: true, IsInitial: true},
+	{Key: "in_progress", Name: "In progress", Description: "Work is underway", Category: "started", Position: 20, OnMainGraph: true},
+	{Key: "in_review", Name: "In review", Description: "Awaiting review", Category: "review", Position: 30, OnMainGraph: true},
+	{Key: "done", Name: "Done", Description: "Completed successfully", Category: "completed", Position: 40, OnMainGraph: true, IsTerminal: true},
+	{Key: "blocked", Name: "Blocked", Description: "Stuck on an external factor", Category: "blocked", Position: 50, OnMainGraph: false},
+	{Key: "cancelled", Name: "Cancelled", Description: "Cancelled", Category: "cancelled", Position: 60, OnMainGraph: false, IsTerminal: true},
+}
+
+type issueWorkflowSeedStatus struct {
+	Key         string
+	Name        string
+	Description string
+	Category    string
+	Position    float64
+	OnMainGraph bool
+	IsInitial   bool
+	IsTerminal  bool
+}
+
+type issueWorkflowStatus struct {
+	ID          pgtype.UUID
+	WorkflowID  pgtype.UUID
+	Key         string
+	Name        string
+	Description pgtype.Text
+	Category    string
+	Color       pgtype.Text
+	Icon        pgtype.Text
+	Position    float64
+	OnMainGraph bool
+	IsInitial   bool
+	IsTerminal  bool
+}
+
+type issueWorkflowTransition struct {
+	Status      issueWorkflowStatus
+	ActionLabel pgtype.Text
+	Description pgtype.Text
+}
+
+type issueStatusResponse struct {
+	ID          string  `json:"id"`
+	Key         string  `json:"key"`
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+	Category    string  `json:"category"`
+	Color       *string `json:"color,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	Position    float64 `json:"position"`
+	OnMainGraph bool    `json:"on_main_graph"`
+	IsInitial   bool    `json:"is_initial"`
+	IsTerminal  bool    `json:"is_terminal"`
+}
+
+type issueTransitionResponse struct {
+	issueStatusResponse
+	ActionLabel           *string `json:"action_label,omitempty"`
+	TransitionDescription *string `json:"transition_description,omitempty"`
+}
+
+type issueAvailableTransitionsResponse struct {
+	IssueID       string                    `json:"issue_id"`
+	WorkflowID    string                    `json:"workflow_id"`
+	CurrentStatus issueStatusResponse       `json:"current_status"`
+	Transitions   []issueTransitionResponse `json:"transitions"`
+}
+
+func (h *Handler) ensureDefaultIssueWorkflow(ctx context.Context, workspaceID, projectID pgtype.UUID) (pgtype.UUID, error) {
+	if h.DB == nil {
+		return pgtype.UUID{}, errors.New("database executor unavailable")
+	}
+
+	workflow, err := h.findDefaultIssueWorkflow(ctx, workspaceID, projectID)
+	if err == nil {
+		return workflow, nil
+	}
+	if !isNoRows(err) {
+		return pgtype.UUID{}, err
+	}
+
+	tx, err := h.TxStarter.Begin(ctx)
+	if err != nil {
+		return pgtype.UUID{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	workflow, err = h.findDefaultIssueWorkflowTx(ctx, tx, workspaceID, projectID)
+	if err == nil {
+		return workflow, tx.Commit(ctx)
+	}
+	if !isNoRows(err) {
+		return pgtype.UUID{}, err
+	}
+
+	var name string
+	var description string
+	var row pgx.Row
+	if projectID.Valid {
+		name = "Default"
+		description = "Default issue workflow"
+		row = tx.QueryRow(ctx, `
+			INSERT INTO issue_workflow (workspace_id, project_id, name, description, is_default)
+			VALUES ($1, $2, $3, $4, true)
+			ON CONFLICT DO NOTHING
+			RETURNING id
+		`, workspaceID, projectID, name, description)
+	} else {
+		name = "Default"
+		description = "Default workflow for projectless issues"
+		row = tx.QueryRow(ctx, `
+			INSERT INTO issue_workflow (workspace_id, project_id, name, description, is_default)
+			VALUES ($1, NULL, $2, $3, true)
+			ON CONFLICT DO NOTHING
+			RETURNING id
+		`, workspaceID, name, description)
+	}
+	if err := row.Scan(&workflow); err != nil {
+		if !isNoRows(err) {
+			return pgtype.UUID{}, err
+		}
+		workflow, err = h.findDefaultIssueWorkflowTx(ctx, tx, workspaceID, projectID)
+		if err != nil {
+			return pgtype.UUID{}, err
+		}
+	}
+
+	if err := seedDefaultIssueWorkflowTx(ctx, tx, workflow); err != nil {
+		return pgtype.UUID{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return pgtype.UUID{}, err
+	}
+	return workflow, nil
+}
+
+func (h *Handler) findDefaultIssueWorkflow(ctx context.Context, workspaceID, projectID pgtype.UUID) (pgtype.UUID, error) {
+	if projectID.Valid {
+		var workflowID pgtype.UUID
+		err := h.DB.QueryRow(ctx, `
+			SELECT id FROM issue_workflow
+			WHERE workspace_id = $1 AND project_id = $2 AND is_default = true
+			LIMIT 1
+		`, workspaceID, projectID).Scan(&workflowID)
+		return workflowID, err
+	}
+	var workflowID pgtype.UUID
+	err := h.DB.QueryRow(ctx, `
+		SELECT id FROM issue_workflow
+		WHERE workspace_id = $1 AND project_id IS NULL AND is_default = true
+		LIMIT 1
+	`, workspaceID).Scan(&workflowID)
+	return workflowID, err
+}
+
+func (h *Handler) findDefaultIssueWorkflowTx(ctx context.Context, tx pgx.Tx, workspaceID, projectID pgtype.UUID) (pgtype.UUID, error) {
+	if projectID.Valid {
+		var workflowID pgtype.UUID
+		err := tx.QueryRow(ctx, `
+			SELECT id FROM issue_workflow
+			WHERE workspace_id = $1 AND project_id = $2 AND is_default = true
+			LIMIT 1
+		`, workspaceID, projectID).Scan(&workflowID)
+		return workflowID, err
+	}
+	var workflowID pgtype.UUID
+	err := tx.QueryRow(ctx, `
+		SELECT id FROM issue_workflow
+		WHERE workspace_id = $1 AND project_id IS NULL AND is_default = true
+		LIMIT 1
+	`, workspaceID).Scan(&workflowID)
+	return workflowID, err
+}
+
+func seedDefaultIssueWorkflowTx(ctx context.Context, tx pgx.Tx, workflowID pgtype.UUID) error {
+	for _, s := range defaultIssueWorkflowStatuses {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO issue_status_def (workflow_id, key, name, description, category, position, on_main_graph, is_initial, is_terminal)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			ON CONFLICT (workflow_id, key) DO NOTHING
+		`, workflowID, s.Key, s.Name, s.Description, s.Category, s.Position, s.OnMainGraph, s.IsInitial, s.IsTerminal); err != nil {
+			return err
+		}
+	}
+
+	for _, from := range defaultIssueWorkflowStatuses {
+		var fromID pgtype.UUID
+		if err := tx.QueryRow(ctx, `
+			SELECT id FROM issue_status_def WHERE workflow_id = $1 AND key = $2
+		`, workflowID, from.Key).Scan(&fromID); err != nil {
+			return err
+		}
+		for _, to := range defaultIssueWorkflowStatuses {
+			if from.Key == to.Key {
+				continue
+			}
+			var toID pgtype.UUID
+			if err := tx.QueryRow(ctx, `
+				SELECT id FROM issue_status_def WHERE workflow_id = $1 AND key = $2
+			`, workflowID, to.Key).Scan(&toID); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO issue_status_transition (workflow_id, from_status_id, to_status_id, action_label)
+				VALUES ($1, $2, $3, $4)
+				ON CONFLICT DO NOTHING
+			`, workflowID, fromID, toID, "Move to "+to.Key); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (h *Handler) resolveIssueStatusKey(ctx context.Context, workspaceID, projectID pgtype.UUID, requested string) (string, error) {
+	statusKey := strings.TrimSpace(requested)
+	workflowID, err := h.ensureDefaultIssueWorkflow(ctx, workspaceID, projectID)
+	if err != nil {
+		return "", err
+	}
+	if statusKey == "" {
+		initial, err := h.loadInitialIssueStatus(ctx, workflowID)
+		if err != nil {
+			return "", err
+		}
+		return initial.Key, nil
+	}
+	if _, err := h.loadIssueStatusByKey(ctx, workflowID, statusKey); err != nil {
+		return "", err
+	}
+	return statusKey, nil
+}
+
+func (h *Handler) loadInitialIssueStatus(ctx context.Context, workflowID pgtype.UUID) (issueWorkflowStatus, error) {
+	return h.scanIssueWorkflowStatus(h.DB.QueryRow(ctx, `
+		SELECT id, workflow_id, key, name, description, category, color, icon, position, on_main_graph, is_initial, is_terminal
+		FROM issue_status_def
+		WHERE workflow_id = $1 AND is_initial = true
+		ORDER BY position ASC
+		LIMIT 1
+	`, workflowID))
+}
+
+func (h *Handler) loadIssueStatusByKey(ctx context.Context, workflowID pgtype.UUID, key string) (issueWorkflowStatus, error) {
+	return h.scanIssueWorkflowStatus(h.DB.QueryRow(ctx, `
+		SELECT id, workflow_id, key, name, description, category, color, icon, position, on_main_graph, is_initial, is_terminal
+		FROM issue_status_def
+		WHERE workflow_id = $1 AND key = $2
+	`, workflowID, key))
+}
+
+func (h *Handler) scanIssueWorkflowStatus(row pgx.Row) (issueWorkflowStatus, error) {
+	var s issueWorkflowStatus
+	err := row.Scan(&s.ID, &s.WorkflowID, &s.Key, &s.Name, &s.Description, &s.Category, &s.Color, &s.Icon, &s.Position, &s.OnMainGraph, &s.IsInitial, &s.IsTerminal)
+	return s, err
+}
+
+func (h *Handler) listIssueTransitions(ctx context.Context, workflowID, fromStatusID pgtype.UUID) ([]issueWorkflowTransition, error) {
+	rows, err := h.DB.Query(ctx, `
+		SELECT sd.id, sd.workflow_id, sd.key, sd.name, sd.description, sd.category, sd.color, sd.icon,
+		       sd.position, sd.on_main_graph, sd.is_initial, sd.is_terminal,
+		       tr.action_label, tr.description
+		FROM issue_status_transition tr
+		JOIN issue_status_def sd ON sd.id = tr.to_status_id
+		WHERE tr.workflow_id = $1 AND tr.from_status_id = $2
+		ORDER BY sd.position ASC, sd.key ASC
+	`, workflowID, fromStatusID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []issueWorkflowTransition{}
+	for rows.Next() {
+		var tr issueWorkflowTransition
+		if err := rows.Scan(
+			&tr.Status.ID,
+			&tr.Status.WorkflowID,
+			&tr.Status.Key,
+			&tr.Status.Name,
+			&tr.Status.Description,
+			&tr.Status.Category,
+			&tr.Status.Color,
+			&tr.Status.Icon,
+			&tr.Status.Position,
+			&tr.Status.OnMainGraph,
+			&tr.Status.IsInitial,
+			&tr.Status.IsTerminal,
+			&tr.ActionLabel,
+			&tr.Description,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, tr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (h *Handler) GetIssueAvailableTransitions(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	issue, ok := h.loadIssueForUser(w, r, id)
+	if !ok {
+		return
+	}
+	workflowID, err := h.ensureDefaultIssueWorkflow(r.Context(), issue.WorkspaceID, issue.ProjectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load issue workflow")
+		return
+	}
+	current, err := h.loadIssueStatusByKey(r.Context(), workflowID, issue.Status)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load current status")
+		return
+	}
+	transitions, err := h.listIssueTransitions(r.Context(), workflowID, current.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load available transitions")
+		return
+	}
+	resp := issueAvailableTransitionsResponse{
+		IssueID:       uuidToString(issue.ID),
+		WorkflowID:    uuidToString(workflowID),
+		CurrentStatus: issueStatusToResponse(current),
+		Transitions:   make([]issueTransitionResponse, len(transitions)),
+	}
+	for i, tr := range transitions {
+		resp.Transitions[i] = issueTransitionToResponse(tr)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func issueStatusToResponse(s issueWorkflowStatus) issueStatusResponse {
+	return issueStatusResponse{
+		ID:          uuidToString(s.ID),
+		Key:         s.Key,
+		Name:        s.Name,
+		Description: textToPtr(s.Description),
+		Category:    s.Category,
+		Color:       textToPtr(s.Color),
+		Icon:        textToPtr(s.Icon),
+		Position:    s.Position,
+		OnMainGraph: s.OnMainGraph,
+		IsInitial:   s.IsInitial,
+		IsTerminal:  s.IsTerminal,
+	}
+}
+
+func issueTransitionToResponse(tr issueWorkflowTransition) issueTransitionResponse {
+	return issueTransitionResponse{
+		issueStatusResponse:   issueStatusToResponse(tr.Status),
+		ActionLabel:           textToPtr(tr.ActionLabel),
+		TransitionDescription: textToPtr(tr.Description),
+	}
+}
+
+func (h *Handler) ensureDefaultIssueWorkflowForProject(ctx context.Context, project db.Project) error {
+	_, err := h.ensureDefaultIssueWorkflow(ctx, project.WorkspaceID, project.ID)
+	return err
+}
+
+func isNoRows(err error) bool {
+	return errors.Is(err, pgx.ErrNoRows) || errors.Is(err, sql.ErrNoRows)
+}
+
+func issueWorkflowErrorResponse(err error) (int, string) {
+	if isNoRows(err) {
+		return http.StatusUnprocessableEntity, "status is not defined in this issue workflow"
+	}
+	return http.StatusInternalServerError, "failed to resolve issue workflow"
+}

--- a/server/internal/handler/issue_workflow_test.go
+++ b/server/internal/handler/issue_workflow_test.go
@@ -1,0 +1,189 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateIssueAcceptsProjectCustomWorkflowStatus(t *testing.T) {
+	projectID := createWorkflowTestProject(t, "Workflow custom status project")
+	seedWorkflowTestDefaultIssueWorkflow(t, projectID)
+	insertWorkflowTestStatus(t, projectID, "ready_for_demo", "Ready for demo")
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":      "Custom workflow status issue",
+		"project_id": projectID,
+		"status":     "ready_for_demo",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue custom status: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created issue: %v", err)
+	}
+	if created.Status != "ready_for_demo" {
+		t.Fatalf("CreateIssue custom status: expected ready_for_demo, got %q", created.Status)
+	}
+}
+
+func TestIssueAvailableTransitionsReturnsDefaultWorkflow(t *testing.T) {
+	issueID := createTestIssue(t, "Workflow default transitions", "todo", "medium")
+	t.Cleanup(func() { deleteTestIssue(t, issueID) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/"+issueID+"/available-transitions", nil)
+	req = withURLParam(req, "id", issueID)
+	testHandler.GetIssueAvailableTransitions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetIssueAvailableTransitions: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		IssueID       string `json:"issue_id"`
+		CurrentStatus struct {
+			Key string `json:"key"`
+		} `json:"current_status"`
+		Transitions []struct {
+			Key string `json:"key"`
+		} `json:"transitions"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode transitions: %v", err)
+	}
+	if resp.IssueID != issueID {
+		t.Fatalf("issue_id = %q, want %q", resp.IssueID, issueID)
+	}
+	if resp.CurrentStatus.Key != "todo" {
+		t.Fatalf("current_status.key = %q, want todo", resp.CurrentStatus.Key)
+	}
+	if len(resp.Transitions) == 0 {
+		t.Fatalf("expected default workflow transitions from todo")
+	}
+	seen := map[string]bool{}
+	for _, tr := range resp.Transitions {
+		seen[tr.Key] = true
+	}
+	for _, key := range []string{"backlog", "in_progress", "in_review", "done", "blocked", "cancelled"} {
+		if !seen[key] {
+			t.Fatalf("expected transition to %q in default workflow, got %+v", key, resp.Transitions)
+		}
+	}
+}
+
+func TestDefaultIssueWorkflowMatchesDocumentedStatuses(t *testing.T) {
+	projectID := createWorkflowTestProject(t, "Workflow documentation alignment project")
+	seedWorkflowTestDefaultIssueWorkflow(t, projectID)
+
+	var workflowID string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT id FROM issue_workflow
+		WHERE workspace_id = $1 AND project_id = $2 AND is_default = true
+	`, testWorkspaceID, projectID).Scan(&workflowID); err != nil {
+		t.Fatalf("load default workflow: %v", err)
+	}
+
+	rows, err := testPool.Query(context.Background(), `
+		SELECT key, description
+		FROM issue_status_def
+		WHERE workflow_id = $1
+		ORDER BY position ASC
+	`, workflowID)
+	if err != nil {
+		t.Fatalf("query default statuses: %v", err)
+	}
+	defer rows.Close()
+
+	gotDescriptions := map[string]string{}
+	var gotOrder []string
+	for rows.Next() {
+		var key string
+		var description string
+		if err := rows.Scan(&key, &description); err != nil {
+			t.Fatalf("scan status: %v", err)
+		}
+		gotOrder = append(gotOrder, key)
+		gotDescriptions[key] = description
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error: %v", err)
+	}
+
+	wantOrder := []string{"backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"}
+	if len(gotOrder) != len(wantOrder) {
+		t.Fatalf("default status count = %d (%v), want %d", len(gotOrder), gotOrder, len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if gotOrder[i] != want {
+			t.Fatalf("status order[%d] = %q, want %q (full order %v)", i, gotOrder[i], want, gotOrder)
+		}
+	}
+
+	wantDescriptions := map[string]string{
+		"backlog":     "Parked before the main workflow starts",
+		"todo":        "Ready to start",
+		"in_progress": "Work is underway",
+		"in_review":   "Awaiting review",
+		"done":        "Completed successfully",
+		"blocked":     "Stuck on an external factor",
+		"cancelled":   "Cancelled",
+	}
+	for key, want := range wantDescriptions {
+		if gotDescriptions[key] != want {
+			t.Fatalf("description[%s] = %q, want %q", key, gotDescriptions[key], want)
+		}
+	}
+}
+
+func createWorkflowTestProject(t *testing.T, title string) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title": title,
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateProject %q: expected 201, got %d: %s", title, w.Code, w.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+		t.Fatalf("decode project: %v", err)
+	}
+	t.Cleanup(func() {
+		req := newRequest("DELETE", "/api/projects/"+project.ID, nil)
+		req = withURLParam(req, "id", project.ID)
+		testHandler.DeleteProject(httptest.NewRecorder(), req)
+	})
+	return project.ID
+}
+
+func seedWorkflowTestDefaultIssueWorkflow(t *testing.T, projectID string) {
+	t.Helper()
+	projectUUID := parseUUID(projectID)
+	workspaceUUID := parseUUID(testWorkspaceID)
+	if _, err := testHandler.ensureDefaultIssueWorkflow(context.Background(), workspaceUUID, projectUUID); err != nil {
+		t.Fatalf("seed default workflow: %v", err)
+	}
+}
+
+func insertWorkflowTestStatus(t *testing.T, projectID, key, name string) {
+	t.Helper()
+	var workflowID string
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT id FROM issue_workflow
+		WHERE workspace_id = $1 AND project_id = $2 AND is_default = true
+	`, testWorkspaceID, projectID).Scan(&workflowID); err != nil {
+		t.Fatalf("load default workflow: %v", err)
+	}
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO issue_status_def (workflow_id, key, name, category, position, on_main_graph)
+		VALUES ($1, $2, $3, 'started', 50, true)
+	`, workflowID, key, name); err != nil {
+		t.Fatalf("insert custom status: %v", err)
+	}
+}

--- a/server/migrations/068_issue_workflows.down.sql
+++ b/server/migrations/068_issue_workflows.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE issue DROP CONSTRAINT IF EXISTS issue_status_check;
+ALTER TABLE issue ADD CONSTRAINT issue_status_check
+    CHECK (status IN ('backlog', 'todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'));
+
+DROP TABLE IF EXISTS issue_status_transition;
+DROP TABLE IF EXISTS issue_status_def;
+DROP TABLE IF EXISTS issue_workflow;

--- a/server/migrations/068_issue_workflows.up.sql
+++ b/server/migrations/068_issue_workflows.up.sql
@@ -1,0 +1,140 @@
+CREATE TABLE issue_workflow (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspace(id) ON DELETE CASCADE,
+    project_id UUID REFERENCES project(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    is_default BOOLEAN NOT NULL DEFAULT false,
+    selector JSONB NOT NULL DEFAULT '{}',
+    allow_freeform BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (project_id IS NOT NULL OR is_default = true)
+);
+
+CREATE UNIQUE INDEX idx_issue_workflow_default_project
+    ON issue_workflow(project_id)
+    WHERE is_default AND project_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_issue_workflow_default_orphan
+    ON issue_workflow(workspace_id)
+    WHERE is_default AND project_id IS NULL;
+
+CREATE UNIQUE INDEX idx_issue_workflow_project_name
+    ON issue_workflow(project_id, lower(name))
+    WHERE project_id IS NOT NULL;
+
+CREATE TABLE issue_status_def (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workflow_id UUID NOT NULL REFERENCES issue_workflow(id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    category TEXT NOT NULL CHECK (category IN ('backlog', 'unstarted', 'started', 'review', 'completed', 'cancelled', 'blocked')),
+    color TEXT,
+    icon TEXT,
+    position FLOAT NOT NULL DEFAULT 0,
+    on_main_graph BOOLEAN NOT NULL DEFAULT true,
+    is_initial BOOLEAN NOT NULL DEFAULT false,
+    is_terminal BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (workflow_id, key)
+);
+
+CREATE UNIQUE INDEX idx_issue_status_one_initial_per_workflow
+    ON issue_status_def(workflow_id)
+    WHERE is_initial;
+
+CREATE TABLE issue_status_transition (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workflow_id UUID NOT NULL REFERENCES issue_workflow(id) ON DELETE CASCADE,
+    from_status_id UUID NOT NULL REFERENCES issue_status_def(id) ON DELETE CASCADE,
+    to_status_id UUID NOT NULL REFERENCES issue_status_def(id) ON DELETE CASCADE,
+    action_label TEXT,
+    description TEXT,
+    guard JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (workflow_id, from_status_id, to_status_id)
+);
+
+CREATE INDEX idx_issue_status_def_workflow_position ON issue_status_def(workflow_id, position);
+CREATE INDEX idx_issue_status_transition_from ON issue_status_transition(workflow_id, from_status_id);
+
+ALTER TABLE issue DROP CONSTRAINT IF EXISTS issue_status_check;
+
+CREATE OR REPLACE FUNCTION seed_default_issue_workflow(workflow_uuid UUID)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    from_status UUID;
+    to_status UUID;
+    from_key TEXT;
+    to_key TEXT;
+    status_keys TEXT[] := ARRAY['backlog', 'todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled'];
+BEGIN
+    INSERT INTO issue_status_def (workflow_id, key, name, description, category, position, on_main_graph, is_initial, is_terminal)
+    VALUES
+        (workflow_uuid, 'backlog', 'Backlog', 'Parked before the main workflow starts', 'backlog', 0, false, false, false),
+        (workflow_uuid, 'todo', 'TODO', 'Ready to start', 'unstarted', 10, true, true, false),
+        (workflow_uuid, 'in_progress', 'In progress', 'Work is underway', 'started', 20, true, false, false),
+        (workflow_uuid, 'in_review', 'In review', 'Awaiting review', 'review', 30, true, false, false),
+        (workflow_uuid, 'done', 'Done', 'Completed successfully', 'completed', 40, true, false, true),
+        (workflow_uuid, 'blocked', 'Blocked', 'Stuck on an external factor', 'blocked', 50, false, false, false),
+        (workflow_uuid, 'cancelled', 'Cancelled', 'Cancelled', 'cancelled', 60, false, false, true)
+    ON CONFLICT (workflow_id, key) DO NOTHING;
+
+    FOREACH from_key IN ARRAY status_keys LOOP
+        SELECT id INTO from_status FROM issue_status_def WHERE workflow_id = workflow_uuid AND key = from_key;
+        FOREACH to_key IN ARRAY status_keys LOOP
+            IF from_key <> to_key THEN
+                SELECT id INTO to_status FROM issue_status_def WHERE workflow_id = workflow_uuid AND key = to_key;
+                INSERT INTO issue_status_transition (workflow_id, from_status_id, to_status_id, action_label)
+                VALUES (workflow_uuid, from_status, to_status, 'Move to ' || to_key)
+                ON CONFLICT DO NOTHING;
+            END IF;
+        END LOOP;
+    END LOOP;
+END $$;
+
+DO $$
+DECLARE
+    ws RECORD;
+    p RECORD;
+    wf_id UUID;
+BEGIN
+    FOR ws IN SELECT id FROM workspace LOOP
+        INSERT INTO issue_workflow (workspace_id, project_id, name, description, is_default)
+        VALUES (ws.id, NULL, 'Default', 'Default workflow for projectless issues', true)
+        ON CONFLICT DO NOTHING
+        RETURNING id INTO wf_id;
+
+        IF wf_id IS NULL THEN
+            SELECT id INTO wf_id
+            FROM issue_workflow
+            WHERE workspace_id = ws.id AND project_id IS NULL AND is_default = true
+            LIMIT 1;
+        END IF;
+
+        PERFORM seed_default_issue_workflow(wf_id);
+    END LOOP;
+
+    FOR p IN SELECT id, workspace_id FROM project LOOP
+        wf_id := NULL;
+        INSERT INTO issue_workflow (workspace_id, project_id, name, description, is_default)
+        VALUES (p.workspace_id, p.id, 'Default', 'Default issue workflow', true)
+        ON CONFLICT DO NOTHING
+        RETURNING id INTO wf_id;
+
+        IF wf_id IS NULL THEN
+            SELECT id INTO wf_id
+            FROM issue_workflow
+            WHERE project_id = p.id AND is_default = true
+            LIMIT 1;
+        END IF;
+
+        PERFORM seed_default_issue_workflow(wf_id);
+    END LOOP;
+END $$;
+
+DROP FUNCTION seed_default_issue_workflow(UUID);


### PR DESCRIPTION
## Summary
- Add workflow/status/transition schema seeded from the documented seven issue statuses.
- Resolve create/update/batch issue status keys against the default workflow while preserving public `issue.status` strings.
- Add `GET /api/issues/{id}/available-transitions` and `multica issue transitions <id>`.
- Remove CLI closed-set status validation so custom keys reach the API.
- Share implementation plan in `.plans/customizable-issue-workflows.md` and `/home/congvc/.gstack/projects/multica/plan` on the host.

## Test Plan
- `cd server && PATH=/home/congvc/.local/go1.26.1/bin:$PATH go run ./cmd/migrate up`
- `cd server && PATH=/home/congvc/.local/go1.26.1/bin:$PATH go test ./internal/handler -run 'Test(CreateIssueAcceptsProjectCustomWorkflowStatus|IssueAvailableTransitionsReturnsDefaultWorkflow|DefaultIssueWorkflowMatchesDocumentedStatuses)' -count=1 -v`
- `cd server && PATH=/home/congvc/.local/go1.26.1/bin:$PATH go test ./cmd/multica ./cmd/server ./internal/handler -count=1`
- `cd server && PATH=/home/congvc/.local/go1.26.1/bin:$PATH go test ./... -count=1`

## Notes
- Push to `origin` is blocked for this credential (`congvc-dev` lacks write permission to `multica-ai/multica`), so the branch is pushed to fork `congvc-dev/multica`.
- Independent review handoff was attempted via subagent, but the subagent could not access the diff artifact; no external review approval is claimed.
