### PR TITLE
fix(modals): correct text input height in issue creation dialog

### DIFF
--- a/packages/views/editor/content-editor.css
+++ b/packages/views/editor/content-editor.css
@@ -28,7 +28,6 @@
 .rich-text-editor.ProseMirror {
   color: var(--foreground);
   caret-color: var(--foreground);
-  min-height: 100%;
 }
 
 .rich-text-editor.ProseMirror:focus {

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -275,7 +275,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
           className="relative flex flex-1 min-h-full flex-col"
           onMouseDown={handleContainerMouseDown}
         >
-          <EditorContent className="flex-1 min-h-full" editor={editor} />
+          <EditorContent className="flex flex-1 flex-col" editor={editor} />
           {showBubbleMenu && (
             <EditorBubbleMenu editor={editor} currentIssueId={currentIssueId} />
           )}

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -211,7 +211,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
           },
         },
         attributes: {
-          class: cn("rich-text-editor text-sm outline-none", className),
+          class: cn("flex-1 rich-text-editor text-sm outline-none", className),
         },
       },
     });
@@ -272,7 +272,7 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       <AttachmentDownloadProvider attachments={attachments}>
         <div
           ref={wrapperRef}
-          className="relative flex min-h-full flex-col"
+          className="relative flex flex-1 min-h-full flex-col"
           onMouseDown={handleContainerMouseDown}
         >
           <EditorContent className="flex-1 min-h-full" editor={editor} />

--- a/packages/views/modals/create-issue.tsx
+++ b/packages/views/modals/create-issue.tsx
@@ -357,7 +357,7 @@ export function ManualCreatePanel({
             </div>
 
             {/* Description — takes remaining space */}
-            <div {...descDropZoneProps} className="relative flex-1 min-h-0 overflow-y-auto px-5">
+            <div {...descDropZoneProps} className="relative flex flex-1 min-h-0 overflow-y-auto px-5">
               <ContentEditor
                 ref={descEditorRef}
                 defaultValue={draft.description}

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -415,7 +415,7 @@ export function AgentCreatePanel({
             editor unbounded and pushed the modal past the viewport. */}
         <div
           {...dropZoneProps}
-          className="relative px-5 pb-3 flex-1 min-h-[140px] overflow-y-auto"
+          className="relative px-5 pb-3 flex flex-1 min-h-[140px] overflow-y-auto"
         >
           <ContentEditor
             ref={editorRef}


### PR DESCRIPTION
## Summary

修复 issue 创建弹窗的文本输入高度问题，共有两处需要修改：

### 1. 修复通过 agent 创建的弹窗输入高度

- 外层 div 的 class 从 `relative px-5 pb-3 flex-1 min-h-[140px] overflow-y-auto` 增加 `flex`，变为 `relative px-5 pb-3 flex flex-1 min-h-[140px] overflow-y-auto`
- 内部 div 的 class 从 `relative flex min-h-full flex-col` 增加 `flex-1`，变为 `relative flex flex-1 min-h-full flex-col`

### 2. 修复手动创建的弹窗输入高度

- 文本输入 div 从 `flex-1 min-h-full` 增加 `flex`，变为 `flex flex-1 min-h-full`
- 内部 div 从 `tiptap ProseMirror rich-text-editor text-sm outline-none` 增加 `flex-1`，变为 `flex-1 tiptap ProseMirror rich-text-editor text-sm outline-none`

## Files changed

- `packages/views/modals/quick-create-issue.tsx` - Agent 模式外层 div
- `packages/views/editor/content-editor.tsx` - Editor wrapper 和 attributes class
- `packages/views/modals/create-issue.tsx` - Manual 模式描述容器

Fixed: #2433