### PR TITLE
fix(projects): pre-fill project on per-status "+" create-issue

### DIFF
--- a/packages/views/issues/components/board-column.tsx
+++ b/packages/views/issues/components/board-column.tsx
@@ -28,6 +28,7 @@ export function BoardColumn({
   childProgressMap,
   totalCount,
   footer,
+  projectId,
 }: {
   status: IssueStatus;
   issueIds: string[];
@@ -35,6 +36,8 @@ export function BoardColumn({
   childProgressMap?: Map<string, ChildProgress>;
   totalCount?: number;
   footer?: ReactNode;
+  /** When set, the per-column "+" pre-fills the project on the create form. */
+  projectId?: string;
 }) {
   const cfg = STATUS_CONFIG[status];
   const { setNodeRef, isOver } = useDroppable({ id: status });
@@ -80,7 +83,11 @@ export function BoardColumn({
                   variant="ghost"
                   size="icon-sm"
                   className="rounded-full text-muted-foreground"
-                  onClick={() => useModalStore.getState().open("create-issue", { status })}
+                  onClick={() =>
+                    useModalStore
+                      .getState()
+                      .open("create-issue", { status, ...(projectId ? { project_id: projectId } : {}) })
+                  }
                 >
                   <Plus className="size-3.5" />
                 </Button>

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -106,6 +106,7 @@ export function BoardView({
   childProgressMap = EMPTY_PROGRESS_MAP,
   myIssuesScope,
   myIssuesFilter,
+  projectId,
 }: {
   issues: Issue[];
   visibleStatuses: IssueStatus[];
@@ -119,6 +120,8 @@ export function BoardView({
   /** When set, per-status load-more targets the scoped cache instead of the workspace one. */
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
+  /** When set, the per-column "+" pre-fills the project on the create form. */
+  projectId?: string;
 }) {
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
@@ -289,6 +292,7 @@ export function BoardView({
             issueMap={issueMapRef.current}
             childProgressMap={childProgressMap}
             myIssuesOpts={myIssuesOpts}
+            projectId={projectId}
           />
         ))}
 
@@ -317,12 +321,14 @@ function PaginatedBoardColumn({
   issueMap,
   childProgressMap,
   myIssuesOpts,
+  projectId,
 }: {
   status: IssueStatus;
   issueIds: string[];
   issueMap: Map<string, Issue>;
   childProgressMap?: Map<string, ChildProgress>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  projectId?: string;
 }) {
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByStatus(
     status,
@@ -335,6 +341,7 @@ function PaginatedBoardColumn({
       issueMap={issueMap}
       childProgressMap={childProgressMap}
       totalCount={total}
+      projectId={projectId}
       footer={
         hasMore ? (
           <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -25,6 +25,7 @@ export function ListView({
   childProgressMap = EMPTY_PROGRESS_MAP,
   myIssuesScope,
   myIssuesFilter,
+  projectId,
 }: {
   issues: Issue[];
   visibleStatuses: IssueStatus[];
@@ -32,6 +33,8 @@ export function ListView({
   /** When set, per-status load-more targets the scoped cache instead of the workspace one. */
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
+  /** When set, the per-section "+" pre-fills the project on the create form. */
+  projectId?: string;
 }) {
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
@@ -86,6 +89,7 @@ export function ListView({
             issues={issuesByStatus.get(status) ?? []}
             childProgressMap={childProgressMap}
             myIssuesOpts={myIssuesOpts}
+            projectId={projectId}
           />
         ))}
       </Accordion.Root>
@@ -98,11 +102,13 @@ function StatusAccordionItem({
   issues,
   childProgressMap,
   myIssuesOpts,
+  projectId,
 }: {
   status: IssueStatus;
   issues: Issue[];
   childProgressMap: Map<string, ChildProgress>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
+  projectId?: string;
 }) {
   const { t } = useT("issues");
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
@@ -153,7 +159,7 @@ function StatusAccordionItem({
                   onClick={() =>
                     useModalStore
                       .getState()
-                      .open("create-issue", { status })
+                      .open("create-issue", { status, ...(projectId ? { project_id: projectId } : {}) })
                   }
                 />
               }

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -182,6 +182,7 @@ function ProjectIssuesContent({
           childProgressMap={childProgressMap}
           myIssuesScope={scope}
           myIssuesFilter={filter}
+          projectId={projectId}
         />
       ) : (
         <ListView
@@ -190,6 +191,7 @@ function ProjectIssuesContent({
           childProgressMap={childProgressMap}
           myIssuesScope={scope}
           myIssuesFilter={filter}
+          projectId={projectId}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Threads `projectId` from `ProjectDetail` through `BoardView`/`ListView` into `BoardColumn`/`StatusAccordionItem`.
- Per-status "+" button on the project detail page now opens the create-issue modal with both `status` and `project_id` set, so the new issue is auto-tagged with the current project.
- Empty-state "Create issue" button (`project-detail.tsx:164`) already worked; this fixes the per-column path that previously passed only `{ status }`.

Fixes [MUL-1791](mention://issue/cfe2107a-9e04-4065-81a5-c8ce4cc9f8e9).

## Test plan
- [ ] Open a project's detail page, switch to Board view, click "+" on any status column → create-issue modal opens with the project pre-selected.
- [ ] Same flow in List view (per-status accordion "+" button).
- [ ] Verify the global Issues page (no project context) still opens the modal without a project selected.
- [x] `pnpm --filter @multica/views typecheck` passes.
- [x] `pnpm --filter @multica/views exec vitest run modals/create-issue.test` passes.