### PR TITLE
fix(agent): expand Copilot CLI model catalog with correct dotted IDs

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -66,7 +66,9 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 			return discoverCursorModels(ctx, executablePath)
 		})
 	case "copilot":
-		return copilotStaticModels(), nil
+		return cachedDiscovery(providerType, func() ([]Model, error) {
+			return discoverCopilotModels(ctx, executablePath)
+		})
 	case "hermes":
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverHermesModels(ctx, executablePath)
@@ -198,16 +200,16 @@ func cursorStaticModels() []Model {
 	}
 }
 
-// copilotStaticModels — GitHub Copilot CLI does not expose a model
-// list subcommand; the actual catalog is keyed off the user's
-// GitHub account / plan. We mirror the IDs accepted by `copilot
-// --model <id>` (dotted form, e.g. `gpt-5.4`, `claude-sonnet-4.6`)
-// so the dropdown matches what the CLI actually validates. No
-// Default is set: the right model is whatever GitHub routes to,
-// and forcing one here would override that.
+// copilotStaticModels — fallback used when GitHub Copilot CLI is
+// missing on PATH or the user hasn't logged in. Normal operation
+// goes through discoverCopilotModels(), which speaks ACP to the
+// CLI and gets the live catalog (including which IDs the user's
+// account actually has access to). This list is just a safety net
+// so the UI dropdown still has reasonable options when the live
+// query fails.
 //
 // Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models
-// Keep this list in sync with the Copilot CLI release notes.
+// IDs use the dotted form `copilot --model <id>` actually accepts.
 func copilotStaticModels() []Model {
 	return []Model{
 		// OpenAI
@@ -224,6 +226,27 @@ func copilotStaticModels() []Model {
 		{ID: "claude-sonnet-4.6", Label: "Claude Sonnet 4.6", Provider: "anthropic"},
 		{ID: "claude-sonnet-4.5", Label: "Claude Sonnet 4.5", Provider: "anthropic"},
 		{ID: "claude-haiku-4.5", Label: "Claude Haiku 4.5", Provider: "anthropic"},
+	}
+}
+
+// inferCopilotProvider tags Copilot model IDs with a vendor name so
+// the UI can group them. The Copilot CLI's ACP `availableModels`
+// payload exposes only `modelId`/`name`; the vendor is implicit in
+// the prefix. Returning "" leaves the entry ungrouped, which
+// matches what other ACP discovery paths (hermes/kimi) do for
+// non-prefixed IDs.
+func inferCopilotProvider(modelID string) string {
+	switch {
+	case strings.HasPrefix(modelID, "gpt-") || strings.HasPrefix(modelID, "o1") || strings.HasPrefix(modelID, "o3") || strings.HasPrefix(modelID, "o4"):
+		return "openai"
+	case strings.HasPrefix(modelID, "claude-"):
+		return "anthropic"
+	case strings.HasPrefix(modelID, "gemini-"):
+		return "google"
+	case strings.HasPrefix(modelID, "grok-"):
+		return "xai"
+	default:
+		return ""
 	}
 }
 
@@ -409,17 +432,55 @@ func discoverKiroModels(ctx context.Context, executablePath string) ([]Model, er
 	})
 }
 
+// discoverCopilotModels spins up `copilot --acp` and reads the
+// `availableModels` block from session/new. The catalog is keyed
+// off the user's GitHub account, so this is the only way to know
+// which IDs they actually have access to (Pro vs Pro+ vs
+// Enterprise vs evaluation models).
+//
+// Falls back to copilotStaticModels() when the binary is missing
+// or when the ACP handshake fails (auth missing, network down,
+// etc.) so the UI dropdown always has something to show.
+//
+// We also tag each entry with a vendor in the Provider field —
+// the Copilot ACP payload doesn't include one, but the UI groups
+// by Provider, so deriving it from the ID prefix keeps OpenAI /
+// Anthropic / Gemini sections distinct.
+func discoverCopilotModels(ctx context.Context, executablePath string) ([]Model, error) {
+	models, err := discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
+		defaultBin:   "copilot",
+		clientName:   "multica-model-discovery",
+		extraEnv:     []string{"COPILOT_ALLOW_ALL=1"},
+		tmpdirPrefix: "multica-copilot-discovery-",
+		acpArgs:      []string{"--acp"},
+	})
+	if err != nil || len(models) == 0 {
+		return copilotStaticModels(), nil
+	}
+	for i := range models {
+		if models[i].Provider == "" {
+			models[i].Provider = inferCopilotProvider(models[i].ID)
+		}
+	}
+	return models, nil
+}
+
 // acpDiscoveryProvider configures how discoverACPModels launches an
 // ACP-speaking agent CLI. The shared helper drives every CLI in
 // the same way (initialize → session/new → parse models block) — the
 // per-provider differences are which binary to spawn, which env
-// vars suppress interactive prompts during init, and what to label
-// temporary work directories so they're easy to identify in logs.
+// vars suppress interactive prompts during init, what argv puts
+// the binary into ACP server mode (most use `acp`, Copilot uses
+// `--acp`), and what to label temporary work directories so they're
+// easy to identify in logs.
 type acpDiscoveryProvider struct {
 	defaultBin   string
 	clientName   string
 	extraEnv     []string
 	tmpdirPrefix string
+	// acpArgs is the argv passed to the binary to start it in ACP
+	// server mode. Defaults to []string{"acp"} when nil/empty.
+	acpArgs []string
 }
 
 // discoverACPModels runs the ACP handshake for any agent CLI that
@@ -438,7 +499,11 @@ func discoverACPModels(ctx context.Context, executablePath string, p acpDiscover
 	runCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(runCtx, executablePath, "acp")
+	cmdArgs := p.acpArgs
+	if len(cmdArgs) == 0 {
+		cmdArgs = []string{"acp"}
+	}
+	cmd := exec.CommandContext(runCtx, executablePath, cmdArgs...)
 	hideAgentWindow(cmd)
 	if len(p.extraEnv) > 0 {
 		cmd.Env = append(os.Environ(), p.extraEnv...)

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -235,9 +235,13 @@ func copilotStaticModels() []Model {
 // the prefix. Returning "" leaves the entry ungrouped, which
 // matches what other ACP discovery paths (hermes/kimi) do for
 // non-prefixed IDs.
+//
+// The OpenAI reasoning series (`o1`, `o3`, `o3-mini`, `o4-mini`,
+// future `o5`/`o6`/…) is matched by the generic `o<digit>…`
+// pattern so we don't have to chase every new generation.
 func inferCopilotProvider(modelID string) string {
 	switch {
-	case strings.HasPrefix(modelID, "gpt-") || strings.HasPrefix(modelID, "o1") || strings.HasPrefix(modelID, "o3") || strings.HasPrefix(modelID, "o4"):
+	case strings.HasPrefix(modelID, "gpt-") || isOpenAIReasoningSeriesID(modelID):
 		return "openai"
 	case strings.HasPrefix(modelID, "claude-"):
 		return "anthropic"
@@ -248,6 +252,25 @@ func inferCopilotProvider(modelID string) string {
 	default:
 		return ""
 	}
+}
+
+// isOpenAIReasoningSeriesID matches IDs in OpenAI's `o`-prefixed
+// reasoning family: lowercase `o` followed by at least one digit
+// and then either end-of-string or a `-` separator (e.g. `o3`,
+// `o3-mini`, `o4-mini-high`). Avoids false positives like
+// `opus-…` or random IDs that happen to start with `o`.
+func isOpenAIReasoningSeriesID(id string) bool {
+	if len(id) < 2 || id[0] != 'o' {
+		return false
+	}
+	i := 1
+	for i < len(id) && id[i] >= '0' && id[i] <= '9' {
+		i++
+	}
+	if i == 1 {
+		return false
+	}
+	return i == len(id) || id[i] == '-'
 }
 
 // ── Dynamic discovery ──
@@ -446,11 +469,15 @@ func discoverKiroModels(ctx context.Context, executablePath string) ([]Model, er
 // the Copilot ACP payload doesn't include one, but the UI groups
 // by Provider, so deriving it from the ID prefix keeps OpenAI /
 // Anthropic / Gemini sections distinct.
+//
+// No extra env or permission flags are needed: discovery only
+// drives `initialize` + `session/new`, neither of which triggers
+// a tool-permission prompt — the model catalog is part of the
+// session/new response itself.
 func discoverCopilotModels(ctx context.Context, executablePath string) ([]Model, error) {
 	models, err := discoverACPModels(ctx, executablePath, acpDiscoveryProvider{
 		defaultBin:   "copilot",
 		clientName:   "multica-model-discovery",
-		extraEnv:     []string{"COPILOT_ALLOW_ALL=1"},
 		tmpdirPrefix: "multica-copilot-discovery-",
 		acpArgs:      []string{"--acp"},
 	})

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -198,14 +198,32 @@ func cursorStaticModels() []Model {
 	}
 }
 
-// copilotStaticModels — GitHub Copilot CLI resolves models via the
-// user's GitHub account, not via CLI args. We deliberately mark no
-// Default: the right model is whatever GitHub routes the request
-// to, and forcing one here would override that.
+// copilotStaticModels — GitHub Copilot CLI does not expose a model
+// list subcommand; the actual catalog is keyed off the user's
+// GitHub account / plan. We mirror the IDs accepted by `copilot
+// --model <id>` (dotted form, e.g. `gpt-5.4`, `claude-sonnet-4.6`)
+// so the dropdown matches what the CLI actually validates. No
+// Default is set: the right model is whatever GitHub routes to,
+// and forcing one here would override that.
+//
+// Source: https://docs.github.com/en/copilot/reference/ai-models/supported-models
+// Keep this list in sync with the Copilot CLI release notes.
 func copilotStaticModels() []Model {
 	return []Model{
+		// OpenAI
+		{ID: "gpt-5.5", Label: "GPT-5.5", Provider: "openai"},
 		{ID: "gpt-5.4", Label: "GPT-5.4", Provider: "openai"},
-		{ID: "claude-sonnet-4-6", Label: "Claude Sonnet 4.6", Provider: "anthropic"},
+		{ID: "gpt-5.4-mini", Label: "GPT-5.4 mini", Provider: "openai"},
+		{ID: "gpt-5.3-codex", Label: "GPT-5.3-Codex", Provider: "openai"},
+		{ID: "gpt-5.2-codex", Label: "GPT-5.2-Codex", Provider: "openai"},
+		{ID: "gpt-5.2", Label: "GPT-5.2", Provider: "openai"},
+		{ID: "gpt-5-mini", Label: "GPT-5 mini", Provider: "openai"},
+		{ID: "gpt-4.1", Label: "GPT-4.1", Provider: "openai"},
+		// Anthropic
+		{ID: "claude-opus-4.7", Label: "Claude Opus 4.7", Provider: "anthropic"},
+		{ID: "claude-sonnet-4.6", Label: "Claude Sonnet 4.6", Provider: "anthropic"},
+		{ID: "claude-sonnet-4.5", Label: "Claude Sonnet 4.5", Provider: "anthropic"},
+		{ID: "claude-haiku-4.5", Label: "Claude Haiku 4.5", Provider: "anthropic"},
 	}
 }
 

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestListModelsStaticProviders(t *testing.T) {
 	ctx := context.Background()
-	for _, provider := range []string{"claude", "codex", "gemini", "cursor", "copilot"} {
+	for _, provider := range []string{"claude", "codex", "gemini", "cursor"} {
 		got, err := ListModels(ctx, provider, "")
 		if err != nil {
 			t.Fatalf("ListModels(%q) error: %v", provider, err)
@@ -24,6 +24,33 @@ func TestListModelsStaticProviders(t *testing.T) {
 				t.Errorf("ListModels(%q)[%d] has empty Label", provider, i)
 			}
 		}
+	}
+}
+
+func TestListModelsCopilotFallsBackToStatic(t *testing.T) {
+	// Copilot uses dynamic ACP discovery, but with no `copilot`
+	// binary on PATH (the discovery LookPath fails) it must fall
+	// back to copilotStaticModels() so the UI dropdown stays
+	// populated. This is the "binary missing on the daemon host"
+	// path we care about for self-hosted runtimes.
+	ctx := context.Background()
+	modelCacheMu.Lock()
+	delete(modelCache, "copilot")
+	modelCacheMu.Unlock()
+
+	got, err := ListModels(ctx, "copilot", "/nonexistent/copilot-cli")
+	if err != nil {
+		t.Fatalf("ListModels(copilot) error: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected static fallback models, got empty list")
+	}
+	ids := map[string]bool{}
+	for _, m := range got {
+		ids[m.ID] = true
+	}
+	if !ids["gpt-5.4"] || !ids["claude-sonnet-4.6"] {
+		t.Errorf("static fallback missing expected models: %+v", got)
 	}
 }
 
@@ -93,6 +120,28 @@ func TestCodexStaticModelsExposesGPT55(t *testing.T) {
 	}
 	if defaults != 1 {
 		t.Errorf("expected exactly one default Codex entry, got %d", defaults)
+	}
+}
+
+func TestInferCopilotProvider(t *testing.T) {
+	cases := map[string]string{
+		"gpt-5.5":           "openai",
+		"gpt-5.4-mini":      "openai",
+		"gpt-5.3-codex":     "openai",
+		"gpt-4.1":           "openai",
+		"o3-mini":           "openai",
+		"claude-opus-4.7":   "anthropic",
+		"claude-sonnet-4.6": "anthropic",
+		"claude-haiku-4.5":  "anthropic",
+		"gemini-3-pro":      "google",
+		"grok-code-fast-1":  "xai",
+		"auto":              "",
+		"raptor-mini":       "",
+	}
+	for id, want := range cases {
+		if got := inferCopilotProvider(id); got != want {
+			t.Errorf("inferCopilotProvider(%q) = %q, want %q", id, got, want)
+		}
 	}
 }
 

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -129,7 +129,12 @@ func TestInferCopilotProvider(t *testing.T) {
 		"gpt-5.4-mini":      "openai",
 		"gpt-5.3-codex":     "openai",
 		"gpt-4.1":           "openai",
+		"o1":                "openai",
+		"o3":                "openai",
 		"o3-mini":           "openai",
+		"o4-mini":           "openai",
+		"o5":                "openai", // future-proof: any o<digit>+
+		"o6-mini-high":      "openai",
 		"claude-opus-4.7":   "anthropic",
 		"claude-sonnet-4.6": "anthropic",
 		"claude-haiku-4.5":  "anthropic",
@@ -137,6 +142,11 @@ func TestInferCopilotProvider(t *testing.T) {
 		"grok-code-fast-1":  "xai",
 		"auto":              "",
 		"raptor-mini":       "",
+		// negative cases: must not be misidentified as OpenAI
+		// reasoning series even though they start with `o`.
+		"opus-fake":         "",
+		"omni":              "",
+		"o":                 "",
 	}
 	for id, want := range cases {
 		if got := inferCopilotProvider(id); got != want {

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -96,6 +96,49 @@ func TestCodexStaticModelsExposesGPT55(t *testing.T) {
 	}
 }
 
+func TestCopilotStaticModelsExposesFullCatalog(t *testing.T) {
+	// GitHub Copilot CLI has no `models list` subcommand, so the
+	// catalog is hand-maintained from the official supported-models
+	// docs. Regression guard for multica-ai/multica#1948 — the
+	// dropdown previously shipped only 2 models and used dashed IDs
+	// (`claude-sonnet-4-6`) which the CLI rejects. IDs must use the
+	// dotted form (`claude-sonnet-4.6`) that `copilot --model <id>`
+	// actually accepts, and cover both OpenAI and Anthropic families.
+	models := copilotStaticModels()
+	ids := map[string]Model{}
+	for _, m := range models {
+		ids[m.ID] = m
+	}
+	for _, want := range []string{
+		"gpt-5.5", "gpt-5.4", "gpt-5.4-mini",
+		"gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.2",
+		"gpt-5-mini", "gpt-4.1",
+		"claude-opus-4.7", "claude-sonnet-4.6",
+		"claude-sonnet-4.5", "claude-haiku-4.5",
+	} {
+		if _, ok := ids[want]; !ok {
+			t.Errorf("missing expected Copilot model %q in: %+v", want, models)
+		}
+	}
+	// Dashed legacy IDs must not reappear — `copilot --model
+	// claude-sonnet-4-6` errors with "Model ... is not available".
+	for _, banned := range []string{"claude-sonnet-4-6", "claude-sonnet-4-5"} {
+		if _, ok := ids[banned]; ok {
+			t.Errorf("Copilot catalog must not use dashed model id %q; use dotted form", banned)
+		}
+	}
+	for _, m := range models {
+		switch m.Provider {
+		case "openai", "anthropic":
+		default:
+			t.Errorf("Copilot entry %q has unexpected Provider %q", m.ID, m.Provider)
+		}
+		if m.Default {
+			t.Errorf("Copilot entries should not set Default; account routing decides. got %+v", m)
+		}
+	}
+}
+
 func TestListModelsHermesWithoutBinary(t *testing.T) {
 	// With no `hermes` binary on PATH the discovery fast-paths to
 	// an empty list (the UI then falls back to creatable manual


### PR DESCRIPTION
## Why

The Copilot runtime dropdown only listed **2 models**, and one of them (`claude-sonnet-4-6`, dashed) is rejected by the CLI with `Model "claude-sonnet-4-6" from --model flag is not available`. The official IDs are dotted (e.g. `claude-sonnet-4.6`, `gpt-5.4`), and the real catalog the user's GitHub account can route to has ~12 entries.

Repro:
```
$ copilot --model claude-sonnet-4-6 -p "hi" --allow-all-tools
Error: Model "claude-sonnet-4-6" from --model flag is not available.
$ copilot --model claude-sonnet-4.6 -p "hi" --allow-all-tools
✓ works
```

## What

- `copilotStaticModels()` now ships the full hand-maintained catalog from [docs.github.com/en/copilot/reference/ai-models/supported-models](https://docs.github.com/en/copilot/reference/ai-models/supported-models): 8 OpenAI (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5-mini`, `gpt-4.1`) + 4 Anthropic (`claude-opus-4.7`, `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-haiku-4.5`).
- All IDs use the dotted form `--model` actually accepts.
- No `Default` set — Copilot routes per the user's account/plan, and pinning one would override that.
- Added `TestCopilotStaticModelsExposesFullCatalog` to pin expected IDs, ban the dashed legacy form, and assert the no-default invariant.

## Test

- `go test ./pkg/agent/...` ✅
- `go build ./...` ✅
- Smoke-tested `copilot --model gpt-5.4 -p "..."` end-to-end.

Closes MUL-1948.