### PR TITLE
refactor(daemon): follow-up nits on repoCache interface + /health test timeout

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -50,7 +50,7 @@ type workspaceState struct {
 	repoRefreshMu   sync.Mutex
 }
 
-type repoCache interface {
+type repoCacheBackend interface {
 	Lookup(workspaceID, url string) string
 	Sync(workspaceID string, repos []repocache.RepoInfo) error
 	CreateWorktree(params repocache.WorktreeParams) (*repocache.WorktreeResult, error)
@@ -60,7 +60,7 @@ type repoCache interface {
 type Daemon struct {
 	cfg       Config
 	client    *Client
-	repoCache repoCache
+	repoCache repoCacheBackend
 	logger    *slog.Logger
 
 	mu           sync.Mutex

--- a/server/internal/daemon/health_test.go
+++ b/server/internal/daemon/health_test.go
@@ -171,7 +171,7 @@ func TestHealthHandlerRespondsWhileTaskRepoLookupWaits(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected 200, got %d", rec.Code)
 		}
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("/health blocked behind task repo cache lookup")
 	}
 


### PR DESCRIPTION
## What does this PR do?

Two non-blocking nits from the post-merge review of #2211 (daemon health responsiveness during repo lookup):

1. **Rename the package-local `repoCache` interface to `repoCacheBackend`.**
   Previously the field declaration in `Daemon` read `repoCache repoCache` — type and field share the same identifier. Go allows it, but the renamed interface reads cleaner and avoids the shadow.
2. **Relax the `/health` deadline in `TestHealthHandlerRespondsWhileTaskRepoLookupWaits` from 200ms to 1s.**
   On the old (broken) lock placement `/health` blocks indefinitely behind `d.mu`, so any sane upper bound still fail-fast detects the regression. 1s leaves more headroom on heavily loaded CI runners without weakening what the test asserts.

No production behavior changes — `*repocache.Cache` continues to satisfy the renamed interface implicitly, and the test still proves the same regression.

## Related Issue

Follow-up to #2211.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement (no behavior change)
- [x] Tests (adjusting an existing test threshold)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/daemon.go`: rename `repoCache` interface → `repoCacheBackend`; update the field type accordingly.
- `server/internal/daemon/health_test.go`: bump the `/health` timeout in `TestHealthHandlerRespondsWhileTaskRepoLookupWaits` from `200ms` → `1s`.

## How to Test

- `cd server && go build ./...`
- `cd server && go test -race ./internal/daemon -count=1`
- `cd server && go test ./internal/daemon -run TestHealthHandlerRespondsWhileTaskRepoLookupWaits -count=1`

Local verification:
- `go build ./...` ✓
- `go test -race ./internal/daemon -count=1` ✓ (7.282s)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run targeted local verification for the changed package/file
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude (Multica `pr-review` follow-up).

**Prompt / approach:** Address the two non-blocking nits surfaced in the post-merge review of #2211 — narrow scope, no behavior change in production code paths.