### PR TITLE
fix(inbox): show Multica logo for system-actor notifications

### DIFF
--- a/packages/core/types/inbox.ts
+++ b/packages/core/types/inbox.ts
@@ -25,7 +25,7 @@ export interface InboxItem {
   workspace_id: string;
   recipient_type: "member" | "agent";
   recipient_id: string;
-  actor_type: "member" | "agent" | null;
+  actor_type: "member" | "agent" | "system" | null;
   actor_id: string | null;
   type: InboxItemType;
   severity: InboxSeverity;

--- a/packages/core/workspace/hooks.ts
+++ b/packages/core/workspace/hooks.ts
@@ -22,6 +22,7 @@ export function useActorName() {
   const getActorName = (type: string, id: string) => {
     if (type === "member") return getMemberName(id);
     if (type === "agent") return getAgentName(id);
+    if (type === "system") return "Multica";
     return "System";
   };
 

--- a/packages/ui/components/common/actor-avatar.tsx
+++ b/packages/ui/components/common/actor-avatar.tsx
@@ -3,12 +3,14 @@
 import { useState, useEffect } from "react";
 import { Bot } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
+import { MulticaIcon } from "./multica-icon";
 
 interface ActorAvatarProps {
   name: string;
   initials: string;
   avatarUrl?: string | null;
   isAgent?: boolean;
+  isSystem?: boolean;
   size?: number;
   className?: string;
 }
@@ -18,6 +20,7 @@ function ActorAvatar({
   initials,
   avatarUrl,
   isAgent,
+  isSystem,
   size = 20,
   className,
 }: ActorAvatarProps) {
@@ -46,6 +49,8 @@ function ActorAvatar({
           className="h-full w-full object-cover"
           onError={() => setImgError(true)}
         />
+      ) : isSystem ? (
+        <MulticaIcon noSpin style={{ width: size * 0.55, height: size * 0.55 }} />
       ) : isAgent ? (
         <Bot style={{ width: size * 0.55, height: size * 0.55 }} />
       ) : (

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -53,6 +53,7 @@ export function ActorAvatar({
       initials={getActorInitials(actorType, actorId)}
       avatarUrl={getActorAvatarUrl(actorType, actorId)}
       isAgent={actorType === "agent"}
+      isSystem={actorType === "system"}
       size={size}
       className={className}
     />


### PR DESCRIPTION
## Summary

Inbox notifications from system actors (e.g. GitHub PR closed) were rendering with an "S" initials fallback avatar. The avatar now shows the Multica icon when `actor_type === "system"`, so users immediately see this is a Multica-generated event.

Refs: MUL-2105

## Changes

- `packages/ui/components/common/actor-avatar.tsx` — new `isSystem` prop on the base avatar; renders `MulticaIcon` instead of initials.
- `packages/views/common/actor-avatar.tsx` — passes `isSystem={actorType === "system"}` to the base.
- `packages/core/workspace/hooks.ts` — `getActorName` returns `"Multica"` for `type === "system"` (used as the hover tooltip).
- `packages/core/types/inbox.ts` — extends `actor_type` union with `"system"` to match the backend payload.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @multica/views test` — 377 passed
- [x] `pnpm --filter @multica/core test` — 226 passed
- [ ] Verify in staging: close a linked GitHub PR and confirm the inbox notification shows the Multica logo instead of "S"