### PR TITLE
[codex] Let Claude agents inherit local MCP settings

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -419,9 +419,11 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 		"--output-format", "stream-json",
 		"--input-format", "stream-json",
 		"--verbose",
-		"--strict-mcp-config",
-		"--permission-mode", "bypassPermissions",
 	}
+	if len(opts.McpConfig) > 0 {
+		args = append(args, "--strict-mcp-config")
+	}
+	args = append(args, "--permission-mode", "bypassPermissions")
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 	}

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -199,10 +199,34 @@ func TestTrySendDropsWhenFull(t *testing.T) {
 	}
 }
 
-func TestBuildClaudeArgsIncludesStrictMCPConfig(t *testing.T) {
+func TestBuildClaudeArgsOmitsStrictMCPConfigWithoutMcpConfig(t *testing.T) {
 	t.Parallel()
 
 	args := buildClaudeArgs(ExecOptions{}, slog.Default())
+	expected := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--input-format", "stream-json",
+		"--verbose",
+		"--permission-mode", "bypassPermissions",
+	}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Fatalf("expected args[%d] = %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestBuildClaudeArgsIncludesStrictMCPConfigWithMcpConfig(t *testing.T) {
+	t.Parallel()
+
+	args := buildClaudeArgs(ExecOptions{
+		McpConfig: json.RawMessage(`{"mcpServers":{"test":{"command":"echo"}}}`),
+	}, slog.Default())
 	expected := []string{
 		"-p",
 		"--output-format", "stream-json",


### PR DESCRIPTION
## Summary

- Stop passing `--strict-mcp-config` to Claude Code when Multica has no explicit per-agent `mcp_config`.
- Keep strict MCP mode when Multica does provide `mcp_config`, preserving the controlled per-agent override path.
- Split the Claude args test so both inheritance and explicit-config behavior are covered.

## Why

Daemon-spawned Claude agents were always launched with `--strict-mcp-config`. When no `--mcp-config` file was supplied, Claude ignored the host user's normal local MCP settings, so locally configured MCP servers such as chrome-devtools were unavailable to agents.

This makes local Claude MCP configuration the default source of truth, while still allowing Multica-owned `mcp_config` to lock the MCP surface down when configured.

Tracker: STO-66
Parent context: STO-55

## Validation

- `go test ./pkg/agent -run 'TestBuildClaudeArgs(OmitsStrictMCPConfigWithoutMcpConfig|IncludesStrictMCPConfigWithMcpConfig)' -count=1`
- `go test ./pkg/agent -count=1`
- `go test ./pkg/agent ./internal/daemon -count=1`
