### PR TITLE
Fix OpenCode daemon permission mode

### DIFF
--- a/server/pkg/agent/opencode.go
+++ b/server/pkg/agent/opencode.go
@@ -17,7 +17,9 @@ import (
 // opencodeBlockedArgs are flags hardcoded by the daemon that must not be
 // overridden by user-configured custom_args.
 var opencodeBlockedArgs = map[string]blockedArgMode{
-	"--format": blockedWithValue, // json output format for daemon communication
+	"--format":                          blockedWithValue,  // json output format for daemon communication
+	"--dangerously-skip-permissions":    blockedStandalone, // non-interactive daemon approval mode
+	"--no-dangerously-skip-permissions": blockedStandalone,
 }
 
 // opencodeBackend implements Backend by spawning `opencode run --format json`
@@ -49,7 +51,7 @@ func (b *opencodeBackend) Execute(ctx context.Context, prompt string, opts ExecO
 	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
-	args := []string{"run", "--format", "json"}
+	args := []string{"run", "--format", "json", "--dangerously-skip-permissions"}
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}

--- a/server/pkg/agent/opencode_test.go
+++ b/server/pkg/agent/opencode_test.go
@@ -1,14 +1,17 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewReturnsOpencodeBackend(t *testing.T) {
@@ -711,6 +714,69 @@ func TestOpencodeProcessEventsErrorDoesNotRevertToCompleted(t *testing.T) {
 	}
 
 	close(ch)
+}
+
+func TestOpencodeBackendInvokesRunWithSkipPermissions(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	tempDir := t.TempDir()
+	argsFile := filepath.Join(tempDir, "argv.txt")
+	fakePath := filepath.Join(tempDir, "opencode")
+	script := "#!/bin/sh\n" +
+		": > \"$OPENCODE_ARGS_FILE\"\n" +
+		"for arg in \"$@\"; do\n" +
+		"  printf '%s\\n' \"$arg\" >> \"$OPENCODE_ARGS_FILE\"\n" +
+		"done\n" +
+		"printf '%s\\n' '{\"type\":\"text\",\"sessionID\":\"ses_args\",\"part\":{\"type\":\"text\",\"text\":\"done\"}}'\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("opencode", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"OPENCODE_ARGS_FILE": argsFile},
+	})
+	if err != nil {
+		t.Fatalf("new opencode backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt", ExecOptions{
+		Timeout:    5 * time.Second,
+		CustomArgs: []string{"--no-dangerously-skip-permissions"},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	<-session.Result
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	found := false
+	for _, arg := range args {
+		if arg == "--dangerously-skip-permissions" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected opencode argv to include --dangerously-skip-permissions, got %v", args)
+	}
+	for _, arg := range args {
+		if arg == "--no-dangerously-skip-permissions" {
+			t.Fatalf("custom args must not disable daemon permissions, got %v", args)
+		}
+	}
 }
 
 // ── Windows native-binary resolution tests ──


### PR DESCRIPTION
## Summary
- Add `--dangerously-skip-permissions` to daemon-launched `opencode run --format json` so OpenCode does not wait for interactive tool approval.
- Block custom args from disabling or duplicating the daemon-managed permission flag.
- Add a regression test that records the fake OpenCode argv and verifies the permission flag is present while `--no-dangerously-skip-permissions` is filtered.

## Root cause
EVI-45 showed repeated `opencode timed out after 2h0m0s` runs with empty run-messages and no checkout/log/output artifacts. Local `opencode run --help` for OpenCode 1.14.30 shows the supported non-interactive approval flag is `--dangerously-skip-permissions`; the backend only set `OPENCODE_PERMISSION={"*":"allow"}`, which did not prevent the daemon-launched run from waiting for permissions.

## Verification
- `cd server && go test ./pkg/agent -run TestOpencodeBackendInvokesRunWithSkipPermissions -count=1`
- `cd server && go test ./pkg/agent -run Opencode -count=1`
- `cd server && go test ./pkg/agent -run TestCodexExecuteSemanticInactivityAllowsContinuousDeltaProgress -count=1`
- `cd server && go test ./pkg/agent -count=1`
- `git diff --check`

## Notes
- First full `go test ./pkg/agent -count=1` run hit the existing low-threshold Codex semantic inactivity timing test once under parallel load; the targeted Codex test and full package rerun both passed.
