### PR TITLE
fix(ui): let DropdownMenu popup size to content

### DIFF
--- a/packages/ui/components/ui/dropdown-menu.tsx
+++ b/packages/ui/components/ui/dropdown-menu.tsx
@@ -51,7 +51,7 @@ function DropdownMenuContent({
             e.stopPropagation()
             onClick?.(e)
           }}
-          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn("z-50 max-h-(--available-height) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         />
       </MenuPrimitive.Positioner>


### PR DESCRIPTION
## Summary
- `DropdownMenuContent` had `w-(--anchor-width)`, which forced the popup to match the trigger's width. With icon-sm kebab triggers (~32px) the popup was clamped by `min-w-32` to 128px, and longer items like "Unresolve thread" / "标记为已解决" wrapped to two lines.
- Anchor-width matching is correct for Select / Combobox (untouched), but a generic kebab menu should size to its own content. Removed `w-(--anchor-width)` and kept `min-w-32` as the floor.

Fixes [MUL-1910](mention://issue/0bfd3b18-4577-4319-8312-4ddbe9cba5a8).

## Test plan
- [ ] Open a comment kebab on a thread root in the issue detail; "Resolve thread" / "Unresolve thread" render on a single line in both en and zh-Hans.
- [ ] Spot-check other kebabs (issue actions, agent row actions, etc.) still align to trigger and don't visually regress.
- [ ] `pnpm typecheck` ✅