### PR TITLE
feat(feedback): nudge users toward GitHub for discussion and faster traction

### DIFF
--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -29,7 +29,8 @@
     "toast_sent": "Thanks for the feedback!",
     "toast_failed": "Failed to send feedback",
     "send": "Send feedback",
-    "sending": "Sending…"
+    "sending": "Sending…",
+    "github_hint": "Want to discuss or get faster traction? Open an issue on GitHub →"
   },
   "issue_picker": {
     "search_placeholder": "Search issues...",

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -29,7 +29,8 @@
     "toast_sent": "感谢反馈！",
     "toast_failed": "发送反馈失败",
     "send": "发送反馈",
-    "sending": "发送中..."
+    "sending": "发送中...",
+    "github_hint": "想要讨论或更快的处理？来 GitHub 提 issue →"
   },
   "issue_picker": {
     "search_placeholder": "搜索 issue...",

--- a/packages/views/modals/feedback.tsx
+++ b/packages/views/modals/feedback.tsx
@@ -96,6 +96,14 @@ export function FeedbackModal({ onClose }: { onClose: () => void }) {
           <DialogDescription>
             {t(($) => $.feedback.description)}
           </DialogDescription>
+          <a
+            href="https://github.com/multica-ai/multica/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            {t(($) => $.feedback.github_hint)}
+          </a>
         </DialogHeader>
 
         <div className="flex-1 min-h-0 px-5 pb-3">


### PR DESCRIPTION
## Summary

- Adds a small linked CTA below the Feedback modal description pointing to `github.com/multica-ai/multica/issues`.
- Sets clearer user expectations: in-app feedback = weekly-aggregated, free-form input; GitHub = trackable, faster-traction channel for concrete bugs and feature requests.
- i18n in en + zh-Hans following `conventions.zh.mdx` voice rules (spaces around Latin terms, full-width punctuation, ASCII ellipsis).

Motivation: weekly feedback reports consistently surface bugs / feature requests that have either already been filed or already been fixed in `multica-ai/multica`. Surfacing GitHub at the entry point lets users who want a tracked, public channel skip the weekly aggregation lag — and reduces noise in the feedback table.

## Files touched

- `packages/views/modals/feedback.tsx` — adds a single `<a>` in `DialogHeader` rendering `feedback.github_hint`.
- `packages/views/locales/en/modals.json` — `feedback.github_hint`.
- `packages/views/locales/zh-Hans/modals.json` — `feedback.github_hint`.

3 files, 12 insertions, 2 deletions. No type changes, no test changes.

## Copy

- EN: "Want to discuss or get faster traction? Open an issue on GitHub →"
- ZH: "想要讨论或更快的处理？来 GitHub 提 issue →"

## Test plan

- [x] `pnpm typecheck` (all 6 packages green, cached + fresh)
- [x] `pnpm --filter @multica/views test` — 370 / 370 passing
- [x] `pnpm --filter @multica/views lint` — 0 errors (pre-existing warnings unchanged)
- [ ] Manual: open Feedback modal in web + desktop, verify hint renders below description, click opens GitHub issues page in new tab
- [ ] Manual: switch language to 中文, verify ZH copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)