### PR TITLE
fix(chat): unify chat & comment send shortcut to Mod+Enter

### DIFF
--- a/packages/ui/components/common/submit-button.tsx
+++ b/packages/ui/components/common/submit-button.tsx
@@ -1,7 +1,13 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { ArrowUp, Loader2, Square } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@multica/ui/components/ui/tooltip";
 
 interface SubmitButtonProps {
   onClick: () => void;
@@ -9,25 +15,52 @@ interface SubmitButtonProps {
   loading?: boolean;
   running?: boolean;
   onStop?: () => void;
+  /**
+   * Tooltip shown over the send button when idle. Pass a string or a node
+   * (e.g. `Send · ⌘↵`). Omit to render no tooltip.
+   * Callers compose the shortcut hint themselves to keep this component
+   * free of `@multica/core` (platform-detection) and i18n imports.
+   */
+  tooltip?: ReactNode;
+  /** Tooltip shown over the stop button while a run is in progress. */
+  stopTooltip?: ReactNode;
 }
 
-function SubmitButton({ onClick, disabled, loading, running, onStop }: SubmitButtonProps) {
+function SubmitButton({
+  onClick,
+  disabled,
+  loading,
+  running,
+  onStop,
+  tooltip,
+  stopTooltip,
+}: SubmitButtonProps) {
   if (running) {
-    return (
+    const stopButton = (
       <Button size="icon-sm" onClick={onStop}>
         <Square className="fill-current" />
       </Button>
     );
+    if (!stopTooltip) return stopButton;
+    return (
+      <Tooltip>
+        <TooltipTrigger render={stopButton} />
+        <TooltipContent side="top">{stopTooltip}</TooltipContent>
+      </Tooltip>
+    );
   }
 
-  return (
+  const submitButton = (
     <Button size="icon-sm" disabled={disabled || loading} onClick={onClick}>
-      {loading ? (
-        <Loader2 className="animate-spin" />
-      ) : (
-        <ArrowUp />
-      )}
+      {loading ? <Loader2 className="animate-spin" /> : <ArrowUp />}
     </Button>
+  );
+  if (!tooltip) return submitButton;
+  return (
+    <Tooltip>
+      <TooltipTrigger render={submitButton} />
+      <TooltipContent side="top">{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -7,6 +7,7 @@ import { ContentEditor, type ContentEditorRef } from "../../editor";
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { useChatStore, DRAFT_NEW_SESSION } from "@multica/core/chat";
 import { createLogger } from "@multica/core/logger";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import { useT } from "../../i18n";
 
 const logger = createLogger("chat.ui");
@@ -140,8 +141,10 @@ export function ChatInput({
             // Chat is short-form — the floating formatting toolbar is
             // more distraction than feature here.
             showBubbleMenu={false}
-            // Enter sends; Shift-Enter inserts a hard break.
-            submitOnEnter
+            // Mod+Enter submits. Bare Enter falls through to Tiptap's
+            // default, which continues lists/quotes and breaks paragraphs.
+            // Without this, Enter-as-send would steal the only key that
+            // continues a bullet list, leaving users stuck after one item.
           />
         </div>
         {leftAdornment && (
@@ -156,6 +159,8 @@ export function ChatInput({
             disabled={isEmpty || !!disabled || !!noAgent}
             running={isRunning}
             onStop={onStop}
+            tooltip={`${t(($) => $.input.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
+            stopTooltip={t(($) => $.input.stop_tooltip)}
           />
         </div>
       </div>

--- a/packages/views/editor/extensions/submit-shortcut.test.ts
+++ b/packages/views/editor/extensions/submit-shortcut.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { getExtensionField } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
+import { createSubmitExtension } from "./submit-shortcut";
+
+function getShortcuts(
+  ext: ReturnType<typeof createSubmitExtension>,
+  editor: Partial<Editor>,
+): Record<string, () => boolean> {
+  const fn = getExtensionField<
+    () => Record<string, () => boolean>
+  >(ext, "addKeyboardShortcuts", {
+    name: "submitShortcut",
+    options: {},
+    storage: {},
+    editor: editor as Editor,
+    type: null,
+  });
+  return fn?.() ?? {};
+}
+
+describe("createSubmitExtension", () => {
+  const baseEditor = {
+    view: { composing: false } as unknown as Editor["view"],
+    isActive: () => false,
+  } as Partial<Editor>;
+
+  it("Mod-Enter always submits", () => {
+    const onSubmit = vi.fn(() => true);
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnter: false }),
+      baseEditor,
+    );
+
+    expect(shortcuts["Mod-Enter"]).toBeDefined();
+    shortcuts["Mod-Enter"]!();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("bare Enter is not bound when submitOnEnter is false", () => {
+    const onSubmit = vi.fn(() => true);
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnter: false }),
+      baseEditor,
+    );
+
+    expect(shortcuts.Enter).toBeUndefined();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("bare Enter submits when submitOnEnter is true", () => {
+    const onSubmit = vi.fn(() => true);
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      baseEditor,
+    );
+
+    expect(shortcuts.Enter).toBeDefined();
+    expect(shortcuts.Enter!()).toBe(true);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter is suppressed during IME composition", () => {
+    const onSubmit = vi.fn(() => true);
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      {
+        view: { composing: true } as unknown as Editor["view"],
+        isActive: () => false,
+      },
+    );
+
+    expect(shortcuts.Enter!()).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("Enter is suppressed inside a code block", () => {
+    const onSubmit = vi.fn(() => true);
+    const shortcuts = getShortcuts(
+      createSubmitExtension(onSubmit, { submitOnEnter: true }),
+      {
+        view: { composing: false } as unknown as Editor["view"],
+        isActive: (name: string) => name === "codeBlock",
+      },
+    );
+
+    expect(shortcuts.Enter!()).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/views/issues/components/comment-input.tsx
+++ b/packages/views/issues/components/comment-input.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { useRef, useState, useCallback } from "react";
-import { ArrowUp, Loader2, Maximize2, Minimize2 } from "lucide-react";
-import { Button } from "@multica/ui/components/ui/button";
+import { Maximize2, Minimize2 } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { cn } from "@multica/ui/lib/utils";
 import { ContentEditor, type ContentEditorRef, useFileDropZone, FileDropOverlay } from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
+import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
+import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
 import { useT } from "../../i18n";
 
 interface CommentInputProps {
@@ -96,17 +97,12 @@ function CommentInput({ issueId, onSubmit }: CommentInputProps) {
           size="sm"
           onSelect={(file) => editorRef.current?.uploadFile(file)}
         />
-        <Button
-          size="icon-sm"
-          disabled={isEmpty || submitting}
+        <SubmitButton
           onClick={handleSubmit}
-        >
-          {submitting ? (
-            <Loader2 className="animate-spin" />
-          ) : (
-            <ArrowUp />
-          )}
-        </Button>
+          disabled={isEmpty}
+          loading={submitting}
+          tooltip={`${t(($) => $.comment.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
+        />
       </div>
       {isDragOver && <FileDropOverlay />}
     </div>

--- a/packages/views/locales/en/chat.json
+++ b/packages/views/locales/en/chat.json
@@ -9,7 +9,9 @@
     "placeholder_no_agent": "Create an agent to start chatting",
     "placeholder_archived": "This session is archived",
     "placeholder_named": "Tell {{name}} what to do…",
-    "placeholder_default": "Tell me what to do…"
+    "placeholder_default": "Tell me what to do…",
+    "send_tooltip": "Send",
+    "stop_tooltip": "Stop"
   },
   "message_list": {
     "show_details": "Show details",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -173,6 +173,7 @@
     "reply_count_one": "{{count}} reply",
     "reply_count_other": "{{count}} replies",
     "leave_comment_placeholder": "Leave a comment...",
+    "send_tooltip": "Send",
     "expand_tooltip": "Expand",
     "collapse_tooltip": "Collapse",
     "resolve": {

--- a/packages/views/locales/zh-Hans/chat.json
+++ b/packages/views/locales/zh-Hans/chat.json
@@ -8,7 +8,9 @@
     "placeholder_no_agent": "创建一个智能体后才能开始对话",
     "placeholder_archived": "此会话已归档",
     "placeholder_named": "告诉 {{name}} 该做什么...",
-    "placeholder_default": "告诉我该做什么..."
+    "placeholder_default": "告诉我该做什么...",
+    "send_tooltip": "发送",
+    "stop_tooltip": "停止"
   },
   "message_list": {
     "show_details": "查看详情",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -171,6 +171,7 @@
     "delete_failed": "删除评论失败",
     "reply_count_other": "{{count}} 条回复",
     "leave_comment_placeholder": "留下评论...",
+    "send_tooltip": "发送",
     "expand_tooltip": "展开",
     "collapse_tooltip": "收起",
     "resolve": {


### PR DESCRIPTION
## Summary

Closes [MUL-2034](mention://issue/dab0787d-826a-47a9-bee8-c5ddc7eee47b).

The chat input previously sent on bare `Enter` while the comment input sent on `Mod+Enter`. Two issues fell out of that:

- Inconsistent muscle memory between the two surfaces.
- In chat, `Enter`-as-send stole the only key that continues a TipTap bullet/ordered list. `Shift+Enter` falls through to ProseMirror's `HardBreak` (a `<br>` inside the same list item) and does not continue the list — so chat users were stuck at one bullet.

## Changes

- **`chat-input.tsx`** — drop `submitOnEnter`. Chat now matches the editor default: `Mod+Enter` (⌘↵ / Ctrl+Enter) sends, bare `Enter` falls through to TipTap (continues lists, breaks paragraphs).
- **`submit-button.tsx`** — accept optional `tooltip` and `stopTooltip` props so callers can surface the shortcut. Kept dumb: no `@multica/core` or i18n imports, callers compose the shortcut hint themselves (uses `formatShortcut(modKey, enterKey)` from `@multica/core/platform`).
- **`comment-input.tsx`** — route through the shared `SubmitButton` and pass the tooltip, dropping the inline `<Button>` duplicate.
- **i18n** — add `chat.input.send_tooltip` / `stop_tooltip` and `issues.comment.send_tooltip` (EN + zh-Hans).
- **test** — new `submit-shortcut.test.ts` pins five behaviors: `Mod-Enter` always submits, bare `Enter` unbound when `submitOnEnter=false`, bare `Enter` submits when `true`, IME-composition guard, code-block guard.

No change to `submit-shortcut.ts` itself — its IME / code-block guards now sit on the `Enter` branch that chat no longer activates, but the prop and the guards remain in place for the existing extension contract.

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run editor/extensions/submit-shortcut.test.ts` — 5/5 green.
- [x] `pnpm --filter @multica/views test` — 353/353 green.
- [x] `pnpm typecheck` — all 6 tasks green.
- [x] `pnpm lint` — no new warnings introduced (3 pre-existing in unrelated files).
- [ ] Manual: chat input — `- a` `Enter` `b` should produce a two-item bullet list.
- [ ] Manual: chat input — Chinese IME compose then `Enter` should commit text, not send.
- [ ] Manual: chat input — inside a fenced code block, `Enter` should insert a newline, not send.
- [ ] Manual: chat & comment — hover send button shows `Send · ⌘↵` (or `Send · Ctrl+Enter` on non-Mac).
- [ ] Manual: comment input behavior unchanged (already `Mod+Enter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)