### PR TITLE
fix(agent): stop filtering Pi extension tools via hardcoded --tools allowlist

### DIFF
--- a/server/pkg/agent/pi.go
+++ b/server/pkg/agent/pi.go
@@ -316,7 +316,6 @@ var piBlockedArgs = map[string]blockedArgMode{
 //	--session <path>            session log file (created upfront, reused on resume)
 //	--provider <name>           provider, when Model is "provider/id"
 //	--model <id>                model identifier
-//	--tools read,bash,...       explicit tool allowlist (pi has no --yolo)
 //	--append-system-prompt <s>  extra system instructions
 //
 // Custom args appended before the positional prompt. The prompt is a
@@ -338,7 +337,11 @@ func buildPiArgs(prompt, sessionPath string, opts ExecOptions, logger *slog.Logg
 			args = append(args, "--model", model)
 		}
 	}
-	args = append(args, "--tools", "read,bash,edit,write,grep,find,ls")
+	// Note: we intentionally do NOT pass --tools here. Omitting it lets
+	// Pi use its full tool registry, including user-installed extension
+	// tools. Passing --tools acts as a restrictive allowlist that
+	// silently filters out extension-registered tools (#2379).
+	// Users who want to restrict tools can do so via custom_args.
 	if opts.SystemPrompt != "" {
 		args = append(args, "--append-system-prompt", opts.SystemPrompt)
 	}

--- a/server/pkg/agent/pi_test.go
+++ b/server/pkg/agent/pi_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestBuildPiArgsNoToolAllowlist(t *testing.T) {
+	// Extension tools registered via Pi's registerTool() must not be
+	// filtered out by a hardcoded --tools allowlist. Omitting --tools
+	// lets Pi use its full tool registry. See #2379.
+	args := buildPiArgs("test prompt", "/tmp/session.jsonl", ExecOptions{}, slog.Default())
+	for i, arg := range args {
+		if arg == "--tools" {
+			t.Errorf("buildPiArgs emits --tools %q; should not restrict tool registry (see #2379)", args[i+1])
+		}
+	}
+}
+
+func TestBuildPiArgsBasicFlags(t *testing.T) {
+	args := buildPiArgs("hello world", "/tmp/s.jsonl", ExecOptions{
+		Model:        "anthropic/claude-sonnet-4-20250514",
+		SystemPrompt: "be helpful",
+	}, slog.Default())
+
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-p", "--mode json", "--session /tmp/s.jsonl", "--provider anthropic", "--model claude-sonnet-4-20250514", "--append-system-prompt"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in args, got: %v", want, args)
+		}
+	}
+
+	// Prompt must be the last positional argument.
+	if args[len(args)-1] != "hello world" {
+		t.Errorf("prompt should be last arg, got %q", args[len(args)-1])
+	}
+}
+
+func TestBuildPiArgsCustomArgsAppended(t *testing.T) {
+	// Users can still restrict tools via custom_args if desired.
+	args := buildPiArgs("prompt", "/tmp/s.jsonl", ExecOptions{
+		CustomArgs: []string{"--tools", "read,bash"},
+	}, slog.Default())
+
+	found := false
+	for i, arg := range args {
+		if arg == "--tools" && i+1 < len(args) && args[i+1] == "read,bash" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("custom --tools should pass through via custom_args, got: %v", args)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Removes the hardcoded `--tools read,bash,edit,write,grep,find,ls` from `buildPiArgs()` so Pi's full tool registry — including user-installed extension tools — is available to agents.

## Related Issue

Closes #2379

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/pkg/agent/pi.go`: Remove hardcoded `--tools` allowlist from `buildPiArgs()`. Add comment explaining the intentional omission. Users can still restrict tools via `custom_args` (--tools is not in `piBlockedArgs`).
- `server/pkg/agent/pi_test.go` (new): Add `TestBuildPiArgsNoToolAllowlist`, `TestBuildPiArgsBasicFlags`, and `TestBuildPiArgsCustomArgsAppended`.

## Thinking Path

1. **Issue**: Pi extensions register tools via `pi.registerTool()`, but Multica-spawned Pi sessions only see `read,bash,edit,write,grep,find,ls`.
2. **Root cause**: `buildPiArgs()` passes `--tools <allowlist>`. Pi's SDK uses this as a restrictive filter — `_refreshToolRegistry()` calls `isAllowedTool(name)` which returns false for any tool not in the allowlist.
3. **Why omitting works**: When `--tools` is not passed, `allowedToolNames` is `undefined`, making `isAllowedTool()` a no-op. All tools (built-in + extension) pass through. This matches Pi's standalone behavior.
4. **Security**: `bash` was already in the allowlist, so extensions do not expand the attack surface. Pi's `-p` mode handles tool auto-approval independently.
5. **Escape hatch**: `--tools` is intentionally absent from `piBlockedArgs`, so users who want a restrictive allowlist can still pass it via `custom_args`.

## How to Test

1. Install a Pi extension that registers a custom tool (e.g. via `pi.registerTool()`)
2. Create a Multica workspace agent using Pi runtime
3. Ask the agent to list its available tools
4. **Before**: only `read, bash, edit, write, grep, find, ls`
5. **After**: extension tools are also available

Automated:
```bash
cd server && go test ./pkg/agent/ -run TestBuildPiArgs -v
```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy**, **starter-content**, and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against conventions
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code (via OpenClaw)

**Prompt / approach:** Analyzed issue #2379 root cause by reading Pi SDK code referenced in the bug report, traced the `--tools` flag through `buildPiArgs()` → Pi CLI → SDK `createAgentSession()` → `_refreshToolRegistry()`, confirmed omitting the flag makes the filter a no-op.