### PR TITLE
refactor(projects): pass projectId prop to ProjectIssuesContent

### DIFF
--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -97,10 +97,12 @@ function PropRow({
 const projectViewStore = createIssueViewStore("project_issues_view");
 
 function ProjectIssuesContent({
+  projectId,
   projectIssues,
   scope,
   filter,
 }: {
+  projectId: string;
   projectIssues: Issue[];
   scope: string;
   filter: MyIssuesFilter;
@@ -156,9 +158,7 @@ function ProjectIssuesContent({
           size="sm"
           className="mt-1"
           onClick={() =>
-            useModalStore
-              .getState()
-              .open("create-issue", { project_id: scope.replace("project:", "") })
+            useModalStore.getState().open("create-issue", { project_id: projectId })
           }
         >
           <Plus className="size-3.5 mr-1.5" />
@@ -600,6 +600,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
           <ViewStoreProvider store={projectViewStore}>
               <IssuesHeader scopedIssues={projectIssues} />
               <ProjectIssuesContent
+                projectId={projectId}
                 projectIssues={projectIssues}
                 scope={projectScope}
                 filter={projectFilter}


### PR DESCRIPTION
## Summary

Tiny follow-up to #2080. The empty-state `+ New Issue` button currently re-derives the project ID by stripping the `project:` prefix off the `scope` string:

```tsx
useModalStore.getState().open("create-issue", { project_id: scope.replace("project:", "") })
```

`ProjectDetail` already holds `projectId` as a prop and passes it everywhere else, so it's cleaner to thread it down to `ProjectIssuesContent` and pass it directly into `open("create-issue", { project_id })`. This removes a hidden dependency on the `project:<id>` scope-string format — if someone ever changes how `projectScope` is built, the empty-state action would silently send a malformed UUID.

No behavior change. Empty-state button still pre-selects the current project; `scope` is still passed through to `MyIssuesViewControls` / `MyIssuesNoMatchEmpty` as before.

## Test plan

- [x] `pnpm --filter @multica/views typecheck` — clean
- [ ] Manual: open a project with no issues, confirm the `+ New Issue` button still opens the create-issue modal with the project pre-selected