### PR TITLE
fix(web): match Changelog header link to GitHub ghost button

### DIFF
--- a/apps/web/features/landing/components/landing-header.tsx
+++ b/apps/web/features/landing/components/landing-header.tsx
@@ -47,10 +47,8 @@ export function LandingHeader({
           <Link
             href="/changelog"
             className={cn(
-              "hidden text-[13px] font-medium transition-colors sm:inline-flex",
-              variant === "dark"
-                ? "text-white/72 hover:text-white"
-                : "text-[#0a0d12]/64 hover:text-[#0a0d12]",
+              headerButtonClassName("ghost", variant),
+              "hidden sm:inline-flex",
             )}
           >
             {t.header.changelog}


### PR DESCRIPTION
## Summary
- The Changelog link in the landing header rendered as bare text next to two pill-shaped buttons (GitHub ghost + Login solid), which broke the row's visual rhythm.
- Reuse the shared `headerButtonClassName("ghost", variant)` helper so Changelog inherits the same shape, padding, border, and font as the GitHub button. Both secondary actions now read as one family, with the Login solid button continuing to be the primary CTA.

## Test plan
- [ ] Visit landing page (`/`) on dark hero — Changelog and GitHub buttons should be visually identical aside from the GitHub icon; spacing matches the GitHub↔Login gap.
- [ ] Visit a light-variant landing surface (e.g. `/changelog`) — Changelog button picks up the light ghost styling.
- [ ] Verify mobile (`< sm` breakpoint) still hides Changelog (ghost helper class is overridden by `hidden sm:inline-flex`).