### PR TITLE
fix(issues): prune deleted issues from recents

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -358,6 +358,7 @@ export function useDeleteIssue() {
 
       pruneDeletedIssueFromListCaches(qc, wsId, id);
       pruneDeletedIssueFromParentChildrenCaches(qc, wsId, id, metadata);
+      useRecentIssuesStore.getState().forgetIssue(wsId, id);
       qc.removeQueries({ queryKey: issueKeys.detail(wsId, id) });
       return { id, metadata, prevLists, prevMyLists, prevDetail, prevChildren };
     },
@@ -512,12 +513,14 @@ export function useBatchDeleteIssues() {
         );
       }
 
+      const recentStore = useRecentIssuesStore.getState();
       for (const id of ids) {
         const metadata = metadataById.get(id);
         pruneDeletedIssueFromListCaches(qc, wsId, id);
         if (metadata) {
           pruneDeletedIssueFromParentChildrenCaches(qc, wsId, id, metadata);
         }
+        recentStore.forgetIssue(wsId, id);
       }
       return { prevLists, prevMyLists, prevChildren, parentIssueIds, metadataById };
     },

--- a/packages/core/issues/stores/recent-issues-store.ts
+++ b/packages/core/issues/stores/recent-issues-store.ts
@@ -88,6 +88,10 @@ export const useRecentIssuesStore = create<RecentIssuesState>()(
           }
           return changed ? { byWorkspace: next } : state;
         }),
+      removeItem: (id) =>
+        set((state) => ({
+          items: state.items.filter((i) => i.id !== id),
+        })),
     }),
     {
       name: "multica_recent_issues",

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -13,6 +13,7 @@ import {
   onIssueMetadataChanged,
   onIssueUpdated,
 } from "./ws-updaters";
+import { useRecentIssuesStore } from "./stores";
 import { issueKeys } from "./queries";
 import { labelKeys } from "../labels/queries";
 import { projectKeys } from "../projects/queries";
@@ -126,6 +127,7 @@ describe("onIssueLabelsChanged", () => {
 
   beforeEach(() => {
     qc = new QueryClient();
+    useRecentIssuesStore.setState({ items: [] });
   });
 
   it("patches the per-issue label cache when present (LabelPicker source)", () => {
@@ -534,5 +536,26 @@ describe("project gantt cache invalidation", () => {
   it("invalidates the project Gantt cache on issue:deleted", () => {
     onIssueDeleted(qc, WS_ID, ISSUE_ID);
     expectInvalidated(qc, issueKeys.projectGantt(WS_ID, PROJECT_ID));
+  });
+});
+
+describe("onIssueDeleted", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+    useRecentIssuesStore.setState({ items: [] });
+  });
+
+  it("prunes deleted issues from recent history", () => {
+    const { recordVisit } = useRecentIssuesStore.getState();
+    recordVisit(ISSUE_ID);
+    recordVisit("other-issue");
+
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+
+    expect(useRecentIssuesStore.getState().items.map((i) => i.id)).toEqual([
+      "other-issue",
+    ]);
   });
 });

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { issueKeys } from "./queries";
 import { labelKeys } from "../labels/queries";
 import { projectKeys } from "../projects/queries";
+import { useRecentIssuesStore } from "./stores";
 import {
   addIssueToBuckets,
   findIssueLocation,
@@ -178,4 +179,5 @@ export function onIssueDeleted(
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: projectKeys.all(wsId) });
+  useRecentIssuesStore.getState().forgetIssue(wsId, issueId);
 }

--- a/packages/core/query-client.test.ts
+++ b/packages/core/query-client.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "./api";
+import { createQueryClient } from "./query-client";
+
+describe("createQueryClient", () => {
+  it("does not retry 404 ApiError responses", () => {
+    const qc = createQueryClient();
+    const retry = qc.getDefaultOptions().queries?.retry;
+
+    expect(typeof retry).toBe("function");
+    expect(
+      retry instanceof Function
+        ? retry(0, new ApiError("missing", 404, "Not Found"))
+        : retry,
+    ).toBe(false);
+  });
+
+  it("keeps one retry for transient errors", () => {
+    const qc = createQueryClient();
+    const retry = qc.getDefaultOptions().queries?.retry;
+
+    expect(
+      retry instanceof Function ? retry(0, new Error("boom")) : retry,
+    ).toBe(true);
+    expect(
+      retry instanceof Function ? retry(1, new Error("boom")) : retry,
+    ).toBe(false);
+  });
+});

--- a/packages/core/query-client.ts
+++ b/packages/core/query-client.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
+import { ApiError } from "./api";
 
 export function createQueryClient(): QueryClient {
   return new QueryClient({
@@ -8,7 +9,10 @@ export function createQueryClient(): QueryClient {
         gcTime: 10 * 60 * 1000, // 10 minutes
         refetchOnWindowFocus: false,
         refetchOnReconnect: true,
-        retry: 1,
+        retry: (failureCount, error) => {
+          if (error instanceof ApiError && error.status === 404) return false;
+          return failureCount < 1;
+        },
       },
       mutations: {
         retry: false,

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -65,13 +65,17 @@ const {
   mockClipboardWrite: vi.fn(() => Promise.resolve()),
 }));
 
-vi.mock("@multica/core/api", () => ({
-  api: {
-    getBaseUrl: () => "http://127.0.0.1:8080",
-    searchIssues: mockSearchIssues,
-    searchProjects: mockSearchProjects,
-  },
-}));
+vi.mock("@multica/core/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@multica/core/api")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      searchIssues: mockSearchIssues,
+      searchProjects: mockSearchProjects,
+    },
+  };
+});
 
 vi.mock("@multica/core/issues/stores", () => {
   const EMPTY: Array<{ id: string; visitedAt: number }> = [];

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -31,7 +31,7 @@ import type {
   SearchIssueResult,
   SearchProjectResult,
 } from "@multica/core/types";
-import { api } from "@multica/core/api";
+import { ApiError, api } from "@multica/core/api";
 import {
   openCreateIssueWithPreference,
   selectRecentIssues,
@@ -147,6 +147,15 @@ export function SearchCommand() {
   const recentDetailQueries = useQueries({
     queries: recentItems.map((item) => issueDetailOptions(wsId, item.id)),
   });
+  useEffect(() => {
+    recentDetailQueries.forEach((q, index) => {
+      if (q.error instanceof ApiError && q.error.status === 404) {
+        const stale = recentItems[index];
+        if (stale) useRecentIssuesStore.getState().forgetIssue(wsId, stale.id);
+      }
+    });
+  }, [recentDetailQueries, recentItems]);
+
   const recentIssues = useMemo(
     () =>
       recentDetailQueries.flatMap((q) => (q.data ? [q.data] : [])),


### PR DESCRIPTION
## Summary
- stop retrying 404 API query failures globally
- add recent issue removal and prune deleted issues from local and websocket delete paths
- prune stale Cmd+K recent entries when detail lookup returns 404
- add focused unit coverage for recent pruning and 404 retry behavior

Fixes #1996

## Testing
- Not run: dependencies are not installed in this checkout, and full pnpm install is risky with only ~1.4GB free disk.