### PR TITLE
feat(issues): show identifier in detail page breadcrumb

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -629,6 +629,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
               </>
             )}
+            <span className="text-muted-foreground tabular-nums shrink-0">
+              {issue.identifier}
+            </span>
             <span className="truncate font-medium text-foreground">
               {issue.title}
             </span>


### PR DESCRIPTION
## Summary

- Add the current issue's identifier to the detail page breadcrumb, sitting between the parent identifier (if any) and the title.
- Reuses the existing parent identifier styling (`text-muted-foreground tabular-nums`), no link since the breadcrumb already represents the current page.

Result:

```
Workspace › MUL-123  Issue title
Workspace › MUL-100 › MUL-123  Issue title    (sub-issue)
```

Refs #2243. Companion PR adds the same identifier to the right-hand Properties sidebar.

## Test plan

- [ ] Open an issue with no parent — breadcrumb reads `Workspace › <ID>  <title>`
- [ ] Open a sub-issue — breadcrumb reads `Workspace › <PARENT> › <ID>  <title>`
- [ ] Long titles still truncate without pushing the identifier off-screen
- [ ] No regression in `issue-detail.test.tsx` (existing breadcrumb test only asserts workspace link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)