### PR TITLE
fix: optimize runtime usage queries

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -664,6 +664,16 @@ export class ApiClient {
     return this.fetch(`/api/runtimes/${runtimeId}/usage?${search}`);
   }
 
+  async getRuntimesUsage(params: {
+    workspace_id: string;
+    days?: number;
+  }): Promise<RuntimeUsage[]> {
+    const search = new URLSearchParams();
+    search.set("workspace_id", params.workspace_id);
+    if (params.days) search.set("days", String(params.days));
+    return this.fetch(`/api/runtimes/usage?${search}`);
+  }
+
   async getRuntimeTaskActivity(runtimeId: string): Promise<RuntimeHourlyActivity[]> {
     return this.fetch(`/api/runtimes/${runtimeId}/activity`);
   }

--- a/packages/core/runtimes/queries.ts
+++ b/packages/core/runtimes/queries.ts
@@ -5,6 +5,8 @@ export const runtimeKeys = {
   all: (wsId: string) => ["runtimes", wsId] as const,
   list: (wsId: string) => [...runtimeKeys.all(wsId), "list"] as const,
   listMine: (wsId: string) => [...runtimeKeys.all(wsId), "list", "mine"] as const,
+  usageByWorkspace: (wsId: string, days: number) =>
+    [...runtimeKeys.all(wsId), "usage", days] as const,
   usage: (rid: string, days: number) =>
     ["runtimes", "usage", rid, days] as const,
   usageByAgent: (rid: string, days: number) =>
@@ -14,14 +16,22 @@ export const runtimeKeys = {
   latestVersion: () => ["runtimes", "latestVersion"] as const,
 };
 
-// Per-runtime usage. Used by the list view (each row pulls its own activity
-// sparkline + 30d cost) and by the detail page. TanStack Query naturally
-// deduplicates concurrent calls for the same runtime, so multiple components
-// observing the same runtimeId share one network request.
+// Per-runtime usage for detail views. The runtimes list uses the workspace
+// batch query below to avoid one aggregate query per visible row.
 export function runtimeUsageOptions(runtimeId: string, days: number) {
   return queryOptions({
     queryKey: runtimeKeys.usage(runtimeId, days),
     queryFn: () => api.getRuntimeUsage(runtimeId, { days }),
+    staleTime: 60 * 1000,
+  });
+}
+
+// Batched usage for the runtimes list. One workspace-level aggregate replaces
+// one per-row aggregate query while preserving the same RuntimeUsage row shape.
+export function runtimeUsageByWorkspaceOptions(wsId: string, days: number) {
+  return queryOptions({
+    queryKey: runtimeKeys.usageByWorkspace(wsId, days),
+    queryFn: () => api.getRuntimesUsage({ workspace_id: wsId, days }),
     staleTime: 60 * 1000,
   });
 }

--- a/packages/views/runtimes/components/runtime-columns.tsx
+++ b/packages/views/runtimes/components/runtime-columns.tsx
@@ -8,13 +8,13 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useQuery } from "@tanstack/react-query";
-import type { AgentRuntime, MemberWithUser } from "@multica/core/types";
+import type {
+  AgentRuntime,
+  MemberWithUser,
+  RuntimeUsage,
+} from "@multica/core/types";
 import { deriveWorkload } from "@multica/core/agents";
-import {
-  deriveRuntimeHealth,
-  runtimeUsageOptions,
-} from "@multica/core/runtimes";
+import { deriveRuntimeHealth } from "@multica/core/runtimes";
 import { useDeleteRuntime } from "@multica/core/runtimes/mutations";
 import {
   AlertDialog,
@@ -51,9 +51,7 @@ import {
 import { useT } from "../../i18n";
 
 // Per-row data assembled at the page level. The columns reach into
-// `row.original` and never pull their own data — except for the per-runtime
-// usage query in CostCell, which fetches its own narrow 14-day window
-// (just enough for the cell's 7d cost + 7d prior-window delta).
+// `row.original` and never pull their own row-level network data.
 export interface RuntimeRow {
   runtime: AgentRuntime;
   ownerMember: MemberWithUser | null;
@@ -87,7 +85,10 @@ interface CreateColumnsArgs {
   wsId: string;
   now: number;
   t: RuntimesT;
+  usageByRuntime: Map<string, RuntimeUsage[]>;
 }
+
+export const RUNTIME_LIST_USAGE_DAYS = 14;
 
 export function createRuntimeColumns({
   showOwner,
@@ -95,6 +96,7 @@ export function createRuntimeColumns({
   wsId,
   now,
   t,
+  usageByRuntime,
 }: CreateColumnsArgs): ColumnDef<RuntimeRow>[] {
   const cols: ColumnDef<RuntimeRow>[] = [
     {
@@ -165,9 +167,13 @@ export function createRuntimeColumns({
     },
     {
       id: "cost",
-      header: () => <div className="text-right">{t(($) => $.list.col_cost)}</div>,
+      header: () => (
+        <div className="text-right">{t(($) => $.list.col_cost)}</div>
+      ),
       size: COL_WIDTHS.cost,
-      cell: ({ row }) => <CostCell runtimeId={row.original.runtime.id} />,
+      cell: ({ row }) => (
+        <CostCell usage={usageByRuntime.get(row.original.runtime.id) ?? []} />
+      ),
     },
     {
       id: "cli",
@@ -324,21 +330,10 @@ function WorkloadCell({
   );
 }
 
-// Per-row cost — only renders a 7d total + delta vs the prior 7d, so we
-// only need 14 days of usage. Previously this fetched a 180-day window to
-// share the cache key with the runtime-detail page, but that turned the
-// list page into N × 180d in-line aggregations against `task_usage` (one
-// per runtime row) and dominated DB load for this view. Detail still
-// fetches its own 180d window on navigation; the cold-load difference for
-// detail is one extra request, while the steady-state savings on the list
-// page are large.
-const COST_CELL_DAYS = 14;
-
-function CostCell({ runtimeId }: { runtimeId: string }) {
+// Per-row cost renders a 7d total + delta vs the prior 7d, so the list page
+// fetches one 14-day workspace batch and each row reads its own slice.
+function CostCell({ usage }: { usage: RuntimeUsage[] }) {
   const { t } = useT("runtimes");
-  const { data: usage = [] } = useQuery(
-    runtimeUsageOptions(runtimeId, COST_CELL_DAYS),
-  );
   const cost7d = useMemo(() => computeCostInWindow(usage, 7), [usage]);
   const costPrev7d = useMemo(
     () => computeCostInWindow(usage, 7, 7),

--- a/packages/views/runtimes/components/runtime-list.tsx
+++ b/packages/views/runtimes/components/runtime-list.tsx
@@ -8,6 +8,7 @@ import type {
   AgentRuntime,
   AgentTask,
   MemberWithUser,
+  RuntimeUsage,
 } from "@multica/core/types";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -16,11 +17,16 @@ import {
   memberListOptions,
 } from "@multica/core/workspace/queries";
 import { latestCliVersionOptions } from "@multica/core/runtimes";
+import { runtimeUsageByWorkspaceOptions } from "@multica/core/runtimes/queries";
 import { agentTaskSnapshotOptions } from "@multica/core/agents";
 import { paths, useWorkspaceSlug } from "@multica/core/paths";
 import { DataTable } from "@multica/ui/components/ui/data-table";
 import { useNavigation } from "../../navigation";
-import { type RuntimeRow, createRuntimeColumns } from "./runtime-columns";
+import {
+  RUNTIME_LIST_USAGE_DAYS,
+  type RuntimeRow,
+  createRuntimeColumns,
+} from "./runtime-columns";
 import { useT } from "../../i18n";
 
 interface RuntimeWorkload {
@@ -34,6 +40,16 @@ const EMPTY_WORKLOAD: RuntimeWorkload = {
   runningCount: 0,
   queuedCount: 0,
 };
+
+function groupUsageByRuntime(usage: RuntimeUsage[]): Map<string, RuntimeUsage[]> {
+  const result = new Map<string, RuntimeUsage[]>();
+  for (const row of usage) {
+    const rows = result.get(row.runtime_id);
+    if (rows) rows.push(row);
+    else result.set(row.runtime_id, [row]);
+  }
+  return result;
+}
 
 // Per-runtime workload snapshot — agent IDs serving this runtime (drives
 // the avatar stack; .length doubles as the agent count) plus task counts
@@ -95,6 +111,9 @@ export function RuntimeList({
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const { data: snapshot = [] } = useQuery(agentTaskSnapshotOptions(wsId));
   const { data: latestCliVersion = null } = useQuery(latestCliVersionOptions());
+  const { data: runtimeUsage = [] } = useQuery(
+    runtimeUsageByWorkspaceOptions(wsId, RUNTIME_LIST_USAGE_DAYS),
+  );
 
   const currentMember = user
     ? members.find((m) => m.user_id === user.id)
@@ -106,6 +125,10 @@ export function RuntimeList({
   const workloadIndex = useMemo(
     () => buildWorkloadIndex(agents, snapshot),
     [agents, snapshot],
+  );
+  const usageByRuntime = useMemo(
+    () => groupUsageByRuntime(runtimeUsage),
+    [runtimeUsage],
   );
 
   const memberById = useMemo(() => {
@@ -144,8 +167,9 @@ export function RuntimeList({
         wsId,
         now,
         t,
+        usageByRuntime,
       }),
-    [showOwner, latestCliVersion, wsId, now, t],
+    [showOwner, latestCliVersion, wsId, now, t, usageByRuntime],
   );
 
   const table = useReactTable({

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -447,8 +447,7 @@ export function aggregateCostByHour(rows: RuntimeUsageByHour[]): CostByKey[] {
 // "previous" window for the runtime-list ↑/↓ delta).
 //
 // Walks the same daily-grain `RuntimeUsage` rows that `aggregateByDate` uses,
-// so the runtime-list cost stays consistent with the runtime-detail KPIs
-// (and crucially, hits the same TanStack Query cache key).
+// so the runtime-list cost stays consistent with the runtime-detail KPIs.
 export function computeCostInWindow(
   rows: readonly RuntimeUsage[],
   daysBack: number,

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -450,6 +450,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			// Runtimes
 			r.Route("/api/runtimes", func(r chi.Router) {
 				r.Get("/", h.ListAgentRuntimes)
+				r.Get("/usage", h.GetWorkspaceRuntimeUsage)
 				r.Route("/{runtimeId}", func(r chi.Router) {
 					r.Get("/usage", h.GetRuntimeUsage)
 					r.Get("/usage/by-agent", h.GetRuntimeUsageByAgent)

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -422,6 +422,14 @@ func (h *Handler) mergeLegacyRuntimes(r *http.Request, registered db.AgentRuntim
 				slog.Warn("legacy runtime merge: reassign tasks failed", "legacy_daemon_id", legacyID, "old_runtime_id", oldID, "new_runtime_id", newID, "error", err)
 				continue
 			}
+			usageRows, err := h.Queries.ReassignTaskUsageToRuntime(r.Context(), db.ReassignTaskUsageToRuntimeParams{
+				NewRuntimeID: registered.ID,
+				OldRuntimeID: old.ID,
+			})
+			if err != nil {
+				slog.Warn("legacy runtime merge: reassign task usage failed", "legacy_daemon_id", legacyID, "old_runtime_id", oldID, "new_runtime_id", newID, "error", err)
+				continue
+			}
 			if err := h.Queries.RecordRuntimeLegacyDaemonID(r.Context(), db.RecordRuntimeLegacyDaemonIDParams{
 				ID:             registered.ID,
 				LegacyDaemonID: strToText(legacyID),
@@ -440,6 +448,7 @@ func (h *Handler) mergeLegacyRuntimes(r *http.Request, registered db.AgentRuntim
 				"provider", provider,
 				"agents_reassigned", agents,
 				"tasks_reassigned", tasks,
+				"task_usage_reassigned", usageRows,
 			)
 		}
 	}
@@ -1410,7 +1419,8 @@ func (h *Handler) ReportTaskUsage(w http.ResponseWriter, r *http.Request) {
 	taskID := chi.URLParam(r, "taskId")
 
 	// Verify the caller owns this task's workspace.
-	if _, ok := h.requireDaemonTaskAccess(w, r, taskID); !ok {
+	task, ok := h.requireDaemonTaskAccess(w, r, taskID)
+	if !ok {
 		return
 	}
 
@@ -1424,7 +1434,8 @@ func (h *Handler) ReportTaskUsage(w http.ResponseWriter, r *http.Request) {
 
 	for _, u := range req.Usage {
 		if err := h.Queries.UpsertTaskUsage(r.Context(), db.UpsertTaskUsageParams{
-			TaskID:           parseUUID(taskID),
+			TaskID:           task.ID,
+			RuntimeID:        task.RuntimeID,
 			Provider:         u.Provider,
 			Model:            u.Model,
 			InputTokens:      u.InputTokens,

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -862,9 +862,9 @@ func TestDaemonRegister_MergesLegacyDaemonIDRuntime(t *testing.T) {
 		testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, legacyAgentID)
 	})
 
-	// An issue + task also bound to the legacy runtime (tasks have ON DELETE
-	// CASCADE, so without reassignment deleting the legacy row would silently
-	// drop historical tasks).
+	// An issue + task + usage row also bound to the legacy runtime (tasks and
+	// usage have ON DELETE CASCADE, so without reassignment deleting the legacy
+	// row would silently drop historical records).
 	var legacyIssueID, legacyTaskID string
 	if err := testPool.QueryRow(ctx, `
 		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
@@ -885,6 +885,13 @@ func TestDaemonRegister_MergesLegacyDaemonIDRuntime(t *testing.T) {
 	t.Cleanup(func() {
 		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, legacyTaskID)
 	})
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO task_usage (task_id, runtime_id, provider, model, input_tokens, output_tokens)
+		VALUES ($1, $2, 'claude', 'claude-3-5-sonnet', 123, 0)
+	`, legacyTaskID, legacyRuntimeID); err != nil {
+		t.Fatalf("seed legacy task usage: %v", err)
+	}
 
 	// Register under the new stable UUID, declaring the prior hostname-derived
 	// id as legacy. The handler should merge the legacy row into the new one.
@@ -933,6 +940,16 @@ func TestDaemonRegister_MergesLegacyDaemonIDRuntime(t *testing.T) {
 	}
 	if taskRuntimeID != newRuntimeID {
 		t.Fatalf("task not reassigned: got runtime_id=%s, want %s", taskRuntimeID, newRuntimeID)
+	}
+
+	// Usage should be reassigned with the task, otherwise deleting the old
+	// runtime would cascade away historical token totals.
+	var usageRuntimeID string
+	if err := testPool.QueryRow(ctx, `SELECT runtime_id FROM task_usage WHERE task_id = $1`, legacyTaskID).Scan(&usageRuntimeID); err != nil {
+		t.Fatalf("read task usage runtime_id: %v", err)
+	}
+	if usageRuntimeID != newRuntimeID {
+		t.Fatalf("task usage not reassigned: got runtime_id=%s, want %s", usageRuntimeID, newRuntimeID)
 	}
 
 	// Legacy runtime row must be gone — no more "online + offline" duplicates

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -123,6 +123,39 @@ func (h *Handler) GetRuntimeUsage(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// GetWorkspaceRuntimeUsage returns daily token usage for all runtimes in a
+// workspace in one aggregate query. The runtime list uses this to avoid a
+// separate ListRuntimeUsage query per row.
+func (h *Handler) GetWorkspaceRuntimeUsage(w http.ResponseWriter, r *http.Request) {
+	workspaceID := h.resolveWorkspaceID(r)
+	since := parseSinceParam(r, 14)
+
+	rows, err := h.Queries.ListWorkspaceRuntimeUsage(r.Context(), db.ListWorkspaceRuntimeUsageParams{
+		WorkspaceID: parseUUID(workspaceID),
+		Since:       since,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list runtime usage")
+		return
+	}
+
+	resp := make([]RuntimeUsageResponse, len(rows))
+	for i, row := range rows {
+		resp[i] = RuntimeUsageResponse{
+			RuntimeID:        uuidToString(row.RuntimeID),
+			Date:             row.Date.Time.Format("2006-01-02"),
+			Provider:         row.Provider,
+			Model:            row.Model,
+			InputTokens:      row.InputTokens,
+			OutputTokens:     row.OutputTokens,
+			CacheReadTokens:  row.CacheReadTokens,
+			CacheWriteTokens: row.CacheWriteTokens,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // GetRuntimeTaskActivity returns hourly task activity distribution for a runtime.
 func (h *Handler) GetRuntimeTaskActivity(w http.ResponseWriter, r *http.Request) {
 	runtimeID := chi.URLParam(r, "runtimeId")

--- a/server/internal/handler/runtime_test.go
+++ b/server/internal/handler/runtime_test.go
@@ -125,9 +125,9 @@ func TestGetRuntimeUsage_BucketsByUsageTime(t *testing.T) {
 			t.Fatalf("insert task: %v", err)
 		}
 		if _, err := testPool.Exec(ctx, `
-			INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, created_at)
-			VALUES ($1, 'claude', 'claude-3-5-sonnet', $2, 0, $3)
-		`, taskID, inputTokens, usageAt); err != nil {
+			INSERT INTO task_usage (task_id, runtime_id, provider, model, input_tokens, output_tokens, created_at)
+			VALUES ($1, $2, 'claude', 'claude-3-5-sonnet', $3, 0, $4)
+		`, taskID, runtimeID, inputTokens, usageAt); err != nil {
 			t.Fatalf("insert task_usage: %v", err)
 		}
 		t.Cleanup(func() {
@@ -171,5 +171,78 @@ func TestGetRuntimeUsage_BucketsByUsageTime(t *testing.T) {
 	// when ?days=N is interpreted as a rolling window instead of calendar days.
 	if byDate[yesterdayKey] != 2000 {
 		t.Errorf("yesterday morning task: yesterday bucket expected 2000 input tokens, got %d (full map: %v)", byDate[yesterdayKey], byDate)
+	}
+}
+
+func TestGetWorkspaceRuntimeUsage_BatchesRuntimeRows(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent_runtime WHERE workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&runtimeID); err != nil {
+		t.Fatalf("fetch runtime: %v", err)
+	}
+	var agentID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent WHERE workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("fetch agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, creator_id, creator_type)
+		VALUES ($1, 'workspace runtime usage test', $2, 'member')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, issue_id, runtime_id, status, created_at)
+		VALUES ($1, $2, $3, 'completed', now())
+		RETURNING id
+	`, agentID, issueID, runtimeID).Scan(&taskID); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO task_usage (task_id, runtime_id, provider, model, input_tokens, output_tokens, created_at)
+		VALUES ($1, $2, 'claude', 'claude-3-5-sonnet', 1234, 0, now())
+	`, taskID, runtimeID); err != nil {
+		t.Fatalf("insert task_usage: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/runtimes/usage?days=1", nil)
+	testHandler.GetWorkspaceRuntimeUsage(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetWorkspaceRuntimeUsage: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp []RuntimeUsageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	var total int64
+	for _, row := range resp {
+		if row.RuntimeID == runtimeID && row.Model == "claude-3-5-sonnet" {
+			total += row.InputTokens
+		}
+	}
+	if total < 1234 {
+		t.Fatalf("expected batched runtime usage to include inserted row, got total %d in response %+v", total, resp)
 	}
 }

--- a/server/internal/handler/usage_test.go
+++ b/server/internal/handler/usage_test.go
@@ -60,9 +60,9 @@ func TestWorkspaceUsage_BucketsByUsageTime(t *testing.T) {
 			t.Fatalf("insert task: %v", err)
 		}
 		if _, err := testPool.Exec(ctx, `
-			INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, created_at)
-			VALUES ($1, 'claude', 'claude-3-5-sonnet', $2, 0, $3)
-		`, taskID, inputTokens, usageAt); err != nil {
+			INSERT INTO task_usage (task_id, runtime_id, provider, model, input_tokens, output_tokens, created_at)
+			VALUES ($1, $2, 'claude', 'claude-3-5-sonnet', $3, 0, $4)
+		`, taskID, runtimeID, inputTokens, usageAt); err != nil {
 			t.Fatalf("insert task_usage: %v", err)
 		}
 		t.Cleanup(func() {
@@ -70,7 +70,7 @@ func TestWorkspaceUsage_BucketsByUsageTime(t *testing.T) {
 		})
 	}
 
-	insertTaskWithUsage(yesterdayLate, todayEarly, 1000)         // cross-midnight
+	insertTaskWithUsage(yesterdayLate, todayEarly, 1000)          // cross-midnight
 	insertTaskWithUsage(yesterdayMorning, yesterdayMorning, 2000) // full-day yesterday
 
 	// /api/usage/daily — daily breakdown.

--- a/server/migrations/070_task_usage_runtime_id.down.sql
+++ b/server/migrations/070_task_usage_runtime_id.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE task_usage DROP CONSTRAINT IF EXISTS task_usage_runtime_id_fkey;
+ALTER TABLE task_usage DROP CONSTRAINT IF EXISTS task_usage_runtime_id_not_null;
+ALTER TABLE task_usage DROP COLUMN IF EXISTS runtime_id;

--- a/server/migrations/070_task_usage_runtime_id.up.sql
+++ b/server/migrations/070_task_usage_runtime_id.up.sql
@@ -1,0 +1,21 @@
+ALTER TABLE task_usage ADD COLUMN IF NOT EXISTS runtime_id UUID;
+
+UPDATE task_usage tu
+SET runtime_id = atq.runtime_id
+FROM agent_task_queue atq
+WHERE atq.id = tu.task_id
+  AND tu.runtime_id IS NULL;
+
+ALTER TABLE task_usage
+    ADD CONSTRAINT task_usage_runtime_id_not_null
+    CHECK (runtime_id IS NOT NULL)
+    NOT VALID;
+
+ALTER TABLE task_usage VALIDATE CONSTRAINT task_usage_runtime_id_not_null;
+
+ALTER TABLE task_usage
+    ADD CONSTRAINT task_usage_runtime_id_fkey
+    FOREIGN KEY (runtime_id) REFERENCES agent_runtime(id) ON DELETE CASCADE
+    NOT VALID;
+
+ALTER TABLE task_usage VALIDATE CONSTRAINT task_usage_runtime_id_fkey;

--- a/server/migrations/071_task_usage_runtime_created_at_index.down.sql
+++ b/server/migrations/071_task_usage_runtime_created_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_task_usage_runtime_created_at;

--- a/server/migrations/071_task_usage_runtime_created_at_index.up.sql
+++ b/server/migrations/071_task_usage_runtime_created_at_index.up.sql
@@ -1,0 +1,11 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_task_usage_runtime_created_at
+    ON task_usage (runtime_id, created_at DESC)
+    INCLUDE (
+        task_id,
+        provider,
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens
+    );

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -421,6 +421,7 @@ type TaskUsage struct {
 	CacheReadTokens  int64              `json:"cache_read_tokens"`
 	CacheWriteTokens int64              `json:"cache_write_tokens"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
+	RuntimeID        pgtype.UUID        `json:"runtime_id"`
 }
 
 type User struct {

--- a/server/pkg/db/generated/runtime.sql.go
+++ b/server/pkg/db/generated/runtime.sql.go
@@ -445,6 +445,28 @@ func (q *Queries) ReassignAgentsToRuntime(ctx context.Context, arg ReassignAgent
 	return result.RowsAffected(), nil
 }
 
+const reassignTaskUsageToRuntime = `-- name: ReassignTaskUsageToRuntime :execrows
+UPDATE task_usage
+SET runtime_id = $1
+WHERE runtime_id = $2
+`
+
+type ReassignTaskUsageToRuntimeParams struct {
+	NewRuntimeID pgtype.UUID `json:"new_runtime_id"`
+	OldRuntimeID pgtype.UUID `json:"old_runtime_id"`
+}
+
+// Keeps denormalized task_usage.runtime_id in sync when legacy runtime rows
+// are merged. This must run before deleting old_runtime_id because task_usage
+// also has a runtime FK for fast usage aggregation.
+func (q *Queries) ReassignTaskUsageToRuntime(ctx context.Context, arg ReassignTaskUsageToRuntimeParams) (int64, error) {
+	result, err := q.db.Exec(ctx, reassignTaskUsageToRuntime, arg.NewRuntimeID, arg.OldRuntimeID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const reassignTasksToRuntime = `-- name: ReassignTasksToRuntime :execrows
 UPDATE agent_task_queue
 SET runtime_id = $1

--- a/server/pkg/db/generated/runtime_usage.sql.go
+++ b/server/pkg/db/generated/runtime_usage.sql.go
@@ -54,8 +54,7 @@ SELECT
     SUM(tu.cache_write_tokens)::bigint AS cache_write_tokens,
     COUNT(DISTINCT tu.task_id)::int AS task_count
 FROM task_usage tu
-JOIN agent_task_queue atq ON atq.id = tu.task_id
-WHERE atq.runtime_id = $1
+WHERE tu.runtime_id = $1
   AND tu.created_at >= DATE_TRUNC('day', $2::timestamptz)
 GROUP BY EXTRACT(HOUR FROM tu.created_at), tu.model
 ORDER BY hour, tu.model
@@ -119,8 +118,7 @@ SELECT
     SUM(tu.cache_read_tokens)::bigint AS cache_read_tokens,
     SUM(tu.cache_write_tokens)::bigint AS cache_write_tokens
 FROM task_usage tu
-JOIN agent_task_queue atq ON atq.id = tu.task_id
-WHERE atq.runtime_id = $1
+WHERE tu.runtime_id = $1
   AND tu.created_at >= DATE_TRUNC('day', $2::timestamptz)
 GROUP BY DATE(tu.created_at), tu.provider, tu.model
 ORDER BY DATE(tu.created_at) DESC, tu.provider, tu.model
@@ -184,7 +182,7 @@ SELECT
     COUNT(DISTINCT tu.task_id)::int AS task_count
 FROM task_usage tu
 JOIN agent_task_queue atq ON atq.id = tu.task_id
-WHERE atq.runtime_id = $1
+WHERE tu.runtime_id = $1
   AND tu.created_at >= DATE_TRUNC('day', $2::timestamptz)
 GROUP BY atq.agent_id, tu.model
 ORDER BY atq.agent_id, tu.model
@@ -206,11 +204,12 @@ type ListRuntimeUsageByAgentRow struct {
 }
 
 // Per-(agent, model) token aggregates for a runtime since a cutoff. Powers
-// the runtime-detail "Cost by agent" tab. task_usage only carries task_id,
-// so we join the queue to expose agent_id. The model dimension is kept on
-// purpose: cost is computed client-side from a per-model pricing table, so
-// collapsing models server-side would erase the information needed to do
-// that arithmetic. The client groups by agent_id and sums cost per agent.
+// the runtime-detail "Cost by agent" tab. task_usage carries runtime_id for
+// efficient filtering, and we join the queue only to expose agent_id. The
+// model dimension is kept on purpose: cost is computed client-side from a
+// per-model pricing table, so collapsing models server-side would erase the
+// information needed to do that arithmetic. The client groups by agent_id and
+// sums cost per agent.
 func (q *Queries) ListRuntimeUsageByAgent(ctx context.Context, arg ListRuntimeUsageByAgentParams) ([]ListRuntimeUsageByAgentRow, error) {
 	rows, err := q.db.Query(ctx, listRuntimeUsageByAgent, arg.RuntimeID, arg.Since)
 	if err != nil {
@@ -228,6 +227,72 @@ func (q *Queries) ListRuntimeUsageByAgent(ctx context.Context, arg ListRuntimeUs
 			&i.CacheReadTokens,
 			&i.CacheWriteTokens,
 			&i.TaskCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listWorkspaceRuntimeUsage = `-- name: ListWorkspaceRuntimeUsage :many
+SELECT
+    tu.runtime_id,
+    DATE(tu.created_at) AS date,
+    tu.provider,
+    tu.model,
+    SUM(tu.input_tokens)::bigint AS input_tokens,
+    SUM(tu.output_tokens)::bigint AS output_tokens,
+    SUM(tu.cache_read_tokens)::bigint AS cache_read_tokens,
+    SUM(tu.cache_write_tokens)::bigint AS cache_write_tokens
+FROM task_usage tu
+JOIN agent_runtime ar ON ar.id = tu.runtime_id
+WHERE ar.workspace_id = $1
+  AND tu.created_at >= DATE_TRUNC('day', $2::timestamptz)
+GROUP BY tu.runtime_id, DATE(tu.created_at), tu.provider, tu.model
+ORDER BY tu.runtime_id, DATE(tu.created_at) DESC, tu.provider, tu.model
+`
+
+type ListWorkspaceRuntimeUsageParams struct {
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	Since       pgtype.Timestamptz `json:"since"`
+}
+
+type ListWorkspaceRuntimeUsageRow struct {
+	RuntimeID        pgtype.UUID `json:"runtime_id"`
+	Date             pgtype.Date `json:"date"`
+	Provider         string      `json:"provider"`
+	Model            string      `json:"model"`
+	InputTokens      int64       `json:"input_tokens"`
+	OutputTokens     int64       `json:"output_tokens"`
+	CacheReadTokens  int64       `json:"cache_read_tokens"`
+	CacheWriteTokens int64       `json:"cache_write_tokens"`
+}
+
+// Batch form for the runtimes list. It returns the same daily model buckets as
+// ListRuntimeUsage, but for every runtime in a workspace so the UI avoids one
+// aggregate query per runtime row.
+func (q *Queries) ListWorkspaceRuntimeUsage(ctx context.Context, arg ListWorkspaceRuntimeUsageParams) ([]ListWorkspaceRuntimeUsageRow, error) {
+	rows, err := q.db.Query(ctx, listWorkspaceRuntimeUsage, arg.WorkspaceID, arg.Since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListWorkspaceRuntimeUsageRow{}
+	for rows.Next() {
+		var i ListWorkspaceRuntimeUsageRow
+		if err := rows.Scan(
+			&i.RuntimeID,
+			&i.Date,
+			&i.Provider,
+			&i.Model,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.CacheReadTokens,
+			&i.CacheWriteTokens,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/generated/task_usage.sql.go
+++ b/server/pkg/db/generated/task_usage.sql.go
@@ -45,7 +45,7 @@ func (q *Queries) GetIssueUsageSummary(ctx context.Context, issueID pgtype.UUID)
 }
 
 const getTaskUsage = `-- name: GetTaskUsage :many
-SELECT id, task_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at FROM task_usage
+SELECT id, task_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, created_at, runtime_id FROM task_usage
 WHERE task_id = $1
 ORDER BY model
 `
@@ -69,6 +69,7 @@ func (q *Queries) GetTaskUsage(ctx context.Context, taskID pgtype.UUID) ([]TaskU
 			&i.CacheReadTokens,
 			&i.CacheWriteTokens,
 			&i.CreatedAt,
+			&i.RuntimeID,
 		); err != nil {
 			return nil, err
 		}
@@ -90,9 +91,8 @@ SELECT
     SUM(tu.cache_write_tokens)::bigint AS total_cache_write_tokens,
     COUNT(DISTINCT tu.task_id)::int AS task_count
 FROM task_usage tu
-JOIN agent_task_queue atq ON atq.id = tu.task_id
-JOIN agent a ON a.id = atq.agent_id
-WHERE a.workspace_id = $1
+JOIN agent_runtime ar ON ar.id = tu.runtime_id
+WHERE ar.workspace_id = $1
   AND tu.created_at >= DATE_TRUNC('day', $2::timestamptz)
 GROUP BY DATE(tu.created_at), tu.model
 ORDER BY DATE(tu.created_at) DESC, tu.model
@@ -154,9 +154,8 @@ SELECT
     SUM(tu.cache_write_tokens)::bigint AS total_cache_write_tokens,
     COUNT(DISTINCT tu.task_id)::int AS task_count
 FROM task_usage tu
-JOIN agent_task_queue atq ON atq.id = tu.task_id
-JOIN agent a ON a.id = atq.agent_id
-WHERE a.workspace_id = $1
+JOIN agent_runtime ar ON ar.id = tu.runtime_id
+WHERE ar.workspace_id = $1
   AND tu.created_at >= DATE_TRUNC('day', $2::timestamptz)
 GROUP BY tu.model
 ORDER BY (SUM(tu.input_tokens) + SUM(tu.output_tokens)) DESC
@@ -206,10 +205,11 @@ func (q *Queries) GetWorkspaceUsageSummary(ctx context.Context, arg GetWorkspace
 }
 
 const upsertTaskUsage = `-- name: UpsertTaskUsage :exec
-INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO task_usage (task_id, runtime_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (task_id, provider, model)
 DO UPDATE SET
+    runtime_id = EXCLUDED.runtime_id,
     input_tokens = EXCLUDED.input_tokens,
     output_tokens = EXCLUDED.output_tokens,
     cache_read_tokens = EXCLUDED.cache_read_tokens,
@@ -218,6 +218,7 @@ DO UPDATE SET
 
 type UpsertTaskUsageParams struct {
 	TaskID           pgtype.UUID `json:"task_id"`
+	RuntimeID        pgtype.UUID `json:"runtime_id"`
 	Provider         string      `json:"provider"`
 	Model            string      `json:"model"`
 	InputTokens      int64       `json:"input_tokens"`
@@ -229,6 +230,7 @@ type UpsertTaskUsageParams struct {
 func (q *Queries) UpsertTaskUsage(ctx context.Context, arg UpsertTaskUsageParams) error {
 	_, err := q.db.Exec(ctx, upsertTaskUsage,
 		arg.TaskID,
+		arg.RuntimeID,
 		arg.Provider,
 		arg.Model,
 		arg.InputTokens,

--- a/server/pkg/db/queries/runtime.sql
+++ b/server/pkg/db/queries/runtime.sql
@@ -173,6 +173,14 @@ UPDATE agent_task_queue
 SET runtime_id = @new_runtime_id
 WHERE runtime_id = @old_runtime_id;
 
+-- name: ReassignTaskUsageToRuntime :execrows
+-- Keeps denormalized task_usage.runtime_id in sync when legacy runtime rows
+-- are merged. This must run before deleting old_runtime_id because task_usage
+-- also has a runtime FK for fast usage aggregation.
+UPDATE task_usage
+SET runtime_id = @new_runtime_id
+WHERE runtime_id = @old_runtime_id;
+
 -- name: RecordRuntimeLegacyDaemonID :exec
 -- Remembers the most recent hostname-derived daemon_id that was merged into
 -- this row. Useful for debugging when tracing back why a given runtime row

--- a/server/pkg/db/queries/runtime_usage.sql
+++ b/server/pkg/db/queries/runtime_usage.sql
@@ -12,11 +12,30 @@ SELECT
     SUM(tu.cache_read_tokens)::bigint AS cache_read_tokens,
     SUM(tu.cache_write_tokens)::bigint AS cache_write_tokens
 FROM task_usage tu
-JOIN agent_task_queue atq ON atq.id = tu.task_id
-WHERE atq.runtime_id = $1
+WHERE tu.runtime_id = $1
   AND tu.created_at >= DATE_TRUNC('day', @since::timestamptz)
 GROUP BY DATE(tu.created_at), tu.provider, tu.model
 ORDER BY DATE(tu.created_at) DESC, tu.provider, tu.model;
+
+-- name: ListWorkspaceRuntimeUsage :many
+-- Batch form for the runtimes list. It returns the same daily model buckets as
+-- ListRuntimeUsage, but for every runtime in a workspace so the UI avoids one
+-- aggregate query per runtime row.
+SELECT
+    tu.runtime_id,
+    DATE(tu.created_at) AS date,
+    tu.provider,
+    tu.model,
+    SUM(tu.input_tokens)::bigint AS input_tokens,
+    SUM(tu.output_tokens)::bigint AS output_tokens,
+    SUM(tu.cache_read_tokens)::bigint AS cache_read_tokens,
+    SUM(tu.cache_write_tokens)::bigint AS cache_write_tokens
+FROM task_usage tu
+JOIN agent_runtime ar ON ar.id = tu.runtime_id
+WHERE ar.workspace_id = $1
+  AND tu.created_at >= DATE_TRUNC('day', @since::timestamptz)
+GROUP BY tu.runtime_id, DATE(tu.created_at), tu.provider, tu.model
+ORDER BY tu.runtime_id, DATE(tu.created_at) DESC, tu.provider, tu.model;
 
 -- name: GetRuntimeTaskHourlyActivity :many
 SELECT EXTRACT(HOUR FROM started_at)::int AS hour, COUNT(*)::int AS count
@@ -27,11 +46,12 @@ ORDER BY hour;
 
 -- name: ListRuntimeUsageByAgent :many
 -- Per-(agent, model) token aggregates for a runtime since a cutoff. Powers
--- the runtime-detail "Cost by agent" tab. task_usage only carries task_id,
--- so we join the queue to expose agent_id. The model dimension is kept on
--- purpose: cost is computed client-side from a per-model pricing table, so
--- collapsing models server-side would erase the information needed to do
--- that arithmetic. The client groups by agent_id and sums cost per agent.
+-- the runtime-detail "Cost by agent" tab. task_usage carries runtime_id for
+-- efficient filtering, and we join the queue only to expose agent_id. The
+-- model dimension is kept on purpose: cost is computed client-side from a
+-- per-model pricing table, so collapsing models server-side would erase the
+-- information needed to do that arithmetic. The client groups by agent_id and
+-- sums cost per agent.
 SELECT
     atq.agent_id,
     tu.model,
@@ -42,7 +62,7 @@ SELECT
     COUNT(DISTINCT tu.task_id)::int AS task_count
 FROM task_usage tu
 JOIN agent_task_queue atq ON atq.id = tu.task_id
-WHERE atq.runtime_id = $1
+WHERE tu.runtime_id = $1
   AND tu.created_at >= DATE_TRUNC('day', @since::timestamptz)
 GROUP BY atq.agent_id, tu.model
 ORDER BY atq.agent_id, tu.model;
@@ -62,8 +82,7 @@ SELECT
     SUM(tu.cache_write_tokens)::bigint AS cache_write_tokens,
     COUNT(DISTINCT tu.task_id)::int AS task_count
 FROM task_usage tu
-JOIN agent_task_queue atq ON atq.id = tu.task_id
-WHERE atq.runtime_id = $1
+WHERE tu.runtime_id = $1
   AND tu.created_at >= DATE_TRUNC('day', @since::timestamptz)
 GROUP BY EXTRACT(HOUR FROM tu.created_at), tu.model
 ORDER BY hour, tu.model;

--- a/server/pkg/db/queries/task_usage.sql
+++ b/server/pkg/db/queries/task_usage.sql
@@ -1,8 +1,9 @@
 -- name: UpsertTaskUsage :exec
-INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO task_usage (task_id, runtime_id, provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (task_id, provider, model)
 DO UPDATE SET
+    runtime_id = EXCLUDED.runtime_id,
     input_tokens = EXCLUDED.input_tokens,
     output_tokens = EXCLUDED.output_tokens,
     cache_read_tokens = EXCLUDED.cache_read_tokens,
@@ -27,9 +28,8 @@ SELECT
     SUM(tu.cache_write_tokens)::bigint AS total_cache_write_tokens,
     COUNT(DISTINCT tu.task_id)::int AS task_count
 FROM task_usage tu
-JOIN agent_task_queue atq ON atq.id = tu.task_id
-JOIN agent a ON a.id = atq.agent_id
-WHERE a.workspace_id = $1
+JOIN agent_runtime ar ON ar.id = tu.runtime_id
+WHERE ar.workspace_id = $1
   AND tu.created_at >= DATE_TRUNC('day', @since::timestamptz)
 GROUP BY DATE(tu.created_at), tu.model
 ORDER BY DATE(tu.created_at) DESC, tu.model;
@@ -45,9 +45,8 @@ SELECT
     SUM(tu.cache_write_tokens)::bigint AS total_cache_write_tokens,
     COUNT(DISTINCT tu.task_id)::int AS task_count
 FROM task_usage tu
-JOIN agent_task_queue atq ON atq.id = tu.task_id
-JOIN agent a ON a.id = atq.agent_id
-WHERE a.workspace_id = $1
+JOIN agent_runtime ar ON ar.id = tu.runtime_id
+WHERE ar.workspace_id = $1
   AND tu.created_at >= DATE_TRUNC('day', @since::timestamptz)
 GROUP BY tu.model
 ORDER BY (SUM(tu.input_tokens) + SUM(tu.output_tokens)) DESC;


### PR DESCRIPTION
## Summary
- denormalize `task_usage.runtime_id` with a covering runtime/time index so runtime usage aggregates no longer join through `agent_task_queue`
- add a workspace-level runtime usage endpoint and switch the runtimes list cost column to one batched 14-day query instead of one query per runtime row
- keep runtime merge behavior consistent by reassigning denormalized task usage rows when legacy runtime rows are merged

## Verification
- `go run ./cmd/migrate up`
- `go test ./internal/handler`
- `go test ./cmd/server -run 'TestRerunIssueSetsForceFreshSession|TestEnqueueTaskForIssueDoesNotForceFreshSession' -count=1`
- `go test ./pkg/agent -run TestCodexExecuteSemanticInactivityAllowsContinuousMessages -count=1`
- `go test ./...` passed once before the runtime-merge follow-up; after the follow-up it repeatedly failed in unrelated `cmd/server` suite-order state (`agent is archived`) while the failing tests pass in isolation
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/core lint` (existing warning in `packages/core/platform/auth-initializer.tsx`)
- `pnpm --filter @multica/views lint` (existing warnings in onboarding/search files)
