### PR TITLE
fix(views): hide archived agents from runtime detail

### DIFF
--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -119,7 +119,9 @@ export function RuntimeDetail({ runtime }: { runtime: AgentRuntime }) {
   const isRuntimeOwner = user && runtime.owner_id === user.id;
   const canDelete = isAdmin || isRuntimeOwner;
 
-  const servingAgents = agents.filter((a) => a.runtime_id === runtime.id);
+  const servingAgents = agents.filter(
+    (a) => a.runtime_id === runtime.id && !a.archived_at,
+  );
 
   const handleDelete = () => {
     deleteMutation.mutate(runtime.id, {


### PR DESCRIPTION
## What does this PR do?

This fixes the runtime detail page so archived agents no longer appear in the "Serving agents" section.

The bug happened because the page loaded the full agent list including archived agents, then filtered only by `runtime_id`. That made archived agents look like they were still actively served by the runtime. Filtering out agents with `archived_at` set matches the rest of the product, where archived agents are treated as inactive and unavailable for assignment.
## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #2096

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/views/runtimes/components/runtime-detail.tsx`
- Changed the `servingAgents` filter from `a.runtime_id === runtime.id` to `a.runtime_id === runtime.id && !a.archived_at

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Create or use a runtime with an agent bound to it.
2. Archive that agent without clearing its `runtime_id`.
3. Open the runtime detail page and confirm the archived agent no longer appears in "Serving agents".

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** OpenCode
**Prompt / approach:**
I used AI to inspect the runtime detail page and compare its handling of archived agents with the rest of the product. The investigation found that the runtime page fetched agents with `include_archived=true` and then filtered only on `runtime_id`, which caused archived agents to appear as serving. The fix was kept minimal by updating that filter to exclude archived agents.

## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
