### PR TITLE
fix(web): redesign 404 + break NoAccessPage redirect loop

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { buttonVariants } from "@multica/ui/components/ui/button";
 

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,61 +1,17 @@
-import { Instrument_Serif } from "next/font/google";
-
-// Editorial-style 404. Cream + ink + terracotta palette is intentionally
-// inline — these brand experiments have not been promoted to design tokens.
-// The route lives outside the (landing) group's font scope, so we attach
-// Instrument Serif locally to match the editorial direction.
-const CREAM = "#faf9f6";
-const INK = "#1b1812";
-const TERRACOTTA = "#a64a2c";
-
-const editorialSerif = Instrument_Serif({
-  subsets: ["latin"],
-  weight: "400",
-  variable: "--font-serif",
-});
+import Link from "next/link";
+import { buttonVariants } from "@multica/ui/components/ui/button";
 
 export default function NotFound() {
   return (
-    <section
-      className={`${editorialSerif.variable} relative flex min-h-screen flex-col items-center justify-center px-6 py-16`}
-      style={{ backgroundColor: CREAM, color: INK }}
-    >
-      {/* tracking is wider than Tailwind's tracking-widest (0.1em) — editorial eyebrow detail, deliberate. */}
-      <div
-        className="flex items-center gap-3 text-xs uppercase tracking-[0.25em]"
-        style={{ color: TERRACOTTA }}
-      >
-        <span aria-hidden="true" className="inline-block h-px w-10" style={{ background: TERRACOTTA }} />
-        <span>error · not found</span>
-        <span aria-hidden="true" className="inline-block h-px w-10" style={{ background: TERRACOTTA }} />
-      </div>
-
-      {/* Fluid hero size + ultra-tight leading; outside the Tailwind type scale by design. */}
-      <h1 className="mt-12 font-serif text-[clamp(7rem,16vw,15rem)] leading-[0.85] tracking-tight">
-        404
-      </h1>
-
-      <p className="mt-10 max-w-xl text-center font-serif text-3xl leading-tight">
-        This page{" "}
-        <em className="not-italic" style={{ color: TERRACOTTA }}>
-          doesn&rsquo;t exist
-        </em>
-        .
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 px-6 py-24 text-center">
+      <p className="text-sm font-medium text-muted-foreground">404</p>
+      <h1 className="text-2xl font-semibold tracking-tight">Page not found</h1>
+      <p className="max-w-md text-sm text-muted-foreground">
+        The page you are looking for doesn&rsquo;t exist or has been moved.
       </p>
-      <p
-        className="mt-5 max-w-md text-center text-sm leading-relaxed"
-        style={{ color: INK, opacity: 0.6 }}
-      >
-        The URL may have changed, the resource may be deleted, or you arrived from a stale link.
-      </p>
-
-      <a
-        href="/"
-        className="mt-12 inline-flex h-10 items-center rounded-full px-6 text-sm font-medium transition hover:opacity-90"
-        style={{ background: INK, color: CREAM }}
-      >
+      <Link href="/" className={buttonVariants({ className: "mt-2" })}>
         Back to Multica
-      </a>
-    </section>
+      </Link>
+    </main>
   );
 }

--- a/packages/views/workspace/no-access-page.test.tsx
+++ b/packages/views/workspace/no-access-page.test.tsx
@@ -32,6 +32,16 @@ describe("NoAccessPage", () => {
     expect(navigate).toHaveBeenCalledWith("/");
   });
 
+  it("clears last_workspace_slug cookie on mount so the proxy stops looping us back", () => {
+    document.cookie = "last_workspace_slug=stale; path=/";
+    render(<NoAccessPage />);
+    // Assert empty value, not just absence of "stale" — the proxy reads any
+    // truthy value as a redirect target, so a buggy clear that left e.g.
+    // `last_workspace_slug=other` would still trap users.
+    const value = document.cookie.match(/last_workspace_slug=([^;]*)/)?.[1];
+    expect(value ?? "").toBe("");
+  });
+
   it("fully logs out on 'Sign in as a different user' instead of just navigating", () => {
     render(<NoAccessPage />);
     fireEvent.click(

--- a/packages/views/workspace/no-access-page.tsx
+++ b/packages/views/workspace/no-access-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { Button } from "@multica/ui/components/ui/button";
 import { paths } from "@multica/core/paths";
 import { useNavigation } from "../navigation";
@@ -15,6 +16,19 @@ import { DragStrip } from "../platform";
 export function NoAccessPage() {
   const nav = useNavigation();
   const logout = useLogout();
+
+  // Clear stale `last_workspace_slug` cookie. The web proxy redirects `/` to
+  // `/<lastSlug>/issues` based on this cookie alone (no access check). When
+  // the cookie points at a workspace the user has just lost access to, the
+  // user gets trapped in a loop: NoAccessPage → click "Go to my workspaces"
+  // → `/` → proxy redirects back to the same bad slug → NoAccessPage.
+  // Clearing the cookie here lets the proxy fall through to the landing page,
+  // which then resolves the correct destination via the workspace list.
+  // No-op outside the browser (desktop renderer also has document, harmless).
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.cookie = "last_workspace_slug=; path=/; max-age=0; SameSite=Lax";
+  }, []);
   return (
     <div className="flex min-h-svh flex-col">
       <DragStrip />


### PR DESCRIPTION
## Summary

Two related fixes for dead-end UX paths on web.

- **404 page rewrite** (`apps/web/app/not-found.tsx`) — replace the editorial-style page (hardcoded cream/ink/terracotta palette, Instrument Serif, fluid clamp typography) with a minimal version using semantic tokens (\`text-muted-foreground\`) and the project's \`buttonVariants\` helper.
- **NoAccessPage redirect loop fix** (\`packages/views/workspace/no-access-page.tsx\`) — clear the stale \`last_workspace_slug\` cookie on mount so users who lost access to their last workspace can escape.

## Why the redirect loop happens

\`apps/web/proxy.ts:50-58\` redirects \`/\` to \`/<lastSlug>/issues\` based on the cookie alone — no access check. So:

1. User gets evicted from their workspace; cookie still points at it.
2. They land on \`NoAccessPage\` and click "Go to my workspaces".
3. Button calls \`nav.push("/")\` → proxy reads cookie → redirects back to the same bad slug.
4. \`[workspaceSlug]/layout.tsx\` again fails to resolve → renders \`NoAccessPage\`. Loop.

Clearing the cookie inside \`NoAccessPage\` lets the proxy fall through to the landing page, where \`RedirectIfAuthenticated\` runs \`resolvePostAuthDestination(workspaces, hasOnboarded)\` to pick the correct target (next workspace, \`/workspaces/new\`, or \`/onboarding\`).

Side effect: user loses "last used workspace" preference, but \`apps/web/app/[workspaceSlug]/layout.tsx:51-56\` rewrites the cookie on the next workspace visit, so the window is < 1 navigation.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm --filter @multica/views test\` — 256 passed (incl. new \`clears last_workspace_slug cookie on mount\` case)
- [x] \`pnpm --filter @multica/web test\` — 20 passed
- [ ] Manual: trigger NoAccessPage by visiting a non-existent slug → click "Go to my workspaces" → lands on a real workspace, no loop
- [ ] Manual: visit a non-existent route → 404 page renders with semantic tokens, button navigates home

🤖 Generated with [Claude Code](https://claude.com/claude-code)