### PR TITLE
fix(timeline): tolerate malformed cache data instead of white-screening (#2143, #2147)

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -27,6 +27,7 @@ import {
   mapAllEntries,
   filterAllEntries,
   prependToLatestPage,
+  collectDeletedCommentIds,
   type TimelineCacheData,
 } from "./timeline-cache";
 
@@ -392,26 +393,7 @@ export function useDeleteComment(issueId: string) {
       });
 
       // Cascade: collect all child comment IDs across every loaded page.
-      const toRemove = new Set<string>([commentId]);
-      for (const [, data] of prevSnapshots) {
-        if (!data) continue;
-        let changed = true;
-        while (changed) {
-          changed = false;
-          for (const page of data.pages) {
-            for (const e of page.entries) {
-              if (
-                e.parent_id &&
-                toRemove.has(e.parent_id) &&
-                !toRemove.has(e.id)
-              ) {
-                toRemove.add(e.id);
-                changed = true;
-              }
-            }
-          }
-        }
-      }
+      const toRemove = collectDeletedCommentIds(prevSnapshots, commentId);
 
       qc.setQueriesData<TimelineCacheData>(
         { queryKey: ["issues", "timeline", issueId] },

--- a/packages/core/issues/timeline-cache.test.ts
+++ b/packages/core/issues/timeline-cache.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapAllEntries,
+  filterAllEntries,
+  prependToLatestPage,
+  type TimelineCacheData,
+} from "./timeline-cache";
+import type { TimelineEntry } from "../types";
+
+// Exercises the defensive guards added for upstream#2143 / #2147:
+// `timeline.filter is not a function`. The Inbox page / issue detail reads
+// the flattened timeline via a hook that iterates `data.pages[].entries`.
+// A malformed cache entry (wrong shape from a persisted older build, a
+// stale setQueryData caller in future code) used to white-screen the whole
+// route. These helpers now tolerate non-array shapes and return the data
+// unchanged, so the consumer falls back to "empty timeline" instead of
+// crashing the React tree.
+
+function entry(id: string, createdAt: string): TimelineEntry {
+  return {
+    type: "comment",
+    id,
+    actor_type: "member",
+    actor_id: "u",
+    created_at: createdAt,
+  };
+}
+
+function wellFormed(entries: TimelineEntry[]): TimelineCacheData {
+  return {
+    pages: [
+      {
+        entries,
+        next_cursor: null,
+        prev_cursor: null,
+        has_more_before: false,
+        has_more_after: false,
+      },
+    ],
+    pageParams: [{ mode: "latest" }],
+  };
+}
+
+describe("timeline-cache helpers — malformed-shape tolerance", () => {
+  it("mapAllEntries returns data unchanged when pages is not an array", () => {
+    const bad = { pages: null as unknown, pageParams: [] } as unknown as TimelineCacheData;
+    const out = mapAllEntries(bad, (e) => ({ ...e, content: "modified" }));
+    expect(out).toBe(bad);
+  });
+
+  it("mapAllEntries returns data unchanged when pages is an object (e.g. { entries: [...] } accidentally stored)", () => {
+    const bad = { pages: { entries: [] } as unknown, pageParams: [] } as unknown as TimelineCacheData;
+    const out = mapAllEntries(bad, (e) => e);
+    expect(out).toBe(bad);
+  });
+
+  it("mapAllEntries skips pages whose entries is not an array, keeps others", () => {
+    const mixed = {
+      pages: [
+        { entries: null, next_cursor: null, prev_cursor: null, has_more_before: false, has_more_after: false },
+        { entries: [entry("c1", "2026-05-06T01:00:00Z")], next_cursor: null, prev_cursor: null, has_more_before: false, has_more_after: false },
+      ],
+      pageParams: [{ mode: "latest" }, { mode: "before", cursor: "x" }],
+    } as unknown as TimelineCacheData;
+    const out = mapAllEntries(mixed, (e) => ({ ...e, content: "x" }));
+    // First page (malformed) returned verbatim; second page rebuilt with mapped entries.
+    expect(out).toBeDefined();
+    expect(out!.pages[0]).toBe(mixed.pages[0]);
+    expect(out!.pages[1]!.entries[0]).toMatchObject({ id: "c1", content: "x" });
+  });
+
+  it("filterAllEntries returns data unchanged when pages is not an array", () => {
+    const bad = { pages: undefined as unknown, pageParams: [] } as unknown as TimelineCacheData;
+    const out = filterAllEntries(bad, () => true);
+    expect(out).toBe(bad);
+  });
+
+  it("filterAllEntries skips pages with non-array entries", () => {
+    const mixed = {
+      pages: [
+        { entries: "not-an-array" as unknown, next_cursor: null, prev_cursor: null, has_more_before: false, has_more_after: false },
+        { entries: [entry("c1", "t1"), entry("c2", "t2")], next_cursor: null, prev_cursor: null, has_more_before: false, has_more_after: false },
+      ],
+      pageParams: [{ mode: "latest" }, { mode: "before", cursor: "x" }],
+    } as unknown as TimelineCacheData;
+    const out = filterAllEntries(mixed, (e) => e.id === "c1");
+    expect(out).toBeDefined();
+    expect(out!.pages[0]).toBe(mixed.pages[0]);
+    expect(out!.pages[1]!.entries.map((e) => e.id)).toEqual(["c2"]);
+  });
+
+  it("prependToLatestPage returns data unchanged when pages is not an array", () => {
+    const bad = { pages: {} as unknown, pageParams: [] } as unknown as TimelineCacheData;
+    const out = prependToLatestPage(bad, entry("new", "t"));
+    expect(out).toBe(bad);
+  });
+
+  it("prependToLatestPage returns data unchanged when first page entries is not an array", () => {
+    const bad = {
+      pages: [
+        { entries: null as unknown, next_cursor: null, prev_cursor: null, has_more_before: false, has_more_after: false },
+      ],
+      pageParams: [{ mode: "latest" }],
+    } as unknown as TimelineCacheData;
+    const out = prependToLatestPage(bad, entry("new", "t"));
+    expect(out).toBe(bad);
+  });
+
+  // Sanity: helpers still work on well-formed data.
+  it("mapAllEntries maps entries on well-formed data", () => {
+    const data = wellFormed([entry("c1", "t1"), entry("c2", "t2")]);
+    const out = mapAllEntries(data, (e) =>
+      e.id === "c1" ? { ...e, content: "changed" } : e,
+    );
+    expect(out).toBeDefined();
+    expect(out!.pages[0]!.entries[0]).toMatchObject({ id: "c1", content: "changed" });
+    // Identity preserved for unchanged entry.
+    expect(out!.pages[0]!.entries[1]).toBe(data.pages[0]!.entries[1]);
+  });
+});

--- a/packages/core/issues/timeline-cache.test.ts
+++ b/packages/core/issues/timeline-cache.test.ts
@@ -3,6 +3,7 @@ import {
   mapAllEntries,
   filterAllEntries,
   prependToLatestPage,
+  collectDeletedCommentIds,
   type TimelineCacheData,
 } from "./timeline-cache";
 import type { TimelineEntry } from "../types";
@@ -16,13 +17,14 @@ import type { TimelineEntry } from "../types";
 // unchanged, so the consumer falls back to "empty timeline" instead of
 // crashing the React tree.
 
-function entry(id: string, createdAt: string): TimelineEntry {
+function entry(id: string, createdAt: string, parentId?: string): TimelineEntry {
   return {
     type: "comment",
     id,
     actor_type: "member",
     actor_id: "u",
     created_at: createdAt,
+    ...(parentId ? { parent_id: parentId } : {}),
   };
 }
 
@@ -116,5 +118,97 @@ describe("timeline-cache helpers — malformed-shape tolerance", () => {
     expect(out!.pages[0]!.entries[0]).toMatchObject({ id: "c1", content: "changed" });
     // Identity preserved for unchanged entry.
     expect(out!.pages[0]!.entries[1]).toBe(data.pages[0]!.entries[1]);
+  });
+});
+
+// useDeleteComment.onMutate uses this helper to walk every open timeline
+// window (latest + around-mode caches) and collect the root comment plus all
+// descendants before calling filterAllEntries. Before this helper existed,
+// the walk ran inline in mutations.ts and read `data.pages` / `page.entries`
+// unguarded — the same shape that white-screened the render side in
+// upstream#2143 / #2147 could have crashed the delete path too.
+describe("collectDeletedCommentIds", () => {
+  it("returns a set containing only the root when snapshots are empty", () => {
+    const out = collectDeletedCommentIds([], "c1");
+    expect(out).toEqual(new Set(["c1"]));
+  });
+
+  it("cascades through direct children on a single snapshot", () => {
+    const snap: [unknown, TimelineCacheData] = [
+      ["issues", "timeline", "i1"],
+      wellFormed([
+        entry("c1", "t1"),
+        entry("c2", "t2", "c1"),
+        entry("c3", "t3", "c1"),
+      ]),
+    ];
+    const out = collectDeletedCommentIds([snap], "c1");
+    expect(out).toEqual(new Set(["c1", "c2", "c3"]));
+  });
+
+  it("cascades through multi-level nesting (grandchildren)", () => {
+    const snap: [unknown, TimelineCacheData] = [
+      ["k"],
+      wellFormed([
+        entry("c1", "t1"),
+        entry("c2", "t2", "c1"),
+        entry("c3", "t3", "c2"),
+        entry("unrelated", "t4"),
+      ]),
+    ];
+    const out = collectDeletedCommentIds([snap], "c1");
+    expect(out).toEqual(new Set(["c1", "c2", "c3"]));
+    expect(out.has("unrelated")).toBe(false);
+  });
+
+  it("merges descendants found across multiple snapshots (latest + around window)", () => {
+    // Parent on latest page, reply on an older around-mode window.
+    const latest: [unknown, TimelineCacheData] = [
+      ["k1"],
+      wellFormed([entry("c1", "t1")]),
+    ];
+    const around: [unknown, TimelineCacheData] = [
+      ["k2"],
+      wellFormed([entry("c2", "t2", "c1")]),
+    ];
+    const out = collectDeletedCommentIds([latest, around], "c1");
+    expect(out).toEqual(new Set(["c1", "c2"]));
+  });
+
+  it("skips snapshots whose data.pages is not an array (no throw)", () => {
+    const bad: [unknown, TimelineCacheData] = [
+      ["k"],
+      { pages: null as unknown, pageParams: [] } as unknown as TimelineCacheData,
+    ];
+    const good: [unknown, TimelineCacheData] = [
+      ["k2"],
+      wellFormed([entry("c1", "t1"), entry("c2", "t2", "c1")]),
+    ];
+    expect(() => collectDeletedCommentIds([bad, good], "c1")).not.toThrow();
+    const out = collectDeletedCommentIds([bad, good], "c1");
+    // Good snapshot still processed.
+    expect(out).toEqual(new Set(["c1", "c2"]));
+  });
+
+  it("skips pages whose entries is not an array (no throw, other pages processed)", () => {
+    const snap: [unknown, TimelineCacheData] = [
+      ["k"],
+      {
+        pages: [
+          { entries: null, next_cursor: null, prev_cursor: null, has_more_before: false, has_more_after: false },
+          { entries: [entry("c2", "t2", "c1")], next_cursor: null, prev_cursor: null, has_more_before: false, has_more_after: false },
+        ],
+        pageParams: [{ mode: "latest" }, { mode: "before", cursor: "x" }],
+      } as unknown as TimelineCacheData,
+    ];
+    expect(() => collectDeletedCommentIds([snap], "c1")).not.toThrow();
+    const out = collectDeletedCommentIds([snap], "c1");
+    expect(out).toEqual(new Set(["c1", "c2"]));
+  });
+
+  it("tolerates undefined data in a snapshot", () => {
+    const missing: [unknown, TimelineCacheData | undefined] = [["k"], undefined];
+    expect(() => collectDeletedCommentIds([missing], "c1")).not.toThrow();
+    expect(collectDeletedCommentIds([missing], "c1")).toEqual(new Set(["c1"]));
   });
 });

--- a/packages/core/issues/timeline-cache.ts
+++ b/packages/core/issues/timeline-cache.ts
@@ -11,14 +11,19 @@ export type TimelineCacheData = InfiniteData<TimelinePage, TimelinePageParam>;
 
 /** Map fn over every entry across every page, preserving page identity for
  *  any page whose entries don't change so React.memo on CommentCard isn't
- *  defeated by gratuitous reference churn. */
+ *  defeated by gratuitous reference churn.
+ *
+ *  Defensive on shape: pages / entries may be non-arrays if a malformed
+ *  entry was ever written to the cache. Return unchanged in that case so
+ *  downstream consumers don't inherit a corrupted cache. */
 export function mapAllEntries(
   data: TimelineCacheData | undefined,
   fn: (e: TimelineEntry) => TimelineEntry,
 ): TimelineCacheData | undefined {
-  if (!data) return data;
+  if (!data || !Array.isArray(data.pages)) return data;
   let pagesChanged = false;
   const pages = data.pages.map((page) => {
+    if (!page || !Array.isArray(page.entries)) return page;
     let entriesChanged = false;
     const entries = page.entries.map((e) => {
       const next = fn(e);
@@ -38,9 +43,10 @@ export function filterAllEntries(
   data: TimelineCacheData | undefined,
   predicate: (e: TimelineEntry) => boolean,
 ): TimelineCacheData | undefined {
-  if (!data) return data;
+  if (!data || !Array.isArray(data.pages)) return data;
   let pagesChanged = false;
   const pages = data.pages.map((page) => {
+    if (!page || !Array.isArray(page.entries)) return page;
     const entries = page.entries.filter((e) => !predicate(e));
     if (entries.length === page.entries.length) return page;
     pagesChanged = true;
@@ -58,9 +64,9 @@ export function prependToLatestPage(
   data: TimelineCacheData | undefined,
   entry: TimelineEntry,
 ): TimelineCacheData | undefined {
-  if (!data || data.pages.length === 0) return data;
+  if (!data || !Array.isArray(data.pages) || data.pages.length === 0) return data;
   const first = data.pages[0];
-  if (!first) return data;
+  if (!first || !Array.isArray(first.entries)) return data;
   if (first.has_more_after) return data; // not at latest; skip silently
   if (first.entries.some((e) => e.id === entry.id)) return data;
   return {

--- a/packages/core/issues/timeline-cache.ts
+++ b/packages/core/issues/timeline-cache.ts
@@ -56,6 +56,41 @@ export function filterAllEntries(
   return { ...data, pages };
 }
 
+/** Collect the root id plus every descendant (by parent_id chain) across a
+ *  set of paginated cache snapshots. Used by useDeleteComment.onMutate to
+ *  cascade a delete through every open timeline window atomically.
+ *
+ *  Defensive on shape: same contract as the other helpers here — bad pages
+ *  or entries are skipped silently so a malformed cache can't throw on the
+ *  write path (upstream#2143 / #2147). */
+export function collectDeletedCommentIds(
+  snapshots: Iterable<readonly [unknown, TimelineCacheData | undefined]>,
+  rootId: string,
+): Set<string> {
+  const toRemove = new Set<string>([rootId]);
+  for (const [, data] of snapshots) {
+    if (!data || !Array.isArray(data.pages)) continue;
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const page of data.pages) {
+        if (!page || !Array.isArray(page.entries)) continue;
+        for (const e of page.entries) {
+          if (
+            e.parent_id &&
+            toRemove.has(e.parent_id) &&
+            !toRemove.has(e.id)
+          ) {
+            toRemove.add(e.id);
+            changed = true;
+          }
+        }
+      }
+    }
+  }
+  return toRemove;
+}
+
 /** Prepend a new entry to the latest page (pages[0]). Caller must verify
  *  the cache is at-latest before calling — otherwise the entry is hidden
  *  behind a "show newer" gap and shouldn't be injected. Returns the data

--- a/packages/views/issues/hooks/use-issue-timeline.test.tsx
+++ b/packages/views/issues/hooks/use-issue-timeline.test.tsx
@@ -315,4 +315,51 @@ describe("useIssueTimeline", () => {
     });
     expect(result.current.newEntriesBelowCount).toBe(0);
   });
+
+  // Regression: upstream#2143 / #2147 — `timeline.filter is not a function`.
+  // A malformed cache entry (non-array pages / entries) used to crash the
+  // render tree because consumers call `timeline.filter(...)` directly on
+  // the returned value. The flattening memo now coerces to an empty array
+  // on any unexpected shape.
+  describe("malformed cache data → empty timeline (no crash)", () => {
+    it("returns [] when data.pages is not an array", () => {
+      queryState.data = { pages: null, pageParams: [] };
+      const { result } = renderHook(() => useIssueTimeline("issue-1", "user-1"));
+      expect(result.current.timeline).toEqual([]);
+      // Consumer pattern that previously crashed — proves it no longer does.
+      expect(() => result.current.timeline.filter(() => true)).not.toThrow();
+    });
+
+    it("returns [] when data is a bare object without pages (legacy shape)", () => {
+      queryState.data = {};
+      const { result } = renderHook(() => useIssueTimeline("issue-1", "user-1"));
+      expect(result.current.timeline).toEqual([]);
+    });
+
+    it("skips pages whose entries is not an array, keeps well-formed pages", () => {
+      queryState.data = {
+        pages: [
+          { ...emptyPage(), entries: null, has_more_after: false },
+          {
+            ...emptyPage(),
+            entries: [
+              { type: "comment", id: "c1", actor_type: "member", actor_id: "u", created_at: "2026-05-06T01:00:00Z" },
+            ],
+          },
+        ],
+        pageParams: [{ mode: "latest" }, { mode: "before", cursor: "x" }],
+      };
+      const { result } = renderHook(() => useIssueTimeline("issue-1", "user-1"));
+      expect(result.current.timeline.map((e) => e.id)).toEqual(["c1"]);
+    });
+
+    it("returns [] when a single page is null", () => {
+      queryState.data = {
+        pages: [null],
+        pageParams: [{ mode: "latest" }],
+      };
+      const { result } = renderHook(() => useIssueTimeline("issue-1", "user-1"));
+      expect(result.current.timeline).toEqual([]);
+    });
+  });
 });

--- a/packages/views/issues/hooks/use-issue-timeline.test.tsx
+++ b/packages/views/issues/hooks/use-issue-timeline.test.tsx
@@ -67,6 +67,19 @@ const queryState = vi.hoisted(() => ({
   isLoading: false,
 }));
 
+// Shared query-client mocks. Hoisted so tests can inspect setQueryData calls
+// (capture the updater functions WS handlers pass in, then invoke them with
+// crafted `old` values — this is how we exercise the upstream#2143 / #2147
+// invariant + shape-guard without wiring a real QueryClient).
+const qcMocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  setQueryData: vi.fn(),
+  setQueriesData: vi.fn(),
+  getQueryData: vi.fn(),
+  getQueriesData: vi.fn(() => []),
+  cancelQueries: vi.fn(),
+}));
+
 function emptyPage() {
   return {
     entries: [],
@@ -93,14 +106,7 @@ vi.mock("@tanstack/react-query", async () => {
       isFetchingNextPage: false,
       isFetchingPreviousPage: false,
     }),
-    useQueryClient: () => ({
-      invalidateQueries: vi.fn(),
-      setQueryData: vi.fn(),
-      setQueriesData: vi.fn(),
-      getQueryData: vi.fn(),
-      getQueriesData: vi.fn(() => []),
-      cancelQueries: vi.fn(),
-    }),
+    useQueryClient: () => qcMocks,
     useMutationState: () => [],
   };
 });
@@ -121,6 +127,12 @@ import { useIssueTimeline } from "./use-issue-timeline";
 describe("useIssueTimeline", () => {
   beforeEach(() => {
     wsHandlers.clear();
+    qcMocks.invalidateQueries.mockClear();
+    qcMocks.setQueryData.mockClear();
+    qcMocks.setQueriesData.mockClear();
+    qcMocks.getQueryData.mockClear();
+    qcMocks.getQueriesData.mockClear();
+    qcMocks.cancelQueries.mockClear();
     queryState.data = {
       pages: [{ ...emptyPage(), has_more_after: false }],
       pageParams: [{ mode: "latest" }],
@@ -360,6 +372,148 @@ describe("useIssueTimeline", () => {
       };
       const { result } = renderHook(() => useIssueTimeline("issue-1", "user-1"));
       expect(result.current.timeline).toEqual([]);
+    });
+  });
+
+  // Follow-up to upstream#2143 / #2147: we already tolerate malformed cache
+  // on the *read* side (memo guards), but we still don't know which writer
+  // pollutes the cache. The dev-only `assertTimelineShape` invariant fires
+  // at the top of every timeline setQueryData updater so the first bad write
+  // throws loudly in dev/test, pinpointing the polluter instead of silently
+  // degrading. Prod keeps tolerating (NODE_ENV gate + shape guards below).
+  describe("setQueryData invariant (dev-only)", () => {
+    // Helper: invoke a WS handler and pull the updater callback the hook
+    // passed to setQueryData, so we can exercise it with synthetic `old`.
+    function captureUpdater(
+      handlerEvent: string,
+      payload: unknown,
+    ): (old: unknown) => unknown {
+      const handler = wsHandlers.get(handlerEvent);
+      expect(handler).toBeDefined();
+      act(() => handler!(payload));
+      const lastCall = qcMocks.setQueryData.mock.calls.at(-1);
+      expect(lastCall).toBeDefined();
+      const updater = lastCall![1] as (old: unknown) => unknown;
+      expect(typeof updater).toBe("function");
+      return updater;
+    }
+
+    const goodPage = {
+      entries: [
+        { type: "comment", id: "c1", actor_type: "member", actor_id: "u", parent_id: null, created_at: "2026-05-06T01:00:00Z" },
+      ],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    };
+
+    it("throws when data.pages is not an array (comment:created path)", () => {
+      renderHook(() => useIssueTimeline("issue-1", "user-1"));
+      const updater = captureUpdater("comment:created", {
+        comment: {
+          id: "n",
+          issue_id: "issue-1",
+          author_type: "member",
+          author_id: "u",
+          content: "hi",
+          parent_id: null,
+          created_at: "2026-05-06T05:00:00Z",
+          updated_at: "2026-05-06T05:00:00Z",
+          type: "comment",
+          reactions: [],
+          attachments: [],
+        },
+      });
+      expect(() => updater({ pages: null, pageParams: [] })).toThrow(
+        /data\.pages is not an array/,
+      );
+    });
+
+    it("throws when a page has non-array entries (comment:deleted path)", () => {
+      renderHook(() => useIssueTimeline("issue-1", "user-1"));
+      const updater = captureUpdater("comment:deleted", {
+        comment_id: "c1",
+        issue_id: "issue-1",
+      });
+      expect(() =>
+        updater({
+          pages: [{ ...goodPage, entries: null }],
+          pageParams: [{ mode: "latest" }],
+        }),
+      ).toThrow(/data\.pages\[0\]\.entries is not an array/);
+    });
+
+    it("no-ops (undefined → undefined) on empty cache, does not throw", () => {
+      renderHook(() => useIssueTimeline("issue-1", "user-1"));
+      const updater = captureUpdater("comment:updated", {
+        comment: {
+          id: "c1",
+          issue_id: "issue-1",
+          author_type: "member",
+          author_id: "u",
+          content: "edit",
+          parent_id: null,
+          created_at: "2026-05-06T01:00:00Z",
+          updated_at: "2026-05-06T06:00:00Z",
+          type: "comment",
+          reactions: [],
+          attachments: [],
+        },
+      });
+      expect(() => updater(undefined)).not.toThrow();
+    });
+
+    it("does NOT throw on well-formed cache (sanity)", () => {
+      renderHook(() => useIssueTimeline("issue-1", "user-1"));
+      const updater = captureUpdater("reaction:added", {
+        issue_id: "issue-1",
+        reaction: { id: "r1", comment_id: "c1", emoji: "+1", actor_type: "member", actor_id: "u" },
+      });
+      expect(() =>
+        updater({ pages: [goodPage], pageParams: [{ mode: "latest" }] }),
+      ).not.toThrow();
+    });
+
+    it("stays silent in production (NODE_ENV=production): the bad cache passes through to the shape guards downstream", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      try {
+        renderHook(() => useIssueTimeline("issue-1", "user-1"));
+        const updater = captureUpdater("comment:deleted", {
+          comment_id: "c1",
+          issue_id: "issue-1",
+        });
+        // Prod behavior: invariant off, the comment:deleted walk returns
+        // `old` unchanged when pages is not an array (new guard below it).
+        const bad = { pages: null, pageParams: [] };
+        expect(() => updater(bad)).not.toThrow();
+        expect(updater(bad)).toBe(bad);
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it("comment:deleted walk skips non-array page.entries in production (no throw, other pages processed)", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      try {
+        renderHook(() => useIssueTimeline("issue-1", "user-1"));
+        const updater = captureUpdater("comment:deleted", {
+          comment_id: "c1",
+          issue_id: "issue-1",
+        });
+        const mixed = {
+          pages: [
+            { ...goodPage, entries: null },
+            goodPage,
+          ],
+          pageParams: [{ mode: "latest" }, { mode: "before", cursor: "x" }],
+        };
+        // Should not throw even though one page has non-array entries.
+        const out = updater(mixed) as { pages: unknown[] };
+        expect(Array.isArray(out.pages)).toBe(true);
+      } finally {
+        vi.unstubAllEnvs();
+      }
     });
   });
 });

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -95,7 +95,11 @@ export function useIssueTimeline(
   // isAtLatest is the cache-invariant we use to decide where WS-delivered
   // entries belong. It's true when the FIRST loaded page reports no newer
   // entries on the server — i.e. the user is looking at the live tail.
-  const isAtLatest = data?.pages[0]?.has_more_after === false;
+  //
+  // Same shape-guard as the timeline memo below: a malformed `data.pages`
+  // (not an array) previously crashed `data.pages[0]` and white-screened the
+  // whole issue route (upstream#2143 / #2147).
+  const isAtLatest = Array.isArray(data?.pages) && data!.pages[0]?.has_more_after === false;
 
   const [submitting, setSubmitting] = useState(false);
   const [newEntriesBelowCount, setNewEntriesBelowCount] = useState(0);
@@ -103,10 +107,19 @@ export function useIssueTimeline(
   // Flatten pages → ASC array for the legacy UI consumer. pages are DESC
   // newest-first; the consumer (issue-detail.tsx) renders chronologically
   // (oldest at top). Concat → DESC; reverse once at the end → ASC.
+  //
+  // Defensive on pages / entries shape: consumers like `issue-detail.tsx`
+  // call `timeline.filter(...)` directly. A malformed cache entry (stale
+  // shape from a persisted older build, gzip/proxy mishap, hand-written
+  // setQueryData in a future caller) would otherwise white-screen the whole
+  // tab (see upstream#2143 / #2147: `timeline.filter is not a function`).
+  // Coerce to `[]` on any unexpected shape so the UI degrades to empty
+  // instead of crashing the route.
   const timeline = useMemo<TimelineEntry[]>(() => {
-    if (!data) return [];
+    if (!data || !Array.isArray(data.pages)) return [];
     const flat: TimelineEntry[] = [];
     for (const page of data.pages) {
+      if (!page || !Array.isArray(page.entries)) continue;
       for (const entry of page.entries) flat.push(entry);
     }
     return flat.reverse();
@@ -425,11 +438,13 @@ export function useIssueTimeline(
   // (DESC pages → ASC flat), so the offset within page[0] becomes
   // (totalEntries - 1) - target_index.
   const targetFlatIndex = useMemo(() => {
-    if (!data || data.pages.length === 0) return null;
+    if (!data || !Array.isArray(data.pages) || data.pages.length === 0) return null;
     const first = data.pages[0];
-    if (!first || first.target_index == null) return null;
+    if (!first || !Array.isArray(first.entries) || first.target_index == null) return null;
     let total = 0;
-    for (const p of data.pages) total += p.entries.length;
+    for (const p of data.pages) {
+      if (p && Array.isArray(p.entries)) total += p.entries.length;
+    }
     return total - 1 - first.target_index;
   }, [data]);
 

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -42,6 +42,35 @@ import { useT } from "../../i18n";
 
 type TLData = TimelineCacheData;
 
+// Dev-only invariant: fire loudly if any WS/mutation path hands a non-array-
+// shaped cache to a setQueryData updater. Production behavior is already
+// tolerant (shape guards in timeline-cache.ts + the flattening memo below),
+// so this exists purely to surface the upstream polluter in dev/test — the
+// thing that got us upstream#2143 / #2147 in the first place. NODE_ENV is
+// checked at call time so tests can flip to "production" via vi.stubEnv.
+function assertTimelineShape(label: string, data: TLData | undefined): void {
+  if (process.env.NODE_ENV === "production") return;
+  if (data === undefined) return;
+  if (!data || typeof data !== "object") {
+    throw new Error(
+      `[timeline-cache/${label}] invariant: cache root has type ${typeof data}`,
+    );
+  }
+  if (!Array.isArray(data.pages)) {
+    throw new Error(
+      `[timeline-cache/${label}] invariant: data.pages is not an array`,
+    );
+  }
+  for (let i = 0; i < data.pages.length; i++) {
+    const page = data.pages[i];
+    if (!page || !Array.isArray(page.entries)) {
+      throw new Error(
+        `[timeline-cache/${label}] invariant: data.pages[${i}].entries is not an array`,
+      );
+    }
+  }
+}
+
 function commentToTimelineEntry(c: Comment): TimelineEntry {
   return {
     type: "comment",
@@ -153,9 +182,10 @@ export function useIssueTimeline(
         const { comment } = payload as CommentCreatedPayload;
         if (comment.issue_id !== issueId) return;
         if (isAtLatest) {
-          qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) =>
-            prependToLatestPage(old, commentToTimelineEntry(comment)),
-          );
+          qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) => {
+            assertTimelineShape("comment:created", old);
+            return prependToLatestPage(old, commentToTimelineEntry(comment));
+          });
         } else {
           // Reading older history — don't yank scroll position. Surface a
           // counter so the UI can offer "jump to latest (N new)".
@@ -172,11 +202,12 @@ export function useIssueTimeline(
       (payload: unknown) => {
         const { comment } = payload as CommentUpdatedPayload;
         if (comment.issue_id !== issueId) return;
-        qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) =>
-          mapAllEntries(old, (e) =>
+        qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) => {
+          assertTimelineShape("comment:updated", old);
+          return mapAllEntries(old, (e) =>
             e.id === comment.id ? commentToTimelineEntry(comment) : e,
-          ),
-        );
+          );
+        });
       },
       [qc, issueId, around],
     ),
@@ -191,12 +222,14 @@ export function useIssueTimeline(
         // Cascade through replies. Walk pages collectively; a reply may live
         // on a different page than its parent.
         qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) => {
-          if (!old) return old;
+          assertTimelineShape("comment:deleted", old);
+          if (!old || !Array.isArray(old.pages)) return old;
           const idsToRemove = new Set<string>([comment_id]);
           let changed = true;
           while (changed) {
             changed = false;
             for (const page of old.pages) {
+              if (!page || !Array.isArray(page.entries)) continue;
               for (const e of page.entries) {
                 if (
                   e.parent_id &&
@@ -225,9 +258,10 @@ export function useIssueTimeline(
         const entry = p.entry;
         if (!entry || !entry.id) return;
         if (isAtLatest) {
-          qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) =>
-            prependToLatestPage(old, entry),
-          );
+          qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) => {
+            assertTimelineShape("activity:created", old);
+            return prependToLatestPage(old, entry);
+          });
         } else {
           setNewEntriesBelowCount((c) => c + 1);
         }
@@ -242,14 +276,15 @@ export function useIssueTimeline(
       (payload: unknown) => {
         const { reaction, issue_id } = payload as ReactionAddedPayload;
         if (issue_id !== issueId) return;
-        qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) =>
-          mapAllEntries(old, (e) => {
+        qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) => {
+          assertTimelineShape("reaction:added", old);
+          return mapAllEntries(old, (e) => {
             if (e.id !== reaction.comment_id) return e;
             const existing = e.reactions ?? [];
             if (existing.some((r) => r.id === reaction.id)) return e;
             return { ...e, reactions: [...existing, reaction] };
-          }),
-        );
+          });
+        });
       },
       [qc, issueId, around],
     ),
@@ -261,8 +296,9 @@ export function useIssueTimeline(
       (payload: unknown) => {
         const p = payload as ReactionRemovedPayload;
         if (p.issue_id !== issueId) return;
-        qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) =>
-          mapAllEntries(old, (e) => {
+        qc.setQueryData<TLData>(issueKeys.timeline(issueId, around), (old: TLData | undefined) => {
+          assertTimelineShape("reaction:removed", old);
+          return mapAllEntries(old, (e) => {
             if (e.id !== p.comment_id) return e;
             return {
               ...e,
@@ -275,8 +311,8 @@ export function useIssueTimeline(
                   ),
               ),
             };
-          }),
-        );
+          });
+        });
       },
       [qc, issueId, around],
     ),


### PR DESCRIPTION
## Summary

Fixes #2143 and #2147 — opening an issue crashes with `timeline.filter is not a function` and, because no route-level `errorElement` exists, traps the user on every subsequent issue click.

The cursor-pagination refactor (#2128) already moved past the exact crash site on `main` (the legacy `timeline.filter` call at the old `IssueDetail` `useMemo` is gone), but the replacement hook still assumes `data.pages` and `page.entries` are arrays without verifying. A single malformed cache entry — from a hand-written `setQueryData` in future code, a persisted older shape after a client upgrade, or a proxy / gzip mishap on the response body — would white-screen the issue route in exactly the same way.

This PR coerces to `[]` on any unexpected shape so the UI degrades to "empty timeline" instead of throwing, then adds a dev-only invariant to flush out the upstream polluter, and finally hardens the last remaining unguarded walk on the mutation side.

## Changes

### 1. Shape guards (`a889ac72`)

- **`packages/views/issues/hooks/use-issue-timeline.ts`** — guards in three spots that indexed `data.pages` / `page.entries` without checking: the flattening memo, `isAtLatest`, and `targetFlatIndex`.
- **`packages/core/issues/timeline-cache.ts`** — the same guards in `mapAllEntries` / `filterAllEntries` / `prependToLatestPage` so WS handlers don't amplify corruption.

### 2. Dev-only invariant + `comment:deleted` walk guards (`bce97c50`)

- **`use-issue-timeline.ts`** — new `assertTimelineShape(label, data)` helper wired as the first statement of every `setQueryData` updater (6 sites: `comment:created`, `comment:updated`, `comment:deleted`, `activity:created`, `reaction:added`, `reaction:removed`). In dev/test the first writer handing a bad shape throws loudly with its label; in prod it no-ops (NODE_ENV checked at call time so tests can flip it via `vi.stubEnv`). The inner `comment:deleted` cascade walk now has the same `Array.isArray` guards as the helpers below it.
- **Tests** — a `setQueryData invariant (dev-only)` describe block exercises the captured updater callbacks with synthetic `old` values, asserting throw-in-dev and silent-pass-in-prod.

### 3. `useDeleteComment` cascade hardening (`e42687f3`)

- **`packages/core/issues/mutations.ts`** — the `onMutate` cascade-collection walk was the last write-side site iterating `data.pages` / `page.entries` unguarded. Extracted to `collectDeletedCommentIds(snapshots, rootId)` in `timeline-cache.ts` alongside the other shape-guarded helpers. `packages/core/` forbids `process.env`, so pure guards + unit tests are the correct layer (not the dev-only invariant).
- **Tests** — 7 new cases in `timeline-cache.test.ts`: empty / single-snapshot / multi-level / cross-snapshot cascade; bad `pages`; bad `entries`; `undefined` data.

## Why both layers

Shape guards make the symptom non-fatal in prod. The dev-only invariant makes the *root cause* loud in dev so we can eventually track down whichever writer is polluting the cache — static review of each `setQueryData` site did not pinpoint it.

## Notes

- Existing `timeline`, `isAtLatest`, and `newEntriesBelowCount` behavior on well-formed data is unchanged — the guards only kick in on shapes that would have thrown before.
- Follow-up worth considering (not in this PR): add a route-level `errorElement` in `apps/desktop/src/renderer/src/routes.tsx`. Any future render exception still white-screens the tab without one.

## Test plan

- [x] `pnpm --filter @multica/core exec vitest run issues` — 4 files / 22 tests pass
- [x] `pnpm --filter @multica/views exec vitest run issues/hooks/use-issue-timeline` — 17 tests pass
- [x] `pnpm --filter @multica/core typecheck` / `pnpm --filter @multica/views typecheck` — clean
- [ ] Manual: reproduce the original crash path on `main` (issue detail with long timeline + @agent-triggered WS burst) and verify no white-screen after checkout of this branch.