### PR TITLE
fix(attachments): preserve original filename on /uploads/* downloads

### DIFF
--- a/server/internal/storage/local.go
+++ b/server/internal/storage/local.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,6 +16,18 @@ import (
 type LocalStorage struct {
 	uploadDir string
 	baseURL   string
+}
+
+// metaSuffix is the on-disk extension for the sidecar JSON file that
+// captures an upload's original filename and sniffed content type. The
+// sidecar exists so ServeFile can set Content-Disposition the way S3's
+// PutObject path already does, instead of letting the browser fall back
+// to the storage-key basename for the download filename.
+const metaSuffix = ".meta.json"
+
+type localMeta struct {
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
 }
 
 // NewLocalStorageFromEnv creates a LocalStorage from environment variables.
@@ -79,6 +92,9 @@ func (s *LocalStorage) Delete(ctx context.Context, key string) {
 			slog.Error("local storage Delete failed", "key", key, "error", err)
 		}
 	}
+	if err := os.Remove(filePath + metaSuffix); err != nil && !os.IsNotExist(err) {
+		slog.Error("local storage meta Delete failed", "key", key, "error", err)
+	}
 }
 
 func (s *LocalStorage) DeleteKeys(ctx context.Context, keys []string) {
@@ -95,6 +111,18 @@ func (s *LocalStorage) Upload(ctx context.Context, key string, data []byte, cont
 	if err := os.WriteFile(dest, data, 0644); err != nil {
 		return "", fmt.Errorf("local storage WriteFile: %w", err)
 	}
+	// Best-effort sidecar so ServeFile can restore the original filename in
+	// Content-Disposition. A failure here is logged but does not fail the
+	// upload — the file is still usable, just without the human-readable
+	// download name.
+	if filename != "" || contentType != "" {
+		body, err := json.Marshal(localMeta{Filename: filename, ContentType: contentType})
+		if err != nil {
+			slog.Error("local storage meta marshal failed", "key", key, "error", err)
+		} else if err := os.WriteFile(dest+metaSuffix, body, 0644); err != nil {
+			slog.Error("local storage meta write failed", "key", key, "error", err)
+		}
+	}
 
 	if s.baseURL != "" {
 		return fmt.Sprintf("%s/uploads/%s", s.baseURL, key), nil
@@ -110,9 +138,36 @@ func (s *LocalStorage) ServeFile(w http.ResponseWriter, r *http.Request, filenam
 	filePath := filepath.Join(s.uploadDir, filename)
 	slog.Info("serving file", "filename", filename, "filepath", filePath)
 
+	// Mirror the S3 Upload path: when sidecar metadata exists for this key,
+	// set Content-Disposition with the original uploaded filename. Without
+	// it, browsers download the file under the storage-key basename (the
+	// UUID + extension) instead of the human-readable name the uploader
+	// chose. Uploads from before the sidecar landed have no .meta.json on
+	// disk and fall through to the existing behavior.
+	if meta, ok := readLocalMeta(filePath); ok && meta.Filename != "" {
+		safe := sanitizeFilename(meta.Filename)
+		disposition := "attachment"
+		if isInlineContentType(meta.ContentType) {
+			disposition = "inline"
+		}
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`%s; filename="%s"`, disposition, safe))
+	}
+
 	// Use http.ServeFile which has built-in path traversal protection
 	// It sanitizes the path and prevents access outside the directory
 	http.ServeFile(w, r, filePath)
+}
+
+func readLocalMeta(filePath string) (localMeta, bool) {
+	body, err := os.ReadFile(filePath + metaSuffix)
+	if err != nil {
+		return localMeta{}, false
+	}
+	var meta localMeta
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return localMeta{}, false
+	}
+	return meta, true
 }
 
 func (s *LocalStorage) UploadFromReader(ctx context.Context, key string, reader io.Reader, contentType string, filename string) (string, error) {

--- a/server/internal/storage/local_test.go
+++ b/server/internal/storage/local_test.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -211,5 +213,124 @@ func TestLocalStorage_KeyFromURL_Empty(t *testing.T) {
 
 	if got := store.KeyFromURL(""); got != "" {
 		t.Errorf("KeyFromURL(\"\") = %q, want empty string", got)
+	}
+}
+
+// TestLocalStorage_ServeFile_ContentDispositionFromSidecar verifies the fix
+// for issue #2442: downloads served from /uploads/* must carry the original
+// uploaded filename in Content-Disposition, mirroring the S3 Upload path's
+// existing ContentDisposition behavior. Without this, browsers fall back to
+// the storage-key basename (UUID + ext) for the download filename.
+func TestLocalStorage_ServeFile_ContentDispositionFromSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("LOCAL_UPLOAD_DIR", tmpDir)
+
+	store := NewLocalStorageFromEnv()
+	if store == nil {
+		t.Fatal("NewLocalStorageFromEnv returned nil")
+	}
+
+	cases := []struct {
+		name        string
+		key         string
+		contentType string
+		filename    string
+		wantHeader  string
+	}{
+		{
+			name:        "attachment for non-inline type",
+			key:         "workspaces/ws-1/abc.xlsx",
+			contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+			filename:    "Bwave JE_V1.xlsx",
+			wantHeader:  `attachment; filename="Bwave JE_V1.xlsx"`,
+		},
+		{
+			name:        "inline for image",
+			key:         "workspaces/ws-1/def.png",
+			contentType: "image/png",
+			filename:    "screenshot 2026-05-11.png",
+			wantHeader:  `inline; filename="screenshot 2026-05-11.png"`,
+		},
+		{
+			name:        "filename with header-injection characters is sanitized",
+			key:         "workspaces/ws-1/ghi.txt",
+			contentType: "text/plain",
+			filename:    "weird\";name.txt",
+			wantHeader:  `attachment; filename="weird__name.txt"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if _, err := store.Upload(ctx, tc.key, []byte("body"), tc.contentType, tc.filename); err != nil {
+				t.Fatalf("Upload failed: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/uploads/"+tc.key, nil)
+			rec := httptest.NewRecorder()
+			store.ServeFile(rec, req, tc.key)
+
+			got := rec.Header().Get("Content-Disposition")
+			if got != tc.wantHeader {
+				t.Errorf("Content-Disposition = %q, want %q", got, tc.wantHeader)
+			}
+		})
+	}
+}
+
+// TestLocalStorage_ServeFile_NoSidecarFallback documents the graceful
+// degradation path: files uploaded before the sidecar landed (or written
+// out-of-band) have no .meta.json on disk and ServeFile must not set
+// Content-Disposition — leaving the existing pre-fix behavior intact.
+func TestLocalStorage_ServeFile_NoSidecarFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("LOCAL_UPLOAD_DIR", tmpDir)
+
+	store := NewLocalStorageFromEnv()
+	if store == nil {
+		t.Fatal("NewLocalStorageFromEnv returned nil")
+	}
+
+	key := "legacy-no-sidecar.txt"
+	if err := os.WriteFile(filepath.Join(tmpDir, key), []byte("body"), 0644); err != nil {
+		t.Fatalf("seed write failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/uploads/"+key, nil)
+	rec := httptest.NewRecorder()
+	store.ServeFile(rec, req, key)
+
+	if got := rec.Header().Get("Content-Disposition"); got != "" {
+		t.Errorf("Content-Disposition = %q, want empty (no sidecar fallback)", got)
+	}
+}
+
+// TestLocalStorage_Delete_RemovesSidecar verifies the cleanup half of the
+// fix: when the upload is deleted, its sidecar metadata file disappears too.
+// Otherwise the upload directory grows orphan .meta.json files forever.
+func TestLocalStorage_Delete_RemovesSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("LOCAL_UPLOAD_DIR", tmpDir)
+
+	store := NewLocalStorageFromEnv()
+	if store == nil {
+		t.Fatal("NewLocalStorageFromEnv returned nil")
+	}
+
+	ctx := context.Background()
+	key := "deleteme.txt"
+	if _, err := store.Upload(ctx, key, []byte("body"), "text/plain", "original.txt"); err != nil {
+		t.Fatalf("Upload failed: %v", err)
+	}
+	sidecar := filepath.Join(tmpDir, key+metaSuffix)
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("sidecar should exist after Upload: %v", err)
+	}
+
+	store.Delete(ctx, key)
+
+	if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+		t.Errorf("sidecar should be removed after Delete, got err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #2442. Local-storage attachment downloads were saving under the storage-key basename (`019e1823-6080-70fe-98-3339f4a29679.xlsx`) instead of the original uploaded filename (`Bwave JE_V1.xlsx`) because `LocalStorage.ServeFile` delegated to `http.ServeFile` without ever setting `Content-Disposition`.

The S3 backend already captures filename + content-type at upload time via `PutObject.ContentDisposition` (`s3.go:186-187`), so this was a sibling asymmetry rather than a missing feature decision — the inline/attachment policy already lives in `sanitizeFilename` and `isInlineContentType`.

## What changed

- `LocalStorage.Upload` writes a sidecar `<key>.meta.json` beside the data file containing `{filename, content_type}`. Best-effort: a write failure is logged but does not fail the upload.
- `LocalStorage.ServeFile` reads the sidecar when present and sets `Content-Disposition: <disposition>; filename="<safe>"` using the same `sanitizeFilename` and `isInlineContentType` helpers the S3 path uses. Inline for images / video / audio / PDF, attachment for everything else.
- `LocalStorage.Delete` removes the sidecar alongside the data file so the upload directory doesn't grow orphans.
- Pre-existing uploads (no sidecar on disk) fall through to the previous behavior — no migration, no version pin.

## Test plan

- [x] `go test ./internal/storage/...` — three new tests cover attachment-vs-inline disposition, header-injection sanitization, the no-sidecar fallback, and sidecar cleanup on Delete. All eleven storage tests pass.
- [x] `go vet ./internal/storage/...` clean.
- [x] `go build ./...` clean.
- [ ] Manual on self-host: upload a file named `Bwave JE_V1.xlsx`, click the download from the issue page, verify the saved filename matches the upload name and not the storage-key UUID.