### PR TITLE
fix(agent): include JSON-RPC error data field in ACP error messages

### DIFF
--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -568,11 +568,31 @@ func (c *hermesClient) handleResponse(raw map[string]json.RawMessage) {
 
 	if errData, hasErr := raw["error"]; hasErr {
 		var rpcErr struct {
-			Code    int    `json:"code"`
-			Message string `json:"message"`
+			Code    int             `json:"code"`
+			Message string          `json:"message"`
+			Data    json.RawMessage `json:"data"`
 		}
 		_ = json.Unmarshal(errData, &rpcErr)
-		pr.ch <- rpcResult{err: fmt.Errorf("%s: %s (code=%d)", pr.method, rpcErr.Message, rpcErr.Code)}
+		// JSON-RPC `data` carries the provider-specific reason (e.g. Kiro
+		// returns "No session found with id" for code=-32603). Surface it
+		// in the wrapped error so daemon logs / UI can show *why* the
+		// agent failed instead of a bare "Internal error". `data` may be
+		// any JSON value: render strings unquoted, everything else as raw
+		// JSON.
+		detail := ""
+		if len(rpcErr.Data) > 0 && string(rpcErr.Data) != "null" {
+			var s string
+			if err := json.Unmarshal(rpcErr.Data, &s); err == nil {
+				detail = s
+			} else {
+				detail = string(rpcErr.Data)
+			}
+		}
+		if detail != "" {
+			pr.ch <- rpcResult{err: fmt.Errorf("%s: %s (code=%d, data=%s)", pr.method, rpcErr.Message, rpcErr.Code, detail)}
+		} else {
+			pr.ch <- rpcResult{err: fmt.Errorf("%s: %s (code=%d)", pr.method, rpcErr.Message, rpcErr.Code)}
+		}
 	} else {
 		// If this is a prompt response, extract usage and stop reason.
 		if pr.method == "session/prompt" {

--- a/server/pkg/agent/hermes_test.go
+++ b/server/pkg/agent/hermes_test.go
@@ -220,6 +220,74 @@ func TestHermesClientHandleLineError(t *testing.T) {
 	}
 }
 
+// TestHermesClientHandleLineErrorWithData guards #2192-class regressions: when
+// an ACP backend returns -32603 (Internal error), the meaningful reason lives
+// in the `data` field. Dropping it leaves operators with a bare "Internal
+// error" and no way to tell apart "session expired", "model unavailable",
+// "auth lost", etc. Kiro CLI 2.2.x emits `data` as a string; some backends use
+// objects/arrays — both must round-trip into the wrapped Go error.
+func TestHermesClientHandleLineErrorWithStringData(t *testing.T) {
+	t.Parallel()
+
+	c := &hermesClient{
+		pending: make(map[int]*pendingRPC),
+	}
+	pr := &pendingRPC{ch: make(chan rpcResult, 1), method: "session/prompt"}
+	c.pending[3] = pr
+
+	c.handleLine(`{"jsonrpc":"2.0","id":3,"error":{"code":-32603,"message":"Internal error","data":"No session found with id"}}`)
+
+	res := <-pr.ch
+	if res.err == nil {
+		t.Fatal("expected error")
+	}
+	want := "session/prompt: Internal error (code=-32603, data=No session found with id)"
+	if got := res.err.Error(); got != want {
+		t.Errorf("error: got %q, want %q", got, want)
+	}
+}
+
+func TestHermesClientHandleLineErrorWithObjectData(t *testing.T) {
+	t.Parallel()
+
+	c := &hermesClient{
+		pending: make(map[int]*pendingRPC),
+	}
+	pr := &pendingRPC{ch: make(chan rpcResult, 1), method: "session/prompt"}
+	c.pending[5] = pr
+
+	c.handleLine(`{"jsonrpc":"2.0","id":5,"error":{"code":-32000,"message":"quota","data":{"reason":"limit","remaining":0}}}`)
+
+	res := <-pr.ch
+	if res.err == nil {
+		t.Fatal("expected error")
+	}
+	want := `session/prompt: quota (code=-32000, data={"reason":"limit","remaining":0})`
+	if got := res.err.Error(); got != want {
+		t.Errorf("error: got %q, want %q", got, want)
+	}
+}
+
+func TestHermesClientHandleLineErrorWithNullData(t *testing.T) {
+	t.Parallel()
+
+	c := &hermesClient{
+		pending: make(map[int]*pendingRPC),
+	}
+	pr := &pendingRPC{ch: make(chan rpcResult, 1), method: "initialize"}
+	c.pending[7] = pr
+
+	c.handleLine(`{"jsonrpc":"2.0","id":7,"error":{"code":-32600,"message":"bad request","data":null}}`)
+
+	res := <-pr.ch
+	if res.err == nil {
+		t.Fatal("expected error")
+	}
+	if got := res.err.Error(); got != "initialize: bad request (code=-32600)" {
+		t.Errorf("error: got %q", got)
+	}
+}
+
 // ── agent → client request handling ──
 
 // bufferWriter is a test stand-in for cmd.StdinPipe that captures


### PR DESCRIPTION
ACP backends (Kiro, Hermes, Kimi) put the actionable reason for code=-32603 'Internal error' in the JSON-RPC `data` field, e.g. "No session found with id". The wrapped Go error only carried `code` and `message`, leaving operators staring at a bare "kiro session/prompt failed: session/prompt: Internal error (code=-32603)" with no way to tell apart session expiry, model unavailability, lost auth, or quota.

Parse `data` too. Strings render unquoted; objects/arrays render as raw JSON; null/missing keeps the previous format unchanged.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
