### PR TITLE
fix(github): plumb GITHUB_APP_SLUG / GITHUB_WEBHOOK_SECRET through self-host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,13 @@ ALLOWED_ORIGINS=
 # `Authorization: Bearer <token>`.
 # REALTIME_METRICS_TOKEN=
 
+# GitHub App integration (Settings → Integrations "Connect GitHub")
+# Both must be set for the Connect button to enable and for webhooks to be
+# accepted; leave empty to disable the integration. See docs/github-integration.
+# GITHUB_APP_SLUG is the tail of https://github.com/apps/<slug>.
+GITHUB_APP_SLUG=
+GITHUB_WEBHOOK_SECRET=
+
 # Frontend
 FRONTEND_PORT=3000
 FRONTEND_ORIGIN=http://localhost:3000

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -58,9 +58,11 @@ services:
       APP_ENV: ${APP_ENV:-production}
       MULTICA_DEV_VERIFICATION_CODE: ${MULTICA_DEV_VERIFICATION_CODE:-}
       MULTICA_APP_URL: ${MULTICA_APP_URL:-http://localhost:3000}
-      ALLOW_SIGNUP: ${ALLOW_SIGNUP:-true}                                     
-      ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}                                     
-      ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-} 
+      ALLOW_SIGNUP: ${ALLOW_SIGNUP:-true}
+      ALLOWED_EMAILS: ${ALLOWED_EMAILS:-}
+      ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-}
+      GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
+      GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET:-}
     restart: unless-stopped
 
   frontend:


### PR DESCRIPTION
## Summary

- Add `GITHUB_APP_SLUG` and `GITHUB_WEBHOOK_SECRET` to `.env.example` with a short note pointing at the integration docs.
- Forward both vars from the host env into the backend service in `docker-compose.selfhost.yml`.

The GitHub App integration (#1817) reads these env vars and only enables the Connect button + webhook acceptance when both are set (`server/internal/handler/github.go:110`). Until now `.env.example` did not list them and the self-host compose file did not pass them through, so self-hosters following `docs/github-integration.mdx` had no working way to turn the feature on.

Refs [MUL-2107](mention://issue/a511b66e-5a79-4cbd-900c-c6fefd60ce2f).

## Test plan

- [ ] `docker compose -f docker-compose.selfhost.yml config` shows both vars on the backend service.
- [ ] With both vars exported, `GET /api/workspaces/{id}/github/connect` returns `configured: true` and a `github.com/apps/<slug>/installations/new?state=...` URL.
- [ ] With both vars unset, Settings → Integrations still renders with Connect disabled (no regression).