### PR TITLE
docs(changelog): add v0.2.27 entry

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -284,6 +284,29 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.27",
+        date: "2026-05-07",
+        title: "Cleaner Chat, GitHub Skill Imports & Workflow Polish",
+        changes: [],
+        features: [
+          "Import skills directly from GitHub URLs",
+          "Copy an issue's local workdir path from the issue menu",
+          "`multica workspace update` lets CLI users edit workspace details",
+        ],
+        improvements: [
+          "Chat history is now grouped into one Active / Archived menu, with easier reply copying and cleaner process details",
+          "Inbox automatically selects the next item after you archive the current one",
+          "New sub-issues now inherit the parent issue's project and status",
+          "Autopilots pause themselves after repeated failures, making noisy automations easier to fix",
+        ],
+        fixes: [
+          "Chinese input no longer submits too early while you are choosing characters",
+          "GitHub skill imports and older OpenClaw setups now fail with clearer guidance",
+          "Issue timelines and live agent status cards stay accurate in more edge cases",
+          "The desktop app is less likely to blank or break after updates",
+        ],
+      },
+      {
         version: "0.2.26",
         date: "2026-05-06",
         title: "Full i18n Rollout, Long-Issue Timeline & System Notifications Toggle",

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -286,24 +286,18 @@ export function createEnDict(allowSignup: boolean): LandingDict {
       {
         version: "0.2.27",
         date: "2026-05-07",
-        title: "Cleaner Chat, GitHub Skill Imports & Workflow Polish",
+        title: "Smoother Chat, GitHub Skill Import & Stability Fixes",
         changes: [],
         features: [
-          "Import skills directly from GitHub URLs",
-          "Copy an issue's local workdir path from the issue menu",
-          "`multica workspace update` lets CLI users edit workspace details",
+          "Import reusable skills directly from GitHub links",
         ],
         improvements: [
-          "Chat history is now grouped into one Active / Archived menu, with easier reply copying and cleaner process details",
-          "Inbox automatically selects the next item after you archive the current one",
-          "New sub-issues now inherit the parent issue's project and status",
-          "Autopilots pause themselves after repeated failures, making noisy automations easier to fix",
+          "Chat and Inbox feel smoother, with clearer history, easier reply copying, and faster triage after archiving",
+          "Issue actions keep more context, from easier access to the local folder to sub-issues inheriting the right project and status",
+          "Autopilots pause themselves after repeated failures, so noisy automations are easier to catch and fix",
         ],
         fixes: [
-          "Chinese input no longer submits too early while you are choosing characters",
-          "GitHub skill imports and older OpenClaw setups now fail with clearer guidance",
-          "Issue timelines and live agent status cards stay accurate in more edge cases",
-          "The desktop app is less likely to blank or break after updates",
+          "Chinese input, desktop updates, long issue timelines, and live status updates are more reliable",
         ],
       },
       {

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -284,6 +284,29 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.27",
+        date: "2026-05-07",
+        title: "Chat 更清爽、Skill 支持 GitHub 导入，日常体验更顺手",
+        changes: [],
+        features: [
+          "支持直接从 GitHub URL 导入 Skill",
+          "Issue 菜单可一键复制本地 workdir 路径",
+          "`multica workspace update` 支持通过 CLI 修改工作区信息",
+        ],
+        improvements: [
+          "Chat 历史合并为一个 Active / Archived 菜单，复制回复更方便，过程信息展示更清爽",
+          "Inbox 归档当前项后会自动选中下一项",
+          "新建子 Issue 会自动带上父 Issue 的项目和状态",
+          "Autopilot 连续失败后会自动暂停，异常自动化更容易处理",
+        ],
+        fixes: [
+          "中文输入法选字时不再误触发提交",
+          "GitHub Skill 导入和旧版 OpenClaw 的失败提示更清楚",
+          "Issue 时间线和 Agent 实时状态卡在更多边界情况下保持准确",
+          "桌面端升级后更不容易白屏或异常中断",
+        ],
+      },
+      {
         version: "0.2.26",
         date: "2026-05-06",
         title: "i18n 全量铺开、长 Issue Timeline 提速与系统通知开关",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -286,24 +286,18 @@ export function createZhDict(allowSignup: boolean): LandingDict {
       {
         version: "0.2.27",
         date: "2026-05-07",
-        title: "Chat 更清爽、Skill 支持 GitHub 导入，日常体验更顺手",
+        title: "Chat 更顺手，Skill 支持 GitHub 导入，稳定性更好",
         changes: [],
         features: [
-          "支持直接从 GitHub URL 导入 Skill",
-          "Issue 菜单可一键复制本地 workdir 路径",
-          "`multica workspace update` 支持通过 CLI 修改工作区信息",
+          "支持直接通过 GitHub 链接导入可复用 Skill",
         ],
         improvements: [
-          "Chat 历史合并为一个 Active / Archived 菜单，复制回复更方便，过程信息展示更清爽",
-          "Inbox 归档当前项后会自动选中下一项",
-          "新建子 Issue 会自动带上父 Issue 的项目和状态",
-          "Autopilot 连续失败后会自动暂停，异常自动化更容易处理",
+          "Chat 和 Inbox 更顺手，历史更清晰，复制回复更方便，归档后能更快处理下一项",
+          "Issue 操作会保留更多上下文，例如更容易找到对应本地文件夹，子 Issue 也会带上正确的项目和状态",
+          "Autopilot 连续失败后会自动暂停，异常自动化更容易发现和修复",
         ],
         fixes: [
-          "中文输入法选字时不再误触发提交",
-          "GitHub Skill 导入和旧版 OpenClaw 的失败提示更清楚",
-          "Issue 时间线和 Agent 实时状态卡在更多边界情况下保持准确",
-          "桌面端升级后更不容易白屏或异常中断",
+          "中文输入、桌面端升级、长 Issue 时间线和实时状态展示更稳定",
         ],
       },
       {


### PR DESCRIPTION
Summary: Adds v0.2.27 changelog entries in English and Chinese with concise, user-facing wording. Verification: git diff --check passes; pnpm --filter web lint could not run because node_modules/eslint are missing in this checkout.