### PR TITLE
fix(views): validate workspace slug against reserved ones

### DIFF
--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -33,9 +33,11 @@ import {
   WORKSPACE_SLUG_CONFLICT_ERROR,
   WORKSPACE_SLUG_FORMAT_ERROR,
   WORKSPACE_SLUG_REGEX,
+  WORKSPACE_SLUG_RESERVED_ERROR,
   isWorkspaceSlugConflict,
   nameToWorkspaceSlug,
 } from "../../workspace/slug";
+import { isReservedSlug } from "@multica/core/paths";
 
 /**
  * Step 2 — create your first workspace, or continue with one set up in
@@ -104,7 +106,8 @@ export function StepWorkspace({
     slug.length > 0 && !WORKSPACE_SLUG_REGEX.test(slug)
       ? WORKSPACE_SLUG_FORMAT_ERROR
       : null;
-  const slugError = slugValidationError ?? slugServerError;
+  const slugReservedError = slug.length > 0 && isReservedSlug(slug) ? WORKSPACE_SLUG_RESERVED_ERROR : null;
+  const slugError = slugValidationError ?? slugReservedError ?? slugServerError;
   const canCreate =
     name.trim().length > 0 && slug.trim().length > 0 && !slugError;
 

--- a/packages/views/workspace/create-workspace-form.test.tsx
+++ b/packages/views/workspace/create-workspace-form.test.tsx
@@ -99,4 +99,18 @@ describe("CreateWorkspaceForm", () => {
       screen.getByRole("button", { name: /create workspace/i }),
     ).toBeDisabled();
   });
+
+  it("disables submit when slug is reserved", () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText(/workspace name/i), {
+      target: { value: "Valid Name" },
+    });
+    fireEvent.change(screen.getByLabelText(/workspace url/i), {
+      target: { value: "admin" },
+    });
+    expect(
+      screen.getByRole("button", { name: /create workspace/i }),
+    ).toBeDisabled();
+    expect(screen.getByText(/reserved and cannot be used/i)).toBeInTheDocument();
+  });
 });

--- a/packages/views/workspace/create-workspace-form.tsx
+++ b/packages/views/workspace/create-workspace-form.tsx
@@ -11,10 +11,12 @@ import type { Workspace } from "@multica/core/types";
 import { isImeComposing } from "@multica/core/utils";
 import {
   WORKSPACE_SLUG_REGEX,
+  WORKSPACE_SLUG_RESERVED_ERROR,
   isWorkspaceSlugConflict,
   nameToWorkspaceSlug,
 } from "./slug";
 import { useT } from "../i18n";
+import { isReservedSlug } from "@multica/core/paths";
 
 export interface CreateWorkspaceFormProps {
   onSuccess: (workspace: Workspace) => void | Promise<void>;
@@ -32,7 +34,8 @@ export function CreateWorkspaceForm({ onSuccess }: CreateWorkspaceFormProps) {
     slug.length > 0 && !WORKSPACE_SLUG_REGEX.test(slug)
       ? t(($) => $.create_form.errors.slug_format)
       : null;
-  const slugError = slugValidationError ?? slugServerError;
+  const slugReservedError = slug.length > 0 && isReservedSlug(slug) ? WORKSPACE_SLUG_RESERVED_ERROR : null;
+  const slugError = slugValidationError ?? slugReservedError ?? slugServerError;
   const canSubmit =
     name.trim().length > 0 && slug.trim().length > 0 && !slugError;
 

--- a/packages/views/workspace/slug.ts
+++ b/packages/views/workspace/slug.ts
@@ -6,6 +6,9 @@ export const WORKSPACE_SLUG_FORMAT_ERROR =
 export const WORKSPACE_SLUG_CONFLICT_ERROR =
   "That workspace URL is already taken.";
 
+export const WORKSPACE_SLUG_RESERVED_ERROR =
+"That workspace URL is reserved and cannot be used.";
+
 /**
  * Auto-generate a slug from a workspace name.
  *


### PR DESCRIPTION
## What does this PR do?

When creating a new workspace, the UI currently allows the user to select a reserved slug and errors when attempting to create the workspace. This confused me so I've updated the UI to show an inline error when this happens instead.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Attempt to create a new workspace with a reserved slug e.g. `multica`
2. Attempt to press "Create workspace"
3. Observe that the button is disabled when it wasn't before

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** N/A


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->

Before:
<img width="531" height="376" alt="image" src="https://github.com/user-attachments/assets/1306fb69-d2da-4e48-aad5-ba9cc40522a2" />

After:
<img width="512" height="401" alt="image" src="https://github.com/user-attachments/assets/9d9c7b19-3b09-4375-b521-2062454730de" />

