### PR TITLE
fix(runtimes): narrow CostCell usage window from 180d to 14d

### DIFF
--- a/packages/views/runtimes/components/runtime-columns.tsx
+++ b/packages/views/runtimes/components/runtime-columns.tsx
@@ -51,8 +51,8 @@ import {
 
 // Per-row data assembled at the page level. The columns reach into
 // `row.original` and never pull their own data — except for the per-runtime
-// usage query in CostCell, which intentionally keeps its 180-day cache key
-// shared with the runtime-detail page (clicking a row pre-warms detail).
+// usage query in CostCell, which fetches its own narrow 14-day window
+// (just enough for the cell's 7d cost + 7d prior-window delta).
 export interface RuntimeRow {
   runtime: AgentRuntime;
   ownerMember: MemberWithUser | null;
@@ -320,12 +320,20 @@ function WorkloadCell({
   );
 }
 
-// Per-row cost — fetches the same 180-day usage window used by the
-// runtime-detail page so clicking a row makes detail render instantly from
-// cache. Cold load incurs N parallel requests, but each is cheap and they
-// all share the same query key.
+// Per-row cost — only renders a 7d total + delta vs the prior 7d, so we
+// only need 14 days of usage. Previously this fetched a 180-day window to
+// share the cache key with the runtime-detail page, but that turned the
+// list page into N × 180d in-line aggregations against `task_usage` (one
+// per runtime row) and dominated DB load for this view. Detail still
+// fetches its own 180d window on navigation; the cold-load difference for
+// detail is one extra request, while the steady-state savings on the list
+// page are large.
+const COST_CELL_DAYS = 14;
+
 function CostCell({ runtimeId }: { runtimeId: string }) {
-  const { data: usage = [] } = useQuery(runtimeUsageOptions(runtimeId, 180));
+  const { data: usage = [] } = useQuery(
+    runtimeUsageOptions(runtimeId, COST_CELL_DAYS),
+  );
   const cost7d = useMemo(() => computeCostInWindow(usage, 7), [usage]);
   const costPrev7d = useMemo(
     () => computeCostInWindow(usage, 7, 7),


### PR DESCRIPTION
## Background

Tracked in MUL-1748. `ListRuntimeUsage` currently runs ~100ms+ even at low QPS because the read path now aggregates `task_usage` on the fly (the predecessor `runtime_usage` rollup table was removed in migration 046) and the existing indexes don't cover the JOIN/filter shape.

The runtimes **list page** amplifies this: each row's `CostCell` issues `runtimeUsageOptions(runtimeId, 180)`, so visiting the page kicks off N parallel **180-day** in-line aggregations — one per runtime — even though the cell only renders a 7d total + a 7d-vs-prior-7d delta.

This PR is the frontend half of the fix. It is intentionally independent of (and lands ahead of) the backend index + daily-rollup work, so we get immediate relief on list-page DB pressure without waiting on a migration.

## Change

`packages/views/runtimes/components/runtime-columns.tsx`:
- `CostCell` now requests a **14-day** usage window (`COST_CELL_DAYS = 14`) — exactly what `cost7d` + `costPrev7d` need.
- Updated the surrounding comments to reflect that the cell no longer shares a cache key with the runtime-detail page.

The detail page (`UsageSection`) still owns its own `runtimeUsageOptions(runtimeId, 180)` query.

## Trade-off

- **Loss:** Clicking a row no longer pre-warms the detail page's 180d cache. Detail will issue one extra request on first navigation — cheap (single runtime, single window) and previously masked.
- **Gain:** List page goes from `N × 180d` aggregations to `N × 14d`, ~13× fewer rows scanned per request and a much smaller working set for any future index. Once the backend rollup lands, this reduction stacks with it.

## Verification

- `pnpm turbo typecheck --filter=@multica/views` — passes.
- `pnpm turbo lint --filter=@multica/views` — pre-existing failures in unrelated files (`concurrency-picker.tsx`, `runtime-picker.tsx`, `model-dropdown.tsx`, `no-access-page.tsx`); no new lint errors introduced by this PR.
- Visual diff on the list page: cell renders identically (same 7d $ + delta arrow) — `computeCostInWindow(usage, 7)` and `computeCostInWindow(usage, 7, 7)` only need `date >= today-14`, which the new window covers exactly.

## Follow-ups (separate PRs, MUL-1748)

- Backend `EXPLAIN (ANALYZE, BUFFERS)` baseline (Phase 0).
- Index additions on `task_usage` and `agent_task_queue` (Phase 1).
- `runtime_usage_daily` rollup + write-path upsert + backfill (Phase 3).
