### PR TITLE
fix(transcript): expand long single-line Agent messages (multica#2282)

### DIFF
--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -96,7 +96,7 @@ function getEventLabel(item: TimelineItem): string {
 function getEventSummary(item: TimelineItem): string {
   switch (item.type) {
     case "text":
-      return item.content?.split("\n").filter(Boolean).pop() ?? "";
+      return item.content?.split("\n").find((l) => l.trim().length > 0) ?? "";
     case "thinking":
       return item.content?.slice(0, 200) ?? "";
     case "tool_use": {
@@ -592,7 +592,7 @@ const TranscriptEventRow = ({
     (item.type === "tool_use" && item.input && Object.keys(item.input).length > 0) ||
     (item.type === "tool_result" && item.output && item.output.length > 0) ||
     (item.type === "thinking" && item.content && item.content.length > 0) ||
-    (item.type === "text" && item.content && item.content.split("\n").length > 1) ||
+    (item.type === "text" && item.content && item.content.length > 0) ||
     (item.type === "error" && item.content && item.content.length > 0);
 
   return (


### PR DESCRIPTION
## Summary

- Fixes [#2282](https://github.com/multica-ai/multica/issues/2282). Agent text rows in the run-records dialog (`查看记录` / `AgentTranscriptDialog`) now show a chevron and expand for any non-empty message — not just multi-line ones. Bash/Read/etc. already behaved this way; text was the odd one out because `hasDetail` required `split("\n").length > 1`.
- Lead the collapsed summary with the first non-empty line instead of the last, so multi-paragraph Agent replies preview the lede and the row stays stable while content streams in.
- RFC posted on [MUL-1912](https://multica.ai) and approved before implementing.

## Test plan

- [x] `pnpm --filter @multica/views typecheck` clean
- [x] `pnpm --filter @multica/views test` — 330 tests, all pass
- [ ] Manual: open transcript on a task whose Agent reply is one long single line → chevron appears → expanding shows full message in the existing scrollable `<pre>`
- [ ] Manual: multi-paragraph Agent reply → collapsed row shows first non-empty line; expanding still shows full content