### PR TITLE
ci(lint): enable lint in CI + fix lint debt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build, type check, and test
-        run: pnpm exec turbo build typecheck test --filter='!@multica/docs'
+      - name: Build, type check, lint, and test
+        run: pnpm exec turbo build typecheck lint test --filter='!@multica/docs'
 
   backend:
     runs-on: ubuntu-latest

--- a/packages/core/auth/utils.ts
+++ b/packages/core/auth/utils.ts
@@ -15,6 +15,7 @@
 export function sanitizeNextUrl(raw: string | null): string | null {
   if (!raw) return null;
   if (!raw.startsWith("/") || raw.startsWith("//")) return null;
+  // eslint-disable-next-line no-control-regex -- intentional: rejecting control chars is the whole point
   if (/[\x00-\x1f\\]/.test(raw)) return null;
   return raw;
 }

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -5,21 +5,28 @@ import reactHooksPlugin from "eslint-plugin-react-hooks";
 /** @type {import("eslint").Linter.Config[]} */
 export default [
   ...baseConfig,
+  // React rules (JSX only)
   {
     files: ["**/*.{jsx,tsx}"],
-    plugins: {
-      react: reactPlugin,
-      "react-hooks": reactHooksPlugin,
-    },
+    plugins: { react: reactPlugin },
     rules: {
       ...reactPlugin.configs.recommended.rules,
       ...reactPlugin.configs["jsx-runtime"].rules,
-      ...reactHooksPlugin.configs["recommended-latest"].rules,
       "react/prop-types": "off",
       "react/no-unknown-property": "off",
     },
     settings: {
       react: { version: "detect" },
+    },
+  },
+  // React Hooks rules apply to .ts files too — hooks (useEffect, useCallback,
+  // useMemo) can live in plain .ts modules and we want exhaustive-deps to
+  // run + inline disable comments to resolve.
+  {
+    files: ["**/*.{ts,tsx,js,jsx}"],
+    plugins: { "react-hooks": reactHooksPlugin },
+    rules: {
+      ...reactHooksPlugin.configs["recommended-latest"].rules,
     },
   },
 ];

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -330,6 +330,7 @@ function MermaidLightbox({
 }
 
 function MermaidDiagram({ chart }: { chart: string }) {
+  const { t } = useT("editor");
   const reactId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
   const diagramId = useMemo(
@@ -386,7 +387,7 @@ function MermaidDiagram({ chart }: { chart: string }) {
   if (error) {
     return (
       <div ref={containerRef} className="mermaid-diagram mermaid-diagram-error">
-        <p>Unable to render Mermaid diagram.</p>
+        <p>{t(($) => $.mermaid.render_error)}</p>
         <pre>
           <code>{chart}</code>
         </pre>
@@ -426,7 +427,7 @@ function MermaidDiagram({ chart }: { chart: string }) {
           )}
         </>
       ) : (
-        <div className="mermaid-diagram-loading">Rendering diagram…</div>
+        <div className="mermaid-diagram-loading">{t(($) => $.mermaid.rendering)}</div>
       )}
     </div>
   );

--- a/packages/views/invitations/invitations-page.test.tsx
+++ b/packages/views/invitations/invitations-page.test.tsx
@@ -56,13 +56,20 @@ vi.mock("@multica/core/api", () => ({
   },
 }));
 
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../locales/en/common.json";
+import enInvite from "../locales/en/invite.json";
 import { InvitationsPage } from "./invitations-page";
+
+const TEST_RESOURCES = { en: { common: enCommon, invite: enInvite } };
 
 function renderWithClient(client: QueryClient = new QueryClient()) {
   return render(
-    <QueryClientProvider client={client}>
-      <InvitationsPage />
-    </QueryClientProvider>,
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <QueryClientProvider client={client}>
+        <InvitationsPage />
+      </QueryClientProvider>
+    </I18nProvider>,
   );
 }
 

--- a/packages/views/invitations/invitations-page.tsx
+++ b/packages/views/invitations/invitations-page.tsx
@@ -14,6 +14,7 @@ import type { Invitation } from "@multica/core/types";
 import { useNavigation } from "../navigation";
 import { useLogout } from "../auth";
 import { DragStrip } from "../platform";
+import { useT } from "../i18n";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import { Checkbox } from "@multica/ui/components/ui/checkbox";
@@ -39,6 +40,7 @@ import { LogOut, Mail, Users } from "lucide-react";
  *    action.
  */
 export function InvitationsPage() {
+  const { t } = useT("invite");
   const { push } = useNavigation();
   const qc = useQueryClient();
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -112,7 +114,7 @@ export function InvitationsPage() {
       setError(
         e instanceof Error
           ? e.message
-          : "Failed to process invitations. Please try again.",
+          : t(($) => $.batch.error_generic),
       );
       // Partial success: any accepts that landed before the failure ALREADY
       // set onboarded_at on the backend (the AcceptInvitation transaction
@@ -157,12 +159,12 @@ export function InvitationsPage() {
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
               <Mail className="h-6 w-6 text-muted-foreground" />
             </div>
-            <h2 className="text-lg font-semibold">No pending invitations</h2>
+            <h2 className="text-lg font-semibold">{t(($) => $.batch.empty_title)}</h2>
             <p className="text-sm text-muted-foreground text-center">
-              Continue to set up your own workspace.
+              {t(($) => $.batch.empty_hint)}
             </p>
             <Button onClick={() => push(paths.onboarding())}>
-              Continue to setup
+              {t(($) => $.batch.empty_continue)}
             </Button>
           </CardContent>
         </Card>
@@ -172,10 +174,8 @@ export function InvitationsPage() {
 
   const submitLabel =
     selected.size === 0
-      ? "Skip and set up my own workspace"
-      : selected.size === 1
-        ? "Join 1 workspace"
-        : `Join ${selected.size} workspaces`;
+      ? t(($) => $.batch.submit_skip)
+      : t(($) => $.batch.submit_join, { count: selected.size });
 
   return (
     <InvitationsShell>
@@ -187,11 +187,10 @@ export function InvitationsPage() {
             </div>
             <div className="space-y-1">
               <h2 className="text-xl font-semibold">
-                You&apos;ve been invited
+                {t(($) => $.batch.title)}
               </h2>
               <p className="text-sm text-muted-foreground">
-                Pick the workspaces you want to join. You can always handle the
-                rest later from the sidebar.
+                {t(($) => $.batch.subtitle)}
               </p>
             </div>
           </div>
@@ -212,7 +211,7 @@ export function InvitationsPage() {
             onClick={handleSubmit}
             disabled={submitting}
           >
-            {submitting ? "Joining..." : submitLabel}
+            {submitting ? t(($) => $.batch.joining) : submitLabel}
           </Button>
 
           {error && (
@@ -233,7 +232,15 @@ function InvitationRow({
   checked: boolean;
   onToggle: () => void;
 }) {
-  const inviter = invitation.inviter_name || invitation.inviter_email || "Someone";
+  const { t } = useT("invite");
+  const inviter =
+    invitation.inviter_name ||
+    invitation.inviter_email ||
+    t(($) => $.batch.row_inviter_fallback);
+  const roleLine =
+    invitation.role === "admin"
+      ? t(($) => $.batch.row_invited_admin, { inviter })
+      : t(($) => $.batch.row_invited_member, { inviter });
   return (
     <li>
       <label
@@ -246,11 +253,10 @@ function InvitationRow({
         />
         <div className="flex-1 min-w-0 space-y-1">
           <div className="font-medium truncate">
-            {invitation.workspace_name ?? "Workspace"}
+            {invitation.workspace_name ?? t(($) => $.batch.row_workspace_fallback)}
           </div>
           <div className="text-xs text-muted-foreground truncate">
-            {inviter} invited you as{" "}
-            {invitation.role === "admin" ? "an admin" : "a member"}
+            {roleLine}
           </div>
         </div>
       </label>
@@ -259,6 +265,7 @@ function InvitationRow({
 }
 
 function InvitationsShell({ children }: { children: ReactNode }) {
+  const { t } = useT("invite");
   const logout = useLogout();
   return (
     <div className="relative flex min-h-svh flex-col bg-background">
@@ -270,7 +277,7 @@ function InvitationsShell({ children }: { children: ReactNode }) {
         onClick={logout}
       >
         <LogOut />
-        Log out
+        {t(($) => $.batch.log_out)}
       </Button>
       <div className="flex flex-1 flex-col items-center justify-center px-6 pb-12">
         {children}

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -644,7 +644,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                     </Button>
                   }
                 />
-                <TooltipContent side="bottom">Archive</TooltipContent>
+                <TooltipContent side="bottom">{t(($) => $.detail.archive_tooltip)}</TooltipContent>
               </Tooltip>
             )}
             <Tooltip>

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -54,5 +54,9 @@
   },
   "title_editor": {
     "title_aria_label": "Title"
+  },
+  "mermaid": {
+    "render_error": "Unable to render Mermaid diagram.",
+    "rendering": "Rendering diagram…"
   }
 }

--- a/packages/views/locales/en/invite.json
+++ b/packages/views/locales/en/invite.json
@@ -33,5 +33,22 @@
   "errors": {
     "accept_failed": "Failed to accept invitation",
     "decline_failed": "Failed to decline invitation"
+  },
+  "batch": {
+    "log_out": "Log out",
+    "empty_title": "No pending invitations",
+    "empty_hint": "Continue to set up your own workspace.",
+    "empty_continue": "Continue to setup",
+    "title": "You've been invited",
+    "subtitle": "Pick the workspaces you want to join. You can always handle the rest later from the sidebar.",
+    "submit_skip": "Skip and set up my own workspace",
+    "submit_join_one": "Join 1 workspace",
+    "submit_join_other": "Join {{count}} workspaces",
+    "joining": "Joining...",
+    "error_generic": "Failed to process invitations. Please try again.",
+    "row_workspace_fallback": "Workspace",
+    "row_inviter_fallback": "Someone",
+    "row_invited_admin": "{{inviter}} invited you as an admin",
+    "row_invited_member": "{{inviter}} invited you as a member"
   }
 }

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -122,6 +122,7 @@
     "members_group": "Members",
     "agents_group": "Agents",
     "mark_done_tooltip": "Mark as done",
+    "archive_tooltip": "Archive",
     "pin_tooltip": "Pin to sidebar",
     "unpin_tooltip": "Unpin from sidebar",
     "sidebar_tooltip": "Toggle sidebar",

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -54,5 +54,9 @@
   },
   "title_editor": {
     "title_aria_label": "标题"
+  },
+  "mermaid": {
+    "render_error": "无法渲染 Mermaid 图。",
+    "rendering": "渲染中…"
   }
 }

--- a/packages/views/locales/zh-Hans/invite.json
+++ b/packages/views/locales/zh-Hans/invite.json
@@ -33,5 +33,21 @@
   "errors": {
     "accept_failed": "接受邀请失败",
     "decline_failed": "拒绝邀请失败"
+  },
+  "batch": {
+    "log_out": "退出登录",
+    "empty_title": "没有待处理的邀请",
+    "empty_hint": "继续创建你自己的工作区。",
+    "empty_continue": "继续创建",
+    "title": "你被邀请加入工作区",
+    "subtitle": "选择你想加入的工作区。其余的可以之后在侧边栏处理。",
+    "submit_skip": "跳过，创建我自己的工作区",
+    "submit_join_other": "加入 {{count}} 个工作区",
+    "joining": "加入中...",
+    "error_generic": "处理邀请失败，请重试。",
+    "row_workspace_fallback": "工作区",
+    "row_inviter_fallback": "某人",
+    "row_invited_admin": "{{inviter}} 邀请你以管理员身份加入",
+    "row_invited_member": "{{inviter}} 邀请你以成员身份加入"
   }
 }

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -121,6 +121,7 @@
     "members_group": "成员",
     "agents_group": "智能体",
     "mark_done_tooltip": "标记为已完成",
+    "archive_tooltip": "归档",
     "pin_tooltip": "固定到侧边栏",
     "unpin_tooltip": "从侧边栏取消固定",
     "sidebar_tooltip": "切换侧边栏",


### PR DESCRIPTION
## Summary

CI 之前没跑 lint（只跑 build + typecheck + test），所以 i18n PR 加的 ESLint i18next 护栏一直没生效——main 上现在还有 10 个硬编码英文 lint error。

- 加 `lint` 到 `.github/workflows/ci.yml` 的 turbo 命令
- `packages/eslint-config/react.js` 把 react-hooks 规则从 `**/*.{jsx,tsx}` 扩到 `.ts` 也覆盖（`use-agent-presence.ts` / `use-runtime-health.ts` 这些 .ts 里有 hooks，靠 inline-disable 注释，但 plugin 在 .ts 没注册 → 报 "Definition for rule not found"）
- 修了暴露出来的 10 个 i18n error：
  - `editor/readonly-content.tsx` mermaid fallback（render-error + rendering）
  - `issues/issue-detail.tsx` Archive tooltip
  - `invitations/invitations-page.tsx` 整页（新建 `invite.batch.*` 子树）
- `invitations-page.test.tsx` 加 `I18nProvider` wrapper，否则 `getByRole({name: /skip/i})` 查不到翻译后的按钮文案
- `core/auth/utils.ts` 那条 `[\x00-\x1f\\]` 正则是有意拦控制字符，加 inline `eslint-disable no-control-regex` + 解释注释

## Test plan

- [x] `pnpm typecheck` 全过
- [x] `pnpm test` 全过
- [x] `pnpm exec turbo lint --filter='!@multica/docs'` 全过（0 error，3 个 hooks deps warning，warnings 不 fail CI）
- [ ] CI run on this PR 应该绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)