### PR TITLE
fix(priority): align low priority badge color with text-info icon

### DIFF
--- a/packages/core/issues/config/priority.ts
+++ b/packages/core/issues/config/priority.ts
@@ -15,6 +15,6 @@ export const PRIORITY_CONFIG: Record<
   urgent: { label: "Urgent", bars: 4, color: "text-destructive", badgeBg: "bg-priority", badgeText: "text-white" },
   high: { label: "High", bars: 3, color: "text-warning", badgeBg: "bg-priority/80", badgeText: "text-white" },
   medium: { label: "Medium", bars: 2, color: "text-warning", badgeBg: "bg-priority/15", badgeText: "text-priority" },
-  low: { label: "Low", bars: 1, color: "text-info", badgeBg: "bg-priority/10", badgeText: "text-priority" },
+  low: { label: "Low", bars: 1, color: "text-info", badgeBg: "bg-info/10", badgeText: "text-info" },
   none: { label: "No priority", bars: 0, color: "text-muted-foreground", badgeBg: "bg-muted", badgeText: "text-muted-foreground" },
 };

--- a/packages/core/projects/config.ts
+++ b/packages/core/projects/config.ts
@@ -34,6 +34,6 @@ export const PROJECT_PRIORITY_CONFIG: Record<
   urgent: { label: "Urgent", bars: 4, color: "text-destructive", badgeBg: "bg-priority", badgeText: "text-white" },
   high: { label: "High", bars: 3, color: "text-warning", badgeBg: "bg-priority/80", badgeText: "text-white" },
   medium: { label: "Medium", bars: 2, color: "text-warning", badgeBg: "bg-priority/15", badgeText: "text-priority" },
-  low: { label: "Low", bars: 1, color: "text-info", badgeBg: "bg-priority/10", badgeText: "text-priority" },
+  low: { label: "Low", bars: 1, color: "text-info", badgeBg: "bg-info/10", badgeText: "text-info" },
   none: { label: "No priority", bars: 0, color: "text-muted-foreground", badgeBg: "bg-muted", badgeText: "text-muted-foreground" },
 };


### PR DESCRIPTION
## What does this PR do?

Aligns the **Low** priority badge color with its `text-info` icon. The badge in the priority picker dropdown was using `bg-priority/10` + `text-priority` (orange tint), which is inconsistent with the icon's `text-info` (blue) and stands out from the other priority levels (Urgent / High / Medium all keep badge colors aligned with their icons).

Applies the fix to both issue and project priority configs.

The mock `PRIORITY_CONFIG` in `packages/views/issues/components/issue-detail.test.tsx:234` already assumed the corrected shape (`bg-info/10` / `text-info`), so the source files had silently drifted from the test fixture — this PR brings the source back into line with the existing test expectation.

## Related Issue

Closes #2289

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation update
- [ ] Tests
- [ ] CI / infrastructure

## Changes Made

- `packages/core/issues/config/priority.ts` — `low` row: `badgeBg: "bg-priority/10"` → `"bg-info/10"`, `badgeText: "text-priority"` → `"text-info"`
- `packages/core/projects/config.ts` — same change in `PROJECT_PRIORITY_CONFIG`

Total diff: 2 files, +2/-2.

## How to Test

1. Open any issue detail page
2. Click the priority field to open the priority picker dropdown
3. Verify the **Low** badge now appears blue (matching its icon), not orange
4. Repeat in a project priority picker (Projects view)

## Risks

None. This is a pure design-token swap — no behavior, data, or API change. The `--info` token is already defined in `packages/ui/styles/tokens.css` and used elsewhere (e.g. `packages/views/agents/config.ts:11`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass — `pnpm --filter @multica/core typecheck && test` (215 tests) + `pnpm --filter @multica/views typecheck && test` (327 tests), all green
- [x] I have added or updated tests where applicable — existing mock in `issue-detail.test.tsx:234` already encodes the correct shape, no new tests needed
- [ ] If this change affects the UI, I have included before/after screenshots — **screenshots to be added by the PR author after pulling the branch and running the dev server (Claude Code cannot capture GUI)**
- [x] I have updated relevant documentation to reflect my changes — N/A (pure token change)
- [x] If I added a new runtime / coding tool / UI tab, I synced landing copy / starter-content / docs — N/A
- [x] If this PR touches Chinese product copy, I checked against `apps/docs/.../conventions.zh.mdx` — N/A
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge