### PR TITLE
fix(settings): switch language without reload

### DIFF
--- a/packages/core/i18n/provider.tsx
+++ b/packages/core/i18n/provider.tsx
@@ -17,8 +17,9 @@ export function I18nProvider({
   children,
 }: I18nProviderProps) {
   // Lazy init via useState so the instance survives re-renders.
-  // Locale + resources are determined at boot and never change at runtime —
-  // language switching goes through window.location.reload().
+  // Locale + resources are determined at boot, while the active language can
+  // switch in-place via i18n.changeLanguage because every supported locale is
+  // already present in resources.
   const [instance] = useState(() => createI18n(locale, resources));
   return <I18nextProvider i18n={instance}>{children}</I18nextProvider>;
 }

--- a/packages/core/i18n/user-locale-sync.tsx
+++ b/packages/core/i18n/user-locale-sync.tsx
@@ -14,9 +14,9 @@ import { SUPPORTED_LOCALES, type SupportedLocale } from "./types";
 // Mounts inside CoreProvider so it has access to the auth store + locale
 // adapter + i18n instance. Renders nothing.
 //
-// Loop safety: reload only fires when user.language is a supported locale AND
-// differs from the active i18n.language. After reload, pickLocale reads the
-// freshly-persisted value from the adapter, locales match, effect no-ops.
+// Loop safety: language switching only fires when user.language is a supported
+// locale AND differs from the active i18n.language. After changeLanguage,
+// locales match and the effect no-ops.
 export function UserLocaleSync() {
   const userLanguage = useAuthStore((s) => s.user?.language ?? null);
   const adapter = useLocaleAdapter();
@@ -29,7 +29,7 @@ export function UserLocaleSync() {
     }
     if (userLanguage === i18n.language) return;
     adapter.persist(userLanguage as SupportedLocale);
-    if (typeof window !== "undefined") window.location.reload();
+    void i18n.changeLanguage(userLanguage);
   }, [userLanguage, i18n.language, adapter]);
 
   return null;

--- a/packages/views/settings/components/preferences-tab.test.tsx
+++ b/packages/views/settings/components/preferences-tab.test.tsx
@@ -106,7 +106,7 @@ describe("PreferencesTab — Language switcher", () => {
     expect(mockReload).not.toHaveBeenCalled();
   });
 
-  it("when not logged in: persists + reloads, no PATCH", async () => {
+  it("when not logged in: persists and switches language in-place, no PATCH", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     render(<PreferencesTab />, { wrapper: I18nWrapper });
 
@@ -126,11 +126,11 @@ describe("PreferencesTab — Language switcher", () => {
 
     expect(mockPersist).toHaveBeenCalledWith("ja");
     expect(mockUpdateMe).not.toHaveBeenCalled();
-    expect(mockReload).toHaveBeenCalledTimes(1);
+    expect(mockReload).not.toHaveBeenCalled();
     expect(mockToastWarning).not.toHaveBeenCalled();
   });
 
-  it("when logged in + PATCH success: persists + PATCH + reload immediately", async () => {
+  it("when logged in + PATCH success: persists, patches, and avoids reload", async () => {
     userRef.current = { id: "user-1" };
     mockUpdateMe.mockResolvedValueOnce({});
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
@@ -141,10 +141,10 @@ describe("PreferencesTab — Language switcher", () => {
     expect(mockPersist).toHaveBeenCalledWith("zh-Hans");
     expect(mockUpdateMe).toHaveBeenCalledWith({ language: "zh-Hans" });
     expect(mockToastWarning).not.toHaveBeenCalled();
-    expect(mockReload).toHaveBeenCalledTimes(1);
+    expect(mockReload).not.toHaveBeenCalled();
   });
 
-  it("when logged in + PATCH fails: shows toast and delays reload by 2.5s", async () => {
+  it("when logged in + PATCH fails: shows toast without reloading", async () => {
     userRef.current = { id: "user-1" };
     mockUpdateMe.mockRejectedValueOnce(new Error("network"));
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
@@ -152,18 +152,12 @@ describe("PreferencesTab — Language switcher", () => {
 
     await user.click(screen.getByRole("radio", { name: "中文" }));
 
-    // Local persist still happened so the reload below sees the new locale.
+    // Local persist still happened so this device keeps the new locale.
     expect(mockPersist).toHaveBeenCalledWith("zh-Hans");
     expect(mockUpdateMe).toHaveBeenCalledWith({ language: "zh-Hans" });
     // Toast surfaced the sync failure.
     expect(mockToastWarning).toHaveBeenCalledTimes(1);
-    // Reload deferred so the toast is visible.
     expect(mockReload).not.toHaveBeenCalled();
-
-    act(() => {
-      vi.advanceTimersByTime(2500);
-    });
-    expect(mockReload).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/views/settings/components/preferences-tab.tsx
+++ b/packages/views/settings/components/preferences-tab.tsx
@@ -125,18 +125,17 @@ export function PreferencesTab() {
     { value: "ja", label: t(($) => $.preferences.language.japanese) },
   ];
 
-  // Persist locally → sync to user.language → reload. Reload (vs in-place
-  // changeLanguage) avoids hydration mismatch and is the i18next-recommended
-  // pattern for App Router.
+  // Persist locally, apply the already-loaded i18n bundle in-place, then sync
+  // to user.language for other devices. Avoiding a full reload keeps the
+  // settings page stable and prevents losing unsaved UI state elsewhere.
   //
-  // If the cross-device sync (PATCH /api/me) fails, the local cookie is
-  // already written so the new locale will take effect after reload — but
-  // the user's other devices won't see the change. Surface that explicitly
-  // via a toast and delay the reload long enough for the toast to be read,
-  // otherwise the failure would be invisible.
+  // If the cross-device sync (PATCH /api/me) fails, the local preference has
+  // still changed for this device. Surface that explicitly via a toast so the
+  // user knows other devices may not pick it up yet.
   const handleLanguageChange = async (next: SupportedLocale) => {
     if (next === currentLocale) return;
     localeAdapter.persist(next);
+    await i18n.changeLanguage(next);
 
     let syncFailed = false;
     if (user) {
@@ -149,11 +148,7 @@ export function PreferencesTab() {
 
     if (syncFailed) {
       toast.warning(t(($) => $.preferences.language.sync_failed));
-      // Give the toast 2.5s of visible time before navigating away.
-      setTimeout(() => window.location.reload(), 2500);
-      return;
     }
-    window.location.reload();
   };
 
   return (


### PR DESCRIPTION
## Summary
- switch language in-place with i18n.changeLanguage instead of reloading the app
- keep local persistence and user.language sync behavior
- update user locale sync to avoid reloads when pulling language from profile
- update preferences language-switch tests for no-reload behavior

Fixes #2194

## Testing
- Not run: dependencies are not installed in this checkout, and full pnpm install is risky with only ~1.4GB free disk.