### PR TITLE
Fix Windows self-host installer version check

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -160,6 +160,21 @@ function Get-WindowsCliArch {
     Write-Fail "Unsupported Windows architecture ($details). Only x64 and ARM64 are supported."
 }
 
+function Get-InstalledCliVersion {
+    try {
+        $firstLine = multica version 2>$null | Select-Object -First 1
+        if ("$firstLine" -match '\b(v?\d+(?:\.\d+)+)\b') {
+            $version = $Matches[1]
+            if ($version -notlike 'v*') {
+                $version = "v$version"
+            }
+            return $version
+        }
+    } catch {}
+
+    return $null
+}
+
 # ---------------------------------------------------------------------------
 # CLI Installation
 # ---------------------------------------------------------------------------
@@ -196,9 +211,21 @@ function Install-CliBinary {
     $checksumUrl = "https://github.com/multica-ai/multica/releases/download/$latest/checksums.txt"
     try {
         $checksums = Invoke-WebRequest -Uri $checksumUrl -UseBasicParsing -ErrorAction Stop
+        $checksumContent = if ($checksums.Content -is [byte[]]) {
+            [System.Text.Encoding]::UTF8.GetString($checksums.Content)
+        } else {
+            [string]$checksums.Content
+        }
         $zipFile = Join-Path $tmpDir "multica.zip"
         $actualHash = (Get-FileHash -Path $zipFile -Algorithm SHA256).Hash.ToLower()
-        $expectedLine = ($checksums.Content -split "`n") | Where-Object { $_ -match "multica-cli-$version-windows-$arch\.zip" } | Select-Object -First 1
+        $releaseAsset = "multica-cli-$version-windows-$arch.zip"
+        $legacyAsset = "multica_windows_$arch.zip"
+        $expectedLine = ($checksumContent -split "`r?`n") |
+            Where-Object {
+                $_ -match [regex]::Escape($releaseAsset) -or
+                $_ -match [regex]::Escape($legacyAsset)
+            } |
+            Select-Object -First 1
         if ($expectedLine) {
             $expectedHash = ($expectedLine -split "\s+")[0].ToLower()
             if ($actualHash -ne $expectedHash) {
@@ -207,7 +234,7 @@ function Install-CliBinary {
             }
             Write-Ok "Checksum verified"
         } else {
-            Write-Warn "Could not find checksum entry for windows_$arch — skipping verification."
+            Write-Warn "Could not find checksum entry for $releaseAsset — skipping verification."
         }
     } catch {
         Write-Warn "Could not download checksums.txt — skipping verification."
@@ -253,18 +280,18 @@ function Add-ToUserPath {
 
 function Install-Cli {
     if (Test-CommandExists "multica") {
-        $currentVer = (multica version 2>$null) -replace '.*?(v[\d.]+).*','$1'
+        $currentVer = Get-InstalledCliVersion
         $latestVer = Get-LatestVersion
 
-        $currentCmp = $currentVer -replace '^v',''
+        $currentCmp = if ($currentVer) { $currentVer -replace '^v','' } else { $null }
         $latestCmp = if ($latestVer) { $latestVer -replace '^v','' } else { $null }
 
-        $isUpToDate = -not $latestCmp
+        $isUpToDate = $currentCmp -and -not $latestCmp
         if (-not $isUpToDate) {
             try {
-                $isUpToDate = [System.Version]$currentCmp -ge [System.Version]$latestCmp
+                $isUpToDate = $currentCmp -and $latestCmp -and ([System.Version]$currentCmp -ge [System.Version]$latestCmp)
             } catch {
-                $isUpToDate = $currentCmp -eq $latestCmp
+                $isUpToDate = $currentCmp -and $latestCmp -and ($currentCmp -eq $latestCmp)
             }
         }
 
@@ -276,7 +303,7 @@ function Install-Cli {
         Write-Info "Multica CLI $currentVer installed, latest is $latestVer - upgrading..."
         Install-CliBinary
 
-        $newVer = (multica version 2>$null) -replace '.*?(v[\d.]+).*','$1'
+        $newVer = Get-InstalledCliVersion
         Write-Ok "Multica CLI upgraded ($currentVer -> $newVer)"
         return
     }


### PR DESCRIPTION
## Summary
- parse only the first `multica version` line when checking the installed CLI version
- avoid unnecessary CLI reinstalls when the installed version already matches the latest release
- normalize checksum content when PowerShell returns `checksums.txt` as bytes and match both current and legacy Windows asset names

Fixes #2092

## Testing
- PowerShell parser check for `scripts/install.ps1`
- `$env:MULTICA_MODE="local"; & .\scripts\install.ps1`