### PR TITLE
fix(desktop): add custom route error UX

### DIFF
--- a/apps/desktop/src/renderer/src/components/route-error-boundary.test.tsx
+++ b/apps/desktop/src/renderer/src/components/route-error-boundary.test.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { NotFoundPage, RouteErrorBoundary } from "./route-error-boundary";
+
+function renderWithRouter(path: string, element: ReactNode) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/:workspaceSlug/*",
+        element,
+      },
+    ],
+    { initialEntries: [path] },
+  );
+
+  return render(<RouterProvider router={router} />);
+}
+
+describe("NotFoundPage", () => {
+  it("renders a custom 404 message instead of React Router's default developer copy", () => {
+    renderWithRouter("/acme/missing-route", <NotFoundPage />);
+
+    expect(screen.getByRole("heading", { name: "Page not found" })).toBeInTheDocument();
+    expect(screen.getByText("Error 404")).toBeInTheDocument();
+    expect(screen.getByText("/acme/missing-route")).toBeInTheDocument();
+    expect(screen.queryByText(/Hey developer/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("RouteErrorBoundary", () => {
+  it("renders a friendly error state for thrown route errors", () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/broken",
+          element: <div />,
+          errorElement: <RouteErrorBoundary />,
+          loader: () => {
+            throw new Response("Not found", { status: 404, statusText: "Not Found" });
+          },
+        },
+      ],
+      { initialEntries: ["/broken"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(screen.getByRole("heading", { name: "Page not found" })).toBeInTheDocument();
+    expect(screen.getByText("Error 404")).toBeInTheDocument();
+    expect(screen.queryByText(/Unexpected Application Error/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/components/route-error-boundary.test.tsx
+++ b/apps/desktop/src/renderer/src/components/route-error-boundary.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import { NotFoundPage, RouteErrorBoundary } from "./route-error-boundary";
@@ -30,7 +30,7 @@ describe("NotFoundPage", () => {
 });
 
 describe("RouteErrorBoundary", () => {
-  it("renders a friendly error state for thrown route errors", () => {
+  it("renders a friendly error state for thrown route errors", async () => {
     const router = createMemoryRouter(
       [
         {
@@ -47,7 +47,9 @@ describe("RouteErrorBoundary", () => {
 
     render(<RouterProvider router={router} />);
 
-    expect(screen.getByRole("heading", { name: "Page not found" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Page not found" })).toBeInTheDocument(),
+    );
     expect(screen.getByText("Error 404")).toBeInTheDocument();
     expect(screen.queryByText(/Unexpected Application Error/i)).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/components/route-error-boundary.tsx
+++ b/apps/desktop/src/renderer/src/components/route-error-boundary.tsx
@@ -1,0 +1,99 @@
+import { AlertTriangle, ArrowLeft, Home } from "lucide-react";
+import {
+  isRouteErrorResponse,
+  useLocation,
+  useNavigate,
+  useParams,
+  useRouteError,
+} from "react-router-dom";
+import { Button } from "@multica/ui/components/ui/button";
+
+function getErrorDetails(error: unknown) {
+  if (isRouteErrorResponse(error)) {
+    return {
+      status: error.status,
+      title: error.status === 404 ? "Page not found" : "Something went wrong",
+      message:
+        error.status === 404
+          ? "This page does not exist, or it may have moved."
+          : error.statusText || "Multica hit an unexpected error while opening this page.",
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      status: undefined,
+      title: "Something went wrong",
+      message: error.message || "Multica hit an unexpected error while opening this page.",
+    };
+  }
+
+  return {
+    status: undefined,
+    title: "Something went wrong",
+    message: "Multica hit an unexpected error while opening this page.",
+  };
+}
+
+export function RouteErrorBoundary() {
+  const error = useRouteError();
+  return <RouteErrorState {...getErrorDetails(error)} />;
+}
+
+export function NotFoundPage() {
+  return (
+    <RouteErrorState
+      status={404}
+      title="Page not found"
+      message="This page does not exist, or it may have moved."
+    />
+  );
+}
+
+function RouteErrorState({
+  status,
+  title,
+  message,
+}: {
+  status?: number;
+  title: string;
+  message: string;
+}) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { workspaceSlug } = useParams<{ workspaceSlug?: string }>();
+  const homePath = workspaceSlug ? `/${workspaceSlug}/issues` : "/";
+
+  return (
+    <main className="flex min-h-full items-center justify-center bg-background px-6 py-16 text-foreground">
+      <section className="w-full max-w-md rounded-2xl border border-border bg-card p-8 text-center shadow-sm">
+        <div className="mx-auto mb-5 flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <AlertTriangle className="size-6" aria-hidden="true" />
+        </div>
+
+        {status ? (
+          <p className="mb-2 text-sm font-medium text-muted-foreground">Error {status}</p>
+        ) : null}
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">{message}</p>
+
+        {location.pathname ? (
+          <p className="mt-4 truncate rounded-lg bg-muted px-3 py-2 text-xs text-muted-foreground">
+            {location.pathname}
+          </p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-center">
+          <Button type="button" variant="outline" onClick={() => navigate(-1)}>
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            Go back
+          </Button>
+          <Button type="button" onClick={() => navigate(homePath, { replace: true })}>
+            <Home className="size-4" aria-hidden="true" />
+            Go to issues
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/desktop/src/renderer/src/routes.tsx
+++ b/apps/desktop/src/renderer/src/routes.tsx
@@ -30,7 +30,7 @@ import { Download, Server } from "lucide-react";
 import { DaemonSettingsTab } from "./components/daemon-settings-tab";
 import { UpdatesSettingsTab } from "./components/updates-settings-tab";
 import { WorkspaceRouteLayout } from "./components/workspace-route-layout";
-import { DesktopRouteErrorPage } from "./components/route-error-page";
+import { NotFoundPage, RouteErrorBoundary } from "./components/route-error-boundary";
 
 /**
  * Wraps `SettingsPage` so the desktop-only extra tabs can pull their labels
@@ -109,7 +109,7 @@ function PageShell() {
 export const appRoutes: RouteObject[] = [
   {
     element: <PageShell />,
-    errorElement: <DesktopRouteErrorPage />,
+    errorElement: <RouteErrorBoundary />,
     children: [
       { index: true, element: null },
       {
@@ -201,7 +201,17 @@ export const appRoutes: RouteObject[] = [
             element: <DesktopSettingsRoute />,
             handle: { title: "Settings" },
           },
+          {
+            path: "*",
+            element: <NotFoundPage />,
+            handle: { title: "Page not found" },
+          },
         ],
+      },
+      {
+        path: "*",
+        element: <NotFoundPage />,
+        handle: { title: "Page not found" },
       },
     ],
   },


### PR DESCRIPTION
## Summary
- add a desktop route error boundary so thrown route/application errors render a friendly in-app state
- add wildcard 404 routes for unknown desktop tab paths
- cover the custom 404/error UI with renderer tests

Fixes #2006

## Validation
- `git diff --check`
- `corepack pnpm --filter @multica/desktop test -- src/renderer/src/components/route-error-boundary.test.tsx` *(blocked: local `node_modules` is missing, so `vitest` is not installed in this checkout)*