### PR TITLE
docs(cli): drop stale `multica runtime ping` from CLI reference

### DIFF
--- a/apps/docs/content/docs/cli.mdx
+++ b/apps/docs/content/docs/cli.mdx
@@ -99,7 +99,6 @@ For the difference between token types, see [Authentication and tokens](/auth-to
 | `multica runtime list` | List runtimes in the current workspace |
 | `multica runtime usage` | Show resource usage |
 | `multica runtime activity` | Recent activity log |
-| `multica runtime ping <id>` | Ping a runtime to check it's online |
 | `multica runtime update <id> ...` | Update a runtime's configuration |
 
 ## Miscellaneous

--- a/apps/docs/content/docs/cli.zh.mdx
+++ b/apps/docs/content/docs/cli.zh.mdx
@@ -99,7 +99,6 @@ Token 类型的详细区分见 [认证与令牌](/auth-tokens)。
 | `multica runtime list` | 列出当前工作区的 runtime |
 | `multica runtime usage` | 查看资源使用情况 |
 | `multica runtime activity` | 近期活动记录 |
-| `multica runtime ping <id>` | 立即戳一次 runtime 检查在线 |
 | `multica runtime update <id> ...` | 更新 runtime 配置 |
 
 ## 杂项


### PR DESCRIPTION
## Summary

- Remove the `multica runtime ping <id>` row from `apps/docs/content/docs/cli.mdx` and `cli.zh.mdx`.
- The command itself was removed back in #1554 ("feat(runtimes): remove Test Connection / runtime ping feature") together with the server handler, `PingStore`, `pending_ping` heartbeat field, daemon `handlePing`, and the `PingSection` UI. The CLI reference pages were missed in that cleanup, so users following the docs hit `command undefined` on `runtime ping -h`.
- Runtime reachability is now detected automatically via daemon heartbeat / Online status — no replacement command is needed.

Closes #2276

## Test plan

- [x] `git diff` shows only the two doc lines removed; no other changes.
- [x] Confirmed `server/cmd/multica/cmd_runtime.go` only registers `list / usage / activity / update`, so the docs now match the actual CLI surface.
- [ ] Docs site preview renders the `Daemon and runtimes` table without the removed row.