### PR TITLE
fix(daemon): suppress git console windows on Windows

### DIFF
--- a/server/cmd/multica/cmd_daemon.go
+++ b/server/cmd/multica/cmd_daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon"
 	logger_pkg "github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/util"
 )
 
 var daemonCmd = &cobra.Command{
@@ -301,6 +302,8 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 }
 
 func runDaemonForeground(cmd *cobra.Command) error {
+	util.EnsureHiddenConsole()
+
 	profile := resolveProfile(cmd)
 
 	serverURL := cli.FlagOrEnv(cmd, "server-url", "MULTICA_SERVER_URL", "")

--- a/server/internal/daemon/execenv/git.go
+++ b/server/internal/daemon/execenv/git.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/multica-ai/multica/server/internal/util"
 )
 
 // detectGitRepo checks if dir is inside a git repository (regular or bare).
@@ -18,14 +17,14 @@ import (
 func detectGitRepo(dir string) (string, bool) {
 	// Try regular repo first.
 	cmd := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.Output(); err == nil {
 		return strings.TrimSpace(string(out)), true
 	}
 
 	// Try bare repo: git-dir is "." for bare repos when -C points at the repo.
 	cmd = exec.Command("git", "-C", dir, "rev-parse", "--is-bare-repository")
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.Output(); err == nil && strings.TrimSpace(string(out)) == "true" {
 		return dir, true
 	}
@@ -36,7 +35,7 @@ func detectGitRepo(dir string) (string, bool) {
 // fetchOrigin runs `git fetch origin` to ensure the local repo has the latest remote refs.
 func fetchOrigin(gitRoot string) error {
 	cmd := exec.Command("git", "-C", gitRoot, "fetch", "origin")
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git fetch origin: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -48,7 +47,7 @@ func fetchOrigin(gitRoot string) error {
 func getRemoteDefaultBranch(gitRoot string) string {
 	// Try symbolic-ref of origin/HEAD (set by `git clone` or `git remote set-head`).
 	cmd := exec.Command("git", "-C", gitRoot, "symbolic-ref", "refs/remotes/origin/HEAD")
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.Output(); err == nil {
 		ref := strings.TrimSpace(string(out))
 		// ref looks like "refs/remotes/origin/main" — return "origin/main".
@@ -60,14 +59,14 @@ func getRemoteDefaultBranch(gitRoot string) string {
 
 	// Fallback: check if origin/main exists.
 	cmd = exec.Command("git", "-C", gitRoot, "rev-parse", "--verify", "origin/main")
-	util.HideConsoleWindow(cmd)
+
 	if err := cmd.Run(); err == nil {
 		return "origin/main"
 	}
 
 	// Fallback: check if origin/master exists.
 	cmd = exec.Command("git", "-C", gitRoot, "rev-parse", "--verify", "origin/master")
-	util.HideConsoleWindow(cmd)
+
 	if err := cmd.Run(); err == nil {
 		return "origin/master"
 	}
@@ -93,7 +92,7 @@ func setupGitWorktree(gitRoot, worktreePath, branchName, baseRef string) error {
 
 func runGitWorktreeAdd(gitRoot, worktreePath, branchName, baseRef string) error {
 	cmd := exec.Command("git", "-C", gitRoot, "worktree", "add", "-b", branchName, worktreePath, baseRef)
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree add: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -104,7 +103,7 @@ func runGitWorktreeAdd(gitRoot, worktreePath, branchName, baseRef string) error 
 func removeGitWorktree(gitRoot, worktreePath, branchName string, logger *slog.Logger) {
 	// Remove the worktree.
 	cmd := exec.Command("git", "-C", gitRoot, "worktree", "remove", "--force", worktreePath)
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.CombinedOutput(); err != nil {
 		logger.Warn("execenv: git worktree remove failed", "output", strings.TrimSpace(string(out)), "error", err)
 	}
@@ -112,7 +111,7 @@ func removeGitWorktree(gitRoot, worktreePath, branchName string, logger *slog.Lo
 	// Delete the branch (best-effort).
 	if branchName != "" {
 		cmd = exec.Command("git", "-C", gitRoot, "branch", "-D", branchName)
-		util.HideConsoleWindow(cmd)
+	
 		if out, err := cmd.CombinedOutput(); err != nil {
 			logger.Warn("execenv: git branch delete failed", "branch", branchName, "output", strings.TrimSpace(string(out)), "error", err)
 		}
@@ -123,7 +122,7 @@ func removeGitWorktree(gitRoot, worktreePath, branchName string, logger *slog.Lo
 func excludeFromGit(worktreePath, pattern string) error {
 	// Resolve the actual git dir for this worktree.
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-dir")
-	util.HideConsoleWindow(cmd)
+
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("resolve git dir: %w", err)

--- a/server/internal/daemon/execenv/git.go
+++ b/server/internal/daemon/execenv/git.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/util"
 )
 
 // detectGitRepo checks if dir is inside a git repository (regular or bare).
@@ -16,12 +18,14 @@ import (
 func detectGitRepo(dir string) (string, bool) {
 	// Try regular repo first.
 	cmd := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.Output(); err == nil {
 		return strings.TrimSpace(string(out)), true
 	}
 
 	// Try bare repo: git-dir is "." for bare repos when -C points at the repo.
 	cmd = exec.Command("git", "-C", dir, "rev-parse", "--is-bare-repository")
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.Output(); err == nil && strings.TrimSpace(string(out)) == "true" {
 		return dir, true
 	}
@@ -32,6 +36,7 @@ func detectGitRepo(dir string) (string, bool) {
 // fetchOrigin runs `git fetch origin` to ensure the local repo has the latest remote refs.
 func fetchOrigin(gitRoot string) error {
 	cmd := exec.Command("git", "-C", gitRoot, "fetch", "origin")
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git fetch origin: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -43,6 +48,7 @@ func fetchOrigin(gitRoot string) error {
 func getRemoteDefaultBranch(gitRoot string) string {
 	// Try symbolic-ref of origin/HEAD (set by `git clone` or `git remote set-head`).
 	cmd := exec.Command("git", "-C", gitRoot, "symbolic-ref", "refs/remotes/origin/HEAD")
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.Output(); err == nil {
 		ref := strings.TrimSpace(string(out))
 		// ref looks like "refs/remotes/origin/main" — return "origin/main".
@@ -54,12 +60,14 @@ func getRemoteDefaultBranch(gitRoot string) string {
 
 	// Fallback: check if origin/main exists.
 	cmd = exec.Command("git", "-C", gitRoot, "rev-parse", "--verify", "origin/main")
+	util.HideConsoleWindow(cmd)
 	if err := cmd.Run(); err == nil {
 		return "origin/main"
 	}
 
 	// Fallback: check if origin/master exists.
 	cmd = exec.Command("git", "-C", gitRoot, "rev-parse", "--verify", "origin/master")
+	util.HideConsoleWindow(cmd)
 	if err := cmd.Run(); err == nil {
 		return "origin/master"
 	}
@@ -85,6 +93,7 @@ func setupGitWorktree(gitRoot, worktreePath, branchName, baseRef string) error {
 
 func runGitWorktreeAdd(gitRoot, worktreePath, branchName, baseRef string) error {
 	cmd := exec.Command("git", "-C", gitRoot, "worktree", "add", "-b", branchName, worktreePath, baseRef)
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree add: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -95,6 +104,7 @@ func runGitWorktreeAdd(gitRoot, worktreePath, branchName, baseRef string) error 
 func removeGitWorktree(gitRoot, worktreePath, branchName string, logger *slog.Logger) {
 	// Remove the worktree.
 	cmd := exec.Command("git", "-C", gitRoot, "worktree", "remove", "--force", worktreePath)
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		logger.Warn("execenv: git worktree remove failed", "output", strings.TrimSpace(string(out)), "error", err)
 	}
@@ -102,6 +112,7 @@ func removeGitWorktree(gitRoot, worktreePath, branchName string, logger *slog.Lo
 	// Delete the branch (best-effort).
 	if branchName != "" {
 		cmd = exec.Command("git", "-C", gitRoot, "branch", "-D", branchName)
+		util.HideConsoleWindow(cmd)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			logger.Warn("execenv: git branch delete failed", "branch", branchName, "output", strings.TrimSpace(string(out)), "error", err)
 		}
@@ -112,6 +123,7 @@ func removeGitWorktree(gitRoot, worktreePath, branchName string, logger *slog.Lo
 func excludeFromGit(worktreePath, pattern string) error {
 	// Resolve the actual git dir for this worktree.
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-dir")
+	util.HideConsoleWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("resolve git dir: %w", err)

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
-	"github.com/multica-ai/multica/server/internal/util"
 )
 
 // gcLoop periodically scans local workspace directories and removes those
@@ -551,7 +550,7 @@ func (d *Daemon) pruneWorktree(barePath string) {
 	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "-C", barePath, "worktree", "prune")
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.CombinedOutput(); err != nil {
 		d.logger.Warn("gc: worktree prune failed",
 			"repo", barePath,

--- a/server/internal/daemon/gc.go
+++ b/server/internal/daemon/gc.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/internal/util"
 )
 
 // gcLoop periodically scans local workspace directories and removes those
@@ -550,6 +551,7 @@ func (d *Daemon) pruneWorktree(barePath string) {
 	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "-C", barePath, "worktree", "prune")
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		d.logger.Warn("gc: worktree prune failed",
 			"repo", barePath,

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/multica-ai/multica/server/internal/util"
 )
 
 // gitEnv returns an environment for git subprocesses that contact remotes.
@@ -245,7 +244,7 @@ const modernFetchRefspec = "+refs/heads/*:refs/remotes/origin/*"
 func gitCloneBare(url, dest string) error {
 	cmd := exec.Command("git", "clone", "--bare", url, dest)
 	cmd.Env = gitEnv()
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Clean up partial clone.
 		os.RemoveAll(dest)
@@ -286,7 +285,7 @@ func gitFetch(barePath string) error {
 	// on this call.
 	cmd := exec.Command("git", "-C", barePath, "remote", "set-head", "origin", "--auto")
 	cmd.Env = gitEnv()
-	util.HideConsoleWindow(cmd)
+
 	_ = cmd.Run()
 	return nil
 }
@@ -296,7 +295,7 @@ func gitFetch(barePath string) error {
 func runGitFetch(barePath string) error {
 	cmd := exec.Command("git", "-C", barePath, "fetch", "origin")
 	cmd.Env = gitEnv()
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git fetch: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -331,7 +330,7 @@ func ensureRemoteTrackingLayout(barePath string) error {
 	// Non-fatal: if this fails we fall back to origin/main, origin/master.
 	cmd := exec.Command("git", "-C", barePath, "remote", "set-head", "origin", "--auto")
 	cmd.Env = gitEnv()
-	util.HideConsoleWindow(cmd)
+
 	_ = cmd.Run()
 	return nil
 }
@@ -341,7 +340,7 @@ func ensureRemoteTrackingLayout(barePath string) error {
 // real git errors.
 func readFetchRefspec(barePath string) (string, error) {
 	cmd := exec.Command("git", "-C", barePath, "config", "--get", "remote.origin.fetch")
-	util.HideConsoleWindow(cmd)
+
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {
@@ -354,7 +353,7 @@ func readFetchRefspec(barePath string) (string, error) {
 
 func setFetchRefspec(barePath, refspec string) error {
 	cmd := exec.Command("git", "-C", barePath, "config", "remote.origin.fetch", refspec)
-	util.HideConsoleWindow(cmd)
+
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("set remote.origin.fetch: %s: %w", strings.TrimSpace(string(out)), err)
@@ -540,7 +539,7 @@ func resolveBaseRef(barePath, requestedRef string) (string, error) {
 
 func gitRefExists(repoPath, ref string) bool {
 	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", ref)
-	util.HideConsoleWindow(cmd)
+
 	return cmd.Run() == nil
 }
 
@@ -571,7 +570,7 @@ func createWorktree(gitRoot, worktreePath, branchName, baseRef string) (string, 
 
 func runWorktreeAdd(gitRoot, worktreePath, branchName, baseRef string) error {
 	cmd := exec.Command("git", "-C", gitRoot, "worktree", "add", "-b", branchName, worktreePath, baseRef)
-	util.HideConsoleWindow(cmd)
+
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree add: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -606,14 +605,12 @@ func isGitWorktree(path string) bool {
 func updateExistingWorktree(worktreePath, branchName, baseRef string) (string, error) {
 	// Discard any leftover uncommitted changes from the previous task.
 	resetCmd := exec.Command("git", "-C", worktreePath, "reset", "--hard")
-	util.HideConsoleWindow(resetCmd)
 	if out, err := resetCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("git reset --hard: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	// Clean untracked files (e.g. build artifacts from previous task).
 	cleanCmd := exec.Command("git", "-C", worktreePath, "clean", "-fd")
-	util.HideConsoleWindow(cleanCmd)
 	if out, err := cleanCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("git clean -fd: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -624,7 +621,6 @@ func updateExistingWorktree(worktreePath, branchName, baseRef string) (string, e
 	// legacy/migration-pending cache. Either form is valid as a checkout
 	// startpoint.
 	checkoutCmd := exec.Command("git", "-C", worktreePath, "checkout", "-b", branchName, baseRef)
-	util.HideConsoleWindow(checkoutCmd)
 	out, err := checkoutCmd.CombinedOutput()
 	if err == nil {
 		return branchName, nil
@@ -636,7 +632,6 @@ func updateExistingWorktree(worktreePath, branchName, baseRef string) (string, e
 	// Branch name collision: append timestamp and retry once.
 	branchName = fmt.Sprintf("%s-%d", branchName, time.Now().Unix())
 	checkoutCmd = exec.Command("git", "-C", worktreePath, "checkout", "-b", branchName, baseRef)
-	util.HideConsoleWindow(checkoutCmd)
 	if out2, err2 := checkoutCmd.CombinedOutput(); err2 != nil {
 		return "", fmt.Errorf("git checkout -b (retry): %s: %w", strings.TrimSpace(string(out2)), err2)
 	}
@@ -676,12 +671,10 @@ func getRemoteDefaultBranch(barePath string) string {
 	//    it here would later fail in `git worktree add` with a confusing
 	//    "invalid reference" error.
 	symrefCmd := exec.Command("git", "-C", barePath, "symbolic-ref", "refs/remotes/origin/HEAD")
-	util.HideConsoleWindow(symrefCmd)
 	if out, err := symrefCmd.Output(); err == nil {
 		ref := strings.TrimSpace(string(out))
 		if ref != "" {
 			verifyCmd := exec.Command("git", "-C", barePath, "rev-parse", "--verify", ref)
-			util.HideConsoleWindow(verifyCmd)
 			if err := verifyCmd.Run(); err == nil {
 				return ref
 			}
@@ -690,7 +683,7 @@ func getRemoteDefaultBranch(barePath string) string {
 	// 2) Common default branch names under the origin namespace.
 	for _, candidate := range []string{"refs/remotes/origin/main", "refs/remotes/origin/master"} {
 		cmd := exec.Command("git", "-C", barePath, "rev-parse", "--verify", candidate)
-		util.HideConsoleWindow(cmd)
+	
 		if err := cmd.Run(); err == nil {
 			return candidate
 		}
@@ -705,7 +698,7 @@ func getRemoteDefaultBranch(barePath string) string {
 	if bareRef != "" {
 		originRef := "refs/remotes/origin/" + strings.TrimPrefix(bareRef, "refs/heads/")
 		cmd := exec.Command("git", "-C", barePath, "rev-parse", "--verify", originRef)
-		util.HideConsoleWindow(cmd)
+	
 		if err := cmd.Run(); err == nil {
 			return originRef
 		}
@@ -719,7 +712,6 @@ func getRemoteDefaultBranch(barePath string) string {
 	originCount := 0
 	var singleton string
 	foreachCmd := exec.Command("git", "-C", barePath, "for-each-ref", "--format=%(refname)", "refs/remotes/origin/")
-	util.HideConsoleWindow(foreachCmd)
 	if out, err := foreachCmd.Output(); err == nil {
 		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 			line = strings.TrimSpace(line)
@@ -757,7 +749,7 @@ func getRemoteDefaultBranch(barePath string) string {
 // succeeds first.
 func bareHeadBranch(barePath string) string {
 	cmd := exec.Command("git", "-C", barePath, "symbolic-ref", "HEAD")
-	util.HideConsoleWindow(cmd)
+
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -767,7 +759,6 @@ func bareHeadBranch(barePath string) string {
 		return ""
 	}
 	verifyCmd := exec.Command("git", "-C", barePath, "rev-parse", "--verify", ref)
-	util.HideConsoleWindow(verifyCmd)
 	if err := verifyCmd.Run(); err != nil {
 		return ""
 	}
@@ -825,7 +816,7 @@ git interpret-trailers --in-place --trailer "$TRAILER" "$COMMIT_MSG_FILE"
 // worktrees created from this cache.
 func installCoAuthoredByHook(worktreePath string) error {
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-common-dir")
-	util.HideConsoleWindow(cmd)
+
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("resolve git common dir: %w", err)
@@ -869,7 +860,7 @@ func isDaemonInstalledHook(contents []byte) bool {
 // the path.
 func removeCoAuthoredByHook(worktreePath string) error {
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-common-dir")
-	util.HideConsoleWindow(cmd)
+
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("resolve git common dir: %w", err)
@@ -900,7 +891,7 @@ func removeCoAuthoredByHook(worktreePath string) error {
 // excludeFromGit adds a pattern to the worktree's .git/info/exclude file.
 func excludeFromGit(worktreePath, pattern string) error {
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-dir")
-	util.HideConsoleWindow(cmd)
+
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("resolve git dir: %w", err)

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/multica-ai/multica/server/internal/util"
 )
 
 // gitEnv returns an environment for git subprocesses that contact remotes.
@@ -243,6 +245,7 @@ const modernFetchRefspec = "+refs/heads/*:refs/remotes/origin/*"
 func gitCloneBare(url, dest string) error {
 	cmd := exec.Command("git", "clone", "--bare", url, dest)
 	cmd.Env = gitEnv()
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Clean up partial clone.
 		os.RemoveAll(dest)
@@ -283,6 +286,7 @@ func gitFetch(barePath string) error {
 	// on this call.
 	cmd := exec.Command("git", "-C", barePath, "remote", "set-head", "origin", "--auto")
 	cmd.Env = gitEnv()
+	util.HideConsoleWindow(cmd)
 	_ = cmd.Run()
 	return nil
 }
@@ -292,6 +296,7 @@ func gitFetch(barePath string) error {
 func runGitFetch(barePath string) error {
 	cmd := exec.Command("git", "-C", barePath, "fetch", "origin")
 	cmd.Env = gitEnv()
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git fetch: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -326,6 +331,7 @@ func ensureRemoteTrackingLayout(barePath string) error {
 	// Non-fatal: if this fails we fall back to origin/main, origin/master.
 	cmd := exec.Command("git", "-C", barePath, "remote", "set-head", "origin", "--auto")
 	cmd.Env = gitEnv()
+	util.HideConsoleWindow(cmd)
 	_ = cmd.Run()
 	return nil
 }
@@ -334,7 +340,9 @@ func ensureRemoteTrackingLayout(barePath string) error {
 // the empty string if it's not set. Distinguishes "missing" (exit 1) from
 // real git errors.
 func readFetchRefspec(barePath string) (string, error) {
-	out, err := exec.Command("git", "-C", barePath, "config", "--get", "remote.origin.fetch").Output()
+	cmd := exec.Command("git", "-C", barePath, "config", "--get", "remote.origin.fetch")
+	util.HideConsoleWindow(cmd)
+	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {
 			return "", nil // key missing, not an error
@@ -345,7 +353,9 @@ func readFetchRefspec(barePath string) (string, error) {
 }
 
 func setFetchRefspec(barePath, refspec string) error {
-	out, err := exec.Command("git", "-C", barePath, "config", "remote.origin.fetch", refspec).CombinedOutput()
+	cmd := exec.Command("git", "-C", barePath, "config", "remote.origin.fetch", refspec)
+	util.HideConsoleWindow(cmd)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("set remote.origin.fetch: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -530,6 +540,7 @@ func resolveBaseRef(barePath, requestedRef string) (string, error) {
 
 func gitRefExists(repoPath, ref string) bool {
 	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", ref)
+	util.HideConsoleWindow(cmd)
 	return cmd.Run() == nil
 }
 
@@ -560,6 +571,7 @@ func createWorktree(gitRoot, worktreePath, branchName, baseRef string) (string, 
 
 func runWorktreeAdd(gitRoot, worktreePath, branchName, baseRef string) error {
 	cmd := exec.Command("git", "-C", gitRoot, "worktree", "add", "-b", branchName, worktreePath, baseRef)
+	util.HideConsoleWindow(cmd)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree add: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -594,12 +606,14 @@ func isGitWorktree(path string) bool {
 func updateExistingWorktree(worktreePath, branchName, baseRef string) (string, error) {
 	// Discard any leftover uncommitted changes from the previous task.
 	resetCmd := exec.Command("git", "-C", worktreePath, "reset", "--hard")
+	util.HideConsoleWindow(resetCmd)
 	if out, err := resetCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("git reset --hard: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	// Clean untracked files (e.g. build artifacts from previous task).
 	cleanCmd := exec.Command("git", "-C", worktreePath, "clean", "-fd")
+	util.HideConsoleWindow(cleanCmd)
 	if out, err := cleanCmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("git clean -fd: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -610,6 +624,7 @@ func updateExistingWorktree(worktreePath, branchName, baseRef string) (string, e
 	// legacy/migration-pending cache. Either form is valid as a checkout
 	// startpoint.
 	checkoutCmd := exec.Command("git", "-C", worktreePath, "checkout", "-b", branchName, baseRef)
+	util.HideConsoleWindow(checkoutCmd)
 	out, err := checkoutCmd.CombinedOutput()
 	if err == nil {
 		return branchName, nil
@@ -621,6 +636,7 @@ func updateExistingWorktree(worktreePath, branchName, baseRef string) (string, e
 	// Branch name collision: append timestamp and retry once.
 	branchName = fmt.Sprintf("%s-%d", branchName, time.Now().Unix())
 	checkoutCmd = exec.Command("git", "-C", worktreePath, "checkout", "-b", branchName, baseRef)
+	util.HideConsoleWindow(checkoutCmd)
 	if out2, err2 := checkoutCmd.CombinedOutput(); err2 != nil {
 		return "", fmt.Errorf("git checkout -b (retry): %s: %w", strings.TrimSpace(string(out2)), err2)
 	}
@@ -659,17 +675,23 @@ func getRemoteDefaultBranch(barePath string) string {
 	//    repo can leave a symref pointing at a deleted ref, and returning
 	//    it here would later fail in `git worktree add` with a confusing
 	//    "invalid reference" error.
-	if out, err := exec.Command("git", "-C", barePath, "symbolic-ref", "refs/remotes/origin/HEAD").Output(); err == nil {
+	symrefCmd := exec.Command("git", "-C", barePath, "symbolic-ref", "refs/remotes/origin/HEAD")
+	util.HideConsoleWindow(symrefCmd)
+	if out, err := symrefCmd.Output(); err == nil {
 		ref := strings.TrimSpace(string(out))
 		if ref != "" {
-			if err := exec.Command("git", "-C", barePath, "rev-parse", "--verify", ref).Run(); err == nil {
+			verifyCmd := exec.Command("git", "-C", barePath, "rev-parse", "--verify", ref)
+			util.HideConsoleWindow(verifyCmd)
+			if err := verifyCmd.Run(); err == nil {
 				return ref
 			}
 		}
 	}
 	// 2) Common default branch names under the origin namespace.
 	for _, candidate := range []string{"refs/remotes/origin/main", "refs/remotes/origin/master"} {
-		if err := exec.Command("git", "-C", barePath, "rev-parse", "--verify", candidate).Run(); err == nil {
+		cmd := exec.Command("git", "-C", barePath, "rev-parse", "--verify", candidate)
+		util.HideConsoleWindow(cmd)
+		if err := cmd.Run(); err == nil {
 			return candidate
 		}
 	}
@@ -682,7 +704,9 @@ func getRemoteDefaultBranch(barePath string) string {
 	bareRef := bareHeadBranch(barePath)
 	if bareRef != "" {
 		originRef := "refs/remotes/origin/" + strings.TrimPrefix(bareRef, "refs/heads/")
-		if err := exec.Command("git", "-C", barePath, "rev-parse", "--verify", originRef).Run(); err == nil {
+		cmd := exec.Command("git", "-C", barePath, "rev-parse", "--verify", originRef)
+		util.HideConsoleWindow(cmd)
+		if err := cmd.Run(); err == nil {
 			return originRef
 		}
 	}
@@ -694,7 +718,9 @@ func getRemoteDefaultBranch(barePath string) string {
 	//    "legacy empty" apart from "ambiguous".
 	originCount := 0
 	var singleton string
-	if out, err := exec.Command("git", "-C", barePath, "for-each-ref", "--format=%(refname)", "refs/remotes/origin/").Output(); err == nil {
+	foreachCmd := exec.Command("git", "-C", barePath, "for-each-ref", "--format=%(refname)", "refs/remotes/origin/")
+	util.HideConsoleWindow(foreachCmd)
+	if out, err := foreachCmd.Output(); err == nil {
 		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 			line = strings.TrimSpace(line)
 			if line == "" || line == "refs/remotes/origin/HEAD" {
@@ -730,7 +756,9 @@ func getRemoteDefaultBranch(barePath string) string {
 // modern caches should never reach this path because origin/* resolution
 // succeeds first.
 func bareHeadBranch(barePath string) string {
-	out, err := exec.Command("git", "-C", barePath, "symbolic-ref", "HEAD").Output()
+	cmd := exec.Command("git", "-C", barePath, "symbolic-ref", "HEAD")
+	util.HideConsoleWindow(cmd)
+	out, err := cmd.Output()
 	if err != nil {
 		return ""
 	}
@@ -738,7 +766,9 @@ func bareHeadBranch(barePath string) string {
 	if ref == "" {
 		return ""
 	}
-	if err := exec.Command("git", "-C", barePath, "rev-parse", "--verify", ref).Run(); err != nil {
+	verifyCmd := exec.Command("git", "-C", barePath, "rev-parse", "--verify", ref)
+	util.HideConsoleWindow(verifyCmd)
+	if err := verifyCmd.Run(); err != nil {
 		return ""
 	}
 	return ref
@@ -795,6 +825,7 @@ git interpret-trailers --in-place --trailer "$TRAILER" "$COMMIT_MSG_FILE"
 // worktrees created from this cache.
 func installCoAuthoredByHook(worktreePath string) error {
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-common-dir")
+	util.HideConsoleWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("resolve git common dir: %w", err)
@@ -838,6 +869,7 @@ func isDaemonInstalledHook(contents []byte) bool {
 // the path.
 func removeCoAuthoredByHook(worktreePath string) error {
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-common-dir")
+	util.HideConsoleWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("resolve git common dir: %w", err)
@@ -868,6 +900,7 @@ func removeCoAuthoredByHook(worktreePath string) error {
 // excludeFromGit adds a pattern to the worktree's .git/info/exclude file.
 func excludeFromGit(worktreePath, pattern string) error {
 	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-dir")
+	util.HideConsoleWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("resolve git dir: %w", err)

--- a/server/internal/util/proc_other.go
+++ b/server/internal/util/proc_other.go
@@ -2,7 +2,5 @@
 
 package util
 
-import "os/exec"
-
-// HideConsoleWindow is a no-op on non-Windows platforms.
-func HideConsoleWindow(cmd *exec.Cmd) {}
+// EnsureHiddenConsole is a no-op on non-Windows platforms.
+func EnsureHiddenConsole() {}

--- a/server/internal/util/proc_other.go
+++ b/server/internal/util/proc_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package util
+
+import "os/exec"
+
+// HideConsoleWindow is a no-op on non-Windows platforms.
+func HideConsoleWindow(cmd *exec.Cmd) {}

--- a/server/internal/util/proc_windows.go
+++ b/server/internal/util/proc_windows.go
@@ -2,23 +2,30 @@
 
 package util
 
-import (
-	"os/exec"
-	"syscall"
+import "syscall"
+
+var (
+	kernel32          = syscall.NewLazyDLL("kernel32.dll")
+	user32            = syscall.NewLazyDLL("user32.dll")
+	procAllocConsole  = kernel32.NewProc("AllocConsole")
+	procGetConsoleWnd = kernel32.NewProc("GetConsoleWindow")
+	procShowWindow    = user32.NewProc("ShowWindow")
 )
 
-// createNewConsole allocates a fresh console for the child process. Combined
-// with HideWindow=true (STARTF_USESHOWWINDOW + SW_HIDE) the console window
-// stays off-screen, and any grandchildren inherit this hidden console instead
-// of each allocating their own visible one.
-const createNewConsole = 0x00000010
+const swHide = 0
 
-// HideConsoleWindow configures cmd to suppress the console window on Windows
-// while still giving descendant processes a hidden console to inherit.
-func HideConsoleWindow(cmd *exec.Cmd) {
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
+// EnsureHiddenConsole guarantees the daemon owns a console that is not
+// visible to the user. Every child process (git, cmd, etc.) inherits this
+// hidden console automatically, so no per-call SysProcAttr gymnastics are
+// needed.
+func EnsureHiddenConsole() {
+	if hwnd, _, _ := procGetConsoleWnd.Call(); hwnd != 0 {
+		return // already have a console
 	}
-	cmd.SysProcAttr.HideWindow = true
-	cmd.SysProcAttr.CreationFlags |= createNewConsole
+	if r, _, _ := procAllocConsole.Call(); r == 0 {
+		return // AllocConsole failed
+	}
+	if hwnd, _, _ := procGetConsoleWnd.Call(); hwnd != 0 {
+		procShowWindow.Call(hwnd, swHide)
+	}
 }

--- a/server/internal/util/proc_windows.go
+++ b/server/internal/util/proc_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package util
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// createNewConsole allocates a fresh console for the child process. Combined
+// with HideWindow=true (STARTF_USESHOWWINDOW + SW_HIDE) the console window
+// stays off-screen, and any grandchildren inherit this hidden console instead
+// of each allocating their own visible one.
+const createNewConsole = 0x00000010
+
+// HideConsoleWindow configures cmd to suppress the console window on Windows
+// while still giving descendant processes a hidden console to inherit.
+func HideConsoleWindow(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= createNewConsole
+}


### PR DESCRIPTION
## Summary

Fixes #2357

On Windows, the daemon's repo-cache and worktree operations spawn `git.exe` commands that each flash a visible console window. This applies the same fix pattern from #1474 (merged) — which addressed agent process windows — to the daemon's git subprocess calls.

## Changes

- **New:** `server/internal/util/proc_windows.go` — `HideConsoleWindow(cmd)` using `CREATE_NEW_CONSOLE + HideWindow` (same pattern as `server/pkg/agent/proc_windows.go`)
- **New:** `server/internal/util/proc_other.go` — no-op on non-Windows
- **Modified:** `server/internal/daemon/execenv/git.go` — 10 call sites
- **Modified:** `server/internal/daemon/repocache/cache.go` — 22 call sites
- **Modified:** `server/internal/daemon/gc.go` — 1 call site

All 33 `exec.Command("git", ...)` calls in the daemon now suppress console windows on Windows. Inline `.Output()`/`.Run()` chains were extracted to variables where needed.

## Why `CREATE_NEW_CONSOLE` instead of `CREATE_NO_WINDOW`

Matches the approach in `server/pkg/agent/proc_windows.go` (updated after #1521): `CREATE_NO_WINDOW` strips the console entirely, which forces Windows to allocate a new visible console per grandchild when that grandchild is a console-subsystem program. `CREATE_NEW_CONSOLE + HideWindow` gives the child a hidden console that grandchildren inherit, preventing the popup storm.

## Why a shared `internal/util` helper

The git command calls span three packages (`execenv`, `repocache`, `daemon`). Placing `HideConsoleWindow` in `internal/util` avoids duplicating the build-tagged files in each package while keeping the helper internal.

## Testing

- `go vet ./internal/daemon/... ./internal/util/...` — passes clean
- Build-tag separation ensures zero impact on non-Windows platforms

## Thinking Path

1. Identified that #1474 fixed the same class of issue for agent processes but not daemon git commands
2. Traced all `exec.Command("git", ...)` in the daemon packages (33 call sites across 3 files)
3. Created a shared helper mirroring the existing `pkg/agent` pattern
4. Applied systematically to all call sites, extracting inline chains where needed