### PR TITLE
feat(inbox): cursor pagination + infinite scroll

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -798,12 +798,17 @@ export class ApiClient {
   }
 
   // Inbox
+  // The new client ALWAYS sends ?limit, even when the caller passes no
+  // params, so the server can use "no pagination params at all" as the
+  // unambiguous signal for a pre-pagination desktop client. If a future
+  // filter param (e.g. ?status=unread) gets added without a default
+  // limit, it would otherwise fall into the legacy 200-cap branch by
+  // accident.
   async listInbox(params?: { limit?: number; before?: string }): Promise<InboxListPage> {
     const search = new URLSearchParams();
-    if (params?.limit !== undefined) search.set("limit", String(params.limit));
+    search.set("limit", String(params?.limit ?? 50));
     if (params?.before) search.set("before", params.before);
-    const path = search.toString() ? `/api/inbox?${search}` : "/api/inbox";
-    const raw = await this.fetch<unknown>(path);
+    const raw = await this.fetch<unknown>(`/api/inbox?${search}`);
     return parseWithFallback(raw, InboxListPageSchema, EMPTY_INBOX_LIST_PAGE, {
       endpoint: "GET /api/inbox",
     });

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -17,6 +17,7 @@ import type {
   AgentRunCount,
   AgentRuntime,
   InboxItem,
+  InboxListPage,
   IssueSubscriber,
   Comment,
   Reaction,
@@ -91,8 +92,10 @@ import { parseWithFallback } from "./schema";
 import {
   ChildIssuesResponseSchema,
   CommentsListSchema,
+  EMPTY_INBOX_LIST_PAGE,
   EMPTY_LIST_ISSUES_RESPONSE,
   EMPTY_TIMELINE_PAGE,
+  InboxListPageSchema,
   ListIssuesResponseSchema,
   SubscribersListSchema,
   TimelinePageSchema,
@@ -795,8 +798,15 @@ export class ApiClient {
   }
 
   // Inbox
-  async listInbox(): Promise<InboxItem[]> {
-    return this.fetch("/api/inbox");
+  async listInbox(params?: { limit?: number; before?: string }): Promise<InboxListPage> {
+    const search = new URLSearchParams();
+    if (params?.limit !== undefined) search.set("limit", String(params.limit));
+    if (params?.before) search.set("before", params.before);
+    const path = search.toString() ? `/api/inbox?${search}` : "/api/inbox";
+    const raw = await this.fetch<unknown>(path);
+    return parseWithFallback(raw, InboxListPageSchema, EMPTY_INBOX_LIST_PAGE, {
+      endpoint: "GET /api/inbox",
+    });
   }
 
   async markInboxRead(id: string): Promise<InboxItem> {

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -166,6 +166,117 @@ describe("ApiClient schema fallback", () => {
       expect(res).toEqual({ issues: [] });
     });
   });
+
+  // The inbox endpoint serves two shapes — see InboxListPageSchema in
+  // schemas.ts. New servers wrap entries; old servers (and the new server's
+  // no-params legacy path) return a bare array. The schema's union+transform
+  // collapses both into the wrapper shape so the UI never branches on it.
+  describe("listInbox", () => {
+    const sampleItem = {
+      id: "i-1",
+      workspace_id: "ws-1",
+      recipient_type: "member",
+      recipient_id: "u-1",
+      type: "new_comment",
+      severity: "info",
+      issue_id: null,
+      title: "hello",
+      body: null,
+      read: false,
+      archived: false,
+      created_at: "2026-01-01T00:00:00Z",
+    };
+
+    it("accepts the new paginated wrapper shape", async () => {
+      stubFetchJson({
+        entries: [sampleItem],
+        next_cursor: "c-1",
+        has_more: true,
+      });
+      const client = new ApiClient("https://api.example.test");
+      const page = await client.listInbox({ limit: 50 });
+      expect(page.entries).toHaveLength(1);
+      expect(page.next_cursor).toBe("c-1");
+      expect(page.has_more).toBe(true);
+    });
+
+    it("transforms a legacy bare-array response into a single-page wrapper", async () => {
+      // Two distinct items (different ids, no issue_id) — dedup is a no-op.
+      stubFetchJson([
+        { ...sampleItem, id: "i-a", created_at: "2026-01-02T00:00:00Z" },
+        { ...sampleItem, id: "i-b", created_at: "2026-01-01T00:00:00Z" },
+      ]);
+      const client = new ApiClient("https://api.example.test");
+      const page = await client.listInbox();
+      expect(page.entries).toHaveLength(2);
+      expect(page.next_cursor).toBeNull();
+      expect(page.has_more).toBe(false);
+    });
+
+    // Window-period defense: a new web client may briefly hit an old server
+    // (which doesn't dedup at SQL level) before the backend rollout
+    // finishes. Without this transform, the same issue would render
+    // multiple times because the new client deleted its
+    // `deduplicateInboxItems` helper.
+    it("dedups bare-array entries by issue_id, keeping the newest", async () => {
+      stubFetchJson([
+        {
+          ...sampleItem,
+          id: "old",
+          issue_id: "issue-x",
+          created_at: "2026-01-01T00:00:00Z",
+          title: "old",
+        },
+        {
+          ...sampleItem,
+          id: "new",
+          issue_id: "issue-x",
+          created_at: "2026-01-03T00:00:00Z",
+          title: "new",
+        },
+        {
+          ...sampleItem,
+          id: "other",
+          issue_id: "issue-y",
+          created_at: "2026-01-02T00:00:00Z",
+          title: "other",
+        },
+      ]);
+      const client = new ApiClient("https://api.example.test");
+      const page = await client.listInbox();
+      expect(page.entries.map((e) => e.id)).toEqual(["new", "other"]);
+    });
+
+    it("falls back to an empty page on a malformed response", async () => {
+      stubFetchJson({ entries: "not-an-array" });
+      const client = new ApiClient("https://api.example.test");
+      const page = await client.listInbox({ limit: 50 });
+      expect(page.entries).toEqual([]);
+      expect(page.has_more).toBe(false);
+    });
+
+    it("falls back when the response is null", async () => {
+      stubFetchJson(null);
+      const client = new ApiClient("https://api.example.test");
+      const page = await client.listInbox();
+      expect(page.entries).toEqual([]);
+    });
+
+    it("preserves unknown server fields via .loose()", async () => {
+      stubFetchJson({
+        entries: [{ ...sampleItem, future_field: "x" }],
+        next_cursor: null,
+        has_more: false,
+        page_metadata: { took_ms: 1 },
+      });
+      const client = new ApiClient("https://api.example.test");
+      const page = await client.listInbox({ limit: 50 });
+      const entry = page.entries[0] as unknown as Record<string, unknown>;
+      const raw = page as unknown as Record<string, unknown>;
+      expect(entry.future_field).toBe("x");
+      expect(raw.page_metadata).toEqual({ took_ms: 1 });
+    });
+  });
 });
 
 // Direct tests for the helper, decoupled from any specific endpoint —

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -196,6 +196,10 @@ const InboxListPageWrapperSchema = z.object({
 // already deduped, making this a no-op in steady state.
 const dedupByIssueDescending = (items: InboxItem[]): InboxItem[] => {
   const seen = new Set<string>();
+  // localeCompare is safe here: created_at is RFC3339 / ISO 8601 with the
+  // same timezone (UTC, server-emitted), so lexicographic order matches
+  // chronological order. Using Date(...).getTime() would just allocate
+  // for no reason.
   return [...items]
     .sort((a, b) => b.created_at.localeCompare(a.created_at))
     .filter((i) => {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ListIssuesResponse, TimelinePage } from "../types";
+import type { InboxItem, InboxListPage, ListIssuesResponse, TimelinePage } from "../types";
 
 // ---------------------------------------------------------------------------
 // Schemas for the highest-risk API endpoints — those whose responses drive
@@ -145,3 +145,78 @@ export const SubscribersListSchema = z.array(SubscriberSchema);
 export const ChildIssuesResponseSchema = z.object({
   issues: z.array(IssueSchema).default([]),
 }).loose();
+
+// Inbox item schema — lenient like the others: enum-typed string fields
+// (recipient_type, type, severity, issue_status) stay as `z.string()` so an
+// unknown server-side enum still parses. The TS type still narrows them at
+// the call site via the `as InboxListPage` cast that parseWithFallback
+// performs.
+const InboxItemSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  recipient_type: z.string(),
+  recipient_id: z.string(),
+  actor_type: z.string().nullable().optional(),
+  actor_id: z.string().nullable().optional(),
+  type: z.string(),
+  severity: z.string(),
+  issue_id: z.string().nullable().optional(),
+  title: z.string(),
+  body: z.string().nullable().optional(),
+  issue_status: z.string().nullable().optional(),
+  read: z.boolean(),
+  archived: z.boolean(),
+  created_at: z.string(),
+  details: z.record(z.string(), z.unknown()).nullable().optional(),
+}).loose();
+
+// New paginated wrapper served when the client opts in via ?limit/?before.
+const InboxListPageWrapperSchema = z.object({
+  entries: z.array(InboxItemSchema).default([]),
+  next_cursor: z.string().nullable().default(null),
+  has_more: z.boolean().default(false),
+}).loose();
+
+// InboxListPageSchema accepts both the new wrapper and the legacy bare-array
+// shape returned by old servers (or by the new server's no-params legacy
+// path). The bare-array branch transforms to the wrapper shape with
+// has_more=false so the UI sees a single, complete page and never tries to
+// fetch a "next" page that doesn't exist.
+//
+// This is the boundary defense for the "new client, old server" drift case;
+// the reverse case ("old client, new server") is handled server-side by the
+// listInboxLegacy path.
+//
+// Why per-issue dedup happens here too: an *old* server has no SQL
+// DISTINCT ON, so the bare array contains duplicate rows for the same
+// issue. The new client deleted its `deduplicateInboxItems` helper
+// (relying on server-side dedup), so without this transform the deploy
+// window between web rollout and backend rollout would render the same
+// issue multiple times. Cheap defense — the new server's legacy path is
+// already deduped, making this a no-op in steady state.
+const dedupByIssueDescending = (items: InboxItem[]): InboxItem[] => {
+  const seen = new Set<string>();
+  return [...items]
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .filter((i) => {
+      const key = i.issue_id ?? i.id;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+};
+
+export const InboxListPageSchema = z.union([
+  InboxListPageWrapperSchema,
+  z.array(InboxItemSchema).transform((items) => ({
+    entries: dedupByIssueDescending(items as InboxItem[]),
+    next_cursor: null,
+    has_more: false,
+  })),
+]);
+
+export const EMPTY_INBOX_LIST_PAGE: InboxListPage = {
+  entries: [],
+  next_cursor: null,
+  has_more: false,
+};

--- a/packages/core/inbox/inbox-cache.ts
+++ b/packages/core/inbox/inbox-cache.ts
@@ -1,0 +1,97 @@
+import type { InfiniteData } from "@tanstack/react-query";
+import type { InboxItem, InboxListPage } from "../types";
+
+/**
+ * Shape of the cursor-paginated inbox cache. Modeled on `TimelineCacheData`
+ * — same primitives, different domain. Consumers (mutations, WS updaters,
+ * tests) all reference this so the cache shape doesn't drift.
+ */
+export type InboxCacheData = InfiniteData<InboxListPage, string | null>;
+
+/**
+ * Map fn over every inbox item across every page. Preserves page reference
+ * identity when nothing in that page changed so React.memo on row components
+ * isn't defeated by gratuitous reference churn.
+ */
+export function mapAllItems(
+  data: InboxCacheData | undefined,
+  fn: (i: InboxItem) => InboxItem,
+): InboxCacheData | undefined {
+  if (!data) return data;
+  let pagesChanged = false;
+  const pages = data.pages.map((page) => {
+    let entriesChanged = false;
+    const entries = page.entries.map((e) => {
+      const next = fn(e);
+      if (next !== e) entriesChanged = true;
+      return next;
+    });
+    if (!entriesChanged) return page;
+    pagesChanged = true;
+    return { ...page, entries };
+  });
+  if (!pagesChanged) return data;
+  return { ...data, pages };
+}
+
+/** Filter out items matching the predicate from every page. */
+export function filterAllItems(
+  data: InboxCacheData | undefined,
+  predicate: (i: InboxItem) => boolean,
+): InboxCacheData | undefined {
+  if (!data) return data;
+  let pagesChanged = false;
+  const pages = data.pages.map((page) => {
+    const entries = page.entries.filter((e) => !predicate(e));
+    if (entries.length === page.entries.length) return page;
+    pagesChanged = true;
+    return { ...page, entries };
+  });
+  if (!pagesChanged) return data;
+  return { ...data, pages };
+}
+
+/**
+ * Prepend a WS-pushed inbox item to the latest page (pages[0]).
+ *
+ * Honors the SQL DISTINCT ON dedup invariant: when an item shares an
+ * `issue_id` with an existing entry, the existing one is removed first so
+ * each issue only appears once in the rendered list.
+ *
+ * Returns `data` unchanged when:
+ *   - the cache is empty / not initialized (the next query refetch will
+ *     populate it from the server, including the new item)
+ *   - an item with the same `id` is already present (WS replay)
+ */
+export function prependToLatestPage(
+  data: InboxCacheData | undefined,
+  item: InboxItem,
+): InboxCacheData | undefined {
+  if (!data || data.pages.length === 0) return data;
+  const first = data.pages[0];
+  if (!first) return data;
+
+  // Dedup by id (handles WS replay / setQueryData racing with refetch).
+  if (first.entries.some((e) => e.id === item.id)) return data;
+
+  // Per-issue dedup: an existing entry for the same issue must be removed
+  // so the new (newer) one takes its slot. Walk every page — a stale entry
+  // for the same issue could live anywhere if pagination was already deep.
+  const issueId = item.issue_id;
+  const cleared = issueId
+    ? data.pages.map((page) => {
+        const filtered = page.entries.filter((e) => e.issue_id !== issueId);
+        if (filtered.length === page.entries.length) return page;
+        return { ...page, entries: filtered };
+      })
+    : data.pages;
+
+  const head = cleared[0]!;
+  return {
+    ...data,
+    pages: [
+      { ...head, entries: [item, ...head.entries] },
+      ...cleared.slice(1),
+    ],
+  };
+}

--- a/packages/core/inbox/inbox-cache.ts
+++ b/packages/core/inbox/inbox-cache.ts
@@ -34,8 +34,13 @@ export function mapAllItems(
   return { ...data, pages };
 }
 
-/** Filter out items matching the predicate from every page. */
-export function filterAllItems(
+/**
+ * Remove items matching the predicate from every page. NOTE: predicate
+ * semantics are *removal* (`true` → drop), opposite of `Array.filter`.
+ * Named explicitly to avoid the easy mistake of treating it like
+ * `Array.filter` and inverting the boolean.
+ */
+export function removeMatchingItems(
   data: InboxCacheData | undefined,
   predicate: (i: InboxItem) => boolean,
 ): InboxCacheData | undefined {

--- a/packages/core/inbox/mutations.ts
+++ b/packages/core/inbox/mutations.ts
@@ -2,21 +2,38 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { inboxKeys } from "./queries";
 import {
-  filterAllItems,
   mapAllItems,
+  removeMatchingItems,
   type InboxCacheData,
 } from "./inbox-cache";
 import { useWorkspaceId } from "../hooks";
 
-// Each mutation invalidates the unread-count query so the badge stays in
-// sync with the optimistic list update. The badge derives from a separate
-// endpoint now (see useInboxUnreadCount) so list-only invalidation isn't
-// enough.
-function invalidateInbox(
+// Why these mutations no longer invalidate the LIST query:
+//
+// useInfiniteQuery refetches every loaded page with its cached pageParam on
+// invalidate. After a row is archived, page 0 (no cursor) shifts up to
+// include items previously on page 1, while page 1 still uses a cursor
+// pointing at the now-archived row — so the same item appears on both
+// pages. The old client-side `deduplicateInboxItems` masked this; deleting
+// it surfaced the bug.
+//
+// All mutations whose effect the client can predict EXACTLY (mark-read /
+// archive-single / mark-all-read / archive-all / archive-all-read) apply
+// optimistically and skip the list invalidate — the local cache is already
+// correct. Only the unread-count query is invalidated (it's a single
+// non-paginated query, immune to the cross-page issue).
+//
+// `useArchiveCompletedInbox` is the lone exception: it filters by
+// issue.status server-side, so the client can't enumerate which inbox
+// items are affected. It still invalidates the list and inherits the
+// cross-page-duplicate risk in the rare case a user with deeply scrolled
+// pagination triggers it. Acceptable trade-off — same behavior as the
+// timeline cache today.
+
+function invalidateUnreadCount(
   qc: ReturnType<typeof useQueryClient>,
   wsId: string,
 ) {
-  qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
   qc.invalidateQueries({ queryKey: inboxKeys.unreadCount(wsId) });
 }
 
@@ -38,7 +55,7 @@ export function useMarkInboxRead() {
     onError: (_err, _id, ctx) => {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
-    onSettled: () => invalidateInbox(qc, wsId),
+    onSettled: () => invalidateUnreadCount(qc, wsId),
   });
 }
 
@@ -58,7 +75,7 @@ export function useArchiveInbox() {
         .find((i) => i.id === id);
       const issueId = target?.issue_id ?? null;
       qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
-        filterAllItems(old, (item) =>
+        removeMatchingItems(old, (item) =>
           item.id === id || (issueId !== null && item.issue_id === issueId),
         ),
       );
@@ -67,7 +84,7 @@ export function useArchiveInbox() {
     onError: (_err, _id, ctx) => {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
-    onSettled: () => invalidateInbox(qc, wsId),
+    onSettled: () => invalidateUnreadCount(qc, wsId),
   });
 }
 
@@ -89,7 +106,7 @@ export function useMarkAllInboxRead() {
     onError: (_err, _vars, ctx) => {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
-    onSettled: () => invalidateInbox(qc, wsId),
+    onSettled: () => invalidateUnreadCount(qc, wsId),
   });
 }
 
@@ -98,7 +115,19 @@ export function useArchiveAllInbox() {
   const wsId = useWorkspaceId();
   return useMutation({
     mutationFn: () => api.archiveAllInbox(),
-    onSettled: () => invalidateInbox(qc, wsId),
+    onMutate: async () => {
+      await qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
+      const prev = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+      // Wipe every loaded page — server is archiving everything.
+      qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
+        removeMatchingItems(old, () => true),
+      );
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
+    },
+    onSettled: () => invalidateUnreadCount(qc, wsId),
   });
 }
 
@@ -107,7 +136,18 @@ export function useArchiveAllReadInbox() {
   const wsId = useWorkspaceId();
   return useMutation({
     mutationFn: () => api.archiveAllReadInbox(),
-    onSettled: () => invalidateInbox(qc, wsId),
+    onMutate: async () => {
+      await qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
+      const prev = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+      qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
+        removeMatchingItems(old, (item) => item.read),
+      );
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
+    },
+    onSettled: () => invalidateUnreadCount(qc, wsId),
   });
 }
 
@@ -115,7 +155,14 @@ export function useArchiveCompletedInbox() {
   const qc = useQueryClient();
   const wsId = useWorkspaceId();
   return useMutation({
+    // Server-side filter on issue.status — the client can't enumerate
+    // which inbox items are affected, so this is the only mutation that
+    // still invalidates the list. Inherits the cross-page duplicate
+    // risk on deeply paginated caches; same as timeline today.
     mutationFn: () => api.archiveCompletedInbox(),
-    onSettled: () => invalidateInbox(qc, wsId),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+      invalidateUnreadCount(qc, wsId);
+    },
   });
 }

--- a/packages/core/inbox/mutations.ts
+++ b/packages/core/inbox/mutations.ts
@@ -1,8 +1,24 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { inboxKeys } from "./queries";
+import {
+  filterAllItems,
+  mapAllItems,
+  type InboxCacheData,
+} from "./inbox-cache";
 import { useWorkspaceId } from "../hooks";
-import type { InboxItem } from "../types";
+
+// Each mutation invalidates the unread-count query so the badge stays in
+// sync with the optimistic list update. The badge derives from a separate
+// endpoint now (see useInboxUnreadCount) so list-only invalidation isn't
+// enough.
+function invalidateInbox(
+  qc: ReturnType<typeof useQueryClient>,
+  wsId: string,
+) {
+  qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+  qc.invalidateQueries({ queryKey: inboxKeys.unreadCount(wsId) });
+}
 
 export function useMarkInboxRead() {
   const qc = useQueryClient();
@@ -11,18 +27,18 @@ export function useMarkInboxRead() {
     mutationFn: (id: string) => api.markInboxRead(id),
     onMutate: async (id) => {
       await qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
-      const prev = qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId));
-      qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), (old) =>
-        old?.map((item) => (item.id === id ? { ...item, read: true } : item)),
+      const prev = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+      qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
+        mapAllItems(old, (item) =>
+          item.id === id ? { ...item, read: true } : item,
+        ),
       );
       return { prev };
     },
     onError: (_err, _id, ctx) => {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
-    },
+    onSettled: () => invalidateInbox(qc, wsId),
   });
 }
 
@@ -33,15 +49,17 @@ export function useArchiveInbox() {
     mutationFn: (id: string) => api.archiveInbox(id),
     onMutate: async (id) => {
       await qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
-      const prev = qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId));
-      // Archive all items for the same issue (same behavior as store)
-      const target = prev?.find((i) => i.id === id);
-      const issueId = target?.issue_id;
-      qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), (old) =>
-        old?.map((item) =>
-          item.id === id || (issueId && item.issue_id === issueId)
-            ? { ...item, archived: true }
-            : item,
+      const prev = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+      // Find the target so we can issue-archive (removing siblings on the
+      // same issue) — server does the same in ArchiveInboxItem when the
+      // issue_id is set.
+      const target = prev?.pages
+        .flatMap((p) => p.entries)
+        .find((i) => i.id === id);
+      const issueId = target?.issue_id ?? null;
+      qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
+        filterAllItems(old, (item) =>
+          item.id === id || (issueId !== null && item.issue_id === issueId),
         ),
       );
       return { prev };
@@ -49,9 +67,7 @@ export function useArchiveInbox() {
     onError: (_err, _id, ctx) => {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
-    },
+    onSettled: () => invalidateInbox(qc, wsId),
   });
 }
 
@@ -62,9 +78,9 @@ export function useMarkAllInboxRead() {
     mutationFn: () => api.markAllInboxRead(),
     onMutate: async () => {
       await qc.cancelQueries({ queryKey: inboxKeys.list(wsId) });
-      const prev = qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId));
-      qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), (old) =>
-        old?.map((item) =>
+      const prev = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+      qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
+        mapAllItems(old, (item) =>
           !item.archived ? { ...item, read: true } : item,
         ),
       );
@@ -73,9 +89,7 @@ export function useMarkAllInboxRead() {
     onError: (_err, _vars, ctx) => {
       if (ctx?.prev) qc.setQueryData(inboxKeys.list(wsId), ctx.prev);
     },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
-    },
+    onSettled: () => invalidateInbox(qc, wsId),
   });
 }
 
@@ -84,9 +98,7 @@ export function useArchiveAllInbox() {
   const wsId = useWorkspaceId();
   return useMutation({
     mutationFn: () => api.archiveAllInbox(),
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
-    },
+    onSettled: () => invalidateInbox(qc, wsId),
   });
 }
 
@@ -95,9 +107,7 @@ export function useArchiveAllReadInbox() {
   const wsId = useWorkspaceId();
   return useMutation({
     mutationFn: () => api.archiveAllReadInbox(),
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
-    },
+    onSettled: () => invalidateInbox(qc, wsId),
   });
 }
 
@@ -106,8 +116,6 @@ export function useArchiveCompletedInbox() {
   const wsId = useWorkspaceId();
   return useMutation({
     mutationFn: () => api.archiveCompletedInbox(),
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
-    },
+    onSettled: () => invalidateInbox(qc, wsId),
   });
 }

--- a/packages/core/inbox/queries.ts
+++ b/packages/core/inbox/queries.ts
@@ -1,59 +1,66 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import {
+  infiniteQueryOptions,
+  queryOptions,
+  useQuery,
+} from "@tanstack/react-query";
 import { api } from "../api";
-import type { InboxItem } from "../types";
 
 export const inboxKeys = {
   all: (wsId: string) => ["inbox", wsId] as const,
   list: (wsId: string) => [...inboxKeys.all(wsId), "list"] as const,
+  unreadCount: (wsId: string) =>
+    [...inboxKeys.all(wsId), "unread-count"] as const,
 };
 
-export function inboxListOptions(wsId: string) {
-  return queryOptions({
+// 50 matches the server's inboxDefaultLimit. Bumping it requires no server
+// change (server caps at 100) but should be done with intent — larger pages
+// = more items rendered per scroll-to-bottom.
+const INBOX_PAGE_SIZE = 50;
+
+/**
+ * Cursor-paginated inbox listing. The cache shape is `InfiniteData<InboxListPage>`;
+ * consumers flatten via `data?.pages.flatMap(p => p.entries)`.
+ *
+ * Per-issue dedup happens server-side (SQL `DISTINCT ON (COALESCE(issue_id, id))`)
+ * so the client never sees duplicates and never has to reconcile across page
+ * boundaries — the failure mode of doing dedup in JS over a paginated list.
+ *
+ * WS-pushed new items go through `prependToLatestPage` in `inbox-cache.ts`
+ * to keep the same dedup invariant after live updates.
+ */
+export function inboxListInfiniteOptions(wsId: string) {
+  return infiniteQueryOptions({
     queryKey: inboxKeys.list(wsId),
-    queryFn: () => api.listInbox(),
+    queryFn: ({ pageParam }) =>
+      api.listInbox({
+        limit: INBOX_PAGE_SIZE,
+        ...(pageParam ? { before: pageParam } : {}),
+      }),
+    initialPageParam: null as string | null,
+    getNextPageParam: (last) =>
+      last.has_more && last.next_cursor ? last.next_cursor : undefined,
   });
 }
 
 /**
- * Unread inbox count for the given workspace, aligned with what the inbox
- * list UI renders: archived items excluded, then deduplicated by issue so a
- * single issue with three unread notifications counts once.
+ * Unread inbox count for the badge. Calls the dedicated count endpoint
+ * (which dedups per-issue server-side, matching the listing) instead of
+ * deriving from the loaded list — that derivation can't work once the list
+ * is paginated, since the badge would only count the loaded pages.
  */
-export function useInboxUnreadCount(wsId: string | null | undefined): number {
+export function inboxUnreadCountOptions(wsId: string) {
+  return queryOptions({
+    queryKey: inboxKeys.unreadCount(wsId),
+    queryFn: async () => (await api.getUnreadInboxCount()).count,
+  });
+}
+
+export function useInboxUnreadCount(
+  wsId: string | null | undefined,
+): number {
   const { data } = useQuery({
-    queryKey: inboxKeys.list(wsId ?? ""),
-    queryFn: () => api.listInbox(),
+    ...inboxUnreadCountOptions(wsId ?? ""),
     enabled: !!wsId,
-    select: (items: InboxItem[]) =>
-      deduplicateInboxItems(items).filter((i) => !i.read).length,
   });
   return data ?? 0;
-}
-
-/**
- * Deduplicate inbox items by issue_id (one entry per issue, Linear-style).
- * Exported for consumers to use in useMemo — not in queryOptions select
- * (to avoid new array references on every cache update).
- */
-export function deduplicateInboxItems(items: InboxItem[]): InboxItem[] {
-  const active = items.filter((i) => !i.archived);
-  const groups = new Map<string, InboxItem[]>();
-  for (const item of active) {
-    const key = item.issue_id ?? item.id;
-    const group = groups.get(key) ?? [];
-    group.push(item);
-    groups.set(key, group);
-  }
-  const merged: InboxItem[] = [];
-  for (const group of groups.values()) {
-    group.sort(
-      (a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-    );
-    if (group[0]) merged.push(group[0]);
-  }
-  return merged.sort(
-    (a, b) =>
-      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-  );
 }

--- a/packages/core/inbox/ws-updaters.test.ts
+++ b/packages/core/inbox/ws-updaters.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { QueryClient } from "@tanstack/react-query";
-import { onInboxIssueDeleted, onInboxIssueStatusChanged } from "./ws-updaters";
+import {
+  onInboxIssueDeleted,
+  onInboxIssueStatusChanged,
+  onInboxNew,
+} from "./ws-updaters";
 import { inboxKeys } from "./queries";
-import type { InboxItem } from "../types";
+import type { InboxCacheData } from "./inbox-cache";
+import type { InboxItem, InboxListPage } from "../types";
 
 const wsId = "ws-1";
 
@@ -32,43 +37,124 @@ function makeItem(
   };
 }
 
+// Helper: build the InfiniteData<InboxListPage> shape that React Query stores
+// for a cursor-paginated query. Tests work directly with this so we exercise
+// the same cache invariants the production cache enforces.
+function makeCache(
+  pages: InboxItem[][],
+  hasMore = false,
+): InboxCacheData {
+  const inboxPages: InboxListPage[] = pages.map((entries, idx) => ({
+    entries,
+    next_cursor: hasMore || idx < pages.length - 1 ? `cursor-${idx}` : null,
+    has_more: hasMore || idx < pages.length - 1,
+  }));
+  return {
+    pages: inboxPages,
+    pageParams: pages.map((_, idx) => (idx === 0 ? null : `cursor-${idx - 1}`)),
+  };
+}
+
 describe("onInboxIssueDeleted", () => {
-  it("removes all inbox items referencing the deleted issue", () => {
+  it("removes all inbox items referencing the deleted issue across pages", () => {
     const qc = new QueryClient();
-    const items = [
-      makeItem("i1", "issue-a"),
-      makeItem("i2", "issue-a"),
-      makeItem("i3", "issue-b"),
-      makeItem("i4", null),
-    ];
-    qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), items);
+    qc.setQueryData<InboxCacheData>(
+      inboxKeys.list(wsId),
+      makeCache([
+        [makeItem("i1", "issue-a"), makeItem("i2", "issue-a")],
+        [makeItem("i3", "issue-b"), makeItem("i4", null)],
+      ]),
+    );
 
     onInboxIssueDeleted(qc, wsId, "issue-a");
 
-    const after = qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId));
-    expect(after?.map((i) => i.id)).toEqual(["i3", "i4"]);
+    const after = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+    const flat = after?.pages.flatMap((p) => p.entries.map((e) => e.id));
+    expect(flat).toEqual(["i3", "i4"]);
   });
 
   it("is a no-op when the inbox cache is empty", () => {
     const qc = new QueryClient();
     expect(() => onInboxIssueDeleted(qc, wsId, "issue-a")).not.toThrow();
-    expect(qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId))).toBeUndefined();
+    expect(qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId))).toBeUndefined();
   });
 });
 
 describe("onInboxIssueStatusChanged", () => {
   it("updates issue_status only for items referencing the issue", () => {
     const qc = new QueryClient();
-    const items = [
-      makeItem("i1", "issue-a", { issue_status: "todo" }),
-      makeItem("i2", "issue-b", { issue_status: "todo" }),
-    ];
-    qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), items);
+    qc.setQueryData<InboxCacheData>(
+      inboxKeys.list(wsId),
+      makeCache([
+        [
+          makeItem("i1", "issue-a", { issue_status: "todo" }),
+          makeItem("i2", "issue-b", { issue_status: "todo" }),
+        ],
+      ]),
+    );
 
     onInboxIssueStatusChanged(qc, wsId, "issue-a", "done");
 
-    const after = qc.getQueryData<InboxItem[]>(inboxKeys.list(wsId));
-    expect(after?.find((i) => i.id === "i1")?.issue_status).toBe("done");
-    expect(after?.find((i) => i.id === "i2")?.issue_status).toBe("todo");
+    const after = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+    const flat = after?.pages.flatMap((p) => p.entries) ?? [];
+    expect(flat.find((i) => i.id === "i1")?.issue_status).toBe("done");
+    expect(flat.find((i) => i.id === "i2")?.issue_status).toBe("todo");
+  });
+});
+
+describe("onInboxNew", () => {
+  it("prepends a brand-new item to pages[0]", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<InboxCacheData>(
+      inboxKeys.list(wsId),
+      makeCache([[makeItem("i1", "issue-a")]]),
+    );
+
+    onInboxNew(qc, wsId, makeItem("i2", "issue-b"));
+
+    const after = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+    expect(after?.pages[0]?.entries.map((e) => e.id)).toEqual(["i2", "i1"]);
+  });
+
+  it("dedups by id when the WS message replays an existing item", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<InboxCacheData>(
+      inboxKeys.list(wsId),
+      makeCache([[makeItem("i1", "issue-a")]]),
+    );
+
+    onInboxNew(qc, wsId, makeItem("i1", "issue-a", { title: "replay" }));
+
+    const after = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+    const flat = after?.pages.flatMap((p) => p.entries) ?? [];
+    expect(flat.map((e) => e.id)).toEqual(["i1"]);
+    // The original (cached) row is preserved — we don't trust a duplicate
+    // payload to override an item we already have.
+    expect(flat[0]?.title).toBe("item i1");
+  });
+
+  it("collapses prior entries for the same issue (DISTINCT ON invariant)", () => {
+    const qc = new QueryClient();
+    qc.setQueryData<InboxCacheData>(
+      inboxKeys.list(wsId),
+      makeCache([
+        [makeItem("old", "issue-a", { title: "old" })],
+        [makeItem("older", "issue-a", { title: "older" })],
+      ]),
+    );
+
+    onInboxNew(qc, wsId, makeItem("new", "issue-a", { title: "new" }));
+
+    const after = qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId));
+    const flat = after?.pages.flatMap((p) => p.entries) ?? [];
+    expect(flat.map((e) => e.id)).toEqual(["new"]);
+  });
+
+  it("leaves the cache untouched when the query is not yet initialized", () => {
+    const qc = new QueryClient();
+    expect(() =>
+      onInboxNew(qc, wsId, makeItem("i1", null)),
+    ).not.toThrow();
+    expect(qc.getQueryData<InboxCacheData>(inboxKeys.list(wsId))).toBeUndefined();
   });
 });

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -1,15 +1,30 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { inboxKeys } from "./queries";
+import {
+  filterAllItems,
+  mapAllItems,
+  prependToLatestPage,
+  type InboxCacheData,
+} from "./inbox-cache";
 import type { InboxItem, IssueStatus } from "../types";
 
-export function onInboxNew(
-  qc: QueryClient,
-  wsId: string,
-  _item: InboxItem,
-) {
-  // Use invalidateQueries instead of setQueryData — triggers a refetch that
-  // reliably notifies all observers. The inbox list is small so this is cheap.
-  qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+/**
+ * Apply a WS-pushed new inbox item to the paginated cache. Uses surgical
+ * prepend (mirrors timeline-cache.prependToLatestPage) instead of a wholesale
+ * `invalidateQueries` so the user's scroll position and any in-flight
+ * `fetchNextPage` aren't disturbed when a notification arrives.
+ *
+ * Inbox is single-direction (new items always belong at the top), so unlike
+ * the timeline we don't need an `isAtLatest` gate — pages[0] is always the
+ * newest page.
+ */
+export function onInboxNew(qc: QueryClient, wsId: string, item: InboxItem) {
+  qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
+    prependToLatestPage(old, item),
+  );
+  // The badge query is independent of the list query, so a list mutation
+  // does not refresh it on its own. Invalidate to trigger a refetch.
+  qc.invalidateQueries({ queryKey: inboxKeys.unreadCount(wsId) });
 }
 
 export function onInboxIssueStatusChanged(
@@ -18,8 +33,8 @@ export function onInboxIssueStatusChanged(
   issueId: string,
   status: IssueStatus,
 ) {
-  qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), (old) =>
-    old?.map((i) =>
+  qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
+    mapAllItems(old, (i) =>
       i.issue_id === issueId ? { ...i, issue_status: status } : i,
     ),
   );
@@ -33,11 +48,13 @@ export function onInboxIssueDeleted(
   wsId: string,
   issueId: string,
 ) {
-  qc.setQueryData<InboxItem[]>(inboxKeys.list(wsId), (old) =>
-    old?.filter((i) => i.issue_id !== issueId),
+  qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
+    filterAllItems(old, (i) => i.issue_id === issueId),
   );
+  qc.invalidateQueries({ queryKey: inboxKeys.unreadCount(wsId) });
 }
 
 export function onInboxInvalidate(qc: QueryClient, wsId: string) {
   qc.invalidateQueries({ queryKey: inboxKeys.list(wsId) });
+  qc.invalidateQueries({ queryKey: inboxKeys.unreadCount(wsId) });
 }

--- a/packages/core/inbox/ws-updaters.ts
+++ b/packages/core/inbox/ws-updaters.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { inboxKeys } from "./queries";
 import {
-  filterAllItems,
+  removeMatchingItems,
   mapAllItems,
   prependToLatestPage,
   type InboxCacheData,
@@ -49,7 +49,7 @@ export function onInboxIssueDeleted(
   issueId: string,
 ) {
   qc.setQueryData<InboxCacheData>(inboxKeys.list(wsId), (old) =>
-    filterAllItems(old, (i) => i.issue_id === issueId),
+    removeMatchingItems(old, (i) => i.issue_id === issueId),
   );
   qc.invalidateQueries({ queryKey: inboxKeys.unreadCount(wsId) });
 }

--- a/packages/core/types/inbox.ts
+++ b/packages/core/types/inbox.ts
@@ -38,3 +38,13 @@ export interface InboxItem {
   created_at: string;
   details: Record<string, string> | null;
 }
+
+// Cursor-paginated wrapper served by GET /api/inbox?limit=&before=. Old
+// servers still return InboxItem[] directly; the schema layer converts that
+// shape into this one with has_more=false so the UI treats the legacy
+// response as a single, complete page.
+export interface InboxListPage {
+  entries: InboxItem[];
+  next_cursor: string | null;
+  has_more: boolean;
+}

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -39,7 +39,7 @@ export type {
   IssueUsageSummary,
 } from "./agent";
 export type { Workspace, WorkspaceRepo, Member, MemberRole, User, MemberWithUser, Invitation } from "./workspace";
-export type { InboxItem, InboxSeverity, InboxItemType } from "./inbox";
+export type { InboxItem, InboxListPage, InboxSeverity, InboxItemType } from "./inbox";
 export type { NotificationGroupKey, NotificationGroupValue, NotificationPreferences, NotificationPreferenceResponse } from "./notification-preference";
 export type { Comment, CommentType, CommentAuthorType, Reaction } from "./comment";
 export type { Label, CreateLabelRequest, UpdateLabelRequest, ListLabelsResponse, IssueLabelsResponse } from "./label";

--- a/packages/views/chat/components/context-anchor.tsx
+++ b/packages/views/chat/components/context-anchor.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Focus } from "lucide-react";
 import type { ContextAnchor } from "@multica/core/chat";
 import { useChatStore } from "@multica/core/chat";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { issueDetailOptions } from "@multica/core/issues/queries";
 import { projectDetailOptions } from "@multica/core/projects/queries";
-import { inboxListOptions } from "@multica/core/inbox/queries";
+import { inboxListInfiniteOptions } from "@multica/core/inbox/queries";
 import { Button } from "@multica/ui/components/ui/button";
 import {
   Tooltip,
@@ -58,15 +58,19 @@ export function useRouteAnchorCandidate(wsId: string): {
     : null;
 
   // Inbox: the anchor is the issue behind the currently selected notification.
-  const { data: inboxItems = [] } = useQuery({
-    ...inboxListOptions(wsId),
+  // Only the loaded pages are searched — fine because the user can only have
+  // selected an item that's already on screen, so it's by definition in the
+  // pages we've already fetched.
+  const { data: inboxData } = useInfiniteQuery({
+    ...inboxListInfiniteOptions(wsId),
     enabled: isInbox,
   });
   const inboxKey = isInbox ? searchParams.get("issue") : null;
   const inboxSelectedIssueId =
     isInbox && inboxKey
-      ? inboxItems.find((i) => (i.issue_id ?? i.id) === inboxKey)?.issue_id ??
-        null
+      ? inboxData?.pages
+          .flatMap((p) => p.entries)
+          .find((i) => (i.issue_id ?? i.id) === inboxKey)?.issue_id ?? null
       : null;
 
   // One issue fetch covers both /issues/:id and inbox-derived anchors.

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -2,14 +2,13 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useDefaultLayout } from "react-resizable-panels";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
 import {
-  inboxListOptions,
-  deduplicateInboxItems,
+  inboxListInfiniteOptions,
   useInboxUnreadCount,
 } from "@multica/core/inbox/queries";
 import {
@@ -51,6 +50,7 @@ import {
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
 import { PageHeader } from "../../layout/page-header";
+import { InfiniteScrollSentinel } from "../../issues/components/infinite-scroll-sentinel";
 import { InboxListItem, useTimeAgo } from "./inbox-list-item";
 import { useTypeLabels } from "./inbox-detail-label";
 import { getInboxDisplayTitle } from "./inbox-display";
@@ -70,8 +70,20 @@ export function InboxPage() {
   }, [urlIssue]);
 
   const wsId = useWorkspaceId();
-  const { data: rawItems = [], isLoading: loading } = useQuery(inboxListOptions(wsId));
-  const items = useMemo(() => deduplicateInboxItems(rawItems), [rawItems]);
+  const {
+    data,
+    isLoading: loading,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery(inboxListInfiniteOptions(wsId));
+  // Per-issue dedup is now done server-side (SQL DISTINCT ON in
+  // ListInboxItemsLatest), so just flatten across pages — no client-side
+  // dedup pass needed.
+  const items = useMemo<InboxItem[]>(
+    () => data?.pages.flatMap((p) => p.entries) ?? [],
+    [data],
+  );
 
   const selected = items.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
 
@@ -253,6 +265,14 @@ export function InboxPage() {
           onArchive={() => handleArchive(item.id)}
         />
       ))}
+      {hasNextPage && (
+        <InfiniteScrollSentinel
+          loading={isFetchingNextPage}
+          onVisible={() => {
+            if (!isFetchingNextPage) fetchNextPage();
+          }}
+        />
+      )}
     </div>
   );
 

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -98,7 +98,7 @@ vi.mock("@multica/core/paths", () => ({
   }),
 }));
 vi.mock("@multica/core/api", async (importOriginal) => ({ ...(await importOriginal<typeof import("@multica/core/api")>()), api: {} }));
-vi.mock("@multica/core/inbox/queries", () => ({ deduplicateInboxItems: (items: unknown[]) => items, inboxKeys: { list: () => ["inbox"] } }));
+vi.mock("@multica/core/inbox/queries", () => ({ useInboxUnreadCount: () => 0 }));
 vi.mock("@multica/core/issues/queries", () => ({ issueDetailOptions: () => ({ queryKey: ["issue"] }) }));
 vi.mock("@multica/core/issues/stores/create-mode-store", () => ({ useCreateModeStore: { getState: () => ({ lastMode: "agent" }) } }));
 vi.mock("@multica/core/issues/stores/draft-store", () => ({ useIssueDraftStore: () => false }));

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -65,7 +65,7 @@ import { useAuthStore } from "@multica/core/auth";
 import { useCurrentWorkspace, useWorkspacePaths, paths } from "@multica/core/paths";
 import { workspaceListOptions, myInvitationListOptions, workspaceKeys } from "@multica/core/workspace/queries";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { inboxKeys, deduplicateInboxItems } from "@multica/core/inbox/queries";
+import { useInboxUnreadCount } from "@multica/core/inbox/queries";
 import { api, ApiError } from "@multica/core/api";
 import { useModalStore } from "@multica/core/modals";
 import { useMyRuntimesNeedUpdate } from "@multica/core/runtimes/hooks";
@@ -94,8 +94,6 @@ function isNavActive(pathname: string, href: string): boolean {
 const EMPTY_PINS: PinnedItem[] = [];
 const EMPTY_WORKSPACES: Awaited<ReturnType<typeof api.listWorkspaces>> = [];
 const EMPTY_INVITATIONS: Awaited<ReturnType<typeof api.listMyInvitations>> = [];
-const EMPTY_INBOX: Awaited<ReturnType<typeof api.listInbox>> = [];
-
 // Nav items reference WorkspacePaths method names so they can be resolved
 // against the current workspace slug at render time (see AppSidebar body).
 // Only parameterless paths are valid nav destinations.
@@ -342,15 +340,10 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   const { data: myInvitations = EMPTY_INVITATIONS } = useQuery(myInvitationListOptions());
 
   const wsId = workspace?.id;
-  const { data: inboxItems = EMPTY_INBOX } = useQuery({
-    queryKey: wsId ? inboxKeys.list(wsId) : ["inbox", "disabled"],
-    queryFn: () => api.listInbox(),
-    enabled: !!wsId,
-  });
-  const unreadCount = React.useMemo(
-    () => deduplicateInboxItems(inboxItems).filter((i) => !i.read).length,
-    [inboxItems],
-  );
+  // Inbox unread badge is derived from the dedicated count endpoint, not the
+  // (now paginated) list. Deriving from the list would only count loaded
+  // pages, which is wrong the moment the user has more than one page.
+  const unreadCount = useInboxUnreadCount(wsId);
   const hasRuntimeUpdates = useMyRuntimesNeedUpdate(wsId);
   const { data: pinnedItems = EMPTY_PINS } = useQuery({
     ...pinListOptions(wsId ?? "", userId ?? ""),

--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -14,16 +14,20 @@ import (
 // notificationTest helpers — reuse the integration test fixtures from TestMain
 // (testPool, testUserID, testWorkspaceID are set in integration_test.go).
 
-// inboxItemsForRecipient returns all non-archived inbox items for a given recipient.
-func inboxItemsForRecipient(t *testing.T, queries *db.Queries, recipientID string) []db.ListInboxItemsRow {
+// inboxItemsForRecipient returns all non-archived inbox items for a given
+// recipient. Uses the paginated ListInboxItemsLatest with a high limit because
+// these tests assert behavior over a small fixed dataset; production uses
+// real cursor pagination.
+func inboxItemsForRecipient(t *testing.T, queries *db.Queries, recipientID string) []db.ListInboxItemsLatestRow {
 	t.Helper()
-	items, err := queries.ListInboxItems(context.Background(), db.ListInboxItemsParams{
+	items, err := queries.ListInboxItemsLatest(context.Background(), db.ListInboxItemsLatestParams{
 		WorkspaceID:   util.MustParseUUID(testWorkspaceID),
 		RecipientType: "member",
 		RecipientID:   util.MustParseUUID(recipientID),
+		Limit:         500,
 	})
 	if err != nil {
-		t.Fatalf("ListInboxItems: %v", err)
+		t.Fatalf("ListInboxItemsLatest: %v", err)
 	}
 	return items
 }

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -32,6 +33,24 @@ type InboxItemResponse struct {
 	Details       json.RawMessage `json:"details"`
 }
 
+// InboxListResponse is the paginated wrapper served when the client opts into
+// pagination via ?limit / ?before. Old clients (no params) still receive the
+// raw []InboxItemResponse array via the legacy path; see ListInbox.
+type InboxListResponse struct {
+	Entries    []InboxItemResponse `json:"entries"`
+	NextCursor *string             `json:"next_cursor"`
+	HasMore    bool                `json:"has_more"`
+}
+
+const (
+	inboxDefaultLimit = 50
+	inboxMaxLimit     = 100
+	// inboxLegacyCap honours the spirit of #1968 — old clients couldn't
+	// render thousands of entries without freezing the tab anyway, so the
+	// no-params legacy path returns at most this many newest items.
+	inboxLegacyCap = 200
+)
+
 func inboxToResponse(i db.InboxItem) InboxItemResponse {
 	return InboxItemResponse{
 		ID:            uuidToString(i.ID),
@@ -52,7 +71,28 @@ func inboxToResponse(i db.InboxItem) InboxItemResponse {
 	}
 }
 
-func inboxRowToResponse(r db.ListInboxItemsRow) InboxItemResponse {
+func inboxLatestRowToResponse(r db.ListInboxItemsLatestRow) InboxItemResponse {
+	return InboxItemResponse{
+		ID:            uuidToString(r.ID),
+		WorkspaceID:   uuidToString(r.WorkspaceID),
+		RecipientType: r.RecipientType,
+		RecipientID:   uuidToString(r.RecipientID),
+		Type:          r.Type,
+		Severity:      r.Severity,
+		IssueID:       uuidToPtr(r.IssueID),
+		Title:         r.Title,
+		Body:          textToPtr(r.Body),
+		Read:          r.Read,
+		Archived:      r.Archived,
+		CreatedAt:     timestampToString(r.CreatedAt),
+		IssueStatus:   textToPtr(r.IssueStatus),
+		ActorType:     textToPtr(r.ActorType),
+		ActorID:       uuidToPtr(r.ActorID),
+		Details:       json.RawMessage(r.Details),
+	}
+}
+
+func inboxBeforeRowToResponse(r db.ListInboxItemsBeforeRow) InboxItemResponse {
 	return InboxItemResponse{
 		ID:            uuidToString(r.ID),
 		WorkspaceID:   uuidToString(r.WorkspaceID),
@@ -85,6 +125,17 @@ func (h *Handler) enrichInboxResponse(ctx context.Context, resp InboxItemRespons
 	return resp
 }
 
+// ListInbox serves both legacy and cursor-paginated callers. Old desktop
+// clients (pre-pagination) call GET /inbox with no query string and consume
+// the response body as []InboxItemResponse directly — wrapping the body
+// would crash them with "inbox.filter is not a function" (cf. #2143/#2147
+// on the timeline endpoint). Absence of every pagination param uniquely
+// identifies a legacy caller; new clients always send ?limit=...
+//
+// IMPORTANT: the legacy branch is PERMANENT, not transitional. Desktop
+// users may never auto-update — removing this branch would white-screen
+// every install still on the old client. Treat the no-params contract as a
+// long-term API surface, not as something to drop "once everyone upgrades".
 func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(w, r)
 	if !ok {
@@ -95,22 +146,131 @@ func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	recipientID := parseUUID(userID)
 
-	items, err := h.Queries.ListInboxItems(r.Context(), db.ListInboxItemsParams{
+	q := r.URL.Query()
+	if q.Get("limit") == "" && q.Get("before") == "" {
+		h.listInboxLegacy(w, r, wsUUID, recipientID)
+		return
+	}
+
+	limit := inboxDefaultLimit
+	if raw := q.Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			writeError(w, http.StatusBadRequest, "invalid limit")
+			return
+		}
+		if n > inboxMaxLimit {
+			writeError(w, http.StatusBadRequest, "limit exceeds maximum of 100")
+			return
+		}
+		limit = n
+	}
+
+	if before := q.Get("before"); before != "" {
+		h.listInboxBefore(w, r, wsUUID, recipientID, before, limit)
+		return
+	}
+	h.listInboxLatest(w, r, wsUUID, recipientID, limit)
+}
+
+// listInboxLegacy serves pre-pagination clients with the old []InboxItemResponse
+// shape, capped at inboxLegacyCap to avoid OOM on very large inboxes. This
+// is a permanent compatibility surface (see ListInbox doc) — never delete.
+//
+// Two visible degradations for old desktops are accepted as the price of
+// graceful compatibility:
+//   1. items beyond inboxLegacyCap are unreachable on the old client (it
+//      has no scroll-to-load UI to fetch them). Better than rendering
+//      thousands and freezing the tab — see #1968.
+//   2. the unread badge on old desktops is derived from this list, so it
+//      caps at the unread count within the first 200 items. New clients use
+//      the dedicated /inbox/unread-count endpoint and don't have this cap.
+func (h *Handler) listInboxLegacy(w http.ResponseWriter, r *http.Request, wsUUID, recipientID pgtype.UUID) {
+	items, err := h.Queries.ListInboxItemsLatest(r.Context(), db.ListInboxItemsLatestParams{
 		WorkspaceID:   wsUUID,
 		RecipientType: "member",
-		RecipientID:   parseUUID(userID),
+		RecipientID:   recipientID,
+		Limit:         int32(inboxLegacyCap),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list inbox")
+		return
+	}
+	resp := make([]InboxItemResponse, len(items))
+	for i, item := range items {
+		resp[i] = inboxLatestRowToResponse(item)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) listInboxLatest(w http.ResponseWriter, r *http.Request, wsUUID, recipientID pgtype.UUID, limit int) {
+	// Fetch limit+1 to detect "more rows exist" without a separate COUNT.
+	items, err := h.Queries.ListInboxItemsLatest(r.Context(), db.ListInboxItemsLatestParams{
+		WorkspaceID:   wsUUID,
+		RecipientType: "member",
+		RecipientID:   recipientID,
+		Limit:         int32(limit + 1),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list inbox")
 		return
 	}
 
-	resp := make([]InboxItemResponse, len(items))
+	hasMore := len(items) > limit
+	if hasMore {
+		items = items[:limit]
+	}
+	entries := make([]InboxItemResponse, len(items))
 	for i, item := range items {
-		resp[i] = inboxRowToResponse(item)
+		entries[i] = inboxLatestRowToResponse(item)
 	}
 
+	resp := InboxListResponse{Entries: entries, HasMore: hasMore}
+	if hasMore && len(items) > 0 {
+		last := items[len(items)-1]
+		c := encodeTimelineCursor(last.CreatedAt, last.ID)
+		resp.NextCursor = &c
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) listInboxBefore(w http.ResponseWriter, r *http.Request, wsUUID, recipientID pgtype.UUID, cursor string, limit int) {
+	t, id, err := decodeTimelineCursor(cursor)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid cursor")
+		return
+	}
+
+	items, err := h.Queries.ListInboxItemsBefore(r.Context(), db.ListInboxItemsBeforeParams{
+		WorkspaceID:     wsUUID,
+		RecipientType:   "member",
+		RecipientID:     recipientID,
+		CursorCreatedAt: t,
+		CursorID:        id,
+		RowLimit:        int32(limit + 1),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list inbox")
+		return
+	}
+
+	hasMore := len(items) > limit
+	if hasMore {
+		items = items[:limit]
+	}
+	entries := make([]InboxItemResponse, len(items))
+	for i, item := range items {
+		entries[i] = inboxBeforeRowToResponse(item)
+	}
+
+	resp := InboxListResponse{Entries: entries, HasMore: hasMore}
+	if hasMore && len(items) > 0 {
+		last := items[len(items)-1]
+		c := encodeTimelineCursor(last.CreatedAt, last.ID)
+		resp.NextCursor = &c
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/server/internal/handler/inbox.go
+++ b/server/internal/handler/inbox.go
@@ -179,15 +179,36 @@ func (h *Handler) ListInbox(w http.ResponseWriter, r *http.Request) {
 // shape, capped at inboxLegacyCap to avoid OOM on very large inboxes. This
 // is a permanent compatibility surface (see ListInbox doc) — never delete.
 //
+// What "cap" means after the SQL DISTINCT ON change: the response carries
+// the newest entry for each of up to inboxLegacyCap distinct issues
+// (COALESCE(issue_id, id) for system notifications without an issue). It
+// is *not* "the latest 200 rows" — same issue with 50 unread comments
+// counts as one slot, not 50.
+//
 // Two visible degradations for old desktops are accepted as the price of
 // graceful compatibility:
-//   1. items beyond inboxLegacyCap are unreachable on the old client (it
-//      has no scroll-to-load UI to fetch them). Better than rendering
-//      thousands and freezing the tab — see #1968.
+//   1. issues beyond inboxLegacyCap distinct issues are unreachable on
+//      the old client (it has no scroll-to-load UI to fetch them).
+//      Better than rendering thousands and freezing the tab — see #1968.
 //   2. the unread badge on old desktops is derived from this list, so it
-//      caps at the unread count within the first 200 items. New clients use
-//      the dedicated /inbox/unread-count endpoint and don't have this cap.
+//      reflects the unread state of the newest entry per issue, across the
+//      first 200 distinct issues. An issue at position 201+ that is the
+//      user's only unread item will not contribute to the badge. New
+//      clients use the dedicated /inbox/unread-count endpoint and don't
+//      have this cap.
+//
+// Observability: every request hitting this branch is logged at info with
+// X-Client-Platform / X-Client-Version so we can track how much real
+// install-base sits on the legacy contract. Required for any future
+// "raise minimum supported client version" decision (cf. MUL-1795 A1).
 func (h *Handler) listInboxLegacy(w http.ResponseWriter, r *http.Request, wsUUID, recipientID pgtype.UUID) {
+	slog.Info("inbox: legacy list",
+		append(logger.RequestAttrs(r),
+			"recipient_id", uuidToString(recipientID),
+			"workspace_id", uuidToString(wsUUID),
+			"client_platform", r.Header.Get("X-Client-Platform"),
+			"client_version", r.Header.Get("X-Client-Version"),
+		)...)
 	items, err := h.Queries.ListInboxItemsLatest(r.Context(), db.ListInboxItemsLatestParams{
 		WorkspaceID:   wsUUID,
 		RecipientType: "member",

--- a/server/internal/handler/inbox_test.go
+++ b/server/internal/handler/inbox_test.go
@@ -1,0 +1,242 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/multica-ai/multica/server/internal/middleware"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// withWorkspaceContext seeds the workspace into the request context so handlers
+// that read via ctxWorkspaceID() see the test workspace. The middleware does
+// this in production; tests bypass middleware so we set it explicitly.
+func withWorkspaceContext(req *http.Request, workspaceID string) *http.Request {
+	ctx := middleware.SetMemberContext(req.Context(), workspaceID, db.Member{})
+	return req.WithContext(ctx)
+}
+
+// seedInboxItems inserts <count> inbox items for the test user with timestamps
+// staggered one minute apart (oldest first → newest last). Returns the inserted
+// IDs in chronological order.
+func seedInboxItems(t *testing.T, count int, withIssue bool) []string {
+	t.Helper()
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-time.Duration(count) * time.Minute)
+
+	var issueID *string
+	if withIssue {
+		var iid string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO issue (workspace_id, number, title, description, status, creator_type, creator_id)
+			VALUES ($1, 9001, 'Inbox test issue', '', 'todo', 'member', $2)
+			RETURNING id
+		`, testWorkspaceID, testUserID).Scan(&iid); err != nil {
+			t.Fatalf("seed issue: %v", err)
+		}
+		issueID = &iid
+		t.Cleanup(func() {
+			testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, iid)
+		})
+	}
+
+	ids := make([]string, count)
+	for i := 0; i < count; i++ {
+		var id string
+		ts := base.Add(time.Duration(i) * time.Minute)
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO inbox_item (workspace_id, recipient_type, recipient_id, type, severity, issue_id, title, body, created_at, details)
+			VALUES ($1, 'member', $2, 'comment', 'info', $3, $4, '', $5, '{}'::jsonb)
+			RETURNING id
+		`, testWorkspaceID, testUserID, issueID, fmt.Sprintf("inbox %d", i), ts).Scan(&id); err != nil {
+			t.Fatalf("seed inbox %d: %v", i, err)
+		}
+		ids[i] = id
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM inbox_item WHERE recipient_id = $1`, testUserID)
+	})
+	return ids
+}
+
+func fetchInboxLegacy(t *testing.T) ([]InboxItemResponse, int) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/inbox", nil)
+	req = withWorkspaceContext(req, testWorkspaceID)
+	testHandler.ListInbox(w, req)
+	var resp []InboxItemResponse
+	if w.Code == http.StatusOK {
+		json.NewDecoder(w.Body).Decode(&resp)
+	}
+	return resp, w.Code
+}
+
+func fetchInboxPaginated(t *testing.T, query string) (InboxListResponse, int) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/inbox?"+query, nil)
+	req = withWorkspaceContext(req, testWorkspaceID)
+	testHandler.ListInbox(w, req)
+	var resp InboxListResponse
+	if w.Code == http.StatusOK {
+		json.NewDecoder(w.Body).Decode(&resp)
+	}
+	return resp, w.Code
+}
+
+// TestListInbox_LegacyNoParamsReturnsArray verifies that requests without any
+// pagination parameters get the bare []InboxItemResponse contract that pre-
+// pagination clients rely on. Wrapping the body would crash old desktops.
+func TestListInbox_LegacyNoParamsReturnsArray(t *testing.T) {
+	seedInboxItems(t, 5, false)
+
+	resp, code := fetchInboxLegacy(t)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if len(resp) != 5 {
+		t.Fatalf("expected 5 items, got %d", len(resp))
+	}
+}
+
+// TestListInbox_LegacyPathCappedAt200 ensures the no-params path bounds the
+// response so an unexpectedly large inbox doesn't OOM old clients.
+func TestListInbox_LegacyPathCappedAt200(t *testing.T) {
+	seedInboxItems(t, 250, false)
+
+	resp, code := fetchInboxLegacy(t)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if len(resp) != inboxLegacyCap {
+		t.Fatalf("expected legacy cap %d items, got %d", inboxLegacyCap, len(resp))
+	}
+}
+
+// TestListInbox_PaginatedLatestPage exercises the new wrapper contract: a
+// `limit=N` request returns at most N entries plus a cursor when more exist.
+func TestListInbox_PaginatedLatestPage(t *testing.T) {
+	seedInboxItems(t, 10, false)
+
+	resp, code := fetchInboxPaginated(t, "limit=5")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if len(resp.Entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(resp.Entries))
+	}
+	if !resp.HasMore {
+		t.Fatalf("expected has_more=true with 10 items and limit=5")
+	}
+	if resp.NextCursor == nil || *resp.NextCursor == "" {
+		t.Fatalf("expected next_cursor on a non-final page")
+	}
+}
+
+// TestListInbox_PaginatedFinalPage verifies the cursor is omitted and
+// has_more=false on the last page.
+func TestListInbox_PaginatedFinalPage(t *testing.T) {
+	seedInboxItems(t, 3, false)
+
+	resp, code := fetchInboxPaginated(t, "limit=10")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if len(resp.Entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(resp.Entries))
+	}
+	if resp.HasMore {
+		t.Fatalf("expected has_more=false on a final page")
+	}
+}
+
+// TestListInbox_CursorPagination walks two pages and verifies entries are
+// disjoint and ordered newest-first.
+func TestListInbox_CursorPagination(t *testing.T) {
+	seedInboxItems(t, 6, false)
+
+	page1, code := fetchInboxPaginated(t, "limit=3")
+	if code != http.StatusOK {
+		t.Fatalf("page1: expected 200, got %d", code)
+	}
+	if len(page1.Entries) != 3 || !page1.HasMore || page1.NextCursor == nil {
+		t.Fatalf("page1: bad shape: %+v", page1)
+	}
+
+	page2, code := fetchInboxPaginated(t, "limit=3&before="+*page1.NextCursor)
+	if code != http.StatusOK {
+		t.Fatalf("page2: expected 200, got %d", code)
+	}
+	if len(page2.Entries) != 3 {
+		t.Fatalf("page2: expected 3 entries, got %d", len(page2.Entries))
+	}
+
+	seen := map[string]bool{}
+	for _, e := range page1.Entries {
+		seen[e.ID] = true
+	}
+	for _, e := range page2.Entries {
+		if seen[e.ID] {
+			t.Fatalf("page2 entry %s already on page1 (cursor pagination should be disjoint)", e.ID)
+		}
+	}
+}
+
+// TestListInbox_PerIssueDedup verifies that multiple unarchived inbox items
+// for the same issue collapse to a single row in the listing — the SQL-level
+// equivalent of the old client-side deduplicateInboxItems helper.
+func TestListInbox_PerIssueDedup(t *testing.T) {
+	seedInboxItems(t, 4, true) // all 4 items share one issue
+
+	resp, code := fetchInboxPaginated(t, "limit=50")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("expected 1 deduped entry, got %d", len(resp.Entries))
+	}
+}
+
+// TestListInbox_InvalidLimit rejects a non-numeric or out-of-range limit.
+func TestListInbox_InvalidLimit(t *testing.T) {
+	for _, q := range []string{"limit=abc", "limit=0", "limit=200"} {
+		_, code := fetchInboxPaginated(t, q)
+		if code != http.StatusBadRequest {
+			t.Fatalf("limit=%q: expected 400, got %d", q, code)
+		}
+	}
+}
+
+// TestListInbox_InvalidCursor returns 400 on a malformed cursor.
+func TestListInbox_InvalidCursor(t *testing.T) {
+	_, code := fetchInboxPaginated(t, "limit=10&before=not-a-cursor")
+	if code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on bad cursor, got %d", code)
+	}
+}
+
+// TestCountUnreadInbox_DedupsByIssue ensures the badge count uses the same
+// per-issue dedup as the listing — otherwise the badge would say 5 but the
+// list would render 1, confusing users.
+func TestCountUnreadInbox_DedupsByIssue(t *testing.T) {
+	seedInboxItems(t, 4, true) // 4 unread items, all sharing one issue
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/inbox/unread/count", nil)
+	req = withWorkspaceContext(req, testWorkspaceID)
+	testHandler.CountUnreadInbox(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]int64
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["count"] != 1 {
+		t.Fatalf("expected count=1 (deduped), got %d", resp["count"])
+	}
+}

--- a/server/internal/handler/inbox_test.go
+++ b/server/internal/handler/inbox_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -64,15 +65,25 @@ func seedInboxItems(t *testing.T, count int, withIssue bool) []string {
 	return ids
 }
 
+// fetchInboxLegacy hits the legacy no-params path and asserts the wire shape
+// is a JSON array. Wrapping the body in {entries:...} would white-screen
+// pre-pagination desktops (cf. #2143/#2147 on timeline) — guarding the
+// shape here prevents an accidental refactor from regressing it silently.
 func fetchInboxLegacy(t *testing.T) ([]InboxItemResponse, int) {
 	t.Helper()
 	w := httptest.NewRecorder()
 	req := newRequest("GET", "/api/inbox", nil)
 	req = withWorkspaceContext(req, testWorkspaceID)
 	testHandler.ListInbox(w, req)
+	body := w.Body.Bytes()
 	var resp []InboxItemResponse
 	if w.Code == http.StatusOK {
-		json.NewDecoder(w.Body).Decode(&resp)
+		if !bytes.HasPrefix(bytes.TrimSpace(body), []byte("[")) {
+			t.Fatalf("legacy path must serve a JSON array, got: %s", body)
+		}
+		if err := json.Unmarshal(body, &resp); err != nil {
+			t.Fatalf("decode legacy body: %v", err)
+		}
 	}
 	return resp, w.Code
 }
@@ -106,7 +117,8 @@ func TestListInbox_LegacyNoParamsReturnsArray(t *testing.T) {
 }
 
 // TestListInbox_LegacyPathCappedAt200 ensures the no-params path bounds the
-// response so an unexpectedly large inbox doesn't OOM old clients.
+// response by *distinct issues*, not raw rows: 250 inbox items spread
+// across 250 issues collapse at the 200-issue cap.
 func TestListInbox_LegacyPathCappedAt200(t *testing.T) {
 	seedInboxItems(t, 250, false)
 
@@ -116,6 +128,23 @@ func TestListInbox_LegacyPathCappedAt200(t *testing.T) {
 	}
 	if len(resp) != inboxLegacyCap {
 		t.Fatalf("expected legacy cap %d items, got %d", inboxLegacyCap, len(resp))
+	}
+}
+
+// TestListInbox_LegacyDedupBeforeCap pins the dedup × cap interaction:
+// 250 inbox items all sharing the same issue must collapse to 1 row, not
+// fill the 200-row cap with duplicates of one issue. Catches a regression
+// where DISTINCT ON gets dropped accidentally and the legacy cap silently
+// over-counts.
+func TestListInbox_LegacyDedupBeforeCap(t *testing.T) {
+	seedInboxItems(t, 250, true) // all 250 share one issue
+
+	resp, code := fetchInboxLegacy(t)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 deduped item, got %d", len(resp))
 	}
 }
 

--- a/server/migrations/069_inbox_keyset_index.down.sql
+++ b/server/migrations/069_inbox_keyset_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_inbox_active_keyset;

--- a/server/migrations/069_inbox_keyset_index.up.sql
+++ b/server/migrations/069_inbox_keyset_index.up.sql
@@ -10,8 +10,16 @@
 -- The pre-existing idx_inbox_recipient (recipient_type, recipient_id, read)
 -- only covered the per-recipient unread-count query; it cannot drive the
 -- workspace-scoped keyset pagination, so we add a new index rather than
--- replace it. Keeping it for now until the unread-count query is verified
--- to use the new index too.
+-- replace it.
+--
+-- Not using CREATE INDEX CONCURRENTLY here for the same reason 068
+-- (timeline keyset) didn't: at current scale (early-stage product, 2–10
+-- person workspaces) the build is sub-second and the brief share-lock is
+-- acceptable. When inbox_item grows past ~1M rows the lock window will
+-- matter — at that point revisit ALL keyset indexes (068 + 069) together
+-- and either rebuild via CONCURRENTLY in an ops one-off or tighten the
+-- migration runner to support non-transactional migrations. Don't fix
+-- one in isolation; it just creates inconsistency.
 
 CREATE INDEX IF NOT EXISTS idx_inbox_active_keyset
     ON inbox_item (workspace_id, recipient_type, recipient_id, created_at DESC, id DESC)

--- a/server/migrations/069_inbox_keyset_index.up.sql
+++ b/server/migrations/069_inbox_keyset_index.up.sql
@@ -1,0 +1,18 @@
+-- Composite partial index backing cursor-paginated inbox listing. The query
+-- shape is:
+--   WHERE workspace_id=$1 AND recipient_type=$2 AND recipient_id=$3
+--     AND archived=false AND (created_at, id) < ($4, $5)
+--   ORDER BY created_at DESC, id DESC LIMIT $6
+-- With (workspace_id, recipient_type, recipient_id, created_at DESC, id DESC)
+-- under the archived=false predicate, the planner can serve this as an
+-- index-only scan with no sort.
+--
+-- The pre-existing idx_inbox_recipient (recipient_type, recipient_id, read)
+-- only covered the per-recipient unread-count query; it cannot drive the
+-- workspace-scoped keyset pagination, so we add a new index rather than
+-- replace it. Keeping it for now until the unread-count query is verified
+-- to use the new index too.
+
+CREATE INDEX IF NOT EXISTS idx_inbox_active_keyset
+    ON inbox_item (workspace_id, recipient_type, recipient_id, created_at DESC, id DESC)
+    WHERE archived = false;

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -121,7 +121,7 @@ func (q *Queries) ArchiveInboxItem(ctx context.Context, id pgtype.UUID) (InboxIt
 }
 
 const countUnreadInbox = `-- name: CountUnreadInbox :one
-SELECT count(*) FROM inbox_item
+SELECT COUNT(DISTINCT COALESCE(issue_id, id))::bigint FROM inbox_item
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false
 `
 
@@ -131,11 +131,14 @@ type CountUnreadInboxParams struct {
 	RecipientID   pgtype.UUID `json:"recipient_id"`
 }
 
+// Count of distinct issues (or item-id for issueless items) with at least
+// one unread, unarchived inbox entry. Aligned with ListInboxItemsLatest's
+// per-issue dedup so the badge count matches the rendered list length.
 func (q *Queries) CountUnreadInbox(ctx context.Context, arg CountUnreadInboxParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countUnreadInbox, arg.WorkspaceID, arg.RecipientType, arg.RecipientID)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const createInboxItem = `-- name: CreateInboxItem :one
@@ -257,22 +260,31 @@ func (q *Queries) GetInboxItemInWorkspace(ctx context.Context, arg GetInboxItemI
 	return i, err
 }
 
-const listInboxItems = `-- name: ListInboxItems :many
-SELECT i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details,
-       iss.status as issue_status
-FROM inbox_item i
-LEFT JOIN issue iss ON iss.id = i.issue_id
-WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
-ORDER BY i.created_at DESC
+const listInboxItemsBefore = `-- name: ListInboxItemsBefore :many
+SELECT id, workspace_id, recipient_type, recipient_id, type, severity,
+       issue_id, title, body, read, archived, created_at, actor_type,
+       actor_id, details, issue_status FROM (
+  SELECT DISTINCT ON (COALESCE(i.issue_id, i.id)) i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details, iss.status AS issue_status
+  FROM inbox_item i
+  LEFT JOIN issue iss ON iss.id = i.issue_id
+  WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
+  ORDER BY COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
+) AS deduped
+WHERE (deduped.created_at, deduped.id) < ($4::timestamptz, $5::uuid)
+ORDER BY created_at DESC, id DESC
+LIMIT $6
 `
 
-type ListInboxItemsParams struct {
-	WorkspaceID   pgtype.UUID `json:"workspace_id"`
-	RecipientType string      `json:"recipient_type"`
-	RecipientID   pgtype.UUID `json:"recipient_id"`
+type ListInboxItemsBeforeParams struct {
+	WorkspaceID     pgtype.UUID        `json:"workspace_id"`
+	RecipientType   string             `json:"recipient_type"`
+	RecipientID     pgtype.UUID        `json:"recipient_id"`
+	CursorCreatedAt pgtype.Timestamptz `json:"cursor_created_at"`
+	CursorID        pgtype.UUID        `json:"cursor_id"`
+	RowLimit        int32              `json:"row_limit"`
 }
 
-type ListInboxItemsRow struct {
+type ListInboxItemsBeforeRow struct {
 	ID            pgtype.UUID        `json:"id"`
 	WorkspaceID   pgtype.UUID        `json:"workspace_id"`
 	RecipientType string             `json:"recipient_type"`
@@ -291,15 +303,112 @@ type ListInboxItemsRow struct {
 	IssueStatus   pgtype.Text        `json:"issue_status"`
 }
 
-func (q *Queries) ListInboxItems(ctx context.Context, arg ListInboxItemsParams) ([]ListInboxItemsRow, error) {
-	rows, err := q.db.Query(ctx, listInboxItems, arg.WorkspaceID, arg.RecipientType, arg.RecipientID)
+// Cursor-paginated older-than-cursor slice with the same per-issue dedup as
+// ListInboxItemsLatest. The (created_at, id) tuple keyset is exclusive of
+// the cursor row.
+func (q *Queries) ListInboxItemsBefore(ctx context.Context, arg ListInboxItemsBeforeParams) ([]ListInboxItemsBeforeRow, error) {
+	rows, err := q.db.Query(ctx, listInboxItemsBefore,
+		arg.WorkspaceID,
+		arg.RecipientType,
+		arg.RecipientID,
+		arg.CursorCreatedAt,
+		arg.CursorID,
+		arg.RowLimit,
+	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListInboxItemsRow{}
+	items := []ListInboxItemsBeforeRow{}
 	for rows.Next() {
-		var i ListInboxItemsRow
+		var i ListInboxItemsBeforeRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.RecipientType,
+			&i.RecipientID,
+			&i.Type,
+			&i.Severity,
+			&i.IssueID,
+			&i.Title,
+			&i.Body,
+			&i.Read,
+			&i.Archived,
+			&i.CreatedAt,
+			&i.ActorType,
+			&i.ActorID,
+			&i.Details,
+			&i.IssueStatus,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listInboxItemsLatest = `-- name: ListInboxItemsLatest :many
+SELECT id, workspace_id, recipient_type, recipient_id, type, severity,
+       issue_id, title, body, read, archived, created_at, actor_type,
+       actor_id, details, issue_status FROM (
+  SELECT DISTINCT ON (COALESCE(i.issue_id, i.id)) i.id, i.workspace_id, i.recipient_type, i.recipient_id, i.type, i.severity, i.issue_id, i.title, i.body, i.read, i.archived, i.created_at, i.actor_type, i.actor_id, i.details, iss.status AS issue_status
+  FROM inbox_item i
+  LEFT JOIN issue iss ON iss.id = i.issue_id
+  WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
+  ORDER BY COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
+) AS deduped
+ORDER BY created_at DESC, id DESC
+LIMIT $4
+`
+
+type ListInboxItemsLatestParams struct {
+	WorkspaceID   pgtype.UUID `json:"workspace_id"`
+	RecipientType string      `json:"recipient_type"`
+	RecipientID   pgtype.UUID `json:"recipient_id"`
+	Limit         int32       `json:"limit"`
+}
+
+type ListInboxItemsLatestRow struct {
+	ID            pgtype.UUID        `json:"id"`
+	WorkspaceID   pgtype.UUID        `json:"workspace_id"`
+	RecipientType string             `json:"recipient_type"`
+	RecipientID   pgtype.UUID        `json:"recipient_id"`
+	Type          string             `json:"type"`
+	Severity      string             `json:"severity"`
+	IssueID       pgtype.UUID        `json:"issue_id"`
+	Title         string             `json:"title"`
+	Body          pgtype.Text        `json:"body"`
+	Read          bool               `json:"read"`
+	Archived      bool               `json:"archived"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	ActorType     pgtype.Text        `json:"actor_type"`
+	ActorID       pgtype.UUID        `json:"actor_id"`
+	Details       []byte             `json:"details"`
+	IssueStatus   pgtype.Text        `json:"issue_status"`
+}
+
+// Newest-first inbox listing with per-issue dedup (Linear-style: an issue
+// with multiple unarchived notifications appears once, with the newest
+// entry winning). The DISTINCT ON dedups; the outer slice applies the
+// cursor page LIMIT. COALESCE(issue_id, id) keeps system notifications
+// (issue_id NULL) one-per-row.
+func (q *Queries) ListInboxItemsLatest(ctx context.Context, arg ListInboxItemsLatestParams) ([]ListInboxItemsLatestRow, error) {
+	rows, err := q.db.Query(ctx, listInboxItemsLatest,
+		arg.WorkspaceID,
+		arg.RecipientType,
+		arg.RecipientID,
+		arg.Limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListInboxItemsLatestRow{}
+	for rows.Next() {
+		var i ListInboxItemsLatestRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.WorkspaceID,

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -1,10 +1,37 @@
--- name: ListInboxItems :many
-SELECT i.*,
-       iss.status as issue_status
-FROM inbox_item i
-LEFT JOIN issue iss ON iss.id = i.issue_id
-WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
-ORDER BY i.created_at DESC;
+-- name: ListInboxItemsLatest :many
+-- Newest-first inbox listing with per-issue dedup (Linear-style: an issue
+-- with multiple unarchived notifications appears once, with the newest
+-- entry winning). The DISTINCT ON dedups; the outer slice applies the
+-- cursor page LIMIT. COALESCE(issue_id, id) keeps system notifications
+-- (issue_id NULL) one-per-row.
+SELECT id, workspace_id, recipient_type, recipient_id, type, severity,
+       issue_id, title, body, read, archived, created_at, actor_type,
+       actor_id, details, issue_status FROM (
+  SELECT DISTINCT ON (COALESCE(i.issue_id, i.id)) i.*, iss.status AS issue_status
+  FROM inbox_item i
+  LEFT JOIN issue iss ON iss.id = i.issue_id
+  WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
+  ORDER BY COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
+) AS deduped
+ORDER BY created_at DESC, id DESC
+LIMIT $4;
+
+-- name: ListInboxItemsBefore :many
+-- Cursor-paginated older-than-cursor slice with the same per-issue dedup as
+-- ListInboxItemsLatest. The (created_at, id) tuple keyset is exclusive of
+-- the cursor row.
+SELECT id, workspace_id, recipient_type, recipient_id, type, severity,
+       issue_id, title, body, read, archived, created_at, actor_type,
+       actor_id, details, issue_status FROM (
+  SELECT DISTINCT ON (COALESCE(i.issue_id, i.id)) i.*, iss.status AS issue_status
+  FROM inbox_item i
+  LEFT JOIN issue iss ON iss.id = i.issue_id
+  WHERE i.workspace_id = $1 AND i.recipient_type = $2 AND i.recipient_id = $3 AND i.archived = false
+  ORDER BY COALESCE(i.issue_id, i.id), i.created_at DESC, i.id DESC
+) AS deduped
+WHERE (deduped.created_at, deduped.id) < (sqlc.arg('cursor_created_at')::timestamptz, sqlc.arg('cursor_id')::uuid)
+ORDER BY created_at DESC, id DESC
+LIMIT sqlc.arg('row_limit');
 
 -- name: GetInboxItem :one
 SELECT * FROM inbox_item
@@ -37,7 +64,10 @@ UPDATE inbox_item SET archived = true
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND issue_id = $4 AND archived = false;
 
 -- name: CountUnreadInbox :one
-SELECT count(*) FROM inbox_item
+-- Count of distinct issues (or item-id for issueless items) with at least
+-- one unread, unarchived inbox entry. Aligned with ListInboxItemsLatest's
+-- per-issue dedup so the badge count matches the rendered list length.
+SELECT COUNT(DISTINCT COALESCE(issue_id, id))::bigint FROM inbox_item
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false;
 
 -- name: MarkAllInboxRead :execrows


### PR DESCRIPTION
## Summary
- Inbox switches from "fetch every unarchived item, dedup in JS" to cursor pagination + per-issue SQL `DISTINCT ON`. Backend caps the legacy no-params response at 200 *distinct issues* (graceful degradation for desktop installs that may never auto-update); new clients walk pages of 50.
- WS-pushed inbox notifications now surgically prepend into the InfiniteQuery cache (mirrors `timeline-cache`), preserving scroll position and the SQL dedup invariant. Mark-read / archive mutations operate on the paginated cache shape.
- Bidirectional schema defense: zod union accepts both the new wrapper and the legacy bare-array shape (with dedup) so a brief web-vs-backend deploy gap doesn't render duplicates.

## Compatibility matrix

| Client | Server | Path |
|---|---|---|
| Old desktop (never updates) | New | `listInboxLegacy` returns capped `[]InboxItemResponse` — **permanent compatibility surface** |
| New web | Old (deploy window) | Schema transforms array → `{entries, has_more: false}` with per-issue dedup |
| New | New | Full cursor pagination + WS surgical prepend |

Two visible degradations on never-updated desktops are accepted by design (documented in `inbox.go`):
- issues beyond 200 distinct issues unreachable (no scroll-to-load on the old client)
- unread badge reflects unread state of the newest entry per issue, across the first 200 distinct issues — an issue at position 201+ that is the user's only unread item won't contribute to the badge

## Observability

`listInboxLegacy` logs `client_platform` / `client_version` on every hit so we can track install-base on the legacy contract before any future "raise minimum supported client version" decision (cf. MUL-1795 A1).

## Test plan
- [x] `go test ./internal/handler/ -run Inbox` — 10 cases (legacy / pagination / cursor / dedup / **dedup×cap interaction** / invalid params / count dedup); legacy helper now asserts `[` shape prefix
- [x] `pnpm --filter @multica/core exec vitest run api/schema` — schema accepts wrapper / dedups legacy array / falls back on malformed
- [x] `pnpm --filter @multica/core exec vitest run inbox` — `prependToLatestPage` dedup-by-id and dedup-by-issue cases
- [x] `pnpm typecheck` and `pnpm lint` clean
- [x] `make test` — full Go suite
- [ ] Manual: load inbox with >50 items, scroll to load more, receive WS notification, mark read, archive
- [ ] Manual: verify on desktop dev build that the no-params path still returns array shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)