### PR TITLE
fix(desktop): resolve Linux WM_CLASS and icon naming for scoped package

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -46,6 +46,14 @@ linux:
   # Yaru). Forcing `multica` makes every Linux identity slot agree and
   # matches `StartupWMClass=Multica` (productName-derived).
   executableName: multica
+  # Explicit icon path prevents electron-builder from deriving the icon name
+  # from the scoped npm package name (@multica/desktop → @multicadesktop),
+  # which would produce an Icon=@multicadesktop entry in the .desktop file
+  # and install icons under /usr/share/icons/hicolor/*/apps/@multicadesktop.png.
+  # The leading @ violates the freedesktop icon naming spec, causing GNOME/
+  # KDE/Deepin to fail resolving the icon. resources/icon.png is the same
+  # 1024x1024 PNG used by the BrowserWindow icon option in createWindow().
+  icon: resources/icon.png
   # Pin StartupWMClass explicitly to the WM_CLASS that Electron emits on
   # X11. Electron derives WM_CLASS from `app.getName()`, which in packaged
   # builds resolves to `productName` (`Multica`). Without an explicit

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -214,6 +214,17 @@ if (is.dev) {
   app.setPath("userData", join(app.getPath("appData"), DEV_APP_NAME));
 }
 
+// Linux production: set a clean app name so Electron emits "Multica" as
+// WM_CLASS instead of deriving it from the scoped npm package name
+// (@multica/desktop). WM_CLASS mismatch with the .desktop entry's
+// StartupWMClass prevents GNOME/KDE/Deepin from associating the running
+// window with the .desktop file, which breaks icon display and taskbar
+// pinning. macOS and dev builds are unaffected (macOS uses Info.plist,
+// dev already has app.setName above).
+if (!is.dev && process.platform === "linux") {
+  app.setName("Multica");
+}
+
 // --- Protocol registration -----------------------------------------------
 
 if (process.defaultApp) {


### PR DESCRIPTION
## Summary

Fixes the Linux desktop integration issue where the Multica Electron app
cannot be pinned to the taskbar and shows a fallback icon on GNOME/KDE/Deepin.

## Root Cause

The npm package is scoped (`@multica/desktop`). Electron derives `WM_CLASS`
from `app.getName()`, which resolves to the npm package name in production
— producing `WM_CLASS="@multica/desktop"`. GNOME Shell cannot match this to
the `.desktop` entry's `StartupWMClass=Multica`, so it falls back to the
theme default icon and prevents taskbar pinning.

Additionally, `electron-builder` derives icon filenames from the scoped
package name, producing `@multicadesktop.png` paths that violate the
freedesktop icon naming spec.

## Changes

### `apps/desktop/src/main/index.ts`

Added `app.setName("Multica")` on Linux production builds so Electron emits
a clean `WM_CLASS` that matches the `.desktop` entry. Guarded with
`!is.dev && process.platform === "linux"` — macOS uses `Info.plist` for
naming, and dev builds already override the name to `"Multica Canary"`.

### `apps/desktop/electron-builder.yml`

Added `icon: resources/icon.png` to the Linux target configuration so
`electron-builder` generates correct icon paths (`multica.png` instead of
`@multicadesktop.png`), consistent with the existing `executableName: multica`
override.

## Verification

- `xprop WM_CLASS` confirms: `Multica` (correct) instead of `@multica/desktop` (broken)
- App shows correct icon in dock and can be pinned to taskbar on Zorin OS 18.1 (Deepin)
- Dev builds and macOS/Windows are unaffected

Closes issue where packaged Linux builds showed generic gear icon and
could not be pinned to dash/taskbar.