### PR TITLE
fix(timeline): include merge-truncation case in has_more_before (#2192)

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1053,6 +1053,16 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                           <div className="flex min-w-0 flex-1 items-center gap-1">
                             <span className="shrink-0 font-medium">{getActorName(entry.actor_type, entry.actor_id)}</span>
                             <span className="truncate">{formatActivity(entry, t, getActorName)}</span>
+                            {/* Coalesce badge for non-task actions: task_completed / task_failed already
+                                bake the count into their translation, so suppress the badge there to
+                                avoid showing "×N" twice. */}
+                            {(entry.coalesced_count ?? 1) > 1 &&
+                              entry.action !== "task_completed" &&
+                              entry.action !== "task_failed" && (
+                                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs font-medium tabular-nums text-muted-foreground">
+                                  {t(($) => $.activity.coalesced_badge, { count: entry.coalesced_count ?? 1 })}
+                                </span>
+                              )}
                             <Tooltip>
                               <TooltipTrigger
                                 render={

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -152,7 +152,8 @@
     "task_completed_one": "completed the task",
     "task_completed_other": "completed the task ({{count}} times)",
     "task_failed_one": "task failed",
-    "task_failed_other": "task failed ({{count}} times)"
+    "task_failed_other": "task failed ({{count}} times)",
+    "coalesced_badge": "×{{count}}"
   },
   "comment": {
     "delete_title": "Delete comment",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -151,7 +151,8 @@
     "task_completed_one": "完成了 task",
     "task_completed_other": "完成了 task（{{count}} 次）",
     "task_failed_one": "task 失败",
-    "task_failed_other": "task 失败（{{count}} 次）"
+    "task_failed_other": "task 失败（{{count}} 次）",
+    "coalesced_badge": "×{{count}}"
   },
   "comment": {
     "delete_title": "删除评论",

--- a/server/internal/handler/activity.go
+++ b/server/internal/handler/activity.go
@@ -226,9 +226,7 @@ func (h *Handler) listTimelineLatest(w http.ResponseWriter, r *http.Request, iss
 
 	entries := h.mergeTimelineDesc(r, comments, activities, limit)
 	resp := TimelineResponse{Entries: entries}
-	// has_more_before: the page is full → there are likely more older. If the
-	// page is partial it means we hit the bottom of one or both tables.
-	resp.HasMoreBefore = len(entries) >= limit && (len(comments) >= limit || len(activities) >= limit)
+	resp.HasMoreBefore = hasMoreBeyond(len(comments), len(activities), len(entries), limit)
 	if resp.HasMoreBefore && len(entries) > 0 {
 		c := encodeTimelineCursor(entryTimestamp(entries[len(entries)-1]), entryID(entries[len(entries)-1]))
 		resp.NextCursor = &c
@@ -270,7 +268,7 @@ func (h *Handler) listTimelineBefore(w http.ResponseWriter, r *http.Request, iss
 		Entries:      entries,
 		HasMoreAfter: true, // we're paging older from a known position, so newer exists
 	}
-	resp.HasMoreBefore = len(entries) >= limit && (len(comments) >= limit || len(activities) >= limit)
+	resp.HasMoreBefore = hasMoreBeyond(len(comments), len(activities), len(entries), limit)
 	if resp.HasMoreBefore && len(entries) > 0 {
 		c := encodeTimelineCursor(entryTimestamp(entries[len(entries)-1]), entryID(entries[len(entries)-1]))
 		resp.NextCursor = &c
@@ -311,7 +309,7 @@ func (h *Handler) listTimelineAfter(w http.ResponseWriter, r *http.Request, issu
 	// reverse to DESC for the response.
 	entries := h.mergeTimelineAscThenReverse(r, comments, activities, limit)
 	resp := TimelineResponse{Entries: entries, HasMoreBefore: true}
-	resp.HasMoreAfter = len(entries) >= limit && (len(comments) >= limit || len(activities) >= limit)
+	resp.HasMoreAfter = hasMoreBeyond(len(comments), len(activities), len(entries), limit)
 	if resp.HasMoreAfter && len(entries) > 0 {
 		c := encodeTimelineCursor(entryTimestamp(entries[0]), entryID(entries[0]))
 		resp.PrevCursor = &c
@@ -419,8 +417,8 @@ func (h *Handler) listTimelineAround(w http.ResponseWriter, r *http.Request, iss
 
 	resp := TimelineResponse{
 		Entries:       entries,
-		HasMoreBefore: len(olderComments) >= beforeLimit || len(olderActivities) >= beforeLimit,
-		HasMoreAfter:  len(newerComments) >= afterLimit || len(newerActivities) >= afterLimit,
+		HasMoreBefore: hasMoreBeyond(len(olderComments), len(olderActivities), len(olderEntries), beforeLimit),
+		HasMoreAfter:  hasMoreBeyond(len(newerComments), len(newerActivities), len(newerEntries), afterLimit),
 		TargetIndex:   &targetIdx,
 	}
 	if resp.HasMoreBefore {
@@ -449,6 +447,23 @@ func (h *Handler) fetchSingleEntry(r *http.Request, issue db.Issue, id pgtype.UU
 		return activityToEntry(a), true
 	}
 	return TimelineEntry{}, false
+}
+
+// hasMoreBeyond reports whether entries exist beyond the page on the side the
+// caller is paginating away from (older for "before", newer for "after").
+//
+// Three independent signals, any of which means "more rows exist":
+//  1. comments >= limit — the comments query was capped, DB has more.
+//  2. activities >= limit — the activities query was capped, DB has more.
+//  3. comments+activities > entries — the in-memory merge dropped rows that
+//     could not all fit in the page (#2192). This is the case the original
+//     formula missed, which made older comments unreachable when neither
+//     individual query hit the limit but their combined total exceeded it.
+func hasMoreBeyond(comments, activities, entries, limit int) bool {
+	if limit <= 0 {
+		return false
+	}
+	return comments >= limit || activities >= limit || comments+activities > entries
 }
 
 // mergeTimelineDesc takes comments + activities sorted DESC by (created_at, id)

--- a/server/internal/handler/activity_test.go
+++ b/server/internal/handler/activity_test.go
@@ -330,3 +330,99 @@ func TestListTimeline_LegacyShapeForPreCursorClients(t *testing.T) {
 		t.Fatalf("empty issue must render as [], got %q", got)
 	}
 }
+
+// TestHasMoreBeyond covers the truth table for the page-boundary helper. The
+// 8 rows enumerate every meaningful combination of (per-table cap hit) ×
+// (merge truncation), including the #2192 shape (case "merge truncation
+// without per-table cap") which the original formula missed.
+func TestHasMoreBeyond(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		comments, activities, entries, limit int
+		want                                 bool
+	}{
+		{"empty page", 0, 0, 0, 50, false},
+		{"partial page no truncation", 5, 3, 8, 50, false},
+		{"comments hit limit only", 50, 3, 50, 50, true},
+		{"activities hit limit only", 3, 50, 50, 50, true},
+		{"both hit limit", 50, 50, 50, 50, true},
+		// #2192: 48 comments + 49 activities, neither alone hits 50, merge
+		// truncated 47 rows. Old formula reported false; new reports true.
+		{"#2192 merge truncation", 48, 49, 50, 50, true},
+		{"exact-fit merge no truncation", 30, 20, 50, 50, false},
+		{"limit zero rejects", 100, 100, 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasMoreBeyond(tc.comments, tc.activities, tc.entries, tc.limit); got != tc.want {
+				t.Fatalf("hasMoreBeyond(c=%d, a=%d, e=%d, lim=%d) = %v, want %v",
+					tc.comments, tc.activities, tc.entries, tc.limit, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestListTimeline_MergeTruncationKeepsOlderReachable reproduces #2192 against
+// real DB rows: 48 comments dated older than 49 activities, default limit 50.
+// Pre-fix, the latest page reported has_more_before=false and the 47 older
+// comments were unreachable. Post-fix, the cursor + has_more_before flag let
+// the client walk to page 2 and recover them.
+func TestListTimeline_MergeTruncationKeepsOlderReachable(t *testing.T) {
+	issueID := createIssueForTimeline(t, "2192 merge truncation regression")
+	ctx := context.Background()
+
+	// 48 older comments, then 49 newer activities. The seedTimelineEntries
+	// helper inserts comments first (older block) then activities (newer
+	// block) — exactly the #2192 shape.
+	commentIDs, _ := seedTimelineEntries(t, issueID, 48, 49)
+
+	first, code := fetchTimeline(t, issueID, "limit=50")
+	if code != http.StatusOK {
+		t.Fatalf("first page: expected 200, got %d", code)
+	}
+	if len(first.Entries) != 50 {
+		t.Fatalf("first page should be full at 50 entries, got %d", len(first.Entries))
+	}
+	if !first.HasMoreBefore {
+		t.Fatalf("first page must report has_more_before=true (47 older comments dropped by merge)")
+	}
+	if first.NextCursor == nil {
+		t.Fatalf("first page must emit next_cursor when has_more_before=true")
+	}
+
+	// Page 2: walk older. Must surface the 47 older comments that the merge
+	// dropped on page 1.
+	second, code := fetchTimeline(t, issueID, "limit=50&before="+*first.NextCursor)
+	if code != http.StatusOK {
+		t.Fatalf("second page: expected 200, got %d", code)
+	}
+	if len(second.Entries) != 47 {
+		t.Fatalf("second page should return the 47 dropped older comments, got %d", len(second.Entries))
+	}
+
+	// Spot-check: every entry on page 2 must be a comment (the activities
+	// block was strictly newer).
+	for i, e := range second.Entries {
+		if e.Type != "comment" {
+			t.Fatalf("page 2 entry %d: expected comment, got %s", i, e.Type)
+		}
+	}
+
+	// Spot-check: page 2 must include the very oldest comment we seeded —
+	// otherwise the cursor walk lost data, which is precisely what #2192
+	// was about.
+	oldestSeeded := commentIDs[0]
+	found := false
+	for _, e := range second.Entries {
+		if e.ID == oldestSeeded {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("page 2 missing the oldest seeded comment %s — cursor walk lost data", oldestSeeded)
+	}
+
+	// Sanity: don't leak DB internals if something later changes the helper.
+	_ = ctx
+}


### PR DESCRIPTION
## Summary

Fixes #2192 — older comments became unreachable on issues where activity-log entries crowded them out of the latest 50-entry page. The "显示更早 / show earlier" button was hidden and no cursor was emitted, so the 47 oldest comments could only be retrieved via CLI.

## Root cause

`has_more_before` in `server/internal/handler/activity.go` used:

```go
len(entries) >= limit && (len(comments) >= limit || len(activities) >= limit)
```

This only catches the case where a per-table SQL query was capped at limit. It misses the case where both tables return partial rows but their **sum** exceeds the merged page size — the in-memory merge then silently truncates older rows. With 48 comments + 49 activities and limit=50, neither query individually hits 50, but `48+49=97 > 50` → 47 rows dropped, and `has_more_before` was wrongly `false`.

## Fix

Extract `hasMoreBeyond(comments, activities, entries, limit)` with the missing third disjunct, applied uniformly at all four sites (`listTimelineLatest`, `Before`, `After`, `Around`):

```go
return comments >= limit || activities >= limit || comments+activities > entries
```

## Frontend UX (paired commit)

While verifying the fix in-browser, the merged batch shows up as a single coalesced row (e.g. 48 `status_changed` collapsed to one) with **no count visible** — the existing `coalesced_count` field was only rendered for `task_completed` / `task_failed`. Added a `×N` count badge for the rest so the merge density is visible to the user.

## Backwards compatibility (carefully verified)

| Scenario | Outcome |
|---|---|
| New backend + pre-cursor client (≤ v0.2.25) | Hits `listTimelineLegacy` (returns raw array), never reads `has_more_before`. **Zero impact.** |
| New backend + v0.2.26 desktop client | `has_more_before` flips from "wrongly `false`" to "correctly `true`/`false`". Same field, same type, same shape — strict improvement. **Zero risk.** |
| New backend + this-PR frontend | "Show earlier" button works; coalesce count badge visible. |
| Old backend + new frontend | `coalesced_count` is computed in `useMemo` on the client (`issue-detail.tsx`), not from the API — frontend changes are independent of backend. |

API contract unchanged: no field renames, no new request params, no shape changes, `listTimelineLegacy` branch untouched. Desktop clients can ship at their normal cadence.

## Test plan

- [x] `TestHasMoreBeyond` — table-driven truth table (8 cases) including the exact #2192 shape `(c=48, a=49, e=50, limit=50)`
- [x] `TestListTimeline_MergeTruncationKeepsOlderReachable` — e2e regression with 48 comments + 49 activities, asserts page 2 returns the 47 dropped comments and the very oldest comment is recovered
- [x] `go build ./... && go vet ./... && gofmt -l` clean
- [x] `pnpm typecheck && pnpm test && pnpm lint` clean
- [x] Reproduced manually with `.context/seed_2192.sql` (gitignored): pre-fix UI hides "show earlier"; post-fix the button appears and clicking it loads the older comments
- [ ] CI green