### PR TITLE
fix(daemon/execenv): refresh stale Codex auth.json across env reuse

### DIFF
--- a/server/internal/daemon/execenv/codex_home.go
+++ b/server/internal/daemon/execenv/codex_home.go
@@ -80,6 +80,12 @@ func prepareCodexHomeWithOpts(codexHome string, opts CodexHomeOptions, logger *s
 		}
 	}
 
+	// Surface the resulting auth.json state (file kind only, never contents)
+	// so operators diagnosing token-refresh failures can tell whether the
+	// per-task home is tracking the shared ~/.codex/auth.json or has drifted
+	// into a stale local copy.
+	logCodexAuthState(filepath.Join(codexHome, "auth.json"), logger)
+
 	// Copy config files (isolated per task).
 	for _, name := range codexCopiedFiles {
 		src := filepath.Join(sharedHome, name)
@@ -195,31 +201,61 @@ func ensureDirSymlink(src, dst string) error {
 	return createDirLink(src, dst)
 }
 
-// ensureSymlink creates a symlink dst → src. If src doesn't exist, it's a no-op.
-// If dst already exists as a correct symlink, it's a no-op. If dst is a broken
-// symlink, it's replaced.
+// ensureSymlink ensures dst tracks src. If src doesn't exist, it's a no-op.
+// If dst is already a symlink pointing at src, it's a no-op. Otherwise — a
+// wrong-target symlink, a broken symlink, or a regular file left over from a
+// prior createFileLink copy fallback — dst is removed and recreated via
+// createFileLink so the per-task home doesn't drift from the shared source.
+//
+// The "regular file" branch matters on Windows: when os.Symlink fails (no
+// Developer Mode / not elevated), createFileLink falls back to copying the
+// file. Without this re-creation step, a once-stale auth.json would never
+// pick up token refreshes from the shared ~/.codex/auth.json, leaving Codex
+// stuck on a revoked refresh token across env reuses (issue #2081).
 func ensureSymlink(src, dst string) error {
 	if _, err := os.Stat(src); os.IsNotExist(err) {
 		return nil // source doesn't exist — skip
 	}
 
-	// Check if dst already exists.
 	if fi, err := os.Lstat(dst); err == nil {
 		if fi.Mode()&os.ModeSymlink != 0 {
-			// It's a symlink — check if it points to the right place.
-			target, err := os.Readlink(dst)
-			if err == nil && target == src {
-				return nil // already correct
+			if target, err := os.Readlink(dst); err == nil && target == src {
+				return nil // symlink already points to src
 			}
-			// Wrong target — remove and recreate.
-			os.Remove(dst)
-		} else {
-			// Regular file exists — don't overwrite.
-			return nil
+		}
+		// Wrong-target symlink, broken symlink, or stale regular file —
+		// drop it so createFileLink can re-link/re-copy from the current src.
+		if err := os.Remove(dst); err != nil {
+			return fmt.Errorf("remove stale dst %s: %w", dst, err)
 		}
 	}
 
 	return createFileLink(src, dst)
+}
+
+// logCodexAuthState records the kind of auth.json the per-task CODEX_HOME
+// ended up with — symlink (with target), regular file (with size + mtime),
+// or missing — so an operator chasing refresh_token_reused / token_expired
+// reports can immediately tell whether the per-task home is tracking the
+// shared ~/.codex/auth.json or has drifted into a stale local copy.
+//
+// Never logs the file contents.
+func logCodexAuthState(authPath string, logger *slog.Logger) {
+	fi, err := os.Lstat(authPath)
+	if err != nil {
+		logger.Info("execenv: codex auth.json absent", "path", authPath, "error", err)
+		return
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		target, _ := os.Readlink(authPath)
+		logger.Info("execenv: codex auth.json is symlink", "path", authPath, "target", target)
+		return
+	}
+	logger.Info("execenv: codex auth.json is regular file",
+		"path", authPath,
+		"size", fi.Size(),
+		"mtime", fi.ModTime().UTC(),
+	)
 }
 
 // (The daemon used to write a minimal inline config here; the authoritative

--- a/server/internal/daemon/execenv/codex_home_link_test.go
+++ b/server/internal/daemon/execenv/codex_home_link_test.go
@@ -121,7 +121,7 @@ func TestEnsureSymlink_SkipsWhenSourceMissing(t *testing.T) {
 	}
 }
 
-func TestEnsureSymlink_SkipsExistingRegularFile(t *testing.T) {
+func TestEnsureSymlink_ReplacesStaleRegularFile(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
@@ -130,14 +130,50 @@ func TestEnsureSymlink_SkipsExistingRegularFile(t *testing.T) {
 	os.WriteFile(src, []byte("new"), 0o644)
 	os.WriteFile(dst, []byte("old"), 0o644)
 
+	// Regression for issue #2081: a regular file at dst (e.g. left over from
+	// the Windows copy fallback in createFileLink) must be replaced so the
+	// per-task home picks up changes to the shared source — otherwise a
+	// once-stale auth.json never refreshes across env reuses.
 	if err := ensureSymlink(src, dst); err != nil {
 		t.Fatalf("ensureSymlink: %v", err)
 	}
 
-	// Should not be replaced.
-	data, _ := os.ReadFile(dst)
-	if string(data) != "old" {
-		t.Errorf("existing file content changed to %q", data)
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(data) != "new" {
+		t.Errorf("dst content = %q, want %q (file should be re-linked/re-copied from src)", data, "new")
+	}
+}
+
+func TestEnsureSymlink_RefreshesAfterCopyFallbackThenSrcChange(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "auth.json")
+	dst := filepath.Join(dir, "task-auth.json")
+
+	// Simulate the Windows copy fallback: first link is a copy of v1.
+	os.WriteFile(src, []byte(`{"refresh_token":"v1"}`), 0o644)
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("seed copy fallback: %v", err)
+	}
+
+	// Shared source rotates to v2 (e.g. Codex Desktop refreshed the token).
+	os.WriteFile(src, []byte(`{"refresh_token":"v2"}`), 0o644)
+
+	// Reuse path runs ensureSymlink again — expected to refresh dst from src.
+	if err := ensureSymlink(src, dst); err != nil {
+		t.Fatalf("ensureSymlink: %v", err)
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(data) != `{"refresh_token":"v2"}` {
+		t.Errorf("dst content after refresh = %q, want v2 contents", data)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1380,6 +1380,51 @@ func TestPrepareCodexHomeSkipsMissingFiles(t *testing.T) {
 	}
 }
 
+// Regression for issue #2081: when the per-task auth.json is a stale regular
+// file (e.g. left behind from an earlier Windows copy fallback), a subsequent
+// Reuse() / prepareCodexHome must refresh it from the shared source rather
+// than preserve the stale copy. Without this, Codex would keep retrying with
+// a refresh token the OAuth server has already revoked, surfacing as
+// `refresh_token_reused` / `token_expired` until the user manually nukes the
+// workspace directory.
+func TestPrepareCodexHome_RefreshesStaleAuthCopyOnReuse(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv.
+
+	sharedHome := t.TempDir()
+	os.WriteFile(filepath.Join(sharedHome, "auth.json"), []byte(`{"refresh_token":"v1"}`), 0o644)
+	t.Setenv("CODEX_HOME", sharedHome)
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+
+	// Pre-seed the per-task home with a stale regular-file auth.json,
+	// simulating a previous run where os.Symlink failed and createFileLink
+	// fell back to copying.
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("mkdir codex-home: %v", err)
+	}
+	stalePath := filepath.Join(codexHome, "auth.json")
+	if err := os.WriteFile(stalePath, []byte(`{"refresh_token":"v0_stale"}`), 0o644); err != nil {
+		t.Fatalf("seed stale auth: %v", err)
+	}
+
+	// Shared source rotates to v2 while the per-task copy is still stuck on v0.
+	os.WriteFile(filepath.Join(sharedHome, "auth.json"), []byte(`{"refresh_token":"v2"}`), 0o644)
+
+	if err := prepareCodexHome(codexHome, testLogger()); err != nil {
+		t.Fatalf("prepareCodexHome failed: %v", err)
+	}
+
+	// After Reuse, dst should mirror the current shared source — either as a
+	// fresh symlink (preferred) or as a fresh copy (Windows fallback).
+	data, err := os.ReadFile(stalePath)
+	if err != nil {
+		t.Fatalf("read auth.json: %v", err)
+	}
+	if string(data) != `{"refresh_token":"v2"}` {
+		t.Errorf("auth.json content = %q, want refreshed v2 contents", data)
+	}
+}
+
 func TestEnsureCodexSandboxConfigCreatesDefaultLinux(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- Treat a stale regular-file `dst` in `ensureSymlink` the same as a wrong-target / broken symlink: remove it and re-link/re-copy from the shared source. Without this, a per-task `codex-home/auth.json` that was written as a copy (Windows fallback when `os.Symlink` is unavailable) would never be refreshed across env reuse, so a refresh-token rotation in the shared `~/.codex/auth.json` would leave the daemon handing Codex a revoked token.
- Add a tiny `logCodexAuthState` info log (file kind, symlink target, size, mtime — never contents) emitted from `prepareCodexHomeWithOpts`, so operators chasing the same symptom in future incidents can see at a glance whether the per-task home is tracking the shared auth or has drifted into a stale local copy.
- Adds focused regression tests for the new behavior (stale regular file gets replaced; copy-fallback `dst` picks up the next shared rotation; full `prepareCodexHome` reuse path on a stale auth file).

## Context

Reported in #2081. Symptom on Windows self-hosted: every Codex task fails immediately with `refresh_token_reused` / `token_expired`, even though Codex Desktop / Codex CLI on the same machine work normally. Logs show `execenv: reusing env` + `reused=true` and Codex retrying refresh against an OAuth server that has already revoked the refresh token. The user's workaround was renaming `<workspaces_root>/<workspace-id>` to `.bak` so the next task force-rebuilds the env.

The user confirmed Developer Mode is enabled and admin runs were also tried, so the per-task auth state must already be a stuck regular-file copy. The previous `ensureSymlink` had a "Regular file exists — don't overwrite" branch that returned early in exactly that case, which is what made the staleness sticky across reuses.

This PR is the "fix the sticky copy trap + add observability" half of the plan (direction A in the issue thread). It does **not** include the auth-error self-heal in `agent/codex.go` or the UI reset action — those are deliberately deferred to keep this change small and reviewable, per the discussion on the issue.

## Test plan

- [x] `go test ./server/internal/daemon/execenv/...` (all pass on darwin)
- [x] `go build ./...`
- [ ] Manual reproduction on Windows would be ideal but the original reporter no longer has a stuck repro to compare against; the unit tests directly simulate the Windows copy-fallback + shared-source rotation sequence.