### PR TITLE
feat(web): add Changelog link to landing header

### DIFF
--- a/apps/web/features/landing/components/landing-header.tsx
+++ b/apps/web/features/landing/components/landing-header.tsx
@@ -45,6 +45,17 @@ export function LandingHeader({
 
         <div className="flex items-center gap-2.5 sm:gap-3">
           <Link
+            href="/changelog"
+            className={cn(
+              "hidden text-[13px] font-medium transition-colors sm:inline-flex",
+              variant === "dark"
+                ? "text-white/72 hover:text-white"
+                : "text-[#0a0d12]/64 hover:text-[#0a0d12]",
+            )}
+          >
+            {t.header.changelog}
+          </Link>
+          <Link
             href={githubUrl}
             target="_blank"
             rel="noreferrer"

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -7,6 +7,7 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     github: "GitHub",
     login: "Log in",
     dashboard: "Dashboard",
+    changelog: "Changelog",
   },
 
   hero: {

--- a/apps/web/features/landing/i18n/types.ts
+++ b/apps/web/features/landing/i18n/types.ts
@@ -20,7 +20,7 @@ type FooterGroup = {
 };
 
 export type LandingDict = {
-  header: { github: string; login: string; dashboard: string };
+  header: { github: string; login: string; dashboard: string; changelog: string };
   hero: {
     headlineLine1: string;
     headlineLine2: string;

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -7,6 +7,7 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     github: "GitHub",
     login: "\u767b\u5f55",
     dashboard: "\u8fdb\u5165\u5de5\u4f5c\u53f0",
+    changelog: "\u66f4\u65b0\u65e5\u5fd7",
   },
 
   hero: {


### PR DESCRIPTION
## Summary

Done #2361 
- Adds a Changelog link to the marketing site's top navigation, sitting next to the GitHub button on landing, about, changelog and download pages.
- Hidden below the `sm` breakpoint so the mobile header stays compact; styled as a low-emphasis text link to keep the GitHub / Login CTAs primary.
- Adds `header.changelog` translations for both English ("Changelog") and Simplified Chinese ("更新日志").

## Test plan

- [x] `pnpm --filter @multica/web run typecheck`
- [x] `pnpm --filter @multica/web run lint` (clean for touched files)
- [ ] Visual check on the staging deploy: link visible in dark and light header variants, navigates to `/changelog`, hidden on mobile.