### PR TITLE
fix: parse pi --list-models table output format

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -299,9 +299,6 @@ func discoverPiModels(ctx context.Context, executablePath string) ([]Model, erro
 	return parsePiModels(text), nil
 }
 
-// parsePiModels accepts the `pi --list-models` output and extracts
-// model IDs. Pi's format uses `provider:model` rows; we normalize to
-// the same `provider/model` form as opencode for UI consistency.
 func parsePiModels(output string) []Model {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -312,15 +309,22 @@ func parsePiModels(output string) []Model {
 		if line == "" {
 			continue
 		}
-		first := strings.Fields(line)
-		if len(first) == 0 {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
 			continue
 		}
-		id := first[0]
-		if !strings.ContainsAny(id, ":/") {
+		first := fields[0]
+		if strings.EqualFold(first, "provider") {
 			continue
 		}
-		// Normalize ":" to "/" since pi uses colon but opencode/UI uses slash.
+		var id string
+		if strings.ContainsAny(first, ":/") {
+			id = first
+		} else if len(fields) >= 2 {
+			id = first + "/" + fields[1]
+		} else {
+			continue
+		}
 		id = strings.Replace(id, ":", "/", 1)
 		if seen[id] {
 			continue

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -197,6 +197,29 @@ bareword
 	}
 }
 
+func TestParsePiModelsTableFormat(t *testing.T) {
+	input := `provider             model                   context  max-out  thinking  images
+bailian-coding-plan  glm-4.7                 202.8K   16.4K    no        no
+bailian-coding-plan  qwen3.6-plus            1M       65.5K    no        yes
+opencode             claude-sonnet-4-6       1M       64K      yes       yes
+opencode             claude-sonnet-4-6       1M       64K      yes       yes
+bareword-only-line
+`
+	models := parsePiModels(input)
+	if len(models) != 3 {
+		t.Fatalf("expected 3 models (header skipped, duplicate deduped, bareword skipped), got %d: %+v", len(models), models)
+	}
+	if models[0].ID != "bailian-coding-plan/glm-4.7" || models[0].Provider != "bailian-coding-plan" {
+		t.Errorf("unexpected first model: %+v", models[0])
+	}
+	if models[1].ID != "bailian-coding-plan/qwen3.6-plus" || models[1].Provider != "bailian-coding-plan" {
+		t.Errorf("unexpected second model: %+v", models[1])
+	}
+	if models[2].ID != "opencode/claude-sonnet-4-6" || models[2].Provider != "opencode" {
+		t.Errorf("unexpected third model: %+v", models[2])
+	}
+}
+
 func TestParseOpenclawAgents(t *testing.T) {
 	input := `deepseek-v4   deepseek-v4
 claude-sonnet claude-sonnet-4-6


### PR DESCRIPTION
## What does this PR do?

Fixes pi runtime model discovery returning an empty list, which causes the UI to display "No models available." when selecting pi as an agent runtime.

The `pi --list-models` CLI output recently changed from a compact `provider:model` per-line format to a multi-column table:

```
provider             model                   context  max-out
bailian-coding-plan  glm-4.7                 202.8K   16.4K
opencode             claude-sonnet-4-6       1M       64K
```

The existing `parsePiModels` parser read only the first whitespace-delimited token (`bailian-coding-plan`), checked for `:` or `/` (absent), and silently discarded every line — yielding an empty model list.

## Related Issue

None — discovered during local self-hosted setup.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`server/pkg/agent/models.go`** — Updated `parsePiModels` to handle both output formats:
  - New table format: joins column 0 (provider) and column 1 (model) into `provider/model`
  - Legacy `provider:model` format: retained with existing `:` → `/` normalization
  - Header row is skipped via case-insensitive `provider` token match

- **`server/pkg/agent/models_test.go`** — Added `TestParsePiModelsTableFormat` covering:
  - Header row exclusion
  - Provider+model column concatenation
  - Duplicate deduplication
  - Malformed single-token line rejection

## How to Test

1. Configure a pi runtime in the Multica UI
2. Select pi as the agent runtime — the model dropdown should populate with all available models
3. Run: `go test ./pkg/agent/ -run TestParsePiModels -v` (2 tests, both pass)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable

## AI Disclosure

N/A