### PR TITLE
fix(priority): align dropdown badge colors with PriorityIcon semantic tokens

### DIFF
--- a/apps/web/app/custom.css
+++ b/apps/web/app/custom.css
@@ -39,7 +39,6 @@
     --success: oklch(0.55 0.16 145);
     --warning: oklch(0.75 0.16 85);
     --info: oklch(0.55 0.18 250);
-    --priority: oklch(0.65 0.18 50);
     --scrollbar-thumb: oklch(0 0 0 / 10%);
     --scrollbar-thumb-hover: oklch(0 0 0 / 18%);
     --scrollbar-track: transparent;

--- a/packages/core/issues/config/priority.ts
+++ b/packages/core/issues/config/priority.ts
@@ -12,9 +12,9 @@ export const PRIORITY_CONFIG: Record<
   IssuePriority,
   { label: string; bars: number; color: string; badgeBg: string; badgeText: string }
 > = {
-  urgent: { label: "Urgent", bars: 4, color: "text-destructive", badgeBg: "bg-priority", badgeText: "text-white" },
-  high: { label: "High", bars: 3, color: "text-warning", badgeBg: "bg-priority/80", badgeText: "text-white" },
-  medium: { label: "Medium", bars: 2, color: "text-warning", badgeBg: "bg-priority/15", badgeText: "text-priority" },
-  low: { label: "Low", bars: 1, color: "text-info", badgeBg: "bg-priority/10", badgeText: "text-priority" },
+  urgent: { label: "Urgent", bars: 4, color: "text-destructive", badgeBg: "bg-destructive/10", badgeText: "text-destructive" },
+  high: { label: "High", bars: 3, color: "text-warning", badgeBg: "bg-warning/10", badgeText: "text-warning" },
+  medium: { label: "Medium", bars: 2, color: "text-warning", badgeBg: "bg-warning/10", badgeText: "text-warning" },
+  low: { label: "Low", bars: 1, color: "text-info", badgeBg: "bg-info/10", badgeText: "text-info" },
   none: { label: "No priority", bars: 0, color: "text-muted-foreground", badgeBg: "bg-muted", badgeText: "text-muted-foreground" },
 };

--- a/packages/core/projects/config.ts
+++ b/packages/core/projects/config.ts
@@ -31,9 +31,9 @@ export const PROJECT_PRIORITY_CONFIG: Record<
   ProjectPriority,
   { label: string; bars: number; color: string; badgeBg: string; badgeText: string }
 > = {
-  urgent: { label: "Urgent", bars: 4, color: "text-destructive", badgeBg: "bg-priority", badgeText: "text-white" },
-  high: { label: "High", bars: 3, color: "text-warning", badgeBg: "bg-priority/80", badgeText: "text-white" },
-  medium: { label: "Medium", bars: 2, color: "text-warning", badgeBg: "bg-priority/15", badgeText: "text-priority" },
-  low: { label: "Low", bars: 1, color: "text-info", badgeBg: "bg-priority/10", badgeText: "text-priority" },
+  urgent: { label: "Urgent", bars: 4, color: "text-destructive", badgeBg: "bg-destructive/10", badgeText: "text-destructive" },
+  high: { label: "High", bars: 3, color: "text-warning", badgeBg: "bg-warning/10", badgeText: "text-warning" },
+  medium: { label: "Medium", bars: 2, color: "text-warning", badgeBg: "bg-warning/10", badgeText: "text-warning" },
+  low: { label: "Low", bars: 1, color: "text-info", badgeBg: "bg-info/10", badgeText: "text-info" },
   none: { label: "No priority", bars: 0, color: "text-muted-foreground", badgeBg: "bg-muted", badgeText: "text-muted-foreground" },
 };

--- a/packages/ui/styles/tokens.css
+++ b/packages/ui/styles/tokens.css
@@ -27,7 +27,6 @@
     --color-info: var(--info);
     --color-brand: var(--brand);
     --color-brand-foreground: var(--brand-foreground);
-    --color-priority: var(--priority);
     --color-accent-foreground: var(--accent-foreground);
     --color-accent: var(--accent);
     --color-muted-foreground: var(--muted-foreground);
@@ -94,7 +93,6 @@
     --success: oklch(0.55 0.16 145);
     --warning: oklch(0.75 0.16 85);
     --info: oklch(0.55 0.18 250);
-    --priority: oklch(0.65 0.18 50);
     --scrollbar-thumb: oklch(0 0 0 / 10%);
     --scrollbar-thumb-hover: oklch(0 0 0 / 18%);
     --scrollbar-track: transparent;
@@ -141,7 +139,6 @@
     --success: oklch(0.65 0.15 145);
     --warning: oklch(0.70 0.16 85);
     --info: oklch(0.65 0.18 250);
-    --priority: oklch(0.70 0.18 50);
     --scrollbar-thumb: oklch(1 0 0 / 8%);
     --scrollbar-thumb-hover: oklch(1 0 0 / 18%);
     --scrollbar-track: transparent;


### PR DESCRIPTION
## Summary
- Dropdown priority badge previously used a parallel `bg-priority` orange family with opacity gradient, while the `PriorityIcon` rendered outside used semantic tokens (`text-destructive` / `text-warning` / `text-info`). Most visible on **Low**: blue in lists, orange in the picker.
- Switch the badge to the same semantic tokens as the icon: Urgent → red, High/Medium → yellow, Low → blue, None → muted. High and Medium now share a color and rely on `bars` count for differentiation, mirroring the icon.
- Drop the unused `--priority` / `--color-priority` token from `packages/ui/styles/tokens.css` and `apps/web/app/custom.css`.

Closes #2289

## Test plan
- [x] `pnpm typecheck` (all 6 packages green)
- [x] `pnpm test` (333 tests green; existing `issue-detail.test.tsx` mock already encoded the semantic colors, so the mock now matches the source of truth)
- [ ] Manually verify in the priority picker dropdown — Urgent badge red, High/Medium yellow, Low blue, None muted; outer `PriorityIcon` colors unchanged