### PR TITLE
fix(projects): add resource_count breadcrumb instead of inlining resources

### DIFF
--- a/packages/core/types/project.ts
+++ b/packages/core/types/project.ts
@@ -16,6 +16,7 @@ export interface Project {
   updated_at: string;
   issue_count: number;
   done_count: number;
+  resource_count: number;
 }
 
 export interface CreateProjectRequest {

--- a/server/cmd/multica/cmd_project.go
+++ b/server/cmd/multica/cmd_project.go
@@ -225,6 +225,14 @@ func runProjectGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get project: %w", err)
 	}
 
+	// Breadcrumb to the resources sub-collection. Goes to stderr so JSON on
+	// stdout stays parseable; the `resource_count` field on the response is
+	// the programmatic equivalent. JSON numbers decode as float64.
+	if n, _ := project["resource_count"].(float64); n > 0 {
+		fmt.Fprintf(os.Stderr, "%d resource(s) attached — run `multica project resource list %s` to view.\n",
+			int64(n), strVal(project, "id"))
+	}
+
 	output, _ := cmd.Flags().GetString("output")
 	if output == "table" {
 		lead := formatLead(project)

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -119,7 +119,9 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica attachment download <id> [-o <dir>]` — Download an attachment file locally by ID\n")
 	b.WriteString("- `multica autopilot list [--status X] --output json` — List autopilots (scheduled/triggered agent automations) in the workspace\n")
 	b.WriteString("- `multica autopilot get <id> --output json` — Get autopilot details including triggers\n")
-	b.WriteString("- `multica autopilot runs <id> [--limit N] --output json` — List execution history for an autopilot\n\n")
+	b.WriteString("- `multica autopilot runs <id> [--limit N] --output json` — List execution history for an autopilot\n")
+	b.WriteString("- `multica project get <id> --output json` — Get project details. Includes `resource_count`; the resources themselves live at the sub-collection below.\n")
+	b.WriteString("- `multica project resource list <project-id> --output json` — List resources (e.g. github_repo) attached to a project. Use this when `resource_count > 0` and you need the actual refs.\n\n")
 
 	b.WriteString("### Write\n")
 	b.WriteString("- `multica issue create --title \"...\" [--description \"...\"] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--project <project-id>] [--due-date <RFC3339>] [--attachment <path>]` — Create a new issue. `--attachment` may be repeated to upload multiple files; labels and subscribers are not accepted here, attach them after create with the commands below.\n")

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -313,11 +313,12 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := projectToResponse(project)
 	resourceResp := make([]ProjectResourceResponse, len(resourceRows))
 	for i, row := range resourceRows {
 		resourceResp[i] = projectResourceToResponse(row)
 	}
+	resp := projectToResponse(project)
+	resp.ResourceCount = int64(len(resourceResp))
 	h.publish(protocol.EventProjectCreated, workspaceID, "member", userID, map[string]any{"project": resp})
 	for _, rr := range resourceResp {
 		h.publish(protocol.EventProjectResourceCreated, workspaceID, "member", userID, map[string]any{
@@ -325,22 +326,15 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 			"project_id": resp.ID,
 		})
 	}
-	writeJSON(w, http.StatusCreated, map[string]any{
-		"id":             resp.ID,
-		"workspace_id":   resp.WorkspaceID,
-		"title":          resp.Title,
-		"description":    resp.Description,
-		"icon":           resp.Icon,
-		"status":         resp.Status,
-		"priority":       resp.Priority,
-		"lead_type":      resp.LeadType,
-		"lead_id":        resp.LeadID,
-		"created_at":     resp.CreatedAt,
-		"updated_at":     resp.UpdatedAt,
-		"issue_count":    resp.IssueCount,
-		"done_count":     resp.DoneCount,
-		"resource_count": int64(len(resourceResp)),
-		"resources":      resourceResp,
+	// One-shot create echo: the parent ProjectResponse fields plus the just-
+	// created resources. This is a transient creation echo, not a contract for
+	// reads — GET /projects/{id} stays metadata-only with resource_count.
+	writeJSON(w, http.StatusCreated, struct {
+		ProjectResponse
+		Resources []ProjectResourceResponse `json:"resources"`
+	}{
+		ProjectResponse: resp,
+		Resources:       resourceResp,
 	})
 }
 
@@ -433,6 +427,7 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := projectToResponse(project)
+	resp.ResourceCount = h.loadProjectResourceCount(r.Context(), project.ID)
 	h.publish(protocol.EventProjectUpdated, workspaceID, "member", userID, map[string]any{"project": resp})
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/server/internal/handler/project.go
+++ b/server/internal/handler/project.go
@@ -30,6 +30,11 @@ type ProjectResponse struct {
 	UpdatedAt   string  `json:"updated_at"`
 	IssueCount  int64   `json:"issue_count"`
 	DoneCount   int64   `json:"done_count"`
+	// ResourceCount is a breadcrumb pointing at the sub-collection at
+	// /api/projects/{id}/resources. Resources themselves stay out of this
+	// payload to keep parent metadata and child collections separate; clients
+	// that need the list call ListProjectResources directly.
+	ResourceCount int64 `json:"resource_count"`
 }
 
 func projectToResponse(p db.Project) ProjectResponse {
@@ -54,6 +59,14 @@ func (h *Handler) loadProjectIssueStats(ctx context.Context, projectID pgtype.UU
 		return 0, 0
 	}
 	return stats[0].TotalCount, stats[0].DoneCount
+}
+
+func (h *Handler) loadProjectResourceCount(ctx context.Context, projectID pgtype.UUID) int64 {
+	rows, err := h.Queries.GetProjectResourceCounts(ctx, []pgtype.UUID{projectID})
+	if err != nil || len(rows) == 0 {
+		return 0
+	}
+	return rows[0].ResourceCount
 }
 
 type CreateProjectRequest struct {
@@ -111,8 +124,9 @@ func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Batch-fetch issue stats for all projects
+	// Batch-fetch issue stats and resource counts for all projects
 	statsMap := make(map[string]db.GetProjectIssueStatsRow)
+	resourceCountMap := make(map[string]int64)
 	if len(projects) > 0 {
 		projectIDs := make([]pgtype.UUID, len(projects))
 		for i, p := range projects {
@@ -124,6 +138,12 @@ func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 				statsMap[uuidToString(s.ProjectID)] = s
 			}
 		}
+		counts, err := h.Queries.GetProjectResourceCounts(r.Context(), projectIDs)
+		if err == nil {
+			for _, c := range counts {
+				resourceCountMap[uuidToString(c.ProjectID)] = c.ResourceCount
+			}
+		}
 	}
 
 	resp := make([]ProjectResponse, len(projects))
@@ -133,6 +153,7 @@ func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 			resp[i].IssueCount = s.TotalCount
 			resp[i].DoneCount = s.DoneCount
 		}
+		resp[i].ResourceCount = resourceCountMap[resp[i].ID]
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"projects": resp, "total": len(resp)})
 }
@@ -157,6 +178,7 @@ func (h *Handler) GetProject(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := projectToResponse(project)
 	resp.IssueCount, resp.DoneCount = h.loadProjectIssueStats(r.Context(), project.ID)
+	resp.ResourceCount = h.loadProjectResourceCount(r.Context(), project.ID)
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -304,20 +326,21 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{
-		"id":           resp.ID,
-		"workspace_id": resp.WorkspaceID,
-		"title":        resp.Title,
-		"description":  resp.Description,
-		"icon":         resp.Icon,
-		"status":       resp.Status,
-		"priority":     resp.Priority,
-		"lead_type":    resp.LeadType,
-		"lead_id":      resp.LeadID,
-		"created_at":   resp.CreatedAt,
-		"updated_at":   resp.UpdatedAt,
-		"issue_count":  resp.IssueCount,
-		"done_count":   resp.DoneCount,
-		"resources":    resourceResp,
+		"id":             resp.ID,
+		"workspace_id":   resp.WorkspaceID,
+		"title":          resp.Title,
+		"description":    resp.Description,
+		"icon":           resp.Icon,
+		"status":         resp.Status,
+		"priority":       resp.Priority,
+		"lead_type":      resp.LeadType,
+		"lead_id":        resp.LeadID,
+		"created_at":     resp.CreatedAt,
+		"updated_at":     resp.UpdatedAt,
+		"issue_count":    resp.IssueCount,
+		"done_count":     resp.DoneCount,
+		"resource_count": int64(len(resourceResp)),
+		"resources":      resourceResp,
 	})
 }
 
@@ -668,8 +691,9 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 		total = results[0].totalCount
 	}
 
-	// Batch-fetch issue stats
+	// Batch-fetch issue stats and resource counts
 	statsMap := make(map[string]db.GetProjectIssueStatsRow)
+	resourceCountMap := make(map[string]int64)
 	if len(results) > 0 {
 		projectIDs := make([]pgtype.UUID, len(results))
 		for i, r := range results {
@@ -681,6 +705,12 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 				statsMap[uuidToString(s.ProjectID)] = s
 			}
 		}
+		counts, err := h.Queries.GetProjectResourceCounts(ctx, projectIDs)
+		if err == nil {
+			for _, c := range counts {
+				resourceCountMap[uuidToString(c.ProjectID)] = c.ResourceCount
+			}
+		}
 	}
 
 	resp := make([]SearchProjectResponse, len(results))
@@ -690,6 +720,7 @@ func (h *Handler) SearchProjects(w http.ResponseWriter, r *http.Request) {
 			pr.IssueCount = s.TotalCount
 			pr.DoneCount = s.DoneCount
 		}
+		pr.ResourceCount = resourceCountMap[pr.ID]
 		spr := SearchProjectResponse{
 			ProjectResponse: pr,
 			MatchSource:     row.matchSource,

--- a/server/internal/handler/project_resource_test.go
+++ b/server/internal/handler/project_resource_test.go
@@ -248,6 +248,61 @@ func TestProjectResourceCountBreadcrumb(t *testing.T) {
 	if !found {
 		t.Fatalf("project %s not found in ListProjects response", project.ID)
 	}
+
+	// UpdateProject must preserve the breadcrumb. A title-only PUT used to
+	// reset resource_count to 0 because UpdateProject didn't reload the count.
+	w = httptest.NewRecorder()
+	req = newRequest("PUT", "/api/projects/"+project.ID, map[string]any{
+		"title": "Resource count breadcrumb (updated)",
+	})
+	req = withURLParam(req, "id", project.ID)
+	testHandler.UpdateProject(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateProject: %d %s", w.Code, w.Body.String())
+	}
+	var updated ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode UpdateProject: %v", err)
+	}
+	if updated.ResourceCount != 1 {
+		t.Errorf("UpdateProject ResourceCount = %d, want 1", updated.ResourceCount)
+	}
+}
+
+// TestCreateProjectWithResourcesEchoesCount asserts the create-with-resources
+// echo carries resource_count matching the attached resources, so the HTTP
+// response and the published project:created event agree.
+func TestCreateProjectWithResourcesEchoesCount(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Create echo with resource_count",
+		"resources": []map[string]any{
+			{
+				"resource_type": "github_repo",
+				"resource_ref":  map[string]any{"url": "https://github.com/multica-ai/echo-count"},
+			},
+		},
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateProject with resources: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		ID            string                    `json:"id"`
+		ResourceCount int64                     `json:"resource_count"`
+		Resources     []ProjectResourceResponse `json:"resources"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode CreateProject: %v", err)
+	}
+	defer func() {
+		r := newRequest("DELETE", "/api/projects/"+resp.ID, nil)
+		r = withURLParam(r, "id", resp.ID)
+		testHandler.DeleteProject(httptest.NewRecorder(), r)
+	}()
+	if resp.ResourceCount != 1 || len(resp.Resources) != 1 {
+		t.Errorf("CreateProject echo: resource_count=%d resources=%d, want 1/1", resp.ResourceCount, len(resp.Resources))
+	}
 }
 
 func TestCreateProjectRollsBackOnInvalidResource(t *testing.T) {

--- a/server/internal/handler/project_resource_test.go
+++ b/server/internal/handler/project_resource_test.go
@@ -168,6 +168,88 @@ func TestCreateProjectAttachesResources(t *testing.T) {
 	}
 }
 
+// TestProjectResourceCountBreadcrumb asserts the resource_count breadcrumb
+// surfaces on GetProject and ListProjects so agents know to call
+// /api/projects/{id}/resources without inlining the sub-collection.
+func TestProjectResourceCountBreadcrumb(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Resource count breadcrumb",
+	})
+	testHandler.CreateProject(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateProject: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var project ProjectResponse
+	if err := json.NewDecoder(w.Body).Decode(&project); err != nil {
+		t.Fatalf("decode CreateProject: %v", err)
+	}
+	defer func() {
+		r := newRequest("DELETE", "/api/projects/"+project.ID, nil)
+		r = withURLParam(r, "id", project.ID)
+		testHandler.DeleteProject(httptest.NewRecorder(), r)
+	}()
+
+	getCount := func() int64 {
+		w := httptest.NewRecorder()
+		req := newRequest("GET", "/api/projects/"+project.ID, nil)
+		req = withURLParam(req, "id", project.ID)
+		testHandler.GetProject(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("GetProject: %d %s", w.Code, w.Body.String())
+		}
+		var resp ProjectResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode GetProject: %v", err)
+		}
+		return resp.ResourceCount
+	}
+	if got := getCount(); got != 0 {
+		t.Errorf("initial GetProject ResourceCount = %d, want 0", got)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("POST", "/api/projects/"+project.ID+"/resources", map[string]any{
+		"resource_type": "github_repo",
+		"resource_ref":  map[string]any{"url": "https://github.com/multica-ai/breadcrumb"},
+	})
+	req = withURLParam(req, "id", project.ID)
+	testHandler.CreateProjectResource(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateProjectResource: %d %s", w.Code, w.Body.String())
+	}
+
+	if got := getCount(); got != 1 {
+		t.Errorf("after attach GetProject ResourceCount = %d, want 1", got)
+	}
+
+	w = httptest.NewRecorder()
+	req = newRequest("GET", "/api/projects?workspace_id="+testWorkspaceID, nil)
+	testHandler.ListProjects(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListProjects: %d %s", w.Code, w.Body.String())
+	}
+	var list struct {
+		Projects []ProjectResponse `json:"projects"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&list); err != nil {
+		t.Fatalf("decode ListProjects: %v", err)
+	}
+	found := false
+	for _, p := range list.Projects {
+		if p.ID == project.ID {
+			found = true
+			if p.ResourceCount != 1 {
+				t.Errorf("ListProjects[%s].ResourceCount = %d, want 1", p.ID, p.ResourceCount)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("project %s not found in ListProjects response", project.ID)
+	}
+}
+
 func TestCreateProjectRollsBackOnInvalidResource(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := newRequest("POST", "/api/projects?workspace_id="+testWorkspaceID, map[string]any{

--- a/server/pkg/db/generated/project_resource.sql.go
+++ b/server/pkg/db/generated/project_resource.sql.go
@@ -96,6 +96,38 @@ func (q *Queries) GetProjectResource(ctx context.Context, id pgtype.UUID) (Proje
 	return i, err
 }
 
+const getProjectResourceCounts = `-- name: GetProjectResourceCounts :many
+SELECT project_id, count(*)::bigint AS resource_count
+FROM project_resource
+WHERE project_id = ANY($1::uuid[])
+GROUP BY project_id
+`
+
+type GetProjectResourceCountsRow struct {
+	ProjectID     pgtype.UUID `json:"project_id"`
+	ResourceCount int64       `json:"resource_count"`
+}
+
+func (q *Queries) GetProjectResourceCounts(ctx context.Context, projectIds []pgtype.UUID) ([]GetProjectResourceCountsRow, error) {
+	rows, err := q.db.Query(ctx, getProjectResourceCounts, projectIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetProjectResourceCountsRow{}
+	for rows.Next() {
+		var i GetProjectResourceCountsRow
+		if err := rows.Scan(&i.ProjectID, &i.ResourceCount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getProjectResourceInWorkspace = `-- name: GetProjectResourceInWorkspace :one
 SELECT id, project_id, workspace_id, resource_type, resource_ref, label, position, created_at, created_by FROM project_resource
 WHERE id = $1 AND workspace_id = $2

--- a/server/pkg/db/queries/project_resource.sql
+++ b/server/pkg/db/queries/project_resource.sql
@@ -28,3 +28,9 @@ DELETE FROM project_resource WHERE id = $1;
 
 -- name: CountProjectResources :one
 SELECT count(*) FROM project_resource WHERE project_id = $1;
+
+-- name: GetProjectResourceCounts :many
+SELECT project_id, count(*)::bigint AS resource_count
+FROM project_resource
+WHERE project_id = ANY(sqlc.arg('project_ids')::uuid[])
+GROUP BY project_id;


### PR DESCRIPTION
## Summary

Closes #2087.

`multica project get` returned project metadata with no signal that resources existed, leaving agents (and any other ad-hoc consumer) with no way to discover the attached resources unless they already knew about `/api/projects/{id}/resources` or the daemon-written `.multica/project/resources.json`.

This fixes the discoverability gap **without** denormalizing the sub-collection into the parent payload.

### Why not inline `resources` (the alternative in #2088)

Inlining the full resource list into `GetProject`:

- conflates parent metadata with a child sub-collection — once shipped, removing it is a breaking change
- locks the schema-by-`resource_type` `resource_ref` shape into the project endpoint's contract; every future resource type bleeds into `GET /projects/{id}`
- is asymmetric with `ListProjects` (where N+1 makes inlining impractical), forcing clients to remember "list ≠ get"
- sets a precedent that future sub-collections (milestones, integrations, view configs…) all have to choose to inline-or-not

### What this PR does instead

- **`ProjectResponse.ResourceCount`** — a scalar breadcrumb populated on `GetProject`, `ListProjects`, `SearchProjects`, and the with-resources `CreateProject` echo. Tells callers that resources exist and how many; clients fetch them via the existing `multica project resource list <id>` / `GET /api/projects/{id}/resources` endpoint.
- **`GetProjectResourceCounts :many`** — new batched sqlc query so `ListProjects` / `SearchProjects` cost one extra aggregated query, not N+1.
- **`multica project get` CLI** — when `resource_count > 0` it prints a stderr hint pointing at `multica project resource list <id>`. JSON on stdout stays parseable.
- **Agent meta-skill** (`runtime_config.go`) — lists `multica project get` and `multica project resource list` in the Available Commands section so agents that read CLAUDE.md / AGENTS.md know about both paths even outside the Project Context injection.

When the team wants a true "fetch parent + children in one shot" for any reason, the right vehicle is a generic opt-in `?include=resources,milestones,...` parameter (Stripe / JSON:API style). That can be added later without touching this contract.

### Replaces

This is intended to replace #2088 — same goal (close #2087), different shape. Recommend closing #2088.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages green; new `TestProjectResourceCountBreadcrumb` covers `GetProject` and `ListProjects` paths (skipped locally without DB; runs in CI)
- [x] `go build ./...` clean
- [ ] CI green (postgres-backed handler tests + integration)
- [ ] Manual: `multica project get <id> --output json` shows `resource_count`; stderr hint appears when > 0; JSON on stdout still parses with `jq`