### PR TITLE
fix(agent): scope pi colon-to-slash normalization to legacy format

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -299,6 +299,11 @@ func discoverPiModels(ctx context.Context, executablePath string) ([]Model, erro
 	return parsePiModels(text), nil
 }
 
+// parsePiModels accepts the `pi --list-models` output. Pi historically
+// emitted `provider:model` per line and now emits a multi-column table
+// (`provider  model  context …`); both shapes are normalized to
+// `provider/model` to match opencode/UI conventions. The case-insensitive
+// `provider` token in column 0 is treated as the table header and skipped.
 func parsePiModels(output string) []Model {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -319,13 +324,15 @@ func parsePiModels(output string) []Model {
 		}
 		var id string
 		if strings.ContainsAny(first, ":/") {
-			id = first
+			// Legacy `provider:model` format — normalize colon to slash.
+			// Restricted to this branch so a model name with a `:` in
+			// the table format's column 1 is not silently rewritten.
+			id = strings.Replace(first, ":", "/", 1)
 		} else if len(fields) >= 2 {
 			id = first + "/" + fields[1]
 		} else {
 			continue
 		}
-		id = strings.Replace(id, ":", "/", 1)
 		if seen[id] {
 			continue
 		}

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -202,12 +202,13 @@ func TestParsePiModelsTableFormat(t *testing.T) {
 bailian-coding-plan  glm-4.7                 202.8K   16.4K    no        no
 bailian-coding-plan  qwen3.6-plus            1M       65.5K    no        yes
 opencode             claude-sonnet-4-6       1M       64K      yes       yes
+opencode             claude-sonnet-4-6:exp   1M       64K      yes       yes
 opencode             claude-sonnet-4-6       1M       64K      yes       yes
 bareword-only-line
 `
 	models := parsePiModels(input)
-	if len(models) != 3 {
-		t.Fatalf("expected 3 models (header skipped, duplicate deduped, bareword skipped), got %d: %+v", len(models), models)
+	if len(models) != 4 {
+		t.Fatalf("expected 4 models (header skipped, duplicate deduped, bareword skipped), got %d: %+v", len(models), models)
 	}
 	if models[0].ID != "bailian-coding-plan/glm-4.7" || models[0].Provider != "bailian-coding-plan" {
 		t.Errorf("unexpected first model: %+v", models[0])
@@ -217,6 +218,11 @@ bareword-only-line
 	}
 	if models[2].ID != "opencode/claude-sonnet-4-6" || models[2].Provider != "opencode" {
 		t.Errorf("unexpected third model: %+v", models[2])
+	}
+	// Colon inside a model name in column 1 must be preserved — only
+	// the legacy `provider:model` form gets colon→slash normalization.
+	if models[3].ID != "opencode/claude-sonnet-4-6:exp" || models[3].Provider != "opencode" {
+		t.Errorf("expected ':' inside table-format model name to be preserved: %+v", models[3])
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2281. The original fix added table-format parsing to `parsePiModels` but kept the unconditional

```go
id = strings.Replace(id, ":", "/", 1)
```

which is correct for the legacy `provider:model` shape but is too aggressive for the new table format: a model name with a `:` inside (e.g. `claude-sonnet-4-6:exp` in column 1) would be silently rewritten to `claude-sonnet-4-6/exp`.

This PR scopes the colon→slash normalization to the legacy branch only, and restores a short doc comment describing the dual-format contract that was dropped during the refactor.

## Related Issue

Follow-up surfaced during review of #2281.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`server/pkg/agent/models.go`** — move `strings.Replace(":", "/", 1)` into the legacy `provider:model` branch; restore a doc comment describing dual-format input and the header-skip behavior.
- **`server/pkg/agent/models_test.go`** — extend `TestParsePiModelsTableFormat` with a row whose model column contains `:` (`claude-sonnet-4-6:exp`) and assert it is preserved verbatim in the resulting ID.

## How to Test

```
cd server && go test ./pkg/agent/ -run TestParsePiModels -v
```

Both tests pass; legacy `provider:model` parsing is unchanged.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable

## AI Disclosure

Authored by the agent **J** while reviewing #2281.