### PR TITLE
fix(daemon): keep daemon health responsive during repo lookup

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -44,11 +44,17 @@ type workspaceState struct {
 	repoRefreshMu   sync.Mutex
 }
 
+type repoCache interface {
+	Lookup(workspaceID, url string) string
+	Sync(workspaceID string, repos []repocache.RepoInfo) error
+	CreateWorktree(params repocache.WorktreeParams) (*repocache.WorktreeResult, error)
+}
+
 // Daemon is the local agent runtime that polls for and executes tasks.
 type Daemon struct {
 	cfg       Config
 	client    *Client
-	repoCache *repocache.Cache
+	repoCache repoCache
 	logger    *slog.Logger
 
 	mu           sync.Mutex
@@ -458,6 +464,11 @@ func (d *Daemon) registerTaskRepos(workspaceID string, repos []RepoData) {
 		return
 	}
 
+	type repoCandidate struct {
+		url     string
+		tracked bool
+	}
+
 	d.mu.Lock()
 	ws, ok := d.workspaces[workspaceID]
 	if !ok {
@@ -467,7 +478,7 @@ func (d *Daemon) registerTaskRepos(workspaceID string, repos []RepoData) {
 	if ws.taskRepoURLs == nil {
 		ws.taskRepoURLs = make(map[string]struct{}, len(repos))
 	}
-	toSync := make([]RepoData, 0, len(repos))
+	candidates := make([]repoCandidate, 0, len(repos))
 	for _, repo := range repos {
 		url := strings.TrimSpace(repo.URL)
 		if url == "" {
@@ -477,14 +488,21 @@ func (d *Daemon) registerTaskRepos(workspaceID string, repos []RepoData) {
 		// AND the cache already has it.
 		_, inWorkspace := ws.allowedRepoURLs[url]
 		_, inTask := ws.taskRepoURLs[url]
-		if (inWorkspace || inTask) && d.repoCache != nil && d.repoCache.Lookup(workspaceID, url) != "" {
-			ws.taskRepoURLs[url] = struct{}{}
-			continue
-		}
 		ws.taskRepoURLs[url] = struct{}{}
-		toSync = append(toSync, RepoData{URL: url})
+		candidates = append(candidates, repoCandidate{
+			url:     url,
+			tracked: inWorkspace || inTask,
+		})
 	}
 	d.mu.Unlock()
+
+	toSync := make([]RepoData, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.tracked && d.repoCache != nil && d.repoCache.Lookup(workspaceID, candidate.url) != "" {
+			continue
+		}
+		toSync = append(toSync, RepoData{URL: candidate.url})
+	}
 
 	if d.repoCache != nil && len(toSync) > 0 {
 		// Sync in the background — same shape used at workspace registration.

--- a/server/internal/daemon/health_test.go
+++ b/server/internal/daemon/health_test.go
@@ -6,8 +6,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/daemon/repocache"
 )
 
 func TestHealthHandlerReportsCLIVersionAndActiveTaskCount(t *testing.T) {
@@ -128,6 +131,104 @@ func TestShutdownHandlerRejectsNonPost(t *testing.T) {
 	if cancelled {
 		t.Fatal("GET request should not trigger cancellation")
 	}
+}
+
+func TestHealthHandlerRespondsWhileTaskRepoLookupWaits(t *testing.T) {
+	const workspaceID = "ws-health"
+	const repoURL = "https://github.com/org/repo.git"
+	cache := newBlockingLookupRepoCache("/cache/org/repo.git")
+	d := &Daemon{
+		cfg: Config{CLIVersion: "v1.0.0"},
+		workspaces: map[string]*workspaceState{
+			workspaceID: {
+				workspaceID:     workspaceID,
+				runtimeIDs:      []string{"rt-1"},
+				allowedRepoURLs: map[string]struct{}{repoURL: {}},
+				taskRepoURLs:    map[string]struct{}{},
+			},
+		},
+		repoCache: cache,
+		logger:    slog.Default(),
+	}
+	defer cache.release()
+
+	registerDone := make(chan struct{})
+	go func() {
+		d.registerTaskRepos(workspaceID, []RepoData{{URL: repoURL}})
+		close(registerDone)
+	}()
+	cache.waitForLookup(t)
+
+	rec := httptest.NewRecorder()
+	healthDone := make(chan struct{})
+	go func() {
+		d.healthHandler(time.Now()).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+		close(healthDone)
+	}()
+
+	select {
+	case <-healthDone:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("/health blocked behind task repo cache lookup")
+	}
+
+	cache.release()
+	select {
+	case <-registerDone:
+	case <-time.After(time.Second):
+		t.Fatal("registerTaskRepos did not unblock after repo lookup finished")
+	}
+}
+
+type blockingLookupRepoCache struct {
+	path          string
+	lookupSeen    chan struct{}
+	releaseLookup chan struct{}
+	releaseOnce   sync.Once
+}
+
+func newBlockingLookupRepoCache(path string) *blockingLookupRepoCache {
+	return &blockingLookupRepoCache{
+		path:          path,
+		lookupSeen:    make(chan struct{}),
+		releaseLookup: make(chan struct{}),
+	}
+}
+
+func (c *blockingLookupRepoCache) Lookup(_, _ string) string {
+	select {
+	case <-c.lookupSeen:
+	default:
+		close(c.lookupSeen)
+	}
+	<-c.releaseLookup
+	return c.path
+}
+
+func (c *blockingLookupRepoCache) Sync(string, []repocache.RepoInfo) error {
+	return nil
+}
+
+func (c *blockingLookupRepoCache) CreateWorktree(repocache.WorktreeParams) (*repocache.WorktreeResult, error) {
+	return nil, nil
+}
+
+func (c *blockingLookupRepoCache) waitForLookup(t *testing.T) {
+	t.Helper()
+	select {
+	case <-c.lookupSeen:
+	case <-time.After(time.Second):
+		t.Fatal("registerTaskRepos did not call repo lookup")
+	}
+}
+
+func (c *blockingLookupRepoCache) release() {
+	c.releaseOnce.Do(func() {
+		close(c.releaseLookup)
+	})
 }
 
 func assertActiveTaskCount(t *testing.T, h http.HandlerFunc, want int64) {


### PR DESCRIPTION
## What does this PR do?

Fixes a local daemon responsiveness issue where the runtime page can stay stuck on `Local daemon Starting...` while task repo registration is waiting on repo cache lookup.

Previously, `registerTaskRepos` updated task-scoped repo URLs and checked the repo cache while holding the daemon-wide `d.mu` lock. If repo cache lookup is slow or waiting behind git/cache work, that lock hold can block other daemon paths that need the same mutex. In practice, `/health` can be delayed even though the daemon process is still alive, so the UI keeps treating the local daemon as not ready.

This change keeps the mutex scope limited to in-memory workspace state updates. It collects the normalized repo candidates while holding `d.mu`, releases the mutex, and only then calls repo cache lookup to decide which repos still need background sync. The production repo cache behavior is unchanged.

The regression test uses a small fake repo cache with a blocking `Lookup`, so it directly verifies that `/health` remains responsive without relying on real git commands or network timing.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Updated `server/internal/daemon/daemon.go` so `registerTaskRepos` no longer calls repo cache lookup while holding the daemon mutex.
- Added a small package-local `repoCache` interface for the daemon methods already used by production code, which allows the daemon tests to inject a deterministic blocking cache.
- Added `TestHealthHandlerRespondsWhileTaskRepoLookupWaits` to verify `/health` can return while task repo registration is blocked in repo cache lookup.

## How to Test

1. Run `cd server && go test ./internal/daemon -run TestHealthHandlerRespondsWhileTaskRepoLookupWaits -count=1`.
2. Run `cd server && go test ./internal/daemon -count=1`.
3. Run `git diff --cached --check` before committing, or `git diff --check upstream/main...HEAD` after committing.
4. Start a local daemon in an environment where repo cache/git access is slow, then verify the runtime page no longer stays stuck on `Local daemon Starting...` because `/health` can return promptly.

Local verification notes:
- `cd server && go test ./internal/daemon -run TestHealthHandlerRespondsWhileTaskRepoLookupWaits -count=1` passed.
- `cd server && go test ./internal/daemon -count=1` passed.
- `git diff --cached --check` passed before commit.
- Normal pre-push verification passed: lint, typecheck, test, and build.
- The regression test was also checked against the previous lock placement: with the old implementation it fails because `/health` blocks behind task repo cache lookup; with this change it passes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run targeted local verification for the changed package/file
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
I used Codex to trace the local daemon startup symptom to `registerTaskRepos` holding the daemon mutex while checking repo cache state, port the downstream fix from `furtherref/multica#38` onto upstream `main`, and replace the original slow git/network-based regression test with a deterministic blocking repo-cache fake.

## Screenshots (optional)

Original symptom: the runtime page can keep showing the local daemon as `Starting...` because the `/health` request is delayed while task repo registration is blocked behind repo cache lookup.

<img width="300" height="49" alt="d190ee877fe7defeb36dfa6dbc6e7fa4" src="https://github.com/user-attachments/assets/f24e43ed-693d-4ea0-b1eb-c0cdf1d4deca" />

