### PR TITLE
fix(cli): allow --mode run_only on autopilot create/update

### DIFF
--- a/apps/docs/content/docs/autopilots.mdx
+++ b/apps/docs/content/docs/autopilots.mdx
@@ -25,10 +25,6 @@ An autopilot has two execution modes. **Start with "create issue" mode.**
 - **Create issue mode** (`create_issue`) — default, **recommended**. Each trigger first creates an issue in the workspace (the title supports interpolation like `{{date}}`), then assigns the issue to the agent through the normal assignment flow. All work lands on the issue board with the same history, comments, and status as a manually assigned issue.
 - **Run-only mode** (`run_only`) — skips issue creation and enqueues a `task` directly. The run is invisible on the board — you can only see it in the autopilot's run history.
 
-<Callout type="warning">
-**Run-only mode is currently unstable.** The CLI labels it "not yet supported end-to-end," and the dispatch path has known issues. New users should stick to create issue mode and wait for run-only mode to ship a stable release before switching.
-</Callout>
-
 ## Run it on a schedule
 
 Every autopilot needs at least one `schedule` trigger. Cron uses the **standard 5-field format** (minute hour day month weekday), with **1-minute** minimum granularity (no seconds). Timezone is IANA-formatted (for example, `Asia/Shanghai`) and determines which timezone the cron expression is interpreted in.

--- a/apps/docs/content/docs/autopilots.zh.mdx
+++ b/apps/docs/content/docs/autopilots.zh.mdx
@@ -25,10 +25,6 @@ Autopilot 有两种执行模式，**建议从"先建 issue 模式"开始**：
 - **先建 issue 模式**（`create_issue`）—— 默认，**推荐**。每次触发先在工作区里建一个 issue（标题支持 `{{date}}` 这样的插值），再按分配流程把 issue 派给智能体。所有工作都落在 issue 看板上，历史、评论、状态和手动分配的 issue 完全一致。
 - **直跑模式**（`run_only`）—— 不建 issue，直接入队一个 `task`。看板上看不到这一次运行——只能在 Autopilot 的运行历史里看到。
 
-<Callout type="warning">
-**直跑模式当前不稳定**——目前在 CLI 里被标注为"not yet supported end-to-end"，派发路径有已知问题。新用户只使用先建 issue 模式，等直跑模式 ship 稳定版再切。
-</Callout>
-
 ## 让它按时间跑
 
 每个 Autopilot 至少要一个 `schedule` 触发器。Cron 是**标准 5 字段格式**（分 时 日 月 周），最小粒度 **1 分钟**（没有秒级）。时区用 IANA 格式（例如 `Asia/Shanghai`），决定 cron 表达式按哪个时区解读。

--- a/server/cmd/multica/cmd_autopilot.go
+++ b/server/cmd/multica/cmd_autopilot.go
@@ -111,7 +111,7 @@ func init() {
 	autopilotCreateCmd.Flags().String("title", "", "Autopilot title (required)")
 	autopilotCreateCmd.Flags().String("description", "", "Autopilot description (used as task prompt)")
 	autopilotCreateCmd.Flags().String("agent", "", "Assignee agent (name or ID) — required")
-	autopilotCreateCmd.Flags().String("mode", "", "Execution mode: create_issue (required). run_only is not yet supported end-to-end.")
+	autopilotCreateCmd.Flags().String("mode", "", "Execution mode: create_issue or run_only (required)")
 	autopilotCreateCmd.Flags().String("priority", "none", "Priority for created issues (none, low, medium, high, urgent)")
 	autopilotCreateCmd.Flags().String("project", "", "Project ID (optional)")
 	autopilotCreateCmd.Flags().String("issue-title-template", "", "Template for issue titles (create_issue mode)")
@@ -124,7 +124,7 @@ func init() {
 	autopilotUpdateCmd.Flags().String("project", "", "New project ID (use empty string to clear)")
 	autopilotUpdateCmd.Flags().String("priority", "", "New priority")
 	autopilotUpdateCmd.Flags().String("status", "", "New status (active, paused)")
-	autopilotUpdateCmd.Flags().String("mode", "", "New execution mode (create_issue)")
+	autopilotUpdateCmd.Flags().String("mode", "", "New execution mode (create_issue or run_only)")
 	autopilotUpdateCmd.Flags().String("issue-title-template", "", "New issue title template")
 	autopilotUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 
@@ -263,14 +263,10 @@ func runAutopilotCreate(cmd *cobra.Command, _ []string) error {
 	}
 	mode, _ := cmd.Flags().GetString("mode")
 	if mode == "" {
-		return fmt.Errorf("--mode is required (create_issue)")
+		return fmt.Errorf("--mode is required (create_issue or run_only)")
 	}
-	// run_only is a valid value server-side but the dispatch path is not wired
-	// end-to-end (daemon /start resolves workspace only via issue/chat, and the
-	// agent prompt expects an issue ID). Keep the CLI to create_issue until the
-	// server path is fixed to avoid shipping a mode that returns 404 on start.
-	if mode != "create_issue" {
-		return fmt.Errorf("--mode must be create_issue (run_only is not yet supported end-to-end)")
+	if mode != "create_issue" && mode != "run_only" {
+		return fmt.Errorf("--mode must be create_issue or run_only")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -370,8 +366,8 @@ func runAutopilotUpdate(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("mode") {
 		v, _ := cmd.Flags().GetString("mode")
-		if v != "create_issue" {
-			return fmt.Errorf("--mode must be create_issue (run_only is not yet supported end-to-end)")
+		if v != "create_issue" && v != "run_only" {
+			return fmt.Errorf("--mode must be create_issue or run_only")
 		}
 		body["execution_mode"] = v
 	}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -585,6 +585,34 @@ func TestInjectRuntimeConfigClaude(t *testing.T) {
 	}
 }
 
+// Regression test for #2347: the runtime config injected into agent harnesses
+// must advertise both autopilot execution modes on create AND update, so an
+// agent acting as a CLI user is not confined to create_issue.
+func TestInjectRuntimeConfigAutopilotAdvertisesBothModes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	if _, err := InjectRuntimeConfig(dir, "claude", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("failed to read CLAUDE.md: %v", err)
+	}
+
+	s := string(content)
+	for _, want := range []string{
+		"multica autopilot create --title \"...\" --agent <name> --mode create_issue|run_only",
+		"multica autopilot update <id>",
+		"[--mode create_issue|run_only]",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("CLAUDE.md missing %q", want)
+		}
+	}
+}
+
 func TestInjectRuntimeConfigGemini(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -146,8 +146,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("  - The same rule applies to `--description` on `multica issue create` and `multica issue update` — use `--description-stdin` and pipe a HEREDOC for any multi-line description; the inline `--description \"...\"` form is for short single-line text only.\n")
 	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
 	b.WriteString("- `multica label create --name \"...\" --color \"#hex\"` — Define a new workspace label (use this only when the label you need does not exist yet; reuse existing labels via `multica label list` first)\n")
-	b.WriteString("- `multica autopilot create --title \"...\" --agent <name> --mode create_issue [--description \"...\"]` — Create an autopilot\n")
-	b.WriteString("- `multica autopilot update <id> [--title X] [--description X] [--status active|paused]` — Update an autopilot\n")
+	b.WriteString("- `multica autopilot create --title \"...\" --agent <name> --mode create_issue|run_only [--description \"...\"]` — Create an autopilot\n")
+	b.WriteString("- `multica autopilot update <id> [--title X] [--description X] [--status active|paused] [--mode create_issue|run_only]` — Update an autopilot\n")
 	b.WriteString("- `multica autopilot trigger <id>` — Manually trigger an autopilot to run once\n")
 	b.WriteString("- `multica autopilot delete <id>` — Delete an autopilot\n\n")
 


### PR DESCRIPTION
## Summary

- Drop the CLI guard that rejected `--mode run_only` on `multica autopilot create` and `multica autopilot update`. The dispatch path is fully wired end-to-end (`handler/autopilot.go`, `service/autopilot.go:dispatchRunOnly`, `daemon.go:ClaimTaskByRuntime`, `service/task.go:ResolveTaskWorkspaceID`) and has regression coverage (`TestStartTask_AutopilotRunOnlyTask_ResolvesWorkspace`, `TestClaimTask_AutopilotRunOnly_PopulatesWorkspaceID`). The guard was a stale leftover from before the daemon workspace-resolution fixes landed.
- Update flag help text and error messages on both subcommands to advertise both `create_issue` and `run_only`.
- Remove the matching "currently unstable" callout from `apps/docs/content/docs/autopilots{,.zh}.mdx` so docs stop contradicting the CLI.

Update keeps `--mode` switchable per product owner direction — agents are expected to make the right call when changing mode, same as a human operator.

Closes #2347

## Test plan

- [x] `go build ./cmd/multica/...`
- [x] `go test ./cmd/multica/...`
- [x] `go vet ./cmd/multica/...`
- [ ] Manual: `multica autopilot create --title test --agent <agent> --mode run_only` succeeds
- [ ] Manual: `multica autopilot update <id> --mode run_only` succeeds and the autopilot fires correctly on its next trigger