### PR TITLE
docs(self-hosting): document Caddy WebSocket essentials

### DIFF
--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -191,7 +191,8 @@ In production, put a reverse proxy in front of both the backend and frontend to 
 ```
 multica.example.com {
     # WebSocket route — must come before the catch-all
-    handle /ws* {
+    @multica_ws path /ws /ws/*
+    handle @multica_ws {
         reverse_proxy localhost:8080 {
             flush_interval -1
         }
@@ -210,7 +211,8 @@ app.example.com {
 }
 
 api.example.com {
-    handle /ws* {
+    @multica_ws path /ws /ws/*
+    handle @multica_ws {
         reverse_proxy localhost:8080 {
             flush_interval -1
         }
@@ -222,7 +224,7 @@ api.example.com {
 
 Two non-obvious bits inside the `/ws` block are worth calling out — both are common reasons real-time updates "stop working" on a Caddy-fronted self-host:
 
-- **`handle /ws*` (not `/ws`)** — `handle /ws` is an exact-path matcher, so future path variants (`/ws/subscribe`, `/ws/v2`, ...) fall through to the frontend block. The trailing `*` makes it a prefix match.
+- **`path /ws /ws/*` (not `/ws*`)** — bare `handle /ws` is an exact match, so future path variants under `/ws/` fall through to the frontend block. The obvious shortcut `handle /ws*` overcorrects in the other direction: Caddy's `*` is a glob without a path-segment boundary, so it would also catch unrelated paths like `/ws-foo`, which is a legitimate workspace URL (only the exact slug `ws` is reserved). Listing `/ws` and `/ws/*` explicitly covers both real cases without overreach.
 - **`flush_interval -1`** — disables response buffering so WebSocket frames are forwarded as soon as they arrive. Without it, frames can sit behind Caddy's default flush window, which looks like delayed comments, missing typing indicators, or "comments only appear after a page refresh."
 
 ### Nginx

--- a/SELF_HOSTING_ADVANCED.md
+++ b/SELF_HOSTING_ADVANCED.md
@@ -186,15 +186,44 @@ In production, put a reverse proxy in front of both the backend and frontend to 
 
 ### Caddy (Recommended)
 
+**Single-domain layout** — frontend and backend served on the same hostname (this is what `docker-compose.selfhost.yml` defaults to):
+
+```
+multica.example.com {
+    # WebSocket route — must come before the catch-all
+    handle /ws* {
+        reverse_proxy localhost:8080 {
+            flush_interval -1
+        }
+    }
+
+    # Everything else → frontend
+    reverse_proxy localhost:3000
+}
+```
+
+**Separate-domain layout** — frontend and backend on different hostnames:
+
 ```
 app.example.com {
     reverse_proxy localhost:3000
 }
 
 api.example.com {
+    handle /ws* {
+        reverse_proxy localhost:8080 {
+            flush_interval -1
+        }
+    }
+
     reverse_proxy localhost:8080
 }
 ```
+
+Two non-obvious bits inside the `/ws` block are worth calling out — both are common reasons real-time updates "stop working" on a Caddy-fronted self-host:
+
+- **`handle /ws*` (not `/ws`)** — `handle /ws` is an exact-path matcher, so future path variants (`/ws/subscribe`, `/ws/v2`, ...) fall through to the frontend block. The trailing `*` makes it a prefix match.
+- **`flush_interval -1`** — disables response buffering so WebSocket frames are forwarded as soon as they arrive. Without it, frames can sit behind Caddy's default flush window, which looks like delayed comments, missing typing indicators, or "comments only appear after a page refresh."
 
 ### Nginx
 

--- a/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
@@ -342,7 +342,8 @@ In production, put a reverse proxy in front of both the backend and frontend to 
 ```
 multica.example.com {
     # WebSocket route — must come before the catch-all
-    handle /ws* {
+    @multica_ws path /ws /ws/*
+    handle @multica_ws {
         reverse_proxy localhost:8080 {
             flush_interval -1
         }
@@ -361,7 +362,8 @@ app.example.com {
 }
 
 api.example.com {
-    handle /ws* {
+    @multica_ws path /ws /ws/*
+    handle @multica_ws {
         reverse_proxy localhost:8080 {
             flush_interval -1
         }
@@ -373,7 +375,7 @@ api.example.com {
 
 Two non-obvious bits inside the `/ws` block are worth calling out — both are common reasons real-time updates "stop working" on a Caddy-fronted self-host:
 
-- **`handle /ws*` (not `/ws`)** — `handle /ws` is an exact-path matcher, so future path variants (`/ws/subscribe`, `/ws/v2`, ...) fall through to the frontend block. The trailing `*` makes it a prefix match.
+- **`path /ws /ws/*` (not `/ws*`)** — bare `handle /ws` is an exact match, so future path variants under `/ws/` fall through to the frontend block. The obvious shortcut `handle /ws*` overcorrects in the other direction: Caddy's `*` is a glob without a path-segment boundary, so it would also catch unrelated paths like `/ws-foo`, which is a legitimate workspace URL (only the exact slug `ws` is reserved). Listing `/ws` and `/ws/*` explicitly covers both real cases without overreach.
 - **`flush_interval -1`** — disables response buffering so WebSocket frames are forwarded as soon as they arrive. Without it, frames can sit behind Caddy's default flush window, which looks like delayed comments, missing typing indicators, or "comments only appear after a page refresh."
 
 ### Nginx

--- a/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
@@ -337,15 +337,44 @@ In production, put a reverse proxy in front of both the backend and frontend to 
 
 ### Caddy (Recommended)
 
+**Single-domain layout** — frontend and backend served on the same hostname (this is what `docker-compose.selfhost.yml` defaults to):
+
+```
+multica.example.com {
+    # WebSocket route — must come before the catch-all
+    handle /ws* {
+        reverse_proxy localhost:8080 {
+            flush_interval -1
+        }
+    }
+
+    # Everything else → frontend
+    reverse_proxy localhost:3000
+}
+```
+
+**Separate-domain layout** — frontend and backend on different hostnames:
+
 ```
 app.example.com {
     reverse_proxy localhost:3000
 }
 
 api.example.com {
+    handle /ws* {
+        reverse_proxy localhost:8080 {
+            flush_interval -1
+        }
+    }
+
     reverse_proxy localhost:8080
 }
 ```
+
+Two non-obvious bits inside the `/ws` block are worth calling out — both are common reasons real-time updates "stop working" on a Caddy-fronted self-host:
+
+- **`handle /ws*` (not `/ws`)** — `handle /ws` is an exact-path matcher, so future path variants (`/ws/subscribe`, `/ws/v2`, ...) fall through to the frontend block. The trailing `*` makes it a prefix match.
+- **`flush_interval -1`** — disables response buffering so WebSocket frames are forwarded as soon as they arrive. Without it, frames can sit behind Caddy's default flush window, which looks like delayed comments, missing typing indicators, or "comments only appear after a page refresh."
 
 ### Nginx
 


### PR DESCRIPTION
Closes #2430

## Summary

A self-hosted user with a single-domain Caddy deployment (#2430) found that real-time sync (comments, typing indicators, notifications) was silently broken — comments only appeared after a manual page refresh. The fix had two parts, neither of which was documented:

- `handle` block needs to actually cover the WebSocket path. The obvious-looking `handle /ws*` overshoots (Caddy's `*` is a glob, no segment boundary — it would also match `/ws-foo`, which is a legitimate workspace URL: `server/internal/handler/reserved_slugs.json` only reserves the exact slug `ws`). A named matcher `@multica_ws path /ws /ws/*` is precise.
- `flush_interval -1` inside the `/ws` `reverse_proxy`. Without it, Caddy can hold WebSocket frames behind its default flush window.

This PR updates the `Caddy (Recommended)` section in `SELF_HOSTING_ADVANCED.md` (and its mirror in `apps/docs/content/docs/getting-started/self-hosting.zh.mdx`) to:

- Add a **single-domain layout** example with a precise `@multica_ws` matcher (this is the layout `docker-compose.selfhost.yml` defaults to, and the one the user hit).
- Apply the same matcher to the **separate-domain layout** example for consistency.
- Add a short note explaining *why* both bits matter, calling out the `/ws*` overreach explicitly, with the user-visible symptom ("comments only appear after a page refresh") so the next person searching for that string lands on the fix.

No code, server, or compose changes — docs only.

## Test plan
- [ ] Render the updated `SELF_HOSTING_ADVANCED.md` on GitHub and confirm code fences / matcher syntax display correctly.
- [ ] Render the updated `self-hosting.zh.mdx` in the docs site preview (Vercel build attached to this PR) and confirm the new subsections appear under `Reverse Proxy → Caddy (Recommended)`.
- [ ] Sanity-check the Caddy snippets against the official Caddy v2 docs — named matchers, `path` directive multi-value list, `reverse_proxy` block syntax, `flush_interval -1`.