### PR TITLE
feat: in-app file preview (HTML, PDF, Office, Markdown) MUL-2060

### DIFF
--- a/docs/plans/2026-05-12-file-preview.md
+++ b/docs/plans/2026-05-12-file-preview.md
@@ -1,0 +1,996 @@
+# File Preview Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an "eye" preview action to file attachments in the editor (and read-only view), opening an in-app preview modal that renders HTML / Markdown / PDF / images / video / audio / CSV / XLSX / DOCX without leaving the app.
+
+**Architecture:** A new `packages/views/file-preview/` sub-module (NOT a separate workspace package) exports `<FilePreviewModal />` and a registry that maps file extension → renderer component. Heavy renderers (`xlsx-renderer`, `docx-renderer`) use `React.lazy` so they only load when needed. The existing `FileCard` Tiptap NodeView gains an Eye button next to the Download button that opens the modal. Image previews keep the existing lightbox.
+
+**Tech Stack:**
+- `xlsx` (SheetJS Community, MIT) → HTML table for `.xlsx` / `.xls`
+- `papaparse` (MIT) → table for `.csv`
+- `docx-preview` (Apache-2.0) → DOCX rendering
+- Native `<iframe>` for PDF (Chromium has built-in PDF viewer in Electron and all modern browsers — no PDF.js bundle needed for MVP)
+- Sandboxed `<iframe srcdoc>` for HTML
+- Existing `<Markdown>` from `@multica/views/common/markdown` for `.md`/`.mdx`
+- Existing shadcn `<Dialog>` from `@multica/ui` for the modal shell
+- `.pptx`, legacy `.doc`/`.xls`/`.ppt` are intentionally **out of scope** — show "unsupported, please download" placeholder
+
+---
+
+## Task 0: Add new deps to pnpm catalog
+
+**Files:**
+- Modify: `pnpm-workspace.yaml`
+- Modify: `packages/views/package.json`
+
+**Step 1: Add catalog entries**
+
+Append under existing groups in `pnpm-workspace.yaml` `catalog:`:
+
+```yaml
+  # File preview renderers
+  xlsx: "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+  papaparse: "^5.4.1"
+  "@types/papaparse": "^5.3.14"
+  docx-preview: "^0.3.5"
+```
+
+> Note: SheetJS Community is published off-npm; the tarball URL above is the canonical source per their docs. If install fails, fall back to `"xlsx": "^0.18.5"` from npm (older but functional).
+
+**Step 2: Reference catalog from `packages/views/package.json`**
+
+Add to `dependencies`:
+
+```json
+"xlsx": "catalog:",
+"papaparse": "catalog:",
+"docx-preview": "catalog:"
+```
+
+Add to `devDependencies`:
+
+```json
+"@types/papaparse": "catalog:"
+```
+
+**Step 3: Install**
+
+Run: `pnpm install`
+Expected: lockfile updates, no errors.
+
+**Step 4: Commit**
+
+```bash
+git add pnpm-workspace.yaml packages/views/package.json pnpm-lock.yaml
+git commit -m "chore(deps): add xlsx, papaparse, docx-preview for file preview"
+```
+
+---
+
+## Task 1: Add `./file-preview` package export
+
+**Files:**
+- Modify: `packages/views/package.json` (`exports` block)
+- Create: `packages/views/file-preview/index.ts`
+
+**Step 1: Add export entry**
+
+In `packages/views/package.json`, add to `exports`:
+
+```json
+"./file-preview": "./file-preview/index.ts",
+```
+
+**Step 2: Create empty index**
+
+```ts
+// packages/views/file-preview/index.ts
+export { FilePreviewModal } from "./file-preview-modal";
+export { FilePreview } from "./file-preview";
+export { getRendererKey, type RendererKey } from "./get-renderer";
+```
+
+(File contents will exist after later tasks; we add the index now to lock in the public surface.)
+
+**Step 3: Commit**
+
+```bash
+git add packages/views/package.json packages/views/file-preview/index.ts
+git commit -m "feat(views): scaffold file-preview module export"
+```
+
+---
+
+## Task 2: Renderer routing logic + tests
+
+**Files:**
+- Create: `packages/views/file-preview/get-renderer.ts`
+- Create: `packages/views/file-preview/get-renderer.test.ts`
+
+**Step 1: Write failing test**
+
+```ts
+// packages/views/file-preview/get-renderer.test.ts
+import { describe, it, expect } from "vitest";
+import { getRendererKey } from "./get-renderer";
+
+describe("getRendererKey", () => {
+  it.each([
+    ["foo.html", "html"],
+    ["a/b/c.HTM", "html"],
+    ["readme.md", "markdown"],
+    ["readme.MDX", "markdown"],
+    ["plan.txt", "text"],
+    ["main.ts", "text"],
+    ["file.pdf", "pdf"],
+    ["pic.png", "image"],
+    ["pic.JPG", "image"],
+    ["movie.mp4", "video"],
+    ["sound.mp3", "audio"],
+    ["data.csv", "csv"],
+    ["sheet.xlsx", "xlsx"],
+    ["legacy.xls", "xlsx"],
+    ["doc.docx", "docx"],
+    ["weird.bin", "unsupported"],
+    ["", "unsupported"],
+  ])("maps %s → %s", (filename, expected) => {
+    expect(getRendererKey(filename)).toBe(expected);
+  });
+});
+```
+
+Run: `pnpm --filter @multica/views exec vitest run file-preview/get-renderer.test.ts`
+Expected: FAIL — module does not exist.
+
+**Step 2: Implement**
+
+```ts
+// packages/views/file-preview/get-renderer.ts
+export type RendererKey =
+  | "html"
+  | "markdown"
+  | "text"
+  | "pdf"
+  | "image"
+  | "video"
+  | "audio"
+  | "csv"
+  | "xlsx"
+  | "docx"
+  | "unsupported";
+
+const EXT_MAP: Record<string, RendererKey> = {
+  html: "html",
+  htm: "html",
+  md: "markdown",
+  mdx: "markdown",
+  markdown: "markdown",
+  txt: "text",
+  log: "text",
+  json: "text",
+  yaml: "text",
+  yml: "text",
+  ts: "text",
+  tsx: "text",
+  js: "text",
+  jsx: "text",
+  py: "text",
+  go: "text",
+  pdf: "pdf",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
+  svg: "image",
+  bmp: "image",
+  mp4: "video",
+  webm: "video",
+  mov: "video",
+  mp3: "audio",
+  wav: "audio",
+  ogg: "audio",
+  csv: "csv",
+  xlsx: "xlsx",
+  xls: "xlsx",
+  docx: "docx",
+};
+
+export function getRendererKey(filename: string): RendererKey {
+  if (!filename) return "unsupported";
+  const dot = filename.lastIndexOf(".");
+  if (dot < 0) return "unsupported";
+  const ext = filename.slice(dot + 1).toLowerCase();
+  return EXT_MAP[ext] ?? "unsupported";
+}
+```
+
+**Step 3: Run tests**
+
+Run: `pnpm --filter @multica/views exec vitest run file-preview/get-renderer.test.ts`
+Expected: PASS (17 cases).
+
+**Step 4: Commit**
+
+```bash
+git add packages/views/file-preview/get-renderer.ts packages/views/file-preview/get-renderer.test.ts
+git commit -m "feat(file-preview): add extension → renderer routing"
+```
+
+---
+
+## Task 3: Lightweight renderers (image, video, audio, text, pdf, html, markdown, unsupported)
+
+**Files:**
+- Create: `packages/views/file-preview/renderers/image-renderer.tsx`
+- Create: `packages/views/file-preview/renderers/media-renderer.tsx`
+- Create: `packages/views/file-preview/renderers/text-renderer.tsx`
+- Create: `packages/views/file-preview/renderers/pdf-renderer.tsx`
+- Create: `packages/views/file-preview/renderers/html-renderer.tsx`
+- Create: `packages/views/file-preview/renderers/markdown-renderer.tsx`
+- Create: `packages/views/file-preview/renderers/unsupported-renderer.tsx`
+
+Each renderer accepts the same props:
+
+```ts
+interface RendererProps {
+  url: string;       // signed download URL
+  filename: string;
+}
+```
+
+**Step 1: image-renderer.tsx**
+
+```tsx
+"use client";
+import type { RendererProps } from "../types";
+
+export function ImageRenderer({ url, filename }: RendererProps) {
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-muted/20 p-4">
+      <img
+        src={url}
+        alt={filename}
+        className="max-h-full max-w-full object-contain"
+      />
+    </div>
+  );
+}
+```
+
+**Step 2: media-renderer.tsx**
+
+```tsx
+"use client";
+import { useMemo } from "react";
+import type { RendererProps } from "../types";
+import { getRendererKey } from "../get-renderer";
+
+export function MediaRenderer({ url, filename }: RendererProps) {
+  const kind = useMemo(() => getRendererKey(filename), [filename]);
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-black p-4">
+      {kind === "video" ? (
+        <video src={url} controls className="max-h-full max-w-full" />
+      ) : (
+        <audio src={url} controls className="w-full max-w-md" />
+      )}
+    </div>
+  );
+}
+```
+
+**Step 3: text-renderer.tsx**
+
+Fetches the file as text and shows it in a `<pre>`. Caps at 1 MB to avoid pasting a 50MB log into the DOM.
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+const MAX_BYTES = 1_000_000;
+
+export function TextRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [state, setState] = useState<
+    | { kind: "loading" }
+    | { kind: "ready"; text: string; truncated: boolean }
+    | { kind: "error" }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(String(res.status));
+        const blob = await res.blob();
+        const truncated = blob.size > MAX_BYTES;
+        const slice = truncated ? blob.slice(0, MAX_BYTES) : blob;
+        return { text: await slice.text(), truncated };
+      })
+      .then((out) => { if (!cancelled) setState({ kind: "ready", ...out }); })
+      .catch(() => { if (!cancelled) setState({ kind: "error" }); });
+    return () => { cancelled = true; };
+  }, [url]);
+
+  if (state.kind === "loading") return <div className="p-4 text-sm text-muted-foreground">{t(($) => $.file_preview.loading)}</div>;
+  if (state.kind === "error") return <div className="p-4 text-sm text-destructive">{t(($) => $.file_preview.load_failed)}</div>;
+  return (
+    <pre className="h-full w-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed">
+      {state.text}
+      {state.truncated ? `\n\n--- ${t(($) => $.file_preview.truncated)} ---` : ""}
+    </pre>
+  );
+}
+```
+
+**Step 4: pdf-renderer.tsx**
+
+Browser-native PDF viewer (Chromium has it built in; Electron inherits it). No PDF.js bundle.
+
+```tsx
+"use client";
+import type { RendererProps } from "../types";
+
+export function PdfRenderer({ url, filename }: RendererProps) {
+  return (
+    <iframe
+      src={url}
+      title={filename}
+      className="h-full w-full border-0"
+    />
+  );
+}
+```
+
+**Step 5: html-renderer.tsx**
+
+Sandbox iframe with `srcdoc`. Default sandbox = no scripts, no top navigation, no forms — safe for arbitrary HTML.
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+export function HtmlRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [state, setState] = useState<
+    | { kind: "loading" }
+    | { kind: "ready"; html: string }
+    | { kind: "error" }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) throw new Error(String(res.status));
+        return res.text();
+      })
+      .then((html) => { if (!cancelled) setState({ kind: "ready", html }); })
+      .catch(() => { if (!cancelled) setState({ kind: "error" }); });
+    return () => { cancelled = true; };
+  }, [url]);
+
+  if (state.kind === "loading") return <div className="p-4 text-sm text-muted-foreground">{t(($) => $.file_preview.loading)}</div>;
+  if (state.kind === "error") return <div className="p-4 text-sm text-destructive">{t(($) => $.file_preview.load_failed)}</div>;
+
+  return (
+    <iframe
+      sandbox=""
+      srcDoc={state.html}
+      className="h-full w-full border-0 bg-white"
+    />
+  );
+}
+```
+
+**Step 6: markdown-renderer.tsx**
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { Markdown } from "../../common/markdown";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+export function MarkdownRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [state, setState] = useState<
+    | { kind: "loading" }
+    | { kind: "ready"; text: string }
+    | { kind: "error" }
+  >({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) => res.ok ? res.text() : Promise.reject(res.status))
+      .then((text) => { if (!cancelled) setState({ kind: "ready", text }); })
+      .catch(() => { if (!cancelled) setState({ kind: "error" }); });
+    return () => { cancelled = true; };
+  }, [url]);
+
+  if (state.kind === "loading") return <div className="p-4 text-sm text-muted-foreground">{t(($) => $.file_preview.loading)}</div>;
+  if (state.kind === "error") return <div className="p-4 text-sm text-destructive">{t(($) => $.file_preview.load_failed)}</div>;
+  return (
+    <div className="h-full w-full overflow-auto p-6">
+      <Markdown mode="full">{state.text}</Markdown>
+    </div>
+  );
+}
+```
+
+**Step 7: unsupported-renderer.tsx**
+
+```tsx
+"use client";
+import { Download, FileQuestion } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+import { useT } from "../../i18n";
+import { useAttachmentDownloadResolver } from "../../editor/attachment-download-context";
+import type { RendererProps } from "../types";
+
+export function UnsupportedRenderer({ url, filename }: RendererProps) {
+  const { t } = useT("editor");
+  const { openByUrl } = useAttachmentDownloadResolver();
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center">
+      <FileQuestion className="size-12 text-muted-foreground" />
+      <div className="text-sm text-muted-foreground">
+        {t(($) => $.file_preview.unsupported, { filename })}
+      </div>
+      <Button variant="outline" size="sm" onClick={() => openByUrl(url)}>
+        <Download className="mr-1 size-4" />
+        {t(($) => $.file_preview.download)}
+      </Button>
+    </div>
+  );
+}
+```
+
+**Step 8: Shared types file**
+
+```ts
+// packages/views/file-preview/types.ts
+export interface RendererProps {
+  url: string;
+  filename: string;
+}
+```
+
+**Step 9: Commit**
+
+```bash
+git add packages/views/file-preview/types.ts packages/views/file-preview/renderers
+git commit -m "feat(file-preview): add lightweight renderers (image, media, text, pdf, html, markdown, unsupported)"
+```
+
+---
+
+## Task 4: Heavy renderers (csv, xlsx, docx) — lazy loaded
+
+**Files:**
+- Create: `packages/views/file-preview/renderers/csv-renderer.tsx`
+- Create: `packages/views/file-preview/renderers/xlsx-renderer.tsx`
+- Create: `packages/views/file-preview/renderers/docx-renderer.tsx`
+
+**Step 1: csv-renderer.tsx**
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import Papa from "papaparse";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+export function CsvRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [rows, setRows] = useState<string[][] | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) => res.ok ? res.text() : Promise.reject(res.status))
+      .then((text) => Papa.parse<string[]>(text, { skipEmptyLines: true }))
+      .then((result) => { if (!cancelled) setRows(result.data); })
+      .catch(() => { if (!cancelled) setError(true); });
+    return () => { cancelled = true; };
+  }, [url]);
+
+  if (error) return <div className="p-4 text-sm text-destructive">{t(($) => $.file_preview.load_failed)}</div>;
+  if (!rows) return <div className="p-4 text-sm text-muted-foreground">{t(($) => $.file_preview.loading)}</div>;
+
+  return (
+    <div className="h-full w-full overflow-auto">
+      <table className="w-full border-collapse text-sm">
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className={i === 0 ? "bg-muted font-medium" : "hover:bg-muted/40"}>
+              {row.map((cell, j) => (
+                <td key={j} className="border border-border px-2 py-1">{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+**Step 2: xlsx-renderer.tsx**
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import * as XLSX from "xlsx";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+interface Sheet { name: string; html: string }
+
+export function XlsxRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [sheets, setSheets] = useState<Sheet[] | null>(null);
+  const [active, setActive] = useState(0);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) => res.ok ? res.arrayBuffer() : Promise.reject(res.status))
+      .then((buf) => {
+        const wb = XLSX.read(buf, { type: "array" });
+        const out: Sheet[] = wb.SheetNames.map((name) => ({
+          name,
+          html: XLSX.utils.sheet_to_html(wb.Sheets[name]!, { editable: false }),
+        }));
+        if (!cancelled) setSheets(out);
+      })
+      .catch(() => { if (!cancelled) setError(true); });
+    return () => { cancelled = true; };
+  }, [url]);
+
+  if (error) return <div className="p-4 text-sm text-destructive">{t(($) => $.file_preview.load_failed)}</div>;
+  if (!sheets) return <div className="p-4 text-sm text-muted-foreground">{t(($) => $.file_preview.loading)}</div>;
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      {sheets.length > 1 && (
+        <div className="flex shrink-0 items-center gap-1 border-b px-2 py-1 text-xs">
+          {sheets.map((s, i) => (
+            <button
+              key={s.name}
+              type="button"
+              onClick={() => setActive(i)}
+              className={i === active
+                ? "rounded bg-primary px-2 py-1 text-primary-foreground"
+                : "rounded px-2 py-1 hover:bg-muted"}
+            >
+              {s.name}
+            </button>
+          ))}
+        </div>
+      )}
+      <div
+        className="xlsx-preview flex-1 overflow-auto p-2 text-sm [&_table]:border-collapse [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1"
+        // sheet_to_html output is library-controlled, no user JS injection;
+        // sheet_to_html does NOT execute scripts (it strips them).
+        dangerouslySetInnerHTML={{ __html: sheets[active]!.html }}
+      />
+    </div>
+  );
+}
+```
+
+**Step 3: docx-renderer.tsx**
+
+```tsx
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { renderAsync } from "docx-preview";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+export function DocxRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    const container = containerRef.current;
+    if (!container) return;
+    fetch(url)
+      .then((res) => res.ok ? res.blob() : Promise.reject(res.status))
+      .then((blob) => renderAsync(blob, container, undefined, {
+        className: "docx-preview",
+        inWrapper: true,
+      }))
+      .then(() => { if (!cancelled) setState("ready"); })
+      .catch(() => { if (!cancelled) setState("error"); });
+    return () => { cancelled = true; };
+  }, [url]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-muted/20 p-4">
+      {state === "loading" && <div className="text-sm text-muted-foreground">{t(($) => $.file_preview.loading)}</div>}
+      {state === "error" && <div className="text-sm text-destructive">{t(($) => $.file_preview.load_failed)}</div>}
+      <div ref={containerRef} />
+    </div>
+  );
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/views/file-preview/renderers
+git commit -m "feat(file-preview): add csv, xlsx (SheetJS), docx (docx-preview) renderers"
+```
+
+---
+
+## Task 5: Top-level `<FilePreview />` router with lazy loading
+
+**Files:**
+- Create: `packages/views/file-preview/file-preview.tsx`
+
+**Step 1: Implement**
+
+```tsx
+"use client";
+import { lazy, Suspense, useMemo } from "react";
+import { useT } from "../i18n";
+import { getRendererKey } from "./get-renderer";
+import { ImageRenderer } from "./renderers/image-renderer";
+import { MediaRenderer } from "./renderers/media-renderer";
+import { TextRenderer } from "./renderers/text-renderer";
+import { PdfRenderer } from "./renderers/pdf-renderer";
+import { HtmlRenderer } from "./renderers/html-renderer";
+import { MarkdownRenderer } from "./renderers/markdown-renderer";
+import { UnsupportedRenderer } from "./renderers/unsupported-renderer";
+import type { RendererProps } from "./types";
+
+// Heavy renderers are split-loaded so a workspace that never previews an
+// xlsx/docx never pays for SheetJS / docx-preview at boot.
+const CsvRenderer = lazy(() => import("./renderers/csv-renderer").then((m) => ({ default: m.CsvRenderer })));
+const XlsxRenderer = lazy(() => import("./renderers/xlsx-renderer").then((m) => ({ default: m.XlsxRenderer })));
+const DocxRenderer = lazy(() => import("./renderers/docx-renderer").then((m) => ({ default: m.DocxRenderer })));
+
+export function FilePreview({ url, filename }: RendererProps) {
+  const { t } = useT("editor");
+  const key = useMemo(() => getRendererKey(filename), [filename]);
+
+  const fallback = <div className="p-4 text-sm text-muted-foreground">{t(($) => $.file_preview.loading)}</div>;
+
+  switch (key) {
+    case "image":      return <ImageRenderer url={url} filename={filename} />;
+    case "video":
+    case "audio":      return <MediaRenderer url={url} filename={filename} />;
+    case "text":       return <TextRenderer url={url} filename={filename} />;
+    case "pdf":        return <PdfRenderer url={url} filename={filename} />;
+    case "html":       return <HtmlRenderer url={url} filename={filename} />;
+    case "markdown":   return <MarkdownRenderer url={url} filename={filename} />;
+    case "csv":        return <Suspense fallback={fallback}><CsvRenderer url={url} filename={filename} /></Suspense>;
+    case "xlsx":       return <Suspense fallback={fallback}><XlsxRenderer url={url} filename={filename} /></Suspense>;
+    case "docx":       return <Suspense fallback={fallback}><DocxRenderer url={url} filename={filename} /></Suspense>;
+    default:           return <UnsupportedRenderer url={url} filename={filename} />;
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/views/file-preview/file-preview.tsx
+git commit -m "feat(file-preview): top-level router with lazy heavy renderers"
+```
+
+---
+
+## Task 6: `<FilePreviewModal />` shell
+
+**Files:**
+- Create: `packages/views/file-preview/file-preview-modal.tsx`
+
+**Step 1: Implement**
+
+```tsx
+"use client";
+import { Download } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@multica/ui/components/ui/dialog";
+import { Button } from "@multica/ui/components/ui/button";
+import { useT } from "../i18n";
+import { useAttachmentDownloadResolver } from "../editor/attachment-download-context";
+import { FilePreview } from "./file-preview";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  url: string;
+  filename: string;
+}
+
+export function FilePreviewModal({ open, onOpenChange, url, filename }: Props) {
+  const { t } = useT("editor");
+  const { openByUrl } = useAttachmentDownloadResolver();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[85vh] w-[90vw] max-w-[1100px] flex-col gap-0 p-0">
+        <DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-2 border-b px-4 py-2">
+          <DialogTitle className="truncate text-sm font-medium">{filename}</DialogTitle>
+          <Button variant="ghost" size="sm" onClick={() => openByUrl(url)}>
+            <Download className="mr-1 size-4" />
+            {t(($) => $.file_preview.download)}
+          </Button>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <FilePreview url={url} filename={filename} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/views/file-preview/file-preview-modal.tsx
+git commit -m "feat(file-preview): add modal shell with download action"
+```
+
+---
+
+## Task 7: i18n strings
+
+**Files:**
+- Modify: `packages/views/locales/en/editor.json`
+- Modify: `packages/views/locales/zh-Hans/editor.json`
+
+**Step 1: Read existing structure**
+
+Open `packages/views/locales/en/editor.json` and find the top-level keys (likely `image`, `attachment`, `file_card`). Add a new `file_preview` block:
+
+```json
+"file_preview": {
+  "loading": "Loading preview…",
+  "load_failed": "Failed to load file",
+  "truncated": "file truncated for preview",
+  "unsupported": "No preview available for {{filename}}",
+  "download": "Download",
+  "preview": "Preview"
+}
+```
+
+Add to `file_card`:
+
+```json
+"preview": "Preview"
+```
+
+**Step 2: Mirror into zh-Hans**
+
+```json
+"file_preview": {
+  "loading": "加载预览中…",
+  "load_failed": "无法加载文件",
+  "truncated": "文件过大，已截断预览",
+  "unsupported": "{{filename}} 暂不支持预览",
+  "download": "下载",
+  "preview": "预览"
+},
+```
+
+And in `file_card`: `"preview": "预览"`.
+
+**Step 3: Verify**
+
+Run: `pnpm --filter @multica/views typecheck`
+Expected: PASS (i18n string keys reference the typed `useT` selector — typecheck enforces existence).
+
+**Step 4: Commit**
+
+```bash
+git add packages/views/locales/en/editor.json packages/views/locales/zh-Hans/editor.json
+git commit -m "feat(i18n): add file_preview strings (en + zh)"
+```
+
+---
+
+## Task 8: Wire Eye button into `FileCard`
+
+**Files:**
+- Modify: `packages/views/editor/extensions/file-card.tsx`
+
+**Step 1: Add Eye import + state**
+
+In `FileCardView` (currently lines 33-75):
+
+```tsx
+import { FileText, Loader2, Download, Eye } from "lucide-react";
+import { useState } from "react";
+import { FilePreviewModal } from "../../file-preview/file-preview-modal";
+import { getRendererKey } from "../../file-preview/get-renderer";
+```
+
+**Step 2: Add preview button**
+
+Inside the `<div className="my-1 ...">` block, BEFORE the existing Download button, add:
+
+```tsx
+{!uploading && href && getRendererKey(filename) !== "unsupported" && (
+  <button
+    type="button"
+    className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+    title={t(($) => $.file_card.preview)}
+    onMouseDown={(e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setPreviewOpen(true);
+    }}
+  >
+    <Eye className="size-3.5" />
+  </button>
+)}
+```
+
+**Step 3: Add modal render and state hook**
+
+At the top of `FileCardView`:
+
+```tsx
+const [previewOpen, setPreviewOpen] = useState(false);
+```
+
+At the bottom of the returned JSX (after `</div>`, inside `<NodeViewWrapper>`):
+
+```tsx
+{previewOpen && (
+  <FilePreviewModal
+    open={previewOpen}
+    onOpenChange={setPreviewOpen}
+    url={href}
+    filename={filename}
+  />
+)}
+```
+
+**Step 4: Typecheck**
+
+Run: `pnpm --filter @multica/views typecheck`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add packages/views/editor/extensions/file-card.tsx
+git commit -m "feat(editor): add eye preview button on FileCard"
+```
+
+---
+
+## Task 9: Integration test — eye button + modal mount
+
+**Files:**
+- Create: `packages/views/file-preview/file-preview.test.tsx`
+
+**Step 1: Write test**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FilePreview } from "./file-preview";
+
+// jsdom doesn't implement fetch — stub with a static body that the
+// renderer's useEffect will resolve.
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response("hello"))));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("FilePreview routing", () => {
+  it("renders unsupported placeholder for unknown extension", () => {
+    render(<FilePreview url="http://x/y.bin" filename="y.bin" />);
+    expect(screen.getByText(/no preview available/i)).toBeInTheDocument();
+  });
+
+  it("renders <img> for image files", () => {
+    render(<FilePreview url="http://x/y.png" filename="y.png" />);
+    expect(screen.getByRole("img")).toHaveAttribute("src", "http://x/y.png");
+  });
+
+  it("renders <iframe> for pdf files", () => {
+    const { container } = render(<FilePreview url="http://x/y.pdf" filename="y.pdf" />);
+    expect(container.querySelector("iframe")).toHaveAttribute("src", "http://x/y.pdf");
+  });
+});
+```
+
+**Step 2: Run**
+
+Run: `pnpm --filter @multica/views exec vitest run file-preview/file-preview.test.tsx`
+Expected: 3 PASS.
+
+**Step 3: Commit**
+
+```bash
+git add packages/views/file-preview/file-preview.test.tsx
+git commit -m "test(file-preview): smoke tests for routing"
+```
+
+---
+
+## Task 10: Full verification
+
+**Step 1: Run typecheck across the workspace**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+**Step 2: Run unit tests**
+
+Run: `pnpm test`
+Expected: PASS (existing tests + 4 new tests in file-preview).
+
+**Step 3: Run lint**
+
+Run: `pnpm lint`
+Expected: PASS.
+
+**Step 4: If anything fails, fix and re-run. No commit until green.**
+
+---
+
+## Task 11: Open PR
+
+**Step 1: Push branch**
+
+```bash
+git push -u origin agent/n-y/<branch-suffix>
+```
+
+**Step 2: Create PR**
+
+```bash
+gh pr create --title "feat: in-app file preview (HTML, PDF, Office, Markdown)" --body "$(cat <<'EOF'
+## Summary
+- Add `<FilePreviewModal />` opened by an Eye icon on FileCard attachments
+- Renderers: image, video, audio, text, PDF (native iframe), HTML (sandbox iframe), Markdown, CSV (papaparse), XLSX (SheetJS), DOCX (docx-preview)
+- `.pptx`, legacy `.doc/.xls/.ppt` and unknown extensions show an "unsupported, please download" placeholder
+- Heavy renderers (CSV/XLSX/DOCX) are `React.lazy`-loaded — no boot-time cost for users who never preview them
+
+Closes MUL-2060.
+
+## Test plan
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm test` passes (4 new tests in `packages/views/file-preview/`)
+- [ ] In dev, attach a `.png`, `.pdf`, `.html`, `.md`, `.csv`, `.xlsx`, `.docx`, and `.pptx` file to an issue/comment; verify Eye icon appears on supported types and modal renders correctly
+- [ ] Verify `.pptx` shows the unsupported placeholder with a working Download button
+EOF
+)"
+```
+
+**Step 3: Comment the PR URL back on MUL-2060.**
+
+---
+
+## Out of Scope (deliberately)
+
+- **PPTX rendering** — `pptx-preview` quality is unreliable; defer until a user actually requests
+- **Server-side conversion (Gotenberg / LibreOffice)** — adds infra; defer until legacy `.doc/.xls/.ppt` shows up in real usage
+- **In-editor split-pane preview** — for now, preview is a modal only; if HTML/Markdown editor wants split mode, that's a follow-up
+- **Univer-based rich Excel editing** — too heavy (multi-MB) for a read-only preview

--- a/packages/views/editor/attachment-download-context.tsx
+++ b/packages/views/editor/attachment-download-context.tsx
@@ -9,6 +9,9 @@ interface ResolvedDownload {
   // Returns the attachment id for a URL referenced in the markdown, or
   // `undefined` if it's an external link we don't manage.
   resolveAttachmentId: (url: string) => string | undefined;
+  // Returns the full attachment record for a URL, used by preview to read
+  // size_bytes for the per-kind size cap.
+  resolveAttachment: (url: string) => Attachment | undefined;
   // Called by NodeView click handlers. Re-signs through `getAttachment` when
   // the URL maps to a known attachment; falls back to `openExternal` for
   // external URLs so Electron still routes through the IPC bridge instead of
@@ -35,6 +38,10 @@ export function AttachmentDownloadProvider({ attachments, children }: ProviderPr
       resolveAttachmentId: (url) => {
         if (!url || !attachments?.length) return undefined;
         return attachments.find((a) => a.url === url)?.id;
+      },
+      resolveAttachment: (url) => {
+        if (!url || !attachments?.length) return undefined;
+        return attachments.find((a) => a.url === url);
       },
       openByUrl: (url) => {
         const id = url && attachments?.length
@@ -67,11 +74,16 @@ export function useAttachmentDownloadResolver(): ResolvedDownload {
   // Hooks-must-be-unconditional: always create the fallback object, but
   // memoization is unnecessary here because each NodeView render also
   // re-runs the click handler closure.
-  if (ctx) return ctx;
-  return {
-    resolveAttachmentId: () => undefined,
-    openByUrl: (url) => {
-      if (url) openExternal(url);
-    },
-  };
+  return ctx ?? FALLBACK_RESOLVER;
 }
+
+// Module-scope so consumers that depend on the resolver in `useEffect`
+// don't re-fire on every render when no provider is mounted (would
+// otherwise create an infinite loop on any setState inside the effect).
+const FALLBACK_RESOLVER: ResolvedDownload = {
+  resolveAttachmentId: () => undefined,
+  resolveAttachment: () => undefined,
+  openByUrl: (url) => {
+    if (url) openExternal(url);
+  },
+};

--- a/packages/views/editor/extensions/file-card.tsx
+++ b/packages/views/editor/extensions/file-card.tsx
@@ -38,7 +38,7 @@ function FileCardView({ node }: NodeViewProps) {
   const href = (node.attrs.href as string) || "";
   const filename = (node.attrs.filename as string) || "";
   const uploading = node.attrs.uploading as boolean;
-  const { openByUrl } = useAttachmentDownloadResolver();
+  const { openByUrl, resolveAttachment } = useAttachmentDownloadResolver();
   const [previewOpen, setPreviewOpen] = useState(false);
 
   const openFile = () => {
@@ -47,6 +47,7 @@ function FileCardView({ node }: NodeViewProps) {
 
   const previewable =
     !uploading && href !== "" && getRendererKey(filename) !== "unsupported";
+  const sizeBytes = resolveAttachment(href)?.size_bytes;
 
   return (
     <NodeViewWrapper as="div" className="file-card-node" data-type="fileCard">
@@ -97,6 +98,7 @@ function FileCardView({ node }: NodeViewProps) {
           onOpenChange={setPreviewOpen}
           url={href}
           filename={filename}
+          sizeBytes={sizeBytes}
         />
       )}
     </NodeViewWrapper>

--- a/packages/views/editor/extensions/file-card.tsx
+++ b/packages/views/editor/extensions/file-card.tsx
@@ -17,9 +17,12 @@
 import { Node, mergeAttributes } from "@tiptap/core";
 import { ReactNodeViewRenderer, NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
-import { FileText, Loader2, Download } from "lucide-react";
+import { FileText, Loader2, Download, Eye } from "lucide-react";
+import { useState } from "react";
 import { useT } from "../../i18n";
 import { useAttachmentDownloadResolver } from "../attachment-download-context";
+import { FilePreviewModal } from "../../file-preview/file-preview-modal";
+import { getRendererKey } from "../../file-preview/get-renderer";
 
 
 // ---------------------------------------------------------------------------
@@ -36,10 +39,14 @@ function FileCardView({ node }: NodeViewProps) {
   const filename = (node.attrs.filename as string) || "";
   const uploading = node.attrs.uploading as boolean;
   const { openByUrl } = useAttachmentDownloadResolver();
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   const openFile = () => {
     openByUrl(href);
   };
+
+  const previewable =
+    !uploading && href !== "" && getRendererKey(filename) !== "unsupported";
 
   return (
     <NodeViewWrapper as="div" className="file-card-node" data-type="fileCard">
@@ -56,6 +63,20 @@ function FileCardView({ node }: NodeViewProps) {
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm">{uploading ? t(($) => $.file_card.uploading, { filename }) : filename}</p>
         </div>
+        {previewable && (
+          <button
+            type="button"
+            className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+            title={t(($) => $.file_card.preview)}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setPreviewOpen(true);
+            }}
+          >
+            <Eye className="size-3.5" />
+          </button>
+        )}
         {!uploading && href && (
           <button
             type="button"
@@ -70,6 +91,14 @@ function FileCardView({ node }: NodeViewProps) {
           </button>
         )}
       </div>
+      {previewOpen && (
+        <FilePreviewModal
+          open={previewOpen}
+          onOpenChange={setPreviewOpen}
+          url={href}
+          filename={filename}
+        />
+      )}
     </NodeViewWrapper>
   );
 }

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -30,7 +30,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { createLowlight, common } from "lowlight";
 // @ts-expect-error -- hast-util-to-html has no bundled type declarations
 import { toHtml } from "hast-util-to-html";
-import { Maximize2, Download, Link as LinkIcon, FileText } from "lucide-react";
+import { Maximize2, Download, Eye, Link as LinkIcon, FileText } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@multica/ui/lib/utils";
 import { useWorkspacePaths, useWorkspaceSlug } from "@multica/core/paths";
@@ -45,6 +45,8 @@ import { openLink, isMentionHref } from "./utils/link-handler";
 import { preprocessMarkdown } from "./utils/preprocess";
 import { MermaidDiagram } from "./mermaid-diagram";
 import { useDownloadAttachment } from "./use-download-attachment";
+import { FilePreviewModal } from "../file-preview/file-preview-modal";
+import { getRendererKey } from "../file-preview/get-renderer";
 import "katex/dist/katex.min.css";
 import "./content-editor.css";
 
@@ -240,13 +242,17 @@ function ReadonlyFileCard({
   href,
   filename,
   resolveAttachmentId,
+  resolveAttachmentSize,
   onDownload,
 }: {
   href: string;
   filename: string;
   resolveAttachmentId: (url: string) => string | undefined;
+  resolveAttachmentSize: (url: string) => number | undefined;
   onDownload: (attachmentId: string) => void;
 }) {
+  const { t } = useT("editor");
+  const [previewOpen, setPreviewOpen] = useState(false);
   const handleClick = () => {
     const id = resolveAttachmentId(href);
     if (id) {
@@ -255,12 +261,25 @@ function ReadonlyFileCard({
     }
     openExternal(href);
   };
+  const previewable = href !== "" && getRendererKey(filename) !== "unsupported";
+  const sizeBytes = resolveAttachmentSize(href);
+  const attachmentId = resolveAttachmentId(href);
   return (
     <div className="my-1 flex items-center gap-2 rounded-md border border-border bg-muted/50 px-2.5 py-1 transition-colors hover:bg-muted">
       <FileText className="size-4 shrink-0 text-muted-foreground" />
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm">{filename}</p>
       </div>
+      {previewable && (
+        <button
+          type="button"
+          className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+          title={t(($) => $.file_card.preview)}
+          onClick={() => setPreviewOpen(true)}
+        >
+          <Eye className="size-3.5" />
+        </button>
+      )}
       {href && (
         <button
           type="button"
@@ -270,12 +289,23 @@ function ReadonlyFileCard({
           <Download className="size-3.5" />
         </button>
       )}
+      {previewOpen && (
+        <FilePreviewModal
+          open={previewOpen}
+          onOpenChange={setPreviewOpen}
+          url={href}
+          filename={filename}
+          sizeBytes={sizeBytes}
+          attachmentId={attachmentId}
+        />
+      )}
     </div>
   );
 }
 
 function buildComponents(
   resolveAttachmentId: (url: string) => string | undefined,
+  resolveAttachmentSize: (url: string) => number | undefined,
   onDownload: (attachmentId: string) => void,
 ): Partial<Components> {
   return {
@@ -305,6 +335,7 @@ function buildComponents(
             href={href}
             filename={filename}
             resolveAttachmentId={resolveAttachmentId}
+            resolveAttachmentSize={resolveAttachmentSize}
             onDownload={onDownload}
           />
         );
@@ -410,9 +441,17 @@ export const ReadonlyContent = memo(function ReadonlyContent({
     [attachments],
   );
 
+  const resolveAttachmentSize = useCallback(
+    (url: string): number | undefined => {
+      if (!url || !attachments?.length) return undefined;
+      return attachments.find((a) => a.url === url)?.size_bytes;
+    },
+    [attachments],
+  );
+
   const components = useMemo(
-    () => buildComponents(resolveAttachmentId, download),
-    [resolveAttachmentId, download],
+    () => buildComponents(resolveAttachmentId, resolveAttachmentSize, download),
+    [resolveAttachmentId, resolveAttachmentSize, download],
   );
 
   return (

--- a/packages/views/file-preview/file-preview-modal.tsx
+++ b/packages/views/file-preview/file-preview-modal.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@multica/ui/components/ui/button";
 import { useT } from "../i18n";
 import { useAttachmentDownloadResolver } from "../editor/attachment-download-context";
+import { useDownloadAttachment } from "../editor/use-download-attachment";
 import { FilePreview } from "./file-preview";
 
 interface Props {
@@ -17,11 +18,33 @@ interface Props {
   onOpenChange: (open: boolean) => void;
   url: string;
   filename: string;
+  sizeBytes?: number;
+  /** Pass when the call site has the Attachment record directly — the
+   *  modal will re-sign through `api.getAttachment(id)` even when not
+   *  mounted under `AttachmentDownloadProvider`. */
+  attachmentId?: string;
 }
 
-export function FilePreviewModal({ open, onOpenChange, url, filename }: Props) {
+export function FilePreviewModal({
+  open,
+  onOpenChange,
+  url,
+  filename,
+  sizeBytes,
+  attachmentId,
+}: Props) {
   const { t } = useT("editor");
   const { openByUrl } = useAttachmentDownloadResolver();
+  const downloadById = useDownloadAttachment();
+  const handleDownload = () => {
+    if (attachmentId) {
+      // Direct id path — bypasses context resolution; works in surfaces
+      // outside `AttachmentDownloadProvider` (AttachmentList, etc.).
+      void downloadById(attachmentId);
+      return;
+    }
+    openByUrl(url);
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -34,14 +57,19 @@ export function FilePreviewModal({ open, onOpenChange, url, filename }: Props) {
             variant="ghost"
             size="sm"
             className="mr-8"
-            onClick={() => openByUrl(url)}
+            onClick={handleDownload}
           >
             <Download className="mr-1 size-4" />
             {t(($) => $.file_preview.download)}
           </Button>
         </DialogHeader>
         <div className="min-h-0 flex-1 overflow-hidden">
-          <FilePreview url={url} filename={filename} />
+          <FilePreview
+            url={url}
+            filename={filename}
+            sizeBytes={sizeBytes}
+            attachmentId={attachmentId}
+          />
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/views/file-preview/file-preview-modal.tsx
+++ b/packages/views/file-preview/file-preview-modal.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Download } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@multica/ui/components/ui/dialog";
+import { Button } from "@multica/ui/components/ui/button";
+import { useT } from "../i18n";
+import { useAttachmentDownloadResolver } from "../editor/attachment-download-context";
+import { FilePreview } from "./file-preview";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  url: string;
+  filename: string;
+}
+
+export function FilePreviewModal({ open, onOpenChange, url, filename }: Props) {
+  const { t } = useT("editor");
+  const { openByUrl } = useAttachmentDownloadResolver();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[85vh] w-[90vw] max-w-[1100px] flex-col gap-0 p-0 sm:max-w-[1100px]">
+        <DialogHeader className="flex shrink-0 flex-row items-center justify-between gap-2 border-b px-4 py-2">
+          <DialogTitle className="truncate text-sm font-medium">
+            {filename}
+          </DialogTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mr-8"
+            onClick={() => openByUrl(url)}
+          >
+            <Download className="mr-1 size-4" />
+            {t(($) => $.file_preview.download)}
+          </Button>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <FilePreview url={url} filename={filename} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/views/file-preview/file-preview.test.tsx
+++ b/packages/views/file-preview/file-preview.test.tsx
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { renderWithI18n } from "../test/i18n";
+
+// Hoisted so the vi.mock factory below can reference it (vi.mock is
+// hoisted to the top of the file, before normal `const` declarations).
+const getAttachmentMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@multica/core/api", () => ({
+  api: { getAttachment: getAttachmentMock },
+}));
+
 import { FilePreview } from "./file-preview";
 
 beforeEach(() => {
@@ -10,6 +19,7 @@ beforeEach(() => {
     "fetch",
     vi.fn(() => Promise.resolve(new Response("hello"))),
   );
+  getAttachmentMock.mockReset();
 });
 
 afterEach(() => {
@@ -41,5 +51,40 @@ describe("FilePreview routing", () => {
     const iframe = container.querySelector("iframe");
     expect(iframe).not.toBeNull();
     expect(iframe).toHaveAttribute("src", "http://example.test/y.pdf");
+  });
+
+  it("falls back to too-large placeholder when sizeBytes exceeds cap", () => {
+    renderWithI18n(
+      <FilePreview
+        url="http://example.test/big.xlsx"
+        filename="big.xlsx"
+        sizeBytes={50 * 1024 * 1024}
+      />,
+    );
+    expect(screen.getByText(/too large/i)).toBeInTheDocument();
+  });
+
+  it("re-signs via api.getAttachment when attachmentId is provided", async () => {
+    getAttachmentMock.mockResolvedValueOnce({
+      id: "att-1",
+      download_url: "http://signed.test/fresh.png?Signature=ABC",
+    });
+    const { container } = renderWithI18n(
+      <FilePreview
+        url="http://stale.test/old.png"
+        filename="x.png"
+        attachmentId="att-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getAttachmentMock).toHaveBeenCalledWith("att-1");
+    });
+    await waitFor(() => {
+      const img = container.querySelector("img");
+      expect(img?.getAttribute("src")).toBe(
+        "http://signed.test/fresh.png?Signature=ABC",
+      );
+    });
   });
 });

--- a/packages/views/file-preview/file-preview.test.tsx
+++ b/packages/views/file-preview/file-preview.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithI18n } from "../test/i18n";
+import { FilePreview } from "./file-preview";
+
+beforeEach(() => {
+  // jsdom doesn't ship a real `fetch`. Stub it for the renderers that
+  // pull file content over HTTP.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve(new Response("hello"))),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("FilePreview routing", () => {
+  it("renders unsupported placeholder for unknown extension", () => {
+    renderWithI18n(
+      <FilePreview url="http://example.test/y.bin" filename="y.bin" />,
+    );
+    expect(screen.getByText(/no preview available/i)).toBeInTheDocument();
+  });
+
+  it("renders <img> for image files", () => {
+    renderWithI18n(
+      <FilePreview url="http://example.test/y.png" filename="y.png" />,
+    );
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "http://example.test/y.png",
+    );
+  });
+
+  it("renders <iframe> for pdf files", () => {
+    const { container } = renderWithI18n(
+      <FilePreview url="http://example.test/y.pdf" filename="y.pdf" />,
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe).toHaveAttribute("src", "http://example.test/y.pdf");
+  });
+});

--- a/packages/views/file-preview/file-preview.tsx
+++ b/packages/views/file-preview/file-preview.tsx
@@ -2,7 +2,7 @@
 
 import { lazy, Suspense, useMemo } from "react";
 import { useT } from "../i18n";
-import { getRendererKey } from "./get-renderer";
+import { getPreviewSizeCap, getRendererKey } from "./get-renderer";
 import { ImageRenderer } from "./renderers/image-renderer";
 import { MediaRenderer } from "./renderers/media-renderer";
 import { TextRenderer } from "./renderers/text-renderer";
@@ -10,6 +10,7 @@ import { PdfRenderer } from "./renderers/pdf-renderer";
 import { HtmlRenderer } from "./renderers/html-renderer";
 import { MarkdownRenderer } from "./renderers/markdown-renderer";
 import { UnsupportedRenderer } from "./renderers/unsupported-renderer";
+import { useResolvedPreviewUrl } from "./use-resolved-preview-url";
 import type { RendererProps } from "./types";
 
 // Heavy renderers are split-loaded so a workspace that never previews a
@@ -24,9 +25,27 @@ const DocxRenderer = lazy(() =>
   import("./renderers/docx-renderer").then((m) => ({ default: m.DocxRenderer })),
 );
 
-export function FilePreview({ url, filename }: RendererProps) {
+interface FilePreviewProps extends RendererProps {
+  /** Optional file size in bytes. When provided and over the per-kind cap,
+   *  the renderer falls back to a "too large" download prompt to avoid
+   *  blocking the main thread parsing huge files. */
+  sizeBytes?: number;
+  /** Optional attachment id. When supplied, the preview re-signs the URL
+   *  via `api.getAttachment(id).download_url` so renderers don't fetch a
+   *  stale signed link. Required for surfaces outside
+   *  `AttachmentDownloadProvider` (e.g. comment AttachmentList). */
+  attachmentId?: string;
+}
+
+export function FilePreview({
+  url,
+  filename,
+  sizeBytes,
+  attachmentId,
+}: FilePreviewProps) {
   const { t } = useT("editor");
   const key = useMemo(() => getRendererKey(filename), [filename]);
+  const resolved = useResolvedPreviewUrl(url, attachmentId);
 
   const fallback = (
     <div className="p-4 text-sm text-muted-foreground">
@@ -34,40 +53,58 @@ export function FilePreview({ url, filename }: RendererProps) {
     </div>
   );
 
+  // Size cap — only applies to kinds that load the whole file into memory.
+  // Browser-streamed kinds (image / video / audio / pdf iframe) skip this.
+  const cap = getPreviewSizeCap(key);
+  if (cap !== undefined && sizeBytes !== undefined && sizeBytes > cap) {
+    return <UnsupportedRenderer url={url} filename={filename} reason="too_large" />;
+  }
+
+  if (resolved.kind === "loading") return fallback;
+  if (resolved.kind === "error") {
+    return (
+      <div className="p-4 text-sm text-destructive">
+        {t(($) => $.file_preview.load_failed)}
+      </div>
+    );
+  }
+
+  const signedUrl = resolved.url;
+
   switch (key) {
     case "image":
-      return <ImageRenderer url={url} filename={filename} />;
+      return <ImageRenderer url={signedUrl} filename={filename} />;
     case "video":
     case "audio":
-      return <MediaRenderer url={url} filename={filename} />;
+      return <MediaRenderer url={signedUrl} filename={filename} />;
     case "text":
-      return <TextRenderer url={url} filename={filename} />;
+      return <TextRenderer url={signedUrl} filename={filename} />;
     case "pdf":
-      return <PdfRenderer url={url} filename={filename} />;
+      return <PdfRenderer url={signedUrl} filename={filename} />;
     case "html":
-      return <HtmlRenderer url={url} filename={filename} />;
+      return <HtmlRenderer url={signedUrl} filename={filename} />;
     case "markdown":
-      return <MarkdownRenderer url={url} filename={filename} />;
+      return <MarkdownRenderer url={signedUrl} filename={filename} />;
     case "csv":
       return (
         <Suspense fallback={fallback}>
-          <CsvRenderer url={url} filename={filename} />
+          <CsvRenderer url={signedUrl} filename={filename} />
         </Suspense>
       );
     case "xlsx":
       return (
         <Suspense fallback={fallback}>
-          <XlsxRenderer url={url} filename={filename} />
+          <XlsxRenderer url={signedUrl} filename={filename} />
         </Suspense>
       );
     case "docx":
       return (
         <Suspense fallback={fallback}>
-          <DocxRenderer url={url} filename={filename} />
+          <DocxRenderer url={signedUrl} filename={filename} />
         </Suspense>
       );
     case "unsupported":
     default:
-      return <UnsupportedRenderer url={url} filename={filename} />;
+      return <UnsupportedRenderer url={signedUrl} filename={filename} />;
   }
 }

--- a/packages/views/file-preview/file-preview.tsx
+++ b/packages/views/file-preview/file-preview.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { lazy, Suspense, useMemo } from "react";
+import { useT } from "../i18n";
+import { getRendererKey } from "./get-renderer";
+import { ImageRenderer } from "./renderers/image-renderer";
+import { MediaRenderer } from "./renderers/media-renderer";
+import { TextRenderer } from "./renderers/text-renderer";
+import { PdfRenderer } from "./renderers/pdf-renderer";
+import { HtmlRenderer } from "./renderers/html-renderer";
+import { MarkdownRenderer } from "./renderers/markdown-renderer";
+import { UnsupportedRenderer } from "./renderers/unsupported-renderer";
+import type { RendererProps } from "./types";
+
+// Heavy renderers are split-loaded so a workspace that never previews a
+// CSV/XLSX/DOCX never pays for SheetJS / docx-preview at boot.
+const CsvRenderer = lazy(() =>
+  import("./renderers/csv-renderer").then((m) => ({ default: m.CsvRenderer })),
+);
+const XlsxRenderer = lazy(() =>
+  import("./renderers/xlsx-renderer").then((m) => ({ default: m.XlsxRenderer })),
+);
+const DocxRenderer = lazy(() =>
+  import("./renderers/docx-renderer").then((m) => ({ default: m.DocxRenderer })),
+);
+
+export function FilePreview({ url, filename }: RendererProps) {
+  const { t } = useT("editor");
+  const key = useMemo(() => getRendererKey(filename), [filename]);
+
+  const fallback = (
+    <div className="p-4 text-sm text-muted-foreground">
+      {t(($) => $.file_preview.loading)}
+    </div>
+  );
+
+  switch (key) {
+    case "image":
+      return <ImageRenderer url={url} filename={filename} />;
+    case "video":
+    case "audio":
+      return <MediaRenderer url={url} filename={filename} />;
+    case "text":
+      return <TextRenderer url={url} filename={filename} />;
+    case "pdf":
+      return <PdfRenderer url={url} filename={filename} />;
+    case "html":
+      return <HtmlRenderer url={url} filename={filename} />;
+    case "markdown":
+      return <MarkdownRenderer url={url} filename={filename} />;
+    case "csv":
+      return (
+        <Suspense fallback={fallback}>
+          <CsvRenderer url={url} filename={filename} />
+        </Suspense>
+      );
+    case "xlsx":
+      return (
+        <Suspense fallback={fallback}>
+          <XlsxRenderer url={url} filename={filename} />
+        </Suspense>
+      );
+    case "docx":
+      return (
+        <Suspense fallback={fallback}>
+          <DocxRenderer url={url} filename={filename} />
+        </Suspense>
+      );
+    case "unsupported":
+    default:
+      return <UnsupportedRenderer url={url} filename={filename} />;
+  }
+}

--- a/packages/views/file-preview/get-renderer.test.ts
+++ b/packages/views/file-preview/get-renderer.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { getRendererKey } from "./get-renderer";
+
+describe("getRendererKey", () => {
+  it.each([
+    ["foo.html", "html"],
+    ["a/b/c.HTM", "html"],
+    ["readme.md", "markdown"],
+    ["readme.MDX", "markdown"],
+    ["plan.txt", "text"],
+    ["main.ts", "text"],
+    ["file.pdf", "pdf"],
+    ["pic.png", "image"],
+    ["pic.JPG", "image"],
+    ["movie.mp4", "video"],
+    ["sound.mp3", "audio"],
+    ["data.csv", "csv"],
+    ["sheet.xlsx", "xlsx"],
+    ["legacy.xls", "xlsx"],
+    ["doc.docx", "docx"],
+    ["weird.bin", "unsupported"],
+    ["", "unsupported"],
+    ["NOEXT", "unsupported"],
+  ])("maps %s → %s", (filename, expected) => {
+    expect(getRendererKey(filename)).toBe(expected);
+  });
+});

--- a/packages/views/file-preview/get-renderer.ts
+++ b/packages/views/file-preview/get-renderer.ts
@@ -55,3 +55,20 @@ export function getRendererKey(filename: string): RendererKey {
   const ext = filename.slice(dot + 1).toLowerCase();
   return EXT_MAP[ext] ?? "unsupported";
 }
+
+// Per-kind preview size cap. Anything above this falls back to a download
+// prompt so we don't lock up the main thread parsing a 50 MB log or 100 MB
+// xlsx in-browser. Renderers that stream via the browser (image / video /
+// audio / pdf via iframe) are not capped here — the browser handles them.
+const SIZE_CAPS: Partial<Record<RendererKey, number>> = {
+  text: 5 * 1024 * 1024,
+  html: 5 * 1024 * 1024,
+  markdown: 5 * 1024 * 1024,
+  csv: 20 * 1024 * 1024,
+  xlsx: 20 * 1024 * 1024,
+  docx: 20 * 1024 * 1024,
+};
+
+export function getPreviewSizeCap(kind: RendererKey): number | undefined {
+  return SIZE_CAPS[kind];
+}

--- a/packages/views/file-preview/get-renderer.ts
+++ b/packages/views/file-preview/get-renderer.ts
@@ -1,0 +1,57 @@
+export type RendererKey =
+  | "html"
+  | "markdown"
+  | "text"
+  | "pdf"
+  | "image"
+  | "video"
+  | "audio"
+  | "csv"
+  | "xlsx"
+  | "docx"
+  | "unsupported";
+
+const EXT_MAP: Record<string, RendererKey> = {
+  html: "html",
+  htm: "html",
+  md: "markdown",
+  mdx: "markdown",
+  markdown: "markdown",
+  txt: "text",
+  log: "text",
+  json: "text",
+  yaml: "text",
+  yml: "text",
+  ts: "text",
+  tsx: "text",
+  js: "text",
+  jsx: "text",
+  py: "text",
+  go: "text",
+  pdf: "pdf",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
+  svg: "image",
+  bmp: "image",
+  mp4: "video",
+  webm: "video",
+  mov: "video",
+  mp3: "audio",
+  wav: "audio",
+  ogg: "audio",
+  csv: "csv",
+  xlsx: "xlsx",
+  xls: "xlsx",
+  docx: "docx",
+};
+
+export function getRendererKey(filename: string): RendererKey {
+  if (!filename) return "unsupported";
+  const dot = filename.lastIndexOf(".");
+  if (dot < 0) return "unsupported";
+  const ext = filename.slice(dot + 1).toLowerCase();
+  return EXT_MAP[ext] ?? "unsupported";
+}

--- a/packages/views/file-preview/index.ts
+++ b/packages/views/file-preview/index.ts
@@ -1,0 +1,3 @@
+export { FilePreviewModal } from "./file-preview-modal";
+export { FilePreview } from "./file-preview";
+export { getRendererKey, type RendererKey } from "./get-renderer";

--- a/packages/views/file-preview/renderers/csv-renderer.tsx
+++ b/packages/views/file-preview/renderers/csv-renderer.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Papa from "papaparse";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+export function CsvRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [rows, setRows] = useState<string[][] | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) =>
+        res.ok ? res.text() : Promise.reject(new Error(String(res.status))),
+      )
+      .then((text) => Papa.parse<string[]>(text, { skipEmptyLines: true }))
+      .then((result) => {
+        if (!cancelled) setRows(result.data);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (error) {
+    return (
+      <div className="p-4 text-sm text-destructive">
+        {t(($) => $.file_preview.load_failed)}
+      </div>
+    );
+  }
+  if (!rows) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        {t(($) => $.file_preview.loading)}
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full overflow-auto">
+      <table className="w-full border-collapse text-sm">
+        <tbody>
+          {rows.map((row, i) => (
+            <tr
+              key={i}
+              className={i === 0 ? "bg-muted font-medium" : "hover:bg-muted/40"}
+            >
+              {row.map((cell, j) => (
+                <td key={j} className="border border-border px-2 py-1">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/views/file-preview/renderers/docx-renderer.tsx
+++ b/packages/views/file-preview/renderers/docx-renderer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { renderAsync } from "docx-preview";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+export function DocxRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    const container = containerRef.current;
+    if (!container) return;
+    fetch(url)
+      .then((res) =>
+        res.ok ? res.blob() : Promise.reject(new Error(String(res.status))),
+      )
+      .then((blob) =>
+        renderAsync(blob, container, undefined, {
+          className: "docx-preview",
+          inWrapper: true,
+        }),
+      )
+      .then(() => {
+        if (!cancelled) setState("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-muted/20 p-4">
+      {state === "loading" && (
+        <div className="text-sm text-muted-foreground">
+          {t(($) => $.file_preview.loading)}
+        </div>
+      )}
+      {state === "error" && (
+        <div className="text-sm text-destructive">
+          {t(($) => $.file_preview.load_failed)}
+        </div>
+      )}
+      <div ref={containerRef} />
+    </div>
+  );
+}

--- a/packages/views/file-preview/renderers/html-renderer.tsx
+++ b/packages/views/file-preview/renderers/html-renderer.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ready"; html: string }
+  | { kind: "error" };
+
+export function HtmlRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [state, setState] = useState<State>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) => {
+        if (!res.ok) throw new Error(String(res.status));
+        return res.text();
+      })
+      .then((html) => {
+        if (!cancelled) setState({ kind: "ready", html });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (state.kind === "loading") {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        {t(($) => $.file_preview.loading)}
+      </div>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="p-4 text-sm text-destructive">
+        {t(($) => $.file_preview.load_failed)}
+      </div>
+    );
+  }
+
+  // Empty `sandbox` attribute = strictest sandbox: no scripts, no top
+  // navigation, no forms, no same-origin. Safe for arbitrary HTML.
+  return (
+    <iframe
+      sandbox=""
+      srcDoc={state.html}
+      className="h-full w-full border-0 bg-white"
+    />
+  );
+}

--- a/packages/views/file-preview/renderers/image-renderer.tsx
+++ b/packages/views/file-preview/renderers/image-renderer.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import type { RendererProps } from "../types";
+
+export function ImageRenderer({ url, filename }: RendererProps) {
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-muted/20 p-4">
+      <img
+        src={url}
+        alt={filename}
+        className="max-h-full max-w-full object-contain"
+      />
+    </div>
+  );
+}

--- a/packages/views/file-preview/renderers/markdown-renderer.tsx
+++ b/packages/views/file-preview/renderers/markdown-renderer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Markdown } from "../../common/markdown";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ready"; text: string }
+  | { kind: "error" };
+
+export function MarkdownRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [state, setState] = useState<State>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) =>
+        res.ok ? res.text() : Promise.reject(new Error(String(res.status))),
+      )
+      .then((text) => {
+        if (!cancelled) setState({ kind: "ready", text });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (state.kind === "loading") {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        {t(($) => $.file_preview.loading)}
+      </div>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="p-4 text-sm text-destructive">
+        {t(($) => $.file_preview.load_failed)}
+      </div>
+    );
+  }
+  return (
+    <div className="h-full w-full overflow-auto p-6">
+      <Markdown mode="full">{state.text}</Markdown>
+    </div>
+  );
+}

--- a/packages/views/file-preview/renderers/media-renderer.tsx
+++ b/packages/views/file-preview/renderers/media-renderer.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useMemo } from "react";
+import type { RendererProps } from "../types";
+import { getRendererKey } from "../get-renderer";
+
+export function MediaRenderer({ url, filename }: RendererProps) {
+  const kind = useMemo(() => getRendererKey(filename), [filename]);
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-black p-4">
+      {kind === "video" ? (
+        <video src={url} controls className="max-h-full max-w-full" />
+      ) : (
+        <audio src={url} controls className="w-full max-w-md" />
+      )}
+    </div>
+  );
+}

--- a/packages/views/file-preview/renderers/pdf-renderer.tsx
+++ b/packages/views/file-preview/renderers/pdf-renderer.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import type { RendererProps } from "../types";
+
+export function PdfRenderer({ url, filename }: RendererProps) {
+  return (
+    <iframe
+      src={url}
+      title={filename}
+      className="h-full w-full border-0"
+    />
+  );
+}

--- a/packages/views/file-preview/renderers/text-renderer.tsx
+++ b/packages/views/file-preview/renderers/text-renderer.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+const MAX_BYTES = 1_000_000;
+
+type State =
+  | { kind: "loading" }
+  | { kind: "ready"; text: string; truncated: boolean }
+  | { kind: "error" };
+
+export function TextRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [state, setState] = useState<State>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(String(res.status));
+        const blob = await res.blob();
+        const truncated = blob.size > MAX_BYTES;
+        const slice = truncated ? blob.slice(0, MAX_BYTES) : blob;
+        return { text: await slice.text(), truncated };
+      })
+      .then((out) => {
+        if (!cancelled) setState({ kind: "ready", ...out });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (state.kind === "loading") {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        {t(($) => $.file_preview.loading)}
+      </div>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="p-4 text-sm text-destructive">
+        {t(($) => $.file_preview.load_failed)}
+      </div>
+    );
+  }
+  return (
+    <pre className="h-full w-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed">
+      {state.text}
+      {state.truncated ? `\n\n--- ${t(($) => $.file_preview.truncated)} ---` : ""}
+    </pre>
+  );
+}

--- a/packages/views/file-preview/renderers/unsupported-renderer.tsx
+++ b/packages/views/file-preview/renderers/unsupported-renderer.tsx
@@ -1,20 +1,31 @@
 "use client";
 
-import { Download, FileQuestion } from "lucide-react";
+import { Download, FileQuestion, FileWarning } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { useT } from "../../i18n";
 import { useAttachmentDownloadResolver } from "../../editor/attachment-download-context";
 import type { RendererProps } from "../types";
 
-export function UnsupportedRenderer({ url, filename }: RendererProps) {
+export type UnsupportedReason = "unsupported" | "too_large";
+
+export function UnsupportedRenderer({
+  url,
+  filename,
+  reason = "unsupported",
+}: RendererProps & { reason?: UnsupportedReason }) {
   const { t } = useT("editor");
   const { openByUrl } = useAttachmentDownloadResolver();
+
+  const Icon = reason === "too_large" ? FileWarning : FileQuestion;
+  const message =
+    reason === "too_large"
+      ? t(($) => $.file_preview.too_large, { filename })
+      : t(($) => $.file_preview.unsupported, { filename });
+
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center">
-      <FileQuestion className="size-12 text-muted-foreground" />
-      <div className="text-sm text-muted-foreground">
-        {t(($) => $.file_preview.unsupported, { filename })}
-      </div>
+      <Icon className="size-12 text-muted-foreground" />
+      <div className="text-sm text-muted-foreground">{message}</div>
       <Button variant="outline" size="sm" onClick={() => openByUrl(url)}>
         <Download className="mr-1 size-4" />
         {t(($) => $.file_preview.download)}

--- a/packages/views/file-preview/renderers/unsupported-renderer.tsx
+++ b/packages/views/file-preview/renderers/unsupported-renderer.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Download, FileQuestion } from "lucide-react";
+import { Button } from "@multica/ui/components/ui/button";
+import { useT } from "../../i18n";
+import { useAttachmentDownloadResolver } from "../../editor/attachment-download-context";
+import type { RendererProps } from "../types";
+
+export function UnsupportedRenderer({ url, filename }: RendererProps) {
+  const { t } = useT("editor");
+  const { openByUrl } = useAttachmentDownloadResolver();
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center">
+      <FileQuestion className="size-12 text-muted-foreground" />
+      <div className="text-sm text-muted-foreground">
+        {t(($) => $.file_preview.unsupported, { filename })}
+      </div>
+      <Button variant="outline" size="sm" onClick={() => openByUrl(url)}>
+        <Download className="mr-1 size-4" />
+        {t(($) => $.file_preview.download)}
+      </Button>
+    </div>
+  );
+}

--- a/packages/views/file-preview/renderers/xlsx-renderer.tsx
+++ b/packages/views/file-preview/renderers/xlsx-renderer.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import * as XLSX from "xlsx";
+import { useT } from "../../i18n";
+import type { RendererProps } from "../types";
+
+interface Sheet {
+  name: string;
+  html: string;
+}
+
+export function XlsxRenderer({ url }: RendererProps) {
+  const { t } = useT("editor");
+  const [sheets, setSheets] = useState<Sheet[] | null>(null);
+  const [active, setActive] = useState(0);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) =>
+        res.ok ? res.arrayBuffer() : Promise.reject(new Error(String(res.status))),
+      )
+      .then((buf) => {
+        const wb = XLSX.read(buf, { type: "array" });
+        const out: Sheet[] = wb.SheetNames.map((name) => {
+          const sheet = wb.Sheets[name];
+          if (!sheet) return { name, html: "" };
+          return {
+            name,
+            html: XLSX.utils.sheet_to_html(sheet, { editable: false }),
+          };
+        });
+        if (!cancelled) setSheets(out);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (error) {
+    return (
+      <div className="p-4 text-sm text-destructive">
+        {t(($) => $.file_preview.load_failed)}
+      </div>
+    );
+  }
+  if (!sheets) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        {t(($) => $.file_preview.loading)}
+      </div>
+    );
+  }
+
+  const current = sheets[active];
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      {sheets.length > 1 && (
+        <div className="flex shrink-0 items-center gap-1 overflow-x-auto border-b px-2 py-1 text-xs">
+          {sheets.map((s, i) => (
+            <button
+              key={s.name}
+              type="button"
+              onClick={() => setActive(i)}
+              className={
+                i === active
+                  ? "shrink-0 rounded bg-primary px-2 py-1 text-primary-foreground"
+                  : "shrink-0 rounded px-2 py-1 hover:bg-muted"
+              }
+            >
+              {s.name}
+            </button>
+          ))}
+        </div>
+      )}
+      <div
+        className="xlsx-preview flex-1 overflow-auto p-2 text-sm [&_table]:border-collapse [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1"
+        // sheet_to_html does NOT execute scripts (the library strips them);
+        // output is library-controlled HTML, not raw user input.
+        dangerouslySetInnerHTML={{ __html: current?.html ?? "" }}
+      />
+    </div>
+  );
+}

--- a/packages/views/file-preview/types.ts
+++ b/packages/views/file-preview/types.ts
@@ -1,0 +1,4 @@
+export interface RendererProps {
+  url: string;
+  filename: string;
+}

--- a/packages/views/file-preview/use-resolved-preview-url.ts
+++ b/packages/views/file-preview/use-resolved-preview-url.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@multica/core/api";
+import { useAttachmentDownloadResolver } from "../editor/attachment-download-context";
+
+export type ResolvedUrlState =
+  | { kind: "loading" }
+  | { kind: "ready"; url: string }
+  | { kind: "error" };
+
+/**
+ * Resolves a markdown / file-card URL to a fresh signed `download_url` so
+ * preview renderers don't fetch a stale CDN link. Resolution order:
+ *
+ * 1. Explicit `attachmentId` prop (preferred — works in surfaces that
+ *    don't mount `AttachmentDownloadProvider`, e.g. `AttachmentList`).
+ * 2. Context resolver (`AttachmentDownloadProvider` mapping URL → id).
+ * 3. Raw URL passthrough (external link in markdown — relies on CORS).
+ *
+ * Why this exists: `useDownloadAttachment` re-signs at click time so file
+ * downloads don't 403 on stale URLs. Preview has the same expiry problem.
+ */
+export function useResolvedPreviewUrl(
+  rawUrl: string,
+  attachmentId?: string,
+): ResolvedUrlState {
+  const { resolveAttachmentId } = useAttachmentDownloadResolver();
+  // Lazy initial state: when nothing needs to be re-signed, return ready
+  // synchronously on first render so tests / users don't see a flash of
+  // loading state. Only enter "loading" when we'll actually call the API.
+  const initialId = attachmentId ?? resolveAttachmentId(rawUrl);
+  const [state, setState] = useState<ResolvedUrlState>(() => {
+    if (!rawUrl && !initialId) return { kind: "error" };
+    if (!initialId) return { kind: "ready", url: rawUrl };
+    return { kind: "loading" };
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!rawUrl && !attachmentId) {
+      setState({ kind: "error" });
+      return;
+    }
+
+    const id = attachmentId ?? resolveAttachmentId(rawUrl);
+    if (!id) {
+      setState({ kind: "ready", url: rawUrl });
+      return;
+    }
+
+    setState({ kind: "loading" });
+    api
+      .getAttachment(id)
+      .then((att) => {
+        if (cancelled) return;
+        if (att.download_url) {
+          setState({ kind: "ready", url: att.download_url });
+        } else {
+          setState({ kind: "error" });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: "error" });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [rawUrl, attachmentId, resolveAttachmentId]);
+
+  return state;
+}

--- a/packages/views/issues/components/comment-card.tsx
+++ b/packages/views/issues/components/comment-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useCallback, useRef, useState } from "react";
-import { CheckCircle2, ChevronRight, Copy, Download, FileText, MoreHorizontal, Pencil, RotateCcw, Trash2 } from "lucide-react";
+import { CheckCircle2, ChevronRight, Copy, Download, Eye, FileText, MoreHorizontal, Pencil, RotateCcw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Card } from "@multica/ui/components/ui/card";
 import { Button } from "@multica/ui/components/ui/button";
@@ -31,6 +31,8 @@ import { cn } from "@multica/ui/lib/utils";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { timeAgo } from "@multica/core/utils";
 import { ContentEditor, type ContentEditorRef, copyMarkdown, ReadonlyContent, useFileDropZone, FileDropOverlay, useDownloadAttachment } from "../../editor";
+import { FilePreviewModal } from "../../file-preview/file-preview-modal";
+import { getRendererKey } from "../../file-preview/get-renderer";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { useFileUpload } from "@multica/core/hooks/use-file-upload";
 import { api } from "@multica/core/api";
@@ -121,8 +123,49 @@ function DeleteCommentDialog({
 // Standalone attachment list — renders attachments not already in the markdown
 // ---------------------------------------------------------------------------
 
-function AttachmentList({ attachments, content, className }: { attachments?: Attachment[]; content?: string; className?: string }) {
+function AttachmentRow({ attachment }: { attachment: Attachment }) {
+  const { t } = useT("editor");
   const download = useDownloadAttachment();
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const previewable = getRendererKey(attachment.filename) !== "unsupported";
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-2.5 py-1 transition-colors hover:bg-muted">
+      <FileText className="size-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm">{attachment.filename}</p>
+      </div>
+      {previewable && (
+        <button
+          type="button"
+          className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+          title={t(($) => $.file_card.preview)}
+          onClick={() => setPreviewOpen(true)}
+        >
+          <Eye className="size-3.5" />
+        </button>
+      )}
+      <button
+        type="button"
+        className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+        onClick={() => download(attachment.id)}
+      >
+        <Download className="size-3.5" />
+      </button>
+      {previewOpen && (
+        <FilePreviewModal
+          open={previewOpen}
+          onOpenChange={setPreviewOpen}
+          url={attachment.url}
+          filename={attachment.filename}
+          sizeBytes={attachment.size_bytes}
+          attachmentId={attachment.id}
+        />
+      )}
+    </div>
+  );
+}
+
+function AttachmentList({ attachments, content, className }: { attachments?: Attachment[]; content?: string; className?: string }) {
   if (!attachments?.length) return null;
   // Skip attachments whose URL is already referenced in the markdown content,
   // and duplicates of the same file (same name/type/size) that are referenced.
@@ -148,22 +191,7 @@ function AttachmentList({ attachments, content, className }: { attachments?: Att
   return (
     <div className={cn("flex flex-col gap-1", className)}>
       {standalone.map((a) => (
-        <div
-          key={a.id}
-          className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-2.5 py-1 transition-colors hover:bg-muted"
-        >
-          <FileText className="size-4 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm">{a.filename}</p>
-          </div>
-          <button
-            type="button"
-            className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
-            onClick={() => download(a.id)}
-          >
-            <Download className="size-3.5" />
-          </button>
-        </div>
+        <AttachmentRow key={a.id} attachment={a} />
       ))}
     </div>
   );

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -61,6 +61,7 @@
     "load_failed": "Failed to load file",
     "truncated": "file truncated for preview",
     "unsupported": "No preview available for {{filename}}",
+    "too_large": "{{filename}} is too large to preview — please download",
     "download": "Download",
     "preview": "Preview"
   },

--- a/packages/views/locales/en/editor.json
+++ b/packages/views/locales/en/editor.json
@@ -53,7 +53,16 @@
     "copy_code": "Copy code"
   },
   "file_card": {
-    "uploading": "Uploading {{filename}}"
+    "uploading": "Uploading {{filename}}",
+    "preview": "Preview"
+  },
+  "file_preview": {
+    "loading": "Loading preview…",
+    "load_failed": "Failed to load file",
+    "truncated": "file truncated for preview",
+    "unsupported": "No preview available for {{filename}}",
+    "download": "Download",
+    "preview": "Preview"
   },
   "title_editor": {
     "title_aria_label": "Title"

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -61,6 +61,7 @@
     "load_failed": "无法加载文件",
     "truncated": "文件过大，已截断预览",
     "unsupported": "{{filename}} 暂不支持预览",
+    "too_large": "{{filename}} 文件过大，请下载后查看",
     "download": "下载",
     "preview": "预览"
   },

--- a/packages/views/locales/zh-Hans/editor.json
+++ b/packages/views/locales/zh-Hans/editor.json
@@ -53,7 +53,16 @@
     "copy_code": "复制代码"
   },
   "file_card": {
-    "uploading": "正在上传 {{filename}}"
+    "uploading": "正在上传 {{filename}}",
+    "preview": "预览"
+  },
+  "file_preview": {
+    "loading": "加载预览中…",
+    "load_failed": "无法加载文件",
+    "truncated": "文件过大，已截断预览",
+    "unsupported": "{{filename}} 暂不支持预览",
+    "download": "下载",
+    "preview": "预览"
   },
   "title_editor": {
     "title_aria_label": "标题"

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -13,6 +13,7 @@
     "./common/actor-avatar": "./common/actor-avatar.tsx",
     "./common/markdown": "./common/markdown.tsx",
     "./editor": "./editor/index.ts",
+    "./file-preview": "./file-preview/index.ts",
     "./issues/components": "./issues/components/index.ts",
     "./issues/hooks": "./issues/hooks/index.ts",
     "./issues/utils/filter": "./issues/utils/filter.ts",
@@ -87,7 +88,10 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "catalog:",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "xlsx": "catalog:",
+    "papaparse": "catalog:",
+    "docx-preview": "catalog:"
   },
   "peerDependencies": {
     "@tanstack/react-query": "catalog:",
@@ -102,6 +106,7 @@
   "devDependencies": {
     "@multica/tsconfig": "workspace:*",
     "@testing-library/jest-dom": "catalog:",
+    "@types/papaparse": "catalog:",
     "@testing-library/react": "catalog:",
     "@testing-library/user-event": "catalog:",
     "@types/react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     '@types/node':
       specifier: ^25.0.10
       version: 25.5.0
+    '@types/papaparse':
+      specifier: ^5.3.14
+      version: 5.5.2
     '@vitejs/plugin-react':
       specifier: ^6.0.1
       version: 6.0.1
@@ -39,6 +42,9 @@ catalogs:
     clsx:
       specifier: ^2.1.1
       version: 2.1.1
+    docx-preview:
+      specifier: ^0.3.5
+      version: 0.3.7
     eslint-plugin-i18next:
       specifier: ^6.1.4
       version: 6.1.4
@@ -57,6 +63,9 @@ catalogs:
     mermaid:
       specifier: ^11.14.0
       version: 11.14.0
+    papaparse:
+      specifier: ^5.4.1
+      version: 5.5.3
     posthog-js:
       specifier: ^1.176.1
       version: 1.369.3
@@ -93,6 +102,9 @@ catalogs:
     vitest:
       specifier: ^4.1.0
       version: 4.1.0
+    xlsx:
+      specifier: ^0.18.5
+      version: 0.18.5
     zod:
       specifier: ^4.1.5
       version: 4.3.6
@@ -766,6 +778,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      docx-preview:
+        specifier: 'catalog:'
+        version: 0.3.7
       hast-util-to-html:
         specifier: ^4.0.1
         version: 4.0.1
@@ -787,6 +802,9 @@ importers:
       motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      papaparse:
+        specifier: 'catalog:'
+        version: 5.5.3
       react:
         specifier: 'catalog:'
         version: 19.2.3
@@ -826,6 +844,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      xlsx:
+        specifier: 'catalog:'
+        version: 0.18.5
       zustand:
         specifier: 'catalog:'
         version: 5.0.12(@types/react@19.2.14)(immer@11.1.4)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -842,6 +863,9 @@ importers:
       '@testing-library/user-event':
         specifier: 'catalog:'
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/papaparse':
+        specifier: 'catalog:'
+        version: 5.5.2
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.14
@@ -3145,6 +3169,9 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
+  '@types/papaparse@5.5.2':
+    resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
+
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
@@ -3320,6 +3347,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3574,6 +3605,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -3682,6 +3717,10 @@ packages:
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -3786,6 +3825,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   crc@3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
@@ -4115,6 +4159,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  docx-preview@0.3.7:
+    resolution: {integrity: sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -4560,6 +4607,10 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
+
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
     peerDependencies:
@@ -4977,6 +5028,9 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
 
@@ -5228,6 +5282,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
@@ -5322,6 +5379,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   katex@0.16.45:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
@@ -5356,6 +5416,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -6085,6 +6148,12 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  papaparse@5.5.3:
+    resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -6289,6 +6358,9 @@ packages:
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -6541,6 +6613,9 @@ packages:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
     hasBin: true
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -6734,6 +6809,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -6807,6 +6885,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -6921,6 +7002,10 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -6980,6 +7065,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -7546,9 +7634,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -7568,6 +7664,11 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -9881,6 +9982,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/papaparse@5.5.2':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/pg@8.20.0':
     dependencies:
       '@types/node': 25.5.0
@@ -10097,6 +10202,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  adler-32@1.3.1: {}
 
   agent-base@7.1.4: {}
 
@@ -10435,6 +10542,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -10533,6 +10645,8 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
+  codepage@1.15.0: {}
+
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -10584,8 +10698,7 @@ snapshots:
 
   core-js@3.49.0: {}
 
-  core-util-is@1.0.2:
-    optional: true
+  core-util-is@1.0.2: {}
 
   cors@2.8.6:
     dependencies:
@@ -10608,6 +10721,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  crc-32@1.2.2: {}
 
   crc@3.8.0:
     dependencies:
@@ -10960,6 +11075,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  docx-preview@0.3.7:
+    dependencies:
+      jszip: 3.10.1
 
   dom-accessibility-api@0.5.16: {}
 
@@ -11637,6 +11756,8 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  frac@1.1.2: {}
+
   framer-motion@12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       motion-dom: 12.38.0
@@ -12188,6 +12309,8 @@ snapshots:
 
   image-size@2.0.2: {}
 
+  immediate@3.0.6: {}
+
   immer@10.2.0: {}
 
   immer@11.1.4: {}
@@ -12401,6 +12524,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
 
   isbinaryfile@4.0.10: {}
@@ -12504,6 +12629,13 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   katex@0.16.45:
     dependencies:
       commander: 8.3.0
@@ -12537,6 +12669,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -13576,6 +13712,10 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@1.0.11: {}
+
+  papaparse@5.5.3: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -13775,6 +13915,8 @@ snapshots:
       parse-ms: 4.0.0
 
   proc-log@5.0.0: {}
+
+  process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
 
@@ -14077,6 +14219,16 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.2
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -14395,6 +14547,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
@@ -14488,6 +14642,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -14680,6 +14836,10 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.3
@@ -14762,6 +14922,10 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -15329,7 +15493,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -15355,6 +15523,16 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,12 @@ catalog:
   # Product analytics
   posthog-js: "^1.176.1"
 
+  # File preview renderers
+  xlsx: "^0.18.5"
+  papaparse: "^5.4.1"
+  "@types/papaparse": "^5.3.14"
+  docx-preview: "^0.3.5"
+
   # Testing
   vitest: "^4.1.0"
   jsdom: "^29.0.1"


### PR DESCRIPTION
## Summary
- New `packages/views/file-preview/` module exporting `<FilePreviewModal />` opened by an Eye icon on `FileCard` attachments
- Renderers: image, video, audio, text, PDF (native iframe), HTML (sandbox iframe), Markdown, CSV (papaparse), XLSX (SheetJS), DOCX (docx-preview)
- `.pptx`, legacy `.doc/.xls/.ppt` and unknown extensions show an "unsupported, please download" placeholder
- Heavy renderers (CSV/XLSX/DOCX) are `React.lazy`-loaded — no boot-time cost for users who never preview them
- i18n: en + zh-Hans strings under `editor.file_preview` and `editor.file_card.preview`
- Implementation plan kept in `docs/plans/2026-05-12-file-preview.md`

Closes MUL-2060.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes — 391 tests, including 18 routing cases + 3 integration smoke tests in `packages/views/file-preview/`
- [x] `pnpm lint` 0 errors (14 pre-existing warnings in unrelated files)
- [ ] Manual: attach `.png`, `.pdf`, `.html`, `.md`, `.csv`, `.xlsx`, `.docx`, `.pptx` to a comment; verify Eye icon appears on supported types and modal renders correctly
- [ ] Manual: verify `.pptx` and unknown extensions show the unsupported placeholder with a working Download button