### PR TITLE
fix(timeline): legacy array shape for pre-#2128 clients (#2143, #2147)

### DIFF
--- a/server/internal/handler/activity.go
+++ b/server/internal/handler/activity.go
@@ -116,6 +116,19 @@ func (h *Handler) ListTimeline(w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := r.URL.Query()
+
+	// Backwards-compat: pre-#2128 clients (Multica.app ≤ v0.2.25 and any cached
+	// web build older than the matching server) call /timeline with no query
+	// string and consume the response body as TimelineEntry[] directly. The
+	// new client always sends ?limit=..., so absence of every pagination param
+	// uniquely identifies a legacy caller. Drop this branch once the desktop
+	// auto-update has rolled the user base past v0.2.26.
+	if q.Get("limit") == "" && q.Get("before") == "" &&
+		q.Get("after") == "" && q.Get("around") == "" {
+		h.listTimelineLegacy(w, r, issue)
+		return
+	}
+
 	limit := timelineDefaultLimit
 	if raw := q.Get("limit"); raw != "" {
 		n, err := strconv.Atoi(raw)
@@ -152,6 +165,42 @@ func (h *Handler) ListTimeline(w http.ResponseWriter, r *http.Request) {
 	default:
 		h.listTimelineLatest(w, r, issue, limit)
 	}
+}
+
+// listTimelineLegacy serves clients that predate cursor pagination (#2128) —
+// notably Multica.app ≤ v0.2.25, where the renderer reads the response body
+// as TimelineEntry[] directly and would crash with "timeline.filter is not a
+// function" against the new wrapped shape (#2143, #2147). Returned bounded
+// at legacyTimelineCap to honour the spirit of #1968 — old clients couldn't
+// render thousands of entries without freezing the tab anyway.
+func (h *Handler) listTimelineLegacy(w http.ResponseWriter, r *http.Request, issue db.Issue) {
+	const legacyTimelineCap = 200
+	ctx := r.Context()
+	comments, err := h.Queries.ListCommentsLatest(ctx, db.ListCommentsLatestParams{
+		IssueID: issue.ID, WorkspaceID: issue.WorkspaceID, Limit: legacyTimelineCap,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list comments")
+		return
+	}
+	activities, err := h.Queries.ListActivitiesLatest(ctx, db.ListActivitiesLatestParams{
+		IssueID: issue.ID, Limit: legacyTimelineCap,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list activities")
+		return
+	}
+	entries := h.mergeTimelineDesc(r, comments, activities, legacyTimelineCap)
+	// Old contract: ASC (oldest → newest).
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+	// Old client does `data: timeline = []` which defaults undefined, not
+	// null — render an empty issue as "[]" not "null".
+	if entries == nil {
+		entries = []TimelineEntry{}
+	}
+	writeJSON(w, http.StatusOK, entries)
 }
 
 // listTimelineLatest fetches the most recent <limit> entries (no cursor).

--- a/server/internal/handler/activity_test.go
+++ b/server/internal/handler/activity_test.go
@@ -94,7 +94,9 @@ func TestListTimeline_DefaultLatestPage(t *testing.T) {
 	issueID := createIssueForTimeline(t, "Latest page test")
 	seedTimelineEntries(t, issueID, 60, 60) // 120 total; default limit is 50
 
-	resp, code := fetchTimeline(t, issueID, "")
+	// Empty query string is now reserved for the legacy compat path; new
+	// client always sends ?limit=... so emulate that here.
+	resp, code := fetchTimeline(t, issueID, "limit=50")
 	if code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", code)
 	}
@@ -265,7 +267,7 @@ func TestListTimeline_MergedCommentAndActivity(t *testing.T) {
 		t.Fatalf("seed comment: %v", err)
 	}
 
-	resp, code := fetchTimeline(t, issueID, "")
+	resp, code := fetchTimeline(t, issueID, "limit=50")
 	if code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", code)
 	}
@@ -279,5 +281,52 @@ func TestListTimeline_MergedCommentAndActivity(t *testing.T) {
 	}
 	if !strings.Contains(*resp.Entries[0].Content, "merge test") {
 		t.Fatalf("comment content lost in merge: %v", resp.Entries[0].Content)
+	}
+}
+
+// TestListTimeline_LegacyShapeForPreCursorClients pins the backwards-compat
+// contract for clients that predate cursor pagination (#2128). They call
+// /timeline with no query string and read the body as TimelineEntry[]
+// directly — returning the new wrapped shape there is what caused #2143 /
+// #2147. Asserts: array shape, ASC order, "[]" (not "null") on empty issue.
+func TestListTimeline_LegacyShapeForPreCursorClients(t *testing.T) {
+	issueID := createIssueForTimeline(t, "Legacy compat test")
+	seedTimelineEntries(t, issueID, 3, 2) // 5 total
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/issues/"+issueID+"/timeline", nil)
+	req = withURLParam(req, "id", issueID)
+	testHandler.ListTimeline(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Must decode as a bare array, not the wrapped TimelineResponse.
+	var entries []TimelineEntry
+	if err := json.NewDecoder(w.Body).Decode(&entries); err != nil {
+		t.Fatalf("legacy response must be a JSON array: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries (3 comments + 2 activities), got %d", len(entries))
+	}
+	for i := 1; i < len(entries); i++ {
+		if entries[i-1].CreatedAt > entries[i].CreatedAt {
+			t.Fatalf("legacy contract requires ASC order, got %s before %s",
+				entries[i-1].CreatedAt, entries[i].CreatedAt)
+		}
+	}
+
+	// Empty issue must render as "[]" (not "null") — old client does
+	// `data: timeline = []` which defaults undefined but not null.
+	emptyID := createIssueForTimeline(t, "Empty legacy test")
+	w2 := httptest.NewRecorder()
+	req2 := newRequest("GET", "/api/issues/"+emptyID+"/timeline", nil)
+	req2 = withURLParam(req2, "id", emptyID)
+	testHandler.ListTimeline(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("empty issue: expected 200, got %d", w2.Code)
+	}
+	if got := strings.TrimSpace(w2.Body.String()); got != "[]" {
+		t.Fatalf("empty issue must render as [], got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Hotfix for the `timeline.filter is not a function` crash hitting every Multica.app ≤ v0.2.25 desktop user since the v0.2.26 backend rolled out (#2143, #2147).

#2128 changed `GET /api/issues/:id/timeline` from a bare `TimelineEntry[]` to a wrapped `{ entries, next_cursor, ... }` object. Old desktop bundles read the body as an array directly, so any issue open immediately threw — bug reports landed within ten minutes of the v0.2.26 release.

The new client always sends `?limit=...`. Absence of every pagination param (`limit` / `before` / `after` / `around`) uniquely identifies a legacy caller, so a top-of-handler branch dispatches them to a `listTimelineLegacy` that returns the old shape (`[]TimelineEntry`, ASC, capped at 200). New clients fall through unchanged.

## Why server-side, not a client guard

A renderer-side `Array.isArray` guard (e.g. PR #2150) only stops the white-screen — old clients would still see an empty timeline because the wrapped object isn't unpacked. Fixing the contract on the server restores the correct rendering for everyone without touching the desktop release pipeline.

## Plan to remove this branch

Once desktop auto-update has rolled the user base past v0.2.26 (verifiable via metrics on `listTimelineLegacy` calls trending to zero), delete the legacy branch + helper. Comment in code references this.

## Test plan

- [x] `go test ./server/internal/handler -run TestListTimeline` — all 10 tests pass, including new `TestListTimeline_LegacyShapeForPreCursorClients`
- [x] `make test` — full Go suite green (22 packages)
- [ ] Smoke verify on staging: install v0.2.25 desktop, point at hotfixed backend, open any issue → no crash
- [ ] After deploy: confirm #2143 / #2147 reporters can re-open issues

## Out of scope

- `/api/issues/:id/comments` default cap of 50 (also from #2128) — shape is unchanged so no crash; addressed separately if needed.
- Desktop release shipping the new client to user machines — should follow this hotfix to drain the legacy traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)