### PR TITLE
fix(docs): keep zh internal links inside the zh locale

### DIFF
--- a/apps/docs/app/[lang]/[...slug]/page.tsx
+++ b/apps/docs/app/[lang]/[...slug]/page.tsx
@@ -9,6 +9,14 @@ import { notFound } from "next/navigation";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { Metadata } from "next";
 import { docsAlternates } from "@/lib/site";
+import { i18n, type Lang } from "@/lib/i18n";
+import { DocsLocaleProvider, LocaleLink } from "@/components/locale-link";
+
+function asLang(lang: string): Lang {
+  return (i18n.languages as readonly string[]).includes(lang)
+    ? (lang as Lang)
+    : (i18n.defaultLanguage as Lang);
+}
 
 export default async function Page(props: {
   params: Promise<{ lang: string; slug: string[] }>;
@@ -18,13 +26,16 @@ export default async function Page(props: {
   if (!page) notFound();
 
   const MDX = page.data.body;
+  const lang = asLang(params.lang);
 
   return (
     <DocsPage toc={page.data.toc}>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents }} />
+        <DocsLocaleProvider lang={lang}>
+          <MDX components={{ ...defaultMdxComponents, a: LocaleLink }} />
+        </DocsLocaleProvider>
       </DocsBody>
     </DocsPage>
   );

--- a/apps/docs/app/[lang]/page.tsx
+++ b/apps/docs/app/[lang]/page.tsx
@@ -8,6 +8,7 @@ import { Byline, NumberedCards, NumberedCard, NumberedSteps, Step } from "@/comp
 import { i18n, type Lang } from "@/lib/i18n";
 import { homeCopy } from "@/lib/translations";
 import { docsAlternates } from "@/lib/site";
+import { DocsLocaleProvider, LocaleLink } from "@/components/locale-link";
 
 function asLang(lang: string): Lang {
   return (i18n.languages as readonly string[]).includes(lang)
@@ -52,15 +53,18 @@ export default async function Page({
       />
       <Byline items={[...copy.byline]} />
       <DocsBody>
-        <MDX
-          components={{
-            ...defaultMdxComponents,
-            NumberedCards,
-            NumberedCard,
-            NumberedSteps,
-            Step,
-          }}
-        />
+        <DocsLocaleProvider lang={lang}>
+          <MDX
+            components={{
+              ...defaultMdxComponents,
+              a: LocaleLink,
+              NumberedCards,
+              NumberedCard,
+              NumberedSteps,
+              Step,
+            }}
+          />
+        </DocsLocaleProvider>
       </DocsBody>
     </DocsPage>
   );

--- a/apps/docs/components/editorial.tsx
+++ b/apps/docs/components/editorial.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import Link from "next/link";
 import type { ReactNode } from "react";
+import { useDocsLocale } from "@/components/locale-link";
+import { prefixLocale } from "@/lib/locale-link";
 
 /**
  * Byline — editorial metadata strip with ruled top + bottom borders.
@@ -55,9 +59,10 @@ export function NumberedCard({
   tag?: string;
   children: ReactNode;
 }) {
+  const lang = useDocsLocale();
   return (
     <Link
-      href={href}
+      href={prefixLocale(href, lang)}
       className="group flex flex-col gap-2.5 border-r border-border px-0 py-5 pr-4 no-underline last:border-r-0 md:px-4 md:first:pl-0 md:last:pr-0"
     >
       <div className="font-mono text-[0.6875rem] uppercase tracking-[0.08em] text-muted-foreground">

--- a/apps/docs/components/locale-link.tsx
+++ b/apps/docs/components/locale-link.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import {
+  createContext,
+  useContext,
+  type AnchorHTMLAttributes,
+  type ReactNode,
+} from "react";
+import { i18n, type Lang } from "@/lib/i18n";
+import { prefixLocale } from "@/lib/locale-link";
+
+const DocsLocaleContext = createContext<Lang>(i18n.defaultLanguage as Lang);
+
+// Wraps the rendered MDX subtree so descendant <LocaleLink>s and any
+// editorial component using `useDocsLocale()` know which language the page
+// was rendered in. Mounted at each docs page entry; never elsewhere.
+export function DocsLocaleProvider({
+  lang,
+  children,
+}: {
+  lang: Lang;
+  children: ReactNode;
+}) {
+  return (
+    <DocsLocaleContext.Provider value={lang}>
+      {children}
+    </DocsLocaleContext.Provider>
+  );
+}
+
+export function useDocsLocale(): Lang {
+  return useContext(DocsLocaleContext);
+}
+
+// Drop-in replacement for the MDX-rendered `<a>` element. Keeps the same
+// surface shape as the default `a` from `defaultMdxComponents` but routes
+// internal links through the locale prefixer + next/link so client-side
+// navigation stays inside the active locale.
+export function LocaleLink({
+  href,
+  ...rest
+}: AnchorHTMLAttributes<HTMLAnchorElement> & { href?: string }) {
+  const lang = useDocsLocale();
+  if (!href) return <a {...rest} />;
+  const final = prefixLocale(href, lang);
+  return <Link href={final} {...rest} />;
+}

--- a/apps/docs/lib/locale-link.test.ts
+++ b/apps/docs/lib/locale-link.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { prefixLocale } from "./locale-link";
+
+describe("prefixLocale", () => {
+  it("prefixes root-relative paths with the active non-default locale", () => {
+    expect(prefixLocale("/workspaces", "zh")).toBe("/zh/workspaces");
+    expect(prefixLocale("/agents-create", "zh")).toBe("/zh/agents-create");
+  });
+
+  it("preserves anchors and query strings on prefixed paths", () => {
+    expect(prefixLocale("/providers#claude-code", "zh")).toBe(
+      "/zh/providers#claude-code",
+    );
+    expect(prefixLocale("/agents?from=docs", "zh")).toBe(
+      "/zh/agents?from=docs",
+    );
+  });
+
+  it("rewrites the bare root path to the locale root", () => {
+    expect(prefixLocale("/", "zh")).toBe("/zh");
+  });
+
+  it("leaves the default language untouched (URLs are prefix-less)", () => {
+    expect(prefixLocale("/workspaces", "en")).toBe("/workspaces");
+    expect(prefixLocale("/", "en")).toBe("/");
+  });
+
+  it("does not double-prefix paths that already carry a known locale", () => {
+    expect(prefixLocale("/zh/workspaces", "zh")).toBe("/zh/workspaces");
+    expect(prefixLocale("/en/workspaces", "zh")).toBe("/en/workspaces");
+  });
+
+  it("leaves external URLs alone", () => {
+    expect(prefixLocale("https://multica.ai/download", "zh")).toBe(
+      "https://multica.ai/download",
+    );
+    expect(prefixLocale("mailto:hello@multica.ai", "zh")).toBe(
+      "mailto:hello@multica.ai",
+    );
+    expect(prefixLocale("tel:+1234567890", "zh")).toBe("tel:+1234567890");
+  });
+
+  it("leaves in-page anchors and relative paths alone", () => {
+    expect(prefixLocale("#section", "zh")).toBe("#section");
+    expect(prefixLocale("./sibling", "zh")).toBe("./sibling");
+    expect(prefixLocale("../sibling", "zh")).toBe("../sibling");
+  });
+
+  it("returns empty/undefined hrefs unchanged", () => {
+    expect(prefixLocale("", "zh")).toBe("");
+  });
+});

--- a/apps/docs/lib/locale-link.ts
+++ b/apps/docs/lib/locale-link.ts
@@ -1,0 +1,31 @@
+import { i18n } from "./i18n";
+
+// Add the active locale prefix to root-relative MDX links so internal
+// navigation inside Chinese (or any non-default-language) docs stays in
+// that language. Without this, `[xx](/workspaces)` written in a `*.zh.mdx`
+// renders as `<a href="/workspaces">`, which Next's basePath rewrites to
+// `/docs/workspaces` and the docs middleware then routes to English —
+// leaking the reader out of their chosen locale.
+//
+// We deliberately do NOT touch:
+//   - external links (`https:`, `mailto:`, `tel:`, etc.)
+//   - in-page anchors (`#section`)
+//   - relative paths (`./foo`, `../bar`)
+//   - paths already prefixed with a known locale
+//   - the default language (URLs are intentionally prefix-less under
+//     `hideLocale: 'default-locale'`)
+export function prefixLocale(href: string, lang: string): string {
+  if (!href) return href;
+  if (lang === i18n.defaultLanguage) return href;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return href;
+  if (href.startsWith("#")) return href;
+  if (!href.startsWith("/")) return href;
+
+  const segments = href.split("/").filter(Boolean);
+  const first = segments[0];
+  if (first && (i18n.languages as readonly string[]).includes(first)) {
+    return href;
+  }
+
+  return href === "/" ? `/${lang}` : `/${lang}${href}`;
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,6 +8,7 @@
     "build": "fumadocs-mdx && next build",
     "start": "next start",
     "typecheck": "fumadocs-mdx && tsc --noEmit",
+    "test": "vitest run",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
@@ -27,6 +28,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "tailwindcss": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.{ts,tsx}"],
+    exclude: ["node_modules/**", ".next/**", ".source/**"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,7 +243,7 @@ importers:
         version: 15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       fumadocs-mdx:
         specifier: ^12.0.3
-        version: 12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
       fumadocs-ui:
         specifier: ^15.5.2
         version: 15.8.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(tailwindcss@4.2.2)
@@ -281,6 +281,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1))
 
   apps/web:
     dependencies:
@@ -11700,7 +11703,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  fumadocs-mdx@12.0.3(fumadocs-core@15.8.5(@types/react@19.2.14)(lucide-react@1.0.1(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-router@7.14.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@8.0.1(@types/node@25.5.0)(jiti@2.6.1)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -11722,6 +11725,7 @@ snapshots:
     optionalDependencies:
       next: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
+      vite: 8.0.1(@types/node@25.5.0)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Closes #2173.

Markdown links like `[xx](/workspaces)` written in `*.zh.mdx` rendered as bare `<a href="/workspaces">`, which Next's `basePath: /docs` rewrote to `/docs/workspaces` and the docs middleware then routed to English — silently kicking Chinese readers out of their chosen locale on every internal click. (27 files / 178 root-relative links across the Chinese docs.)

This PR fixes it at the MDX-component layer rather than touching the 178 source links, so newly added Chinese pages don't have to remember to write the locale-prefixed form. The logic also generalizes — adding a new language (e.g. `ja`) only needs a config + content update, no change to `LocaleLink` / `prefixLocale`.

- `apps/docs/lib/locale-link.ts` — pure `prefixLocale(href, lang)` helper. Skips externals (`https:`, `mailto:`, `tel:`), in-page anchors, relative paths, already-prefixed paths, and the default language (URLs stay prefix-less under `hideLocale: 'default-locale'`).
- `apps/docs/components/locale-link.tsx` — `DocsLocaleProvider` + `useDocsLocale` + `<LocaleLink>` (a drop-in MDX `a` override that runs the helper, then `next/link`).
- Both docs entry points (`[lang]/[...slug]/page.tsx`, `[lang]/page.tsx`) now wrap the MDX body in `DocsLocaleProvider` and pass `a: LocaleLink` through `components`.
- `editorial.tsx`'s `<NumberedCard>` (used on the home page) reads `useDocsLocale()` and runs the same helper on its `href`, so the card grid links also stay in-locale.

## Test plan

- [x] `pnpm --filter @multica/docs test` (8 new unit tests covering `/foo` → `/zh/foo`, anchors + queries preserved, `/zh/foo` not double-prefixed, externals/anchors/relative paths untouched, default language untouched, root-path edge case)
- [x] `pnpm --filter @multica/docs typecheck` passes
- [ ] Manual smoke: visit `/docs/zh/how-multica-works`, click any in-text link → should land on `/docs/zh/<page>` and stay in Chinese; English pages should be unchanged