### PR TITLE
fix(realtime): allow same-origin WebSocket (mobile/CLI)

### DIFF
--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -89,7 +89,7 @@ func checkOrigin(r *http.Request) bool {
 	// allowlist below defends against) does not apply. This matches the
 	// gorilla/websocket default CheckOrigin behavior; the allowlist exists
 	// in addition to support cross-origin browser clients (web/desktop).
-	if u, err := url.Parse(origin); err == nil && u.Host == r.Host {
+	if u, err := url.Parse(origin); err == nil && strings.EqualFold(u.Host, r.Host) {
 		return true
 	}
 	origins := allowedWSOrigins.Load().([]string)

--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -81,13 +82,15 @@ func checkOrigin(r *http.Request) bool {
 	if origin == "" {
 		return true
 	}
-	// Native mobile clients authenticate with an explicit first-frame token.
-	// Origin is a browser CSRF control, so only skip it for mobile requests
-	// that are not carrying the browser session cookie.
-	if r.URL.Query().Get("client_platform") == "mobile" {
-		if _, err := r.Cookie(auth.AuthCookieName); err == http.ErrNoCookie {
-			return true
-		}
+	// Same-origin: native clients (mobile, CLI) have no real page host, so
+	// their WebSocket library fills Origin with the connection target —
+	// which equals the server's own Host. They authenticate via bearer
+	// token, not auto-attached cookies, so CSRF (the attack the explicit
+	// allowlist below defends against) does not apply. This matches the
+	// gorilla/websocket default CheckOrigin behavior; the allowlist exists
+	// in addition to support cross-origin browser clients (web/desktop).
+	if u, err := url.Parse(origin); err == nil && u.Host == r.Host {
+		return true
 	}
 	origins := allowedWSOrigins.Load().([]string)
 	for _, allowed := range origins {

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -329,6 +329,7 @@ func TestCheckOrigin(t *testing.T) {
 		{"empty origin allowed", "api.multica.ai", "", true},
 		{"same-origin allowed (native client default)", "localhost:8080", "http://localhost:8080", true},
 		{"same-origin allowed (https)", "api.multica.ai", "https://api.multica.ai", true},
+		{"same-origin allowed (case-insensitive host, RFC 7230)", "API.Multica.AI", "https://api.multica.ai", true},
 		{"whitelisted origin allowed (web cross-origin)", "localhost:8080", "http://localhost:3000", true},
 		{"whitelisted origin allowed (prod web)", "api.multica.ai", "https://multica.ai", true},
 		{"unknown origin rejected (CSWSH defense)", "api.multica.ai", "https://evil.com", false},

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -81,46 +81,6 @@ func connectWS(t *testing.T, server *httptest.Server) *websocket.Conn {
 	return conn
 }
 
-func TestCheckOrigin_AllowsMobileClientWithoutCookie(t *testing.T) {
-	prevOrigins := allowedWSOrigins.Load().([]string)
-	SetAllowedOrigins([]string{"https://app.example.com"})
-	t.Cleanup(func() { SetAllowedOrigins(prevOrigins) })
-
-	req := httptest.NewRequest(http.MethodGet, "/ws?client_platform=mobile", nil)
-	req.Header.Set("Origin", "https://not-allowed.example.com")
-
-	if !checkOrigin(req) {
-		t.Fatal("expected mobile request without browser auth cookie to bypass Origin whitelist")
-	}
-}
-
-func TestCheckOrigin_RejectsDisallowedOriginWithoutMobileClient(t *testing.T) {
-	prevOrigins := allowedWSOrigins.Load().([]string)
-	SetAllowedOrigins([]string{"https://app.example.com"})
-	t.Cleanup(func() { SetAllowedOrigins(prevOrigins) })
-
-	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
-	req.Header.Set("Origin", "https://not-allowed.example.com")
-
-	if checkOrigin(req) {
-		t.Fatal("expected disallowed Origin without mobile client platform to be rejected")
-	}
-}
-
-func TestCheckOrigin_RejectsMobileClientWithBrowserCookie(t *testing.T) {
-	prevOrigins := allowedWSOrigins.Load().([]string)
-	SetAllowedOrigins([]string{"https://app.example.com"})
-	t.Cleanup(func() { SetAllowedOrigins(prevOrigins) })
-
-	req := httptest.NewRequest(http.MethodGet, "/ws?client_platform=mobile", nil)
-	req.Header.Set("Origin", "https://not-allowed.example.com")
-	req.AddCookie(&http.Cookie{Name: auth.AuthCookieName, Value: "browser-session"})
-
-	if checkOrigin(req) {
-		t.Fatal("expected disallowed mobile Origin with browser auth cookie to be rejected")
-	}
-}
-
 // totalClients counts all currently registered clients.
 func totalClients(hub *Hub) int {
 	hub.mu.RLock()
@@ -350,4 +310,41 @@ func (l *lockedWriter) Write(p []byte) (int, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.w.Write(p)
+}
+
+func TestCheckOrigin(t *testing.T) {
+	prev := allowedWSOrigins.Load().([]string)
+	SetAllowedOrigins([]string{
+		"http://localhost:3000",
+		"https://multica.ai",
+	})
+	t.Cleanup(func() { SetAllowedOrigins(prev) })
+
+	cases := []struct {
+		name   string
+		host   string
+		origin string
+		want   bool
+	}{
+		{"empty origin allowed", "api.multica.ai", "", true},
+		{"same-origin allowed (native client default)", "localhost:8080", "http://localhost:8080", true},
+		{"same-origin allowed (https)", "api.multica.ai", "https://api.multica.ai", true},
+		{"whitelisted origin allowed (web cross-origin)", "localhost:8080", "http://localhost:3000", true},
+		{"whitelisted origin allowed (prod web)", "api.multica.ai", "https://multica.ai", true},
+		{"unknown origin rejected (CSWSH defense)", "api.multica.ai", "https://evil.com", false},
+		{"different port rejected", "localhost:8080", "http://localhost:9999", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+			r.Host = tc.host
+			if tc.origin != "" {
+				r.Header.Set("Origin", tc.origin)
+			}
+			if got := checkOrigin(r); got != tc.want {
+				t.Fatalf("checkOrigin(host=%q, origin=%q) = %v, want %v", tc.host, tc.origin, got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

`CheckOrigin` 当前用 `?client_platform=mobile` + 无 cookie 作为 mobile 旁路条件(#2318)。但 mobile 客户端连 `ws://localhost:8080/ws` 时不带这个 query 参数,WS 库自动把 Origin 填成连接目标 host(等于服务器 Host),被原白名单逻辑拒成 403。

把 mobile 专用旁路换成**同源放行**:`Origin.host == r.Host` 直接通过。这就是 gorilla/websocket 出厂默认行为,跨域白名单照旧用于浏览器 web/desktop 客户端。Native 客户端从此零配置。

## 改动

- `server/internal/realtime/hub.go` — `checkOrigin` 加同源分支,移除 `client_platform=mobile` 旁路;import 加 `net/url`
- `server/internal/realtime/hub_test.go` — 删掉 3 个固化旧旁路行为的测试,加 `TestCheckOrigin` 表驱动覆盖 7 个场景

## 安全性

CSRF 多层防御保留(SameSite=Strict cookie / CSRF token HMAC / 成员检查 / scope 授权 / TLS)。CSWSH 攻击:浏览器**强制**把 Origin 填成页面 origin(Fetch 规范 forbidden header),evil.com 的 Origin 永远是 evil.com,既不同源也不在白名单 → 拒。

子域名劫持:同源比较是严格 host:port 相等,`attacker.multica.com` ≠ `api.multica.com` → 拒。

#2318 实际上在 `client_platform=mobile` + 无 cookie 路径下**完全跳过** Origin 检查;同源方案反而是 Origin 检查的强化版,把 gorilla 官方默认安全路径合回来。

## Test plan

- [x] `cd server && go test ./internal/realtime/ -run TestCheckOrigin -v` — 7/7 PASS
- [x] `cd server && go test ./internal/realtime/ -count=1` — 整包绿
- [ ] 本地启后端 + `pnpm dev:mobile`,看服务器日志出 `ws client connected` 而非 `ws: rejected origin`
- [ ] web dev 跨域(`:3000` → `:8080`)WS 仍正常连接

Closes [MUL-2027](https://github.com/multica-ai/multica/issues/2027)

🤖 Generated with [Claude Code](https://claude.com/claude-code)