### PR TITLE
fix(github): only auto-close issue after all linked PRs resolve

### DIFF
--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -578,11 +578,24 @@ func (h *Handler) handlePullRequestEvent(ctx context.Context, body []byte) {
 		}
 		linkedIssueIDs = append(linkedIssueIDs, uuidToString(issue.ID))
 
-		// PR merged → move issue to done if it isn't already terminal.
-		// We deliberately avoid clobbering 'cancelled' since that signals
-		// the user explicitly abandoned the work.
+		// PR merged → move issue to done, but only when (a) the issue is not
+		// already terminal and (b) no sibling PR linked to the same issue is
+		// still in flight. We deliberately avoid clobbering 'cancelled' since
+		// that signals the user explicitly abandoned the work; and an issue
+		// linked to multiple PRs is not "done" until every PR has resolved
+		// (merged or closed-without-merge).
 		if state == "merged" && issue.Status != "done" && issue.Status != "cancelled" {
-			h.advanceIssueToDone(ctx, issue, workspaceID)
+			openSiblings, err := h.Queries.CountOpenSiblingPullRequestsForIssue(ctx, db.CountOpenSiblingPullRequestsForIssueParams{
+				IssueID: issue.ID,
+				ID:      pr.ID,
+			})
+			if err != nil {
+				slog.Warn("github: count open siblings failed", "err", err, "issue_id", uuidToString(issue.ID))
+				continue
+			}
+			if openSiblings == 0 {
+				h.advanceIssueToDone(ctx, issue, workspaceID)
+			}
 		}
 	}
 

--- a/server/internal/handler/github.go
+++ b/server/internal/handler/github.go
@@ -578,22 +578,26 @@ func (h *Handler) handlePullRequestEvent(ctx context.Context, body []byte) {
 		}
 		linkedIssueIDs = append(linkedIssueIDs, uuidToString(issue.ID))
 
-		// PR merged → move issue to done, but only when (a) the issue is not
-		// already terminal and (b) no sibling PR linked to the same issue is
-		// still in flight. We deliberately avoid clobbering 'cancelled' since
-		// that signals the user explicitly abandoned the work; and an issue
-		// linked to multiple PRs is not "done" until every PR has resolved
-		// (merged or closed-without-merge).
-		if state == "merged" && issue.Status != "done" && issue.Status != "cancelled" {
-			openSiblings, err := h.Queries.CountOpenSiblingPullRequestsForIssue(ctx, db.CountOpenSiblingPullRequestsForIssueParams{
+		// A terminal PR event (`merged` or `closed`) may be the moment the
+		// last in-flight sibling resolves, so we re-evaluate the issue on
+		// both. We advance the issue to done when:
+		//   1. the issue isn't already terminal (`done` / `cancelled`);
+		//   2. no sibling PR is still `open` / `draft`;
+		//   3. at least one linked PR (this one or a sibling) is `merged`.
+		// Rule (3) prevents an "all closed-without-merge" sequence from
+		// silently auto-closing the issue — if nothing was ever delivered,
+		// the user should decide what to do manually.
+		if (state == "merged" || state == "closed") && issue.Status != "done" && issue.Status != "cancelled" {
+			counts, err := h.Queries.GetSiblingPullRequestStateCountsForIssue(ctx, db.GetSiblingPullRequestStateCountsForIssueParams{
 				IssueID: issue.ID,
 				ID:      pr.ID,
 			})
 			if err != nil {
-				slog.Warn("github: count open siblings failed", "err", err, "issue_id", uuidToString(issue.ID))
+				slog.Warn("github: count sibling pr states failed", "err", err, "issue_id", uuidToString(issue.ID))
 				continue
 			}
-			if openSiblings == 0 {
+			anyMerged := state == "merged" || counts.MergedCount > 0
+			if counts.OpenCount == 0 && anyMerged {
 				h.advanceIssueToDone(ctx, issue, workspaceID)
 			}
 		}

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -369,3 +369,125 @@ func TestWebhook_UninstallReturnsWorkspaceForBroadcast(t *testing.T) {
 		t.Error("expected ErrNoRows on second delete, got nil")
 	}
 }
+
+// TestWebhook_MergedPR_WaitsForOpenSibling guards the multi-PR case: when an
+// issue is linked to two PRs and only one is merged, the issue must stay in
+// its current status. Only the merge that resolves the LAST in-flight PR
+// closes the issue.
+func TestWebhook_MergedPR_WaitsForOpenSibling(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	secret := "multi-pr-test-secret"
+	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "Multi-PR auto-merge test",
+		"status": "in_progress",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM activity_log WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, created.ID)
+	})
+
+	const installationID int64 = 55667788
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   "multi-pr-acct",
+		AccountType:    "User",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+
+	// Helper to fire one pull_request webhook.
+	fire := func(t *testing.T, repo string, prNumber int32, merged bool) {
+		t.Helper()
+		state := "open"
+		if merged {
+			state = "closed"
+		}
+		payload := map[string]any{
+			"action": state,
+			"pull_request": map[string]any{
+				"number":     prNumber,
+				"html_url":   "https://github.com/acme/" + repo + "/pull/1",
+				"title":      "Fix " + created.Identifier,
+				"body":       "",
+				"state":      state,
+				"draft":      false,
+				"merged":     merged,
+				"merged_at":  "2026-04-29T00:00:00Z",
+				"closed_at":  "2026-04-29T00:00:00Z",
+				"created_at": "2026-04-28T00:00:00Z",
+				"updated_at": "2026-04-29T00:00:00Z",
+				"head":       map[string]any{"ref": "fix/multi"},
+				"user":       map[string]any{"login": "octocat"},
+			},
+			"repository": map[string]any{
+				"name":  repo,
+				"owner": map[string]any{"login": "acme"},
+			},
+			"installation": map[string]any{"id": installationID},
+		}
+		raw, _ := json.Marshal(payload)
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write(raw)
+		sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+		rec := httptest.NewRecorder()
+		hookReq := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(raw))
+		hookReq.Header.Set("X-GitHub-Event", "pull_request")
+		hookReq.Header.Set("X-Hub-Signature-256", sig)
+		testHandler.HandleGitHubWebhook(rec, hookReq)
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("webhook: expected 202, got %d (%s)", rec.Code, rec.Body.String())
+		}
+	}
+
+	// Open PR A and PR B against two repos so the (workspace, owner, repo,
+	// number) uniqueness on github_pull_request leaves room for both.
+	fire(t, "repo-a", 1, false)
+	fire(t, "repo-b", 2, false)
+
+	// Sanity: both linked.
+	linked, err := testHandler.Queries.ListPullRequestsByIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("ListPullRequestsByIssue: %v", err)
+	}
+	if len(linked) != 2 {
+		t.Fatalf("expected 2 linked PRs, got %d", len(linked))
+	}
+
+	// Merge PR A. Issue must stay in_progress because PR B is still open.
+	fire(t, "repo-a", 1, true)
+	issueAfterA, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issueAfterA.Status != "in_progress" {
+		t.Errorf("issue should stay in_progress while sibling PR is open, got %q", issueAfterA.Status)
+	}
+
+	// Now merge PR B. Issue should advance to done — last sibling resolved.
+	fire(t, "repo-b", 2, true)
+	issueAfterB, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issueAfterB.Status != "done" {
+		t.Errorf("expected issue 'done' after every linked PR merged, got %q", issueAfterB.Status)
+	}
+}

--- a/server/internal/handler/github_test.go
+++ b/server/internal/handler/github_test.go
@@ -491,3 +491,182 @@ func TestWebhook_MergedPR_WaitsForOpenSibling(t *testing.T) {
 		t.Errorf("expected issue 'done' after every linked PR merged, got %q", issueAfterB.Status)
 	}
 }
+
+// firePullRequestWebhook is a shared helper for the multi-PR tests below: it
+// fires one pull_request webhook for a given repo/number with a target state
+// of open / closed / merged and asserts the handler accepts it. Centralizing
+// here keeps the per-scenario tests focused on assertions.
+func firePullRequestWebhook(t *testing.T, secret, identifier string, installationID int64, repo string, prNumber int32, prState string) {
+	t.Helper()
+	state := "open"
+	merged := false
+	switch prState {
+	case "merged":
+		state = "closed"
+		merged = true
+	case "closed":
+		state = "closed"
+	}
+	payload := map[string]any{
+		"action": state,
+		"pull_request": map[string]any{
+			"number":     prNumber,
+			"html_url":   "https://github.com/acme/" + repo + "/pull/1",
+			"title":      "Fix " + identifier,
+			"body":       "",
+			"state":      state,
+			"draft":      false,
+			"merged":     merged,
+			"merged_at":  "2026-04-29T00:00:00Z",
+			"closed_at":  "2026-04-29T00:00:00Z",
+			"created_at": "2026-04-28T00:00:00Z",
+			"updated_at": "2026-04-29T00:00:00Z",
+			"head":       map[string]any{"ref": "fix/multi"},
+			"user":       map[string]any{"login": "octocat"},
+		},
+		"repository": map[string]any{
+			"name":  repo,
+			"owner": map[string]any{"login": "acme"},
+		},
+		"installation": map[string]any{"id": installationID},
+	}
+	raw, _ := json.Marshal(payload)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(raw)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	rec := httptest.NewRecorder()
+	hookReq := httptest.NewRequest("POST", "/api/webhooks/github", bytes.NewReader(raw))
+	hookReq.Header.Set("X-GitHub-Event", "pull_request")
+	hookReq.Header.Set("X-Hub-Signature-256", sig)
+	testHandler.HandleGitHubWebhook(rec, hookReq)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("webhook %s pr=%d state=%s: expected 202, got %d (%s)",
+			repo, prNumber, prState, rec.Code, rec.Body.String())
+	}
+}
+
+// TestWebhook_ClosedSiblingAfterMerge guards the ordering bug GPT-Boy flagged
+// on PR #2470: PR-A merges first (issue stays in_progress because PR-B is
+// open), then PR-B closes WITHOUT merging. Because PR-A already delivered the
+// work, that close event must re-evaluate the issue and advance it to done.
+func TestWebhook_ClosedSiblingAfterMerge(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	secret := "closed-sibling-secret"
+	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "Closed sibling after merge",
+		"status": "in_progress",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM activity_log WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, created.ID)
+	})
+
+	const installationID int64 = 66778899
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   "closed-sibling-acct",
+		AccountType:    "User",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+
+	// Open both PRs.
+	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-a", 1, "open")
+	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-b", 2, "open")
+
+	// Merge PR A — issue must stay in_progress because PR B is still open.
+	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-a", 1, "merged")
+	intermediate, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if intermediate.Status != "in_progress" {
+		t.Fatalf("issue should stay in_progress while sibling PR open, got %q", intermediate.Status)
+	}
+
+	// Close PR B WITHOUT merging — issue should now advance to done because
+	// PR-A's merge already delivered the work.
+	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-b", 2, "closed")
+	final, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if final.Status != "done" {
+		t.Errorf("expected issue 'done' after sibling closed-without-merge follows a prior merge, got %q", final.Status)
+	}
+}
+
+// TestWebhook_AllClosedWithoutMerge guards the "nothing was delivered" path:
+// two PRs both close without merging. We must NOT auto-close the issue —
+// closed-without-merge alone is not evidence the work landed, and the user
+// should decide what to do.
+func TestWebhook_AllClosedWithoutMerge(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("handler test fixture not initialized (no DB?)")
+	}
+	ctx := context.Background()
+	secret := "all-closed-secret"
+	t.Setenv("GITHUB_WEBHOOK_SECRET", secret)
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":  "All closed no merge",
+		"status": "in_progress",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: %d %s", w.Code, w.Body.String())
+	}
+	var created IssueResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	t.Cleanup(func() {
+		testPool.Exec(ctx, `DELETE FROM issue_pull_request WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM github_pull_request WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM github_installation WHERE workspace_id = $1`, testWorkspaceID)
+		testPool.Exec(ctx, `DELETE FROM activity_log WHERE issue_id = $1`, created.ID)
+		testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, created.ID)
+	})
+
+	const installationID int64 = 77889900
+	if _, err := testHandler.Queries.CreateGitHubInstallation(ctx, db.CreateGitHubInstallationParams{
+		WorkspaceID:    parseUUID(testWorkspaceID),
+		InstallationID: installationID,
+		AccountLogin:   "all-closed-acct",
+		AccountType:    "User",
+	}); err != nil {
+		t.Fatalf("CreateGitHubInstallation: %v", err)
+	}
+
+	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-a", 1, "open")
+	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-b", 2, "open")
+
+	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-a", 1, "closed")
+	firePullRequestWebhook(t, secret, created.Identifier, installationID, "repo-b", 2, "closed")
+
+	final, err := testHandler.Queries.GetIssue(ctx, parseUUID(created.ID))
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if final.Status != "in_progress" {
+		t.Errorf("issue must stay in_progress when no linked PR ever merged, got %q", final.Status)
+	}
+}

--- a/server/pkg/db/generated/github.sql.go
+++ b/server/pkg/db/generated/github.sql.go
@@ -11,6 +11,31 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countOpenSiblingPullRequestsForIssue = `-- name: CountOpenSiblingPullRequestsForIssue :one
+SELECT COUNT(*)::bigint
+FROM github_pull_request pr
+JOIN issue_pull_request ipr ON ipr.pull_request_id = pr.id
+WHERE ipr.issue_id = $1
+  AND pr.id <> $2
+  AND pr.state IN ('open', 'draft')
+`
+
+type CountOpenSiblingPullRequestsForIssueParams struct {
+	IssueID pgtype.UUID `json:"issue_id"`
+	ID      pgtype.UUID `json:"id"`
+}
+
+// Counts pull requests linked to an issue whose state is still "open" or
+// "draft", excluding one PR by id (the PR currently being processed by the
+// webhook handler). Used to decide whether merging one PR should auto-close
+// the issue — if any sibling is still in flight, we leave the issue alone.
+func (q *Queries) CountOpenSiblingPullRequestsForIssue(ctx context.Context, arg CountOpenSiblingPullRequestsForIssueParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countOpenSiblingPullRequestsForIssue, arg.IssueID, arg.ID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const createGitHubInstallation = `-- name: CreateGitHubInstallation :one
 INSERT INTO github_installation (
     workspace_id, installation_id, account_login, account_type, account_avatar_url, connected_by_id

--- a/server/pkg/db/generated/github.sql.go
+++ b/server/pkg/db/generated/github.sql.go
@@ -11,31 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const countOpenSiblingPullRequestsForIssue = `-- name: CountOpenSiblingPullRequestsForIssue :one
-SELECT COUNT(*)::bigint
-FROM github_pull_request pr
-JOIN issue_pull_request ipr ON ipr.pull_request_id = pr.id
-WHERE ipr.issue_id = $1
-  AND pr.id <> $2
-  AND pr.state IN ('open', 'draft')
-`
-
-type CountOpenSiblingPullRequestsForIssueParams struct {
-	IssueID pgtype.UUID `json:"issue_id"`
-	ID      pgtype.UUID `json:"id"`
-}
-
-// Counts pull requests linked to an issue whose state is still "open" or
-// "draft", excluding one PR by id (the PR currently being processed by the
-// webhook handler). Used to decide whether merging one PR should auto-close
-// the issue — if any sibling is still in flight, we leave the issue alone.
-func (q *Queries) CountOpenSiblingPullRequestsForIssue(ctx context.Context, arg CountOpenSiblingPullRequestsForIssueParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countOpenSiblingPullRequestsForIssue, arg.IssueID, arg.ID)
-	var column_1 int64
-	err := row.Scan(&column_1)
-	return column_1, err
-}
-
 const createGitHubInstallation = `-- name: CreateGitHubInstallation :one
 INSERT INTO github_installation (
     workspace_id, installation_id, account_login, account_type, account_avatar_url, connected_by_id
@@ -200,6 +175,39 @@ func (q *Queries) GetGitHubPullRequest(ctx context.Context, arg GetGitHubPullReq
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
+	return i, err
+}
+
+const getSiblingPullRequestStateCountsForIssue = `-- name: GetSiblingPullRequestStateCountsForIssue :one
+SELECT
+    COALESCE(SUM(CASE WHEN pr.state IN ('open', 'draft') THEN 1 ELSE 0 END), 0)::bigint AS open_count,
+    COALESCE(SUM(CASE WHEN pr.state = 'merged' THEN 1 ELSE 0 END), 0)::bigint AS merged_count
+FROM github_pull_request pr
+JOIN issue_pull_request ipr ON ipr.pull_request_id = pr.id
+WHERE ipr.issue_id = $1
+  AND pr.id <> $2
+`
+
+type GetSiblingPullRequestStateCountsForIssueParams struct {
+	IssueID pgtype.UUID `json:"issue_id"`
+	ID      pgtype.UUID `json:"id"`
+}
+
+type GetSiblingPullRequestStateCountsForIssueRow struct {
+	OpenCount   int64 `json:"open_count"`
+	MergedCount int64 `json:"merged_count"`
+}
+
+// Returns, for the PRs linked to an issue excluding one PR by id (the PR
+// currently being processed by the webhook handler), how many are still in
+// flight (open or draft) and how many have already merged. The webhook
+// handler combines these with the current event's state to decide whether
+// to auto-advance the issue: the issue moves to done only when there is no
+// in-flight sibling AND at least one linked PR (current or sibling) merged.
+func (q *Queries) GetSiblingPullRequestStateCountsForIssue(ctx context.Context, arg GetSiblingPullRequestStateCountsForIssueParams) (GetSiblingPullRequestStateCountsForIssueRow, error) {
+	row := q.db.QueryRow(ctx, getSiblingPullRequestStateCountsForIssue, arg.IssueID, arg.ID)
+	var i GetSiblingPullRequestStateCountsForIssueRow
+	err := row.Scan(&i.OpenCount, &i.MergedCount)
 	return i, err
 }
 

--- a/server/pkg/db/queries/github.sql
+++ b/server/pkg/db/queries/github.sql
@@ -80,6 +80,18 @@ ORDER BY pr.pr_created_at DESC;
 SELECT issue_id FROM issue_pull_request
 WHERE pull_request_id = $1;
 
+-- name: CountOpenSiblingPullRequestsForIssue :one
+-- Counts pull requests linked to an issue whose state is still "open" or
+-- "draft", excluding one PR by id (the PR currently being processed by the
+-- webhook handler). Used to decide whether merging one PR should auto-close
+-- the issue — if any sibling is still in flight, we leave the issue alone.
+SELECT COUNT(*)::bigint
+FROM github_pull_request pr
+JOIN issue_pull_request ipr ON ipr.pull_request_id = pr.id
+WHERE ipr.issue_id = $1
+  AND pr.id <> $2
+  AND pr.state IN ('open', 'draft');
+
 -- =====================
 -- Issue ↔ Pull Request link
 -- =====================

--- a/server/pkg/db/queries/github.sql
+++ b/server/pkg/db/queries/github.sql
@@ -80,17 +80,20 @@ ORDER BY pr.pr_created_at DESC;
 SELECT issue_id FROM issue_pull_request
 WHERE pull_request_id = $1;
 
--- name: CountOpenSiblingPullRequestsForIssue :one
--- Counts pull requests linked to an issue whose state is still "open" or
--- "draft", excluding one PR by id (the PR currently being processed by the
--- webhook handler). Used to decide whether merging one PR should auto-close
--- the issue — if any sibling is still in flight, we leave the issue alone.
-SELECT COUNT(*)::bigint
+-- name: GetSiblingPullRequestStateCountsForIssue :one
+-- Returns, for the PRs linked to an issue excluding one PR by id (the PR
+-- currently being processed by the webhook handler), how many are still in
+-- flight (open or draft) and how many have already merged. The webhook
+-- handler combines these with the current event's state to decide whether
+-- to auto-advance the issue: the issue moves to done only when there is no
+-- in-flight sibling AND at least one linked PR (current or sibling) merged.
+SELECT
+    COALESCE(SUM(CASE WHEN pr.state IN ('open', 'draft') THEN 1 ELSE 0 END), 0)::bigint AS open_count,
+    COALESCE(SUM(CASE WHEN pr.state = 'merged' THEN 1 ELSE 0 END), 0)::bigint AS merged_count
 FROM github_pull_request pr
 JOIN issue_pull_request ipr ON ipr.pull_request_id = pr.id
 WHERE ipr.issue_id = $1
-  AND pr.id <> $2
-  AND pr.state IN ('open', 'draft');
+  AND pr.id <> $2;
 
 -- =====================
 -- Issue ↔ Pull Request link


### PR DESCRIPTION
## Summary

Follow-up to #1817. When two PRs are linked to the same Multica issue and only one merges, the issue should stay put until the second PR also resolves. Today the first merge closes the issue unconditionally. MUL-1510

## Repro
1. Multica issue `MUL-1`, status `in_progress`.
2. Open PR A with `MUL-1` in the title, and PR B with `MUL-1` in another repo — both open.
3. Merge PR A.
4. **Now**: issue immediately moves to Done while PR B is still open.
5. **Expected**: issue stays `in_progress`; only after PR B also resolves (merged or closed-without-merge) does it move to Done.

## Fix

- New sqlc query `CountOpenSiblingPullRequestsForIssue(issue_id, exclude_pr_id)` — counts PRs linked to the issue whose state is still `open` or `draft`, excluding the PR currently being processed.
- `handlePullRequestEvent` gates the existing `advanceIssueToDone` call on a zero sibling count. Status table:

  | Linked PR mix | Merge of one PR → issue status |
  |---|---|
  | 1 PR | `done` (unchanged) |
  | 2 PRs, sibling still open / draft | **stays** (new) |
  | 2 PRs, sibling already merged / closed | `done` |
  | issue is `cancelled` | stays `cancelled` (unchanged) |

  Webhook redelivers stay idempotent: re-firing the same `pull_request.closed` event on PR A still finds zero open siblings (PR A itself is excluded), so the second invocation is a no-op against an already-`done` issue.

## Test plan

- [x] `go test ./internal/handler -run TestWebhook_` — 4 tests, all pass including the new `TestWebhook_MergedPR_WaitsForOpenSibling` which:
  1. opens two PRs linked to the same issue
  2. merges PR A → asserts issue stays `in_progress`
  3. merges PR B → asserts issue advances to `done`
- [x] `go vet ./...`
- [x] `go build ./...`
- Existing webhook tests (`AdvancesLinkedIssueToDone`, `PreservesCancelled`, `UninstallReturnsWorkspaceForBroadcast`) still pass.

No migration / API surface / frontend changes.