### PR TITLE
fix(runtimes): correct broken docs link to /docs/daemon-runtimes

### DIFF
--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -206,7 +206,7 @@ function PageHeaderBar({
         <p className="ml-2 hidden text-xs text-muted-foreground md:block">
           {t(($) => $.page.tagline)}{" "}
           <a
-            href="https://multica.ai/docs/runtimes"
+            href="https://multica.ai/docs/daemon-runtimes"
             target="_blank"
             rel="noopener noreferrer"
             className="underline decoration-muted-foreground/30 underline-offset-4 transition-colors hover:text-foreground"


### PR DESCRIPTION
## What does this PR do?

Fix the "Learn more" link in the Runtimes page header so it actually goes to the docs.

The link previously pointed at `https://multica.ai/docs/runtimes`, which returns a real 404 from the docs site. The published page lives at `/docs/daemon-runtimes`, so the link is now `https://multica.ai/docs/daemon-runtimes`.

## Related Issue

Closes #2464

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/runtimes/components/runtimes-page.tsx:209` — update `href` from `/docs/runtimes` to `/docs/daemon-runtimes`.

## How to Test

1. Open the app, navigate to **Runtimes**.
2. Click **Learn more** in the page header.
3. Verify the new tab loads `https://multica.ai/docs/daemon-runtimes` (HTTP 200) instead of a 404.

```shell
$ curl -sS -o /dev/null -w "%{http_code}\n" https://multica.ai/docs/daemon-runtimes
200
```

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy**, **starter-content**, and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: one-character path change to an external `href`; no behavior other than the link target is affected. No test coverage added — this is a static URL fix that would require a network test to be meaningful.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Audited all `multica.ai` URLs referenced in `apps/` and `packages/` with `curl` to find dead links; only `/docs/runtimes` returned 404 while `/docs/daemon-runtimes` returned 200, so the existing constant was a typo and the fix is the one-line `href` swap.

## Screenshots (optional)

_n/a — link target only._