### PR TITLE
feat(daemon): auto-inject per-agent KUBECONFIG at task dispatch

### DIFF
--- a/server/internal/daemon/agent_kubeconfig.go
+++ b/server/internal/daemon/agent_kubeconfig.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Per-agent kubeconfig auto-injection.
+//
+// The runtime StatefulSet on lue-kube projects one kubeconfig per agent
+// identity into a shared volume — e.g. /etc/multica/kube/boris.kubeconfig
+// for the Bermont CTO, /etc/multica/kube/doug.kubeconfig for the CCS CTO,
+// etc. This file maps a dispatched agent's display name onto the matching
+// path so the daemon can set KUBECONFIG automatically per task — the
+// agent's CLI then runs as a distinct ServiceAccount, with audit logs in
+// the target cluster attributing API calls per-agent rather than to a
+// shared service-account.
+//
+// Resolution is best-effort: if no matching file exists, KUBECONFIG is
+// left unset and the agent runs without cluster credentials (or with
+// whatever its CustomEnv supplies). This keeps the daemon usable in
+// development environments where the kubeconfig volume isn't mounted.
+
+// kubeconfigDirEnv lets operators override the per-agent kubeconfig
+// directory (handy for tests and non-cluster deployments).
+const kubeconfigDirEnv = "MULTICA_KUBECONFIG_DIR"
+
+// defaultKubeconfigDir matches the projected-volume mount in
+// k3s/apps/multica/base/runtime.yaml on lue-kube.
+const defaultKubeconfigDir = "/etc/multica/kube"
+
+// kubeconfigPathForAgent returns the absolute path to the per-agent
+// kubeconfig if a matching file exists, or "" if none. The slug rule
+// is: take the first whitespace-delimited token of the agent's display
+// name, lowercase it, and keep [a-z0-9-]. So "Boris" → "boris",
+// "Doug - CTO" → "doug", "Kael OpenClaw" → "kael".
+func kubeconfigPathForAgent(name string) string {
+	slug := slugifyAgentName(name)
+	if slug == "" {
+		return ""
+	}
+	dir := os.Getenv(kubeconfigDirEnv)
+	if dir == "" {
+		dir = defaultKubeconfigDir
+	}
+	path := filepath.Join(dir, slug+".kubeconfig")
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	return path
+}
+
+// slugifyAgentName extracts a stable filesystem slug from a display name.
+// Empty input or names with no alphanumeric characters return "".
+func slugifyAgentName(name string) string {
+	tokens := strings.Fields(strings.TrimSpace(name))
+	if len(tokens) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range strings.ToLower(tokens[0]) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/server/internal/daemon/agent_kubeconfig_test.go
+++ b/server/internal/daemon/agent_kubeconfig_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSlugifyAgentName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Boris", "boris"},
+		{"  Boris  ", "boris"},
+		{"Doug - CTO", "doug"},
+		{"Kael OpenClaw", "kael"},
+		{"Maggie - COO", "maggie"},
+		{"theo", "theo"},
+		{"K9-Bot", "k9-bot"},
+		{"!!!", ""},
+		{"", ""},
+		{"   ", ""},
+		{"Émilie", "milie"}, // non-ASCII chars are dropped; remaining ASCII forms the slug
+	}
+	for _, tc := range cases {
+		if got := slugifyAgentName(tc.in); got != tc.want {
+			t.Errorf("slugifyAgentName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestKubeconfigPathForAgent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(kubeconfigDirEnv, dir)
+
+	// Drop two files: a regular kubeconfig and a directory with a
+	// kubeconfig-shaped name to verify directories are rejected.
+	if err := os.WriteFile(filepath.Join(dir, "boris.kubeconfig"), []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write boris: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "rogue.kubeconfig"), 0o755); err != nil {
+		t.Fatalf("mkdir rogue: %v", err)
+	}
+
+	cases := []struct {
+		name, agent, want string
+	}{
+		{"exact match", "Boris", filepath.Join(dir, "boris.kubeconfig")},
+		{"title suffix ignored", "Boris - CTO", filepath.Join(dir, "boris.kubeconfig")},
+		{"missing file returns empty", "Doug - CTO", ""},
+		{"directory is not a kubeconfig", "Rogue", ""},
+		{"empty name", "", ""},
+		{"whitespace-only", "   ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := kubeconfigPathForAgent(tc.agent); got != tc.want {
+				t.Errorf("kubeconfigPathForAgent(%q) = %q, want %q", tc.agent, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKubeconfigPathForAgent_DefaultDir(t *testing.T) {
+	// With env unset and no /etc/multica/kube on a typical CI host, the
+	// lookup should silently return "". Don't fail when running on a host
+	// that happens to have the file (developer machine).
+	t.Setenv(kubeconfigDirEnv, "")
+	got := kubeconfigPathForAgent("nonexistent-agent-xyz")
+	if got != "" {
+		t.Errorf("expected empty for unknown agent under default dir, got %q", got)
+	}
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1664,6 +1664,18 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if env.CodexHome != "" {
 		agentEnv["CODEX_HOME"] = env.CodexHome
 	}
+	// Auto-inject KUBECONFIG for per-agent cluster identity. The runtime
+	// pod projects /etc/multica/kube/<slug>.kubeconfig per dispatched
+	// agent so that audit logs in the target cluster attribute API calls
+	// to a distinct ServiceAccount (e.g. "boris" vs "doug") rather than a
+	// shared one. Skipped silently when no matching file exists.
+	if task.Agent != nil {
+		if kc := kubeconfigPathForAgent(task.Agent.Name); kc != "" {
+			agentEnv["KUBECONFIG"] = kc
+			taskLog.Debug("agent kubeconfig auto-injected",
+				"agent", task.Agent.Name, "path", kc)
+		}
+	}
 	// Inject user-configured custom environment variables (e.g. ANTHROPIC_API_KEY,
 	// ANTHROPIC_BASE_URL for router/proxy mode, or CLAUDE_CODE_USE_BEDROCK for
 	// Bedrock). These are set per-agent via the agent settings UI.
@@ -2218,7 +2230,7 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	switch upper {
-	case "HOME", "PATH", "USER", "SHELL", "TERM", "CODEX_HOME":
+	case "HOME", "PATH", "USER", "SHELL", "TERM", "CODEX_HOME", "KUBECONFIG":
 		return true
 	}
 	return false


### PR DESCRIPTION
## Why

The Multica runtime pod on lue-kube projects per-agent kubeconfigs into `/etc/multica/kube/<slug>.kubeconfig` (one ServiceAccount per Paperclip agent — e.g. `boris`/`atlas`/`doug`/`riley`/`theo`). Until now agents had to remember to set `KUBECONFIG` themselves before `kubectl`, and any cluster API call from an unaware skill ran as the shared `devops-agent` SA — losing the audit-attribution we set the per-agent SAs up for.

## What

When a task is dispatched, the daemon now slugs the agent's display name (lowercase first whitespace-delimited token, keep `[a-z0-9-]`) and looks up `/etc/multica/kube/<slug>.kubeconfig`. If the file exists, `KUBECONFIG` is set on the agent's process before launch so `kubectl` runs as that identity by default.

| Display name | Slug | Resolved kubeconfig path |
|---|---|---|
| `Boris` | `boris` | `/etc/multica/kube/boris.kubeconfig` |
| `Doug - CTO` | `doug` | `/etc/multica/kube/doug.kubeconfig` |
| `Kael OpenClaw` | `kael` | `/etc/multica/kube/kael.kubeconfig` |

## Behaviour notes

- Best-effort: missing files are silently skipped, preserving dev environments without the kubeconfig volume.
- `MULTICA_KUBECONFIG_DIR` env overrides the search path (used by tests).
- `KUBECONFIG` is added to `isBlockedEnvKey` so an agent's `custom_env` can't override it and run as the wrong identity.

## Tests

`server/internal/daemon` package suite passes; new tests cover:
- Slug edge cases (whitespace, title suffixes, unicode prefix).
- File-exists vs directory-with-matching-name (directory rejected).
- Default-dir lookup with no env override returns empty for unknown agents.

## Operator docs

Updated `infra/lue-kube/docs/multica-runtime-pod.md` with the new mapping table and "Adding a new agent identity" workflow (committed separately in lue-kube).