### PR TITLE
docs: add Projects page + Autopilot failure visibility note

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -9,6 +9,7 @@
     "workspaces",
     "members-roles",
     "issues",
+    "projects",
     "comments",
     "project-resources",
     "---Agents---",

--- a/apps/docs/content/docs/meta.zh.json
+++ b/apps/docs/content/docs/meta.zh.json
@@ -9,6 +9,7 @@
     "workspaces",
     "members-roles",
     "issues",
+    "projects",
     "comments",
     "---智能体---",
     "agents",

--- a/apps/docs/content/docs/projects.mdx
+++ b/apps/docs/content/docs/projects.mdx
@@ -1,0 +1,49 @@
+---
+title: Projects
+description: Group related issues and track them as one unit — with priority, status, progress, and an owner.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+A **project** in Multica is a container for related [issues](/issues). Use it when a body of work is bigger than one issue but smaller than a full workspace — a launch, a migration, a feature with multiple parts, an investigation that branches into several threads.
+
+Each project has a name, an icon, a description, a **lead** (a member or an [agent](/agents)), a **status** (`planned` / `in_progress` / `paused` / `completed` / `cancelled`), a **priority** (`urgent` / `high` / `medium` / `low` / `none`), and a **progress** percentage that's auto-derived from the status of its linked issues.
+
+## How projects relate to issues
+
+Projects and issues are independent objects with a many-to-one relationship: an issue can belong to **at most one** project; a project holds **any number of** issues. Linking and unlinking is reversible at any time — drag in the board view, or use the project picker on the issue's right-side properties panel.
+
+The progress bar on a project is computed from its linked issues — the more issues hit `done`, the further it fills. Issues that are `cancelled` are excluded from the count; issues in `backlog` count toward the denominator but not the numerator.
+
+## Pinning to the sidebar
+
+Click the pin icon in a project's top-right corner to add it to your sidebar's pinned list. Pinned projects stay one click away no matter where you are in the workspace; everyone on the team can pin independently — pins are personal.
+
+The sidebar **Workspace → Projects** link always shows every project in the workspace; pinning is a personal shortcut on top of that.
+
+## Attaching resources
+
+Each project has a **Resources** section where you attach GitHub repositories. Once attached, any [agent](/agents) assigned to issues in this project can read and write to those repos when executing tasks — Multica passes the repo URLs as context to the [daemon](/daemon-runtimes).
+
+Resources are per-project; if multiple projects share a repo, attach it to each one.
+
+## Deleting a project
+
+Deleting a project **does not delete its issues**. The linked issues are simply unlinked and revert to the workspace's flat issue list. This is intentional — work that was scoped to a project is rarely throwaway, even when the framing of the project changes.
+
+<Callout type="info">
+If you want to delete the work too, archive or delete the issues first, then delete the project.
+</Callout>
+
+## Project lead
+
+The lead is the person — or agent — accountable for the project. It's a soft signal, not an access control: any workspace member can edit a project regardless of who's lead. A project's lead can be:
+
+- A workspace member (human teammate)
+- An [agent](/agents) — useful when the project's work is mostly delegated to an agent (e.g., "Weekly bug triage" led by a triage agent)
+
+## Next
+
+- [Issues](/issues) — the unit of work that lives inside projects
+- [Agents as project lead](/agents) — when an agent is the right owner
+- [How Multica works](/how-multica-works) — the broader picture

--- a/apps/docs/content/docs/projects.zh.mdx
+++ b/apps/docs/content/docs/projects.zh.mdx
@@ -1,0 +1,49 @@
+---
+title: 项目
+description: 把相关的 issue 归为一组当成一个单元来跟进 —— 有优先级、状态、进度和负责人。
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Multica 里的**项目**（project）是相关 [issue](/issues) 的容器。当一摊工作比单个 issue 大、又比整个工作区小的时候用它 —— 一次发布、一次迁移、一个分多块做的功能、一个会拆出多个线索的调研。
+
+每个项目有名字、图标、描述、**负责人**（lead，可以是成员，也可以是 [智能体](/agents)）、**状态**（`planned` / `in_progress` / `paused` / `completed` / `cancelled`）、**优先级**（`urgent` / `high` / `medium` / `low` / `none`），以及一个根据关联 issue 状态自动算出来的**进度**百分比。
+
+## 项目和 issue 的关系
+
+项目和 issue 是独立对象，多对一关系：一个 issue **最多属于一个**项目；一个项目可以容纳**任意多个** issue。关联和解除关联随时可逆 —— 在看板视图里拖动，或者在 issue 右侧 properties 面板用项目选择器。
+
+项目的进度条是按关联 issue 状态自动算出来的 —— 越多 issue 到 `done`，进度条越满。`cancelled` 的 issue 不计入分母；`backlog` 的 issue 计入分母但不计入分子。
+
+## pin 到侧边栏
+
+点项目右上角的 pin 图标，可以把这个项目加到侧边栏的固定区。pin 过的项目无论你在工作区哪里都一键可达；每个人独立 pin —— pin 是个人偏好。
+
+侧边栏 **Workspace → Projects** 链接始终展示工作区里所有项目；pin 只是在这之上的个人快捷方式。
+
+## 关联 resources
+
+每个项目有一个 **Resources** 区，可以挂 GitHub 仓库。挂上之后，被分配到这个项目里 issue 的 [智能体](/agents) 在执行 task 时可以读写这些仓库 —— Multica 会把仓库 URL 作为上下文传给 [守护进程](/daemon-runtimes)。
+
+Resources 是项目级别的；多个项目要共享同一个仓库，要分别挂上。
+
+## 删除项目
+
+删除项目**不会**删除它的 issue。关联的 issue 只是解除关联，回到工作区的扁平 issue 列表。这是刻意的 —— 即使项目本身的框架变了，里面的工作通常也不会是一次性的。
+
+<Callout type="info">
+如果你确实想把工作也删掉，先归档或删除 issue，再删除项目。
+</Callout>
+
+## 项目负责人
+
+负责人是为这个项目负总责的人 —— 或者智能体。这是一个软信号，不是权限控制：工作区任何成员都可以编辑项目，不管谁是负责人。项目负责人可以是：
+
+- 工作区里的成员（人）
+- [智能体](/agents) —— 当项目里的工作大部分要交给智能体时合适（例如"每周 bug 巡检"由一个巡检智能体担任 lead）
+
+## 下一步
+
+- [Issues](/issues) —— 项目里装的工作单元
+- [智能体担任项目负责人](/agents) —— 什么时候由智能体当 lead 合适
+- [Multica 怎么运转](/how-multica-works) —— 整体视图

--- a/apps/docs/content/docs/tasks.mdx
+++ b/apps/docs/content/docs/tasks.mdx
@@ -63,6 +63,8 @@ Automatic retry also has two extra conditions:
 
 <Callout type="warning">
 **Autopilot tasks don't retry automatically** by design. An Autopilot has its own firing cadence (e.g. daily); automatic retries on failure would overlap with the next scheduled run. If you need an immediate re-run after failure, use a manual rerun (next section).
+
+**How you'll know an Autopilot task failed**: a notification lands in your [Inbox](/inbox), and the associated issue's status reverts from `in_progress` back to `todo`. The [Autopilots](/autopilots) page also shows the latest run result per autopilot.
 </Callout>
 
 ## Manual rerun vs. automatic retry

--- a/apps/docs/content/docs/tasks.zh.mdx
+++ b/apps/docs/content/docs/tasks.zh.mdx
@@ -63,6 +63,8 @@ Multica 服务器每 30 秒扫描一次，有两种超时会触发失败：
 
 <Callout type="warning">
 **Autopilots 任务不自动重试**是刻意设计。Autopilot 有自己的触发周期（例如每天一次）；如果失败又自动重试，会和下一个周期的任务重叠。需要失败后立即重跑，用手动重跑（下一节）。
+
+**怎么知道 Autopilot 失败了**：失败的 Autopilot 任务会在你的 [收件箱](/inbox) 里出现一条通知，关联的 issue 状态也会从 `in_progress` 退回 `todo`。直接打开 [Autopilots](/autopilots) 页面也能看到每条 autopilot 的最近运行结果。
 </Callout>
 
 ## 手动重跑和自动重试的区别


### PR DESCRIPTION
## Summary

The audit flagged that **\`projects\` was the most prominently missing docs page** — it appears as a sidebar nav item in onboarding's workspace preview (\`onboarding.json:219\`), but users clicking through to docs found nothing about projects. This PR ships the page in both EN and ZH and registers it in the docs nav.

Also fixes a small gap in \`tasks.{mdx,zh.mdx}\`: the Autopilot no-auto-retry Callout explained the *why* but never the *how do I notice an Autopilot task failed*. Added a sentence pointing users at Inbox + the issue status revert + the Autopilots page's run history.

This is **batch 4 / 5** from the docs+onboarding audit.

## What's in the new \`projects\` page

- What a project is — a container for related [issues](/issues)
- Fields: name, icon, description, lead, status (\`planned\`/\`in_progress\`/\`paused\`/\`completed\`/\`cancelled\`), priority (\`urgent\`/\`high\`/\`medium\`/\`low\`/\`none\`), and an auto-derived progress %
- Project ↔ issue many-to-one relationship; how progress is computed (\`done\` fills numerator, \`cancelled\` skipped, \`backlog\` counts toward denominator)
- Pinning to sidebar (personal, not workspace-wide)
- Resources section — GitHub repos attached and surfaced to the daemon
- Delete behavior — issues unlinked, **not** deleted
- Lead can be a member **or** an agent (useful for autopilot-style projects)

Translations follow PR #2141's mixed-rule (\`task\` / \`issue\` / \`skill\` lowercase in UI/state contexts, Chinese term in long-form prose subjects).

## Out of scope

The audit listed three other locale-but-no-doc pages: \`my-issues\`, \`labels\`, \`settings\`. These were classified as \"low priority — features exist, just undocumented\". Deferring to a future PR — \`projects\` is the only one that's actively cited in onboarding without docs to back it.

## Test plan

- [x] \`pnpm --filter @multica/docs build\` — builds successfully (62+ static pages including new projects + projects.zh)
- [ ] Visual smoke on docs site — verify projects page renders, navigation places it under \"Workspace & team\" between issues and comments
- [ ] Verify ZH page links resolve — \`/agents\`, \`/issues\`, \`/daemon-runtimes\`, \`/how-multica-works\`

## Notes

- Stacks logically on PR #2141 (uses the new mixed-rule conventions) but does not depend on it; can merge in any order.
- Final batch (PR 5) is process-only: PR template checkboxes + landing dict migration to locales/, to prevent the same drift from creeping back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)