### PR TITLE
feat(inbox): auto-archive stale task_failed rows on terminal status

### DIFF
--- a/server/cmd/server/notification_listeners.go
+++ b/server/cmd/server/notification_listeners.go
@@ -139,6 +139,75 @@ func loadUserPrefs(
 	return result
 }
 
+// terminalStatusForTaskFailedDismiss is the set of issue statuses that mark
+// the issue as "the user no longer needs to triage past failures." When a
+// status change lands on one of these, any pre-existing task_failed inbox
+// rows for the issue are archived so the inbox stays a fresh-signal surface.
+// `in_review` is included because in Multica's agent flow that's the most
+// reliable "work delivered" handoff — and a status flip back to in_progress
+// will simply produce new task_failed rows that surface normally.
+var terminalStatusForTaskFailedDismiss = map[string]bool{
+	"in_review": true,
+	"done":      true,
+	"cancelled": true,
+}
+
+// archiveStaleTaskFailedInbox archives all task_failed inbox rows for the
+// given issue and notifies each affected member recipient via
+// inbox:batch-archived so connected clients self-heal.
+func archiveStaleTaskFailedInbox(
+	ctx context.Context,
+	queries *db.Queries,
+	bus *events.Bus,
+	workspaceID string,
+	issueID string,
+) {
+	rows, err := queries.ArchiveInboxByIssueAndType(ctx, db.ArchiveInboxByIssueAndTypeParams{
+		WorkspaceID: parseUUID(workspaceID),
+		IssueID:     parseUUID(issueID),
+		Type:        "task_failed",
+	})
+	if err != nil {
+		slog.Error("auto-archive task_failed inbox: query failed",
+			"workspace_id", workspaceID, "issue_id", issueID, "error", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	// Dedupe recipients: the listener creates one row per failure event per
+	// subscriber, so a long-running issue can yield several rows for the
+	// same recipient.
+	counts := map[string]int{}
+	for _, row := range rows {
+		// Inbox rows for task_failed only target member recipients today
+		// (notifySubscribers skips agent subscribers), but defend the WS
+		// layer against future widening — only members get a personal feed.
+		if row.RecipientType != "member" {
+			continue
+		}
+		counts[util.UUIDToString(row.RecipientID)]++
+	}
+
+	for recipientID, count := range counts {
+		bus.Publish(events.Event{
+			Type:        protocol.EventInboxBatchArchived,
+			WorkspaceID: workspaceID,
+			Payload: map[string]any{
+				"recipient_id": recipientID,
+				"count":        int64(count),
+				"issue_id":     issueID,
+				"reason":       "issue_status_terminal",
+			},
+		})
+	}
+
+	slog.Info("auto-archive task_failed inbox: archived stale rows",
+		"workspace_id", workspaceID, "issue_id", issueID,
+		"row_count", len(rows), "recipient_count", len(counts))
+}
+
 // notifySubscribers queries the subscriber table for an issue, excludes the
 // actor and any extra IDs, and creates inbox items for each remaining member
 // subscriber. Publishes an inbox:new event for each notification.
@@ -568,6 +637,14 @@ func registerNotificationListeners(bus *events.Bus, queries *db.Queries) {
 				nil, "status_changed", "info",
 				issue.Title, "",
 				statusDetails)
+
+			// When the issue progresses past the failure (in_review / done /
+			// cancelled), retire any stale task_failed inbox rows so the
+			// inbox reflects the current state of the work, not its history.
+			// The activity log keeps the full failure history for audit.
+			if terminalStatusForTaskFailedDismiss[issue.Status] {
+				archiveStaleTaskFailedInbox(ctx, queries, bus, e.WorkspaceID, issue.ID)
+			}
 		}
 
 		if priorityChanged, _ := payload["priority_changed"].(bool); priorityChanged {

--- a/server/cmd/server/notification_listeners_test.go
+++ b/server/cmd/server/notification_listeners_test.go
@@ -860,3 +860,262 @@ func TestNotification_ParentBubble_PriorityChangeSuppressed(t *testing.T) {
 		t.Fatalf("expected 0 inbox items bubbled to parent subscriber for priority_changed, got %d", len(items))
 	}
 }
+
+// countInboxByTypeForRecipient counts inbox rows of a given type for a
+// recipient, including archived rows. Used to distinguish "row never created"
+// from "row archived."
+func countInboxByTypeForRecipient(t *testing.T, recipientID, notifType string) (active, archived int) {
+	t.Helper()
+	rows, err := testPool.Query(context.Background(), `
+		SELECT archived FROM inbox_item
+		WHERE workspace_id = $1 AND recipient_type = 'member' AND recipient_id = $2 AND type = $3
+	`, testWorkspaceID, recipientID, notifType)
+	if err != nil {
+		t.Fatalf("countInboxByTypeForRecipient: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var isArchived bool
+		if err := rows.Scan(&isArchived); err != nil {
+			t.Fatalf("countInboxByTypeForRecipient scan: %v", err)
+		}
+		if isArchived {
+			archived++
+		} else {
+			active++
+		}
+	}
+	return active, archived
+}
+
+// publishStatusChange is a small helper to publish the issue:updated event
+// shape used by the notification listener for status-only transitions.
+func publishStatusChange(bus *events.Bus, issueID, newStatus, prevStatus string) {
+	bus.Publish(events.Event{
+		Type:        protocol.EventIssueUpdated,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "member",
+		ActorID:     testUserID,
+		Payload: map[string]any{
+			"issue": handler.IssueResponse{
+				ID:          issueID,
+				WorkspaceID: testWorkspaceID,
+				Title:       "task_failed dismiss test",
+				Status:      newStatus,
+				Priority:    "medium",
+				CreatorType: "member",
+				CreatorID:   testUserID,
+			},
+			"assignee_changed": false,
+			"status_changed":   true,
+			"prev_status":      prevStatus,
+		},
+	})
+}
+
+// TestNotification_StatusChange_ArchivesStaleTaskFailed verifies that when an
+// issue transitions into a terminal status (in_review/done/cancelled), any
+// existing task_failed inbox rows for that issue are archived for every
+// affected member recipient, an inbox:batch-archived event fires per
+// recipient, and sibling notifications on the same issue are untouched.
+func TestNotification_StatusChange_ArchivesStaleTaskFailed(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+
+	subEmail := "notif-archive-task-failed-sub@multica.ai"
+	subID := createTestUser(t, subEmail)
+	t.Cleanup(func() { cleanupTestUser(t, subEmail) })
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	addTestSubscriber(t, issueID, "member", testUserID, "creator")
+	addTestSubscriber(t, issueID, "member", subID, "assignee")
+
+	agentID := "00000000-0000-0000-0000-aaaaaaaaaaaa"
+
+	// Two failed runs land before the status flip.
+	for i := 0; i < 2; i++ {
+		bus.Publish(events.Event{
+			Type:        protocol.EventTaskFailed,
+			WorkspaceID: testWorkspaceID,
+			ActorType:   "system",
+			Payload: map[string]any{
+				"task_id":  "00000000-0000-0000-0000-bbbbbbbbbbbb",
+				"agent_id": agentID,
+				"issue_id": issueID,
+			},
+		})
+	}
+
+	// A separate non-task notification on the same issue, so we can prove
+	// the archive scope is narrow. Use a comment-like notification by
+	// directly inserting a row of a different type.
+	_, err := testPool.Exec(context.Background(), `
+		INSERT INTO inbox_item (workspace_id, recipient_type, recipient_id, type, severity, issue_id, title, details)
+		VALUES ($1, 'member', $2, 'new_comment', 'info', $3, 'sibling notification', '{}')
+	`, testWorkspaceID, testUserID, issueID)
+	if err != nil {
+		t.Fatalf("seed sibling notification: %v", err)
+	}
+
+	if active, _ := countInboxByTypeForRecipient(t, testUserID, "task_failed"); active != 2 {
+		t.Fatalf("precondition: expected 2 active task_failed rows for creator, got %d", active)
+	}
+	if active, _ := countInboxByTypeForRecipient(t, subID, "task_failed"); active != 2 {
+		t.Fatalf("precondition: expected 2 active task_failed rows for sub, got %d", active)
+	}
+
+	// Track the batch-archived events fired during the status change.
+	var batchArchived []events.Event
+	bus.Subscribe(protocol.EventInboxBatchArchived, func(e events.Event) {
+		batchArchived = append(batchArchived, e)
+	})
+
+	publishStatusChange(bus, issueID, "in_review", "in_progress")
+
+	// task_failed rows are archived for both recipients.
+	for _, recipient := range []string{testUserID, subID} {
+		active, archived := countInboxByTypeForRecipient(t, recipient, "task_failed")
+		if active != 0 {
+			t.Fatalf("recipient %s: expected 0 active task_failed rows after terminal status, got %d", recipient, active)
+		}
+		if archived != 2 {
+			t.Fatalf("recipient %s: expected 2 archived task_failed rows after terminal status, got %d", recipient, archived)
+		}
+	}
+
+	// Sibling notification on the same issue is untouched.
+	if active, _ := countInboxByTypeForRecipient(t, testUserID, "new_comment"); active != 1 {
+		t.Fatalf("expected sibling new_comment row to remain active, got %d active", active)
+	}
+
+	// One inbox:batch-archived event per affected recipient.
+	if len(batchArchived) != 2 {
+		t.Fatalf("expected 2 inbox:batch-archived events (one per recipient), got %d", len(batchArchived))
+	}
+	seenRecipients := map[string]bool{}
+	for _, e := range batchArchived {
+		payload, ok := e.Payload.(map[string]any)
+		if !ok {
+			t.Fatalf("inbox:batch-archived: unexpected payload type %T", e.Payload)
+		}
+		recipientID, _ := payload["recipient_id"].(string)
+		if recipientID == "" {
+			t.Fatalf("inbox:batch-archived: missing recipient_id in payload %+v", payload)
+		}
+		if payload["issue_id"] != issueID {
+			t.Fatalf("inbox:batch-archived: expected issue_id %q, got %v", issueID, payload["issue_id"])
+		}
+		if payload["reason"] != "issue_status_terminal" {
+			t.Fatalf("inbox:batch-archived: expected reason 'issue_status_terminal', got %v", payload["reason"])
+		}
+		if count, _ := payload["count"].(int64); count != 2 {
+			t.Fatalf("inbox:batch-archived: expected count=2 for recipient %s, got %v", recipientID, payload["count"])
+		}
+		seenRecipients[recipientID] = true
+	}
+	if !seenRecipients[testUserID] || !seenRecipients[subID] {
+		t.Fatalf("expected batch-archived events for both creator and sub, got %v", seenRecipients)
+	}
+}
+
+// TestNotification_StatusChange_NonTerminalKeepsTaskFailed verifies that a
+// transition to a non-terminal status (e.g. in_progress) does NOT archive
+// existing task_failed inbox rows.
+func TestNotification_StatusChange_NonTerminalKeepsTaskFailed(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	addTestSubscriber(t, issueID, "member", testUserID, "creator")
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventTaskFailed,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "system",
+		Payload: map[string]any{
+			"task_id":  "00000000-0000-0000-0000-bbbbbbbbbbbb",
+			"agent_id": "00000000-0000-0000-0000-aaaaaaaaaaaa",
+			"issue_id": issueID,
+		},
+	})
+
+	if active, _ := countInboxByTypeForRecipient(t, testUserID, "task_failed"); active != 1 {
+		t.Fatalf("precondition: expected 1 active task_failed row, got %d", active)
+	}
+
+	publishStatusChange(bus, issueID, "in_progress", "todo")
+
+	// task_failed row stays active because in_progress is not terminal.
+	active, archived := countInboxByTypeForRecipient(t, testUserID, "task_failed")
+	if active != 1 || archived != 0 {
+		t.Fatalf("expected task_failed row to remain active after non-terminal transition, got active=%d archived=%d", active, archived)
+	}
+}
+
+// TestNotification_StatusChange_ReopenSurfacesNewTaskFailed verifies that
+// after a terminal-status auto-archive, a status flip back to in_progress
+// followed by a new task failure produces a fresh, visible task_failed row.
+// This guards the "reopen and rerun" path described in the design.
+func TestNotification_StatusChange_ReopenSurfacesNewTaskFailed(t *testing.T) {
+	queries := db.New(testPool)
+	bus := newNotificationBus(t, queries)
+
+	issueID := createTestIssue(t, testWorkspaceID, testUserID)
+	t.Cleanup(func() {
+		cleanupInboxForIssue(t, issueID)
+		cleanupTestIssue(t, issueID)
+	})
+
+	addTestSubscriber(t, issueID, "member", testUserID, "creator")
+
+	agentID := "00000000-0000-0000-0000-aaaaaaaaaaaa"
+
+	bus.Publish(events.Event{
+		Type:        protocol.EventTaskFailed,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "system",
+		Payload: map[string]any{
+			"task_id":  "00000000-0000-0000-0000-bbbbbbbbbbbb",
+			"agent_id": agentID,
+			"issue_id": issueID,
+		},
+	})
+
+	// First terminal transition archives the original failure.
+	publishStatusChange(bus, issueID, "in_review", "in_progress")
+	if active, archived := countInboxByTypeForRecipient(t, testUserID, "task_failed"); active != 0 || archived != 1 {
+		t.Fatalf("after terminal transition: expected active=0 archived=1, got active=%d archived=%d", active, archived)
+	}
+
+	// Reviewer kicks the issue back; a rerun fails again.
+	publishStatusChange(bus, issueID, "in_progress", "in_review")
+	bus.Publish(events.Event{
+		Type:        protocol.EventTaskFailed,
+		WorkspaceID: testWorkspaceID,
+		ActorType:   "system",
+		Payload: map[string]any{
+			"task_id":  "00000000-0000-0000-0000-cccccccccccc",
+			"agent_id": agentID,
+			"issue_id": issueID,
+		},
+	})
+
+	// The new failure is visible; the old archived row stays archived.
+	active, archived := countInboxByTypeForRecipient(t, testUserID, "task_failed")
+	if active != 1 {
+		t.Fatalf("expected 1 active task_failed row after reopen+fail, got %d", active)
+	}
+	if archived != 1 {
+		t.Fatalf("expected 1 archived task_failed row preserved from prior cycle, got %d", archived)
+	}
+}

--- a/server/pkg/db/generated/inbox.sql.go
+++ b/server/pkg/db/generated/inbox.sql.go
@@ -91,6 +91,43 @@ func (q *Queries) ArchiveInboxByIssue(ctx context.Context, arg ArchiveInboxByIss
 	return result.RowsAffected(), nil
 }
 
+const archiveInboxByIssueAndType = `-- name: ArchiveInboxByIssueAndType :many
+UPDATE inbox_item SET archived = true
+WHERE workspace_id = $1 AND issue_id = $2 AND type = $3 AND archived = false
+RETURNING recipient_type, recipient_id
+`
+
+type ArchiveInboxByIssueAndTypeParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	IssueID     pgtype.UUID `json:"issue_id"`
+	Type        string      `json:"type"`
+}
+
+type ArchiveInboxByIssueAndTypeRow struct {
+	RecipientType string      `json:"recipient_type"`
+	RecipientID   pgtype.UUID `json:"recipient_id"`
+}
+
+func (q *Queries) ArchiveInboxByIssueAndType(ctx context.Context, arg ArchiveInboxByIssueAndTypeParams) ([]ArchiveInboxByIssueAndTypeRow, error) {
+	rows, err := q.db.Query(ctx, archiveInboxByIssueAndType, arg.WorkspaceID, arg.IssueID, arg.Type)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ArchiveInboxByIssueAndTypeRow{}
+	for rows.Next() {
+		var i ArchiveInboxByIssueAndTypeRow
+		if err := rows.Scan(&i.RecipientType, &i.RecipientID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const archiveInboxItem = `-- name: ArchiveInboxItem :one
 UPDATE inbox_item SET archived = true
 WHERE id = $1

--- a/server/pkg/db/queries/inbox.sql
+++ b/server/pkg/db/queries/inbox.sql
@@ -36,6 +36,11 @@ RETURNING *;
 UPDATE inbox_item SET archived = true
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND issue_id = $4 AND archived = false;
 
+-- name: ArchiveInboxByIssueAndType :many
+UPDATE inbox_item SET archived = true
+WHERE workspace_id = $1 AND issue_id = $2 AND type = $3 AND archived = false
+RETURNING recipient_type, recipient_id;
+
 -- name: CountUnreadInbox :one
 SELECT count(*) FROM inbox_item
 WHERE workspace_id = $1 AND recipient_type = $2 AND recipient_id = $3 AND read = false AND archived = false;


### PR DESCRIPTION
## Summary

- When an issue's status flips to `in_review` / `done` / `cancelled`, the server auto-archives every `task_failed` inbox row for that issue across all member recipients, so the inbox stops carrying stale red dots once the work has moved past the failure.
- Reuses the existing `archived` column rather than introducing a parallel `dismissed` flag — `ListInboxItems` already filters `archived = false`, the WS event `inbox:batch-archived` already exists. Keeping triage state and audit state separate: the `activity_log` is independently append-only and preserves the full `task_failed` history for the issue.
- Scope is narrow: only `type = 'task_failed'` rows are archived. Sibling notifications on the same issue (`status_changed`, mentions, comments, assignment, reactions, etc.) are untouched.
- A status flip back out of a terminal state (e.g. `in_review` → `in_progress`) needs no special handling — `CreateInboxItem` is unconditional, so any new failure on a rerun surfaces normally; only failures that pre-date the most recent terminal transition are archived.

Closes #2291.

## Implementation

- New sqlc query `ArchiveInboxByIssueAndType` in `server/pkg/db/queries/inbox.sql` — `UPDATE … SET archived = true WHERE workspace_id = $1 AND issue_id = $2 AND type = $3 AND archived = false RETURNING recipient_type, recipient_id`. Returning recipients lets the listener fan out a per-recipient WS event.
- New helper `archiveStaleTaskFailedInbox` in `server/cmd/server/notification_listeners.go` runs the query, dedupes recipients (multiple failures on the same issue produce multiple rows per subscriber), and publishes `inbox:batch-archived` with `{recipient_id, count, issue_id, reason: "issue_status_terminal"}` for each affected member. The existing personal-event router in `server/cmd/server/listeners.go` already routes `inbox:batch-archived` to the right user via `SendToUser`.
- Hook lives at the end of the existing `statusChanged` branch of the `issue:updated` listener — gated on a small `terminalStatusForTaskFailedDismiss` allowlist (`in_review`, `done`, `cancelled`).

## Test plan

Three new Go tests in `notification_listeners_test.go` (run via `make test`):

- [ ] `TestNotification_StatusChange_ArchivesStaleTaskFailed` — two failed runs land for two member subscribers; an unrelated `new_comment` row is seeded as a sibling. After flipping the issue to `in_review`, both subscribers' `task_failed` rows are archived (active=0, archived=2 each), the sibling `new_comment` stays active, and exactly one `inbox:batch-archived` event fires per recipient with the correct payload (`recipient_id`, `count=2`, `issue_id`, `reason="issue_status_terminal"`).
- [ ] `TestNotification_StatusChange_NonTerminalKeepsTaskFailed` — flipping into `in_progress` (non-terminal) leaves the existing `task_failed` row active.
- [ ] `TestNotification_StatusChange_ReopenSurfacesNewTaskFailed` — fail → flip to `in_review` (archive) → flip back to `in_progress` → new failure: the new row is visible (active=1) and the previously archived row stays archived (archived=1).

Local: `cd server && go vet ./... && go build ./... && go test -count=1 -run '^$' ./...` all pass. Full Go test run requires Postgres (Docker not available in this sandbox); CI's pgvector service will run the new integration tests.