### PR TITLE
fix(views): guard IME composition on Enter-to-submit handlers

### DIFF
--- a/packages/core/utils.test.ts
+++ b/packages/core/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRequestId, createSafeId, generateUUID } from "./utils";
+import { createRequestId, createSafeId, generateUUID, isImeComposing } from "./utils";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -29,5 +29,27 @@ describe("utils id helpers", () => {
 
     expect(createRequestId()).toBe("12345678");
     expect(createRequestId(12)).toBe("123456781234");
+  });
+});
+
+describe("isImeComposing", () => {
+  it("returns true when nativeEvent.isComposing is set (React synthetic event)", () => {
+    expect(isImeComposing({ nativeEvent: { isComposing: true, keyCode: 13 } })).toBe(true);
+  });
+
+  it("returns true when nativeEvent.keyCode is 229 (Safari edge case)", () => {
+    // Safari clears isComposing on the keydown that ends composition; keyCode
+    // stays 229 throughout, which is the only reliable signal in that browser.
+    expect(isImeComposing({ nativeEvent: { isComposing: false, keyCode: 229 } })).toBe(true);
+  });
+
+  it("returns true for native KeyboardEvent without nativeEvent wrapper", () => {
+    expect(isImeComposing({ isComposing: true, keyCode: 13 })).toBe(true);
+    expect(isImeComposing({ isComposing: false, keyCode: 229 })).toBe(true);
+  });
+
+  it("returns false when not composing", () => {
+    expect(isImeComposing({ nativeEvent: { isComposing: false, keyCode: 13 } })).toBe(false);
+    expect(isImeComposing({ isComposing: false, keyCode: 13 })).toBe(false);
   });
 });

--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -48,3 +48,28 @@ export function createSafeId(): string {
 export function createRequestId(length = 8): string {
   return createSafeId().replace(/-/g, "").slice(0, length);
 }
+
+/**
+ * True when the keyboard event fires while an IME is composing a multi-key
+ * input (e.g. Chinese pinyin, Japanese kana). The Enter that commits the
+ * composition must NOT trigger submit/send/create handlers.
+ *
+ * Accepts both React synthetic events and native DOM `KeyboardEvent`s.
+ *
+ * Why both `isComposing` and `keyCode === 229`:
+ * - `isComposing` is the standard signal but Safari clears it on the keydown
+ *   that ends composition, so a bare check misses the very Enter that submits.
+ * - During composition the browser reports `keyCode === 229` regardless of
+ *   the actual key, which keeps working in Safari's edge case.
+ *
+ * Always read from `nativeEvent` when present — React's synthetic event is
+ * normalized but the native event reflects the browser's real state.
+ */
+export function isImeComposing(event: {
+  isComposing?: boolean;
+  keyCode?: number;
+  nativeEvent?: { isComposing?: boolean; keyCode?: number };
+}): boolean {
+  const e = event.nativeEvent ?? event;
+  return Boolean(e.isComposing) || e.keyCode === 229;
+}

--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -455,7 +455,10 @@ function DescriptionEditorBody({
           placeholder={t(($) => $.inspector.description_placeholder)}
           rows={6}
           onKeyDown={(e) => {
-            if (e.key === "Escape") onClose();
+            if (e.key === "Escape") {
+              onClose();
+              return;
+            }
             if (isImeComposing(e)) return;
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               e.preventDefault();
@@ -584,7 +587,10 @@ function InlineEditPopover({
               }}
               placeholder={placeholder}
               onKeyDown={(e) => {
-                if (e.key === "Escape") setOpen(false);
+                if (e.key === "Escape") {
+                  setOpen(false);
+                  return;
+                }
                 if (isImeComposing(e)) return;
                 if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
                   e.preventDefault();

--- a/packages/views/agents/components/agent-detail-inspector.tsx
+++ b/packages/views/agents/components/agent-detail-inspector.tsx
@@ -19,7 +19,7 @@ import {
 } from "@multica/core/agents";
 import { api } from "@multica/core/api";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
-import { timeAgo } from "@multica/core/utils";
+import { isImeComposing, timeAgo } from "@multica/core/utils";
 import { Button } from "@multica/ui/components/ui/button";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { Input } from "@multica/ui/components/ui/input";
@@ -456,6 +456,7 @@ function DescriptionEditorBody({
           rows={6}
           onKeyDown={(e) => {
             if (e.key === "Escape") onClose();
+            if (isImeComposing(e)) return;
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               e.preventDefault();
               void commit();
@@ -561,11 +562,14 @@ function InlineEditPopover({
               }}
               placeholder={placeholder}
               onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  setOpen(false);
+                  return;
+                }
+                if (isImeComposing(e)) return;
                 if (e.key === "Enter") {
                   e.preventDefault();
                   void commit();
-                } else if (e.key === "Escape") {
-                  setOpen(false);
                 }
               }}
               className="h-8"
@@ -581,6 +585,7 @@ function InlineEditPopover({
               placeholder={placeholder}
               onKeyDown={(e) => {
                 if (e.key === "Escape") setOpen(false);
+                if (isImeComposing(e)) return;
                 if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
                   e.preventDefault();
                   void commit();

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -12,6 +12,7 @@ import type {
   MemberWithUser,
   CreateAgentRequest,
 } from "@multica/core/types";
+import { isImeComposing } from "@multica/core/utils";
 import {
   Dialog,
   DialogContent,
@@ -172,7 +173,10 @@ export function CreateAgentDialog({
               onChange={(e) => setName(e.target.value)}
               placeholder={t(($) => $.create_dialog.name_placeholder)}
               className="mt-1"
-              onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              onKeyDown={(e) => {
+                if (isImeComposing(e)) return;
+                if (e.key === "Enter") handleSubmit();
+              }}
             />
           </div>
 

--- a/packages/views/editor/extensions/mention-suggestion.tsx
+++ b/packages/views/editor/extensions/mention-suggestion.tsx
@@ -18,6 +18,7 @@ import { workspaceKeys } from "@multica/core/workspace/queries";
 import { useAuthStore } from "@multica/core/auth";
 import { canAssignAgentToIssue } from "@multica/core/permissions";
 import { api } from "@multica/core/api";
+import { isImeComposing } from "@multica/core/utils";
 import type {
   Issue,
   ListIssuesCache,
@@ -204,6 +205,9 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
 
     useImperativeHandle(ref, () => ({
       onKeyDown: ({ event }) => {
+        // IME is composing — don't intercept Enter/Arrow as picker actions;
+        // those keys belong to the IME (Enter commits composition, etc).
+        if (isImeComposing(event)) return false;
         if (event.key === "ArrowUp") {
           if (displayItems.length === 0) return true;
           setSelectedIndex(

--- a/packages/views/issues/components/labels-panel.tsx
+++ b/packages/views/issues/components/labels-panel.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { labelListOptions, useCreateLabel, useUpdateLabel, useDeleteLabel } from "@multica/core/labels";
 import type { Label } from "@multica/core/types";
+import { isImeComposing } from "@multica/core/utils";
 import { LabelChip } from "../../labels/label-chip";
 import { useT } from "../../i18n";
 
@@ -116,6 +117,7 @@ export function LabelsPanel() {
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
           onKeyDown={(e) => {
+            if (isImeComposing(e)) return;
             if (e.key === "Enter") handleCreate();
           }}
           className="flex-1"
@@ -152,8 +154,12 @@ export function LabelsPanel() {
                         if (e.target.value.trim()) setEditError("");
                       }}
                       onKeyDown={(e) => {
+                        if (e.key === "Escape") {
+                          cancelEdit();
+                          return;
+                        }
+                        if (isImeComposing(e)) return;
                         if (e.key === "Enter") saveEdit(label.id);
-                        if (e.key === "Escape") cancelEdit();
                       }}
                       className="flex-1 h-8"
                       maxLength={32}

--- a/packages/views/issues/components/pickers/property-picker.tsx
+++ b/packages/views/issues/components/pickers/property-picker.tsx
@@ -12,6 +12,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@multica/ui/components/ui/tooltip";
+import { isImeComposing } from "@multica/core/utils";
 import { useT } from "../../../i18n";
 
 const HIGHLIGHT_CLASS = "bg-accent";
@@ -107,6 +108,9 @@ export function PropertyPicker({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // IME is composing — Enter/Arrow belong to the IME (Enter commits
+      // composition; Arrow rotates candidates). Don't hijack them.
+      if (isImeComposing(e)) return;
       const items = getItems();
       if (items.length === 0) return;
 

--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -23,6 +23,7 @@ import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
 import { cn } from "@multica/ui/lib/utils";
 import { useCreateWorkspace } from "@multica/core/workspace/mutations";
 import type { Workspace } from "@multica/core/types";
+import { isImeComposing } from "@multica/core/utils";
 import { DragStrip } from "@multica/views/platform";
 import { StepHeader } from "../components/step-header";
 import { RadioMark } from "../components/option-card";
@@ -201,7 +202,10 @@ export function StepWorkspace({
           value={name}
           onChange={(e) => handleNameChange(e.target.value)}
           placeholder={t(($) => $.step_workspace.name_placeholder)}
-          onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+          onKeyDown={(e) => {
+            if (isImeComposing(e)) return;
+            if (e.key === "Enter") handleCreate();
+          }}
         />
       </div>
       <div className="flex flex-col gap-1.5">
@@ -222,7 +226,10 @@ export function StepWorkspace({
             onChange={(e) => handleSlugChange(e.target.value)}
             placeholder={t(($) => $.step_workspace.slug_placeholder)}
             className="border-0 bg-transparent font-mono shadow-none focus-visible:ring-0"
-            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            onKeyDown={(e) => {
+              if (isImeComposing(e)) return;
+              if (e.key === "Enter") handleCreate();
+            }}
           />
         </div>
         {slugError && <p className="text-xs text-destructive">{slugError}</p>}

--- a/packages/views/settings/components/delete-workspace-dialog.tsx
+++ b/packages/views/settings/components/delete-workspace-dialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
 import { Button } from "@multica/ui/components/ui/button";
+import { isImeComposing } from "@multica/core/utils";
 import { useT } from "../../i18n";
 
 /**
@@ -83,6 +84,7 @@ export function DeleteWorkspaceDialog({
             value={typed}
             onChange={(e) => setTyped(e.target.value)}
             onKeyDown={(e) => {
+              if (isImeComposing(e)) return;
               if (e.key === "Enter") {
                 e.preventDefault();
                 submit();

--- a/packages/views/skills/components/create-skill-dialog.tsx
+++ b/packages/views/skills/components/create-skill-dialog.tsx
@@ -17,6 +17,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@multica/core/api";
 import type { Skill } from "@multica/core/types";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { isImeComposing } from "@multica/core/utils";
 import {
   skillDetailOptions,
   workspaceKeys,
@@ -163,6 +164,7 @@ function ManualForm({
             }}
             placeholder={t(($) => $.create.manual.name_placeholder)}
             onKeyDown={(e) => {
+              if (isImeComposing(e)) return;
               if (e.key === "Enter") submit();
             }}
           />

--- a/packages/views/workspace/create-workspace-form.tsx
+++ b/packages/views/workspace/create-workspace-form.tsx
@@ -8,6 +8,7 @@ import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import { useCreateWorkspace } from "@multica/core/workspace/mutations";
 import type { Workspace } from "@multica/core/types";
+import { isImeComposing } from "@multica/core/utils";
 import {
   WORKSPACE_SLUG_REGEX,
   isWorkspaceSlugConflict,
@@ -79,7 +80,10 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
             value={name}
             onChange={(e) => handleNameChange(e.target.value)}
             placeholder={t(($) => $.create_form.name_placeholder)}
-            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            onKeyDown={(e) => {
+              if (isImeComposing(e)) return;
+              if (e.key === "Enter") handleCreate();
+            }}
           />
         </div>
         <div className="space-y-1.5">
@@ -96,7 +100,10 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
               onChange={(e) => handleSlugChange(e.target.value)}
               placeholder={t(($) => $.create_form.url_placeholder)}
               className="border-0 shadow-none focus-visible:ring-0"
-              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              onKeyDown={(e) => {
+                if (isImeComposing(e)) return;
+                if (e.key === "Enter") handleCreate();
+              }}
             />
           </div>
           {slugError && (


### PR DESCRIPTION
## Summary

中文/日文/韩文输入法用 Enter 上屏。当同一个 Enter 还触发 submit/create 时，表单在用户还没打完字的时候就会被提交（[MUL-1817](https://multica.ai/issues/MUL-1817)）。

修法：在 `@multica/core/utils` 加一个共享的 `isImeComposing` predicate，同时判断 `nativeEvent.isComposing` 和 `keyCode === 229`（Safari 在 commit keydown 那一帧把 `isComposing` 清掉，但 `keyCode` 一直是 229，是该浏览器唯一可靠的信号）。然后在所有「Enter → 提交/创建」的 handler 里逐个加守卫。

## 改动范围

- **新增工具：** `packages/core/utils.ts` `isImeComposing` + 单测覆盖 React 合成事件 / 原生 DOM 事件 / Safari 边界
- **加守卫的 Enter 处理点（IME 可触达的输入）：**
  - Workspace 名称：onboarding step + create-workspace-form
  - Agent 名称/描述：create-agent-dialog + agent-detail-inspector
  - Skill 名称：create-skill-dialog
  - Label 创建/编辑：labels-panel
  - 富文本 mention 选择器：mention-suggestion
  - 通用属性 picker 搜索：property-picker
  - 删除 workspace 的输入名确认：delete-workspace-dialog
- **Tiptap 编辑器主路径：** `submit-shortcut.ts` 已经走 `view.composing` 守卫，未改动
- **故意跳过：** numeric / email / URL / 文件路径输入框（IME 不会进）—— concurrency-picker、cloud-waitlist-expand、members-tab、bubble-menu、skill-detail-page 文件路径

## Test plan

- [x] `pnpm typecheck` 全 monorepo 通过
- [x] `pnpm --filter @multica/views test` 327/327 通过
- [x] `pnpm --filter @multica/core exec vitest run utils.test.ts` 14/14 通过（含新增 4 个 IME 用例）
- [x] `pnpm lint` 无新增告警
- [ ] 手动 QA：用中文 IME 在以下场景按回车，确认是上屏而不是提交
  - [ ] 创建 workspace（onboarding + workspace-form）
  - [ ] 创建 agent（名字含中文）
  - [ ] 编辑 agent 名字 / 描述
  - [ ] 创建 / 编辑 label（中文 label）
  - [ ] @mention 用中文搜索人/issue
  - [ ] property picker 用中文搜索
  - [ ] 删除 workspace 输入中文 workspace 名确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)