### PR TITLE
docs(daemon): refresh stale comment for inline system prompt path

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1835,9 +1835,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	//   - hermes is driven through ACP and starts from a long-lived Hermes home;
 	//     deployments that cross a wrapper/container boundary can miss the
 	//     task-workdir AGENTS.md even when the prompt itself is delivered.
-	// Pass Multica-defined identity/persona instructions inline so the backend
-	// can prepend them to the turn payload instead of relying only on file
-	// discovery.
+	//   - kiro and kimi are wrapped through their own CLIs whose cwd handling
+	//     is opaque enough that we can't trust the file-based path either.
+	// Pass the full runtime brief inline (CLI catalog + workflow steps + agent
+	// identity/persona + skills + project context) so the backend prepends the
+	// same payload that file-based runtimes pick up from disk. Without this,
+	// these providers silently miss the workflow section and never call
+	// `multica issue status` / `multica issue comment add`, leaving issues
+	// stuck in `todo`.
 	if providerNeedsInlineSystemPrompt(provider) {
 		execOpts.SystemPrompt = runtimeBrief
 	}


### PR DESCRIPTION
## Summary

After #2355 the inline `execOpts.SystemPrompt` path now carries the full runtime brief (CLI catalog + workflow + persona + skills + project context), not just identity/persona instructions, but the comment block immediately above the inline branch still described it as the latter. Tiny doc-only update so the next maintainer reading this site gets an accurate explanation of why the inline payload is load-bearing.

While I was there:
- Added `kiro` / `kimi` to the bullet list (they joined `providerNeedsInlineSystemPrompt` in #2328 but were never mentioned in the surrounding rationale).
- Spelled out the concrete failure mode (issues silently stay in \`todo\` because the workflow section is missed) so the comment is searchable when someone hits the same symptom.

No code changes — comment-only.

## Test plan

- [x] \`go vet ./internal/daemon/...\` clean
- [x] No code paths touched, so no functional regression risk