### PR TITLE
fix(timeline): rescue orphaned replies + bump page size to 50

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -519,7 +519,7 @@ export class ApiClient {
   async listTimeline(
     issueId: string,
     pageParam: TimelinePageParam = { mode: "latest" },
-    limit = 30,
+    limit = 50,
   ): Promise<TimelinePage> {
     const params = new URLSearchParams();
     params.set("limit", String(limit));

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -522,6 +522,43 @@ describe("IssueDetail (shared)", () => {
     expect(screen.getByText("I can help with this")).toBeInTheDocument();
   });
 
+  // Orphan-reply rescue (#1857): a reply whose parent is paginated out of the
+  // current page used to disappear from the UI entirely, since only the
+  // root's CommentCard knew to pull replies from repliesByParent. Now the
+  // reply is promoted to top-level and rendered standalone, so the user
+  // never loses sight of comment content even when the page boundary cuts
+  // through a thread.
+  it("renders orphaned replies (parent not in timeline) at top level", async () => {
+    mockApiObj.listTimeline.mockResolvedValue({
+      entries: [
+        {
+          type: "comment",
+          id: "reply-1",
+          actor_type: "member",
+          actor_id: "user-1",
+          // parent_id refers to a comment that is NOT in this page (would
+          // happen if the merge truncation drops the root or pagination
+          // splits the thread).
+          parent_id: "missing-parent",
+          content: "Reply with no visible parent",
+          created_at: "2026-01-18T00:00:00Z",
+          updated_at: "2026-01-18T00:00:00Z",
+          comment_type: "comment",
+        },
+      ],
+      next_cursor: null,
+      prev_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Reply with no visible parent")).toBeInTheDocument();
+    });
+  });
+
   it("sends empty description when editor is cleared", async () => {
     renderIssueDetail();
 

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -292,10 +292,22 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // CommentCard can skip re-rendering when the only thing that moved was
   // unrelated parent state (e.g. composer draft, sidebar toggle).
   const timelineView = useMemo(() => {
-    const topLevel = timeline.filter((e) => e.type === "activity" || !e.parent_id);
+    // Orphan-reply rescue (#1857): a reply whose parent_id points to a
+    // comment that isn't in the loaded timeline gets promoted to top-level
+    // instead of disappearing. Without this, paginating between a root and
+    // its replies (or a backend bug that drops the root from the page) hides
+    // the entire reply subtree because only the root's CommentCard knows to
+    // pull its children out of repliesByParent.
+    const idsInTimeline = new Set(timeline.map((e) => e.id));
+    const topLevel = timeline.filter(
+      (e) =>
+        e.type === "activity" ||
+        !e.parent_id ||
+        !idsInTimeline.has(e.parent_id),
+    );
     const repliesByParent = new Map<string, TimelineEntry[]>();
     for (const e of timeline) {
-      if (e.type === "comment" && e.parent_id) {
+      if (e.type === "comment" && e.parent_id && idsInTimeline.has(e.parent_id)) {
         const list = repliesByParent.get(e.parent_id) ?? [];
         list.push(e);
         repliesByParent.set(e.parent_id, list);

--- a/server/internal/handler/activity.go
+++ b/server/internal/handler/activity.go
@@ -60,7 +60,7 @@ const (
 	// they decorate the comment stream. Without that split, an issue with
 	// sparse comments but dense activity (agent runs, status flips) triggered
 	// "show older" prematurely and felt like comments had vanished.
-	timelineDefaultLimit = 30
+	timelineDefaultLimit = 50
 	timelineMaxLimit     = 100
 )
 


### PR DESCRIPTION
## Summary

Two related changes for the same UX problem ([#1857](https://github.com/multica-ai/multica/issues/1857) follow-up).

### 1. Orphan-reply rescue

The grouping in \`issue-detail.tsx\` put replies under their parent's \`CommentCard\`, looking them up via \`repliesByParent.get(parentId)\`. When a reply's parent wasn't in the loaded timeline — pagination boundary, merge truncation, future backend bug — the entire reply subtree dropped off the screen, since the orphan replies sat in the map with no \`CommentCard\` around to render them.

MUL-1847 hit this on the OLD backend: 1 root + 29 replies, the root was the oldest entry and the merge dropped it, so all 29 replies vanished from the UI even though the API returned them.

A reply whose \`parent_id\` points to a comment NOT in the loaded timeline is now promoted to top-level. It still loses its visual indentation under the missing parent, but it stops disappearing.

### 2. Page size 50

With activities decoupled from the comment budget (#2253) and the off-by-one fixed (#2259), 50 fits the typical issue without any "Show older" interaction. Cost is bounded — SQL fetches \`limit+1 = 51\` comments + 50 activities through the keyset index from migration 068; response body grows ~70% over 30 but stays well under the legacy compat path's 200-row cap. UI renders 100 entries comfortably; \`CommentCard\`s memoize.

Frontend default in \`client.ts\` (\`limit = 50\`) matches the new backend default (\`timelineDefaultLimit = 50\`).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` clean (328 passing, +1 new)
- [x] New render-level test: \`renders orphaned replies (parent not in timeline) at top level\`
- [x] \`go vet ./...\` / \`go build ./...\` clean
- [ ] Manual: open MUL-1847 (1 root + 29 replies) after backend deploy, confirm the thread renders even if the root drops off any future page
- [ ] Manual: open an issue with 49 / 50 / 51 comments and confirm the new threshold