### PR TITLE
fix(storage): use virtual-hosted-style URLs for non-AWS S3 endpoints (MUL-3681)

### DIFF
--- a/server/internal/storage/s3.go
+++ b/server/internal/storage/s3.go
@@ -16,11 +16,12 @@ import (
 )
 
 type S3Storage struct {
-	client      *s3.Client
-	bucket      string
-	region      string // used to construct virtual-hosted-style public URLs when no CDN/endpoint is set
-	cdnDomain   string // if set, returned URLs use this instead of bucket name
-	endpointURL string // if set, use path-style URLs (e.g. MinIO)
+	client       *s3.Client
+	bucket       string
+	region       string // used to construct virtual-hosted-style public URLs when no CDN/endpoint is set
+	cdnDomain    string // if set, returned URLs use this instead of bucket name
+	endpointURL  string // if set, points at an S3-compatible store (Aliyun OSS, R2, MinIO, ...)
+	usePathStyle bool   // mirrors s3.Options.UsePathStyle — must match SDK to get URLs the bucket actually serves
 }
 
 // NewS3StorageFromEnv creates an S3Storage from environment variables.
@@ -69,6 +70,10 @@ func NewS3StorageFromEnv() *S3Storage {
 	cdnDomain := os.Getenv("CLOUDFRONT_DOMAIN")
 
 	endpointURL := os.Getenv("AWS_ENDPOINT_URL")
+	// Aliyun OSS / Cloudflare R2 / Backblaze B2 require virtual-hosted style;
+	// MinIO and a few other S3-compatible stores need path style.
+	// Default to virtual-hosted (false). Set S3_FORCE_PATH_STYLE=true to opt in.
+	usePathStyle := os.Getenv("S3_FORCE_PATH_STYLE") == "true"
 	s3Opts := []func(*s3.Options){}
 	if endpointURL != "" {
 		s3Opts = append(s3Opts, func(o *s3.Options) {
@@ -77,13 +82,14 @@ func NewS3StorageFromEnv() *S3Storage {
 		})
 	}
 
-	slog.Info("S3 storage initialized", "bucket", bucket, "region", region, "cdn_domain", cdnDomain, "endpoint_url", endpointURL)
+	slog.Info("S3 storage initialized", "bucket", bucket, "region", region, "cdn_domain", cdnDomain, "endpoint_url", endpointURL, "use_path_style", usePathStyle)
 	return &S3Storage{
-		client:      s3.NewFromConfig(cfg, s3Opts...),
-		bucket:      bucket,
-		region:      region,
-		cdnDomain:   cdnDomain,
-		endpointURL: endpointURL,
+		client:       s3.NewFromConfig(cfg, s3Opts...),
+		bucket:       bucket,
+		region:       region,
+		cdnDomain:    cdnDomain,
+		endpointURL:  endpointURL,
+		usePathStyle: usePathStyle,
 	}
 }
 
@@ -115,9 +121,16 @@ func (s *S3Storage) storageClass() types.StorageClass {
 //	"https://my-bucket.s3.us-east-1.amazonaws.com/uploads/x/y.png" → "uploads/x/y.png"
 func (s *S3Storage) KeyFromURL(rawURL string) string {
 	if s.endpointURL != "" {
-		prefix := strings.TrimRight(s.endpointURL, "/") + "/" + s.bucket + "/"
-		if strings.HasPrefix(rawURL, prefix) {
-			return strings.TrimPrefix(rawURL, prefix)
+		// path-style: https://<host>/<bucket>/<key>
+		pathPrefix := strings.TrimRight(s.endpointURL, "/") + "/" + s.bucket + "/"
+		if strings.HasPrefix(rawURL, pathPrefix) {
+			return strings.TrimPrefix(rawURL, pathPrefix)
+		}
+		// virtual-hosted style: https://<bucket>.<host>/<key>
+		scheme, host := splitEndpointHost(s.endpointURL)
+		vhostPrefix := scheme + "://" + s.bucket + "." + host + "/"
+		if strings.HasPrefix(rawURL, vhostPrefix) {
+			return strings.TrimPrefix(rawURL, vhostPrefix)
 		}
 	}
 
@@ -211,10 +224,34 @@ func (s *S3Storage) uploadedURL(key string) string {
 		return fmt.Sprintf("https://%s/%s", s.cdnDomain, key)
 	}
 	if s.endpointURL != "" {
-		return fmt.Sprintf("%s/%s/%s", strings.TrimRight(s.endpointURL, "/"), s.bucket, key)
+		// Match the addressing style used by the SDK. Aliyun OSS public access
+		// REQUIRES virtual-hosted style (`<bucket>.<host>`); the path-style
+		// form returns SecondLevelDomainForbidden. MinIO-style stores opt into
+		// path style via S3_FORCE_PATH_STYLE=true.
+		if s.usePathStyle {
+			return fmt.Sprintf("%s/%s/%s", strings.TrimRight(s.endpointURL, "/"), s.bucket, key)
+		}
+		scheme, host := splitEndpointHost(s.endpointURL)
+		return fmt.Sprintf("%s://%s.%s/%s", scheme, s.bucket, host, key)
 	}
 	if strings.Contains(s.bucket, ".") {
 		return fmt.Sprintf("https://s3.%s.amazonaws.com/%s/%s", s.region, s.bucket, key)
 	}
 	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", s.bucket, s.region, key)
+}
+
+// splitEndpointHost splits an endpoint URL like "https://oss-us-west-1.aliyuncs.com"
+// into ("https", "oss-us-west-1.aliyuncs.com"). Trailing slashes and any path are
+// dropped; missing scheme defaults to https.
+func splitEndpointHost(endpoint string) (scheme, host string) {
+	rest := strings.TrimRight(endpoint, "/")
+	scheme = "https"
+	if i := strings.Index(rest, "://"); i >= 0 {
+		scheme = rest[:i]
+		rest = rest[i+3:]
+	}
+	if i := strings.Index(rest, "/"); i >= 0 {
+		rest = rest[:i]
+	}
+	return scheme, rest
 }

--- a/server/internal/storage/s3_test.go
+++ b/server/internal/storage/s3_test.go
@@ -2,10 +2,11 @@ package storage
 
 import "testing"
 
-func TestS3StorageKeyFromURL_CustomEndpointPreservesNestedKey(t *testing.T) {
+func TestS3StorageKeyFromURL_CustomEndpointPathStylePreservesNestedKey(t *testing.T) {
 	s := &S3Storage{
-		bucket:      "test-bucket",
-		endpointURL: "http://localhost:9000",
+		bucket:       "test-bucket",
+		endpointURL:  "http://localhost:9000",
+		usePathStyle: true,
 	}
 
 	rawURL := "http://localhost:9000/test-bucket/uploads/abc/file.png"
@@ -17,14 +18,28 @@ func TestS3StorageKeyFromURL_CustomEndpointPreservesNestedKey(t *testing.T) {
 
 func TestS3StorageKeyFromURL_CustomEndpointWithTrailingSlash(t *testing.T) {
 	s := &S3Storage{
-		bucket:      "test-bucket",
-		endpointURL: "http://localhost:9000/",
+		bucket:       "test-bucket",
+		endpointURL:  "http://localhost:9000/",
+		usePathStyle: true,
 	}
 
 	rawURL := "http://localhost:9000/test-bucket/uploads/abc/file.png"
 
 	if got := s.KeyFromURL(rawURL); got != "uploads/abc/file.png" {
 		t.Fatalf("KeyFromURL(%q) = %q, want %q", rawURL, got, "uploads/abc/file.png")
+	}
+}
+
+func TestS3StorageKeyFromURL_CustomEndpointVirtualHostedPreservesNestedKey(t *testing.T) {
+	s := &S3Storage{
+		bucket:      "multica-uploads-prod",
+		endpointURL: "https://oss-us-west-1.aliyuncs.com",
+	}
+
+	rawURL := "https://multica-uploads-prod.oss-us-west-1.aliyuncs.com/workspaces/abc/file.png"
+
+	if got := s.KeyFromURL(rawURL); got != "workspaces/abc/file.png" {
+		t.Fatalf("KeyFromURL(%q) = %q, want %q", rawURL, got, "workspaces/abc/file.png")
 	}
 }
 
@@ -95,12 +110,13 @@ func TestS3StorageUploadedURL(t *testing.T) {
 	const key = "uploads/abc/file.png"
 
 	cases := []struct {
-		name        string
-		bucket      string
-		region      string
-		cdnDomain   string
-		endpointURL string
-		want        string
+		name         string
+		bucket       string
+		region       string
+		cdnDomain    string
+		endpointURL  string
+		usePathStyle bool
+		want         string
 	}{
 		{
 			name:   "default aws virtual hosted style",
@@ -122,18 +138,34 @@ func TestS3StorageUploadedURL(t *testing.T) {
 			want:      "https://cdn.example.com/uploads/abc/file.png",
 		},
 		{
-			name:        "endpoint only",
-			bucket:      "test-bucket",
-			region:      "us-east-1",
-			endpointURL: "http://localhost:9000",
-			want:        "http://localhost:9000/test-bucket/uploads/abc/file.png",
+			name:         "endpoint with explicit path style (MinIO)",
+			bucket:       "test-bucket",
+			region:       "us-east-1",
+			endpointURL:  "http://localhost:9000",
+			usePathStyle: true,
+			want:         "http://localhost:9000/test-bucket/uploads/abc/file.png",
 		},
 		{
-			name:        "endpoint with trailing slash",
-			bucket:      "test-bucket",
-			region:      "us-east-1",
-			endpointURL: "http://localhost:9000/",
-			want:        "http://localhost:9000/test-bucket/uploads/abc/file.png",
+			name:         "endpoint with trailing slash, path style",
+			bucket:       "test-bucket",
+			region:       "us-east-1",
+			endpointURL:  "http://localhost:9000/",
+			usePathStyle: true,
+			want:         "http://localhost:9000/test-bucket/uploads/abc/file.png",
+		},
+		{
+			name:        "aliyun oss virtual hosted style by default",
+			bucket:      "multica-uploads-prod",
+			region:      "oss-us-west-1",
+			endpointURL: "https://oss-us-west-1.aliyuncs.com",
+			want:        "https://multica-uploads-prod.oss-us-west-1.aliyuncs.com/uploads/abc/file.png",
+		},
+		{
+			name:        "aliyun oss virtual hosted with trailing slash",
+			bucket:      "multica-uploads-prod",
+			region:      "oss-us-west-1",
+			endpointURL: "https://oss-us-west-1.aliyuncs.com/",
+			want:        "https://multica-uploads-prod.oss-us-west-1.aliyuncs.com/uploads/abc/file.png",
 		},
 		{
 			name:        "endpoint and cdn both set prefers cdn",
@@ -148,13 +180,36 @@ func TestS3StorageUploadedURL(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &S3Storage{
-				bucket:      tc.bucket,
-				region:      tc.region,
-				cdnDomain:   tc.cdnDomain,
-				endpointURL: tc.endpointURL,
+				bucket:       tc.bucket,
+				region:       tc.region,
+				cdnDomain:    tc.cdnDomain,
+				endpointURL:  tc.endpointURL,
+				usePathStyle: tc.usePathStyle,
 			}
 			if got := s.uploadedURL(key); got != tc.want {
 				t.Fatalf("uploadedURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitEndpointHost(t *testing.T) {
+	cases := []struct {
+		endpoint string
+		scheme   string
+		host     string
+	}{
+		{"https://oss-us-west-1.aliyuncs.com", "https", "oss-us-west-1.aliyuncs.com"},
+		{"https://oss-us-west-1.aliyuncs.com/", "https", "oss-us-west-1.aliyuncs.com"},
+		{"http://localhost:9000", "http", "localhost:9000"},
+		{"http://localhost:9000/", "http", "localhost:9000"},
+		{"oss-us-west-1.aliyuncs.com", "https", "oss-us-west-1.aliyuncs.com"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.endpoint, func(t *testing.T) {
+			scheme, host := splitEndpointHost(tc.endpoint)
+			if scheme != tc.scheme || host != tc.host {
+				t.Fatalf("splitEndpointHost(%q) = (%q, %q), want (%q, %q)", tc.endpoint, scheme, host, tc.scheme, tc.host)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Follow-up to e21c66a2 (`fix(storage): make S3 path style configurable for OSS-compatible endpoints`). That commit flipped the SDK default to virtual-hosted, so PutObject now goes to `<bucket>.<host>` correctly — but the URL we hand back to the client (and the parser that reverses it) was still hardcoded to path-style:

- `uploadedURL()` → `https://<host>/<bucket>/<key>`
- `KeyFromURL()` only matched that path-style prefix

Aliyun OSS public access rejects path-style on its standard regional endpoint with `SecondLevelDomainForbidden`. So uploads succeed and then 403 on the next page load.

## What this changes

- Lift `usePathStyle` onto `S3Storage` so the URL builder always matches the SDK's addressing.
- `uploadedURL()`: default (virtual-hosted) builds `https://<bucket>.<host>/<key>` — works on OSS / R2 / B2. Path-style branch unchanged for MinIO-style stores that opt in via `S3_FORCE_PATH_STYLE=true`.
- `KeyFromURL()`: recognise both path-style and virtual-hosted prefixes, so reverse-resolution and deletes keep working through the transition (and across endpoint reconfigs).
- New helper `splitEndpointHost()` for parsing the endpoint URL into scheme + host.

## Repro before this fix

```
S3_BUCKET=multica-uploads-prod
AWS_ENDPOINT_URL=https://oss-us-west-1.aliyuncs.com
```

Upload returns `https://oss-us-west-1.aliyuncs.com/multica-uploads-prod/...` → 403:

```xml
<Error>
  <Code>SecondLevelDomainForbidden</Code>
  <Message>The bucket you are attempting to access must be addressed using OSS third level domain.</Message>
</Error>
```

After this fix the URL is `https://multica-uploads-prod.oss-us-west-1.aliyuncs.com/...` → 200.

## Test plan

- [x] `go test ./server/internal/storage/...` — added cases for OSS virtual-hosted URLs (with and without trailing slash), MinIO path-style opt-in for `KeyFromURL`, and `splitEndpointHost` parsing.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [ ] Manual upload against an Aliyun OSS bucket on staging / production.

## Notes for reviewers

- AWS-only deployments are unaffected: the `endpointURL` branch only runs when `AWS_ENDPOINT_URL` is set.
- MinIO / dev stacks that already had `S3_FORCE_PATH_STYLE=true` keep their existing path-style URLs — that branch is the same code path as before.
- Records previously written with the broken path-style URL on OSS were never accessible publicly, so there's no regression risk for existing data; new uploads will write correct URLs.
