### PR TITLE
fix(agent/openclaw): block tasks if openclaw < 2026.5.5 with upgrade hint

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -8,9 +8,24 @@ import (
 	"io"
 	"log/slog"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
+
+// minOpenclawVersion is the lowest openclaw version that emits its
+// --json result on stdout. PR #2101 swapped the adapter from reading
+// stderr to stdout; older builds wrote JSON to stderr and now appear
+// to silently produce no output. The check in Execute fails fast with
+// a hardcoded upgrade hint so users see an actionable message instead
+// of "openclaw returned no parseable output".
+const minOpenclawVersion = "2026.5.5"
+
+// openclawVersionPattern extracts a three-segment dotted version from
+// arbitrary `openclaw --version` output (e.g. "openclaw 2026.5.5",
+// "openclaw v2026.5.5 c37871e").
+var openclawVersionPattern = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)`)
 
 // openclawBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args.
@@ -37,6 +52,10 @@ func (b *openclawBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}
 	if _, err := exec.LookPath(execPath); err != nil {
 		return nil, fmt.Errorf("openclaw executable not found at %q: %w", execPath, err)
+	}
+
+	if err := checkOpenclawVersion(ctx, execPath); err != nil {
+		return nil, err
 	}
 
 	timeout := opts.Timeout
@@ -186,6 +205,59 @@ func customArgsContains(args []string, flag string) bool {
 		}
 	}
 	return false
+}
+
+// checkOpenclawVersion runs `<execPath> --version` and returns a
+// user-facing error when the installed openclaw is older than
+// minOpenclawVersion. The returned error becomes the task's failure
+// comment, so the message intentionally names the detected version
+// and the upgrade command.
+func checkOpenclawVersion(ctx context.Context, execPath string) error {
+	cmd := exec.CommandContext(ctx, execPath, "--version")
+	hideAgentWindow(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("openclaw --version failed: %w", err)
+	}
+	detected, ok := parseOpenclawVersion(string(out))
+	if !ok {
+		return fmt.Errorf("could not parse openclaw version from output: %q", strings.TrimSpace(string(out)))
+	}
+	if compareOpenclawVersion(detected, minOpenclawVersion) < 0 {
+		return fmt.Errorf("openclaw %s is below the minimum supported version %s. Run `openclaw update` to upgrade and try again.", detected, minOpenclawVersion)
+	}
+	return nil
+}
+
+// parseOpenclawVersion extracts the first three-segment dotted version
+// from arbitrary `openclaw --version` output. Returns ok=false when no
+// match is found.
+func parseOpenclawVersion(raw string) (string, bool) {
+	m := openclawVersionPattern.FindString(raw)
+	if m == "" {
+		return "", false
+	}
+	return m, true
+}
+
+// compareOpenclawVersion compares two three-segment dotted versions
+// numerically. Returns -1, 0, or +1 like bytes.Compare. Inputs must be
+// well-formed (matched by openclawVersionPattern); malformed segments
+// compare as zero.
+func compareOpenclawVersion(a, b string) int {
+	aParts := strings.SplitN(a, ".", 3)
+	bParts := strings.SplitN(b, ".", 3)
+	for i := 0; i < 3; i++ {
+		ai, _ := strconv.Atoi(aParts[i])
+		bi, _ := strconv.Atoi(bParts[i])
+		if ai < bi {
+			return -1
+		}
+		if ai > bi {
+			return 1
+		}
+	}
+	return 0
 }
 
 // ── Event handlers ──

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -1,9 +1,12 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1226,5 +1229,148 @@ func TestOpenclawProcessOutputStdoutFixture(t *testing.T) {
 	}
 	if !gotText {
 		t.Errorf("expected a MessageText event containing %q", "hi")
+	}
+}
+
+// ── Version gate tests (MUL-1803) ──
+
+func TestParseOpenclawVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{"bare", "2026.5.5", "2026.5.5", true},
+		{"with prefix", "openclaw 2026.5.5", "2026.5.5", true},
+		{"with v prefix", "openclaw v2026.5.5", "2026.5.5", true},
+		{"with commit suffix", "openclaw 2026.5.5 c37871e", "2026.5.5", true},
+		{"trailing newline", "openclaw 2026.5.5\n", "2026.5.5", true},
+		{"two segments rejected", "openclaw 2026.5", "", false},
+		{"no version at all", "openclaw build info", "", false},
+		{"empty", "", "", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := parseOpenclawVersion(c.in)
+			if ok != c.ok {
+				t.Fatalf("ok = %v, want %v (input=%q)", ok, c.ok, c.in)
+			}
+			if got != c.want {
+				t.Errorf("got %q, want %q (input=%q)", got, c.want, c.in)
+			}
+		})
+	}
+}
+
+func TestCompareOpenclawVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"2026.5.5", "2026.5.5", 0},
+		{"2026.5.4", "2026.5.5", -1},
+		{"2026.5.6", "2026.5.5", 1},
+		{"2026.4.99", "2026.5.0", -1},
+		{"2027.0.0", "2026.99.99", 1},
+		{"0.0.0", "2026.5.5", -1},
+	}
+
+	for _, c := range cases {
+		got := compareOpenclawVersion(c.a, c.b)
+		if got != c.want {
+			t.Errorf("compareOpenclawVersion(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// TestOpenclawExecuteRejectsOldVersion verifies that an openclaw build
+// older than minOpenclawVersion is blocked at task-start with a
+// user-facing error naming the detected version and the upgrade
+// command. Without this gate, the task would silently fail with
+// "openclaw returned no parseable output" because pre-2026.5 builds
+// emit JSON on stderr (see PR #2101).
+func TestOpenclawExecuteRejectsOldVersion(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "openclaw")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo 'openclaw 2026.4.9 abc123'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo 'fake openclaw should not have been invoked' >&2\n" +
+		"exit 99\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("openclaw", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new openclaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err = backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err == nil {
+		t.Fatal("expected Execute to return a version error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"2026.4.9", "2026.5.5", "openclaw update"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}
+
+// TestOpenclawExecuteAllowsCurrentVersion verifies that an openclaw
+// build at or above minOpenclawVersion clears the version gate and
+// proceeds to the actual run. The fake exits without producing JSON,
+// so the eventual Result is a downstream failure — but the failure
+// must NOT be the version-gate error.
+func TestOpenclawExecuteAllowsCurrentVersion(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "openclaw")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then\n" +
+		"  echo 'openclaw 2026.5.5 c37871e'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("openclaw", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new openclaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Execute returned synchronous error past the version gate: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case result := <-session.Result:
+		if strings.Contains(result.Error, "openclaw update") {
+			t.Errorf("version gate fired for a current version: %q", result.Error)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #2101. That PR swapped the openclaw runtime adapter from reading `--json` on stderr to stdout, fixing openclaw 2026.5+. The trade-off was that **pre-2026.5 openclaw users now break the same way 2026.5+ users used to break**: the adapter sees an empty stdout and falls through to `"openclaw returned no parseable output"` — accurate, but cryptic.

This PR adds a per-task version gate so old-build users instead see an actionable error naming the detected version and the upgrade command.

## Changes

- **`server/pkg/agent/openclaw.go`**: new `checkOpenclawVersion(ctx, execPath)` runs `openclaw --version`, extracts a three-segment dotted version with a regex, and rejects anything below `2026.5.5`. Called at the top of `Execute()`, right after the `LookPath` probe. Helpers `parseOpenclawVersion` and `compareOpenclawVersion` plus `minOpenclawVersion` and `openclawVersionPattern`.
- **`server/pkg/agent/openclaw_test.go`**: unit tests for `parseOpenclawVersion` (8 cases incl. bare/v-prefix/commit-suffix/two-segment-rejected) and `compareOpenclawVersion` (6 cases incl. boundary at minor/major rollover); two integration tests using shell-script fakes — one printing `2026.4.9` (expects the upgrade error containing both versions and `openclaw update`), one printing `2026.5.5` (expects the version gate to clear and the run to proceed past it).

## Design choices

- **Per-task, uncached.** Cache would create a "user upgrades openclaw → daemon still reports old version → tasks stay broken until daemon restart" trap. `exec("openclaw --version")` is ~20ms; negligible vs. typical task duration.
- **No startup-time check.** A startup warning would land in daemon logs the user never reads. Letting the failure surface at task time puts it where users actually look — the issue's failure comment.
- **`--version` is assumed to always work.** Per discussion: every shipped openclaw build supports it; not engineering fallback paths for a hypothetical case.
- **Error message is hardcoded** with detected version, target version, and `openclaw update`. It surfaces directly as the task's failure comment, so it must be self-explanatory.

## Verification

```
$ go test ./pkg/agent/ -run "Openclaw|ParseOpenclawVersion|CompareOpenclawVersion"
ok  github.com/multica-ai/multica/server/pkg/agent  1.688s
$ go test ./pkg/agent/
ok  github.com/multica-ai/multica/server/pkg/agent  7.617s
$ go vet ./pkg/agent/...   # clean
$ go build ./...           # clean
```

## Test plan

- [ ] CI green (backend + frontend)
- [ ] Manually: install pre-2026.5 openclaw, assign a task, confirm the failure comment names `openclaw update`
- [ ] Manually: install 2026.5.5+, assign a task, confirm normal completion (no version-error noise in logs)
- [ ] Manually: with old openclaw → fail → upgrade openclaw → assign a fresh task without daemon restart → confirm the next task succeeds