### PR TITLE
fix(timeline): sync around state on falsy prop transitions (#1968 follow-up)

### DIFF
--- a/packages/views/issues/hooks/use-issue-timeline.test.tsx
+++ b/packages/views/issues/hooks/use-issue-timeline.test.tsx
@@ -41,16 +41,24 @@ vi.mock("@multica/core/issues/mutations", () => ({
   }),
 }));
 
+// Spy on issueTimelineInfiniteOptions so tests can assert which `around` value
+// the hook actually fed to useInfiniteQuery on each render.
+const queriesMock = vi.hoisted(() => ({
+  issueTimelineInfiniteOptions: vi.fn(
+    (id: string, around?: string | null) => ({
+      queryKey: around
+        ? ["issues", "timeline", id, "around", around]
+        : ["issues", "timeline", id],
+      queryFn: () => Promise.resolve({}),
+      initialPageParam: { mode: "latest" as const },
+      getNextPageParam: () => undefined,
+      getPreviousPageParam: () => undefined,
+    }),
+  ),
+}));
+
 vi.mock("@multica/core/issues/queries", () => ({
-  issueTimelineInfiniteOptions: (id: string, around?: string | null) => ({
-    queryKey: around
-      ? ["issues", "timeline", id, "around", around]
-      : ["issues", "timeline", id],
-    queryFn: () => Promise.resolve(emptyPage()),
-    initialPageParam: { mode: "latest" as const },
-    getNextPageParam: () => undefined,
-    getPreviousPageParam: () => undefined,
-  }),
+  issueTimelineInfiniteOptions: queriesMock.issueTimelineInfiniteOptions,
   issueKeys: {
     timeline: (id: string, around?: string | null) =>
       around
@@ -121,6 +129,7 @@ import { useIssueTimeline } from "./use-issue-timeline";
 describe("useIssueTimeline", () => {
   beforeEach(() => {
     wsHandlers.clear();
+    queriesMock.issueTimelineInfiniteOptions.mockClear();
     queryState.data = {
       pages: [{ ...emptyPage(), has_more_after: false }],
       pageParams: [{ mode: "latest" }],
@@ -281,6 +290,32 @@ describe("useIssueTimeline", () => {
       });
     });
     expect(result.current.newEntriesBelowCount).toBe(0);
+  });
+
+  // Regression: when the inbox split-pane is open and the user clicks a
+  // comment-notification (around=<id>) and then a notification for the SAME
+  // issue without a comment_id (around=undefined), <IssueDetail> stays
+  // mounted (keyed on issueId, see inbox-page.tsx). The hook therefore has
+  // to react to the around prop transitioning back to falsy — otherwise the
+  // around-mode cache is re-served on every subsequent click and entries
+  // outside the original window appear "lost" until a hard refresh.
+  it("syncs around state when the prop transitions back to undefined", () => {
+    const { rerender } = renderHook(
+      ({ around }: { around?: string | null }) =>
+        useIssueTimeline("issue-1", "user-1", { around }),
+      { initialProps: { around: "comment-X" as string | null | undefined } },
+    );
+
+    // First render is anchored on comment-X.
+    const firstAround = queriesMock.issueTimelineInfiniteOptions.mock.calls.at(-1)?.[1];
+    expect(firstAround).toBe("comment-X");
+
+    rerender({ around: undefined });
+
+    // After transitioning to undefined, the next call MUST use the latest
+    // (around=null) cache, not keep re-using the comment-X anchor.
+    const lastAround = queriesMock.issueTimelineInfiniteOptions.mock.calls.at(-1)?.[1];
+    expect(lastAround).toBeNull();
   });
 
   it("jumpToLatest clears newEntriesBelowCount", () => {

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -74,10 +74,12 @@ export function useIssueTimeline(
 
   // Internal anchor state. Starts as the caller's around prop; jumpToLatest
   // clears it. A new around prop (e.g. user clicks a different inbox item)
-  // resets it via the effect below.
+  // resets it via the effect below — including transitions back to null when
+  // the caller switches to a notification without comment_id, otherwise the
+  // cached around-page is re-served forever after the first inbox jump.
   const [around, setAround] = useState<string | null>(options.around ?? null);
   useEffect(() => {
-    if (options.around) setAround(options.around);
+    setAround(options.around ?? null);
   }, [options.around]);
 
   const query = useInfiniteQuery(issueTimelineInfiniteOptions(issueId, around));


### PR DESCRIPTION
## Summary

Follow-up to #2128 / #1968. The cursor-paginated timeline keeps an internal \`around\` anchor in \`useState\`, which the prop is supposed to drive. The effect that propagates the prop into state has a truthy guard:

```ts
useEffect(() => {
  if (options.around) setAround(options.around);   // skipped on null
}, [options.around]);
```

That guard means a transition from \`around=<commentId>\` → \`around=undefined\` is silently dropped. The cached around-page keeps being re-served on every subsequent render.

## Reproduction (UX)

This bug is only reachable from the inbox split-pane, because that is the one place \`<IssueDetail>\` stays mounted across notification clicks (it is keyed on \`issueId\` in \`inbox-page.tsx\` so composer drafts and scroll position survive — direct navigation from the issue list always remounts and is unaffected).

1. Open a comment-notification for issue X (\`comment_id = "abc"\`) — issue view loads in around-mode anchored on \`abc\`, ~50 entries near \`abc\`.
2. Click another notification for **the same** issue X without a \`comment_id\` (status / assignment / sub-issue) → \`highlightCommentId\` becomes \`undefined\`.
3. UI keeps rendering the around-mode window from step 1; entries outside it stay hidden, including new ones arriving over WS.
4. Hard refresh fixes it (drops cache, \`IssueDetail\` remounts).

Severity: P1 (UX). No data loss — entries persist on the backend and reappear on hard refresh.

## Fix

One-line: drop the truthy guard so the effect handles all prop transitions, including → \`null\`. \`useState\`'s initialiser already covers the mount-time read.

```ts
useEffect(() => {
  setAround(options.around ?? null);
}, [options.around]);
```

## Test

Adds a regression test in \`use-issue-timeline.test.tsx\` that asserts \`useInfiniteQuery\` is re-keyed on the \`around: "comment-X"\` → \`around: undefined\` transition. Verified the test fails on \`upstream/main\` without the fix and passes with it.

## Test plan

- [x] \`pnpm --filter @multica/views exec vitest run issues/hooks/use-issue-timeline.test\` — 8/8 pass with the fix; the new test fails (as expected) without it
- [x] \`pnpm --filter @multica/views typecheck\` — clean
- [ ] Manual smoke: from inbox split-pane, open a comment-notification then a sibling notification for the same issue without \`comment_id\` — verify the full timeline renders without a hard refresh

## Related lower-priority findings

Three other timeline issues surfaced during root-cause analysis. \#2204 already addressed the merge-truncation case (\`HasMoreBefore\`). The remaining two will be filed separately:

- **Orphan replies** — \`issue-detail.tsx\` filters \`topLevel\` by \`!parent_id\`; replies whose top-level ancestor is outside the loaded around-window never render. Needs a "load context" affordance, so out of scope for this PR.
- **WS \`comment:created\` dropped in around-mode** — \`isAtLatest === false\` short-circuits cache writes even when the parent is already in cache. Needs additional cache-membership check; also out of scope here.