### PR TITLE
Pass agent instructions inline to Hermes

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1582,6 +1582,15 @@ func gcMetaForTask(task Task) (execenv.GCMeta, bool) {
 	return meta, true
 }
 
+func providerNeedsInlineSystemPrompt(provider string) bool {
+	switch provider {
+	case "openclaw", "hermes":
+		return true
+	default:
+		return false
+	}
+}
+
 func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot int, taskLog *slog.Logger) (TaskResult, error) {
 	// Refuse to spawn an agent without a workspace. An empty workspace_id
 	// here would make MULTICA_WORKSPACE_ID empty in the agent env, and the
@@ -1803,13 +1812,17 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		CustomArgs:                customArgs,
 		McpConfig:                 mcpConfig,
 	}
-	// openclaw loads its bootstrap files (AGENTS.md, SOUL.md, ...) from its own
-	// workspace dir rather than the task workdir, so the AGENTS.md written by
-	// execenv.InjectRuntimeConfig is never read. Pass agent instructions inline
-	// via SystemPrompt so the backend can prepend them to the --message payload.
-	// Other providers already surface instructions through their runtime config
-	// file and don't need this.
-	if provider == "openclaw" {
+	// Some providers do not reliably load the per-task runtime config files we
+	// write into the task workdir:
+	//   - openclaw loads bootstrap files (AGENTS.md, SOUL.md, ...) from its own
+	//     workspace dir rather than the task workdir.
+	//   - hermes is driven through ACP and starts from a long-lived Hermes home;
+	//     deployments that cross a wrapper/container boundary can miss the
+	//     task-workdir AGENTS.md even when the prompt itself is delivered.
+	// Pass Multica-defined identity/persona instructions inline so the backend
+	// can prepend them to the turn payload instead of relying only on file
+	// discovery.
+	if providerNeedsInlineSystemPrompt(provider) {
 		execOpts.SystemPrompt = instructions
 	}
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -177,6 +177,29 @@ func TestNewTaskSlotSemaphoreReturnsStableSlotIndexes(t *testing.T) {
 	}
 }
 
+func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		provider string
+		want     bool
+	}{
+		{provider: "openclaw", want: true},
+		{provider: "hermes", want: true},
+		{provider: "codex", want: false},
+		{provider: "claude", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			t.Parallel()
+			if got := providerNeedsInlineSystemPrompt(tc.provider); got != tc.want {
+				t.Fatalf("providerNeedsInlineSystemPrompt(%q) = %v, want %v", tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildPromptContainsIssueID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes the Hermes-specific gap where Multica-defined agent identity/persona instructions can be missed by Hermes tasks.

## Problem

Multica already writes agent identity instructions into the per-task runtime config (`AGENTS.md`) via `execenv.InjectRuntimeConfig`.

That works for providers that reliably read the task workdir config. Hermes is different because it is driven through ACP and often runs from a long-lived Hermes home. In deployments like K3 Lens, there is also a wrapper/container boundary:

`multica daemon` → Hermes wrapper → `docker compose exec hermes hermes acp`

That means the prompt itself reaches Hermes, but the per-task `AGENTS.md` can be missed, so agents may not see the Multica-defined identity/persona instructions.

## Change

Treat Hermes like OpenClaw for this path and pass the agent instructions inline through `ExecOptions.SystemPrompt`.

The Hermes backend already prepends `SystemPrompt` to the `session/prompt` text, so this makes the Multica-defined identity instructions part of the actual ACP turn payload instead of relying only on runtime config file discovery.

## Validation

- `docker run --rm -v "$PWD/server":/src -w /src golang:1.26 gofmt -w internal/daemon/daemon.go internal/daemon/daemon_test.go`
- `docker run --rm -v "$PWD/server":/src -w /src golang:1.26 go test ./internal/daemon -run TestProviderNeedsInlineSystemPrompt`
- `docker run --rm -v "$PWD/server":/src -w /src golang:1.26 go test ./internal/daemon`
