### PR TITLE
feat(claude): discover custom models from local Claude Code config

### DIFF
--- a/packages/views/agents/components/model-dropdown.tsx
+++ b/packages/views/agents/components/model-dropdown.tsx
@@ -152,6 +152,11 @@ export function ModelDropdown({
               onChange={(e) => setSearch(e.target.value)}
               className="h-8"
             />
+            {!search.trim() && (
+              <p className="mt-1 px-1 text-[11px] text-muted-foreground">
+                {t(($) => $.pickers.model_custom_hint)}
+              </p>
+            )}
           </div>
           <div className="max-h-72 overflow-y-auto p-1">
             {modelsQuery.isLoading && (

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -163,6 +163,7 @@
     "model_tooltip": "Model · {{value}}",
     "model_managed_by_runtime": "Managed by runtime",
     "model_search_placeholder": "Search or type a model ID",
+    "model_custom_hint": "Type any model ID supported by your runtime",
     "model_discovering": "Discovering models…",
     "model_default_badge": "default",
     "model_empty": "No models available",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -159,6 +159,7 @@
     "model_tooltip": "模型 · {{value}}",
     "model_managed_by_runtime": "由运行时管理",
     "model_search_placeholder": "搜索或输入模型 ID",
+    "model_custom_hint": "输入运行时支持的任意模型 ID",
     "model_discovering": "正在发现模型...",
     "model_default_badge": "默认",
     "model_empty": "暂无可用模型",

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -56,7 +57,9 @@ const modelCacheTTL = 60 * time.Second
 func ListModels(ctx context.Context, providerType, executablePath string) ([]Model, error) {
 	switch providerType {
 	case "claude":
-		return claudeStaticModels(), nil
+		return cachedDiscovery(providerType, func() ([]Model, error) {
+			return discoverClaudeModels(), nil
+		})
 	case "codex":
 		return codexStaticModels(), nil
 	case "gemini":
@@ -146,6 +149,94 @@ func claudeStaticModels() []Model {
 		{ID: "claude-opus-4-6", Label: "Claude Opus 4.6", Provider: "anthropic"},
 		{ID: "claude-sonnet-4-5", Label: "Claude Sonnet 4.5", Provider: "anthropic"},
 	}
+}
+
+// discoverClaudeModels returns the static catalog augmented with any
+// custom model IDs found in the user's local Claude Code configuration
+// (~/.claude/settings.json). This lets operators who run non-Anthropic
+// models behind a proxy (e.g. mimo, GLM) see their models in the
+// Multica picker without manual entry.
+//
+// Discovery reads two sources:
+//   - env vars ANTHROPIC_MODEL / ANTHROPIC_DEFAULT_*_MODEL
+//   - top-level "model" field (skipped when it's a well-known alias)
+//
+// The static catalog is always included so official models remain
+// available even when the config file is absent.
+func discoverClaudeModels() []Model {
+	static := claudeStaticModels()
+	extra := readClaudeSettingsModels()
+	if len(extra) == 0 {
+		return static
+	}
+	seen := map[string]bool{}
+	for _, m := range static {
+		seen[m.ID] = true
+	}
+	for _, id := range extra {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		static = append(static, Model{ID: id, Label: id, Provider: "anthropic"})
+	}
+	return static
+}
+
+// claudeModelAliases are short names that the Claude CLI resolves
+// internally. We skip them when reading the top-level "model" field
+// from settings.json because they don't match any real model ID.
+var claudeModelAliases = map[string]bool{
+	"opus": true, "sonnet": true, "haiku": true,
+	"opus-4": true, "sonnet-4": true, "haiku-4": true,
+}
+
+// readClaudeSettingsModels reads ~/.claude/settings.json and extracts
+// model IDs from env vars (ANTHROPIC_MODEL, ANTHROPIC_DEFAULT_*_MODEL)
+// and the top-level "model" field.
+func readClaudeSettingsModels() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		return nil
+	}
+	var cfg struct {
+		Model string            `json:"model"`
+		Env   map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var result []string
+	add := func(id string) {
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		result = append(result, id)
+	}
+	if cfg.Env != nil {
+		if v := cfg.Env["ANTHROPIC_MODEL"]; v != "" {
+			add(v)
+		}
+		for _, key := range []string{
+			"ANTHROPIC_DEFAULT_SONNET_MODEL",
+			"ANTHROPIC_DEFAULT_OPUS_MODEL",
+			"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		} {
+			if v := cfg.Env[key]; v != "" {
+				add(v)
+			}
+		}
+	}
+	if cfg.Model != "" && !claudeModelAliases[cfg.Model] {
+		add(cfg.Model)
+	}
+	return result
 }
 
 func codexStaticModels() []Model {


### PR DESCRIPTION
## Summary

- Claude provider now reads `~/.claude/settings.json` to discover custom model IDs configured via `ANTHROPIC_MODEL` / `ANTHROPIC_DEFAULT_*_MODEL` env vars
- Discovered models are appended to the static catalog (official Anthropic models remain available)
- Adds a hint below the model search input to make custom model entry more discoverable
- i18n strings added for en and zh-Hans

## Motivation

Users running non-Anthropic models behind a proxy (e.g. mimo, GLM) configure their Claude Code CLI via `~/.claude/settings.json` env vars. Previously, the Multica model picker only showed the 5 hardcoded Anthropic models, requiring users to discover the hidden "type a custom model ID" feature. This change automatically surfaces configured models in the picker.

## Changes

### Backend (`server/pkg/agent/models.go`)
- Changed `claude` case in `ListModels()` from static-only to cached dynamic discovery
- Added `discoverClaudeModels()` — merges static catalog with models from settings.json
- Added `readClaudeSettingsModels()` — reads `~/.claude/settings.json` env vars
- Skips well-known aliases (`opus`, `sonnet`, `haiku`) that aren't real model IDs

### Frontend (`packages/views/agents/components/model-dropdown.tsx`)
- Added hint text below search input: "Type any model ID supported by your runtime"

### i18n
- `en/agents.json`: added `pickers.model_custom_hint`
- `zh-Hans/agents.json`: added `pickers.model_custom_hint`

## Test plan
- [x] `go test ./server/pkg/agent/ -run TestListModels` passes
- [ ] Verify model picker shows custom models from `~/.claude/settings.json` env vars
- [ ] Verify hint text appears below search input in model dropdown
- [ ] Verify custom model entry still works (type and select)

🤖 Generated with [Claude Code](https://claude.ai/code)