### PR TITLE
feat(settings): rename Appearance → Preferences and persist tab in ?tab=

### DIFF
--- a/apps/docs/content/docs/developers/conventions.mdx
+++ b/apps/docs/content/docs/developers/conventions.mdx
@@ -242,7 +242,7 @@ Examples:
 - `issues.toolbar.batch_update_success`
 - `issues.detail.comment_form.placeholder`
 - `inbox.empty.title`
-- `settings.appearance.language.title`
+- `settings.preferences.language.title`
 
 ### Web-only / desktop-only copy
 
@@ -278,7 +278,7 @@ When the glossary doesn't cover a term, look at:
 1. `apps/docs/content/docs/*.zh.mdx` — the de facto Chinese voice standard, 20+ pages of consistent translation
 2. `packages/views/locales/zh-Hans/auth.json` and `editor.json` — JSON structure + selector API patterns
 3. `packages/views/auth/login-page.tsx` — component-level selector API call site
-4. `packages/views/settings/components/appearance-tab.tsx` — language switcher reference
+4. `packages/views/settings/components/preferences-tab.tsx` — language switcher reference
 
 ---
 

--- a/apps/docs/content/docs/developers/conventions.zh.mdx
+++ b/apps/docs/content/docs/developers/conventions.zh.mdx
@@ -242,7 +242,7 @@ i18next 用 `_one` / `_other`；中文不区分语法单复数，只填 `_other`
 - `issues.toolbar.batch_update_success`
 - `issues.detail.comment_form.placeholder`
 - `inbox.empty.title`
-- `settings.appearance.language.title`
+- `settings.preferences.language.title`
 
 ### Web-only / Desktop-only 文案位置
 
@@ -278,7 +278,7 @@ i18next 用 `_one` / `_other`；中文不区分语法单复数，只填 `_other`
 1. `apps/docs/content/docs/*.zh.mdx` —— CN voice 事实标准，20+ 篇高度一致
 2. `packages/views/locales/zh-Hans/auth.json` 和 `editor.json` —— JSON 结构 + selector API 用法参考
 3. `packages/views/auth/login-page.tsx` —— 组件层 selector API 调用参考
-4. `packages/views/settings/components/appearance-tab.tsx` —— 语言切换器参考
+4. `packages/views/settings/components/preferences-tab.tsx` —— 语言切换器参考
 
 ---
 

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -1,5 +1,5 @@
 {
-  "appearance": {
+  "preferences": {
     "theme": {
       "title": "Theme",
       "light": "Light",
@@ -19,7 +19,7 @@
     "workspace_fallback": "Workspace",
     "tabs": {
       "profile": "Profile",
-      "appearance": "Appearance",
+      "preferences": "Preferences",
       "notifications": "Notifications",
       "tokens": "API Tokens",
       "general": "General",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -1,5 +1,5 @@
 {
-  "appearance": {
+  "preferences": {
     "theme": {
       "title": "主题",
       "light": "浅色",
@@ -19,7 +19,7 @@
     "workspace_fallback": "工作区",
     "tabs": {
       "profile": "个人资料",
-      "appearance": "外观",
+      "preferences": "偏好设置",
       "notifications": "通知",
       "tokens": "API Token",
       "general": "通用",

--- a/packages/views/settings/components/preferences-tab.test.tsx
+++ b/packages/views/settings/components/preferences-tab.test.tsx
@@ -55,7 +55,7 @@ vi.mock("@multica/core/auth", async () => {
   return { ...actual, useAuthStore };
 });
 
-import { AppearanceTab } from "./appearance-tab";
+import { PreferencesTab } from "./preferences-tab";
 
 const TEST_RESOURCES = {
   en: { common: enCommon, auth: enAuth, settings: enSettings },
@@ -69,7 +69,7 @@ function I18nWrapper({ children }: { children: ReactNode }) {
   );
 }
 
-describe("AppearanceTab — Language switcher", () => {
+describe("PreferencesTab — Language switcher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     userRef.current = null;
@@ -87,7 +87,7 @@ describe("AppearanceTab — Language switcher", () => {
 
   it("does nothing when clicking the current locale", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<AppearanceTab />, { wrapper: I18nWrapper });
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("radio", { name: "English" }));
 
@@ -98,7 +98,7 @@ describe("AppearanceTab — Language switcher", () => {
 
   it("when not logged in: persists + reloads, no PATCH", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<AppearanceTab />, { wrapper: I18nWrapper });
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("radio", { name: "中文" }));
 
@@ -112,7 +112,7 @@ describe("AppearanceTab — Language switcher", () => {
     userRef.current = { id: "user-1" };
     mockUpdateMe.mockResolvedValueOnce({});
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<AppearanceTab />, { wrapper: I18nWrapper });
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("radio", { name: "中文" }));
 
@@ -126,7 +126,7 @@ describe("AppearanceTab — Language switcher", () => {
     userRef.current = { id: "user-1" };
     mockUpdateMe.mockRejectedValueOnce(new Error("network"));
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-    render(<AppearanceTab />, { wrapper: I18nWrapper });
+    render(<PreferencesTab />, { wrapper: I18nWrapper });
 
     await user.click(screen.getByRole("radio", { name: "中文" }));
 

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -88,7 +88,7 @@ function WindowMockup({
   );
 }
 
-export function AppearanceTab() {
+export function PreferencesTab() {
   const { theme, setTheme } = useTheme();
   const { t, i18n } = useT("settings");
   const localeAdapter = useLocaleAdapter();
@@ -104,14 +104,14 @@ export function AppearanceTab() {
     : DEFAULT_LOCALE;
 
   const themeOptions = [
-    { value: "light" as const, label: t(($) => $.appearance.theme.light) },
-    { value: "dark" as const, label: t(($) => $.appearance.theme.dark) },
-    { value: "system" as const, label: t(($) => $.appearance.theme.system) },
+    { value: "light" as const, label: t(($) => $.preferences.theme.light) },
+    { value: "dark" as const, label: t(($) => $.preferences.theme.dark) },
+    { value: "system" as const, label: t(($) => $.preferences.theme.system) },
   ];
 
   const languageOptions: { value: SupportedLocale; label: string }[] = [
-    { value: "en", label: t(($) => $.appearance.language.english) },
-    { value: "zh-Hans", label: t(($) => $.appearance.language.chinese) },
+    { value: "en", label: t(($) => $.preferences.language.english) },
+    { value: "zh-Hans", label: t(($) => $.preferences.language.chinese) },
   ];
 
   // Persist locally → sync to user.language → reload. Reload (vs in-place
@@ -137,7 +137,7 @@ export function AppearanceTab() {
     }
 
     if (syncFailed) {
-      toast.warning(t(($) => $.appearance.language.sync_failed));
+      toast.warning(t(($) => $.preferences.language.sync_failed));
       // Give the toast 2.5s of visible time before navigating away.
       setTimeout(() => window.location.reload(), 2500);
       return;
@@ -149,7 +149,7 @@ export function AppearanceTab() {
     <div className="space-y-8">
       <section className="space-y-4">
         <h2 className="text-sm font-semibold">
-          {t(($) => $.appearance.theme.title)}
+          {t(($) => $.preferences.theme.title)}
         </h2>
         <div className="flex gap-6" role="radiogroup">
           {themeOptions.map((opt) => {
@@ -203,7 +203,7 @@ export function AppearanceTab() {
 
       <section className="space-y-4">
         <h2 className="text-sm font-semibold">
-          {t(($) => $.appearance.language.title)}
+          {t(($) => $.preferences.language.title)}
         </h2>
         <div className="flex gap-3" role="radiogroup">
           {languageOptions.map((opt) => {

--- a/packages/views/settings/components/settings-page.tsx
+++ b/packages/views/settings/components/settings-page.tsx
@@ -1,11 +1,21 @@
 "use client";
 
 import React from "react";
-import { User, Palette, Key, Settings, Users, FolderGit2, FlaskConical, Bell } from "lucide-react";
+import {
+  User,
+  SlidersHorizontal,
+  Key,
+  Settings,
+  Users,
+  FolderGit2,
+  FlaskConical,
+  Bell,
+} from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@multica/ui/components/ui/tabs";
 import { useCurrentWorkspace } from "@multica/core/paths";
+import { useNavigation } from "../../navigation";
 import { AccountTab } from "./account-tab";
-import { AppearanceTab } from "./appearance-tab";
+import { PreferencesTab } from "./preferences-tab";
 import { TokensTab } from "./tokens-tab";
 import { WorkspaceTab } from "./workspace-tab";
 import { MembersTab } from "./members-tab";
@@ -14,10 +24,10 @@ import { LabsTab } from "./labs-tab";
 import { NotificationsTab } from "./notifications-tab";
 import { useT } from "../../i18n";
 
-const ACCOUNT_TAB_KEYS = ["profile", "appearance", "notifications", "tokens"] as const;
+const ACCOUNT_TAB_KEYS = ["profile", "preferences", "notifications", "tokens"] as const;
 const ACCOUNT_TAB_ICONS = {
   profile: User,
-  appearance: Palette,
+  preferences: SlidersHorizontal,
   notifications: Bell,
   tokens: Key,
 } as const;
@@ -36,6 +46,9 @@ const WORKSPACE_TAB_ICONS = {
   members: Users,
 } as const;
 
+const DEFAULT_TAB = "profile";
+const TAB_QUERY_KEY = "tab";
+
 export interface ExtraSettingsTab {
   value: string;
   label: string;
@@ -51,10 +64,37 @@ interface SettingsPageProps {
 export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
   const { t } = useT("settings");
   const workspaceName = useCurrentWorkspace()?.name;
+  const navigation = useNavigation();
+
+  // Whitelist of valid tab values; unknown ?tab=… values silently fall back to
+  // the default. Whitelisting also blocks junk like ?tab=<script> from
+  // surfacing in the DOM via Radix Tabs internals.
+  const validTabs = React.useMemo(
+    () =>
+      new Set<string>([
+        ...ACCOUNT_TAB_KEYS,
+        ...Object.values(WORKSPACE_TAB_VALUES),
+        ...(extraAccountTabs?.map((tab) => tab.value) ?? []),
+      ]),
+    [extraAccountTabs],
+  );
+
+  const tabFromUrl = navigation.searchParams.get(TAB_QUERY_KEY);
+  const activeTab =
+    tabFromUrl && validTabs.has(tabFromUrl) ? tabFromUrl : DEFAULT_TAB;
+
+  // replace (not push) so settings tab switches don't pollute browser history.
+  // Preserve any other query params the page may carry.
+  const handleTabChange = (next: string) => {
+    const params = new URLSearchParams(navigation.searchParams);
+    params.set(TAB_QUERY_KEY, next);
+    navigation.replace(`${navigation.pathname}?${params.toString()}`);
+  };
 
   return (
     <Tabs
-      defaultValue="profile"
+      value={activeTab}
+      onValueChange={handleTabChange}
       orientation="vertical"
       className="flex-1 min-h-0 gap-0 flex flex-col md:flex-row md:overflow-hidden overflow-y-auto"
     >
@@ -102,7 +142,7 @@ export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
       <div className="flex-1 min-w-0 md:overflow-y-auto">
         <div className="w-full max-w-3xl mx-auto p-4 md:p-6">
           <TabsContent value="profile"><AccountTab /></TabsContent>
-          <TabsContent value="appearance"><AppearanceTab /></TabsContent>
+          <TabsContent value="preferences"><PreferencesTab /></TabsContent>
           <TabsContent value="notifications"><NotificationsTab /></TabsContent>
           <TabsContent value="tokens"><TokensTab /></TabsContent>
           <TabsContent value="workspace"><WorkspaceTab /></TabsContent>


### PR DESCRIPTION
## Summary

- Rename the **Appearance** tab to **Preferences** (`偏好设置`). The tab held both theme and language — "Appearance" semantically excludes localization. "Preferences" matches Linear/Slack/Discord and leaves headroom for timezone / date format later.
- Persist the active settings tab in the URL via `?tab=…` so refresh/share/back-forward work. Unknown values silently fall back to `profile`.
- File rename: `appearance-tab.tsx` → `preferences-tab.tsx`; component `AppearanceTab` → `PreferencesTab`. i18n top-level key `appearance` → `preferences`. Icon `Palette` → `SlidersHorizontal`.

## Why query param (not path-based)

Settings tabs are UI modifier state, not resources. Query keeps the single Next.js route file (`apps/web/app/[workspaceSlug]/(dashboard)/settings/page.tsx`) and the desktop memory router unchanged — `NavigationAdapter` already exposes `searchParams` cross-platform. Unknown `?tab=…` falls back gracefully; path-based would need explicit 404 handling and dual-app folder restructuring.

If we later add nested flows like `/settings/members/<id>/edit`, revisit and migrate to path.

## Behavior

- `/{slug}/settings?tab=members` → lands on Members
- Refresh stays on the active tab
- Share `?tab=labs` deep-links
- `?tab=foobar` silently falls back to Profile
- Tab switches use `replace()` so they don't pollute browser history
- Desktop `daemon` / `updates` extras are also whitelisted

## Test plan

- [x] `pnpm typecheck` (6/6)
- [x] `pnpm test` — 41 files / 314 tests, includes `locales/parity` for en ↔ zh-Hans key parity
- [x] `preferences-tab.test.tsx` (4/4) — language switcher behaviors preserved
- [ ] Manual: refresh on each tab keeps active tab
- [ ] Manual: `?tab=garbage` falls back to Profile, no console errors
- [ ] Manual: desktop tab extras (`daemon`, `updates`) persist via `?tab=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)