### PR TITLE
fix: add clipboard fallback for self-hosted HTTP deployments

### DIFF
--- a/apps/desktop/src/renderer/src/components/daemon-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/daemon-panel.tsx
@@ -16,6 +16,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { Button } from "@multica/ui/components/ui/button";
 import {
   Dialog,
@@ -195,7 +196,7 @@ export function DaemonPanel({
   const handleCopy = useCallback(async () => {
     const text = filtered.map((l) => l.raw).join("\n");
     try {
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       toast.success(
         `Copied ${filtered.length} line${filtered.length === 1 ? "" : "s"}`,
       );

--- a/apps/web/features/landing/components/download/cli-section.tsx
+++ b/apps/web/features/landing/components/download/cli-section.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Check, Copy, Terminal } from "lucide-react";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { useLocale } from "../../i18n";
 
 const INSTALL_CMD =
@@ -63,11 +64,11 @@ function CommandBlock({
 
   const onCopy = async () => {
     try {
-      await navigator.clipboard.writeText(cmd);
+      await copyToClipboard(cmd);
       setCopied(true);
       setTimeout(() => setCopied(false), 1800);
     } catch {
-      // clipboard may be unavailable (insecure context) — silent no-op
+      // clipboard may be unavailable — silent no-op
     }
   };
 

--- a/packages/ui/lib/clipboard.ts
+++ b/packages/ui/lib/clipboard.ts
@@ -1,0 +1,33 @@
+/**
+ * Drop-in replacement for navigator.clipboard.writeText() that works in
+ * insecure contexts (HTTP without SSL).
+ *
+ * Same contract: returns Promise<void>, throws on failure.
+ * Tries the Clipboard API first, falls back to execCommand("copy").
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Clipboard API may throw even when present (e.g. iframe without
+      // clipboard-write permission). Fall through to legacy path.
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "-9999px";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  const ok = document.execCommand("copy");
+  document.body.removeChild(textarea);
+  if (!ok) {
+    throw new Error("Clipboard write failed");
+  }
+}

--- a/packages/ui/markdown/CodeBlock.tsx
+++ b/packages/ui/markdown/CodeBlock.tsx
@@ -4,6 +4,7 @@ import { Copy, Check } from "lucide-react"
 import { Button } from "@multica/ui/components/ui/button"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip"
 import { cn } from '@multica/ui/lib/utils'
+import { copyToClipboard } from '../lib/clipboard'
 
 export interface CodeBlockProps {
   code: string
@@ -129,7 +130,7 @@ export function CodeBlock({
 
   const handleCopy = React.useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(code)
+      await copyToClipboard(code)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch (err) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
     "./markdown/mentions": "./markdown/mentions.ts",
     "./hooks/*": "./hooks/*.ts",
     "./lib/utils": "./lib/utils.ts",
+    "./lib/clipboard": "./lib/clipboard.ts",
     "./lib/data-table": "./lib/data-table.ts",
     "./styles/tokens.css": "./styles/tokens.css",
     "./styles/base.css": "./styles/base.css"

--- a/packages/views/common/task-transcript/agent-transcript-dialog.tsx
+++ b/packages/views/common/task-transcript/agent-transcript-dialog.tsx
@@ -19,6 +19,7 @@ import {
   Filter,
 } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { Dialog, DialogContent, DialogTitle } from "@multica/ui/components/ui/dialog";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@multica/ui/components/ui/collapsible";
 import {
@@ -250,7 +251,7 @@ export function AgentTranscriptDialog({
         return `[${label}] ${summary}`;
       })
       .join("\n");
-    navigator.clipboard.writeText(text).then(() => {
+    copyToClipboard(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });

--- a/packages/views/editor/extensions/code-block-view.tsx
+++ b/packages/views/editor/extensions/code-block-view.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { NodeViewWrapper, NodeViewContent } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
 import { Copy, Check } from "lucide-react";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { useT } from "../../i18n";
 import { MermaidDiagram } from "../mermaid-diagram";
 
@@ -37,7 +38,7 @@ function CodeBlockView({ node }: NodeViewProps) {
   const handleCopy = async () => {
     const text = node.textContent;
     if (!text) return;
-    await navigator.clipboard.writeText(text);
+    await copyToClipboard(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/packages/views/editor/extensions/image-view.tsx
+++ b/packages/views/editor/extensions/image-view.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@multica/ui/lib/utils";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { useT } from "../../i18n";
 import { useAttachmentDownloadResolver } from "../attachment-download-context";
 
@@ -79,7 +80,7 @@ function ImageView({ node, editor, selected, deleteNode }: NodeViewProps) {
 
   const handleCopyLink = async () => {
     try {
-      await navigator.clipboard.writeText(src);
+      await copyToClipboard(src);
       toast.success(t(($) => $.image.link_copied));
     } catch {
       toast.error(t(($) => $.image.copy_link_failed));

--- a/packages/views/editor/link-hover-card.tsx
+++ b/packages/views/editor/link-hover-card.tsx
@@ -15,6 +15,7 @@ import { computePosition, offset, flip, shift } from "@floating-ui/dom";
 import { ExternalLink, Copy } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@multica/ui/components/ui/button";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { useWorkspaceSlug } from "@multica/core/paths";
 import { useT } from "../i18n";
 import { openLink, isMentionHref } from "./utils/link-handler";
@@ -171,7 +172,7 @@ function LinkHoverCard({
     e.stopPropagation();
     e.preventDefault();
     try {
-      await navigator.clipboard.writeText(href);
+      await copyToClipboard(href);
       toast.success(t(($) => $.link_hover.link_copied));
     } catch {
       toast.error(t(($) => $.link_hover.copy_failed));

--- a/packages/views/editor/readonly-content.tsx
+++ b/packages/views/editor/readonly-content.tsx
@@ -33,6 +33,7 @@ import { toHtml } from "hast-util-to-html";
 import { Maximize2, Download, Link as LinkIcon, FileText } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@multica/ui/lib/utils";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { useWorkspacePaths, useWorkspaceSlug } from "@multica/core/paths";
 import type { Attachment } from "@multica/core/types";
 import { useNavigation } from "../navigation";
@@ -198,7 +199,7 @@ function ReadonlyImage({
   };
   const handleCopyLink = async () => {
     try {
-      await navigator.clipboard.writeText(imgSrc);
+      await copyToClipboard(imgSrc);
       toast.success(t(($) => $.image.link_copied));
     } catch {
       toast.error(t(($) => $.image.copy_link_failed));

--- a/packages/views/editor/utils/clipboard.ts
+++ b/packages/views/editor/utils/clipboard.ts
@@ -1,6 +1,5 @@
-/**
- * Copy markdown content to the clipboard.
- */
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
+
 export async function copyMarkdown(markdown: string): Promise<void> {
-  await navigator.clipboard.writeText(markdown);
+  await copyToClipboard(markdown);
 }

--- a/packages/views/issues/actions/issue-actions-menu-items.tsx
+++ b/packages/views/issues/actions/issue-actions-menu-items.tsx
@@ -3,6 +3,7 @@
 import { useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import {
   ArrowDown,
   ArrowUp,
@@ -134,7 +135,7 @@ export function IssueActionsMenuItems({
       toast.error(t(($) => $.detail.workdir_path_unavailable));
       return;
     }
-    navigator.clipboard.writeText(latestWorkDir).then(
+    copyToClipboard(latestWorkDir).then(
       () => toast.success(t(($) => $.detail.workdir_path_copied)),
       () => toast.error(t(($) => $.detail.workdir_path_copy_failed)),
     );

--- a/packages/views/issues/actions/use-issue-actions.ts
+++ b/packages/views/issues/actions/use-issue-actions.ts
@@ -3,6 +3,7 @@
 import { useCallback, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import type {
   Issue,
   MemberWithUser,
@@ -122,7 +123,7 @@ export function useIssueActions(issue: Issue | null): UseIssueActionsResult {
     if (!issueId) return;
     const url = navigation.getShareableUrl(paths.issueDetail(issueId));
     try {
-      await navigator.clipboard.writeText(url);
+      await copyToClipboard(url);
       toast.success(t(($) => $.detail.link_copied));
     } catch {
       toast.error(t(($) => $.detail.link_copy_failed));

--- a/packages/views/onboarding/steps/cli-install-instructions.tsx
+++ b/packages/views/onboarding/steps/cli-install-instructions.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Check, Copy, Terminal } from "lucide-react";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { useT } from "../../i18n";
 
 const INSTALL_CMD =
@@ -13,8 +14,8 @@ function CopyButton({ text }: { text: string }) {
   const { t } = useT("onboarding");
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(text);
+  const handleCopy = async () => {
+    await copyToClipboard(text);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -6,6 +6,7 @@ import { Check, ChevronRight, Link2, ListTodo, MoreHorizontal, PanelRight, Pin, 
 import { useQuery } from "@tanstack/react-query";
 import { cn } from "@multica/ui/lib/utils";
 import { toast } from "sonner";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import type { Issue, IssueStatus, ProjectStatus, ProjectPriority } from "@multica/core/types";
 import { useAuthStore } from "@multica/core/auth";
 import { projectDetailOptions } from "@multica/core/projects/queries";
@@ -560,8 +561,8 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
                   }
                 />
                 <DropdownMenuContent align="end" className="w-auto">
-                  <DropdownMenuItem onClick={() => {
-                    navigator.clipboard.writeText(window.location.href);
+                  <DropdownMenuItem onClick={async () => {
+                    await copyToClipboard(window.location.href);
                     toast.success(t(($) => $.detail.toast_link_copied));
                   }}>
                     <Link2 className="h-3.5 w-3.5" />

--- a/packages/views/runtimes/components/connect-remote-dialog.tsx
+++ b/packages/views/runtimes/components/connect-remote-dialog.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from "@multica/ui/components/ui/dialog";
 import { Button } from "@multica/ui/components/ui/button";
+import { copyToClipboard as copyText } from "@multica/ui/lib/clipboard";
 import { useNavigation } from "../../navigation";
 import { useT } from "../../i18n";
 
@@ -56,8 +57,8 @@ export function ConnectRemoteDialog({ onClose }: { onClose: () => void }) {
   useWSEvent("daemon:register", handleDaemonRegister);
 
   const copyToClipboard = useCallback(
-    (text: string, key: string) => {
-      navigator.clipboard.writeText(text);
+    async (text: string, key: string) => {
+      await copyText(text);
       setCopied(key);
     },
     [],

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -26,6 +26,7 @@ import {
 import { Command as CommandPrimitive } from "cmdk";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import type { SearchIssueResult, SearchProjectResult } from "@multica/core/types";
 import { api } from "@multica/core/api";
 import { selectRecentIssues, useRecentIssuesStore } from "@multica/core/issues/stores";
@@ -228,7 +229,7 @@ export function SearchCommand() {
           icon: Link2,
           keywords: ["copy", "link", "share", "url", identifier.toLowerCase()],
           onSelect: () => {
-            void navigator.clipboard.writeText(getShareableUrl(pathname));
+            void copyToClipboard(getShareableUrl(pathname));
             toast.success(t(($) => $.toast.link_copied));
             setOpen(false);
           },
@@ -239,7 +240,7 @@ export function SearchCommand() {
           icon: Copy,
           keywords: ["copy", "id", "identifier", identifier.toLowerCase()],
           onSelect: () => {
-            void navigator.clipboard.writeText(identifier);
+            void copyToClipboard(identifier);
             toast.success(t(($) => $.toast.copied_identifier, { identifier }));
             setOpen(false);
           },

--- a/packages/views/settings/components/tokens-tab.tsx
+++ b/packages/views/settings/components/tokens-tab.tsx
@@ -35,6 +35,7 @@ import {
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { toast } from "sonner";
 import { api } from "@multica/core/api";
+import { copyToClipboard } from "@multica/ui/lib/clipboard";
 import { useT } from "../../i18n";
 
 const EXPIRY_KEYS = ["30", "90", "365", "never"] as const;
@@ -95,7 +96,7 @@ export function TokensTab() {
 
   const handleCopyToken = async () => {
     if (!newToken) return;
-    await navigator.clipboard.writeText(newToken);
+    await copyToClipboard(newToken);
     setTokenCopied(true);
     setTimeout(() => setTokenCopied(false), 2000);
   };


### PR DESCRIPTION
`navigator.clipboard.writeText()` requires a secure context (HTTPS or localhost). Self-hosted deployments over plain HTTP cause all copy buttons to fail silently or throw — most notably during the daemon installation flow after login.

## Solution

- Add `copyToClipboard()` in `packages/ui/lib/clipboard.ts` as a drop-in replacement for `navigator.clipboard.writeText()`
- Same contract: `Promise<void>`, throws on failure
- Tries the Clipboard API first, falls back to legacy `document.execCommand('copy')` with a temporary textarea
- Replace all direct `navigator.clipboard.writeText()` call sites (16 files) — no logic changes to existing error handling

## Test plan

- [x] Self-host over HTTP (kubectl port-forward), verified copy buttons work
- [x] `pnpm typecheck` passes
- [x] Verify copy still works over HTTPS (no regression)
