### PR TITLE
docs(util): clarify EnsureHiddenConsole call-order contract

### DIFF
--- a/server/internal/util/proc_windows.go
+++ b/server/internal/util/proc_windows.go
@@ -18,6 +18,11 @@ const swHide = 0
 // visible to the user. Every child process (git, cmd, etc.) inherits this
 // hidden console automatically, so no per-call SysProcAttr gymnastics are
 // needed.
+//
+// MUST be called at daemon startup before any child process is spawned —
+// the inherited hidden console only protects children started after this
+// returns. A child spawned earlier will allocate its own visible console
+// window and reintroduce the popup-flash regression from #2357.
 func EnsureHiddenConsole() {
 	if hwnd, _, _ := procGetConsoleWnd.Call(); hwnd != 0 {
 		return // already have a console


### PR DESCRIPTION
## Summary

Adds a documentation note to `EnsureHiddenConsole` in `server/internal/util/proc_windows.go` clarifying that it MUST be called at daemon startup *before* any child process is spawned — otherwise children launched earlier will allocate their own visible console window and reintroduce the popup-flash regression that #2358 just fixed.

The function itself is already correctly invoked as the first line of `runDaemonForeground`, so this is a doc-only change to lock in the contract for future call sites and refactors.

## Why

The single-init design relies on call order: the inherited hidden console only protects children spawned *after* `AllocConsole + SW_HIDE` returns. Without this note, a future contributor adding daemon-side initialization (especially anything in `init()` or pre-startup hooks) could quietly invalidate the fix on Windows, and the regression would not show up in Linux/macOS CI because `proc_other.go` is a no-op.

## Test plan

- [x] Doc-only change, no behavior impact.
- [x] `git diff` shows only the 5 added comment lines.
- [ ] CI build passes.