### PR TITLE
fix(projects): show URL tooltip on already-attached repos in Add Resource list

### DIFF
--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -118,16 +118,21 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
                 <div className="space-y-1">
                   {workspace.repos.map((repo) => {
                     const isAttached = attachedUrls.has(repo.url);
+                    const isDisabled = isAttached || createResource.isPending;
                     return (
+                      // Use aria-disabled instead of the native `disabled` attribute so
+                      // hover events still reach the tooltip trigger on attached rows
+                      // (browsers suppress pointer events on disabled form controls).
                       <button
                         key={repo.url}
                         type="button"
-                        disabled={isAttached || createResource.isPending}
+                        aria-disabled={isDisabled}
                         onClick={async () => {
+                          if (isDisabled) return;
                           await handleAttach(repo.url);
                           setAddOpen(false);
                         }}
-                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-left hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-left hover:bg-accent transition-colors aria-disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-transparent"
                       >
                         <FolderGit className="size-3.5" />
                         <Tooltip>


### PR DESCRIPTION
## Summary

Follow-up to #2080. The repo button inside the `Add Resource` popover used the native `disabled` attribute when a repo was already attached:

```tsx
<button disabled={isAttached || createResource.isPending} ...>
  <Tooltip><TooltipTrigger render={<span>{repo.url}</span>} />...</Tooltip>
</button>
```

Browsers suppress pointer events on disabled form controls, so the tooltip wrapping the URL text never fires for already-attached rows. The bug spec explicitly says \"hovering over any URL should also show the complete URL in a tooltip\" — \"any\" includes attached rows.

This switches the button to `aria-disabled` + a click guard. The row still announces as disabled to assistive tech, still looks visually disabled (`aria-disabled:opacity-50 aria-disabled:cursor-not-allowed`), and the click is still a no-op when attached / mid-mutation — but hover events now reach the `TooltipTrigger`.

## Test plan

- [x] `pnpm --filter @multica/views typecheck` — clean
- [ ] Manual: open `Add Resource` on a project where at least one workspace repo is already attached. Hover the URL text on the attached row → tooltip with the full URL appears. Click is still a no-op on attached rows.
- [ ] Manual: hover an unattached row → tooltip still appears, click still attaches the repo.