### PR TITLE
feat(issues): show identifier in detail page sidebar

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -495,9 +495,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${propertiesOpen ? "rotate-90" : ""}`} />
         </button>
         {propertiesOpen && <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 pl-2">
-          <PropRow label={t(($) => $.detail.prop_id)}>
-            <span className="text-muted-foreground tabular-nums">{issue.identifier}</span>
-          </PropRow>
           <PropRow label={t(($) => $.detail.prop_status)}>
             <StatusPicker status={issue.status} onUpdate={handleUpdateField} align="start" />
           </PropRow>
@@ -552,6 +549,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${detailsOpen ? "rotate-90" : ""}`} />
         </button>
         {detailsOpen && <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 pl-2">
+          <PropRow label={t(($) => $.detail.prop_id)} interactive={false}>
+            <span className="text-muted-foreground tabular-nums">{issue.identifier}</span>
+          </PropRow>
           <PropRow label={t(($) => $.detail.prop_created_by)}>
             <ActorAvatar actorType={issue.creator_type} actorId={issue.creator_id} size={18} enableHoverCard />
             <span className="cursor-pointer truncate">{getActorName(issue.creator_type, issue.creator_id)}</span>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -549,7 +549,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${detailsOpen ? "rotate-90" : ""}`} />
         </button>
         {detailsOpen && <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 pl-2">
-          <PropRow label={t(($) => $.detail.prop_id)} interactive={false}>
+          <PropRow label={t(($) => $.detail.prop_id)}>
             <span className="text-muted-foreground tabular-nums">{issue.identifier}</span>
           </PropRow>
           <PropRow label={t(($) => $.detail.prop_created_by)}>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -495,6 +495,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${propertiesOpen ? "rotate-90" : ""}`} />
         </button>
         {propertiesOpen && <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 pl-2">
+          <PropRow label={t(($) => $.detail.prop_id)}>
+            <span className="text-muted-foreground tabular-nums">{issue.identifier}</span>
+          </PropRow>
           <PropRow label={t(($) => $.detail.prop_status)}>
             <StatusPicker status={issue.status} onUpdate={handleUpdateField} align="start" />
           </PropRow>

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -100,6 +100,7 @@
     "section_parent_issue": "Parent issue",
     "section_details": "Details",
     "section_token_usage": "Token usage",
+    "prop_id": "ID",
     "prop_status": "Status",
     "prop_priority": "Priority",
     "prop_assignee": "Assignee",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -99,6 +99,7 @@
     "section_parent_issue": "父 issue",
     "section_details": "详情",
     "section_token_usage": "Token 用量",
+    "prop_id": "ID",
     "prop_status": "状态",
     "prop_priority": "优先级",
     "prop_assignee": "负责人",


### PR DESCRIPTION
## Summary

- Add an `ID` row to the **Details** section of the issue detail sidebar (top of group, before Created by / Created / Updated), exposing the issue's identifier as plain selectable text.
- Add the matching `prop_id` key to the `en` and `zh-Hans` locale files.

The Properties group is the editable-picker group (Status, Priority, Assignee, Due date, Project, Labels) — putting a read-only ID there made it look clickable. Details already houses the other read-only metadata, which is the right neighborhood.

The row uses the default interactive `PropRow` to stay consistent with its sibling rows (Created by / Created / Updated) — they all hover-highlight today, so suppressing hover on just `ID` would be inconsistent. Whether the whole Details group should switch to non-interactive is a separate, broader decision and out of scope for this PR.

Refs #2243. Companion PR adds the same identifier to the page header breadcrumb.

## Test plan

- [ ] Open any issue → Details section shows `ID  <identifier>` as the first row
- [ ] Hover behavior matches the other Details rows (Created by / Created / Updated)
- [ ] Toggle Details section closed/open — ID row collapses with the rest
- [ ] Switch app to Chinese — label localizes (still renders as `ID` per glossary)
- [ ] `pnpm --filter @multica/views exec vitest run locales/parity.test.ts` passes (both locales updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)