### PR TITLE
[FAL-52] Mobile foundation route group and shell

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,43 @@
+# Multica Web
+
+## Mobile workspace routes
+
+Mobile workspace UI lives inside the existing Next.js app under:
+
+```text
+/{workspaceSlug}/m
+/{workspaceSlug}/m/issues
+/{workspaceSlug}/m/kanban
+/{workspaceSlug}/m/projects
+/{workspaceSlug}/m/inbox
+/{workspaceSlug}/m/runtime
+/{workspaceSlug}/m/chat
+/{workspaceSlug}/m/settings
+```
+
+`/{workspaceSlug}/m` redirects to `/{workspaceSlug}/m/issues`. These routes are
+implemented with the `apps/web/app/[workspaceSlug]/(mobile)/m` route group, so
+they do not collide with the existing desktop routes at
+`/{workspaceSlug}/issues`, `/{workspaceSlug}/projects`, and related paths.
+
+The mobile shell uses the same web auth, cookie, CSRF, API, and WebSocket setup
+as the desktop web routes. The WebSocket client derives `/ws` from the current
+origin, so Tailscale Serve can expose a single HTTPS host while mapping `/ws`
+directly to the backend.
+
+Expected Tailscale Serve shape:
+
+```text
+https://<host>.<tailnet>.ts.net/      -> apps/web Next.js server
+https://<host>.<tailnet>.ts.net/api/* -> backend through existing Next rewrite
+https://<host>.<tailnet>.ts.net/auth/* -> backend through existing Next rewrite
+https://<host>.<tailnet>.ts.net/ws    -> backend :8080 /ws
+```
+
+iPhone Safari verification starts at:
+
+```text
+https://<host>.<tailnet>.ts.net/{workspaceSlug}/m/issues
+```
+
+After login, any placeholder route above should render inside the mobile shell.

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/chat/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/chat/page.tsx
@@ -1,0 +1,5 @@
+import { MobilePlaceholderPage } from "@/features/mobile/mobile-placeholder";
+
+export default function Page() {
+  return <MobilePlaceholderPage title="Chat" />;
+}

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/inbox/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/inbox/page.tsx
@@ -1,0 +1,5 @@
+import { MobilePlaceholderPage } from "@/features/mobile/mobile-placeholder";
+
+export default function Page() {
+  return <MobilePlaceholderPage title="Inbox" />;
+}

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/issues/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/issues/page.tsx
@@ -1,0 +1,5 @@
+import { MobilePlaceholderPage } from "@/features/mobile/mobile-placeholder";
+
+export default function Page() {
+  return <MobilePlaceholderPage title="Issues" />;
+}

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/kanban/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/kanban/page.tsx
@@ -1,0 +1,5 @@
+import { MobilePlaceholderPage } from "@/features/mobile/mobile-placeholder";
+
+export default function Page() {
+  return <MobilePlaceholderPage title="Kanban" />;
+}

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/layout.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/layout.tsx
@@ -1,0 +1,12 @@
+import type { Viewport } from "next";
+import { MobileShell } from "@/features/mobile/mobile-shell";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <MobileShell>{children}</MobileShell>;
+}

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from "next/navigation";
+import { mobileRoutes } from "@/features/mobile/mobile-routes";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ workspaceSlug: string }>;
+}) {
+  const { workspaceSlug } = await params;
+  redirect(mobileRoutes(workspaceSlug).root);
+}

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/projects/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/projects/page.tsx
@@ -1,0 +1,5 @@
+import { MobilePlaceholderPage } from "@/features/mobile/mobile-placeholder";
+
+export default function Page() {
+  return <MobilePlaceholderPage title="Projects" />;
+}

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/runtime/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/runtime/page.tsx
@@ -1,0 +1,5 @@
+import { MobilePlaceholderPage } from "@/features/mobile/mobile-placeholder";
+
+export default function Page() {
+  return <MobilePlaceholderPage title="Runtime" />;
+}

--- a/apps/web/app/[workspaceSlug]/(mobile)/m/settings/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(mobile)/m/settings/page.tsx
@@ -1,0 +1,5 @@
+import { MobilePlaceholderPage } from "@/features/mobile/mobile-placeholder";
+
+export default function Page() {
+  return <MobilePlaceholderPage title="Settings" />;
+}

--- a/apps/web/features/mobile/mobile-placeholder.test.tsx
+++ b/apps/web/features/mobile/mobile-placeholder.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MobilePlaceholderPage } from "./mobile-placeholder";
+
+describe("MobilePlaceholderPage", () => {
+  it("renders the fixed foundation placeholder copy", () => {
+    render(<MobilePlaceholderPage title="Issues" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Issues" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("ここに Issues が来ます")).toBeInTheDocument();
+  });
+});

--- a/apps/web/features/mobile/mobile-placeholder.tsx
+++ b/apps/web/features/mobile/mobile-placeholder.tsx
@@ -1,0 +1,19 @@
+export function MobilePlaceholderPage({ title }: { title: string }) {
+  return (
+    <section className="min-h-full px-4 pb-8 pt-5">
+      <div className="border-b border-border pb-5">
+        <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          Mobile foundation
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold text-foreground">
+          {title}
+        </h1>
+      </div>
+      <div className="flex min-h-[55svh] items-center justify-center text-center">
+        <p className="text-base font-medium text-muted-foreground">
+          ここに {title} が来ます
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/features/mobile/mobile-routes.test.ts
+++ b/apps/web/features/mobile/mobile-routes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  MOBILE_BOTTOM_NAV_ITEMS,
+  MOBILE_DRAWER_NAV_ITEMS,
+  mobileRoutes,
+} from "./mobile-routes";
+
+describe("mobileRoutes", () => {
+  it("builds workspace-scoped /m routes without colliding with desktop routes", () => {
+    expect(mobileRoutes("acme")).toEqual({
+      root: "/acme/m/issues",
+      kanban: "/acme/m/kanban",
+      issues: "/acme/m/issues",
+      projects: "/acme/m/projects",
+      inbox: "/acme/m/inbox",
+      runtime: "/acme/m/runtime",
+      chat: "/acme/m/chat",
+      settings: "/acme/m/settings",
+    });
+  });
+
+  it("keeps the bottom navigation to five primary tabs", () => {
+    expect(MOBILE_BOTTOM_NAV_ITEMS).toHaveLength(5);
+    expect(MOBILE_BOTTOM_NAV_ITEMS.map((item) => item.routeKey)).toEqual([
+      "kanban",
+      "issues",
+      "projects",
+      "inbox",
+      "settings",
+    ]);
+  });
+
+  it("keeps secondary mobile routes reachable from the drawer", () => {
+    expect(MOBILE_DRAWER_NAV_ITEMS.map((item) => item.routeKey)).toEqual([
+      "runtime",
+      "chat",
+    ]);
+  });
+});

--- a/apps/web/features/mobile/mobile-routes.ts
+++ b/apps/web/features/mobile/mobile-routes.ts
@@ -1,0 +1,40 @@
+export type MobileRouteKey =
+  | "kanban"
+  | "issues"
+  | "projects"
+  | "inbox"
+  | "runtime"
+  | "chat"
+  | "settings";
+
+export interface MobileNavItem {
+  label: string;
+  routeKey: MobileRouteKey;
+}
+
+export function mobileRoutes(workspaceSlug: string): Record<MobileRouteKey | "root", string> {
+  const base = `/${encodeURIComponent(workspaceSlug)}/m`;
+  return {
+    root: `${base}/issues`,
+    kanban: `${base}/kanban`,
+    issues: `${base}/issues`,
+    projects: `${base}/projects`,
+    inbox: `${base}/inbox`,
+    runtime: `${base}/runtime`,
+    chat: `${base}/chat`,
+    settings: `${base}/settings`,
+  };
+}
+
+export const MOBILE_BOTTOM_NAV_ITEMS = [
+  { label: "Kanban", routeKey: "kanban" },
+  { label: "Issues", routeKey: "issues" },
+  { label: "Projects", routeKey: "projects" },
+  { label: "Inbox", routeKey: "inbox" },
+  { label: "Settings", routeKey: "settings" },
+] as const satisfies readonly MobileNavItem[];
+
+export const MOBILE_DRAWER_NAV_ITEMS = [
+  { label: "Runtime", routeKey: "runtime" },
+  { label: "Chat", routeKey: "chat" },
+] as const satisfies readonly MobileNavItem[];

--- a/apps/web/features/mobile/mobile-shell.test.tsx
+++ b/apps/web/features/mobile/mobile-shell.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WorkspaceSlugProvider } from "@multica/core/paths";
+import { NavigationProvider } from "@multica/views/navigation";
+import type { NavigationAdapter } from "@multica/views/navigation";
+import { MobileShellFrame } from "./mobile-shell";
+
+function renderShell(pathname = "/acme/m/issues") {
+  const adapter: NavigationAdapter = {
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    pathname,
+    searchParams: new URLSearchParams(),
+  };
+
+  render(
+    <NavigationProvider value={adapter}>
+      <WorkspaceSlugProvider slug="acme">
+        <MobileShellFrame>
+          <main>route body</main>
+        </MobileShellFrame>
+      </WorkspaceSlugProvider>
+    </NavigationProvider>,
+  );
+
+  return adapter;
+}
+
+describe("MobileShellFrame", () => {
+  it("renders app chrome with current workspace and five bottom tabs", () => {
+    renderShell("/acme/m/projects");
+
+    expect(screen.getByText("acme")).toBeInTheDocument();
+    expect(screen.getByText("route body")).toBeInTheDocument();
+
+    const tabs = screen.getAllByRole("link").filter((link) =>
+      link.getAttribute("aria-label")?.startsWith("Open mobile "),
+    );
+    expect(tabs).toHaveLength(5);
+    expect(tabs.map((tab) => tab.getAttribute("href"))).toEqual([
+      "/acme/m/kanban",
+      "/acme/m/issues",
+      "/acme/m/projects",
+      "/acme/m/inbox",
+      "/acme/m/settings",
+    ]);
+
+    expect(screen.getByRole("link", { current: "page" })).toHaveAttribute(
+      "href",
+      "/acme/m/projects",
+    );
+  });
+
+  it("uses the navigation adapter for back navigation", async () => {
+    const user = userEvent.setup();
+    const adapter = renderShell();
+
+    await user.click(screen.getByRole("button", { name: "Go back" }));
+
+    expect(adapter.back).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a drawer with secondary routes", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    await user.click(screen.getByRole("button", { name: "Open mobile menu" }));
+
+    expect(screen.getByRole("dialog", { name: "Mobile menu" })).toBeVisible();
+    expect(screen.getByRole("link", { name: /Runtime/ })).toHaveAttribute(
+      "href",
+      "/acme/m/runtime",
+    );
+    expect(screen.getByRole("link", { name: /Chat/ })).toHaveAttribute(
+      "href",
+      "/acme/m/chat",
+    );
+  });
+});

--- a/apps/web/features/mobile/mobile-shell.tsx
+++ b/apps/web/features/mobile/mobile-shell.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import {
+  ChevronLeft,
+  Inbox,
+  Kanban,
+  ListTodo,
+  Menu,
+  MessageCircle,
+  PanelsTopLeft,
+  Server,
+  Settings,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import { useRequiredWorkspaceSlug } from "@multica/core/paths";
+import { MulticaIcon } from "@multica/ui/components/common/multica-icon";
+import { cn } from "@multica/ui/lib/utils";
+import { DashboardGuard, WorkspacePresencePrefetch } from "@multica/views/layout";
+import { AppLink, useNavigation } from "@multica/views/navigation";
+import {
+  MOBILE_BOTTOM_NAV_ITEMS,
+  MOBILE_DRAWER_NAV_ITEMS,
+  type MobileRouteKey,
+  mobileRoutes,
+} from "./mobile-routes";
+
+const MOBILE_NAV_ICONS: Record<MobileRouteKey, LucideIcon> = {
+  kanban: Kanban,
+  issues: ListTodo,
+  projects: PanelsTopLeft,
+  inbox: Inbox,
+  runtime: Server,
+  chat: MessageCircle,
+  settings: Settings,
+};
+
+function isActiveRoute(pathname: string, href: string) {
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function MobileShell({ children }: { children: ReactNode }) {
+  return (
+    <DashboardGuard
+      loadingFallback={
+        <div className="flex h-svh items-center justify-center bg-background">
+          <MulticaIcon className="size-6 animate-pulse" />
+        </div>
+      }
+    >
+      <WorkspacePresencePrefetch />
+      <MobileShellFrame>{children}</MobileShellFrame>
+    </DashboardGuard>
+  );
+}
+
+export function MobileShellFrame({ children }: { children: ReactNode }) {
+  const workspaceSlug = useRequiredWorkspaceSlug();
+  const navigation = useNavigation();
+  const routes = mobileRoutes(workspaceSlug);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  return (
+    <div className="flex h-svh flex-col overflow-hidden overscroll-none bg-background text-foreground [&_button]:touch-manipulation [&_input]:text-base">
+      <header className="shrink-0 border-b border-border bg-background/95 px-3 pb-2 pt-[max(env(safe-area-inset-top),0px)] backdrop-blur">
+        <div className="flex min-h-14 items-center gap-2">
+          <button
+            type="button"
+            aria-label="Go back"
+            onClick={navigation.back}
+            className="grid min-h-11 min-w-11 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <ChevronLeft className="size-5" aria-hidden="true" />
+          </button>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Workspace
+            </p>
+            <p className="truncate text-lg font-semibold leading-tight">
+              {workspaceSlug}
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Open mobile menu"
+            onClick={() => setDrawerOpen(true)}
+            className="grid min-h-11 min-w-11 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Menu className="size-5" aria-hidden="true" />
+          </button>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        {children}
+      </div>
+
+      <nav
+        aria-label="Mobile primary"
+        className="shrink-0 border-t border-border bg-background/95 px-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] pt-2 backdrop-blur"
+      >
+        <div className="grid grid-cols-5 gap-1">
+          {MOBILE_BOTTOM_NAV_ITEMS.map((item) => {
+            const href = routes[item.routeKey];
+            const active = isActiveRoute(navigation.pathname, href);
+            const Icon = MOBILE_NAV_ICONS[item.routeKey];
+            return (
+              <AppLink
+                key={item.routeKey}
+                href={href}
+                aria-label={`Open mobile ${item.label}`}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex min-h-12 flex-col items-center justify-center gap-1 rounded-md px-1 text-[11px] font-medium leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  active
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                )}
+              >
+                <Icon className="size-5" aria-hidden="true" />
+                <span className="max-w-full truncate">{item.label}</span>
+              </AppLink>
+            );
+          })}
+        </div>
+      </nav>
+
+      {drawerOpen ? (
+        <div className="fixed inset-0 z-50">
+          <button
+            type="button"
+            aria-label="Close mobile menu overlay"
+            className="absolute inset-0 bg-background/70 backdrop-blur-sm"
+            onClick={() => setDrawerOpen(false)}
+          />
+          <aside
+            role="dialog"
+            aria-modal="true"
+            aria-label="Mobile menu"
+            className="absolute bottom-0 right-0 top-0 flex w-[min(21rem,86vw)] flex-col border-l border-border bg-background pb-[max(env(safe-area-inset-bottom),1rem)] pt-[max(env(safe-area-inset-top),1rem)] shadow-2xl"
+          >
+            <div className="flex min-h-14 items-center gap-3 border-b border-border px-4">
+              <div className="grid size-9 place-items-center rounded-md bg-primary text-primary-foreground">
+                <MulticaIcon className="size-5" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  Current workspace
+                </p>
+                <p className="truncate text-base font-semibold">
+                  {workspaceSlug}
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close mobile menu"
+                onClick={() => setDrawerOpen(false)}
+                className="grid min-h-11 min-w-11 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <X className="size-5" aria-hidden="true" />
+              </button>
+            </div>
+            <div className="flex-1 space-y-6 overflow-y-auto px-3 py-4">
+              <section aria-label="Secondary mobile routes" className="space-y-1">
+                {MOBILE_DRAWER_NAV_ITEMS.map((item) => {
+                  const href = routes[item.routeKey];
+                  const active = isActiveRoute(navigation.pathname, href);
+                  const Icon = MOBILE_NAV_ICONS[item.routeKey];
+                  return (
+                    <AppLink
+                      key={item.routeKey}
+                      href={href}
+                      aria-current={active ? "page" : undefined}
+                      onClick={() => setDrawerOpen(false)}
+                      className={cn(
+                        "flex min-h-11 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                        active
+                          ? "bg-primary text-primary-foreground"
+                          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                      )}
+                    >
+                      <Icon className="size-5" aria-hidden="true" />
+                      {item.label}
+                    </AppLink>
+                  );
+                })}
+              </section>
+            </div>
+          </aside>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

`apps/web` 内に `/[workspaceSlug]/m/...` の mobile route group と mobile shell を追加しました。既存の web auth / CoreProvider / NavigationAdapter / origin-derived `/ws` をそのまま使い、desktop route とは URL と layout を分離しています。

Closes [FAL-52](mention://issue/05b6d840-2341-44e9-ac7c-0f33945e970b)

## 変更内容

- `apps/web/app/[workspaceSlug]/(mobile)/m/`: `/m` redirect と `kanban` / `issues` / `projects` / `inbox` / `runtime` / `chat` / `settings` placeholder routes を追加
- `apps/web/features/mobile/mobile-shell.tsx`: safe-area / overscroll / input font-size 対策込みの mobile shell、上部 app bar、戻るボタン、5-tab bottom nav、secondary drawer を追加
- `apps/web/features/mobile/mobile-routes.ts`: `/[workspaceSlug]/m/...` 専用 route builder と bottom/drawer nav 定義を追加
- `apps/web/features/mobile/mobile-placeholder.tsx`: foundation 用 placeholder page を追加
- `apps/web/features/mobile/*.test.*`: route shape、5-tab nav、drawer secondary routes、placeholder copy の RED/GREEN tests を追加
- `apps/web/README.md`: mobile route 入口と Tailscale Serve 想定構成を追記

## Definition of Done 充足状況

- [ ] iPhone 実機で Tailscale 経由 (`https://<host>.<tailnet>.ts.net/...`) に到達し、login → mobile route group のいずれかの placeholder にナビゲートできる
- [x] bottom tab nav の 5 タブ程度が placeholder で正しく描画され、画面遷移が動く
- [x] `pnpm typecheck` `pnpm lint` `pnpm test` pass
- [x] 既存 `apps/web` desktop ルート / `apps/desktop` の動作・テストに regression なし
- [ ] `wss://.../ws` が 101 を返し、既存 realtime client が接続成功状態になる (PC 側 Serve 設定済の前提で 1 度実機確認)
- [x] packages 境界違反なし (`apps/web/platform/` 以外で `next/*` を import しない / `packages/core` に DOM・localStorage・process.env が漏れない)

未チェック 2 件は ADR v2 §5.2 の iPhone 実機 + Tailscale Serve 設定が必要なため、ユーザー環境での handoff 確認対象です。

## 動作確認方法

```bash
pnpm dev:web
```

- URL: `http://localhost:3000/{workspaceSlug}/m/issues`
- Tailscale 想定 URL: `https://<host>.<tailnet>.ts.net/{workspaceSlug}/m/issues`
- 確認手順:
  1. login 済みまたは login にリダイレクトされる状態で mobile URL にアクセス
  2. `/m/issues` placeholder が mobile shell 内に描画される
  3. bottom nav から Kanban / Issues / Projects / Inbox / Settings に遷移できる
  4. drawer から Runtime / Chat placeholder に遷移できる
  5. Tailscale Serve 設定済み環境で `/ws` が backend に到達し、既存 realtime client が接続できる

## Test plan

- [x] `pnpm install` (rebase 後の upstream i18n deps を同期)
- [x] `pnpm --filter @multica/web exec next typegen` (stale `.next/dev` route type cache refresh)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] iPhone Safari + Tailscale Serve 実機確認

## TDD 履歴

- RED: `088b4f0f` — failing tests for mobile foundation
- GREEN: `ebe9ba84` — implementation rebased onto `multica-ai/multica:main`

## 既知の制限 / 技術判断

- 5/7 の NEEDS_FIX 指摘を受け、`multica-ai/multica:main` (`bda475cb`) へ rebase しました。
- redundant lint-debt fixes は upstream #2129 / #2122 側を採用し、この PR からは drop 済みです。差分は mobile foundation files/tests/README のみです。
- upstream `multica-ai/multica` への branch push は `falconbear` credential が READ 権限のため 403 でした。PR head は fork `falconbear/multica:fal-52-mobile-foundation`、base は `multica-ai/multica:main` です。
- Tailscale Serve 設定と iPhone 実機確認は issue scope 通りユーザー作業として残しています。
