### PR TITLE
feat(inbox): add issue filters for inbox grouping

### DIFF
--- a/packages/core/inbox/index.ts
+++ b/packages/core/inbox/index.ts
@@ -1,3 +1,4 @@
 export * from "./queries";
 export * from "./mutations";
 export * from "./ws-updaters";
+export * from "./stores/view-store";

--- a/packages/core/inbox/stores/index.ts
+++ b/packages/core/inbox/stores/index.ts
@@ -1,0 +1,1 @@
+export * from "./view-store";

--- a/packages/core/inbox/stores/view-store.ts
+++ b/packages/core/inbox/stores/view-store.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import {
+  viewStorePersistOptions,
+  viewStoreSlice,
+  type IssueViewState,
+} from "../../issues/stores/view-store";
+import { registerForWorkspaceRehydration } from "../../platform/workspace-storage";
+
+export const useInboxViewStore = create<IssueViewState>()(
+  persist(viewStoreSlice, viewStorePersistOptions("multica_inbox_view"))
+);
+
+registerForWorkspaceRehydration(() => useInboxViewStore.persist.rehydrate());

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,8 @@
     "./inbox/queries": "./inbox/queries.ts",
     "./inbox/mutations": "./inbox/mutations.ts",
     "./inbox/ws-updaters": "./inbox/ws-updaters.ts",
+    "./inbox/stores": "./inbox/stores/index.ts",
+    "./inbox/stores/view-store": "./inbox/stores/view-store.ts",
     "./notification-preferences": "./notification-preferences/index.ts",
     "./notification-preferences/queries": "./notification-preferences/queries.ts",
     "./notification-preferences/mutations": "./notification-preferences/mutations.ts",

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -22,6 +22,12 @@ import {
 } from "@multica/core/inbox/mutations";
 
 import { IssueDetail } from "../../issues/components";
+import { IssuesFilterMenu } from "../../issues/components/issues-header";
+import { filterIssues } from "../../issues/utils/filter";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import { useClearFiltersOnWorkspaceChange } from "@multica/core/issues/stores/view-store";
+import { useInboxViewStore } from "@multica/core/inbox/stores/view-store";
+import { issueListOptions } from "@multica/core/issues/queries";
 import { ErrorBoundary } from "@multica/ui/components/common/error-boundary";
 import { useNavigation } from "../../navigation";
 import { toast } from "sonner";
@@ -34,7 +40,7 @@ import {
   ListChecks,
   ArrowLeft,
 } from "lucide-react";
-import type { InboxItem } from "@multica/core/types";
+import type { Issue, InboxItem } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
 import {
   ResizablePanelGroup,
@@ -71,9 +77,58 @@ export function InboxPage() {
 
   const wsId = useWorkspaceId();
   const { data: rawItems = [], isLoading: loading } = useQuery(inboxListOptions(wsId));
+  const { data: allIssues = [] } = useQuery(issueListOptions(wsId));
   const items = useMemo(() => deduplicateInboxItems(rawItems), [rawItems]);
+  const statusFilters = useInboxViewStore((s) => s.statusFilters);
+  const priorityFilters = useInboxViewStore((s) => s.priorityFilters);
+  const assigneeFilters = useInboxViewStore((s) => s.assigneeFilters);
+  const includeNoAssignee = useInboxViewStore((s) => s.includeNoAssignee);
+  const creatorFilters = useInboxViewStore((s) => s.creatorFilters);
+  const projectFilters = useInboxViewStore((s) => s.projectFilters);
+  const includeNoProject = useInboxViewStore((s) => s.includeNoProject);
+  const labelFilters = useInboxViewStore((s) => s.labelFilters);
+  useClearFiltersOnWorkspaceChange(useInboxViewStore, wsId);
 
-  const selected = items.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
+  const issueById = useMemo(() => {
+    const map = new Map<string, Issue>();
+    for (const issue of allIssues) map.set(issue.id, issue);
+    return map;
+  }, [allIssues]);
+  const filterableIssues = useMemo(() => {
+    return items
+      .map((item) => issueById.get(item.issue_id ?? ""))
+      .filter((issue): issue is Issue => !!issue);
+  }, [items, issueById]);
+  const filteredIssueIds = useMemo(() => {
+    const filtered = filterIssues(filterableIssues, {
+      statusFilters,
+      priorityFilters,
+      assigneeFilters,
+      includeNoAssignee,
+      creatorFilters,
+      projectFilters,
+      includeNoProject,
+      labelFilters,
+    });
+    return new Set(filtered.map((issue) => issue.id));
+  }, [filterableIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters]);
+  const hasActiveIssueFilters = useMemo(() => {
+    return (
+      statusFilters.length > 0 ||
+      priorityFilters.length > 0 ||
+      assigneeFilters.length > 0 ||
+      includeNoAssignee ||
+      creatorFilters.length > 0 ||
+      projectFilters.length > 0 ||
+      includeNoProject ||
+      labelFilters.length > 0
+    );
+  }, [statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters]);
+  const filteredItems = useMemo(() => {
+    if (!hasActiveIssueFilters) return items;
+    return items.filter((item) => item.issue_id && filteredIssueIds.has(item.issue_id));
+  }, [items, hasActiveIssueFilters, filteredIssueIds]);
+  const selected = filteredItems.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
 
   // Track the last key we actually resolved against the inbox list. Lets the
   // fallback effect distinguish "shared-link to a notification not in our
@@ -145,15 +200,15 @@ export function InboxPage() {
   };
 
   const handleArchive = (id: string) => {
-    const idx = items.findIndex((i) => i.id === id);
-    const archived = idx >= 0 ? items[idx] : null;
+    const idx = filteredItems.findIndex((i) => i.id === id);
+    const archived = idx >= 0 ? filteredItems[idx] : null;
     const wasSelected =
       !!archived && (archived.issue_id ?? archived.id) === selectedKey;
     if (wasSelected) {
       // List is sorted newest-first; prefer the next (older) item, fall back
       // to the previous (newer) one when archiving at the bottom, and only
       // clear the selection when nothing else is left.
-      const next = items[idx + 1] ?? items[idx - 1] ?? null;
+      const next = filteredItems[idx + 1] ?? filteredItems[idx - 1] ?? null;
       setSelectedKey(next ? (next.issue_id ?? next.id) : "");
     }
     archiveMutation.mutate(id, {
@@ -202,49 +257,54 @@ export function InboxPage() {
           </span>
         )}
       </div>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground"
-            />
-          }
-        >
-          <MoreHorizontal className="h-4 w-4" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-auto">
-          <DropdownMenuItem onClick={handleMarkAllRead}>
-            <CheckCheck className="h-4 w-4" />
-            {t(($) => $.menu.mark_all_read)}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={handleArchiveAll}>
-            <Archive className="h-4 w-4" />
-            {t(($) => $.menu.archive_all)}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleArchiveAllRead}>
-            <BookCheck className="h-4 w-4" />
-            {t(($) => $.menu.archive_all_read)}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleArchiveCompleted}>
-            <ListChecks className="h-4 w-4" />
-            {t(($) => $.menu.archive_completed)}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <div className="flex items-center gap-1">
+        <ViewStoreProvider store={useInboxViewStore}>
+          <IssuesFilterMenu scopedIssues={filterableIssues} />
+        </ViewStoreProvider>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground"
+              />
+            }
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-auto">
+            <DropdownMenuItem onClick={handleMarkAllRead}>
+              <CheckCheck className="h-4 w-4" />
+              {t(($) => $.menu.mark_all_read)}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={handleArchiveAll}>
+              <Archive className="h-4 w-4" />
+              {t(($) => $.menu.archive_all)}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleArchiveAllRead}>
+              <BookCheck className="h-4 w-4" />
+              {t(($) => $.menu.archive_all_read)}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleArchiveCompleted}>
+              <ListChecks className="h-4 w-4" />
+              {t(($) => $.menu.archive_completed)}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
     </PageHeader>
   );
 
-  const listBody = items.length === 0 ? (
+  const listBody = filteredItems.length === 0 ? (
     <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
       <Inbox className="mb-3 h-8 w-8 text-muted-foreground/50" />
       <p className="text-sm">{t(($) => $.list.empty)}</p>
     </div>
   ) : (
     <div>
-      {items.map((item) => (
+      {filteredItems.map((item) => (
         <InboxListItem
           key={item.id}
           item={item}
@@ -442,7 +502,7 @@ export function InboxPage() {
           <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
             <Inbox className="mb-3 h-10 w-10 text-muted-foreground/30" />
             <p className="text-sm">
-              {items.length === 0
+              {filteredItems.length === 0
                 ? t(($) => $.detail.empty)
                 : t(($) => $.detail.select_prompt)}
             </p>

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -450,15 +450,11 @@ function LabelSubContent({
 }
 
 // ---------------------------------------------------------------------------
-// IssuesHeader
+// IssuesFilterMenu
 // ---------------------------------------------------------------------------
 
-export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
+export function IssuesFilterMenu({ scopedIssues }: { scopedIssues: Issue[] }) {
   const { t } = useT("issues");
-  const scope = useIssuesScopeStore((s) => s.scope);
-  const setScope = useIssuesScopeStore((s) => s.setScope);
-
-  const viewMode = useViewStore((s) => s.viewMode);
   const statusFilters = useViewStore((s) => s.statusFilters);
   const priorityFilters = useViewStore((s) => s.priorityFilters);
   const assigneeFilters = useViewStore((s) => s.assigneeFilters);
@@ -467,9 +463,6 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
   const projectFilters = useViewStore((s) => s.projectFilters);
   const includeNoProject = useViewStore((s) => s.includeNoProject);
   const labelFilters = useViewStore((s) => s.labelFilters);
-  const sortBy = useViewStore((s) => s.sortBy);
-  const sortDirection = useViewStore((s) => s.sortDirection);
-  const cardProperties = useViewStore((s) => s.cardProperties);
   const act = useViewStoreApi().getState();
 
   const counts = useIssueCounts(scopedIssues);
@@ -486,6 +479,206 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
       labelFilters,
     }) > 0;
 
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <DropdownMenuTrigger
+          render={
+            <TooltipTrigger
+              render={
+                <Button variant="ghost" size="icon-sm" className="relative text-muted-foreground">
+                  <Filter className="size-4" />
+                  {hasActiveFilters && (
+                    <span className="absolute top-0 right-0 size-1.5 rounded-full bg-brand" />
+                  )}
+                </Button>
+              }
+            />
+          }
+        />
+        <TooltipContent side="bottom">{t(($) => $.filters.tooltip)}</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" className="w-auto">
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <CircleDot className="size-3.5" />
+            <span className="flex-1">{t(($) => $.filters.section_status)}</span>
+            {statusFilters.length > 0 && (
+              <span className="text-xs text-primary font-medium">
+                {statusFilters.length}
+              </span>
+            )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-auto min-w-48">
+            {ALL_STATUSES.map((s) => {
+              const checked = statusFilters.includes(s);
+              const count = counts.status.get(s) ?? 0;
+              return (
+                <DropdownMenuCheckboxItem
+                  key={s}
+                  checked={checked}
+                  onCheckedChange={() => act.toggleStatusFilter(s)}
+                  className={FILTER_ITEM_CLASS}
+                >
+                  <HoverCheck checked={checked} />
+                  <StatusIcon status={s} className="h-3.5 w-3.5" />
+                  {t(($) => $.status[s])}
+                  {count > 0 && (
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {t(($) => $.filters.issue_count, { count })}
+                    </span>
+                  )}
+                </DropdownMenuCheckboxItem>
+              );
+            })}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <SignalHigh className="size-3.5" />
+            <span className="flex-1">{t(($) => $.filters.section_priority)}</span>
+            {priorityFilters.length > 0 && (
+              <span className="text-xs text-primary font-medium">
+                {priorityFilters.length}
+              </span>
+            )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-auto min-w-44">
+            {PRIORITY_ORDER.map((p) => {
+              const checked = priorityFilters.includes(p);
+              const count = counts.priority.get(p) ?? 0;
+              return (
+                <DropdownMenuCheckboxItem
+                  key={p}
+                  checked={checked}
+                  onCheckedChange={() => act.togglePriorityFilter(p)}
+                  className={FILTER_ITEM_CLASS}
+                >
+                  <HoverCheck checked={checked} />
+                  <PriorityIcon priority={p} />
+                  {t(($) => $.priority[p])}
+                  {count > 0 && (
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {t(($) => $.filters.issue_count, { count })}
+                    </span>
+                  )}
+                </DropdownMenuCheckboxItem>
+              );
+            })}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <User className="size-3.5" />
+            <span className="flex-1">{t(($) => $.filters.section_assignee)}</span>
+            {(assigneeFilters.length > 0 || includeNoAssignee) && (
+              <span className="text-xs text-primary font-medium">
+                {assigneeFilters.length + (includeNoAssignee ? 1 : 0)}
+              </span>
+            )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-auto min-w-52 p-0">
+            <ActorSubContent
+              counts={counts.assignee}
+              selected={assigneeFilters}
+              onToggle={act.toggleAssigneeFilter}
+              showNoAssignee
+              includeNoAssignee={includeNoAssignee}
+              onToggleNoAssignee={act.toggleNoAssignee}
+              noAssigneeCount={counts.noAssignee}
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <UserPen className="size-3.5" />
+            <span className="flex-1">{t(($) => $.filters.section_creator)}</span>
+            {creatorFilters.length > 0 && (
+              <span className="text-xs text-primary font-medium">
+                {creatorFilters.length}
+              </span>
+            )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-auto min-w-52 p-0">
+            <ActorSubContent
+              counts={counts.creator}
+              selected={creatorFilters}
+              onToggle={act.toggleCreatorFilter}
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <FolderKanban className="size-3.5" />
+            <span className="flex-1">{t(($) => $.filters.section_project)}</span>
+            {(projectFilters.length > 0 || includeNoProject) && (
+              <span className="text-xs text-primary font-medium">
+                {projectFilters.length + (includeNoProject ? 1 : 0)}
+              </span>
+            )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-auto min-w-52 p-0">
+            <ProjectSubContent
+              counts={counts.project}
+              selected={projectFilters}
+              onToggle={act.toggleProjectFilter}
+              includeNoProject={includeNoProject}
+              onToggleNoProject={act.toggleNoProject}
+              noProjectCount={counts.noProject}
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <Tag className="size-3.5" />
+            <span className="flex-1">{t(($) => $.filters.section_label)}</span>
+            {labelFilters.length > 0 && (
+              <span className="text-xs text-primary font-medium">
+                {labelFilters.length}
+              </span>
+            )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-auto min-w-52 p-0">
+            <LabelSubContent
+              counts={counts.label}
+              selected={labelFilters}
+              onToggle={act.toggleLabelFilter}
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        {hasActiveFilters && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={act.clearFilters}>
+              {t(($) => $.filters.reset)}
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IssuesHeader
+// ---------------------------------------------------------------------------
+
+export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
+  const { t } = useT("issues");
+  const scope = useIssuesScopeStore((s) => s.scope);
+  const setScope = useIssuesScopeStore((s) => s.setScope);
+
+  const viewMode = useViewStore((s) => s.viewMode);
+  const sortBy = useViewStore((s) => s.sortBy);
+  const sortDirection = useViewStore((s) => s.sortDirection);
+  const cardProperties = useViewStore((s) => s.cardProperties);
+  const act = useViewStoreApi().getState();
   const SORT_LABEL_KEY: Record<typeof SORT_OPTIONS[number]["value"], "sort_manual" | "sort_priority" | "sort_due_date" | "sort_created" | "sort_title"> = {
     position: "sort_manual",
     priority: "sort_priority",
@@ -543,196 +736,7 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
 
       {/* Right: filter + display + view toggle */}
       <div className="flex items-center gap-1">
-        {/* Filter */}
-        <DropdownMenu>
-          <Tooltip>
-            <DropdownMenuTrigger
-              render={
-                <TooltipTrigger
-                  render={
-                    <Button variant="outline" size="icon-sm" className="relative text-muted-foreground">
-                      <Filter className="size-4" />
-                      {hasActiveFilters && (
-                        <span className="absolute top-0 right-0 size-1.5 rounded-full bg-brand" />
-                      )}
-                    </Button>
-                  }
-                />
-              }
-            />
-            <TooltipContent side="bottom">{t(($) => $.filters.tooltip)}</TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent align="end" className="w-auto">
-            {/* Status */}
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <CircleDot className="size-3.5" />
-                <span className="flex-1">{t(($) => $.filters.section_status)}</span>
-                {statusFilters.length > 0 && (
-                  <span className="text-xs text-primary font-medium">
-                    {statusFilters.length}
-                  </span>
-                )}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="w-auto min-w-48">
-                {ALL_STATUSES.map((s) => {
-                  const checked = statusFilters.includes(s);
-                  const count = counts.status.get(s) ?? 0;
-                  return (
-                    <DropdownMenuCheckboxItem
-                      key={s}
-                      checked={checked}
-                      onCheckedChange={() => act.toggleStatusFilter(s)}
-                      className={FILTER_ITEM_CLASS}
-                    >
-                      <HoverCheck checked={checked} />
-                      <StatusIcon status={s} className="h-3.5 w-3.5" />
-                      {t(($) => $.status[s])}
-                      {count > 0 && (
-                        <span className="ml-auto text-xs text-muted-foreground">
-                          {t(($) => $.filters.issue_count, { count })}
-                        </span>
-                      )}
-                    </DropdownMenuCheckboxItem>
-                  );
-                })}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-
-            {/* Priority */}
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <SignalHigh className="size-3.5" />
-                <span className="flex-1">{t(($) => $.filters.section_priority)}</span>
-                {priorityFilters.length > 0 && (
-                  <span className="text-xs text-primary font-medium">
-                    {priorityFilters.length}
-                  </span>
-                )}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="w-auto min-w-44">
-                {PRIORITY_ORDER.map((p) => {
-                  const checked = priorityFilters.includes(p);
-                  const count = counts.priority.get(p) ?? 0;
-                  return (
-                    <DropdownMenuCheckboxItem
-                      key={p}
-                      checked={checked}
-                      onCheckedChange={() => act.togglePriorityFilter(p)}
-                      className={FILTER_ITEM_CLASS}
-                    >
-                      <HoverCheck checked={checked} />
-                      <PriorityIcon priority={p} />
-                      {t(($) => $.priority[p])}
-                      {count > 0 && (
-                        <span className="ml-auto text-xs text-muted-foreground">
-                          {t(($) => $.filters.issue_count, { count })}
-                        </span>
-                      )}
-                    </DropdownMenuCheckboxItem>
-                  );
-                })}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-
-            {/* Assignee */}
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <User className="size-3.5" />
-                <span className="flex-1">{t(($) => $.filters.section_assignee)}</span>
-                {(assigneeFilters.length > 0 || includeNoAssignee) && (
-                  <span className="text-xs text-primary font-medium">
-                    {assigneeFilters.length + (includeNoAssignee ? 1 : 0)}
-                  </span>
-                )}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="w-auto min-w-52 p-0">
-                <ActorSubContent
-                  counts={counts.assignee}
-                  selected={assigneeFilters}
-                  onToggle={act.toggleAssigneeFilter}
-                  showNoAssignee
-                  includeNoAssignee={includeNoAssignee}
-                  onToggleNoAssignee={act.toggleNoAssignee}
-                  noAssigneeCount={counts.noAssignee}
-                />
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-
-            {/* Creator */}
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <UserPen className="size-3.5" />
-                <span className="flex-1">{t(($) => $.filters.section_creator)}</span>
-                {creatorFilters.length > 0 && (
-                  <span className="text-xs text-primary font-medium">
-                    {creatorFilters.length}
-                  </span>
-                )}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="w-auto min-w-52 p-0">
-                <ActorSubContent
-                  counts={counts.creator}
-                  selected={creatorFilters}
-                  onToggle={act.toggleCreatorFilter}
-                />
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-
-            {/* Project */}
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <FolderKanban className="size-3.5" />
-                <span className="flex-1">{t(($) => $.filters.section_project)}</span>
-                {(projectFilters.length > 0 || includeNoProject) && (
-                  <span className="text-xs text-primary font-medium">
-                    {projectFilters.length + (includeNoProject ? 1 : 0)}
-                  </span>
-                )}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="w-auto min-w-52 p-0">
-                <ProjectSubContent
-                  counts={counts.project}
-                  selected={projectFilters}
-                  onToggle={act.toggleProjectFilter}
-                  includeNoProject={includeNoProject}
-                  onToggleNoProject={act.toggleNoProject}
-                  noProjectCount={counts.noProject}
-                />
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-
-            {/* Label */}
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <Tag className="size-3.5" />
-                <span className="flex-1">{t(($) => $.filters.section_label)}</span>
-                {labelFilters.length > 0 && (
-                  <span className="text-xs text-primary font-medium">
-                    {labelFilters.length}
-                  </span>
-                )}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent className="w-auto min-w-52 p-0">
-                <LabelSubContent
-                  counts={counts.label}
-                  selected={labelFilters}
-                  onToggle={act.toggleLabelFilter}
-                />
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-
-            {/* Reset */}
-            {hasActiveFilters && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={act.clearFilters}>
-                  {t(($) => $.filters.reset)}
-                </DropdownMenuItem>
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <IssuesFilterMenu scopedIssues={scopedIssues} />
 
         {/* Display settings */}
         <Popover>


### PR DESCRIPTION
## Summary

Add issue filter functionality to the inbox page, allowing users to filter inbox notifications by issue attributes (status, priority, assignee, creator, project, labels).

This feature was requested in issue #2317 to help users manage large volumes of inbox notifications (e.g., stock analysis scenarios with many tasks).

## Changes

- **New  component**: Extracted from  for reuse in inbox
- **New **: Separate Zustand store for inbox filter state, ensuring inbox filters are isolated from /issues page filters
- **Filter support**: Status, priority, assignee, creator, project, and labels
- **Filter button styling**: Changed from  to  to match the mark-as-read button

## Test plan

- [x] TypeScript type check passes
- [x] All existing tests pass
- [ ] Browser verification

Closes #2317