### PR TITLE
fix(editor): sync external description updates + conflict resolution dialog

### DIFF
--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -32,9 +32,17 @@ vi.mock("./bubble-menu", () => ({
 
 const editorRef = vi.hoisted<{ current: unknown }>(() => ({ current: null }));
 const onCreateFired = vi.hoisted(() => ({ value: false }));
+const capturedHandlers = vi.hoisted<{
+  onFocus?: (args: { editor: unknown }) => void;
+  onBlur?: (args: { editor: unknown }) => void;
+}>(() => ({}));
 
 vi.mock("@tiptap/react", () => ({
-  useEditor: (options: { onCreate?: (args: { editor: unknown }) => void }) => {
+  useEditor: (options: {
+    onCreate?: (args: { editor: unknown }) => void;
+    onFocus?: (args: { editor: unknown }) => void;
+    onBlur?: (args: { editor: unknown }) => void;
+  }) => {
     if (!editorRef.current) {
       editorRef.current = {
         get isFocused() {
@@ -56,6 +64,8 @@ vi.mock("@tiptap/react", () => ({
         },
       };
     }
+    capturedHandlers.onFocus = options?.onFocus;
+    capturedHandlers.onBlur = options?.onBlur;
     if (!onCreateFired.value) {
       onCreateFired.value = true;
       options?.onCreate?.({ editor: editorRef.current });
@@ -69,6 +79,14 @@ vi.mock("@tiptap/react", () => ({
   ),
 }));
 
+function fireFocus() {
+  capturedHandlers.onFocus?.({ editor: editorRef.current });
+}
+
+function fireBlur() {
+  capturedHandlers.onBlur?.({ editor: editorRef.current });
+}
+
 import { ContentEditor } from "./content-editor";
 
 describe("ContentEditor", () => {
@@ -79,6 +97,8 @@ describe("ContentEditor", () => {
     editorState.markdown = "";
     editorRef.current = null;
     onCreateFired.value = false;
+    capturedHandlers.onFocus = undefined;
+    capturedHandlers.onBlur = undefined;
   });
 
   it("focuses the editor when clicking the empty container area", () => {
@@ -134,6 +154,207 @@ describe("ContentEditor", () => {
     rerender(<ContentEditor defaultValue="same content" />);
 
     expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("on blur with no external change, does not invoke onExternalConflict", async () => {
+    const onExternalConflict = vi.fn();
+    editorState.markdown = "stable content";
+
+    render(
+      <ContentEditor
+        defaultValue="stable content"
+        onUpdate={() => {}}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+
+    fireFocus();
+    // User types something, but external value is unchanged.
+    editorState.markdown = "user typed";
+    fireBlur();
+
+    await Promise.resolve();
+    expect(onExternalConflict).not.toHaveBeenCalled();
+  });
+
+  it("on blur with external change but no local edits, applies external silently", async () => {
+    const onExternalConflict = vi.fn();
+    editorState.markdown = "old";
+
+    const { rerender } = render(
+      <ContentEditor
+        defaultValue="old"
+        onUpdate={() => {}}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+
+    fireFocus();
+    editorState.isFocused = true;
+    // External update arrives mid-edit (existing dirty-guard effect skips
+    // because the editor is focused).
+    rerender(
+      <ContentEditor
+        defaultValue="external change"
+        onUpdate={() => {}}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+    // User didn't type — editor markdown still matches baseline.
+    editorState.isFocused = false;
+    fireBlur();
+
+    await Promise.resolve();
+    expect(onExternalConflict).not.toHaveBeenCalled();
+    expect(mockSetContent).toHaveBeenCalledWith(
+      "external change",
+      expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+    );
+  });
+
+  it("on blur with conflict, invokes onExternalConflict with local/external/baseline", async () => {
+    const onExternalConflict = vi
+      .fn()
+      .mockResolvedValue({ type: "local" });
+    editorState.markdown = "baseline";
+
+    const { rerender } = render(
+      <ContentEditor
+        defaultValue="baseline"
+        onUpdate={() => {}}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+
+    fireFocus();
+    editorState.isFocused = true;
+    rerender(
+      <ContentEditor
+        defaultValue="external change"
+        onUpdate={() => {}}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+    editorState.markdown = "user typed";
+    editorState.isFocused = false;
+    fireBlur();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onExternalConflict).toHaveBeenCalledWith({
+      local: "user typed",
+      external: "external change",
+      baseline: "baseline",
+    });
+  });
+
+  it("resolution=local: leaves editor content and does not call setContent", async () => {
+    const onExternalConflict = vi
+      .fn()
+      .mockResolvedValue({ type: "local" });
+    editorState.markdown = "baseline";
+
+    const { rerender } = render(
+      <ContentEditor
+        defaultValue="baseline"
+        onUpdate={() => {}}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+
+    fireFocus();
+    editorState.isFocused = true;
+    rerender(
+      <ContentEditor
+        defaultValue="external"
+        onUpdate={() => {}}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+    editorState.markdown = "user typed";
+    editorState.isFocused = false;
+    fireBlur();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("resolution=external: setContent with external, no onUpdate emit", async () => {
+    const onUpdate = vi.fn();
+    const onExternalConflict = vi
+      .fn()
+      .mockResolvedValue({ type: "external" });
+    editorState.markdown = "baseline";
+
+    const { rerender } = render(
+      <ContentEditor
+        defaultValue="baseline"
+        onUpdate={onUpdate}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+
+    fireFocus();
+    editorState.isFocused = true;
+    rerender(
+      <ContentEditor
+        defaultValue="external value"
+        onUpdate={onUpdate}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+    editorState.markdown = "user typed";
+    editorState.isFocused = false;
+    fireBlur();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockSetContent).toHaveBeenCalledWith(
+      "external value",
+      expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+    );
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("resolution=merged: setContent with merged + onUpdate fires with merged content", async () => {
+    const onUpdate = vi.fn();
+    const onExternalConflict = vi
+      .fn()
+      .mockResolvedValue({ type: "merged", content: "merged result" });
+    editorState.markdown = "baseline";
+
+    const { rerender } = render(
+      <ContentEditor
+        defaultValue="baseline"
+        onUpdate={onUpdate}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+
+    fireFocus();
+    editorState.isFocused = true;
+    rerender(
+      <ContentEditor
+        defaultValue="external value"
+        onUpdate={onUpdate}
+        onExternalConflict={onExternalConflict}
+      />,
+    );
+    editorState.markdown = "user typed";
+    editorState.isFocused = false;
+    fireBlur();
+
+    // setContent in real Tiptap mutates editor markdown; mock it.
+    editorState.markdown = "merged result";
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockSetContent).toHaveBeenCalledWith(
+      "merged result",
+      expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+    );
+    expect(onUpdate).toHaveBeenCalledWith("merged result");
   });
 
   it("does not sync when editor is unfocused but has unsaved local edits", () => {

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -30,34 +30,38 @@ vi.mock("./bubble-menu", () => ({
   EditorBubbleMenu: () => null,
 }));
 
+const editorRef = vi.hoisted<{ current: unknown }>(() => ({ current: null }));
+const onCreateFired = vi.hoisted(() => ({ value: false }));
+
 vi.mock("@tiptap/react", () => ({
-  useEditor: () => ({
-    get isFocused() {
-      return editorState.isFocused;
-    },
-    get isDestroyed() {
-      return editorState.isDestroyed;
-    },
-    commands: {
-      focus: mockFocus,
-      clearContent: vi.fn(),
-      setContent: mockSetContent,
-      setTextSelection: mockSetTextSelection,
-    },
-    getMarkdown: () => editorState.markdown,
-    state: {
-      doc: {
-        content: {
-          size: 0,
+  useEditor: (options: { onCreate?: (args: { editor: unknown }) => void }) => {
+    if (!editorRef.current) {
+      editorRef.current = {
+        get isFocused() {
+          return editorState.isFocused;
         },
-      },
-      selection: {
-        empty: true,
-        from: 0,
-        to: 0,
-      },
-    },
-  }),
+        get isDestroyed() {
+          return editorState.isDestroyed;
+        },
+        commands: {
+          focus: mockFocus,
+          clearContent: vi.fn(),
+          setContent: mockSetContent,
+          setTextSelection: mockSetTextSelection,
+        },
+        getMarkdown: () => editorState.markdown,
+        state: {
+          doc: { content: { size: 0 } },
+          selection: { empty: true, from: 0, to: 0 },
+        },
+      };
+    }
+    if (!onCreateFired.value) {
+      onCreateFired.value = true;
+      options?.onCreate?.({ editor: editorRef.current });
+    }
+    return editorRef.current;
+  },
   EditorContent: ({ className }: { className?: string }) => (
     <div className={className} data-testid="editor-content">
       <div className="ProseMirror rich-text-editor" data-testid="prosemirror" />
@@ -73,6 +77,8 @@ describe("ContentEditor", () => {
     editorState.isFocused = false;
     editorState.isDestroyed = false;
     editorState.markdown = "";
+    editorRef.current = null;
+    onCreateFired.value = false;
   });
 
   it("focuses the editor when clicking the empty container area", () => {
@@ -126,6 +132,33 @@ describe("ContentEditor", () => {
     const { rerender } = render(<ContentEditor defaultValue="same content" />);
 
     rerender(<ContentEditor defaultValue="same content" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("does not sync when editor is unfocused but has unsaved local edits", () => {
+    // Initial render: editor seeded with "old content". onCreate fires and
+    // sets lastEmittedRef = "old content". User then types — editor markdown
+    // diverges from lastEmittedRef but the debounce hasn't fired yet, so
+    // onUpdate hasn't been called and `lastEmittedRef` still holds the old
+    // value. User blurs (so isFocused=false). External update arrives.
+    // We must NOT clobber the unsaved local edits.
+    editorState.markdown = "old content";
+    const { rerender } = render(
+      <ContentEditor defaultValue="old content" onUpdate={() => {}} />,
+    );
+
+    // User typed locally, then blurred. Debounce hasn't flushed yet so
+    // lastEmittedRef inside the component still reflects "old content".
+    editorState.isFocused = false;
+    editorState.markdown = "user typed but unsaved";
+
+    rerender(
+      <ContentEditor
+        defaultValue="external update from another agent"
+        onUpdate={() => {}}
+      />,
+    );
 
     expect(mockSetContent).not.toHaveBeenCalled();
   });

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 const mockFocus = vi.hoisted(() => vi.fn());
+const mockSetContent = vi.hoisted(() => vi.fn());
+const mockSetTextSelection = vi.hoisted(() => vi.fn());
+const editorState = vi.hoisted(() => ({
+  isFocused: false,
+  isDestroyed: false,
+  markdown: "",
+}));
 
 vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({}),
@@ -25,11 +32,19 @@ vi.mock("./bubble-menu", () => ({
 
 vi.mock("@tiptap/react", () => ({
   useEditor: () => ({
+    get isFocused() {
+      return editorState.isFocused;
+    },
+    get isDestroyed() {
+      return editorState.isDestroyed;
+    },
     commands: {
       focus: mockFocus,
       clearContent: vi.fn(),
+      setContent: mockSetContent,
+      setTextSelection: mockSetTextSelection,
     },
-    getMarkdown: () => "",
+    getMarkdown: () => editorState.markdown,
     state: {
       doc: {
         content: {
@@ -38,6 +53,8 @@ vi.mock("@tiptap/react", () => ({
       },
       selection: {
         empty: true,
+        from: 0,
+        to: 0,
       },
     },
   }),
@@ -53,6 +70,9 @@ import { ContentEditor } from "./content-editor";
 describe("ContentEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    editorState.isFocused = false;
+    editorState.isDestroyed = false;
+    editorState.markdown = "";
   });
 
   it("focuses the editor when clicking the empty container area", () => {
@@ -72,5 +92,41 @@ describe("ContentEditor", () => {
     fireEvent.mouseDown(screen.getByTestId("prosemirror"));
 
     expect(mockFocus).not.toHaveBeenCalled();
+  });
+
+  it("syncs editor content when defaultValue changes externally and editor is unfocused", () => {
+    editorState.markdown = "old content";
+    const { rerender } = render(<ContentEditor defaultValue="old content" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+
+    editorState.markdown = "old content"; // editor still holds old content
+    rerender(<ContentEditor defaultValue="new content from server" />);
+
+    expect(mockSetContent).toHaveBeenCalledTimes(1);
+    expect(mockSetContent).toHaveBeenCalledWith(
+      "new content from server",
+      expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+    );
+  });
+
+  it("does not sync when editor is currently focused (user is typing)", () => {
+    editorState.markdown = "old content";
+    const { rerender } = render(<ContentEditor defaultValue="old content" />);
+
+    editorState.isFocused = true;
+    editorState.markdown = "user-typed-content";
+    rerender(<ContentEditor defaultValue="incoming external change" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("does not sync when defaultValue equals current editor markdown", () => {
+    editorState.markdown = "same content";
+    const { rerender } = render(<ContentEditor defaultValue="same content" />);
+
+    rerender(<ContentEditor defaultValue="same content" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -35,6 +35,7 @@ const onCreateFired = vi.hoisted(() => ({ value: false }));
 const capturedHandlers = vi.hoisted<{
   onFocus?: (args: { editor: unknown }) => void;
   onBlur?: (args: { editor: unknown }) => void;
+  onUpdate?: (args: { editor: unknown }) => void;
 }>(() => ({}));
 
 vi.mock("@tiptap/react", () => ({
@@ -42,6 +43,7 @@ vi.mock("@tiptap/react", () => ({
     onCreate?: (args: { editor: unknown }) => void;
     onFocus?: (args: { editor: unknown }) => void;
     onBlur?: (args: { editor: unknown }) => void;
+    onUpdate?: (args: { editor: unknown }) => void;
   }) => {
     if (!editorRef.current) {
       editorRef.current = {
@@ -66,6 +68,7 @@ vi.mock("@tiptap/react", () => ({
     }
     capturedHandlers.onFocus = options?.onFocus;
     capturedHandlers.onBlur = options?.onBlur;
+    capturedHandlers.onUpdate = options?.onUpdate;
     if (!onCreateFired.value) {
       onCreateFired.value = true;
       options?.onCreate?.({ editor: editorRef.current });
@@ -87,6 +90,10 @@ function fireBlur() {
   capturedHandlers.onBlur?.({ editor: editorRef.current });
 }
 
+function fireOnUpdate() {
+  capturedHandlers.onUpdate?.({ editor: editorRef.current });
+}
+
 import { ContentEditor } from "./content-editor";
 
 describe("ContentEditor", () => {
@@ -99,6 +106,7 @@ describe("ContentEditor", () => {
     onCreateFired.value = false;
     capturedHandlers.onFocus = undefined;
     capturedHandlers.onBlur = undefined;
+    capturedHandlers.onUpdate = undefined;
   });
 
   it("focuses the editor when clicking the empty container area", () => {
@@ -248,7 +256,8 @@ describe("ContentEditor", () => {
     });
   });
 
-  it("resolution=local: leaves editor content and does not call setContent", async () => {
+  it("resolution=local: leaves editor content alone but emits local via onUpdate", async () => {
+    const onUpdate = vi.fn();
     const onExternalConflict = vi
       .fn()
       .mockResolvedValue({ type: "local" });
@@ -257,7 +266,7 @@ describe("ContentEditor", () => {
     const { rerender } = render(
       <ContentEditor
         defaultValue="baseline"
-        onUpdate={() => {}}
+        onUpdate={onUpdate}
         onExternalConflict={onExternalConflict}
       />,
     );
@@ -267,7 +276,7 @@ describe("ContentEditor", () => {
     rerender(
       <ContentEditor
         defaultValue="external"
-        onUpdate={() => {}}
+        onUpdate={onUpdate}
         onExternalConflict={onExternalConflict}
       />,
     );
@@ -278,6 +287,85 @@ describe("ContentEditor", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(mockSetContent).not.toHaveBeenCalled();
+    // Debounce is cancelled when we enter the conflict path, so the existing
+    // onUpdate-via-debounce never fires; the resolver branch must emit
+    // local explicitly so the server gets it.
+    expect(onUpdate).toHaveBeenCalledWith("user typed");
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let the pending debounce fire while the conflict resolver is awaiting", async () => {
+    vi.useFakeTimers();
+    try {
+      const onUpdate = vi.fn();
+      let resolveConflict!: (r: { type: string; content?: string }) => void;
+      const onExternalConflict = vi.fn(
+        () =>
+          new Promise<{ type: string; content?: string }>((resolve) => {
+            resolveConflict = resolve;
+          }),
+      );
+      editorState.markdown = "baseline";
+
+      const { rerender } = render(
+        <ContentEditor
+          defaultValue="baseline"
+          onUpdate={onUpdate}
+          debounceMs={1500}
+          onExternalConflict={
+            onExternalConflict as unknown as React.ComponentProps<
+              typeof ContentEditor
+            >["onExternalConflict"]
+          }
+        />,
+      );
+
+      fireFocus();
+      editorState.isFocused = true;
+
+      // External update arrives mid-edit.
+      rerender(
+        <ContentEditor
+          defaultValue="external value"
+          onUpdate={onUpdate}
+          debounceMs={1500}
+          onExternalConflict={
+            onExternalConflict as unknown as React.ComponentProps<
+              typeof ContentEditor
+            >["onExternalConflict"]
+          }
+        />,
+      );
+
+      // User types — internal onUpdate sets a 1500ms debounce that would
+      // normally fire onUpdate(local) at the end of the window.
+      editorState.markdown = "user typed";
+      fireOnUpdate();
+
+      // User blurs — conflict path triggers, resolver promise is pending.
+      editorState.isFocused = false;
+      fireBlur();
+      await Promise.resolve();
+
+      // Walk the clock well past the debounce window; the timer must have
+      // been cancelled when we entered the conflict path.
+      vi.advanceTimersByTime(5000);
+      expect(onUpdate).not.toHaveBeenCalled();
+
+      // Resolve with external; expect a setContent for external and NO
+      // onUpdate write (server already has external).
+      resolveConflict({ type: "external" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockSetContent).toHaveBeenCalledWith(
+        "external value",
+        expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+      );
+      expect(onUpdate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("resolution=external: setContent with external, no onUpdate emit", async () => {

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -223,17 +223,31 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     // Guards (in order):
     //   1. Skip when the editor is focused — the user is typing locally and
     //      clobbering their input would lose the caret + in-flight characters.
-    //   2. Skip when the incoming markdown matches what the editor already
+    //   2. Skip when the editor has unsaved local edits (dirty). `isFocused`
+    //      is not enough: after blur, there's a window before the `onUpdate`
+    //      debounce fires where the editor's markdown diverges from what's
+    //      been emitted to the parent. `lastEmittedRef.current` is updated
+    //      only inside `onCreate` and after the debounce flushes, so a
+    //      mismatch with the current editor markdown means there's unsaved
+    //      local content we must not clobber.
+    //   3. Skip when the incoming markdown matches what the editor already
     //      holds — avoids a no-op transaction when the cache reflects a write
     //      this same editor just emitted via `onUpdate`.
-    //   3. Pass `emitUpdate: false` so the synced write does not re-trigger
+    //   4. Pass `emitUpdate: false` so the synced write does not re-trigger
     //      `onUpdate` → `onUpdateRef` → server save (self-write loop).
     useEffect(() => {
       if (!editor || editor.isDestroyed) return;
       if (editor.isFocused) return;
 
-      const incoming = defaultValue ? preprocessMarkdown(defaultValue) : "";
       const current = stripBlobUrls(editor.getMarkdown()).trimEnd();
+      if (
+        lastEmittedRef.current !== null &&
+        current !== lastEmittedRef.current
+      ) {
+        return;
+      }
+
+      const incoming = defaultValue ? preprocessMarkdown(defaultValue) : "";
       const incomingNormalized = stripBlobUrls(incoming).trimEnd();
       if (incomingNormalized === current) return;
 

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -38,6 +38,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
+import type { Editor } from "@tiptap/core";
 import { cn } from "@multica/ui/lib/utils";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
 import { useWorkspaceSlug } from "@multica/core/paths";
@@ -67,6 +68,21 @@ function stripBlobUrls(md: string): string {
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolution returned by `onExternalConflict` to tell ContentEditor how to
+ * reconcile a conflict that occurred while the user was focus-editing.
+ *
+ * - "local": keep what the user typed; the existing onUpdate path will persist
+ *   it to the server (last-write-wins on this side).
+ * - "external": discard the user's edits and apply the external content.
+ * - "merged": apply the user-authored merged content AND emit it to onUpdate
+ *   so the merged version is persisted server-side.
+ */
+export type ContentEditorResolution =
+  | { type: "local" }
+  | { type: "external" }
+  | { type: "merged"; content: string };
+
 interface ContentEditorProps {
   defaultValue?: string;
   onUpdate?: (markdown: string) => void;
@@ -76,6 +92,19 @@ interface ContentEditorProps {
   onSubmit?: () => void;
   onBlur?: () => void;
   onUploadFile?: (file: File) => Promise<UploadResult | null>;
+  /**
+   * Called on blur when the external `defaultValue` has changed during the
+   * user's focus session AND the user has made local edits that diverge.
+   * The implementor typically opens a conflict dialog and returns the user's
+   * choice. If undefined or the returned resolution is `{ type: "local" }`,
+   * ContentEditor takes no further action and the existing onUpdate path
+   * persists the local edits.
+   */
+  onExternalConflict?: (params: {
+    local: string;
+    external: string;
+    baseline: string;
+  }) => Promise<ContentEditorResolution>;
   /** Show the floating formatting toolbar on text selection. Defaults true. */
   showBubbleMenu?: boolean;
   /** When true, bare Enter submits (chat-style). Mod-Enter always submits. */
@@ -122,6 +151,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       onSubmit,
       onBlur,
       onUploadFile,
+      onExternalConflict,
       showBubbleMenu = true,
       submitOnEnter = false,
       currentIssueId,
@@ -134,7 +164,13 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     const onSubmitRef = useRef(onSubmit);
     const onBlurRef = useRef(onBlur);
     const onUploadFileRef = useRef(onUploadFile);
+    const onExternalConflictRef = useRef(onExternalConflict);
+    const defaultValueRef = useRef(defaultValue);
     const lastEmittedRef = useRef<string | null>(null);
+    // Captures the external value at focus-start so we can detect "external
+    // changed during this focus session". Set in onFocus, consumed (and
+    // cleared) in onBlur.
+    const focusBaselineRef = useRef<string | null>(null);
 
     // Current workspace slug kept in a ref so the click handler always sees the
     // latest value without recreating the editor. Used by openLink to prefix
@@ -148,8 +184,71 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     onSubmitRef.current = onSubmit;
     onBlurRef.current = onBlur;
     onUploadFileRef.current = onUploadFile;
+    onExternalConflictRef.current = onExternalConflict;
+    defaultValueRef.current = defaultValue;
 
     const queryClient = useQueryClient();
+
+    // Apply a conflict resolution by mutating the editor and bookkeeping refs.
+    // - "local": no-op; the existing onUpdate debounce will persist local edits.
+    // - "external"/"merged": cancel any pending local save, replace content
+    //   with `emitUpdate: false` (so we don't re-fire onUpdate), and update
+    //   `lastEmittedRef` so the next typed character is detected as dirty.
+    //   "merged" additionally emits onUpdate so the merged version is saved.
+    function applyResolution(
+      ed: Editor,
+      r: ContentEditorResolution,
+      externalSnapshot: string,
+    ) {
+      if (r.type === "local") return;
+
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = undefined;
+      }
+
+      const newContent =
+        r.type === "external" ? externalSnapshot : r.content;
+      ed.commands.setContent(newContent, {
+        emitUpdate: false,
+        contentType: "markdown",
+      });
+      lastEmittedRef.current = stripBlobUrls(ed.getMarkdown()).trimEnd();
+
+      if (r.type === "merged") {
+        onUpdateRef.current?.(lastEmittedRef.current);
+      }
+    }
+
+    // On blur, decide whether an external update arrived during this focus
+    // session and, if so, whether it conflicts with local edits.
+    //
+    //   external === baseline → no external change happened; nothing to do.
+    //   local === baseline    → user didn't type; apply external silently.
+    //   local === external    → user happened to converge on external; no-op.
+    //   otherwise             → real conflict; defer to onExternalConflict.
+    async function handleBlurConflict(ed: Editor) {
+      const baseline = focusBaselineRef.current;
+      focusBaselineRef.current = null;
+      if (baseline === null) return;
+
+      const local = stripBlobUrls(ed.getMarkdown()).trimEnd();
+      const external = stripBlobUrls(
+        preprocessMarkdown(defaultValueRef.current ?? ""),
+      ).trimEnd();
+
+      if (external === baseline) return;
+      if (local === baseline) {
+        applyResolution(ed, { type: "external" }, external);
+        return;
+      }
+      if (local === external) return;
+
+      const resolver = onExternalConflictRef.current;
+      if (!resolver) return;
+      const resolution = await resolver({ local, external, baseline });
+      applyResolution(ed, resolution, external);
+    }
 
     const editor = useEditor({
       immediatelyRender: false,
@@ -179,7 +278,13 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
           onUpdateRef.current?.(md);
         }, debounceMs);
       },
-      onBlur: () => {
+      onFocus: () => {
+        focusBaselineRef.current = stripBlobUrls(
+          preprocessMarkdown(defaultValueRef.current ?? ""),
+        ).trimEnd();
+      },
+      onBlur: ({ editor: ed }) => {
+        void handleBlurConflict(ed);
         onBlurRef.current?.();
       },
       editorProps: {

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -211,6 +211,46 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       };
     }, []);
 
+    // Sync external `defaultValue` changes into the editor.
+    //
+    // Tiptap's `useEditor` reads `content` only at mount; later prop updates
+    // are silently ignored ([ueberdosis/tiptap#5831]). When a WS event or
+    // another client updates `issue.description`, the TanStack Query cache
+    // produces a new prop here — without this effect the editor keeps showing
+    // stale content until the consumer remounts (`key={id}` only fires on
+    // issue switch, not on same-issue updates).
+    //
+    // Guards (in order):
+    //   1. Skip when the editor is focused — the user is typing locally and
+    //      clobbering their input would lose the caret + in-flight characters.
+    //   2. Skip when the incoming markdown matches what the editor already
+    //      holds — avoids a no-op transaction when the cache reflects a write
+    //      this same editor just emitted via `onUpdate`.
+    //   3. Pass `emitUpdate: false` so the synced write does not re-trigger
+    //      `onUpdate` → `onUpdateRef` → server save (self-write loop).
+    useEffect(() => {
+      if (!editor || editor.isDestroyed) return;
+      if (editor.isFocused) return;
+
+      const incoming = defaultValue ? preprocessMarkdown(defaultValue) : "";
+      const current = stripBlobUrls(editor.getMarkdown()).trimEnd();
+      const incomingNormalized = stripBlobUrls(incoming).trimEnd();
+      if (incomingNormalized === current) return;
+
+      const { from, to } = editor.state.selection;
+      editor.commands.setContent(incoming, {
+        emitUpdate: false,
+        contentType: "markdown",
+      });
+
+      const docSize = editor.state.doc.content.size;
+      const clampedFrom = Math.min(from, docSize);
+      const clampedTo = Math.min(to, docSize);
+      editor.commands.setTextSelection({ from: clampedFrom, to: clampedTo });
+
+      lastEmittedRef.current = stripBlobUrls(editor.getMarkdown()).trimEnd();
+    }, [defaultValue, editor]);
+
     useImperativeHandle(ref, () => ({
       getMarkdown: () => stripBlobUrls(editor?.getMarkdown() ?? ""),
       clearContent: () => {

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -189,22 +189,30 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
 
     const queryClient = useQueryClient();
 
-    // Apply a conflict resolution by mutating the editor and bookkeeping refs.
-    // - "local": no-op; the existing onUpdate debounce will persist local edits.
-    // - "external"/"merged": cancel any pending local save, replace content
-    //   with `emitUpdate: false` (so we don't re-fire onUpdate), and update
-    //   `lastEmittedRef` so the next typed character is detected as dirty.
-    //   "merged" additionally emits onUpdate so the merged version is saved.
+    // Apply a conflict resolution by mutating the editor and explicitly
+    // emitting onUpdate when the chosen content needs to land on the server.
+    //
+    // The caller MUST cancel any pending onUpdate debounce before invoking
+    // this function — once we're on the conflict path, the only writes to
+    // the server come from here, not from the debounce.
+    //
+    // - "local":   editor already holds the user's text; emit it explicitly
+    //              so the server receives the local version.
+    // - "external": setContent to the external snapshot; no emit needed —
+    //              the server already has external (that's where it came
+    //              from); we just sync the editor view.
+    // - "merged":  setContent to the merged content + emit so the server
+    //              stores the merged version.
     function applyResolution(
       ed: Editor,
       r: ContentEditorResolution,
       externalSnapshot: string,
+      localSnapshot: string,
     ) {
-      if (r.type === "local") return;
-
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = undefined;
+      if (r.type === "local") {
+        lastEmittedRef.current = localSnapshot;
+        onUpdateRef.current?.(localSnapshot);
+        return;
       }
 
       const newContent =
@@ -227,6 +235,13 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
     //   local === baseline    → user didn't type; apply external silently.
     //   local === external    → user happened to converge on external; no-op.
     //   otherwise             → real conflict; defer to onExternalConflict.
+    //
+    // When we reach the resolver path we MUST cancel the pending onUpdate
+    // debounce before awaiting, otherwise the dialog dwell would let the
+    // debounce timer fire and push the user's local content to the server —
+    // a later "external"/"merged" resolution would then silently lose the
+    // server-side conflict choice (the editor would update locally but the
+    // server would keep the prematurely-saved local version).
     async function handleBlurConflict(ed: Editor) {
       const baseline = focusBaselineRef.current;
       focusBaselineRef.current = null;
@@ -239,15 +254,21 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
 
       if (external === baseline) return;
       if (local === baseline) {
-        applyResolution(ed, { type: "external" }, external);
+        applyResolution(ed, { type: "external" }, external, local);
         return;
       }
       if (local === external) return;
 
       const resolver = onExternalConflictRef.current;
       if (!resolver) return;
+
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = undefined;
+      }
+
       const resolution = await resolver({ local, external, baseline });
-      applyResolution(ed, resolution, external);
+      applyResolution(ed, resolution, external, local);
     }
 
     const editor = useEditor({

--- a/packages/views/editor/description-conflict-dialog.test.tsx
+++ b/packages/views/editor/description-conflict-dialog.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enEditor from "../locales/en/editor.json";
+
+vi.mock("./readonly-content", () => ({
+  ReadonlyContent: ({ content }: { content: string }) => (
+    <div data-testid="readonly">{content}</div>
+  ),
+}));
+
+import { DescriptionConflictDialog } from "./description-conflict-dialog";
+
+const TEST_RESOURCES = { en: { editor: enEditor } };
+
+function I18nWrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof DescriptionConflictDialog>> = {},
+) {
+  const onResolve = vi.fn();
+  const ui: ReactElement = (
+    <DescriptionConflictDialog
+      open
+      local="LOCAL"
+      external="EXTERNAL"
+      onResolve={onResolve}
+      {...overrides}
+    />
+  );
+  const utils = render(ui, { wrapper: I18nWrapper });
+  return { onResolve, ...utils };
+}
+
+describe("DescriptionConflictDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders both sides as readonly markdown", () => {
+    renderDialog();
+    const rendered = screen.getAllByTestId("readonly").map((n) => n.textContent);
+    expect(rendered).toContain("LOCAL");
+    expect(rendered).toContain("EXTERNAL");
+  });
+
+  it("Keep mine → resolves with { type: 'local' }", () => {
+    const { onResolve } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /keep mine/i }));
+    expect(onResolve).toHaveBeenCalledWith({ type: "local" });
+  });
+
+  it("Use theirs → resolves with { type: 'external' }", () => {
+    const { onResolve } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /use theirs/i }));
+    expect(onResolve).toHaveBeenCalledWith({ type: "external" });
+  });
+
+  it("Merge manually → opens textarea; Save merge → resolves with merged content", () => {
+    const { onResolve } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /merge manually/i }));
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea).toBeTruthy();
+    fireEvent.change(textarea, { target: { value: "merged final content" } });
+    fireEvent.click(screen.getByRole("button", { name: /save merge/i }));
+
+    expect(onResolve).toHaveBeenCalledWith({
+      type: "merged",
+      content: "merged final content",
+    });
+  });
+
+  it("Save merge with whitespace-only content → resolves as 'local' (avoid silent wipe)", () => {
+    const { onResolve } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /merge manually/i }));
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "   \n  " } });
+    fireEvent.click(screen.getByRole("button", { name: /save merge/i }));
+    expect(onResolve).toHaveBeenCalledWith({ type: "local" });
+  });
+});

--- a/packages/views/editor/description-conflict-dialog.tsx
+++ b/packages/views/editor/description-conflict-dialog.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+/**
+ * DescriptionConflictDialog — shown on blur when an external update to an
+ * issue description landed during the user's focus session AND the user
+ * also made local edits that diverge.
+ *
+ * Three resolutions: keep local, use external, or hand-merge in a textarea.
+ * An empty/whitespace-only merge is downgraded to "local" so the user can't
+ * silently wipe the description.
+ *
+ * UI is intentionally minimal for v1 — two side-by-side ReadonlyContent
+ * panels, no diff highlighting. Visual polish can land via a follow-up
+ * once design owns it.
+ */
+
+import { useState } from "react";
+import { useT } from "../i18n";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@multica/ui/components/ui/dialog";
+import { Button } from "@multica/ui/components/ui/button";
+import { Textarea } from "@multica/ui/components/ui/textarea";
+import { ReadonlyContent } from "./readonly-content";
+import type { ContentEditorResolution } from "./content-editor";
+
+interface DescriptionConflictDialogProps {
+  open: boolean;
+  local: string;
+  external: string;
+  onResolve: (resolution: ContentEditorResolution) => void;
+}
+
+export function DescriptionConflictDialog({
+  open,
+  local,
+  external,
+  onResolve,
+}: DescriptionConflictDialogProps) {
+  const { t } = useT("editor");
+  const [mergeMode, setMergeMode] = useState(false);
+  const [mergedDraft, setMergedDraft] = useState(
+    () =>
+      `<<<<<<< ${"yours"}\n${local}\n=======\n${external}\n>>>>>>> ${"theirs"}\n`,
+  );
+
+  function handleSaveMerge() {
+    const trimmed = mergedDraft.trim();
+    if (trimmed.length === 0) {
+      onResolve({ type: "local" });
+      return;
+    }
+    onResolve({ type: "merged", content: mergedDraft });
+  }
+
+  return (
+    <Dialog open={open}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{t(($) => $.conflict_dialog.title)}</DialogTitle>
+          <DialogDescription>
+            {t(($) => $.conflict_dialog.description)}
+          </DialogDescription>
+        </DialogHeader>
+
+        {mergeMode ? (
+          <div className="flex flex-col gap-2">
+            <Textarea
+              value={mergedDraft}
+              onChange={(e) => setMergedDraft(e.target.value)}
+              placeholder={t(($) => $.conflict_dialog.merge_placeholder)}
+              className="min-h-[240px] font-mono text-xs"
+            />
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <section className="rounded-lg border p-3">
+              <header className="mb-2 text-xs font-medium text-muted-foreground">
+                {t(($) => $.conflict_dialog.your_version)}
+              </header>
+              <ReadonlyContent content={local} />
+            </section>
+            <section className="rounded-lg border p-3">
+              <header className="mb-2 text-xs font-medium text-muted-foreground">
+                {t(($) => $.conflict_dialog.their_version)}
+              </header>
+              <ReadonlyContent content={external} />
+            </section>
+          </div>
+        )}
+
+        <DialogFooter>
+          {mergeMode ? (
+            <>
+              <Button variant="ghost" onClick={() => setMergeMode(false)}>
+                {t(($) => $.conflict_dialog.cancel)}
+              </Button>
+              <Button onClick={handleSaveMerge}>
+                {t(($) => $.conflict_dialog.save_merge)}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="ghost" onClick={() => onResolve({ type: "local" })}>
+                {t(($) => $.conflict_dialog.keep_mine)}
+              </Button>
+              <Button variant="ghost" onClick={() => onResolve({ type: "external" })}>
+                {t(($) => $.conflict_dialog.use_theirs)}
+              </Button>
+              <Button onClick={() => setMergeMode(true)}>
+                {t(($) => $.conflict_dialog.merge_manually)}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/views/editor/index.ts
+++ b/packages/views/editor/index.ts
@@ -2,7 +2,9 @@ export {
   ContentEditor,
   type ContentEditorProps,
   type ContentEditorRef,
+  type ContentEditorResolution,
 } from "./content-editor";
+export { DescriptionConflictDialog } from "./description-conflict-dialog";
 export {
   TitleEditor,
   type TitleEditorProps,

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -24,7 +24,15 @@ import { Button } from "@multica/ui/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@multica/ui/components/ui/resizable";
 import { Sheet, SheetContent } from "@multica/ui/components/ui/sheet";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
-import { ContentEditor, type ContentEditorRef, TitleEditor, useFileDropZone, FileDropOverlay } from "../../editor";
+import {
+  ContentEditor,
+  type ContentEditorRef,
+  type ContentEditorResolution,
+  TitleEditor,
+  useFileDropZone,
+  FileDropOverlay,
+  DescriptionConflictDialog,
+} from "../../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import {
   Tooltip,
@@ -606,6 +614,25 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   const { isDragOver: descDragOver, dropZoneProps: descDropZoneProps } = useFileDropZone({
     onDrop: (files) => files.forEach((f) => descEditorRef.current?.uploadFile(f)),
   });
+
+  // Conflict dialog state for description external-edit conflicts. When the
+  // editor blurs and a real conflict is detected, `handleDescriptionConflict`
+  // captures the snapshot in state and returns a promise; the dialog drives
+  // resolution. Snapshot is intentionally frozen the moment the conflict
+  // surfaces — later WS updates do not mutate what the user is comparing.
+  const [descConflict, setDescConflict] = useState<{
+    local: string;
+    external: string;
+    resolve: (r: ContentEditorResolution) => void;
+  } | null>(null);
+
+  const handleDescriptionConflict = useCallback(
+    ({ local, external }: { local: string; external: string }) =>
+      new Promise<ContentEditorResolution>((resolve) => {
+        setDescConflict({ local, external, resolve });
+      }),
+    [],
+  );
   // Description uploads don't pass issueId — the URL lives in the markdown.
   // This avoids stale attachment records when users delete images from the editor.
   const handleDescriptionUpload = useCallback(
@@ -974,9 +1001,21 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
               placeholder={t(($) => $.detail.desc_placeholder)}
               onUpdate={(md) => handleUpdateField({ description: md })}
               onUploadFile={handleDescriptionUpload}
+              onExternalConflict={handleDescriptionConflict}
               debounceMs={1500}
               currentIssueId={id}
             />
+            {descConflict && (
+              <DescriptionConflictDialog
+                open
+                local={descConflict.local}
+                external={descConflict.external}
+                onResolve={(r) => {
+                  descConflict.resolve(r);
+                  setDescConflict(null);
+                }}
+              />
+            )}
 
             <div className="flex items-center gap-1 mt-3">
               <ReactionBar

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -58,5 +58,17 @@
   "mermaid": {
     "render_error": "Unable to render Mermaid diagram.",
     "rendering": "Rendering diagram…"
+  },
+  "conflict_dialog": {
+    "title": "Description was updated",
+    "description": "This description was changed by someone else while you were editing. Choose how to resolve the conflict.",
+    "your_version": "Your version",
+    "their_version": "Their version",
+    "keep_mine": "Keep mine",
+    "use_theirs": "Use theirs",
+    "merge_manually": "Merge manually",
+    "merge_placeholder": "Edit the merged result here…",
+    "save_merge": "Save merge",
+    "cancel": "Cancel"
   }
 }

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -58,5 +58,17 @@
   "mermaid": {
     "render_error": "无法渲染 Mermaid 图。",
     "rendering": "渲染中…"
+  },
+  "conflict_dialog": {
+    "title": "描述已被更新",
+    "description": "你正在编辑这条描述时,有其他人也修改了它。选择如何解决冲突。",
+    "your_version": "你的版本",
+    "their_version": "对方的版本",
+    "keep_mine": "用我的",
+    "use_theirs": "用对方的",
+    "merge_manually": "手动合并",
+    "merge_placeholder": "在这里编辑合并后的结果…",
+    "save_merge": "保存合并",
+    "cancel": "取消"
   }
 }


### PR DESCRIPTION
## Summary

Fixes [MUL-2035](mention://issue/334245a1-1815-48f5-a46e-c06506c05012) — issue description not refreshing in chat when changed externally — and lays in a conflict-resolution UX for concurrent edits.

The core bug was that Tiptap v3's `useEditor` reads `content` only at mount; the prop never re-syncs ([ueberdosis/tiptap#5831](https://github.com/ueberdosis/tiptap/issues/5831)). When a WS event / agent / autopilot updates `issue.description`, the editor kept showing stale content until the issue was closed and reopened.

Layered fix:

1. **External-sync useEffect** with three guards (focused / dirty / content-equal) so external updates land in the editor without clobbering a user mid-edit.
2. **Dirty guard** comparing `editor.getMarkdown()` to `lastEmittedRef.current` so the blur-before-debounce-flush window doesn't lose unsaved input.
3. **On-blur conflict detection** that classifies into 4 cases (`external === baseline`, `local === baseline`, `local === external`, otherwise) and only surfaces a dialog on real conflicts.
4. **DescriptionConflictDialog** — side-by-side panels with three buttons (keep mine / use theirs / merge manually). Empty merge downgrades to "local" to avoid silent wipes.

Industry-pattern research informed the choice of *blur-time modal* over alternatives (Linear-style CRDT no-UI, Notion-style silent LWW, Slack-style field lock, mid-edit banner). See issue thread for the comparative analysis.

## Commits in this PR

- `72cd37c0` — `fix(editor): sync ContentEditor when defaultValue changes externally`
- `3ec6c726` — `fix(editor): add dirty guard to external content sync`
- `4541cadb` — `feat(editor): detect external content conflicts on blur`
- `532d322a` — `feat(editor): add DescriptionConflictDialog component`
- `ac4baa2b` — `feat(issues): wire description conflict dialog into issue-detail`

## Test plan

- [x] `pnpm --filter @multica/views test` — 46 files, 363 tests pass (12 new in `content-editor.test.tsx`, 5 new in `description-conflict-dialog.test.tsx`)
- [x] `pnpm typecheck` — clean across views / web / desktop
- [ ] Manual: open an issue in two browser windows. Edit description in window B → window A should refresh on blur with no banner.
- [ ] Manual: focus description in window A, type a paragraph. Edit description in window B. Blur window A → conflict dialog appears with both versions. Test each resolution path.
- [ ] Manual: focus description without typing. Edit elsewhere. Blur → silent apply (no dialog).
- [ ] Manual: same description in both windows, both blur without changes → no dialog.

## Out of scope (follow-ups)

- Description version history (separate ADR + DB change)
- Character-level / block-level diff highlighting in the dialog (currently no diff lib; will land with design)
- Generalising the conflict pattern to title / comment fields
- CRDT migration evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)