### PR TITLE
docs(changelog): add v0.2.28 entry for 2026-05-08 release

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -284,6 +284,33 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.28",
+        date: "2026-05-08",
+        title: "Daemon Disk-Usage CLI, Timeline Polish & Task Usage Rollup",
+        changes: [],
+        features: [
+          "New `multica daemon disk-usage` CLI surfaces per-task and per-workspace disk footprint",
+          "Skill picker in agent settings has a search box for fast lookup",
+          "Daemon GC extends to chat, autopilot, and quick-create tasks",
+          "Issue detail breadcrumb now shows the MUL-xxxx identifier for quick reference",
+        ],
+        improvements: [
+          "Timeline page size bumped to 50, with per-pool keyset cursors for comments and activities",
+          "'Show older / newer' affordances now appear in edge cases and look clearly clickable",
+          "Server `task_usage` rolls up into a daily aggregate table, dropping DB load significantly",
+          "Daemon health check stays responsive while repo lookups are in flight",
+          "Runtime stats exclude archived agents for accurate active counts",
+        ],
+        fixes: [
+          "Linux daemon self-restart uses `brew prefix` symlinks, so Homebrew Cellar deletion no longer orphans runtimes",
+          "CLI short IDs now route correctly — copied prefixes no longer 404",
+          "Windows non-ASCII comment / description input lands via new `--content-file` / `--description-file` flags",
+          "Windows / Linux desktop replaces the Electron placeholder icon with the Multica asterisk",
+          "Orphaned timeline replies are now correctly surfaced",
+          "Timeline comment pagination budget excludes activities, so heavy activity no longer crowds out real comments",
+        ],
+      },
+      {
         version: "0.2.27",
         date: "2026-05-07",
         title: "Smoother Chat, GitHub Skill Import & Stability Fixes",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -284,6 +284,33 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.28",
+        date: "2026-05-08",
+        title: "Daemon 磁盘占用 CLI、Timeline 打磨与任务用量聚合提速",
+        changes: [],
+        features: [
+          "新增 `multica daemon disk-usage` CLI，按 task / workspace 维度查看磁盘占用",
+          "Skill Picker 弹窗新增搜索框，Agent 设置里挑技能更快",
+          "Daemon GC 覆盖扩展到 chat、autopilot、quick-create 任务",
+          "Issue 详情页面包屑直接显示 MUL-xxxx identifier",
+        ],
+        improvements: [
+          "Timeline 分页 size 提到 50，评论与活动按池独立 keyset 游标，长 Issue 翻页更顺",
+          "Show older / newer 按钮在边界场景也能正确出现，且视觉上更明显是可点击的",
+          "服务端 `task_usage` 聚合到每日 rollup 表，DB 负载明显下降",
+          "Daemon health check 在 repo 查询时不再阻塞，始终保持响应",
+          "Runtime 统计排除已归档的 agent，活跃数字更准",
+        ],
+        fixes: [
+          "Linux 上 daemon self-restart 改走 `brew prefix` 软链，Homebrew Cellar 删除后不再让 runtime 失联",
+          "CLI 短 ID 现在可以正确路由，复制粘贴的短前缀不再 404",
+          "Windows 上非 ASCII 字符评论 / 描述输入新增 `--content-file` / `--description-file`",
+          "Windows / Linux 桌面端用 Multica asterisk 替换 Electron 默认占位图标",
+          "Timeline 中孤立的 reply 现在会被正确捞回展示",
+          "Timeline 评论分页预算不再把 activity 算进去，避免活动多时挤掉真实评论",
+        ],
+      },
+      {
         version: "0.2.27",
         date: "2026-05-07",
         title: "Chat 更顺手，Skill 支持 GitHub 导入，稳定性更好",


### PR DESCRIPTION
## Summary

- Adds the v0.2.28 (2026-05-08) entry to both `zh.ts` and `en.ts` on the landing `/changelog` page
- Covers the 17 commits between `v0.2.27` and current `main`: daemon disk-usage CLI, skill picker search, timeline polish (page-size, keyset cursors, orphaned replies, off-by-one), `task_usage` daily rollup, daemon-health responsiveness, runtime-stat archived-agent fix, Linux Cellar self-restart fix, CLI short-id routing, Windows non-ASCII input flags, desktop icon swap
- Bullets are kept to a single line each, matching the style of prior entries

## Test plan

- [x] `pnpm --filter @multica/web typecheck` passes locally
- [x] `eslint` clean on the two modified files
- [ ] Visually verify the new entry renders on `/changelog` once the preview deploys