### PR TITLE
fix(quick-create): remove duplicate keyboard shortcut on agent submit button

### DIFF
--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -121,7 +121,7 @@
       "version_missing": "This agent's daemon doesn't report a CLI version. Create with agent needs multica CLI ≥ {{min}}. Upgrade the daemon and reconnect, or switch to manual create.",
       "version_below": "This agent's daemon CLI is {{current}} — Create with agent needs ≥ {{min}}. Upgrade the daemon, or switch to manual create.",
       "prompt_placeholder": "Tell the agent what to do, e.g. \"let Bohan fix the inbox loading slowness in the Web project\"",
-      "submit": "Create (⌘↵)",
+      "submit": "Create",
       "sending": "Sending…",
       "uploading": "Uploading…",
       "sent_label": "Sent",

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -121,7 +121,7 @@
       "version_missing": "该智能体的 daemon 没有报告 CLI 版本。通过智能体创建需要 multica CLI ≥ {{min}}。请升级 daemon 并重连，或切换到手动创建。",
       "version_below": "该智能体的 daemon CLI 是 {{current}}——通过智能体创建需要 ≥ {{min}}。请升级 daemon，或切换到手动创建。",
       "prompt_placeholder": "告诉智能体要做什么，例如：\"让 Bohan 修一下 Web 项目里收件箱加载慢的问题\"",
-      "submit": "创建（⌘↵）",
+      "submit": "创建",
       "sending": "发送中...",
       "uploading": "上传中...",
       "sent_label": "已发送",


### PR DESCRIPTION
## Summary
- The Create button in Quick Create's agent mode rendered the shortcut hint twice (e.g. `Create (⌘↵) (⌘↵)`): the translation string already contained `(⌘↵)` and the JSX appended another `formatShortcut(modKey, enterKey)` suffix.
- Removed the hardcoded shortcut from the en and zh-Hans translations; the JSX `formatShortcut()` is platform-aware so it stays the single source of truth (also fixes the wrong shortcut shown to non-Mac users).

Fixes [MUL-1770](mention://issue/94f17af6-8885-4560-aee2-231339da572f).

## Test plan
- [ ] Open Quick Create, switch to agent mode, confirm the submit button shows `Create (⌘↵)` on macOS and `Create (Ctrl+Enter)` on Windows/Linux — only once.
- [ ] `pnpm typecheck`