### PR TITLE
fix(execenv): switch every provider's Windows reply template to --content-file

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -16,20 +16,42 @@ import (
 	"github.com/multica-ai/multica/server/internal/util"
 )
 
-// resolveTextFlag picks between a `--<name>` flag value and a paired
-// `--<name>-stdin` flag, mirroring the existing `--content` / `--content-stdin`
-// pattern. It returns the resolved string and an error when both are set or
-// stdin is requested but produces no body. Inline flag values are passed
-// through util.UnescapeBackslashEscapes so bash-double-quoted `\n` becomes a
-// real newline; stdin bodies are returned verbatim so literal backslashes
+// resolveTextFlag picks between a `--<name>` inline value, a `--<name>-stdin`
+// flag, and a `--<name>-file <path>` flag, mirroring the existing `--content`
+// / `--content-stdin` pattern. It returns the resolved string and an error
+// when more than one source is set, or when stdin/file is requested but
+// produces no body. Inline flag values are passed through
+// util.UnescapeBackslashEscapes so bash-double-quoted `\n` becomes a real
+// newline; stdin and file bodies are returned verbatim so literal backslashes
 // survive intact.
+//
+// The `-file` source exists for Windows agents: piping HEREDOC content to
+// `--<name>-stdin` from Windows PowerShell silently drops non-ASCII bytes
+// (PowerShell 5.1's `$OutputEncoding` defaults to ASCIIEncoding when piping
+// to a native command), so Chinese / Cyrillic / any non-ASCII content
+// arrives as `?`. Reading a UTF-8 file directly bypasses the shell's pipe
+// re-encoding entirely. See issues #2198 / #2236 / #2376.
 func resolveTextFlag(cmd *cobra.Command, flagName string) (string, bool, error) {
 	stdinFlag := flagName + "-stdin"
+	fileFlag := flagName + "-file"
 	useStdin, _ := cmd.Flags().GetBool(stdinFlag)
 	inline, _ := cmd.Flags().GetString(flagName)
-	if useStdin && inline != "" {
-		return "", false, fmt.Errorf("--%s and --%s are mutually exclusive", flagName, stdinFlag)
+	filePath, _ := cmd.Flags().GetString(fileFlag)
+
+	sources := 0
+	if useStdin {
+		sources++
 	}
+	if inline != "" {
+		sources++
+	}
+	if filePath != "" {
+		sources++
+	}
+	if sources > 1 {
+		return "", false, fmt.Errorf("--%s, --%s, and --%s are mutually exclusive", flagName, stdinFlag, fileFlag)
+	}
+
 	if useStdin {
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
@@ -38,6 +60,17 @@ func resolveTextFlag(cmd *cobra.Command, flagName string) (string, bool, error) 
 		body := strings.TrimSuffix(string(data), "\n")
 		if body == "" {
 			return "", false, fmt.Errorf("stdin content for --%s is empty", stdinFlag)
+		}
+		return body, true, nil
+	}
+	if filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", false, fmt.Errorf("read file for --%s: %w", fileFlag, err)
+		}
+		body := strings.TrimSuffix(string(data), "\n")
+		if body == "" {
+			return "", false, fmt.Errorf("file content for --%s is empty", fileFlag)
 		}
 		return body, true, nil
 	}
@@ -222,6 +255,7 @@ func init() {
 	issueCreateCmd.Flags().String("title", "", "Issue title (required)")
 	issueCreateCmd.Flags().String("description", "", "Issue description (decodes \\n, \\r, \\t, \\\\; pipe via --description-stdin to preserve literal backslashes)")
 	issueCreateCmd.Flags().Bool("description-stdin", false, "Read issue description from stdin (preserves multi-line content verbatim)")
+	issueCreateCmd.Flags().String("description-file", "", "Read issue description from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
 	issueCreateCmd.Flags().String("status", "", "Issue status")
 	issueCreateCmd.Flags().String("priority", "", "Issue priority")
 	issueCreateCmd.Flags().String("assignee", "", "Assignee name (member or agent; fuzzy match)")
@@ -236,6 +270,7 @@ func init() {
 	issueUpdateCmd.Flags().String("title", "", "New title")
 	issueUpdateCmd.Flags().String("description", "", "New description (decodes \\n, \\r, \\t, \\\\; pipe via --description-stdin to preserve literal backslashes)")
 	issueUpdateCmd.Flags().Bool("description-stdin", false, "Read new description from stdin (preserves multi-line content verbatim)")
+	issueUpdateCmd.Flags().String("description-file", "", "Read new description from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
 	issueUpdateCmd.Flags().String("status", "", "New status")
 	issueUpdateCmd.Flags().String("priority", "", "New priority")
 	issueUpdateCmd.Flags().String("assignee", "", "New assignee name (member or agent; fuzzy match)")
@@ -273,6 +308,7 @@ func init() {
 	// issue comment add
 	issueCommentAddCmd.Flags().String("content", "", "Comment content (decodes \\n, \\r, \\t, \\\\; pipe via --content-stdin for multi-line bodies or to preserve literal backslashes)")
 	issueCommentAddCmd.Flags().Bool("content-stdin", false, "Read comment content from stdin (preserves multi-line content verbatim)")
+	issueCommentAddCmd.Flags().String("content-file", "", "Read comment content from a UTF-8 file (preserves multi-line content verbatim; use this on Windows when stdin piping mangles non-ASCII bytes)")
 	issueCommentAddCmd.Flags().String("parent", "", "Parent comment ID (reply to a specific comment)")
 	issueCommentAddCmd.Flags().StringSlice("attachment", nil, "File path(s) to attach (can be specified multiple times)")
 	issueCommentAddCmd.Flags().String("output", "json", "Output format: table or json")
@@ -623,7 +659,7 @@ func runIssueUpdate(cmd *cobra.Command, args []string) error {
 		v, _ := cmd.Flags().GetString("title")
 		body["title"] = v
 	}
-	if cmd.Flags().Changed("description") || cmd.Flags().Changed("description-stdin") {
+	if cmd.Flags().Changed("description") || cmd.Flags().Changed("description-stdin") || cmd.Flags().Changed("description-file") {
 		desc, _, err := resolveTextFlag(cmd, "description")
 		if err != nil {
 			return err
@@ -881,7 +917,7 @@ func runIssueCommentAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if !hasContent {
-		return fmt.Errorf("--content or --content-stdin is required")
+		return fmt.Errorf("--content, --content-stdin, or --content-file is required")
 	}
 
 	client, err := newAPIClient(cmd)

--- a/server/cmd/multica/cmd_issue_test.go
+++ b/server/cmd/multica/cmd_issue_test.go
@@ -41,11 +41,12 @@ func pipeStdin(t *testing.T, body string, fn func()) {
 }
 
 // newFlagTestCmd builds a throwaway cobra.Command carrying the inline +
-// stdin flag pair that resolveTextFlag expects.
+// stdin + file flag triplet that resolveTextFlag expects.
 func newFlagTestCmd(name string) *cobra.Command {
 	c := &cobra.Command{Use: "test"}
 	c.Flags().String(name, "", "")
 	c.Flags().Bool(name+"-stdin", false, "")
+	c.Flags().String(name+"-file", "", "")
 	return c
 }
 
@@ -96,6 +97,85 @@ func TestResolveTextFlag(t *testing.T) {
 		}
 		if ok || got != "" {
 			t.Errorf("expected absent flag to yield (\"\", false), got (%q, %v)", got, ok)
+		}
+	})
+
+	// --content-file / --description-file exists for Windows agents — piping
+	// HEREDOC content through Windows PowerShell silently drops non-ASCII
+	// bytes (PS 5.1's $OutputEncoding defaults to ASCIIEncoding when piping
+	// to a native command), so Chinese / Cyrillic / etc. arrive as `?`.
+	// Reading the body straight off disk skips the shell entirely.
+	// See issues #2198, #2236, #2376.
+	t.Run("file body is preserved verbatim with non-ASCII content", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + string(os.PathSeparator) + "desc.md"
+		body := "标题 / Заголовок\n\n中文段落 with `code` and \"quotes\".\n"
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+		c := newFlagTestCmd("description")
+		_ = c.Flags().Set("description-file", path)
+		got, ok, err := resolveTextFlag(c, "description")
+		if err != nil || !ok {
+			t.Fatalf("unexpected: ok=%v err=%v", ok, err)
+		}
+		want := "标题 / Заголовок\n\n中文段落 with `code` and \"quotes\"."
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("file path that doesn't exist surfaces a useful error", func(t *testing.T) {
+		c := newFlagTestCmd("content")
+		_ = c.Flags().Set("content-file", "/this/path/does/not/exist.txt")
+		_, _, err := resolveTextFlag(c, "content")
+		if err == nil {
+			t.Fatalf("expected error for missing file")
+		}
+		if !strings.Contains(err.Error(), "content-file") {
+			t.Errorf("error should mention --content-file, got %v", err)
+		}
+	})
+
+	t.Run("empty file is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + string(os.PathSeparator) + "empty.md"
+		if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+		c := newFlagTestCmd("description")
+		_ = c.Flags().Set("description-file", path)
+		_, _, err := resolveTextFlag(c, "description")
+		if err == nil {
+			t.Fatalf("expected error for empty file")
+		}
+	})
+
+	t.Run("file plus inline is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + string(os.PathSeparator) + "x.md"
+		if err := os.WriteFile(path, []byte("body"), 0o644); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+		c := newFlagTestCmd("description")
+		_ = c.Flags().Set("description", "inline")
+		_ = c.Flags().Set("description-file", path)
+		if _, _, err := resolveTextFlag(c, "description"); err == nil {
+			t.Fatalf("expected mutually-exclusive error for inline + file")
+		}
+	})
+
+	t.Run("file plus stdin is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + string(os.PathSeparator) + "x.md"
+		if err := os.WriteFile(path, []byte("body"), 0o644); err != nil {
+			t.Fatalf("write tempfile: %v", err)
+		}
+		c := newFlagTestCmd("description")
+		_ = c.Flags().Set("description-stdin", "true")
+		_ = c.Flags().Set("description-file", path)
+		if _, _, err := resolveTextFlag(c, "description"); err == nil {
+			t.Fatalf("expected mutually-exclusive error for stdin + file")
 		}
 	})
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2050,7 +2050,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// the same (agent, issue) pair. The work_dir path is stored in DB on
 	// task completion and passed back via PriorWorkDir on the next claim.
 
-	prompt := BuildPrompt(task)
+	prompt := BuildPrompt(task, provider)
 
 	// Pass the daemon's auth credentials and context so the spawned agent CLI
 	// can call the Multica API and the local daemon (e.g. `multica repo checkout`).

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -214,7 +214,7 @@ func TestBuildPromptContainsIssueID(t *testing.T) {
 				{Name: "Concise", Content: "Be concise."},
 			},
 		},
-	})
+	}, "claude")
 
 	// Prompt should contain the issue ID and CLI hint.
 	for _, want := range []string{
@@ -240,7 +240,7 @@ func TestBuildPromptNoIssueDetails(t *testing.T) {
 	prompt := BuildPrompt(Task{
 		IssueID: "test-id",
 		Agent:   &AgentData{Name: "Test"},
-	})
+	}, "claude")
 
 	// Prompt should not contain issue title/description (agent fetches via CLI).
 	for _, absent := range []string{"**Issue:**", "**Summary:**"} {
@@ -259,7 +259,7 @@ func TestBuildPromptAutopilotRunOnly(t *testing.T) {
 		AutopilotTitle:       "Daily dependency check",
 		AutopilotDescription: "Check dependencies and report outdated packages.",
 		AutopilotSource:      "manual",
-	})
+	}, "claude")
 
 	for _, want := range []string{
 		"run-only mode",
@@ -291,7 +291,7 @@ func TestBuildPromptCommentTriggered(t *testing.T) {
 		TriggerCommentID:      commentID,
 		TriggerCommentContent: commentContent,
 		Agent:                 &AgentData{Name: "Test"},
-	})
+	}, "claude")
 
 	// Prompt should contain the comment content, the trigger comment id, and
 	// the full reply command with --parent. Re-emitting --parent on every turn
@@ -336,7 +336,7 @@ func TestBuildPromptCommentTriggeredByAgent(t *testing.T) {
 		TriggerAuthorType:     "agent",
 		TriggerAuthorName:     "Atlas",
 		Agent:                 &AgentData{Name: "Test"},
-	})
+	}, "claude")
 
 	for _, want := range []string{
 		"Another agent (Atlas)",
@@ -362,7 +362,7 @@ func TestBuildPromptCommentTriggeredByMember(t *testing.T) {
 		TriggerAuthorType:     "member",
 		TriggerAuthorName:     "Alice",
 		Agent:                 &AgentData{Name: "Test"},
-	})
+	}, "claude")
 
 	if !strings.Contains(prompt, "A user just left a new comment") {
 		t.Fatalf("member-triggered prompt should label the author as a user\n---\n%s", prompt)
@@ -391,7 +391,7 @@ func TestBuildPromptCommentTriggeredNoContent(t *testing.T) {
 		IssueID:          "test-id",
 		TriggerCommentID: "comment-id",
 		Agent:            &AgentData{Name: "Test"},
-	})
+	}, "claude")
 
 	if !strings.Contains(prompt, "multica issue get") {
 		t.Fatal("prompt missing CLI hint")

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1010,41 +1010,89 @@ func TestInjectRuntimeConfigRequiresExplicitCommentPost(t *testing.T) {
 	}
 }
 
-// TestInjectRuntimeConfigDirectsMultiLineWritesToStdin pins the guidance that
-// any multi-line content for `multica issue comment add` must go through
-// `--content-stdin` + a HEREDOC. Agents that reached for the inline
-// `--content "...\n\n..."` form ended up with literal 4-char `\n` sequences
-// in stored comments because bash does not expand backslash escapes inside
-// double quotes; see MUL-1467. This test prevents the multi-line guidance
-// from silently regressing back into a "for special characters" footnote.
-func TestInjectRuntimeConfigDirectsMultiLineWritesToStdin(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	if _, err := InjectRuntimeConfig(dir, "claude", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
-		t.Fatalf("InjectRuntimeConfig failed: %v", err)
-	}
-	data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
-	if err != nil {
-		t.Fatalf("read CLAUDE.md: %v", err)
-	}
-	s := string(data)
+// TestInjectRuntimeConfigAvailableCommandsIsNeutral pins that the global
+// Available Commands section lists the three input modes neutrally for
+// every non-Codex provider on every host OS, with no "MUST pipe via stdin"
+// mandate.
+//
+// Background: #1795 / #1851 introduced "MUST pipe via stdin" /
+// `--description-stdin` directives in the global section to fix Codex's
+// habit of emitting literal `\n` inside `--content "..."` (MUL-1467).
+// That mandate landed in the all-provider section and ended up steering
+// every provider at stdin — which then broke non-ASCII bytes on Windows
+// shells (#2198 / #2236 / #2376). This rollback keeps the strong
+// Codex-specific mandate in the Codex-Specific section (pinned by
+// TestInjectRuntimeConfigCodexLinuxEmphasizesStdin) and leaves the global
+// section neutral.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestInjectRuntimeConfigAvailableCommandsIsNeutral(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
 
-	for _, want := range []string{
-		"multi-line content",
-		"MUST pipe via stdin",
-		"--content-stdin",
-		"<<'COMMENT'",
-		"`--description`",
-		"--description-stdin",
-	} {
-		if !strings.Contains(s, want) {
-			t.Errorf("CLAUDE.md missing multi-line guidance %q\n---\n%s", want, s)
+	for _, host := range []string{"linux", "darwin", "windows"} {
+		for _, provider := range []string{"claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "cursor", "gemini"} {
+			t.Run(provider+"/"+host, func(t *testing.T) {
+				runtimeGOOS = host
+				dir := t.TempDir()
+				if _, err := InjectRuntimeConfig(dir, provider, TaskContextForEnv{IssueID: "issue-1"}); err != nil {
+					t.Fatalf("InjectRuntimeConfig failed: %v", err)
+				}
+
+				configFile := "CLAUDE.md"
+				if provider != "claude" {
+					configFile = "AGENTS.md"
+				}
+				if provider == "gemini" {
+					configFile = "GEMINI.md"
+				}
+				data, err := os.ReadFile(filepath.Join(dir, configFile))
+				if err != nil {
+					t.Fatalf("read %s: %v", configFile, err)
+				}
+				s := string(data)
+
+				// Available Commands lists all three input modes as fact.
+				for _, want := range []string{
+					"`--content \"...\"`",
+					"`--content-stdin`",
+					"`--content-file <path>`",
+					"`--description-stdin`",
+					"`--description-file <path>`",
+				} {
+					if !strings.Contains(s, want) {
+						t.Errorf("%s missing flag mention %q\n---\n%s", configFile, want, s)
+					}
+				}
+
+				// "MUST pipe via stdin" must NOT appear in any non-Codex
+				// provider's runtime config: it was the over-spread of
+				// the Codex-specific fix.
+				for _, banned := range []string{
+					"MUST pipe via stdin",
+					"Agent-authored comments should always pipe content via stdin",
+					"use `--description-stdin` and pipe a HEREDOC",
+				} {
+					if strings.Contains(s, banned) {
+						t.Errorf("%s carries over-spread Codex mandate %q for non-Codex provider %s\n---\n%s", configFile, banned, provider, s)
+					}
+				}
+			})
 		}
 	}
 }
 
-func TestInjectRuntimeConfigCodexEmphasizesStdinForFormattedComments(t *testing.T) {
-	t.Parallel()
+// TestInjectRuntimeConfigCodexLinuxEmphasizesStdin pins the
+// Codex-Specific Comment Formatting section's "MUST stdin" mandate on
+// non-Windows hosts. This is the MUL-1467 / #1795 / #1851 fix scoped
+// back to where it belongs.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestInjectRuntimeConfigCodexLinuxEmphasizesStdin(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "linux"
+
 	dir := t.TempDir()
 	if _, err := InjectRuntimeConfig(dir, "codex", TaskContextForEnv{
 		IssueID:          "issue-1",
@@ -1068,6 +1116,46 @@ func TestInjectRuntimeConfigCodexEmphasizesStdinForFormattedComments(t *testing.
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("AGENTS.md missing Codex multiline guidance %q\n---\n%s", want, s)
+		}
+	}
+}
+
+// TestInjectRuntimeConfigCodexWindowsUsesContentFile pins that on Windows
+// the Codex-Specific section directs the agent at `--content-file` instead
+// of `--content-stdin`. PowerShell 5.1 / cmd.exe re-encode piped HEREDOC
+// bytes through the active console codepage and silently drop non-ASCII
+// as `?` before reaching `multica.exe` (#2198 / #2236 / #2376).
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestInjectRuntimeConfigCodexWindowsUsesContentFile(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "windows"
+
+	dir := t.TempDir()
+	if _, err := InjectRuntimeConfig(dir, "codex", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	s := string(data)
+	for _, want := range []string{
+		"On Windows, **always write the comment body to a UTF-8 file",
+		"$OutputEncoding",
+		"--content-file",
+		"silently dropping non-ASCII characters as `?`",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("AGENTS.md missing Codex/Windows file-first guidance %q\n---\n%s", want, s)
+		}
+	}
+	for _, banned := range []string{
+		"always use `--content-stdin` with a HEREDOC, even for short single-line replies",
+	} {
+		if strings.Contains(s, banned) {
+			t.Errorf("AGENTS.md still carries Codex stdin mandate %q on Windows\n---\n%s", banned, s)
 		}
 	}
 }

--- a/server/internal/daemon/execenv/reply_instructions.go
+++ b/server/internal/daemon/execenv/reply_instructions.go
@@ -11,22 +11,74 @@ import "fmt"
 // The explicit "do not reuse --parent from previous turns" wording exists
 // because resumed Claude sessions keep prior turns' tool calls in context
 // and will otherwise copy the old --parent UUID forward.
-func BuildCommentReplyInstructions(issueID, triggerCommentID string) string {
+//
+// The template is provider- and platform-aware:
+//
+//   - Windows + any provider → write a UTF-8 file, post with `--content-file`.
+//     This is the only path that survives Windows shells (PowerShell 5.1
+//     defaults to ASCIIEncoding when piping to native commands and drops
+//     non-ASCII as `?`; cmd.exe is at the mercy of `chcp`). The original
+//     reports — #2198 (Chinese), #2236 (Chinese), #2376 (Cyrillic, observed
+//     on a non-Codex agent) — all match this signature.
+//   - Linux/macOS + Codex → stdin/HEREDOC. Codex tends to emit literal `\n`
+//     escapes inside `--content "..."` and produce broken multi-line stored
+//     comments (MUL-1467); stdin sidesteps that.
+//   - Linux/macOS + non-Codex → lightweight inline `--content "..."`.
+//     The CLI's `util.UnescapeBackslashEscapes` decodes `\n` server-side,
+//     so escaped multi-line works correctly. This is the pre-#1795 default,
+//     restored after we found #1795 / #1851 had expanded a Codex-specific
+//     fix into a global mandate that broke Windows non-ASCII for every
+//     provider.
+func BuildCommentReplyInstructions(provider, issueID, triggerCommentID string) string {
 	if triggerCommentID == "" {
 		return ""
 	}
+	if runtimeGOOS == "windows" {
+		return fmt.Sprintf(
+			"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
+				"do NOT reuse --parent values from previous turns in this session.\n\n"+
+				"On Windows, write the reply body to a UTF-8 file with your file-write tool, then post it with `--content-file`. "+
+				"Do NOT pipe via `--content-stdin` — Windows PowerShell 5.1's `$OutputEncoding` defaults to ASCIIEncoding when piping to native commands and silently drops non-ASCII (Chinese, Japanese, Cyrillic, accents, emoji) as `?` before the bytes reach `multica.exe`. "+
+				"Do NOT use inline `--content`; it is easy to lose formatting or accidentally compress a structured reply into one line.\n\n"+
+				"Use this form, preserving the same issue ID and --parent value:\n\n"+
+				"    # 1. Write the reply body to a UTF-8 file (e.g. reply.md) with your file-write tool.\n"+
+				"    # 2. Then run:\n"+
+				"    multica issue comment add %s --parent %s --content-file ./reply.md\n\n"+
+				"Do NOT write literal `\\n` escapes to simulate line breaks; the file preserves real newlines.\n",
+			issueID, triggerCommentID,
+		)
+	}
+	if provider == "codex" {
+		return fmt.Sprintf(
+			"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
+				"do NOT reuse --parent values from previous turns in this session.\n\n"+
+				"Always use `--content-stdin` with a HEREDOC for agent-authored issue comments, even when the reply is a single line. "+
+				"Do NOT use inline `--content`; it is easy to lose formatting or accidentally compress a structured reply into one line.\n\n"+
+				"Use this form, preserving the same issue ID and --parent value:\n\n"+
+				"    cat <<'COMMENT' | multica issue comment add %s --parent %s --content-stdin\n"+
+				"    First paragraph.\n"+
+				"\n"+
+				"    Second paragraph.\n"+
+				"    COMMENT\n\n"+
+				"Do NOT write literal `\\n` escapes to simulate line breaks; the HEREDOC preserves real newlines.\n",
+			issueID, triggerCommentID,
+		)
+	}
+	// Non-Codex providers on Linux/macOS: lightweight inline template, no
+	// platform branch. Pre-#1795 default, restored after we found that
+	// #1795 / #1851 had expanded a Codex-specific fix into a global mandate
+	// that broke Windows non-ASCII for every provider. The CLI decodes
+	// `\n` etc. server-side, so escaped multi-line is fine; for richer
+	// formatting the agent can still reach for `--content-stdin` (works
+	// on Linux/macOS) or `--content-file <path>` (works on every platform),
+	// both listed in Available Commands above.
 	return fmt.Sprintf(
 		"If you decide to reply, post it as a comment — always use the trigger comment ID below, "+
 			"do NOT reuse --parent values from previous turns in this session.\n\n"+
-			"Always use `--content-stdin` with a HEREDOC for agent-authored issue comments, even when the reply is a single line. "+
-			"Do NOT use inline `--content`; it is easy to lose formatting or accidentally compress a structured reply into one line.\n\n"+
 			"Use this form, preserving the same issue ID and --parent value:\n\n"+
-			"    cat <<'COMMENT' | multica issue comment add %s --parent %s --content-stdin\n"+
-			"    First paragraph.\n"+
-			"\n"+
-			"    Second paragraph.\n"+
-			"    COMMENT\n\n"+
-			"Do NOT write literal `\\n` escapes to simulate line breaks; the HEREDOC preserves real newlines.\n",
+			"    multica issue comment add %s --parent %s --content \"...\"\n\n"+
+			"For multi-line bodies, code blocks, or content with quotes/backticks, prefer `--content-stdin` "+
+			"(pipe a HEREDOC) or `--content-file <path>` (read a UTF-8 file). See Available Commands above for the full menu.\n",
 		issueID, triggerCommentID,
 	)
 }

--- a/server/internal/daemon/execenv/reply_instructions_test.go
+++ b/server/internal/daemon/execenv/reply_instructions_test.go
@@ -7,43 +7,154 @@ import (
 	"testing"
 )
 
-func TestBuildCommentReplyInstructionsIncludesTriggerID(t *testing.T) {
-	t.Parallel()
+// TestBuildCommentReplyInstructionsCodexLinux pins that the strong
+// "MUST use --content-stdin + HEREDOC" mandate stays alive for Codex on
+// non-Windows hosts. Codex's habit of emitting literal `\n` inside
+// `--content "..."` is the original reason this mandate exists
+// (#1795 / #1851); on Linux/macOS stdin is the right answer.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestBuildCommentReplyInstructionsCodexLinux(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "linux"
 
 	issueID := "11111111-1111-1111-1111-111111111111"
 	triggerID := "22222222-2222-2222-2222-222222222222"
 
-	got := BuildCommentReplyInstructions(issueID, triggerID)
+	got := BuildCommentReplyInstructions("codex", issueID, triggerID)
 
 	for _, want := range []string{
-		"multica issue comment add " + issueID + " --parent " + triggerID,
+		"multica issue comment add " + issueID + " --parent " + triggerID + " --content-stdin",
 		"Always use `--content-stdin`",
 		"even when the reply is a single line",
-		"--content-stdin",
 		"<<'COMMENT'",
 		"Do NOT write literal `\\n` escapes to simulate line breaks",
 		"do NOT reuse --parent values from previous turns",
 	} {
 		if !strings.Contains(got, want) {
-			t.Fatalf("reply instructions missing %q\n---\n%s", want, got)
+			t.Fatalf("codex/linux reply instructions missing %q\n---\n%s", want, got)
 		}
 	}
 
 	if strings.Contains(got, "--content \"...\"") {
-		t.Fatalf("reply instructions should not offer inline --content form\n---\n%s", got)
+		t.Fatalf("codex reply instructions should not offer inline --content form\n---\n%s", got)
+	}
+}
+
+// TestBuildCommentReplyInstructionsNonCodexLinux pins that every non-Codex
+// provider on Linux/macOS gets the lightweight pre-#1795 inline template.
+// The "MUST stdin" mandate was originally a Codex-specific fix that
+// #1795 / #1851 accidentally spread to every provider, breaking Windows
+// non-ASCII for all of them (#2198 / #2236 / #2376). Non-Codex providers
+// handle inline escaping correctly and the CLI server-decodes `\n` etc.,
+// so the inline template works on every non-Windows platform.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestBuildCommentReplyInstructionsNonCodexLinux(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+
+	issueID := "11111111-1111-1111-1111-111111111111"
+	triggerID := "22222222-2222-2222-2222-222222222222"
+
+	for _, host := range []string{"linux", "darwin"} {
+		for _, provider := range []string{"claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "cursor", "gemini"} {
+			name := provider + "/" + host
+			t.Run(name, func(t *testing.T) {
+				runtimeGOOS = host
+				got := BuildCommentReplyInstructions(provider, issueID, triggerID)
+
+				for _, want := range []string{
+					"multica issue comment add " + issueID + " --parent " + triggerID + " --content \"...\"",
+					"do NOT reuse --parent values from previous turns",
+					"If you decide to reply",
+				} {
+					if !strings.Contains(got, want) {
+						t.Errorf("%s reply instructions missing %q\n---\n%s", name, want, got)
+					}
+				}
+
+				// Non-Codex / non-Windows providers must NOT receive the
+				// Codex-specific "MUST stdin" mandate or its HEREDOC
+				// template — that was the over-spread of #1795 / #1851.
+				for _, banned := range []string{
+					"Always use `--content-stdin`",
+					"<<'COMMENT'",
+					"--parent " + triggerID + " --content-stdin",
+					"--parent " + triggerID + " --content-file",
+				} {
+					if strings.Contains(got, banned) {
+						t.Errorf("%s reply instructions still steers at codex template: %q\n---\n%s", name, banned, got)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestBuildCommentReplyInstructionsWindowsUsesContentFile pins that on
+// Windows every provider — Codex AND non-Codex — gets the
+// `--content-file` template. The bug is shell-layer, not provider-layer:
+// any agent on Windows piping HEREDOC through PowerShell loses non-ASCII
+// bytes (PS 5.1's `$OutputEncoding` defaults to ASCIIEncoding). Issues
+// #2198 (Chinese, Codex), #2236 (Chinese, Codex), #2376 (Cyrillic,
+// non-Codex agent name) all match this signature.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestBuildCommentReplyInstructionsWindowsUsesContentFile(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "windows"
+
+	issueID := "11111111-1111-1111-1111-111111111111"
+	triggerID := "22222222-2222-2222-2222-222222222222"
+
+	for _, provider := range []string{"codex", "claude", "opencode", "openclaw", "hermes", "kimi", "kiro", "cursor", "gemini"} {
+		t.Run(provider+"/windows", func(t *testing.T) {
+			got := BuildCommentReplyInstructions(provider, issueID, triggerID)
+			for _, want := range []string{
+				"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file",
+				"On Windows, write the reply body to a UTF-8 file",
+				"Do NOT pipe via `--content-stdin`",
+				"silently drops non-ASCII",
+				"$OutputEncoding",
+			} {
+				if !strings.Contains(got, want) {
+					t.Errorf("%s reply instructions missing %q\n---\n%s", provider, want, got)
+				}
+			}
+			for _, banned := range []string{
+				"<<'COMMENT'",
+				"--parent " + triggerID + " --content-stdin",
+				"cat <<",
+			} {
+				if strings.Contains(got, banned) {
+					t.Errorf("%s/windows reply instructions should not contain %q\n---\n%s", provider, banned, got)
+				}
+			}
+		})
 	}
 }
 
 func TestBuildCommentReplyInstructionsEmptyWhenNoTrigger(t *testing.T) {
 	t.Parallel()
 
-	if got := BuildCommentReplyInstructions("issue-id", ""); got != "" {
-		t.Fatalf("expected empty string when triggerCommentID is empty, got %q", got)
+	for _, provider := range []string{"codex", "claude", "opencode"} {
+		if got := BuildCommentReplyInstructions(provider, "issue-id", ""); got != "" {
+			t.Fatalf("expected empty string when triggerCommentID is empty for %s, got %q", provider, got)
+		}
 	}
 }
 
+// Pins runtimeGOOS to "linux" so the helper output is deterministic.
+// Provider is "claude" — exercises the non-codex inline path through
+// InjectRuntimeConfig end-to-end. Not parallel: mutates runtimeGOOS.
 func TestInjectRuntimeConfigCommentTriggerUsesHelper(t *testing.T) {
-	t.Parallel()
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "linux"
+
 	dir := t.TempDir()
 
 	issueID := "11111111-1111-1111-1111-111111111111"
@@ -71,5 +182,71 @@ func TestInjectRuntimeConfigCommentTriggerUsesHelper(t *testing.T) {
 		if !strings.Contains(s, want) {
 			t.Errorf("CLAUDE.md missing %q", want)
 		}
+	}
+}
+
+// TestInjectRuntimeConfigWindowsCommentTriggerHasNoStdin asserts the
+// end-to-end CLAUDE.md / AGENTS.md surface for a comment-triggered task on
+// a Windows daemon — across Codex and non-Codex providers — has no
+// prescriptive `--content-stdin` directive that could steer the agent at
+// the broken Windows pipe path.
+//
+// Not parallel: mutates the package-level runtimeGOOS.
+func TestInjectRuntimeConfigWindowsCommentTriggerHasNoStdin(t *testing.T) {
+	saved := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = saved })
+	runtimeGOOS = "windows"
+
+	issueID := "11111111-1111-1111-1111-111111111111"
+	triggerID := "22222222-2222-2222-2222-222222222222"
+	ctx := TaskContextForEnv{
+		IssueID:          issueID,
+		TriggerCommentID: triggerID,
+	}
+
+	for _, provider := range []string{"claude", "codex", "opencode"} {
+		t.Run(provider, func(t *testing.T) {
+			dir := t.TempDir()
+			if _, err := InjectRuntimeConfig(dir, provider, ctx); err != nil {
+				t.Fatalf("InjectRuntimeConfig failed: %v", err)
+			}
+			fileName := "CLAUDE.md"
+			if provider != "claude" {
+				fileName = "AGENTS.md"
+			}
+			data, err := os.ReadFile(filepath.Join(dir, fileName))
+			if err != nil {
+				t.Fatalf("read %s: %v", fileName, err)
+			}
+			s := string(data)
+
+			for _, want := range []string{
+				"multica issue comment add " + issueID + " --parent " + triggerID + " --content-file",
+				"--content-file",
+				"--description-file",
+				"On Windows, write the reply body to a UTF-8 file",
+			} {
+				if !strings.Contains(s, want) {
+					t.Errorf("%s missing %q\n---\n%s", fileName, want, s)
+				}
+			}
+
+			// Prescriptive stdin directives must NOT appear anywhere in
+			// the Windows surface. Pin sentence-level substrings (not
+			// bare flag names) so anti-prescriptive prose like "do NOT
+			// pipe via `--content-stdin`" doesn't trip the ban.
+			for _, banned := range []string{
+				"--parent " + triggerID + " --content-stdin",
+				"always use `--content-stdin` with a HEREDOC, even for short single-line replies",
+				"MUST pipe via stdin",
+				"use `--description-stdin` and pipe a HEREDOC",
+				"<<'COMMENT'",
+				"Agent-authored comments should always pipe content via stdin",
+			} {
+				if strings.Contains(s, banned) {
+					t.Errorf("%s still steers agent at stdin: %q\n---\n%s", fileName, banned, s)
+				}
+			}
+		})
 	}
 }

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -5,8 +5,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
+
+// runtimeGOOS is the host-platform string used by buildMetaSkillContent and
+// BuildCommentReplyInstructions to emit Windows-specific guidance. Defaults
+// to runtime.GOOS; tests override it to exercise the cross-platform branches
+// deterministically without having to run on every target OS.
+var runtimeGOOS = runtime.GOOS
 
 // formatProjectResource renders a single resource as a human-readable bullet.
 // Unknown resource types fall back to a JSON-encoded ref so the agent can
@@ -132,18 +139,28 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	b.WriteString("- `multica issue label remove <issue-id> <label-id>` — Detach a label from an issue\n")
 	b.WriteString("- `multica issue subscriber add <issue-id> [--user <name>|--user-id <uuid>]` — Subscribe a member or agent to issue updates (defaults to the caller when neither flag is set; the two flags are mutually exclusive)\n")
 	b.WriteString("- `multica issue subscriber remove <issue-id> [--user <name>|--user-id <uuid>]` — Unsubscribe a member or agent\n")
-	b.WriteString("- `multica issue comment add <issue-id> --content-stdin [--parent <comment-id>] [--attachment <path>]` — Post a comment. Agent-authored comments should always pipe content via stdin, even for short single-line replies. Use `--parent` to reply to a specific comment; `--attachment` may be repeated.\n")
-	b.WriteString("  - **For comment content, you MUST pipe via stdin; this is mandatory for multi-line content (anything with line breaks, paragraphs, code blocks, backticks, or quotes).** Do not use inline `--content` and do not write `\\n` escapes. Use a HEREDOC instead:\n")
-	b.WriteString("\n")
-	b.WriteString("    ```\n")
-	b.WriteString("    cat <<'COMMENT' | multica issue comment add <issue-id> --content-stdin\n")
-	b.WriteString("    First paragraph.\n")
-	b.WriteString("\n")
-	b.WriteString("    Second paragraph with `code` and \"quotes\".\n")
-	b.WriteString("    COMMENT\n")
-	b.WriteString("    ```\n")
-	b.WriteString("\n")
-	b.WriteString("  - The same rule applies to `--description` on `multica issue create` and `multica issue update` — use `--description-stdin` and pipe a HEREDOC for any multi-line description; the inline `--description \"...\"` form is for short single-line text only.\n")
+	// Available Commands lists `multica issue comment add` and the
+	// description flags neutrally — three input modes, pick what fits.
+	// The previous "MUST pipe via stdin" mandate (#1795 / #1851) was
+	// originally a Codex-specific fix for codex emitting literal `\n`
+	// escapes inside `--content "..."`, but it landed in this global
+	// section and ended up steering every provider at stdin, which then
+	// burned non-ASCII bytes on Windows where the agent's shell layer
+	// (typically PowerShell) re-encodes the pipe through an ASCII /
+	// non-UTF-8 codepage and drops non-representable bytes as `?`
+	// (issues #2198 / #2236 / #2376).
+	//
+	// Strong "MUST" wording lives in the Codex-Specific section below
+	// where it actually belongs; non-Codex providers handle inline
+	// escaping correctly and can pick whichever flag suits their
+	// content. The `--content-file` line in the menu doubles as a
+	// pointer at the Windows-safe path.
+	b.WriteString("- `multica issue comment add <issue-id> [--content \"...\" | --content-stdin | --content-file <path>] [--parent <comment-id>] [--attachment <path>]` — Post a comment. Three input modes, pick whichever fits the content:\n")
+	b.WriteString("  - `--content \"...\"` for short single-line text. The CLI decodes `\\n`, `\\r`, `\\t`, `\\\\` so escaped multi-line is OK; do not embed raw newlines in the argument.\n")
+	b.WriteString("  - `--content-stdin` to pipe the body via HEREDOC. Preserves multi-line and special characters verbatim. Cleanest in `bash` / `zsh`.\n")
+	b.WriteString("  - `--content-file <path>` to read a UTF-8 file off disk. Preserves bytes verbatim regardless of the shell — use this on Windows when stdin would re-encode non-ASCII (Chinese, Japanese, Cyrillic, accents, emoji) through the console codepage and drop them as `?`.\n")
+	b.WriteString("  - Use `--parent` to reply to a specific comment; `--attachment` may be repeated.\n")
+	b.WriteString("- `multica issue create` / `multica issue update` accept the same three modes for `--description`: `--description \"...\"`, `--description-stdin`, or `--description-file <path>`.\n")
 	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
 	b.WriteString("- `multica label create --name \"...\" --color \"#hex\"` — Define a new workspace label (use this only when the label you need does not exist yet; reuse existing labels via `multica label list` first)\n")
 	b.WriteString("- `multica autopilot create --title \"...\" --agent <name> --mode create_issue|run_only [--description \"...\"]` — Create an autopilot\n")
@@ -153,9 +170,15 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 
 	if provider == "codex" {
 		b.WriteString("## Codex-Specific Comment Formatting\n\n")
-		b.WriteString("Codex often follows the per-turn reply command literally. For issue comments, always use `--content-stdin` with a HEREDOC, even for short single-line replies. ")
-		b.WriteString("Never use inline `--content` for agent-authored comments. Keep the same `--parent` value from the trigger comment when replying. ")
-		b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
+		if runtimeGOOS == "windows" {
+			b.WriteString("Codex often follows the per-turn reply command literally. On Windows, **always write the comment body to a UTF-8 file with your file-write tool first, then post it with `--content-file <path>`** — do NOT pipe via `--content-stdin`. PowerShell 5.1's `$OutputEncoding` defaults to ASCIIEncoding when piping to a native command, silently dropping non-ASCII characters as `?` before they reach `multica.exe`. Never use inline `--content` for agent-authored comments. ")
+			b.WriteString("Keep the same `--parent` value from the trigger comment when replying. ")
+			b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
+		} else {
+			b.WriteString("Codex often follows the per-turn reply command literally. For issue comments, always use `--content-stdin` with a HEREDOC, even for short single-line replies. ")
+			b.WriteString("Never use inline `--content` for agent-authored comments. Keep the same `--parent` value from the trigger comment when replying. ")
+			b.WriteString("Do not compress a multi-paragraph answer into one line and do not rely on `\\n` escapes.\n\n")
+		}
 	}
 
 	// Inject available repositories section.
@@ -252,7 +275,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("4. **Decide whether a reply is warranted.** If you produced actual work this turn (investigated, fixed, answered a real question), post the result via step 6 — that is a normal reply, not a noise comment. If the triggering comment was a pure acknowledgment / thanks / sign-off from another agent AND you produced no work this turn, do NOT post a reply — and do NOT post a comment saying 'No reply needed' or similar. Simply exit with no output. Silence is a valid and preferred way to end agent-to-agent conversations.\n")
 		b.WriteString("5. If a reply IS warranted: do any requested work first, then **decide whether to include any `@mention` link.** The default is NO mention. Only mention when you are escalating to a human owner who is not yet involved, delegating a concrete new sub-task to another agent for the first time, or the user explicitly asked you to loop someone in. Never @mention the agent you are replying to as a thank-you or sign-off.\n")
 		b.WriteString("6. **If you reply, post it as a comment — this step is mandatory when you reply.** Text in your terminal or run logs is NOT delivered to the user. ")
-		b.WriteString(BuildCommentReplyInstructions(ctx.IssueID, ctx.TriggerCommentID))
+		b.WriteString(BuildCommentReplyInstructions(provider, ctx.IssueID, ctx.TriggerCommentID))
 		b.WriteString("7. Do NOT change the issue status unless the comment explicitly asks for it\n\n")
 	} else {
 		// Assignment-triggered: defer to agent Skills for workflow specifics.

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -9,13 +9,17 @@ import (
 
 // BuildPrompt constructs the task prompt for an agent CLI.
 // Keep this minimal — detailed instructions live in CLAUDE.md / AGENTS.md
-// injected by execenv.InjectRuntimeConfig.
-func BuildPrompt(task Task) string {
+// injected by execenv.InjectRuntimeConfig. The provider string is used by
+// comment-triggered tasks: Codex's per-turn reply template needs the
+// platform-aware "stdin or file" variant, every other provider gets a
+// lightweight inline template (or Windows file for any provider on
+// Windows).
+func BuildPrompt(task Task, provider string) string {
 	if task.ChatSessionID != "" {
 		return buildChatPrompt(task)
 	}
 	if task.TriggerCommentID != "" {
-		return buildCommentPrompt(task)
+		return buildCommentPrompt(task, provider)
 	}
 	if task.AutopilotRunID != "" {
 		return buildAutopilotPrompt(task)
@@ -107,7 +111,7 @@ func buildQuickCreatePrompt(task Task) string {
 // The reply instructions (including the current TriggerCommentID as --parent)
 // are re-emitted on every turn so resumed sessions cannot carry forward a
 // previous turn's --parent UUID.
-func buildCommentPrompt(task Task) string {
+func buildCommentPrompt(task Task, provider string) string {
 	var b strings.Builder
 	b.WriteString("You are running as a local coding agent for a Multica workspace.\n\n")
 	fmt.Fprintf(&b, "Your assigned issue ID is: %s\n\n", task.IssueID)
@@ -128,7 +132,7 @@ func buildCommentPrompt(task Task) string {
 	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then decide how to proceed.\n\n", task.IssueID)
 	fmt.Fprintf(&b, "If you need comment history, `multica issue comment list %s --output json` returns all comments for the issue (server caps at 2000). Pass `--since <RFC3339>` to fetch only comments newer than a known cursor.\n\n", task.IssueID)
-	b.WriteString(execenv.BuildCommentReplyInstructions(task.IssueID, task.TriggerCommentID))
+	b.WriteString(execenv.BuildCommentReplyInstructions(provider, task.IssueID, task.TriggerCommentID))
 	return b.String()
 }
 


### PR DESCRIPTION
Three user reports converge on the same Windows-shell encoding bug:

- #2198 / #2236 — Chinese, Codex on Win11. Agent-generated comments / descriptions arrive as `?`.
- #2376 — Cyrillic, non-Codex agent (\"Ops Lead\") on Win11 Desktop. Title preserved (argv → CreateProcessW UTF-16), description / agent reply garbled (stdin → shell-codepage re-encoding).

woodcoal's independent diagnosis on #2198 ([comment](https://github.com/multica-ai/multica/issues/2198#issuecomment-4421558014)) confirms the root cause: Windows PowerShell 5.1's `\$OutputEncoding` defaults to `ASCIIEncoding` when piping to a native command, so non-ASCII bytes are silently replaced with `?` before they reach `multica.exe`. The CLI's stdin parsing is fine; the bytes are corrupted upstream in the agent's shell layer. This is consistent across providers — #2376 shows a non-Codex agent hitting the same signature.

This PR supersedes #2265 (which scoped the fix to Codex only — too narrow per #2376) and the original #2247 (merged then reverted in #2252).

## CLI changes

Add `--content-file <path>` to `multica issue comment add` and `--description-file <path>` to `multica issue {create,update}`. The CLI reads bytes off disk via `os.ReadFile` and skips the shell entirely; UTF-8 survives end-to-end regardless of `\$OutputEncoding` or `chcp`. The three input modes (`--content`, `--content-stdin`, `--content-file`) are mutually exclusive.

## Runtime config changes

`buildMetaSkillContent`'s Available Commands section is rewritten as a neutral three-mode menu. The previous unconditional \"MUST pipe via stdin\" / `--description-stdin` mandate (over-spread from #1795 / #1851's Codex-multi-line fix) is gone for non-Codex providers; the strong directive now lives only in the Codex-Specific section, which branches on host:

- Codex / Linux+macOS: `--content-stdin` + HEREDOC (preserves MUL-1467 protection against codex's literal `\\n` habit).
- Codex / Windows: `--content-file` (PowerShell ASCII pipe is the exact bug we're patching).

## Per-turn reply template changes

`BuildCommentReplyInstructions` takes a `provider` arg and branches provider × OS:

- **Windows + any provider → `--content-file`**. The bug is shell-layer, not provider-layer; #2376 shows non-Codex agents on Windows also hit it. All providers write a UTF-8 file with their file-write tool and post via `--content-file ./reply.md`.
- Linux/macOS + Codex → stdin/HEREDOC (MUL-1467 protection).
- Linux/macOS + non-Codex → lightweight pre-#1795 inline `--content \"...\"`. The CLI server-side decodes `\\n`, so escaped multi-line works; the agent retains stdin / file as escape hatches for richer formatting.

`BuildPrompt` and `buildCommentPrompt` gain a `provider` arg; `daemon.runTask` already has it in scope.

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `TestResolveTextFlag` covers file-source verbatim with non-ASCII (`标题 / Заголовок / 中文段落`), missing-file error, empty-file rejection, three-way mutual exclusion.
- [x] `TestInjectRuntimeConfigAvailableCommandsIsNeutral` — every non-Codex provider × {linux, darwin, windows} pins the three-mode menu present + over-spread \"MUST stdin\" substrings absent.
- [x] `TestInjectRuntimeConfigCodexLinuxEmphasizesStdin` / `TestInjectRuntimeConfigCodexWindowsUsesContentFile` — Codex section's per-OS branch.
- [x] `TestBuildCommentReplyInstructionsCodexLinux` / `TestBuildCommentReplyInstructionsNonCodexLinux` / `TestBuildCommentReplyInstructionsWindowsUsesContentFile` — the reply-template provider × OS matrix, all combinations covered.
- [x] `TestInjectRuntimeConfigWindowsCommentTriggerHasNoStdin` — end-to-end AGENTS.md / CLAUDE.md on Windows has no prescriptive stdin directive, for claude / codex / opencode.
- [ ] Manual repro on Win11 + Chinese/Cyrillic: assign an issue, confirm the agent's reply renders non-ASCII correctly instead of `?`.

Closes #2198, #2236, #2376.