### PR TITLE
fix(core): stop leaking recent issues across workspaces

### DIFF
--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -109,7 +109,7 @@ export function useCreateIssue() {
       );
       // Surface the just-created issue in cmd+k's Recent list without
       // requiring the user to open it first.
-      useRecentIssuesStore.getState().recordVisit(newIssue.id);
+      useRecentIssuesStore.getState().recordVisit(wsId, newIssue.id);
       // Invalidate parent's children query so sub-issues list updates immediately
       if (newIssue.parent_issue_id) {
         qc.invalidateQueries({ queryKey: issueKeys.children(wsId, newIssue.parent_issue_id) });

--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -1,7 +1,11 @@
 export { useIssueSelectionStore } from "./selection-store";
 export { useCreateModeStore, type CreateMode } from "./create-mode-store";
 export { useIssueDraftStore } from "./draft-store";
-export { useRecentIssuesStore, type RecentIssueEntry } from "./recent-issues-store";
+export {
+  useRecentIssuesStore,
+  selectRecentIssues,
+  type RecentIssueEntry,
+} from "./recent-issues-store";
 export {
   ViewStoreProvider,
   useViewStore,

--- a/packages/core/issues/stores/recent-issues-store.test.ts
+++ b/packages/core/issues/stores/recent-issues-store.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useRecentIssuesStore, selectRecentIssues } from "./recent-issues-store";
+
+beforeEach(() => {
+  useRecentIssuesStore.setState({ byWorkspace: {} });
+});
+
+describe("useRecentIssuesStore.recordVisit", () => {
+  it("keeps visits namespaced by workspace id", () => {
+    const { recordVisit } = useRecentIssuesStore.getState();
+    recordVisit("ws-a", "issue-1");
+    recordVisit("ws-b", "issue-2");
+
+    const state = useRecentIssuesStore.getState().byWorkspace;
+    expect(state["ws-a"]?.map((e) => e.id)).toEqual(["issue-1"]);
+    expect(state["ws-b"]?.map((e) => e.id)).toEqual(["issue-2"]);
+  });
+
+  it("moves the most recent visit to the front and dedupes", () => {
+    const { recordVisit } = useRecentIssuesStore.getState();
+    recordVisit("ws-a", "issue-1");
+    recordVisit("ws-a", "issue-2");
+    recordVisit("ws-a", "issue-1");
+
+    const ids = useRecentIssuesStore
+      .getState()
+      .byWorkspace["ws-a"]?.map((e) => e.id);
+    expect(ids).toEqual(["issue-1", "issue-2"]);
+  });
+
+  it("caps each workspace's bucket at 20 entries", () => {
+    const { recordVisit } = useRecentIssuesStore.getState();
+    for (let i = 0; i < 25; i++) recordVisit("ws-a", `issue-${i}`);
+    expect(useRecentIssuesStore.getState().byWorkspace["ws-a"]).toHaveLength(20);
+  });
+});
+
+describe("useRecentIssuesStore.pruneWorkspaces", () => {
+  it("drops buckets for workspaces not in the active set", () => {
+    const { recordVisit, pruneWorkspaces } = useRecentIssuesStore.getState();
+    recordVisit("ws-a", "issue-1");
+    recordVisit("ws-b", "issue-2");
+    recordVisit("ws-c", "issue-3");
+
+    pruneWorkspaces(["ws-a", "ws-c"]);
+    const state = useRecentIssuesStore.getState().byWorkspace;
+    expect(Object.keys(state).sort()).toEqual(["ws-a", "ws-c"]);
+  });
+
+  it("is a no-op when every bucket is still active", () => {
+    const { recordVisit, pruneWorkspaces } = useRecentIssuesStore.getState();
+    recordVisit("ws-a", "issue-1");
+    const before = useRecentIssuesStore.getState().byWorkspace;
+    pruneWorkspaces(["ws-a"]);
+    expect(useRecentIssuesStore.getState().byWorkspace).toBe(before);
+  });
+});
+
+describe("selectRecentIssues", () => {
+  it("returns the bucket for the given workspace", () => {
+    useRecentIssuesStore.getState().recordVisit("ws-a", "issue-1");
+    const items = selectRecentIssues("ws-a")(useRecentIssuesStore.getState());
+    expect(items.map((e) => e.id)).toEqual(["issue-1"]);
+  });
+
+  it("returns a stable empty array when wsId is null or unknown", () => {
+    const a = selectRecentIssues(null)(useRecentIssuesStore.getState());
+    const b = selectRecentIssues(null)(useRecentIssuesStore.getState());
+    const c = selectRecentIssues("missing")(useRecentIssuesStore.getState());
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+    expect(a).toEqual([]);
+  });
+});

--- a/packages/core/issues/stores/recent-issues-store.ts
+++ b/packages/core/issues/stores/recent-issues-store.ts
@@ -2,13 +2,11 @@
 
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import {
-  createWorkspaceAwareStorage,
-  registerForWorkspaceRehydration,
-} from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
 
 const MAX_RECENT_ISSUES = 20;
+const MAX_WORKSPACES = 50;
+const EMPTY: RecentIssueEntry[] = [];
 
 export interface RecentIssueEntry {
   id: string;
@@ -16,33 +14,82 @@ export interface RecentIssueEntry {
 }
 
 interface RecentIssuesState {
-  items: RecentIssueEntry[];
-  recordVisit: (id: string) => void;
+  byWorkspace: Record<string, RecentIssueEntry[]>;
+  recordVisit: (wsId: string, id: string) => void;
+  pruneWorkspaces: (activeWsIds: string[]) => void;
 }
 
+// Namespace by workspace id (UUID) instead of namespacing the storage key by
+// slug. The storage-key approach (see createWorkspaceAwareStorage) breaks when
+// a setter fires from a child component's mount-effect before
+// WorkspaceRouteLayout's effect has set the current slug — child effects run
+// before parent effects, so writes land in the un-namespaced bare key and
+// leak across workspaces (bug surfaced by /<slug>/issues firing per-id GETs
+// for recents from other workspaces, most returning 404).
+//
+// Keying on wsId (rather than slug) means the data survives workspace renames
+// and matches the wsId that callers already have via useWorkspaceId().
 export const useRecentIssuesStore = create<RecentIssuesState>()(
   persist(
     (set) => ({
-      items: [],
-      recordVisit: (id) =>
+      byWorkspace: {},
+      recordVisit: (wsId, id) =>
         set((state) => {
-          const filtered = state.items.filter((i) => i.id !== id);
+          const bucket = state.byWorkspace[wsId] ?? EMPTY;
+          const filtered = bucket.filter((i) => i.id !== id);
           const updated: RecentIssueEntry = { id, visitedAt: Date.now() };
-          return {
-            items: [updated, ...filtered].slice(0, MAX_RECENT_ISSUES),
+          const nextBucket = [updated, ...filtered].slice(0, MAX_RECENT_ISSUES);
+
+          let nextByWorkspace = {
+            ...state.byWorkspace,
+            [wsId]: nextBucket,
           };
+
+          // LRU defense: if pruneWorkspaces never gets a chance to run (offline,
+          // failed list query) and the user touches lots of workspaces, cap the
+          // total to avoid unbounded growth. Evict the workspace whose most
+          // recent visit is the oldest.
+          const ids = Object.keys(nextByWorkspace);
+          if (ids.length > MAX_WORKSPACES) {
+            const oldest = ids.reduce((oldestId, candidateId) => {
+              const a = nextByWorkspace[oldestId]?.[0]?.visitedAt ?? 0;
+              const b = nextByWorkspace[candidateId]?.[0]?.visitedAt ?? 0;
+              return b < a ? candidateId : oldestId;
+            });
+            const { [oldest]: _, ...rest } = nextByWorkspace;
+            nextByWorkspace = rest;
+          }
+
+          return { byWorkspace: nextByWorkspace };
+        }),
+      pruneWorkspaces: (activeWsIds) =>
+        set((state) => {
+          const allow = new Set(activeWsIds);
+          let changed = false;
+          const next: Record<string, RecentIssueEntry[]> = {};
+          for (const [wsId, items] of Object.entries(state.byWorkspace)) {
+            if (allow.has(wsId)) next[wsId] = items;
+            else changed = true;
+          }
+          return changed ? { byWorkspace: next } : state;
         }),
     }),
     {
       name: "multica_recent_issues",
-      storage: createJSONStorage(() =>
-        createWorkspaceAwareStorage(defaultStorage),
-      ),
-      partialize: (state) => ({ items: state.items }),
+      storage: createJSONStorage(() => defaultStorage),
+      partialize: (state) => ({ byWorkspace: state.byWorkspace }),
+      // v0 stored a flat `items` array under the bare key (or, when the
+      // workspace slug happened to be set at write time, under
+      // `multica_recent_issues:<slug>`). Both shapes are unsafe to surface
+      // because v0 entries don't know which workspace they belonged to —
+      // drop them and let the cache repopulate as the user visits issues.
+      version: 1,
+      migrate: () => ({ byWorkspace: {} }),
     },
   ),
 );
 
-registerForWorkspaceRehydration(() =>
-  useRecentIssuesStore.persist.rehydrate(),
-);
+export function selectRecentIssues(wsId: string | null) {
+  return (state: RecentIssuesState) =>
+    wsId ? (state.byWorkspace[wsId] ?? EMPTY) : EMPTY;
+}

--- a/packages/core/platform/workspace-storage.test.ts
+++ b/packages/core/platform/workspace-storage.test.ts
@@ -20,13 +20,19 @@ afterEach(() => {
 });
 
 describe("workspace-aware storage", () => {
-  it("uses plain key when no workspace is set", () => {
+  it("drops writes and returns null for reads when no workspace is set", () => {
     const adapter = mockAdapter();
     setCurrentWorkspace(null, null);
     const storage = createWorkspaceAwareStorage(adapter);
 
     storage.setItem("draft", "data");
-    expect(adapter.setItem).toHaveBeenCalledWith("draft", "data");
+    expect(adapter.setItem).not.toHaveBeenCalled();
+
+    expect(storage.getItem("draft")).toBeNull();
+    expect(adapter.getItem).not.toHaveBeenCalled();
+
+    storage.removeItem("draft");
+    expect(adapter.removeItem).not.toHaveBeenCalled();
   });
 
   it("namespaces key with slug when workspace is set", () => {

--- a/packages/core/platform/workspace-storage.ts
+++ b/packages/core/platform/workspace-storage.ts
@@ -94,14 +94,24 @@ export function registerForWorkspaceRehydration(fn: () => void) {
 /**
  * Storage that automatically namespaces keys with the current workspace slug.
  * Reads _currentSlug at call time, so it follows workspace switches dynamically.
+ *
+ * When no workspace is active (e.g. zustand persist's initial hydration before
+ * WorkspaceRouteLayout has called setCurrentWorkspace, or a setter firing from
+ * a child component's mount-effect before the parent layout's effect has run),
+ * reads return null and writes are dropped — explicitly NOT a fallback to the
+ * un-namespaced bare key, which used to leak workspace-scoped data across
+ * workspaces. Persisted stores get a real read once setCurrentWorkspace
+ * triggers their registered rehydrate fn.
  */
 export function createWorkspaceAwareStorage(adapter: StorageAdapter): StateStorage {
-  const resolve = (key: string) =>
-    _currentSlug ? `${key}:${_currentSlug}` : key;
-
   return {
-    getItem: (key) => adapter.getItem(resolve(key)),
-    setItem: (key, value) => adapter.setItem(resolve(key), value),
-    removeItem: (key) => adapter.removeItem(resolve(key)),
+    getItem: (key) =>
+      _currentSlug ? adapter.getItem(`${key}:${_currentSlug}`) : null,
+    setItem: (key, value) => {
+      if (_currentSlug) adapter.setItem(`${key}:${_currentSlug}`, value);
+    },
+    removeItem: (key) => {
+      if (_currentSlug) adapter.removeItem(`${key}:${_currentSlug}`);
+    },
   };
 }

--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -239,11 +239,18 @@ const mockRecordVisit = vi.fn();
 vi.mock("@multica/core/issues/stores", () => ({
   useRecentIssuesStore: Object.assign(
     (selector?: any) => {
-      const state = { items: [], recordVisit: mockRecordVisit };
+      const state = { byWorkspace: {}, recordVisit: mockRecordVisit, pruneWorkspaces: vi.fn() };
       return selector ? selector(state) : state;
     },
-    { getState: () => ({ items: [], recordVisit: mockRecordVisit }) },
+    {
+      getState: () => ({
+        byWorkspace: {},
+        recordVisit: mockRecordVisit,
+        pruneWorkspaces: vi.fn(),
+      }),
+    },
   ),
+  selectRecentIssues: () => () => [],
   useCommentCollapseStore: (selector?: any) => {
     const state = {
       collapsedByIssue: {},

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -391,9 +391,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const recordVisit = useRecentIssuesStore((s) => s.recordVisit);
   useEffect(() => {
     if (issue) {
-      recordVisit(issue.id);
+      recordVisit(wsId, issue.id);
     }
-  }, [issue?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [issue?.id, wsId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Fire `onDelete` once when the issue transitions from loaded to missing.
   // Delete goes through a shell-level modal, so the caller (e.g. inbox) can't

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -195,11 +195,18 @@ vi.mock("@multica/core/issues/stores/selection-store", () => ({
 vi.mock("@multica/core/issues/stores/recent-issues-store", () => ({
   useRecentIssuesStore: Object.assign(
     (selector?: any) => {
-      const state = { items: [], recordVisit: vi.fn() };
+      const state = { byWorkspace: {}, recordVisit: vi.fn(), pruneWorkspaces: vi.fn() };
       return selector ? selector(state) : state;
     },
-    { getState: () => ({ items: [], recordVisit: vi.fn() }) },
+    {
+      getState: () => ({
+        byWorkspace: {},
+        recordVisit: vi.fn(),
+        pruneWorkspaces: vi.fn(),
+      }),
+    },
   ),
+  selectRecentIssues: () => () => [],
 }));
 
 vi.mock("@multica/core/modals", () => ({

--- a/packages/views/layout/use-dashboard-guard.ts
+++ b/packages/views/layout/use-dashboard-guard.ts
@@ -11,6 +11,7 @@ import {
   useHasOnboarded,
 } from "@multica/core/paths";
 import { workspaceListOptions } from "@multica/core/workspace";
+import { useRecentIssuesStore } from "@multica/core/issues/stores";
 import { useNavigation } from "../navigation";
 
 /**
@@ -62,6 +63,16 @@ export function useDashboardGuard() {
   useEffect(() => {
     useNavigationStore.getState().onPathChange(pathname);
   }, [pathname]);
+
+  // Drop recent-issues buckets for workspaces the user no longer belongs to.
+  // Runs once the workspace list resolves, and again whenever membership
+  // changes (workspace deleted, user kicked, user left).
+  useEffect(() => {
+    if (!workspaceListFetched) return;
+    useRecentIssuesStore
+      .getState()
+      .pruneWorkspaces(workspaces.map((w) => w.id));
+  }, [workspaceListFetched, workspaces]);
 
   return { user, isLoading, workspace };
 }

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -67,12 +67,23 @@ vi.mock("@multica/core/api", () => ({
   },
 }));
 
-vi.mock("@multica/core/issues/stores", () => ({
-  useRecentIssuesStore: (selector?: (state: { items: typeof mockRecentItems.current }) => unknown) => {
-    const state = { items: mockRecentItems.current };
-    return selector ? selector(state) : state;
-  },
-}));
+vi.mock("@multica/core/issues/stores", () => {
+  const EMPTY: Array<{ id: string; visitedAt: number }> = [];
+  return {
+    useRecentIssuesStore: (
+      selector?: (state: {
+        byWorkspace: Record<string, typeof mockRecentItems.current>;
+      }) => unknown,
+    ) => {
+      const state = { byWorkspace: { "ws-test": mockRecentItems.current } };
+      return selector ? selector(state) : state;
+    },
+    selectRecentIssues:
+      (wsId: string | null) =>
+      (state: { byWorkspace: Record<string, typeof mockRecentItems.current> }) =>
+        wsId ? (state.byWorkspace[wsId] ?? EMPTY) : EMPTY,
+  };
+});
 
 vi.mock("@multica/core", () => ({
   useWorkspaceId: () => "ws-test",

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -28,7 +28,7 @@ import { useQueries, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { SearchIssueResult, SearchProjectResult } from "@multica/core/types";
 import { api } from "@multica/core/api";
-import { useRecentIssuesStore } from "@multica/core/issues/stores";
+import { selectRecentIssues, useRecentIssuesStore } from "@multica/core/issues/stores";
 import { issueDetailOptions } from "@multica/core/issues/queries";
 import { useWorkspaceId } from "@multica/core";
 import { paths, useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
@@ -139,8 +139,8 @@ export function SearchCommand() {
   const { push, pathname, getShareableUrl } = useNavigation();
   const open = useSearchStore((s) => s.open);
   const setOpen = useSearchStore((s) => s.setOpen);
-  const recentItems = useRecentIssuesStore((s) => s.items);
   const wsId = useWorkspaceId();
+  const recentItems = useRecentIssuesStore(selectRecentIssues(wsId));
   const p: WorkspacePaths = useWorkspacePaths();
   const { theme, setTheme } = useTheme();
   const currentWorkspace = useCurrentWorkspace();


### PR DESCRIPTION
## What does this PR do?

Stops the issue list page (and every other page that mounts `SearchCommand`) from firing ~20 individual `GET /api/issues/{id}` requests against ids from other workspaces, most of which 404.

Two layered fixes:

1. **`recent-issues-store` keys by `wsId` inside state** rather than relying on `createWorkspaceAwareStorage`'s storage-key namespacing. The old approach broke when a setter fired before `WorkspaceRouteLayout`'s mount-effect — child effects run before parent effects in React, so `recordVisit` from `IssueDetail` wrote to the un-namespaced bare localStorage key, leaking the visit into every other workspace.
2. **`createWorkspaceAwareStorage` fails closed on null slug** instead of falling back to the bare key. Reads return `null`, writes are dropped. Persisted stores still get a correct read once `setCurrentWorkspace` fires their registered rehydrate fn. The other nine stores using this storage gain defense-in-depth for free.

Membership-based pruning is wired into `useDashboardGuard`: as soon as the workspace list query resolves, `pruneWorkspaces` drops buckets for workspaces the user no longer belongs to (deleted, kicked, left). LRU cap of 50 workspaces serves as a fallback if the list never loads.

## Related Issue

Closes multica-ai/multica#2402

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/issues/stores/recent-issues-store.ts` — re-shaped state to `{ byWorkspace: Record<wsId, RecentIssueEntry[]> }`, exposes `recordVisit(wsId, id)` and `pruneWorkspaces(activeWsIds)`. Uses `defaultStorage` directly (no workspace-aware storage). Persist `version: 1` with a migrate that drops v0 entries since they don't know their workspace.
- `packages/core/issues/stores/recent-issues-store.test.ts` — new tests for cross-workspace isolation, dedupe/ordering, 20-per-workspace cap, prune behavior, and selector reference stability.
- `packages/core/issues/stores/index.ts` — export `selectRecentIssues`.
- `packages/core/issues/mutations.ts` — `useCreateIssue` passes `wsId` to `recordVisit`.
- `packages/views/issues/components/issue-detail.tsx` — passes `wsId` to `recordVisit`.
- `packages/views/search/search-command.tsx` — reads recents via `selectRecentIssues(wsId)` instead of `s.items`.
- `packages/views/layout/use-dashboard-guard.ts` — calls `pruneWorkspaces` whenever the workspace list resolves.
- `packages/core/platform/workspace-storage.ts` — `createWorkspaceAwareStorage` returns `null` / no-ops when `_currentSlug` is null instead of falling back to the bare key.
- `packages/core/platform/workspace-storage.test.ts` — replaced the "uses plain key when no workspace is set" case with one that asserts reads return null and writes are dropped.
- Updated existing test mocks in `issue-detail.test.tsx`, `issues-page.test.tsx`, `search-command.test.tsx` to match the new store shape.

## How to Test

1. Sign in, open workspace A, click through ~20 issues so the recents list fills up.
2. Switch to a freshly-created workspace B that has one issue.
3. Open `/<B-slug>/issues` with the Network panel and backend log visible.
4. **Before this PR:** ~20 `GET /api/issues/{id}` requests, most 404. **After this PR:** only the issues list query + the legitimately-cached recent issue (if it belongs to B) fire; no cross-workspace 404s.
5. Open cmd+k → Recent — shows only issues that belong to the current workspace.
6. Switch workspaces — Recent immediately reflects the destination workspace's bucket, no rehydration delay.
7. Leave / delete a workspace — its bucket disappears the next time the workspace list refetches.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, backend-request count only
- [x] I have updated relevant documentation to reflect my changes — no doc surface affected
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy / starter-content / docs — N/A
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` — N/A
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

**Risks:**

- Users with persisted v0 recents will see their cmd+k Recent list reset once. The list repopulates as they visit issues. Acceptable — the v0 entries are exactly the polluted ones causing the bug.
- The bare-key fallback removal affects all nine other stores using `createWorkspaceAwareStorage`. None of them previously relied on the bare-key path for legitimate data (their persisted data has always been intended as workspace-scoped); the only behavior change is that any setter accidentally firing with null slug now silently drops the write instead of leaking it globally.

## AI Disclosure

**AI tool used:** Claude Code (Opus 4.7, 1M context)

**Prompt / approach:**

Started from a backend log showing the per-id 404 burst on the issue list page. Asked Claude to systematically debug — root-cause investigation before any fix — which traced the call chain from the issue list page to `SearchCommand` to `useRecentIssuesStore`'s persisted state. Identified two compounding causes: (a) eager `useQueries` fan-out from a globally-mounted component, and (b) the workspace-aware storage's bare-key fallback racing React effect order. Discussed two alternative architectures (storage-key namespacing vs. state-internal namespacing) and chose state-internal because it eliminates the timing dependency entirely. Implemented in two atomic commits with full test coverage.