### PR TITLE
Avoid retryable errors after accepted comments

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -954,8 +955,17 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 		body["attachment_ids"] = attachmentIDs
 	}
 	var result map[string]any
-	if err := client.PostJSON(ctx, "/api/issues/"+issueID+"/comments", body, &result); err != nil {
-		return fmt.Errorf("add comment: %w", err)
+	respData, postErr := client.PostJSONBytes(ctx, "/api/issues/"+issueID+"/comments", body)
+	if postErr != nil {
+		return fmt.Errorf("add comment: %w", postErr)
+	}
+	if len(strings.TrimSpace(string(respData))) > 0 {
+		if err := json.Unmarshal(respData, &result); err != nil {
+			// The comment has already been accepted by the server. Returning a
+			// non-zero exit here invites agent retries that duplicate the comment,
+			// so keep the command successful and surface only a warning.
+			fmt.Fprintf(os.Stderr, "warning: comment was accepted but response decoding failed: %v\n", err)
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "Comment added to issue %s.\n", issueRef.Display)
@@ -963,6 +973,9 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 	output, _ := cmd.Flags().GetString("output")
 	if output == "table" {
 		return nil
+	}
+	if result == nil {
+		result = map[string]any{"status": "posted"}
 	}
 	return cli.PrintJSON(os.Stdout, result)
 }

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -484,6 +484,47 @@ func TestRunIssueRunMessagesResolvesShortTaskPrefix(t *testing.T) {
 	}
 }
 
+func TestRunIssueCommentAddTreatsAcceptedInvalidJSONAsSuccess(t *testing.T) {
+	issueID := "1881a167-4bb6-4602-944b-f40ce4192fe6"
+	postCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/issues/MUL-1852":
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":         issueID,
+				"identifier": "MUL-1852",
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/issues/"+issueID+"/comments":
+			postCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id"`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("MULTICA_SERVER_URL", srv.URL)
+	t.Setenv("MULTICA_WORKSPACE_ID", "ws-1")
+	t.Setenv("MULTICA_TOKEN", "test-token")
+
+	cmd := &cobra.Command{Use: "add"}
+	cmd.Flags().String("content", "", "")
+	cmd.Flags().Bool("content-stdin", false, "")
+	cmd.Flags().String("parent", "", "")
+	cmd.Flags().StringSlice("attachment", nil, "")
+	cmd.Flags().String("output", "json", "")
+	_ = cmd.Flags().Set("content", "hello")
+
+	if err := runIssueCommentAdd(cmd, []string{"MUL-1852"}); err != nil {
+		t.Fatalf("accepted comment should not return retryable error, got %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("postCount = %d, want 1", postCount)
+	}
+}
+
 func TestResolveAssignee(t *testing.T) {
 	membersResp := []map[string]any{
 		{"user_id": "user-1111", "name": "Alice Smith"},

--- a/server/internal/cli/client.go
+++ b/server/internal/cli/client.go
@@ -181,32 +181,48 @@ func (c *APIClient) DeleteJSON(ctx context.Context, path string) error {
 
 // PostJSON performs a POST request with a JSON body.
 func (c *APIClient) PostJSON(ctx context.Context, path string, body any, out any) error {
-	data, err := json.Marshal(body)
+	respData, err := c.PostJSONBytes(ctx, path, body)
 	if err != nil {
 		return err
+	}
+	if out == nil {
+		return nil
+	}
+	return json.Unmarshal(respData, out)
+}
+
+// PostJSONBytes performs a POST request with a JSON body and returns the raw
+// response bytes after the server has returned a 2xx/3xx status. This is useful
+// for side-effecting commands that must not turn a successful write into a
+// retryable failure merely because local response decoding/formatting failed.
+func (c *APIClient) PostJSONBytes(ctx context.Context, path string, body any) ([]byte, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+path, bytes.NewReader(data))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	c.setHeaders(req)
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		respData, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("POST %s returned %d: %s", path, resp.StatusCode, strings.TrimSpace(string(respData)))
+		return nil, fmt.Errorf("POST %s returned %d: %s", path, resp.StatusCode, strings.TrimSpace(string(respData)))
 	}
-	if out == nil {
-		return nil
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return respData, fmt.Errorf("read POST %s response: %w", path, err)
 	}
-	return json.NewDecoder(resp.Body).Decode(out)
+	return respData, nil
 }
 
 // PutJSON performs a PUT request with a JSON body.


### PR DESCRIPTION
## Summary
- add a raw POST helper for side-effecting CLI calls
- make `multica issue comment add` treat a successful server accept as success even if local response JSON decoding fails
- return a minimal JSON fallback instead of a non-zero exit to avoid duplicate comment retries
- add regression coverage for accepted-but-invalid JSON responses

## Verification
- `docker run --rm -v "$PWD/server:/src" -w /src golang:tip gofmt -w internal/cli/client.go cmd/multica/cmd_issue.go cmd/multica/cmd_issue_test.go`
- `docker run --rm -v "$PWD/server:/src" -w /src golang:tip go test ./internal/cli ./cmd/multica`
