### PR TITLE
feat(agent): add qwenpaw as a first-class agent provider

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,41 @@
+name: Daily Sync from Upstream
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # 每天 UTC 0:00 (北京时间 8:00)
+  workflow_dispatch:      # 支持手动触发
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: v0.x-bump
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/multica-ai/multica.git
+          git fetch upstream
+
+      - name: Merge upstream/main into v0.x-bump
+        run: |
+          git merge upstream/main --no-edit || {
+            echo "Merge conflict detected, creating PR for manual resolution"
+            git checkout -b sync/$(date +%Y%m%d)
+            git add -A
+            git commit -m "chore: resolve merge conflicts $(date +%Y%m%d)"
+            git push origin sync/$(date +%Y%m%d) \
+              -o merge_request.create \
+              -o merge_request.title="Sync: resolve merge conflicts $(date +%Y%m%d)"
+            exit 1
+          }
+
+      - name: Push to origin
+        run: git push origin v0.x-bump

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	CLIVersion                     string                // multica CLI version (e.g. "0.1.13")
 	LaunchedBy                     string                // "desktop" when spawned by the Electron app, empty for standalone
 	Profile                        string                // profile name (empty = default)
-	Agents                         map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro
+	Agents                         map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, qwenpaw
 	WorkspacesRoot                 string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask               bool                  // preserve env after task for debugging
 	HealthPort                     int                   // local HTTP port for health checks (default: 19514)
@@ -174,8 +174,15 @@ func LoadConfig(overrides Overrides) (Config, error) {
 			Model: strings.TrimSpace(os.Getenv("MULTICA_KIRO_MODEL")),
 		}
 	}
+	qwenpawPath := envOrDefault("MULTICA_QWENPAW_PATH", "qwenpaw")
+	if _, err := exec.LookPath(qwenpawPath); err == nil {
+		agents["qwenpaw"] = AgentEntry{
+			Path:  qwenpawPath,
+			Model: strings.TrimSpace(os.Getenv("MULTICA_QWENPAW_MODEL")),
+		}
+	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, or kiro-cli and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, kiro-cli, or qwenpaw and ensure it is on PATH")
 	}
 
 	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -56,13 +56,14 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Cursor:   writes {workDir}/AGENTS.md  (skills discovered natively from .cursor/skills/)
 // For Kimi:     writes {workDir}/AGENTS.md  (Kimi Code CLI reads AGENTS.md natively; skills auto-discovered from project skills dirs)
 // For Kiro:     writes {workDir}/AGENTS.md  (Kiro CLI reads AGENTS.md natively; skills auto-discovered from project skills dirs)
+// For QwenPaw:  writes {workDir}/AGENTS.md  (QwenPaw ACP reads the task workspace)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) error {
 	content := buildMetaSkillContent(provider, ctx)
 
 	switch provider {
 	case "claude":
 		return os.WriteFile(filepath.Join(workDir, "CLAUDE.md"), []byte(content), 0o644)
-	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro":
+	case "codex", "copilot", "opencode", "openclaw", "hermes", "pi", "cursor", "kimi", "kiro", "qwenpaw":
 		return os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte(content), 0o644)
 	case "gemini":
 		return os.WriteFile(filepath.Join(workDir, "GEMINI.md"), []byte(content), 0o644)
@@ -276,8 +277,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro":
 			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, Kimi, and Kiro discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "gemini", "hermes":
-			// Gemini reads GEMINI.md directly; Hermes has no native skills discovery path
+		case "gemini", "hermes", "qwenpaw":
+			// Gemini reads GEMINI.md directly; Hermes and QwenPaw have no native skills discovery path
 			// wired up in resolveSkillsDir, so both fall back to .agent_context/skills/.
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")
 		default:

--- a/server/internal/daemon/qwenpaw_config_test.go
+++ b/server/internal/daemon/qwenpaw_config_test.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLoadConfigDiscoversQwenPaw(t *testing.T) {
+	dir := t.TempDir()
+	name := "qwenpaw"
+	script := []byte("#!/usr/bin/env sh\nexit 0\n")
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+		script = []byte("@echo off\r\nexit /b 0\r\n")
+	}
+	fakeQwenPaw := filepath.Join(dir, name)
+	if err := os.WriteFile(fakeQwenPaw, script, 0o755); err != nil {
+		t.Fatalf("write fake qwenpaw: %v", err)
+	}
+
+	t.Setenv("MULTICA_QWENPAW_PATH", fakeQwenPaw)
+	t.Setenv("MULTICA_QWENPAW_MODEL", "dashscope:qwen3.6-plus")
+	t.Setenv("MULTICA_QWENPAW_BYPASS_PERMISSIONS", "false")
+
+	cfg, err := LoadConfig(Overrides{DaemonID: "test-daemon"})
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	entry, ok := cfg.Agents["qwenpaw"]
+	if !ok {
+		t.Fatalf("qwenpaw agent not discovered: %#v", cfg.Agents)
+	}
+	if entry.Path != fakeQwenPaw {
+		t.Fatalf("qwenpaw path = %q, want %q", entry.Path, fakeQwenPaw)
+	}
+	if entry.Model != "dashscope:qwen3.6-plus" {
+		t.Fatalf("qwenpaw model = %q", entry.Model)
+	}
+}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,6 +1,6 @@
 // Package agent provides a unified interface for executing prompts via
 // coding agents (Claude Code, Codex, Copilot, OpenCode, OpenClaw, Hermes,
-// Gemini, Pi, Cursor, Kimi, Kiro). It mirrors the happy-cli AgentBackend
+// Gemini, Pi, Cursor, Kimi, Kiro, QwenPaw). It mirrors the happy-cli AgentBackend
 // pattern, translated to idiomatic Go.
 package agent
 
@@ -89,13 +89,13 @@ type Result struct {
 
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli)
+	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli, qwenpaw)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro".
+// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro", "qwenpaw".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -124,8 +124,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &kimiBackend{cfg: cfg}, nil
 	case "kiro":
 		return &kiroBackend{cfg: cfg}, nil
+	case "qwenpaw":
+		return &qwenpawBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, qwenpaw)", agentType)
 	}
 }
 
@@ -152,6 +154,7 @@ var launchHeaders = map[string]string{
 	"pi":       "pi (json mode)",
 	"kimi":     "kimi acp",
 	"kiro":     "kiro-cli acp",
+	"qwenpaw":  "qwenpaw acp",
 }
 
 // LaunchHeader returns the user-visible launch skeleton for agentType, or an

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -72,7 +72,7 @@ func TestLaunchHeaderCoversAllSupportedBackends(t *testing.T) {
 	// entry to launchHeaders in agent.go and extend this list.
 	supported := []string{
 		"claude", "codex", "copilot", "cursor", "gemini",
-		"hermes", "kimi", "kiro", "openclaw", "opencode", "pi",
+		"hermes", "kimi", "kiro", "openclaw", "opencode", "pi", "qwenpaw",
 	}
 	for _, t_ := range supported {
 		if header := LaunchHeader(t_); header == "" {

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -79,6 +79,8 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverKiroModels(ctx, executablePath)
 		})
+	case "qwenpaw":
+		return []Model{}, nil
 	case "opencode":
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverOpenCodeModels(ctx, executablePath)

--- a/server/pkg/agent/qwenpaw.go
+++ b/server/pkg/agent/qwenpaw.go
@@ -1,0 +1,406 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// qwenpawBlockedArgs are flags hardcoded by the daemon that must not be
+// overridden by user-configured custom_args. QwenPaw is launched as an ACP
+// stdio server and the Multica task directory is passed as the QwenPaw
+// workspace so file tools operate inside the isolated task environment.
+var qwenpawBlockedArgs = map[string]blockedArgMode{
+	"acp":                  blockedStandalone,
+	"--bypass-permissions": blockedStandalone,
+	"--workspace":          blockedWithValue,
+}
+
+// qwenpawBackend implements Backend by spawning `qwenpaw acp` and speaking the
+// standard ACP JSON-RPC transport over stdin/stdout. It reuses Multica's shared
+// hermesClient ACP adapter because QwenPaw's `qwenpaw acp` command uses the
+// official agent-client-protocol SDK.
+type qwenpawBackend struct {
+	cfg Config
+}
+
+func (b *qwenpawBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "qwenpaw"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("qwenpaw executable not found at %q: %w", execPath, err)
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	qwenpawArgs := []string{"acp"}
+	if qwenpawBypassPermissions(b.cfg.Env) {
+		qwenpawArgs = append(qwenpawArgs, "--bypass-permissions")
+	}
+	if opts.Cwd != "" {
+		qwenpawArgs = append(qwenpawArgs, "--workspace", opts.Cwd)
+	}
+	qwenpawArgs = append(qwenpawArgs, filterCustomArgs(opts.CustomArgs, qwenpawBlockedArgs, b.cfg.Logger)...)
+
+	cmd := exec.CommandContext(runCtx, execPath, qwenpawArgs...)
+	hideAgentWindow(cmd)
+	b.cfg.Logger.Info("agent command", "exec", execPath, "args", qwenpawArgs)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("qwenpaw stdout pipe: %w", err)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("qwenpaw stdin pipe: %w", err)
+	}
+	providerErr := newACPProviderErrorSniffer("qwenpaw")
+	cmd.Stderr = io.MultiWriter(newLogWriter(b.cfg.Logger, "[qwenpaw:stderr] "), providerErr)
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("start qwenpaw: %w", err)
+	}
+
+	b.cfg.Logger.Info("qwenpaw acp started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	var outputMu sync.Mutex
+	var output strings.Builder
+	var streamingCurrentTurn atomic.Bool
+
+	promptDone := make(chan hermesPromptResult, 1)
+
+	c := &hermesClient{
+		cfg:          b.cfg,
+		stdin:        stdin,
+		pending:      make(map[int]*pendingRPC),
+		pendingTools: make(map[string]*pendingToolCall),
+		acceptNotification: func(string) bool {
+			return streamingCurrentTurn.Load()
+		},
+		onMessage: func(msg Message) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
+			if msg.Type == MessageToolUse {
+				msg.Tool = qwenpawToolNameFromTitle(msg.Tool)
+			}
+			if msg.Type == MessageText {
+				outputMu.Lock()
+				output.WriteString(msg.Content)
+				outputMu.Unlock()
+			}
+			trySend(msgCh, msg)
+		},
+		onPromptDone: func(result hermesPromptResult) {
+			if !streamingCurrentTurn.Load() {
+				return
+			}
+			select {
+			case promptDone <- result:
+			default:
+			}
+		},
+	}
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			c.handleLine(line)
+		}
+		c.closeAllPending(fmt.Errorf("qwenpaw process exited"))
+	}()
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+		defer func() {
+			_ = stdin.Close()
+			_ = cmd.Wait()
+		}()
+
+		startTime := time.Now()
+		finalStatus := "completed"
+		var finalError string
+		var sessionID string
+
+		_, err := c.request(runCtx, "initialize", map[string]any{
+			"protocolVersion": 1,
+			"clientInfo": map[string]any{
+				"name":    "multica-agent-sdk",
+				"version": "0.2.0",
+			},
+			"clientCapabilities": map[string]any{},
+		})
+		if err != nil {
+			finalStatus = "failed"
+			finalError = fmt.Sprintf("qwenpaw initialize failed: %v", err)
+			resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		cwd := opts.Cwd
+		if cwd == "" {
+			cwd = "."
+		}
+
+		if opts.ResumeSessionID != "" {
+			result, err := qwenpawLoadOrResumeSession(runCtx, c, cwd, opts.ResumeSessionID)
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("qwenpaw session/load failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			var changed bool
+			sessionID, changed = resolveResumedSessionID(opts.ResumeSessionID, result)
+			if changed {
+				b.cfg.Logger.Warn("agent returned a different session id on resume; continuing with the new id",
+					"backend", "qwenpaw",
+					"requested", opts.ResumeSessionID,
+					"actual", sessionID,
+				)
+			}
+		} else {
+			result, err := c.request(runCtx, "session/new", map[string]any{
+				"cwd":        cwd,
+				"mcpServers": []any{},
+			})
+			if err != nil {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("qwenpaw session/new failed: %v", err)
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+			sessionID = extractACPSessionID(result)
+			if sessionID == "" {
+				finalStatus = "failed"
+				finalError = "qwenpaw session/new returned no session ID"
+				resCh <- Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
+				return
+			}
+		}
+
+		c.sessionID = sessionID
+		b.cfg.Logger.Info("qwenpaw session created", "session_id", sessionID)
+
+		if qwenpawBypassPermissions(b.cfg.Env) {
+			if _, err := c.request(runCtx, "session/set_config_option", map[string]any{
+				"sessionId":  sessionID,
+				"session_id": sessionID,
+				"configId":   "mode",
+				"config_id":  "mode",
+				"value":      "bypassPermissions",
+			}); err != nil {
+				b.cfg.Logger.Warn("qwenpaw bypassPermissions mode was not accepted; continuing with QwenPaw defaults", "error", err)
+			}
+		}
+
+		if opts.Model != "" {
+			if _, err := c.request(runCtx, "session/set_model", map[string]any{
+				"sessionId": sessionID,
+				"modelId":   opts.Model,
+			}); err != nil {
+				b.cfg.Logger.Warn("qwenpaw set_session_model failed", "error", err, "requested_model", opts.Model)
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("qwenpaw could not switch to model %q: %v", opts.Model, err)
+				resCh <- Result{
+					Status:     finalStatus,
+					Error:      finalError,
+					DurationMs: time.Since(startTime).Milliseconds(),
+					SessionID:  sessionID,
+				}
+				return
+			}
+			b.cfg.Logger.Info("qwenpaw session model set", "model", opts.Model)
+		}
+
+		userText := prompt
+		if opts.SystemPrompt != "" {
+			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
+		}
+		promptBlocks := []map[string]any{
+			{"type": "text", "text": userText},
+		}
+
+		streamingCurrentTurn.Store(true)
+		_, err = c.request(runCtx, "session/prompt", map[string]any{
+			"sessionId": sessionID,
+			"content":   promptBlocks,
+			"prompt":    promptBlocks,
+		})
+		if err != nil {
+			if runCtx.Err() == context.DeadlineExceeded {
+				finalStatus = "timeout"
+				finalError = fmt.Sprintf("qwenpaw timed out after %s", timeout)
+			} else if runCtx.Err() == context.Canceled {
+				finalStatus = "aborted"
+				finalError = "execution cancelled"
+			} else {
+				finalStatus = "failed"
+				finalError = fmt.Sprintf("qwenpaw session/prompt failed: %v", err)
+			}
+		} else {
+			select {
+			case pr := <-promptDone:
+				if pr.stopReason == "cancelled" {
+					finalStatus = "aborted"
+					finalError = "qwenpaw cancelled the prompt"
+				}
+				c.usageMu.Lock()
+				c.usage.InputTokens += pr.usage.InputTokens
+				c.usage.OutputTokens += pr.usage.OutputTokens
+				c.usageMu.Unlock()
+			default:
+			}
+		}
+
+		duration := time.Since(startTime)
+		b.cfg.Logger.Info("qwenpaw finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		_ = stdin.Close()
+		cancel()
+		<-readerDone
+
+		outputMu.Lock()
+		finalOutput := output.String()
+		outputMu.Unlock()
+
+		if finalStatus == "completed" && finalOutput == "" {
+			if msg := providerErr.message(); msg != "" {
+				finalStatus = "failed"
+				finalError = msg
+			}
+		}
+
+		c.usageMu.Lock()
+		u := c.usage
+		c.usageMu.Unlock()
+
+		var usageMap map[string]TokenUsage
+		if u.InputTokens > 0 || u.OutputTokens > 0 || u.CacheReadTokens > 0 {
+			model := opts.Model
+			if model == "" {
+				model = "unknown"
+			}
+			usageMap = map[string]TokenUsage{model: u}
+		}
+
+		resCh <- Result{
+			Status:     finalStatus,
+			Output:     finalOutput,
+			Error:      finalError,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  sessionID,
+			Usage:      usageMap,
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func qwenpawLoadOrResumeSession(ctx context.Context, c *hermesClient, cwd, sessionID string) ([]byte, error) {
+	result, err := c.request(ctx, "session/load", map[string]any{
+		"cwd":        cwd,
+		"sessionId":  sessionID,
+		"mcpServers": []any{},
+	})
+	if err == nil {
+		return result, nil
+	}
+	return c.request(ctx, "session/resume", map[string]any{
+		"cwd":        cwd,
+		"sessionId":  sessionID,
+		"mcpServers": []any{},
+	})
+}
+
+func qwenpawBypassPermissions(env map[string]string) bool {
+	if value := strings.TrimSpace(env["MULTICA_QWENPAW_BYPASS_PERMISSIONS"]); value != "" {
+		switch strings.ToLower(value) {
+		case "0", "false", "no", "off":
+			return false
+		default:
+			return true
+		}
+	}
+	if value := strings.TrimSpace(os.Getenv("MULTICA_QWENPAW_BYPASS_PERMISSIONS")); value != "" {
+		switch strings.ToLower(value) {
+		case "0", "false", "no", "off":
+			return false
+		default:
+			return true
+		}
+	}
+	return true
+}
+
+func qwenpawToolNameFromTitle(title string) string {
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return ""
+	}
+	if idx := strings.Index(t, ":"); idx > 0 {
+		t = strings.TrimSpace(t[:idx])
+	}
+
+	lower := strings.ToLower(t)
+	// Check exact matches first, then prefix-based fallbacks.
+	// Order matters: check exact "file_search" before prefix "file" → "file_search" is wrong.
+	switch lower {
+	case "read", "read file", "file_read", "file reader":
+		return "read_file"
+	case "write", "write file", "file_write":
+		return "write_file"
+	case "edit", "patch", "apply patch":
+		return "edit_file"
+	case "shell", "bash", "terminal", "execute_shell_command", "run command", "run shell command":
+		return "terminal"
+	case "glob":
+		return "glob"
+	case "file_search":
+		return "search_files"
+	case "search_query":
+		return "web_search"
+	case "web search":
+		return "web_search"
+	case "fetch", "web fetch", "open":
+		return "web_fetch"
+	case "todo", "todo write", "todo_list":
+		return "todo_write"
+	}
+	if strings.HasPrefix(lower, "grep") || strings.HasPrefix(lower, "search") || strings.HasPrefix(lower, "find") {
+		return "search_files"
+	}
+	return strings.ReplaceAll(lower, " ", "_")
+}

--- a/server/pkg/agent/qwenpaw_test.go
+++ b/server/pkg/agent/qwenpaw_test.go
@@ -1,0 +1,453 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestQwenPawBypassPermissionsDefault(t *testing.T) {
+	env := map[string]string{}
+	if !qwenpawBypassPermissions(env) {
+		t.Fatal("expected bypassPermissions to be enabled by default when env is empty")
+	}
+}
+
+func TestQwenPawBypassPermissionsDisabledByEnvMap(t *testing.T) {
+	env := map[string]string{"MULTICA_QWENPAW_BYPASS_PERMISSIONS": "false"}
+	if qwenpawBypassPermissions(env) {
+		t.Fatal("expected false env value to disable bypassPermissions")
+	}
+}
+
+func TestQwenPawBypassPermissionsDisabledByEnvMapOff(t *testing.T) {
+	for _, v := range []string{"0", "false", "no", "off"} {
+		env := map[string]string{"MULTICA_QWENPAW_BYPASS_PERMISSIONS": v}
+		if qwenpawBypassPermissions(env) {
+			t.Fatalf("expected %q to disable bypassPermissions", v)
+		}
+	}
+}
+
+func TestQwenPawBypassPermissionsEnabledByEnvMap(t *testing.T) {
+	for _, v := range []string{"1", "true", "yes", "anything-else"} {
+		env := map[string]string{"MULTICA_QWENPAW_BYPASS_PERMISSIONS": v}
+		if !qwenpawBypassPermissions(env) {
+			t.Fatalf("expected %q to enable bypassPermissions", v)
+		}
+	}
+}
+
+func TestQwenPawToolNameFromTitle(t *testing.T) {
+	tests := map[string]string{
+		"execute_shell_command":   "terminal",
+		"Run command: git status":   "terminal",
+		"Read file: README.md":      "read_file",
+		"file_search":               "search_files",
+		"Apply Patch":               "edit_file",
+		"Shell: ls -la":             "terminal",
+		"Read: /path/to/file":       "read_file",
+		"Write: new content":        "write_file",
+		"Edit: line 42":             "edit_file",
+		"Search: pattern":            "search_files",
+		"grep in files":             "search_files",
+		"Glob: **/*.go":             "glob",
+		"Web Search: latest news":   "web_search",
+		"search_query: weather":      "web_search",
+		"Fetch: https://example.com": "web_fetch",
+		"Open: https://example.com": "web_fetch",
+		"Todo write":                "todo_write",
+		"custom tool":               "custom_tool",
+		"":                          "",
+		"Read":                      "read_file",
+	}
+
+	for input, want := range tests {
+		got := qwenpawToolNameFromTitle(input)
+		if got != want {
+			t.Fatalf("qwenpawToolNameFromTitle(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestQwenPawBackendSmokeACP(t *testing.T) {
+	tempDir := t.TempDir()
+	argsFile := filepath.Join(tempDir, "argv.txt")
+	fakePy := filepath.Join(tempDir, "fake_qwenpaw.py")
+	fakePath := filepath.Join(tempDir, "qwenpaw")
+	launcher := []byte("#!/usr/bin/env sh\nexec python3 \"" + fakePy + "\" \"$@\"\n")
+	if runtime.GOOS == "windows" {
+		fakePath += ".bat"
+		launcher = []byte("@echo off\r\npython \"%~dp0fake_qwenpaw.py\" %*\r\n")
+	}
+
+	writeTestExecutable(t, fakePath, launcher)
+	if err := os.WriteFile(fakePy, []byte(fakeQwenPawACPPython()), 0o755); err != nil {
+		t.Fatalf("write fake qwenpaw python: %v", err)
+	}
+
+	backend, err := New("qwenpaw", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env:            map[string]string{"QWENPAW_ARGS_FILE": argsFile},
+	})
+	if err != nil {
+		t.Fatalf("new qwenpaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "hello from multica", ExecOptions{
+		Cwd:        tempDir,
+		Timeout:    5 * time.Second,
+		CustomArgs: []string{"acp", "--workspace", "ignored", "--debug"},
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var messages []Message
+	messagesDone := make(chan struct{})
+	go func() {
+		defer close(messagesDone)
+		for msg := range session.Messages {
+			messages = append(messages, msg)
+		}
+	}()
+
+	result := <-session.Result
+	<-messagesDone
+
+	if result.Status != "completed" {
+		t.Fatalf("status = %q error = %q", result.Status, result.Error)
+	}
+	if result.Output != "pong" {
+		t.Fatalf("output = %q, want pong", result.Output)
+	}
+	if result.SessionID != "ses_new" {
+		t.Fatalf("session id = %q, want ses_new", result.SessionID)
+	}
+	if usage := result.Usage["unknown"]; usage.InputTokens != 3 || usage.OutputTokens != 2 {
+		t.Fatalf("usage = %+v, want input=3 output=2", usage)
+	}
+	if len(messages) != 1 || messages[0].Type != MessageText || messages[0].Content != "pong" {
+		t.Fatalf("messages = %+v, want one text message", messages)
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	args := make([]string, 0, len(lines))
+	for _, line := range lines {
+		args = append(args, strings.TrimSpace(line))
+	}
+	wantPrefix := []string{"acp", "--bypass-permissions", "--workspace", tempDir}
+	if len(args) < len(wantPrefix) {
+		t.Fatalf("argv too short: %q", args)
+	}
+	for i, want := range wantPrefix {
+		if args[i] != want {
+			t.Fatalf("arg[%d] = %q, want %q (full: %q)", i, args[i], want, args)
+		}
+	}
+	for _, blocked := range []string{"ignored"} {
+		for _, got := range args {
+			if got == blocked {
+				t.Fatalf("blocked custom arg %q was not filtered: %q", blocked, args)
+			}
+		}
+	}
+	if args[len(args)-1] != "--debug" {
+		t.Fatalf("allowed custom arg was not preserved: %q", args)
+	}
+}
+
+func TestQwenPawBackendSmokeACPBypassPermissionsDisabled(t *testing.T) {
+	tempDir := t.TempDir()
+	argsFile := filepath.Join(tempDir, "argv.txt")
+	fakePy := filepath.Join(tempDir, "fake_qwenpaw.py")
+	fakePath := filepath.Join(tempDir, "qwenpaw")
+	launcher := []byte("#!/usr/bin/env sh\nexec python3 \"" + fakePy + "\" \"$@\"\n")
+	if runtime.GOOS == "windows" {
+		fakePath += ".bat"
+		launcher = []byte("@echo off\r\npython \"%~dp0fake_qwenpaw.py\" %*\r\n")
+	}
+
+	writeTestExecutable(t, fakePath, launcher)
+	if err := os.WriteFile(fakePy, []byte(fakeQwenPawACPPython()), 0o755); err != nil {
+		t.Fatalf("write fake qwenpaw python: %v", err)
+	}
+
+	backend, err := New("qwenpaw", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+		Env: map[string]string{
+			"QWENPAW_ARGS_FILE":                   argsFile,
+			"MULTICA_QWENPAW_BYPASS_PERMISSIONS":  "false",
+		},
+	})
+	if err != nil {
+		t.Fatalf("new qwenpaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "hello", ExecOptions{
+		Cwd:     tempDir,
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("status = %q error = %q", result.Status, result.Error)
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(raw)), "\n")
+
+	hasBypass := false
+	for _, arg := range args {
+		if arg == "--bypass-permissions" {
+			hasBypass = true
+			break
+		}
+	}
+	if hasBypass {
+		t.Fatalf("expected no --bypass-permissions when MULTICA_QWENPAW_BYPASS_PERMISSIONS=false, got args: %q", args)
+	}
+}
+
+func TestQwenPawBackendSessionResume(t *testing.T) {
+	tempDir := t.TempDir()
+	fakePy := filepath.Join(tempDir, "fake_qwenpaw.py")
+	fakePath := filepath.Join(tempDir, "qwenpaw")
+	launcher := []byte("#!/usr/bin/env sh\nexec python3 \"" + fakePy + "\" \"$@\"\n")
+	if runtime.GOOS == "windows" {
+		fakePath += ".bat"
+		launcher = []byte("@echo off\r\npython \"%~dp0fake_qwenpaw.py\" %*\r\n")
+	}
+
+	writeTestExecutable(t, fakePath, launcher)
+	if err := os.WriteFile(fakePy, []byte(fakeQwenPawACPSessionResumePython()), 0o755); err != nil {
+		t.Fatalf("write fake qwenpaw python: %v", err)
+	}
+
+	backend, err := New("qwenpaw", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new qwenpaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "resume test", ExecOptions{
+		Cwd:             tempDir,
+		Timeout:         5 * time.Second,
+		ResumeSessionID: "ses_previous",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("status = %q error = %q", result.Status, result.Error)
+	}
+	if result.SessionID != "ses_resumed" {
+		t.Fatalf("session id = %q, want ses_resumed", result.SessionID)
+	}
+}
+
+func TestQwenPawBackendSetModelFailure(t *testing.T) {
+	tempDir := t.TempDir()
+	fakePy := filepath.Join(tempDir, "fake_qwenpaw.py")
+	fakePath := filepath.Join(tempDir, "qwenpaw")
+	launcher := []byte("#!/usr/bin/env sh\nexec python3 \"" + fakePy + "\" \"$@\"\n")
+	if runtime.GOOS == "windows" {
+		fakePath += ".bat"
+		launcher = []byte("@echo off\r\npython \"%~dp0fake_qwenpaw.py\" %*\r\n")
+	}
+
+	writeTestExecutable(t, fakePath, launcher)
+	if err := os.WriteFile(fakePy, []byte(fakeQwenPawACPModelRejectPython()), 0o755); err != nil {
+		t.Fatalf("write fake qwenpaw python: %v", err)
+	}
+
+	backend, err := New("qwenpaw", Config{
+		ExecutablePath: fakePath,
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("new qwenpaw backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	session, err := backend.Execute(ctx, "test", ExecOptions{
+		Cwd:     tempDir,
+		Timeout: 5 * time.Second,
+		Model:   "bad-model",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	result := <-session.Result
+	if result.Status != "failed" {
+		t.Fatalf("status = %q, want failed", result.Status)
+	}
+	if result.Error == "" {
+		t.Fatalf("expected non-empty error, got %q", result.Error)
+	}
+	if !strings.Contains(result.Error, "bad-model") {
+		t.Fatalf("error = %q, want it to mention the model name", result.Error)
+	}
+}
+
+func fakeQwenPawACPPython() string {
+	return `import json
+import os
+import sys
+
+args_file = os.environ.get("QWENPAW_ARGS_FILE")
+if args_file:
+    with open(args_file, "w", encoding="utf-8") as fh:
+        for arg in sys.argv[1:]:
+            fh.write(arg + "\n")
+
+for line in sys.stdin:
+    req = json.loads(line)
+    method = req.get("method")
+    req_id = req.get("id")
+    params = req.get("params", {})
+    if method == "initialize":
+        result = {
+            "protocolVersion": 1,
+            "agentCapabilities": {"loadSession": True},
+        }
+    elif method == "session/new":
+        result = {"sessionId": "ses_new"}
+    elif method == "session/set_config_option":
+        params_val = params.get("value")
+        if params_val != "bypassPermissions":
+            result = {"error": "expected bypassPermissions"}
+        else:
+            result = {}
+    elif method == "session/set_model":
+        model_id = params.get("modelId")
+        if model_id == "bad-model":
+            sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": -32603, "message": "model not found: " + model_id}}) + "\n")
+            sys.stdout.flush()
+            continue
+        result = {}
+    elif method == "session/prompt":
+        sys.stdout.write(json.dumps({
+            "jsonrpc": "2.0",
+            "method": "session/notification",
+            "params": {
+                "sessionId": "ses_new",
+                "update": {
+                    "type": "AgentMessageChunk",
+                    "content": {"type": "text", "text": "pong"},
+                },
+            },
+        }) + "\n")
+        sys.stdout.flush()
+        result = {
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 3, "outputTokens": 2},
+        }
+    else:
+        result = {}
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}) + "\n")
+    sys.stdout.flush()
+`
+}
+
+func fakeQwenPawACPSessionResumePython() string {
+	return `import json
+import sys
+
+# Track what methods are called
+called = []
+
+for line in sys.stdin:
+    req = json.loads(line)
+    method = req.get("method")
+    req_id = req.get("id")
+    params = req.get("params", {})
+
+    if method == "initialize":
+        result = {"protocolVersion": 1, "agentCapabilities": {"loadSession": True}}
+    elif method == "session/load":
+        called.append("load")
+        # Return error so it falls back to resume
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": -32603, "message": "session not found"}}) + "\n")
+        sys.stdout.flush()
+        continue
+    elif method == "session/resume":
+        called.append("resume")
+        result = {"sessionId": "ses_resumed"}
+    elif method == "session/prompt":
+        result = {
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+        }
+    else:
+        result = {}
+
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}) + "\n")
+    sys.stdout.flush()
+`
+}
+
+func fakeQwenPawACPModelRejectPython() string {
+	return `import json
+import sys
+
+for line in sys.stdin:
+    req = json.loads(line)
+    method = req.get("method")
+    req_id = req.get("id")
+    params = req.get("params", {})
+
+    if method == "initialize":
+        result = {"protocolVersion": 1, "agentCapabilities": {"loadSession": True}}
+    elif method == "session/new":
+        result = {"sessionId": "ses_new"}
+    elif method == "session/set_model":
+        model_id = params.get("modelId", params.get("model_id", ""))
+        if model_id == "bad-model":
+            # Return error to indicate model rejection
+            sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req_id, "error": {"code": -32603, "message": "model not supported: " + model_id}}) + "\n")
+            sys.stdout.flush()
+            continue
+        result = {}
+    elif method == "session/prompt":
+        result = {"stopReason": "end_turn", "usage": {"inputTokens": 1, "outputTokens": 1}}
+    else:
+        result = {}
+
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result}) + "\n")
+    sys.stdout.flush()
+`
+}


### PR DESCRIPTION
## Summary

Adds QwenPaw as a new agent provider in Multica, allowing QwenPaw to be selected as the runtime for agent tasks.

- **New backend**: `qwenpawBackend` implementing the `Backend` interface via ACP stdio transport (reuses `hermesClient`)
- **Daemon discovery**: QwenPaw discovered from PATH via `MULTICA_QWENPAW_PATH` (default: `qwenpaw`), with optional model via `MULTICA_QWENPAW_MODEL`
- **Workspace isolation**: tasks are passed as `--workspace <task-dir>` so QwenPaw's file tools operate inside the isolated task environment
- **bypassPermissions**: on by default; set `MULTICA_QWENPAW_BYPASS_PERMISSIONS=0` to disable
- **AGENTS.md injection**: runtime config is written so QwenPaw can read task context and skills from `.agent_context/skills/`

## Files changed

| File | Change |
|------|--------|
| `server/pkg/agent/qwenpaw.go` | New — ACP client backend |
| `server/pkg/agent/qwenpaw_test.go` | New — 7 tests |
| `server/internal/daemon/qwenpaw_config_test.go` | New — daemon discovery |
| `server/pkg/agent/agent.go` | Register qwenpaw factory + launch header |
| `server/pkg/agent/agent_test.go` | Add qwenpaw to supported list |
| `server/pkg/agent/models.go` | qwenpaw returns empty model list (ACP doesn't expose model discovery yet) |
| `server/internal/daemon/config.go` | Discover qwenpaw via env vars |
| `server/internal/daemon/execenv/runtime_config.go` | AGENTS.md injection |

## Test plan

```bash
go test ./pkg/agent -run 'QwenPaw|LaunchHeader' -count=1
go test ./internal/daemon -run TestLoadConfigDiscoversQwenPaw -count=1
go test ./internal/daemon/execenv
```

All tests pass on this PR.

## Deployment

After merge, self-hosting users should:
1. Install patched QwenPaw from `stclaw` source: `pip install -e ".[dev]"`
2. Build patched Multica from this branch
3. Set `MULTICA_QWENPAW_PATH` / `MULTICA_QWENPAW_MODEL` as needed