### PR TITLE
fix(openclaw): parse wrapped run results

### DIFF
--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -445,22 +445,32 @@ func tryParseOpenclawEvent(line string) (openclawEvent, bool) {
 	return event, true
 }
 
-// tryParseOpenclawResult attempts to parse a line as a final result blob
-// (the legacy format with payloads + meta). Lines must start with '{' to be
-// considered — we no longer scan for braces at arbitrary positions, which
-// avoids false matches on log lines containing JSON fragments.
+// tryParseOpenclawResult attempts to parse a line as a final result blob.
+// OpenClaw has emitted both the legacy direct format (`payloads` + `meta`) and
+// a newer run wrapper (`runId`, `status`, `result`). Lines must start with '{'
+// to be considered so log lines containing JSON fragments are not false
+// positives.
 func tryParseOpenclawResult(raw string) (openclawResult, bool) {
 	if len(raw) == 0 || raw[0] != '{' {
 		return openclawResult{}, false
 	}
 	var result openclawResult
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+	if err := json.Unmarshal([]byte(raw), &result); err == nil && hasOpenclawResultData(result) {
+		return result, true
+	}
+
+	var wrapped openclawRunResult
+	if err := json.Unmarshal([]byte(raw), &wrapped); err != nil {
 		return openclawResult{}, false
 	}
-	if result.Payloads == nil && result.Meta.DurationMs == 0 {
+	if wrapped.Result == nil || !hasOpenclawResultData(*wrapped.Result) {
 		return openclawResult{}, false
 	}
-	return result, true
+	return *wrapped.Result, true
+}
+
+func hasOpenclawResultData(result openclawResult) bool {
+	return result.Payloads != nil || result.Meta.DurationMs != 0 || result.Meta.AgentMeta != nil
 }
 
 // buildOpenclawEventResult extracts text and metadata from a final result blob.
@@ -617,6 +627,13 @@ type openclawErrorData struct {
 type openclawResult struct {
 	Payloads []openclawPayload `json:"payloads"`
 	Meta     openclawMeta      `json:"meta"`
+}
+
+// openclawRunResult is the newer OpenClaw wrapper around the legacy result.
+// The user-visible answer still lives under result.payloads; the rest of the
+// wrapper is run diagnostics that must not be surfaced as the assistant reply.
+type openclawRunResult struct {
+	Result *openclawResult `json:"result"`
 }
 
 type openclawPayload struct {

--- a/server/pkg/agent/openclaw_test.go
+++ b/server/pkg/agent/openclaw_test.go
@@ -893,6 +893,70 @@ func TestOpenclawProcessOutputMultilineJSONWithLeadingLogs(t *testing.T) {
 	close(ch)
 }
 
+func TestOpenclawProcessOutputWrappedRunResult(t *testing.T) {
+	t.Parallel()
+
+	b := &openclawBackend{cfg: Config{Logger: slog.Default()}}
+	ch := make(chan Message, 256)
+
+	wrapped := openclawRunResult{
+		Result: &openclawResult{
+			Payloads: []openclawPayload{{Text: "Clean visible reply"}},
+			Meta: openclawMeta{
+				DurationMs: 15705,
+				AgentMeta: map[string]any{
+					"sessionId": "multica-1778407314447248422",
+					"model":     "gpt-5.5",
+					"usage": map[string]any{
+						"input":     float64(17264),
+						"output":    float64(457),
+						"cacheRead": float64(37376),
+					},
+					"systemPromptReport": map[string]any{
+						"finalPromptText": "diagnostic prompt text must not leak",
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(map[string]any{
+		"runId":   "ab49855c-be6b-4f32-89d9-374ccea812f1",
+		"status":  "ok",
+		"summary": "completed",
+		"result":  wrapped.Result,
+	}, "", "  ")
+
+	res := b.processOutput(strings.NewReader(string(data)), ch)
+
+	if res.status != "completed" {
+		t.Errorf("status: got %q, want %q", res.status, "completed")
+	}
+	if res.output != "Clean visible reply" {
+		t.Errorf("output: got %q, want %q", res.output, "Clean visible reply")
+	}
+	if strings.Contains(res.output, "systemPromptReport") || strings.Contains(res.output, "finalPromptText") {
+		t.Fatalf("diagnostic wrapper leaked into output: %q", res.output)
+	}
+	if res.sessionID != "multica-1778407314447248422" {
+		t.Errorf("sessionID: got %q", res.sessionID)
+	}
+	if res.model != "gpt-5.5" {
+		t.Errorf("model: got %q", res.model)
+	}
+	if res.usage.InputTokens != 17264 || res.usage.OutputTokens != 457 || res.usage.CacheReadTokens != 37376 {
+		t.Errorf("usage: got %+v", res.usage)
+	}
+
+	close(ch)
+	var msgs []Message
+	for m := range ch {
+		msgs = append(msgs, m)
+	}
+	if len(msgs) != 1 || msgs[0].Content != "Clean visible reply" {
+		t.Errorf("expected one clean text message, got %+v", msgs)
+	}
+}
+
 // ── openclawInt64 tests ──
 
 func TestOpenclawInt64Float(t *testing.T) {


### PR DESCRIPTION
## Summary
- parse newer OpenClaw run-wrapper JSON by unwrapping result.payloads/result.meta
- keep legacy payloads/meta parsing behavior intact
- add a regression test that ensures diagnostic fields like systemPromptReport/finalPromptText do not leak into assistant output

## Root cause
Newer OpenClaw builds can emit a wrapper shaped like { runId, status, result: { payloads, meta } }. The adapter only recognized the legacy top-level { payloads, meta } shape, so the wrapper could be treated as raw output and surfaced as noisy user-visible task/comment text.

## Validation
- go test ./pkg/agent
- go test ./...