### PR TITLE
feat(issues): add Copy local workdir path to issue menu

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -95,6 +95,11 @@ export interface AgentTask {
    * with a meaningful title instead of falling through to "Untracked").
    */
   kind?: "comment" | "autopilot" | "chat" | "quick_create" | "direct";
+  /**
+   * Local working directory pinned for this task by the daemon. Empty until
+   * the daemon reports a work_dir (typically once execution starts).
+   */
+  work_dir?: string;
 }
 
 export interface Agent {

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDown,
   ArrowUp,
   Calendar,
+  FolderOpen,
   Link2,
   MoreHorizontal,
   Pin,
@@ -90,6 +91,7 @@ export function IssueActionsMenuItems({
     updateField,
     togglePin,
     copyLink,
+    copyWorkdirPath,
     openCreateSubIssue,
     openSetParent,
     openAddChild,
@@ -237,6 +239,10 @@ export function IssueActionsMenuItems({
       <P.Item onClick={copyLink}>
         <Link2 className="h-3.5 w-3.5" />
         {t(($) => $.actions.copy_link)}
+      </P.Item>
+      <P.Item onClick={copyWorkdirPath}>
+        <FolderOpen className="h-3.5 w-3.5" />
+        {t(($) => $.actions.copy_workdir_path)}
       </P.Item>
 
       <P.Separator />

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
 import {
   ArrowDown,
   ArrowUp,
@@ -13,12 +16,14 @@ import {
   Trash2,
   UserMinus,
 } from "lucide-react";
-import type { Issue } from "@multica/core/types";
+import type { AgentTask, Issue } from "@multica/core/types";
+import { api } from "@multica/core/api";
 import {
   ALL_STATUSES,
   PRIORITY_ORDER,
   PRIORITY_CONFIG,
 } from "@multica/core/issues/config";
+import { issueKeys } from "@multica/core/issues/queries";
 import { StatusIcon } from "../components/status-icon";
 import { PriorityIcon } from "../components/priority-icon";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -91,7 +96,6 @@ export function IssueActionsMenuItems({
     updateField,
     togglePin,
     copyLink,
-    copyWorkdirPath,
     openCreateSubIssue,
     openSetParent,
     openAddChild,
@@ -104,6 +108,37 @@ export function IssueActionsMenuItems({
     d.setDate(d.getDate() + days);
     return d.toISOString();
   };
+
+  // Subscribe to the issue's task list so the cache is warm by the time the
+  // user clicks "Copy local workdir path". The query only fires while the
+  // menu is open (Base UI portals the menu content lazily) — list views
+  // that wrap every row in IssueActionsContextMenu pay nothing until the
+  // menu actually opens.
+  //
+  // The query shares its key with ExecutionLogSection, so navigating from
+  // the issue detail page is a free cache hit.
+  const { data: tasks } = useQuery({
+    queryKey: issueKeys.tasks(issue.id),
+    queryFn: () => api.listTasksByIssue(issue.id),
+    staleTime: 30_000,
+  });
+
+  // Synchronous click handler — the awaited fetch in the previous version
+  // dropped the browser's transient user activation, which made
+  // navigator.clipboard.writeText() reject from the menu when the cache
+  // was cold. We now read straight from the cached query result and write
+  // to the clipboard inside the same task as the click.
+  const handleCopyWorkdirPath = useCallback(() => {
+    const latestWorkDir = pickLatestWorkDir(tasks);
+    if (!latestWorkDir) {
+      toast.error(t(($) => $.detail.workdir_path_unavailable));
+      return;
+    }
+    navigator.clipboard.writeText(latestWorkDir).then(
+      () => toast.success(t(($) => $.detail.workdir_path_copied)),
+      () => toast.error(t(($) => $.detail.workdir_path_copy_failed)),
+    );
+  }, [tasks, t]);
 
   return (
     <>
@@ -240,7 +275,7 @@ export function IssueActionsMenuItems({
         <Link2 className="h-3.5 w-3.5" />
         {t(($) => $.actions.copy_link)}
       </P.Item>
-      <P.Item onClick={copyWorkdirPath}>
+      <P.Item onClick={handleCopyWorkdirPath}>
         <FolderOpen className="h-3.5 w-3.5" />
         {t(($) => $.actions.copy_workdir_path)}
       </P.Item>
@@ -281,4 +316,16 @@ export function IssueActionsMenuItems({
       </P.Item>
     </>
   );
+}
+
+function pickLatestWorkDir(tasks: AgentTask[] | undefined): string | undefined {
+  if (!tasks?.length) return undefined;
+  let latest: AgentTask | undefined;
+  for (const task of tasks) {
+    if (!task.work_dir) continue;
+    if (!latest || task.created_at > latest.created_at) {
+      latest = task;
+    }
+  }
+  return latest?.work_dir;
 }

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -1,13 +1,12 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type {
   Issue,
   MemberWithUser,
   Agent,
-  AgentTask,
   UpdateIssueRequest,
 } from "@multica/core/types";
 import { useAuthStore } from "@multica/core/auth";
@@ -15,8 +14,6 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
-import { issueKeys } from "@multica/core/issues/queries";
-import { api } from "@multica/core/api";
 import {
   memberListOptions,
   agentListOptions,
@@ -37,7 +34,6 @@ export interface UseIssueActionsResult {
   updateField: (updates: Partial<UpdateIssueRequest>) => void;
   togglePin: () => void;
   copyLink: () => Promise<void>;
-  copyWorkdirPath: () => Promise<void>;
   openCreateSubIssue: () => void;
   openSetParent: () => void;
   openAddChild: () => void;
@@ -85,7 +81,6 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
   const createPin = useCreatePin();
   const deletePin = useDeletePin();
   const openModal = useModalStore((s) => s.open);
-  const queryClient = useQueryClient();
 
   const issueId = issue?.id ?? null;
   const issueStatus = issue?.status ?? null;
@@ -139,42 +134,6 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
     }
   }, [paths, issueId, navigation, t]);
 
-  // Resolve the local workdir path of the issue's most recent task that
-  // recorded one (work_dir is pinned by the daemon when execution starts).
-  // The cache is shared with ExecutionLogSection — `issueKeys.tasks` —
-  // so we serve from cache when the user has the issue page open and fall
-  // back to a fresh fetch otherwise.
-  const copyWorkdirPath = useCallback(async () => {
-    if (!issueId) return;
-    let tasks = queryClient.getQueryData<AgentTask[]>(issueKeys.tasks(issueId));
-    if (!tasks) {
-      try {
-        tasks = await queryClient.fetchQuery({
-          queryKey: issueKeys.tasks(issueId),
-          queryFn: () => api.listTasksByIssue(issueId),
-          staleTime: 30_000,
-        });
-      } catch {
-        toast.error(t(($) => $.detail.workdir_path_copy_failed));
-        return;
-      }
-    }
-    const sorted = [...(tasks ?? [])].sort((a, b) =>
-      b.created_at.localeCompare(a.created_at),
-    );
-    const workDir = sorted.find((task) => !!task.work_dir)?.work_dir;
-    if (!workDir) {
-      toast.error(t(($) => $.detail.workdir_path_unavailable));
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(workDir);
-      toast.success(t(($) => $.detail.workdir_path_copied));
-    } catch {
-      toast.error(t(($) => $.detail.workdir_path_copy_failed));
-    }
-  }, [issueId, queryClient, t]);
-
   const openCreateSubIssue = useCallback(() => {
     if (!issueId) return;
     openModal("create-issue", {
@@ -213,7 +172,6 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
     updateField,
     togglePin,
     copyLink,
-    copyWorkdirPath,
     openCreateSubIssue,
     openSetParent,
     openAddChild,

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -1,12 +1,13 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type {
   Issue,
   MemberWithUser,
   Agent,
+  AgentTask,
   UpdateIssueRequest,
 } from "@multica/core/types";
 import { useAuthStore } from "@multica/core/auth";
@@ -14,6 +15,8 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
+import { issueKeys } from "@multica/core/issues/queries";
+import { api } from "@multica/core/api";
 import {
   memberListOptions,
   agentListOptions,
@@ -34,6 +37,7 @@ export interface UseIssueActionsResult {
   updateField: (updates: Partial<UpdateIssueRequest>) => void;
   togglePin: () => void;
   copyLink: () => Promise<void>;
+  copyWorkdirPath: () => Promise<void>;
   openCreateSubIssue: () => void;
   openSetParent: () => void;
   openAddChild: () => void;
@@ -81,6 +85,7 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
   const createPin = useCreatePin();
   const deletePin = useDeletePin();
   const openModal = useModalStore((s) => s.open);
+  const queryClient = useQueryClient();
 
   const issueId = issue?.id ?? null;
   const issueStatus = issue?.status ?? null;
@@ -134,6 +139,42 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
     }
   }, [paths, issueId, navigation, t]);
 
+  // Resolve the local workdir path of the issue's most recent task that
+  // recorded one (work_dir is pinned by the daemon when execution starts).
+  // The cache is shared with ExecutionLogSection — `issueKeys.tasks` —
+  // so we serve from cache when the user has the issue page open and fall
+  // back to a fresh fetch otherwise.
+  const copyWorkdirPath = useCallback(async () => {
+    if (!issueId) return;
+    let tasks = queryClient.getQueryData<AgentTask[]>(issueKeys.tasks(issueId));
+    if (!tasks) {
+      try {
+        tasks = await queryClient.fetchQuery({
+          queryKey: issueKeys.tasks(issueId),
+          queryFn: () => api.listTasksByIssue(issueId),
+          staleTime: 30_000,
+        });
+      } catch {
+        toast.error(t(($) => $.detail.workdir_path_copy_failed));
+        return;
+      }
+    }
+    const sorted = [...(tasks ?? [])].sort((a, b) =>
+      b.created_at.localeCompare(a.created_at),
+    );
+    const workDir = sorted.find((task) => !!task.work_dir)?.work_dir;
+    if (!workDir) {
+      toast.error(t(($) => $.detail.workdir_path_unavailable));
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(workDir);
+      toast.success(t(($) => $.detail.workdir_path_copied));
+    } catch {
+      toast.error(t(($) => $.detail.workdir_path_copy_failed));
+    }
+  }, [issueId, queryClient, t]);
+
   const openCreateSubIssue = useCallback(() => {
     if (!issueId) return;
     openModal("create-issue", {
@@ -172,6 +213,7 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
     updateField,
     togglePin,
     copyLink,
+    copyWorkdirPath,
     openCreateSubIssue,
     openSetParent,
     openAddChild,

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -128,7 +128,10 @@
     "sidebar_tooltip": "Toggle sidebar",
     "update_failed": "Failed to update issue",
     "link_copied": "Link copied",
-    "link_copy_failed": "Failed to copy link"
+    "link_copy_failed": "Failed to copy link",
+    "workdir_path_copied": "Workdir path copied",
+    "workdir_path_copy_failed": "Failed to copy workdir path",
+    "workdir_path_unavailable": "No local workdir yet — issue has not been run by a local agent"
   },
   "timeline": {
     "show_older": "Show older",
@@ -248,6 +251,7 @@
     "pin_to_sidebar": "Pin to sidebar",
     "unpin_from_sidebar": "Unpin from sidebar",
     "copy_link": "Copy link",
+    "copy_workdir_path": "Copy local workdir path",
     "more": "More",
     "create_sub_issue": "Create sub-issue",
     "set_parent_issue": "Set parent issue...",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -127,7 +127,10 @@
     "sidebar_tooltip": "切换侧边栏",
     "update_failed": "更新 issue 失败",
     "link_copied": "已复制链接",
-    "link_copy_failed": "复制链接失败"
+    "link_copy_failed": "复制链接失败",
+    "workdir_path_copied": "已复制本地 workdir 路径",
+    "workdir_path_copy_failed": "复制本地 workdir 路径失败",
+    "workdir_path_unavailable": "暂无本地 workdir — 这个 issue 还没被本地 agent 运行过"
   },
   "timeline": {
     "show_older": "显示更早",
@@ -241,6 +244,7 @@
     "pin_to_sidebar": "固定到侧边栏",
     "unpin_from_sidebar": "从侧边栏取消固定",
     "copy_link": "复制链接",
+    "copy_workdir_path": "复制本地 workdir 路径",
     "more": "更多",
     "create_sub_issue": "创建子 issue",
     "set_parent_issue": "设置父 issue...",

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -158,6 +158,7 @@ type AgentTaskResponse struct {
 	CreatedAt               string                `json:"created_at"`
 	PriorSessionID          string                `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
 	PriorWorkDir            string                `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
+	WorkDir                 string                `json:"work_dir,omitempty"`                  // local working directory pinned for this task; populated once the daemon reports it
 	TriggerCommentID        *string               `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
 	TriggerCommentContent   string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
 	TriggerSummary          *string               `json:"trigger_summary,omitempty"`           // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
@@ -197,6 +198,10 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 	if t.FailureReason.Valid {
 		failureReason = t.FailureReason.String
 	}
+	workDir := ""
+	if t.WorkDir.Valid {
+		workDir = t.WorkDir.String
+	}
 	return AgentTaskResponse{
 		ID:               uuidToString(t.ID),
 		AgentID:          uuidToString(t.AgentID),
@@ -216,6 +221,7 @@ func taskToResponse(t db.AgentTaskQueue) AgentTaskResponse {
 		CreatedAt:        timestampToString(t.CreatedAt),
 		TriggerCommentID: uuidToPtr(t.TriggerCommentID),
 		TriggerSummary:   textToPtr(t.TriggerSummary),
+		WorkDir:          workDir,
 		// Surface task source so the UI can distinguish issue-linked tasks
 		// from chat-spawned or autopilot-spawned ones; all three may arrive
 		// with issue_id = "" once a task has no linked issue.


### PR DESCRIPTION
## Summary

- Add a **Copy local workdir path** menu item to the issue dropdown / context menu, sitting next to **Copy link**
- Backend: surface the daemon-pinned `work_dir` on `AgentTaskResponse` so the frontend can resolve it without recomputing `PredictRootDir` client-side
- Action picks the most recent task that has a recorded `work_dir` (work_dir is pinned by the daemon when execution starts) and writes it to the clipboard
- If no task has run yet on this machine, surface a clear toast: "No local workdir yet — issue has not been run by a local agent"
- i18n: en + zh-Hans entries for the menu label and the three toast outcomes (success / failure / unavailable)

Closes [MUL-1818](https://multica.app/issues/0fe6285b-c9b0-40d3-aec8-117f6218c0d7).

## Test plan

- [ ] Open an issue that has been run by a local agent → menu → **Copy local workdir path** copies the workdir to clipboard
- [ ] Open an issue with no runs yet → action shows the "No local workdir yet" toast
- [ ] Right-click an issue row in the issue list → same action available in the context menu
- [ ] Switch UI language to 中文 → menu label and toasts render in Chinese