### PR TITLE
fix(chat): keep editor mounted across lazy session creation

### DIFF
--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -62,14 +62,30 @@ export function ChatInput({
   const editorRef = useRef<ContentEditorRef>(null);
   const activeSessionId = useChatStore((s) => s.activeSessionId);
   const selectedAgentId = useChatStore((s) => s.selectedAgentId);
-  // Scope the new-chat draft by agent:
-  //   1. Switching agents while composing a brand-new chat gives each
-  //      agent its own draft (no cross-agent leakage).
-  //   2. Tiptap's Placeholder extension is only applied at mount; this
-  //      key changes on agent switch so the editor remounts and the
-  //      `Tell {agent} what to do…` placeholder refreshes.
+  // Two keys with deliberately different concerns:
+  //
+  // `draftKey` — zustand storage key. Scopes the in-progress draft per
+  // session so different sessions don't bleed text into each other; for
+  // brand-new chats it falls back to a per-agent slot so switching agents
+  // mid-compose gives each agent its own draft. This is a STORAGE key, not
+  // a React identity.
+  //
+  // `editorKey` — React `key` on the ContentEditor. Used ONLY to force a
+  // remount when the user explicitly switches agent (so Tiptap's
+  // Placeholder, which only reads on mount, refreshes to "Tell {agent}…").
+  // Crucially this does NOT include `activeSessionId`: when the user
+  // uploads a file in a brand-new chat, `handleUploadFile` first awaits
+  // `ensureSession` which lazily creates the session and flips
+  // `activeSessionId` from null → uuid mid-upload. If the editor key
+  // depended on session id, that flip would unmount the editor right as
+  // the blob preview was inserted, dropping the in-progress upload's
+  // image node before file-upload.ts could swap it for the CDN URL — the
+  // user would see the image flash on then disappear. Keeping editor
+  // identity stable across the lazy-create event is what makes
+  // first-upload-creates-session work the same as second-upload.
   const draftKey =
     activeSessionId ?? `${DRAFT_NEW_SESSION}:${selectedAgentId ?? ""}`;
+  const editorKey = selectedAgentId ?? "no-agent";
   // Select a primitive — empty-string fallback keeps referential stability.
   const inputDraft = useChatStore((s) => s.inputDrafts[draftKey] ?? "");
   const setInputDraft = useChatStore((s) => s.setInputDraft);
@@ -201,9 +217,9 @@ export function ChatInput({
         {topSlot}
         <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">
           <ContentEditor
-            // Remount the editor when the active session changes so its
-            // uncontrolled defaultValue picks up the new session's draft.
-            key={draftKey}
+            // See the editorKey / draftKey split note above — editorKey
+            // intentionally does not depend on activeSessionId.
+            key={editorKey}
             ref={editorRef}
             defaultValue={inputDraft}
             placeholder={placeholder}


### PR DESCRIPTION
## Summary

- First file upload in a brand-new chat showed the image then immediately blanked out — fixed by stopping the editor from remounting when `activeSessionId` flips during the upload.
- Splits the conflated `draftKey` into two concerns: `draftKey` (zustand storage, unchanged) vs `editorKey` (React identity, no longer includes session id).
- Pure frontend; no backend / CLI / API changes.

## Root cause

`<ContentEditor key={draftKey}>` and `draftKey` included `activeSessionId`. In a brand-new chat, `chat-window.tsx`'s `handleUploadFile` `await ensureSession("")` *before* forwarding the file — the lazy-create flips `activeSessionId` from `null` to a uuid **mid-upload**, the `draftKey` changes, the editor remounts, and the blob image node inserted by `uploadAndInsertFile` is destroyed before the swap-to-CDN-URL walk can find it. `URL.revokeObjectURL` then releases the blob → broken image.

The create-issue modal uses the same draft-store pattern but doesn't hit this because it never sets a `key` on its ContentEditor.

## Fix

Split storage key from React identity key:

\`\`\`tsx
const draftKey  = activeSessionId ?? \`\${DRAFT_NEW_SESSION}:\${selectedAgentId ?? ""}\`;  // unchanged
const editorKey = selectedAgentId ?? "no-agent";                                        // new — drops session id
// ...
<ContentEditor key={editorKey} defaultValue={inputDraft} ... />
\`\`\`

`editorKey` still varies on `selectedAgentId` so Tiptap's Placeholder refreshes on agent switch (the original reason `key` was added). It no longer varies on session id, so lazy session creation can't unmount the editor mid-upload.

## Test plan

- [ ] In a brand-new chat (no session), click upload → pick image → confirm image renders and stays visible
- [ ] In an existing session, upload another image → still works (regression check)
- [ ] Switch agent while composing → editor remounts, placeholder refreshes (preserved behaviour)
- [ ] Switch session while composing → draft per session still isolated (preserved behaviour)
- [ ] \`pnpm --filter @multica/views test chat-input\` (4 tests pass locally)
- [ ] \`pnpm --filter @multica/views typecheck\` (passes locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)