### PR TITLE
feat(server): add workspace-level always_redact_env setting (MUL-2495)

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -126,6 +126,7 @@ export interface Agent {
   custom_env: Record<string, string>;
   custom_args: string[];
   custom_env_redacted: boolean;
+  custom_env_redacted_reason?: 'policy' | 'role';
   visibility: AgentVisibility;
   status: AgentStatus;
   max_concurrent_tasks: number;

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -171,7 +171,7 @@ export function AgentOverviewPane({
           <TabContent>
             <EnvTab
               agent={agent}
-              readOnly={agent.custom_env_redacted_reason === 'role'}
+              readOnly={agent.custom_env_redacted}
               onSave={(updates) => onUpdate(agent.id, updates)}
               onDirtyChange={setActiveDirty}
             />

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -171,7 +171,7 @@ export function AgentOverviewPane({
           <TabContent>
             <EnvTab
               agent={agent}
-              readOnly={agent.custom_env_redacted}
+              readOnly={agent.custom_env_redacted_reason === 'role'}
               onSave={(updates) => onUpdate(agent.id, updates)}
               onDirtyChange={setActiveDirty}
             />

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -319,6 +319,12 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	// Check workspace-level always-redact setting.
+	var alwaysRedact bool
+	if ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(workspaceID)); err == nil {
+		alwaysRedact = workspaceAlwaysRedactEnv(ws.Settings)
+	}
+
 	// Resolve the request actor once. Agents bypass the private-agent gate
 	// to preserve A2A collaboration; members must be in allowed_principals
 	// (agent owner or workspace owner/admin) to see private agents.
@@ -334,8 +340,9 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		if skills, ok := skillMap[resp.ID]; ok {
 			resp.Skills = skills
 		}
-		// Redact sensitive fields for users who are not the agent owner or workspace owner/admin.
-		if !canViewAgentEnv(a, userID, member.Role) {
+		// Redact sensitive fields for users who are not the agent owner or workspace owner/admin,
+		// or unconditionally when the workspace opts into always_redact_env.
+		if alwaysRedact || !canViewAgentEnv(a, userID, member.Role) {
 			redactEnv(&resp)
 			redactMcpConfig(&resp)
 		}
@@ -382,9 +389,17 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Redact sensitive fields for users who are not the agent owner or workspace owner/admin.
+	// Redact sensitive fields for users who are not the agent owner or workspace owner/admin,
+	// or unconditionally when the workspace opts into always_redact_env.
 	userID := requestUserID(r)
-	if member, ok := ctxMember(r.Context()); ok {
+	var alwaysRedact bool
+	if ws, err := h.Queries.GetWorkspace(r.Context(), agent.WorkspaceID); err == nil {
+		alwaysRedact = workspaceAlwaysRedactEnv(ws.Settings)
+	}
+	if alwaysRedact {
+		redactEnv(&resp)
+		redactMcpConfig(&resp)
+	} else if member, ok := ctxMember(r.Context()); ok {
 		if !canViewAgentEnv(agent, userID, member.Role) {
 			redactEnv(&resp)
 			redactMcpConfig(&resp)
@@ -612,6 +627,24 @@ type UpdateAgentRequest struct {
 	// Distinguishing those modes is why this is a pointer; the raw-fields
 	// map captured at decode time tells us whether the key was sent.
 	ThinkingLevel *string `json:"thinking_level"`
+}
+
+// workspaceAlwaysRedactEnv checks whether the workspace has opted into
+// unconditional redaction of custom_env and mcp_config on read responses,
+// regardless of the caller's role. This is useful for single-tenant
+// self-hosts or security-conscious teams that never want plaintext secrets
+// returned from the API.
+func workspaceAlwaysRedactEnv(settings []byte) bool {
+	if len(settings) == 0 {
+		return false
+	}
+	var s struct {
+		AlwaysRedactEnv bool `json:"always_redact_env"`
+	}
+	if err := json.Unmarshal(settings, &s); err != nil {
+		return false
+	}
+	return s.AlwaysRedactEnv
 }
 
 // canViewAgentEnv checks whether the requesting user is allowed to see the

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -28,25 +28,25 @@ import (
 const maxAgentDescriptionLength = 255
 
 type AgentResponse struct {
-	ID                 string              `json:"id"`
-	WorkspaceID        string              `json:"workspace_id"`
-	RuntimeID          string              `json:"runtime_id"`
-	Name               string              `json:"name"`
-	Description        string              `json:"description"`
-	Instructions       string              `json:"instructions"`
-	AvatarURL          *string             `json:"avatar_url"`
-	RuntimeMode        string              `json:"runtime_mode"`
-	RuntimeConfig      any                 `json:"runtime_config"`
-	CustomEnv          map[string]string   `json:"custom_env"`
-	CustomArgs         []string            `json:"custom_args"`
-	McpConfig          json.RawMessage     `json:"mcp_config"`
-	CustomEnvRedacted       bool                `json:"custom_env_redacted"`
-	CustomEnvRedactedReason string              `json:"custom_env_redacted_reason,omitempty"`
-	McpConfigRedacted  bool                `json:"mcp_config_redacted"`
-	Visibility         string              `json:"visibility"`
-	Status             string              `json:"status"`
-	MaxConcurrentTasks int32               `json:"max_concurrent_tasks"`
-	Model              string              `json:"model"`
+	ID                      string            `json:"id"`
+	WorkspaceID             string            `json:"workspace_id"`
+	RuntimeID               string            `json:"runtime_id"`
+	Name                    string            `json:"name"`
+	Description             string            `json:"description"`
+	Instructions            string            `json:"instructions"`
+	AvatarURL               *string           `json:"avatar_url"`
+	RuntimeMode             string            `json:"runtime_mode"`
+	RuntimeConfig           any               `json:"runtime_config"`
+	CustomEnv               map[string]string `json:"custom_env"`
+	CustomArgs              []string          `json:"custom_args"`
+	McpConfig               json.RawMessage   `json:"mcp_config"`
+	CustomEnvRedacted       bool              `json:"custom_env_redacted"`
+	CustomEnvRedactedReason string            `json:"custom_env_redacted_reason,omitempty"`
+	McpConfigRedacted       bool              `json:"mcp_config_redacted"`
+	Visibility              string            `json:"visibility"`
+	Status                  string            `json:"status"`
+	MaxConcurrentTasks      int32             `json:"max_concurrent_tasks"`
+	Model                   string            `json:"model"`
 	// ThinkingLevel is the runtime-native reasoning/effort token persisted
 	// for this agent (empty = use runtime default). The picker is per-runtime
 	// per-model; the API never normalizes across providers. See MUL-2339.
@@ -191,7 +191,7 @@ type AgentTaskResponse struct {
 	// is empty.
 	RequestingUserName               string `json:"requesting_user_name,omitempty"`
 	RequestingUserProfileDescription string `json:"requesting_user_profile_description,omitempty"`
-	Kind                    string                `json:"kind"`                                // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
+	Kind                             string `json:"kind"` // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
 }
 
 // ChatAttachmentMeta is the structured attachment metadata embedded in

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -40,7 +40,8 @@ type AgentResponse struct {
 	CustomEnv          map[string]string   `json:"custom_env"`
 	CustomArgs         []string            `json:"custom_args"`
 	McpConfig          json.RawMessage     `json:"mcp_config"`
-	CustomEnvRedacted  bool                `json:"custom_env_redacted"`
+	CustomEnvRedacted       bool                `json:"custom_env_redacted"`
+	CustomEnvRedactedReason string              `json:"custom_env_redacted_reason,omitempty"`
 	McpConfigRedacted  bool                `json:"mcp_config_redacted"`
 	Visibility         string              `json:"visibility"`
 	Status             string              `json:"status"`
@@ -321,9 +322,13 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 
 	// Check workspace-level always-redact setting.
 	var alwaysRedact bool
-	if ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(workspaceID)); err == nil {
-		alwaysRedact = workspaceAlwaysRedactEnv(ws.Settings)
+	ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(workspaceID))
+	if err != nil {
+		slog.Warn("GetWorkspace failed for redact check", "workspace_id", workspaceID, "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		return
 	}
+	alwaysRedact = workspaceAlwaysRedactEnv(ws.Settings)
 
 	// Resolve the request actor once. Agents bypass the private-agent gate
 	// to preserve A2A collaboration; members must be in allowed_principals
@@ -342,9 +347,14 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		}
 		// Redact sensitive fields for users who are not the agent owner or workspace owner/admin,
 		// or unconditionally when the workspace opts into always_redact_env.
-		if alwaysRedact || !canViewAgentEnv(a, userID, member.Role) {
+		if alwaysRedact {
 			redactEnv(&resp)
 			redactMcpConfig(&resp)
+			resp.CustomEnvRedactedReason = "policy"
+		} else if !canViewAgentEnv(a, userID, member.Role) {
+			redactEnv(&resp)
+			redactMcpConfig(&resp)
+			resp.CustomEnvRedactedReason = "role"
 		}
 		visible = append(visible, resp)
 	}
@@ -393,16 +403,22 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 	// or unconditionally when the workspace opts into always_redact_env.
 	userID := requestUserID(r)
 	var alwaysRedact bool
-	if ws, err := h.Queries.GetWorkspace(r.Context(), agent.WorkspaceID); err == nil {
-		alwaysRedact = workspaceAlwaysRedactEnv(ws.Settings)
+	ws, err := h.Queries.GetWorkspace(r.Context(), agent.WorkspaceID)
+	if err != nil {
+		slog.Warn("GetWorkspace failed for redact check", "workspace_id", uuidToString(agent.WorkspaceID), "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		return
 	}
+	alwaysRedact = workspaceAlwaysRedactEnv(ws.Settings)
 	if alwaysRedact {
 		redactEnv(&resp)
 		redactMcpConfig(&resp)
+		resp.CustomEnvRedactedReason = "policy"
 	} else if member, ok := ctxMember(r.Context()); ok {
 		if !canViewAgentEnv(agent, userID, member.Role) {
 			redactEnv(&resp)
 			redactMcpConfig(&resp)
+			resp.CustomEnvRedactedReason = "role"
 		}
 	}
 

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -185,3 +185,26 @@ func TestCreateAgent_RejectsDuplicateName(t *testing.T) {
 		t.Fatalf("second CreateAgent with duplicate name: expected 409, got %d: %s", w2.Code, w2.Body.String())
 	}
 }
+
+func TestWorkspaceAlwaysRedactEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings []byte
+		want     bool
+	}{
+		{"nil settings", nil, false},
+		{"empty settings", []byte(`{}`), false},
+		{"false", []byte(`{"always_redact_env": false}`), false},
+		{"true", []byte(`{"always_redact_env": true}`), true},
+		{"invalid json", []byte(`not json`), false},
+		{"other fields only", []byte(`{"theme": "dark"}`), false},
+		{"true among other fields", []byte(`{"theme": "dark", "always_redact_env": true}`), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workspaceAlwaysRedactEnv(tt.settings); got != tt.want {
+				t.Errorf("workspaceAlwaysRedactEnv(%q) = %v, want %v", tt.settings, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -311,6 +311,11 @@ func TestGetAgent_DefaultNoRedactForOwner(t *testing.T) {
 	}
 	ctx := context.Background()
 
+	// Ensure workspace has no always_redact_env policy (guards against test-order leakage).
+	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = NULL WHERE id = $1`, testWorkspaceID); err != nil {
+		t.Fatalf("failed to clear workspace settings: %v", err)
+	}
+
 	agentID := createHandlerTestAgent(t, "no-redact-get-test-agent", nil)
 	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{"SECRET_KEY": "super-secret"}' WHERE id = $1`, agentID); err != nil {
 		t.Fatalf("failed to set custom_env: %v", err)

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -208,3 +208,134 @@ func TestWorkspaceAlwaysRedactEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAgent_AlwaysRedactEnv_OwnerSeesRedacted(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	// Enable always_redact_env on workspace.
+	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = '{"always_redact_env": true}' WHERE id = $1`, testWorkspaceID); err != nil {
+		t.Fatalf("failed to set workspace settings: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `UPDATE workspace SET settings = NULL WHERE id = $1`, testWorkspaceID)
+	})
+
+	agentID := createHandlerTestAgent(t, "redact-get-test-agent", nil)
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{"SECRET_KEY": "super-secret"}' WHERE id = $1`, agentID); err != nil {
+		t.Fatalf("failed to set custom_env: %v", err)
+	}
+
+	req := newRequest("GET", "/agents/"+agentID, nil)
+	req = withURLParam(req, "id", agentID)
+	w := httptest.NewRecorder()
+	testHandler.GetAgent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp AgentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !resp.CustomEnvRedacted {
+		t.Error("expected custom_env_redacted to be true")
+	}
+	if resp.CustomEnvRedactedReason != "policy" {
+		t.Errorf("expected custom_env_redacted_reason to be 'policy', got %q", resp.CustomEnvRedactedReason)
+	}
+	if resp.CustomEnv["SECRET_KEY"] != "****" {
+		t.Errorf("expected SECRET_KEY to be redacted, got %q", resp.CustomEnv["SECRET_KEY"])
+	}
+}
+
+func TestListAgents_AlwaysRedactEnv_OwnerSeesRedacted(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = '{"always_redact_env": true}' WHERE id = $1`, testWorkspaceID); err != nil {
+		t.Fatalf("failed to set workspace settings: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `UPDATE workspace SET settings = NULL WHERE id = $1`, testWorkspaceID)
+	})
+
+	agentName := "redact-list-test-agent"
+	agentID := createHandlerTestAgent(t, agentName, nil)
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{"SECRET_KEY": "super-secret"}' WHERE id = $1`, agentID); err != nil {
+		t.Fatalf("failed to set custom_env: %v", err)
+	}
+
+	req := newRequest("GET", "/agents", nil)
+	w := httptest.NewRecorder()
+	testHandler.ListAgents(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var agents []AgentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &agents); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	var found *AgentResponse
+	for i := range agents {
+		if agents[i].Name == agentName {
+			found = &agents[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("agent not found in list response")
+	}
+	if !found.CustomEnvRedacted {
+		t.Error("expected custom_env_redacted to be true")
+	}
+	if found.CustomEnvRedactedReason != "policy" {
+		t.Errorf("expected custom_env_redacted_reason to be 'policy', got %q", found.CustomEnvRedactedReason)
+	}
+	if found.CustomEnv["SECRET_KEY"] != "****" {
+		t.Errorf("expected SECRET_KEY to be redacted, got %q", found.CustomEnv["SECRET_KEY"])
+	}
+}
+
+func TestGetAgent_DefaultNoRedactForOwner(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	agentID := createHandlerTestAgent(t, "no-redact-get-test-agent", nil)
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{"SECRET_KEY": "super-secret"}' WHERE id = $1`, agentID); err != nil {
+		t.Fatalf("failed to set custom_env: %v", err)
+	}
+
+	req := newRequest("GET", "/agents/"+agentID, nil)
+	req = withURLParam(req, "id", agentID)
+	w := httptest.NewRecorder()
+	testHandler.GetAgent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp AgentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.CustomEnvRedacted {
+		t.Error("expected custom_env_redacted to be false")
+	}
+	if resp.CustomEnvRedactedReason != "" {
+		t.Errorf("expected custom_env_redacted_reason to be empty, got %q", resp.CustomEnvRedactedReason)
+	}
+	if resp.CustomEnv["SECRET_KEY"] != "super-secret" {
+		t.Errorf("expected SECRET_KEY to be visible, got %q", resp.CustomEnv["SECRET_KEY"])
+	}
+}

--- a/server/internal/handler/agent_test.go
+++ b/server/internal/handler/agent_test.go
@@ -209,6 +209,13 @@ func TestWorkspaceAlwaysRedactEnv(t *testing.T) {
 	}
 }
 
+func resetWorkspaceSettings(t *testing.T, workspaceID string) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(), "UPDATE workspace SET settings = '{}'::jsonb WHERE id = $1", workspaceID); err != nil {
+		t.Logf("warning: failed to reset workspace settings: %v", err)
+	}
+}
+
 func TestGetAgent_AlwaysRedactEnv_OwnerSeesRedacted(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
@@ -219,9 +226,7 @@ func TestGetAgent_AlwaysRedactEnv_OwnerSeesRedacted(t *testing.T) {
 	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = '{"always_redact_env": true}' WHERE id = $1`, testWorkspaceID); err != nil {
 		t.Fatalf("failed to set workspace settings: %v", err)
 	}
-	t.Cleanup(func() {
-		testPool.Exec(ctx, `UPDATE workspace SET settings = NULL WHERE id = $1`, testWorkspaceID)
-	})
+	t.Cleanup(func() { resetWorkspaceSettings(t, testWorkspaceID) })
 
 	agentID := createHandlerTestAgent(t, "redact-get-test-agent", nil)
 	if _, err := testPool.Exec(ctx, `UPDATE agent SET custom_env = '{"SECRET_KEY": "super-secret"}' WHERE id = $1`, agentID); err != nil {
@@ -261,9 +266,7 @@ func TestListAgents_AlwaysRedactEnv_OwnerSeesRedacted(t *testing.T) {
 	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = '{"always_redact_env": true}' WHERE id = $1`, testWorkspaceID); err != nil {
 		t.Fatalf("failed to set workspace settings: %v", err)
 	}
-	t.Cleanup(func() {
-		testPool.Exec(ctx, `UPDATE workspace SET settings = NULL WHERE id = $1`, testWorkspaceID)
-	})
+	t.Cleanup(func() { resetWorkspaceSettings(t, testWorkspaceID) })
 
 	agentName := "redact-list-test-agent"
 	agentID := createHandlerTestAgent(t, agentName, nil)
@@ -312,7 +315,7 @@ func TestGetAgent_DefaultNoRedactForOwner(t *testing.T) {
 	ctx := context.Background()
 
 	// Ensure workspace has no always_redact_env policy (guards against test-order leakage).
-	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = NULL WHERE id = $1`, testWorkspaceID); err != nil {
+	if _, err := testPool.Exec(ctx, `UPDATE workspace SET settings = '{}'::jsonb WHERE id = $1`, testWorkspaceID); err != nil {
 		t.Fatalf("failed to clear workspace settings: %v", err)
 	}
 


### PR DESCRIPTION
## What

Adds an opt-in `always_redact_env` workspace setting that forces unconditional redaction of `custom_env` and `mcp_config` on agent GET/LIST responses, regardless of the caller's role.

## Why

Closes #2352 — For single-tenant self-hosts, security-conscious teams, or environments involving screen-sharing/pair-programming, the current role-based gate may not provide sufficient protection. Some deployments want a stricter posture: no human ever sees plaintext secrets on read, regardless of role. Owners can still **write** secrets via the update path; they just can't read them back through the API.

## How

- Added `workspaceAlwaysRedactEnv(settings []byte) bool` helper that parses the workspace settings JSON for `always_redact_env: true`
- In `ListAgents`: queries workspace settings; if enabled, all agent responses get redacted
- In `GetAgent`: same check via `GetWorkspace` query
- Defaults to `false` — zero behavioral change for existing deployments

## Testing

- Unit tests for `workspaceAlwaysRedactEnv` covering nil, empty, false, true, invalid JSON, and mixed-field cases
- `go vet` clean
- Existing redaction logic for non-owner/non-admin callers remains unchanged

## Thinking path

The issue suggested several possible locations for the toggle (env var, workspace setting, TOML config). I chose **workspace settings JSON** because:
1. It already exists and is editable via the API (`PATCH /api/workspaces/:id`)
2. Per-workspace granularity (vs global env var) is more flexible for multi-workspace setups
3. No schema migration needed — the `settings` column is an opaque JSON blob
4. Consistent with how other workspace-level toggles would be added in the future

---

**Checklist:**
- [x] Changes are limited to the issue scope
- [x] `go vet` passes
- [x] Unit tests added
- [x] No breaking changes (opt-in, default off)