### PR TITLE
fix(views): prevent text duplication when toggling create-issue mode

### DIFF
--- a/packages/views/modals/create-issue.test.tsx
+++ b/packages/views/modals/create-issue.test.tsx
@@ -388,4 +388,31 @@ describe("CreateIssueModal", () => {
       }),
     );
   });
+
+  // Title + description are packed into the agent prompt on switch; if we
+  // leave them in the shared draft store, the next agent→manual switch
+  // surfaces the stale manual draft on top of the prompt-as-description,
+  // duplicating the user's text on every round-trip.
+  it("clears the manual draft when packing title and description into the agent prompt", async () => {
+    const user = userEvent.setup();
+
+    renderModal(
+      <ManualCreatePanel
+        onClose={vi.fn()}
+        onSwitchMode={vi.fn()}
+        isExpanded={false}
+        setIsExpanded={vi.fn()}
+        backlogHintIssueId={null}
+        setBacklogHintIssueId={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Issue title"), "Update");
+    await user.type(screen.getByPlaceholderText("Add description..."), "Some body");
+
+    mockSetDraft.mockClear();
+    await user.click(screen.getByRole("button", { name: /Switch to Agent/i }));
+
+    expect(mockSetDraft).toHaveBeenCalledWith({ title: "", description: "" });
+  });
 });

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -268,6 +268,11 @@ export function ManualCreatePanel({
   const switchToAgent = () => {
     const desc = descEditorRef.current?.getMarkdown()?.trim() ?? "";
     const prompt = [title.trim(), desc].filter(Boolean).join("\n\n");
+    // Title + description have been packed into the agent prompt — clear them
+    // from the shared draft so a later agent→manual switch doesn't surface
+    // stale manual state on top of the prompt-as-description, which would
+    // duplicate content on every round-trip.
+    setDraft({ title: "", description: "" });
     setLastMode("agent");
     onSwitchMode?.({
       prompt,


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the Create Issue dialog: alternating clicks on **Switch to Agent** / **Switch to Manual** duplicate and accumulate the typed text on every round-trip.

**Root cause.** `ManualCreatePanel.switchToAgent` packs `title + description` into the agent `prompt`, but leaves both fields in the shared `useIssueDraftStore`. When the user switches back, `AgentCreatePanel.switchToManual` writes the agent markdown into `draft.description` while the stale `draft.title` is still sitting in the store. The manual panel re-mounts, reads both from the store, and the content appears doubled. Each round-trip compounds — the fourth switch turns `"更新"` into `"更新\n\n更新\n\n更新\n\n更新"`.

**Fix.** When packing the manual draft into the agent prompt, clear `title` and `description` from the shared draft store. The data has logically moved into the agent representation, so leaving a copy in the manual draft is the bug.

## Related Issue

Closes <!-- fill in if tracked -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/modals/create-issue.tsx` — `switchToAgent` now calls `setDraft({ title: "", description: "" })` after packing the prompt, with a comment explaining why.
- `packages/views/modals/create-issue.test.tsx` — new regression test `clears the manual draft when packing title and description into the agent prompt` that locks in the behavior.

## How to Test

1. Open the Create Issue dialog in manual mode.
2. Type a title (e.g. `更新`) and/or description.
3. Click **Switch to Agent**, then **Switch to Manual**. Repeat the toggle several times.
4. Before this change: the text is duplicated once per round-trip and accumulates. After this change: each switch shows the content exactly once.

Automated:

```bash
cd packages/views && vitest run modals/create-issue.test.tsx
```

All 4 tests pass, including the new regression test.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** / **starter-content** / **relevant docs** — N/A, pure bug fix.
- [ ] If this PR touches Chinese product copy — N/A, no copy changes.
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** User reported the duplication bug with a screenshot of the Create Issue dialog. I traced the state flow through `ManualCreatePanel.switchToAgent` (packs title + description into prompt), `AgentCreatePanel.switchToManual` (writes agent markdown to `draft.description`), and `useIssueDraftStore` to find the stale `draft.title` that caused the compounding. The fix is a two-line clear in `switchToAgent`, plus a regression test in the existing test file.

## Screenshots (optional)

Before — title `更新` duplicated 4 times after toggling modes 4 times:

<!-- user-provided screenshot goes here -->