### PR TITLE
docs: add 0.2.31 changelog

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -290,7 +290,7 @@ export function createEnDict(allowSignup: boolean): LandingDict {
         title: "GitHub Linking, Chat Attachments & Safer Issue Navigation",
         changes: [],
         features: [
-          "Connect GitHub so linked pull requests appear directly on Multica issues",
+          "Connect GitHub so linked pull requests appear on Multica issues, sync their status, and close the Multica issue automatically when the PR closes",
           "Chat messages can include file attachments and image previews",
           "Agents and runtimes can now be kept public or private for clearer team access",
           "Stopping a single agent task now asks for confirmation before it is terminated",
@@ -304,7 +304,6 @@ export function createEnDict(allowSignup: boolean): LandingDict {
           "Linux desktop packages show the Multica app icon again",
         ],
         fixes: [
-          "Linked issues now close only after every related pull request is resolved",
           "Downloaded attachments keep their original filenames",
           "Local attachments are served more reliably, and upload controls stay disabled until files are ready",
           "Issue creation dialogs keep their text fields at the correct height",

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -287,7 +287,7 @@ export function createEnDict(allowSignup: boolean): LandingDict {
       {
         version: "0.2.31",
         date: "2026-05-12",
-        title: "GitHub Linking, Chat Attachments & Safer Issue Navigation",
+        title: "GitHub Integration, Chat Attachments & Safer Issue Navigation",
         changes: [],
         features: [
           "Connect GitHub so linked pull requests appear on Multica issues, sync their status, and close the Multica issue automatically when the PR closes",

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -285,6 +285,33 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.31",
+        date: "2026-05-12",
+        title: "GitHub Linking, Chat Attachments & Safer Issue Navigation",
+        changes: [],
+        features: [
+          "Connect GitHub so linked pull requests appear directly on Multica issues",
+          "Chat messages can include file attachments and image previews",
+          "Agents and runtimes can now be kept public or private for clearer team access",
+          "Stopping a single agent task now asks for confirmation before it is terminated",
+          "New GitHub integration docs cover both hosted and self-hosted setup",
+        ],
+        improvements: [
+          "Issue links land more reliably on the exact comment or activity you opened",
+          "Long issue timelines scroll more smoothly",
+          "The feedback dialog now points contributors toward GitHub discussions and issues",
+          "Self-hosted Caddy guidance now calls out real-time connection requirements",
+          "Linux desktop packages show the Multica app icon again",
+        ],
+        fixes: [
+          "Linked issues now close only after every related pull request is resolved",
+          "Downloaded attachments keep their original filenames",
+          "Local attachments are served more reliably, and upload controls stay disabled until files are ready",
+          "Issue creation dialogs keep their text fields at the correct height",
+          "Runtime documentation links point to the correct page",
+        ],
+      },
+      {
         version: "0.2.30",
         date: "2026-05-11",
         title: "Mermaid in Issues, Per-Runtime Timezone & Workspace-Leave Runtime Revocation",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -290,7 +290,7 @@ export function createZhDict(allowSignup: boolean): LandingDict {
         title: "GitHub 关联、聊天附件与 Issue 定位优化",
         changes: [],
         features: [
-          "接入 GitHub 后，关联的 Pull Request 会直接显示在 Multica Issue 中",
+          "接入 GitHub 后，关联的 Pull Request 会显示在 Multica Issue 中，状态会同步到 Multica，关闭 PR 后会自动关闭对应 Issue",
           "聊天消息支持添加文件附件和图片预览",
           "Agent 和 runtime 可以设置公开或私有，方便控制团队可见范围",
           "停止单个 agent 任务前会先弹出确认，避免误操作",
@@ -304,7 +304,6 @@ export function createZhDict(allowSignup: boolean): LandingDict {
           "Linux 桌面端安装包恢复显示 Multica 应用图标",
         ],
         fixes: [
-          "关联 Issue 只会在所有相关 Pull Request 都完成后自动关闭",
           "下载附件时保留原始文件名",
           "本地附件访问更稳定，上传按钮会等文件准备好后再可用",
           "创建 Issue 弹窗里的文本框高度显示正确",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -287,7 +287,7 @@ export function createZhDict(allowSignup: boolean): LandingDict {
       {
         version: "0.2.31",
         date: "2026-05-12",
-        title: "GitHub 关联、聊天附件与 Issue 定位优化",
+        title: "GitHub 集成、聊天附件与 Issue 定位优化",
         changes: [],
         features: [
           "接入 GitHub 后，关联的 Pull Request 会显示在 Multica Issue 中，状态会同步到 Multica，关闭 PR 后会自动关闭对应 Issue",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -285,6 +285,33 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.31",
+        date: "2026-05-12",
+        title: "GitHub 关联、聊天附件与 Issue 定位优化",
+        changes: [],
+        features: [
+          "接入 GitHub 后，关联的 Pull Request 会直接显示在 Multica Issue 中",
+          "聊天消息支持添加文件附件和图片预览",
+          "Agent 和 runtime 可以设置公开或私有，方便控制团队可见范围",
+          "停止单个 agent 任务前会先弹出确认，避免误操作",
+          "新增 GitHub 集成文档，覆盖托管版和自托管配置",
+        ],
+        improvements: [
+          "打开 Issue 链接时，会更稳定地定位到指定评论或动态",
+          "很长的 Issue 时间线滚动更顺畅",
+          "反馈入口更明确地引导用户到 GitHub 参与讨论和反馈",
+          "自托管 Caddy 配置文档补充实时连接要求",
+          "Linux 桌面端安装包恢复显示 Multica 应用图标",
+        ],
+        fixes: [
+          "关联 Issue 只会在所有相关 Pull Request 都完成后自动关闭",
+          "下载附件时保留原始文件名",
+          "本地附件访问更稳定，上传按钮会等文件准备好后再可用",
+          "创建 Issue 弹窗里的文本框高度显示正确",
+          "Runtime 文档入口跳转到正确页面",
+        ],
+      },
+      {
         version: "0.2.30",
         date: "2026-05-11",
         title: "Issue 内 Mermaid、Runtime 时区聚合与离开 Workspace 自动吊销",


### PR DESCRIPTION
## Summary
- Add the 2026-05-12 / v0.2.31 changelog entry to the landing changelog.
- Provide matching English and Chinese product-facing release notes for GitHub linking, chat attachments, issue navigation, visibility controls, safer task handling, and related fixes.

## Verification
- `pnpm --filter @multica/web lint` (passes with one existing warning in `apps/web/app/(auth)/login/page.tsx`)

MUL-2103
