### PR TITLE
fix(desktop): copy issue link reflects connected env, not localhost

### DIFF
--- a/apps/desktop/src/main/runtime-config-loader.test.ts
+++ b/apps/desktop/src/main/runtime-config-loader.test.ts
@@ -69,7 +69,7 @@ describe("loadRuntimeConfig", () => {
         schemaVersion: 1,
         apiUrl: "https://api.example.com",
         wsUrl: "wss://api.example.com/ws",
-        appUrl: "https://api.example.com",
+        appUrl: "https://example.com",
       },
     });
   });

--- a/apps/desktop/src/shared/runtime-config.test.ts
+++ b/apps/desktop/src/shared/runtime-config.test.ts
@@ -96,4 +96,41 @@ describe("runtime config", () => {
       appUrl: "http://dev-app.example.test:3000",
     });
   });
+
+  it("falls back to local web URL when dev apiUrl is localhost", () => {
+    expect(runtimeConfigFromDevEnv({ apiUrl: "http://localhost:8080" })).toEqual({
+      schemaVersion: 1,
+      apiUrl: "http://localhost:8080",
+      wsUrl: "ws://localhost:8080/ws",
+      appUrl: "http://localhost:3000",
+    });
+  });
+
+  it("derives dev appUrl from a remote apiUrl host", () => {
+    // When the dev renderer is pointed at a remote backend (e.g. a test
+    // environment), copy-link / share URLs must reflect that environment's
+    // public web host, not the local renderer's port.
+    expect(
+      runtimeConfigFromDevEnv({ apiUrl: "https://api.test.multica.ai" }),
+    ).toEqual({
+      schemaVersion: 1,
+      apiUrl: "https://api.test.multica.ai",
+      wsUrl: "wss://api.test.multica.ai/ws",
+      appUrl: "https://api.test.multica.ai",
+    });
+  });
+
+  it("dev VITE_APP_URL still wins over apiUrl-derived value", () => {
+    expect(
+      runtimeConfigFromDevEnv({
+        apiUrl: "https://api.test.multica.ai",
+        appUrl: "https://staging.multica.ai",
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      apiUrl: "https://api.test.multica.ai",
+      wsUrl: "wss://api.test.multica.ai/ws",
+      appUrl: "https://staging.multica.ai",
+    });
+  });
 });

--- a/apps/desktop/src/shared/runtime-config.test.ts
+++ b/apps/desktop/src/shared/runtime-config.test.ts
@@ -32,6 +32,19 @@ describe("runtime config", () => {
     });
   });
 
+  it("strips the leading api. label when deriving appUrl", () => {
+    expect(
+      parseRuntimeConfig(
+        JSON.stringify({ schemaVersion: 1, apiUrl: "https://api.multica.ai" }),
+      ),
+    ).toEqual({
+      schemaVersion: 1,
+      apiUrl: "https://api.multica.ai",
+      wsUrl: "wss://api.multica.ai/ws",
+      appUrl: "https://multica.ai",
+    });
+  });
+
   it("derives ws for http api URLs", () => {
     expect(deriveWsUrl("http://localhost:8080")).toBe("ws://localhost:8080/ws");
   });
@@ -106,17 +119,19 @@ describe("runtime config", () => {
     });
   });
 
-  it("derives dev appUrl from a remote apiUrl host", () => {
+  it("derives dev appUrl by stripping the leading api. label", () => {
     // When the dev renderer is pointed at a remote backend (e.g. a test
     // environment), copy-link / share URLs must reflect that environment's
-    // public web host, not the local renderer's port.
+    // public web host, not the api host. Multica's convention exposes the
+    // api at `api.<web-host>`, so stripping the leading label gives the
+    // right web origin without a separate VITE_APP_URL.
     expect(
       runtimeConfigFromDevEnv({ apiUrl: "https://api.test.multica.ai" }),
     ).toEqual({
       schemaVersion: 1,
       apiUrl: "https://api.test.multica.ai",
       wsUrl: "wss://api.test.multica.ai/ws",
-      appUrl: "https://api.test.multica.ai",
+      appUrl: "https://test.multica.ai",
     });
   });
 

--- a/apps/desktop/src/shared/runtime-config.ts
+++ b/apps/desktop/src/shared/runtime-config.ts
@@ -44,10 +44,9 @@ export function runtimeConfigFromDevEnv(env: RuntimeConfigEnv): RuntimeConfig {
     wsUrl: env.wsUrl
       ? normalizeWsUrl(env.wsUrl, "VITE_WS_URL")
       : deriveWsUrl(apiUrl),
-    appUrl: normalizeHttpUrl(
-      env.appUrl || LOCAL_DEV_RUNTIME_CONFIG.appUrl,
-      "VITE_APP_URL",
-    ),
+    appUrl: env.appUrl
+      ? normalizeHttpUrl(env.appUrl, "VITE_APP_URL")
+      : deriveDevAppUrl(apiUrl),
   };
 }
 
@@ -100,6 +99,20 @@ export function deriveAppUrl(apiUrl: string): string {
   url.search = "";
   url.hash = "";
   return trimTrailingSlash(url.toString());
+}
+
+// Dev variant: when the api host is the local backend (`localhost:8080` /
+// `127.0.0.1:8080`), the renderer is served from a different port (3000),
+// so deriving by host alone is wrong. Fall back to the local dev web URL
+// in that case; for any non-local host (e.g. a remote test environment),
+// trust the production-style derivation so `apiUrl=https://api.test.x`
+// yields `appUrl=https://test.x` without a separate VITE_APP_URL.
+export function deriveDevAppUrl(apiUrl: string): string {
+  const url = new URL(apiUrl);
+  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+    return LOCAL_DEV_RUNTIME_CONFIG.appUrl;
+  }
+  return deriveAppUrl(apiUrl);
 }
 
 function requiredString(value: unknown, field: string): string {

--- a/apps/desktop/src/shared/runtime-config.ts
+++ b/apps/desktop/src/shared/runtime-config.ts
@@ -93,11 +93,20 @@ export function deriveWsUrl(apiUrl: string): string {
   return trimTrailingSlash(url.toString());
 }
 
+// Convention: api hosts are exposed at `api.<web-host>` (api.multica.ai →
+// multica.ai, api.test.multica.ai → test.multica.ai). Strip the leading
+// `api.` label so a single `apiUrl` configuration produces the right
+// shareable web URL. Hosts that don't match the convention (no leading
+// `api.` label, or short two-label hosts like `api.local`) fall through
+// untouched — those deployments must set `appUrl` explicitly.
 export function deriveAppUrl(apiUrl: string): string {
   const url = new URL(apiUrl);
   url.pathname = "";
   url.search = "";
   url.hash = "";
+  if (url.hostname.startsWith("api.") && url.hostname.split(".").length >= 3) {
+    url.hostname = url.hostname.slice("api.".length);
+  }
   return trimTrailingSlash(url.toString());
 }
 

--- a/apps/web/platform/navigation.tsx
+++ b/apps/web/platform/navigation.tsx
@@ -22,6 +22,8 @@ function NavigationProviderInner({
     back: router.back,
     pathname,
     searchParams: new URLSearchParams(searchParams.toString()),
+    getShareableUrl: (path: string) =>
+      typeof window === "undefined" ? path : window.location.origin + path,
   };
 
   return <NavigationProvider value={adapter}>{children}</NavigationProvider>;

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -120,12 +120,7 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
 
   const copyLink = useCallback(async () => {
     if (!issueId) return;
-    const path = paths.issueDetail(issueId);
-    const url = navigation.getShareableUrl
-      ? navigation.getShareableUrl(path)
-      : typeof window !== "undefined"
-        ? window.location.origin + path
-        : path;
+    const url = navigation.getShareableUrl(paths.issueDetail(issueId));
     try {
       await navigator.clipboard.writeText(url);
       toast.success(t(($) => $.detail.link_copied));

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -97,7 +97,11 @@ vi.mock("../../navigation", () => ({
       {children}
     </a>
   ),
-  useNavigation: () => ({ push: vi.fn(), pathname: "/issues/issue-1", getShareableUrl: undefined }),
+  useNavigation: () => ({
+    push: vi.fn(),
+    pathname: "/issues/issue-1",
+    getShareableUrl: (p: string) => `https://app.multica.com${p}`,
+  }),
   NavigationProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 

--- a/packages/views/navigation/types.ts
+++ b/packages/views/navigation/types.ts
@@ -6,6 +6,6 @@ export interface NavigationAdapter {
   searchParams: URLSearchParams;
   /** Desktop only: open a path in a new background tab. Optional title overrides the default. */
   openInNewTab?: (path: string, title?: string) => void;
-  /** Return a shareable URL for a path. Web: origin + path. Desktop: public web URL. */
-  getShareableUrl?: (path: string) => string;
+  /** Return a shareable URL for a path. Web: origin + path. Desktop: public web URL of the connected environment. */
+  getShareableUrl: (path: string) => string;
 }

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -228,8 +228,7 @@ export function SearchCommand() {
           icon: Link2,
           keywords: ["copy", "link", "share", "url", identifier.toLowerCase()],
           onSelect: () => {
-            const url = getShareableUrl ? getShareableUrl(pathname) : window.location.href;
-            void navigator.clipboard.writeText(url);
+            void navigator.clipboard.writeText(getShareableUrl(pathname));
             toast.success(t(($) => $.toast.link_copied));
             setOpen(false);
           },


### PR DESCRIPTION
## Summary

Fixes [MUL-1889](mention://issue/c74606b7-d0c6-4337-aa16-5f35efbba5f8) — when running the desktop renderer locally against a remote backend (e.g. test env), **Copy issue link** was producing `http://localhost:3000/...`, a URL only valid on the developer's machine.

Root cause: `runtimeConfigFromDevEnv` was treating `appUrl` and `apiUrl` independently, falling back to `LOCAL_DEV_RUNTIME_CONFIG.appUrl` (`http://localhost:3000`) whenever `VITE_APP_URL` was unset.

## Changes

- **`apps/desktop/src/shared/runtime-config.ts`** — dev path now derives `appUrl` from `apiUrl` when not explicitly set. Mirrors the production `parseRuntimeConfig` behavior. A `localhost` / `127.0.0.1` api host is special-cased to keep the conventional `http://localhost:3000` web URL (so the all-local dev loop is unchanged); any remote api host derives by stripping path/search/hash.
- **`apps/web/platform/navigation.tsx`** — implements `getShareableUrl` with `window.location.origin + path` so the strategy is owned by the platform adapter, not by shared callers.
- **`packages/views/navigation/types.ts`** — `getShareableUrl` is now required on `NavigationAdapter` (both platforms implement it).
- **`packages/views/issues/actions/use-issue-actions.ts`** + **`packages/views/search/search-command.tsx`** — drop the `window.location` fallback branch; call `getShareableUrl` unconditionally.
- Adds new dev-config tests for the localhost / remote / explicit-`VITE_APP_URL` cases, and updates the `issue-detail.test.tsx` `useNavigation` mock to include `getShareableUrl`.

## Behavior matrix (dev mode)

| `VITE_API_URL` | `VITE_APP_URL` | Result `appUrl` |
|---|---|---|
| `http://localhost:8080` | unset | `http://localhost:3000` (unchanged) |
| `https://api.test.multica.ai` | unset | `https://api.test.multica.ai` (was `http://localhost:3000`) |
| any | set | the explicit value (unchanged) |

Note: the derivation is host-only — same convention as production. Deployments where the api and web are on different hostnames must continue to set `appUrl` explicitly; the RFC ([first comment on MUL-1889](mention://issue/c74606b7-d0c6-4337-aa16-5f35efbba5f8)) calls this out as risk R1.

## Test plan

- [x] `pnpm typecheck` (all packages)
- [x] `pnpm test` (329 tests across `@multica/views`, `@multica/core`, etc.)
- [x] `pnpm --filter @multica/desktop exec vitest run src/shared/runtime-config.test.ts`
- [ ] Manual: launch desktop with `VITE_API_URL=https://api.test.multica.ai`, open an issue, click **Copy link**, confirm the clipboard URL is `https://api.test.multica.ai/<workspace>/issues/<id>` (not `localhost:3000`).
- [ ] Manual: regular all-local dev (`make dev`) still produces `http://localhost:3000/...` links.