### PR TITLE
Add macOS x64 desktop package target

### DIFF
--- a/apps/desktop/scripts/package.mjs
+++ b/apps/desktop/scripts/package.mjs
@@ -63,6 +63,7 @@ const ARCH_FLAGS = new Map([
 
 const SUPPORTED_CLI_ARCHS = new Set(["x64", "arm64"]);
 const MAC_ALL_PLATFORM_TARGETS = [
+  { platform: "mac", arch: "x64" },
   { platform: "mac", arch: "arm64" },
   { platform: "win", arch: "x64" },
   { platform: "win", arch: "arm64" },

--- a/apps/desktop/scripts/package.test.mjs
+++ b/apps/desktop/scripts/package.test.mjs
@@ -133,6 +133,7 @@ describe("resolveBuildMatrix", () => {
         "arm64",
       ),
     ).toEqual([
+      { platform: "mac", arch: "x64" },
       { platform: "mac", arch: "arm64" },
       { platform: "win", arch: "x64" },
       { platform: "win", arch: "arm64" },


### PR DESCRIPTION
## Summary

- Include macOS x64 in the Desktop `--all-platforms` packaging matrix.
- Update the package script test expectation so the all-platforms matrix covers both macOS architectures.

## Why

The Desktop packaging script supports `--x64`, and the CLI bundling path supports x64, but the all-platforms release matrix only included macOS arm64. Adding macOS x64 lets the existing macOS release packaging path produce Intel Mac Desktop artifacts alongside Apple Silicon builds.

## Validation

- Ran a focused Node import check for `resolveBuildMatrix(..., "darwin", "arm64")` and confirmed it now returns `mac x64`, `mac arm64`, Windows x64/arm64, and Linux x64/arm64.
- Could not run the Vitest target locally because `pnpm` is not installed in this environment.