### PR TITLE
fix(desktop): prevent tab close router sync loop

### DIFF
--- a/apps/desktop/src/renderer/src/stores/tab-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.test.ts
@@ -180,6 +180,61 @@ describe("useTabStore actions", () => {
     expect(s.byWorkspace.acme.tabs[0].id).not.toBe(onlyTabId); // fresh tab
   });
 
+  it("defers disposing the closed tab router until after the store update", () => {
+    vi.useFakeTimers();
+    try {
+      const store = useTabStore.getState();
+      store.switchWorkspace("acme");
+      const closedTabId = store.addTab("/acme/settings", "Settings", "Settings");
+      const closingTab = useTabStore
+        .getState()
+        .byWorkspace.acme.tabs.find((t) => t.id === closedTabId);
+      const dispose = vi.mocked(closingTab!.router.dispose);
+
+      store.closeTab(closedTabId);
+
+      expect(dispose).not.toHaveBeenCalled();
+      expect(
+        useTabStore.getState().byWorkspace.acme.tabs.some((t) => t.id === closedTabId),
+      ).toBe(false);
+
+      vi.runAllTimers();
+
+      expect(dispose).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores router-sync updates from a tab after it has been closed", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const closedTabId = store.addTab("/acme/settings", "Settings", "Settings");
+
+    store.closeTab(closedTabId);
+    const before = useTabStore.getState().byWorkspace.acme;
+
+    store.updateTab(closedTabId, { path: "/acme/runtimes", icon: "Monitor" });
+    store.updateTabHistory(closedTabId, 1, 2);
+
+    expect(useTabStore.getState().byWorkspace.acme).toBe(before);
+    expect(
+      useTabStore.getState().byWorkspace.acme.tabs.some((t) => t.id === closedTabId),
+    ).toBe(false);
+  });
+
+  it("does not replace the tab group for no-op router-sync updates", () => {
+    const store = useTabStore.getState();
+    store.switchWorkspace("acme");
+    const tab = useTabStore.getState().byWorkspace.acme.tabs[0];
+    const before = useTabStore.getState().byWorkspace.acme;
+
+    store.updateTab(tab.id, { path: tab.path, icon: tab.icon, title: tab.title });
+    store.updateTabHistory(tab.id, tab.historyIndex, tab.historyLength);
+
+    expect(useTabStore.getState().byWorkspace.acme).toBe(before);
+  });
+
   it("validateWorkspaceSlugs drops groups for slugs not in the valid set and repoints active", () => {
     const store = useTabStore.getState();
     store.switchWorkspace("acme");

--- a/apps/desktop/src/renderer/src/stores/tab-store.ts
+++ b/apps/desktop/src/renderer/src/stores/tab-store.ts
@@ -350,7 +350,10 @@ export const useTabStore = create<TabStore>()(
         const { slug, group, index } = hit;
 
         const closing = group.tabs[index];
-        closing.router.dispose();
+        const disposeClosingRouter = () => {
+          // Let React unmount the tab's RouterProvider before disposing it.
+          window.setTimeout(() => closing.router.dispose(), 0);
+        };
 
         if (group.tabs.length === 1) {
           // Last tab in this workspace — reseed a default so the workspace
@@ -363,6 +366,7 @@ export const useTabStore = create<TabStore>()(
               [slug]: { tabs: [fresh], activeTabId: fresh.id },
             },
           });
+          disposeClosingRouter();
           return;
         }
 
@@ -378,6 +382,7 @@ export const useTabStore = create<TabStore>()(
             [slug]: { tabs: nextTabs, activeTabId: nextActiveTabId },
           },
         });
+        disposeClosingRouter();
       },
 
       setActiveTab(tabId) {
@@ -402,6 +407,13 @@ export const useTabStore = create<TabStore>()(
         const { slug, group, index } = hit;
         const current = group.tabs[index];
         const next: Tab = { ...current, ...patch };
+        if (
+          next.path === current.path &&
+          next.title === current.title &&
+          next.icon === current.icon
+        ) {
+          return;
+        }
         const nextTabs = [...group.tabs];
         nextTabs[index] = next;
         set({
@@ -418,6 +430,12 @@ export const useTabStore = create<TabStore>()(
         if (!hit) return;
         const { slug, group, index } = hit;
         const current = group.tabs[index];
+        if (
+          current.historyIndex === historyIndex &&
+          current.historyLength === historyLength
+        ) {
+          return;
+        }
         const next: Tab = { ...current, historyIndex, historyLength };
         const nextTabs = [...group.tabs];
         nextTabs[index] = next;


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop tab-closing freeze that can happen after closing several tabs and then continuing to close tabs.

The desktop tab system keeps one `createMemoryRouter` per tab and renders each tab through a `RouterProvider`. Previously, `closeTab` disposed the closing tab's router synchronously before the store update had given React a chance to unmount that tab's `RouterProvider`. If a router subscription or title/path sync still ran during that same closing turn, it could keep writing back into the tab store while the tab list was being replaced. In practice, the desktop window can become stuck when closing tabs repeatedly.

This change makes tab closing happen in a safer order:

1. Remove or reseed the tab in the Zustand store first, so React can unmount the closing tab's `RouterProvider`.
2. Dispose the closed tab's router on the next macrotask.
3. Ignore router-sync updates for tab IDs that are no longer present.
4. Avoid replacing the tab group for no-op path/title/icon or history updates, which prevents needless rerender churn during router sync.

The regression tests cover both sides of the race: router disposal is deferred until after the tab has been removed from the store, and stale router-sync updates from a closed tab no longer mutate the active tab group.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Updated `apps/desktop/src/renderer/src/stores/tab-store.ts` so `closeTab` defers router disposal until after the store update has removed or replaced the closed tab.
- Kept stale router-sync updates harmless by returning early when `updateTab` / `updateTabHistory` cannot find the tab ID.
- Added no-op guards for unchanged tab metadata and history updates so router sync does not replace the workspace tab group unnecessarily.
- Added regression coverage in `apps/desktop/src/renderer/src/stores/tab-store.test.ts` for deferred router disposal, closed-tab sync updates, and no-op router-sync updates.

## How to Test

1. Run `pnpm --filter @multica/desktop test -- src/renderer/src/stores/tab-store.test.ts`.
2. Run `pnpm --filter @multica/desktop typecheck`.
3. Run `pnpm --filter @multica/desktop lint`.
4. Run `git diff --check upstream/main...HEAD`.
5. In the desktop app, open several tabs, close multiple tabs one after another, then keep closing tabs; the UI should remain responsive and the remaining tab should continue rendering normally.

Local verification notes:
- `pnpm --filter @multica/desktop test -- src/renderer/src/stores/tab-store.test.ts` passed.
- `pnpm --filter @multica/desktop typecheck` passed.
- `pnpm --filter @multica/desktop lint` passed with existing warnings only.
- `git diff --check upstream/main...HEAD` passed.
- Normal pre-push verification passed: lint, typecheck, test, and build.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run targeted local verification for the changed package/file
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
I used Codex to reproduce and trace the desktop tab-closing freeze from the tab close action into the per-tab memory router lifecycle. The investigation focused on the order of Zustand tab-store updates, React `RouterProvider` unmounting, and router sync subscriptions. Codex then helped port the downstream fix onto upstream `main`, add regression tests for the close/dispose ordering and stale router-sync updates, and run targeted plus pre-push verification.

## Screenshots (optional)

<img width="200" height="25" alt="5a221f424fdf24ae406394c13c807c4d" src="https://github.com/user-attachments/assets/bff29661-1a30-4ef1-9d9b-9454e6bf58b0" />

