### PR TITLE
fix(daemon): add kiro and kimi to providerNeedsInlineSystemPrompt whitelist

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1599,7 +1599,7 @@ func gcMetaForTask(task Task) (execenv.GCMeta, bool) {
 
 func providerNeedsInlineSystemPrompt(provider string) bool {
 	switch provider {
-	case "openclaw", "hermes":
+	case "openclaw", "hermes", "kiro", "kimi":
 		return true
 	default:
 		return false

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -186,6 +186,8 @@ func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
 	}{
 		{provider: "openclaw", want: true},
 		{provider: "hermes", want: true},
+		{provider: "kiro", want: true},
+		{provider: "kimi", want: true},
 		{provider: "codex", want: false},
 		{provider: "claude", want: false},
 	}


### PR DESCRIPTION
## Summary

- Adds `kiro` and `kimi` to the daemon's `providerNeedsInlineSystemPrompt` whitelist so the daemon sets `ExecOptions.SystemPrompt` for them, matching the existing Hermes path.
- Both backends already prepend `SystemPrompt` to the user prompt in their ACP turn payloads (`server/pkg/agent/kiro.go:244-247`, `server/pkg/agent/kimi.go:256-257`); they were just missing the daemon-side opt-in.
- Without this, deployments that rely on inline injection (e.g. K3 Lens-style `multica daemon → wrapper → docker compose exec ... acp`) miss per-task `AGENTS.md`, so the agent never sees its identity / persona instructions.

## Why

Same architecture as Hermes (already whitelisted in #2283), so they share the same failure mode. Aligning ahead of any field report.

## Test plan

- [x] `go test ./internal/daemon -run TestProviderNeedsInlineSystemPrompt` passes (new `kiro` / `kimi` cases included).
- [x] `go vet ./internal/daemon` clean.
- [ ] In a Kiro / Kimi K3 Lens-style deployment, run a minimal agent task and confirm a marker string from the injected instructions shows up at the top of the prompt.