### PR TITLE
fix(runtime): persist CLI update requests in Redis

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -106,6 +106,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		h.TaskService.Wakeup = opts.DaemonWakeup
 	}
 	if rdb != nil {
+		h.UpdateStore = handler.NewRedisUpdateStore(rdb)
 		h.ModelListStore = handler.NewRedisModelListStore(rdb)
 		h.LocalSkillListStore = handler.NewRedisLocalSkillListStore(rdb)
 		h.LocalSkillImportStore = handler.NewRedisLocalSkillImportStore(rdb)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -671,10 +671,25 @@ func (h *Handler) processHeartbeat(ctx context.Context, rt db.AgentRuntime) (*pr
 		Status:    "ok",
 	}
 
-	if pending := h.UpdateStore.PopPending(runtimeID); pending != nil {
-		ack.PendingUpdate = &protocol.DaemonHeartbeatPendingUpdate{
-			ID:            pending.ID,
-			TargetVersion: pending.TargetVersion,
+	probeUpdateCtx, cancelProbeUpdate := context.WithTimeout(ctx, heartbeatHasPendingTimeout)
+	hasUpdate, probeUpdateErr := h.UpdateStore.HasPending(probeUpdateCtx, runtimeID)
+	cancelProbeUpdate()
+	switch {
+	case probeUpdateErr == nil && hasUpdate:
+		pending, popUpdateErr := h.UpdateStore.PopPending(ctx, runtimeID)
+		if popUpdateErr != nil {
+			slog.Warn("update PopPending failed", "error", popUpdateErr, "runtime_id", runtimeID)
+		} else if pending != nil {
+			ack.PendingUpdate = &protocol.DaemonHeartbeatPendingUpdate{
+				ID:            pending.ID,
+				TargetVersion: pending.TargetVersion,
+			}
+		}
+	case probeUpdateErr != nil:
+		if errors.Is(probeUpdateErr, context.DeadlineExceeded) || errors.Is(probeUpdateErr, context.Canceled) {
+			slog.Warn("update HasPending timed out", "runtime_id", runtimeID)
+		} else {
+			slog.Warn("update HasPending failed", "error", probeUpdateErr, "runtime_id", runtimeID)
 		}
 	}
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -59,7 +59,7 @@ type Handler struct {
 	TaskService           *service.TaskService
 	AutopilotService      *service.AutopilotService
 	EmailService          *service.EmailService
-	UpdateStore           *UpdateStore
+	UpdateStore           UpdateStore
 	ModelListStore        ModelListStore
 	LocalSkillListStore   LocalSkillListStore
 	LocalSkillImportStore LocalSkillImportStore
@@ -97,7 +97,7 @@ func New(queries *db.Queries, txStarter txStarter, hub *realtime.Hub, bus *event
 		TaskService:           taskSvc,
 		AutopilotService:      service.NewAutopilotService(queries, txStarter, bus, taskSvc),
 		EmailService:          emailService,
-		UpdateStore:           NewUpdateStore(),
+		UpdateStore:           NewInMemoryUpdateStore(),
 		ModelListStore:        NewInMemoryModelListStore(),
 		LocalSkillListStore:   NewInMemoryLocalSkillListStore(),
 		LocalSkillImportStore: NewInMemoryLocalSkillImportStore(),

--- a/server/internal/handler/runtime_update.go
+++ b/server/internal/handler/runtime_update.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -10,7 +12,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// In-memory update store
+// CLI update request store
 // ---------------------------------------------------------------------------
 
 type UpdateStatus string
@@ -33,27 +35,69 @@ type UpdateRequest struct {
 	Error         string       `json:"error,omitempty"`
 	CreatedAt     time.Time    `json:"created_at"`
 	UpdatedAt     time.Time    `json:"updated_at"`
+	RunStartedAt  *time.Time   `json:"-"`
 }
 
-// UpdateStore is a thread-safe in-memory store for CLI update requests.
-type UpdateStore struct {
+const (
+	updatePendingTimeout = 120 * time.Second
+	updateRunningTimeout = 150 * time.Second
+	updateStoreRetention = 5 * time.Minute
+)
+
+type UpdateStore interface {
+	Create(ctx context.Context, runtimeID, targetVersion string) (*UpdateRequest, error)
+	Get(ctx context.Context, id string) (*UpdateRequest, error)
+	HasPending(ctx context.Context, runtimeID string) (bool, error)
+	PopPending(ctx context.Context, runtimeID string) (*UpdateRequest, error)
+	Complete(ctx context.Context, id string, output string) error
+	Fail(ctx context.Context, id string, errMsg string) error
+}
+
+func updateRequestTerminal(status UpdateStatus) bool {
+	return status == UpdateCompleted || status == UpdateFailed || status == UpdateTimeout
+}
+
+func applyUpdateTimeout(req *UpdateRequest, now time.Time) bool {
+	switch req.Status {
+	case UpdatePending:
+		if now.Sub(req.CreatedAt) > updatePendingTimeout {
+			req.Status = UpdateTimeout
+			req.Error = "daemon did not respond within 120 seconds"
+			req.UpdatedAt = now
+			return true
+		}
+	case UpdateRunning:
+		if req.RunStartedAt != nil && now.Sub(*req.RunStartedAt) > updateRunningTimeout {
+			req.Status = UpdateTimeout
+			req.Error = "update did not complete within 150 seconds"
+			req.UpdatedAt = now
+			return true
+		}
+	}
+	return false
+}
+
+// InMemoryUpdateStore is the single-node implementation. Multi-node deploys
+// must use RedisUpdateStore so Web POST, daemon heartbeat, daemon report, and
+// UI polling agree on the same request lifecycle.
+type InMemoryUpdateStore struct {
 	mu       sync.Mutex
 	requests map[string]*UpdateRequest // keyed by update ID
 }
 
-func NewUpdateStore() *UpdateStore {
-	return &UpdateStore{
+func NewInMemoryUpdateStore() *InMemoryUpdateStore {
+	return &InMemoryUpdateStore{
 		requests: make(map[string]*UpdateRequest),
 	}
 }
 
-func (s *UpdateStore) Create(runtimeID, targetVersion string) (*UpdateRequest, error) {
+func (s *InMemoryUpdateStore) Create(_ context.Context, runtimeID, targetVersion string) (*UpdateRequest, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Clean up old requests (>5 minutes).
+	// Clean up old requests.
 	for id, req := range s.requests {
-		if time.Since(req.CreatedAt) > 5*time.Minute {
+		if time.Since(req.CreatedAt) > updateStoreRetention {
 			delete(s.requests, id)
 		}
 	}
@@ -83,39 +127,57 @@ type updateError struct{ msg string }
 
 func (e *updateError) Error() string { return e.msg }
 
-func (s *UpdateStore) Get(id string) *UpdateRequest {
+func (s *InMemoryUpdateStore) Get(_ context.Context, id string) (*UpdateRequest, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	req, ok := s.requests[id]
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	// Check for timeout (both pending and running states).
-	if (req.Status == UpdatePending || req.Status == UpdateRunning) && time.Since(req.CreatedAt) > 120*time.Second {
-		req.Status = UpdateTimeout
-		req.Error = "update did not complete within 120 seconds"
-		req.UpdatedAt = time.Now()
-	}
-	return req
+	applyUpdateTimeout(req, time.Now())
+	return req, nil
 }
 
-// PopPending returns and marks as running the pending update for a runtime.
-func (s *UpdateStore) PopPending(runtimeID string) *UpdateRequest {
+func (s *InMemoryUpdateStore) HasPending(_ context.Context, runtimeID string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	now := time.Now()
 	for _, req := range s.requests {
+		applyUpdateTimeout(req, now)
 		if req.RuntimeID == runtimeID && req.Status == UpdatePending {
-			req.Status = UpdateRunning
-			req.UpdatedAt = time.Now()
-			return req
+			return true, nil
 		}
 	}
-	return nil
+	return false, nil
 }
 
-func (s *UpdateStore) Complete(id string, output string) {
+// PopPending returns and marks as running the pending update for a runtime.
+func (s *InMemoryUpdateStore) PopPending(_ context.Context, runtimeID string) (*UpdateRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var oldest *UpdateRequest
+	now := time.Now()
+	for _, req := range s.requests {
+		applyUpdateTimeout(req, now)
+		if req.RuntimeID == runtimeID && req.Status == UpdatePending {
+			if oldest == nil || req.CreatedAt.Before(oldest.CreatedAt) {
+				oldest = req
+			}
+		}
+	}
+	if oldest != nil {
+		oldest.Status = UpdateRunning
+		startedAt := now
+		oldest.RunStartedAt = &startedAt
+		oldest.UpdatedAt = now
+	}
+	return oldest, nil
+}
+
+func (s *InMemoryUpdateStore) Complete(_ context.Context, id string, output string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -124,9 +186,10 @@ func (s *UpdateStore) Complete(id string, output string) {
 		req.Output = output
 		req.UpdatedAt = time.Now()
 	}
+	return nil
 }
 
-func (s *UpdateStore) Fail(id string, errMsg string) {
+func (s *InMemoryUpdateStore) Fail(_ context.Context, id string, errMsg string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -135,6 +198,7 @@ func (s *UpdateStore) Fail(id string, errMsg string) {
 		req.Error = errMsg
 		req.UpdatedAt = time.Now()
 	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -171,7 +235,7 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	update, err := h.UpdateStore.Create(uuidToString(rt.ID), req.TargetVersion)
+	update, err := h.UpdateStore.Create(r.Context(), uuidToString(rt.ID), req.TargetVersion)
 	if err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return
@@ -182,10 +246,29 @@ func (h *Handler) InitiateUpdate(w http.ResponseWriter, r *http.Request) {
 
 // GetUpdate returns the status of an update request (protected route, called by frontend).
 func (h *Handler) GetUpdate(w http.ResponseWriter, r *http.Request) {
+	runtimeID := chi.URLParam(r, "runtimeId")
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return
+	}
+
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "runtime not found")
+		return
+	}
+	if _, ok := h.requireWorkspaceMember(w, r, uuidToString(rt.WorkspaceID), "runtime not found"); !ok {
+		return
+	}
+
 	updateID := chi.URLParam(r, "updateId")
 
-	update := h.UpdateStore.Get(updateID)
-	if update == nil {
+	update, err := h.UpdateStore.Get(r.Context(), updateID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load update: "+err.Error())
+		return
+	}
+	if update == nil || update.RuntimeID != uuidToString(rt.ID) {
 		writeError(w, http.StatusNotFound, "update not found")
 		return
 	}
@@ -204,6 +287,21 @@ func (h *Handler) ReportUpdateResult(w http.ResponseWriter, r *http.Request) {
 
 	updateID := chi.URLParam(r, "updateId")
 
+	existing, err := h.UpdateStore.Get(r.Context(), updateID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load update: "+err.Error())
+		return
+	}
+	if existing == nil || existing.RuntimeID != runtimeID {
+		writeError(w, http.StatusNotFound, "update not found")
+		return
+	}
+	if updateRequestTerminal(existing.Status) {
+		slog.Debug("ignoring stale update report", "runtime_id", runtimeID, "update_id", updateID, "status", existing.Status)
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
 	var req struct {
 		Status string `json:"status"` // "running", "completed", or "failed"
 		Output string `json:"output"`
@@ -216,9 +314,17 @@ func (h *Handler) ReportUpdateResult(w http.ResponseWriter, r *http.Request) {
 
 	switch req.Status {
 	case "completed":
-		h.UpdateStore.Complete(updateID, req.Output)
+		if err := h.UpdateStore.Complete(r.Context(), updateID, req.Output); err != nil {
+			slog.Error("UpdateStore Complete failed", "error", err, "update_id", updateID)
+			writeError(w, http.StatusInternalServerError, "failed to persist completion")
+			return
+		}
 	case "failed":
-		h.UpdateStore.Fail(updateID, req.Error)
+		if err := h.UpdateStore.Fail(r.Context(), updateID, req.Error); err != nil {
+			slog.Error("UpdateStore Fail failed", "error", err, "update_id", updateID)
+			writeError(w, http.StatusInternalServerError, "failed to persist failure")
+			return
+		}
 	case "running":
 		// No-op: status is already "running" from PopPending. This call is
 		// just a progress signal from the daemon to confirm it received the

--- a/server/internal/handler/runtime_update_redis_store.go
+++ b/server/internal/handler/runtime_update_redis_store.go
@@ -1,0 +1,260 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Redis-backed implementation of UpdateStore. CLI updates have the same
+// pending-request shape as model-list and runtime-local-skill requests:
+// frontend creates the request, daemon claims it on heartbeat, daemon reports
+// a terminal result, and the UI polls by request ID. In multi-node deploys all
+// four calls can hit different API replicas, so the lifecycle must live in
+// shared storage.
+
+const (
+	updateKeyPrefix          = "mul:update:req:"
+	updatePendingPrefix      = "mul:update:pending:"
+	updateActivePrefix       = "mul:update:active:"
+	updateRedisPopMaxRetries = 5
+)
+
+func updateKey(id string) string               { return updateKeyPrefix + id }
+func updatePendingKey(runtimeID string) string { return updatePendingPrefix + runtimeID }
+func updateActiveKey(runtimeID string) string  { return updateActivePrefix + runtimeID }
+
+var deleteIfValueScript = redis.NewScript(`
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+return 0
+`)
+
+type RedisUpdateStore struct {
+	rdb *redis.Client
+}
+
+func NewRedisUpdateStore(rdb *redis.Client) *RedisUpdateStore {
+	return &RedisUpdateStore{rdb: rdb}
+}
+
+func (s *RedisUpdateStore) Create(ctx context.Context, runtimeID, targetVersion string) (*UpdateRequest, error) {
+	now := time.Now()
+	req := &UpdateRequest{
+		ID:            randomID(),
+		RuntimeID:     runtimeID,
+		Status:        UpdatePending,
+		TargetVersion: targetVersion,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	data, err := s.marshalRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	activeKey := updateActiveKey(runtimeID)
+	ok, err := s.rdb.SetNX(ctx, activeKey, req.ID, updateStoreRetention).Result()
+	if err != nil {
+		return nil, fmt.Errorf("reserve active update: %w", err)
+	}
+	if !ok {
+		return nil, errUpdateInProgress
+	}
+
+	pipe := s.rdb.TxPipeline()
+	pipe.Set(ctx, updateKey(req.ID), data, updateStoreRetention)
+	pipe.ZAdd(ctx, updatePendingKey(runtimeID), redis.Z{
+		Score:  float64(now.UnixNano()),
+		Member: req.ID,
+	})
+	pipe.Expire(ctx, updatePendingKey(runtimeID), updateStoreRetention*2)
+	if _, err := pipe.Exec(ctx); err != nil {
+		_ = s.clearActiveIfMatches(ctx, runtimeID, req.ID)
+		_ = s.rdb.Del(ctx, updateKey(req.ID)).Err()
+		_ = s.rdb.ZRem(ctx, updatePendingKey(runtimeID), req.ID).Err()
+		return nil, fmt.Errorf("persist update request: %w", err)
+	}
+	return req, nil
+}
+
+func (s *RedisUpdateStore) Get(ctx context.Context, id string) (*UpdateRequest, error) {
+	return s.loadRequest(ctx, id)
+}
+
+func (s *RedisUpdateStore) loadRequest(ctx context.Context, id string) (*UpdateRequest, error) {
+	raw, err := s.rdb.Get(ctx, updateKey(id)).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get update request: %w", err)
+	}
+	req, err := s.unmarshalRequest(raw)
+	if err != nil {
+		return nil, err
+	}
+	if applyUpdateTimeout(req, time.Now()) {
+		if err := s.persistRequest(ctx, req); err != nil {
+			return nil, err
+		}
+		if err := s.clearActiveIfMatches(ctx, req.RuntimeID, req.ID); err != nil {
+			return nil, err
+		}
+		s.rdb.ZRem(ctx, updatePendingKey(req.RuntimeID), req.ID)
+	}
+	return req, nil
+}
+
+func (s *RedisUpdateStore) persistRequest(ctx context.Context, req *UpdateRequest) error {
+	data, err := s.marshalRequest(req)
+	if err != nil {
+		return err
+	}
+	if err := s.rdb.Set(ctx, updateKey(req.ID), data, updateStoreRetention).Err(); err != nil {
+		return fmt.Errorf("persist update request: %w", err)
+	}
+	return nil
+}
+
+type redisUpdateEnvelope struct {
+	Public       *UpdateRequest `json:"r"`
+	RunStartedAt *time.Time     `json:"s,omitempty"`
+}
+
+func (s *RedisUpdateStore) marshalRequest(req *UpdateRequest) ([]byte, error) {
+	env := redisUpdateEnvelope{Public: req, RunStartedAt: req.RunStartedAt}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("marshal update request: %w", err)
+	}
+	return data, nil
+}
+
+func (s *RedisUpdateStore) unmarshalRequest(raw []byte) (*UpdateRequest, error) {
+	var env redisUpdateEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("decode update request: %w", err)
+	}
+	if env.Public == nil {
+		return nil, fmt.Errorf("decode update request: missing payload")
+	}
+	env.Public.RunStartedAt = env.RunStartedAt
+	return env.Public, nil
+}
+
+func (s *RedisUpdateStore) HasPending(ctx context.Context, runtimeID string) (bool, error) {
+	cnt, err := s.rdb.ZCard(ctx, updatePendingKey(runtimeID)).Result()
+	if err != nil {
+		return false, fmt.Errorf("zcard pending updates: %w", err)
+	}
+	return cnt > 0, nil
+}
+
+func (s *RedisUpdateStore) PopPending(ctx context.Context, runtimeID string) (*UpdateRequest, error) {
+	pendingKey := updatePendingKey(runtimeID)
+
+	for attempt := 0; attempt < updateRedisPopMaxRetries; attempt++ {
+		ids, err := s.rdb.ZRange(ctx, pendingKey, 0, 0).Result()
+		if err != nil {
+			return nil, fmt.Errorf("zrange pending updates: %w", err)
+		}
+		if len(ids) == 0 {
+			return nil, nil
+		}
+		id := ids[0]
+
+		req, err := s.loadRequest(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if req == nil {
+			s.rdb.ZRem(ctx, pendingKey, id)
+			continue
+		}
+		if req.Status != UpdatePending {
+			s.rdb.ZRem(ctx, pendingKey, id)
+			continue
+		}
+
+		now := time.Now()
+		req.Status = UpdateRunning
+		req.RunStartedAt = &now
+		req.UpdatedAt = now
+		data, err := s.marshalRequest(req)
+		if err != nil {
+			return nil, err
+		}
+
+		result, err := claimPendingScript.Run(
+			ctx, s.rdb,
+			[]string{pendingKey, updateKey(id)},
+			id, data, int(updateStoreRetention.Seconds()),
+		).Int64()
+		if err != nil {
+			return nil, fmt.Errorf("claim pending update: %w", err)
+		}
+		if result == 0 {
+			continue
+		}
+		return req, nil
+	}
+	return nil, nil
+}
+
+func (s *RedisUpdateStore) Complete(ctx context.Context, id string, output string) error {
+	req, err := s.loadRequest(ctx, id)
+	if err != nil {
+		return err
+	}
+	if req == nil || updateRequestTerminal(req.Status) {
+		return nil
+	}
+	req.Status = UpdateCompleted
+	req.Output = output
+	req.UpdatedAt = time.Now()
+	if err := s.persistRequest(ctx, req); err != nil {
+		return err
+	}
+	if err := s.clearActiveIfMatches(ctx, req.RuntimeID, req.ID); err != nil {
+		return err
+	}
+	s.rdb.ZRem(ctx, updatePendingKey(req.RuntimeID), req.ID)
+	return nil
+}
+
+func (s *RedisUpdateStore) Fail(ctx context.Context, id string, errMsg string) error {
+	req, err := s.loadRequest(ctx, id)
+	if err != nil {
+		return err
+	}
+	if req == nil || updateRequestTerminal(req.Status) {
+		return nil
+	}
+	req.Status = UpdateFailed
+	req.Error = errMsg
+	req.UpdatedAt = time.Now()
+	if err := s.persistRequest(ctx, req); err != nil {
+		return err
+	}
+	if err := s.clearActiveIfMatches(ctx, req.RuntimeID, req.ID); err != nil {
+		return err
+	}
+	s.rdb.ZRem(ctx, updatePendingKey(req.RuntimeID), req.ID)
+	return nil
+}
+
+func (s *RedisUpdateStore) clearActiveIfMatches(ctx context.Context, runtimeID, id string) error {
+	if runtimeID == "" || id == "" {
+		return nil
+	}
+	if err := deleteIfValueScript.Run(ctx, s.rdb, []string{updateActiveKey(runtimeID)}, id).Err(); err != nil {
+		return fmt.Errorf("clear active update: %w", err)
+	}
+	return nil
+}

--- a/server/internal/handler/runtime_update_redis_store_test.go
+++ b/server/internal/handler/runtime_update_redis_store_test.go
@@ -1,0 +1,277 @@
+package handler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRedisUpdateStore_EnvelopePersistsRunStartedAt(t *testing.T) {
+	store := &RedisUpdateStore{}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	req := &UpdateRequest{
+		ID:            "upd-1",
+		RuntimeID:     "rt-1",
+		Status:        UpdateRunning,
+		TargetVersion: "v1.2.3",
+		CreatedAt:     now.Add(-time.Second),
+		UpdatedAt:     now,
+		RunStartedAt:  &now,
+	}
+
+	data, err := store.marshalRequest(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got, err := store.unmarshalRequest(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.RunStartedAt == nil {
+		t.Fatal("RunStartedAt lost on round trip")
+	}
+	if !got.RunStartedAt.Equal(now) {
+		t.Fatalf("RunStartedAt = %s, want %s", got.RunStartedAt, now)
+	}
+	if got.TargetVersion != "v1.2.3" {
+		t.Fatalf("target version lost: %+v", got)
+	}
+}
+
+func TestRedisUpdateStore_CreateGetComplete(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+	store := NewRedisUpdateStore(rdb)
+
+	req, err := store.Create(ctx, "runtime-1", "v1.2.3")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if req.Status != UpdatePending {
+		t.Fatalf("initial status = %s", req.Status)
+	}
+
+	got, err := store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil || got.ID != req.ID || got.TargetVersion != "v1.2.3" {
+		t.Fatalf("round trip mismatch: %+v", got)
+	}
+
+	if err := store.Complete(ctx, req.ID, "updated"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	got, err = store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get after complete: %v", err)
+	}
+	if got.Status != UpdateCompleted || got.Output != "updated" {
+		t.Fatalf("completed request mismatch: %+v", got)
+	}
+
+	if _, err := store.Create(ctx, "runtime-1", "v1.2.4"); err != nil {
+		t.Fatalf("create after complete should be allowed: %v", err)
+	}
+}
+
+func TestRedisUpdateStore_PopPendingAcrossInstances(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+
+	nodeA := NewRedisUpdateStore(rdb)
+	nodeB := NewRedisUpdateStore(rdb)
+
+	req, err := nodeA.Create(ctx, "runtime-cross", "v1.2.3")
+	if err != nil {
+		t.Fatalf("node A create: %v", err)
+	}
+
+	popped, err := nodeB.PopPending(ctx, "runtime-cross")
+	if err != nil {
+		t.Fatalf("node B pop: %v", err)
+	}
+	if popped == nil {
+		t.Fatal("node B did not see node A's pending update")
+	}
+	if popped.ID != req.ID || popped.Status != UpdateRunning {
+		t.Fatalf("popped mismatch: %+v", popped)
+	}
+	if popped.RunStartedAt == nil {
+		t.Fatal("RunStartedAt not set after pop")
+	}
+
+	again, err := nodeB.PopPending(ctx, "runtime-cross")
+	if err != nil {
+		t.Fatalf("node B second pop: %v", err)
+	}
+	if again != nil {
+		t.Fatalf("expected no more pending, got %+v", again)
+	}
+}
+
+func TestRedisUpdateStore_ReportAndPollAcrossInstances(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+
+	nodeA := NewRedisUpdateStore(rdb)
+	nodeB := NewRedisUpdateStore(rdb)
+	nodeC := NewRedisUpdateStore(rdb)
+	nodeD := NewRedisUpdateStore(rdb)
+
+	req, err := nodeA.Create(ctx, "runtime-report", "v1.2.3")
+	if err != nil {
+		t.Fatalf("node A create: %v", err)
+	}
+	if _, err := nodeB.PopPending(ctx, "runtime-report"); err != nil {
+		t.Fatalf("node B pop: %v", err)
+	}
+	if err := nodeC.Complete(ctx, req.ID, "updated to v1.2.3"); err != nil {
+		t.Fatalf("node C complete: %v", err)
+	}
+
+	got, err := nodeD.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("node D get: %v", err)
+	}
+	if got == nil || got.Status != UpdateCompleted || got.Output != "updated to v1.2.3" {
+		t.Fatalf("node D terminal state mismatch: %+v", got)
+	}
+}
+
+func TestRedisUpdateStore_FailAcrossInstances(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+
+	nodeA := NewRedisUpdateStore(rdb)
+	nodeB := NewRedisUpdateStore(rdb)
+	nodeC := NewRedisUpdateStore(rdb)
+
+	req, err := nodeA.Create(ctx, "runtime-fail", "v1.2.3")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := nodeB.PopPending(ctx, "runtime-fail"); err != nil {
+		t.Fatalf("pop: %v", err)
+	}
+	if err := nodeC.Fail(ctx, req.ID, "download failed"); err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	got, err := nodeA.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != UpdateFailed || got.Error != "download failed" {
+		t.Fatalf("failed request mismatch: %+v", got)
+	}
+}
+
+func TestRedisUpdateStore_RejectsConcurrentActive(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+	store := NewRedisUpdateStore(rdb)
+
+	req, err := store.Create(ctx, "runtime-active", "v1.2.3")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := store.Create(ctx, "runtime-active", "v1.2.4"); err != errUpdateInProgress {
+		t.Fatalf("second create error = %v, want errUpdateInProgress", err)
+	}
+	if err := store.Complete(ctx, req.ID, "done"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if _, err := store.Create(ctx, "runtime-active", "v1.2.4"); err != nil {
+		t.Fatalf("create after terminal should succeed: %v", err)
+	}
+}
+
+func TestRedisUpdateStore_RunningTimeoutClearsActive(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+	store := NewRedisUpdateStore(rdb)
+
+	req, err := store.Create(ctx, "runtime-timeout", "v1.2.3")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	popped, err := store.PopPending(ctx, "runtime-timeout")
+	if err != nil {
+		t.Fatalf("pop: %v", err)
+	}
+	if popped == nil || popped.Status != UpdateRunning {
+		t.Fatalf("expected running, got %+v", popped)
+	}
+
+	aged := time.Now().Add(-(updateRunningTimeout + time.Second))
+	popped.RunStartedAt = &aged
+	if err := store.persistRequest(ctx, popped); err != nil {
+		t.Fatalf("persist aged request: %v", err)
+	}
+
+	got, err := store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != UpdateTimeout {
+		t.Fatalf("status = %s, want timeout", got.Status)
+	}
+	if _, err := store.Create(ctx, "runtime-timeout", "v1.2.4"); err != nil {
+		t.Fatalf("create after timeout should succeed: %v", err)
+	}
+}
+
+func TestRedisUpdateStore_PopPendingConcurrent(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	ctx := context.Background()
+	store := NewRedisUpdateStore(rdb)
+
+	req, err := store.Create(ctx, "runtime-race", "v1.2.3")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	results := make(chan *UpdateRequest, n)
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			popped, err := store.PopPending(ctx, "runtime-race")
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- popped
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent pop error: %v", err)
+	}
+
+	winners := 0
+	for popped := range results {
+		if popped != nil {
+			winners++
+			if popped.ID != req.ID {
+				t.Fatalf("winner popped wrong id: %s", popped.ID)
+			}
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("expected exactly one winner, got %d", winners)
+	}
+}
+
+var (
+	_ UpdateStore = (*InMemoryUpdateStore)(nil)
+	_ UpdateStore = (*RedisUpdateStore)(nil)
+)

--- a/server/internal/handler/runtime_update_test.go
+++ b/server/internal/handler/runtime_update_test.go
@@ -1,0 +1,111 @@
+package handler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestInMemoryUpdateStore_HasPending(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryUpdateStore()
+
+	if has, err := store.HasPending(ctx, "rt-1"); err != nil || has {
+		t.Fatalf("empty store should not report pending: has=%v err=%v", has, err)
+	}
+
+	if _, err := store.Create(ctx, "rt-1", "v1.2.3"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if has, err := store.HasPending(ctx, "rt-1"); err != nil || !has {
+		t.Fatalf("expected pending=true after Create: has=%v err=%v", has, err)
+	}
+	if has, err := store.HasPending(ctx, "rt-2"); err != nil || has {
+		t.Fatalf("expected pending=false for unrelated runtime: has=%v err=%v", has, err)
+	}
+
+	if _, err := store.PopPending(ctx, "rt-1"); err != nil {
+		t.Fatalf("pop: %v", err)
+	}
+	if has, err := store.HasPending(ctx, "rt-1"); err != nil || has {
+		t.Fatalf("expected pending=false after PopPending: has=%v err=%v", has, err)
+	}
+}
+
+func TestInMemoryUpdateStore_PopPendingIgnoresTerminalHistory(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryUpdateStore()
+
+	first, err := store.Create(ctx, "rt-1", "v1.2.3")
+	if err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	if err := store.Fail(ctx, first.ID, "allow next request"); err != nil {
+		t.Fatalf("fail first: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond)
+	second, err := store.Create(ctx, "rt-1", "v1.2.4")
+	if err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+
+	got, err := store.PopPending(ctx, "rt-1")
+	if err != nil {
+		t.Fatalf("pop: %v", err)
+	}
+	if got == nil || got.ID != second.ID {
+		t.Fatalf("expected second request, got %+v", got)
+	}
+}
+
+func TestInMemoryUpdateStore_RunningRequestTimesOut(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryUpdateStore()
+
+	req, err := store.Create(ctx, "rt-timeout", "v1.2.3")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	claimed, err := store.PopPending(ctx, "rt-timeout")
+	if err != nil {
+		t.Fatalf("pop: %v", err)
+	}
+	if claimed == nil || claimed.Status != UpdateRunning {
+		t.Fatalf("expected running request, got %+v", claimed)
+	}
+	if claimed.RunStartedAt == nil {
+		t.Fatal("expected RunStartedAt after PopPending")
+	}
+
+	aged := time.Now().Add(-(updateRunningTimeout + time.Second))
+	claimed.RunStartedAt = &aged
+	got, err := store.Get(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != UpdateTimeout {
+		t.Fatalf("status = %s, want timeout", got.Status)
+	}
+	if got.Error == "" {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestInMemoryUpdateStore_RejectsConcurrentActiveUntilTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryUpdateStore()
+
+	req, err := store.Create(ctx, "rt-1", "v1.2.3")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := store.Create(ctx, "rt-1", "v1.2.4"); err != errUpdateInProgress {
+		t.Fatalf("second create error = %v, want errUpdateInProgress", err)
+	}
+	if err := store.Complete(ctx, req.ID, "done"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if _, err := store.Create(ctx, "rt-1", "v1.2.4"); err != nil {
+		t.Fatalf("create after terminal should succeed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Convert CLI runtime update requests from a process-local concrete store to a context-aware store interface.
- Add a Redis-backed update store so Web POST, daemon heartbeat, daemon report, and UI polling share state across API replicas.
- Wire the Redis store when `rdb != nil`, keep the in-memory implementation for single-node dev/tests, and harden update poll/report runtime ownership checks.
- Add focused in-memory and Redis-store regression coverage for cross-instance claim/report/poll behavior.

## Test Plan

- `go test ./internal/handler -run 'Test(InMemoryUpdateStore|RedisUpdateStore)'`
- `go test ./internal/handler -run '^$'`
- `go test ./cmd/server -run '^$'`
- `go test ./internal/daemon`

Note: `go test ./internal/handler ./cmd/server ./internal/daemon` was also attempted. `internal/daemon` passed, but handler/server integration tests failed against the local test DB with pre-existing schema/seed issues such as missing `agent_task_queue.trigger_summary`, missing `notification_preference`, workspace FK failures, and readiness returning 503. The focused tests and compile-only package checks above pass.
