### PR TITLE
fix(editor): keep empty markdown list items editable

### DIFF
--- a/packages/views/editor/extensions/markdown-paste.test.ts
+++ b/packages/views/editor/extensions/markdown-paste.test.ts
@@ -46,6 +46,15 @@ interface JsonNode {
   content?: JsonNode[];
 }
 
+function findAll(json: JsonNode, type: string): JsonNode[] {
+  const hits: JsonNode[] = [];
+  if (json.type === type) hits.push(json);
+  for (const child of json.content ?? []) {
+    hits.push(...findAll(child, type));
+  }
+  return hits;
+}
+
 function findFirst(json: JsonNode, type: string): JsonNode | undefined {
   if (json.type === type) return json;
   for (const child of json.content ?? []) {
@@ -139,6 +148,22 @@ describe("markdownPaste — code block context", () => {
     const types = (json.content ?? []).map((n) => n.type);
     // Markdown parsing produced a heading at the top.
     expect(types).toContain("heading");
+  });
+
+  it("keeps empty ordered list items editable after Markdown paste", () => {
+    editor = makeEditor({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
+
+    editor.commands.setTextSelection(1);
+    paste(editor, "### Requirement\n\n1. \n2.");
+
+    const json = editor.getJSON() as JsonNode;
+    const items = findAll(json, "listItem");
+
+    expect(items).toHaveLength(2);
+    expect(items.every((item) => item.content?.[0]?.type === "paragraph")).toBe(true);
   });
 
   it("inserts JSON clipboard text without running the Markdown parser", () => {

--- a/packages/views/editor/extensions/markdown-paste.ts
+++ b/packages/views/editor/extensions/markdown-paste.ts
@@ -26,7 +26,7 @@
  * only keeps narrow deterministic exits for editor-owned slices, code block
  * context, structured plain text, and large payloads.
  */
-import { Extension } from "@tiptap/core";
+import { Extension, type JSONContent } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Slice } from "@tiptap/pm/model";
 
@@ -77,6 +77,19 @@ function classifyPaste({
   return "markdown";
 }
 
+function ensureEditableListItems(node: JSONContent): JSONContent {
+  const content = node.content?.map(ensureEditableListItems);
+
+  if (node.type === "listItem" && (!content || content.length === 0)) {
+    return {
+      ...node,
+      content: [{ type: "paragraph" }],
+    };
+  }
+
+  return content ? { ...node, content } : node;
+}
+
 export function createMarkdownPasteExtension() {
   return Extension.create({
     name: "markdownPaste",
@@ -110,7 +123,7 @@ export function createMarkdownPasteExtension() {
 
               // Everything else (VS Code, text editors, .md files, terminals,
               // web pages): parse text/plain as Markdown.
-              const json = editor.markdown.parse(text);
+              const json = ensureEditableListItems(editor.markdown.parse(text));
               const node = editor.schema.nodeFromJSON(json);
               const slice = Slice.maxOpen(node.content);
               const tr = view.state.tr.replaceSelection(slice);


### PR DESCRIPTION
## What does this PR do?

Fixes an editor caret placement issue when users paste Markdown that contains empty ordered-list items, such as:

```md
### Requirement

1. 
2.
```

After paste, the Markdown parser can produce empty `listItem` nodes that render as bare `<li></li>` elements. Those nodes do not contain a paragraph for the caret to target. In the issue creation editor, clicking back into the first empty item can cause the browser / ProseMirror coordinate mapping to place the caret in the next item instead, making the first item difficult to edit.

The investigation traced the behavior to the Markdown paste path rather than the issue creation dialog shell: `markdownPaste` parses clipboard text through `editor.markdown.parse`, then inserts the parsed JSON into the ProseMirror document. For empty ordered-list items, the parsed JSON may contain list items with no child content.

This change normalizes parsed Markdown JSON before insertion. Any empty `listItem` gets an empty paragraph child, so pasted empty list items remain valid editable positions while preserving normal Markdown paste behavior.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Tests
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Added a narrow Markdown JSON normalization step in `packages/views/editor/extensions/markdown-paste.ts` that inserts an empty paragraph into otherwise empty list items.
- Kept the existing paste classification intact: native, literal, and normal Markdown paste flows are still selected the same way.
- Added regression coverage for pasting an empty ordered list under a heading and verifying each pasted list item remains editable.


## How to Test

- `pnpm --dir packages/views exec vitest run editor/extensions/markdown-paste.test.ts --reporter=dot`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views exec eslint editor/extensions/markdown-paste.ts editor/extensions/markdown-paste.test.ts`
- `git diff --check -- packages/views/editor/extensions/markdown-paste.ts packages/views/editor/extensions/markdown-paste.test.ts`

Local verification:

- Targeted paste extension tests passed: 7 tests.
- `@multica/views` typecheck passed.
- ESLint passed for the changed files.
- Whitespace check passed for the changed files.
- ECC pre-push verification passed: lint, typecheck, test, and build.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
Port the downstream fix from `furtherref/multica#50` onto upstream `main`, preserving normal Markdown paste behavior while making empty pasted ordered-list items editable. The debugging path reproduced the Markdown parser output, identified empty `listItem` nodes as the root cause, added a failing regression test, then fixed the parser output normalization before insertion.


## Screenshots

<img width="300" height="100" alt="d4544ba6-ecd0-43e5-9662-6579b0c01904" src="https://github.com/user-attachments/assets/42a23015-fa6b-41bf-b6b1-98729342484a" />
