### PR TITLE
Fix OpenClaw JSON output parsing

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -21,13 +21,13 @@ import (
 // change it without also updating those consumers.
 const openclawNoParseableOutput = "openclaw returned no parseable output"
 
-// minOpenclawVersion is the lowest openclaw version that emits its
+// minOpenclawVersion is the lowest openclaw version known to emit its
 // --json result on stdout. PR #2101 swapped the adapter from reading
 // stderr to stdout; older builds wrote JSON to stderr and now appear
 // to silently produce no output. The check in Execute fails fast with
 // a hardcoded upgrade hint so users see an actionable message instead
 // of "openclaw returned no parseable output".
-const minOpenclawVersion = "2026.5.5"
+const minOpenclawVersion = "2026.5.4"
 
 // openclawVersionPattern extracts a three-segment dotted version from
 // arbitrary `openclaw --version` output (e.g. "openclaw 2026.5.5",
@@ -291,8 +291,9 @@ type openclawEventResult struct {
 // log overflow and is captured separately by the caller. The stream may
 // contain:
 //
-//   - A final result JSON (with payloads + meta) — the format openclaw 2026.5.x
-//     emits today, typically pretty-printed across many lines
+//   - A final result JSON — either the legacy payloads/meta shape or the
+//     wrapped OpenClaw 2026.5 result shape, typically pretty-printed across
+//     many lines
 //   - NDJSON streaming events (type: "text", "tool_use", "tool_result", "error",
 //     "step_start", "step_finish") — supported for forward compatibility and
 //     other backends sharing this code path; openclaw does not emit these today
@@ -407,7 +408,7 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 			continue
 		}
 
-		// Try parsing as a final result blob (legacy format).
+		// Try parsing as a final result blob.
 		if result, ok := tryParseOpenclawResult(line); ok {
 			gotEvents = true
 			res := b.buildOpenclawEventResult(result, ch, &output)
@@ -442,6 +443,9 @@ func (b *openclawBackend) processOutput(r io.Reader, ch chan<- Message) openclaw
 	if !gotEvents {
 		trimmed := strings.TrimSpace(strings.Join(rawLines, "\n"))
 		if trimmed != "" {
+			if strings.HasPrefix(trimmed, "{") {
+				return openclawEventResult{status: "failed", errMsg: openclawNoParseableOutput}
+			}
 			return openclawEventResult{status: "completed", output: trimmed}
 		}
 		return openclawEventResult{
@@ -483,7 +487,7 @@ func parseWholeBufferOpenclawResult(buf []byte) (openclawResult, bool) {
 	for i, line := range lines {
 		if len(line) > 0 && line[0] == '{' {
 			candidate := strings.TrimSpace(strings.Join(lines[i:], "\n"))
-			if result, ok := tryParseOpenclawResult(candidate); ok {
+			if result, ok := tryParseOpenclawResultPrefix(candidate); ok {
 				return result, true
 			}
 			return openclawResult{}, false
@@ -508,10 +512,11 @@ func tryParseOpenclawEvent(line string) (openclawEvent, bool) {
 	return event, true
 }
 
-// tryParseOpenclawResult attempts to parse a line as a final result blob
-// (the legacy format with payloads + meta). Lines must start with '{' to be
-// considered — we no longer scan for braces at arbitrary positions, which
-// avoids false matches on log lines containing JSON fragments.
+// tryParseOpenclawResult attempts to parse a line as a final result blob. It
+// accepts the legacy format with payloads + meta and the OpenClaw 2026.5
+// wrapper shape with result.payloads + result.meta. Lines must start with '{'
+// to be considered — we no longer scan for braces at arbitrary positions,
+// which avoids false matches on log lines containing JSON fragments.
 func tryParseOpenclawResult(raw string) (openclawResult, bool) {
 	if len(raw) == 0 || raw[0] != '{' {
 		return openclawResult{}, false
@@ -520,10 +525,36 @@ func tryParseOpenclawResult(raw string) (openclawResult, bool) {
 	if err := json.Unmarshal([]byte(raw), &result); err != nil {
 		return openclawResult{}, false
 	}
-	if result.Payloads == nil && result.Meta.DurationMs == 0 {
+	if isOpenclawResult(result) {
+		return result, true
+	}
+
+	var wrapped openclawWrappedResult
+	if err := json.Unmarshal([]byte(raw), &wrapped); err != nil {
 		return openclawResult{}, false
 	}
-	return result, true
+	if wrapped.Result == nil || !isOpenclawResult(*wrapped.Result) {
+		return openclawResult{}, false
+	}
+	return *wrapped.Result, true
+}
+
+// tryParseOpenclawResultPrefix parses the first JSON object in raw as an
+// OpenClaw result. This handles pretty-printed results followed by diagnostics.
+func tryParseOpenclawResultPrefix(raw string) (openclawResult, bool) {
+	if len(raw) == 0 || raw[0] != '{' {
+		return openclawResult{}, false
+	}
+	var first json.RawMessage
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	if err := decoder.Decode(&first); err != nil {
+		return openclawResult{}, false
+	}
+	return tryParseOpenclawResult(string(first))
+}
+
+func isOpenclawResult(result openclawResult) bool {
+	return result.Payloads != nil || result.Meta.DurationMs != 0 || result.Meta.AgentMeta != nil
 }
 
 // buildOpenclawEventResult extracts text and metadata from a final result blob.
@@ -539,6 +570,9 @@ func (b *openclawBackend) buildOpenclawEventResult(result openclawResult, ch cha
 	var sessionID string
 	var model string
 	var usage TokenUsage
+	if result.Meta.SessionID != "" {
+		sessionID = result.Meta.SessionID
+	}
 	if result.Meta.AgentMeta != nil {
 		if sid, ok := result.Meta.AgentMeta["sessionId"].(string); ok {
 			sessionID = sid
@@ -682,11 +716,18 @@ type openclawResult struct {
 	Meta     openclawMeta      `json:"meta"`
 }
 
+type openclawWrappedResult struct {
+	RunID  string          `json:"runId"`
+	Status string          `json:"status"`
+	Result *openclawResult `json:"result"`
+}
+
 type openclawPayload struct {
 	Text string `json:"text"`
 }
 
 type openclawMeta struct {
 	DurationMs int64          `json:"durationMs"`
+	SessionID  string         `json:"sessionId"`
 	AgentMeta  map[string]any `json:"agentMeta"`
 }

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -23,6 +23,57 @@ func TestNewReturnsOpenclawBackend(t *testing.T) {
 	}
 }
 
+func TestOpenclawExecuteParsesStdoutWrappedResult(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "openclaw")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo 'openclaw 2026.5.4'; exit 0; fi\n" +
+		"echo '[info] diagnostic on stderr' >&2\n" +
+		"printf '%s\\n' '{\"runId\":\"run_stdout\",\"status\":\"ok\",\"result\":{\"payloads\":[{\"type\":\"text\",\"text\":\"stdout wrapped\"}],\"meta\":{\"agentMeta\":{\"sessionId\":\"ses_stdout\",\"model\":\"deepseek-chat\",\"usage\":{\"input\":12,\"output\":3}}}}}'\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("openclaw", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new openclaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		if result.Status != "completed" {
+			t.Fatalf("status: got %q, want completed (error=%q)", result.Status, result.Error)
+		}
+		if result.Output != "stdout wrapped" {
+			t.Errorf("output: got %q, want %q", result.Output, "stdout wrapped")
+		}
+		if result.SessionID != "ses_stdout" {
+			t.Errorf("sessionID: got %q, want %q", result.SessionID, "ses_stdout")
+		}
+		if got := result.Usage["deepseek-chat"].InputTokens; got != 12 {
+			t.Errorf("input tokens: got %d, want 12", got)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 // ── Legacy result format tests (processOutput with final JSON blob) ──
 
 func TestOpenclawProcessOutputHappyPath(t *testing.T) {
@@ -77,6 +128,52 @@ func TestOpenclawProcessOutputHappyPath(t *testing.T) {
 	if msgs[0].Content != "Hello from openclaw" {
 		t.Errorf("message content: got %q", msgs[0].Content)
 	}
+}
+
+func TestOpenclawProcessOutputWrappedResult(t *testing.T) {
+	t.Parallel()
+
+	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	result := openclawWrappedResult{
+		RunID:  "run_123",
+		Status: "ok",
+		Result: &openclawResult{
+			Payloads: []openclawPayload{{Text: "Hello from wrapped openclaw"}},
+			Meta: openclawMeta{
+				AgentMeta: map[string]any{
+					"sessionId": "ses_wrapped",
+					"model":     "deepseek-chat",
+					"usage": map[string]any{
+						"input":  float64(42),
+						"output": float64(7),
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(result)
+
+	res := b.processOutput(strings.NewReader(string(data)), ch)
+
+	if res.status != "completed" {
+		t.Errorf("status: got %q, want %q", res.status, "completed")
+	}
+	if res.output != "Hello from wrapped openclaw" {
+		t.Errorf("output: got %q, want wrapped payload text", res.output)
+	}
+	if res.sessionID != "ses_wrapped" {
+		t.Errorf("sessionID: got %q, want %q", res.sessionID, "ses_wrapped")
+	}
+	if res.model != "deepseek-chat" {
+		t.Errorf("model: got %q, want %q", res.model, "deepseek-chat")
+	}
+	if res.usage.InputTokens != 42 || res.usage.OutputTokens != 7 {
+		t.Errorf("usage: got %+v", res.usage)
+	}
+
+	close(ch)
 }
 
 func TestOpenclawProcessOutputMultiplePayloads(t *testing.T) {
@@ -167,6 +264,35 @@ func TestOpenclawProcessOutputWithLeadingLogLines(t *testing.T) {
 	close(ch)
 }
 
+func TestOpenclawProcessOutputWithNoiseAndWrappedResult(t *testing.T) {
+	t.Parallel()
+
+	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	result := openclawWrappedResult{
+		RunID:  "run_noise",
+		Status: "ok",
+		Result: &openclawResult{
+			Payloads: []openclawPayload{{Text: "Done after noise"}},
+			Meta:     openclawMeta{DurationMs: 100},
+		},
+	}
+	data, _ := json.Marshal(result)
+	input := "[info] starting\n" + string(data) + "\n[debug] finished"
+
+	res := b.processOutput(strings.NewReader(input), ch)
+
+	if res.status != "completed" {
+		t.Errorf("status: got %q, want %q", res.status, "completed")
+	}
+	if res.output != "Done after noise" {
+		t.Errorf("output: got %q, want %q", res.output, "Done after noise")
+	}
+
+	close(ch)
+}
+
 func TestOpenclawProcessOutputIgnoresTrailingLogLinesAfterJSON(t *testing.T) {
 	t.Parallel()
 
@@ -204,6 +330,24 @@ func TestOpenclawProcessOutputNoJSON(t *testing.T) {
 	}
 	if res.output != "not json at all" {
 		t.Errorf("output: got %q", res.output)
+	}
+
+	close(ch)
+}
+
+func TestOpenclawProcessOutputMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	res := b.processOutput(strings.NewReader(`{"payloads":[`), ch)
+
+	if res.status != "failed" {
+		t.Errorf("status: got %q, want %q", res.status, "failed")
+	}
+	if res.errMsg != "openclaw returned no parseable output" {
+		t.Errorf("errMsg: got %q", res.errMsg)
 	}
 
 	close(ch)
@@ -1409,12 +1553,12 @@ func TestCompareOpenclawVersion(t *testing.T) {
 		a, b string
 		want int
 	}{
-		{"2026.5.5", "2026.5.5", 0},
-		{"2026.5.4", "2026.5.5", -1},
-		{"2026.5.6", "2026.5.5", 1},
+		{"2026.5.4", "2026.5.4", 0},
+		{"2026.5.3", "2026.5.4", -1},
+		{"2026.5.5", "2026.5.4", 1},
 		{"2026.4.99", "2026.5.0", -1},
 		{"2027.0.0", "2026.99.99", 1},
-		{"0.0.0", "2026.5.5", -1},
+		{"0.0.0", "2026.5.4", -1},
 	}
 
 	for _, c := range cases {
@@ -1459,7 +1603,7 @@ func TestOpenclawExecuteRejectsOldVersion(t *testing.T) {
 		t.Fatal("expected Execute to return a version error, got nil")
 	}
 	msg := err.Error()
-	for _, want := range []string{"2026.4.9", "2026.5.5", "openclaw update"} {
+	for _, want := range []string{"2026.4.9", "2026.5.4", "openclaw update"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error message missing %q: %s", want, msg)
 		}
@@ -1480,7 +1624,7 @@ func TestOpenclawExecuteAllowsCurrentVersion(t *testing.T) {
 	fakePath := filepath.Join(t.TempDir(), "openclaw")
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"--version\" ]; then\n" +
-		"  echo 'openclaw 2026.5.5 c37871e'\n" +
+		"  echo 'openclaw 2026.5.4 c37871e'\n" +
 		"  exit 0\n" +
 		"fi\n" +
 		"exit 0\n"


### PR DESCRIPTION
## Problem
OpenClaw JSON output handling changed across recent 2026.5 builds. Main already reads current OpenClaw stdout output and blocks older unsupported versions, but the parser still only accepted the legacy top-level `{payloads, meta}` shape. Wrapped results such as `{runId, status, result: {payloads, meta}}` could still be reported as no parseable output.

## Fix
- Accept both legacy `{payloads, meta}` results and wrapped `{runId, status, result: {payloads, meta}}` results.
- Lower the supported OpenClaw floor to `2026.5.4`, matching the locally observed version that emits stdout wrapped JSON.
- Preserve existing payload, session, model, and usage extraction.
- Keep stderr as daemon log output, matching current main after #2101 and #2181.
- Treat empty or malformed JSON-mode output as a clear failure instead of a completed raw-text result.

## Validation
- `cd server && go test ./pkg/agent -run "Openclaw|ParseOpenclawVersion|CompareOpenclawVersion" -count=1`
- `cd server && go test ./pkg/agent -count=1 -parallel=1`

Note: `cd server && go test ./pkg/agent -count=1` hit existing Kiro/Codex process-fixture timing flakes under parallel execution; the failed tests passed when run directly, and the package passed with `-parallel=1`.
