### PR TITLE
fix(agent): add --skip-trust flag to gemini CLI invocation

### DIFF
--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -239,21 +239,24 @@ type geminiModelStats struct {
 //
 //	-p / --prompt         non-interactive prompt (the user's task)
 //	--yolo                auto-approve all tool executions
+//	--skip-trust          bypass trusted-directory check (required for headless/daemon use, v0.41+)
 //	-o stream-json        streaming NDJSON output for live events
 //	-m <model>            optional model override
 //	-r <session>          resume a previous session (if provided)
 // geminiBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args.
 var geminiBlockedArgs = map[string]blockedArgMode{
-	"-p":     blockedWithValue,  // non-interactive prompt
-	"--yolo": blockedStandalone, // auto-approve tool use
-	"-o":     blockedWithValue,  // stream-json output format
+	"-p":           blockedWithValue,  // non-interactive prompt
+	"--yolo":       blockedStandalone, // auto-approve tool use
+	"--skip-trust": blockedStandalone, // trust bypass (always set by daemon)
+	"-o":           blockedWithValue,  // stream-json output format
 }
 
 func buildGeminiArgs(prompt string, opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{
 		"-p", prompt,
 		"--yolo",
+		"--skip-trust",
 		"-o", "stream-json",
 	}
 	if opts.Model != "" {


### PR DESCRIPTION
## Problem

Gemini CLI v0.41+ introduced a trusted-directory security check. When the daemon spawns Gemini in headless mode (`--yolo -p`), it exits with **code 55** if the working directory is not pre-trusted:

```
Gemini CLI is not running in a trusted directory. To proceed, either use `--skip-trust`,
set the `GEMINI_CLI_TRUST_WORKSPACE=true` environment variable, or trust this directory
in interactive mode.
```

Since the daemon always runs non-interactively, the trust prompt can never appear, so every Gemini agent run fails immediately.

## Fix

Pass `--skip-trust` unconditionally in `buildGeminiArgs`. This bypasses the trust check for the session — equivalent to `GEMINI_CLI_TRUST_WORKSPACE=true` but scoped to a single invocation.

The flag is also added to `geminiBlockedArgs` so users cannot accidentally override it via `custom_args`.

## Tested

Reproduced exit 55 on Gemini CLI v0.41.1 without the flag; confirmed exit 0 with `--skip-trust`.