### PR TITLE
fix(daemon): tighten 404 task-not-found semantics — server + final guard

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1463,11 +1463,12 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 
 	_ = d.client.ReportProgress(ctx, task.ID, "Finishing task", 2, 2)
 
-	// Check if the task was cancelled while it was running (e.g. issue
-	// was reassigned). If so, skip reporting results — the server already
-	// moved the task to 'cancelled' so complete/fail would fail anyway.
-	if status, err := d.client.GetTaskStatus(ctx, task.ID); err == nil && status == "cancelled" {
-		taskLog.Info("task cancelled during execution, discarding result")
+	// Final pre-completion check: if the server already moved the task to
+	// "cancelled" or deleted the row outright, skip reporting — the
+	// complete/fail callbacks would fail anyway. Reuse shouldInterruptAgent
+	// so this guard honors the same signals as the in-flight watcher.
+	if status, err := d.client.GetTaskStatus(ctx, task.ID); shouldInterruptAgent(status, err) {
+		taskLog.Info("task cancelled during execution, discarding result", "status", status, "error", err)
 		return
 	}
 

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -78,7 +78,15 @@ func (h *Handler) requireDaemonTaskAccess(w http.ResponseWriter, r *http.Request
 	}
 	task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "task not found")
+		// Only treat pgx.ErrNoRows as a real "task gone" signal — daemon
+		// uses this 404 to interrupt the running agent, so a transient DB
+		// error must not be reported as a deletion.
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "task not found")
+			return db.AgentTaskQueue{}, false
+		}
+		slog.Warn("get agent task failed", "task_id", taskID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to load task")
 		return db.AgentTaskQueue{}, false
 	}
 

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,7 +12,9 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/multica-ai/multica/server/internal/middleware"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 // slowProbeLocalSkillListStore wraps a LocalSkillListStore but blocks inside
@@ -320,6 +323,50 @@ func TestGetTaskStatus_WithDaemonToken_CrossWorkspace(t *testing.T) {
 	testHandler.GetTaskStatus(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("GetTaskStatus with correct workspace token: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestGetTaskStatus_TransientDBError_Returns500 verifies that a transient DB
+// error from GetAgentTask is reported as 500 rather than 404. The daemon
+// uses 404+"task not found" as a hard cancel signal; a transient lookup
+// failure must therefore not be smuggled into that body, otherwise a single
+// DB hiccup would kill an in-flight agent.
+func TestGetTaskStatus_TransientDBError_Returns500(t *testing.T) {
+	h := &Handler{}
+	h.Queries = db.New(&mockDB{getUserErr: errors.New("connection reset by peer")})
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("GET", "/api/daemon/tasks/00000000-0000-0000-0000-000000000001/status", nil,
+		"00000000-0000-0000-0000-000000000000", "test-daemon")
+	req = withURLParam(req, "taskId", "00000000-0000-0000-0000-000000000001")
+
+	h.GetTaskStatus(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("transient DB error: expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "task not found") {
+		t.Fatalf("transient DB error must not surface as %q (daemon treats that as a deletion): %s", "task not found", w.Body.String())
+	}
+}
+
+// TestGetTaskStatus_ErrNoRows_Returns404 verifies that an actually-missing
+// task row still returns the 404+"task not found" body the daemon relies on
+// to interrupt the running agent.
+func TestGetTaskStatus_ErrNoRows_Returns404(t *testing.T) {
+	h := &Handler{}
+	h.Queries = db.New(&mockDB{getUserErr: pgx.ErrNoRows})
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("GET", "/api/daemon/tasks/00000000-0000-0000-0000-000000000001/status", nil,
+		"00000000-0000-0000-0000-000000000000", "test-daemon")
+	req = withURLParam(req, "taskId", "00000000-0000-0000-0000-000000000001")
+
+	h.GetTaskStatus(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("ErrNoRows: expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "task not found") {
+		t.Fatalf("ErrNoRows: expected body to contain %q, got %s", "task not found", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Two follow-ups on top of #2107 — both noted in the review thread.

1. **Server: `requireDaemonTaskAccess` now distinguishes `pgx.ErrNoRows` from other DB errors.** Before this change any `GetAgentTask` failure (transient pool / connection error included) was reported as `404 "task not found"`. Combined with #2107 — which made the daemon treat that 404 as a hard cancel signal — a single DB hiccup could kill an in-flight agent. After this change only `pgx.ErrNoRows` produces the cancel-triggering body; everything else is `500 "failed to load task"` plus a warn log.

2. **Daemon: the post-`runTask` guard in `handleTask` now reuses `shouldInterruptAgent`.** That guard was still matching only `status == "cancelled"`, so a task deleted between the in-flight watcher's last poll and `runTask` returning would slip through and we'd try to `CompleteTask` against a missing row, only learning about it from the 404 on the completion callback. The watcher and the final guard now share the same truth table.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Tests (added)

## Changes Made

- `server/internal/handler/daemon.go` — branch on `isNotFound(err)` (existing helper, `errors.Is(err, pgx.ErrNoRows)`); fall through to `500 "failed to load task"` for anything else, with a `slog.Warn` so transient errors are still observable.
- `server/internal/handler/daemon_test.go` — two new unit tests using the existing `mockDB` pattern: `TestGetTaskStatus_TransientDBError_Returns500` and `TestGetTaskStatus_ErrNoRows_Returns404`. Body inspection asserts that the cancel-triggering string `"task not found"` is **not** present in the 500 response.
- `server/internal/daemon/daemon.go` — replace `err == nil && status == "cancelled"` in the post-`runTask` guard with `shouldInterruptAgent(status, err)`. Existing `TestShouldInterruptAgent` already covers the truth table, so no new daemon test was needed for this part.

## How to Test

```bash
cd server
# New unit tests (no DB required for these — they use mockDB):
go test ./internal/handler/ -run 'TestGetTaskStatus_(TransientDBError_Returns500|ErrNoRows_Returns404)' -v -count=1
# Daemon side keeps existing coverage green under -race:
go test -race ./internal/daemon/ -count=1
```

CI will exercise the handler tests against a real PostgreSQL service. Locally I verified `go build ./...`, `go vet ./internal/handler/ ./internal/daemon/`, and `gofmt` on the touched files.

## Risks

- **Behavior change for existing daemon clients on transient DB errors.** Before: 404. After: 500. Daemons retry on transient errors instead of cancelling, which is what we want — but any downstream consumer that tested only for 404 would now see 500. None today do; `GetTaskStatus` and the other endpoints touched go straight into `requireDaemonTaskAccess`.
- **No migration / wire-format change.** Same JSON envelope, same status codes for the not-found case.

## Checklist

- [x] Tests added for both branches of the new server logic
- [x] No UI changes — backend only
- [x] No backwards-compat shims
- [x] Daemon and server changes are independent commits

## AI Disclosure

**AI tool used:** Claude (claude-opus-4-7)

**Approach:** Follow-up on the review of #2107. Two correctness gaps were identified during review (one by me as the reviewer, one expanded by GPT-Boy in the review thread). Wrote the server-side test first using the same `mockDB` pattern as `TestFindOrCreateUserGating`, then made the minimal handler change, then aligned the daemon's post-`runTask` guard with the in-flight watcher's truth table.