### PR TITLE
Add task dispatched analytics event

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -89,7 +89,7 @@ Every event is assigned to one dashboard category:
 
 | Category | Events |
 |---|---|
-| `core_loop` | `workspace_created`, `runtime_registered`, `runtime_ready`, `runtime_failed`, `runtime_offline`, `agent_created`, `issue_created`, `chat_message_sent`, `agent_task_queued`, `agent_task_started`, `agent_task_completed`, `agent_task_failed`, `agent_task_cancelled`, `autopilot_run_started`, `autopilot_run_completed`, `autopilot_run_failed` |
+| `core_loop` | `workspace_created`, `runtime_registered`, `runtime_ready`, `runtime_failed`, `runtime_offline`, `agent_created`, `issue_created`, `chat_message_sent`, `agent_task_queued`, `agent_task_dispatched`, `agent_task_started`, `agent_task_completed`, `agent_task_failed`, `agent_task_cancelled`, `autopilot_run_started`, `autopilot_run_completed`, `autopilot_run_failed` |
 | `onboarding_support` | `onboarding_started`, `onboarding_questionnaire_submitted`, `onboarding_completed`, `onboarding_runtime_path_selected`, `onboarding_runtime_detected`, `starter_content_decided` |
 | `acquisition` | `signup`, `download_intent_expressed`, `download_page_viewed`, `download_initiated`, `cloud_waitlist_joined` |
 | `ops_feedback` | `feedback_opened`, `feedback_submitted` |
@@ -247,10 +247,14 @@ is queued.
 | `agent_id` | string (UUID) | Chat agent. |
 | `source` | string | Always `chat`. |
 
-### `agent_task_queued` / `agent_task_started` / `agent_task_completed`
+### `agent_task_queued` / `agent_task_dispatched` / `agent_task_started` / `agent_task_completed`
 
 Canonical task lifecycle events emitted from `agent_task_queue` state
-transitions. These replace `issue_executed` for core loop success metrics.
+transitions. `agent_task_dispatched` fires when the backend claims a queued
+task for a runtime, before the daemon marks it running with
+`agent_task_started`. These events replace `issue_executed` for core loop
+success metrics and allow the activation funnel to split queue backlog from
+claim/start handoff.
 
 | Property | Type | Description |
 |---|---|---|

--- a/server/internal/analytics/events.go
+++ b/server/internal/analytics/events.go
@@ -14,6 +14,7 @@ const (
 	EventIssueCreated                  = "issue_created"
 	EventChatMessageSent               = "chat_message_sent"
 	EventAgentTaskQueued               = "agent_task_queued"
+	EventAgentTaskDispatched           = "agent_task_dispatched"
 	EventAgentTaskStarted              = "agent_task_started"
 	EventAgentTaskCompleted            = "agent_task_completed"
 	EventAgentTaskFailed               = "agent_task_failed"
@@ -305,6 +306,10 @@ func ChatMessageSent(userID, workspaceID, chatSessionID, taskID, agentID, runtim
 
 func AgentTaskQueued(ctx TaskContext) Event {
 	return agentTaskEvent(EventAgentTaskQueued, ctx, nil)
+}
+
+func AgentTaskDispatched(ctx TaskContext) Event {
+	return agentTaskEvent(EventAgentTaskDispatched, ctx, nil)
 }
 
 func AgentTaskStarted(ctx TaskContext) Event {

--- a/server/internal/analytics/events_test.go
+++ b/server/internal/analytics/events_test.go
@@ -38,3 +38,30 @@ func TestFailedEventsUseWillRetry(t *testing.T) {
 		t.Fatalf("autopilot failure should not emit recoverable")
 	}
 }
+
+func TestAgentTaskDispatchedUsesTaskCoreProperties(t *testing.T) {
+	ctx := TaskContext{
+		UserID:      "user-1",
+		WorkspaceID: "workspace-1",
+		AgentID:     "agent-1",
+		TaskID:      "task-1",
+		IssueID:     "issue-1",
+		Source:      SourceManual,
+		RuntimeMode: "local",
+		Provider:    "codex",
+	}
+	ev := AgentTaskDispatched(ctx)
+
+	if ev.Name != EventAgentTaskDispatched {
+		t.Fatalf("event name = %q, want %q", ev.Name, EventAgentTaskDispatched)
+	}
+	if got := ev.WorkspaceID; got != "workspace-1" {
+		t.Fatalf("workspace_id = %q, want workspace-1", got)
+	}
+	if got := ev.Properties["task_id"]; got != "task-1" {
+		t.Fatalf("task_id = %v, want task-1", got)
+	}
+	if got := ev.Properties["runtime_mode"]; got != "local" {
+		t.Fatalf("runtime_mode = %v, want local", got)
+	}
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -110,6 +110,10 @@ func (s *TaskService) captureTaskQueued(ctx context.Context, task db.AgentTaskQu
 	s.captureTaskEvent(ctx, analytics.AgentTaskQueued(s.taskAnalyticsContext(ctx, task)))
 }
 
+func (s *TaskService) captureTaskDispatched(ctx context.Context, task db.AgentTaskQueue) {
+	s.captureTaskEvent(ctx, analytics.AgentTaskDispatched(s.taskAnalyticsContext(ctx, task)))
+}
+
 func (s *TaskService) AnalyticsContextForTask(ctx context.Context, task db.AgentTaskQueue) analytics.TaskContext {
 	return s.taskAnalyticsContext(ctx, task)
 }
@@ -707,6 +711,7 @@ func (s *TaskService) ClaimTask(ctx context.Context, agentID pgtype.UUID) (*db.A
 	}
 
 	slog.Info("task claimed", "task_id", util.UUIDToString(task.ID), "agent_id", util.UUIDToString(agentID))
+	s.captureTaskDispatched(ctx, task)
 
 	// Refresh agent status from active tasks. This avoids a stale unconditional
 	// working write racing after a just-cancelled claim.


### PR DESCRIPTION
## Summary

- Add `agent_task_dispatched` to the canonical analytics event catalog.
- Emit the event when `ClaimTask` successfully transitions a task from queued to dispatched.
- Document the queued -> dispatched -> started -> terminal task lifecycle for the activation funnel.
- Add a unit test for dispatched task core properties.

## Tests

- `git diff --check`
- `go test ./internal/analytics ./internal/service`

## Context

MUL-1898 needs the PostHog-side funnel to distinguish backend queue backlog from the runtime claim/start handoff. DB analysis already has `dispatched_at`; this adds the matching PostHog event.
