### PR TITLE
docs(cli): clarify <id> accepts both issue key and UUID

### DIFF
--- a/apps/docs/content/docs/cli.mdx
+++ b/apps/docs/content/docs/cli.mdx
@@ -44,10 +44,14 @@ For the difference between token types, see [Authentication and tokens](/auth-to
 
 ## Issues and projects
 
+<Callout type="info">
+`list` commands (`multica issue list`, `autopilot list`, `project list`, etc.) print short, copy-paste-ready IDs by default — issue keys like `MUL-123` for issues, short UUID prefixes for the rest. The `<id>` argument on the follow-up commands below accepts either the short ID or the full UUID, so the typical flow is `multica issue list` → copy the key → `multica issue get MUL-123`. Pass `--full-id` to a list command when you need the canonical UUID.
+</Callout>
+
 | Command | Purpose |
 |---|---|
-| `multica issue list` | List issues |
-| `multica issue get <id>` | Show a single issue |
+| `multica issue list` | List issues (prints copy-paste-ready issue keys) |
+| `multica issue get <id>` | Show a single issue (accepts an issue key or a UUID) |
 | `multica issue create --title "..."` | Create a new issue |
 | `multica issue update <id> ...` | Update an issue (status, priority, assignee, etc.) |
 | `multica issue assign <id> --agent <slug>` | Assign to an agent (triggers a task immediately) |

--- a/apps/docs/content/docs/cli.zh.mdx
+++ b/apps/docs/content/docs/cli.zh.mdx
@@ -44,10 +44,14 @@ Token 类型的详细区分见 [认证与令牌](/auth-tokens)。
 
 ## Issue 和 Project
 
+<Callout type="info">
+`list` 类命令（`multica issue list`、`autopilot list`、`project list` 等）表格里默认显示**可直接复制**的短 ID：issue 是 key（如 `MUL-123`），其余资源是 UUID 短前缀。下面表格里的 `<id>` 同时接受短 ID 和完整 UUID，所以典型用法是 `multica issue list` → 复制 key → `multica issue get MUL-123`。需要完整 UUID 时给 `list` 加 `--full-id`。
+</Callout>
+
 | 命令 | 用途 |
 |---|---|
-| `multica issue list` | 列出 issue |
-| `multica issue get <id>` | 查看单条 issue |
+| `multica issue list` | 列出 issue（默认显示可复制的 issue key） |
+| `multica issue get <id>` | 查看单条 issue（接受 issue key 或 UUID） |
 | `multica issue create --title "..."` | 创建新 issue |
 | `multica issue update <id> ...` | 修改 issue（状态、优先级、分配人等） |
 | `multica issue assign <id> --agent <slug>` | 分配给智能体（立即触发任务） |

--- a/apps/docs/content/docs/cli/reference.zh.mdx
+++ b/apps/docs/content/docs/cli/reference.zh.mdx
@@ -253,9 +253,12 @@ multica issue list --limit 20 --output json
 ### Get Issue
 
 ```bash
-multica issue get <id>
+multica issue get MUL-123
+multica issue get <uuid>
 multica issue get <id> --output json
 ```
+
+`<id>` 同时接受 issue key（`multica issue list` 表格里直接显示，例如 `MUL-123`）和完整 UUID（给 `list` 加 `--full-id` 可显示）。同样的规则适用于下面 `update` / `assign` / `status` / `comment` / `subscriber` / `runs` 等接受 `<id>` 的命令。
 
 ### Create Issue
 


### PR DESCRIPTION
## Summary
- The CLI started accepting routable short IDs across `issue` / `autopilot` / `project` / `label` / `task-run` workflows on 2026-05-08 (shipped in v0.2.28). The docs still showed `<id>` placeholders only, so new users walking the natural flow `multica issue list` → copy a `MUL-123` key → `multica issue get MUL-123` weren't sure it was supported.
- Adds a `<Callout>` at the top of the **Issue and Project** section in both the EN and ZH cheat-sheet pages (`docs/cli.mdx`, `docs/cli.zh.mdx`) explaining that list outputs print copy-paste-ready short IDs and that the `<id>` argument on follow-up commands accepts either form.
- Adds a concrete `multica issue get MUL-123` example to the ZH **CLI Reference** page (`docs/cli/reference.zh.mdx`) and a one-line note that the same rule applies to the other `<id>`-taking commands.

Closes the docs gap reported in #2278.

## Test plan
- [ ] `pnpm dev` the docs app and visit `/docs/zh/cli`, `/docs/cli`, and `/docs/zh/cli/reference` to confirm the callout renders and the table reads cleanly.