### PR TITLE
refactor(integrations): drop installation list from Settings tab

### DIFF
--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -167,14 +167,9 @@
     "connect_disabled_tooltip": "GitHub App is not configured on this server",
     "not_configured": "GitHub integration is not configured for this deployment. Operators must set",
     "not_configured_and": "and",
-    "loading": "Loading…",
-    "empty": "No GitHub accounts connected yet.",
-    "connected_at": "{{type}} · connected {{date}}",
     "manage_hint": "Only admins and owners can manage integrations.",
     "toast_not_configured": "GitHub integration is not configured for this deployment",
-    "toast_open_failed": "Failed to open GitHub install",
-    "toast_disconnected": "Disconnected GitHub account",
-    "toast_disconnect_failed": "Failed to disconnect"
+    "toast_open_failed": "Failed to open GitHub install"
   },
   "repositories": {
     "section_title": "Repositories",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -167,14 +167,9 @@
     "connect_disabled_tooltip": "服务端未配置 GitHub App",
     "not_configured": "当前部署没有配置 GitHub 集成。运维需要设置",
     "not_configured_and": "和",
-    "loading": "加载中…",
-    "empty": "还没有连接 GitHub 账户。",
-    "connected_at": "{{type}} · {{date}} 连接",
     "manage_hint": "只有管理员和所有者可以管理集成。",
     "toast_not_configured": "当前部署未配置 GitHub 集成",
-    "toast_open_failed": "打开 GitHub 安装页失败",
-    "toast_disconnected": "已断开 GitHub 账户",
-    "toast_disconnect_failed": "断开连接失败"
+    "toast_open_failed": "打开 GitHub 安装页失败"
   },
   "repositories": {
     "section_title": "代码仓库",

--- a/packages/views/settings/components/integrations-tab.tsx
+++ b/packages/views/settings/components/integrations-tab.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Trash2 } from "lucide-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
 import { useAuthStore } from "@multica/core/auth";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { memberListOptions } from "@multica/core/workspace/queries";
-import { githubInstallationsOptions, githubKeys } from "@multica/core/github/queries";
+import { githubInstallationsOptions } from "@multica/core/github/queries";
 import { api } from "@multica/core/api";
 import { useT } from "../../i18n";
 
@@ -27,21 +26,19 @@ export function IntegrationsTab() {
   const { t } = useT("settings");
   const wsId = useWorkspaceId();
   const user = useAuthStore((s) => s.user);
-  const qc = useQueryClient();
   const { data: members = [] } = useQuery(memberListOptions(wsId));
   const [connecting, setConnecting] = useState(false);
 
   const currentMember = members.find((m) => m.user_id === user?.id) ?? null;
   const canManage = currentMember?.role === "owner" || currentMember?.role === "admin";
 
-  // The list endpoint is admin-only; non-admins would see a 403 toast and
-  // an empty configured state. Gate the query on canManage so members get
-  // a clean read-only view.
-  const { data, isLoading } = useQuery({
+  // Only used to gate the Connect button + show a "not configured" hint;
+  // we no longer render the installation list here — admins manage existing
+  // installations on GitHub directly via the Connect flow.
+  const { data } = useQuery({
     ...githubInstallationsOptions(wsId),
     enabled: !!wsId && canManage,
   });
-  const installations = data?.installations ?? [];
   const configured = data?.configured ?? false;
 
   async function handleConnect() {
@@ -57,16 +54,6 @@ export function IntegrationsTab() {
       toast.error(e instanceof Error ? e.message : t(($) => $.integrations.toast_open_failed));
     } finally {
       setConnecting(false);
-    }
-  }
-
-  async function handleDisconnect(installationDbId: string) {
-    try {
-      await api.deleteGitHubInstallation(wsId, installationDbId);
-      qc.invalidateQueries({ queryKey: githubKeys.installations(wsId) });
-      toast.success(t(($) => $.integrations.toast_disconnected));
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : t(($) => $.integrations.toast_disconnect_failed));
     }
   }
 
@@ -113,55 +100,6 @@ export function IntegrationsTab() {
                 {t(($) => $.integrations.not_configured_and)}{" "}
                 <code className="rounded bg-muted px-1 py-0.5 text-[10px]">GITHUB_WEBHOOK_SECRET</code>.
               </p>
-            )}
-
-            {canManage && configured && (
-              <div className="space-y-2">
-                {isLoading && <p className="text-xs text-muted-foreground">{t(($) => $.integrations.loading)}</p>}
-                {!isLoading && installations.length === 0 && (
-                  <p className="text-xs text-muted-foreground">
-                    {t(($) => $.integrations.empty)}
-                  </p>
-                )}
-                {installations.map((inst) => (
-                  <div
-                    key={inst.id}
-                    className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      {inst.account_avatar_url && (
-                        <img
-                          src={inst.account_avatar_url}
-                          alt=""
-                          className="h-6 w-6 rounded-full shrink-0"
-                        />
-                      )}
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium truncate">{inst.account_login}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {t(($) => $.integrations.connected_at, {
-                            type: inst.account_type,
-                            date: new Date(inst.created_at).toLocaleDateString("en-US", {
-                              month: "short",
-                              day: "numeric",
-                            }),
-                          })}
-                        </p>
-                      </div>
-                    </div>
-                    {canManage && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-muted-foreground hover:text-destructive shrink-0"
-                        onClick={() => handleDisconnect(inst.id)}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    )}
-                  </div>
-                ))}
-              </div>
             )}
 
             {!canManage && (


### PR DESCRIPTION
## Summary
- The Integrations tab listed each GitHub installation with avatar + account name + "User · connected <date>" + disconnect button. The title regularly displayed "unknown" because `fetchInstallationAccount` (server side) doesn't sign with an App JWT, so the unauthenticated `GET /app/installations/{id}` call falls through to the literal `"unknown"` placeholder.
- Beyond the bug, the per-account framing also leaked GitHub's data model into the UX. Users coming to Integrations want to know "what's wired up to this workspace?" — repos, not which GitHub account owns the App installation.
- Collapse the card to just the GitHub mark + description + Connect button (with the existing "not configured" hint + role gate intact). Existing installations remain fully manageable from GitHub's own Settings → Applications page, which is exactly where the Connect flow lands you anyway.

## Test plan
- [ ] Open Settings → Integrations as an admin on a workspace that has at least one installed GitHub App — verify the list/avatar/disconnect rows are gone, only the Connect button + description remain.
- [ ] Open as a non-admin member — the `manage_hint` line still renders, Connect button is hidden.
- [ ] Verify Connect button is correctly disabled when `GITHUB_APP_SLUG` / `GITHUB_WEBHOOK_SECRET` env vars are missing (the "not configured" hint still appears).
- [ ] Click Connect → GitHub installation page opens in a new tab; pre-existing installations are visible there.
- [ ] `pnpm typecheck` clean (no orphan imports / dead i18n key references).