### PR TITLE
feat(inbox): auto-select next item after archiving

### DIFF
--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -144,8 +144,17 @@ export function InboxPage() {
   };
 
   const handleArchive = (id: string) => {
-    const archived = items.find((i) => i.id === id);
-    if (archived && (archived.issue_id ?? archived.id) === selectedKey) setSelectedKey("");
+    const idx = items.findIndex((i) => i.id === id);
+    const archived = idx >= 0 ? items[idx] : null;
+    const wasSelected =
+      !!archived && (archived.issue_id ?? archived.id) === selectedKey;
+    if (wasSelected) {
+      // List is sorted newest-first; prefer the next (older) item, fall back
+      // to the previous (newer) one when archiving at the bottom, and only
+      // clear the selection when nothing else is left.
+      const next = items[idx + 1] ?? items[idx - 1] ?? null;
+      setSelectedKey(next ? (next.issue_id ?? next.id) : "");
+    }
     archiveMutation.mutate(id, {
       onError: () => toast.error(t(($) => $.errors.archive_failed)),
     });
@@ -265,10 +274,7 @@ export function InboxPage() {
         setSelectedKey("");
       }}
       onDone={() => {
-        setSelectedKey("");
-        archiveMutation.mutate(selected.id, {
-          onError: () => toast.error(t(($) => $.errors.archive_failed)),
-        });
+        handleArchive(selected.id);
       }}
     />
   ) : selected ? (


### PR DESCRIPTION
## Summary

- Archiving the currently selected inbox item now auto-selects the next (older) item instead of clearing the selection.
- Falls back to the previous (newer) item when archiving at the bottom; only clears when the list is empty afterwards.
- Detail panel's `onDone` path now routes through the same `handleArchive`, so "Mark done" and the Archive button get the same auto-select behavior.

Resolves [MUL-1806](mention://issue/70202300-7038-4211-bbaf-e6de947894ae).

## Test plan
- [ ] Archive an inbox item that is currently selected → next item gets selected, detail panel shows it.
- [ ] Archive the last item in the list → previous item gets selected.
- [ ] Archive the only remaining item → selection clears, detail panel shows empty state.
- [ ] Archive an item that is NOT currently selected → selection unchanged.
- [ ] Detail panel "Mark done" → archives + auto-selects next.
- [ ] Mobile: archiving the open item lands on the next item (also auto-select on mobile).
- [ ] Batch archive (Archive all / Archive read / Archive completed) still clears selection — unchanged behavior.