### PR TITLE
feat(issues): inline status & assignee pickers on sub-issue rows

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -139,11 +139,26 @@ export function useUpdateIssue() {
 
       // Resolve parent_issue_id from the freshest source so we can keep the
       // parent's children cache in sync (used by the parent issue's
-      // sub-issues list).
-      const parentId =
+      // sub-issues list). Falls back to scanning loaded children caches —
+      // when the user navigates straight to a parent's detail page, the
+      // child may live only there, not in detail/list.
+      let parentId: string | null =
         prevDetail?.parent_issue_id ??
         (prevList ? findIssueLocation(prevList, id)?.issue.parent_issue_id : null) ??
         null;
+      if (!parentId) {
+        const childrenCaches = qc.getQueriesData<Issue[]>({
+          queryKey: [...issueKeys.all(wsId), "children"],
+        });
+        for (const [key, data] of childrenCaches) {
+          if (!data?.some((c) => c.id === id)) continue;
+          const candidate = key[key.length - 1];
+          if (typeof candidate === "string") {
+            parentId = candidate;
+            break;
+          }
+        }
+      }
       const prevChildren = parentId
         ? qc.getQueryData<Issue[]>(issueKeys.children(wsId, parentId))
         : undefined;

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -259,13 +259,46 @@ export function useBatchUpdateIssues() {
         for (const id of ids) next = patchIssueInBuckets(next, id, updates);
         return next;
       });
-      return { prevList };
+
+      // Mirror the optimistic patch into any loaded children cache so
+      // sub-issue rows on a parent's detail page reflect the change too.
+      const idSet = new Set(ids);
+      const childrenCaches = qc.getQueriesData<Issue[]>({
+        queryKey: [...issueKeys.all(wsId), "children"],
+      });
+      const prevChildren = new Map<string, Issue[] | undefined>();
+      const affectedParentIds = new Set<string>();
+      for (const [key, data] of childrenCaches) {
+        if (!data?.some((c) => idSet.has(c.id))) continue;
+        const parentId = key[key.length - 1];
+        if (typeof parentId !== "string") continue;
+        affectedParentIds.add(parentId);
+        prevChildren.set(parentId, data);
+        qc.setQueryData<Issue[]>(issueKeys.children(wsId, parentId), (old) =>
+          old?.map((c) => (idSet.has(c.id) ? { ...c, ...updates } : c)),
+        );
+      }
+
+      return { prevList, prevChildren, affectedParentIds };
     },
     onError: (_err, _vars, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
+      if (ctx?.prevChildren) {
+        for (const [parentId, snapshot] of ctx.prevChildren) {
+          qc.setQueryData(issueKeys.children(wsId, parentId), snapshot);
+        }
+      }
     },
-    onSettled: () => {
+    onSettled: (_data, _err, _vars, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
+      if (ctx?.affectedParentIds && ctx.affectedParentIds.size > 0) {
+        for (const parentId of ctx.affectedParentIds) {
+          qc.invalidateQueries({
+            queryKey: issueKeys.children(wsId, parentId),
+          });
+        }
+        qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+      }
     },
   });
 }
@@ -284,6 +317,17 @@ export function useBatchDeleteIssues() {
           const loc = findIssueLocation(prevList, id);
           if (loc?.issue.parent_issue_id) parentIssueIds.add(loc.issue.parent_issue_id);
         }
+      }
+      // Children cache may be the only place sub-issues live when the user
+      // operates from a parent's detail page; collect parents from there too.
+      const idSet = new Set(ids);
+      const childrenCaches = qc.getQueriesData<Issue[]>({
+        queryKey: [...issueKeys.all(wsId), "children"],
+      });
+      for (const [key, data] of childrenCaches) {
+        if (!data?.some((c) => idSet.has(c.id))) continue;
+        const parentId = key[key.length - 1];
+        if (typeof parentId === "string") parentIssueIds.add(parentId);
       }
       qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) => {
         if (!old) return old;

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -319,15 +319,23 @@ export function useBatchDeleteIssues() {
         }
       }
       // Children cache may be the only place sub-issues live when the user
-      // operates from a parent's detail page; collect parents from there too.
+      // operates from a parent's detail page. Collect affected parents and
+      // optimistically filter the deleted ids out of each children cache so
+      // the row disappears immediately, mirroring the list-cache behaviour.
       const idSet = new Set(ids);
       const childrenCaches = qc.getQueriesData<Issue[]>({
         queryKey: [...issueKeys.all(wsId), "children"],
       });
+      const prevChildren = new Map<string, Issue[] | undefined>();
       for (const [key, data] of childrenCaches) {
         if (!data?.some((c) => idSet.has(c.id))) continue;
         const parentId = key[key.length - 1];
-        if (typeof parentId === "string") parentIssueIds.add(parentId);
+        if (typeof parentId !== "string") continue;
+        parentIssueIds.add(parentId);
+        prevChildren.set(parentId, data);
+        qc.setQueryData<Issue[]>(issueKeys.children(wsId, parentId), (old) =>
+          old?.filter((c) => !idSet.has(c.id)),
+        );
       }
       qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) => {
         if (!old) return old;
@@ -335,10 +343,15 @@ export function useBatchDeleteIssues() {
         for (const id of ids) next = removeIssueFromBuckets(next, id);
         return next;
       });
-      return { prevList, parentIssueIds };
+      return { prevList, prevChildren, parentIssueIds };
     },
     onError: (_err, _ids, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
+      if (ctx?.prevChildren) {
+        for (const [parentId, snapshot] of ctx.prevChildren) {
+          qc.setQueryData(issueKeys.children(wsId, parentId), snapshot);
+        }
+      }
     },
     onSettled: (_data, _err, _ids, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });

--- a/packages/views/issues/components/batch-action-toolbar.tsx
+++ b/packages/views/issues/components/batch-action-toolbar.tsx
@@ -19,8 +19,19 @@ import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-st
 import { useBatchUpdateIssues, useBatchDeleteIssues } from "@multica/core/issues/mutations";
 import { StatusPicker, PriorityPicker, AssigneePicker } from "./pickers";
 import { useT } from "../../i18n";
+import { cn } from "@multica/ui/lib/utils";
 
-export function BatchActionToolbar() {
+export function BatchActionToolbar({
+  placement = "fixed-bottom",
+}: {
+  /**
+   * "fixed-bottom" — floats at the bottom of the viewport (default; used by
+   * full-screen issue lists).
+   * "inline" — renders in normal flow so callers can place it adjacent to
+   * the selected rows (used inside scrollable sections like sub-issues).
+   */
+  placement?: "fixed-bottom" | "inline";
+}) {
   const { t } = useT("issues");
   const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
   const clear = useIssueSelectionStore((s) => s.clear);
@@ -61,7 +72,14 @@ export function BatchActionToolbar() {
 
   return (
     <>
-      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg">
+      <div
+        className={cn(
+          "z-50 flex items-center gap-1 rounded-lg border bg-background px-2 py-1.5 shadow-lg",
+          placement === "fixed-bottom"
+            ? "fixed bottom-6 left-1/2 -translate-x-1/2"
+            : "mb-2 w-fit",
+        )}
+      >
         <div className="flex items-center gap-1.5 pl-1 pr-2 border-r mr-1">
           <span className="text-sm font-medium">{t(($) => $.batch.selected, { count })}</span>
           <button

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -213,11 +213,16 @@ function SubIssueRow({ child }: { child: Issue }) {
     [child.id, updateIssue, t],
   );
 
-  // The row is wrapped in AppLink for navigation. Stop propagation on the
-  // pickers / checkbox so clicking them does not navigate.
-  const stopPropagation = (e: React.SyntheticEvent) => {
+  // The row is wrapped in AppLink for navigation. The picker triggers need
+  // both stopPropagation and preventDefault to suppress the link's default
+  // navigation; the checkbox only needs stopPropagation (preventDefault would
+  // also block the native checkbox toggle on some browsers).
+  const stopPickerNav = (e: React.SyntheticEvent) => {
     e.stopPropagation();
     e.preventDefault();
+  };
+  const stopCheckboxNav = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
   };
 
   return (
@@ -229,12 +234,14 @@ function SubIssueRow({ child }: { child: Issue }) {
       )}
     >
       <div
-        onClick={stopPropagation}
-        onMouseDown={stopPropagation}
-        onPointerDown={stopPropagation}
+        onClick={stopCheckboxNav}
+        onMouseDown={stopCheckboxNav}
+        onPointerDown={stopCheckboxNav}
         className={cn(
           "flex h-4 w-4 shrink-0 items-center justify-center transition-opacity",
-          selected ? "opacity-100" : "opacity-0 group-hover/row:opacity-100",
+          selected
+            ? "opacity-100"
+            : "opacity-0 group-hover/row:opacity-100 focus-within:opacity-100",
         )}
       >
         <input
@@ -246,9 +253,9 @@ function SubIssueRow({ child }: { child: Issue }) {
         />
       </div>
       <div
-        onClick={stopPropagation}
-        onMouseDown={stopPropagation}
-        onPointerDown={stopPropagation}
+        onClick={stopPickerNav}
+        onMouseDown={stopPickerNav}
+        onPointerDown={stopPickerNav}
         className="flex shrink-0"
       >
         <StatusPicker
@@ -277,9 +284,9 @@ function SubIssueRow({ child }: { child: Issue }) {
         {child.title}
       </span>
       <div
-        onClick={stopPropagation}
-        onMouseDown={stopPropagation}
-        onPointerDown={stopPropagation}
+        onClick={stopPickerNav}
+        onMouseDown={stopPickerNav}
+        onPointerDown={stopPickerNav}
         className="flex shrink-0"
       >
         <AssigneePicker

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -190,7 +190,7 @@ function TimelineSkeleton() {
 }
 
 // ---------------------------------------------------------------------------
-// SubIssueRow — sub-issue list item with inline status editing
+// SubIssueRow — sub-issue list item with inline status & assignee editing
 // ---------------------------------------------------------------------------
 
 function SubIssueRow({ child }: { child: Issue }) {
@@ -210,7 +210,7 @@ function SubIssueRow({ child }: { child: Issue }) {
   );
 
   // The row is wrapped in AppLink for navigation. Stop propagation on the
-  // status picker so clicking the icon opens the popover instead of navigating.
+  // pickers so clicking them opens the popover instead of navigating.
   const stopPropagation = (e: React.SyntheticEvent) => {
     e.stopPropagation();
     e.preventDefault();
@@ -252,20 +252,34 @@ function SubIssueRow({ child }: { child: Issue }) {
       >
         {child.title}
       </span>
-      {child.assignee_type && child.assignee_id ? (
-        <ActorAvatar
-          actorType={child.assignee_type}
-          actorId={child.assignee_id}
-          size={20}
-          className="shrink-0"
-          enableHoverCard
+      <div
+        onClick={stopPropagation}
+        onMouseDown={stopPropagation}
+        onPointerDown={stopPropagation}
+        className="flex shrink-0"
+      >
+        <AssigneePicker
+          assigneeType={child.assignee_type}
+          assigneeId={child.assignee_id}
+          onUpdate={handleUpdate}
+          align="end"
+          trigger={
+            child.assignee_type && child.assignee_id ? (
+              <ActorAvatar
+                actorType={child.assignee_type}
+                actorId={child.assignee_id}
+                size={20}
+                className="shrink-0"
+              />
+            ) : (
+              <span
+                aria-hidden
+                className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
+              />
+            )
+          }
         />
-      ) : (
-        <span
-          aria-hidden
-          className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
-        />
-      )}
+      </div>
     </AppLink>
   );
 }

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -58,6 +58,8 @@ import { useWorkspaceId } from "@multica/core/hooks";
 import { issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions } from "@multica/core/issues/queries";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import { useRecentIssuesStore } from "@multica/core/issues/stores";
+import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
+import { BatchActionToolbar } from "./batch-action-toolbar";
 import { useIssueTimeline } from "../hooks/use-issue-timeline";
 import { useIssueReactions } from "../hooks/use-issue-reactions";
 import { useIssueSubscribers } from "../hooks/use-issue-subscribers";
@@ -197,6 +199,8 @@ function SubIssueRow({ child }: { child: Issue }) {
   const { t } = useT("issues");
   const paths = useWorkspacePaths();
   const updateIssue = useUpdateIssue();
+  const selected = useIssueSelectionStore((s) => s.selectedIds.has(child.id));
+  const toggleSelected = useIssueSelectionStore((s) => s.toggle);
   const isDone = child.status === "done" || child.status === "cancelled";
 
   const handleUpdate = useCallback(
@@ -210,7 +214,7 @@ function SubIssueRow({ child }: { child: Issue }) {
   );
 
   // The row is wrapped in AppLink for navigation. Stop propagation on the
-  // pickers so clicking them opens the popover instead of navigating.
+  // pickers / checkbox so clicking them does not navigate.
   const stopPropagation = (e: React.SyntheticEvent) => {
     e.stopPropagation();
     e.preventDefault();
@@ -219,8 +223,28 @@ function SubIssueRow({ child }: { child: Issue }) {
   return (
     <AppLink
       href={paths.issueDetail(child.id)}
-      className="flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors group/row"
+      className={cn(
+        "flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors group/row",
+        selected && "bg-accent/30",
+      )}
     >
+      <div
+        onClick={stopPropagation}
+        onMouseDown={stopPropagation}
+        onPointerDown={stopPropagation}
+        className={cn(
+          "flex h-4 w-4 shrink-0 items-center justify-center transition-opacity",
+          selected ? "opacity-100" : "opacity-0 group-hover/row:opacity-100",
+        )}
+      >
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={() => toggleSelected(child.id)}
+          aria-label={`Select ${child.identifier}`}
+          className="cursor-pointer accent-primary"
+        />
+      </div>
       <div
         onClick={stopPropagation}
         onMouseDown={stopPropagation}
@@ -546,6 +570,30 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   });
   const [subIssuesCollapsed, setSubIssuesCollapsed] = useState(false);
 
+  // Selection store is global (workspace-scoped); clear it whenever this
+  // issue detail is mounted or switched, so leftover selections from the
+  // main list view (or another sub-issue list) don't leak into this one.
+  const clearSelection = useIssueSelectionStore((s) => s.clear);
+  const selectedIds = useIssueSelectionStore((s) => s.selectedIds);
+  const selectIds = useIssueSelectionStore((s) => s.select);
+  const deselectIds = useIssueSelectionStore((s) => s.deselect);
+  useEffect(() => {
+    clearSelection();
+    return clearSelection;
+  }, [id, clearSelection]);
+
+  const childIssueIds = useMemo(() => childIssues.map((c) => c.id), [childIssues]);
+  const childSelectedCount = childIssueIds.filter((cid) =>
+    selectedIds.has(cid),
+  ).length;
+  const allChildrenSelected =
+    childIssueIds.length > 0 && childSelectedCount === childIssueIds.length;
+  const someChildrenSelected = childSelectedCount > 0;
+  const handleToggleSelectAllChildren = useCallback(() => {
+    if (allChildrenSelected) deselectIds(childIssueIds);
+    else selectIds(childIssueIds);
+  }, [allChildrenSelected, childIssueIds, deselectIds, selectIds]);
+
   const loading = issueLoading;
 
   // Scroll to highlighted comment once timeline loads (fire only once per highlightCommentId)
@@ -778,6 +826,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
 
   const detailContent = (
     <div className="flex h-full min-w-0 flex-1 flex-col">
+        <BatchActionToolbar />
         <PageHeader className="gap-2 bg-background text-sm">
           <div className="flex flex-1 items-center gap-1.5 min-w-0">
             {workspace && (
@@ -971,7 +1020,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
           {childIssues.length > 0 && (() => {
             const doneCount = childIssues.filter((c) => c.status === "done").length;
             return (
-              <div className="mt-10">
+              <div className="mt-10 group/sub-issues">
                 {/* Header */}
                 <div className="flex items-center gap-2 mb-2">
                   <button
@@ -993,6 +1042,21 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       {doneCount}/{childIssues.length}
                     </span>
                   </div>
+                  <input
+                    type="checkbox"
+                    checked={allChildrenSelected}
+                    ref={(el) => {
+                      if (el) el.indeterminate = someChildrenSelected && !allChildrenSelected;
+                    }}
+                    onChange={handleToggleSelectAllChildren}
+                    aria-label="Select all sub-issues"
+                    className={cn(
+                      "ml-1 cursor-pointer accent-primary transition-opacity",
+                      someChildrenSelected
+                        ? "opacity-100"
+                        : "opacity-0 group-hover/sub-issues:opacity-100 focus-visible:opacity-100",
+                    )}
+                  />
                   <Tooltip>
                     <TooltipTrigger
                       render={

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -37,8 +37,10 @@ import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, Command
 import { AvatarGroup, AvatarGroupCount } from "@multica/ui/components/ui/avatar";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { PropRow } from "../../common/prop-row";
-import type { IssueStatus, IssuePriority, TimelineEntry } from "@multica/core/types";
+import type { Issue, IssueStatus, IssuePriority, TimelineEntry, UpdateIssueRequest } from "@multica/core/types";
 import { STATUS_CONFIG, PRIORITY_CONFIG } from "@multica/core/issues/config";
+import { useUpdateIssue } from "@multica/core/issues/mutations";
+import { toast } from "sonner";
 import { StatusIcon, PriorityIcon, StatusPicker, PriorityPicker, DueDatePicker, AssigneePicker, LabelPicker } from ".";
 import { IssueActionsDropdown, useIssueActions } from "../actions";
 import { ProjectPicker } from "../../projects/components/project-picker";
@@ -184,6 +186,87 @@ function TimelineSkeleton() {
         </div>
       ))}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SubIssueRow — sub-issue list item with inline status editing
+// ---------------------------------------------------------------------------
+
+function SubIssueRow({ child }: { child: Issue }) {
+  const { t } = useT("issues");
+  const paths = useWorkspacePaths();
+  const updateIssue = useUpdateIssue();
+  const isDone = child.status === "done" || child.status === "cancelled";
+
+  const handleUpdate = useCallback(
+    (updates: Partial<UpdateIssueRequest>) => {
+      updateIssue.mutate(
+        { id: child.id, ...updates },
+        { onError: () => toast.error(t(($) => $.detail.update_failed)) },
+      );
+    },
+    [child.id, updateIssue, t],
+  );
+
+  // The row is wrapped in AppLink for navigation. Stop propagation on the
+  // status picker so clicking the icon opens the popover instead of navigating.
+  const stopPropagation = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  };
+
+  return (
+    <AppLink
+      href={paths.issueDetail(child.id)}
+      className="flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors group/row"
+    >
+      <div
+        onClick={stopPropagation}
+        onMouseDown={stopPropagation}
+        onPointerDown={stopPropagation}
+        className="flex shrink-0"
+      >
+        <StatusPicker
+          status={child.status}
+          onUpdate={handleUpdate}
+          align="start"
+          trigger={
+            <StatusIcon
+              status={child.status}
+              className="h-[15px] w-[15px] shrink-0"
+            />
+          }
+        />
+      </div>
+      <span className="text-[11px] text-muted-foreground tabular-nums font-medium shrink-0">
+        {child.identifier}
+      </span>
+      <span
+        className={cn(
+          "text-sm truncate flex-1",
+          isDone
+            ? "text-muted-foreground"
+            : "group-hover/row:text-foreground",
+        )}
+      >
+        {child.title}
+      </span>
+      {child.assignee_type && child.assignee_id ? (
+        <ActorAvatar
+          actorType={child.assignee_type}
+          actorId={child.assignee_id}
+          size={20}
+          className="shrink-0"
+          enableHoverCard
+        />
+      ) : (
+        <span
+          aria-hidden
+          className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
+        />
+      )}
+    </AppLink>
   );
 }
 
@@ -916,49 +999,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 {/* List */}
                 {!subIssuesCollapsed && (
                   <div className="overflow-hidden rounded-lg border bg-card/30 divide-y divide-border/60">
-                    {childIssues.map((child) => {
-                      const isDone =
-                        child.status === "done" || child.status === "cancelled";
-                      return (
-                        <AppLink
-                          key={child.id}
-                          href={paths.issueDetail(child.id)}
-                          className="flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors group/row"
-                        >
-                          <StatusIcon
-                            status={child.status}
-                            className="h-[15px] w-[15px] shrink-0"
-                          />
-                          <span className="text-[11px] text-muted-foreground tabular-nums font-medium shrink-0">
-                            {child.identifier}
-                          </span>
-                          <span
-                            className={cn(
-                              "text-sm truncate flex-1",
-                              isDone
-                                ? "text-muted-foreground"
-                                : "group-hover/row:text-foreground",
-                            )}
-                          >
-                            {child.title}
-                          </span>
-                          {child.assignee_type && child.assignee_id ? (
-                            <ActorAvatar
-                              actorType={child.assignee_type}
-                              actorId={child.assignee_id}
-                              size={20}
-                              className="shrink-0"
-                              enableHoverCard
-                            />
-                          ) : (
-                            <span
-                              aria-hidden
-                              className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
-                            />
-                          )}
-                        </AppLink>
-                      );
-                    })}
+                    {childIssues.map((child) => (
+                      <SubIssueRow key={child.id} child={child} />
+                    ))}
                   </div>
                 )}
               </div>

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -213,30 +213,17 @@ function SubIssueRow({ child }: { child: Issue }) {
     [child.id, updateIssue, t],
   );
 
-  // The row is wrapped in AppLink for navigation. The picker triggers need
-  // both stopPropagation and preventDefault to suppress the link's default
-  // navigation; the checkbox only needs stopPropagation (preventDefault would
-  // also block the native checkbox toggle on some browsers).
-  const stopPickerNav = (e: React.SyntheticEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-  };
-  const stopCheckboxNav = (e: React.SyntheticEvent) => {
-    e.stopPropagation();
-  };
-
+  // AppLink wraps only the title/identifier area. Pickers and checkbox are
+  // siblings, so their clicks never navigate — no stopPropagation acrobatics
+  // and no risk of the native checkbox / picker triggers being blocked.
   return (
-    <AppLink
-      href={paths.issueDetail(child.id)}
+    <div
       className={cn(
         "flex items-center gap-2.5 px-3 py-2 hover:bg-accent/50 transition-colors group/row",
         selected && "bg-accent/30",
       )}
     >
       <div
-        onClick={stopCheckboxNav}
-        onMouseDown={stopCheckboxNav}
-        onPointerDown={stopCheckboxNav}
         className={cn(
           "flex h-4 w-4 shrink-0 items-center justify-center transition-opacity",
           selected
@@ -252,66 +239,57 @@ function SubIssueRow({ child }: { child: Issue }) {
           className="cursor-pointer accent-primary"
         />
       </div>
-      <div
-        onClick={stopPickerNav}
-        onMouseDown={stopPickerNav}
-        onPointerDown={stopPickerNav}
-        className="flex shrink-0"
+      <StatusPicker
+        status={child.status}
+        onUpdate={handleUpdate}
+        align="start"
+        trigger={
+          <StatusIcon
+            status={child.status}
+            className="h-[15px] w-[15px] shrink-0"
+          />
+        }
+      />
+      <AppLink
+        href={paths.issueDetail(child.id)}
+        className="flex min-w-0 flex-1 items-center gap-2.5"
       >
-        <StatusPicker
-          status={child.status}
-          onUpdate={handleUpdate}
-          align="start"
-          trigger={
-            <StatusIcon
-              status={child.status}
-              className="h-[15px] w-[15px] shrink-0"
+        <span className="text-[11px] text-muted-foreground tabular-nums font-medium shrink-0">
+          {child.identifier}
+        </span>
+        <span
+          className={cn(
+            "text-sm truncate flex-1",
+            isDone
+              ? "text-muted-foreground"
+              : "group-hover/row:text-foreground",
+          )}
+        >
+          {child.title}
+        </span>
+      </AppLink>
+      <AssigneePicker
+        assigneeType={child.assignee_type}
+        assigneeId={child.assignee_id}
+        onUpdate={handleUpdate}
+        align="end"
+        trigger={
+          child.assignee_type && child.assignee_id ? (
+            <ActorAvatar
+              actorType={child.assignee_type}
+              actorId={child.assignee_id}
+              size={20}
+              className="shrink-0"
             />
-          }
-        />
-      </div>
-      <span className="text-[11px] text-muted-foreground tabular-nums font-medium shrink-0">
-        {child.identifier}
-      </span>
-      <span
-        className={cn(
-          "text-sm truncate flex-1",
-          isDone
-            ? "text-muted-foreground"
-            : "group-hover/row:text-foreground",
-        )}
-      >
-        {child.title}
-      </span>
-      <div
-        onClick={stopPickerNav}
-        onMouseDown={stopPickerNav}
-        onPointerDown={stopPickerNav}
-        className="flex shrink-0"
-      >
-        <AssigneePicker
-          assigneeType={child.assignee_type}
-          assigneeId={child.assignee_id}
-          onUpdate={handleUpdate}
-          align="end"
-          trigger={
-            child.assignee_type && child.assignee_id ? (
-              <ActorAvatar
-                actorType={child.assignee_type}
-                actorId={child.assignee_id}
-                size={20}
-                className="shrink-0"
-              />
-            ) : (
-              <span
-                aria-hidden
-                className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
-              />
-            )
-          }
-        />
-      </div>
-    </AppLink>
+          ) : (
+            <span
+              aria-hidden
+              className="h-5 w-5 rounded-full border border-dashed border-muted-foreground/30 shrink-0"
+            />
+          )
+        }
+      />
+    </div>
   );
 }
 
@@ -833,7 +811,6 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
 
   const detailContent = (
     <div className="flex h-full min-w-0 flex-1 flex-col">
-        <BatchActionToolbar />
         <PageHeader className="gap-2 bg-background text-sm">
           <div className="flex flex-1 items-center gap-1.5 min-w-0">
             {workspace && (
@@ -1080,6 +1057,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                     <TooltipContent side="bottom">{t(($) => $.detail.add_sub_issue_tooltip)}</TooltipContent>
                   </Tooltip>
                 </div>
+
+                {/* Inline batch toolbar — appears next to the rows when
+                    selections exist, instead of as a far-away fixed bar. */}
+                <BatchActionToolbar placement="inline" />
 
                 {/* List */}
                 {!subIssuesCollapsed && (


### PR DESCRIPTION
## Summary
- Sub-issue rows in the parent issue's detail page now expose inline `StatusPicker` and `AssigneePicker` on their respective slots (status icon, assignee avatar/placeholder).
- Clicks on the pickers `stopPropagation` so the row's `AppLink` does not navigate.
- Reuses existing `useUpdateIssue` mutation (optimistic update + WS invalidation already wired) — no new API.

Refs MUL-2005.

## Test plan
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx` (11/11)
- [ ] Manual: open a parent issue with children, click the status icon on a sub-issue row → status popover opens, switching status updates the row inline without navigation.
- [ ] Manual: click the assignee avatar (or dashed placeholder) on a sub-issue row → assignee popover opens; selecting/clearing an assignee updates the row inline.