### PR TITLE
Auto-transition issue status from comments

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -466,6 +466,7 @@ describe("IssueDetail (shared)", () => {
       { user_id: "user-1", name: "Test User", email: "test@test.com", role: "admin" },
     ]);
     mockApiObj.listAgents.mockResolvedValue([]);
+    mockApiObj.updateIssue.mockResolvedValue({ ...mockIssue, status: "done" });
   });
 
   it("shows loading skeleton while data is loading", () => {
@@ -577,6 +578,22 @@ describe("IssueDetail (shared)", () => {
     });
 
     expect(screen.getByText("I can help with this")).toBeInTheDocument();
+  });
+
+  it("renders the mark-done button on the issue detail toolbar", async () => {
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Implement authentication")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Mark as done"));
+
+    await waitFor(() => {
+      expect(mockApiObj.updateIssue).toHaveBeenCalledWith("issue-1", {
+        status: "done",
+      });
+    });
   });
 
   describe("highlightCommentId scroll-to-comment", () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -807,6 +807,17 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   // Called before the `if (!issue)` early return so hook order stays stable.
   const actions = useIssueActions(issue);
   const handleUpdateField = actions.updateField;
+  const markDoneIssue = useUpdateIssue();
+
+  const handleMarkDone = useCallback(() => {
+    markDoneIssue.mutate(
+      { id, status: "done" },
+      {
+        onSuccess: () => onDone?.(),
+        onError: () => toast.error(t(($) => $.detail.update_failed)),
+      },
+    );
+  }, [id, markDoneIssue, onDone, t]);
 
   const handleToggleSidebar = useCallback(() => {
     if (isMobile) {
@@ -1038,7 +1049,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             </span>
           </div>
           <div className="flex items-center gap-1 shrink-0">
-            {onDone && issue.status !== "done" && issue.status !== "cancelled" && (
+            {issue.status !== "done" && issue.status !== "cancelled" && (
               <Tooltip>
                 <TooltipTrigger
                   render={
@@ -1046,7 +1057,9 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       variant="ghost"
                       size="icon-sm"
                       className="text-muted-foreground"
-                      onClick={() => { handleUpdateField({ status: "done" }); onDone?.(); }}
+                      onClick={handleMarkDone}
+                      disabled={markDoneIssue.isPending}
+                      aria-label={t(($) => $.detail.mark_done_tooltip)}
                     >
                       <CircleCheck />
                     </Button>
@@ -1064,6 +1077,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       size="icon-sm"
                       className="text-muted-foreground"
                       onClick={() => { onDone(); }}
+                      aria-label={t(($) => $.detail.archive_tooltip)}
                     >
                       <Archive />
                     </Button>

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -240,6 +242,12 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	groupedAtt := h.groupAttachments(r, []pgtype.UUID{comment.ID})
 	resp := commentToResponse(comment, nil, groupedAtt[uuidToString(comment.ID)])
 	slog.Info("comment created", append(logger.RequestAttrs(r), "comment_id", uuidToString(comment.ID), "issue_id", issueID)...)
+
+	memberCompletionIntent := authorType == "member" && comment.Type == "comment" && isIssueCompletionIntent(comment.Content)
+	if updatedIssue, ok := h.applyAutomaticCommentStatusTransition(r, issue, comment.Type, comment.Content, authorType, authorID); ok {
+		issue = updatedIssue
+	}
+
 	h.publish(protocol.EventCommentCreated, uuidToString(issue.WorkspaceID), authorType, authorID, map[string]any{
 		"comment":             resp,
 		"issue_title":         issue.Title,
@@ -256,11 +264,13 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// If the issue is assigned to an agent with on_comment trigger, enqueue a new task.
 	// Skip when the comment comes from the assigned agent itself to avoid loops.
+	// Skip when a member explicitly marks the issue done in prose; that comment
+	// is a terminal review signal, not new work for the assignee.
 	// Also skip when the comment @mentions others but not the assignee agent —
 	// the user is talking to someone else, not requesting work from the assignee.
 	// Also skip when replying in a member-started thread without mentioning the
 	// assignee — the user is continuing a member-to-member conversation.
-	if authorType == "member" && h.shouldEnqueueOnComment(r.Context(), issue) &&
+	if authorType == "member" && !memberCompletionIntent && h.shouldEnqueueOnComment(r.Context(), issue) &&
 		!h.commentMentionsOthersButNotAssignee(comment.Content, issue) &&
 		!h.isReplyToMemberThread(r.Context(), parentComment, comment.Content, issue) {
 		// Always use the current comment as the trigger so the agent reads
@@ -275,9 +285,192 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// Trigger @mentioned agents: parse agent mentions and enqueue tasks for each.
 	// Pass parentComment so that replies inherit mentions from the thread root.
-	h.enqueueMentionedAgentTasks(r.Context(), issue, comment, parentComment, authorType, authorID)
+	if !memberCompletionIntent {
+		h.enqueueMentionedAgentTasks(r.Context(), issue, comment, parentComment, authorType, authorID)
+	}
 
 	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (h *Handler) applyAutomaticCommentStatusTransition(r *http.Request, issue db.Issue, commentType, content, actorType, actorID string) (db.Issue, bool) {
+	if actorType != "member" || commentType != "comment" {
+		return issue, false
+	}
+
+	targetStatus, ok := automaticStatusForMemberComment(issue.Status, content)
+	if !ok || targetStatus == issue.Status {
+		return issue, false
+	}
+
+	updated, err := h.Queries.UpdateIssueStatus(r.Context(), db.UpdateIssueStatusParams{
+		ID:     issue.ID,
+		Status: targetStatus,
+	})
+	if err != nil {
+		slog.Warn("automatic comment status transition failed",
+			append(logger.RequestAttrs(r), "error", err, "issue_id", uuidToString(issue.ID), "target_status", targetStatus)...)
+		return issue, false
+	}
+
+	prefix := h.getIssuePrefix(r.Context(), updated.WorkspaceID)
+	h.publish(protocol.EventIssueUpdated, uuidToString(updated.WorkspaceID), actorType, actorID, map[string]any{
+		"issue":               issueToResponse(updated, prefix),
+		"assignee_changed":    false,
+		"status_changed":      true,
+		"priority_changed":    false,
+		"due_date_changed":    false,
+		"description_changed": false,
+		"title_changed":       false,
+		"prev_status":         issue.Status,
+		"prev_priority":       issue.Priority,
+		"creator_type":        issue.CreatorType,
+		"creator_id":          uuidToString(issue.CreatorID),
+	})
+
+	return updated, true
+}
+
+func automaticStatusForMemberComment(currentStatus, content string) (string, bool) {
+	if isIssueCompletionIntent(content) {
+		if currentStatus == "cancelled" {
+			return "", false
+		}
+		return "done", true
+	}
+
+	if (currentStatus == "in_review" || currentStatus == "blocked") && !isAcknowledgementOnly(content) {
+		return "in_progress", true
+	}
+
+	return "", false
+}
+
+func isIssueCompletionIntent(content string) bool {
+	normalized := normalizeStatusIntentText(content)
+	if normalized == "" || containsAnyNormalizedPhrase(normalized, issueCompletionNegations) {
+		return false
+	}
+	if _, ok := exactIssueCompletionIntents[normalized]; ok {
+		return true
+	}
+	return containsAnyNormalizedPhrase(normalized, issueCompletionPhrases)
+}
+
+func isAcknowledgementOnly(content string) bool {
+	normalized := normalizeStatusIntentText(content)
+	if normalized == "" {
+		return true
+	}
+	_, ok := acknowledgementOnlyComments[normalized]
+	return ok
+}
+
+func containsAnyNormalizedPhrase(normalized string, phrases []string) bool {
+	padded := " " + normalized + " "
+	for _, phrase := range phrases {
+		if strings.Contains(padded, " "+phrase+" ") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeStatusIntentText(content string) string {
+	var b strings.Builder
+	previousSpace := true
+	for _, r := range strings.ToLower(content) {
+		switch r {
+		case 'ä':
+			r = 'a'
+		case 'ö':
+			r = 'o'
+		case 'ü':
+			r = 'u'
+		case 'ß':
+			b.WriteString("ss")
+			previousSpace = false
+			continue
+		}
+
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			previousSpace = false
+			continue
+		}
+		if !previousSpace {
+			b.WriteByte(' ')
+			previousSpace = true
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+var issueCompletionNegations = []string{
+	"nicht erledigt",
+	"noch nicht erledigt",
+	"nicht fertig",
+	"noch nicht fertig",
+	"nicht abgeschlossen",
+	"noch nicht abgeschlossen",
+	"passt nicht",
+	"noch nicht",
+	"not done",
+	"not finished",
+	"not complete",
+	"not completed",
+	"not resolved",
+	"is not done",
+	"isn t done",
+	"is not finished",
+	"isn t finished",
+}
+
+var exactIssueCompletionIntents = map[string]struct{}{
+	"abgeschlossen": {},
+	"approved":      {},
+	"done":          {},
+	"erledigt":      {},
+	"fertig":        {},
+	"lgtm":          {},
+	"passt":         {},
+	"resolved":      {},
+}
+
+var issueCompletionPhrases = []string{
+	"alles gut",
+	"all done",
+	"aufgabe ist abgeschlossen",
+	"aufgabe ist erledigt",
+	"bitte schliessen",
+	"das ist abgeschlossen",
+	"das ist erledigt",
+	"das passt",
+	"die aufgabe ist abgeschlossen",
+	"die aufgabe ist erledigt",
+	"it is done",
+	"it s done",
+	"ist abgeschlossen",
+	"ist erledigt",
+	"ist fertig",
+	"kann geschlossen werden",
+	"looks good",
+	"task is done",
+	"this is done",
+	"this is finished",
+}
+
+var acknowledgementOnlyComments = map[string]struct{}{
+	"alles klar":  {},
+	"danke":       {},
+	"got it":      {},
+	"ja":          {},
+	"ok":          {},
+	"okay":        {},
+	"sounds good": {},
+	"super":       {},
+	"thank you":   {},
+	"thanks":      {},
+	"verstanden":  {},
 }
 
 // commentMentionsOthersButNotAssignee returns true if the comment @mentions

--- a/server/internal/handler/comment_status_test.go
+++ b/server/internal/handler/comment_status_test.go
@@ -1,0 +1,194 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAutomaticStatusForMemberComment(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentStatus string
+		content       string
+		wantStatus    string
+		wantChange    bool
+	}{
+		{
+			name:          "review feedback reopens work",
+			currentStatus: "in_review",
+			content:       "Bitte noch die Tests fixen.",
+			wantStatus:    "in_progress",
+			wantChange:    true,
+		},
+		{
+			name:          "blocked reply reopens work",
+			currentStatus: "blocked",
+			content:       "Hier ist der fehlende Zugang.",
+			wantStatus:    "in_progress",
+			wantChange:    true,
+		},
+		{
+			name:          "german completion marks done",
+			currentStatus: "in_review",
+			content:       "Die Aufgabe ist erledigt.",
+			wantStatus:    "done",
+			wantChange:    true,
+		},
+		{
+			name:          "completion negation does not mark done",
+			currentStatus: "blocked",
+			content:       "Not done yet, please keep working.",
+			wantStatus:    "in_progress",
+			wantChange:    true,
+		},
+		{
+			name:          "acknowledgement does not reopen review",
+			currentStatus: "in_review",
+			content:       "Danke!",
+			wantChange:    false,
+		},
+		{
+			name:          "cancelled issue stays cancelled",
+			currentStatus: "cancelled",
+			content:       "done",
+			wantChange:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStatus, gotChange := automaticStatusForMemberComment(tt.currentStatus, tt.content)
+			if gotChange != tt.wantChange {
+				t.Fatalf("change = %v, want %v", gotChange, tt.wantChange)
+			}
+			if gotStatus != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", gotStatus, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestCreateCommentAutoTransitionsIssueStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		content    string
+		wantStatus string
+	}{
+		{
+			name:       "review feedback reopens issue",
+			status:     "in_review",
+			content:    "Please revise the edge case handling.",
+			wantStatus: "in_progress",
+		},
+		{
+			name:       "blocked reply reopens issue",
+			status:     "blocked",
+			content:    "The missing token is now available.",
+			wantStatus: "in_progress",
+		},
+		{
+			name:       "completion phrase marks issue done",
+			status:     "in_review",
+			content:    "Die Aufgabe ist erledigt.",
+			wantStatus: "done",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issueID := createTestIssue(t, "comment status "+tt.name, tt.status, "none")
+			t.Cleanup(func() { deleteTestIssue(t, issueID) })
+
+			createMemberComment(t, issueID, tt.content)
+
+			if got := issueStatus(t, issueID); got != tt.wantStatus {
+				t.Fatalf("issue status = %q, want %q", got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestCreateCommentDoneIntentDoesNotTriggerAssignedAgent(t *testing.T) {
+	ctx := context.Background()
+
+	var agentID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID); err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "done intent no trigger",
+		"status":        "in_review",
+		"priority":      "none",
+		"assignee_type": "agent",
+		"assignee_id":   agentID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var issue IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&issue); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() { deleteTestIssue(t, issue.ID) })
+
+	if _, err := testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE issue_id = $1`, issue.ID); err != nil {
+		t.Fatalf("clear initial tasks: %v", err)
+	}
+
+	createMemberComment(t, issue.ID, "Die Aufgabe ist erledigt.")
+
+	if got := issueStatus(t, issue.ID); got != "done" {
+		t.Fatalf("issue status = %q, want done", got)
+	}
+
+	var taskCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1`,
+		issue.ID,
+	).Scan(&taskCount); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if taskCount != 0 {
+		t.Fatalf("expected no agent task after done intent comment, got %d", taskCount)
+	}
+}
+
+func createMemberComment(t *testing.T, issueID, content string) CommentResponse {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": content,
+	})
+	req = withURLParam(req, "id", issueID)
+	testHandler.CreateComment(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var comment CommentResponse
+	if err := json.NewDecoder(w.Body).Decode(&comment); err != nil {
+		t.Fatalf("decode comment: %v", err)
+	}
+	return comment
+}
+
+func issueStatus(t *testing.T, issueID string) string {
+	t.Helper()
+	var status string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT status FROM issue WHERE id = $1`,
+		issueID,
+	).Scan(&status); err != nil {
+		t.Fatalf("read issue status: %v", err)
+	}
+	return status
+}


### PR DESCRIPTION
Implements REA-82. Adds server-side member comment status intent handling for done/reopen flows, keeps done-intent comments from triggering agent reruns, and exposes a mark-done toolbar button on normal issue detail pages. Tests: go test ./internal/handler; pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx; pnpm --filter @multica/views typecheck.