### PR TITLE
fix(cli): add --content-file / --description-file for non-ASCII on Windows

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -16,20 +16,41 @@ import (
 	"github.com/multica-ai/multica/server/internal/util"
 )
 
-// resolveTextFlag picks between a `--<name>` flag value and a paired
-// `--<name>-stdin` flag, mirroring the existing `--content` / `--content-stdin`
-// pattern. It returns the resolved string and an error when both are set or
-// stdin is requested but produces no body. Inline flag values are passed
-// through util.UnescapeBackslashEscapes so bash-double-quoted `\n` becomes a
-// real newline; stdin bodies are returned verbatim so literal backslashes
+// resolveTextFlag picks between a `--<name>` inline value, a `--<name>-stdin`
+// flag, and a `--<name>-file <path>` flag, mirroring the existing `--content`
+// / `--content-stdin` pattern. It returns the resolved string and an error
+// when more than one source is set, or when stdin/file is requested but
+// produces no body. Inline flag values are passed through
+// util.UnescapeBackslashEscapes so bash-double-quoted `\n` becomes a real
+// newline; stdin and file bodies are returned verbatim so literal backslashes
 // survive intact.
+//
+// The `-file` source exists for Windows agents: piping HEREDOC content to
+// `--<name>-stdin` from a non-UTF-8 console (Windows PowerShell 5.1, cmd.exe
+// with default codepage) silently drops non-ASCII bytes — Chinese characters
+// arrive as `?`. Reading a UTF-8 file directly bypasses the shell's pipe
+// re-encoding entirely. See issues #2198, #2236.
 func resolveTextFlag(cmd *cobra.Command, flagName string) (string, bool, error) {
 	stdinFlag := flagName + "-stdin"
+	fileFlag := flagName + "-file"
 	useStdin, _ := cmd.Flags().GetBool(stdinFlag)
 	inline, _ := cmd.Flags().GetString(flagName)
-	if useStdin && inline != "" {
-		return "", false, fmt.Errorf("--%s and --%s are mutually exclusive", flagName, stdinFlag)
+	filePath, _ := cmd.Flags().GetString(fileFlag)
+
+	sources := 0
+	if useStdin {
+		sources++
 	}
+	if inline != "" {
+		sources++
+	}
+	if filePath != "" {
+		sources++
+	}
+	if sources > 1 {
+		return "", false, fmt.Errorf("--%s, --%s, and --%s are mutually exclusive", flagName, stdinFlag, fileFlag)
+	}
+
 	if useStdin {
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
@@ -38,6 +59,17 @@ func resolveTextFlag(cmd *cobra.Command, flagName string) (string, bool, error) 
 		body := strings.TrimSuffix(string(data), "\n")
 		if body == "" {
 			return "", false, fmt.Errorf("stdin content for --%s is empty", stdinFlag)
+		}
+		return body, true, nil
+	}
+	if filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", false, fmt.Errorf("read file for --%s: %w", fileFlag, err)
+		}
+		body := strings.TrimSuffix(string(data), "\n")
+		if body == "" {
+			return "", false, fmt.Errorf("file content for --%s is empty", fileFlag)
 		}
 		return body, true, nil
 	}
@@ -221,6 +253,7 @@ func init() {
 	issueCreateCmd.Flags().String("title", "", "Issue title (required)")
 	issueCreateCmd.Flags().String("description", "", "Issue description (decodes \\n, \\r, \\t, \\\\; pipe via --description-stdin to preserve literal backslashes)")
 	issueCreateCmd.Flags().Bool("description-stdin", false, "Read issue description from stdin (preserves multi-line content verbatim)")
+	issueCreateCmd.Flags().String("description-file", "", "Read issue description from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
 	issueCreateCmd.Flags().String("status", "", "Issue status")
 	issueCreateCmd.Flags().String("priority", "", "Issue priority")
 	issueCreateCmd.Flags().String("assignee", "", "Assignee name (member or agent; fuzzy match)")
@@ -235,6 +268,7 @@ func init() {
 	issueUpdateCmd.Flags().String("title", "", "New title")
 	issueUpdateCmd.Flags().String("description", "", "New description (decodes \\n, \\r, \\t, \\\\; pipe via --description-stdin to preserve literal backslashes)")
 	issueUpdateCmd.Flags().Bool("description-stdin", false, "Read new description from stdin (preserves multi-line content verbatim)")
+	issueUpdateCmd.Flags().String("description-file", "", "Read new description from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
 	issueUpdateCmd.Flags().String("status", "", "New status")
 	issueUpdateCmd.Flags().String("priority", "", "New priority")
 	issueUpdateCmd.Flags().String("assignee", "", "New assignee name (member or agent; fuzzy match)")
@@ -272,6 +306,7 @@ func init() {
 	// issue comment add
 	issueCommentAddCmd.Flags().String("content", "", "Comment content (decodes \\n, \\r, \\t, \\\\; pipe via --content-stdin for multi-line bodies or to preserve literal backslashes)")
 	issueCommentAddCmd.Flags().Bool("content-stdin", false, "Read comment content from stdin (preserves multi-line content verbatim)")
+	issueCommentAddCmd.Flags().String("content-file", "", "Read comment content from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
 	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID (reply to a specific comment)")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
@@ -582,7 +617,7 @@ func runIssueUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("title")
 		body["title"] = v
 	}
-	if cmd.Flags().Changed("description") || cmd.Flags().Changed("description-stdin") {
+	if cmd.Flags().Changed("description") || cmd.Flags().Changed("description-stdin") || cmd.Flags().Changed("description-file") {
 		desc, _, err := resolveTextFlag(cmd, "description")
 		if err != nil {
 			return err
@@ -828,7 +863,7 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if !hasContent {
-		return fmt.Errorf("--content or --content-stdin is required")
+		return fmt.Errorf("--content, --content-stdin, or --content-file is required")
 	}
 
 	client, err := newAPIClient(cmd)

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -39,11 +39,12 @@ func pipeStdin(t *testing.T, body string, fn func()) {
 }
 
 // newFlagTestCmd builds a throwaway cobra.Command carrying the inline +
-// stdin flag pair that resolveTextFlag expects.
+// stdin + file flag triplet that resolveTextFlag expects.
 func newFlagTestCmd(name string) *cobra.Command {
 	c := &cobra.Command{Use: "test"}
 	c.Flags().String(name, "", "")
 	c.Flags().Bool(name+"-stdin", false, "")
+	c.Flags().String(name+"-file", "", "")
 	return c
 }
 
@@ -94,6 +95,85 @@ func TestResolveTextFlag(t *testing.T) {
 		}
 		if ok || got != "" {
 			t.Errorf("expected absent flag to yield (\"\", false), got (%q, %v)", got, ok)
+		}
+	})
+
+	// --content-file / --description-file exists for Windows agents — piping
+	// HEREDOC content through Windows PowerShell 5.1 or cmd.exe re-encodes
+	// non-ASCII bytes through the console codepage, replacing characters the
+	// codepage cannot represent (e.g. Chinese on a non-UTF-8 console) with
+	// `?`. Reading the body straight off disk skips the shell entirely.
+	// See issues #2198, #2236.
+	t.Run("file body is preserved verbatim with non-ASCII content", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + string(os.PathSeparator) + "desc.md"
+		body := "标题\n\n中文段落 with `code` and \"quotes\".\n"
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+		c := newFlagTestCmd("description")
+		_ = c.Flags().Set("description-file", path)
+		got, ok, err := resolveTextFlag(c, "description")
+		if err != nil || !ok {
+			t.Fatalf("unexpected: ok=%v err=%v", ok, err)
+		}
+		want := "标题\n\n中文段落 with `code` and \"quotes\"."
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("file path that doesn't exist surfaces a useful error", func(t *testing.T) {
+		c := newFlagTestCmd("content")
+		_ = c.Flags().Set("content-file", "/this/path/does/not/exist.txt")
+		_, _, err := resolveTextFlag(c, "content")
+		if err == nil {
+			t.Fatalf("expected error for missing file")
+		}
+		if !strings.Contains(err.Error(), "content-file") {
+			t.Errorf("error should mention --content-file, got %v", err)
+		}
+	})
+
+	t.Run("empty file is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + string(os.PathSeparator) + "empty.md"
+		if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+		c := newFlagTestCmd("description")
+		_ = c.Flags().Set("description-file", path)
+		_, _, err := resolveTextFlag(c, "description")
+		if err == nil {
+			t.Fatalf("expected error for empty file")
+		}
+	})
+
+	t.Run("file plus inline is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + string(os.PathSeparator) + "x.md"
+		if err := os.WriteFile(path, []byte("body"), 0o644); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+		c := newFlagTestCmd("description")
+		_ = c.Flags().Set("description", "inline")
+		_ = c.Flags().Set("description-file", path)
+		if _, _, err := resolveTextFlag(c, "description"); err == nil {
+			t.Fatalf("expected mutually-exclusive error for inline + file")
+		}
+	})
+
+	t.Run("file plus stdin is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + string(os.PathSeparator) + "x.md"
+		if err := os.WriteFile(path, []byte("body"), 0o644); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+		c := newFlagTestCmd("description")
+		_ = c.Flags().Set("description-stdin", "true")
+		_ = c.Flags().Set("description-file", path)
+		if _, _, err := resolveTextFlag(c, "description"); err == nil {
+			t.Fatalf("expected mutually-exclusive error for stdin + file")
 		}
 	})
 }

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1015,6 +1015,57 @@ func TestInjectRuntimeConfigDirectsMultiLineWritesToStdin(t *testing.T) {
 	}
 }
 
+// TestInjectRuntimeConfigWindowsRecommendsContentFile pins the Windows-specific
+// fallback added after issues #2198 / #2236, where Chinese characters in
+// agent-authored comments arrived as `?` because Windows PowerShell 5.1 and
+// cmd.exe re-encode piped HEREDOC bytes through the active console codepage,
+// dropping non-ASCII characters before they reach `multica`. The instructions
+// must point agents at `--content-file` / `--description-file` whenever the
+// daemon is hosted on Windows.
+func TestInjectRuntimeConfigWindowsRecommendsContentFile(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+
+	t.Run("windows host emits the file-based fallback", func(t *testing.T) {
+		runtimeGOOS = "windows"
+		dir := t.TempDir()
+		if err := InjectRuntimeConfig(dir, "codex", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
+			t.Fatalf("InjectRuntimeConfig failed: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+		if err != nil {
+			t.Fatalf("read AGENTS.md: %v", err)
+		}
+		s := string(data)
+		for _, want := range []string{
+			"Windows shell encoding caveat",
+			"console codepage",
+			"--content-file",
+			"--description-file",
+			"silently replaced with `?`",
+		} {
+			if !strings.Contains(s, want) {
+				t.Errorf("AGENTS.md missing Windows fallback guidance %q\n---\n%s", want, s)
+			}
+		}
+	})
+
+	t.Run("non-windows host omits the file-based fallback", func(t *testing.T) {
+		runtimeGOOS = "linux"
+		dir := t.TempDir()
+		if err := InjectRuntimeConfig(dir, "codex", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
+			t.Fatalf("InjectRuntimeConfig failed: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+		if err != nil {
+			t.Fatalf("read AGENTS.md: %v", err)
+		}
+		if strings.Contains(string(data), "Windows shell encoding caveat") {
+			t.Errorf("AGENTS.md should not surface Windows guidance when host is %s", runtimeGOOS)
+		}
+	})
+}
+
 func TestInjectRuntimeConfigCodexEmphasizesStdinForFormattedComments(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -989,8 +989,16 @@ func TestInjectRuntimeConfigRequiresExplicitCommentPost(t *testing.T) {
 // in stored comments because bash does not expand backslash escapes inside
 // double quotes; see MUL-1467. This test prevents the multi-line guidance
 // from silently regressing back into a "for special characters" footnote.
+//
+// Pins runtimeGOOS to "linux" so the test is deterministic regardless of
+// the host OS the test runner is on; the Windows branch has a separate
+// file-first contract pinned by TestInjectRuntimeConfigWindowsRecommendsContentFile.
+// Not parallel: mutates the package-level runtimeGOOS.
 func TestInjectRuntimeConfigDirectsMultiLineWritesToStdin(t *testing.T) {
-	t.Parallel()
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "linux"
+
 	dir := t.TempDir()
 	if err := InjectRuntimeConfig(dir, "claude", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
@@ -1016,17 +1024,17 @@ func TestInjectRuntimeConfigDirectsMultiLineWritesToStdin(t *testing.T) {
 }
 
 // TestInjectRuntimeConfigWindowsRecommendsContentFile pins the Windows-specific
-// fallback added after issues #2198 / #2236, where Chinese characters in
-// agent-authored comments arrived as `?` because Windows PowerShell 5.1 and
-// cmd.exe re-encode piped HEREDOC bytes through the active console codepage,
-// dropping non-ASCII characters before they reach `multica`. The instructions
-// must point agents at `--content-file` / `--description-file` whenever the
-// daemon is hosted on Windows.
+// rewrite added after issues #2198 / #2236: agent-authored comments arrive
+// as `?` because Windows PowerShell 5.1 and cmd.exe re-encode piped HEREDOC
+// bytes through the active console codepage, dropping non-ASCII bytes
+// before they reach `multica`. The Windows comment/description block is
+// rewritten file-first — there is no preceding "MUST pipe via stdin" /
+// `--description-stdin` directive that could override it.
 func TestInjectRuntimeConfigWindowsRecommendsContentFile(t *testing.T) {
 	saved := runtimeGOOS
 	t.Cleanup(func() { runtimeGOOS = saved })
 
-	t.Run("windows host emits the file-based fallback", func(t *testing.T) {
+	t.Run("windows host emits the file-first block", func(t *testing.T) {
 		runtimeGOOS = "windows"
 		dir := t.TempDir()
 		if err := InjectRuntimeConfig(dir, "codex", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
@@ -1038,19 +1046,39 @@ func TestInjectRuntimeConfigWindowsRecommendsContentFile(t *testing.T) {
 		}
 		s := string(data)
 		for _, want := range []string{
-			"Windows shell encoding caveat",
+			"On this Windows host",
 			"console codepage",
 			"--content-file",
 			"--description-file",
-			"silently replaced with `?`",
+			"silently drop non-ASCII characters as `?`",
 		} {
 			if !strings.Contains(s, want) {
-				t.Errorf("AGENTS.md missing Windows fallback guidance %q\n---\n%s", want, s)
+				t.Errorf("AGENTS.md missing Windows file-first guidance %q\n---\n%s", want, s)
+			}
+		}
+
+		// The Windows block must NOT carry over any prescriptive
+		// "use stdin" / "pipe a HEREDOC" directive: GPT-Boy's review noted
+		// that even a Windows caveat appended after MUST-stdin lines sets
+		// up a conflicting instruction the agent can latch onto. The
+		// Windows branch is now file-first; stdin appears only in
+		// anti-prescriptive prose like "do NOT pipe via `--content-stdin`",
+		// so the assertions below pin the prescriptive phrasings, not the
+		// bare flag names.
+		for _, banned := range []string{
+			"MUST pipe via stdin",
+			"use `--description-stdin` and pipe a HEREDOC",
+			"<<'COMMENT'",
+			"Agent-authored comments should always pipe content via stdin",
+			"always use `--content-stdin`",
+		} {
+			if strings.Contains(s, banned) {
+				t.Errorf("AGENTS.md still carries non-Windows stdin directive %q on Windows\n---\n%s", banned, s)
 			}
 		}
 	})
 
-	t.Run("non-windows host omits the file-based fallback", func(t *testing.T) {
+	t.Run("non-windows host keeps the stdin-first block", func(t *testing.T) {
 		runtimeGOOS = "linux"
 		dir := t.TempDir()
 		if err := InjectRuntimeConfig(dir, "codex", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
@@ -1060,14 +1088,33 @@ func TestInjectRuntimeConfigWindowsRecommendsContentFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read AGENTS.md: %v", err)
 		}
-		if strings.Contains(string(data), "Windows shell encoding caveat") {
+		s := string(data)
+		if strings.Contains(s, "On this Windows host") {
 			t.Errorf("AGENTS.md should not surface Windows guidance when host is %s", runtimeGOOS)
+		}
+		// On Linux the stdin/HEREDOC contract is the canonical multi-line
+		// guidance — pin that it is still present so we can't accidentally
+		// kill it for non-Windows hosts in a future refactor.
+		for _, want := range []string{
+			"MUST pipe via stdin",
+			"--content-stdin",
+			"--description-stdin",
+		} {
+			if !strings.Contains(s, want) {
+				t.Errorf("AGENTS.md missing Linux stdin guidance %q\n---\n%s", want, s)
+			}
 		}
 	})
 }
 
+// Pins runtimeGOOS to "linux": the Windows branch of the Codex paragraph is
+// covered by TestInjectRuntimeConfigWindowsCommentTriggerHasNoStdin. Not
+// parallel: mutates the package-level runtimeGOOS.
 func TestInjectRuntimeConfigCodexEmphasizesStdinForFormattedComments(t *testing.T) {
-	t.Parallel()
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "linux"
+
 	dir := t.TempDir()
 	if err := InjectRuntimeConfig(dir, "codex", TaskContextForEnv{
 		IssueID:          "issue-1",

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -11,9 +11,30 @@ import "fmt"
 // The explicit "do not reuse --parent from previous turns" wording exists
 // because resumed Claude sessions keep prior turns' tool calls in context
 // and will otherwise copy the old --parent UUID forward.
+//
+// On Windows the template switches to `--content-file` because piping a
+// HEREDOC through PowerShell 5.1 / cmd.exe re-encodes the bytes via the
+// active console codepage, dropping non-ASCII characters as `?` before they
+// reach `multica.exe` — see issues #2198 / #2236. Reading the body off disk
+// preserves UTF-8 verbatim.
 func BuildCommentReplyInstructions(issueID, triggerCommentID string) string {
 	if triggerCommentID == "" {
 		return ""
+	}
+	if runtimeGOOS == "windows" {
+		return fmt.Sprintf(
+			"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
+				"do NOT reuse --parent values from previous turns in this session.\n\n"+
+				"On Windows, write the reply body to a UTF-8 file with your file-write tool, then post it with `--content-file`. "+
+				"Do NOT pipe via `--content-stdin` — Windows PowerShell 5.1 and cmd.exe re-encode piped bytes through the active console codepage and silently drop non-ASCII characters as `?`. "+
+				"Do NOT use inline `--content`; it is easy to lose formatting or accidentally compress a structured reply into one line.\n\n"+
+				"Use this form, preserving the same issue ID and --parent value:\n\n"+
+				"    # 1. Write the reply body to a UTF-8 file (e.g. reply.md) with your file-write tool.\n"+
+				"    # 2. Then run:\n"+
+				"    multica issue comment add %s --parent %s --content-file ./reply.md\n\n"+
+				"Do NOT write literal `\\n` escapes to simulate line breaks; the file preserves real newlines.\n",
+			issueID, triggerCommentID,
+		)
 	}
 	return fmt.Sprintf(
 		"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -73,3 +73,123 @@ func TestInjectRuntimeConfigCommentTriggerUsesHelper(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildCommentReplyInstructionsWindowsUsesContentFile pins that on Windows
+// hosts every per-turn reply prompt — and the workflow block in CLAUDE.md /
+// AGENTS.md — points agents at `--content-file` instead of `--content-stdin`.
+// Without this, the Windows console codepage re-encodes piped HEREDOC bytes
+// and silently drops non-ASCII characters as `?` before they reach
+// `multica.exe` (issues #2198, #2236).
+//
+// Not parallel: mutates the package-level `runtimeGOOS`. Restores it via
+// t.Cleanup so any subsequent `t.Parallel()` tests see the original value.
+func TestBuildCommentReplyInstructionsWindowsUsesContentFile(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+
+	issueID := "11111111-1111-1111-1111-111111111111"
+	triggerID := "22222222-2222-2222-2222-222222222222"
+
+	t.Run("windows host points at --content-file", func(t *testing.T) {
+		runtimeGOOS = "windows"
+		got := BuildCommentReplyInstructions(issueID, triggerID)
+		for _, want := range []string{
+			"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file",
+			"--content-file",
+			"On Windows, write the reply body to a UTF-8 file",
+			"Do NOT pipe via `--content-stdin`",
+			"silently drop non-ASCII characters as `?`",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("Windows reply instructions missing %q\n---\n%s", want, got)
+			}
+		}
+		for _, banned := range []string{
+			"<<'COMMENT'",
+			"--content-stdin\n",
+			"cat <<",
+		} {
+			if strings.Contains(got, banned) {
+				t.Errorf("Windows reply instructions should not contain %q\n---\n%s", banned, got)
+			}
+		}
+	})
+
+	t.Run("non-windows host keeps --content-stdin HEREDOC", func(t *testing.T) {
+		runtimeGOOS = "linux"
+		got := BuildCommentReplyInstructions(issueID, triggerID)
+		for _, want := range []string{
+			"multica issue comment add " + issueID + " --parent " + triggerID + " --content-stdin",
+			"<<'COMMENT'",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("Linux reply instructions missing %q\n---\n%s", want, got)
+			}
+		}
+		if strings.Contains(got, "--content-file") {
+			t.Errorf("Linux reply instructions should not push --content-file\n---\n%s", got)
+		}
+	})
+}
+
+// TestInjectRuntimeConfigWindowsCommentTriggerHasNoStdin asserts the
+// end-to-end CLAUDE.md / AGENTS.md surface for a comment-triggered task on a
+// Windows daemon: the Available Commands section, the Codex-specific
+// paragraph, AND the per-turn reply template all line up on `--content-file`,
+// with no remaining `--content-stdin` directive that would override the
+// Windows fallback. Pins the bug GPT-Boy flagged on PR #2247: the original
+// fix only patched Available Commands, leaving the Codex section and per-turn
+// prompt still mandating stdin.
+func TestInjectRuntimeConfigWindowsCommentTriggerHasNoStdin(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "windows"
+
+	issueID := "11111111-1111-1111-1111-111111111111"
+	triggerID := "22222222-2222-2222-2222-222222222222"
+	ctx := TaskContextForEnv{
+		IssueID:          issueID,
+		TriggerCommentID: triggerID,
+	}
+
+	for _, provider := range []string{"claude", "codex"} {
+		t.Run(provider, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := InjectRuntimeConfig(dir, provider, ctx); err != nil {
+				t.Fatalf("InjectRuntimeConfig failed: %v", err)
+			}
+			fileName := "CLAUDE.md"
+			if provider != "claude" {
+				fileName = "AGENTS.md"
+			}
+			data, err := os.ReadFile(filepath.Join(dir, fileName))
+			if err != nil {
+				t.Fatalf("read %s: %v", fileName, err)
+			}
+			s := string(data)
+
+			for _, want := range []string{
+				"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file",
+				"--content-file",
+				"--description-file",
+				"Windows shell encoding caveat",
+			} {
+				if !strings.Contains(s, want) {
+					t.Errorf("%s missing %q\n---\n%s", fileName, want, s)
+				}
+			}
+
+			// The per-turn reply template, the Codex paragraph, and the
+			// Available Commands section must NOT end up directing the agent
+			// at stdin — that is the exact pattern Windows shells mangle.
+			for _, banned := range []string{
+				"--parent " + triggerID + " --content-stdin",
+				"always use `--content-stdin` with a HEREDOC, even for short single-line replies",
+			} {
+				if strings.Contains(s, banned) {
+					t.Errorf("%s still steers agent at stdin: %q\n---\n%s", fileName, banned, s)
+				}
+			}
+		})
+	}
+}

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -7,8 +7,13 @@ import (
 	"testing"
 )
 
+// Pins runtimeGOOS to "linux": the Windows reply template has its own
+// dedicated test (TestBuildCommentReplyInstructionsWindowsUsesContentFile).
+// Not parallel: mutates the package-level runtimeGOOS.
 func TestBuildCommentReplyInstructionsIncludesTriggerID(t *testing.T) {
-	t.Parallel()
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "linux"
 
 	issueID := "11111111-1111-1111-1111-111111111111"
 	triggerID := "22222222-2222-2222-2222-222222222222"
@@ -42,8 +47,13 @@ func TestBuildCommentReplyInstructionsEmptyWhenNoTrigger(t *testing.T) {
 	}
 }
 
+// Pins runtimeGOOS to "linux" so the helper output is deterministic.
+// Not parallel: mutates the package-level runtimeGOOS.
 func TestInjectRuntimeConfigCommentTriggerUsesHelper(t *testing.T) {
-	t.Parallel()
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "linux"
+
 	dir := t.TempDir()
 
 	issueID := "11111111-1111-1111-1111-111111111111"
@@ -172,19 +182,31 @@ func TestInjectRuntimeConfigWindowsCommentTriggerHasNoStdin(t *testing.T) {
 				"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file",
 				"--content-file",
 				"--description-file",
-				"Windows shell encoding caveat",
+				"On this Windows host",
 			} {
 				if !strings.Contains(s, want) {
 					t.Errorf("%s missing %q\n---\n%s", fileName, want, s)
 				}
 			}
 
-			// The per-turn reply template, the Codex paragraph, and the
-			// Available Commands section must NOT end up directing the agent
-			// at stdin — that is the exact pattern Windows shells mangle.
+			// The Available Commands section, the Codex paragraph, and the
+			// per-turn reply template must NOT end up prescriptively
+			// directing the agent at stdin — that is the exact pattern
+			// Windows shells mangle. Covers GPT-Boy's second blocker on
+			// PR #2247: the original Windows-only fallback was appended
+			// *after* unconditional "MUST pipe via stdin" /
+			// `--description-stdin` lines, leaving agents with
+			// conflicting instructions. We pin the prescriptive
+			// phrasings (not bare flag names) so anti-prescriptive prose
+			// like "do NOT pipe via `--content-stdin`" doesn't trip the
+			// ban.
 			for _, banned := range []string{
 				"--parent " + triggerID + " --content-stdin",
 				"always use `--content-stdin` with a HEREDOC, even for short single-line replies",
+				"MUST pipe via stdin",
+				"use `--description-stdin` and pipe a HEREDOC",
+				"<<'COMMENT'",
+				"Agent-authored comments should always pipe content via stdin",
 			} {
 				if strings.Contains(s, banned) {
 					t.Errorf("%s still steers agent at stdin: %q\n---\n%s", fileName, banned, s)

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -172,9 +172,15 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 
 	if provider == "codex" {
 		b.WriteString("## Codex-Specific Comment Formatting\n\n")
-		b.WriteString("Codex often follows the per-turn reply command literally. For issue comments, always use `--content-stdin` with a HEREDOC, even for short single-line replies. ")
-		b.WriteString("Never use inline `--content` for agent-authored comments. Keep the same `--parent` value from the trigger comment when replying. ")
-		b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
+		if runtimeGOOS == "windows" {
+			b.WriteString("Codex often follows the per-turn reply command literally. On Windows, **always write the comment body to a UTF-8 file with your file-write tool first, then post it with `--content-file <path>`** — do NOT pipe via `--content-stdin`. PowerShell 5.1 / cmd.exe re-encode piped bytes through the active console codepage and silently drop non-ASCII characters as `?`. Never use inline `--content` for agent-authored comments. ")
+			b.WriteString("Keep the same `--parent` value from the trigger comment when replying. ")
+			b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
+		} else {
+			b.WriteString("Codex often follows the per-turn reply command literally. For issue comments, always use `--content-stdin` with a HEREDOC, even for short single-line replies. ")
+			b.WriteString("Never use inline `--content` for agent-authored comments. Keep the same `--parent` value from the trigger comment when replying. ")
+			b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
+		}
 	}
 
 	// Inject available repositories section.

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -5,8 +5,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
+
+// runtimeGOOS is the host-platform string used by buildMetaSkillContent to
+// emit Windows-specific guidance. Defaults to runtime.GOOS; tests override
+// it to exercise the cross-platform branches deterministically without
+// having to run on every target OS.
+var runtimeGOOS = runtime.GOOS
 
 // formatProjectResource renders a single resource as a human-readable bullet.
 // Unknown resource types fall back to a JSON-encoded ref so the agent can
@@ -144,6 +151,18 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("    ```\n")
 	b.WriteString("\n")
 	b.WriteString("  - The same rule applies to `--description` on `multica issue create` and `multica issue update` — use `--description-stdin` and pipe a HEREDOC for any multi-line description; the inline `--description \"...\"` form is for short single-line text only.\n")
+	if runtimeGOOS == "windows" {
+		b.WriteString("  - **Windows shell encoding caveat — read this when your content contains non-ASCII characters (Chinese, Japanese, accents, emoji, etc.).** Windows PowerShell 5.1 (the default on Win11) and `cmd.exe` re-encode piped bytes through the console codepage before they reach `multica`. Characters the active codepage cannot represent are silently replaced with `?`, so `中文` arrives as `??`. To avoid the loss, write the body to a UTF-8 file with your file-write tool and pass `--content-file <path>` (or `--description-file <path>`) instead of piping. The file flag reads bytes directly off disk and skips the shell entirely:\n")
+		b.WriteString("\n")
+		b.WriteString("    ```\n")
+		b.WriteString("    # 1. Write the comment body to a UTF-8 file using your write_file / Write tool.\n")
+		b.WriteString("    # 2. Then run:\n")
+		b.WriteString("    multica issue comment add <issue-id> --content-file ./comment.md\n")
+		b.WriteString("    multica issue create --title \"...\" --description-file ./desc.md\n")
+		b.WriteString("    ```\n")
+		b.WriteString("\n")
+		b.WriteString("    The `--content-file` / `--description-file` flags accept any UTF-8 file path; the file may live anywhere your tool can write to. Prefer them over stdin on Windows whenever the body contains non-ASCII text.\n")
+	}
 	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
 	b.WriteString("- `multica label create --name \"...\" --color \"#hex\"` — Define a new workspace label (use this only when the label you need does not exist yet; reuse existing labels via `multica label list` first)\n")
 	b.WriteString("- `multica autopilot create --title \"...\" --agent <name> --mode create_issue [--description \"...\"]` — Create an autopilot\n")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -139,29 +139,37 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica issue label remove <issue-id> <label-id>` — Detach a label from an issue\n")
 	b.WriteString("- `multica issue subscriber add <issue-id> [--user <name>|--user-id <uuid>]` — Subscribe a member or agent to issue updates (defaults to the caller when neither flag is set; the two flags are mutually exclusive)\n")
 	b.WriteString("- `multica issue subscriber remove <issue-id> [--user <name>|--user-id <uuid>]` — Unsubscribe a member or agent\n")
-	b.WriteString("- `multica issue comment add <issue-id> --content-stdin [--parent <comment-id>] [--attachment <path>]` — Post a comment. Agent-authored comments should always pipe content via stdin, even for short single-line replies. Use `--parent` to reply to a specific comment; `--attachment` may be repeated.\n")
-	b.WriteString("  - **For comment content, you MUST pipe via stdin; this is mandatory for multi-line content (anything with line breaks, paragraphs, code blocks, backticks, or quotes).** Do not use inline `--content` and do not write `\\n` escapes. Use a HEREDOC instead:\n")
-	b.WriteString("\n")
-	b.WriteString("    ```\n")
-	b.WriteString("    cat <<'COMMENT' | multica issue comment add <issue-id> --content-stdin\n")
-	b.WriteString("    First paragraph.\n")
-	b.WriteString("\n")
-	b.WriteString("    Second paragraph with `code` and \"quotes\".\n")
-	b.WriteString("    COMMENT\n")
-	b.WriteString("    ```\n")
-	b.WriteString("\n")
-	b.WriteString("  - The same rule applies to `--description` on `multica issue create` and `multica issue update` — use `--description-stdin` and pipe a HEREDOC for any multi-line description; the inline `--description \"...\"` form is for short single-line text only.\n")
 	if runtimeGOOS == "windows" {
-		b.WriteString("  - **Windows shell encoding caveat — read this when your content contains non-ASCII characters (Chinese, Japanese, accents, emoji, etc.).** Windows PowerShell 5.1 (the default on Win11) and `cmd.exe` re-encode piped bytes through the console codepage before they reach `multica`. Characters the active codepage cannot represent are silently replaced with `?`, so `中文` arrives as `??`. To avoid the loss, write the body to a UTF-8 file with your file-write tool and pass `--content-file <path>` (or `--description-file <path>`) instead of piping. The file flag reads bytes directly off disk and skips the shell entirely:\n")
+		// Windows shells (PowerShell 5.1, cmd.exe) re-encode piped HEREDOC
+		// bytes through the active console codepage before they reach
+		// `multica.exe`, silently replacing characters the codepage cannot
+		// represent with `?`. Steer the agent at `--content-file` /
+		// `--description-file` from the start so there is no contradicting
+		// "MUST pipe via stdin" line for the agent to latch onto. See
+		// issues #2198 / #2236.
+		b.WriteString("- `multica issue comment add <issue-id> --content-file <path> [--parent <comment-id>] [--attachment <path>]` — Post a comment. **On this Windows host, write the body to a UTF-8 file with your file-write tool first, then pass the path via `--content-file` — do NOT pipe via `--content-stdin`.** PowerShell 5.1 and `cmd.exe` re-encode piped bytes through the active console codepage and silently drop non-ASCII characters as `?`, so `中文` arrives as `??`. Use `--parent` to reply to a specific comment; `--attachment` may be repeated.\n")
+		b.WriteString("  - **For comment content, write a UTF-8 file then pass `--content-file <path>`; this preserves multi-line content and non-ASCII bytes (Chinese, Japanese, accents, emoji) verbatim.** Do not use inline `--content` and do not write `\\n` escapes. Example:\n")
 		b.WriteString("\n")
 		b.WriteString("    ```\n")
-		b.WriteString("    # 1. Write the comment body to a UTF-8 file using your write_file / Write tool.\n")
+		b.WriteString("    # 1. Write the comment body to a UTF-8 file using your file-write tool.\n")
 		b.WriteString("    # 2. Then run:\n")
 		b.WriteString("    multica issue comment add <issue-id> --content-file ./comment.md\n")
-		b.WriteString("    multica issue create --title \"...\" --description-file ./desc.md\n")
 		b.WriteString("    ```\n")
 		b.WriteString("\n")
-		b.WriteString("    The `--content-file` / `--description-file` flags accept any UTF-8 file path; the file may live anywhere your tool can write to. Prefer them over stdin on Windows whenever the body contains non-ASCII text.\n")
+		b.WriteString("  - The same rule applies to `--description` on `multica issue create` and `multica issue update` — write the body to a UTF-8 file with your file-write tool and pass `--description-file <path>`. The inline `--description \"...\"` form is acceptable only for ASCII-only single-line text. Do NOT use `--description-stdin` on this host.\n")
+	} else {
+		b.WriteString("- `multica issue comment add <issue-id> --content-stdin [--parent <comment-id>] [--attachment <path>]` — Post a comment. Agent-authored comments should always pipe content via stdin, even for short single-line replies. Use `--parent` to reply to a specific comment; `--attachment` may be repeated.\n")
+		b.WriteString("  - **For comment content, you MUST pipe via stdin; this is mandatory for multi-line content (anything with line breaks, paragraphs, code blocks, backticks, or quotes).** Do not use inline `--content` and do not write `\\n` escapes. Use a HEREDOC instead:\n")
+		b.WriteString("\n")
+		b.WriteString("    ```\n")
+		b.WriteString("    cat <<'COMMENT' | multica issue comment add <issue-id> --content-stdin\n")
+		b.WriteString("    First paragraph.\n")
+		b.WriteString("\n")
+		b.WriteString("    Second paragraph with `code` and \"quotes\".\n")
+		b.WriteString("    COMMENT\n")
+		b.WriteString("    ```\n")
+		b.WriteString("\n")
+		b.WriteString("  - The same rule applies to `--description` on `multica issue create` and `multica issue update` — use `--description-stdin` and pipe a HEREDOC for any multi-line description; the inline `--description \"...\"` form is for short single-line text only.\n")
 	}
 	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
 	b.WriteString("- `multica label create --name \"...\" --color \"#hex\"` — Define a new workspace label (use this only when the label you need does not exist yet; reuse existing labels via `multica label list` first)\n")


### PR DESCRIPTION
## Summary

- Windows PowerShell 5.1 and `cmd.exe` re-encode piped HEREDOC bytes through the active console codepage before they reach `multica.exe`. Characters the codepage cannot represent are silently replaced with `?`, so agents on Chinese Win11 hosts emit `--content-stdin` / `--description-stdin` content where every Chinese character becomes `?` (see #2198, #2236). The `daemon.log` shows the original Chinese because `slog` writes to a file directly — the regression only surfaces in the comment / issue body.
- Add `--content-file <path>` / `--description-file <path>` to `multica issue comment add` and `multica issue {create,update}`. The CLI reads the file straight off disk, preserves UTF-8 bytes verbatim, and skips the shell entirely.
- The runtime config injected into `AGENTS.md` / `CLAUDE.md` now emits a Windows-only fallback section that points agents at the new flags whenever the daemon host runs on Windows; non-Windows hosts keep the existing stdin/HEREDOC guidance untouched.

## Test plan

- [x] `go test ./server/cmd/multica/ -run TestResolveTextFlag` — covers file body preservation with non-ASCII (`标题 / 中文段落`), missing-file error, empty-file rejection, and mutual exclusion against inline / stdin.
- [x] `go test ./server/internal/daemon/execenv/ -run TestInjectRuntimeConfigWindowsRecommendsContentFile` — pins that Windows hosts surface the new fallback (`--content-file`, `--description-file`, `Windows shell encoding caveat`) and non-Windows hosts do not.
- [x] `go vet ./...` clean.
- [ ] Manual repro on Win11 with codex CLI: assign an issue containing Chinese, confirm the agent now writes via `--content-file` and the comment renders Chinese instead of `?`.