### PR TITLE
fix(daemon): self-heal stale runtime IDs and stop Warn-log flood after UI delete

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -55,6 +55,24 @@ func isTaskNotFoundError(err error) bool {
 	return strings.Contains(strings.ToLower(reqErr.Body), "task not found")
 }
 
+// isRuntimeNotFoundError returns true if the error is a 404 with "runtime not
+// found" body. The daemon uses this to detect that a runtime row was deleted
+// server-side (user pressed Delete in the UI, 7-day offline GC fired) while
+// this daemon was still heartbeating or claiming tasks against it — without
+// this signal the daemon would spam Warn ("heartbeat failed", "claim task
+// failed") indefinitely for a dead ID until restart. Callers drop the runtime
+// from local tracking on a true return.
+func isRuntimeNotFoundError(err error) bool {
+	var reqErr *requestError
+	if !errors.As(err, &reqErr) {
+		return false
+	}
+	if reqErr.StatusCode != http.StatusNotFound {
+		return false
+	}
+	return strings.Contains(strings.ToLower(reqErr.Body), "runtime not found")
+}
+
 // Client handles HTTP communication with the Multica server daemon API.
 type Client struct {
 	baseURL string

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -335,6 +335,60 @@ func (d *Daemon) findRuntime(id string) *Runtime {
 	return nil
 }
 
+// dropStaleRuntime removes a runtime ID from local tracking after the server
+// reported it no longer exists (404 "runtime not found" on heartbeat or
+// claim). It also empties the owning workspaceState if this was its last
+// runtime so the next workspaceSyncLoop tick treats the workspace as fresh
+// and goes through registerRuntimesForWorkspace again — without this, the
+// daemon would never recover from a delete because syncWorkspacesFromAPI
+// skips workspaces that already exist in d.workspaces.
+//
+// Idempotent: a second call for the same ID is a cheap no-op (handy because
+// both heartbeat and claim paths may discover the 404 concurrently).
+func (d *Daemon) dropStaleRuntime(runtimeID string) {
+	d.mu.Lock()
+	rt, hadRuntime := d.runtimeIndex[runtimeID]
+	delete(d.runtimeIndex, runtimeID)
+
+	emptiedWorkspace := ""
+	for wsID, ws := range d.workspaces {
+		kept := ws.runtimeIDs[:0]
+		removed := false
+		for _, id := range ws.runtimeIDs {
+			if id == runtimeID {
+				removed = true
+				continue
+			}
+			kept = append(kept, id)
+		}
+		if !removed {
+			continue
+		}
+		ws.runtimeIDs = kept
+		if len(ws.runtimeIDs) == 0 {
+			emptiedWorkspace = wsID
+			delete(d.workspaces, wsID)
+		}
+		break
+	}
+	d.mu.Unlock()
+
+	d.wsHBMu.Lock()
+	delete(d.wsHBLastAck, runtimeID)
+	d.wsHBMu.Unlock()
+
+	if !hadRuntime && emptiedWorkspace == "" {
+		return
+	}
+	if hadRuntime {
+		d.logger.Info("dropped stale runtime from local cache", "runtime_id", runtimeID, "provider", rt.Provider)
+	}
+	if emptiedWorkspace != "" {
+		d.logger.Info("workspace has no runtimes left; next sync will re-register", "workspace_id", emptiedWorkspace)
+	}
+	d.notifyRuntimeSetChanged()
+}
+
 func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, error) {
 	var runtimes []map[string]string
 	for name, entry := range d.cfg.Agents {
@@ -814,6 +868,14 @@ func (d *Daemon) runHeartbeatTick(ctx context.Context, rid string) {
 	resp, err := d.client.SendHeartbeat(ctx, rid)
 	if err != nil {
 		if ctx.Err() == nil {
+			if isRuntimeNotFoundError(err) {
+				// Runtime row is gone server-side (UI delete or 7-day GC).
+				// Drop locally so this loop tears down on the next runtime-set
+				// sync instead of beating against a tombstone every 15s.
+				d.logger.Info("heartbeat: runtime no longer exists server-side; pruning", "runtime_id", rid)
+				d.dropStaleRuntime(rid)
+				return
+			}
 			d.logger.Warn("heartbeat failed", "runtime_id", rid, "error", err)
 		}
 		return
@@ -1334,6 +1396,14 @@ func (d *Daemon) runRuntimePoller(
 		if err != nil {
 			sem <- slot
 			if pollerCtx.Err() == nil {
+				if isRuntimeNotFoundError(err) {
+					// Server-side runtime deletion races the poller; prune
+					// locally and exit so pollLoop's next sync tears this
+					// goroutine down rather than logging Warn every poll.
+					d.logger.Info("claim: runtime no longer exists server-side; pruning", "runtime_id", rid)
+					d.dropStaleRuntime(rid)
+					return
+				}
 				d.logger.Warn("claim task failed", "runtime_id", rid, "error", err)
 			}
 			if err := sleepWithContextOrWakeup(pollerCtx, d.cfg.PollInterval, wakeup); err != nil {

--- a/server/internal/daemon/stale_runtime_test.go
+++ b/server/internal/daemon/stale_runtime_test.go
@@ -1,0 +1,193 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newStaleRuntimeTestDaemon(t *testing.T, serverURL string, hbInterval time.Duration) *Daemon {
+	t.Helper()
+	cfg := Config{ServerBaseURL: serverURL, HeartbeatInterval: hbInterval}
+	return New(cfg, slog.New(slog.NewTextHandler(noopWriter{}, nil)))
+}
+
+func TestDropStaleRuntime_RemovesFromIndexAndWorkspace(t *testing.T) {
+	t.Parallel()
+
+	d := newStaleRuntimeTestDaemon(t, "", 0)
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", []string{"rt-a", "rt-b"}, "", nil, nil)
+	d.runtimeIndex["rt-a"] = Runtime{ID: "rt-a", Provider: "claude"}
+	d.runtimeIndex["rt-b"] = Runtime{ID: "rt-b", Provider: "codex"}
+
+	d.dropStaleRuntime("rt-a")
+
+	if _, ok := d.runtimeIndex["rt-a"]; ok {
+		t.Fatal("rt-a still in runtimeIndex after dropStaleRuntime")
+	}
+	ids := d.workspaces["ws-1"].runtimeIDs
+	if len(ids) != 1 || ids[0] != "rt-b" {
+		t.Fatalf("workspace runtimeIDs after drop: want [rt-b], got %v", ids)
+	}
+}
+
+// TestDropStaleRuntime_EmptyWorkspaceIsRemoved ensures that when the last
+// runtime in a workspace gets pruned, the workspaceState itself is dropped so
+// the next syncWorkspacesFromAPI tick treats it as new and re-registers
+// (otherwise the "already in d.workspaces, skip register" branch would leave
+// the daemon stuck with zero runtimes forever).
+func TestDropStaleRuntime_EmptyWorkspaceIsRemoved(t *testing.T) {
+	t.Parallel()
+
+	d := newStaleRuntimeTestDaemon(t, "", 0)
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", []string{"rt-only"}, "", nil, nil)
+	d.runtimeIndex["rt-only"] = Runtime{ID: "rt-only", Provider: "claude"}
+
+	d.dropStaleRuntime("rt-only")
+
+	if _, ok := d.workspaces["ws-1"]; ok {
+		t.Fatal("workspace still present after its last runtime was pruned; sync would skip re-register")
+	}
+}
+
+func TestDropStaleRuntime_NotifiesRuntimeSet(t *testing.T) {
+	t.Parallel()
+
+	d := newStaleRuntimeTestDaemon(t, "", 0)
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", []string{"rt-a"}, "", nil, nil)
+	d.runtimeIndex["rt-a"] = Runtime{ID: "rt-a", Provider: "claude"}
+
+	ch, unsub := d.runtimeSet.Subscribe()
+	defer unsub()
+
+	d.dropStaleRuntime("rt-a")
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("dropStaleRuntime did not nudge runtime-set subscribers")
+	}
+}
+
+func TestDropStaleRuntime_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	d := newStaleRuntimeTestDaemon(t, "", 0)
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", []string{"rt-a"}, "", nil, nil)
+	d.runtimeIndex["rt-a"] = Runtime{ID: "rt-a", Provider: "claude"}
+
+	d.dropStaleRuntime("rt-a")
+	// Second call against an already-gone ID must not panic or touch other state.
+	d.dropStaleRuntime("rt-a")
+	d.dropStaleRuntime("rt-never-existed")
+}
+
+func TestHeartbeatTick_RuntimeNotFound_PrunesAndStops(t *testing.T) {
+	t.Parallel()
+
+	var hbCalls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hbCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"runtime not found"}`))
+	}))
+	defer srv.Close()
+
+	d := newStaleRuntimeTestDaemon(t, srv.URL, 0)
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", []string{"rt-a"}, "", nil, nil)
+	d.runtimeIndex["rt-a"] = Runtime{ID: "rt-a", Provider: "claude"}
+
+	d.runHeartbeatTick(context.Background(), "rt-a")
+
+	if hbCalls.Load() != 1 {
+		t.Fatalf("expected 1 heartbeat call, got %d", hbCalls.Load())
+	}
+	if _, ok := d.runtimeIndex["rt-a"]; ok {
+		t.Fatal("rt-a not pruned after 404 'runtime not found'")
+	}
+	if _, ok := d.workspaces["ws-1"]; ok {
+		t.Fatal("workspace not pruned after its sole runtime was pruned")
+	}
+}
+
+// TestHeartbeatTick_GenericError_DoesNotPrune pins that the prune path is
+// scoped to "runtime not found" — a generic 5xx or unrelated 404 must NOT
+// silently delete state, otherwise a transient server bug would wipe a
+// healthy daemon's runtime set.
+func TestHeartbeatTick_GenericError_DoesNotPrune(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"upstream wobble"}`))
+	}))
+	defer srv.Close()
+
+	d := newStaleRuntimeTestDaemon(t, srv.URL, 0)
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", []string{"rt-a"}, "", nil, nil)
+	d.runtimeIndex["rt-a"] = Runtime{ID: "rt-a", Provider: "claude"}
+
+	d.runHeartbeatTick(context.Background(), "rt-a")
+
+	if _, ok := d.runtimeIndex["rt-a"]; !ok {
+		t.Fatal("rt-a was pruned on a 500; only 'runtime not found' 404s should prune")
+	}
+	if _, ok := d.workspaces["ws-1"]; !ok {
+		t.Fatal("workspace was pruned on a 500; only 'runtime not found' 404s should prune")
+	}
+}
+
+func TestIsRuntimeNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "404 with runtime not found body",
+			err:  &requestError{Method: "POST", Path: "/api/daemon/heartbeat", StatusCode: 404, Body: `{"error":"runtime not found"}`},
+			want: true,
+		},
+		{
+			name: "404 with workspace not found body",
+			err:  &requestError{Method: "POST", Path: "/api/daemon/heartbeat", StatusCode: 404, Body: `{"error":"workspace not found"}`},
+			want: false,
+		},
+		{
+			name: "500 with runtime not found body",
+			err:  &requestError{Method: "POST", Path: "/api/daemon/heartbeat", StatusCode: 500, Body: "runtime not found"},
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "wrapped error",
+			err:  &wrapErr{inner: &requestError{StatusCode: 404, Body: "runtime not found"}},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isRuntimeNotFoundError(tc.err)
+			if got != tc.want {
+				t.Fatalf("isRuntimeNotFoundError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type wrapErr struct{ inner error }
+
+func (w *wrapErr) Error() string { return "wrap: " + w.inner.Error() }
+func (w *wrapErr) Unwrap() error { return w.inner }

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -707,6 +707,19 @@ func (h *Handler) HandleDaemonWSHeartbeat(ctx context.Context, identity daemonws
 	}
 	rt, err := h.Queries.GetAgentRuntime(ctx, runtimeUUID)
 	if err != nil {
+		// Runtime row no longer exists. User deletes via the UI button and
+		// the 7-day offline GC both reach this branch; both are expected
+		// states, not server faults. Return (nil, nil) so the hub silently
+		// drops the ack — the daemon's HTTP heartbeat will resume after the
+		// WS freshness window expires, hit a 404, and prune the runtime
+		// locally. Logging at Debug keeps a stuck WS+stale-ID daemon from
+		// flooding prod Warn output (one beat per runtime every 15s).
+		if isNotFound(err) {
+			slog.Debug("daemon ws heartbeat: runtime no longer exists; dropping ack",
+				"runtime_id", runtimeID,
+				"daemon_id", identity.DaemonID)
+			return nil, nil
+		}
 		return nil, fmt.Errorf("runtime not found: %w", err)
 	}
 	if identity.WorkspaceID != "" && identity.WorkspaceID != uuidToString(rt.WorkspaceID) {

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5"
+	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
@@ -260,6 +261,33 @@ func TestDaemonHeartbeat_EmptyQueueSkipsPopPending(t *testing.T) {
 	}
 	if importSpy.popCalls != 0 {
 		t.Fatalf("expected 0 PopPending calls on empty import queue, got %d", importSpy.popCalls)
+	}
+}
+
+// TestHandleDaemonWSHeartbeat_RuntimeGone_ReturnsNilAckNoError pins that a WS
+// heartbeat for a runtime row that no longer exists (user deleted it via the UI,
+// or the 7-day offline GC reclaimed it) is treated as an expected state, not a
+// server fault: handler returns (nil, nil) so the hub silently drops the ack
+// without spamming Warn logs every 15s for a stuck connection.
+func TestHandleDaemonWSHeartbeat_RuntimeGone_ReturnsNilAckNoError(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	// A well-formed UUID that intentionally does not correspond to any row.
+	missingRuntimeID := "00000000-0000-0000-0000-0000deadbeef"
+
+	ack, err := testHandler.HandleDaemonWSHeartbeat(context.Background(), daemonws.ClientIdentity{
+		DaemonID:    "test-daemon-stale-ws",
+		WorkspaceID: testWorkspaceID,
+		RuntimeIDs:  []string{missingRuntimeID},
+	}, missingRuntimeID)
+
+	if err != nil {
+		t.Fatalf("expected nil error for missing runtime, got %v", err)
+	}
+	if ack != nil {
+		t.Fatalf("expected nil ack for missing runtime, got %+v", ack)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Clicking Delete on a runtime card (or letting the 7-day offline GC reclaim a runtime) used to start an indefinite Warn-log flood: three independent code paths each emit a Warn entry per heartbeat/poll tick (~3N lines / 15s, where N = providers per daemon), and nothing stopped them short of a daemon restart. Root cause is that the daemon's `syncWorkspacesFromAPI` only registers *new* workspaces, so when the runtime row is hard-deleted server-side but the workspace still exists, the daemon keeps beating against the dead UUID forever.

This PR cuts the noise at both ends:

- **Server-side**: `HandleDaemonWSHeartbeat` now recognises `ErrNoRows` from `GetAgentRuntime` as an expected state (UI delete or GC), returns `(nil, nil)` so the WS hub silently drops the ack instead of warning, and logs the decision at Debug.
- **Daemon-side**: HTTP heartbeat and claim paths recognise a 404 "runtime not found", prune the runtime from local tracking, drop the owning `workspaceState` if it was the last runtime (so the next sync tick re-registers and obtains fresh UUIDs), clear the WS-freshness record, and nudge `runtimeSet` so per-runtime heartbeat/poll goroutines tear themselves down.

The HTTP `RequestLogger` 4xx → Warn classification is intentionally left as-is. Once the daemon self-heals on the first 404, only one access-log Warn line is emitted per deleted runtime, which is acceptable.

## Related Issue

Closes #2391

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

Server:
- `server/internal/handler/daemon.go` — `HandleDaemonWSHeartbeat` treats `GetAgentRuntime` `ErrNoRows` as an expected state; returns `(nil, nil)` with a Debug log.

Daemon:
- `server/internal/daemon/client.go` — new `isRuntimeNotFoundError` helper, mirroring `isWorkspaceNotFoundError` / `isTaskNotFoundError`.
- `server/internal/daemon/daemon.go` — new `Daemon.dropStaleRuntime(runtimeID)` that removes the ID from `runtimeIndex`, strips it from its `workspaceState.runtimeIDs`, drops the `workspaceState` entirely on last-runtime removal (otherwise `syncWorkspacesFromAPI` would skip the re-register branch forever), clears `wsHBLastAck`, and nudges `runtimeSet`. Wired into `runHeartbeatTick` and the poller's `ClaimTask` error branch. Generic 5xx and unrelated 404s deliberately keep the existing Warn path so a transient server bug cannot silently wipe a healthy daemon's runtime set.

Tests:
- `server/internal/handler/daemon_test.go` — `TestHandleDaemonWSHeartbeat_RuntimeGone_ReturnsNilAckNoError`.
- `server/internal/daemon/stale_runtime_test.go` (new) — `dropStaleRuntime` cases (removal, empty-workspace cleanup, runtime-set nudge, idempotency), `runHeartbeatTick` 404 → prune wiring, `runHeartbeatTick` 500 negative path (must NOT prune), `isRuntimeNotFoundError` table.

## How to Test

1. Start a daemon with at least one configured provider (e.g. `make daemon`)
2. Open the UI → Settings → Runtimes, click Delete on one runtime card
3. Confirm the server stderr emits at most a single Info line (`"heartbeat: runtime no longer exists server-side; pruning"`) plus one HTTP 4xx access line, then goes quiet for that runtime
4. Confirm the daemon's other runtimes keep heartbeating without interruption; if the deleted runtime was the only one in its workspace, the next workspace-sync tick should re-register and a fresh runtime row appears in the UI
5. `cd server && go test ./internal/daemon/ ./internal/handler/ -count=1` — both packages green

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code (Opus 4.7, 1M context)

**Prompt / approach:** Started from a server log snippet showing repeated Warn lines after a runtime Delete click. Traced the three contributing code paths (WS handler `ErrNoRows` → Warn; `request_logger` classifying 4xx as Warn; daemon's `syncWorkspacesFromAPI` skipping re-register for already-known workspaces) to a single root cause: the daemon never learns the runtime row was hard-deleted server-side. Implemented as two atomic, independently revertible commits (server-side log downgrade; daemon-side self-heal) with unit tests at both layers and a deliberate negative test guarding against accidentally pruning on transient 5xx.
