### PR TITLE
feat(auth): add pluggable OAuth providers and Feishu/Lark login

### DIFF
--- a/apps/desktop/src/renderer/src/pages/login.tsx
+++ b/apps/desktop/src/renderer/src/pages/login.tsx
@@ -14,9 +14,9 @@ function requireRuntimeAppUrl(): string {
 
 export function DesktopLoginPage() {
   const webUrl = requireRuntimeAppUrl();
-  const handleGoogleLogin = () => {
-    // Open web login page in the default browser with platform=desktop flag.
-    // The web callback will redirect back via multica:// deep link with the token.
+  const handleBrowserLogin = () => {
+    // Open web login in the default browser with platform=desktop flag.
+    // The web callback redirects back via multica:// deep link with the token.
     window.desktopAPI.openExternal(
       `${webUrl}/login?platform=desktop`,
     );
@@ -31,7 +31,7 @@ export function DesktopLoginPage() {
           // Auth store update triggers AppContent re-render → shows DesktopShell.
           // Initial workspace navigation happens in routes.tsx via IndexRedirect.
         }}
-        onGoogleLogin={handleGoogleLogin}
+        onGoogleLogin={handleBrowserLogin}
       />
     </div>
   );

--- a/apps/docs/content/docs/auth-setup.mdx
+++ b/apps/docs/content/docs/auth-setup.mdx
@@ -1,12 +1,12 @@
 ---
 title: Sign-in and signup configuration
-description: Configure email + verification code sign-in, Google OAuth, signup allowlists, and local test codes.
+description: Configure email + verification code sign-in, OAuth providers, signup allowlists, and local test codes.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Mermaid } from "@/components/mermaid";
 
-Multica supports two sign-in methods: **email + verification code** (default) and **Google OAuth** (optional). On successful sign-in, the server issues a JWT cookie with a 30-day lifetime. This page covers how to configure each method, how to restrict who can sign up, and the single biggest trap for self-hosted deployments.
+Multica supports **email + verification code** (default) and optional **OAuth providers** such as Google and Feishu/Lark. On successful sign-in, the server issues a JWT cookie with a 30-day lifetime. This page covers how to configure each method, how to restrict who can sign up, and the single biggest trap for self-hosted deployments.
 
 For the list of environment variables referenced below, see [Environment variables](/environment-variables); for token usage and lifecycle details, see [Authentication and tokens](/auth-tokens).
 
@@ -48,7 +48,7 @@ Production deployments should leave `MULTICA_DEV_VERIFICATION_CODE` empty and se
 
 ## Google OAuth configuration
 
-Optional. Without it, only email + verification code is available; with it, the sign-in page gets a "Sign in with Google" button.
+Optional. Without it, only email + verification code is available; with it, the sign-in page gets a "Sign in with Google" button. Both `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` must be set before the provider appears in `/api/config`.
 
 1. Create an OAuth 2.0 client in the [Google Cloud Console](https://console.cloud.google.com/)
 2. Set the **Authorized redirect URIs** to your Multica frontend address plus `/auth/callback`, for example:
@@ -72,6 +72,50 @@ Optional. Without it, only email + verification code is available; with it, the 
 <Callout type="warning">
 **The redirect URI must match exactly in both the Google Console and `GOOGLE_REDIRECT_URI`** — including protocol (`http` vs `https`), trailing slash, and port. Any mismatch and Google rejects the entire OAuth flow; the error shown to the user is `redirect_uri_mismatch`.
 </Callout>
+
+## Feishu/Lark OAuth configuration
+
+Feishu/Lark OAuth works like Google OAuth: the browser redirects to Feishu/Lark, the server exchanges the returned code for a user access token, reads the user's profile, then issues Multica's own JWT cookie. Multica does **not** persist the Feishu/Lark access token for product use.
+
+1. Create a Feishu/Lark app in the matching open platform:
+
+    - Feishu China: `https://open.feishu.cn`
+    - Lark international: `https://open.larksuite.com`
+    - Private Feishu/Lark: use your private OpenAPI base URL
+
+2. Configure the OAuth redirect URL in the Feishu/Lark app security settings:
+
+    ```text
+    https://multica.yourdomain.com/auth/callback
+    ```
+
+3. Enable the permissions needed for the login user profile, especially email / enterprise email visibility, then publish the app if your tenant requires publication before permissions take effect.
+
+4. Set environment variables and restart the server:
+
+    ```bash
+    LARK_OAUTH_CLIENT_ID=cli_xxxxxxxxxxxxxxxx
+    LARK_OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    LARK_OAUTH_BASE_URL=https://open.feishu.cn
+    LARK_OAUTH_LABEL="Feishu/Lark"
+    LARK_OAUTH_SCOPE=contact:user.email:readonly
+    ```
+
+For Lark international, set `LARK_OAUTH_BASE_URL=https://open.larksuite.com`. For private deployments, set `LARK_OAUTH_BASE_URL` to the private OpenAPI host. If your private deployment exposes non-standard paths, override the derived endpoints with `LARK_OAUTH_AUTHORIZATION_URL`, `LARK_OAUTH_TOKEN_URL`, and `LARK_OAUTH_USERINFO_URL`.
+
+By default, the authorization page uses `https://accounts.feishu.cn` for Feishu China and `https://accounts.larksuite.com` for Lark international, while token and user-info requests use the OpenAPI base URL. For private deployments where the authorization host differs from the OpenAPI host, set `LARK_OAUTH_ACCOUNT_BASE_URL` or the full `LARK_OAUTH_AUTHORIZATION_URL`.
+
+The server accepts `LARK_APP_ID` / `LARK_APP_SECRET` as aliases for `LARK_OAUTH_CLIENT_ID` / `LARK_OAUTH_CLIENT_SECRET`, but the explicit OAuth names are preferred for new deployments.
+
+<Callout type="warning">
+**The Feishu/Lark account must expose an email.** Multica maps OAuth identities to users by email so signup allowlists, invitations, and existing accounts keep working. If Feishu/Lark does not return `enterprise_email` or `email`, login is rejected; enable the relevant field permission in the Feishu/Lark app.
+</Callout>
+
+## Verification code vs direct OAuth login
+
+Email verification code sign-in is the most universal fallback: it works for external collaborators and does not require every organization to run an identity provider, but it depends on deliverability and is awkward when `RESEND_API_KEY` is missing. Feishu/Lark OAuth is better for internal self-hosted deployments because it delegates identity proof to the company's existing tenant, avoids one-time-code delivery problems, and supports both SaaS and private Feishu/Lark through endpoint configuration.
+
+Recommended production posture: keep email verification available as a fallback for external users and break-glass access, and prefer Feishu/Lark OAuth for employees on private/internal instances. If the instance is strictly internal and the Feishu/Lark tenant is reliable, you can make OAuth the primary visible path and retain email only for admin recovery.
 
 ## Restricting who can sign up
 

--- a/apps/docs/content/docs/auth-setup.zh.mdx
+++ b/apps/docs/content/docs/auth-setup.zh.mdx
@@ -1,12 +1,12 @@
 ---
 title: 登录与注册配置
-description: 配 Email 验证码登录、Google OAuth、注册白名单和本地测试验证码。
+description: 配 Email 验证码登录、OAuth provider、注册白名单和本地测试验证码。
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Mermaid } from "@/components/mermaid";
 
-Multica 支持两种登录方式：**Email + 验证码**（默认）和 **Google OAuth**（可选）。登录成功后 server 签发一个 30 天有效期的 JWT cookie。这一页讲怎么配、怎么限制谁能注册、以及本地测试验证码怎么安全使用。
+Multica 支持 **Email + 验证码**（默认）和可选的 **OAuth provider**，例如 Google、飞书/Lark。登录成功后 server 签发一个 30 天有效期的 JWT cookie。这一页讲怎么配、怎么限制谁能注册、以及本地测试验证码怎么安全使用。
 
 上面用到的环境变量的清单见 [环境变量](/environment-variables)；token 怎么用、生命周期细节见 [认证与令牌](/auth-tokens)。
 
@@ -48,7 +48,7 @@ MULTICA_DEV_VERIFICATION_CODE=888888
 
 ## 怎么配 Google OAuth
 
-可选。不配就只有 Email + 验证码登录；配了后登录页会多出「用 Google 登录」按钮。
+可选。不配就只有 Email + 验证码登录；配了后登录页会多出「用 Google 登录」按钮。`GOOGLE_CLIENT_ID` 和 `GOOGLE_CLIENT_SECRET` 都配置后，该 provider 才会出现在 `/api/config`。
 
 1. 去 [Google Cloud Console](https://console.cloud.google.com/) 创建一个 OAuth 2.0 client
 2. **授权的回调 URI**（Authorized redirect URIs）填你的 Multica 前端地址加 `/auth/callback`，例如：
@@ -72,6 +72,50 @@ MULTICA_DEV_VERIFICATION_CODE=888888
 <Callout type="warning">
 **回调 URI 在 Google Console 和 `GOOGLE_REDIRECT_URI` 两处必须完全一致**，包括协议（`http` vs `https`）、尾部斜杠、端口。不一致 Google 会拒绝整个 OAuth 流程，用户看到的错误是 `redirect_uri_mismatch`。
 </Callout>
+
+## 怎么配飞书/Lark OAuth
+
+飞书/Lark OAuth 和 Google OAuth 是同一类流程：浏览器跳转到飞书/Lark，server 用回调里的 code 换取 user access token，读取登录用户资料，然后签发 Multica 自己的 JWT cookie。Multica **不会**把飞书/Lark access token 持久化用于产品功能。
+
+1. 在对应开放平台创建应用：
+
+    - 飞书中国版：`https://open.feishu.cn`
+    - Lark 国际版：`https://open.larksuite.com`
+    - 私有化飞书/Lark：使用你的私有 OpenAPI base URL
+
+2. 在飞书/Lark 应用的安全设置中配置 OAuth 回调地址：
+
+    ```text
+    https://multica.yourdomain.com/auth/callback
+    ```
+
+3. 开通登录用户资料所需权限，尤其是 email / enterprise email 字段可见权限；如果租户要求发布后权限才生效，记得发布应用。
+
+4. 设置环境变量并重启 server：
+
+    ```bash
+    LARK_OAUTH_CLIENT_ID=cli_xxxxxxxxxxxxxxxx
+    LARK_OAUTH_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    LARK_OAUTH_BASE_URL=https://open.feishu.cn
+    LARK_OAUTH_LABEL="飞书/Lark"
+    LARK_OAUTH_SCOPE=contact:user.email:readonly
+    ```
+
+Lark 国际版使用 `LARK_OAUTH_BASE_URL=https://open.larksuite.com`。私有化部署则把 `LARK_OAUTH_BASE_URL` 指向私有 OpenAPI host。如果你的私有化环境路径不标准，可以进一步用 `LARK_OAUTH_AUTHORIZATION_URL`、`LARK_OAUTH_TOKEN_URL`、`LARK_OAUTH_USERINFO_URL` 覆盖派生出来的三个 endpoint。
+
+默认情况下，授权页使用飞书中国版的 `https://accounts.feishu.cn`，或 Lark 国际版的 `https://accounts.larksuite.com`；token 和 user-info 请求使用 OpenAPI base URL。私有化部署里如果授权 host 和 OpenAPI host 不同，请设置 `LARK_OAUTH_ACCOUNT_BASE_URL`，或直接设置完整的 `LARK_OAUTH_AUTHORIZATION_URL`。
+
+server 兼容 `LARK_APP_ID` / `LARK_APP_SECRET` 作为 `LARK_OAUTH_CLIENT_ID` / `LARK_OAUTH_CLIENT_SECRET` 的别名，但新部署建议使用显式 OAuth 名称。
+
+<Callout type="warning">
+**飞书/Lark 账号必须能返回邮箱。** Multica 用邮箱把 OAuth 身份映射到用户，这样注册白名单、邀请和已有账号都能沿用。如果飞书/Lark 不返回 `enterprise_email` 或 `email`，登录会被拒绝；请在飞书/Lark 应用里开通相关字段权限。
+</Callout>
+
+## 验证码登录 vs 直接 OAuth 登录
+
+Email 验证码登录是最通用的兜底：适合外部协作者，不要求组织已经有统一身份源；缺点是依赖邮件可达性，`RESEND_API_KEY` 没配时生产体验很差。飞书/Lark OAuth 更适合企业内部 self-host：身份校验交给现有飞书/Lark 租户，避免验证码投递问题，也能通过 endpoint 配置兼容公网 SaaS 和私有化飞书/Lark。
+
+生产建议：保留邮箱验证码作为外部用户和管理员兜底；内部员工优先使用飞书/Lark OAuth。若实例严格内用、飞书/Lark 租户稳定，可以把 OAuth 作为主入口，只保留邮箱作为管理员恢复通道。
 
 ## 怎么限制谁能注册
 

--- a/apps/docs/content/docs/environment-variables.mdx
+++ b/apps/docs/content/docs/environment-variables.mdx
@@ -44,9 +44,11 @@ Multica uses [Resend](https://resend.com/) to send verification codes and invite
 
 **Behavior when `RESEND_API_KEY` is unset**: the server does not error, but every email that should have been sent (verification codes, invite links) **is written to the server's stdout only**. Convenient for local development — copy the code out of the server logs; **in production, forgetting to set this creates a silent black hole**, with users never receiving email and no error surfaced.
 
-## Google OAuth configuration
+## OAuth provider configuration
 
-Optional. Leave unset for email + verification code only; configure it to add "Sign in with Google" on the sign-in page.
+Optional. Leave unset for email + verification code only; configure one or more providers to add OAuth buttons on the sign-in page. Providers are returned by `/api/config` at runtime, so frontend rebuilds are not required after server restart.
+
+### Google
 
 | Variable | Default | Description |
 |---|---|---|
@@ -54,9 +56,22 @@ Optional. Leave unset for email + verification code only; configure it to add "S
 | `GOOGLE_CLIENT_SECRET` | empty | Google Cloud OAuth secret |
 | `GOOGLE_REDIRECT_URI` | `http://localhost:3000/auth/callback` | OAuth callback URL (self-host: replace with your frontend domain) |
 
-**Takes effect at runtime**: the frontend reads these settings via `/api/config` at runtime, so **changing them requires no frontend rebuild or redeploy** — restart the server and they apply.
+### Feishu/Lark
 
-Full setup (including Google Cloud Console steps) is in [Sign-in and signup configuration](/auth-setup#google-oauth-configuration).
+| Variable | Default | Description |
+|---|---|---|
+| `LARK_OAUTH_CLIENT_ID` | empty | Feishu/Lark app ID, usually `cli_...`. `LARK_APP_ID` is accepted as an alias |
+| `LARK_OAUTH_CLIENT_SECRET` | empty | Feishu/Lark app secret. `LARK_APP_SECRET` is accepted as an alias |
+| `LARK_OAUTH_BASE_URL` | `https://open.feishu.cn` | OpenAPI base URL for token and user-info APIs. Use `https://open.larksuite.com` for Lark international, or your private OpenAPI host for private deployments |
+| `LARK_OAUTH_ACCOUNT_BASE_URL` | `https://accounts.feishu.cn` or `https://accounts.larksuite.com` | Authorization-page base URL derived from `LARK_OAUTH_BASE_URL`; set explicitly for private deployments whose auth host differs from OpenAPI |
+| `LARK_OAUTH_LABEL` | `Feishu/Lark` | Button label provider name |
+| `LARK_OAUTH_SCOPE` | empty | Optional OAuth scope string. When empty, Feishu/Lark authorizes the app's granted scopes |
+| `LARK_OAUTH_PKCE` | `true` | Whether the browser authorization request includes PKCE |
+| `LARK_OAUTH_AUTHORIZATION_URL` | derived from account base URL | Advanced override for private/non-standard deployments |
+| `LARK_OAUTH_TOKEN_URL` | derived from base URL | Advanced override for private/non-standard deployments |
+| `LARK_OAUTH_USERINFO_URL` | derived from base URL | Advanced override for private/non-standard deployments |
+
+Full setup is in [Google OAuth configuration](/auth-setup#google-oauth-configuration) and [Feishu/Lark OAuth configuration](/auth-setup#feishulark-oauth-configuration).
 
 ## File storage configuration
 

--- a/apps/docs/content/docs/environment-variables.zh.mdx
+++ b/apps/docs/content/docs/environment-variables.zh.mdx
@@ -44,9 +44,11 @@ Multica 用 [Resend](https://resend.com/) 发验证码和邀请邮件。
 
 **不设 `RESEND_API_KEY` 时的行为**：server 不会报错，但所有本该发出去的邮件（验证码、邀请链接）**只打到 server 的 stdout**。本地开发时方便——你从 server 日志里抄验证码；**生产环境忘记设就是黑洞**，用户收不到邮件也没任何错误提示。
 
-## 怎么配 Google OAuth
+## 怎么配 OAuth provider
 
-可选。不设则只有邮箱 + 验证码登录；设了就在登录页出现「用 Google 登录」。
+可选。不设则只有邮箱 + 验证码登录；配置一个或多个 provider 后，登录页会显示对应 OAuth 按钮。前端通过 `/api/config` 运行时读取 provider 列表，所以改完重启 server 即可，不需要重建前端。
+
+### Google
 
 | 环境变量 | 默认值 | 说明 |
 |---|---|---|
@@ -54,9 +56,22 @@ Multica 用 [Resend](https://resend.com/) 发验证码和邀请邮件。
 | `GOOGLE_CLIENT_SECRET` | 空 | Google Cloud OAuth secret |
 | `GOOGLE_REDIRECT_URI` | `http://localhost:3000/auth/callback` | OAuth 回调地址（self-host 换成你的前端域名）|
 
-**热生效**：前端在运行时通过 `/api/config` 拿这些配置，**改了不用重启前端也不用重建镜像**——改完重启 server 即可。
+### 飞书/Lark
 
-完整配置步骤（含 Google Cloud Console 操作）详见 [登录与注册配置](/auth-setup#怎么配-google-oauth)。
+| 环境变量 | 默认值 | 说明 |
+|---|---|---|
+| `LARK_OAUTH_CLIENT_ID` | 空 | 飞书/Lark app ID，通常是 `cli_...`。兼容别名 `LARK_APP_ID` |
+| `LARK_OAUTH_CLIENT_SECRET` | 空 | 飞书/Lark app secret。兼容别名 `LARK_APP_SECRET` |
+| `LARK_OAUTH_BASE_URL` | `https://open.feishu.cn` | token 和 user-info API 使用的 OpenAPI base URL。Lark 国际版用 `https://open.larksuite.com`，私有化部署填私有 OpenAPI host |
+| `LARK_OAUTH_ACCOUNT_BASE_URL` | `https://accounts.feishu.cn` 或 `https://accounts.larksuite.com` | 授权页 base URL，会根据 `LARK_OAUTH_BASE_URL` 自动派生；如果私有化环境的认证 host 和 OpenAPI host 不同，请显式设置 |
+| `LARK_OAUTH_LABEL` | `Feishu/Lark` | 登录按钮上的 provider 名称 |
+| `LARK_OAUTH_SCOPE` | 空 | 可选 OAuth scope；为空时使用应用已开通的授权范围 |
+| `LARK_OAUTH_PKCE` | `true` | 浏览器授权请求是否带 PKCE |
+| `LARK_OAUTH_AUTHORIZATION_URL` | 从 account base URL 派生 | 私有化/非标准路径的高级覆盖 |
+| `LARK_OAUTH_TOKEN_URL` | 从 base URL 派生 | 私有化/非标准路径的高级覆盖 |
+| `LARK_OAUTH_USERINFO_URL` | 从 base URL 派生 | 私有化/非标准路径的高级覆盖 |
+
+完整配置步骤见 [Google OAuth 配置](/auth-setup#怎么配-google-oauth) 和 [飞书/Lark OAuth 配置](/auth-setup#怎么配飞书lark-oauth)。
 
 ## 怎么配文件存储
 

--- a/apps/web/app/(auth)/login/oauth-redirect.ts
+++ b/apps/web/app/(auth)/login/oauth-redirect.ts
@@ -1,0 +1,4 @@
+export function getBrowserOAuthRedirectUri(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return `${window.location.origin}/auth/callback`;
+}

--- a/apps/web/app/(auth)/login/page.test.tsx
+++ b/apps/web/app/(auth)/login/page.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { I18nProvider } from "@multica/core/i18n/react";
+import { renderToString } from "react-dom/server";
 import enCommon from "@multica/views/locales/en/common.json";
 import enAuth from "@multica/views/locales/en/auth.json";
 import enSettings from "@multica/views/locales/en/settings.json";
@@ -84,6 +85,8 @@ vi.mock("@multica/core/api", () => ({
   },
 }));
 
+import { configStore } from "@multica/core/config";
+import { getBrowserOAuthRedirectUri } from "./oauth-redirect";
 import LoginPage from "./page";
 
 describe("LoginPage", () => {
@@ -92,6 +95,7 @@ describe("LoginPage", () => {
     searchParamsState.params = new URLSearchParams();
     authStateRef.state.user = null;
     authStateRef.state.isLoading = false;
+    configStore.getState().setAuthConfig({ allowSignup: true, oauthProviders: [] });
   });
 
   it("renders login form with email input and continue button", () => {
@@ -163,6 +167,65 @@ describe("LoginPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Network error")).toBeInTheDocument();
     });
+  });
+
+  it("renders OAuth providers from runtime config", () => {
+    configStore.getState().setAuthConfig({
+      allowSignup: true,
+      oauthProviders: [
+        {
+          id: "feishu_lark",
+          label: "Feishu/Lark",
+          client_id: "cli_lark",
+          authorization_url: "https://open.feishu.cn/open-apis/authen/v1/authorize",
+        },
+      ],
+    });
+
+    render(<LoginPage />, { wrapper: createWrapper() });
+
+    expect(
+      screen.getByRole("button", { name: "Continue with Feishu/Lark" }),
+    ).toBeInTheDocument();
+  });
+
+  it("server-renders without reading window during render", () => {
+    configStore.getState().setAuthConfig({
+      allowSignup: true,
+      oauthProviders: [
+        {
+          id: "feishu_lark",
+          label: "Feishu/Lark",
+          client_id: "cli_lark",
+          authorization_url: "https://accounts.feishu.cn/open-apis/authen/v1/authorize",
+        },
+      ],
+    });
+
+    const originalWindow = globalThis.window;
+    vi.stubGlobal("window", undefined);
+    try {
+      expect(window).toBeUndefined();
+      expect(() =>
+        renderToString(
+          createWrapper()({
+            children: <LoginPage />,
+          }),
+        ),
+      ).not.toThrow();
+    } finally {
+      vi.stubGlobal("window", originalWindow);
+    }
+  });
+
+  it("returns no OAuth redirect URI when there is no browser window", () => {
+    const originalWindow = globalThis.window;
+    vi.stubGlobal("window", undefined);
+    try {
+      expect(getBrowserOAuthRedirectUri()).toBeUndefined();
+    } finally {
+      vi.stubGlobal("window", originalWindow);
+    }
   });
 
   // Regression: MUL-1080 — if the user is already authenticated on the web

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -27,6 +27,7 @@ import { setLoggedInCookie } from "@/features/auth/auth-cookie";
 import Link from "next/link";
 import { LoginPage, validateCliCallback } from "@multica/views/auth";
 import { useT } from "@multica/views/i18n";
+import { getBrowserOAuthRedirectUri } from "./oauth-redirect";
 
 /**
  * Pick where a logged-in user with no explicit `?next=` should land.
@@ -58,7 +59,7 @@ function LoginPageContent() {
   const router = useRouter();
   const qc = useQueryClient();
   const { t } = useT("auth");
-  const googleClientId = useConfigStore((state) => state.googleClientId);
+  const oauthProviders = useConfigStore((state) => state.oauthProviders);
   const user = useAuthStore((s) => s.user);
   const isLoading = useAuthStore((s) => s.isLoading);
   const searchParams = useSearchParams();
@@ -110,7 +111,7 @@ function LoginPageContent() {
     void resolveLoggedInDestination(qc, hasOnboarded, list).then((dest) =>
       router.replace(dest),
     );
-  }, [isLoading, user, router, nextUrl, cliCallbackRaw, isDesktopHandoff, hasOnboarded, qc]);
+  }, [isLoading, user, router, nextUrl, cliCallbackRaw, isDesktopHandoff, hasOnboarded, qc, t]);
 
   const handleSuccess = async () => {
     // Read the latest user snapshot directly — the closure's `hasOnboarded`
@@ -126,9 +127,9 @@ function LoginPageContent() {
     router.push(dest);
   };
 
-  // Build Google OAuth state: encode platform + next URL so the callback
+  // Build OAuth state: encode provider + platform + next URL so the callback
   // can redirect to the right place after login.
-  const googleState = [
+  const oauthState = [
     platform === "desktop" ? "platform:desktop" : "",
     nextUrl ? `next:${nextUrl}` : "",
   ]
@@ -188,15 +189,17 @@ function LoginPageContent() {
   return (
     <LoginPage
       onSuccess={handleSuccess}
-      google={
-        googleClientId
-          ? {
-              clientId: googleClientId,
-              redirectUri: `${window.location.origin}/auth/callback`,
-              state: googleState,
-            }
-          : undefined
-      }
+      oauthProviders={oauthProviders.map((provider) => ({
+        id: provider.id,
+        label: provider.label,
+        clientId: provider.client_id,
+        authorizationUrl: provider.authorization_url,
+        scope: provider.scope,
+        pkce: provider.pkce,
+        extraAuthParams: provider.extra_auth_params,
+      }))}
+      oauthState={oauthState}
+      oauthRedirectUri={getBrowserOAuthRedirectUri()}
       cliCallback={
         cliCallbackRaw && validateCliCallback(cliCallbackRaw)
           ? { url: cliCallbackRaw, state: cliState }

--- a/apps/web/app/auth/callback/page.test.tsx
+++ b/apps/web/app/auth/callback/page.test.tsx
@@ -6,6 +6,7 @@ const {
   mockPush,
   mockSearchParams,
   mockLoginWithGoogle,
+  mockLoginWithOAuthProvider,
   mockListWorkspaces,
   mockListMyInvitations,
   mockSetQueryData,
@@ -13,6 +14,7 @@ const {
   mockPush: vi.fn(),
   mockSearchParams: new URLSearchParams(),
   mockLoginWithGoogle: vi.fn(),
+  mockLoginWithOAuthProvider: vi.fn(),
   mockListWorkspaces: vi.fn(),
   mockListMyInvitations: vi.fn(),
   mockSetQueryData: vi.fn(),
@@ -49,7 +51,10 @@ vi.mock("@multica/core/auth", async () => {
   return {
     ...actual,
     useAuthStore: (selector: (s: unknown) => unknown) =>
-      selector({ loginWithGoogle: mockLoginWithGoogle }),
+      selector({
+        loginWithGoogle: mockLoginWithGoogle,
+        loginWithOAuthProvider: mockLoginWithOAuthProvider,
+      }),
   };
 });
 
@@ -65,6 +70,7 @@ vi.mock("@multica/core/api", () => ({
     listWorkspaces: mockListWorkspaces,
     listMyInvitations: mockListMyInvitations,
     googleLogin: vi.fn(),
+    oauthLogin: vi.fn(),
   },
 }));
 
@@ -80,6 +86,7 @@ describe("CallbackPage", () => {
     );
     mockSearchParams.set("code", "test-code");
     mockLoginWithGoogle.mockResolvedValue(makeUser());
+    mockLoginWithOAuthProvider.mockResolvedValue(makeUser());
     mockListWorkspaces.mockResolvedValue([]);
     mockListMyInvitations.mockResolvedValue([]);
   });
@@ -180,5 +187,22 @@ describe("CallbackPage", () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(paths.onboarding());
     });
+  });
+
+  it("uses the provider encoded in OAuth state for Feishu/Lark callback", async () => {
+    mockSearchParams.set("state", "provider:feishu_lark,next:/invite/lark-invite");
+
+    render(<CallbackPage />);
+
+    await waitFor(() => {
+      expect(mockLoginWithOAuthProvider).toHaveBeenCalledWith(
+        "feishu_lark",
+        "test-code",
+        "http://localhost:3000/auth/callback",
+        undefined,
+      );
+    });
+    expect(mockLoginWithGoogle).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith("/invite/lark-invite");
   });
 });

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -22,6 +22,7 @@ function CallbackContent() {
   const searchParams = useSearchParams();
   const qc = useQueryClient();
   const loginWithGoogle = useAuthStore((s) => s.loginWithGoogle);
+  const loginWithOAuthProvider = useAuthStore((s) => s.loginWithOAuthProvider);
   const [error, setError] = useState("");
   const [desktopToken, setDesktopToken] = useState<string | null>(null);
 
@@ -40,6 +41,10 @@ function CallbackContent() {
 
     const state = searchParams.get("state") || "";
     const stateParts = state.split(",");
+    const providerPart = stateParts.find((p) => p.startsWith("provider:"));
+    const provider = providerPart ? providerPart.slice(9) : "google";
+    const noncePart = stateParts.find((p) => p.startsWith("nonce:"));
+    const nonce = noncePart ? noncePart.slice(6) : "";
     const isDesktop = stateParts.includes("platform:desktop");
     const nextPart = stateParts.find((p) => p.startsWith("next:"));
     // Strip "next:" prefix, then drop anything that isn't a safe relative path
@@ -47,11 +52,19 @@ function CallbackContent() {
     const nextUrl = sanitizeNextUrl(nextPart ? nextPart.slice(5) : null);
 
     const redirectUri = `${window.location.origin}/auth/callback`;
+    const codeVerifier = provider !== "google" && nonce
+      ? sessionStorage.getItem(`multica_oauth_pkce:${provider}:${nonce}`) ?? undefined
+      : undefined;
+    if (provider !== "google" && nonce) {
+      sessionStorage.removeItem(`multica_oauth_pkce:${provider}:${nonce}`);
+    }
 
     if (isDesktop) {
       // Desktop flow: exchange code for token, then redirect via deep link
-      api
-        .googleLogin(code, redirectUri)
+      const login = provider === "google"
+        ? api.googleLogin(code, redirectUri)
+        : api.oauthLogin(provider, { code, redirectUri, codeVerifier });
+      login
         .then(({ token }) => {
           setDesktopToken(token);
           window.location.href = `multica://auth/callback?token=${encodeURIComponent(token)}`;
@@ -61,7 +74,10 @@ function CallbackContent() {
         });
     } else {
       // Normal web flow
-      loginWithGoogle(code, redirectUri)
+      const login = provider === "google"
+        ? loginWithGoogle(code, redirectUri)
+        : loginWithOAuthProvider(provider, code, redirectUri, codeVerifier);
+      login
         .then(async (loggedInUser) => {
           const wsList = await api.listWorkspaces();
           qc.setQueryData(workspaceKeys.list(), wsList);
@@ -107,7 +123,7 @@ function CallbackContent() {
           setError(err instanceof Error ? err.message : "Login failed");
         });
     }
-  }, [searchParams, loginWithGoogle, router, qc]);
+  }, [searchParams, loginWithGoogle, loginWithOAuthProvider, router, qc]);
 
   if (desktopToken) {
     return (

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -5,19 +5,16 @@ test.describe("Authentication", () => {
   test("login page renders correctly", async ({ page }) => {
     await page.goto("/login");
 
-    await expect(page.locator("h1")).toContainText("Multica");
-    await expect(page.locator('input[placeholder="Email"]')).toBeVisible();
-    await expect(page.locator('input[placeholder="Name"]')).toBeVisible();
-    await expect(page.locator('button[type="submit"]')).toContainText(
-      "Sign in",
-    );
+    await expect(page.getByText("Sign in to Multica")).toBeVisible();
+    await expect(page.getByPlaceholder("you@example.com")).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toContainText("Continue");
   });
 
   test("login and redirect to /issues", async ({ page }) => {
     await loginAsDefault(page);
 
     await expect(page).toHaveURL(/\/issues/);
-    await expect(page.locator("text=All Issues")).toBeVisible();
+    await expect(page.getByRole("button", { name: "All" })).toBeVisible();
   });
 
   test("unauthenticated user is redirected to /login", async ({ page }) => {
@@ -39,8 +36,8 @@ test.describe("Authentication", () => {
     // Open the workspace dropdown menu
     await openWorkspaceMenu(page);
 
-    // Click Sign out
-    await page.locator("text=Sign out").click();
+    // Click Log out
+    await page.getByRole("menuitem", { name: "Log out" }).click();
 
     await page.waitForURL("**/login", { timeout: 10000 });
     await expect(page).toHaveURL(/\/login/);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -21,12 +21,12 @@ export async function loginAsDefault(page: Page): Promise<string> {
   );
 
   const token = api.getToken();
-  await page.goto("/login");
-  await page.evaluate((t) => {
+  await page.addInitScript((t) => {
     localStorage.setItem("multica_token", t);
   }, token);
   await page.goto(`/${workspace.slug}/issues`);
   await page.waitForURL("**/issues", { timeout: 10000 });
+  await page.getByRole("button", { name: "Start blank workspace" }).click({ timeout: 2000 }).catch(() => {});
   return workspace.slug;
 }
 
@@ -43,7 +43,7 @@ export async function createTestApi(): Promise<TestApiClient> {
 
 export async function openWorkspaceMenu(page: Page) {
   // Click the workspace switcher button (has ChevronDown icon)
-  await page.locator("aside button").first().click();
+  await page.getByRole("button", { name: /E2E Workspace/ }).click();
   // Wait for dropdown to appear
-  await page.locator('[class*="popover"]').waitFor({ state: "visible" });
+  await page.getByRole("menuitem", { name: "Log out" }).waitFor({ state: "visible" });
 }

--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -33,6 +33,37 @@ describe("ApiClient", () => {
     }
   });
 
+  it("logs 401 responses as warnings instead of errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "missing authorization" }), {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const client = new ApiClient("https://api.example.test", { logger });
+
+    await expect(client.getMe()).rejects.toMatchObject({
+      status: 401,
+      message: "missing authorization",
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "← 401 /api/me",
+      expect.objectContaining({ error: "missing authorization" }),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
   it("uses the expected HTTP contract for autopilot endpoints", async () => {
     const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
       new Response(JSON.stringify({ autopilots: [], runs: [], total: 0 }), {
@@ -143,5 +174,65 @@ describe("ApiClient", () => {
     expect(headers["X-Client-Platform"]).toBeUndefined();
     expect(headers["X-Client-Version"]).toBeUndefined();
     expect(headers["X-Client-OS"]).toBeUndefined();
+  });
+
+  it("posts generic OAuth login requests to the selected provider endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ token: "jwt", user: { id: "u1", email: "a@example.com" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ApiClient("https://api.example.test");
+    await client.oauthLogin("feishu_lark", {
+      code: "oauth-code",
+      redirectUri: "https://app.example.test/auth/callback",
+      codeVerifier: "pkce-verifier",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/auth/oauth/feishu_lark",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          code: "oauth-code",
+          redirect_uri: "https://app.example.test/auth/callback",
+          code_verifier: "pkce-verifier",
+        }),
+      }),
+    );
+  });
+
+  it("falls back when app config OAuth provider shape drifts", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({
+          cdn_domain: 123,
+          allow_signup: "yes",
+          oauth_providers: [
+            {
+              id: "feishu_lark",
+              label: null,
+              client_id: "cli_lark",
+              authorization_url: "https://open.feishu.cn/open-apis/authen/v1/authorize",
+            },
+          ],
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const client = new ApiClient("https://api.example.test");
+
+    await expect(client.getConfig()).resolves.toEqual({
+      cdn_domain: "",
+      allow_signup: true,
+      oauth_providers: [],
+    });
   });
 });

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -93,6 +93,7 @@ import {
   CommentsListSchema,
   EMPTY_LIST_ISSUES_RESPONSE,
   EMPTY_TIMELINE_PAGE,
+  AppConfigSchema,
   ListIssuesResponseSchema,
   SubscribersListSchema,
   TimelinePageSchema,
@@ -121,6 +122,31 @@ export interface ApiClientOptions {
 export interface LoginResponse {
   token: string;
   user: User;
+}
+
+export interface OAuthProviderPublicConfig {
+  id: string;
+  label: string;
+  client_id: string;
+  authorization_url: string;
+  scope?: string;
+  pkce?: boolean;
+  extra_auth_params?: Record<string, string>;
+}
+
+export interface OAuthLoginInput {
+  code: string;
+  redirectUri: string;
+  codeVerifier?: string;
+}
+
+export interface AppConfigResponse {
+  cdn_domain: string;
+  allow_signup: boolean;
+  google_client_id?: string;
+  oauth_providers?: OAuthProviderPublicConfig[];
+  posthog_key?: string;
+  posthog_host?: string;
 }
 
 // --- Starter content (post-onboarding import) -----------------------------
@@ -283,7 +309,7 @@ export class ApiClient {
     if (!res.ok) {
       if (res.status === 401) this.handleUnauthorized();
       const { message, body } = await this.parseErrorBody(res, `API error: ${res.status} ${res.statusText}`);
-      const logLevel = res.status === 404 ? "warn" : "error";
+      const logLevel = res.status === 401 || res.status === 404 ? "warn" : "error";
       this.logger[logLevel](`← ${res.status} ${path}`, { rid, duration: `${Date.now() - start}ms`, error: message });
       throw new ApiError(message, res.status, res.statusText, body);
     }
@@ -317,6 +343,17 @@ export class ApiClient {
     return this.fetch("/auth/google", {
       method: "POST",
       body: JSON.stringify({ code, redirect_uri: redirectUri }),
+    });
+  }
+
+  async oauthLogin(provider: string, input: OAuthLoginInput): Promise<LoginResponse> {
+    return this.fetch(`/auth/oauth/${encodeURIComponent(provider)}`, {
+      method: "POST",
+      body: JSON.stringify({
+        code: input.code,
+        redirect_uri: input.redirectUri,
+        code_verifier: input.codeVerifier,
+      }),
     });
   }
 
@@ -840,14 +877,15 @@ export class ApiClient {
   }
 
   // App Config
-  async getConfig(): Promise<{
-    cdn_domain: string;
-    allow_signup: boolean;
-    google_client_id?: string;
-    posthog_key?: string;
-    posthog_host?: string;
-  }> {
-    return this.fetch("/api/config");
+  async getConfig(): Promise<AppConfigResponse> {
+    const raw = await this.fetch<unknown>("/api/config");
+    return parseWithFallback(raw, AppConfigSchema, {
+      cdn_domain: "",
+      allow_signup: true,
+      oauth_providers: [],
+    }, {
+      endpoint: "GET /api/config",
+    });
   }
 
   // Workspaces

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -145,3 +145,22 @@ export const SubscribersListSchema = z.array(SubscriberSchema);
 export const ChildIssuesResponseSchema = z.object({
   issues: z.array(IssueSchema).default([]),
 }).loose();
+
+const OAuthProviderPublicConfigSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  client_id: z.string(),
+  authorization_url: z.string(),
+  scope: z.string().optional(),
+  pkce: z.boolean().optional(),
+  extra_auth_params: z.record(z.string(), z.string()).optional(),
+}).loose();
+
+export const AppConfigSchema = z.object({
+  cdn_domain: z.string().default(""),
+  allow_signup: z.boolean().default(true),
+  google_client_id: z.string().optional(),
+  oauth_providers: z.array(OAuthProviderPublicConfigSchema).optional(),
+  posthog_key: z.string().optional(),
+  posthog_host: z.string().optional(),
+}).loose();

--- a/packages/core/auth/store.test.ts
+++ b/packages/core/auth/store.test.ts
@@ -90,4 +90,29 @@ describe("authStore.initialize — token mode", () => {
     expect(store.getState().user).toEqual(fakeUser);
     expect(storage.snapshot().multica_token).toBe("t");
   });
+
+  it("logs in with a selected OAuth provider and persists the returned token", async () => {
+    const storage = makeStorage();
+    const api = {
+      setToken: vi.fn(),
+      oauthLogin: vi.fn().mockResolvedValue({ token: "oauth-jwt", user: fakeUser }),
+    } as unknown as ApiClient;
+    const store = createAuthStore({ api, storage });
+
+    const user = await store.getState().loginWithOAuthProvider(
+      "feishu_lark",
+      "oauth-code",
+      "https://app.example.test/auth/callback",
+      "pkce-verifier",
+    );
+
+    expect(api.oauthLogin).toHaveBeenCalledWith("feishu_lark", {
+      code: "oauth-code",
+      redirectUri: "https://app.example.test/auth/callback",
+      codeVerifier: "pkce-verifier",
+    });
+    expect(storage.snapshot().multica_token).toBe("oauth-jwt");
+    expect(api.setToken).toHaveBeenCalledWith("oauth-jwt");
+    expect(user).toEqual(fakeUser);
+  });
 });

--- a/packages/core/auth/store.ts
+++ b/packages/core/auth/store.ts
@@ -21,6 +21,12 @@ export interface AuthState {
   sendCode: (email: string) => Promise<void>;
   verifyCode: (email: string, code: string) => Promise<User>;
   loginWithGoogle: (code: string, redirectUri: string) => Promise<User>;
+  loginWithOAuthProvider: (
+    provider: string,
+    code: string,
+    redirectUri: string,
+    codeVerifier?: string,
+  ) => Promise<User>;
   loginWithToken: (token: string) => Promise<User>;
   logout: () => void;
   setUser: (user: User) => void;
@@ -93,6 +99,27 @@ export function createAuthStore(options: AuthStoreOptions) {
 
     loginWithGoogle: async (code: string, redirectUri: string) => {
       const { token, user } = await api.googleLogin(code, redirectUri);
+      if (!cookieAuth) {
+        storage.setItem("multica_token", token);
+        api.setToken(token);
+      }
+      onLogin?.();
+      identifyAnalytics(user.id, { email: user.email, name: user.name });
+      set({ user });
+      return user;
+    },
+
+    loginWithOAuthProvider: async (
+      provider: string,
+      code: string,
+      redirectUri: string,
+      codeVerifier?: string,
+    ) => {
+      const { token, user } = await api.oauthLogin(provider, {
+        code,
+        redirectUri,
+        codeVerifier,
+      });
       if (!cookieAuth) {
         storage.setItem("multica_token", token);
         api.setToken(token);

--- a/packages/core/config/index.ts
+++ b/packages/core/config/index.ts
@@ -1,21 +1,28 @@
 import { createStore } from "zustand/vanilla";
 import { useStore } from "zustand";
+import type { OAuthProviderPublicConfig } from "../api/client";
 
 interface ConfigState {
   cdnDomain: string;
   allowSignup: boolean;
   googleClientId: string;
+  oauthProviders: OAuthProviderPublicConfig[];
   setCdnDomain: (domain: string) => void;
-  setAuthConfig: (config: { allowSignup: boolean; googleClientId?: string }) => void;
+  setAuthConfig: (config: {
+    allowSignup: boolean;
+    googleClientId?: string;
+    oauthProviders?: OAuthProviderPublicConfig[];
+  }) => void;
 }
 
 export const configStore = createStore<ConfigState>((set) => ({
   cdnDomain: "",
   allowSignup: true,
   googleClientId: "",
+  oauthProviders: [],
   setCdnDomain: (domain) => set({ cdnDomain: domain }),
-  setAuthConfig: ({ allowSignup, googleClientId = "" }) =>
-    set({ allowSignup, googleClientId }),
+  setAuthConfig: ({ allowSignup, googleClientId = "", oauthProviders = [] }) =>
+    set({ allowSignup, googleClientId, oauthProviders }),
 }));
 
 export function useConfigStore(): ConfigState;

--- a/packages/core/platform/auth-initializer.tsx
+++ b/packages/core/platform/auth-initializer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { getApi } from "../api";
+import { ApiError, getApi } from "../api";
 import { useAuthStore } from "../auth";
 import {
   captureSignupSource,
@@ -50,9 +50,20 @@ export function AuthInitializer({
       .getConfig()
       .then((cfg) => {
         if (cfg.cdn_domain) configStore.getState().setCdnDomain(cfg.cdn_domain);
+        const oauthProviders = cfg.oauth_providers ?? (cfg.google_client_id
+          ? [{
+              id: "google",
+              label: "Google",
+              client_id: cfg.google_client_id,
+              authorization_url: "https://accounts.google.com/o/oauth2/v2/auth",
+              scope: "openid email profile",
+              extra_auth_params: { access_type: "offline", prompt: "select_account" },
+            }]
+          : []);
         configStore.getState().setAuthConfig({
           allowSignup: cfg.allow_signup,
           googleClientId: cfg.google_client_id,
+          oauthProviders,
         });
         if (cfg.posthog_key) {
           initAnalytics({
@@ -92,6 +103,11 @@ export function AuthInitializer({
           qc.setQueryData(workspaceKeys.list(), wsList);
         })
         .catch((err) => {
+          if (err instanceof ApiError && err.status === 401) {
+            logger.debug("cookie auth init skipped: unauthenticated session");
+            onAuthFailure();
+            return;
+          }
           logger.error("cookie auth init failed", err);
           onAuthFailure();
         });

--- a/packages/views/auth/login-page.test.tsx
+++ b/packages/views/auth/login-page.test.tsx
@@ -389,6 +389,47 @@ describe("LoginPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders a generic browser sign-in button for desktop handoff", () => {
+    renderWithI18n(<LoginPage onSuccess={onSuccess} onGoogleLogin={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: /continue in browser/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /continue with google/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders configured OAuth provider buttons and redirects with provider state", async () => {
+    renderWithI18n(
+      <LoginPage
+        onSuccess={onSuccess}
+        oauthProviders={[
+          {
+            id: "feishu_lark",
+            label: "Feishu/Lark",
+            clientId: "cli_lark",
+            authorizationUrl: "https://open.feishu.cn/open-apis/authen/v1/authorize",
+            scope: "contact:user.email:readonly",
+          },
+        ]}
+        oauthState="next:/invite/abc123"
+        oauthRedirectUri="https://app.example.test/auth/callback"
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /continue with feishu\/lark/i }));
+
+    const redirected = new URL(window.location.href);
+    expect(`${redirected.origin}${redirected.pathname}`).toBe("https://open.feishu.cn/open-apis/authen/v1/authorize");
+    expect(redirected.searchParams.get("client_id")).toBe("cli_lark");
+    expect(redirected.searchParams.get("response_type")).toBe("code");
+    expect(redirected.searchParams.get("redirect_uri")).toBe("https://app.example.test/auth/callback");
+    expect(redirected.searchParams.get("scope")).toBe("contact:user.email:readonly");
+    expect(redirected.searchParams.get("state")).toBe("provider:feishu_lark,next:/invite/abc123");
+  });
+
   // -------------------------------------------------------------------------
   // CLI callback — existing session
   // -------------------------------------------------------------------------

--- a/packages/views/auth/login-page.tsx
+++ b/packages/views/auth/login-page.tsx
@@ -35,6 +35,17 @@ interface GoogleAuthConfig {
   state?: string;
 }
 
+export interface OAuthProviderConfig {
+  id: string;
+  label: string;
+  clientId: string;
+  authorizationUrl: string;
+  scope?: string;
+  pkce?: boolean;
+  extraAuthParams?: Record<string, string>;
+  state?: string;
+}
+
 interface CliCallbackConfig {
   /** Validated localhost callback URL */
   url: string;
@@ -50,6 +61,12 @@ interface LoginPageProps {
   onSuccess: () => void;
   /** Google OAuth config. Omit to disable Google login. */
   google?: GoogleAuthConfig;
+  /** OAuth providers returned by the runtime config endpoint. */
+  oauthProviders?: OAuthProviderConfig[];
+  /** Opaque state shared by all configured OAuth providers. */
+  oauthState?: string;
+  /** Redirect URI shared by all configured OAuth providers. */
+  oauthRedirectUri?: string;
   /** CLI callback config for authorizing CLI tools. */
   cliCallback?: CliCallbackConfig;
   /** Called after a token is obtained (e.g. to set cookies). */
@@ -70,6 +87,38 @@ interface LoginPageProps {
 function redirectToCliCallback(url: string, token: string, state: string) {
   const separator = url.includes("?") ? "&" : "?";
   window.location.href = `${url}${separator}token=${encodeURIComponent(token)}&state=${encodeURIComponent(state)}`;
+}
+
+function base64UrlEncode(bytes: Uint8Array) {
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function oauthPKCEStorageKey(provider: string, nonce: string) {
+  return `multica_oauth_pkce:${provider}:${nonce}`;
+}
+
+async function createPKCEPair() {
+  if (!window.crypto?.getRandomValues || !window.crypto?.subtle) {
+    throw new Error("OAuth PKCE requires Web Crypto support");
+  }
+  const random = new Uint8Array(32);
+  window.crypto.getRandomValues(random);
+  const verifier = base64UrlEncode(random);
+  const digest = await window.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier),
+  );
+  return {
+    verifier,
+    challenge: base64UrlEncode(new Uint8Array(digest)),
+  };
 }
 
 /**
@@ -101,6 +150,9 @@ export function LoginPage({
   logo,
   onSuccess,
   google,
+  oauthProviders = [],
+  oauthState,
+  oauthRedirectUri,
   cliCallback,
   onTokenObtained,
   onGoogleLogin,
@@ -268,22 +320,57 @@ export function LoginPage({
     }
   };
 
+  const handleOAuthLogin = async (provider: OAuthProviderConfig) => {
+    const redirectUri = oauthRedirectUri || `${window.location.origin}/auth/callback`;
+    const stateParts = [`provider:${provider.id}`];
+    if (provider.pkce) {
+      const nonce = Math.random().toString(36).slice(2);
+      const { verifier, challenge } = await createPKCEPair();
+      sessionStorage.setItem(oauthPKCEStorageKey(provider.id, nonce), verifier);
+      stateParts.push(`nonce:${nonce}`);
+      provider = {
+        ...provider,
+        extraAuthParams: {
+          ...provider.extraAuthParams,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        },
+      };
+    }
+    const providerState = provider.state ?? oauthState;
+    if (providerState) stateParts.push(providerState);
+    const state = stateParts.join(",");
+    const params = new URLSearchParams({
+      client_id: provider.clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      state,
+    });
+    if (provider.scope) params.set("scope", provider.scope);
+    for (const [key, value] of Object.entries(provider.extraAuthParams ?? {})) {
+      params.set(key, value);
+    }
+    window.location.href = `${provider.authorizationUrl}?${params}`;
+  };
+
   const handleGoogleLogin = () => {
-    if (onGoogleLogin) {
+    if (onGoogleLogin && !google) {
       onGoogleLogin();
       return;
     }
     if (!google) return;
-    const params = new URLSearchParams({
-      client_id: google.clientId,
-      redirect_uri: google.redirectUri,
-      response_type: "code",
+    handleOAuthLogin({
+      id: "google",
+      label: "Google",
+      clientId: google.clientId,
+      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       scope: "openid email profile",
-      access_type: "offline",
-      prompt: "select_account",
+      extraAuthParams: {
+        access_type: "offline",
+        prompt: "select_account",
+      },
+      state: google.state,
     });
-    if (google.state) params.set("state", google.state);
-    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
   };
 
   // -------------------------------------------------------------------------
@@ -448,7 +535,7 @@ export function LoginPage({
               ? t(($) => $.signin.sending)
               : t(($) => $.signin.continue)}
           </Button>
-          {(google || onGoogleLogin) && (
+          {(google || onGoogleLogin || oauthProviders.length > 0) && (
             <>
               <div className="relative w-full">
                 <div className="absolute inset-0 flex items-center">
@@ -460,34 +547,51 @@ export function LoginPage({
                   </span>
                 </div>
               </div>
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full"
-                size="lg"
-                onClick={handleGoogleLogin}
-                disabled={loading}
-              >
-                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-                {t(($) => $.signin.google)}
-              </Button>
+              {(google || onGoogleLogin) && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  size="lg"
+                  onClick={handleGoogleLogin}
+                  disabled={loading}
+                >
+                  {google && (
+                    <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                      <path
+                        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                        fill="#4285F4"
+                      />
+                      <path
+                        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                        fill="#34A853"
+                      />
+                      <path
+                        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                        fill="#FBBC05"
+                      />
+                      <path
+                        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                        fill="#EA4335"
+                      />
+                    </svg>
+                  )}
+                  {google ? t(($) => $.signin.google) : t(($) => $.signin.browser)}
+                </Button>
+              )}
+              {oauthProviders.map((provider) => (
+                <Button
+                  key={provider.id}
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  size="lg"
+                  onClick={() => handleOAuthLogin(provider)}
+                  disabled={loading}
+                >
+                  {t(($) => $.signin.oauth_provider, { provider: provider.label })}
+                </Button>
+              ))}
             </>
           )}
           {extra && <div className="w-full pt-1 text-center">{extra}</div>}

--- a/packages/views/locales/en/auth.json
+++ b/packages/views/locales/en/auth.json
@@ -5,7 +5,9 @@
     "continue": "Continue",
     "sending": "Sending code...",
     "divider": "or",
-    "google": "Continue with Google"
+    "google": "Continue with Google",
+    "browser": "Continue in browser",
+    "oauth_provider": "Continue with {{provider}}"
   },
   "verify": {
     "title": "Check your email",

--- a/packages/views/locales/zh-Hans/auth.json
+++ b/packages/views/locales/zh-Hans/auth.json
@@ -5,7 +5,9 @@
     "continue": "继续",
     "sending": "发送验证码...",
     "divider": "或",
-    "google": "使用 Google 登录"
+    "google": "使用 Google 登录",
+    "browser": "在浏览器中继续登录",
+    "oauth_provider": "使用 {{provider}} 登录"
   },
   "verify": {
     "title": "查看你的邮箱",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -207,6 +207,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	r.Post("/auth/send-code", h.SendCode)
 	r.Post("/auth/verify-code", h.VerifyCode)
 	r.Post("/auth/google", h.GoogleLogin)
+	r.Post("/auth/oauth/{provider}", h.OAuthLogin)
 	r.Post("/auth/logout", h.Logout)
 
 	// Public API

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -16,11 +15,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/service"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -431,16 +432,10 @@ type GoogleLoginRequest struct {
 	RedirectURI string `json:"redirect_uri"`
 }
 
-type googleTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	IDToken     string `json:"id_token"`
-	TokenType   string `json:"token_type"`
-}
-
-type googleUserInfo struct {
-	Email   string `json:"email"`
-	Name    string `json:"name"`
-	Picture string `json:"picture"`
+type OAuthLoginRequest struct {
+	Code         string `json:"code"`
+	RedirectURI  string `json:"redirect_uri"`
+	CodeVerifier string `json:"code_verifier,omitempty"`
 }
 
 func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
@@ -455,80 +450,62 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientID := os.Getenv("GOOGLE_CLIENT_ID")
-	clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
-	if clientID == "" || clientSecret == "" {
-		writeError(w, http.StatusServiceUnavailable, "Google login is not configured")
+	h.loginWithOAuthProvider(w, r, service.OAuthProviderGoogle, OAuthLoginRequest{
+		Code:        req.Code,
+		RedirectURI: firstNonEmpty(req.RedirectURI, os.Getenv("GOOGLE_REDIRECT_URI")),
+	})
+}
+
+func (h *Handler) OAuthLogin(w http.ResponseWriter, r *http.Request) {
+	providerID := strings.TrimSpace(chi.URLParam(r, "provider"))
+	if providerID == "" {
+		writeError(w, http.StatusBadRequest, "provider is required")
 		return
 	}
 
-	redirectURI := req.RedirectURI
-	if redirectURI == "" {
-		redirectURI = os.Getenv("GOOGLE_REDIRECT_URI")
+	var req OAuthLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Code == "" {
+		writeError(w, http.StatusBadRequest, "code is required")
+		return
 	}
 
-	// Exchange authorization code for tokens.
-	tokenResp, err := http.PostForm("https://oauth2.googleapis.com/token", url.Values{
-		"code":          {req.Code},
-		"client_id":     {clientID},
-		"client_secret": {clientSecret},
-		"redirect_uri":  {redirectURI},
-		"grant_type":    {"authorization_code"},
+	h.loginWithOAuthProvider(w, r, providerID, req)
+}
+
+func (h *Handler) oauthProviderRegistry() *service.OAuthProviderRegistry {
+	if h.OAuthProviders != nil {
+		return h.OAuthProviders
+	}
+	return service.NewOAuthProviderRegistryFromEnv(http.DefaultClient)
+}
+
+func (h *Handler) loginWithOAuthProvider(w http.ResponseWriter, r *http.Request, providerID string, req OAuthLoginRequest) {
+	provider, ok := h.oauthProviderRegistry().Get(providerID)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "OAuth login provider is not configured")
+		return
+	}
+
+	identity, err := provider.Exchange(r.Context(), service.OAuthExchangeRequest{
+		Code:         req.Code,
+		RedirectURI:  req.RedirectURI,
+		CodeVerifier: req.CodeVerifier,
 	})
 	if err != nil {
-		slog.Error("google oauth token exchange failed", "error", err)
-		writeError(w, http.StatusBadGateway, "failed to exchange code with Google")
-		return
-	}
-	defer tokenResp.Body.Close()
-
-	tokenBody, err := io.ReadAll(tokenResp.Body)
-	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to read Google token response")
+		slog.Error("oauth provider login failed", append(logger.RequestAttrs(r), "provider", providerID, "error", err)...)
+		writeError(w, http.StatusBadGateway, "failed to sign in with OAuth provider")
 		return
 	}
 
-	if tokenResp.StatusCode != http.StatusOK {
-		slog.Error("google oauth token exchange returned error", "status", tokenResp.StatusCode, "body", string(tokenBody))
-		writeError(w, http.StatusBadRequest, "failed to exchange code with Google")
+	email := strings.ToLower(strings.TrimSpace(identity.Email))
+	if email == "" {
+		writeError(w, http.StatusBadRequest, "OAuth account has no email")
 		return
 	}
-
-	var gToken googleTokenResponse
-	if err := json.Unmarshal(tokenBody, &gToken); err != nil {
-		writeError(w, http.StatusBadGateway, "failed to parse Google token response")
-		return
-	}
-
-	// Fetch user info from Google.
-	userInfoReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://www.googleapis.com/oauth2/v2/userinfo", nil)
-	if err != nil {
-		slog.Error("failed to create userinfo request", "error", err)
-		writeError(w, http.StatusInternalServerError, "internal error")
-		return
-	}
-	userInfoReq.Header.Set("Authorization", "Bearer "+gToken.AccessToken)
-
-	userInfoResp, err := http.DefaultClient.Do(userInfoReq)
-	if err != nil {
-		slog.Error("google userinfo fetch failed", "error", err)
-		writeError(w, http.StatusBadGateway, "failed to fetch user info from Google")
-		return
-	}
-	defer userInfoResp.Body.Close()
-
-	var gUser googleUserInfo
-	if err := json.NewDecoder(userInfoResp.Body).Decode(&gUser); err != nil {
-		writeError(w, http.StatusBadGateway, "failed to parse Google user info")
-		return
-	}
-
-	if gUser.Email == "" {
-		writeError(w, http.StatusBadRequest, "Google account has no email")
-		return
-	}
-
-	email := strings.ToLower(strings.TrimSpace(gUser.Email))
 
 	user, isNew, err := h.findOrCreateUser(r.Context(), email)
 	if err != nil {
@@ -542,22 +519,22 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	if isNew {
 		evt := analytics.Signup(uuidToString(user.ID), user.Email, signupSourceFromRequest(r))
-		evt.Properties["auth_method"] = "google"
+		evt.Properties["auth_method"] = providerID
 		h.Analytics.Capture(evt)
 	}
 
-	// Update name and avatar from Google profile if the user was just created
+	// Update name and avatar from the provider profile if the user was just created
 	// (default name is email prefix) or has no avatar yet.
 	needsUpdate := false
 	newName := user.Name
 	newAvatar := user.AvatarUrl
 
-	if gUser.Name != "" && user.Name == strings.Split(email, "@")[0] {
-		newName = gUser.Name
+	if identity.Name != "" && user.Name == strings.Split(email, "@")[0] {
+		newName = identity.Name
 		needsUpdate = true
 	}
-	if gUser.Picture != "" && !user.AvatarUrl.Valid {
-		newAvatar = pgtype.Text{String: gUser.Picture, Valid: true}
+	if identity.AvatarURL != "" && !user.AvatarUrl.Valid {
+		newAvatar = pgtype.Text{String: identity.AvatarURL, Valid: true}
 		needsUpdate = true
 	}
 
@@ -574,7 +551,7 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 
 	tokenString, err := h.issueJWT(user)
 	if err != nil {
-		slog.Warn("google login failed", append(logger.RequestAttrs(r), "error", err, "email", email)...)
+		slog.Warn("oauth login failed", append(logger.RequestAttrs(r), "provider", providerID, "error", err, "email", email)...)
 		writeError(w, http.StatusInternalServerError, "failed to generate token")
 		return
 	}
@@ -589,11 +566,20 @@ func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	slog.Info("user logged in via google", append(logger.RequestAttrs(r), "user_id", uuidToString(user.ID), "email", user.Email)...)
+	slog.Info("user logged in via oauth", append(logger.RequestAttrs(r), "provider", providerID, "user_id", uuidToString(user.ID), "email", user.Email)...)
 	writeJSON(w, http.StatusOK, LoginResponse{
 		Token: tokenString,
 		User:  userToResponse(user),
 	})
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // IssueCliToken returns a fresh JWT for the authenticated user.

--- a/server/internal/handler/config.go
+++ b/server/internal/handler/config.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"net/http"
 	"os"
+
+	"github.com/multica-ai/multica/server/internal/service"
 )
 
 type AppConfig struct {
@@ -10,8 +12,9 @@ type AppConfig struct {
 	// Public auth config consumed by the web app at runtime so self-hosted
 	// deployments do not need to rebuild the frontend image when operators
 	// toggle signup or wire Google OAuth.
-	AllowSignup    bool   `json:"allow_signup"`
-	GoogleClientID string `json:"google_client_id,omitempty"`
+	AllowSignup    bool                                `json:"allow_signup"`
+	GoogleClientID string                              `json:"google_client_id,omitempty"`
+	OAuthProviders []service.OAuthProviderPublicConfig `json:"oauth_providers"`
 
 	// PostHog public config for the frontend. The key is the same Project
 	// API Key the backend uses; returning it here (instead of baking it
@@ -30,6 +33,7 @@ func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	config := AppConfig{
 		AllowSignup:    os.Getenv("ALLOW_SIGNUP") != "false",
 		GoogleClientID: os.Getenv("GOOGLE_CLIENT_ID"),
+		OAuthProviders: service.NewOAuthProviderRegistryFromEnv(http.DefaultClient).PublicConfigs(),
 	}
 	if h.Storage != nil {
 		config.CdnDomain = h.Storage.CdnDomain()

--- a/server/internal/handler/config_test.go
+++ b/server/internal/handler/config_test.go
@@ -14,6 +14,11 @@ func TestGetConfigIncludesRuntimeAuthConfig(t *testing.T) {
 
 	t.Setenv("ALLOW_SIGNUP", "false")
 	t.Setenv("GOOGLE_CLIENT_ID", "google-client-id")
+	t.Setenv("GOOGLE_CLIENT_SECRET", "google-client-secret")
+	t.Setenv("LARK_OAUTH_CLIENT_ID", "")
+	t.Setenv("LARK_OAUTH_CLIENT_SECRET", "")
+	t.Setenv("LARK_APP_ID", "")
+	t.Setenv("LARK_APP_SECRET", "")
 	t.Setenv("POSTHOG_API_KEY", "phc_test")
 	t.Setenv("POSTHOG_HOST", "https://eu.i.posthog.com")
 
@@ -39,10 +44,65 @@ func TestGetConfigIncludesRuntimeAuthConfig(t *testing.T) {
 	if cfg.GoogleClientID != "google-client-id" {
 		t.Fatalf("google_client_id: want google-client-id, got %q", cfg.GoogleClientID)
 	}
+	if len(cfg.OAuthProviders) != 1 {
+		t.Fatalf("oauth_providers: want 1 Google provider, got %#v", cfg.OAuthProviders)
+	}
+	if cfg.OAuthProviders[0].ID != "google" || cfg.OAuthProviders[0].ClientID != "google-client-id" {
+		t.Fatalf("oauth_providers[0]: unexpected provider config %#v", cfg.OAuthProviders[0])
+	}
 	if cfg.PosthogKey != "phc_test" {
 		t.Fatalf("posthog_key: want phc_test, got %q", cfg.PosthogKey)
 	}
 	if cfg.PosthogHost != "https://eu.i.posthog.com" {
 		t.Fatalf("posthog_host: want https://eu.i.posthog.com, got %q", cfg.PosthogHost)
+	}
+}
+
+func TestGetConfigIncludesFeishuLarkOAuthProvider(t *testing.T) {
+	t.Setenv("GOOGLE_CLIENT_ID", "")
+	t.Setenv("GOOGLE_CLIENT_SECRET", "")
+	t.Setenv("LARK_OAUTH_CLIENT_ID", "cli_lark")
+	t.Setenv("LARK_OAUTH_CLIENT_SECRET", "super-secret")
+	t.Setenv("LARK_OAUTH_BASE_URL", "https://open.larksuite.com")
+	t.Setenv("LARK_OAUTH_LABEL", "Company Lark")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	w := httptest.NewRecorder()
+
+	testHandler.GetConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw config: %v", err)
+	}
+	if _, ok := raw["lark_oauth_client_secret"]; ok {
+		t.Fatalf("config leaked lark secret: %s", w.Body.String())
+	}
+
+	var cfg AppConfig
+	if err := json.Unmarshal(w.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if len(cfg.OAuthProviders) != 1 {
+		t.Fatalf("oauth_providers: want 1 Feishu/Lark provider, got %#v", cfg.OAuthProviders)
+	}
+	provider := cfg.OAuthProviders[0]
+	if provider.ID != "feishu_lark" {
+		t.Fatalf("provider id: %q", provider.ID)
+	}
+	if provider.Label != "Company Lark" {
+		t.Fatalf("provider label: %q", provider.Label)
+	}
+	if provider.ClientID != "cli_lark" {
+		t.Fatalf("provider client_id: %q", provider.ClientID)
+	}
+	if provider.AuthorizationURL != "https://accounts.larksuite.com/open-apis/authen/v1/authorize" {
+		t.Fatalf("provider authorization_url: %q", provider.AuthorizationURL)
+	}
+	if !provider.PKCE {
+		t.Fatalf("provider should require PKCE")
 	}
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -59,6 +59,7 @@ type Handler struct {
 	TaskService           *service.TaskService
 	AutopilotService      *service.AutopilotService
 	EmailService          *service.EmailService
+	OAuthProviders        *service.OAuthProviderRegistry
 	UpdateStore           UpdateStore
 	ModelListStore        ModelListStore
 	LocalSkillListStore   LocalSkillListStore

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/multica-ai/multica/server/internal/analytics"
+	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/realtime"
 	"github.com/multica-ai/multica/server/internal/service"
@@ -1540,6 +1541,93 @@ func TestVerifyCode(t *testing.T) {
 	}
 	if resp.User.Email != email {
 		t.Fatalf("VerifyCode: expected email '%s', got '%s'", email, resp.User.Email)
+	}
+}
+
+func TestOAuthLoginWithFeishuLarkProvider(t *testing.T) {
+	const email = "oauth-lark-test@multica.ai"
+	ctx := context.Background()
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM "user" WHERE email = $1`, email)
+	})
+
+	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/open-apis/authen/v2/oauth/token":
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode token request: %v", err)
+			}
+			if body["code"] != "oauth-code" || body["code_verifier"] != "pkce-verifier" {
+				t.Fatalf("unexpected token request body: %#v", body)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"user-token","token_type":"Bearer","expires_in":7200}`))
+		case "/open-apis/authen/v1/user_info":
+			if got := r.Header.Get("Authorization"); got != "Bearer user-token" {
+				t.Fatalf("userinfo authorization header: %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"code": 0,
+				"msg": "success",
+				"data": {
+					"name": "Lark User",
+					"avatar_url": "https://avatar.example/lark.png",
+					"email": "personal@example.com",
+					"enterprise_email": "oauth-lark-test@multica.ai"
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected provider path: %s", r.URL.Path)
+		}
+	}))
+	defer providerServer.Close()
+
+	t.Setenv("LARK_OAUTH_CLIENT_ID", "cli_lark")
+	t.Setenv("LARK_OAUTH_CLIENT_SECRET", "lark-secret")
+	t.Setenv("LARK_OAUTH_BASE_URL", providerServer.URL)
+
+	origProviders := testHandler.OAuthProviders
+	testHandler.OAuthProviders = service.NewOAuthProviderRegistryFromEnv(providerServer.Client())
+	t.Cleanup(func() { testHandler.OAuthProviders = origProviders })
+
+	w := httptest.NewRecorder()
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(map[string]string{
+		"code":          "oauth-code",
+		"redirect_uri":  "http://localhost:3000/auth/callback",
+		"code_verifier": "pkce-verifier",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/auth/oauth/feishu_lark", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	req = withURLParam(req, "provider", "feishu_lark")
+
+	testHandler.OAuthLogin(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("OAuthLogin: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp LoginResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode login response: %v", err)
+	}
+	if resp.Token == "" {
+		t.Fatalf("OAuthLogin: expected token")
+	}
+	if resp.User.Email != email {
+		t.Fatalf("OAuthLogin email: want %s, got %s", email, resp.User.Email)
+	}
+
+	var hasAuthCookie bool
+	for _, cookie := range w.Result().Cookies() {
+		if cookie.Name == auth.AuthCookieName && cookie.Value != "" {
+			hasAuthCookie = true
+		}
+	}
+	if !hasAuthCookie {
+		t.Fatalf("OAuthLogin: expected %s cookie", auth.AuthCookieName)
 	}
 }
 

--- a/server/internal/service/oauth.go
+++ b/server/internal/service/oauth.go
@@ -1,0 +1,435 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const (
+	OAuthProviderGoogle      = "google"
+	OAuthProviderFeishuLark  = "feishu_lark"
+	defaultGoogleAuthorize   = "https://accounts.google.com/o/oauth2/v2/auth"
+	defaultGoogleToken       = "https://oauth2.googleapis.com/token"
+	defaultGoogleUserInfo    = "https://www.googleapis.com/oauth2/v2/userinfo"
+	defaultLarkOpenAPIBase   = "https://open.feishu.cn"
+	defaultFeishuAccountBase = "https://accounts.feishu.cn"
+	defaultLarkAccountBase   = "https://accounts.larksuite.com"
+	defaultLarkProviderLabel = "Feishu/Lark"
+)
+
+type OAuthProviderPublicConfig struct {
+	ID               string            `json:"id"`
+	Label            string            `json:"label"`
+	ClientID         string            `json:"client_id"`
+	AuthorizationURL string            `json:"authorization_url"`
+	Scope            string            `json:"scope,omitempty"`
+	PKCE             bool              `json:"pkce,omitempty"`
+	ExtraAuthParams  map[string]string `json:"extra_auth_params,omitempty"`
+}
+
+type OAuthExchangeRequest struct {
+	Code         string
+	RedirectURI  string
+	CodeVerifier string
+}
+
+type OAuthIdentity struct {
+	Email     string
+	Name      string
+	AvatarURL string
+}
+
+type OAuthLoginProvider interface {
+	ID() string
+	PublicConfig() OAuthProviderPublicConfig
+	Exchange(ctx context.Context, req OAuthExchangeRequest) (OAuthIdentity, error)
+}
+
+type OAuthProviderRegistry struct {
+	providers map[string]OAuthLoginProvider
+	order     []string
+}
+
+func NewOAuthProviderRegistryFromEnv(client *http.Client) *OAuthProviderRegistry {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	registry := &OAuthProviderRegistry{providers: map[string]OAuthLoginProvider{}}
+	if p := newGoogleOAuthProviderFromEnv(client); p != nil {
+		registry.add(p)
+	}
+	if p := newLarkOAuthProviderFromEnv(client); p != nil {
+		registry.add(p)
+	}
+	return registry
+}
+
+func (r *OAuthProviderRegistry) add(provider OAuthLoginProvider) {
+	r.providers[provider.ID()] = provider
+	r.order = append(r.order, provider.ID())
+}
+
+func (r *OAuthProviderRegistry) Get(id string) (OAuthLoginProvider, bool) {
+	if r == nil {
+		return nil, false
+	}
+	provider, ok := r.providers[id]
+	return provider, ok
+}
+
+func (r *OAuthProviderRegistry) PublicConfigs() []OAuthProviderPublicConfig {
+	if r == nil {
+		return nil
+	}
+	configs := make([]OAuthProviderPublicConfig, 0, len(r.order))
+	for _, id := range r.order {
+		configs = append(configs, r.providers[id].PublicConfig())
+	}
+	return configs
+}
+
+type googleOAuthProvider struct {
+	client           *http.Client
+	clientID         string
+	clientSecret     string
+	authorizationURL string
+	tokenURL         string
+	userInfoURL      string
+}
+
+func newGoogleOAuthProviderFromEnv(client *http.Client) *googleOAuthProvider {
+	clientID := strings.TrimSpace(os.Getenv("GOOGLE_CLIENT_ID"))
+	clientSecret := strings.TrimSpace(os.Getenv("GOOGLE_CLIENT_SECRET"))
+	if clientID == "" || clientSecret == "" {
+		return nil
+	}
+	return &googleOAuthProvider{
+		client:           client,
+		clientID:         clientID,
+		clientSecret:     clientSecret,
+		authorizationURL: envOrDefault("GOOGLE_AUTHORIZATION_URL", defaultGoogleAuthorize),
+		tokenURL:         envOrDefault("GOOGLE_TOKEN_URL", defaultGoogleToken),
+		userInfoURL:      envOrDefault("GOOGLE_USERINFO_URL", defaultGoogleUserInfo),
+	}
+}
+
+func (p *googleOAuthProvider) ID() string {
+	return OAuthProviderGoogle
+}
+
+func (p *googleOAuthProvider) PublicConfig() OAuthProviderPublicConfig {
+	return OAuthProviderPublicConfig{
+		ID:               p.ID(),
+		Label:            "Google",
+		ClientID:         p.clientID,
+		AuthorizationURL: p.authorizationURL,
+		Scope:            "openid email profile",
+		ExtraAuthParams: map[string]string{
+			"access_type": "offline",
+			"prompt":      "select_account",
+		},
+	}
+}
+
+type googleTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
+type googleUserInfo struct {
+	Email   string `json:"email"`
+	Name    string `json:"name"`
+	Picture string `json:"picture"`
+}
+
+func (p *googleOAuthProvider) Exchange(ctx context.Context, req OAuthExchangeRequest) (OAuthIdentity, error) {
+	form := url.Values{
+		"code":          {req.Code},
+		"client_id":     {p.clientID},
+		"client_secret": {p.clientSecret},
+		"redirect_uri":  {req.RedirectURI},
+		"grant_type":    {"authorization_code"},
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return OAuthIdentity{}, err
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	tokenResp, err := p.client.Do(httpReq)
+	if err != nil {
+		return OAuthIdentity{}, fmt.Errorf("google token exchange failed: %w", err)
+	}
+	defer tokenResp.Body.Close()
+
+	tokenBody, err := io.ReadAll(tokenResp.Body)
+	if err != nil {
+		return OAuthIdentity{}, fmt.Errorf("read google token response: %w", err)
+	}
+	if tokenResp.StatusCode != http.StatusOK {
+		return OAuthIdentity{}, fmt.Errorf("google token exchange returned %d: %s", tokenResp.StatusCode, string(tokenBody))
+	}
+
+	var token googleTokenResponse
+	if err := json.Unmarshal(tokenBody, &token); err != nil {
+		return OAuthIdentity{}, fmt.Errorf("parse google token response: %w", err)
+	}
+	if token.AccessToken == "" {
+		return OAuthIdentity{}, errors.New("google token response missing access_token")
+	}
+
+	userReq, err := http.NewRequestWithContext(ctx, http.MethodGet, p.userInfoURL, nil)
+	if err != nil {
+		return OAuthIdentity{}, err
+	}
+	userReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	userResp, err := p.client.Do(userReq)
+	if err != nil {
+		return OAuthIdentity{}, fmt.Errorf("google userinfo fetch failed: %w", err)
+	}
+	defer userResp.Body.Close()
+	if userResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(userResp.Body)
+		return OAuthIdentity{}, fmt.Errorf("google userinfo returned %d: %s", userResp.StatusCode, string(body))
+	}
+
+	var user googleUserInfo
+	if err := json.NewDecoder(userResp.Body).Decode(&user); err != nil {
+		return OAuthIdentity{}, fmt.Errorf("parse google userinfo: %w", err)
+	}
+	email := strings.ToLower(strings.TrimSpace(user.Email))
+	if email == "" {
+		return OAuthIdentity{}, errors.New("Google account has no email")
+	}
+	return OAuthIdentity{Email: email, Name: strings.TrimSpace(user.Name), AvatarURL: strings.TrimSpace(user.Picture)}, nil
+}
+
+type larkOAuthProvider struct {
+	client           *http.Client
+	clientID         string
+	clientSecret     string
+	label            string
+	authorizationURL string
+	tokenURL         string
+	userInfoURL      string
+	scope            string
+	pkce             bool
+}
+
+func newLarkOAuthProviderFromEnv(client *http.Client) *larkOAuthProvider {
+	clientID := firstEnv("LARK_OAUTH_CLIENT_ID", "LARK_APP_ID")
+	clientSecret := firstEnv("LARK_OAUTH_CLIENT_SECRET", "LARK_APP_SECRET")
+	if clientID == "" || clientSecret == "" {
+		return nil
+	}
+
+	baseURL := normalizeBaseURL(firstEnv("LARK_OAUTH_BASE_URL", "LARK_OPENAPI_BASE_URL"))
+	if baseURL == "" {
+		baseURL = defaultLarkOpenAPIBase
+	}
+
+	return &larkOAuthProvider{
+		client:           client,
+		clientID:         clientID,
+		clientSecret:     clientSecret,
+		label:            envOrDefault("LARK_OAUTH_LABEL", defaultLarkProviderLabel),
+		authorizationURL: envOrDefault("LARK_OAUTH_AUTHORIZATION_URL", defaultLarkAuthorizationURL(baseURL)),
+		tokenURL:         envOrDefault("LARK_OAUTH_TOKEN_URL", baseURL+"/open-apis/authen/v2/oauth/token"),
+		userInfoURL:      envOrDefault("LARK_OAUTH_USERINFO_URL", baseURL+"/open-apis/authen/v1/user_info"),
+		scope:            strings.TrimSpace(os.Getenv("LARK_OAUTH_SCOPE")),
+		pkce:             envBoolDefault("LARK_OAUTH_PKCE", true),
+	}
+}
+
+func (p *larkOAuthProvider) ID() string {
+	return OAuthProviderFeishuLark
+}
+
+func (p *larkOAuthProvider) PublicConfig() OAuthProviderPublicConfig {
+	return OAuthProviderPublicConfig{
+		ID:               p.ID(),
+		Label:            p.label,
+		ClientID:         p.clientID,
+		AuthorizationURL: p.authorizationURL,
+		Scope:            p.scope,
+		PKCE:             p.pkce,
+	}
+}
+
+type larkTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Code        int    `json:"code"`
+	Msg         string `json:"msg"`
+	Data        *struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+	} `json:"data"`
+}
+
+type larkUserInfoEnvelope struct {
+	Code int          `json:"code"`
+	Msg  string       `json:"msg"`
+	Data larkUserInfo `json:"data"`
+}
+
+type larkUserInfo struct {
+	Name            string `json:"name"`
+	EnName          string `json:"en_name"`
+	AvatarURL       string `json:"avatar_url"`
+	Email           string `json:"email"`
+	EnterpriseEmail string `json:"enterprise_email"`
+}
+
+func (p *larkOAuthProvider) Exchange(ctx context.Context, req OAuthExchangeRequest) (OAuthIdentity, error) {
+	body := map[string]string{
+		"grant_type":    "authorization_code",
+		"client_id":     p.clientID,
+		"client_secret": p.clientSecret,
+		"code":          req.Code,
+		"redirect_uri":  req.RedirectURI,
+	}
+	if req.CodeVerifier != "" {
+		body["code_verifier"] = req.CodeVerifier
+	}
+
+	tokenBody, err := json.Marshal(body)
+	if err != nil {
+		return OAuthIdentity{}, err
+	}
+	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.tokenURL, strings.NewReader(string(tokenBody)))
+	if err != nil {
+		return OAuthIdentity{}, err
+	}
+	tokenReq.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	tokenResp, err := p.client.Do(tokenReq)
+	if err != nil {
+		return OAuthIdentity{}, fmt.Errorf("Feishu/Lark token exchange failed: %w", err)
+	}
+	defer tokenResp.Body.Close()
+
+	rawTokenBody, err := io.ReadAll(tokenResp.Body)
+	if err != nil {
+		return OAuthIdentity{}, fmt.Errorf("read Feishu/Lark token response: %w", err)
+	}
+	if tokenResp.StatusCode != http.StatusOK {
+		return OAuthIdentity{}, fmt.Errorf("Feishu/Lark token exchange returned %d: %s", tokenResp.StatusCode, string(rawTokenBody))
+	}
+
+	var token larkTokenResponse
+	if err := json.Unmarshal(rawTokenBody, &token); err != nil {
+		return OAuthIdentity{}, fmt.Errorf("parse Feishu/Lark token response: %w", err)
+	}
+	accessToken := strings.TrimSpace(token.AccessToken)
+	if accessToken == "" && token.Data != nil {
+		accessToken = strings.TrimSpace(token.Data.AccessToken)
+	}
+	if accessToken == "" {
+		return OAuthIdentity{}, fmt.Errorf("Feishu/Lark token response missing access_token: code=%d msg=%s", token.Code, token.Msg)
+	}
+
+	userReq, err := http.NewRequestWithContext(ctx, http.MethodGet, p.userInfoURL, nil)
+	if err != nil {
+		return OAuthIdentity{}, err
+	}
+	userReq.Header.Set("Authorization", "Bearer "+accessToken)
+
+	userResp, err := p.client.Do(userReq)
+	if err != nil {
+		return OAuthIdentity{}, fmt.Errorf("Feishu/Lark userinfo fetch failed: %w", err)
+	}
+	defer userResp.Body.Close()
+	if userResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(userResp.Body)
+		return OAuthIdentity{}, fmt.Errorf("Feishu/Lark userinfo returned %d: %s", userResp.StatusCode, string(body))
+	}
+
+	var envelope larkUserInfoEnvelope
+	if err := json.NewDecoder(userResp.Body).Decode(&envelope); err != nil {
+		return OAuthIdentity{}, fmt.Errorf("parse Feishu/Lark userinfo: %w", err)
+	}
+	if envelope.Code != 0 {
+		return OAuthIdentity{}, fmt.Errorf("Feishu/Lark userinfo error: code=%d msg=%s", envelope.Code, envelope.Msg)
+	}
+
+	user := envelope.Data
+	email := strings.ToLower(strings.TrimSpace(user.EnterpriseEmail))
+	if email == "" {
+		email = strings.ToLower(strings.TrimSpace(user.Email))
+	}
+	if email == "" {
+		return OAuthIdentity{}, errors.New("Feishu/Lark account has no email")
+	}
+
+	name := strings.TrimSpace(user.Name)
+	if name == "" {
+		name = strings.TrimSpace(user.EnName)
+	}
+	return OAuthIdentity{Email: email, Name: name, AvatarURL: strings.TrimSpace(user.AvatarURL)}, nil
+}
+
+func firstEnv(keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func envBoolDefault(key string, fallback bool) bool {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	switch strings.ToLower(value) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		slog.Warn("invalid boolean env value; using default", "key", key, "value", value, "default", fallback)
+		return fallback
+	}
+}
+
+func normalizeBaseURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	return strings.TrimRight(raw, "/")
+}
+
+func defaultLarkAuthorizationURL(openAPIBaseURL string) string {
+	accountBaseURL := normalizeBaseURL(os.Getenv("LARK_OAUTH_ACCOUNT_BASE_URL"))
+	if accountBaseURL == "" {
+		switch {
+		case strings.Contains(openAPIBaseURL, "open.larksuite.com"):
+			accountBaseURL = defaultLarkAccountBase
+		case strings.Contains(openAPIBaseURL, "open.feishu.cn"):
+			accountBaseURL = defaultFeishuAccountBase
+		default:
+			accountBaseURL = openAPIBaseURL
+		}
+	}
+	return accountBaseURL + "/open-apis/authen/v1/authorize"
+}

--- a/server/internal/service/oauth_test.go
+++ b/server/internal/service/oauth_test.go
@@ -1,0 +1,153 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOAuthRegistryFromEnvExposesConfiguredProviders(t *testing.T) {
+	t.Setenv("GOOGLE_CLIENT_ID", "google-client")
+	t.Setenv("GOOGLE_CLIENT_SECRET", "google-secret")
+	t.Setenv("LARK_OAUTH_CLIENT_ID", "cli_lark")
+	t.Setenv("LARK_OAUTH_CLIENT_SECRET", "lark-secret")
+	t.Setenv("LARK_OAUTH_BASE_URL", "https://open.larksuite.com")
+	t.Setenv("LARK_OAUTH_LABEL", "Company Lark")
+	t.Setenv("LARK_OAUTH_SCOPE", "contact:user.email:readonly")
+
+	registry := NewOAuthProviderRegistryFromEnv(http.DefaultClient)
+	configs := registry.PublicConfigs()
+
+	if len(configs) != 2 {
+		t.Fatalf("provider count: want 2, got %d: %#v", len(configs), configs)
+	}
+
+	google := configs[0]
+	if google.ID != "google" || google.Label != "Google" || google.ClientID != "google-client" {
+		t.Fatalf("google public config mismatch: %#v", google)
+	}
+	if google.AuthorizationURL != "https://accounts.google.com/o/oauth2/v2/auth" {
+		t.Fatalf("google authorization URL: %q", google.AuthorizationURL)
+	}
+	if google.ExtraAuthParams["access_type"] != "offline" || google.ExtraAuthParams["prompt"] != "select_account" {
+		t.Fatalf("google extra params missing: %#v", google.ExtraAuthParams)
+	}
+
+	lark := configs[1]
+	if lark.ID != "feishu_lark" || lark.Label != "Company Lark" || lark.ClientID != "cli_lark" {
+		t.Fatalf("lark public config mismatch: %#v", lark)
+	}
+	if lark.AuthorizationURL != "https://accounts.larksuite.com/open-apis/authen/v1/authorize" {
+		t.Fatalf("lark authorization URL: %q", lark.AuthorizationURL)
+	}
+	if !lark.PKCE {
+		t.Fatalf("lark public config should require PKCE")
+	}
+	if lark.Scope != "contact:user.email:readonly" {
+		t.Fatalf("lark scope: %q", lark.Scope)
+	}
+
+	raw, err := json.Marshal(configs)
+	if err != nil {
+		t.Fatalf("marshal configs: %v", err)
+	}
+	if string(raw) == "" || containsSensitiveOAuthValue(string(raw), "google-secret", "lark-secret") {
+		t.Fatalf("public config leaked a client secret: %s", raw)
+	}
+}
+
+func TestLarkOAuthProviderExchangeUsesConfiguredEndpoints(t *testing.T) {
+	var sawTokenRequest bool
+	var sawUserInfoRequest bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/open-apis/authen/v2/oauth/token":
+			sawTokenRequest = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("token method: want POST, got %s", r.Method)
+			}
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode token request: %v", err)
+			}
+			want := map[string]string{
+				"grant_type":    "authorization_code",
+				"client_id":     "cli_lark",
+				"client_secret": "lark-secret",
+				"code":          "auth-code",
+				"redirect_uri":  "http://localhost:3000/auth/callback",
+				"code_verifier": "pkce-verifier",
+			}
+			for key, value := range want {
+				if body[key] != value {
+					t.Fatalf("token request %s: want %q, got %q in %#v", key, value, body[key], body)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"user-token","token_type":"Bearer","expires_in":7200}`))
+		case "/open-apis/authen/v1/user_info":
+			sawUserInfoRequest = true
+			if got := r.Header.Get("Authorization"); got != "Bearer user-token" {
+				t.Fatalf("userinfo authorization header: %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"code": 0,
+				"msg": "success",
+				"data": {
+					"name": "Ada Lovelace",
+					"avatar_url": "https://avatar.example/ada.png",
+					"email": "ada.personal@example.com",
+					"enterprise_email": "ada@company.example"
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("LARK_OAUTH_CLIENT_ID", "cli_lark")
+	t.Setenv("LARK_OAUTH_CLIENT_SECRET", "lark-secret")
+	t.Setenv("LARK_OAUTH_BASE_URL", server.URL)
+
+	registry := NewOAuthProviderRegistryFromEnv(server.Client())
+	provider, ok := registry.Get("feishu_lark")
+	if !ok {
+		t.Fatalf("feishu_lark provider should be configured")
+	}
+
+	identity, err := provider.Exchange(context.Background(), OAuthExchangeRequest{
+		Code:         "auth-code",
+		RedirectURI:  "http://localhost:3000/auth/callback",
+		CodeVerifier: "pkce-verifier",
+	})
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if !sawTokenRequest || !sawUserInfoRequest {
+		t.Fatalf("exchange did not call all expected endpoints: token=%v userinfo=%v", sawTokenRequest, sawUserInfoRequest)
+	}
+	if identity.Email != "ada@company.example" {
+		t.Fatalf("identity email: want enterprise email, got %q", identity.Email)
+	}
+	if identity.Name != "Ada Lovelace" {
+		t.Fatalf("identity name: %q", identity.Name)
+	}
+	if identity.AvatarURL != "https://avatar.example/ada.png" {
+		t.Fatalf("identity avatar: %q", identity.AvatarURL)
+	}
+}
+
+func containsSensitiveOAuthValue(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if needle != "" && strings.Contains(haystack, needle) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add a pluggable OAuth provider registry on the backend, with Google migrated into the provider model and `/auth/google` kept compatible.
- Add Feishu/Lark OAuth login via `/auth/oauth/{provider}`, including PKCE, runtime `/api/config` provider discovery, and SaaS/Lark/private endpoint configuration.
- Update web and desktop login flows so providers render from runtime config and callbacks route by provider state.
- Document Feishu/Lark setup, environment variables, and verification-code vs OAuth deployment guidance.

## Test Plan
- `pnpm typecheck`
- `pnpm test`
- `pnpm exec turbo build typecheck lint test --filter='!@multica/docs'`
- `docker exec multica-feishu-server-dev sh -lc '/usr/local/go/bin/go build ./...'`
- `docker exec multica-feishu-server-dev sh -lc '/usr/local/go/bin/go test ./...'`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3001 NEXT_PUBLIC_API_URL=http://127.0.0.1:8080 pnpm exec playwright test e2e/auth.spec.ts --project=chromium`
