### PR TITLE
feat(email): add Postmark provider alongside Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,9 +48,18 @@ MULTICA_IMAGE_TAG=latest
 MULTICA_BACKEND_IMAGE=ghcr.io/multica-ai/multica-backend
 MULTICA_WEB_IMAGE=ghcr.io/multica-ai/multica-web
 
-# Email (Resend)
-# For local/dev use, leave RESEND_API_KEY empty — generated codes print to stdout.
-# For production, set your Resend API key and change RESEND_FROM_EMAIL to a domain verified in your Resend account.
+# Email
+# Provider selection (in order of precedence):
+#   1. Postmark  — set POSTMARK_SERVER_TOKEN
+#   2. Resend    — set RESEND_API_KEY
+#   3. Fallback  — neither set: verification codes print to stdout (dev only)
+# If both are set, Postmark takes precedence and a warning is logged.
+#
+# Postmark
+POSTMARK_SERVER_TOKEN=
+POSTMARK_FROM_EMAIL=noreply@multica.ai
+#
+# Resend
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=noreply@multica.ai
 

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -25,14 +25,37 @@ These have sensible defaults and only need to be set when tuning a large or cons
 
 ### Email (Required for Authentication)
 
-Multica uses email-based magic link authentication via [Resend](https://resend.com).
+Multica uses email-based magic link authentication. You can choose between **Postmark** and **Resend** as your email provider.
+
+#### Provider selection
+
+The backend picks a provider based on which environment variables are set:
+
+| Priority | Condition | Provider used |
+|----------|-----------|---------------|
+| 1 | `POSTMARK_SERVER_TOKEN` is set | Postmark |
+| 2 | `RESEND_API_KEY` is set | Resend |
+| 3 | Neither is set | Fallback — codes printed to backend logs (dev only) |
+
+If both variables are set, **Postmark takes precedence** and a warning is logged at startup.
+
+#### Postmark
+
+| Variable | Description |
+|----------|-------------|
+| `POSTMARK_SERVER_TOKEN` | Postmark server API token |
+| `POSTMARK_FROM_EMAIL` | Sender address (default: `noreply@multica.ai`) |
+
+> **Important:** Postmark requires a verified sender signature or domain. Sending from an unverified address will fail with a 422 error. Verify your sender in the [Postmark account portal](https://account.postmarkapp.com/signature_domains) before going live.
+
+#### Resend
 
 | Variable | Description |
 |----------|-------------|
 | `RESEND_API_KEY` | Your Resend API key |
-| `RESEND_FROM_EMAIL` | Sender email address (default: `noreply@multica.ai`) |
+| `RESEND_FROM_EMAIL` | Sender address (default: `noreply@multica.ai`) |
 
-> **Note:** If Resend is not configured, generated verification codes are printed to backend logs. A fixed local testing code is disabled by default; to opt in on a private test instance, set `APP_ENV=development` and `MULTICA_DEV_VERIFICATION_CODE` to a 6-digit value. It is ignored when `APP_ENV=production`.
+> **Note:** If neither provider is configured, generated verification codes are printed to backend logs. A fixed local testing code is disabled by default; to opt in on a private test instance, set `APP_ENV=development` and `MULTICA_DEV_VERIFICATION_CODE` to a 6-digit value. It is ignored when `APP_ENV=production`.
 
 ### Google OAuth (Optional)
 

--- a/server/internal/service/email.go
+++ b/server/internal/service/email.go
@@ -1,8 +1,13 @@
 package service
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"html"
+	"log"
+	"net/http"
 	"os"
 	"strings"
 	"unicode"
@@ -16,77 +21,198 @@ import (
 // a full phishing pitch into a workspace name that gets sent from our domain.
 const maxSubjectFieldRunes = 60
 
+// emailSender is the internal interface for email delivery.
+// resendSender, postmarkSender, and logSender each implement it.
+type emailSender interface {
+	sendVerificationCode(to, code string) error
+	sendInvitationEmail(to, inviterName, workspaceName, invitationID string) error
+}
+
+// EmailService is the public-facing email service used by handlers.
+// Provider selection is encapsulated here; no handler references a concrete provider.
 type EmailService struct {
-	client    *resend.Client
-	fromEmail string
+	sender emailSender
 }
 
 func NewEmailService() *EmailService {
-	apiKey := os.Getenv("RESEND_API_KEY")
-	from := os.Getenv("RESEND_FROM_EMAIL")
-	if from == "" {
-		from = "noreply@multica.ai"
+	postmarkToken := os.Getenv("POSTMARK_SERVER_TOKEN")
+	resendKey := os.Getenv("RESEND_API_KEY")
+
+	// POSTMARK_FROM_EMAIL takes precedence; RESEND_FROM_EMAIL is the fallback.
+	fromEmail := os.Getenv("POSTMARK_FROM_EMAIL")
+	if fromEmail == "" {
+		fromEmail = os.Getenv("RESEND_FROM_EMAIL")
+	}
+	if fromEmail == "" {
+		fromEmail = "noreply@multica.ai"
 	}
 
-	var client *resend.Client
-	if apiKey != "" {
-		client = resend.NewClient(apiKey)
+	var sender emailSender
+	switch {
+	case postmarkToken != "":
+		if resendKey != "" {
+			log.Println("[email] both POSTMARK_SERVER_TOKEN and RESEND_API_KEY are set; using Postmark")
+		}
+		sender = &postmarkSender{token: postmarkToken, from: fromEmail}
+	case resendKey != "":
+		sender = &resendSender{client: resend.NewClient(resendKey), from: fromEmail}
+	default:
+		sender = &logSender{}
 	}
 
-	return &EmailService{
-		client:    client,
-		fromEmail: from,
-	}
+	return &EmailService{sender: sender}
 }
 
 // SendVerificationCode sends a one-time login code. The code is server-generated
 // (6-digit numeric) so no user-controlled text reaches the email body here.
-// If that ever changes, escape the user-controlled fields the same way
-// SendInvitationEmail does.
 func (s *EmailService) SendVerificationCode(to, code string) error {
-	if s.client == nil {
-		fmt.Printf("[DEV] Verification code for %s: %s\n", to, code)
-		return nil
-	}
-
-	params := &resend.SendEmailRequest{
-		From:    s.fromEmail,
-		To:      []string{to},
-		Subject: "Your Multica verification code",
-		Html: fmt.Sprintf(
-			`<div style="font-family: sans-serif; max-width: 400px; margin: 0 auto;">
-				<h2>Your verification code</h2>
-				<p style="font-size: 32px; font-weight: bold; letter-spacing: 8px; margin: 24px 0;">%s</p>
-				<p>This code expires in 10 minutes.</p>
-				<p style="color: #666; font-size: 14px;">If you didn't request this code, you can safely ignore this email.</p>
-			</div>`, code),
-	}
-
-	_, err := s.client.Emails.Send(params)
-	return err
+	return s.sender.sendVerificationCode(to, code)
 }
 
 // SendInvitationEmail notifies the invitee that they have been invited to a workspace.
-// invitationID is included in the URL so the email deep-links to /invite/{id}.
 func (s *EmailService) SendInvitationEmail(to, inviterName, workspaceName, invitationID string) error {
+	return s.sender.sendInvitationEmail(to, inviterName, workspaceName, invitationID)
+}
+
+// --- logSender (fallback when no provider is configured) ---
+
+type logSender struct{}
+
+func (l *logSender) sendVerificationCode(to, code string) error {
+	fmt.Printf("[DEV] Verification code for %s: %s\n", to, code)
+	return nil
+}
+
+func (l *logSender) sendInvitationEmail(to, inviterName, workspaceName, invitationID string) error {
 	appURL := strings.TrimSpace(os.Getenv("FRONTEND_ORIGIN"))
 	if appURL == "" {
 		appURL = "https://app.multica.ai"
 	}
 	inviteURL := fmt.Sprintf("%s/invite/%s", appURL, invitationID)
+	fmt.Printf("[DEV] Invitation email to %s: %s invited you to %s — %s\n", to, inviterName, workspaceName, inviteURL)
+	return nil
+}
 
-	if s.client == nil {
-		fmt.Printf("[DEV] Invitation email to %s: %s invited you to %s — %s\n", to, inviterName, workspaceName, inviteURL)
-		return nil
+// --- resendSender ---
+
+type resendSender struct {
+	client *resend.Client
+	from   string
+}
+
+func (r *resendSender) sendVerificationCode(to, code string) error {
+	params := &resend.SendEmailRequest{
+		From:    r.from,
+		To:      []string{to},
+		Subject: "Your Multica verification code",
+		Html:    verificationCodeHTML(code),
 	}
-
-	params := buildInvitationParams(s.fromEmail, to, inviterName, workspaceName, inviteURL)
-	_, err := s.client.Emails.Send(params)
+	_, err := r.client.Emails.Send(params)
 	return err
 }
 
+func (r *resendSender) sendInvitationEmail(to, inviterName, workspaceName, invitationID string) error {
+	appURL := strings.TrimSpace(os.Getenv("FRONTEND_ORIGIN"))
+	if appURL == "" {
+		appURL = "https://app.multica.ai"
+	}
+	inviteURL := fmt.Sprintf("%s/invite/%s", appURL, invitationID)
+	params := buildInvitationParams(r.from, to, inviterName, workspaceName, inviteURL)
+	_, err := r.client.Emails.Send(params)
+	return err
+}
+
+// --- postmarkSender (plain HTTP — no extra dep) ---
+
+type postmarkSender struct {
+	token string
+	from  string
+}
+
+type postmarkEmailRequest struct {
+	From     string `json:"From"`
+	To       string `json:"To"`
+	Subject  string `json:"Subject"`
+	HtmlBody string `json:"HtmlBody"`
+}
+
+func (p *postmarkSender) post(email postmarkEmailRequest) error {
+	body, err := json.Marshal(email)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://api.postmarkapp.com/email", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Postmark-Server-Token", p.token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("postmark: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (p *postmarkSender) sendVerificationCode(to, code string) error {
+	return p.post(postmarkEmailRequest{
+		From:     p.from,
+		To:       to,
+		Subject:  "Your Multica verification code",
+		HtmlBody: verificationCodeHTML(code),
+	})
+}
+
+func (p *postmarkSender) sendInvitationEmail(to, inviterName, workspaceName, invitationID string) error {
+	appURL := strings.TrimSpace(os.Getenv("FRONTEND_ORIGIN"))
+	if appURL == "" {
+		appURL = "https://app.multica.ai"
+	}
+	inviteURL := fmt.Sprintf("%s/invite/%s", appURL, invitationID)
+	safeWorkspace := html.EscapeString(workspaceName)
+	safeInviter := html.EscapeString(inviterName)
+	subjectInviter := sanitizeSubjectField(inviterName)
+	subjectWorkspace := sanitizeSubjectField(workspaceName)
+	return p.post(postmarkEmailRequest{
+		From:     p.from,
+		To:       to,
+		Subject:  fmt.Sprintf("%s invited you to %s on Multica", subjectInviter, subjectWorkspace),
+		HtmlBody: invitationHTML(safeInviter, safeWorkspace, inviteURL),
+	})
+}
+
+// --- shared HTML builders ---
+
+func verificationCodeHTML(code string) string {
+	return fmt.Sprintf(
+		`<div style="font-family: sans-serif; max-width: 400px; margin: 0 auto;">
+			<h2>Your verification code</h2>
+			<p style="font-size: 32px; font-weight: bold; letter-spacing: 8px; margin: 24px 0;">%s</p>
+			<p>This code expires in 10 minutes.</p>
+			<p style="color: #666; font-size: 14px;">If you didn't request this code, you can safely ignore this email.</p>
+		</div>`, code)
+}
+
+func invitationHTML(safeInviter, safeWorkspace, inviteURL string) string {
+	return fmt.Sprintf(
+		`<div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
+			<h2>You're invited to join %s</h2>
+			<p><strong>%s</strong> invited you to collaborate in the <strong>%s</strong> workspace on Multica.</p>
+			<p style="margin: 24px 0;">
+				<a href="%s" style="display: inline-block; padding: 12px 24px; background: #000; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 500;">Accept invitation</a>
+			</p>
+			<p style="color: #666; font-size: 14px;">You'll need to log in to accept or decline the invitation.</p>
+		</div>`, safeWorkspace, safeInviter, safeWorkspace, inviteURL)
+}
+
 // buildInvitationParams assembles the Resend request for an invitation email.
-// Separated from SendInvitationEmail so the sanitization behavior is unit-testable
+// Separated from resendSender so the sanitization behaviour is unit-testable
 // without needing to mock the Resend SDK.
 func buildInvitationParams(from, to, inviterName, workspaceName, inviteURL string) *resend.SendEmailRequest {
 	safeWorkspace := html.EscapeString(workspaceName)
@@ -98,15 +224,7 @@ func buildInvitationParams(from, to, inviterName, workspaceName, inviteURL strin
 		From:    from,
 		To:      []string{to},
 		Subject: fmt.Sprintf("%s invited you to %s on Multica", subjectInviter, subjectWorkspace),
-		Html: fmt.Sprintf(
-			`<div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
-				<h2>You're invited to join %s</h2>
-				<p><strong>%s</strong> invited you to collaborate in the <strong>%s</strong> workspace on Multica.</p>
-				<p style="margin: 24px 0;">
-					<a href="%s" style="display: inline-block; padding: 12px 24px; background: #000; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 500;">Accept invitation</a>
-				</p>
-				<p style="color: #666; font-size: 14px;">You'll need to log in to accept or decline the invitation.</p>
-			</div>`, safeWorkspace, safeInviter, safeWorkspace, inviteURL),
+		Html:    invitationHTML(safeInviter, safeWorkspace, inviteURL),
 	}
 }
 
@@ -114,8 +232,8 @@ func buildInvitationParams(from, to, inviterName, workspaceName, inviteURL strin
 // Subject is not HTML-rendered, so HTML-escaping would leak literal entities
 // (e.g. &lt;script&gt;) into the recipient's inbox. Instead strip control
 // characters (defense in depth against header-injection-adjacent abuse even
-// though Resend also filters CR/LF) and cap length so attackers can't stuff
-// a full phishing subject into a workspace name.
+// though Resend/Postmark also filter CR/LF) and cap length so attackers can't
+// stuff a full phishing subject into a workspace name.
 func sanitizeSubjectField(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))


### PR DESCRIPTION
## Summary

- Extracts an internal `emailSender` interface in `server/internal/service/email.go` so Resend and Postmark are interchangeable implementations with no provider references leaking into the handler layer
- Adds `postmarkSender` using plain HTTP (no new dependency) — POSTs to `https://api.postmarkapp.com/email` with `X-Postmark-Server-Token` header
- Provider selection at startup: `POSTMARK_SERVER_TOKEN` → Postmark; `RESEND_API_KEY` → Resend; neither → log fallback (unchanged). Both set → Postmark wins, warning logged
- All existing handler call-sites unchanged; all existing tests pass unchanged
- Updates `.env.example` with `POSTMARK_SERVER_TOKEN` and `POSTMARK_FROM_EMAIL` vars and a comment block explaining provider precedence
- Updates `SELF_HOSTING_ADVANCED.md` Email section with side-by-side provider docs and a note about Postmark's verified sender requirement

## Test plan

- [x] Go build passes (`go build ./...`)
- [x] All existing email service unit tests pass (`TestSanitizeSubjectField`, `TestBuildInvitationParams_*`)
- [ ] Manual: set `POSTMARK_SERVER_TOKEN` → verify verification code and invitation emails arrive via Postmark
- [ ] Manual: set only `RESEND_API_KEY` → verify Resend still works unchanged
- [ ] Manual: set neither → verify code prints to logs with no crash

Code Agency AI review agent