### PR TITLE
feat(views): order issue activity newest-first

### DIFF
--- a/e2e/comments-newest-first.spec.ts
+++ b/e2e/comments-newest-first.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+import { createTestApi, loginAsDefault } from "./helpers";
+import type { TestApiClient } from "./fixtures";
+
+// PUL-12: Activity section renders newest root comments first. The composer
+// (CommentInput) sits above the timeline so opening a long ticket shows
+// fresh activity without scroll, and submitting a new comment makes it
+// appear right below the input.
+test.describe("Comments — newest-first ordering", () => {
+  let api: TestApiClient;
+
+  test.beforeEach(async () => {
+    api = await createTestApi();
+  });
+
+  test.afterEach(async () => {
+    await api.cleanup();
+  });
+
+  test("opens long ticket with newest comment visible without scroll", async ({ page }) => {
+    const issue = await api.createIssue("PUL-12 long ticket " + Date.now());
+    // Seed 10 comments, oldest → newest. The 10th is what should be at the
+    // top of the Activity section after the reverse.
+    for (let i = 1; i <= 10; i++) {
+      await api.createComment(issue.id, `Seeded comment ${i}`);
+    }
+
+    const slug = await loginAsDefault(page);
+    await page.goto(`/${slug}/issues/${issue.id}`);
+
+    // Wait for issue detail to load.
+    await expect(page.locator("text=Properties")).toBeVisible();
+
+    const newest = page.locator("text=Seeded comment 10");
+    await expect(newest).toBeVisible();
+
+    // Newest must be in the initial viewport (no scroll). Compare element
+    // top against the page's inner height.
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    const box = await newest.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.y).toBeGreaterThanOrEqual(0);
+    expect(box!.y).toBeLessThan(viewportHeight);
+  });
+
+  test("submitting a new comment shows it at the top with input still in view", async ({ page }) => {
+    const issue = await api.createIssue("PUL-12 submit test " + Date.now());
+    // A handful of older comments so the timeline has body to push against.
+    for (let i = 1; i <= 5; i++) {
+      await api.createComment(issue.id, `Older comment ${i}`);
+    }
+
+    const slug = await loginAsDefault(page);
+    await page.goto(`/${slug}/issues/${issue.id}`);
+    await expect(page.locator("text=Properties")).toBeVisible();
+
+    const commentText = "Brand new top comment " + Date.now();
+    const commentInput = page.locator(
+      'input[placeholder="Leave a comment..."]',
+    );
+    await expect(commentInput).toBeVisible();
+    await commentInput.fill(commentText);
+    await page.locator('form button[type="submit"]').last().click();
+
+    // The new comment is rendered.
+    const newComment = page.locator(`text=${commentText}`);
+    await expect(newComment).toBeVisible();
+
+    // It sits above the older ones in the DOM.
+    const newCommentY = (await newComment.boundingBox())!.y;
+    const olderY = (await page.locator("text=Older comment 5").boundingBox())!.y;
+    expect(newCommentY).toBeLessThan(olderY);
+
+    // The composer is still in the viewport — the user can keep typing.
+    const inputBox = await commentInput.boundingBox();
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    expect(inputBox).not.toBeNull();
+    expect(inputBox!.y).toBeGreaterThanOrEqual(0);
+    expect(inputBox!.y).toBeLessThan(viewportHeight);
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -133,6 +133,14 @@ export class TestApiClient {
     return issue;
   }
 
+  async createComment(issueId: string, content: string) {
+    const res = await this.authedFetch(`/api/issues/${issueId}/comments`, {
+      method: "POST",
+      body: JSON.stringify({ content }),
+    });
+    return res.json();
+  }
+
   async deleteIssue(id: string) {
     await this.authedFetch(`/api/issues/${id}`, { method: "DELETE" });
   }

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -515,4 +515,167 @@ describe("IssueDetail (shared)", () => {
       );
     });
   });
+
+  // ----------------------------------------------------------------------
+  // Timeline order — newest-first reverse on top-level groups (PUL-12).
+  // Threads under a root comment stay chronological; only top-level groups
+  // are reversed. Replies live inside CommentCard's <CollapsibleContent>
+  // which renders children regardless of open state, so we can still query
+  // their `comment-${id}` wrappers from the DOM.
+  // ----------------------------------------------------------------------
+
+  function rootComment(id: string, content: string, created_at: string): TimelineEntry {
+    return {
+      type: "comment",
+      id,
+      actor_type: "member",
+      actor_id: "user-1",
+      content,
+      parent_id: null,
+      created_at,
+      updated_at: created_at,
+      comment_type: "comment",
+    };
+  }
+
+  function reply(id: string, parentId: string, content: string, created_at: string): TimelineEntry {
+    return {
+      type: "comment",
+      id,
+      actor_type: "member",
+      actor_id: "user-1",
+      content,
+      parent_id: parentId,
+      created_at,
+      updated_at: created_at,
+      comment_type: "comment",
+    };
+  }
+
+  function activity(id: string, created_at: string): TimelineEntry {
+    return {
+      type: "activity",
+      id,
+      actor_type: "member",
+      actor_id: "user-1",
+      action: "description_updated",
+      created_at,
+      details: {},
+    };
+  }
+
+  function rootCommentIdsInOrder(container: HTMLElement): string[] {
+    // Top-level wrappers in the Activity section are direct children of
+    // `<div class="mt-4 flex flex-col gap-3">`. Root comments wrap each
+    // CommentCard with `id="comment-${entry.id}"`; reply wrappers also use
+    // that id but live deeper inside CommentCard, so a top-level-only walk
+    // is what we need.
+    const timelineRoot = container.querySelector(
+      "div.mt-4.flex.flex-col.gap-3",
+    );
+    if (!timelineRoot) return [];
+    return Array.from(timelineRoot.children)
+      .filter((el): el is HTMLElement => el instanceof HTMLElement && el.id.startsWith("comment-"))
+      .map((el) => el.id.replace(/^comment-/, ""));
+  }
+
+  it("renders mixed activities + root comments newest-first", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      rootComment("c-old", "oldest comment", "2026-01-01T00:00:00Z"),
+      activity("a-1", "2026-01-02T00:00:00Z"),
+      rootComment("c-mid", "middle comment", "2026-01-03T00:00:00Z"),
+      activity("a-2", "2026-01-04T00:00:00Z"),
+      rootComment("c-new", "newest comment", "2026-01-05T00:00:00Z"),
+    ]);
+
+    const { container } = renderIssueDetail();
+    await waitFor(() => {
+      expect(screen.getByText("newest comment")).toBeInTheDocument();
+    });
+
+    expect(rootCommentIdsInOrder(container)).toEqual(["c-new", "c-mid", "c-old"]);
+  });
+
+  it("preserves chronological order of replies under a reversed root", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      rootComment("parent", "the root", "2026-01-01T00:00:00Z"),
+      reply("r-first", "parent", "first reply", "2026-01-02T00:00:00Z"),
+      reply("r-second", "parent", "second reply", "2026-01-03T00:00:00Z"),
+      rootComment("later", "another root", "2026-01-04T00:00:00Z"),
+    ]);
+
+    const { container } = renderIssueDetail();
+    await waitFor(() => {
+      expect(screen.getByText("another root")).toBeInTheDocument();
+    });
+
+    // Top-level: newer root before older root.
+    expect(rootCommentIdsInOrder(container)).toEqual(["later", "parent"]);
+
+    // Replies under "parent" stay ASC: first then second. Reply wrappers
+    // live inside the parent's CommentCard subtree.
+    const parentCard = container.querySelector("#comment-parent");
+    expect(parentCard).not.toBeNull();
+    const replyIds = Array.from(
+      parentCard!.querySelectorAll('[id^="comment-r-"]'),
+    ).map((el) => (el as HTMLElement).id);
+    expect(replyIds).toEqual(["comment-r-first", "comment-r-second"]);
+  });
+
+  it("renders activities-only timeline without crashing", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      activity("a-1", "2026-01-01T00:00:00Z"),
+      activity("a-2", "2026-01-02T00:00:00Z"),
+      activity("a-3", "2026-01-03T00:00:00Z"),
+    ]);
+
+    const { container } = renderIssueDetail();
+    await waitFor(() => {
+      expect(screen.getAllByText("Activity").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Consecutive activities collapse into one group, so reversing groups
+    // is a no-op for this case. We just want to verify no crash and that
+    // no root comments appear in the timeline section.
+    expect(rootCommentIdsInOrder(container)).toEqual([]);
+  });
+
+  it("reverses a comments-only timeline so newest is first", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      rootComment("c-1", "first", "2026-01-01T00:00:00Z"),
+      rootComment("c-2", "second", "2026-01-02T00:00:00Z"),
+      rootComment("c-3", "third", "2026-01-03T00:00:00Z"),
+    ]);
+
+    const { container } = renderIssueDetail();
+    await waitFor(() => {
+      expect(screen.getByText("third")).toBeInTheDocument();
+    });
+
+    expect(rootCommentIdsInOrder(container)).toEqual(["c-3", "c-2", "c-1"]);
+  });
+
+  it("renders an empty timeline without crashing", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([]);
+
+    const { container } = renderIssueDetail();
+    await waitFor(() => {
+      expect(screen.getAllByText("Activity").length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(rootCommentIdsInOrder(container)).toEqual([]);
+  });
+
+  it("renders a single comment unchanged (reverse is a no-op)", async () => {
+    mockApiObj.listTimeline.mockResolvedValue([
+      rootComment("only", "lonely comment", "2026-01-01T00:00:00Z"),
+    ]);
+
+    const { container } = renderIssueDetail();
+    await waitFor(() => {
+      expect(screen.getByText("lonely comment")).toBeInTheDocument();
+    });
+
+    expect(rootCommentIdsInOrder(container)).toEqual(["only"]);
+  });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -294,7 +294,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       }
     }
 
-    return { repliesByParent, groups };
+    // Reverse top-level groups so the newest root comment / activity batch
+    // sits at the top of the Activity section. Threads (replies under a
+    // root comment) stay ASC — `repliesByParent` is untouched, and
+    // CommentCard.collectReplies walks it in insertion order.
+    const reversed = groups.slice().reverse();
+
+    return { repliesByParent, groups: reversed };
   }, [timeline]);
 
   const {
@@ -946,7 +952,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 card is just a header-style "agent is working" anchor. */}
             <AgentLiveCard key={id} issueId={id} />
 
-            {/* Timeline entries */}
+            {/* Comment input sits above the timeline so newest-first reads
+                naturally: type at the top, see your comment appear at the
+                top, no scroll-to-bottom required. */}
+            <div className="mt-4">
+              <CommentInput issueId={id} onSubmit={submitComment} />
+            </div>
+
+            {/* Timeline entries (newest-first; see timelineView memo) */}
             <div className="mt-4 flex flex-col gap-3">
               {timelineView.groups.map((group) => {
                 if (group.type === "comment") {
@@ -1015,11 +1028,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                   </div>
                 );
               })}
-            </div>
-
-            {/* Bottom comment input — no avatar, full width */}
-            <div className="mt-4">
-              <CommentInput issueId={id} onSubmit={submitComment} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Newest root-level comment (or activity batch) now sits at the top of an issue's Activity section. Threads under a comment keep chronological order — only top-level groups are reversed.
- The composer (CommentInput) moves above the timeline so submitting a new comment makes it appear right beneath the input, no scroll required.
- Implementation is a single `groups.slice().reverse()` at the tail of the `timelineView` memo in `issue-detail.tsx`. `repliesByParent` is untouched; `CommentCard.collectReplies` walks the map in insertion order, which stays ASC because the upstream timeline (server response, optimistic updates, WS-merged inserts in `use-issue-timeline.ts`) is ASC. API / CLI / WS contracts are unchanged — the reverse is render-only.

## Why
PUL-12 — chronological ordering meant a long discussion required scrolling to the bottom to see the freshest activity, which doesn't match how Slack / Linear / Discord treat live threads.

## Test Plan
- [x] `vitest run` for `@multica/views`: 261/261 pass, including 6 new cases in `issue-detail.test.tsx` covering mixed ordering, replies-stay-ASC under a reversed root, and boundary cases (activities-only, comments-only, empty timeline, single comment).
- [x] `tsc --noEmit` for `@multica/views` clean.
- [x] `eslint` for the touched files (`issue-detail.tsx`, `issue-detail.test.tsx`) clean. Pre-existing lint errors in unrelated files on `main` (`agents/`, `projects/`, `workspace/no-access-page.tsx`) were not introduced by this change.
- [ ] **E2E (`e2e/comments-newest-first.spec.ts` — 2 specs added)**: covers open-without-scroll and submit-stays-on-top user flows. Not run locally because the multica server stack wasn't available; please run in CI / a configured env. A small `createComment` helper is added to `e2e/fixtures.ts` to seed timelines via the API.
- [ ] **Browser QA** — recommend exercising:
  - Long ticket (≥ 3 root comments + activities): newest root visible without scroll, threads under it still ASC.
  - Submit a new comment: appears at top, composer stays in viewport.
  - WS-inserted comment from another user while reading the middle: listed in failure-mode #2 of the design doc as a separate follow-up if `overflow-anchor: auto` doesn't hold.

## Out of scope
- API/CLI ordering — `api.listTimeline` and WS handlers stay ASC. Reverse is render-only.
- No `?order=desc` query parameter, no user-facing newest/chrono toggle, no timeline pagination.