### PR TITLE
fix(desktop): restore Multica app icon on Linux

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -32,6 +32,20 @@ mac:
 dmg:
   artifactName: multica-desktop-${version}-mac-${arch}.${ext}
 linux:
+  # Override the Linux executable name to avoid leaking the scoped npm
+  # package name (`@multica/desktop`) into the installed binary, the
+  # `.desktop` file, and the hicolor icon filename. Without this override
+  # electron-builder defaults `executableName` to the package `name`,
+  # which after slash-stripping becomes `@multicadesktop` — producing
+  # `/usr/share/applications/@multicadesktop.desktop`,
+  # `Icon=@multicadesktop`, and
+  # `/usr/share/icons/hicolor/*/apps/@multicadesktop.png`. The leading `@`
+  # violates the freedesktop desktop-entry naming guidance, so GNOME /
+  # Ubuntu fail to associate the running window with the `.desktop` entry
+  # and fall back to the theme's default app icon (the Settings gear on
+  # Yaru). Forcing `multica` makes every Linux identity slot agree and
+  # matches `StartupWMClass=Multica` (productName-derived).
+  executableName: multica
   target:
     - AppImage
     - deb

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -46,6 +46,20 @@ linux:
   # Yaru). Forcing `multica` makes every Linux identity slot agree and
   # matches `StartupWMClass=Multica` (productName-derived).
   executableName: multica
+  # Pin StartupWMClass explicitly to the WM_CLASS that Electron emits on
+  # X11. Electron derives WM_CLASS from `app.getName()`, which in packaged
+  # builds resolves to `productName` (`Multica`). Without an explicit
+  # `StartupWMClass`, electron-builder writes `productName` as the default
+  # — making this declaration redundant with current settings — but
+  # pinning the value here turns a silent future drift (e.g. if anyone
+  # renames productName or sets app.setName at boot) into a visible diff
+  # against this file. The WM_CLASS ↔ StartupWMClass match is what lets
+  # GNOME associate the running window with the `.desktop` entry and
+  # therefore render the right icon. The post-build verification step in
+  # PR #2437 is `xprop WM_CLASS` on a real Ubuntu install.
+  desktop:
+    entry:
+      StartupWMClass: Multica
   target:
     - AppImage
     - deb

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -18,7 +18,18 @@ import type { RuntimeConfigResult } from "../shared/runtime-config";
 // from the running window to the hicolor icon and falls back to the
 // theme default. Consumed in createWindow() (all platforms in dev, Linux
 // in prod) and the macOS dev dock branch.
-const BUNDLED_ICON_PATH = join(__dirname, "../../resources/icon.png");
+//
+// `asarUnpack: resources/**` in electron-builder.yml extracts the icon to
+// `app.asar.unpacked/`, but `__dirname` resolves into `app.asar/`. The
+// Linux native window-icon code path expects a real filesystem path
+// (unlike Electron's nativeImage loader which transparently reads from
+// asar), so swap the segment — same pattern as bundledCliPath() in
+// daemon-manager.ts. In dev `__dirname` has no `app.asar`, so the replace
+// is a no-op.
+const BUNDLED_ICON_PATH = join(__dirname, "../../resources/icon.png").replace(
+  "app.asar",
+  "app.asar.unpacked",
+);
 
 // macOS/Linux GUI launches inherit a minimal PATH from launchd that omits
 // the user's shell config (~/.zshrc, Homebrew, nvm, ~/.local/bin, etc.).

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,10 +11,14 @@ import { getAppVersion } from "./app-version";
 import { loadRuntimeConfig } from "./runtime-config-loader";
 import type { RuntimeConfigResult } from "../shared/runtime-config";
 
-// Bundled icon used for dev-mode dock/taskbar branding. In production the
-// app bundle icon (from electron-builder) wins; this path is only consumed
-// by the `is.dev` branch below.
-const DEV_ICON_PATH = join(__dirname, "../../resources/icon.png");
+// Bundled icon used for dock/taskbar branding. macOS/Windows production
+// builds let the OS pick up the icon from the .app bundle / .exe resources,
+// but Linux production needs an explicit BrowserWindow `icon` — AppImage
+// direct-launch doesn't register the .desktop entry, so GNOME has no path
+// from the running window to the hicolor icon and falls back to the
+// theme default. Consumed in createWindow() (all platforms in dev, Linux
+// in prod) and the macOS dev dock branch.
+const BUNDLED_ICON_PATH = join(__dirname, "../../resources/icon.png");
 
 // macOS/Linux GUI launches inherit a minimal PATH from launchd that omits
 // the user's shell config (~/.zshrc, Homebrew, nvm, ~/.local/bin, etc.).
@@ -106,9 +110,14 @@ function createWindow(): void {
     trafficLightPosition: { x: 16, y: 13 },
     show: false,
     autoHideMenuBar: true,
-    // Windows/Linux pick up the window/taskbar icon from this option in
-    // dev — on macOS it's ignored (dock comes from app.dock.setIcon below).
-    ...(is.dev ? { icon: DEV_ICON_PATH } : {}),
+    // Windows/Linux pick up the window/taskbar icon from this option.
+    // On macOS it's ignored (dock comes from app.dock.setIcon below).
+    // Linux production needs this explicitly because AppImage direct-launch
+    // does not install a .desktop entry, so the WM has no other path to
+    // the bundled icon; without it Ubuntu falls back to the theme default.
+    ...(is.dev || process.platform === "linux"
+      ? { icon: BUNDLED_ICON_PATH }
+      : {}),
     webPreferences: {
       preload: join(__dirname, "../preload/index.js"),
       sandbox: false,
@@ -251,7 +260,7 @@ if (!gotTheLock) {
     // so the Canary dev build is visually distinct from a stock Electron
     // run. `app.dock` is macOS-only — guard the call.
     if (is.dev && process.platform === "darwin" && app.dock) {
-      const icon = nativeImage.createFromPath(DEV_ICON_PATH);
+      const icon = nativeImage.createFromPath(BUNDLED_ICON_PATH);
       if (!icon.isEmpty()) app.dock.setIcon(icon);
     }
 


### PR DESCRIPTION
## Summary

Fixes the Ubuntu app icon regression by closing three gaps in the Linux build:

### 1. Scoped npm name leaked into Linux desktop identity

`electron-builder` defaults `executableName` to the package `name`. With `@multica/desktop` the slash is stripped but the `@` is kept, so the installed `.deb` shipped:

```
/usr/share/applications/@multicadesktop.desktop
Exec="/opt/Multica/@multicadesktop" %U
Icon=@multicadesktop
StartupWMClass=Multica
/usr/share/icons/hicolor/*/apps/@multicadesktop.png
```

The leading `@` violates the freedesktop desktop-entry naming guidance, so GNOME on Ubuntu fails to associate the running window with the `.desktop` entry and falls back to the theme default app icon.

The artifact-filename side of the same leak was already patched in 10618b1f via hardcoded `artifactName`; this PR closes the gap for the **desktop/icon identity** by forcing `executableName: multica`. Post-fix the deb ships:

```
/usr/share/applications/multica.desktop
Icon=multica
/usr/share/icons/hicolor/*/apps/multica.png
```

### 2. No runtime icon fallback for Linux production

`BrowserWindow({ icon })` was only set under `is.dev`. macOS/Windows production rely on the `.app` bundle / `.exe`-embedded icon, but Linux AppImage direct-launches never install a `.desktop` entry, so the WM has no other path to the bundled icon and falls back to the theme default. Now always set on Linux (and keep the existing dev behavior on every platform). Path is resolved against `app.asar.unpacked/` — `__dirname` joins into `app.asar/` but Electron's Linux window-icon code path expects a real filesystem path (same caveat handled by `bundledCliPath()` in `daemon-manager.ts`).

### 3. `StartupWMClass` pinned explicitly

`linux.desktop.entry.StartupWMClass: Multica` makes the contract visible in config. The default already resolves to `productName` (`Multica`), matching the WM_CLASS class that Electron emits from `app.getName()` — so this is a no-op at build time today, but turns any future drift (renaming `productName`, calling `app.setName()` at boot) into a diff against this file instead of a silent regression of the same icon-association bug.

## Test plan

CI covers typecheck/lint. The behavior change is packaging-level and only observable on a real Linux desktop, so it needs manual verification on the next release candidate.

**Deb contents (any Linux build host):**

- [ ] Repackage from this branch (`pnpm --filter @multica/desktop package` with Linux targets enabled)
- [ ] `dpkg -c multica-desktop-*-linux-*.deb | grep -E 'applications|icons/hicolor'` — every path uses `multica`, no `@multicadesktop` anywhere
- [ ] Extract and grep the generated `.desktop` — `Exec=/opt/Multica/multica`, `Icon=multica`, `StartupWMClass=Multica` (all three must agree)

**Ubuntu VM, clean 22.04 + 24.04 GNOME:**

- [ ] `sudo dpkg -i multica-desktop-*-linux-*.deb` → search Multica in Activities → launcher icon = Multica asterisk
- [ ] Launch app → taskbar / window switcher icon = Multica asterisk
- [ ] `xprop WM_CLASS` on the running Multica window — at least one of the two strings is `Multica` (must match the `StartupWMClass` in the `.desktop`, otherwise GNOME can't associate the window even with the rest of the fix)
- [ ] Run the AppImage directly (no AppImageLauncher integration, `chmod +x` and double-click) → window/taskbar icon = Multica asterisk (this is the path that depends on the `BrowserWindow.icon` change)

**Regression smoke:**

- [ ] macOS dmg and Windows nsis builds still show the Multica icon — this PR only widens the conditions under which `icon:` is set, never narrows them.

If the `xprop WM_CLASS` check in step 3 fails (class is `multica` not `Multica`), the fix is to add `--class=Multica` to the `Exec=` line via `linux.desktop.entry.Exec` override, but try the current config on real hardware first — Electron is documented to emit the capitalized form on X11.

Fixes the Ubuntu icon regression reported in https://github.com/multica-ai/multica/issues/2424.