### PR TITLE
fix(skills): drop SKILL.md content from list endpoints

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -26,6 +26,7 @@ import type {
   MemberWithUser,
   User,
   Skill,
+  SkillSummary,
   CreateSkillRequest,
   UpdateSkillRequest,
   SetAgentSkillsRequest,
@@ -913,7 +914,7 @@ export class ApiClient {
   }
 
   // Skills
-  async listSkills(): Promise<Skill[]> {
+  async listSkills(): Promise<SkillSummary[]> {
     return this.fetch("/api/skills");
   }
 
@@ -946,7 +947,7 @@ export class ApiClient {
     });
   }
 
-  async listAgentSkills(agentId: string): Promise<Skill[]> {
+  async listAgentSkills(agentId: string): Promise<SkillSummary[]> {
     return this.fetch(`/api/agents/${agentId}/skills`);
   }
 

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -171,11 +171,11 @@ export interface UpdateAgentRequest {
 
 /**
  * Lightweight skill shape returned by list endpoints (`GET /api/skills`,
- * `GET /api/agents/:id/skills`) and embedded in `Agent.skills`. The full
- * SKILL.md `content` is intentionally omitted — bodies routinely run 50–200KB
- * each and shipping them in list payloads tripped CLI timeouts on
- * high-latency links (GH multica-ai/multica#2174). Use `Skill` from a detail
- * endpoint when you need the body.
+ * `GET /api/agents/:id/skills`). The full SKILL.md `content` is intentionally
+ * omitted — bodies routinely run 50–200KB each and shipping them in list
+ * payloads tripped CLI timeouts on high-latency links (GH
+ * multica-ai/multica#2174). Use `Skill` from a detail endpoint when you need
+ * the body. For skills embedded in an `Agent` payload see `AgentSkillSummary`.
  */
 export interface SkillSummary {
   id: string;

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -115,7 +115,7 @@ export interface Agent {
   max_concurrent_tasks: number;
   model: string;
   owner_id: string | null;
-  skills: Skill[];
+  skills: SkillSummary[];
   created_at: string;
   updated_at: string;
   archived_at: string | null;
@@ -156,17 +156,28 @@ export interface UpdateAgentRequest {
 
 // Skills
 
-export interface Skill {
+/**
+ * Lightweight skill shape returned by list endpoints (`GET /api/skills`,
+ * `GET /api/agents/:id/skills`) and embedded in `Agent.skills`. The full
+ * SKILL.md `content` is intentionally omitted — bodies routinely run 50–200KB
+ * each and shipping them in list payloads tripped CLI timeouts on
+ * high-latency links (GH multica-ai/multica#2174). Use `Skill` from a detail
+ * endpoint when you need the body.
+ */
+export interface SkillSummary {
   id: string;
   workspace_id: string;
   name: string;
   description: string;
-  content: string;
   config: Record<string, unknown>;
-  files: SkillFile[];
   created_by: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface Skill extends SkillSummary {
+  content: string;
+  files: SkillFile[];
 }
 
 export interface SkillFile {

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -115,11 +115,24 @@ export interface Agent {
   max_concurrent_tasks: number;
   model: string;
   owner_id: string | null;
-  skills: SkillSummary[];
+  skills: AgentSkillSummary[];
   created_at: string;
   updated_at: string;
   archived_at: string | null;
   archived_by: string | null;
+}
+
+/**
+ * Minimal skill shape embedded in an Agent payload (`GET /api/agents`,
+ * `GET /api/agents/:id`). Only id/name/description are populated — the
+ * agent list batch query joins exactly those three columns. For full skill
+ * info, use `GET /api/agents/:id/skills` (returns `SkillSummary[]`) or
+ * `GET /api/skills/:id` (returns the full `Skill`).
+ */
+export interface AgentSkillSummary {
+  id: string;
+  name: string;
+  description: string;
 }
 
 export interface CreateAgentRequest {

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -14,6 +14,7 @@ export type {
   UpdateAgentRequest,
   Skill,
   SkillSummary,
+  AgentSkillSummary,
   SkillFile,
   CreateSkillRequest,
   UpdateSkillRequest,

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -13,6 +13,7 @@ export type {
   CreateAgentRequest,
   UpdateAgentRequest,
   Skill,
+  SkillSummary,
   SkillFile,
   CreateSkillRequest,
   UpdateSkillRequest,

--- a/packages/views/skills/components/skill-columns.tsx
+++ b/packages/views/skills/components/skill-columns.tsx
@@ -13,7 +13,7 @@ import type {
   Agent,
   AgentRuntime,
   MemberWithUser,
-  Skill,
+  SkillSummary,
 } from "@multica/core/types";
 import { timeAgo } from "@multica/core/utils";
 import { ActorAvatar } from "@multica/ui/components/common/actor-avatar";
@@ -26,9 +26,11 @@ import { readOrigin, totalFileCount } from "../lib/origin";
 import { useT } from "../../i18n";
 
 // Per-row data assembled at the page level. The columns reach into
-// `row.original` and never pull their own queries.
+// `row.original` and never pull their own queries. `skill` is the list-shape
+// `SkillSummary`; the body and files are loaded only when the user opens the
+// detail page.
 export interface SkillRow {
-  skill: Skill;
+  skill: SkillSummary;
   agents: Agent[];
   creator: MemberWithUser | null;
   // Originating runtime when the skill was imported from a runtime-local
@@ -181,7 +183,7 @@ function SourceCell({
   creator,
   runtime,
 }: {
-  skill: Skill;
+  skill: SkillSummary;
   creator: MemberWithUser | null;
   runtime: AgentRuntime | null;
 }) {

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -12,6 +12,7 @@ import type {
   AgentRuntime,
   MemberWithUser,
   Skill,
+  SkillSummary,
 } from "@multica/core/types";
 import { useQuery } from "@tanstack/react-query";
 import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
@@ -219,7 +220,7 @@ export default function SkillsPage() {
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    const byAssignment = (s: Skill) =>
+    const byAssignment = (s: SkillSummary) =>
       (assignments.get(s.id)?.length ?? 0) > 0;
 
     return skills.filter((s) => {

--- a/packages/views/skills/hooks/use-can-edit-skill.ts
+++ b/packages/views/skills/hooks/use-can-edit-skill.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import type { MemberRole, Skill } from "@multica/core/types";
+import type { MemberRole, SkillSummary } from "@multica/core/types";
 import { useAuthStore } from "@multica/core/auth";
 import { memberListOptions } from "@multica/core/workspace/queries";
 
@@ -18,7 +18,7 @@ import { memberListOptions } from "@multica/core/workspace/queries";
  * the repo rule for workspace-aware hooks.
  */
 export function useCanEditSkill(
-  skill: Skill | null | undefined,
+  skill: SkillSummary | null | undefined,
   wsId: string,
 ): boolean {
   const userId = useAuthStore((s) => s.user?.id ?? null);
@@ -34,7 +34,7 @@ export function useCanEditSkill(
  * (e.g. list rows that compute role once for the whole page).
  */
 export function canEditSkill(
-  skill: Skill,
+  skill: SkillSummary,
   opts: { userId: string | null; role: MemberRole | null },
 ): boolean {
   if (opts.role === "admin" || opts.role === "owner") return true;

--- a/packages/views/skills/lib/origin.ts
+++ b/packages/views/skills/lib/origin.ts
@@ -1,4 +1,4 @@
-import type { Skill } from "@multica/core/types";
+import type { Skill, SkillSummary } from "@multica/core/types";
 
 /**
  * Discriminated view over `Skill.config.origin` — the JSONB blob the backend
@@ -19,7 +19,7 @@ export type OriginInfo = {
   source_url?: string;
 };
 
-export function readOrigin(skill: Skill): OriginInfo {
+export function readOrigin(skill: SkillSummary): OriginInfo {
   const raw = (skill.config?.origin ?? null) as
     | (OriginInfo & Record<string, unknown>)
     | null;
@@ -29,7 +29,12 @@ export function readOrigin(skill: Skill): OriginInfo {
   return { type: "manual" };
 }
 
-/** SKILL.md is always present plus any additional attached files. */
-export function totalFileCount(skill: Skill): number {
-  return (skill.files?.length ?? 0) + 1;
+/**
+ * SKILL.md is always present plus any additional attached files. Accepts a
+ * `SkillSummary` because list endpoints don't return the `files` array — in
+ * that case we only know the body exists, so the count falls back to 1.
+ */
+export function totalFileCount(skill: Skill | SkillSummary): number {
+  const files = (skill as Skill).files;
+  return (files?.length ?? 0) + 1;
 }

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -27,30 +27,30 @@ import (
 const maxAgentDescriptionLength = 255
 
 type AgentResponse struct {
-	ID                 string            `json:"id"`
-	WorkspaceID        string            `json:"workspace_id"`
-	RuntimeID          string            `json:"runtime_id"`
-	Name               string            `json:"name"`
-	Description        string            `json:"description"`
-	Instructions       string            `json:"instructions"`
-	AvatarURL          *string           `json:"avatar_url"`
-	RuntimeMode        string            `json:"runtime_mode"`
-	RuntimeConfig      any               `json:"runtime_config"`
-	CustomEnv          map[string]string `json:"custom_env"`
-	CustomArgs         []string          `json:"custom_args"`
-	McpConfig          json.RawMessage   `json:"mcp_config"`
-	CustomEnvRedacted  bool              `json:"custom_env_redacted"`
-	McpConfigRedacted  bool              `json:"mcp_config_redacted"`
-	Visibility         string            `json:"visibility"`
-	Status             string            `json:"status"`
-	MaxConcurrentTasks int32             `json:"max_concurrent_tasks"`
-	Model              string            `json:"model"`
-	OwnerID            *string           `json:"owner_id"`
-	Skills             []SkillSummaryResponse `json:"skills"`
-	CreatedAt          string            `json:"created_at"`
-	UpdatedAt          string            `json:"updated_at"`
-	ArchivedAt         *string           `json:"archived_at"`
-	ArchivedBy         *string           `json:"archived_by"`
+	ID                 string              `json:"id"`
+	WorkspaceID        string              `json:"workspace_id"`
+	RuntimeID          string              `json:"runtime_id"`
+	Name               string              `json:"name"`
+	Description        string              `json:"description"`
+	Instructions       string              `json:"instructions"`
+	AvatarURL          *string             `json:"avatar_url"`
+	RuntimeMode        string              `json:"runtime_mode"`
+	RuntimeConfig      any                 `json:"runtime_config"`
+	CustomEnv          map[string]string   `json:"custom_env"`
+	CustomArgs         []string            `json:"custom_args"`
+	McpConfig          json.RawMessage     `json:"mcp_config"`
+	CustomEnvRedacted  bool                `json:"custom_env_redacted"`
+	McpConfigRedacted  bool                `json:"mcp_config_redacted"`
+	Visibility         string              `json:"visibility"`
+	Status             string              `json:"status"`
+	MaxConcurrentTasks int32               `json:"max_concurrent_tasks"`
+	Model              string              `json:"model"`
+	OwnerID            *string             `json:"owner_id"`
+	Skills             []AgentSkillSummary `json:"skills"`
+	CreatedAt          string              `json:"created_at"`
+	UpdatedAt          string              `json:"updated_at"`
+	ArchivedAt         *string             `json:"archived_at"`
+	ArchivedBy         *string             `json:"archived_by"`
 }
 
 func agentToResponse(a db.Agent) AgentResponse {
@@ -105,7 +105,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		MaxConcurrentTasks: a.MaxConcurrentTasks,
 		Model:              a.Model.String,
 		OwnerID:            uuidToPtr(a.OwnerID),
-		Skills:             []SkillSummaryResponse{},
+		Skills:             []AgentSkillSummary{},
 		CreatedAt:          timestampToString(a.CreatedAt),
 		UpdatedAt:          timestampToString(a.UpdatedAt),
 		ArchivedAt:         timestampToPtr(a.ArchivedAt),
@@ -134,45 +134,45 @@ type ProjectResourceData struct {
 }
 
 type AgentTaskResponse struct {
-	ID                      string          `json:"id"`
-	AgentID                 string          `json:"agent_id"`
-	RuntimeID               string          `json:"runtime_id"`
-	IssueID                 string          `json:"issue_id"`
-	WorkspaceID             string          `json:"workspace_id"`
-	Status                  string          `json:"status"`
-	Priority                int32           `json:"priority"`
-	DispatchedAt            *string         `json:"dispatched_at"`
-	StartedAt               *string         `json:"started_at"`
-	CompletedAt             *string         `json:"completed_at"`
-	Result                  any             `json:"result"`
-	Error                   *string         `json:"error"`
-	FailureReason           string          `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
-	Attempt                 int32           `json:"attempt"`
-	MaxAttempts             int32           `json:"max_attempts"`
-	ParentTaskID            *string         `json:"parent_task_id,omitempty"`
-	Agent                   *TaskAgentData  `json:"agent,omitempty"`
+	ID                      string                `json:"id"`
+	AgentID                 string                `json:"agent_id"`
+	RuntimeID               string                `json:"runtime_id"`
+	IssueID                 string                `json:"issue_id"`
+	WorkspaceID             string                `json:"workspace_id"`
+	Status                  string                `json:"status"`
+	Priority                int32                 `json:"priority"`
+	DispatchedAt            *string               `json:"dispatched_at"`
+	StartedAt               *string               `json:"started_at"`
+	CompletedAt             *string               `json:"completed_at"`
+	Result                  any                   `json:"result"`
+	Error                   *string               `json:"error"`
+	FailureReason           string                `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
+	Attempt                 int32                 `json:"attempt"`
+	MaxAttempts             int32                 `json:"max_attempts"`
+	ParentTaskID            *string               `json:"parent_task_id,omitempty"`
+	Agent                   *TaskAgentData        `json:"agent,omitempty"`
 	Repos                   []RepoData            `json:"repos,omitempty"`
-	ProjectID               string                `json:"project_id,omitempty"`         // issue's project, when present
-	ProjectTitle            string                `json:"project_title,omitempty"`      // for surfacing in agent context
-	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"`  // resources attached to the project
-	CreatedAt               string          `json:"created_at"`
-	PriorSessionID          string          `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
-	PriorWorkDir            string          `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
-	TriggerCommentID        *string         `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
-	TriggerCommentContent   string          `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
-	TriggerSummary          *string         `json:"trigger_summary,omitempty"`           // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
-	TriggerAuthorType       string          `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind of the triggering comment
-	TriggerAuthorName       string          `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
-	ChatSessionID           string          `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
-	ChatMessage             string          `json:"chat_message,omitempty"`              // user message for chat tasks
-	AutopilotRunID          string          `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot-spawned tasks
-	AutopilotID             string          `json:"autopilot_id,omitempty"`              // autopilot that spawned this task
-	AutopilotTitle          string          `json:"autopilot_title,omitempty"`           // autopilot title used as task context
-	AutopilotDescription    string          `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
-	AutopilotSource         string          `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
-	AutopilotTriggerPayload json.RawMessage `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
-	QuickCreatePrompt       string          `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
-	Kind                    string          `json:"kind"`                                // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
+	ProjectID               string                `json:"project_id,omitempty"`        // issue's project, when present
+	ProjectTitle            string                `json:"project_title,omitempty"`     // for surfacing in agent context
+	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"` // resources attached to the project
+	CreatedAt               string                `json:"created_at"`
+	PriorSessionID          string                `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
+	PriorWorkDir            string                `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
+	TriggerCommentID        *string               `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
+	TriggerCommentContent   string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
+	TriggerSummary          *string               `json:"trigger_summary,omitempty"`           // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
+	TriggerAuthorType       string                `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind of the triggering comment
+	TriggerAuthorName       string                `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
+	ChatSessionID           string                `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
+	ChatMessage             string                `json:"chat_message,omitempty"`              // user message for chat tasks
+	AutopilotRunID          string                `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot-spawned tasks
+	AutopilotID             string                `json:"autopilot_id,omitempty"`              // autopilot that spawned this task
+	AutopilotTitle          string                `json:"autopilot_title,omitempty"`           // autopilot title used as task context
+	AutopilotDescription    string                `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
+	AutopilotSource         string                `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
+	AutopilotTriggerPayload json.RawMessage       `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
+	QuickCreatePrompt       string                `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
+	Kind                    string                `json:"kind"`                                // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
 }
 
 // TaskAgentData holds agent info included in claim responses so the daemon
@@ -273,10 +273,10 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
 		return
 	}
-	skillMap := map[string][]SkillSummaryResponse{}
+	skillMap := map[string][]AgentSkillSummary{}
 	for _, row := range skillRows {
 		agentID := uuidToString(row.AgentID)
-		skillMap[agentID] = append(skillMap[agentID], SkillSummaryResponse{
+		skillMap[agentID] = append(skillMap[agentID], AgentSkillSummary{
 			ID:          uuidToString(row.ID),
 			Name:        row.Name,
 			Description: row.Description,
@@ -308,18 +308,23 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := agentToResponse(agent)
+	// Use the summary query (no `content` column) — the embedded
+	// AgentSkillSummary only needs id/name/description, and reading large
+	// SKILL.md bodies just to discard them is the exact regression we fixed
+	// in #2174.
 	skills, err := h.Queries.ListAgentSkillSummaries(r.Context(), agent.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
 		return
 	}
 	if len(skills) > 0 {
-		resp.Skills = make([]SkillSummaryResponse, len(skills))
+		resp.Skills = make([]AgentSkillSummary, len(skills))
 		for i, s := range skills {
-			resp.Skills[i] = skillSummaryToResponse(
-				s.ID, s.WorkspaceID, s.Name, s.Description, s.Config,
-				s.CreatedBy, s.CreatedAt, s.UpdatedAt,
-			)
+			resp.Skills[i] = AgentSkillSummary{
+				ID:          uuidToString(s.ID),
+				Name:        s.Name,
+				Description: s.Description,
+			}
 		}
 	}
 

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -46,7 +46,7 @@ type AgentResponse struct {
 	MaxConcurrentTasks int32             `json:"max_concurrent_tasks"`
 	Model              string            `json:"model"`
 	OwnerID            *string           `json:"owner_id"`
-	Skills             []SkillResponse   `json:"skills"`
+	Skills             []SkillSummaryResponse `json:"skills"`
 	CreatedAt          string            `json:"created_at"`
 	UpdatedAt          string            `json:"updated_at"`
 	ArchivedAt         *string           `json:"archived_at"`
@@ -105,7 +105,7 @@ func agentToResponse(a db.Agent) AgentResponse {
 		MaxConcurrentTasks: a.MaxConcurrentTasks,
 		Model:              a.Model.String,
 		OwnerID:            uuidToPtr(a.OwnerID),
-		Skills:             []SkillResponse{},
+		Skills:             []SkillSummaryResponse{},
 		CreatedAt:          timestampToString(a.CreatedAt),
 		UpdatedAt:          timestampToString(a.UpdatedAt),
 		ArchivedAt:         timestampToPtr(a.ArchivedAt),
@@ -273,10 +273,10 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
 		return
 	}
-	skillMap := map[string][]SkillResponse{}
+	skillMap := map[string][]SkillSummaryResponse{}
 	for _, row := range skillRows {
 		agentID := uuidToString(row.AgentID)
-		skillMap[agentID] = append(skillMap[agentID], SkillResponse{
+		skillMap[agentID] = append(skillMap[agentID], SkillSummaryResponse{
 			ID:          uuidToString(row.ID),
 			Name:        row.Name,
 			Description: row.Description,
@@ -308,15 +308,18 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := agentToResponse(agent)
-	skills, err := h.Queries.ListAgentSkills(r.Context(), agent.ID)
+	skills, err := h.Queries.ListAgentSkillSummaries(r.Context(), agent.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to load agent skills")
 		return
 	}
 	if len(skills) > 0 {
-		resp.Skills = make([]SkillResponse, len(skills))
+		resp.Skills = make([]SkillSummaryResponse, len(skills))
 		for i, s := range skills {
-			resp.Skills[i] = skillToResponse(s)
+			resp.Skills[i] = skillSummaryToResponse(
+				s.ID, s.WorkspaceID, s.Name, s.Description, s.Config,
+				s.CreatedBy, s.CreatedAt, s.UpdatedAt,
+			)
 		}
 	}
 

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -38,6 +38,22 @@ type SkillResponse struct {
 	UpdatedAt   string  `json:"updated_at"`
 }
 
+// SkillSummaryResponse is the list-endpoint shape: everything SkillResponse
+// has except `content`. SKILL.md bodies routinely run 50–200KB and shipping
+// them in list payloads bloats responses past CLI timeouts on high-latency
+// links (GH multica-ai/multica#2174). Detail endpoints still return the full
+// SkillResponse with content.
+type SkillSummaryResponse struct {
+	ID          string  `json:"id"`
+	WorkspaceID string  `json:"workspace_id"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Config      any     `json:"config"`
+	CreatedBy   *string `json:"created_by"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
 type SkillFileResponse struct {
 	ID        string `json:"id"`
 	SkillID   string `json:"skill_id"`
@@ -53,24 +69,48 @@ type SkillWithFilesResponse struct {
 }
 
 func skillToResponse(s db.Skill) SkillResponse {
-	var config any
-	if s.Config != nil {
-		json.Unmarshal(s.Config, &config)
-	}
-	if config == nil {
-		config = map[string]any{}
-	}
-
 	return SkillResponse{
 		ID:          uuidToString(s.ID),
 		WorkspaceID: uuidToString(s.WorkspaceID),
 		Name:        s.Name,
 		Description: s.Description,
 		Content:     s.Content,
-		Config:      config,
+		Config:      decodeSkillConfig(s.Config),
 		CreatedBy:   uuidToPtr(s.CreatedBy),
 		CreatedAt:   timestampToString(s.CreatedAt),
 		UpdatedAt:   timestampToString(s.UpdatedAt),
+	}
+}
+
+// decodeSkillConfig decodes a JSONB skill.config blob, defaulting to {} when
+// missing or unparseable so the API surface always returns a JSON object.
+func decodeSkillConfig(raw []byte) any {
+	var config any
+	if raw != nil {
+		_ = json.Unmarshal(raw, &config)
+	}
+	if config == nil {
+		return map[string]any{}
+	}
+	return config
+}
+
+func skillSummaryToResponse(
+	id, workspaceID pgtype.UUID,
+	name, description string,
+	config []byte,
+	createdBy pgtype.UUID,
+	createdAt, updatedAt pgtype.Timestamptz,
+) SkillSummaryResponse {
+	return SkillSummaryResponse{
+		ID:          uuidToString(id),
+		WorkspaceID: uuidToString(workspaceID),
+		Name:        name,
+		Description: description,
+		Config:      decodeSkillConfig(config),
+		CreatedBy:   uuidToPtr(createdBy),
+		CreatedAt:   timestampToString(createdAt),
+		UpdatedAt:   timestampToString(updatedAt),
 	}
 }
 
@@ -152,15 +192,18 @@ func (h *Handler) loadSkillForUser(w http.ResponseWriter, r *http.Request, id st
 func (h *Handler) ListSkills(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)
 
-	skills, err := h.Queries.ListSkillsByWorkspace(r.Context(), parseUUID(workspaceID))
+	skills, err := h.Queries.ListSkillSummariesByWorkspace(r.Context(), parseUUID(workspaceID))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list skills")
 		return
 	}
 
-	resp := make([]SkillResponse, len(skills))
+	resp := make([]SkillSummaryResponse, len(skills))
 	for i, s := range skills {
-		resp[i] = skillToResponse(s)
+		resp[i] = skillSummaryToResponse(
+			s.ID, s.WorkspaceID, s.Name, s.Description, s.Config,
+			s.CreatedBy, s.CreatedAt, s.UpdatedAt,
+		)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -1244,15 +1287,18 @@ func (h *Handler) ListAgentSkills(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	skills, err := h.Queries.ListAgentSkills(r.Context(), agent.ID)
+	skills, err := h.Queries.ListAgentSkillSummaries(r.Context(), agent.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list agent skills")
 		return
 	}
 
-	resp := make([]SkillResponse, len(skills))
+	resp := make([]SkillSummaryResponse, len(skills))
 	for i, s := range skills {
-		resp[i] = skillToResponse(s)
+		resp[i] = skillSummaryToResponse(
+			s.ID, s.WorkspaceID, s.Name, s.Description, s.Config,
+			s.CreatedBy, s.CreatedAt, s.UpdatedAt,
+		)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -1307,15 +1353,18 @@ func (h *Handler) SetAgentSkills(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return the updated skills list.
-	skills, err := h.Queries.ListAgentSkills(r.Context(), agent.ID)
+	skills, err := h.Queries.ListAgentSkillSummaries(r.Context(), agent.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list agent skills")
 		return
 	}
 
-	resp := make([]SkillResponse, len(skills))
+	resp := make([]SkillSummaryResponse, len(skills))
 	for i, s := range skills {
-		resp[i] = skillToResponse(s)
+		resp[i] = skillSummaryToResponse(
+			s.ID, s.WorkspaceID, s.Name, s.Description, s.Config,
+			s.CreatedBy, s.CreatedAt, s.UpdatedAt,
+		)
 	}
 	actorType, actorID := h.resolveActor(r, requestUserID(r), uuidToString(agent.WorkspaceID))
 	h.publish(protocol.EventAgentStatus, uuidToString(agent.WorkspaceID), actorType, actorID, map[string]any{"agent_id": uuidToString(agent.ID), "skills": resp})

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -54,6 +54,17 @@ type SkillSummaryResponse struct {
 	UpdatedAt   string  `json:"updated_at"`
 }
 
+// AgentSkillSummary is the still-narrower shape used for skills embedded in
+// an Agent payload (`GET /api/agents`, `GET /api/agents/{id}`). The agent
+// list batch query only joins enough columns to render the assignee chip in
+// the UI; the standalone `/api/agents/{id}/skills` endpoint returns the full
+// SkillSummaryResponse for callers that need the source/origin info.
+type AgentSkillSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
 type SkillFileResponse struct {
 	ID        string `json:"id"`
 	SkillID   string `json:"skill_id"`

--- a/server/internal/handler/skill_list_test.go
+++ b/server/internal/handler/skill_list_test.go
@@ -1,0 +1,132 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestListSkills_OmitsContent guards the fix for GH multica-ai/multica#2174:
+// the workspace skill list endpoint must not ship the SKILL.md `content`
+// blob, which used to bloat the payload past CLI timeouts on workspaces with
+// many large skills. The detail endpoint still returns content (covered by
+// TestGetSkill_IncludesContent below).
+func TestListSkills_OmitsContent(t *testing.T) {
+	skillID := insertHandlerTestSkill(t, "list-omits-content", strings.Repeat("a", 4096))
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/skills?workspace_id="+testWorkspaceID, nil)
+	testHandler.ListSkills(w, req)
+	if w.Code != 200 {
+		t.Fatalf("ListSkills: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Decode into a generic shape so we can prove the wire format has no
+	// `content` field at all — not "content present but empty", which would
+	// still leave the bytes on the wire.
+	var rows []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("ListSkills: failed to decode body: %v", err)
+	}
+
+	var found bool
+	for _, row := range rows {
+		if row["id"] != skillID {
+			continue
+		}
+		found = true
+		if _, ok := row["content"]; ok {
+			t.Fatalf("ListSkills: response must not include `content` field, got: %v", row)
+		}
+		// Other expected list fields should still be present.
+		for _, key := range []string{"id", "name", "description", "config", "created_at", "updated_at", "workspace_id"} {
+			if _, ok := row[key]; !ok {
+				t.Fatalf("ListSkills: missing expected field %q in response: %v", key, row)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("ListSkills: inserted skill %s not in response", skillID)
+	}
+}
+
+// TestGetSkill_IncludesContent confirms the detail endpoint still ships the
+// full SKILL.md body — the list-summary change must not regress single-skill
+// reads.
+func TestGetSkill_IncludesContent(t *testing.T) {
+	body := "# detail body\nstill served on /api/skills/{id}"
+	skillID := insertHandlerTestSkill(t, "detail-includes-content", body)
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/skills/"+skillID, nil)
+	req = withURLParam(req, "id", skillID)
+	testHandler.GetSkill(w, req)
+	if w.Code != 200 {
+		t.Fatalf("GetSkill: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("GetSkill: failed to decode body: %v", err)
+	}
+	if got, _ := resp["content"].(string); got != body {
+		t.Fatalf("GetSkill: expected content %q, got %q", body, got)
+	}
+}
+
+// TestListAgentSkills_OmitsContent: same constraint for the agent-scoped
+// listing — gpt-boy review of the original fix flagged this as a sister case
+// because `multica agent skills list` follows the same shape rules.
+func TestListAgentSkills_OmitsContent(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "Handler Skill Summary Test", nil)
+	skillID := insertHandlerTestSkill(t, "agent-skill-omits-content", strings.Repeat("b", 1024))
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO agent_skill (agent_id, skill_id) VALUES ($1, $2)`,
+		agentID, skillID,
+	); err != nil {
+		t.Fatalf("attach skill to agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/agents/"+agentID+"/skills", nil)
+	req = withURLParam(req, "id", agentID)
+	testHandler.ListAgentSkills(w, req)
+	if w.Code != 200 {
+		t.Fatalf("ListAgentSkills: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("ListAgentSkills: failed to decode body: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("ListAgentSkills: expected at least 1 skill")
+	}
+	for _, row := range rows {
+		if _, ok := row["content"]; ok {
+			t.Fatalf("ListAgentSkills: response must not include `content` field, got: %v", row)
+		}
+	}
+}
+
+// insertHandlerTestSkill writes a skill row directly via SQL and registers a
+// cleanup hook. We bypass the create handler to keep the test focused on the
+// list/detail wire shape and to make it easy to inject a large body.
+func insertHandlerTestSkill(t *testing.T, namePrefix, content string) string {
+	t.Helper()
+	name := namePrefix + "-" + t.Name()
+	var id string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO skill (workspace_id, name, description, content, config, created_by)
+		VALUES ($1, $2, $3, $4, '{}'::jsonb, $5)
+		RETURNING id
+	`, testWorkspaceID, name, "fixture", content, testUserID).Scan(&id); err != nil {
+		t.Fatalf("insert skill: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM skill WHERE id = $1`, id)
+	})
+	return id
+}

--- a/server/pkg/db/generated/skill.sql.go
+++ b/server/pkg/db/generated/skill.sql.go
@@ -161,6 +161,56 @@ func (q *Queries) GetSkillInWorkspace(ctx context.Context, arg GetSkillInWorkspa
 	return i, err
 }
 
+const listAgentSkillSummaries = `-- name: ListAgentSkillSummaries :many
+SELECT s.id, s.workspace_id, s.name, s.description, s.config, s.created_by, s.created_at, s.updated_at
+FROM skill s
+JOIN agent_skill ask ON ask.skill_id = s.id
+WHERE ask.agent_id = $1
+ORDER BY s.name ASC
+`
+
+type ListAgentSkillSummariesRow struct {
+	ID          pgtype.UUID        `json:"id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Config      []byte             `json:"config"`
+	CreatedBy   pgtype.UUID        `json:"created_by"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+}
+
+// Summary variant for the agent skills list endpoint — omits `content` for
+// the same reason as ListSkillSummariesByWorkspace.
+func (q *Queries) ListAgentSkillSummaries(ctx context.Context, agentID pgtype.UUID) ([]ListAgentSkillSummariesRow, error) {
+	rows, err := q.db.Query(ctx, listAgentSkillSummaries, agentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAgentSkillSummariesRow{}
+	for rows.Next() {
+		var i ListAgentSkillSummariesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.Name,
+			&i.Description,
+			&i.Config,
+			&i.CreatedBy,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAgentSkills = `-- name: ListAgentSkills :many
 
 SELECT s.id, s.workspace_id, s.name, s.description, s.content, s.config, s.created_by, s.created_at, s.updated_at FROM skill s
@@ -262,6 +312,57 @@ func (q *Queries) ListSkillFiles(ctx context.Context, skillID pgtype.UUID) ([]Sk
 			&i.SkillID,
 			&i.Path,
 			&i.Content,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSkillSummariesByWorkspace = `-- name: ListSkillSummariesByWorkspace :many
+SELECT id, workspace_id, name, description, config, created_by, created_at, updated_at
+FROM skill
+WHERE workspace_id = $1
+ORDER BY name ASC
+`
+
+type ListSkillSummariesByWorkspaceRow struct {
+	ID          pgtype.UUID        `json:"id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Config      []byte             `json:"config"`
+	CreatedBy   pgtype.UUID        `json:"created_by"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+}
+
+// Same as ListSkillsByWorkspace but omits the SKILL.md `content` column. Used
+// by list endpoints (CLI table, web list page) where the body is never read;
+// shipping it everywhere blew up payload size on workspaces with many skills
+// and caused 15s CLI timeouts from high-latency regions (GH multica-ai/multica#2174).
+func (q *Queries) ListSkillSummariesByWorkspace(ctx context.Context, workspaceID pgtype.UUID) ([]ListSkillSummariesByWorkspaceRow, error) {
+	rows, err := q.db.Query(ctx, listSkillSummariesByWorkspace, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSkillSummariesByWorkspaceRow{}
+	for rows.Next() {
+		var i ListSkillSummariesByWorkspaceRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.Name,
+			&i.Description,
+			&i.Config,
+			&i.CreatedBy,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {

--- a/server/pkg/db/queries/skill.sql
+++ b/server/pkg/db/queries/skill.sql
@@ -5,6 +5,16 @@ SELECT * FROM skill
 WHERE workspace_id = $1
 ORDER BY name ASC;
 
+-- name: ListSkillSummariesByWorkspace :many
+-- Same as ListSkillsByWorkspace but omits the SKILL.md `content` column. Used
+-- by list endpoints (CLI table, web list page) where the body is never read;
+-- shipping it everywhere blew up payload size on workspaces with many skills
+-- and caused 15s CLI timeouts from high-latency regions (GH multica-ai/multica#2174).
+SELECT id, workspace_id, name, description, config, created_by, created_at, updated_at
+FROM skill
+WHERE workspace_id = $1
+ORDER BY name ASC;
+
 -- name: GetSkill :one
 SELECT * FROM skill
 WHERE id = $1;
@@ -60,6 +70,15 @@ DELETE FROM skill_file WHERE skill_id = $1;
 
 -- name: ListAgentSkills :many
 SELECT s.* FROM skill s
+JOIN agent_skill ask ON ask.skill_id = s.id
+WHERE ask.agent_id = $1
+ORDER BY s.name ASC;
+
+-- name: ListAgentSkillSummaries :many
+-- Summary variant for the agent skills list endpoint — omits `content` for
+-- the same reason as ListSkillSummariesByWorkspace.
+SELECT s.id, s.workspace_id, s.name, s.description, s.config, s.created_by, s.created_at, s.updated_at
+FROM skill s
 JOIN agent_skill ask ON ask.skill_id = s.id
 WHERE ask.agent_id = $1
 ORDER BY s.name ASC;


### PR DESCRIPTION
Closes #2174

## Summary

- Adds `ListSkillSummariesByWorkspace` / `ListAgentSkillSummaries` sqlc queries that select every skill column except `content`. `/api/skills` and `/api/agents/{id}/skills` now use them and return a new `SkillSummaryResponse` shape; detail endpoints (`GET /api/skills/{id}`, create/update/import return values) still carry the full SKILL.md body.
- Mirrors the contract on the TS side: introduces `SkillSummary` for the standalone list endpoints and `AgentSkillSummary` (id/name/description only) for skills embedded in `Agent` payloads. The narrower agent-embedded shape matches what the batch query actually joins (`ListAgentSkillsByWorkspace`) and what the frontend actually reads.
- `GetAgent` now loads embedded skills via the summary query — no more reading SKILL.md bodies just to discard them.
- Backend tests (`server/internal/handler/skill_list_test.go`) assert the list responses for both endpoints contain no `content` key, and that the detail endpoint still returns the body.

## Why

Closes the regression in [multica-ai/multica#2174](https://github.com/multica-ai/multica/issues/2174): on a workspace with 30–40 skills the list endpoint shipped multi-megabyte JSON, blew past the CLI's 15s timeout from high-latency regions, and made `multica skill list` unusable. SKILL.md bodies routinely run 50–200KB; sending them on every list call was strictly waste.

## Test plan

- [x] `cd server && go vet ./... && go build ./...`
- [x] `gofmt -l server/internal/handler/{agent,skill,skill_list_test}.go` clean
- [x] `pnpm typecheck`
- [x] `pnpm --filter @multica/views test --run` (327 pass)
- [x] `pnpm --filter @multica/core test --run` (198 pass)
- [ ] CI: new Go integration tests `TestListSkills_OmitsContent`, `TestGetSkill_IncludesContent`, `TestListAgentSkills_OmitsContent` in `server/internal/handler/skill_list_test.go` (require Postgres; run via `make test`).
- [ ] After deploy: re-run `multica skill list --workspace-id 9bb4a900-6b70-4f9a-915e-9f4121582deb` from the affected user — should return promptly with the skill table.

## Notes / follow-ups

- CLI hardcoded 15s timeout (and `http.Client{Timeout: 15s}`) is still there; with this list-side fix it's no longer the active blocker, but a separate change to bump it to ~30s and/or add `MULTICA_HTTP_TIMEOUT` would be the right defense-in-depth follow-up (touches `server/cmd/multica/cmd_*.go` and `server/internal/cli/client.go`). Holding on this PR per scope.
- Release note: list endpoints no longer return `content`. Frontend / CLI consumers in this repo are updated; external scripts that grep for the body in list responses will need to call `GET /api/skills/{id}`.