### PR TITLE
feat(onboarding): localize starter-content (Getting Started project)

### DIFF
--- a/packages/views/onboarding/components/starter-content-prompt.tsx
+++ b/packages/views/onboarding/components/starter-content-prompt.tsx
@@ -25,7 +25,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@multica/ui/components/ui/dialog";
-import { buildImportPayload } from "../utils/starter-content-templates";
+import {
+  buildImportPayload,
+  type StarterContentLocale,
+} from "../utils/starter-content-templates";
 import { useT } from "../../i18n";
 
 /**
@@ -44,7 +47,7 @@ import { useT } from "../../i18n";
  * no client-side cache timing, no stale decisions, no Unknown bugs.
  */
 export function StarterContentPrompt() {
-  const { t } = useT("onboarding");
+  const { t, i18n } = useT("onboarding");
   const workspace = useCurrentWorkspace();
   const user = useAuthStore((s) => s.user);
   const refreshMe = useAuthStore((s) => s.refreshMe);
@@ -87,6 +90,7 @@ export function StarterContentPrompt() {
         workspaceId: workspace.id,
         userName: user.name || user.email,
         questionnaire,
+        locale: resolveLocale(i18n.language),
       });
       const result = await api.importStarterContent(payload);
 
@@ -197,6 +201,12 @@ export function StarterContentPrompt() {
       </DialogContent>
     </Dialog>
   );
+}
+
+// i18next resolves locale names like "zh-Hans-CN" or "en-US"; we only
+// ship en + zh-Hans starter content, so default everything else to en.
+function resolveLocale(language: string): StarterContentLocale {
+  return language.startsWith("zh") ? "zh-Hans" : "en";
 }
 
 // Local helper — mirrors the onboarding flow's mergeQuestionnaire.

--- a/packages/views/onboarding/utils/starter-content-content-en.ts
+++ b/packages/views/onboarding/utils/starter-content-content-en.ts
@@ -1,0 +1,586 @@
+import type { QuestionnaireAnswers } from "@multica/core/onboarding";
+import type { ImportStarterIssuePayload } from "@multica/core/api";
+
+// =============================================================================
+// English starter-content body. Long-form markdown lives here (TypeScript,
+// reviewed as UI). The orchestrator in starter-content-templates.ts picks
+// between this file and starter-content-content-zh.ts based on the user's
+// locale, then hands the result to buildImportPayload.
+// =============================================================================
+
+export const PROJECT = {
+  title: "Getting Started",
+  description:
+    "A few things to try in Multica. Work through them at your own pace.",
+};
+
+interface WelcomeIssueText {
+  title: string;
+  description: string;
+}
+
+export function buildWelcomeIssueText(
+  q: QuestionnaireAnswers,
+  userName: string,
+): WelcomeIssueText {
+  const name = userName.trim() || "there";
+
+  const header = [
+    `Welcome to Multica! 👋`,
+    ``,
+    `This is your workspace's first issue. Below, your agent will reply in a moment — that's how work happens here: you write what you want, your agent (or a teammate) picks it up and replies in the comments.`,
+    ``,
+    `[Learn how Multica works →](https://multica.ai/docs/how-multica-works)`,
+    ``,
+    `---`,
+    ``,
+  ].join("\n");
+
+  const sharedInstructions = [
+    `In your first reply, please:`,
+    ``,
+    `1. **Introduce yourself briefly** — your name, your role, what you're good at.`,
+    `2. **Explain how we work together in Multica**:`,
+    `   - Assigning an issue to you **and** setting its status to **Todo** is what triggers you to start (Backlog pauses you)`,
+    `   - @mentioning you inside a comment is for quick questions`,
+    `   - **Workspace Context** (in Settings → General) is shared background every agent here sees`,
+    `3. **Point them at the *Getting Started* project** in the sidebar and invite them to assign you a real task when they're ready.`,
+    ``,
+    `Keep it friendly and under 200 words. End with one short question that invites ${name} to reply.`,
+  ].join("\n");
+
+  const exploreInstructions = [
+    `In your first reply, please:`,
+    ``,
+    `1. **Introduce yourself briefly** — your name, your role, what you're good at.`,
+    `2. **Explain how we work together in Multica**:`,
+    `   - Assigning an issue to you **and** setting its status to **Todo** triggers you to start (Backlog pauses you)`,
+    `   - @mentioning you inside a comment is for quick questions`,
+    `   - **Workspace Context** (in Settings → General) is shared background every agent here sees`,
+    `3. **Point them at the *Getting Started* project** in the sidebar.`,
+    ``,
+    `Keep it friendly and under 200 words. End with a small, curious question — something like "what's something you've been wondering about lately?" — so ${name} has an easy way to reply without having to come up with a real task yet.`,
+  ].join("\n");
+
+  switch (q.use_case) {
+    case "coding":
+      return {
+        title: "👋 Welcome to Multica — let's work together",
+        description: `${header}Hi agent, this is ${name}'s first time using Multica. They plan to use you mostly for **coding work**.\n\n${sharedInstructions}`,
+      };
+    case "planning":
+      return {
+        title: "👋 Welcome to Multica — let's work together",
+        description: `${header}Hi agent, this is ${name}'s first time using Multica. They want your help with **planning and breaking down work**.\n\n${sharedInstructions}`,
+      };
+    case "writing_research":
+      return {
+        title: "👋 Welcome to Multica — let's work together",
+        description: `${header}Hi agent, this is ${name}'s first time using Multica. They'll use you for **research and writing** — drafting, summarizing, analysis.\n\n${sharedInstructions}`,
+      };
+    case "explore":
+      return {
+        title: "👋 Welcome to Multica — let's work together",
+        description: `${header}Hi agent, this is ${name}'s first time using Multica. They're **exploring** what Multica can do — no specific goal yet.\n\n${exploreInstructions}`,
+      };
+    case "other": {
+      const customUseCase = (q.use_case_other ?? "").trim();
+      const contextLine = customUseCase
+        ? `They told us they want to use you for: "${customUseCase}".`
+        : `They haven't narrowed down their use case yet.`;
+      return {
+        title: "👋 Welcome to Multica — let's work together",
+        description: `${header}Hi agent, this is ${name}'s first time using Multica. ${contextLine}\n\n${sharedInstructions}`,
+      };
+    }
+    default:
+      return {
+        title: "👋 Welcome to Multica — let's work together",
+        description: `${header}Hi agent, this is ${name}'s first time using Multica.\n\n${sharedInstructions}`,
+      };
+  }
+}
+
+export function buildAgentGuidedSubIssues(
+  q: QuestionnaireAnswers,
+): ImportStarterIssuePayload[] {
+  const tier1: ImportStarterIssuePayload[] = [
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "Learn how to trigger your agent on any issue",
+      description: [
+        `**Every issue has a right-side panel** called **Properties**. From there you control who works on what. Agents in Multica are triggered when an issue has:`,
+        ``,
+        `  Assignee = your agent  AND  Status = Todo (not Backlog)`,
+        ``,
+        `**Try it now**:`,
+        `1. In the sidebar, click **New Issue** at the top (or press \`C\`)`,
+        `2. Give it a title like "Test run: summarize our product in 3 bullets"`,
+        `3. On the right panel, find **Assignee** → click → pick your agent`,
+        `4. Find **Status** → click → pick **Todo**`,
+        `5. Scroll down to Activity — a **Live card** appears as your agent starts working`,
+        ``,
+        `**⚠️ Gotcha**: new issues default to Backlog. Agents pause on backlog. A hint dialog will pop up the first time — it's telling you "flip to Todo to start".`,
+        ``,
+        `**You'll know it worked when**: the Live card shows your agent thinking, and the Status flips to **In Progress** automatically.`,
+        ``,
+        `[Learn about assigning issues →](https://multica.ai/docs/assigning-issues)`,
+      ].join("\n"),
+    },
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "Chat with your agent — no issue required",
+      description: [
+        `Not every question needs a whole issue. For quick back-and-forth, use the **Chat panel**.`,
+        ``,
+        `**Where to find it**: look at the **bottom-right corner of the screen** — there's a round button with a **💬 speech bubble icon**. If your agent is working, the button pulses. If there are unread replies, a red badge sits on top of it.`,
+        ``,
+        `**Try it now**:`,
+        `1. Click the 💬 button → a panel slides in from the right`,
+        `2. At the **bottom-left of the input box**, click the agent avatar → pick your agent from the dropdown`,
+        `3. Type a quick question: "What can you help me with in this workspace?"`,
+        `4. Press **Enter**`,
+        ``,
+        `**Bonus — @mention an agent inside a comment**: on any issue, scroll to the comment box at the bottom. Type \`@\` and a dropdown appears listing members, agents, and other issues. Pick an agent → write your question → send. The mentioned agent replies in the comments.`,
+        ``,
+        `**You'll know it worked when**: the agent replies in the chat panel (or comment thread) within a few seconds.`,
+        ``,
+        `[Learn about chat →](https://multica.ai/docs/chat)`,
+      ].join("\n"),
+    },
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "Write your Workspace Context",
+      description: [
+        `**Workspace Context** is a shared system prompt every agent in this workspace reads before starting any task. It's the single most impactful thing you can do to make agent replies sharper.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Open the **sidebar** → scroll to the bottom section labeled **Configure**`,
+        `2. Click **Settings** (⚙️ gear icon, bottom-most item)`,
+        `3. In the left-side tab list, under the **[Your Workspace Name]** group, click **General**`,
+        `4. Scroll down to the **Context** textarea (placeholder says "Provide context to agents...")`,
+        ``,
+        `**Fill it with 3-5 lines**:`,
+        `- Who you are (name, role)`,
+        `- What you're building or working on`,
+        `- How agents should behave (tone, style, defaults)`,
+        ``,
+        `**Example**:`,
+        `> I'm a frontend engineer working on an AI-native task manager. Reply concisely in English. Always explain your reasoning. Prefer TypeScript over JavaScript.`,
+        ``,
+        `Click **Save**.`,
+        ``,
+        `**You'll know it worked when**: the next task you assign to an agent picks up details from this context without you explaining again.`,
+        ``,
+        `[Learn about workspaces →](https://multica.ai/docs/workspaces)`,
+      ].join("\n"),
+    },
+  ];
+
+  const tier2: ImportStarterIssuePayload[] = [];
+
+  if (q.team_size === "team") {
+    tier2.push({
+      status: "todo",
+      priority: "medium",
+      assign_to_self: true,
+      title: "Invite your teammates",
+      description: [
+        `Multica works best when a small team shares agents.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → **Settings** (⚙️, bottom)`,
+        `2. Left tab list → under **[Your Workspace]** group → click **Members** (people icon)`,
+        `3. At the top of the page, click **Add member**`,
+        `4. Enter their email, pick a role (**Owner / Admin / Member**)`,
+        `5. Click **Send invite**`,
+        ``,
+        `They'll receive an email with a join link. Pending invites show in the collapsible "Pending Invitations" section below the member list — you can revoke from there.`,
+        ``,
+        `[Learn about members and roles →](https://multica.ai/docs/members-roles)`,
+      ].join("\n"),
+    });
+  }
+
+  if (q.role === "developer" || q.use_case === "coding") {
+    tier2.push({
+      status: "todo",
+      priority: "medium",
+      assign_to_self: true,
+      title: "Connect a Git repo",
+      description: [
+        `Once connected, any agent can clone, read, and propose changes to your repo when you assign it a task.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → **Settings** (⚙️)`,
+        `2. Left tab list → under **[Your Workspace]** group → **Repositories** (folder with Git branch icon)`,
+        `3. At the bottom of the list, click **+ Add repository**`,
+        `4. Fill the two inline fields:`,
+        `   - **URL** — e.g. \`https://github.com/you/repo.git\``,
+        `   - **Description** — what this repo is for`,
+        `5. Click **Save** at the top of the page`,
+        ``,
+        `Repeat for as many repos as you want to expose.`,
+      ].join("\n"),
+    });
+  }
+
+  tier2.push({
+    status: "todo",
+    priority: "medium",
+    assign_to_self: true,
+    title: "Create a second agent with a different role",
+    description: [
+      `Running a small team of focused agents beats a single generalist. One for coding, one for planning, one for writing — each with their own instructions.`,
+      ``,
+      `**Note**: nothing locks a "Coding Agent" to coding. Instructions are just a system prompt, editable anytime. The split is about keeping each one's replies sharp.`,
+      ``,
+      `**Where to find it**:`,
+      `1. Sidebar → under **Workspace** group → click **Agents** (🤖 bot icon)`,
+      `2. In the left list header, click the **+** button (top-right corner of the list)`,
+      `3. Fill the 4 fields in order:`,
+      `   - **Name** — e.g. "Planning Agent"`,
+      `   - **Description** — "Breaks down loose ideas into scoped work"`,
+      `   - **Visibility** — Workspace (shared) or Private (only you)`,
+      `   - **Runtime** — pick from the dropdown (your connected runtime)`,
+      `4. Click **Create**`,
+      ``,
+      `**You'll know it worked when**: the new agent appears in the Assignee dropdown on any issue, and shows up in the left list on the Agents page.`,
+      ``,
+      `[Learn about creating agents →](https://multica.ai/docs/agents-create)`,
+    ].join("\n"),
+  });
+
+  const tier3: ImportStarterIssuePayload[] = [
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Polish your agent's Instructions",
+      description: [
+        `Creating an agent is just the start. The **Instructions tab** is where you shape how it behaves.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → **Agents** (🤖)`,
+        `2. In the left list, click an agent you want to refine`,
+        `3. In the right panel, you'll see tabs at the top including **Instructions / Skills / Tasks / Settings**`,
+        `4. Click **Instructions**`,
+        `5. Edit the markdown — changes save automatically`,
+        ``,
+        `**Good instructions include**:`,
+        `- The role/persona (e.g. "You're a senior TypeScript engineer")`,
+        `- House rules (e.g. "Always propose tests alongside code")`,
+        `- Output format (e.g. "Return a short summary first, details below")`,
+        ``,
+        `Workspace Context and agent Instructions stack — both are sent on every task. Keep Instructions specific to this agent; keep Context specific to the whole workspace.`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Watch your agent live in action",
+      description: [
+        `**Heads-up task** — nothing to do now, just know this exists.`,
+        ``,
+        `When an agent is working on an issue, a **Live card** appears at the top of the **Activity** section (it sticks to the top of the viewport as you scroll).`,
+        ``,
+        `The card shows in real time:`,
+        `- Which tool the agent is calling (e.g. reading a file, web search)`,
+        `- Streaming thoughts and partial output`,
+        `- Current status (thinking / tool-running / done / failed)`,
+        ``,
+        `After the run finishes, the **Task Run History** below the card lists every past run. Click **View transcript** on any row to open the full interactive transcript — a timeline of every message, thinking step, tool call, and result.`,
+        ``,
+        `**Try it next time you assign an agent**: keep the issue open and watch the Live card appear below the description.`,
+        ``,
+        `[Learn about tasks →](https://multica.ai/docs/tasks)`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Check your Inbox for @mentions and updates",
+      description: [
+        `When someone — or an agent — @mentions you or assigns you an issue, it lands in your **Inbox**.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → the top section (above the **Workspace** group) → click **Inbox** (📥 icon) — an unread count badge shows on the right if you have new items`,
+        ``,
+        `**How it works**:`,
+        `- Left column: notification list, newest first`,
+        `- Right column: the linked issue opens inline, and the specific comment that mentioned you is **auto-highlighted and scrolled into view**`,
+        `- Top-right dropdown: **Mark all as read / Archive all / Archive all read / Archive completed** for bulk cleanup`,
+        ``,
+        `**Tip**: "Archive completed" is the fastest way to clear the noise from issues already finished.`,
+        ``,
+        `[Learn about the inbox →](https://multica.ai/docs/inbox)`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Set up an Autopilot for recurring work",
+      description: [
+        `**Autopilot** turns a prompt into a scheduled task. Every day/week/hour, it auto-creates an issue and assigns it to an agent.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → under **Workspace** group → click **Autopilot** (⚡ Zap icon)`,
+        `2. If you have no autopilots yet, a grid of templates shows up — pick any one to pre-fill the dialog, or click **+ New autopilot** for a blank one`,
+        `3. Fill: **Name** / **Prompt** / **Agent** / **Schedule** (frequency + time + timezone)`,
+        `4. Click **Create**`,
+        ``,
+        `**Good first autopilots**: daily digest of GitHub activity, weekly "what's blocked" check, or a Monday-morning triage of any issues still in Backlog.`,
+        ``,
+        `[Learn about autopilots →](https://multica.ai/docs/autopilots)`,
+      ].join("\n"),
+    },
+  ];
+
+  return [...tier1, ...tier2, ...tier3];
+}
+
+export function buildSelfServeSubIssues(
+  q: QuestionnaireAnswers,
+): ImportStarterIssuePayload[] {
+  const tier1: ImportStarterIssuePayload[] = [
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "Install a runtime (Desktop app or CLI)",
+      description: [
+        `**Why this first**: no runtime = no agents can execute. Everything below Tier 1 waits on this.`,
+        ``,
+        `A **runtime** pairs the daemon (a small background process on your machine) with one AI coding tool — Claude Code, Codex, and so on. If you have several tools installed, you'll see one runtime per tool. The runtime is what executes the tasks your agents pick up.`,
+        ``,
+        `**Option A — Desktop app (macOS, recommended if you're on a Mac)**:`,
+        `1. Go to [github.com/multica-ai/multica/releases/latest](https://github.com/multica-ai/multica/releases/latest) and download the \`.dmg\` for macOS`,
+        `2. Install and open the app`,
+        `3. Sign in with the same account — the daemon is built in, you're done`,
+        ``,
+        `**Option B — CLI (macOS, Linux, or Windows via WSL)**:`,
+        `1. In a terminal, install the CLI:`,
+        `   \`\`\``,
+        `   curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash`,
+        `   \`\`\``,
+        `2. Then run setup (signs you in and starts a background daemon):`,
+        `   \`\`\``,
+        `   multica setup`,
+        `   \`\`\``,
+        `   The daemon keeps running after you close the terminal — you don't have to leave anything open.`,
+        ``,
+        `**Verify**: sidebar → bottom **Configure** section → **Runtimes** → you should see at least one connected runtime.`,
+        ``,
+        `[Learn about runtimes →](https://multica.ai/docs/daemon-runtimes)`,
+      ].join("\n"),
+    },
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "Create your first agent",
+      description: [
+        `**Prerequisite**: task above done (runtime connected).`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → under **Workspace** group → click **Agents** (🤖 bot icon)`,
+        `2. In the left list header, click the **+** button (top-right corner of the list)`,
+        `3. Fill the 4 fields in order:`,
+        `   - **Name** — e.g. "My Coding Agent"`,
+        `   - **Description** — one line about what it does`,
+        `   - **Visibility** — Workspace (shared) or Private (only you)`,
+        `   - **Runtime** — pick the one you just installed`,
+        `4. Click **Create**`,
+        ``,
+        `**Note**: an agent is just an LLM + instructions + workspace access. Nothing locks a "Coding Agent" to coding — same agent can do research, writing, planning. Keep it flexible.`,
+        ``,
+        `**You'll know it worked when**: the new agent appears in the Assignee dropdown on any issue.`,
+        ``,
+        `[Learn about creating agents →](https://multica.ai/docs/agents-create)`,
+      ].join("\n"),
+    },
+  ];
+
+  const tier2: ImportStarterIssuePayload[] = [
+    {
+      status: "todo",
+      priority: "medium",
+      assign_to_self: true,
+      title: "Assign your first real task to your agent",
+      description: [
+        `**Prerequisite**: you have a runtime + agent from the two tasks above.`,
+        ``,
+        `**How Multica triggers agents**:`,
+        `- Assign an issue to an agent`,
+        `- Set status to **Todo** (not Backlog — backlog pauses agents)`,
+        `- The agent picks it up automatically`,
+        ``,
+        `**Try it now**:`,
+        `1. In the sidebar, click **New Issue** at the top (or press \`C\`)`,
+        `2. Title: something you actually want done`,
+        `3. On the right panel, find **Assignee** → click → pick your agent`,
+        `4. Find **Status** → change from Backlog to **Todo**`,
+        `5. Watch the agent reply in the comments and a **Live card** appear in Activity`,
+        ``,
+        `**⚠️ Gotcha**: new issues default to **Backlog**. You must flip to **Todo** to trigger the agent.`,
+        ``,
+        `[Learn about assigning issues →](https://multica.ai/docs/assigning-issues)`,
+      ].join("\n"),
+    },
+    {
+      status: "todo",
+      priority: "medium",
+      assign_to_self: true,
+      title: "Write your Workspace Context",
+      description: [
+        `**Workspace Context** is a shared system prompt every agent in this workspace reads before starting any task. It's the single most impactful thing you can do to make agent replies sharper.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Open the **sidebar** → scroll to the bottom section labeled **Configure**`,
+        `2. Click **Settings** (⚙️ gear icon, bottom-most item)`,
+        `3. In the left-side tab list, under the **[Your Workspace Name]** group, click **General**`,
+        `4. Scroll down to the **Context** textarea`,
+        ``,
+        `**Fill it with 3-5 lines**:`,
+        `- Who you are (name, role)`,
+        `- What you're building or working on`,
+        `- How agents should behave (tone, style, defaults)`,
+        ``,
+        `Click **Save**.`,
+        ``,
+        `**You'll know it worked when**: the next task you assign to an agent picks up details from this context without you explaining again.`,
+        ``,
+        `[Learn about workspaces →](https://multica.ai/docs/workspaces)`,
+      ].join("\n"),
+    },
+  ];
+
+  const tier3: ImportStarterIssuePayload[] = [
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Chat with an agent — once you've created one",
+      description: [
+        `**Prerequisite**: you've created at least one agent (Tier 1 #2).`,
+        ``,
+        `Not every question needs a whole issue. For quick back-and-forth, use the **Chat panel**.`,
+        ``,
+        `**Where to find it**: the **bottom-right corner of the screen** has a round button with a **💬 speech bubble icon**.`,
+        ``,
+        `**Try it**:`,
+        `1. Click the 💬 button → a panel slides in from the right`,
+        `2. At the bottom-left of the input box, pick an agent from the dropdown`,
+        `3. Type a question → press **Enter**`,
+        ``,
+        `**Bonus**: inside any issue's comment box, type \`@\` to mention an agent or member.`,
+        ``,
+        `[Learn about chat →](https://multica.ai/docs/chat)`,
+      ].join("\n"),
+    },
+  ];
+
+  if (q.role === "developer" || q.use_case === "coding") {
+    tier3.push({
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Connect a Git repo",
+      description: [
+        `Once connected, any agent can clone, read, and propose changes to your repo when you assign it a task.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → **Settings** (⚙️)`,
+        `2. Left tab list → **Repositories** (folder with Git branch icon)`,
+        `3. At the bottom of the list, click **+ Add repository**`,
+        `4. Fill **URL** (e.g. \`https://github.com/you/repo.git\`) and **Description**`,
+        `5. Click **Save** at the top of the page`,
+      ].join("\n"),
+    });
+  }
+
+  if (q.team_size === "team") {
+    tier3.push({
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Invite your teammates",
+      description: [
+        `Multica works best when a small team shares agents.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → **Settings** (⚙️, bottom)`,
+        `2. Left tab list → **Members** (people icon)`,
+        `3. Click **Add member** → enter email → pick role → **Send invite**`,
+        ``,
+        `[Learn about members and roles →](https://multica.ai/docs/members-roles)`,
+      ].join("\n"),
+    });
+  }
+
+  tier3.push(
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Shape your agent's Instructions (once it's created)",
+      description: [
+        `**Prerequisite**: you have at least one agent.`,
+        ``,
+        `Creating an agent is just the start. The **Instructions tab** is where you shape how it behaves.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → **Agents** (🤖)`,
+        `2. Click an agent in the left list`,
+        `3. Right panel → click the **Instructions** tab (alongside Skills / Tasks / Settings)`,
+        `4. Edit the markdown — changes save automatically`,
+        ``,
+        `Workspace Context and agent Instructions stack — both are sent on every task. Keep Instructions specific to this agent; keep Context specific to the whole workspace.`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Watch an agent work live (once you've assigned one a task)",
+      description: [
+        `**Heads-up task** — nothing to do now, just know this exists.`,
+        ``,
+        `When an agent is working on an issue, a **Live card** appears at the top of the **Activity** section (it sticks to the top of the viewport as you scroll).`,
+        ``,
+        `It shows in real time which tool the agent is calling, streaming thoughts, and current status. After the run finishes, the **Task Run History** below the card lists every past run — click **View transcript** to open the full timeline.`,
+        ``,
+        `[Learn about tasks →](https://multica.ai/docs/tasks)`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "Set up an Autopilot (once you have an agent)",
+      description: [
+        `**Prerequisite**: you have at least one agent.`,
+        ``,
+        `**Autopilot** turns a prompt into a scheduled task. Every day/week/hour, it auto-creates an issue and assigns it to an agent.`,
+        ``,
+        `**Where to find it**:`,
+        `1. Sidebar → under **Workspace** group → click **Autopilot** (⚡ Zap icon)`,
+        `2. Pick a template, or click **+ New autopilot** for a blank one`,
+        `3. Fill: **Name** / **Prompt** / **Agent** / **Schedule** (frequency + time + timezone) → **Create**`,
+        ``,
+        `[Learn about autopilots →](https://multica.ai/docs/autopilots)`,
+      ].join("\n"),
+    },
+  );
+
+  return [...tier1, ...tier2, ...tier3];
+}

--- a/packages/views/onboarding/utils/starter-content-content-zh.ts
+++ b/packages/views/onboarding/utils/starter-content-content-zh.ts
@@ -1,0 +1,589 @@
+import type { QuestionnaireAnswers } from "@multica/core/onboarding";
+import type { ImportStarterIssuePayload } from "@multica/core/api";
+
+// =============================================================================
+// Chinese starter-content body. Mirrors starter-content-content-en.ts in
+// shape; translated and adapted to the conventions in
+// apps/docs/content/docs/developers/conventions.zh.mdx — task / issue /
+// skill stay lowercase English; agent / runtime / daemon / workspace are
+// translated; product UI labels (Properties, Assignee, Status, Activity,
+// Live card, Inbox, Members, Settings, Runtimes, Configure, Workspace,
+// Repositories, Instructions, Tasks, Skills, Autopilot, etc.) stay in
+// English with English code-style framing matching the actual UI.
+// =============================================================================
+
+export const PROJECT = {
+  title: "上手指南",
+  description: "几件可以在 Multica 里上手试一试的事，按你的节奏走。",
+};
+
+interface WelcomeIssueText {
+  title: string;
+  description: string;
+}
+
+export function buildWelcomeIssueText(
+  q: QuestionnaireAnswers,
+  userName: string,
+): WelcomeIssueText {
+  const name = userName.trim() || "你";
+
+  const header = [
+    `欢迎来到 Multica！👋`,
+    ``,
+    `这是你工作区里的第一个 issue。下面你的智能体马上会回复——这就是 Multica 里工作的方式：你写下你想做的事，智能体（或同事）接手并在评论里回复。`,
+    ``,
+    `[了解 Multica 是怎么运转的 →](https://multica.ai/docs/zh/how-multica-works)`,
+    ``,
+    `---`,
+    ``,
+  ].join("\n");
+
+  const sharedInstructions = [
+    `请你在第一条回复里：`,
+    ``,
+    `1. **简短地自我介绍** —— 名字、定位、擅长的事。`,
+    `2. **说明我们在 Multica 里怎么协作**：`,
+    `   - 把 issue 分配给你 **并** 把状态置为 **Todo** 才会触发你开工（Backlog 状态会让你暂停）`,
+    `   - 在评论里 @你 适合丢一个快速问题`,
+    `   - **Workspace Context**（在 Settings → General）是这个工作区里每个智能体都会读到的共享背景`,
+    `3. **把 ${name} 引到侧边栏的 *上手指南* 项目**，邀请 ${name} 准备好后给你分配一个真实的 task。`,
+    ``,
+    `语气友好、不超过 200 字。结尾抛一个简短的小问题让 ${name} 容易回复。`,
+  ].join("\n");
+
+  const exploreInstructions = [
+    `请你在第一条回复里：`,
+    ``,
+    `1. **简短地自我介绍** —— 名字、定位、擅长的事。`,
+    `2. **说明我们在 Multica 里怎么协作**：`,
+    `   - 把 issue 分配给你 **并** 把状态置为 **Todo** 才会触发你开工（Backlog 状态会让你暂停）`,
+    `   - 在评论里 @你 适合丢一个快速问题`,
+    `   - **Workspace Context**（在 Settings → General）是这个工作区里每个智能体都会读到的共享背景`,
+    `3. **把 ${name} 引到侧边栏的 *上手指南* 项目**。`,
+    ``,
+    `语气友好、不超过 200 字。结尾抛一个轻松的小问题——比如"最近你在琢磨什么有意思的事？"——让 ${name} 不必先想好一个真实任务也能轻松回复。`,
+  ].join("\n");
+
+  switch (q.use_case) {
+    case "coding":
+      return {
+        title: "👋 欢迎来到 Multica —— 一起开工",
+        description: `${header}你好智能体，这是 ${name} 第一次用 Multica。${name} 主要会让你做 **编码相关的工作**。\n\n${sharedInstructions}`,
+      };
+    case "planning":
+      return {
+        title: "👋 欢迎来到 Multica —— 一起开工",
+        description: `${header}你好智能体，这是 ${name} 第一次用 Multica。${name} 希望你帮忙做 **规划与拆解工作**。\n\n${sharedInstructions}`,
+      };
+    case "writing_research":
+      return {
+        title: "👋 欢迎来到 Multica —— 一起开工",
+        description: `${header}你好智能体，这是 ${name} 第一次用 Multica。${name} 会让你做 **调研和写作** —— 起草、摘要、分析。\n\n${sharedInstructions}`,
+      };
+    case "explore":
+      return {
+        title: "👋 欢迎来到 Multica —— 一起开工",
+        description: `${header}你好智能体，这是 ${name} 第一次用 Multica。${name} 还在 **探索** Multica 能做什么 —— 暂时没有具体目标。\n\n${exploreInstructions}`,
+      };
+    case "other": {
+      const customUseCase = (q.use_case_other ?? "").trim();
+      const contextLine = customUseCase
+        ? `${name} 告诉我们想让你做的事是："${customUseCase}"。`
+        : `${name} 还没明确具体的使用场景。`;
+      return {
+        title: "👋 欢迎来到 Multica —— 一起开工",
+        description: `${header}你好智能体，这是 ${name} 第一次用 Multica。${contextLine}\n\n${sharedInstructions}`,
+      };
+    }
+    default:
+      return {
+        title: "👋 欢迎来到 Multica —— 一起开工",
+        description: `${header}你好智能体，这是 ${name} 第一次用 Multica。\n\n${sharedInstructions}`,
+      };
+  }
+}
+
+export function buildAgentGuidedSubIssues(
+  q: QuestionnaireAnswers,
+): ImportStarterIssuePayload[] {
+  const tier1: ImportStarterIssuePayload[] = [
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "学会怎么在任意 issue 上触发你的智能体",
+      description: [
+        `**每个 issue 右侧都有一个 Properties 面板**。从这里控制谁来做什么。Multica 里的智能体被触发的条件是 issue 同时满足：`,
+        ``,
+        `  Assignee = 你的智能体  AND  Status = Todo（不是 Backlog）`,
+        ``,
+        `**现在就试一下**：`,
+        `1. 在侧边栏顶部点 **New Issue**（或按 \`C\`）`,
+        `2. 标题写成类似"试运行：用 3 条 bullet 总结我们的产品"`,
+        `3. 在右侧面板找到 **Assignee** → 点击 → 选你的智能体`,
+        `4. 找到 **Status** → 点击 → 选 **Todo**`,
+        `5. 滚动到 Activity —— 智能体一开工就会出现一张 **Live card**`,
+        ``,
+        `**⚠️ 容易踩**：新建的 issue 默认是 Backlog 状态，智能体在 Backlog 是暂停的。第一次会弹一个提示——意思就是"翻到 Todo 才会开工"。`,
+        ``,
+        `**怎么算成功**：Live card 里出现智能体在思考的状态，Status 自动翻到 **In Progress**。`,
+        ``,
+        `[关于把 issue 分配给智能体 →](https://multica.ai/docs/zh/assigning-issues)`,
+      ].join("\n"),
+    },
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "和智能体聊天 —— 不需要建 issue",
+      description: [
+        `不是每个问题都值得开一个 issue。要快速来回对话，用 **Chat 面板**。`,
+        ``,
+        `**在哪**：看屏幕 **右下角** —— 有一个圆形按钮，上面是一个 **💬 对话气泡**。智能体在工作时按钮会脉动；有未读回复时会有红色小角标。`,
+        ``,
+        `**现在就试一下**：`,
+        `1. 点 💬 按钮 → 一个面板从右侧滑入`,
+        `2. 在 **输入框左下角** 点智能体头像 → 从下拉里选你的智能体`,
+        `3. 输入一个简短问题："这个工作区里你能帮我做什么？"`,
+        `4. 按 **Enter**`,
+        ``,
+        `**附赠技巧 —— 在评论里 @智能体**：在任何 issue 底部的评论框里输入 \`@\`，会弹出一个下拉，列出成员、智能体和其他 issue。选一个智能体 → 写下问题 → 发送。被 @ 的智能体会在评论里回复。`,
+        ``,
+        `**怎么算成功**：智能体在几秒内通过 chat 面板（或评论里）回复。`,
+        ``,
+        `[关于聊天 →](https://multica.ai/docs/zh/chat)`,
+      ].join("\n"),
+    },
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "写一份 Workspace Context",
+      description: [
+        `**Workspace Context** 是一段共享系统提示，这个工作区里每个智能体在执行任何 task 之前都会读它。这是让智能体回复更精准、最有杠杆的一件事。`,
+        ``,
+        `**在哪**：`,
+        `1. 打开 **侧边栏** → 滚到底部 **Configure** 区`,
+        `2. 点 **Settings**（⚙️ 齿轮图标，最底部那个）`,
+        `3. 左侧 tab 列表里，在 **[你的工作区名]** 分组下，点 **General**`,
+        `4. 滚到 **Context** 文本框（占位符是"Provide context to agents..."）`,
+        ``,
+        `**写 3-5 行**：`,
+        `- 你是谁（名字、定位）`,
+        `- 你在做什么（产品、项目）`,
+        `- 智能体应该怎么表现（语气、风格、默认行为）`,
+        ``,
+        `**例子**：`,
+        `> 我是前端工程师，在做一个 AI-native 任务管理产品。回复用中文、简短。永远解释你的推理。优先选 TypeScript 而不是 JavaScript。`,
+        ``,
+        `点 **Save**。`,
+        ``,
+        `**怎么算成功**：你下次分给智能体一个 task，它会自动用上 context 里的信息，不需要你再解释一遍。`,
+        ``,
+        `[关于工作区 →](https://multica.ai/docs/zh/workspaces)`,
+      ].join("\n"),
+    },
+  ];
+
+  const tier2: ImportStarterIssuePayload[] = [];
+
+  if (q.team_size === "team") {
+    tier2.push({
+      status: "todo",
+      priority: "medium",
+      assign_to_self: true,
+      title: "邀请同事加入",
+      description: [
+        `Multica 在小团队共享智能体的场景下最好用。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → **Settings**（⚙️，最底部）`,
+        `2. 左侧 tab 列表 → 在 **[你的工作区]** 分组下 → 点 **Members**（人形图标）`,
+        `3. 页面顶部点 **Add member**`,
+        `4. 填邮箱、选角色（**Owner / Admin / Member**）`,
+        `5. 点 **Send invite**`,
+        ``,
+        `他们会收到一封带加入链接的邮件。已发出的邀请会出现在成员列表下方"Pending Invitations"折叠区，从那里可以撤销。`,
+        ``,
+        `[关于成员与角色 →](https://multica.ai/docs/zh/members-roles)`,
+      ].join("\n"),
+    });
+  }
+
+  if (q.role === "developer" || q.use_case === "coding") {
+    tier2.push({
+      status: "todo",
+      priority: "medium",
+      assign_to_self: true,
+      title: "接入一个 Git 仓库",
+      description: [
+        `接入后，被分配 task 的智能体可以 clone、读取、提交对你仓库的修改。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → **Settings**（⚙️）`,
+        `2. 左侧 tab 列表 → 在 **[你的工作区]** 分组下 → **Repositories**（带 Git 分支图标的文件夹）`,
+        `3. 列表底部点 **+ Add repository**`,
+        `4. 填两个字段：`,
+        `   - **URL** —— 例如 \`https://github.com/you/repo.git\``,
+        `   - **Description** —— 这个仓库是干嘛的`,
+        `5. 在页面顶部点 **Save**`,
+        ``,
+        `想暴露多少个仓库就重复多少次。`,
+      ].join("\n"),
+    });
+  }
+
+  tier2.push({
+    status: "todo",
+    priority: "medium",
+    assign_to_self: true,
+    title: "再创建一个不同分工的智能体",
+    description: [
+      `跑一个分工明确的小型智能体团队，比一个万能选手更好用。一个写代码、一个做规划、一个写文 —— 各自有各自的指令。`,
+      ``,
+      `**说明**：没有什么强制把"编码智能体"锁死在编码上。指令本质就是 system prompt，随时可改。分开是为了让每个智能体的回复更聚焦。`,
+      ``,
+      `**在哪**：`,
+      `1. 侧边栏 → 在 **Workspace** 分组下点 **Agents**（🤖 图标）`,
+      `2. 在左侧列表头部点 **+** 按钮（列表右上角）`,
+      `3. 按顺序填 4 个字段：`,
+      `   - **Name** —— 例如"规划智能体"`,
+      `   - **Description** —— "把零散想法拆成可执行的任务"`,
+      `   - **Visibility** —— Workspace（共享）或 Private（仅自己）`,
+      `   - **Runtime** —— 从下拉里选（你已连接的运行时）`,
+      `4. 点 **Create**`,
+      ``,
+      `**怎么算成功**：新智能体出现在任意 issue 的 Assignee 下拉里，也出现在 Agents 页的左侧列表。`,
+      ``,
+      `[关于创建智能体 →](https://multica.ai/docs/zh/agents-create)`,
+    ].join("\n"),
+  });
+
+  const tier3: ImportStarterIssuePayload[] = [
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "打磨智能体的 Instructions",
+      description: [
+        `创建智能体只是开始。**Instructions tab** 才是塑造它行为的地方。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → **Agents**（🤖）`,
+        `2. 在左侧列表点你想调整的智能体`,
+        `3. 在右侧面板顶部能看到一组 tab，包括 **Instructions / Skills / Tasks / Settings**`,
+        `4. 点 **Instructions**`,
+        `5. 编辑 markdown —— 自动保存`,
+        ``,
+        `**好的指令包含**：`,
+        `- 角色/人设（例如"你是一名资深 TypeScript 工程师"）`,
+        `- 内部规则（例如"代码改动一定要附带测试"）`,
+        `- 输出格式（例如"先一句话总结，再展开细节"）`,
+        ``,
+        `Workspace Context 和智能体 Instructions 是叠加的——每个 task 都会同时带上。Instructions 写这个智能体特有的，Context 写整个工作区都适用的。`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "实时观看智能体工作",
+      description: [
+        `**了解性 task** —— 现在不用做什么，知道有这个东西就行。`,
+        ``,
+        `当智能体在某个 issue 上工作时，**Activity** 区顶部会出现一张 **Live card**（滚动时会粘在视口顶部）。`,
+        ``,
+        `Live card 实时展示：`,
+        `- 智能体正在调用哪个工具（例如读文件、网页搜索）`,
+        `- 流式输出的思考与中间结果`,
+        `- 当前状态（thinking / tool-running / done / failed）`,
+        ``,
+        `执行结束后，Live card 下方的 **Task Run History** 列出每一次运行。任意一行点 **View transcript** 可以打开完整的可交互转录 —— 从消息、思考、工具调用到结果的完整时间线。`,
+        ``,
+        `**下次分配 task 时试一下**：保持 issue 打开，观察 Live card 在描述下方出现。`,
+        ``,
+        `[关于执行任务 →](https://multica.ai/docs/zh/tasks)`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "在 Inbox 里看 @提及与更新",
+      description: [
+        `当有人——或者智能体—— @你 或者把 issue 分给你时，事件会落到你的 **Inbox**。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → 顶部分区（**Workspace** 分组上方）→ 点 **Inbox**（📥 图标）—— 有新消息时右侧会显示未读角标`,
+        ``,
+        `**怎么用**：`,
+        `- 左栏：通知列表，最新在上`,
+        `- 右栏：关联的 issue 内嵌打开，**自动高亮并滚动到** @你的那条具体评论`,
+        `- 右上下拉：**Mark all as read / Archive all / Archive all read / Archive completed** 用于批量整理`,
+        ``,
+        `**小技巧**："Archive completed" 是清掉已经完成 issue 噪音最快的方式。`,
+        ``,
+        `[关于收件箱 →](https://multica.ai/docs/zh/inbox)`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "用 Autopilot 处理周期性工作",
+      description: [
+        `**Autopilot** 把一段 prompt 变成定时 task。每天/每周/每小时自动建一个 issue 并分给智能体。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → 在 **Workspace** 分组下点 **Autopilot**（⚡ 闪电图标）`,
+        `2. 还没有 autopilot 时，会出现一组模板——任选一个会预填弹窗，或者点 **+ New autopilot** 从空白开始`,
+        `3. 填：**Name** / **Prompt** / **Agent** / **Schedule**（频率 + 时间 + 时区）`,
+        `4. 点 **Create**`,
+        ``,
+        `**第一个 autopilot 可以试什么**：每日 GitHub 活动摘要、每周"哪些 issue 被卡住"巡检、每周一早上整理还停在 Backlog 的 issue。`,
+        ``,
+        `[关于自动化 →](https://multica.ai/docs/zh/autopilots)`,
+      ].join("\n"),
+    },
+  ];
+
+  return [...tier1, ...tier2, ...tier3];
+}
+
+export function buildSelfServeSubIssues(
+  q: QuestionnaireAnswers,
+): ImportStarterIssuePayload[] {
+  const tier1: ImportStarterIssuePayload[] = [
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "装一个运行时（桌面应用 或 CLI）",
+      description: [
+        `**为什么先做这个**：没有运行时 = 智能体跑不了任何 task。Tier 1 之下的所有事情都等这个。`,
+        ``,
+        `**运行时**是守护进程（一个跑在你机器上的小后台进程）和一款 AI 编程工具——Claude Code、Codex 等等——的组合。装了多款工具就会出现多个运行时。运行时是真正执行智能体接到的 task 的那一层。`,
+        ``,
+        `**方案 A —— 桌面应用（macOS，Mac 推荐）**：`,
+        `1. 去 [github.com/multica-ai/multica/releases/latest](https://github.com/multica-ai/multica/releases/latest) 下载 macOS 的 \`.dmg\``,
+        `2. 安装并打开`,
+        `3. 用同一个账号登录 —— 守护进程内置，到此结束`,
+        ``,
+        `**方案 B —— CLI（macOS、Linux 或 Windows + WSL）**：`,
+        `1. 在终端装 CLI：`,
+        `   \`\`\``,
+        `   curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash`,
+        `   \`\`\``,
+        `2. 跑 setup（登录并启动后台守护进程）：`,
+        `   \`\`\``,
+        `   multica setup`,
+        `   \`\`\``,
+        `   守护进程会在终端关闭后继续运行 —— 不需要保留终端窗口。`,
+        ``,
+        `**验证**：侧边栏 → 底部 **Configure** 区 → **Runtimes** → 应该至少看到一个已连接的运行时。`,
+        ``,
+        `[关于守护进程与运行时 →](https://multica.ai/docs/zh/daemon-runtimes)`,
+      ].join("\n"),
+    },
+    {
+      status: "todo",
+      priority: "high",
+      assign_to_self: true,
+      title: "创建你的第一个智能体",
+      description: [
+        `**前置条件**：上面那条 task 完成（运行时已连接）。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → 在 **Workspace** 分组下点 **Agents**（🤖 图标）`,
+        `2. 在左侧列表头部点 **+** 按钮（列表右上角）`,
+        `3. 按顺序填 4 个字段：`,
+        `   - **Name** —— 例如"我的编码智能体"`,
+        `   - **Description** —— 一句话说它做什么`,
+        `   - **Visibility** —— Workspace（共享）或 Private（仅自己）`,
+        `   - **Runtime** —— 选你刚才装的那个`,
+        `4. 点 **Create**`,
+        ``,
+        `**说明**：智能体本质上就是 LLM + 指令 + 工作区访问权限。没有什么强制把"编码智能体"锁死在编码上 —— 同一个智能体可以做调研、写作、规划。保持灵活。`,
+        ``,
+        `**怎么算成功**：新智能体出现在任意 issue 的 Assignee 下拉里。`,
+        ``,
+        `[关于创建智能体 →](https://multica.ai/docs/zh/agents-create)`,
+      ].join("\n"),
+    },
+  ];
+
+  const tier2: ImportStarterIssuePayload[] = [
+    {
+      status: "todo",
+      priority: "medium",
+      assign_to_self: true,
+      title: "把第一个真实 task 分给智能体",
+      description: [
+        `**前置条件**：上面两条 task 都做完，你已经有运行时 + 智能体。`,
+        ``,
+        `**Multica 怎么触发智能体**：`,
+        `- 把 issue 分给智能体`,
+        `- 状态置为 **Todo**（不是 Backlog —— Backlog 会让智能体暂停）`,
+        `- 智能体自动接手`,
+        ``,
+        `**现在就试一下**：`,
+        `1. 在侧边栏顶部点 **New Issue**（或按 \`C\`）`,
+        `2. 标题：你真正想做的事`,
+        `3. 在右侧面板找到 **Assignee** → 点击 → 选你的智能体`,
+        `4. 找到 **Status** → 从 Backlog 改为 **Todo**`,
+        `5. 看智能体在评论里回复，Activity 里出现 **Live card**`,
+        ``,
+        `**⚠️ 容易踩**：新 issue 默认是 **Backlog**。必须翻到 **Todo** 才会触发智能体。`,
+        ``,
+        `[关于把 issue 分配给智能体 →](https://multica.ai/docs/zh/assigning-issues)`,
+      ].join("\n"),
+    },
+    {
+      status: "todo",
+      priority: "medium",
+      assign_to_self: true,
+      title: "写一份 Workspace Context",
+      description: [
+        `**Workspace Context** 是一段共享系统提示，这个工作区里每个智能体在执行任何 task 之前都会读它。这是让智能体回复更精准、最有杠杆的一件事。`,
+        ``,
+        `**在哪**：`,
+        `1. 打开 **侧边栏** → 滚到底部 **Configure** 区`,
+        `2. 点 **Settings**（⚙️ 齿轮图标，最底部那个）`,
+        `3. 左侧 tab 列表里，在 **[你的工作区名]** 分组下，点 **General**`,
+        `4. 滚到 **Context** 文本框`,
+        ``,
+        `**写 3-5 行**：`,
+        `- 你是谁（名字、定位）`,
+        `- 你在做什么（产品、项目）`,
+        `- 智能体应该怎么表现（语气、风格、默认行为）`,
+        ``,
+        `点 **Save**。`,
+        ``,
+        `**怎么算成功**：你下次分给智能体一个 task，它会自动用上 context 里的信息，不需要你再解释一遍。`,
+        ``,
+        `[关于工作区 →](https://multica.ai/docs/zh/workspaces)`,
+      ].join("\n"),
+    },
+  ];
+
+  const tier3: ImportStarterIssuePayload[] = [
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "和智能体聊天 —— 创建之后再做",
+      description: [
+        `**前置条件**：你至少创建了一个智能体（Tier 1 #2）。`,
+        ``,
+        `不是每个问题都值得开一个 issue。要快速来回对话，用 **Chat 面板**。`,
+        ``,
+        `**在哪**：屏幕 **右下角** 有一个圆形按钮，上面是 **💬 对话气泡**。`,
+        ``,
+        `**试一下**：`,
+        `1. 点 💬 按钮 → 一个面板从右侧滑入`,
+        `2. 在输入框左下角，从下拉里选一个智能体`,
+        `3. 输入问题 → 按 **Enter**`,
+        ``,
+        `**附赠技巧**：在任意 issue 的评论框里输入 \`@\` 可以提及智能体或成员。`,
+        ``,
+        `[关于聊天 →](https://multica.ai/docs/zh/chat)`,
+      ].join("\n"),
+    },
+  ];
+
+  if (q.role === "developer" || q.use_case === "coding") {
+    tier3.push({
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "接入一个 Git 仓库",
+      description: [
+        `接入后，被分配 task 的智能体可以 clone、读取、提交对你仓库的修改。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → **Settings**（⚙️）`,
+        `2. 左侧 tab 列表 → **Repositories**（带 Git 分支图标的文件夹）`,
+        `3. 列表底部点 **+ Add repository**`,
+        `4. 填 **URL**（例如 \`https://github.com/you/repo.git\`）和 **Description**`,
+        `5. 在页面顶部点 **Save**`,
+      ].join("\n"),
+    });
+  }
+
+  if (q.team_size === "team") {
+    tier3.push({
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "邀请同事加入",
+      description: [
+        `Multica 在小团队共享智能体的场景下最好用。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → **Settings**（⚙️，最底部）`,
+        `2. 左侧 tab 列表 → **Members**（人形图标）`,
+        `3. 点 **Add member** → 填邮箱 → 选角色 → **Send invite**`,
+        ``,
+        `[关于成员与角色 →](https://multica.ai/docs/zh/members-roles)`,
+      ].join("\n"),
+    });
+  }
+
+  tier3.push(
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "塑造智能体的 Instructions（创建之后再做）",
+      description: [
+        `**前置条件**：你至少有一个智能体。`,
+        ``,
+        `创建智能体只是开始。**Instructions tab** 才是塑造它行为的地方。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → **Agents**（🤖）`,
+        `2. 在左侧列表点一个智能体`,
+        `3. 右侧面板 → 点 **Instructions** tab（与 Skills / Tasks / Settings 并列）`,
+        `4. 编辑 markdown —— 自动保存`,
+        ``,
+        `Workspace Context 和智能体 Instructions 是叠加的——每个 task 都会同时带上。Instructions 写这个智能体特有的，Context 写整个工作区都适用的。`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "实时观看智能体工作（分配 task 之后再做）",
+      description: [
+        `**了解性 task** —— 现在不用做什么，知道有这个东西就行。`,
+        ``,
+        `当智能体在某个 issue 上工作时，**Activity** 区顶部会出现一张 **Live card**（滚动时会粘在视口顶部）。`,
+        ``,
+        `Live card 实时展示智能体正在调用哪个工具、流式思考、当前状态。执行结束后，下方的 **Task Run History** 列出每一次运行 —— 点 **View transcript** 可以打开完整时间线。`,
+        ``,
+        `[关于执行任务 →](https://multica.ai/docs/zh/tasks)`,
+      ].join("\n"),
+    },
+    {
+      status: "backlog",
+      priority: "low",
+      assign_to_self: true,
+      title: "搭一个 Autopilot（有了智能体之后再做）",
+      description: [
+        `**前置条件**：你至少有一个智能体。`,
+        ``,
+        `**Autopilot** 把一段 prompt 变成定时 task。每天/每周/每小时自动建一个 issue 并分给智能体。`,
+        ``,
+        `**在哪**：`,
+        `1. 侧边栏 → 在 **Workspace** 分组下点 **Autopilot**（⚡ 闪电图标）`,
+        `2. 选一个模板，或者点 **+ New autopilot** 从空白开始`,
+        `3. 填：**Name** / **Prompt** / **Agent** / **Schedule**（频率 + 时间 + 时区）→ **Create**`,
+        ``,
+        `[关于自动化 →](https://multica.ai/docs/zh/autopilots)`,
+      ].join("\n"),
+    },
+  );
+
+  return [...tier1, ...tier2, ...tier3];
+}

--- a/packages/views/onboarding/utils/starter-content-templates.ts
+++ b/packages/views/onboarding/utils/starter-content-templates.ts
@@ -3,25 +3,31 @@ import type {
   ImportStarterContentPayload,
   ImportStarterIssuePayload,
 } from "@multica/core/api";
+import * as en from "./starter-content-content-en";
+import * as zh from "./starter-content-content-zh";
 
 // =============================================================================
-// Starter content templates.
+// Starter content orchestrator.
 //
-// Pure functions that turn the user's questionnaire answers into the request
-// payload for POST /api/me/starter-content/import. No side effects, no API
-// calls, no DOM — the only consumer is `StarterContentPrompt`, which passes
-// the output straight to the server.
+// Pure functions that turn the user's questionnaire answers + locale into
+// the request payload for POST /api/me/starter-content/import. No side
+// effects, no API calls, no DOM — the only consumer is `StarterContentPrompt`,
+// which passes the output straight to the server.
 //
-// Separation of concerns:
-//   - Markdown/copy lives here (TypeScript, reviewed as UI)
-//   - Batch creation + idempotency + assignee resolution lives in Go
-//     (handler/onboarding.go → ImportStarterContent)
+// Long-form markdown bodies live in sibling files keyed by locale:
+//   - starter-content-content-en.ts  (English)
+//   - starter-content-content-zh.ts  (Simplified Chinese)
+//
+// JSON locales were considered, but ~600 lines of multi-paragraph markdown
+// per language are unreadable as escaped single-line strings; keeping the
+// content in TS lets reviewers see the rendered shape and catch markdown
+// regressions in code review.
+//
+// Server-side concerns (batch creation, idempotency, assignee resolution)
+// live in Go: handler/onboarding.go → ImportStarterContent.
 // =============================================================================
 
-interface WelcomeIssueText {
-  title: string;
-  description: string;
-}
+export type StarterContentLocale = "en" | "zh-Hans";
 
 // Prefix titles with 1. 2. 3. … AFTER the full list is assembled so
 // conditional items (invite team / connect repo) don't break numbering.
@@ -31,582 +37,8 @@ function numberTitles(
   return issues.map((s, i) => ({ ...s, title: `${i + 1}. ${s.title}` }));
 }
 
-export function buildWelcomeIssueText(
-  q: QuestionnaireAnswers,
-  userName: string,
-): WelcomeIssueText {
-  const name = userName.trim() || "there";
-
-  const header = [
-    `Welcome to Multica! 👋`,
-    ``,
-    `This is your workspace's first issue. Below, your agent will reply in a moment — that's how work happens here: you write what you want, your agent (or a teammate) picks it up and replies in the comments.`,
-    ``,
-    `[Learn how Multica works →](https://multica.ai/docs/how-multica-works)`,
-    ``,
-    `---`,
-    ``,
-  ].join("\n");
-
-  const sharedInstructions = [
-    `In your first reply, please:`,
-    ``,
-    `1. **Introduce yourself briefly** — your name, your role, what you're good at.`,
-    `2. **Explain how we work together in Multica**:`,
-    `   - Assigning an issue to you **and** setting its status to **Todo** is what triggers you to start (Backlog pauses you)`,
-    `   - @mentioning you inside a comment is for quick questions`,
-    `   - **Workspace Context** (in Settings → General) is shared background every agent here sees`,
-    `3. **Point them at the *Getting Started* project** in the sidebar and invite them to assign you a real task when they're ready.`,
-    ``,
-    `Keep it friendly and under 200 words. End with one short question that invites ${name} to reply.`,
-  ].join("\n");
-
-  // Softer variant for users who said they're just exploring — no
-  // pressure to "assign a real task", just pull them into a
-  // low-stakes conversation.
-  const exploreInstructions = [
-    `In your first reply, please:`,
-    ``,
-    `1. **Introduce yourself briefly** — your name, your role, what you're good at.`,
-    `2. **Explain how we work together in Multica**:`,
-    `   - Assigning an issue to you **and** setting its status to **Todo** triggers you to start (Backlog pauses you)`,
-    `   - @mentioning you inside a comment is for quick questions`,
-    `   - **Workspace Context** (in Settings → General) is shared background every agent here sees`,
-    `3. **Point them at the *Getting Started* project** in the sidebar.`,
-    ``,
-    `Keep it friendly and under 200 words. End with a small, curious question — something like "what's something you've been wondering about lately?" — so ${name} has an easy way to reply without having to come up with a real task yet.`,
-  ].join("\n");
-
-  switch (q.use_case) {
-    case "coding":
-      return {
-        title: "👋 Welcome to Multica — let's work together",
-        description: `${header}Hi agent, this is ${name}'s first time using Multica. They plan to use you mostly for **coding work**.\n\n${sharedInstructions}`,
-      };
-    case "planning":
-      return {
-        title: "👋 Welcome to Multica — let's work together",
-        description: `${header}Hi agent, this is ${name}'s first time using Multica. They want your help with **planning and breaking down work**.\n\n${sharedInstructions}`,
-      };
-    case "writing_research":
-      return {
-        title: "👋 Welcome to Multica — let's work together",
-        description: `${header}Hi agent, this is ${name}'s first time using Multica. They'll use you for **research and writing** — drafting, summarizing, analysis.\n\n${sharedInstructions}`,
-      };
-    case "explore":
-      return {
-        title: "👋 Welcome to Multica — let's work together",
-        description: `${header}Hi agent, this is ${name}'s first time using Multica. They're **exploring** what Multica can do — no specific goal yet.\n\n${exploreInstructions}`,
-      };
-    case "other": {
-      const customUseCase = (q.use_case_other ?? "").trim();
-      const contextLine = customUseCase
-        ? `They told us they want to use you for: "${customUseCase}".`
-        : `They haven't narrowed down their use case yet.`;
-      return {
-        title: "👋 Welcome to Multica — let's work together",
-        description: `${header}Hi agent, this is ${name}'s first time using Multica. ${contextLine}\n\n${sharedInstructions}`,
-      };
-    }
-    default:
-      return {
-        title: "👋 Welcome to Multica — let's work together",
-        description: `${header}Hi agent, this is ${name}'s first time using Multica.\n\n${sharedInstructions}`,
-      };
-  }
-}
-
-export function buildAgentGuidedSubIssues(
-  q: QuestionnaireAnswers,
-): ImportStarterIssuePayload[] {
-  // --- Tier 1: Core must-learn (Todo / urgent) ------------------------------
-  const tier1: ImportStarterIssuePayload[] = [
-    {
-      status: "todo",
-      priority: "high",
-      assign_to_self: true,
-      title: "Learn how to trigger your agent on any issue",
-      description: [
-        `**Every issue has a right-side panel** called **Properties**. From there you control who works on what. Agents in Multica are triggered when an issue has:`,
-        ``,
-        `  Assignee = your agent  AND  Status = Todo (not Backlog)`,
-        ``,
-        `**Try it now**:`,
-        `1. In the sidebar, click **New Issue** at the top (or press \`C\`)`,
-        `2. Give it a title like "Test run: summarize our product in 3 bullets"`,
-        `3. On the right panel, find **Assignee** (third row) → click → pick your agent`,
-        `4. Find **Status** (top row) → click → pick **Todo**`,
-        `5. Scroll down to Activity — a **Live card** appears as your agent starts working`,
-        ``,
-        `**⚠️ Gotcha**: new issues default to Backlog. Agents pause on backlog. A hint dialog will pop up the first time — it's telling you "flip to Todo to start".`,
-        ``,
-        `**You'll know it worked when**: the Live card shows your agent thinking, and the Status flips to **In Progress** automatically.`,
-        ``,
-        `[Learn about assigning issues →](https://multica.ai/docs/assigning-issues)`,
-      ].join("\n"),
-    },
-    {
-      status: "todo",
-      priority: "high",
-      assign_to_self: true,
-      title: "Chat with your agent — no issue required",
-      description: [
-        `Not every question needs a whole issue. For quick back-and-forth, use the **Chat panel**.`,
-        ``,
-        `**Where to find it**: look at the **bottom-right corner of the screen** — there's a round button with a **💬 speech bubble icon**. If your agent is working, the button pulses. If there are unread replies, a red badge sits on top of it.`,
-        ``,
-        `**Try it now**:`,
-        `1. Click the 💬 button → a panel slides in from the right`,
-        `2. At the **bottom-left of the input box**, click the agent avatar → pick your agent from the dropdown`,
-        `3. Type a quick question: "What can you help me with in this workspace?"`,
-        `4. Press **Enter**`,
-        ``,
-        `**Bonus — @mention an agent inside a comment**: on any issue, scroll to the comment box at the bottom. Type \`@\` and a dropdown appears listing members, agents, and other issues. Pick an agent → write your question → send. The mentioned agent replies in the comments.`,
-        ``,
-        `**You'll know it worked when**: the agent replies in the chat panel (or comment thread) within a few seconds.`,
-        ``,
-        `[Learn about chat →](https://multica.ai/docs/chat)`,
-      ].join("\n"),
-    },
-    {
-      status: "todo",
-      priority: "high",
-      assign_to_self: true,
-      title: "Write your Workspace Context",
-      description: [
-        `**Workspace Context** is a shared system prompt every agent in this workspace reads before starting any task. It's the single most impactful thing you can do to make agent replies sharper.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Open the **sidebar** → scroll to the bottom section labeled **Configure**`,
-        `2. Click **Settings** (⚙️ gear icon, bottom-most item)`,
-        `3. In the left-side tab list, under the **[Your Workspace Name]** group, click **General**`,
-        `4. Scroll down to the **Context** textarea (placeholder says "Provide context to agents...")`,
-        ``,
-        `**Fill it with 3-5 lines**:`,
-        `- Who you are (name, role)`,
-        `- What you're building or working on`,
-        `- How agents should behave (tone, style, defaults)`,
-        ``,
-        `**Example**:`,
-        `> I'm a frontend engineer working on an AI-native task manager. Reply concisely in English. Always explain your reasoning. Prefer TypeScript over JavaScript.`,
-        ``,
-        `Click **Save**.`,
-        ``,
-        `**You'll know it worked when**: the next task you assign to an agent picks up details from this context without you explaining again.`,
-        ``,
-        `[Learn about workspaces →](https://multica.ai/docs/workspaces)`,
-      ].join("\n"),
-    },
-  ];
-
-  // --- Tier 2: Setup (Todo / medium) ----------------------------------------
-  const tier2: ImportStarterIssuePayload[] = [];
-
-  if (q.team_size === "team") {
-    tier2.push({
-      status: "todo",
-      priority: "medium",
-      assign_to_self: true,
-      title: "Invite your teammates",
-      description: [
-        `Multica works best when a small team shares agents.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → **Settings** (⚙️, bottom)`,
-        `2. Left tab list → under **[Your Workspace]** group → click **Members** (people icon)`,
-        `3. At the top of the page, click **Add member**`,
-        `4. Enter their email, pick a role (**Owner / Admin / Member**)`,
-        `5. Click **Send invite**`,
-        ``,
-        `They'll receive an email with a join link. Pending invites show in the collapsible "Pending Invitations" section below the member list — you can revoke from there.`,
-        ``,
-        `[Learn about members and roles →](https://multica.ai/docs/members-roles)`,
-      ].join("\n"),
-    });
-  }
-
-  if (q.role === "developer" || q.use_case === "coding") {
-    tier2.push({
-      status: "todo",
-      priority: "medium",
-      assign_to_self: true,
-      title: "Connect a Git repo",
-      description: [
-        `Once connected, any agent can clone, read, and propose changes to your repo when you assign it a task.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → **Settings** (⚙️)`,
-        `2. Left tab list → under **[Your Workspace]** group → **Repositories** (folder with Git branch icon)`,
-        `3. At the bottom of the list, click **+ Add repository**`,
-        `4. Fill the two inline fields:`,
-        `   - **URL** — e.g. \`https://github.com/you/repo.git\``,
-        `   - **Description** — what this repo is for`,
-        `5. Click **Save** at the top of the page`,
-        ``,
-        `Repeat for as many repos as you want to expose.`,
-      ].join("\n"),
-    });
-  }
-
-  tier2.push({
-    status: "todo",
-    priority: "medium",
-    assign_to_self: true,
-    title: "Create a second agent with a different role",
-    description: [
-      `Running a small team of focused agents beats a single generalist. One for coding, one for planning, one for writing — each with their own instructions.`,
-      ``,
-      `**Note**: nothing locks a "Coding Agent" to coding. Instructions are just a system prompt, editable anytime. The split is about keeping each one's replies sharp.`,
-      ``,
-      `**Where to find it**:`,
-      `1. Sidebar → under **Workspace** group → click **Agents** (🤖 bot icon)`,
-      `2. In the left list header, click the **+** button (top-right corner of the list)`,
-      `3. Fill the 4 fields in order:`,
-      `   - **Name** — e.g. "Planning Agent"`,
-      `   - **Description** — "Breaks down loose ideas into scoped work"`,
-      `   - **Visibility** — Workspace (shared) or Private (only you)`,
-      `   - **Runtime** — pick from the dropdown (your connected runtime)`,
-      `4. Click **Create**`,
-      ``,
-      `**You'll know it worked when**: the new agent appears in the Assignee dropdown on any issue, and shows up in the left list on the Agents page.`,
-      ``,
-      `[Learn about creating agents →](https://multica.ai/docs/agents-create)`,
-    ].join("\n"),
-  });
-
-  // --- Tier 3: Advanced, discover later (Backlog) ---------------------------
-  const tier3: ImportStarterIssuePayload[] = [
-    {
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Polish your agent's Instructions",
-      description: [
-        `Creating an agent is just the start. The **Instructions tab** is where you shape how it behaves.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → **Agents** (🤖)`,
-        `2. In the left list, click an agent you want to refine`,
-        `3. In the right panel, you'll see 6 tabs at the top: **Instructions / Skills / Tasks / Environment / Custom Args / Settings**`,
-        `4. Click **Instructions**`,
-        `5. Edit the markdown — changes save automatically`,
-        ``,
-        `**Good instructions include**:`,
-        `- The role/persona (e.g. "You're a senior TypeScript engineer")`,
-        `- House rules (e.g. "Always propose tests alongside code")`,
-        `- Output format (e.g. "Return a short summary first, details below")`,
-        ``,
-        `Workspace Context and agent Instructions stack — both are sent on every task. Keep Instructions specific to this agent; keep Context specific to the whole workspace.`,
-      ].join("\n"),
-    },
-    {
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Watch your agent live in action",
-      description: [
-        `**Heads-up task** — nothing to do now, just know this exists.`,
-        ``,
-        `When an agent is working on an issue, a **Live card** appears at the top of the **Activity** section (it sticks to the top of the viewport as you scroll).`,
-        ``,
-        `The card shows in real time:`,
-        `- Which tool the agent is calling (e.g. reading a file, web search)`,
-        `- Streaming thoughts and partial output`,
-        `- Current status (thinking / tool-running / done / failed)`,
-        ``,
-        `After the run finishes, the **Task Run History** below the card lists every past run. Click **View transcript** on any row to open the full interactive transcript — a timeline of every message, thinking step, tool call, and result.`,
-        ``,
-        `**Try it next time you assign an agent**: keep the issue open and watch the Live card appear below the description.`,
-        ``,
-        `[Learn about tasks →](https://multica.ai/docs/tasks)`,
-      ].join("\n"),
-    },
-    {
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Check your Inbox for @mentions and updates",
-      description: [
-        `When someone — or an agent — @mentions you or assigns you an issue, it lands in your **Inbox**.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → the top section (above the **Workspace** group) → click **Inbox** (📥 icon) — an unread count badge shows on the right if you have new items`,
-        ``,
-        `**How it works**:`,
-        `- Left column: notification list, newest first`,
-        `- Right column: the linked issue opens inline, and the specific comment that mentioned you is **auto-highlighted and scrolled into view**`,
-        `- Top-right dropdown: **Mark all as read / Archive all / Archive all read / Archive completed** for bulk cleanup`,
-        ``,
-        `**Tip**: "Archive completed" is the fastest way to clear the noise from issues already finished.`,
-        ``,
-        `[Learn about the inbox →](https://multica.ai/docs/inbox)`,
-      ].join("\n"),
-    },
-    {
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Set up an Autopilot for recurring work",
-      description: [
-        `**Autopilot** turns a prompt into a scheduled task. Every day/week/hour, it auto-creates an issue and assigns it to an agent.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → under **Workspace** group → click **Autopilot** (⚡ Zap icon)`,
-        `2. If you have no autopilots yet, a grid of **6 templates** shows up: Daily news digest, PR review reminder, Bug triage, Weekly progress report, Dependency audit, Documentation check`,
-        `3. Click any template → creation dialog opens pre-filled (or click **+ New autopilot** top-right for a blank one)`,
-        `4. Fill: **Name** / **Prompt** (6-line textarea) / **Agent** / **Schedule** (frequency + time + timezone)`,
-        `5. Click **Create**`,
-        ``,
-        `**Good first autopilots**: daily digest of GitHub activity, weekly "what's blocked" check, or a Monday-morning triage of any issues still in Backlog.`,
-        ``,
-        `[Learn about autopilots →](https://multica.ai/docs/autopilots)`,
-      ].join("\n"),
-    },
-  ];
-
-  return numberTitles([...tier1, ...tier2, ...tier3]);
-}
-
-export function buildSelfServeSubIssues(
-  q: QuestionnaireAnswers,
-): ImportStarterIssuePayload[] {
-  // --- Tier 1: Unlock agent ability (Todo / high) ---------------------------
-  // Without a runtime + an agent, nothing else in Multica works. These two
-  // are the gates — everything below them waits on them.
-  const tier1: ImportStarterIssuePayload[] = [
-    {
-      status: "todo",
-      priority: "high",
-      assign_to_self: true,
-      title: "Install a runtime (Desktop app or CLI)",
-      description: [
-        `**Why this first**: no runtime = no agents can execute. Everything below Tier 1 waits on this.`,
-        ``,
-        `A **runtime** is a small background process that runs on your machine. It connects your workspace to AI coding tools (Claude Code, Codex, …) and executes the tasks your agents pick up.`,
-        ``,
-        `**Option A — Desktop app (macOS, recommended if you're on a Mac)**:`,
-        `1. Go to [github.com/multica-ai/multica/releases/latest](https://github.com/multica-ai/multica/releases/latest) and download the \`.dmg\` for macOS`,
-        `2. Install and open the app`,
-        `3. Sign in with the same account — the runtime is built in, you're done`,
-        ``,
-        `**Option B — CLI (macOS, Linux, or Windows via WSL)**:`,
-        `1. In a terminal, install the CLI:`,
-        `   \`\`\``,
-        `   curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash`,
-        `   \`\`\``,
-        `2. Then run setup (signs you in and starts a background daemon):`,
-        `   \`\`\``,
-        `   multica setup`,
-        `   \`\`\``,
-        `   The daemon keeps running after you close the terminal — you don't have to leave anything open.`,
-        ``,
-        `**Verify**: sidebar → bottom **Configure** section → **Runtimes** → you should see at least one connected runtime.`,
-        ``,
-        `[Learn about runtimes →](https://multica.ai/docs/daemon-runtimes)`,
-      ].join("\n"),
-    },
-    {
-      status: "todo",
-      priority: "high",
-      assign_to_self: true,
-      title: "Create your first agent",
-      description: [
-        `**Prerequisite**: task above done (runtime connected).`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → under **Workspace** group → click **Agents** (🤖 bot icon)`,
-        `2. In the left list header, click the **+** button (top-right corner of the list)`,
-        `3. Fill the 4 fields in order:`,
-        `   - **Name** — e.g. "My Coding Agent"`,
-        `   - **Description** — one line about what it does`,
-        `   - **Visibility** — Workspace (shared) or Private (only you)`,
-        `   - **Runtime** — pick the one you just installed`,
-        `4. Click **Create**`,
-        ``,
-        `**Note**: an agent is just an LLM + instructions + workspace access. Nothing locks a "Coding Agent" to coding — same agent can do research, writing, planning. Keep it flexible.`,
-        ``,
-        `**You'll know it worked when**: the new agent appears in the Assignee dropdown on any issue.`,
-        ``,
-        `[Learn about creating agents →](https://multica.ai/docs/agents-create)`,
-      ].join("\n"),
-    },
-  ];
-
-  // --- Tier 2: Core usage after unlock (Todo / medium) ----------------------
-  const tier2: ImportStarterIssuePayload[] = [
-    {
-      status: "todo",
-      priority: "medium",
-      assign_to_self: true,
-      title: "Assign your first real task to your agent",
-      description: [
-        `**Prerequisite**: you have a runtime + agent from the two tasks above.`,
-        ``,
-        `**How Multica triggers agents**:`,
-        `- Assign an issue to an agent`,
-        `- Set status to **Todo** (not Backlog — backlog pauses agents)`,
-        `- The agent picks it up automatically`,
-        ``,
-        `**Try it now**:`,
-        `1. In the sidebar, click **New Issue** at the top (or press \`C\`)`,
-        `2. Title: something you actually want done`,
-        `3. On the right panel, find **Assignee** → click → pick your agent`,
-        `4. Find **Status** → change from Backlog to **Todo**`,
-        `5. Watch the agent reply in the comments and a **Live card** appear in Activity`,
-        ``,
-        `**⚠️ Gotcha**: new issues default to **Backlog**. You must flip to **Todo** to trigger the agent.`,
-        ``,
-        `[Learn about assigning issues →](https://multica.ai/docs/assigning-issues)`,
-      ].join("\n"),
-    },
-    {
-      status: "todo",
-      priority: "medium",
-      assign_to_self: true,
-      title: "Write your Workspace Context",
-      description: [
-        `**Workspace Context** is a shared system prompt every agent in this workspace reads before starting any task. It's the single most impactful thing you can do to make agent replies sharper.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Open the **sidebar** → scroll to the bottom section labeled **Configure**`,
-        `2. Click **Settings** (⚙️ gear icon, bottom-most item)`,
-        `3. In the left-side tab list, under the **[Your Workspace Name]** group, click **General**`,
-        `4. Scroll down to the **Context** textarea`,
-        ``,
-        `**Fill it with 3-5 lines**:`,
-        `- Who you are (name, role)`,
-        `- What you're building or working on`,
-        `- How agents should behave (tone, style, defaults)`,
-        ``,
-        `Click **Save**.`,
-        ``,
-        `**You'll know it worked when**: the next task you assign to an agent picks up details from this context without you explaining again.`,
-        ``,
-        `[Learn about workspaces →](https://multica.ai/docs/workspaces)`,
-      ].join("\n"),
-    },
-  ];
-
-  // --- Tier 3: Advanced, discover later (Backlog) ---------------------------
-  const tier3: ImportStarterIssuePayload[] = [
-    {
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Chat with an agent — once you've created one",
-      description: [
-        `**Prerequisite**: you've created at least one agent (Tier 1 #2).`,
-        ``,
-        `Not every question needs a whole issue. For quick back-and-forth, use the **Chat panel**.`,
-        ``,
-        `**Where to find it**: the **bottom-right corner of the screen** has a round button with a **💬 speech bubble icon**.`,
-        ``,
-        `**Try it**:`,
-        `1. Click the 💬 button → a panel slides in from the right`,
-        `2. At the bottom-left of the input box, pick an agent from the dropdown`,
-        `3. Type a question → press **Enter**`,
-        ``,
-        `**Bonus**: inside any issue's comment box, type \`@\` to mention an agent or member.`,
-        ``,
-        `[Learn about chat →](https://multica.ai/docs/chat)`,
-      ].join("\n"),
-    },
-  ];
-
-  if (q.role === "developer" || q.use_case === "coding") {
-    tier3.push({
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Connect a Git repo",
-      description: [
-        `Once connected, any agent can clone, read, and propose changes to your repo when you assign it a task.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → **Settings** (⚙️)`,
-        `2. Left tab list → **Repositories** (folder with Git branch icon)`,
-        `3. At the bottom of the list, click **+ Add repository**`,
-        `4. Fill **URL** (e.g. \`https://github.com/you/repo.git\`) and **Description**`,
-        `5. Click **Save** at the top of the page`,
-      ].join("\n"),
-    });
-  }
-
-  if (q.team_size === "team") {
-    tier3.push({
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Invite your teammates",
-      description: [
-        `Multica works best when a small team shares agents.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → **Settings** (⚙️, bottom)`,
-        `2. Left tab list → **Members** (people icon)`,
-        `3. Click **Add member** → enter email → pick role → **Send invite**`,
-        ``,
-        `[Learn about members and roles →](https://multica.ai/docs/members-roles)`,
-      ].join("\n"),
-    });
-  }
-
-  tier3.push(
-    {
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Shape your agent's Instructions (once it's created)",
-      description: [
-        `**Prerequisite**: you have at least one agent.`,
-        ``,
-        `Creating an agent is just the start. The **Instructions tab** is where you shape how it behaves.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → **Agents** (🤖)`,
-        `2. Click an agent in the left list`,
-        `3. Right panel → click the **Instructions** tab (out of 6: Instructions / Skills / Tasks / Environment / Custom Args / Settings)`,
-        `4. Edit the markdown — changes save automatically`,
-        ``,
-        `Workspace Context and agent Instructions stack — both are sent on every task. Keep Instructions specific to this agent; keep Context specific to the whole workspace.`,
-      ].join("\n"),
-    },
-    {
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Watch an agent work live (once you've assigned one a task)",
-      description: [
-        `**Heads-up task** — nothing to do now, just know this exists.`,
-        ``,
-        `When an agent is working on an issue, a **Live card** appears at the top of the **Activity** section (it sticks to the top of the viewport as you scroll).`,
-        ``,
-        `It shows in real time which tool the agent is calling, streaming thoughts, and current status. After the run finishes, the **Task Run History** below the card lists every past run — click **View transcript** to open the full timeline.`,
-        ``,
-        `[Learn about tasks →](https://multica.ai/docs/tasks)`,
-      ].join("\n"),
-    },
-    {
-      status: "backlog",
-      priority: "low",
-      assign_to_self: true,
-      title: "Set up an Autopilot (once you have an agent)",
-      description: [
-        `**Prerequisite**: you have at least one agent.`,
-        ``,
-        `**Autopilot** turns a prompt into a scheduled task. Every day/week/hour, it auto-creates an issue and assigns it to an agent.`,
-        ``,
-        `**Where to find it**:`,
-        `1. Sidebar → under **Workspace** group → click **Autopilot** (⚡ Zap icon)`,
-        `2. Pick one of 6 templates, or click **+ New autopilot** top-right`,
-        `3. Fill: **Name** / **Prompt** / **Agent** / **Schedule** (frequency + time + timezone) → **Create**`,
-        ``,
-        `[Learn about autopilots →](https://multica.ai/docs/autopilots)`,
-      ].join("\n"),
-    },
-  );
-
-  return numberTitles([...tier1, ...tier2, ...tier3]);
+function pickContent(locale: StarterContentLocale) {
+  return locale === "zh-Hans" ? zh : en;
 }
 
 /**
@@ -620,18 +52,20 @@ export function buildImportPayload({
   workspaceId,
   userName,
   questionnaire,
+  locale,
 }: {
   workspaceId: string;
   userName: string;
   questionnaire: QuestionnaireAnswers;
+  locale: StarterContentLocale;
 }): ImportStarterContentPayload {
-  const welcome = buildWelcomeIssueText(questionnaire, userName);
+  const content = pickContent(locale);
+  const welcome = content.buildWelcomeIssueText(questionnaire, userName);
   return {
     workspace_id: workspaceId,
     project: {
-      title: "Getting Started",
-      description:
-        "A few things to try in Multica. Work through them at your own pace.",
+      title: content.PROJECT.title,
+      description: content.PROJECT.description,
       icon: "👋",
     },
     welcome_issue_template: {
@@ -639,7 +73,11 @@ export function buildImportPayload({
       description: welcome.description,
       priority: "high",
     },
-    agent_guided_sub_issues: buildAgentGuidedSubIssues(questionnaire),
-    self_serve_sub_issues: buildSelfServeSubIssues(questionnaire),
+    agent_guided_sub_issues: numberTitles(
+      content.buildAgentGuidedSubIssues(questionnaire),
+    ),
+    self_serve_sub_issues: numberTitles(
+      content.buildSelfServeSubIssues(questionnaire),
+    ),
   };
 }


### PR DESCRIPTION
## Summary

The Getting Started project + welcome issue + 10 sub-issues that land in a new user's workspace at the end of onboarding were **hardcoded English**. Chinese users finished a Chinese onboarding flow and arrived to an all-English workspace; the welcome issue's prompt to the agent was also English, so the agent's first reply tended to be English regardless of which template (\"编码智能体\" etc.) the user picked.

This is **batch 2 / 5** from the docs+onboarding audit.

## Architecture

Long-form markdown (~600 lines per language) lives in TS sibling files:

\`\`\`
packages/views/onboarding/utils/
├── starter-content-templates.ts        ← orchestrator + types
├── starter-content-content-en.ts       ← EN content (refactored from prior file)
└── starter-content-content-zh.ts       ← ZH content (new)
\`\`\`

\`buildImportPayload({ ..., locale })\` picks the right content file. \`StarterContentPrompt\` resolves locale via \`i18n.language\` (\`startsWith(\"zh\")\` → \`zh-Hans\`, else \`en\`).

JSON locales were considered but rejected: multi-paragraph markdown becomes unreadable single-line escape soup in JSON. Keeping content in TS lets reviewers see the rendered markdown shape and catch regressions in code review.

## Content fixes (apply to both EN and ZH)

- **Runtime definition**: \`A runtime is a small background process\` was wrong (runtime = daemon × one AI coding tool, per \`daemon-runtimes.mdx\`). Replaced with the correct definition so the welcome agent doesn't seed an incorrect mental model on first contact.
- **UI specifics that would silently rot**: removed hardcoded \`tabs at the top: 6 tabs (Instructions / Skills / Tasks / Environment / Custom Args / Settings)\`, \`(third row)\`, \`grid of 6 templates: Daily news digest, ...\`. Replaced with descriptions that don't depend on exact counts or positions.

## Conventions adherence (ZH)

Per \`conventions.zh.mdx\`:

- \`agent\` → \`智能体\`, \`daemon\` → \`守护进程\`, \`runtime\` → \`运行时\`, \`workspace\` → \`工作区\`
- \`task\` / \`issue\` / \`skill\` stay lowercase English
- Product UI labels (\`Properties\` / \`Assignee\` / \`Status\` / \`Activity\` / \`Live card\` / \`Inbox\` / \`Members\` / \`Settings\` / \`Runtimes\` / \`Configure\` / \`Repositories\` / \`Instructions\` / \`Tasks\` / \`Skills\` / \`Autopilot\`) stay English so the doc text matches what the user sees on screen
- ZH doc links updated to \`/docs/zh/...\` paths

## Test plan

- [x] \`pnpm typecheck\` — 6/6 successful
- [x] \`pnpm test --filter @multica/views\` — 314/314 passed
- [ ] Manual: complete EN onboarding → verify welcome issue + sub-issues are English (regression check)
- [ ] Manual: complete ZH onboarding → verify welcome issue, agent prompt, sub-issues all in Chinese; agent's first reply is in Chinese
- [ ] Manual: verify the welcome-issue branch (workspace has agents at import time) and the self-serve branch (no agents) both render correctly
- [ ] Manual: verify questionnaire conditions (\`team_size === \"team\"\`, \`role === \"developer\"\`) still produce the right conditional sub-issues

## Notes

- This stacks logically on PR #2139 (terminology fixes) but does not depend on it. Either can merge first.
- Follow-up PR (\"PR 3\") will make the conventions decision on \`task\` translation policy and align \`tasks.zh.mdx\` accordingly.
- Future locale additions just add another \`starter-content-content-{locale}.ts\` and one switch case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)