### PR TITLE
chore(pr-template): add drift-prevention checkboxes for runtime/CN copy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,8 @@ Closes #
 - [ ] I have added or updated tests where applicable
 - [ ] If this change affects the UI, I have included before/after screenshots
 - [ ] I have updated relevant documentation to reflect my changes
+- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
+- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
 - [ ] I have considered and documented any risks above
 - [ ] I will address all reviewer comments before requesting merge
 


### PR DESCRIPTION
## Summary

Two checklist items added to \`.github/PULL_REQUEST_TEMPLATE.md\` so PR authors see the specific paths to update **before** drift ships:

1. **Multi-surface sync for new runtimes / coding tools / UI tabs** — \`landing/i18n\`, \`starter-content-content-*.ts\`, and \`apps/docs/content/docs/\`. The audit found that the 11-tool product was advertising as 4-tool on the landing page and as 4-tool in starter-content tutorial, because runtime additions only got logged in changelog.

2. **Chinese copy review against \`conventions.zh.mdx\`** — including the new mixed-rule for \`task\` / \`issue\` / \`skill\` from PR #2141. The audit found \"Agent\" survived in \`landing/zh.ts\` long after the product UI standardized on \"智能体\" because nobody routed landing through the conventions review.

This is **batch 5 / 5** — the final PR from the docs+onboarding audit. Process layer: makes the same drift harder to ship next time.

## What changed

- \`.github/PULL_REQUEST_TEMPLATE.md\` — added two checkboxes to the **Checklist** section.

That's it.

## What did NOT change in this PR

- Migration of \`apps/web/features/landing/i18n/{en,zh}.ts\` to \`packages/views/locales/\` — was on the audit roadmap but is a substantial refactor (~2000 lines of dict structure to JSON migration plus consumer refactors). Left as a future PR; the new PR-template checkbox already mitigates the immediate drift risk.

## Test plan

- [x] PR-template renders correctly when creating a new PR (verifiable by glancing at this PR's body or any subsequent PR)

## The full 5-PR series

1. **#2139** — \`fix(landing+i18n)\`: terminology drift across landing, locales, docs
2. **#2140** — \`feat(onboarding)\`: localize starter-content (Getting Started project)
3. **#2141** — \`docs(conventions)\`: formalize mixed-rule for \`task\` / \`issue\` / \`skill\` in CN
4. **#2144** — \`docs\`: add Projects page + Autopilot failure visibility note
5. **#2145** — this PR — drift-prevention PR-template checkboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)