### PR TITLE
feat(comments): resolve threads with collapsible bar (MUL-1895)

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -523,6 +523,14 @@ export class ApiClient {
     await this.fetch(`/api/comments/${commentId}`, { method: "DELETE" });
   }
 
+  async resolveComment(commentId: string): Promise<Comment> {
+    return this.fetch(`/api/comments/${commentId}/resolve`, { method: "POST" });
+  }
+
+  async unresolveComment(commentId: string): Promise<Comment> {
+    return this.fetch(`/api/comments/${commentId}/resolve`, { method: "DELETE" });
+  }
+
   async addReaction(commentId: string, emoji: string): Promise<Reaction> {
     return this.fetch(`/api/comments/${commentId}/reactions`, {
       method: "POST",

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -432,6 +432,45 @@ export function useDeleteComment(issueId: string) {
   });
 }
 
+export function useResolveComment(issueId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ commentId, resolved }: { commentId: string; resolved: boolean }) =>
+      resolved ? api.resolveComment(commentId) : api.unresolveComment(commentId),
+    onMutate: async ({ commentId, resolved }) => {
+      await qc.cancelQueries({ queryKey: ["issues", "timeline", issueId] });
+      const prevSnapshots = qc.getQueriesData<TimelineCacheData>({
+        queryKey: ["issues", "timeline", issueId],
+      });
+      qc.setQueriesData<TimelineCacheData>(
+        { queryKey: ["issues", "timeline", issueId] },
+        (old) =>
+          mapAllEntries(old, (e) =>
+            e.id === commentId
+              ? {
+                  ...e,
+                  resolved_at: resolved ? new Date().toISOString() : null,
+                  resolved_by_type: resolved ? e.resolved_by_type ?? null : null,
+                  resolved_by_id: resolved ? e.resolved_by_id ?? null : null,
+                }
+              : e,
+          ),
+      );
+      return { prevSnapshots };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prevSnapshots) {
+        for (const [key, prev] of ctx.prevSnapshots) {
+          qc.setQueryData(key, prev);
+        }
+      }
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: issueKeys.timeline(issueId) });
+    },
+  });
+}
+
 export function useToggleCommentReaction(issueId: string) {
   const qc = useQueryClient();
   return useMutation({

--- a/packages/core/permissions/rules.test.ts
+++ b/packages/core/permissions/rules.test.ts
@@ -73,6 +73,9 @@ function makeComment(overrides: Partial<Comment> = {}): Comment {
     attachments: [],
     created_at: "2026-04-01T00:00:00Z",
     updated_at: "2026-04-01T00:00:00Z",
+    resolved_at: null,
+    resolved_by_type: null,
+    resolved_by_id: null,
     ...overrides,
   };
 }

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -45,6 +45,8 @@ import type {
   CommentCreatedPayload,
   CommentUpdatedPayload,
   CommentDeletedPayload,
+  CommentResolvedPayload,
+  CommentUnresolvedPayload,
   ActivityCreatedPayload,
   ReactionAddedPayload,
   ReactionRemovedPayload,
@@ -202,6 +204,7 @@ export function useRealtimeSync(
     const specificEvents = new Set([
       "issue:updated", "issue:created", "issue:deleted", "issue_labels:changed", "inbox:new",
       "comment:created", "comment:updated", "comment:deleted",
+      "comment:resolved", "comment:unresolved",
       "activity:created",
       "reaction:added", "reaction:removed",
       "issue_reaction:added", "issue_reaction:removed",
@@ -350,6 +353,16 @@ export function useRealtimeSync(
     const unsubCommentDeleted = ws.on("comment:deleted", (p) => {
       const { issue_id } = p as CommentDeletedPayload;
       if (issue_id) invalidateTimeline(issue_id);
+    });
+
+    const unsubCommentResolved = ws.on("comment:resolved", (p) => {
+      const { comment } = p as CommentResolvedPayload;
+      if (comment?.issue_id) invalidateTimeline(comment.issue_id);
+    });
+
+    const unsubCommentUnresolved = ws.on("comment:unresolved", (p) => {
+      const { comment } = p as CommentUnresolvedPayload;
+      if (comment?.issue_id) invalidateTimeline(comment.issue_id);
     });
 
     const unsubActivityCreated = ws.on("activity:created", (p) => {
@@ -678,6 +691,8 @@ export function useRealtimeSync(
       unsubCommentCreated();
       unsubCommentUpdated();
       unsubCommentDeleted();
+      unsubCommentResolved();
+      unsubCommentUnresolved();
       unsubActivityCreated();
       unsubReactionAdded();
       unsubReactionRemoved();

--- a/packages/core/types/activity.ts
+++ b/packages/core/types/activity.ts
@@ -1,4 +1,4 @@
-import type { Reaction } from "./comment";
+import type { CommentAuthorType, Reaction } from "./comment";
 import type { Attachment } from "./attachment";
 
 export interface AssigneeFrequencyEntry {
@@ -23,6 +23,9 @@ export interface TimelineEntry {
   comment_type?: string;
   reactions?: Reaction[];
   attachments?: Attachment[];
+  resolved_at?: string | null;
+  resolved_by_type?: CommentAuthorType | null;
+  resolved_by_id?: string | null;
   /** Set by frontend coalescing when consecutive identical activities are merged. */
   coalesced_count?: number;
 }

--- a/packages/core/types/comment.ts
+++ b/packages/core/types/comment.ts
@@ -23,4 +23,7 @@ export interface Comment {
   attachments: import("./attachment").Attachment[];
   created_at: string;
   updated_at: string;
+  resolved_at: string | null;
+  resolved_by_type: CommentAuthorType | null;
+  resolved_by_id: string | null;
 }

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -15,6 +15,8 @@ export type WSEventType =
   | "comment:created"
   | "comment:updated"
   | "comment:deleted"
+  | "comment:resolved"
+  | "comment:unresolved"
   | "agent:status"
   | "agent:created"
   | "agent:archived"
@@ -141,6 +143,14 @@ export interface CommentUpdatedPayload {
 export interface CommentDeletedPayload {
   comment_id: string;
   issue_id: string;
+}
+
+export interface CommentResolvedPayload {
+  comment: Comment;
+}
+
+export interface CommentUnresolvedPayload {
+  comment: Comment;
 }
 
 export interface WorkspaceUpdatedPayload {

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useCallback, useRef, useState } from "react";
-import { ChevronRight, Copy, Download, FileText, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { CheckCircle2, ChevronRight, Copy, Download, FileText, MoreHorizontal, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@multica/ui/components/ui/card";
 import { Button } from "@multica/ui/components/ui/button";
@@ -60,6 +60,14 @@ interface CommentCardProps {
   onEdit: (commentId: string, content: string) => Promise<void>;
   onDelete: (commentId: string) => void;
   onToggleReaction: (commentId: string, emoji: string) => void;
+  /** Toggle the resolved state on the thread root. Only invoked for root entries. */
+  onResolveToggle?: (commentId: string, resolved: boolean) => void;
+  /**
+   * When non-null, the thread root is currently rendered as a resolved-but-
+   * expanded card. Pass a "Collapse" affordance into the header so the user
+   * can fold the thread back to the bar; the parent owns the session state.
+   */
+  onCollapseResolved?: () => void;
   /** ID of the comment to highlight (flash animation). */
   highlightedCommentId?: string | null;
 }
@@ -361,6 +369,8 @@ function CommentCardImpl({
   onEdit,
   onDelete,
   onToggleReaction,
+  onResolveToggle,
+  onCollapseResolved,
   highlightedCommentId,
 }: CommentCardProps) {
   const { t } = useT("issues");
@@ -437,6 +447,20 @@ function CommentCardImpl({
 
   return (
     <Card className={cn("!py-0 !gap-0 overflow-hidden transition-colors duration-700", isTemp && "opacity-60", isHighlighted && "ring-2 ring-brand/50 bg-brand/5")}>
+      {onCollapseResolved && (
+        <button
+          type="button"
+          onClick={onCollapseResolved}
+          className="flex w-full items-center justify-between border-b border-border/50 px-4 py-2.5 text-left text-sm text-muted-foreground hover:bg-muted/50 transition-colors"
+          aria-label={t(($) => $.comment.resolve.collapse)}
+        >
+          <span className="flex items-center gap-2">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            {t(($) => $.comment.resolve.collapse)}
+          </span>
+          <ChevronRight className="h-3.5 w-3.5 -rotate-90" />
+        </button>
+      )}
       <Collapsible open={open} onOpenChange={handleOpenChange}>
         {/* Header — always visible, acts as toggle */}
         <div className="px-4 py-3">
@@ -494,6 +518,24 @@ function CommentCardImpl({
                     <Copy className="h-3.5 w-3.5" />
                     {t(($) => $.comment.copy_action)}
                   </DropdownMenuItem>
+                  {onResolveToggle && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={() => onResolveToggle(entry.id, !entry.resolved_at)}>
+                        {entry.resolved_at ? (
+                          <>
+                            <RotateCcw className="h-3.5 w-3.5" />
+                            {t(($) => $.comment.resolve.unresolve_action)}
+                          </>
+                        ) : (
+                          <>
+                            <CheckCircle2 className="h-3.5 w-3.5" />
+                            {t(($) => $.comment.resolve.resolve_action)}
+                          </>
+                        )}
+                      </DropdownMenuItem>
+                    </>
+                  )}
                   {(canEditEntry || canDeleteEntry) && (
                     <>
                       <DropdownMenuSeparator />

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -35,6 +35,7 @@ import { FileUploadButton } from "@multica/ui/components/common/file-upload-butt
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
 import { ReplyInput } from "./reply-input";
+import { collectThreadReplies } from "./thread-utils";
 import type { TimelineEntry, Attachment } from "@multica/core/types";
 import { useCommentCollapseStore } from "@multica/core/issues/stores";
 import { useT } from "../../i18n";
@@ -426,16 +427,10 @@ function CommentCardImpl({
     }
   };
 
-  // Collect all nested replies recursively into a flat list
-  const allNestedReplies: TimelineEntry[] = [];
-  const collectReplies = (parentId: string) => {
-    const children = allReplies.get(parentId) ?? [];
-    for (const child of children) {
-      allNestedReplies.push(child);
-      collectReplies(child.id);
-    }
-  };
-  collectReplies(entry.id);
+  // Collect all nested replies recursively into a flat list. Helper is
+  // shared with ResolvedThreadBar so the collapsed count matches what the
+  // expanded card renders.
+  const allNestedReplies = collectThreadReplies(entry.id, allReplies);
 
   const replyCount = allNestedReplies.length;
   const contentPreview = (entry.content ?? "").replace(/\n/g, " ").slice(0, 80);

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -243,6 +243,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
       return next;
     });
   }, []);
+  const clearResolvedExpand = useCallback((commentId: string) => {
+    setExpandedResolved((prev) => {
+      if (!prev.has(commentId)) return prev;
+      const next = new Set(prev);
+      next.delete(commentId);
+      return next;
+    });
+  }, []);
   const didHighlightRef = useRef<string | null>(null);
 
   // Issue data from TQ — uses detail query, seeded from list cache if available.
@@ -298,6 +306,19 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     fetchOlder, fetchNewer, jumpToLatest,
     isAtLatest, newEntriesBelowCount,
   } = useIssueTimeline(id, user?.id, { around: highlightCommentId ?? null });
+
+  // Resolve / unresolve must always clear the per-session expand entry so
+  // re-resolving an already-expanded thread folds it back to the bar (the
+  // expand Set is keyed only on commentId, not on resolution state). Without
+  // this wrapper, an expand → unresolve → resolve sequence keeps the thread
+  // visually expanded after the second resolve.
+  const handleResolveToggle = useCallback(
+    (commentId: string, resolved: boolean) => {
+      clearResolvedExpand(commentId);
+      toggleResolveComment(commentId, resolved);
+    },
+    [clearResolvedExpand, toggleResolveComment],
+  );
 
   // Memoized timeline grouping. The same Map / groups references are reused
   // across re-renders that don't change `timeline`, so React.memo on
@@ -1039,7 +1060,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       <div key={entry.id} id={`comment-${entry.id}`}>
                         <ResolvedThreadBar
                           entry={entry}
-                          replies={timelineView.repliesByParent.get(entry.id) ?? []}
+                          repliesByParent={timelineView.repliesByParent}
                           onExpand={() => toggleResolvedExpand(entry.id, true)}
                         />
                       </div>
@@ -1057,7 +1078,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                         onEdit={editComment}
                         onDelete={deleteComment}
                         onToggleReaction={handleToggleReaction}
-                        onResolveToggle={toggleResolveComment}
+                        onResolveToggle={handleResolveToggle}
                         onCollapseResolved={isResolved ? () => toggleResolvedExpand(entry.id, false) : undefined}
                         highlightedCommentId={highlightedId}
                       />

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -44,6 +44,7 @@ import { IssueActionsDropdown, useIssueActions } from "../actions";
 import { ProjectPicker } from "../../projects/components/project-picker";
 import { CommentCard } from "./comment-card";
 import { CommentInput } from "./comment-input";
+import { ResolvedThreadBar } from "./resolved-thread-bar";
 import { AgentLiveCard } from "./agent-live-card";
 import { ExecutionLogSection } from "./execution-log-section";
 import { useQuery } from "@tanstack/react-query";
@@ -230,6 +231,18 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const [tokenUsageOpen, setTokenUsageOpen] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
+
+  // Per-session: which resolved threads the user has temporarily expanded.
+  // Not persisted (matches Linear) — reload collapses everything back to bars.
+  const [expandedResolved, setExpandedResolved] = useState<Set<string>>(() => new Set());
+  const toggleResolvedExpand = useCallback((commentId: string, expand: boolean) => {
+    setExpandedResolved((prev) => {
+      const next = new Set(prev);
+      if (expand) next.add(commentId);
+      else next.delete(commentId);
+      return next;
+    });
+  }, []);
   const didHighlightRef = useRef<string | null>(null);
 
   // Issue data from TQ — uses detail query, seeded from list cache if available.
@@ -279,7 +292,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const {
     timeline, loading: timelineLoading,
     submitComment, submitReply,
-    editComment, deleteComment, toggleReaction: handleToggleReaction,
+    editComment, deleteComment, toggleResolveComment, toggleReaction: handleToggleReaction,
     hasMoreOlder, hasMoreNewer,
     isFetchingOlder, isFetchingNewer,
     fetchOlder, fetchNewer, jumpToLatest,
@@ -1019,6 +1032,19 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               {timelineView.groups.map((group) => {
                 if (group.type === "comment") {
                   const entry = group.entries[0]!;
+                  const isResolved = !!entry.resolved_at;
+                  const isExpanded = expandedResolved.has(entry.id);
+                  if (isResolved && !isExpanded) {
+                    return (
+                      <div key={entry.id} id={`comment-${entry.id}`}>
+                        <ResolvedThreadBar
+                          entry={entry}
+                          replies={timelineView.repliesByParent.get(entry.id) ?? []}
+                          onExpand={() => toggleResolvedExpand(entry.id, true)}
+                        />
+                      </div>
+                    );
+                  }
                   return (
                     <div key={entry.id} id={`comment-${entry.id}`}>
                       <CommentCard
@@ -1031,6 +1057,8 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                         onEdit={editComment}
                         onDelete={deleteComment}
                         onToggleReaction={handleToggleReaction}
+                        onResolveToggle={toggleResolveComment}
+                        onCollapseResolved={isResolved ? () => toggleResolvedExpand(entry.id, false) : undefined}
                         highlightedCommentId={highlightedId}
                       />
                     </div>

--- a/packages/views/issues/components/resolved-thread-bar.tsx
+++ b/packages/views/issues/components/resolved-thread-bar.tsx
@@ -1,0 +1,57 @@
+import { CheckCircle2, ChevronRight } from "lucide-react";
+import { useActorName } from "@multica/core/workspace/hooks";
+import { Card } from "@multica/ui/components/ui/card";
+import type { TimelineEntry } from "@multica/core/types";
+import { useT } from "../../i18n";
+
+interface ResolvedThreadBarProps {
+  /** The resolved root comment. */
+  entry: TimelineEntry;
+  /** Replies belonging to this thread, used for count + author aggregation. */
+  replies: TimelineEntry[];
+  onExpand: () => void;
+}
+
+const MAX_NAMED_AUTHORS = 2;
+
+export function ResolvedThreadBar({ entry, replies, onExpand }: ResolvedThreadBarProps) {
+  const { t } = useT("issues");
+  const { getActorName } = useActorName();
+
+  const authorKeys = new Set<string>();
+  const authors: Array<{ type: string; id: string }> = [];
+  for (const e of [entry, ...replies]) {
+    const key = `${e.actor_type}:${e.actor_id}`;
+    if (authorKeys.has(key)) continue;
+    authorKeys.add(key);
+    authors.push({ type: e.actor_type, id: e.actor_id });
+  }
+  const count = 1 + replies.length;
+
+  let authorsLabel: string;
+  if (authors.length <= MAX_NAMED_AUTHORS) {
+    authorsLabel = authors.map((a) => getActorName(a.type, a.id)).join(", ");
+  } else {
+    const named = authors.slice(0, MAX_NAMED_AUTHORS).map((a) => getActorName(a.type, a.id)).join(", ");
+    const remaining = authors.length - MAX_NAMED_AUTHORS;
+    authorsLabel = t(($) => $.comment.resolve.bar_authors_more, { names: named, count: remaining });
+  }
+
+  return (
+    <Card className="!py-0 !gap-0 overflow-hidden">
+      <button
+        type="button"
+        onClick={onExpand}
+        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/50 transition-colors"
+      >
+        <span className="flex items-center gap-2.5 text-sm text-muted-foreground">
+          <CheckCircle2 className="h-4 w-4 shrink-0" />
+          <span className="truncate">
+            {t(($) => $.comment.resolve.bar, { count, authors: authorsLabel })}
+          </span>
+        </span>
+        <ChevronRight className="h-3.5 w-3.5 rotate-90 shrink-0 text-muted-foreground" />
+      </button>
+    </Card>
+  );
+}

--- a/packages/views/issues/components/resolved-thread-bar.tsx
+++ b/packages/views/issues/components/resolved-thread-bar.tsx
@@ -2,21 +2,28 @@ import { CheckCircle2, ChevronRight } from "lucide-react";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { Card } from "@multica/ui/components/ui/card";
 import type { TimelineEntry } from "@multica/core/types";
+import { collectThreadReplies } from "./thread-utils";
 import { useT } from "../../i18n";
 
 interface ResolvedThreadBarProps {
   /** The resolved root comment. */
   entry: TimelineEntry;
-  /** Replies belonging to this thread, used for count + author aggregation. */
-  replies: TimelineEntry[];
+  /**
+   * Full reply graph keyed by parent_id. The bar walks the graph recursively
+   * so the count + author list match what CommentCard would render in the
+   * expanded view (direct-children-only would undercount nested replies).
+   */
+  repliesByParent: Map<string, TimelineEntry[]>;
   onExpand: () => void;
 }
 
 const MAX_NAMED_AUTHORS = 2;
 
-export function ResolvedThreadBar({ entry, replies, onExpand }: ResolvedThreadBarProps) {
+export function ResolvedThreadBar({ entry, repliesByParent, onExpand }: ResolvedThreadBarProps) {
   const { t } = useT("issues");
   const { getActorName } = useActorName();
+
+  const replies = collectThreadReplies(entry.id, repliesByParent);
 
   const authorKeys = new Set<string>();
   const authors: Array<{ type: string; id: string }> = [];

--- a/packages/views/issues/components/thread-utils.ts
+++ b/packages/views/issues/components/thread-utils.ts
@@ -1,0 +1,24 @@
+import type { TimelineEntry } from "@multica/core/types";
+
+/**
+ * Walks the parent_id graph rooted at `rootId` and returns every descendant in
+ * traversal order. Shared between CommentCard (which renders the expanded
+ * thread) and ResolvedThreadBar (which displays the collapsed count + author
+ * list) so the two views stay in sync — direct-children-only counts diverge
+ * once nested replies exist (see Emacs review on PR #2300).
+ */
+export function collectThreadReplies(
+  rootId: string,
+  repliesByParent: Map<string, TimelineEntry[]>,
+): TimelineEntry[] {
+  const out: TimelineEntry[] = [];
+  const walk = (id: string) => {
+    const children = repliesByParent.get(id) ?? [];
+    for (const child of children) {
+      out.push(child);
+      walk(child.id);
+    }
+  };
+  walk(rootId);
+  return out;
+}

--- a/packages/views/issues/hooks/use-issue-timeline.test.tsx
+++ b/packages/views/issues/hooks/use-issue-timeline.test.tsx
@@ -11,6 +11,7 @@ const stableHandles = vi.hoisted(() => ({
   createMutateAsync: vi.fn(async () => ({})),
   updateMutateAsync: vi.fn(async () => ({})),
   deleteMutateAsync: vi.fn(async () => ({})),
+  resolveMutateAsync: vi.fn(async () => ({})),
   toggleMutate: vi.fn(),
 }));
 
@@ -31,6 +32,11 @@ vi.mock("@multica/core/issues/mutations", () => ({
   }),
   useDeleteComment: () => ({
     mutateAsync: stableHandles.deleteMutateAsync,
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  useResolveComment: () => ({
+    mutateAsync: stableHandles.resolveMutateAsync,
     mutate: vi.fn(),
     isPending: false,
   }),

--- a/packages/views/issues/hooks/use-issue-timeline.ts
+++ b/packages/views/issues/hooks/use-issue-timeline.ts
@@ -33,6 +33,7 @@ import {
   useCreateComment,
   useUpdateComment,
   useDeleteComment,
+  useResolveComment,
   useToggleCommentReaction,
   type ToggleCommentReactionVars,
 } from "@multica/core/issues/mutations";
@@ -120,6 +121,7 @@ export function useIssueTimeline(
   const { mutateAsync: createComment } = useCreateComment(issueId);
   const { mutateAsync: updateComment } = useUpdateComment(issueId);
   const { mutateAsync: deleteCommentAsync } = useDeleteComment(issueId);
+  const { mutateAsync: resolveCommentAsync } = useResolveComment(issueId);
   const { mutate: toggleCommentReaction } = useToggleCommentReaction(issueId);
 
   // Reconnect recovery: drop the cache so the next render refetches the
@@ -343,6 +345,21 @@ export function useIssueTimeline(
     [deleteCommentAsync, t],
   );
 
+  const toggleResolveComment = useCallback(
+    async (commentId: string, resolved: boolean) => {
+      try {
+        await resolveCommentAsync({ commentId, resolved });
+      } catch {
+        toast.error(
+          resolved
+            ? t(($) => $.comment.resolve.resolve_failed)
+            : t(($) => $.comment.resolve.unresolve_failed),
+        );
+      }
+    },
+    [resolveCommentAsync, t],
+  );
+
   // --- Optimistic UI for comment reactions ---
   // Derive at render time from pending mutation variables instead of writing
   // temp data into the cache (which would race with WS events).
@@ -441,6 +458,7 @@ export function useIssueTimeline(
     submitReply,
     editComment,
     deleteComment,
+    toggleResolveComment,
     toggleReaction,
     // Pagination controls (new)
     hasMoreOlder: hasNextPage,

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -174,7 +174,18 @@
     "reply_count_other": "{{count}} replies",
     "leave_comment_placeholder": "Leave a comment...",
     "expand_tooltip": "Expand",
-    "collapse_tooltip": "Collapse"
+    "collapse_tooltip": "Collapse",
+    "resolve": {
+      "resolve_action": "Resolve thread",
+      "unresolve_action": "Unresolve thread",
+      "collapse": "Collapse",
+      "bar_one": "{{count}} resolved comment from {{authors}}",
+      "bar_other": "{{count}} resolved comments from {{authors}}",
+      "bar_authors_more": "{{names}} and {{count}} other",
+      "bar_authors_more_other": "{{names}} and {{count}} others",
+      "resolve_failed": "Failed to resolve thread",
+      "unresolve_failed": "Failed to unresolve thread"
+    }
   },
   "reply": {
     "placeholder": "Leave a reply...",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -181,7 +181,7 @@
       "collapse": "Collapse",
       "bar_one": "{{count}} resolved comment from {{authors}}",
       "bar_other": "{{count}} resolved comments from {{authors}}",
-      "bar_authors_more": "{{names}} and {{count}} other",
+      "bar_authors_more_one": "{{names}} and {{count}} other",
       "bar_authors_more_other": "{{names}} and {{count}} others",
       "resolve_failed": "Failed to resolve thread",
       "unresolve_failed": "Failed to unresolve thread"

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -172,7 +172,16 @@
     "reply_count_other": "{{count}} 条回复",
     "leave_comment_placeholder": "留下评论...",
     "expand_tooltip": "展开",
-    "collapse_tooltip": "收起"
+    "collapse_tooltip": "收起",
+    "resolve": {
+      "resolve_action": "标记为已解决",
+      "unresolve_action": "重新打开",
+      "collapse": "收起",
+      "bar_other": "来自 {{authors}} 的 {{count}} 条已解决评论",
+      "bar_authors_more_other": "{{names}} 等 {{count}} 人",
+      "resolve_failed": "标记已解决失败",
+      "unresolve_failed": "重新打开失败"
+    }
   },
   "reply": {
     "placeholder": "回复...",

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -398,6 +398,8 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			r.Route("/api/comments/{commentId}", func(r chi.Router) {
 				r.Put("/", h.UpdateComment)
 				r.Delete("/", h.DeleteComment)
+				r.Post("/resolve", h.ResolveComment)
+				r.Delete("/resolve", h.UnresolveComment)
 				r.Post("/reactions", h.AddReaction)
 				r.Delete("/reactions", h.RemoveReaction)
 			})

--- a/server/internal/handler/activity.go
+++ b/server/internal/handler/activity.go
@@ -30,12 +30,15 @@ type TimelineEntry struct {
 	Details json.RawMessage `json:"details,omitempty"`
 
 	// Comment-only fields
-	Content     *string              `json:"content,omitempty"`
-	ParentID    *string              `json:"parent_id,omitempty"`
-	UpdatedAt   *string              `json:"updated_at,omitempty"`
-	CommentType *string              `json:"comment_type,omitempty"`
-	Reactions   []ReactionResponse   `json:"reactions,omitempty"`
-	Attachments []AttachmentResponse `json:"attachments,omitempty"`
+	Content        *string              `json:"content,omitempty"`
+	ParentID       *string              `json:"parent_id,omitempty"`
+	UpdatedAt      *string              `json:"updated_at,omitempty"`
+	CommentType    *string              `json:"comment_type,omitempty"`
+	Reactions      []ReactionResponse   `json:"reactions,omitempty"`
+	Attachments    []AttachmentResponse `json:"attachments,omitempty"`
+	ResolvedAt     *string              `json:"resolved_at,omitempty"`
+	ResolvedByType *string              `json:"resolved_by_type,omitempty"`
+	ResolvedByID   *string              `json:"resolved_by_id,omitempty"`
 }
 
 // TimelineResponse wraps the cursor-paginated timeline. Entries are sorted
@@ -519,17 +522,20 @@ func (h *Handler) commentsToEntries(r *http.Request, comments []db.Comment) []Ti
 		updatedAt := timestampToString(c.UpdatedAt)
 		cid := uuidToString(c.ID)
 		out[i] = TimelineEntry{
-			Type:        "comment",
-			ID:          cid,
-			ActorType:   c.AuthorType,
-			ActorID:     uuidToString(c.AuthorID),
-			Content:     &content,
-			CommentType: &commentType,
-			ParentID:    uuidToPtr(c.ParentID),
-			CreatedAt:   timestampToString(c.CreatedAt),
-			UpdatedAt:   &updatedAt,
-			Reactions:   reactions[cid],
-			Attachments: attachments[cid],
+			Type:           "comment",
+			ID:             cid,
+			ActorType:      c.AuthorType,
+			ActorID:        uuidToString(c.AuthorID),
+			Content:        &content,
+			CommentType:    &commentType,
+			ParentID:       uuidToPtr(c.ParentID),
+			CreatedAt:      timestampToString(c.CreatedAt),
+			UpdatedAt:      &updatedAt,
+			Reactions:      reactions[cid],
+			Attachments:    attachments[cid],
+			ResolvedAt:     timestampToPtr(c.ResolvedAt),
+			ResolvedByType: textToPtr(c.ResolvedByType),
+			ResolvedByID:   uuidToPtr(c.ResolvedByID),
 		}
 	}
 	return out

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -294,8 +294,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// A reply in a resolved thread re-opens it. Done after CreateComment commits
-	// so the reply is visible regardless of the unresolve outcome.
-	h.autoUnresolveThreadOnReply(r.Context(), parentComment, uuidToString(issue.WorkspaceID), authorType, authorID)
+	// so the reply is visible regardless of the unresolve outcome. Shared with
+	// the agent task path (TaskService.createAgentComment) — both reply paths
+	// must keep the resolved root in sync.
+	h.TaskService.AutoUnresolveThreadOnReply(r.Context(), parentComment, uuidToString(issue.WorkspaceID), authorType, authorID)
 
 	// If the issue is assigned to an agent with on_comment trigger, enqueue a new task.
 	// Skip when the comment comes from the assigned agent itself to avoid loops.
@@ -742,20 +744,3 @@ func (h *Handler) UnresolveComment(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// autoUnresolveThreadOnReply fires after a reply is created in a resolved
-// thread: clearing resolved_at re-opens the discussion. Errors are logged but
-// not propagated — the reply itself succeeded, the desync is recoverable on
-// the next read. Returns true if an unresolve happened (so callers can publish
-// the event).
-func (h *Handler) autoUnresolveThreadOnReply(ctx context.Context, parent *db.Comment, workspaceID, actorType, actorID string) {
-	if parent == nil || !parent.ResolvedAt.Valid {
-		return
-	}
-	updated, err := h.Queries.UnresolveComment(ctx, parent.ID)
-	if err != nil {
-		slog.Warn("auto-unresolve on reply failed", "error", err, "comment_id", uuidToString(parent.ID))
-		return
-	}
-	resp := commentToResponse(updated, nil, nil)
-	h.publish(protocol.EventCommentUnresolved, workspaceID, actorType, actorID, map[string]any{"comment": resp})
-}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -18,17 +18,20 @@ import (
 )
 
 type CommentResponse struct {
-	ID          string               `json:"id"`
-	IssueID     string               `json:"issue_id"`
-	AuthorType  string               `json:"author_type"`
-	AuthorID    string               `json:"author_id"`
-	Content     string               `json:"content"`
-	Type        string               `json:"type"`
-	ParentID    *string              `json:"parent_id"`
-	CreatedAt   string               `json:"created_at"`
-	UpdatedAt   string               `json:"updated_at"`
-	Reactions   []ReactionResponse   `json:"reactions"`
-	Attachments []AttachmentResponse `json:"attachments"`
+	ID             string               `json:"id"`
+	IssueID        string               `json:"issue_id"`
+	AuthorType     string               `json:"author_type"`
+	AuthorID       string               `json:"author_id"`
+	Content        string               `json:"content"`
+	Type           string               `json:"type"`
+	ParentID       *string              `json:"parent_id"`
+	CreatedAt      string               `json:"created_at"`
+	UpdatedAt      string               `json:"updated_at"`
+	ResolvedAt     *string              `json:"resolved_at"`
+	ResolvedByType *string              `json:"resolved_by_type"`
+	ResolvedByID   *string              `json:"resolved_by_id"`
+	Reactions      []ReactionResponse   `json:"reactions"`
+	Attachments    []AttachmentResponse `json:"attachments"`
 }
 
 func commentToResponse(c db.Comment, reactions []ReactionResponse, attachments []AttachmentResponse) CommentResponse {
@@ -39,17 +42,20 @@ func commentToResponse(c db.Comment, reactions []ReactionResponse, attachments [
 		attachments = []AttachmentResponse{}
 	}
 	return CommentResponse{
-		ID:          uuidToString(c.ID),
-		IssueID:     uuidToString(c.IssueID),
-		AuthorType:  c.AuthorType,
-		AuthorID:    uuidToString(c.AuthorID),
-		Content:     c.Content,
-		Type:        c.Type,
-		ParentID:    uuidToPtr(c.ParentID),
-		CreatedAt:   timestampToString(c.CreatedAt),
-		UpdatedAt:   timestampToString(c.UpdatedAt),
-		Reactions:   reactions,
-		Attachments: attachments,
+		ID:             uuidToString(c.ID),
+		IssueID:        uuidToString(c.IssueID),
+		AuthorType:     c.AuthorType,
+		AuthorID:       uuidToString(c.AuthorID),
+		Content:        c.Content,
+		Type:           c.Type,
+		ParentID:       uuidToPtr(c.ParentID),
+		CreatedAt:      timestampToString(c.CreatedAt),
+		UpdatedAt:      timestampToString(c.UpdatedAt),
+		ResolvedAt:     timestampToPtr(c.ResolvedAt),
+		ResolvedByType: textToPtr(c.ResolvedByType),
+		ResolvedByID:   uuidToPtr(c.ResolvedByID),
+		Reactions:      reactions,
+		Attachments:    attachments,
 	}
 }
 
@@ -286,6 +292,10 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 		"issue_assignee_id":   uuidToPtr(issue.AssigneeID),
 		"issue_status":        issue.Status,
 	})
+
+	// A reply in a resolved thread re-opens it. Done after CreateComment commits
+	// so the reply is visible regardless of the unresolve outcome.
+	h.autoUnresolveThreadOnReply(r.Context(), parentComment, uuidToString(issue.WorkspaceID), authorType, authorID)
 
 	// If the issue is assigned to an agent with on_comment trigger, enqueue a new task.
 	// Skip when the comment comes from the assigned agent itself to avoid loops.
@@ -629,4 +639,123 @@ func (h *Handler) DeleteComment(w http.ResponseWriter, r *http.Request) {
 		"issue_id":   uuidToString(comment.IssueID),
 	})
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// loadRootCommentForActor resolves a {commentId} URL param to a root comment in
+// the caller's workspace. Returns the comment, the workspace UUID, the actor
+// identity, and ok. Resolve / unresolve handlers share this scaffolding so the
+// "must be a root comment" rule lives in one place.
+func (h *Handler) loadRootCommentForActor(w http.ResponseWriter, r *http.Request) (db.Comment, string, string, string, bool) {
+	commentId := chi.URLParam(r, "commentId")
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return db.Comment{}, "", "", "", false
+	}
+	commentUUID, ok := parseUUIDOrBadRequest(w, commentId, "comment id")
+	if !ok {
+		return db.Comment{}, "", "", "", false
+	}
+	workspaceID := h.resolveWorkspaceID(r)
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return db.Comment{}, "", "", "", false
+	}
+	if _, ok := h.workspaceMember(w, r, workspaceID); !ok {
+		return db.Comment{}, "", "", "", false
+	}
+	comment, err := h.Queries.GetCommentInWorkspace(r.Context(), db.GetCommentInWorkspaceParams{
+		ID:          commentUUID,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "comment not found")
+		return db.Comment{}, "", "", "", false
+	}
+	if comment.ParentID.Valid {
+		writeError(w, http.StatusBadRequest, "only root comments can be resolved")
+		return db.Comment{}, "", "", "", false
+	}
+	actorType, actorID := h.resolveActor(r, userID, workspaceID)
+	return comment, workspaceID, actorType, actorID, true
+}
+
+func (h *Handler) ResolveComment(w http.ResponseWriter, r *http.Request) {
+	comment, workspaceID, actorType, actorID, ok := h.loadRootCommentForActor(w, r)
+	if !ok {
+		return
+	}
+	wasResolved := comment.ResolvedAt.Valid
+
+	actorUUID, err := util.ParseUUID(actorID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid actor id")
+		return
+	}
+	updated, err := h.Queries.ResolveComment(r.Context(), db.ResolveCommentParams{
+		ID:             comment.ID,
+		ResolvedByType: pgtype.Text{String: actorType, Valid: true},
+		ResolvedByID:   actorUUID,
+	})
+	if err != nil {
+		slog.Warn("resolve comment failed", append(logger.RequestAttrs(r), "error", err, "comment_id", uuidToString(comment.ID))...)
+		writeError(w, http.StatusInternalServerError, "failed to resolve comment")
+		return
+	}
+
+	grouped := h.groupReactions(r, []pgtype.UUID{updated.ID})
+	groupedAtt := h.groupAttachments(r, []pgtype.UUID{updated.ID})
+	cid := uuidToString(updated.ID)
+	resp := commentToResponse(updated, grouped[cid], groupedAtt[cid])
+
+	// Suppress the event on a re-resolve no-op so consumers do not re-process
+	// an unchanged thread (notifications, log spam).
+	if !wasResolved {
+		slog.Info("comment resolved", append(logger.RequestAttrs(r), "comment_id", cid)...)
+		h.publish(protocol.EventCommentResolved, workspaceID, actorType, actorID, map[string]any{"comment": resp})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) UnresolveComment(w http.ResponseWriter, r *http.Request) {
+	comment, workspaceID, actorType, actorID, ok := h.loadRootCommentForActor(w, r)
+	if !ok {
+		return
+	}
+	wasResolved := comment.ResolvedAt.Valid
+
+	updated, err := h.Queries.UnresolveComment(r.Context(), comment.ID)
+	if err != nil {
+		slog.Warn("unresolve comment failed", append(logger.RequestAttrs(r), "error", err, "comment_id", uuidToString(comment.ID))...)
+		writeError(w, http.StatusInternalServerError, "failed to unresolve comment")
+		return
+	}
+
+	grouped := h.groupReactions(r, []pgtype.UUID{updated.ID})
+	groupedAtt := h.groupAttachments(r, []pgtype.UUID{updated.ID})
+	cid := uuidToString(updated.ID)
+	resp := commentToResponse(updated, grouped[cid], groupedAtt[cid])
+
+	if wasResolved {
+		slog.Info("comment unresolved", append(logger.RequestAttrs(r), "comment_id", cid)...)
+		h.publish(protocol.EventCommentUnresolved, workspaceID, actorType, actorID, map[string]any{"comment": resp})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// autoUnresolveThreadOnReply fires after a reply is created in a resolved
+// thread: clearing resolved_at re-opens the discussion. Errors are logged but
+// not propagated — the reply itself succeeded, the desync is recoverable on
+// the next read. Returns true if an unresolve happened (so callers can publish
+// the event).
+func (h *Handler) autoUnresolveThreadOnReply(ctx context.Context, parent *db.Comment, workspaceID, actorType, actorID string) {
+	if parent == nil || !parent.ResolvedAt.Valid {
+		return
+	}
+	updated, err := h.Queries.UnresolveComment(ctx, parent.ID)
+	if err != nil {
+		slog.Warn("auto-unresolve on reply failed", "error", err, "comment_id", uuidToString(parent.ID))
+		return
+	}
+	resp := commentToResponse(updated, nil, nil)
+	h.publish(protocol.EventCommentUnresolved, workspaceID, actorType, actorID, map[string]any{"comment": resp})
 }

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1394,9 +1394,19 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 	}
 	// Resolve thread root: if parentID points to a reply (has its own parent),
 	// use that parent instead so the comment lands in the top-level thread.
+	// rootComment captures the root row so we can auto-unresolve it after the
+	// reply is committed (see AutoUnresolveThreadOnReply).
+	var rootComment *db.Comment
 	if parentID.Valid {
-		if parent, err := s.Queries.GetComment(ctx, parentID); err == nil && parent.ParentID.Valid {
-			parentID = parent.ParentID
+		if parent, err := s.Queries.GetComment(ctx, parentID); err == nil {
+			if parent.ParentID.Valid {
+				if root, err := s.Queries.GetComment(ctx, parent.ParentID); err == nil {
+					rootComment = &root
+					parentID = root.ID
+				}
+			} else {
+				rootComment = &parent
+			}
 		}
 	}
 	// Expand bare issue identifiers (e.g. MUL-117) into mention links.
@@ -1431,6 +1441,46 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 			},
 			"issue_title":  issue.Title,
 			"issue_status": issue.Status,
+		},
+	})
+	s.AutoUnresolveThreadOnReply(ctx, rootComment, util.UUIDToString(issue.WorkspaceID), "agent", util.UUIDToString(agentID))
+}
+
+// AutoUnresolveThreadOnReply clears resolved_at on the thread root when a
+// reply lands in a resolved thread, and broadcasts comment:unresolved. Shared
+// between the user-facing Handler.CreateComment path and the agent-facing
+// TaskService.createAgentComment path so the resolved-then-replied state can
+// never desync (one of the bugs Emacs flagged on PR #2300). Errors are logged
+// — the reply itself already committed, the desync is recoverable on next read.
+func (s *TaskService) AutoUnresolveThreadOnReply(ctx context.Context, parent *db.Comment, workspaceID, actorType, actorID string) {
+	if parent == nil || !parent.ResolvedAt.Valid {
+		return
+	}
+	updated, err := s.Queries.UnresolveComment(ctx, parent.ID)
+	if err != nil {
+		slog.Warn("auto-unresolve on reply failed", "error", err, "comment_id", util.UUIDToString(parent.ID))
+		return
+	}
+	s.Bus.Publish(events.Event{
+		Type:        protocol.EventCommentUnresolved,
+		WorkspaceID: workspaceID,
+		ActorType:   actorType,
+		ActorID:     actorID,
+		Payload: map[string]any{
+			"comment": map[string]any{
+				"id":               util.UUIDToString(updated.ID),
+				"issue_id":         util.UUIDToString(updated.IssueID),
+				"author_type":      updated.AuthorType,
+				"author_id":        util.UUIDToString(updated.AuthorID),
+				"content":          updated.Content,
+				"type":             updated.Type,
+				"parent_id":        util.UUIDToPtr(updated.ParentID),
+				"created_at":       util.TimestampToString(updated.CreatedAt),
+				"updated_at":       util.TimestampToString(updated.UpdatedAt),
+				"resolved_at":      util.TimestampToPtr(updated.ResolvedAt),
+				"resolved_by_type": util.TextToPtr(updated.ResolvedByType),
+				"resolved_by_id":   util.UUIDToPtr(updated.ResolvedByID),
+			},
 		},
 	})
 }

--- a/server/migrations/069_comment_resolved_at.down.sql
+++ b/server/migrations/069_comment_resolved_at.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS comment_issue_resolved_at_idx;
+ALTER TABLE comment DROP CONSTRAINT IF EXISTS comment_resolved_consistency;
+ALTER TABLE comment
+    DROP COLUMN IF EXISTS resolved_by_id,
+    DROP COLUMN IF EXISTS resolved_by_type,
+    DROP COLUMN IF EXISTS resolved_at;

--- a/server/migrations/069_comment_resolved_at.up.sql
+++ b/server/migrations/069_comment_resolved_at.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE comment
+    ADD COLUMN resolved_at TIMESTAMPTZ NULL,
+    ADD COLUMN resolved_by_type TEXT NULL,
+    ADD COLUMN resolved_by_id UUID NULL;
+
+ALTER TABLE comment
+    ADD CONSTRAINT comment_resolved_consistency CHECK (
+        (resolved_at IS NULL AND resolved_by_type IS NULL AND resolved_by_id IS NULL)
+        OR (resolved_at IS NOT NULL AND resolved_by_type IS NOT NULL AND resolved_by_id IS NOT NULL)
+    );
+
+CREATE INDEX comment_issue_resolved_at_idx ON comment (issue_id, resolved_at);

--- a/server/pkg/db/generated/comment.sql.go
+++ b/server/pkg/db/generated/comment.sql.go
@@ -31,7 +31,7 @@ func (q *Queries) CountComments(ctx context.Context, arg CountCommentsParams) (i
 const createComment = `-- name: CreateComment :one
 INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type, parent_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id
 `
 
 type CreateCommentParams struct {
@@ -66,6 +66,9 @@ func (q *Queries) CreateComment(ctx context.Context, arg CreateCommentParams) (C
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
 	)
 	return i, err
 }
@@ -80,7 +83,7 @@ func (q *Queries) DeleteComment(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getComment = `-- name: GetComment :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
 WHERE id = $1
 `
 
@@ -98,12 +101,15 @@ func (q *Queries) GetComment(ctx context.Context, id pgtype.UUID) (Comment, erro
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
 	)
 	return i, err
 }
 
 const getCommentInWorkspace = `-- name: GetCommentInWorkspace :one
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
 WHERE id = $1 AND workspace_id = $2
 `
 
@@ -126,6 +132,9 @@ func (q *Queries) GetCommentInWorkspace(ctx context.Context, arg GetCommentInWor
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
 	)
 	return i, err
 }
@@ -174,7 +183,7 @@ func (q *Queries) HasAgentRepliedInThread(ctx context.Context, arg HasAgentRepli
 }
 
 const listCommentsAfter = `-- name: ListCommentsAfter :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
 WHERE issue_id = $1 AND workspace_id = $2
   AND (created_at, id) > ($3::timestamptz, $4::uuid)
 ORDER BY created_at ASC, id ASC
@@ -218,6 +227,9 @@ func (q *Queries) ListCommentsAfter(ctx context.Context, arg ListCommentsAfterPa
 			&i.UpdatedAt,
 			&i.ParentID,
 			&i.WorkspaceID,
+			&i.ResolvedAt,
+			&i.ResolvedByType,
+			&i.ResolvedByID,
 		); err != nil {
 			return nil, err
 		}
@@ -230,7 +242,7 @@ func (q *Queries) ListCommentsAfter(ctx context.Context, arg ListCommentsAfterPa
 }
 
 const listCommentsBefore = `-- name: ListCommentsBefore :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
 WHERE issue_id = $1 AND workspace_id = $2
   AND (created_at, id) < ($3::timestamptz, $4::uuid)
 ORDER BY created_at DESC, id DESC
@@ -273,6 +285,9 @@ func (q *Queries) ListCommentsBefore(ctx context.Context, arg ListCommentsBefore
 			&i.UpdatedAt,
 			&i.ParentID,
 			&i.WorkspaceID,
+			&i.ResolvedAt,
+			&i.ResolvedByType,
+			&i.ResolvedByID,
 		); err != nil {
 			return nil, err
 		}
@@ -285,7 +300,7 @@ func (q *Queries) ListCommentsBefore(ctx context.Context, arg ListCommentsBefore
 }
 
 const listCommentsLatest = `-- name: ListCommentsLatest :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
 WHERE issue_id = $1 AND workspace_id = $2
 ORDER BY created_at DESC, id DESC
 LIMIT $3
@@ -319,6 +334,9 @@ func (q *Queries) ListCommentsLatest(ctx context.Context, arg ListCommentsLatest
 			&i.UpdatedAt,
 			&i.ParentID,
 			&i.WorkspaceID,
+			&i.ResolvedAt,
+			&i.ResolvedByType,
+			&i.ResolvedByID,
 		); err != nil {
 			return nil, err
 		}
@@ -331,7 +349,7 @@ func (q *Queries) ListCommentsLatest(ctx context.Context, arg ListCommentsLatest
 }
 
 const listCommentsPaginated = `-- name: ListCommentsPaginated :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
 WHERE issue_id = $1 AND workspace_id = $2
 ORDER BY created_at ASC
 LIMIT $3 OFFSET $4
@@ -369,6 +387,9 @@ func (q *Queries) ListCommentsPaginated(ctx context.Context, arg ListCommentsPag
 			&i.UpdatedAt,
 			&i.ParentID,
 			&i.WorkspaceID,
+			&i.ResolvedAt,
+			&i.ResolvedByType,
+			&i.ResolvedByID,
 		); err != nil {
 			return nil, err
 		}
@@ -381,7 +402,7 @@ func (q *Queries) ListCommentsPaginated(ctx context.Context, arg ListCommentsPag
 }
 
 const listCommentsSince = `-- name: ListCommentsSince :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
 WHERE issue_id = $1 AND workspace_id = $2 AND created_at > $3
 ORDER BY created_at ASC
 `
@@ -412,6 +433,9 @@ func (q *Queries) ListCommentsSince(ctx context.Context, arg ListCommentsSincePa
 			&i.UpdatedAt,
 			&i.ParentID,
 			&i.WorkspaceID,
+			&i.ResolvedAt,
+			&i.ResolvedByType,
+			&i.ResolvedByID,
 		); err != nil {
 			return nil, err
 		}
@@ -424,7 +448,7 @@ func (q *Queries) ListCommentsSince(ctx context.Context, arg ListCommentsSincePa
 }
 
 const listCommentsSincePaginated = `-- name: ListCommentsSincePaginated :many
-SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id FROM comment
+SELECT id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id FROM comment
 WHERE issue_id = $1 AND workspace_id = $2 AND created_at > $3
 ORDER BY created_at ASC
 LIMIT $4 OFFSET $5
@@ -464,6 +488,9 @@ func (q *Queries) ListCommentsSincePaginated(ctx context.Context, arg ListCommen
 			&i.UpdatedAt,
 			&i.ParentID,
 			&i.WorkspaceID,
+			&i.ResolvedAt,
+			&i.ResolvedByType,
+			&i.ResolvedByID,
 		); err != nil {
 			return nil, err
 		}
@@ -475,12 +502,83 @@ func (q *Queries) ListCommentsSincePaginated(ctx context.Context, arg ListCommen
 	return items, nil
 }
 
+const resolveComment = `-- name: ResolveComment :one
+UPDATE comment SET
+    resolved_at = COALESCE(resolved_at, now()),
+    resolved_by_type = COALESCE(resolved_by_type, $2),
+    resolved_by_id = COALESCE(resolved_by_id, $3),
+    updated_at = CASE WHEN resolved_at IS NULL THEN now() ELSE updated_at END
+WHERE id = $1
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id
+`
+
+type ResolveCommentParams struct {
+	ID             pgtype.UUID `json:"id"`
+	ResolvedByType pgtype.Text `json:"resolved_by_type"`
+	ResolvedByID   pgtype.UUID `json:"resolved_by_id"`
+}
+
+// Idempotent: re-resolving keeps the original resolved_at + resolver. Always
+// returns the row so the handler can surface the canonical state.
+func (q *Queries) ResolveComment(ctx context.Context, arg ResolveCommentParams) (Comment, error) {
+	row := q.db.QueryRow(ctx, resolveComment, arg.ID, arg.ResolvedByType, arg.ResolvedByID)
+	var i Comment
+	err := row.Scan(
+		&i.ID,
+		&i.IssueID,
+		&i.AuthorType,
+		&i.AuthorID,
+		&i.Content,
+		&i.Type,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ParentID,
+		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
+	)
+	return i, err
+}
+
+const unresolveComment = `-- name: UnresolveComment :one
+UPDATE comment SET
+    resolved_at = NULL,
+    resolved_by_type = NULL,
+    resolved_by_id = NULL,
+    updated_at = CASE WHEN resolved_at IS NOT NULL THEN now() ELSE updated_at END
+WHERE id = $1
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id
+`
+
+// Idempotent: a no-op clear (already unresolved) just returns the row.
+func (q *Queries) UnresolveComment(ctx context.Context, id pgtype.UUID) (Comment, error) {
+	row := q.db.QueryRow(ctx, unresolveComment, id)
+	var i Comment
+	err := row.Scan(
+		&i.ID,
+		&i.IssueID,
+		&i.AuthorType,
+		&i.AuthorID,
+		&i.Content,
+		&i.Type,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.ParentID,
+		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
+	)
+	return i, err
+}
+
 const updateComment = `-- name: UpdateComment :one
 UPDATE comment SET
     content = $2,
     updated_at = now()
 WHERE id = $1
-RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id
+RETURNING id, issue_id, author_type, author_id, content, type, created_at, updated_at, parent_id, workspace_id, resolved_at, resolved_by_type, resolved_by_id
 `
 
 type UpdateCommentParams struct {
@@ -502,6 +600,9 @@ func (q *Queries) UpdateComment(ctx context.Context, arg UpdateCommentParams) (C
 		&i.UpdatedAt,
 		&i.ParentID,
 		&i.WorkspaceID,
+		&i.ResolvedAt,
+		&i.ResolvedByType,
+		&i.ResolvedByID,
 	)
 	return i, err
 }

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -182,16 +182,19 @@ type ChatSession struct {
 }
 
 type Comment struct {
-	ID          pgtype.UUID        `json:"id"`
-	IssueID     pgtype.UUID        `json:"issue_id"`
-	AuthorType  string             `json:"author_type"`
-	AuthorID    pgtype.UUID        `json:"author_id"`
-	Content     string             `json:"content"`
-	Type        string             `json:"type"`
-	CreatedAt   pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
-	ParentID    pgtype.UUID        `json:"parent_id"`
-	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	ID             pgtype.UUID        `json:"id"`
+	IssueID        pgtype.UUID        `json:"issue_id"`
+	AuthorType     string             `json:"author_type"`
+	AuthorID       pgtype.UUID        `json:"author_id"`
+	Content        string             `json:"content"`
+	Type           string             `json:"type"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	ParentID       pgtype.UUID        `json:"parent_id"`
+	WorkspaceID    pgtype.UUID        `json:"workspace_id"`
+	ResolvedAt     pgtype.Timestamptz `json:"resolved_at"`
+	ResolvedByType pgtype.Text        `json:"resolved_by_type"`
+	ResolvedByID   pgtype.UUID        `json:"resolved_by_id"`
 }
 
 type CommentReaction struct {

--- a/server/pkg/db/queries/comment.sql
+++ b/server/pkg/db/queries/comment.sql
@@ -84,3 +84,25 @@ WHERE parent_id = @parent_id AND author_type = 'agent' AND author_id = @agent_id
 
 -- name: DeleteComment :exec
 DELETE FROM comment WHERE id = $1;
+
+-- name: ResolveComment :one
+-- Idempotent: re-resolving keeps the original resolved_at + resolver. Always
+-- returns the row so the handler can surface the canonical state.
+UPDATE comment SET
+    resolved_at = COALESCE(resolved_at, now()),
+    resolved_by_type = COALESCE(resolved_by_type, $2),
+    resolved_by_id = COALESCE(resolved_by_id, $3),
+    updated_at = CASE WHEN resolved_at IS NULL THEN now() ELSE updated_at END
+WHERE id = $1
+RETURNING *;
+
+-- name: UnresolveComment :one
+-- Idempotent: a no-op clear (already unresolved) just returns the row.
+UPDATE comment SET
+    resolved_at = NULL,
+    resolved_by_type = NULL,
+    resolved_by_id = NULL,
+    updated_at = CASE WHEN resolved_at IS NOT NULL THEN now() ELSE updated_at END
+WHERE id = $1
+RETURNING *;
+

--- a/server/pkg/protocol/events.go
+++ b/server/pkg/protocol/events.go
@@ -11,6 +11,8 @@ const (
 	EventCommentCreated       = "comment:created"
 	EventCommentUpdated       = "comment:updated"
 	EventCommentDeleted       = "comment:deleted"
+	EventCommentResolved      = "comment:resolved"
+	EventCommentUnresolved    = "comment:unresolved"
 	EventReactionAdded        = "reaction:added"
 	EventReactionRemoved      = "reaction:removed"
 	EventIssueReactionAdded   = "issue_reaction:added"


### PR DESCRIPTION
## Summary
- Linear-style "resolve" on comment thread roots: resolved threads collapse into a single bar in the activity feed; clicking expands them inline. Replying auto-unresolves.
- Migration 069 adds `resolved_at` / `resolved_by_type` / `resolved_by_id` to `comment`. New idempotent endpoints `POST/DELETE /api/comments/{id}/resolve`. New WS events `comment:resolved` / `comment:unresolved`.
- Frontend: optimistic mutation, `ResolvedThreadBar` component, menu items on root comments, `Collapse` strip on the expanded resolved card. en + zh-Hans locales.

Implements MUL-1895. Resolution is server-persisted (timestamp + actor); per-user expand state is in-memory only (matches Linear).

## Test plan
- [ ] `pnpm typecheck` passes (verified locally)
- [ ] `cd server && go build ./...` clean (verified locally)
- [ ] Resolve a thread → bar appears, original chronological position preserved
- [ ] Click bar → expands inline; "Collapse" header re-folds
- [ ] Reply inside expanded resolved thread → bar disappears (auto-unresolve)
- [ ] "Unresolve thread" menu item from expanded card → bar disappears
- [ ] Resolve from one client → bar appears on a second client (WS sync)
- [ ] DB constraint `comment_resolved_consistency` rejects partial state
- [ ] Older desktop client hitting new server: thread renders as today (additive fields ignored)

## Notes
- Per-session expand state is `useState<Set<string>>` in `issue-detail.tsx` — not persisted, matching Linear.
- Resolve allowed for any workspace member/agent (small-team default).
- Pre-existing `TestCommentCRUD` fails on `main` (unrelated `first_executed_at` migration drift in test DB) — not introduced by this PR.