### PR TITLE
docs(conventions): formalize mixed-rule for task / issue / skill in CN

### DIFF
--- a/apps/docs/content/docs/developers/conventions.mdx
+++ b/apps/docs/content/docs/developers/conventions.mdx
@@ -95,17 +95,26 @@ Multica's product nouns split into two categories:
 
 This rule is aligned with `apps/docs/content/docs/*.zh.mdx` — the docs are the de facto Chinese voice standard and have been battle-tested across 20+ pages.
 
-### Don't translate — entities (lowercase English)
+### Entities — mixed rule (`issue` / `skill` / `task`)
 
-| Term | Render in Chinese | Example |
+`issue` / `skill` / `task` are Multica's core entities. They have schema columns, API fields, and product UI labels that are all English. In Chinese text, they follow a **mixed rule** — what to use depends on where the word appears:
+
+| Context | Render | Example |
 | --- | --- | --- |
-| Issue | `issue` (lowercase) | "把 issue 分配给智能体"、"创建子 issue" |
-| Skill | `skill` (lowercase) | "为智能体注入 skill" |
-| Task | `task` (lowercase) | "排队中的 task" |
+| **UI strings, state names, code references** | lowercase English | "排队中的 task"、"创建子 issue"、"为智能体注入 skill" |
+| **Doc titles / section headings** | Title-case English **or** the Chinese term | "Issue 与 project"、"Skills"、"执行任务" |
+| **Long-form doc prose, when the entity is the running subject** | Chinese term, with English in parentheses on first mention | "**执行任务**（task）是智能体每一次工作的单位" |
+| **API / DB fields** | always `task` / `issue` / `skill` | `task_id`, `issue_status`, `skill_uuid` |
 
-**Why `issue` / `skill` / `task` stay English while `project` / `autopilot` are translated**:
+Chinese term reference:
 
-- **`issue` / `task`**: dev teams talk in English. The Chinese candidates ("任务" — too vague, almost synonymous with "工作"; "工单" — IT ticket connotation; "议题" — GitHub-style but doesn't match the product feel) all read worse than `issue`.
+- `task` ↔ `执行任务` (or shortened to `任务` once context is clear)
+- `issue` has no settled Chinese translation — leave English; titles may capitalize as `Issue`
+- `skill` has no settled Chinese translation — leave English; titles may capitalize as `Skills`
+
+**Why `issue` / `skill` / `task` aren't forced into Chinese the way `project` / `autopilot` are**:
+
+- **`issue` / `task`**: dev teams talk in English. The Chinese candidates ("任务" — too vague, almost synonymous with "工作"; "工单" — IT ticket connotation; "议题" — GitHub-style but doesn't match the product feel) all read worse than `issue`. **But** in long-form doc prose, repeating lowercase `task` 50× breaks the rhythm — so prose is allowed to use `执行任务`, while UI strings and state names stay lowercase English.
 - **`skill`**: Multica-specific concept with no established Chinese term.
 - **`project` → "项目"**: settled mainstream Chinese word. Feishu / Tower / Teambition / PingCode / GitHub Projects — every Chinese product translates it. No product keeps `project` in Chinese context.
 - **`autopilot` → "自动化"**: in Chinese, "autopilot" associates with Tesla's "自动驾驶" and doesn't match what the feature does (run tasks on a schedule). Notion and Feishu both use "自动化"; that's the industry consensus.

--- a/apps/docs/content/docs/developers/conventions.zh.mdx
+++ b/apps/docs/content/docs/developers/conventions.zh.mdx
@@ -95,20 +95,29 @@ Multica 的产品名词分两类：
 
 这套规则与 `apps/docs/content/docs/*.zh.mdx` 完全对齐 —— docs 是已经实战 20+ 篇的 CN voice 标准。
 
-### 不翻 —— 实体（小写英文）
+### 实体词的混合规则（`issue` / `skill` / `task`）
 
-| 词 | 中文中的写法 | 例 |
+`issue` / `skill` / `task` 是 Multica 的核心实体。schema 字段、API 字段、产品 UI 标签都用英文。中文里采用**混合规则** —— 词出现在哪里决定怎么写：
+
+| 场景 | 写法 | 例 |
 | --- | --- | --- |
-| Issue | `issue`（小写） | "把 issue 分配给智能体"、"创建子 issue" |
-| Skill | `skill`（小写） | "为智能体注入 skill" |
-| Task | `task`（小写） | "排队中的 task" |
+| **UI 短句 / 状态名 / 代码上下文** | 小写英文 | "排队中的 task"、"创建子 issue"、"为智能体注入 skill" |
+| **doc 标题 / 章节标题** | 首字母大写英文，**或**对应中文术语 | "Issue 与 project"、"Skills"、"执行任务" |
+| **doc 正文长篇讨论中作为主语** | 中文术语，首次出现配括号英文 | "**执行任务**（task）是智能体每一次工作的单位" |
+| **API / DB 字段** | 永远 `task` / `issue` / `skill` | `task_id`、`issue_status`、`skill_uuid` |
 
-**为什么 `issue` / `skill` / `task` 不翻而 `project` / `autopilot` 翻**：
+中文术语对照：
 
-- **`issue` / `task`**：dev 团队习惯说英文，"任务"在中文里和"工作"几乎同义太空泛，"工单"是 IT 工单语义，"议题"是 GitHub 风格但用户场景不匹配。三个候选都不如 `issue` 准确。
+- `task` ↔ `执行任务`（上下文清楚后可简写为「任务」）
+- `issue` 没有公认中文译法 —— 保留英文；标题可大写为 `Issue`
+- `skill` 没有公认中文译法 —— 保留英文；标题可大写为 `Skills`
+
+**为什么 `issue` / `skill` / `task` 不强制译，而 `project` / `autopilot` 必译**：
+
+- **`issue` / `task`**：dev 团队习惯说英文，"任务"在中文里和"工作"几乎同义太空泛，"工单"是 IT 工单语义，"议题"是 GitHub 风格但用户场景不匹配 —— 三个候选都不如 `issue` 准确。**但**在长篇 doc 正文里，重复 50 次 `task` 节奏不顺，所以正文允许用 `执行任务`，UI 短句、状态名仍保持小写英文。
 - **`skill`**：Multica 特有概念，没有公认中文译法。
-- **`project` 翻成"项目"**：这是中文里早就稳定的日常词。飞书 / Tower / Teambition / PingCode / GitHub Projects 中文版 0 例外都翻译成"项目"，没有产品保留 `project`。
-- **`autopilot` 翻成"自动化"**：autopilot 在中文里联想到特斯拉的"自动驾驶"，跟产品功能（按周期跑 task）对应不上。Notion / 飞书都用"自动化"，是行业共识。
+- **`project` 翻成「项目」**：中文里早就稳定的日常词。飞书 / Tower / Teambition / PingCode / GitHub Projects 中文版 0 例外都翻译成「项目」，没有产品保留 `project`。
+- **`autopilot` 翻成「自动化」**：autopilot 在中文里联想到特斯拉的「自动驾驶」，跟产品功能（按周期跑 task）对应不上。Notion / 飞书都用「自动化」，是行业共识。
 
 ### 完整翻译 —— 概念词
 


### PR DESCRIPTION
## Summary

The prior conventions rule said \`issue\` / \`skill\` / \`task\` always render as lowercase English in Chinese text. That worked for UI strings but never matched what the sister docs actually do:

- \`tasks.zh.mdx\` is built around \`执行任务\` (translated, used 7× as primary subject + 16× short form 任务)
- \`issues.zh.mdx\` titles "Issue 与 project" (capitalized in title)
- \`skills.zh.mdx\` titles "Skills" (capitalized in title)

Three docs, three patterns — all sensible in context, none matching the old rule. The conventions doc also explicitly cited the sister docs as the voice standard, so the rule was internally inconsistent with itself.

This is **batch 3 / 5** from the docs+onboarding audit.

## What changed

Conventions now describe the de facto pattern as four context-keyed rows:

| Context | Render | Example |
| --- | --- | --- |
| UI strings, state names, code references | lowercase English | \`排队中的 task\`, \`创建子 issue\`, \`为智能体注入 skill\` |
| Doc titles / section headings | Title-case English **or** Chinese term | \`Issue 与 project\`, \`Skills\`, \`执行任务\` |
| Doc prose (entity as running subject) | Chinese term, English in parens on first mention | \`**执行任务**（task）是智能体每一次工作的单位\` |
| API / DB fields | always \`task\` / \`issue\` / \`skill\` | \`task_id\`, \`issue_status\`, \`skill_uuid\` |

Plus the explicit mapping \`task ↔ 执行任务\` so future translation PRs don't have to rediscover it.

## What did NOT change

- No code changes.
- No locale string changes.
- No \`tasks.zh.mdx\` rewrite — it already follows this pattern; this PR just legalizes it.
- The lowercase-in-UI rule is unchanged. The locale audit and PR #2139 already verified ZH locales follow it (with the one slip at \`onboarding.json:10\` fixed there).

## Test plan

- [x] \`pnpm typecheck\` — passes (mdx, no code change)
- [ ] Render docs site preview — verify the new conventions table renders cleanly in fumadocs

## Notes

- Stacks logically on PR #2139 + PR #2140 but does not depend on either; can merge in any order.
- After this lands, future translation PRs should cite this section when justifying \`执行任务\` vs \`task\` choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)