### PR TITLE
fix(timeline): exact-limit comments no longer trigger Show older (MUL-1857)

### DIFF
--- a/server/internal/handler/activity.go
+++ b/server/internal/handler/activity.go
@@ -277,13 +277,17 @@ func (h *Handler) listTimelineLegacy(w http.ResponseWriter, r *http.Request, iss
 // off-page.
 func (h *Handler) listTimelineLatest(w http.ResponseWriter, r *http.Request, issue db.Issue, limit int) {
 	ctx := r.Context()
-	comments, err := h.Queries.ListCommentsLatest(ctx, db.ListCommentsLatestParams{
-		IssueID: issue.ID, WorkspaceID: issue.WorkspaceID, Limit: int32(limit),
+	// Over-fetch comments by one so commentOverflow can distinguish "exactly
+	// <limit> comments exist" (no Show older needed) from ">limit comments
+	// exist" (Show older required).
+	rawComments, err := h.Queries.ListCommentsLatest(ctx, db.ListCommentsLatestParams{
+		IssueID: issue.ID, WorkspaceID: issue.WorkspaceID, Limit: int32(limit + 1),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list comments")
 		return
 	}
+	comments, hasMoreComments := commentOverflow(rawComments, limit)
 	activities, err := h.Queries.ListActivitiesLatest(ctx, db.ListActivitiesLatestParams{
 		IssueID: issue.ID, Limit: int32(limit),
 	})
@@ -294,7 +298,7 @@ func (h *Handler) listTimelineLatest(w http.ResponseWriter, r *http.Request, iss
 
 	entries := h.mergeTimelineDesc(r, comments, activities)
 	resp := TimelineResponse{Entries: entries}
-	resp.HasMoreBefore = hasMoreCommentsBeyond(len(comments), limit)
+	resp.HasMoreBefore = hasMoreComments
 
 	// Per-pool boundaries. For latest mode there is no input cursor; if a
 	// pool returned no rows it carries from the other pool so the encoded
@@ -330,14 +334,15 @@ func (h *Handler) listTimelineBefore(w http.ResponseWriter, r *http.Request, iss
 		return
 	}
 
-	comments, err := h.Queries.ListCommentsBefore(ctx, db.ListCommentsBeforeParams{
+	rawComments, err := h.Queries.ListCommentsBefore(ctx, db.ListCommentsBeforeParams{
 		IssueID: issue.ID, WorkspaceID: issue.WorkspaceID,
-		Column3: inComment.T, Column4: inComment.ID, Limit: int32(limit),
+		Column3: inComment.T, Column4: inComment.ID, Limit: int32(limit + 1),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list comments")
 		return
 	}
+	comments, hasMoreComments := commentOverflow(rawComments, limit)
 	activities, err := h.Queries.ListActivitiesBefore(ctx, db.ListActivitiesBeforeParams{
 		IssueID: issue.ID, Column2: inActivity.T, Column3: inActivity.ID, Limit: int32(limit),
 	})
@@ -351,7 +356,7 @@ func (h *Handler) listTimelineBefore(w http.ResponseWriter, r *http.Request, iss
 		Entries:      entries,
 		HasMoreAfter: true, // we're paging older from a known position, so newer exists
 	}
-	resp.HasMoreBefore = hasMoreCommentsBeyond(len(comments), limit)
+	resp.HasMoreBefore = hasMoreComments
 
 	// Per-pool boundaries. Empty pool carries forward from the input cursor
 	// so subsequent older pages keep advancing past previously-paginated rows
@@ -378,14 +383,18 @@ func (h *Handler) listTimelineAfter(w http.ResponseWriter, r *http.Request, issu
 		return
 	}
 
-	comments, err := h.Queries.ListCommentsAfter(ctx, db.ListCommentsAfterParams{
+	rawComments, err := h.Queries.ListCommentsAfter(ctx, db.ListCommentsAfterParams{
 		IssueID: issue.ID, WorkspaceID: issue.WorkspaceID,
-		Column3: inComment.T, Column4: inComment.ID, Limit: int32(limit),
+		Column3: inComment.T, Column4: inComment.ID, Limit: int32(limit + 1),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list comments")
 		return
 	}
+	// ASC fetch returns oldest-first; trimming to the first <limit> keeps
+	// the rows closest to the cursor and drops the (limit+1)th newest as the
+	// overflow probe.
+	comments, hasMoreComments := commentOverflow(rawComments, limit)
 	activities, err := h.Queries.ListActivitiesAfter(ctx, db.ListActivitiesAfterParams{
 		IssueID: issue.ID, Column2: inActivity.T, Column3: inActivity.ID, Limit: int32(limit),
 	})
@@ -400,7 +409,7 @@ func (h *Handler) listTimelineAfter(w http.ResponseWriter, r *http.Request, issu
 	// off-page bug (#1857).
 	entries := h.mergeTimelineAscThenReverse(r, comments, activities)
 	resp := TimelineResponse{Entries: entries, HasMoreBefore: true}
-	resp.HasMoreAfter = hasMoreCommentsBeyond(len(comments), limit)
+	resp.HasMoreAfter = hasMoreComments
 
 	cOldest, cNewest := commentBoundsAsc(comments, inComment)
 	aOldest, aNewest := activityBoundsAsc(activities, inActivity)
@@ -460,15 +469,17 @@ func (h *Handler) listTimelineAround(w http.ResponseWriter, r *http.Request, iss
 		afterLimit = 0
 	}
 
-	// Older half: keyset Before (anchor exclusive).
-	olderComments, err := h.Queries.ListCommentsBefore(ctx, db.ListCommentsBeforeParams{
+	// Older half: keyset Before (anchor exclusive). Over-fetch comments by
+	// one to detect overflow exactly.
+	rawOlderComments, err := h.Queries.ListCommentsBefore(ctx, db.ListCommentsBeforeParams{
 		IssueID: issue.ID, WorkspaceID: issue.WorkspaceID,
-		Column3: anchorTime, Column4: anchorID, Limit: int32(beforeLimit),
+		Column3: anchorTime, Column4: anchorID, Limit: int32(beforeLimit + 1),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list comments")
 		return
 	}
+	olderComments, hasMoreOlderComments := commentOverflow(rawOlderComments, beforeLimit)
 	olderActivities, err := h.Queries.ListActivitiesBefore(ctx, db.ListActivitiesBeforeParams{
 		IssueID: issue.ID, Column2: anchorTime, Column3: anchorID, Limit: int32(beforeLimit),
 	})
@@ -479,14 +490,15 @@ func (h *Handler) listTimelineAround(w http.ResponseWriter, r *http.Request, iss
 	olderEntries := h.mergeTimelineDesc(r, olderComments, olderActivities)
 
 	// Newer half: keyset After (anchor exclusive).
-	newerComments, err := h.Queries.ListCommentsAfter(ctx, db.ListCommentsAfterParams{
+	rawNewerComments, err := h.Queries.ListCommentsAfter(ctx, db.ListCommentsAfterParams{
 		IssueID: issue.ID, WorkspaceID: issue.WorkspaceID,
-		Column3: anchorTime, Column4: anchorID, Limit: int32(afterLimit),
+		Column3: anchorTime, Column4: anchorID, Limit: int32(afterLimit + 1),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list comments")
 		return
 	}
+	newerComments, hasMoreNewerComments := commentOverflow(rawNewerComments, afterLimit)
 	newerActivities, err := h.Queries.ListActivitiesAfter(ctx, db.ListActivitiesAfterParams{
 		IssueID: issue.ID, Column2: anchorTime, Column3: anchorID, Limit: int32(afterLimit),
 	})
@@ -512,8 +524,8 @@ func (h *Handler) listTimelineAround(w http.ResponseWriter, r *http.Request, iss
 
 	resp := TimelineResponse{
 		Entries:       entries,
-		HasMoreBefore: hasMoreCommentsBeyond(len(olderComments), beforeLimit),
-		HasMoreAfter:  hasMoreCommentsBeyond(len(newerComments), afterLimit),
+		HasMoreBefore: hasMoreOlderComments,
+		HasMoreAfter:  hasMoreNewerComments,
 		TargetIndex:   &targetIdx,
 	}
 
@@ -554,17 +566,24 @@ func (h *Handler) fetchSingleEntry(r *http.Request, issue db.Issue, id pgtype.UU
 	return TimelineEntry{}, false
 }
 
-// hasMoreCommentsBeyond reports whether more COMMENTS exist beyond the page on
-// the side the caller is paginating away from (older for "before", newer for
-// "after"). Activity rows do not gate pagination (#1857): a dense activity
-// stream from agent runs / status flips would otherwise trigger "show older"
-// on issues with only a handful of real comments, making the discussion look
-// like it had disappeared.
-func hasMoreCommentsBeyond(comments, limit int) bool {
+// commentOverflow trims an over-fetched comment slice to <limit> and reports
+// whether the SQL returned more rows than the visible budget. Callers
+// over-fetch by one (limit+1) so the boolean is exact even when the issue has
+// EXACTLY <limit> comments — the prior `len >= limit` check returned true in
+// that case and rendered a "Show older" affordance that revealed nothing.
+//
+// Activity rows do not gate pagination (#1857): a dense activity stream from
+// agent runs / status flips would otherwise trigger "show older" on issues
+// with only a handful of real comments. Activities therefore stay capped at
+// <limit> with no overflow probe.
+func commentOverflow(rows []db.Comment, limit int) ([]db.Comment, bool) {
 	if limit <= 0 {
-		return false
+		return rows, false
 	}
-	return comments >= limit
+	if len(rows) > limit {
+		return rows[:limit], true
+	}
+	return rows, false
 }
 
 // mergeTimelineDesc returns comments + activities merged DESC by

--- a/server/internal/handler/activity_test.go
+++ b/server/internal/handler/activity_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
 // fetchTimeline issues a GET /timeline request with the given query string and
@@ -378,27 +379,42 @@ func TestTimelineCursor_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestHasMoreCommentsBeyond pins the truth table for the page-boundary helper.
-// Activities deliberately don't appear: #1857 reverted them from being a
-// pagination signal. Only the comment count and limit decide whether more
-// rows exist beyond the page.
-func TestHasMoreCommentsBeyond(t *testing.T) {
+// TestCommentOverflow pins the over-fetch / trim contract that gates "Show
+// older". Callers query the SQL with limit+1 and pass the raw rows in; the
+// helper trims to <limit> and reports hasMore. The boundary the user flagged
+// — exactly <limit> comments exist — must report hasMore=false so no
+// affordance appears for content that doesn't exist.
+func TestCommentOverflow(t *testing.T) {
+	mk := func(n int) []db.Comment {
+		out := make([]db.Comment, n)
+		return out
+	}
 	cases := []struct {
-		name            string
-		comments, limit int
-		want            bool
+		name        string
+		fetched     int // rows the SQL returned (caller asked for limit+1)
+		limit       int
+		wantTrimmed int
+		wantMore    bool
 	}{
-		{"empty page", 0, 30, false},
-		{"partial page", 5, 30, false},
-		{"comments hit limit", 30, 30, true},
-		{"comments well over limit", 100, 30, true},
-		{"limit zero rejects", 100, 0, false},
+		{"empty page", 0, 30, 0, false},
+		{"partial page", 5, 30, 5, false},
+		// Issue has exactly limit comments — caller asked for limit+1 and got
+		// only limit back. No older content; "Show older" must NOT appear.
+		{"exactly limit comments", 30, 30, 30, false},
+		// Issue has more than limit — caller asked for limit+1 and got
+		// limit+1 back. Trim the probe row, set hasMore=true.
+		{"one over limit", 31, 30, 30, true},
+		{"well over limit", 100, 30, 30, true},
+		{"limit zero rejects", 100, 0, 100, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := hasMoreCommentsBeyond(tc.comments, tc.limit); got != tc.want {
-				t.Fatalf("hasMoreCommentsBeyond(c=%d, lim=%d) = %v, want %v",
-					tc.comments, tc.limit, got, tc.want)
+			rows, more := commentOverflow(mk(tc.fetched), tc.limit)
+			if len(rows) != tc.wantTrimmed {
+				t.Fatalf("trimmed length: got %d, want %d", len(rows), tc.wantTrimmed)
+			}
+			if more != tc.wantMore {
+				t.Fatalf("hasMore: got %v, want %v", more, tc.wantMore)
 			}
 		})
 	}
@@ -482,6 +498,31 @@ func TestListTimeline_PerPoolCursorWalksAllComments(t *testing.T) {
 		}
 		t.Fatalf("expected to see all %d comments via cursor walk, saw %d. Missing: %v",
 			commentN, len(seen), missing)
+	}
+}
+
+// TestListTimeline_ExactlyLimitCommentsHidesShowOlder pins the boundary the
+// user flagged: an issue with exactly <limit> comments must NOT report
+// has_more_before. Pre-fix the gate was `len(comments) >= limit`, which
+// returned true and rendered a "Show older" button that revealed nothing —
+// older clicks fetched zero rows. The over-fetch + trim probe makes the
+// boundary exact.
+func TestListTimeline_ExactlyLimitCommentsHidesShowOlder(t *testing.T) {
+	issueID := createIssueForTimeline(t, "exactly limit comments boundary")
+	seedTimelineEntries(t, issueID, 30, 0)
+
+	resp, code := fetchTimeline(t, issueID, "limit=30")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if len(resp.Entries) != 30 {
+		t.Fatalf("expected 30 entries on first page, got %d", len(resp.Entries))
+	}
+	if resp.HasMoreBefore {
+		t.Fatalf("has_more_before must be false when comments == limit (issue has nothing older)")
+	}
+	if resp.NextCursor != nil {
+		t.Fatalf("next_cursor must be nil when has_more_before is false, got %q", *resp.NextCursor)
 	}
 }
 


### PR DESCRIPTION
## Summary

Off-by-one in the \`has_more_before\` gate. Pre-fix, the check was \`len(comments) >= limit\`, so an issue with **exactly** \`limit\` comments (e.g. MUL-1847 has 30 comments) reported \`has_more_before=true\`, the "Show older" button rendered, the user clicked, and \`ListCommentsBefore(oldestComment)\` returned zero rows — the affordance pointed at content that didn't exist.

The fix is the standard over-fetch probe: ask the SQL for \`limit+1\` rows; if it returned more than \`limit\`, drop the extra and report \`hasMore=true\`. Otherwise \`hasMore=false\`.

- New helper \`commentOverflow(rows, limit) -> ([]db.Comment, bool)\` replaces the count-based \`hasMoreCommentsBeyond\`. Works for both DESC (latest / before) and ASC (after / around-newer) orderings since both keep the first \`limit\`.
- All four mode handlers (latest, before, after, around) now ask for \`limit+1\` comments and route through the helper.
- Activities still cap at \`limit\` with no overflow probe — they don't gate pagination (#1857), so the boundary doesn't matter for them.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`pnpm typecheck\` clean (no FE changes)
- [ ] DB-backed tests (\`TestCommentOverflow\` + new \`TestListTimeline_ExactlyLimitCommentsHidesShowOlder\`) — need CI's Postgres
- [ ] Manual: open MUL-1847 (exactly 30 comments) and confirm "Show older" no longer appears