### PR TITLE
feat(cli,agents): expose mcp_config via `agent update` + redact on read

### DIFF
--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -144,6 +145,9 @@ func init() {
 	agentUpdateCmd.Flags().String("custom-env", "", "New custom environment variables as JSON object, e.g. '{\"KEY\":\"value\"}'. Treated as secret material — never logged by the CLI, but values passed on the command line are visible to shell history and 'ps'; prefer --custom-env-stdin or --custom-env-file for real secrets. Pass '{}' to clear the map; omit the flag to leave it unchanged.")
 	agentUpdateCmd.Flags().Bool("custom-env-stdin", false, "Read the new --custom-env JSON object from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --custom-env and --custom-env-file.")
 	agentUpdateCmd.Flags().String("custom-env-file", "", "Read the new --custom-env JSON object from a file path (suggested mode: 0600). Mutually exclusive with --custom-env and --custom-env-stdin.")
+	agentUpdateCmd.Flags().String("mcp-config-file", "", "Path to a JSON file containing the agent's MCP server config (schema: {\"mcpServers\":{\"<name>\":{\"command\"?,\"args\"?,\"env\"?,\"url\"?,\"headers\"?,\"type\"?}}}). Suggested mode: 0600 — values are treated as secret material and redacted on read. Mutually exclusive with --mcp-config-stdin and --mcp-config-clear.")
+	agentUpdateCmd.Flags().Bool("mcp-config-stdin", false, "Read the MCP server config JSON from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --mcp-config-file and --mcp-config-clear.")
+	agentUpdateCmd.Flags().Bool("mcp-config-clear", false, "Clear the agent's MCP server config (resets the field to null). Mutually exclusive with --mcp-config-file and --mcp-config-stdin.")
 	agentUpdateCmd.Flags().String("visibility", "", "New visibility: private or workspace")
 	agentUpdateCmd.Flags().String("status", "", "New status")
 	agentUpdateCmd.Flags().Int32("max-concurrent-tasks", 0, "New max concurrent tasks")
@@ -468,6 +472,16 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	} else if ok {
 		body["custom_env"] = ce
 	}
+	if mc, action, err := resolveMcpConfig(cmd); err != nil {
+		return err
+	} else if action == mcpConfigSet {
+		body["mcp_config"] = mc
+	} else if action == mcpConfigClear {
+		// Explicit null tells the server's UpdateAgent handler to fall
+		// through to ClearAgentMcpConfig — COALESCE on the regular
+		// update query cannot drive a column back to NULL.
+		body["mcp_config"] = nil
+	}
 	if cmd.Flags().Changed("model") {
 		v, _ := cmd.Flags().GetString("model")
 		body["model"] = v
@@ -486,7 +500,7 @@ func runAgentUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --custom-env (or --custom-env-stdin, --custom-env-file), --visibility, --status, or --max-concurrent-tasks")
+		return fmt.Errorf("no fields to update; use --name, --description, --instructions, --runtime-id, --runtime-config, --model, --custom-args, --custom-env (or --custom-env-stdin, --custom-env-file), --mcp-config-file (or --mcp-config-stdin, --mcp-config-clear), --visibility, --status, or --max-concurrent-tasks")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -851,6 +865,157 @@ func resolveCustomEnv(cmd *cobra.Command) (map[string]string, bool, error) {
 		return nil, false, err
 	}
 	return ce, true, nil
+}
+
+// mcpConfigAction is the resolved decision for the --mcp-config-* flag
+// group: set the field to a new value, clear it, or leave it alone.
+type mcpConfigAction int
+
+const (
+	mcpConfigUnchanged mcpConfigAction = iota
+	mcpConfigSet
+	mcpConfigClear
+)
+
+// parseMcpConfig validates and normalises an MCP server config blob. The
+// shape mirrors what Claude Code's --mcp-config expects:
+//
+//	{
+//	  "mcpServers": {
+//	    "<name>": { "command"?, "args"?, "env"?, "url"?, "headers"?, "type"? }
+//	  }
+//	}
+//
+// We require either "command" (stdio transport) or "url" (http transport)
+// on each server, and reject unknown fields inside a server spec so typos
+// fail loudly. Error messages avoid echoing input fragments because callers
+// may put OAuth tokens in env / args / headers and json.Unmarshal errors
+// can otherwise leak short slices of the raw payload.
+func parseMcpConfig(raw []byte) (json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("--mcp-config: empty input; use --mcp-config-clear to reset the field")
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil, fmt.Errorf("--mcp-config: payload is null; use --mcp-config-clear to reset the field")
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &top); err != nil {
+		return nil, fmt.Errorf("--mcp-config: must be a JSON object with an \"mcpServers\" key")
+	}
+	servers, ok := top["mcpServers"]
+	if !ok {
+		return nil, fmt.Errorf("--mcp-config: missing required top-level key \"mcpServers\"")
+	}
+
+	var serverMap map[string]json.RawMessage
+	if err := json.Unmarshal(servers, &serverMap); err != nil {
+		return nil, fmt.Errorf("--mcp-config: \"mcpServers\" must be an object mapping server name to spec")
+	}
+	if len(serverMap) == 0 {
+		return nil, fmt.Errorf("--mcp-config: \"mcpServers\" must declare at least one server")
+	}
+
+	type serverSpec struct {
+		Command *string            `json:"command,omitempty"`
+		Args    *[]string          `json:"args,omitempty"`
+		Env     *map[string]string `json:"env,omitempty"`
+		URL     *string            `json:"url,omitempty"`
+		Headers *map[string]string `json:"headers,omitempty"`
+		Type    *string            `json:"type,omitempty"`
+	}
+	for name, specRaw := range serverMap {
+		if name == "" {
+			return nil, fmt.Errorf("--mcp-config: server name must be non-empty")
+		}
+		dec := json.NewDecoder(bytes.NewReader(specRaw))
+		dec.DisallowUnknownFields()
+		var spec serverSpec
+		if err := dec.Decode(&spec); err != nil {
+			return nil, fmt.Errorf("--mcp-config: server %q has invalid shape; allowed fields: command, args, env, url, headers, type", name)
+		}
+		if spec.Command == nil && spec.URL == nil {
+			return nil, fmt.Errorf("--mcp-config: server %q must set either \"command\" (stdio transport) or \"url\" (http transport)", name)
+		}
+	}
+
+	return append(json.RawMessage(nil), trimmed...), nil
+}
+
+// resolveMcpConfig collects the --mcp-config-file, --mcp-config-stdin, and
+// --mcp-config-clear flags and decides which write to perform. The three
+// channels are mutually exclusive so callers can't accidentally set and
+// clear the same field in one call. File and stdin are documented to carry
+// secret material; we read but do not echo the bytes anywhere.
+func resolveMcpConfig(cmd *cobra.Command) (json.RawMessage, mcpConfigAction, error) {
+	fromFile := cmd.Flags().Changed("mcp-config-file")
+	filePath, _ := cmd.Flags().GetString("mcp-config-file")
+	fromStdin, _ := cmd.Flags().GetBool("mcp-config-stdin")
+	clear, _ := cmd.Flags().GetBool("mcp-config-clear")
+
+	count := 0
+	if fromFile {
+		count++
+	}
+	if fromStdin {
+		count++
+	}
+	if clear {
+		count++
+	}
+	switch {
+	case count == 0:
+		return nil, mcpConfigUnchanged, nil
+	case count > 1:
+		return nil, mcpConfigUnchanged, fmt.Errorf("--mcp-config-file, --mcp-config-stdin, and --mcp-config-clear are mutually exclusive; pick one")
+	}
+
+	if clear {
+		return nil, mcpConfigClear, nil
+	}
+
+	var raw []byte
+	switch {
+	case fromStdin:
+		buf, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return nil, mcpConfigUnchanged, fmt.Errorf("read --mcp-config-stdin: %w", err)
+		}
+		raw = buf
+		if strings.TrimSpace(string(raw)) == "" {
+			return nil, mcpConfigUnchanged, fmt.Errorf("--mcp-config-stdin: empty input; use --mcp-config-clear to reset the field")
+		}
+	case fromFile:
+		if filePath == "" {
+			return nil, mcpConfigUnchanged, fmt.Errorf("--mcp-config-file: path must not be empty")
+		}
+		// Warn (but don't fail) when the file is world- or group-readable.
+		// MCP configs routinely embed OAuth tokens; loose permissions are
+		// a real foot-gun, but failing here would block legitimate setups
+		// on filesystems that don't support fine-grained perms (CI tarballs,
+		// some container mounts, Windows). Mirror the documented mode-0600
+		// expectation in the warning so the fix is obvious.
+		if info, statErr := os.Stat(filePath); statErr == nil && info.Mode().IsRegular() {
+			if perm := info.Mode().Perm(); perm&0o077 != 0 {
+				fmt.Fprintf(os.Stderr, "warning: --mcp-config-file %q has permissions %o; expected 0600 to keep secrets out of other users' reach\n", filePath, perm)
+			}
+		}
+		buf, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, mcpConfigUnchanged, fmt.Errorf("read --mcp-config-file: %w", err)
+		}
+		raw = buf
+		if strings.TrimSpace(string(raw)) == "" {
+			return nil, mcpConfigUnchanged, fmt.Errorf("--mcp-config-file %q: empty contents; use --mcp-config-clear to reset the field", filePath)
+		}
+	}
+
+	normalised, err := parseMcpConfig(raw)
+	if err != nil {
+		return nil, mcpConfigUnchanged, err
+	}
+	return normalised, mcpConfigSet, nil
 }
 
 func strVal(m map[string]any, key string) string {

--- a/server/cmd/multica/cmd_agent_test.go
+++ b/server/cmd/multica/cmd_agent_test.go
@@ -29,6 +29,17 @@ func freshAgentUpdateCmd() *cobra.Command {
 	return c
 }
 
+// freshMcpConfigCmd returns a standalone cobra.Command with the three
+// --mcp-config-* flags registered, isolated from any package-level state
+// so subtests can mutate flag values without leaking across each other.
+func freshMcpConfigCmd() *cobra.Command {
+	c := &cobra.Command{Use: "update"}
+	c.Flags().String("mcp-config-file", "", "")
+	c.Flags().Bool("mcp-config-stdin", false, "")
+	c.Flags().Bool("mcp-config-clear", false, "")
+	return c
+}
+
 // TestResolveWorkspaceID_AgentContextSkipsConfig is a regression test for
 // the cross-workspace contamination bug (#1235). Inside a daemon-spawned
 // agent task (MULTICA_AGENT_ID / MULTICA_TASK_ID set), the CLI must NOT
@@ -491,6 +502,433 @@ func TestResolveCustomEnv(t *testing.T) {
 		}
 		if !reflect.DeepEqual(got, map[string]string{}) {
 			t.Fatalf("file {}: got %v, want empty map", got)
+		}
+	})
+}
+
+// TestParseMcpConfig covers the client-side schema validator. The CLI must
+// reject obviously-broken payloads before sending them to the server so the
+// caller gets an actionable error without depending on the server response.
+// The server runs the same validation as defense in depth.
+func TestParseMcpConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr bool
+		// wantSub, when non-empty, is a substring that must appear in the
+		// error message. Useful for asserting the user sees a meaningful
+		// hint, not a generic "bad JSON".
+		wantSub string
+	}{
+		{
+			name: "stdio transport",
+			raw:  `{"mcpServers":{"echo":{"command":"echo","args":["hi"],"env":{"K":"v"}}}}`,
+		},
+		{
+			name: "http transport",
+			raw:  `{"mcpServers":{"remote":{"url":"https://example.com/mcp","headers":{"Authorization":"Bearer x"}}}}`,
+		},
+		{
+			name: "type field accepted",
+			raw:  `{"mcpServers":{"echo":{"command":"echo","type":"stdio"}}}`,
+		},
+		{
+			name:    "empty input",
+			raw:     ``,
+			wantErr: true,
+			wantSub: "empty input",
+		},
+		{
+			name:    "explicit null",
+			raw:     `null`,
+			wantErr: true,
+			wantSub: "--mcp-config-clear",
+		},
+		{
+			name:    "missing mcpServers key",
+			raw:     `{"mcp_servers":{}}`,
+			wantErr: true,
+			wantSub: "mcpServers",
+		},
+		{
+			name:    "mcpServers wrong type",
+			raw:     `{"mcpServers":[]}`,
+			wantErr: true,
+			wantSub: "mcpServers",
+		},
+		{
+			name:    "empty mcpServers map",
+			raw:     `{"mcpServers":{}}`,
+			wantErr: true,
+			wantSub: "at least one server",
+		},
+		{
+			name:    "server missing transport",
+			raw:     `{"mcpServers":{"oauth":{"env":{"TOKEN":"x"}}}}`,
+			wantErr: true,
+			wantSub: "must set either",
+		},
+		{
+			name:    "unknown field in server spec",
+			raw:     `{"mcpServers":{"weird":{"command":"echo","bogus":true}}}`,
+			wantErr: true,
+			wantSub: "invalid shape",
+		},
+		{
+			name:    "wrong type for args",
+			raw:     `{"mcpServers":{"echo":{"command":"echo","args":"oops"}}}`,
+			wantErr: true,
+			wantSub: "invalid shape",
+		},
+		{
+			name:    "not JSON",
+			raw:     `not-json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMcpConfig([]byte(tc.raw))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseMcpConfig(%q): expected error, got nil (result=%s)", tc.raw, got)
+				}
+				if !strings.Contains(err.Error(), "--mcp-config") {
+					t.Fatalf("parseMcpConfig(%q): error must mention --mcp-config, got %q", tc.raw, err)
+				}
+				if tc.wantSub != "" && !strings.Contains(err.Error(), tc.wantSub) {
+					t.Fatalf("parseMcpConfig(%q): expected error to contain %q, got %q", tc.raw, tc.wantSub, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMcpConfig(%q): unexpected error: %v", tc.raw, err)
+			}
+			// Normalised output must still parse cleanly.
+			var roundTrip map[string]any
+			if err := json.Unmarshal(got, &roundTrip); err != nil {
+				t.Fatalf("normalised output is not valid JSON: %v", err)
+			}
+		})
+	}
+}
+
+// TestParseMcpConfigErrorSanitization guards against future changes
+// re-introducing %w wrapping of json.Unmarshal errors on the mcp_config
+// path. The flag is documented to carry secret material (OAuth tokens in
+// env / args / headers), so errors must never echo input fragments.
+func TestParseMcpConfigErrorSanitization(t *testing.T) {
+	secretish := `{"mcpServers":{"gmail":{"command":"node","env":{"OAUTH_TOKEN":verySensitiveValue}}}}` // invalid JSON
+	_, err := parseMcpConfig([]byte(secretish))
+	if err == nil {
+		t.Fatal("expected parse error for invalid JSON")
+	}
+	for _, leak := range []string{"OAUTH_TOKEN", "verySensitiveValue"} {
+		if strings.Contains(err.Error(), leak) {
+			t.Fatalf("parseMcpConfig error leaked input fragment %q: %q", leak, err.Error())
+		}
+	}
+}
+
+// TestResolveMcpConfig exercises the three-channel resolver: file, stdin,
+// clear, mutual exclusion, and the "not supplied" path. Mirrors the
+// resolveCustomEnv tests so future contributors recognise the pattern.
+func TestResolveMcpConfig(t *testing.T) {
+	validConfig := `{"mcpServers":{"echo":{"command":"echo"}}}`
+
+	t.Run("not supplied", func(t *testing.T) {
+		cmd := freshMcpConfigCmd()
+		got, action, err := resolveMcpConfig(cmd)
+		if err != nil || got != nil || action != mcpConfigUnchanged {
+			t.Fatalf("unset flags: got=%s action=%d err=%v", got, action, err)
+		}
+	})
+
+	t.Run("clear flag returns mcpConfigClear", func(t *testing.T) {
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-clear", "true")
+		got, action, err := resolveMcpConfig(cmd)
+		if err != nil {
+			t.Fatalf("clear: err=%v", err)
+		}
+		if action != mcpConfigClear {
+			t.Fatalf("clear: action=%d, want %d", action, mcpConfigClear)
+		}
+		if got != nil {
+			t.Fatalf("clear: got=%s, want nil payload", got)
+		}
+	})
+
+	t.Run("stdin", func(t *testing.T) {
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-stdin", "true")
+		cmd.SetIn(bytes.NewBufferString(validConfig))
+		got, action, err := resolveMcpConfig(cmd)
+		if err != nil || action != mcpConfigSet {
+			t.Fatalf("stdin: action=%d err=%v", action, err)
+		}
+		var v map[string]any
+		if err := json.Unmarshal(got, &v); err != nil {
+			t.Fatalf("stdin: parse normalised: %v", err)
+		}
+		if _, ok := v["mcpServers"]; !ok {
+			t.Fatalf("stdin: normalised payload missing mcpServers: %s", got)
+		}
+	})
+
+	t.Run("file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "mcp.json")
+		if err := os.WriteFile(path, []byte(validConfig), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		_, action, err := resolveMcpConfig(cmd)
+		if err != nil || action != mcpConfigSet {
+			t.Fatalf("file: action=%d err=%v", action, err)
+		}
+	})
+
+	t.Run("mutually exclusive: file + stdin", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "mcp.json")
+		if err := os.WriteFile(path, []byte(validConfig), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		_ = cmd.Flags().Set("mcp-config-stdin", "true")
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("expected mutual-exclusion error, got %v", err)
+		}
+	})
+
+	t.Run("mutually exclusive: file + clear", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "mcp.json")
+		if err := os.WriteFile(path, []byte(validConfig), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		_ = cmd.Flags().Set("mcp-config-clear", "true")
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("expected mutual-exclusion error, got %v", err)
+		}
+	})
+
+	t.Run("mutually exclusive: stdin + clear", func(t *testing.T) {
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-stdin", "true")
+		_ = cmd.Flags().Set("mcp-config-clear", "true")
+		cmd.SetIn(bytes.NewBufferString(validConfig))
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("expected mutual-exclusion error, got %v", err)
+		}
+	})
+
+	t.Run("file: missing path surfaces filesystem error", func(t *testing.T) {
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-file", filepath.Join(t.TempDir(), "does-not-exist.json"))
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--mcp-config-file") {
+			t.Fatalf("expected --mcp-config-file error, got %v", err)
+		}
+	})
+
+	t.Run("file: empty path errors", func(t *testing.T) {
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-file", "")
+		if !cmd.Flags().Changed("mcp-config-file") {
+			t.Fatal("setup: expected mcp-config-file flag to be marked Changed")
+		}
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--mcp-config-file") {
+			t.Fatalf("expected --mcp-config-file empty-path error, got %v", err)
+		}
+	})
+
+	t.Run("file: empty contents errors", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "empty.json")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--mcp-config-file") || !strings.Contains(err.Error(), "--mcp-config-clear") {
+			t.Fatalf("expected --mcp-config-file empty-contents error mentioning --mcp-config-clear, got %v", err)
+		}
+	})
+
+	t.Run("stdin: empty input errors", func(t *testing.T) {
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-stdin", "true")
+		cmd.SetIn(bytes.NewBufferString(""))
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "--mcp-config-stdin") || !strings.Contains(err.Error(), "--mcp-config-clear") {
+			t.Fatalf("expected --mcp-config-stdin empty-input error mentioning --mcp-config-clear, got %v", err)
+		}
+	})
+
+	t.Run("file: invalid JSON propagates parser error", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(path, []byte(`{"mcp_servers":{}}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := freshMcpConfigCmd()
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		_, _, err := resolveMcpConfig(cmd)
+		if err == nil || !strings.Contains(err.Error(), "mcpServers") {
+			t.Fatalf("expected mcpServers validation error, got %v", err)
+		}
+	})
+}
+
+// TestAgentUpdateExposesMcpConfigFlags pins the three flag names on the
+// real package-level command. The point of these flags is to let workspace
+// owners wire MCPs from CLI without going through the server admin — if
+// any of them disappears from --help, that feature breaks silently.
+func TestAgentUpdateExposesMcpConfigFlags(t *testing.T) {
+	for _, flag := range []string{"mcp-config-file", "mcp-config-stdin", "mcp-config-clear"} {
+		if agentUpdateCmd.Flag(flag) == nil {
+			t.Fatalf("agent update must expose --%s", flag)
+		}
+	}
+}
+
+// TestAgentUpdateMcpConfigEndToEnd wires runAgentUpdate against a fake
+// server and asserts the PUT body shape for each of the three channels.
+// Acceptance criteria for this issue are written in terms of the body the
+// server sees, so this is the highest-leverage CLI test.
+func TestAgentUpdateMcpConfigEndToEnd(t *testing.T) {
+	type capture struct {
+		body map[string]any
+	}
+
+	newCmd := func(t *testing.T, captured *capture) *cobra.Command {
+		t.Helper()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPut && r.URL.Path == "/api/agents/agent-123" {
+				_ = json.NewDecoder(r.Body).Decode(&captured.body)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":                  "agent-123",
+					"name":                "TestAgent",
+					"mcp_config":          "<redacted>",
+					"mcp_config_redacted": true,
+				})
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("MULTICA_SERVER_URL", srv.URL)
+		t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+		t.Setenv("MULTICA_TOKEN", "test-token")
+		t.Setenv("HOME", t.TempDir())
+
+		cmd := &cobra.Command{Use: "update"}
+		cmd.Flags().String("name", "", "")
+		cmd.Flags().String("description", "", "")
+		cmd.Flags().String("instructions", "", "")
+		cmd.Flags().String("runtime-id", "", "")
+		cmd.Flags().String("runtime-config", "", "")
+		cmd.Flags().String("model", "", "")
+		cmd.Flags().String("custom-args", "", "")
+		cmd.Flags().String("custom-env", "", "")
+		cmd.Flags().Bool("custom-env-stdin", false, "")
+		cmd.Flags().String("custom-env-file", "", "")
+		cmd.Flags().String("mcp-config-file", "", "")
+		cmd.Flags().Bool("mcp-config-stdin", false, "")
+		cmd.Flags().Bool("mcp-config-clear", false, "")
+		cmd.Flags().String("visibility", "", "")
+		cmd.Flags().String("status", "", "")
+		cmd.Flags().Int32("max-concurrent-tasks", 0, "")
+		cmd.Flags().String("output", "json", "")
+		cmd.Flags().String("profile", "", "")
+		return cmd
+	}
+
+	t.Run("file channel sets mcp_config", func(t *testing.T) {
+		captured := &capture{}
+		cmd := newCmd(t, captured)
+		dir := t.TempDir()
+		path := filepath.Join(dir, "mcp.json")
+		if err := os.WriteFile(path, []byte(`{"mcpServers":{"echo":{"command":"echo"}}}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		if err := runAgentUpdate(cmd, []string{"agent-123"}); err != nil {
+			t.Fatalf("runAgentUpdate: %v", err)
+		}
+		mc, ok := captured.body["mcp_config"]
+		if !ok {
+			t.Fatalf("expected body to include mcp_config, got %+v", captured.body)
+		}
+		// Verified server-side: top-level is the mcpServers object.
+		m, ok := mc.(map[string]any)
+		if !ok || m["mcpServers"] == nil {
+			t.Fatalf("expected mcp_config to be an object with mcpServers, got %T (%v)", mc, mc)
+		}
+	})
+
+	t.Run("stdin channel sets mcp_config", func(t *testing.T) {
+		captured := &capture{}
+		cmd := newCmd(t, captured)
+		_ = cmd.Flags().Set("mcp-config-stdin", "true")
+		cmd.SetIn(bytes.NewBufferString(`{"mcpServers":{"echo":{"command":"echo"}}}`))
+		if err := runAgentUpdate(cmd, []string{"agent-123"}); err != nil {
+			t.Fatalf("runAgentUpdate: %v", err)
+		}
+		if _, ok := captured.body["mcp_config"]; !ok {
+			t.Fatalf("expected body to include mcp_config, got %+v", captured.body)
+		}
+	})
+
+	t.Run("clear flag sends explicit null", func(t *testing.T) {
+		captured := &capture{}
+		cmd := newCmd(t, captured)
+		_ = cmd.Flags().Set("mcp-config-clear", "true")
+		if err := runAgentUpdate(cmd, []string{"agent-123"}); err != nil {
+			t.Fatalf("runAgentUpdate: %v", err)
+		}
+		// Explicit-null is the contract between the CLI and the server's
+		// ClearAgentMcpConfig branch. Any other value here regresses the
+		// clear path.
+		mc, ok := captured.body["mcp_config"]
+		if !ok {
+			t.Fatalf("expected body to include mcp_config key, got %+v", captured.body)
+		}
+		if mc != nil {
+			t.Fatalf("expected mcp_config to be JSON null, got %T (%v)", mc, mc)
+		}
+	})
+
+	t.Run("invalid file payload rejected before send", func(t *testing.T) {
+		captured := &capture{}
+		cmd := newCmd(t, captured)
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(path, []byte(`{"mcp_servers":{}}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_ = cmd.Flags().Set("mcp-config-file", path)
+		err := runAgentUpdate(cmd, []string{"agent-123"})
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "mcpServers") {
+			t.Fatalf("expected mcpServers validation error, got %v", err)
+		}
+		if captured.body != nil {
+			t.Fatalf("server must not be called on validation error, got %+v", captured.body)
 		}
 	})
 }

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -296,11 +296,15 @@ func (h *Handler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		if skills, ok := skillMap[resp.ID]; ok {
 			resp.Skills = skills
 		}
-		// Redact sensitive fields for users who are not the agent owner or workspace owner/admin.
+		// custom_env keeps its role-based redaction (owners/admins see the
+		// real values to debug their own agents). mcp_config is always
+		// redacted on the API regardless of role — the database holds the
+		// only authoritative copy, the daemon claim endpoint is the only
+		// reader that ever sees raw bytes.
 		if !canViewAgentEnv(a, userID, member.Role) {
 			redactEnv(&resp)
-			redactMcpConfig(&resp)
 		}
+		redactMcpConfig(&resp)
 		visible = append(visible, resp)
 	}
 
@@ -334,14 +338,16 @@ func (h *Handler) GetAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Redact sensitive fields for users who are not the agent owner or workspace owner/admin.
+	// custom_env: role-based redaction (see ListAgents). mcp_config:
+	// always redacted on user-facing reads; only the daemon claim endpoint
+	// receives the raw bytes.
 	userID := requestUserID(r)
 	if member, ok := ctxMember(r.Context()); ok {
 		if !canViewAgentEnv(agent, userID, member.Role) {
 			redactEnv(&resp)
-			redactMcpConfig(&resp)
 		}
 	}
+	redactMcpConfig(&resp)
 
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -467,6 +473,10 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 
 	var mc []byte
 	if rawMcpConfig, ok := rawFields["mcp_config"]; ok && !bytes.Equal(bytes.TrimSpace(rawMcpConfig), []byte("null")) {
+		if err := validateMcpConfig(rawMcpConfig); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		mc = append([]byte(nil), rawMcpConfig...)
 	}
 
@@ -507,6 +517,9 @@ func (h *Handler) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := agentToResponse(agent)
+	// Redact mcp_config on every read surface, including realtime events.
+	// The daemon claim endpoint is the only place raw bytes leave the DB.
+	redactMcpConfig(&resp)
 	actorType, actorID := h.resolveActor(r, ownerID, workspaceID)
 	h.publish(protocol.EventAgentCreated, workspaceID, actorType, actorID, map[string]any{"agent": resp})
 
@@ -561,14 +574,89 @@ func redactEnv(resp *AgentResponse) {
 	resp.CustomEnvRedacted = true
 }
 
-// redactMcpConfig removes the mcp_config value from the response when the caller is not
-// authorised to view it. The field is set to null; McpConfigRedacted is set to true so
-// callers know a config exists without seeing its contents (which may contain secrets).
+// mcpConfigRedactedSentinel is the value returned in the mcp_config field of
+// API responses whenever the underlying column is non-null. The plumbing for
+// secrets in mcp_config (OAuth tokens, command args with credentials) is the
+// same as custom_env: the raw value lives in the database and is only ever
+// re-emitted to the trusted daemon claim path. Every other read path —
+// including the workspace owner viewing their own agent — gets a sentinel,
+// because the goal is "never put raw tokens on the wire", not "redact only
+// for less-privileged readers". null in the response unambiguously means
+// "field is unset"; "<redacted>" means "field is set, contents withheld".
+var mcpConfigRedactedSentinel = json.RawMessage(`"<redacted>"`)
+
+// redactMcpConfig replaces the mcp_config value in the response with the
+// sentinel string "<redacted>" whenever the field is set, and flips
+// McpConfigRedacted to true. Callers know a config exists without seeing its
+// contents.
 func redactMcpConfig(resp *AgentResponse) {
 	if resp.McpConfig != nil {
-		resp.McpConfig = nil
+		resp.McpConfig = append(json.RawMessage(nil), mcpConfigRedactedSentinel...)
 		resp.McpConfigRedacted = true
 	}
+}
+
+// validateMcpConfig enforces the wire shape Claude Code expects from
+// --mcp-config: a top-level object with a single key "mcpServers" whose value
+// is itself an object mapping server name → server spec. Each spec may carry
+// command/args/env/url/headers/type, all optional. We reject anything that
+// doesn't match the shape so a typo (e.g. {"mcp_servers":{...}}) fails at
+// write time instead of producing an agent that silently spawns claude
+// without any MCP servers attached.
+//
+// Validation is intentionally shallow: per-server fields are type-checked but
+// not semantically (we don't, for example, demand that "command" be a path
+// that exists on disk). The CLI applies the same validation client-side as
+// defense in depth; the server is the authoritative gate.
+func validateMcpConfig(raw json.RawMessage) error {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		// Clearing the field is handled by ClearAgentMcpConfig; if we reach
+		// this function with an empty or explicit-null payload, the caller is
+		// confused about which code path to take.
+		return errors.New("mcp_config: payload is empty; pass null to clear")
+	}
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &top); err != nil {
+		return errors.New("mcp_config: must be a JSON object with an \"mcpServers\" key")
+	}
+	servers, ok := top["mcpServers"]
+	if !ok {
+		return errors.New("mcp_config: missing required top-level key \"mcpServers\"")
+	}
+
+	var serverMap map[string]json.RawMessage
+	if err := json.Unmarshal(servers, &serverMap); err != nil {
+		return errors.New("mcp_config: \"mcpServers\" must be an object mapping server name to spec")
+	}
+	if len(serverMap) == 0 {
+		return errors.New("mcp_config: \"mcpServers\" must declare at least one server")
+	}
+
+	type serverSpec struct {
+		Command *string            `json:"command,omitempty"`
+		Args    *[]string          `json:"args,omitempty"`
+		Env     *map[string]string `json:"env,omitempty"`
+		URL     *string            `json:"url,omitempty"`
+		Headers *map[string]string `json:"headers,omitempty"`
+		Type    *string            `json:"type,omitempty"`
+	}
+	for name, specRaw := range serverMap {
+		if name == "" {
+			return errors.New("mcp_config: server name must be non-empty")
+		}
+		dec := json.NewDecoder(bytes.NewReader(specRaw))
+		dec.DisallowUnknownFields()
+		var spec serverSpec
+		if err := dec.Decode(&spec); err != nil {
+			return fmt.Errorf("mcp_config: server %q has invalid shape; allowed fields: command, args, env, url, headers, type", name)
+		}
+		if spec.Command == nil && spec.URL == nil {
+			return fmt.Errorf("mcp_config: server %q must set either \"command\" (stdio transport) or \"url\" (http transport)", name)
+		}
+	}
+	return nil
 }
 
 // canManageAgent checks whether the current user can update or archive an agent.
@@ -640,6 +728,10 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	rawMcpConfig, hasMcpConfig := rawFields["mcp_config"]
 	shouldClearMcpConfig := hasMcpConfig && bytes.Equal(bytes.TrimSpace(rawMcpConfig), []byte("null"))
 	if hasMcpConfig && !shouldClearMcpConfig {
+		if err := validateMcpConfig(rawMcpConfig); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		params.McpConfig = append([]byte(nil), rawMcpConfig...)
 	}
 	if req.RuntimeID != nil {
@@ -690,6 +782,7 @@ func (h *Handler) UpdateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := agentToResponse(agent)
+	redactMcpConfig(&resp)
 	slog.Info("agent updated", append(logger.RequestAttrs(r), "agent_id", id, "workspace_id", uuidToString(agent.WorkspaceID))...)
 	userID := requestUserID(r)
 	actorType, actorID := h.resolveActor(r, userID, uuidToString(agent.WorkspaceID))
@@ -735,6 +828,7 @@ func (h *Handler) ArchiveAgent(w http.ResponseWriter, r *http.Request) {
 	wsID := uuidToString(archived.WorkspaceID)
 	slog.Info("agent archived", append(logger.RequestAttrs(r), "agent_id", id, "workspace_id", wsID)...)
 	resp := agentToResponse(archived)
+	redactMcpConfig(&resp)
 	actorType, actorID := h.resolveActor(r, userID, wsID)
 	h.publish(protocol.EventAgentArchived, wsID, actorType, actorID, map[string]any{"agent": resp})
 	writeJSON(w, http.StatusOK, resp)
@@ -764,6 +858,7 @@ func (h *Handler) RestoreAgent(w http.ResponseWriter, r *http.Request) {
 	wsID := uuidToString(restored.WorkspaceID)
 	slog.Info("agent restored", append(logger.RequestAttrs(r), "agent_id", id, "workspace_id", wsID)...)
 	resp := agentToResponse(restored)
+	redactMcpConfig(&resp)
 	userID := requestUserID(r)
 	actorType, actorID := h.resolveActor(r, userID, wsID)
 	h.publish(protocol.EventAgentRestored, wsID, actorType, actorID, map[string]any{"agent": resp})

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1217,7 +1217,7 @@ func TestAgentCRUD(t *testing.T) {
 }
 
 func TestUpdateAgentMcpConfigAbsentPreservesValue(t *testing.T) {
-	agentID := createHandlerTestAgent(t, "Handler Mcp Preserve", []byte(`{"preset":"keep"}`))
+	agentID := createHandlerTestAgent(t, "Handler Mcp Preserve", []byte(`{"mcpServers":{"keep":{"command":"echo"}}}`))
 
 	w := httptest.NewRecorder()
 	req := newRequest("PUT", "/api/agents/"+agentID, map[string]any{
@@ -1233,12 +1233,18 @@ func TestUpdateAgentMcpConfigAbsentPreservesValue(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
 		t.Fatalf("UpdateAgent: decode response: %v", err)
 	}
-	assertJSONEqual(t, updated.McpConfig, `{"preset":"keep"}`)
-	assertJSONEqual(t, fetchAgentMcpConfig(t, agentID), `{"preset":"keep"}`)
+	// Wire responses always carry the redaction sentinel — raw config is
+	// only ever read back via the daemon claim endpoint. DB state is the
+	// authoritative check that the row wasn't clobbered.
+	assertJSONEqual(t, updated.McpConfig, `"<redacted>"`)
+	if !updated.McpConfigRedacted {
+		t.Fatalf("UpdateAgent: expected mcp_config_redacted=true when value is set")
+	}
+	assertJSONEqual(t, fetchAgentMcpConfig(t, agentID), `{"mcpServers":{"keep":{"command":"echo"}}}`)
 }
 
 func TestUpdateAgentMcpConfigNullClearsValue(t *testing.T) {
-	agentID := createHandlerTestAgent(t, "Handler Mcp Clear", []byte(`{"preset":"clear"}`))
+	agentID := createHandlerTestAgent(t, "Handler Mcp Clear", []byte(`{"mcpServers":{"clear":{"command":"echo"}}}`))
 
 	w := httptest.NewRecorder()
 	req := newRequest("PUT", "/api/agents/"+agentID, map[string]any{
@@ -1254,18 +1260,27 @@ func TestUpdateAgentMcpConfigNullClearsValue(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
 		t.Fatalf("UpdateAgent: decode response: %v", err)
 	}
+	// Cleared field: response carries null, redacted flag false (so the UI
+	// can tell "unset" from "set but redacted").
 	assertJSONEqual(t, updated.McpConfig, `null`)
+	if updated.McpConfigRedacted {
+		t.Fatalf("UpdateAgent: expected mcp_config_redacted=false after clearing")
+	}
 	if fetchAgentMcpConfig(t, agentID) != nil {
 		t.Fatalf("UpdateAgent: expected DB mcp_config to be SQL NULL")
 	}
 }
 
 func TestUpdateAgentMcpConfigObjectUpdatesValue(t *testing.T) {
-	agentID := createHandlerTestAgent(t, "Handler Mcp Update", []byte(`{"preset":"old"}`))
+	agentID := createHandlerTestAgent(t, "Handler Mcp Update", []byte(`{"mcpServers":{"old":{"command":"echo"}}}`))
 
 	w := httptest.NewRecorder()
 	req := newRequest("PUT", "/api/agents/"+agentID, map[string]any{
-		"mcp_config": map[string]any{"preset": "new"},
+		"mcp_config": map[string]any{
+			"mcpServers": map[string]any{
+				"new": map[string]any{"command": "echo"},
+			},
+		},
 	})
 	req = withURLParam(req, "id", agentID)
 	testHandler.UpdateAgent(w, req)
@@ -1277,8 +1292,79 @@ func TestUpdateAgentMcpConfigObjectUpdatesValue(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&updated); err != nil {
 		t.Fatalf("UpdateAgent: decode response: %v", err)
 	}
-	assertJSONEqual(t, updated.McpConfig, `{"preset":"new"}`)
-	assertJSONEqual(t, fetchAgentMcpConfig(t, agentID), `{"preset":"new"}`)
+	assertJSONEqual(t, updated.McpConfig, `"<redacted>"`)
+	if !updated.McpConfigRedacted {
+		t.Fatalf("UpdateAgent: expected mcp_config_redacted=true after setting value")
+	}
+	assertJSONEqual(t, fetchAgentMcpConfig(t, agentID), `{"mcpServers":{"new":{"command":"echo"}}}`)
+}
+
+// TestUpdateAgentMcpConfigInvalidRejected covers the validation gate added
+// in this feature: malformed payloads must surface a 400 with a clear
+// message and leave the DB untouched, so a typo can't silently wipe out a
+// working configuration.
+func TestUpdateAgentMcpConfigInvalidRejected(t *testing.T) {
+	original := []byte(`{"mcpServers":{"good":{"command":"echo"}}}`)
+	agentID := createHandlerTestAgent(t, "Handler Mcp Invalid", original)
+
+	cases := []struct {
+		name    string
+		payload any
+		wantSub string
+	}{
+		{
+			name:    "missing mcpServers key",
+			payload: map[string]any{"mcp_servers": map[string]any{}},
+			wantSub: "mcpServers",
+		},
+		{
+			name:    "mcpServers must be object",
+			payload: map[string]any{"mcpServers": []any{"oops"}},
+			wantSub: "mcpServers",
+		},
+		{
+			name:    "empty mcpServers map",
+			payload: map[string]any{"mcpServers": map[string]any{}},
+			wantSub: "at least one server",
+		},
+		{
+			name: "server spec missing transport",
+			payload: map[string]any{
+				"mcpServers": map[string]any{
+					"oauth": map[string]any{"env": map[string]string{"TOKEN": "x"}},
+				},
+			},
+			wantSub: "must set either",
+		},
+		{
+			name: "unknown field in server spec",
+			payload: map[string]any{
+				"mcpServers": map[string]any{
+					"weird": map[string]any{"command": "echo", "bogus": true},
+				},
+			},
+			wantSub: "invalid shape",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newRequest("PUT", "/api/agents/"+agentID, map[string]any{
+				"mcp_config": tc.payload,
+			})
+			req = withURLParam(req, "id", agentID)
+			testHandler.UpdateAgent(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("UpdateAgent: expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), tc.wantSub) {
+				t.Fatalf("UpdateAgent: expected error to mention %q, got %q", tc.wantSub, w.Body.String())
+			}
+			// Original value must be intact — no partial write.
+			assertJSONEqual(t, fetchAgentMcpConfig(t, agentID), string(original))
+		})
+	}
 }
 
 func TestCreateAgentMcpConfigNullStoresSQLNull(t *testing.T) {
@@ -1304,8 +1390,61 @@ func TestCreateAgentMcpConfigNullStoresSQLNull(t *testing.T) {
 	})
 
 	assertJSONEqual(t, created.McpConfig, `null`)
+	if created.McpConfigRedacted {
+		t.Fatalf("CreateAgent: expected mcp_config_redacted=false when field is unset")
+	}
 	if fetchAgentMcpConfig(t, created.ID) != nil {
 		t.Fatalf("CreateAgent: expected DB mcp_config to be SQL NULL")
+	}
+}
+
+// TestCreateAgentMcpConfigInvalidRejected ensures the validator fires on
+// create as well as update — otherwise a malformed config could land via
+// the create path and only get caught when the daemon tried to spawn it.
+func TestCreateAgentMcpConfigInvalidRejected(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/agents", map[string]any{
+		"name":        "Handler Mcp Create Invalid",
+		"runtime_id":  handlerTestRuntimeID(t),
+		"mcp_config":  map[string]any{"mcp_servers": map[string]any{}},
+		"custom_env":  map[string]string{},
+		"custom_args": []string{},
+	})
+	testHandler.CreateAgent(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("CreateAgent: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "mcpServers") {
+		t.Fatalf("CreateAgent: expected error to mention mcpServers, got %q", w.Body.String())
+	}
+}
+
+// TestGetAgentMcpConfigRedactsForOwner is the redaction contract the CLI
+// caller depends on: even the workspace owner reading their own agent must
+// see "<redacted>" — the database is the only authoritative store.
+func TestGetAgentMcpConfigRedactsForOwner(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "Handler Mcp Get", []byte(`{"mcpServers":{"gmail":{"command":"node","env":{"TOKEN":"secret-do-not-leak"}}}}`))
+
+	w := httptest.NewRecorder()
+	req := newRequest("GET", "/api/agents/"+agentID, nil)
+	req = withURLParam(req, "id", agentID)
+	testHandler.GetAgent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetAgent: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := w.Body.String()
+	if strings.Contains(body, "secret-do-not-leak") {
+		t.Fatalf("GetAgent: response leaked raw mcp_config contents: %q", body)
+	}
+
+	var got AgentResponse
+	if err := json.NewDecoder(strings.NewReader(body)).Decode(&got); err != nil {
+		t.Fatalf("GetAgent: decode response: %v", err)
+	}
+	assertJSONEqual(t, got.McpConfig, `"<redacted>"`)
+	if !got.McpConfigRedacted {
+		t.Fatalf("GetAgent: expected mcp_config_redacted=true")
 	}
 }
 

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -443,6 +443,173 @@ func TestBuildClaudeArgsBlocksMcpConfig(t *testing.T) {
 	}
 }
 
+// TestClaudeExecutePropagatesMcpConfigToClaude is the integration check
+// for the per-agent MCP wiring acceptance criterion: when ExecOptions
+// carries an McpConfig payload, the spawned claude process must observe
+// both --mcp-config <path> AND --strict-mcp-config on its argv, and the
+// file at <path> must contain exactly the bytes we set on the agent.
+//
+// We use a POSIX shell fixture so the fake binary can dump its argv and
+// the mcp config file contents to disk, then assert on those after the
+// session completes. The fixture exits without writing any stream-json,
+// so the run is reported as failed — that's fine for this test; we only
+// care about the spawn-side contract.
+func TestClaudeExecutePropagatesMcpConfigToClaude(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv.txt")
+	mcpDumpPath := filepath.Join(dir, "mcp.json")
+
+	fakePath := filepath.Join(dir, "claude")
+	// Drain stdin so writeClaudeInput doesn't fail; then walk the args
+	// looking for --mcp-config, copy the file it points at, and dump the
+	// full argv list to argvPath. Exit non-zero so Execute reports failed.
+	script := `#!/bin/sh
+cat >/dev/null
+i=0
+for arg in "$@"; do
+  i=$((i+1))
+  echo "$arg" >>` + argvPath + `
+  if [ "$arg" = "--mcp-config" ]; then
+    next_arg_index=$((i+1))
+  fi
+done
+shift $((next_arg_index-1))
+cp "$1" ` + mcpDumpPath + ` 2>/dev/null || true
+exit 0
+`
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("claude", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+
+	mcpConfig := json.RawMessage(`{"mcpServers":{"gmail":{"command":"node","args":["./gmail-mcp.js"],"env":{"OAUTH_TOKEN":"sentinel-value"}}}}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{
+		Timeout:   5 * time.Second,
+		McpConfig: mcpConfig,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	// Drain message stream so the lifecycle goroutine can complete.
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case <-session.Result:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	// argvPath now contains one arg per line. Confirm both --mcp-config
+	// and --strict-mcp-config landed on the spawn, and grab the path
+	// claude was pointed at.
+	argvBytes, err := os.ReadFile(argvPath)
+	if err != nil {
+		t.Fatalf("read argv dump: %v", err)
+	}
+	argv := strings.Split(strings.TrimRight(string(argvBytes), "\n"), "\n")
+
+	hasFlag := func(name string) bool {
+		for _, a := range argv {
+			if a == name {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasFlag("--strict-mcp-config") {
+		t.Fatalf("expected --strict-mcp-config in argv, got %v", argv)
+	}
+	if !hasFlag("--mcp-config") {
+		t.Fatalf("expected --mcp-config in argv, got %v", argv)
+	}
+	var mcpPath string
+	for i, a := range argv {
+		if a == "--mcp-config" && i+1 < len(argv) {
+			mcpPath = argv[i+1]
+			break
+		}
+	}
+	if mcpPath == "" {
+		t.Fatalf("--mcp-config value missing from argv: %v", argv)
+	}
+	// The temp file is removed by the spawn lifecycle once the session
+	// goroutine finishes; the fixture copies it to mcpDumpPath while
+	// claude is still alive.
+	got, err := os.ReadFile(mcpDumpPath)
+	if err != nil {
+		t.Fatalf("read mcp config dump: %v", err)
+	}
+	if !bytes.Equal(bytes.TrimSpace(got), bytes.TrimSpace(mcpConfig)) {
+		t.Fatalf("mcp_config file content mismatch:\n got: %s\nwant: %s", got, mcpConfig)
+	}
+}
+
+// TestClaudeExecuteWithoutMcpConfigOmitsFlag asserts the no-op contract
+// from the acceptance criteria: an agent with mcp_config: null spawns
+// claude exactly as before, with no --mcp-config flag attached.
+func TestClaudeExecuteWithoutMcpConfigOmitsFlag(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	dir := t.TempDir()
+	argvPath := filepath.Join(dir, "argv.txt")
+	fakePath := filepath.Join(dir, "claude")
+	script := `#!/bin/sh
+cat >/dev/null
+for arg in "$@"; do
+  echo "$arg" >>` + argvPath + `
+done
+exit 0
+`
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("claude", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+	select {
+	case <-session.Result:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+
+	argvBytes, err := os.ReadFile(argvPath)
+	if err != nil {
+		t.Fatalf("read argv dump: %v", err)
+	}
+	if strings.Contains(string(argvBytes), "--mcp-config") {
+		t.Fatalf("expected no --mcp-config on argv when McpConfig is empty, got: %s", argvBytes)
+	}
+	// --strict-mcp-config is always present by design, regardless of
+	// whether a config is provided.
+	if !strings.Contains(string(argvBytes), "--strict-mcp-config") {
+		t.Fatalf("expected --strict-mcp-config to remain on argv, got: %s", argvBytes)
+	}
+}
+
 func TestWriteMcpConfigToTemp(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #2385 (CLI portion of the per-agent MCP / connector wiring epic).

## What

Adds the missing setter so workspace owners can wire per-agent MCP
connectors (Gmail / Calendar / Notion / Slack / etc.) from outside the
server, and locks down the API read contract so secrets never go on the
wire. UI is a sibling issue and explicitly out of scope here.

### CLI — `multica agent update <id>`

Mirrors the existing `--custom-env-file` / `--custom-env-stdin` shape:

- `--mcp-config-file <path>` — load JSON from disk. Warns (does not
  fail) when permissions are looser than 0600 — MCP configs commonly
  embed OAuth tokens, but failing hard would block CI tarballs and
  some container mounts.
- `--mcp-config-stdin` — load JSON from stdin. Keeps secrets out of
  shell history and `ps`.
- `--mcp-config-clear` — explicit clear; sends `mcp_config: null` so
  the server takes the `ClearAgentMcpConfig` branch (`COALESCE` on the
  ordinary update query can't drive a column back to NULL).

Channels are mutually exclusive. Payloads are validated against the
Claude Code `mcpServers` schema (top-level `mcpServers` object → name →
`command` ⊕ `url` plus optional `args` / `env` / `headers` / `type`)
before they leave the CLI; error messages avoid echoing input fragments
because callers routinely put OAuth tokens inside `env` or `headers`.

### Server

- `validateMcpConfig` enforces the same schema on `Create` + `Update`
  (defense in depth — the server is the authoritative gate). Malformed
  payloads return 400 and the DB row stays intact.
- `redactMcpConfig` now ALWAYS replaces `mcp_config` with the sentinel
  string `"<redacted>"` on user-facing reads (List / Get / Update /
  Create / Archive / Restore + the WS events those publish), regardless
  of caller role. The daemon claim endpoint remains the only reader
  that ever emits raw bytes. `mcp_config: null` unambiguously means
  "unset"; `"<redacted>"` means "set, contents withheld".

## Why the contract changes

- **Always-redact:** the parent issue's spec says \"never return raw tokens
  over the API\". Previous behavior redacted only for non-admins, so the
  workspace owner pulling their own agent saw raw OAuth tokens — that
  was a foot-gun, not a feature.
- **Sentinel string vs `null`:** today `null` is overloaded (\"unset\" OR
  \"redacted\"). Splitting the two means the CLI / Desktop UI can tell at
  a glance whether the agent is wired without having to consult the
  `mcp_config_redacted` flag.

## On-disk lifecycle of the spawned `--mcp-config <path>` file

The daemon writes the agent's config to `os.CreateTemp("", "multica-mcp-*.json")`
once per task, passes the path on argv, and removes the file in the
session goroutine after `cmd.Wait()` returns. The temp file lives
inside the daemon's `$TMPDIR`, which is per-user on every supported
platform — so it is not readable by other workspace users. Long-lived
storage would be wasted: every spawn refreshes from the (authoritative)
DB anyway, and a stale file would only matter on the brief window
between rotate-secret and next-task-spawn.

## Acceptance criteria

- [x] `multica agent update <id> --mcp-config-file fixture.json` succeeds;
      `multica agent get <id> --output json` then returns
      `mcp_config: \"<redacted>\"` and `mcp_config_redacted: true`.
- [x] `multica agent update <id> --mcp-config-stdin < fixture.json`
      produces the same result.
- [x] Invalid JSON (missing `mcpServers` key, wrong type, unknown
      fields, server missing `command`/`url`) is rejected with a clear
      stderr error, non-zero exit, no partial write.
- [x] `multica agent update <id> --mcp-config-clear` resets the field
      to null; subsequent `agent get` shows
      `mcp_config: null, mcp_config_redacted: false`.
- [x] Spawning an agent with populated `mcp_config` invokes `claude`
      with `--mcp-config <path> --strict-mcp-config`; the file at
      `<path>` contains exactly the configured `mcpServers` map.
      (`TestClaudeExecutePropagatesMcpConfigToClaude`)
- [x] Spawning an agent with `mcp_config: null` works exactly as before
      (no `--mcp-config` flag passed).
      (`TestClaudeExecuteWithoutMcpConfigOmitsFlag`)
- [x] Unit tests cover the redaction path and the validation rejections.
- [x] Integration test spawns the spawn pipeline with a fixture
      mcp_config and asserts the flags / file content passed to claude.

## Karpathy-principle assumptions stated up front

1. \"Never return raw tokens over the API\" is the operative redaction
   contract — including for the workspace owner. The desktop UI can
   render the agent connected/disconnected state from
   `mcp_config_redacted` without needing the raw bytes.
2. The temp-file lifecycle for `--mcp-config <path>` is per-spawn and
   per-user-`\$TMPDIR`; long-lived per-agent storage would be a worse
   trade-off (stale files, no extra capability).
3. Validation is shallow: shape only, no semantic checks (e.g., we do
   not require `command` to be a path that exists). The CLI catches
   typos at write time; the daemon already surfaces a runtime error if
   the binary is missing.

## Out of scope (filed separately upstream)

- UI \"Connectors\" tab — the sibling Engineer:Frontend issue.
- `multica agent connector attach` OAuth helper.
- Connector catalog / marketplace.
- Workspace-level default MCPs.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...` (DB-required handler tests skip cleanly in this
      sandbox; CI runs them with a real Postgres).
- [x] `go test ./pkg/agent/ -run 'TestClaudeExecute(Propagates|Without)McpConfig'`
- [x] `go test ./cmd/multica/ -run 'TestParseMcpConfig|TestResolveMcpConfig|TestAgentUpdate(Exposes|McpConfigEndToEnd)'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)