### PR TITLE
refactor(feedback): replace generic description with brand-colored GitHub CTA

### DIFF
--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -22,7 +22,6 @@
   },
   "feedback": {
     "title": "Feedback",
-    "description": "We'd love to hear what's working, what isn't, or what you'd like to see next.",
     "placeholder": "Tell us about your experience, bugs you've found, or features you'd like to see…",
     "toast_uploading": "Please wait for uploads to finish…",
     "toast_too_long": "Message is too long",
@@ -30,7 +29,8 @@
     "toast_failed": "Failed to send feedback",
     "send": "Send feedback",
     "sending": "Sending…",
-    "github_hint": "Want to discuss or get faster traction? Open an issue on GitHub →"
+    "github_hint_prefix": "Want faster traction? Head to ",
+    "github_hint_link": "GitHub"
   },
   "issue_picker": {
     "search_placeholder": "Search issues...",

--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -29,7 +29,7 @@
     "toast_failed": "Failed to send feedback",
     "send": "Send feedback",
     "sending": "Sending…",
-    "github_hint_prefix": "Want faster traction? Head to ",
+    "github_hint_prefix": "Want faster handling and open discussion? Head to ",
     "github_hint_link": "GitHub"
   },
   "issue_picker": {

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -22,7 +22,6 @@
   },
   "feedback": {
     "title": "反馈",
-    "description": "告诉我们哪些好用、哪些不好用、希望接下来做什么。",
     "placeholder": "聊聊你的体验、遇到的 bug，或想看到的功能...",
     "toast_uploading": "请等待上传完成...",
     "toast_too_long": "内容过长",
@@ -30,7 +29,8 @@
     "toast_failed": "发送反馈失败",
     "send": "发送反馈",
     "sending": "发送中...",
-    "github_hint": "想要讨论或更快的处理？来 GitHub 提 issue →"
+    "github_hint_prefix": "想要更快的，请去 ",
+    "github_hint_link": "GitHub"
   },
   "issue_picker": {
     "search_placeholder": "搜索 issue...",

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -29,7 +29,7 @@
     "toast_failed": "发送反馈失败",
     "send": "发送反馈",
     "sending": "发送中...",
-    "github_hint_prefix": "想要更快的，请去 ",
+    "github_hint_prefix": "想被更快处理、参与讨论？请去 ",
     "github_hint_link": "GitHub"
   },
   "issue_picker": {

--- a/packages/views/modals/feedback.tsx
+++ b/packages/views/modals/feedback.tsx
@@ -5,7 +5,6 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@multica/ui/components/ui/dialog";
@@ -93,17 +92,17 @@ export function FeedbackModal({ onClose }: { onClose: () => void }) {
       <DialogContent className="sm:max-w-2xl !h-[28rem] p-0 gap-0 flex flex-col overflow-hidden">
         <DialogHeader className="px-5 pt-4 pb-2 shrink-0">
           <DialogTitle>{t(($) => $.feedback.title)}</DialogTitle>
-          <DialogDescription>
-            {t(($) => $.feedback.description)}
-          </DialogDescription>
-          <a
-            href="https://github.com/multica-ai/multica/issues"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-          >
-            {t(($) => $.feedback.github_hint)}
-          </a>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t(($) => $.feedback.github_hint_prefix)}
+            <a
+              href="https://github.com/multica-ai/multica/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand underline decoration-brand/40 underline-offset-2 hover:decoration-brand"
+            >
+              {t(($) => $.feedback.github_hint_link)}
+            </a>
+          </p>
         </DialogHeader>
 
         <div className="flex-1 min-h-0 px-5 pb-3">


### PR DESCRIPTION
## Summary

Follow-up to #2451. After landing the GitHub hint, the modal head looked like this — three lines of grey, all blending into each other:

```
Feedback
We'd love to hear what's working, what isn't, or what you'd like to see next.
Want to discuss or get faster traction? Open an issue on GitHub →
```

The hint was the whole point of #2451, but it didn't read as a call to action — same colour, same weight, same visual treatment as the throwaway description above it.

This PR:

- Removes `DialogDescription` (placeholder already explains what to type — the description was redundant).
- Shortens the hint to a single short sentence ending in "GitHub", so the link sits at the natural end-of-line fixation point.
- Colours only "GitHub" with `text-brand`, matching the existing link pattern in `packages/views/skills/components/create-skill-dialog.tsx:275`.
- Splits the hint into `github_hint_prefix` + `github_hint_link` (suffix is empty, so no sentence-order brittleness).

## Files

- `packages/views/modals/feedback.tsx` — drop `DialogDescription`, restructure the hint as prefix + brand anchor.
- `packages/views/locales/en/modals.json` — drop `description` + old `github_hint`; add `github_hint_prefix` ("Want faster traction? Head to ") + `github_hint_link` ("GitHub").
- `packages/views/locales/zh-Hans/modals.json` — same shape; prefix follows `conventions.zh.mdx` spacing rules ("想要更快的，请去 " with trailing space before Latin term).

3 files, 15 insertions, 16 deletions.

## Test plan

- [x] `pnpm typecheck` — 6 packages green
- [x] `pnpm --filter @multica/views test` — 374 / 374 passing
- [ ] Manual: open modal on web + desktop, confirm only one grey line + "GitHub" rendered in brand colour with a brand-tinted underline
- [ ] Manual: switch to 中文, verify the ZH copy and that the Latin word "GitHub" sits between spaces on both sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)