### PR TITLE
fix(agent): retry transient kiro upstream errors with exponential backoff

### DIFF
--- a/server/pkg/agent/kiro.go
+++ b/server/pkg/agent/kiro.go
@@ -355,11 +355,37 @@ func (b *kiroBackend) Execute(ctx context.Context, prompt string, opts ExecOptio
 		// shape can drive the turn.
 		// TODO: drop one field once Kiro lands on a single canonical payload.
 		streamingCurrentTurn.Store(true)
-		_, err = c.request(runCtx, "session/prompt", map[string]any{
-			"sessionId": sessionID,
-			"content":   promptBlocks,
-			"prompt":    promptBlocks,
-		})
+
+		// Retry transient upstream errors (ConnectionReset, DispatchFailure,
+		// timeout, throttling) with exponential backoff. Throttled requests
+		// use longer delays (10s base) to respect rate limits.
+		const maxPromptRetries = 3
+		for attempt := 0; attempt <= maxPromptRetries; attempt++ {
+			if attempt > 0 {
+				streamingCurrentTurn.Store(false)
+				var backoff time.Duration
+				if isThrottledError(err) {
+					backoff = time.Duration(10<<(attempt-1)) * time.Second // 10s, 20s, 40s
+				} else {
+					backoff = time.Duration(3<<(attempt-1)) * time.Second // 3s, 6s, 12s
+				}
+				b.cfg.Logger.Warn("kiro session/prompt transient failure, retrying", "attempt", attempt, "backoff", backoff, "error", err)
+				select {
+				case <-time.After(backoff):
+				case <-runCtx.Done():
+				}
+				streamingCurrentTurn.Store(true)
+			}
+			_, err = c.request(runCtx, "session/prompt", map[string]any{
+				"sessionId": sessionID,
+				"content":   promptBlocks,
+				"prompt":    promptBlocks,
+			})
+			if err == nil || runCtx.Err() != nil || !isTransientKiroError(err) {
+				break
+			}
+		}
+
 		if err != nil {
 			if runCtx.Err() == context.DeadlineExceeded {
 				finalStatus = "timeout"
@@ -586,4 +612,30 @@ func kiroToolNameFromTitle(title string) string {
 	}
 
 	return strings.ReplaceAll(lower, " ", "_")
+}
+
+// isTransientKiroError returns true for errors that are likely transient
+// upstream failures (network resets, dispatch failures, timeouts, throttling)
+// and worth retrying.
+func isTransientKiroError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "dispatch failure") ||
+		strings.Contains(msg, "DispatchFailure") ||
+		strings.Contains(msg, "ConnectionReset") ||
+		strings.Contains(msg, "Connection reset by peer") ||
+		strings.Contains(msg, "request has timed out") ||
+		strings.Contains(msg, "throttled") ||
+		strings.Contains(msg, "response error")
+}
+
+// isThrottledError returns true if the error indicates rate limiting,
+// which warrants a longer backoff.
+func isThrottledError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "throttled")
 }


### PR DESCRIPTION
## Problem

When running kiro-cli as an agent runtime, the daemon frequently encounters `-32603 Internal error` responses from the upstream AWS service (CodeWhisperer/Amazon Q). These errors are transient network failures that resolve on their own within seconds, but currently cause immediate task failure.

From analyzing daemon logs over multiple days, we identified **32 occurrences** of `-32603` errors, categorized as:

| Category | Count | Description |
|----------|-------|-------------|
| ConnectionReset / DispatchFailure | 14 | HTTP stream reset by peer |
| dispatch failure (generic) | 13 | Same root cause, less detail |
| throttled | 2 | Rate-limited by upstream |
| request has timed out | 1 | Upstream timeout |
| MCP server transport closed | 1 | MCP process crash |
| response error | 1 | Generic response error |

The vast majority (27/32) are transient network issues that would succeed on retry.

## Solution

Add automatic retry with exponential backoff for `session/prompt` calls when a transient upstream error is detected:

- **Max retries:** 3
- **Backoff for throttling:** 10s → 20s → 40s (longer to respect rate limits)
- **Backoff for other transient errors:** 3s → 6s → 12s
- **Non-transient errors** (e.g. `AccessDeniedException`) fail immediately as before

Helper functions `isTransientKiroError()` and `isThrottledError()` classify errors for retry decisions.

## Production Validation

Tested in production over 3 days (47 tasks completed):

| Metric | Result |
|--------|--------|
| Transient errors detected | 11 |
| Recovered on 1st retry | 7 (64%) |
| Recovered on 2nd retry | 1 (9%) |
| All retries exhausted | 3 (27%) |
| **Overall recovery rate** | **73%** |

**Before this patch:** all 11 transient errors would have caused immediate task failure.
**After this patch:** only 3 tasks failed (sustained upstream outage where the service was unavailable for >12 seconds continuously).

No throttling errors were observed during the test period (the earlier throttling issue had been mitigated), but the longer backoff for throttled requests is included as a safeguard.

## Changes

- `server/pkg/agent/kiro.go`: Wrap `session/prompt` call in a retry loop with exponential backoff for transient errors
- Add `isTransientKiroError()` and `isThrottledError()` helper functions