### PR TITLE
fix(issues): clean caches after issue delete

### DIFF
--- a/packages/core/issues/delete-cache.ts
+++ b/packages/core/issues/delete-cache.ts
@@ -122,7 +122,6 @@ export function invalidateDeletedIssueDependentCaches(
   qc.invalidateQueries({ queryKey: agentActivityKeys.last30d(wsId) });
   qc.invalidateQueries({ queryKey: agentRunCountsKeys.last30d(wsId) });
   qc.invalidateQueries({ queryKey: agentTasksKeys.all(wsId) });
-  qc.invalidateQueries({ queryKey: issueKeys.tasksAll() });
 }
 
 export function invalidateIssueScopedCaches(

--- a/packages/core/issues/delete-cache.ts
+++ b/packages/core/issues/delete-cache.ts
@@ -1,0 +1,167 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import {
+  agentActivityKeys,
+  agentRunCountsKeys,
+  agentTaskSnapshotKeys,
+  agentTasksKeys,
+} from "../agents/queries";
+import { labelKeys } from "../labels/queries";
+import type { Issue, ListIssuesCache } from "../types";
+import { findIssueLocation, removeIssueFromBuckets } from "./cache-helpers";
+import { issueKeys } from "./queries";
+
+export type DeletedIssueCacheMetadata = {
+  parentIssueIds: string[];
+};
+
+function collectParentId(
+  parentIssueIds: Set<string>,
+  parentId: string | null | undefined,
+) {
+  if (parentId) parentIssueIds.add(parentId);
+}
+
+function collectParentFromListCache(
+  parentIssueIds: Set<string>,
+  data: ListIssuesCache | undefined,
+  issueId: string,
+) {
+  const parentId = data
+    ? findIssueLocation(data, issueId)?.issue.parent_issue_id
+    : undefined;
+  collectParentId(parentIssueIds, parentId);
+}
+
+function parentIdFromChildrenKey(key: QueryKey) {
+  const parentId = key[key.length - 1];
+  return typeof parentId === "string" ? parentId : null;
+}
+
+export function collectDeletedIssueCacheMetadata(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+): DeletedIssueCacheMetadata {
+  const parentIssueIds = new Set<string>();
+
+  const detail = qc.getQueryData<Issue>(issueKeys.detail(wsId, issueId));
+  collectParentId(parentIssueIds, detail?.parent_issue_id);
+
+  collectParentFromListCache(
+    parentIssueIds,
+    qc.getQueryData<ListIssuesCache>(issueKeys.list(wsId)),
+    issueId,
+  );
+
+  for (const [, data] of qc.getQueriesData<ListIssuesCache>({
+    queryKey: issueKeys.myAll(wsId),
+  })) {
+    collectParentFromListCache(parentIssueIds, data, issueId);
+  }
+
+  for (const [key, data] of qc.getQueriesData<Issue[]>({
+    queryKey: [...issueKeys.all(wsId), "children"],
+  })) {
+    const child = data?.find((issue) => issue.id === issueId);
+    if (!child) continue;
+    collectParentId(parentIssueIds, child.parent_issue_id);
+    collectParentId(parentIssueIds, parentIdFromChildrenKey(key));
+  }
+
+  return { parentIssueIds: Array.from(parentIssueIds) };
+}
+
+export function pruneDeletedIssueFromListCaches(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+) {
+  qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
+    old ? removeIssueFromBuckets(old, issueId) : old,
+  );
+
+  for (const [key] of qc.getQueriesData<ListIssuesCache>({
+    queryKey: issueKeys.myAll(wsId),
+  })) {
+    qc.setQueryData<ListIssuesCache>(key, (old) =>
+      old ? removeIssueFromBuckets(old, issueId) : old,
+    );
+  }
+}
+
+export function pruneDeletedIssueFromParentChildrenCaches(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+  metadata: DeletedIssueCacheMetadata,
+) {
+  for (const parentId of metadata.parentIssueIds) {
+    qc.setQueryData<Issue[]>(issueKeys.children(wsId, parentId), (old) =>
+      old?.filter((issue) => issue.id !== issueId),
+    );
+  }
+}
+
+export function invalidateDeletedIssueParentCaches(
+  qc: QueryClient,
+  wsId: string,
+  metadata: DeletedIssueCacheMetadata,
+) {
+  if (metadata.parentIssueIds.length === 0) return;
+  for (const parentId of metadata.parentIssueIds) {
+    qc.invalidateQueries({ queryKey: issueKeys.children(wsId, parentId) });
+  }
+  qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+}
+
+export function invalidateDeletedIssueDependentCaches(
+  qc: QueryClient,
+  wsId: string,
+) {
+  qc.invalidateQueries({ queryKey: agentTaskSnapshotKeys.list(wsId) });
+  qc.invalidateQueries({ queryKey: agentActivityKeys.last30d(wsId) });
+  qc.invalidateQueries({ queryKey: agentRunCountsKeys.last30d(wsId) });
+  qc.invalidateQueries({ queryKey: agentTasksKeys.all(wsId) });
+  qc.invalidateQueries({ queryKey: issueKeys.tasksAll() });
+}
+
+export function invalidateIssueScopedCaches(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+) {
+  qc.invalidateQueries({ queryKey: issueKeys.timeline(issueId) });
+  qc.invalidateQueries({ queryKey: issueKeys.reactions(issueId) });
+  qc.invalidateQueries({ queryKey: issueKeys.subscribers(issueId) });
+  qc.invalidateQueries({ queryKey: issueKeys.usage(issueId) });
+  qc.invalidateQueries({ queryKey: issueKeys.attachments(issueId) });
+  qc.invalidateQueries({ queryKey: issueKeys.tasks(issueId) });
+  qc.invalidateQueries({ queryKey: issueKeys.children(wsId, issueId) });
+  qc.invalidateQueries({ queryKey: labelKeys.byIssue(wsId, issueId) });
+}
+
+export function cleanupDeletedIssueCaches(
+  qc: QueryClient,
+  wsId: string,
+  issueId: string,
+  metadata = collectDeletedIssueCacheMetadata(qc, wsId, issueId),
+) {
+  pruneDeletedIssueFromListCaches(qc, wsId, issueId);
+  pruneDeletedIssueFromParentChildrenCaches(qc, wsId, issueId, metadata);
+  invalidateDeletedIssueParentCaches(qc, wsId, metadata);
+
+  qc.removeQueries({ queryKey: issueKeys.detail(wsId, issueId) });
+  qc.removeQueries({ queryKey: issueKeys.timeline(issueId) });
+  qc.removeQueries({ queryKey: issueKeys.reactions(issueId) });
+  qc.removeQueries({ queryKey: issueKeys.subscribers(issueId) });
+  qc.removeQueries({ queryKey: issueKeys.usage(issueId) });
+  qc.removeQueries({ queryKey: issueKeys.attachments(issueId) });
+  qc.removeQueries({ queryKey: issueKeys.tasks(issueId) });
+  qc.removeQueries({ queryKey: issueKeys.children(wsId, issueId) });
+  qc.removeQueries({ queryKey: labelKeys.byIssue(wsId, issueId) });
+
+  qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+  qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
+  qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
+  invalidateDeletedIssueDependentCaches(qc, wsId);
+}

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -412,6 +412,17 @@ export function useBatchDeleteIssues() {
         return;
       }
 
+      if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
+      if (ctx?.prevMyLists) {
+        for (const [key, snapshot] of ctx.prevMyLists) {
+          qc.setQueryData(key, snapshot);
+        }
+      }
+      if (ctx?.prevChildren) {
+        for (const [parentId, snapshot] of ctx.prevChildren) {
+          qc.setQueryData(issueKeys.children(wsId, parentId), snapshot);
+        }
+      }
       for (const id of ids) {
         invalidateIssueScopedCaches(qc, wsId, id);
       }

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -11,9 +11,17 @@ import {
   findIssueLocation,
   getBucket,
   patchIssueInBuckets,
-  removeIssueFromBuckets,
   setBucket,
 } from "./cache-helpers";
+import {
+  cleanupDeletedIssueCaches,
+  collectDeletedIssueCacheMetadata,
+  invalidateDeletedIssueDependentCaches,
+  invalidateDeletedIssueParentCaches,
+  invalidateIssueScopedCaches,
+  pruneDeletedIssueFromListCaches,
+  pruneDeletedIssueFromParentChildrenCaches,
+} from "./delete-cache";
 import { useWorkspaceId } from "../hooks";
 import { useRecentIssuesStore } from "./stores";
 import type { Issue, IssueReaction, IssueStatus } from "../types";
@@ -217,24 +225,56 @@ export function useDeleteIssue() {
   return useMutation({
     mutationFn: (id: string) => api.deleteIssue(id),
     onMutate: async (id) => {
-      await qc.cancelQueries({ queryKey: issueKeys.list(wsId) });
-      const prevList = qc.getQueryData<ListIssuesCache>(issueKeys.list(wsId));
-      const deleted = prevList ? findIssueLocation(prevList, id)?.issue : undefined;
-      qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
-        old ? removeIssueFromBuckets(old, id) : old,
+      await Promise.all([
+        qc.cancelQueries({ queryKey: issueKeys.list(wsId) }),
+        qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) }),
+      ]);
+      const metadata = collectDeletedIssueCacheMetadata(qc, wsId, id);
+      await Promise.all(
+        metadata.parentIssueIds.map((parentId) =>
+          qc.cancelQueries({ queryKey: issueKeys.children(wsId, parentId) }),
+        ),
       );
+      const prevList = qc.getQueryData<ListIssuesCache>(issueKeys.list(wsId));
+      const prevMyLists = qc.getQueriesData<ListIssuesCache>({
+        queryKey: issueKeys.myAll(wsId),
+      });
+      const prevDetail = qc.getQueryData<Issue>(issueKeys.detail(wsId, id));
+      const prevChildren = new Map<string, Issue[] | undefined>();
+      for (const parentId of metadata.parentIssueIds) {
+        prevChildren.set(
+          parentId,
+          qc.getQueryData<Issue[]>(issueKeys.children(wsId, parentId)),
+        );
+      }
+
+      pruneDeletedIssueFromListCaches(qc, wsId, id);
+      pruneDeletedIssueFromParentChildrenCaches(qc, wsId, id, metadata);
       qc.removeQueries({ queryKey: issueKeys.detail(wsId, id) });
-      return { prevList, parentIssueId: deleted?.parent_issue_id };
+      return { id, metadata, prevList, prevMyLists, prevDetail, prevChildren };
     },
     onError: (_err, _id, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
+      if (ctx?.prevMyLists) {
+        for (const [key, snapshot] of ctx.prevMyLists) {
+          qc.setQueryData(key, snapshot);
+        }
+      }
+      if (ctx?.prevDetail) {
+        qc.setQueryData(issueKeys.detail(wsId, ctx.id), ctx.prevDetail);
+      }
+      if (ctx?.prevChildren) {
+        for (const [parentId, snapshot] of ctx.prevChildren) {
+          qc.setQueryData(issueKeys.children(wsId, parentId), snapshot);
+        }
+      }
+    },
+    onSuccess: (_data, id, ctx) => {
+      cleanupDeletedIssueCaches(qc, wsId, id, ctx?.metadata);
     },
     onSettled: (_data, _err, _id, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
-      if (ctx?.parentIssueId) {
-        qc.invalidateQueries({ queryKey: issueKeys.children(wsId, ctx.parentIssueId) });
-        qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
-      }
+      if (ctx?.metadata) invalidateDeletedIssueParentCaches(qc, wsId, ctx.metadata);
     },
   });
 }
@@ -309,57 +349,81 @@ export function useBatchDeleteIssues() {
   return useMutation({
     mutationFn: (ids: string[]) => api.batchDeleteIssues(ids),
     onMutate: async (ids) => {
-      await qc.cancelQueries({ queryKey: issueKeys.list(wsId) });
-      const prevList = qc.getQueryData<ListIssuesCache>(issueKeys.list(wsId));
+      await Promise.all([
+        qc.cancelQueries({ queryKey: issueKeys.list(wsId) }),
+        qc.cancelQueries({ queryKey: issueKeys.myAll(wsId) }),
+      ]);
+      const metadataById = new Map(
+        ids.map((id) => [
+          id,
+          collectDeletedIssueCacheMetadata(qc, wsId, id),
+        ]),
+      );
       const parentIssueIds = new Set<string>();
-      if (prevList) {
-        for (const id of ids) {
-          const loc = findIssueLocation(prevList, id);
-          if (loc?.issue.parent_issue_id) parentIssueIds.add(loc.issue.parent_issue_id);
+      for (const metadata of metadataById.values()) {
+        for (const parentId of metadata.parentIssueIds) {
+          parentIssueIds.add(parentId);
         }
       }
-      // Children cache may be the only place sub-issues live when the user
-      // operates from a parent's detail page. Collect affected parents and
-      // optimistically filter the deleted ids out of each children cache so
-      // the row disappears immediately, mirroring the list-cache behaviour.
-      const idSet = new Set(ids);
-      const childrenCaches = qc.getQueriesData<Issue[]>({
-        queryKey: [...issueKeys.all(wsId), "children"],
+      await Promise.all(
+        Array.from(parentIssueIds).map((parentId) =>
+          qc.cancelQueries({ queryKey: issueKeys.children(wsId, parentId) }),
+        ),
+      );
+      const prevList = qc.getQueryData<ListIssuesCache>(issueKeys.list(wsId));
+      const prevMyLists = qc.getQueriesData<ListIssuesCache>({
+        queryKey: issueKeys.myAll(wsId),
       });
       const prevChildren = new Map<string, Issue[] | undefined>();
-      for (const [key, data] of childrenCaches) {
-        if (!data?.some((c) => idSet.has(c.id))) continue;
-        const parentId = key[key.length - 1];
-        if (typeof parentId !== "string") continue;
-        parentIssueIds.add(parentId);
-        prevChildren.set(parentId, data);
-        qc.setQueryData<Issue[]>(issueKeys.children(wsId, parentId), (old) =>
-          old?.filter((c) => !idSet.has(c.id)),
+      for (const parentId of parentIssueIds) {
+        prevChildren.set(
+          parentId,
+          qc.getQueryData<Issue[]>(issueKeys.children(wsId, parentId)),
         );
       }
-      qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) => {
-        if (!old) return old;
-        let next = old;
-        for (const id of ids) next = removeIssueFromBuckets(next, id);
-        return next;
-      });
-      return { prevList, prevChildren, parentIssueIds };
+
+      for (const id of ids) {
+        const metadata = metadataById.get(id);
+        pruneDeletedIssueFromListCaches(qc, wsId, id);
+        if (metadata) {
+          pruneDeletedIssueFromParentChildrenCaches(qc, wsId, id, metadata);
+        }
+      }
+      return { prevList, prevMyLists, prevChildren, parentIssueIds, metadataById };
     },
     onError: (_err, _ids, ctx) => {
       if (ctx?.prevList) qc.setQueryData(issueKeys.list(wsId), ctx.prevList);
+      if (ctx?.prevMyLists) {
+        for (const [key, snapshot] of ctx.prevMyLists) {
+          qc.setQueryData(key, snapshot);
+        }
+      }
       if (ctx?.prevChildren) {
         for (const [parentId, snapshot] of ctx.prevChildren) {
           qc.setQueryData(issueKeys.children(wsId, parentId), snapshot);
         }
       }
     },
+    onSuccess: (data, ids, ctx) => {
+      if (data.deleted === ids.length) {
+        for (const id of ids) {
+          cleanupDeletedIssueCaches(qc, wsId, id, ctx?.metadataById.get(id));
+        }
+        return;
+      }
+
+      for (const id of ids) {
+        invalidateIssueScopedCaches(qc, wsId, id);
+      }
+      qc.invalidateQueries({ queryKey: issueKeys.all(wsId) });
+      invalidateDeletedIssueDependentCaches(qc, wsId);
+    },
     onSettled: (_data, _err, _ids, ctx) => {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
       if (ctx?.parentIssueIds && ctx.parentIssueIds.size > 0) {
-        for (const parentId of ctx.parentIssueIds) {
-          qc.invalidateQueries({ queryKey: issueKeys.children(wsId, parentId) });
-        }
-        qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
+        invalidateDeletedIssueParentCaches(qc, wsId, {
+          parentIssueIds: Array.from(ctx.parentIssueIds),
+        });
       }
     },
   });

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -1,17 +1,34 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { QueryClient } from "@tanstack/react-query";
-import { onIssueLabelsChanged } from "./ws-updaters";
+import {
+  agentActivityKeys,
+  agentRunCountsKeys,
+  agentTaskSnapshotKeys,
+  agentTasksKeys,
+} from "../agents/queries";
+import { onIssueDeleted, onIssueLabelsChanged } from "./ws-updaters";
 import { issueKeys } from "./queries";
 import { labelKeys } from "../labels/queries";
 import type {
+  AgentActivityBucket,
+  AgentRunCount,
+  AgentTask,
+  Attachment,
   Issue,
+  IssueReaction,
   IssueLabelsResponse,
+  IssueSubscriber,
+  IssueUsageSummary,
   Label,
   ListIssuesCache,
+  TimelineEntry,
 } from "../types";
 
 const WS_ID = "ws-1";
 const ISSUE_ID = "issue-1";
+const OTHER_ISSUE_ID = "issue-2";
+const PARENT_ISSUE_ID = "parent-1";
+const AGENT_ID = "agent-1";
 
 const labelA: Label = {
   id: "label-a",
@@ -53,6 +70,47 @@ const baseIssue: Issue = {
   updated_at: "2025-01-01T00:00:00Z",
 };
 
+const parentedIssue: Issue = {
+  ...baseIssue,
+  parent_issue_id: PARENT_ISSUE_ID,
+};
+
+const otherIssue: Issue = {
+  ...baseIssue,
+  id: OTHER_ISSUE_ID,
+  identifier: "MUL-2",
+  title: "Other",
+};
+
+function makeListCache(...issues: Issue[]): ListIssuesCache {
+  return {
+    byStatus: {
+      todo: { issues, total: issues.length },
+    },
+  };
+}
+
+function makeTask(issueId = ISSUE_ID): AgentTask {
+  return {
+    id: `task-${issueId}`,
+    agent_id: AGENT_ID,
+    runtime_id: "runtime-1",
+    issue_id: issueId,
+    status: "completed",
+    priority: 0,
+    dispatched_at: null,
+    started_at: "2025-01-01T00:00:00Z",
+    completed_at: "2025-01-01T00:01:00Z",
+    result: null,
+    error: null,
+    created_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function expectInvalidated(qc: QueryClient, queryKey: readonly unknown[]) {
+  expect(qc.getQueryState(queryKey)?.isInvalidated).toBe(true);
+}
+
 describe("onIssueLabelsChanged", () => {
   let qc: QueryClient;
 
@@ -91,5 +149,245 @@ describe("onIssueLabelsChanged", () => {
 
     const detail = qc.getQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID));
     expect(detail?.labels).toEqual([labelB]);
+  });
+});
+
+describe("onIssueDeleted", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+  });
+
+  it("removes every cache entry scoped directly to the deleted issue", () => {
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
+    qc.setQueryData<TimelineEntry[]>(issueKeys.timeline(ISSUE_ID), [
+      {
+        type: "activity",
+        id: "activity-1",
+        actor_type: "member",
+        actor_id: "user-1",
+        action: "created",
+        created_at: "2025-01-01T00:00:00Z",
+      },
+    ]);
+    qc.setQueryData<IssueReaction[]>(issueKeys.reactions(ISSUE_ID), [
+      {
+        id: "reaction-1",
+        issue_id: ISSUE_ID,
+        actor_type: "member",
+        actor_id: "user-1",
+        emoji: "+1",
+        created_at: "2025-01-01T00:00:00Z",
+      },
+    ]);
+    qc.setQueryData<IssueSubscriber[]>(issueKeys.subscribers(ISSUE_ID), [
+      {
+        issue_id: ISSUE_ID,
+        user_type: "member",
+        user_id: "user-1",
+        reason: "manual",
+        created_at: "2025-01-01T00:00:00Z",
+      },
+    ]);
+    qc.setQueryData<IssueUsageSummary>(issueKeys.usage(ISSUE_ID), {
+      total_input_tokens: 10,
+      total_output_tokens: 20,
+      total_cache_read_tokens: 0,
+      total_cache_write_tokens: 0,
+      task_count: 1,
+    });
+    qc.setQueryData<Attachment[]>(issueKeys.attachments(ISSUE_ID), [
+      {
+        id: "attachment-1",
+        workspace_id: WS_ID,
+        issue_id: ISSUE_ID,
+        comment_id: null,
+        chat_session_id: null,
+        chat_message_id: null,
+        uploader_type: "member",
+        uploader_id: "user-1",
+        filename: "evidence.png",
+        url: "s3://bucket/evidence.png",
+        download_url: "https://example.test/evidence.png",
+        content_type: "image/png",
+        size_bytes: 1,
+        created_at: "2025-01-01T00:00:00Z",
+      },
+    ]);
+    qc.setQueryData<AgentTask[]>(issueKeys.tasks(ISSUE_ID), [makeTask()]);
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, ISSUE_ID), [otherIssue]);
+    qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(WS_ID, ISSUE_ID), {
+      labels: [labelA],
+    });
+
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, OTHER_ISSUE_ID), otherIssue);
+    qc.setQueryData<TimelineEntry[]>(issueKeys.timeline(OTHER_ISSUE_ID), []);
+    qc.setQueryData<IssueLabelsResponse>(
+      labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID),
+      { labels: [labelB] },
+    );
+
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+
+    expect(qc.getQueryData(issueKeys.detail(WS_ID, ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.timeline(ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.reactions(ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.subscribers(ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.usage(ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.attachments(ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.tasks(ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.children(WS_ID, ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(labelKeys.byIssue(WS_ID, ISSUE_ID))).toBeUndefined();
+
+    expect(qc.getQueryData(issueKeys.detail(WS_ID, OTHER_ISSUE_ID))).toEqual(
+      otherIssue,
+    );
+    expect(qc.getQueryData(issueKeys.timeline(OTHER_ISSUE_ID))).toEqual([]);
+    expect(qc.getQueryData(labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID))).toEqual({
+      labels: [labelB],
+    });
+  });
+
+  it("removes the deleted issue from workspace and my-issues list caches immediately", () => {
+    const myFilter = { assignee_id: AGENT_ID };
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.list(WS_ID),
+      makeListCache(baseIssue, otherIssue),
+    );
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", myFilter),
+      makeListCache(baseIssue, otherIssue),
+    );
+
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+
+    const list = qc.getQueryData<ListIssuesCache>(issueKeys.list(WS_ID));
+    const myList = qc.getQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", myFilter),
+    );
+    expect(list?.byStatus.todo?.issues.map((i) => i.id)).toEqual([
+      OTHER_ISSUE_ID,
+    ]);
+    expect(list?.byStatus.todo?.total).toBe(1);
+    expect(myList?.byStatus.todo?.issues.map((i) => i.id)).toEqual([
+      OTHER_ISSUE_ID,
+    ]);
+    expect(myList?.byStatus.todo?.total).toBe(1);
+    expectInvalidated(qc, issueKeys.list(WS_ID));
+    expectInvalidated(qc, issueKeys.myList(WS_ID, "assigned", myFilter));
+  });
+
+  it("invalidates parent progress when the parent id only exists in detail cache", () => {
+    qc.setQueryData<Issue>(
+      issueKeys.detail(WS_ID, ISSUE_ID),
+      parentedIssue,
+    );
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID), [
+      parentedIssue,
+      otherIssue,
+    ]);
+    qc.setQueryData(issueKeys.childProgress(WS_ID), new Map());
+
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+
+    const parentChildren = qc.getQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+    );
+    expect(parentChildren?.map((i) => i.id)).toEqual([OTHER_ISSUE_ID]);
+    expectInvalidated(qc, issueKeys.children(WS_ID, PARENT_ISSUE_ID));
+    expectInvalidated(qc, issueKeys.childProgress(WS_ID));
+  });
+
+  it("invalidates parent progress when the deleted issue is only present in a children cache", () => {
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID), [
+      parentedIssue,
+      otherIssue,
+    ]);
+    qc.setQueryData(issueKeys.childProgress(WS_ID), new Map());
+
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+
+    const parentChildren = qc.getQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+    );
+    expect(parentChildren?.map((i) => i.id)).toEqual([OTHER_ISSUE_ID]);
+    expectInvalidated(qc, issueKeys.children(WS_ID, PARENT_ISSUE_ID));
+    expectInvalidated(qc, issueKeys.childProgress(WS_ID));
+  });
+
+  it("invalidates parent progress when the parent id only exists in a my-issues cache", () => {
+    const myFilter = { assignee_id: AGENT_ID };
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", myFilter),
+      makeListCache(parentedIssue, otherIssue),
+    );
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID), [
+      otherIssue,
+    ]);
+    qc.setQueryData(issueKeys.childProgress(WS_ID), new Map());
+
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+
+    const myList = qc.getQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", myFilter),
+    );
+    expect(myList?.byStatus.todo?.issues.map((i) => i.id)).toEqual([
+      OTHER_ISSUE_ID,
+    ]);
+    expectInvalidated(qc, issueKeys.children(WS_ID, PARENT_ISSUE_ID));
+    expectInvalidated(qc, issueKeys.childProgress(WS_ID));
+  });
+
+  it("invalidates child progress when the deleted issue is itself a parent", () => {
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, ISSUE_ID), [
+      {
+        ...otherIssue,
+        parent_issue_id: ISSUE_ID,
+      },
+    ]);
+    qc.setQueryData(
+      issueKeys.childProgress(WS_ID),
+      new Map([[ISSUE_ID, { done: 0, total: 1 }]]),
+    );
+
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+
+    expect(qc.getQueryData(issueKeys.children(WS_ID, ISSUE_ID))).toBeUndefined();
+    expectInvalidated(qc, issueKeys.childProgress(WS_ID));
+  });
+
+  it("invalidates agent task and activity caches that can reference the deleted issue", () => {
+    qc.setQueryData<AgentTask[]>(
+      agentTaskSnapshotKeys.list(WS_ID),
+      [makeTask()],
+    );
+    qc.setQueryData<AgentActivityBucket[]>(
+      agentActivityKeys.last30d(WS_ID),
+      [
+        {
+          agent_id: AGENT_ID,
+          bucket_at: "2025-01-01T00:00:00Z",
+          task_count: 1,
+          failed_count: 0,
+        },
+      ],
+    );
+    qc.setQueryData<AgentRunCount[]>(agentRunCountsKeys.last30d(WS_ID), [
+      { agent_id: AGENT_ID, run_count: 1 },
+    ]);
+    qc.setQueryData<AgentTask[]>(agentTasksKeys.detail(WS_ID, AGENT_ID), [
+      makeTask(),
+    ]);
+    qc.setQueryData<AgentTask[]>(issueKeys.tasks(ISSUE_ID), [makeTask()]);
+
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+
+    expectInvalidated(qc, agentTaskSnapshotKeys.list(WS_ID));
+    expectInvalidated(qc, agentActivityKeys.last30d(WS_ID));
+    expectInvalidated(qc, agentRunCountsKeys.last30d(WS_ID));
+    expectInvalidated(qc, agentTasksKeys.detail(WS_ID, AGENT_ID));
+    expect(qc.getQueryData(issueKeys.tasks(ISSUE_ID))).toBeUndefined();
   });
 });

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -5,8 +5,8 @@ import {
   addIssueToBuckets,
   findIssueLocation,
   patchIssueInBuckets,
-  removeIssueFromBuckets,
 } from "./cache-helpers";
+import { cleanupDeletedIssueCaches } from "./delete-cache";
 import type { Issue, IssueLabelsResponse, Label } from "../types";
 import type { ListIssuesCache } from "../types";
 
@@ -107,21 +107,5 @@ export function onIssueDeleted(
   wsId: string,
   issueId: string,
 ) {
-  // Look up the issue before removing it to check for parent_issue_id
-  const listData = qc.getQueryData<ListIssuesCache>(issueKeys.list(wsId));
-  const deleted = listData ? findIssueLocation(listData, issueId)?.issue : undefined;
-
-  qc.setQueryData<ListIssuesCache>(issueKeys.list(wsId), (old) =>
-    old ? removeIssueFromBuckets(old, issueId) : old,
-  );
-  qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
-  qc.removeQueries({ queryKey: issueKeys.detail(wsId, issueId) });
-  qc.removeQueries({ queryKey: issueKeys.timeline(issueId) });
-  qc.removeQueries({ queryKey: issueKeys.reactions(issueId) });
-  qc.removeQueries({ queryKey: issueKeys.subscribers(issueId) });
-  qc.removeQueries({ queryKey: issueKeys.children(wsId, issueId) });
-  if (deleted?.parent_issue_id) {
-    qc.invalidateQueries({ queryKey: issueKeys.children(wsId, deleted.parent_issue_id) });
-    qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
-  }
+  cleanupDeletedIssueCaches(qc, wsId, issueId);
 }

--- a/packages/views/issues/hooks/issue-delete-mutations.test.tsx
+++ b/packages/views/issues/hooks/issue-delete-mutations.test.tsx
@@ -1,0 +1,605 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { setApiInstance } from "@multica/core/api";
+import { agentTaskSnapshotKeys, agentTasksKeys } from "@multica/core/agents/queries";
+import { useBatchDeleteIssues, useDeleteIssue } from "@multica/core/issues/mutations";
+import { issueKeys } from "@multica/core/issues/queries";
+import { labelKeys } from "@multica/core/labels/queries";
+import { WorkspaceSlugProvider } from "@multica/core/paths";
+import { workspaceKeys } from "@multica/core/workspace/queries";
+import type {
+  AgentTask,
+  Attachment,
+  Issue,
+  IssueLabelsResponse,
+  IssueUsageSummary,
+  Label,
+  ListIssuesCache,
+  TimelineEntry,
+  Workspace,
+} from "@multica/core/types";
+
+const WS_ID = "ws-1";
+const SLUG = "test";
+const ISSUE_ID = "issue-1";
+const OTHER_ISSUE_ID = "issue-2";
+const PARENT_ISSUE_ID = "parent-1";
+const AGENT_ID = "agent-1";
+
+const workspace: Workspace = {
+  id: WS_ID,
+  name: "Test",
+  slug: SLUG,
+  description: null,
+  context: null,
+  settings: {},
+  repos: [],
+  issue_prefix: "TST",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const baseIssue: Issue = {
+  id: ISSUE_ID,
+  workspace_id: WS_ID,
+  number: 1,
+  identifier: "TST-1",
+  title: "Deleted issue",
+  description: null,
+  status: "todo",
+  priority: "none",
+  assignee_type: null,
+  assignee_id: null,
+  creator_type: "member",
+  creator_id: "member-1",
+  parent_issue_id: PARENT_ISSUE_ID,
+  project_id: null,
+  position: 0,
+  due_date: null,
+  labels: [],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const otherIssue: Issue = {
+  ...baseIssue,
+  id: OTHER_ISSUE_ID,
+  number: 2,
+  identifier: "TST-2",
+  title: "Other issue",
+  parent_issue_id: null,
+};
+
+const usage: IssueUsageSummary = {
+  total_input_tokens: 10,
+  total_output_tokens: 20,
+  total_cache_read_tokens: 1,
+  total_cache_write_tokens: 2,
+  task_count: 1,
+};
+
+const attachment: Attachment = {
+  id: "attachment-1",
+  workspace_id: WS_ID,
+  issue_id: ISSUE_ID,
+  comment_id: null,
+  chat_session_id: null,
+  chat_message_id: null,
+  uploader_type: "member",
+  uploader_id: "member-1",
+  filename: "evidence.png",
+  url: "s3://bucket/evidence.png",
+  download_url: "https://example.test/evidence.png",
+  content_type: "image/png",
+  size_bytes: 1,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const timeline: TimelineEntry[] = [
+  {
+    type: "activity",
+    id: "activity-1",
+    actor_type: "member",
+    actor_id: "member-1",
+    action: "created",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const label: Label = {
+  id: "label-1",
+  workspace_id: WS_ID,
+  name: "bug",
+  color: "#ef4444",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const issueLabels: IssueLabelsResponse = {
+  labels: [label],
+};
+
+function makeListCache(...issues: Issue[]): ListIssuesCache {
+  return {
+    byStatus: {
+      todo: { issues, total: issues.length },
+    },
+  };
+}
+
+function makeTask(issueId = ISSUE_ID): AgentTask {
+  return {
+    id: `task-${issueId}`,
+    agent_id: AGENT_ID,
+    runtime_id: "runtime-1",
+    issue_id: issueId,
+    status: "completed",
+    priority: 0,
+    dispatched_at: null,
+    started_at: "2026-01-01T00:00:00Z",
+    completed_at: "2026-01-01T00:01:00Z",
+    result: null,
+    error: null,
+    created_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function setup(
+  deleteIssue = vi.fn().mockResolvedValue(undefined),
+  batchDeleteIssues = vi.fn().mockResolvedValue({ deleted: 0 }),
+) {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  qc.setQueryData(workspaceKeys.list(), [workspace]);
+  setApiInstance({
+    listWorkspaces: vi.fn().mockResolvedValue([workspace]),
+    deleteIssue,
+    batchDeleteIssues,
+  } as any);
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>
+      <WorkspaceSlugProvider slug={SLUG}>{children}</WorkspaceSlugProvider>
+    </QueryClientProvider>
+  );
+
+  return { qc, deleteIssue, batchDeleteIssues, wrapper };
+}
+
+function ids(cache: ListIssuesCache | undefined) {
+  return cache?.byStatus.todo?.issues.map((issue) => issue.id);
+}
+
+function expectInvalidated(qc: QueryClient, queryKey: readonly unknown[]) {
+  expect(qc.getQueryState(queryKey)?.isInvalidated).toBe(true);
+}
+
+describe("useDeleteIssue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cleans list, my-list, issue-scoped, and dependent agent caches after a successful single delete", async () => {
+    const { qc, deleteIssue, wrapper } = setup();
+    const assignedFilter = { assignee_id: AGENT_ID };
+    const createdFilter = { creator_id: "member-1" };
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.list(WS_ID),
+      makeListCache(baseIssue, otherIssue),
+    );
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", assignedFilter),
+      makeListCache(baseIssue, otherIssue),
+    );
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "created", createdFilter),
+      makeListCache(baseIssue),
+    );
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
+    qc.setQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+      [baseIssue, otherIssue],
+    );
+    qc.setQueryData<IssueUsageSummary>(issueKeys.usage(ISSUE_ID), usage);
+    qc.setQueryData<AgentTask[]>(agentTaskSnapshotKeys.list(WS_ID), [
+      makeTask(),
+    ]);
+    qc.setQueryData<AgentTask[]>(agentTasksKeys.detail(WS_ID, AGENT_ID), [
+      makeTask(),
+    ]);
+
+    const { result } = renderHook(() => useDeleteIssue(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(ISSUE_ID);
+    });
+
+    expect(deleteIssue).toHaveBeenCalledWith(ISSUE_ID);
+    expect(ids(qc.getQueryData(issueKeys.list(WS_ID)))).toEqual([
+      OTHER_ISSUE_ID,
+    ]);
+    expect(
+      ids(qc.getQueryData(issueKeys.myList(WS_ID, "assigned", assignedFilter))),
+    ).toEqual([OTHER_ISSUE_ID]);
+    expect(
+      ids(qc.getQueryData(issueKeys.myList(WS_ID, "created", createdFilter))),
+    ).toEqual([]);
+    expect(qc.getQueryData(issueKeys.detail(WS_ID, ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.usage(ISSUE_ID))).toBeUndefined();
+    expect(
+      qc
+        .getQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID))
+        ?.map((issue) => issue.id),
+    ).toEqual([OTHER_ISSUE_ID]);
+    expectInvalidated(qc, agentTaskSnapshotKeys.list(WS_ID));
+    expectInvalidated(qc, agentTasksKeys.detail(WS_ID, AGENT_ID));
+  });
+
+  it("optimistically prunes parent children without invalidating them before delete settles", async () => {
+    const pendingDelete = deferred<void>();
+    const { qc, wrapper } = setup(vi.fn(() => pendingDelete.promise));
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
+    qc.setQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+      [baseIssue, otherIssue],
+    );
+
+    const { result } = renderHook(() => useDeleteIssue(), { wrapper });
+    let mutation!: Promise<void>;
+
+    await act(async () => {
+      mutation = result.current.mutateAsync(ISSUE_ID);
+      await Promise.resolve();
+    });
+
+    expect(
+      qc
+        .getQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID))
+        ?.map((issue) => issue.id),
+    ).toEqual([OTHER_ISSUE_ID]);
+    expect(
+      qc.getQueryState(issueKeys.children(WS_ID, PARENT_ISSUE_ID))
+        ?.isInvalidated,
+    ).not.toBe(true);
+
+    await act(async () => {
+      pendingDelete.resolve();
+      await mutation;
+    });
+
+    expectInvalidated(qc, issueKeys.children(WS_ID, PARENT_ISSUE_ID));
+  });
+
+  it("invalidates child progress when a single delete removes a parent issue", async () => {
+    const { qc, wrapper } = setup();
+    const parentIssue = { ...baseIssue, parent_issue_id: null };
+    const childIssue = { ...otherIssue, parent_issue_id: ISSUE_ID };
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), parentIssue);
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, ISSUE_ID), [
+      childIssue,
+    ]);
+    qc.setQueryData(
+      issueKeys.childProgress(WS_ID),
+      new Map([[ISSUE_ID, { done: 0, total: 1 }]]),
+    );
+
+    const { result } = renderHook(() => useDeleteIssue(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(ISSUE_ID);
+    });
+
+    expect(qc.getQueryData(issueKeys.children(WS_ID, ISSUE_ID))).toBeUndefined();
+    expectInvalidated(qc, issueKeys.childProgress(WS_ID));
+  });
+
+  it("restores optimistic snapshots when a single delete fails", async () => {
+    const error = new Error("delete failed");
+    const { qc, wrapper } = setup(vi.fn().mockRejectedValue(error));
+    const assignedFilter = { assignee_id: AGENT_ID };
+    const list = makeListCache(baseIssue, otherIssue);
+    const myList = makeListCache(baseIssue);
+    const children = [baseIssue, otherIssue];
+    qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), list);
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", assignedFilter),
+      myList,
+    );
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
+    qc.setQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+      children,
+    );
+    qc.setQueryData<IssueUsageSummary>(issueKeys.usage(ISSUE_ID), usage);
+
+    const { result } = renderHook(() => useDeleteIssue(), { wrapper });
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync(ISSUE_ID);
+      }),
+    ).rejects.toThrow("delete failed");
+
+    expect(qc.getQueryData(issueKeys.list(WS_ID))).toEqual(list);
+    expect(
+      qc.getQueryData(issueKeys.myList(WS_ID, "assigned", assignedFilter)),
+    ).toEqual(myList);
+    expect(qc.getQueryData(issueKeys.detail(WS_ID, ISSUE_ID))).toEqual(
+      baseIssue,
+    );
+    expect(qc.getQueryData(issueKeys.children(WS_ID, PARENT_ISSUE_ID))).toEqual(
+      children,
+    );
+    expect(qc.getQueryData(issueKeys.usage(ISSUE_ID))).toEqual(usage);
+  });
+});
+
+describe("useBatchDeleteIssues", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cleans list, my-list, issue-scoped, parent, and dependent agent caches after a fully successful batch delete", async () => {
+    const batchDeleteIssues = vi.fn().mockResolvedValue({ deleted: 2 });
+    const { qc, wrapper } = setup(undefined, batchDeleteIssues);
+    const assignedFilter = { assignee_id: AGENT_ID };
+    const createdFilter = { creator_id: "member-1" };
+    const idsToDelete = [ISSUE_ID, OTHER_ISSUE_ID];
+    const childIssue = { ...otherIssue, parent_issue_id: PARENT_ISSUE_ID };
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.list(WS_ID),
+      makeListCache(baseIssue, childIssue),
+    );
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", assignedFilter),
+      makeListCache(baseIssue, childIssue),
+    );
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "created", createdFilter),
+      makeListCache(baseIssue),
+    );
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, OTHER_ISSUE_ID), childIssue);
+    qc.setQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+      [baseIssue, childIssue],
+    );
+    qc.setQueryData(issueKeys.childProgress(WS_ID), {});
+    qc.setQueryData<IssueUsageSummary>(issueKeys.usage(ISSUE_ID), usage);
+    qc.setQueryData<IssueUsageSummary>(
+      issueKeys.usage(OTHER_ISSUE_ID),
+      usage,
+    );
+    qc.setQueryData<AgentTask[]>(issueKeys.tasks(ISSUE_ID), [makeTask()]);
+    qc.setQueryData<AgentTask[]>(issueKeys.tasks(OTHER_ISSUE_ID), [
+      makeTask(OTHER_ISSUE_ID),
+    ]);
+    qc.setQueryData<AgentTask[]>(agentTaskSnapshotKeys.list(WS_ID), [
+      makeTask(),
+    ]);
+    qc.setQueryData<AgentTask[]>(agentTasksKeys.detail(WS_ID, AGENT_ID), [
+      makeTask(),
+    ]);
+
+    const { result } = renderHook(() => useBatchDeleteIssues(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(idsToDelete);
+    });
+
+    expect(batchDeleteIssues).toHaveBeenCalledWith(idsToDelete);
+    expect(ids(qc.getQueryData(issueKeys.list(WS_ID)))).toEqual([]);
+    expect(
+      ids(qc.getQueryData(issueKeys.myList(WS_ID, "assigned", assignedFilter))),
+    ).toEqual([]);
+    expect(
+      ids(qc.getQueryData(issueKeys.myList(WS_ID, "created", createdFilter))),
+    ).toEqual([]);
+    expect(qc.getQueryData(issueKeys.detail(WS_ID, ISSUE_ID))).toBeUndefined();
+    expect(
+      qc.getQueryData(issueKeys.detail(WS_ID, OTHER_ISSUE_ID)),
+    ).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.usage(ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.usage(OTHER_ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.tasks(ISSUE_ID))).toBeUndefined();
+    expect(qc.getQueryData(issueKeys.tasks(OTHER_ISSUE_ID))).toBeUndefined();
+    expect(
+      qc.getQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID)),
+    ).toEqual([]);
+    expectInvalidated(qc, issueKeys.children(WS_ID, PARENT_ISSUE_ID));
+    expectInvalidated(qc, issueKeys.childProgress(WS_ID));
+    expectInvalidated(qc, agentTaskSnapshotKeys.list(WS_ID));
+    expectInvalidated(qc, agentTasksKeys.detail(WS_ID, AGENT_ID));
+  });
+
+  it("invalidates child progress when a full batch delete removes a parent issue", async () => {
+    const batchDeleteIssues = vi.fn().mockResolvedValue({ deleted: 1 });
+    const { qc, wrapper } = setup(undefined, batchDeleteIssues);
+    const parentIssue = { ...baseIssue, parent_issue_id: null };
+    const childIssue = { ...otherIssue, parent_issue_id: ISSUE_ID };
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), parentIssue);
+    qc.setQueryData<Issue[]>(issueKeys.children(WS_ID, ISSUE_ID), [
+      childIssue,
+    ]);
+    qc.setQueryData(
+      issueKeys.childProgress(WS_ID),
+      new Map([[ISSUE_ID, { done: 0, total: 1 }]]),
+    );
+
+    const { result } = renderHook(() => useBatchDeleteIssues(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync([ISSUE_ID]);
+    });
+
+    expect(batchDeleteIssues).toHaveBeenCalledWith([ISSUE_ID]);
+    expect(qc.getQueryData(issueKeys.children(WS_ID, ISSUE_ID))).toBeUndefined();
+    expectInvalidated(qc, issueKeys.childProgress(WS_ID));
+  });
+
+  it("keeps requested issue caches on partial batch delete and broadly invalidates issue and dependent caches", async () => {
+    const batchDeleteIssues = vi.fn().mockResolvedValue({ deleted: 1 });
+    const { qc, wrapper } = setup(undefined, batchDeleteIssues);
+    const idsToDelete = [ISSUE_ID, OTHER_ISSUE_ID];
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.list(WS_ID),
+      makeListCache(baseIssue, otherIssue),
+    );
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, OTHER_ISSUE_ID), otherIssue);
+    qc.setQueryData<IssueUsageSummary>(issueKeys.usage(ISSUE_ID), usage);
+    qc.setQueryData<Attachment[]>(issueKeys.attachments(ISSUE_ID), [
+      attachment,
+    ]);
+    qc.setQueryData<TimelineEntry[]>(issueKeys.timeline(ISSUE_ID), timeline);
+    qc.setQueryData<IssueLabelsResponse>(
+      labelKeys.byIssue(WS_ID, ISSUE_ID),
+      issueLabels,
+    );
+    qc.setQueryData<IssueUsageSummary>(
+      issueKeys.usage(OTHER_ISSUE_ID),
+      usage,
+    );
+    qc.setQueryData<Attachment[]>(issueKeys.attachments(OTHER_ISSUE_ID), [
+      { ...attachment, id: "attachment-2", issue_id: OTHER_ISSUE_ID },
+    ]);
+    qc.setQueryData<TimelineEntry[]>(issueKeys.timeline(OTHER_ISSUE_ID), [
+      { ...timeline[0]!, id: "activity-2" },
+    ]);
+    qc.setQueryData<IssueLabelsResponse>(
+      labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID),
+      issueLabels,
+    );
+    qc.setQueryData<AgentTask[]>(agentTaskSnapshotKeys.list(WS_ID), [
+      makeTask(),
+    ]);
+    qc.setQueryData<AgentTask[]>(agentTasksKeys.detail(WS_ID, AGENT_ID), [
+      makeTask(),
+    ]);
+
+    const { result } = renderHook(() => useBatchDeleteIssues(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync(idsToDelete);
+    });
+
+    expect(batchDeleteIssues).toHaveBeenCalledWith(idsToDelete);
+    expect(ids(qc.getQueryData(issueKeys.list(WS_ID)))).toEqual([]);
+    expect(qc.getQueryData(issueKeys.detail(WS_ID, ISSUE_ID))).toEqual(
+      baseIssue,
+    );
+    expect(qc.getQueryData(issueKeys.detail(WS_ID, OTHER_ISSUE_ID))).toEqual(
+      otherIssue,
+    );
+    expect(qc.getQueryData(issueKeys.usage(ISSUE_ID))).toEqual(usage);
+    expect(qc.getQueryData(issueKeys.attachments(ISSUE_ID))).toEqual([
+      attachment,
+    ]);
+    expect(qc.getQueryData(issueKeys.timeline(ISSUE_ID))).toEqual(timeline);
+    expect(qc.getQueryData(labelKeys.byIssue(WS_ID, ISSUE_ID))).toEqual(
+      issueLabels,
+    );
+    expect(qc.getQueryData(issueKeys.usage(OTHER_ISSUE_ID))).toEqual(usage);
+    expect(qc.getQueryData(issueKeys.attachments(OTHER_ISSUE_ID))).toEqual([
+      { ...attachment, id: "attachment-2", issue_id: OTHER_ISSUE_ID },
+    ]);
+    expect(qc.getQueryData(issueKeys.timeline(OTHER_ISSUE_ID))).toEqual([
+      { ...timeline[0]!, id: "activity-2" },
+    ]);
+    expect(qc.getQueryData(labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID))).toEqual(
+      issueLabels,
+    );
+    expectInvalidated(qc, issueKeys.detail(WS_ID, ISSUE_ID));
+    expectInvalidated(qc, issueKeys.detail(WS_ID, OTHER_ISSUE_ID));
+    expectInvalidated(qc, issueKeys.usage(ISSUE_ID));
+    expectInvalidated(qc, issueKeys.attachments(ISSUE_ID));
+    expectInvalidated(qc, issueKeys.timeline(ISSUE_ID));
+    expectInvalidated(qc, labelKeys.byIssue(WS_ID, ISSUE_ID));
+    expectInvalidated(qc, issueKeys.usage(OTHER_ISSUE_ID));
+    expectInvalidated(qc, issueKeys.attachments(OTHER_ISSUE_ID));
+    expectInvalidated(qc, issueKeys.timeline(OTHER_ISSUE_ID));
+    expectInvalidated(qc, labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID));
+    expectInvalidated(qc, agentTaskSnapshotKeys.list(WS_ID));
+    expectInvalidated(qc, agentTasksKeys.detail(WS_ID, AGENT_ID));
+  });
+
+  it("restores optimistic workspace, my-list, and parent children snapshots when a batch delete fails", async () => {
+    const pendingDelete = deferred<{ deleted: number }>();
+    const { qc, wrapper } = setup(undefined, vi.fn(() => pendingDelete.promise));
+    const assignedFilter = { assignee_id: AGENT_ID };
+    const createdFilter = { creator_id: "member-1" };
+    const list = makeListCache(baseIssue, otherIssue);
+    const assignedMyList = makeListCache(baseIssue, otherIssue);
+    const createdMyList = makeListCache(baseIssue);
+    const children = [baseIssue, otherIssue];
+    qc.setQueryData<ListIssuesCache>(issueKeys.list(WS_ID), list);
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", assignedFilter),
+      assignedMyList,
+    );
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "created", createdFilter),
+      createdMyList,
+    );
+    qc.setQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+      children,
+    );
+
+    const { result } = renderHook(() => useBatchDeleteIssues(), { wrapper });
+    let mutation!: Promise<{ deleted: number }>;
+
+    await act(async () => {
+      mutation = result.current.mutateAsync([ISSUE_ID]);
+      await Promise.resolve();
+    });
+
+    expect(ids(qc.getQueryData(issueKeys.list(WS_ID)))).toEqual([
+      OTHER_ISSUE_ID,
+    ]);
+    expect(
+      ids(qc.getQueryData(issueKeys.myList(WS_ID, "assigned", assignedFilter))),
+    ).toEqual([OTHER_ISSUE_ID]);
+    expect(
+      ids(qc.getQueryData(issueKeys.myList(WS_ID, "created", createdFilter))),
+    ).toEqual([]);
+    expect(
+      qc
+        .getQueryData<Issue[]>(issueKeys.children(WS_ID, PARENT_ISSUE_ID))
+        ?.map((issue) => issue.id),
+    ).toEqual([OTHER_ISSUE_ID]);
+
+    await expect(
+      act(async () => {
+        pendingDelete.reject(new Error("batch delete failed"));
+        await mutation;
+      }),
+    ).rejects.toThrow("batch delete failed");
+
+    expect(qc.getQueryData(issueKeys.list(WS_ID))).toEqual(list);
+    expect(
+      qc.getQueryData(issueKeys.myList(WS_ID, "assigned", assignedFilter)),
+    ).toEqual(assignedMyList);
+    expect(
+      qc.getQueryData(issueKeys.myList(WS_ID, "created", createdFilter)),
+    ).toEqual(createdMyList);
+    expect(qc.getQueryData(issueKeys.children(WS_ID, PARENT_ISSUE_ID))).toEqual(
+      children,
+    );
+  });
+});

--- a/packages/views/issues/hooks/issue-delete-mutations.test.tsx
+++ b/packages/views/issues/hooks/issue-delete-mutations.test.tsx
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryObserver,
+} from "@tanstack/react-query";
 import { setApiInstance } from "@multica/core/api";
 import { agentTaskSnapshotKeys, agentTasksKeys } from "@multica/core/agents/queries";
 import { useBatchDeleteIssues, useDeleteIssue } from "@multica/core/issues/mutations";
@@ -452,16 +456,35 @@ describe("useBatchDeleteIssues", () => {
     expectInvalidated(qc, issueKeys.childProgress(WS_ID));
   });
 
-  it("keeps requested issue caches on partial batch delete and broadly invalidates issue and dependent caches", async () => {
+  it("restores optimistic list snapshots on partial batch delete before invalidating caches", async () => {
     const batchDeleteIssues = vi.fn().mockResolvedValue({ deleted: 1 });
     const { qc, wrapper } = setup(undefined, batchDeleteIssues);
+    const assignedFilter = { assignee_id: AGENT_ID };
+    const createdFilter = { creator_id: "member-1" };
     const idsToDelete = [ISSUE_ID, OTHER_ISSUE_ID];
+    const childIssue = { ...otherIssue, parent_issue_id: PARENT_ISSUE_ID };
+    const list = makeListCache(baseIssue, childIssue);
+    const assignedMyList = makeListCache(baseIssue, childIssue);
+    const createdMyList = makeListCache(baseIssue);
+    const children = [baseIssue, childIssue];
     qc.setQueryData<ListIssuesCache>(
       issueKeys.list(WS_ID),
-      makeListCache(baseIssue, otherIssue),
+      list,
+    );
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "assigned", assignedFilter),
+      assignedMyList,
+    );
+    qc.setQueryData<ListIssuesCache>(
+      issueKeys.myList(WS_ID, "created", createdFilter),
+      createdMyList,
+    );
+    qc.setQueryData<Issue[]>(
+      issueKeys.children(WS_ID, PARENT_ISSUE_ID),
+      children,
     );
     qc.setQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID), baseIssue);
-    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, OTHER_ISSUE_ID), otherIssue);
+    qc.setQueryData<Issue>(issueKeys.detail(WS_ID, OTHER_ISSUE_ID), childIssue);
     qc.setQueryData<IssueUsageSummary>(issueKeys.usage(ISSUE_ID), usage);
     qc.setQueryData<Attachment[]>(issueKeys.attachments(ISSUE_ID), [
       attachment,
@@ -491,51 +514,73 @@ describe("useBatchDeleteIssues", () => {
     qc.setQueryData<AgentTask[]>(agentTasksKeys.detail(WS_ID, AGENT_ID), [
       makeTask(),
     ]);
+    const listRefetch = deferred<ListIssuesCache>();
+    const listObserver = new QueryObserver(qc, {
+      queryKey: issueKeys.list(WS_ID),
+      queryFn: () => listRefetch.promise,
+      refetchOnMount: false,
+      staleTime: Infinity,
+    });
+    const unsubscribeList = listObserver.subscribe(() => {});
 
     const { result } = renderHook(() => useBatchDeleteIssues(), { wrapper });
 
-    await act(async () => {
-      await result.current.mutateAsync(idsToDelete);
-    });
+    try {
+      await act(async () => {
+        await result.current.mutateAsync(idsToDelete);
+      });
 
-    expect(batchDeleteIssues).toHaveBeenCalledWith(idsToDelete);
-    expect(ids(qc.getQueryData(issueKeys.list(WS_ID)))).toEqual([]);
-    expect(qc.getQueryData(issueKeys.detail(WS_ID, ISSUE_ID))).toEqual(
-      baseIssue,
-    );
-    expect(qc.getQueryData(issueKeys.detail(WS_ID, OTHER_ISSUE_ID))).toEqual(
-      otherIssue,
-    );
-    expect(qc.getQueryData(issueKeys.usage(ISSUE_ID))).toEqual(usage);
-    expect(qc.getQueryData(issueKeys.attachments(ISSUE_ID))).toEqual([
-      attachment,
-    ]);
-    expect(qc.getQueryData(issueKeys.timeline(ISSUE_ID))).toEqual(timeline);
-    expect(qc.getQueryData(labelKeys.byIssue(WS_ID, ISSUE_ID))).toEqual(
-      issueLabels,
-    );
-    expect(qc.getQueryData(issueKeys.usage(OTHER_ISSUE_ID))).toEqual(usage);
-    expect(qc.getQueryData(issueKeys.attachments(OTHER_ISSUE_ID))).toEqual([
-      { ...attachment, id: "attachment-2", issue_id: OTHER_ISSUE_ID },
-    ]);
-    expect(qc.getQueryData(issueKeys.timeline(OTHER_ISSUE_ID))).toEqual([
-      { ...timeline[0]!, id: "activity-2" },
-    ]);
-    expect(qc.getQueryData(labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID))).toEqual(
-      issueLabels,
-    );
-    expectInvalidated(qc, issueKeys.detail(WS_ID, ISSUE_ID));
-    expectInvalidated(qc, issueKeys.detail(WS_ID, OTHER_ISSUE_ID));
-    expectInvalidated(qc, issueKeys.usage(ISSUE_ID));
-    expectInvalidated(qc, issueKeys.attachments(ISSUE_ID));
-    expectInvalidated(qc, issueKeys.timeline(ISSUE_ID));
-    expectInvalidated(qc, labelKeys.byIssue(WS_ID, ISSUE_ID));
-    expectInvalidated(qc, issueKeys.usage(OTHER_ISSUE_ID));
-    expectInvalidated(qc, issueKeys.attachments(OTHER_ISSUE_ID));
-    expectInvalidated(qc, issueKeys.timeline(OTHER_ISSUE_ID));
-    expectInvalidated(qc, labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID));
-    expectInvalidated(qc, agentTaskSnapshotKeys.list(WS_ID));
-    expectInvalidated(qc, agentTasksKeys.detail(WS_ID, AGENT_ID));
+      expect(batchDeleteIssues).toHaveBeenCalledWith(idsToDelete);
+      expect(qc.getQueryData(issueKeys.list(WS_ID))).toEqual(list);
+      expect(
+        qc.getQueryData(issueKeys.myList(WS_ID, "assigned", assignedFilter)),
+      ).toEqual(assignedMyList);
+      expect(
+        qc.getQueryData(issueKeys.myList(WS_ID, "created", createdFilter)),
+      ).toEqual(createdMyList);
+      expect(
+        qc.getQueryData(issueKeys.children(WS_ID, PARENT_ISSUE_ID)),
+      ).toEqual(children);
+      expect(qc.getQueryData(issueKeys.detail(WS_ID, ISSUE_ID))).toEqual(
+        baseIssue,
+      );
+      expect(qc.getQueryData(issueKeys.detail(WS_ID, OTHER_ISSUE_ID))).toEqual(
+        childIssue,
+      );
+      expect(qc.getQueryData(issueKeys.usage(ISSUE_ID))).toEqual(usage);
+      expect(qc.getQueryData(issueKeys.attachments(ISSUE_ID))).toEqual([
+        attachment,
+      ]);
+      expect(qc.getQueryData(issueKeys.timeline(ISSUE_ID))).toEqual(timeline);
+      expect(qc.getQueryData(labelKeys.byIssue(WS_ID, ISSUE_ID))).toEqual(
+        issueLabels,
+      );
+      expect(qc.getQueryData(issueKeys.usage(OTHER_ISSUE_ID))).toEqual(usage);
+      expect(qc.getQueryData(issueKeys.attachments(OTHER_ISSUE_ID))).toEqual([
+        { ...attachment, id: "attachment-2", issue_id: OTHER_ISSUE_ID },
+      ]);
+      expect(qc.getQueryData(issueKeys.timeline(OTHER_ISSUE_ID))).toEqual([
+        { ...timeline[0]!, id: "activity-2" },
+      ]);
+      expect(qc.getQueryData(labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID))).toEqual(
+        issueLabels,
+      );
+      expectInvalidated(qc, issueKeys.detail(WS_ID, ISSUE_ID));
+      expectInvalidated(qc, issueKeys.detail(WS_ID, OTHER_ISSUE_ID));
+      expectInvalidated(qc, issueKeys.usage(ISSUE_ID));
+      expectInvalidated(qc, issueKeys.attachments(ISSUE_ID));
+      expectInvalidated(qc, issueKeys.timeline(ISSUE_ID));
+      expectInvalidated(qc, labelKeys.byIssue(WS_ID, ISSUE_ID));
+      expectInvalidated(qc, issueKeys.usage(OTHER_ISSUE_ID));
+      expectInvalidated(qc, issueKeys.attachments(OTHER_ISSUE_ID));
+      expectInvalidated(qc, issueKeys.timeline(OTHER_ISSUE_ID));
+      expectInvalidated(qc, labelKeys.byIssue(WS_ID, OTHER_ISSUE_ID));
+      expectInvalidated(qc, agentTaskSnapshotKeys.list(WS_ID));
+      expectInvalidated(qc, agentTasksKeys.detail(WS_ID, AGENT_ID));
+    } finally {
+      unsubscribeList();
+      listRefetch.resolve(list);
+    }
   });
 
   it("restores optimistic workspace, my-list, and parent children snapshots when a batch delete fails", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes stale frontend state after an issue is deleted.

Thinking path: the backend already deletes the issue and emits `issue:deleted`; the stale UI comes from long-lived React Query caches that are not all cleaned up after the delete. The fix belongs in `packages/core/issues` so websocket delete events, single delete mutations, and batch delete mutations all use the same cache cleanup contract.

This PR centralizes deleted-issue cache cleanup so a successful delete immediately:

- removes issue-scoped query data for detail, timeline, reactions, subscribers, usage, attachments, tasks, children, and labels;
- prunes workspace issue lists and every loaded My Issues list;
- invalidates affected parent children caches and workspace child-progress data, including the case where the deleted issue is itself a parent;
- invalidates agent task snapshot, activity, run-count, per-agent task, and per-issue task caches that can keep links to deleted issues.

Risk: this intentionally invalidates the workspace child-progress aggregate after every successful delete. That is a small, workspace-scoped refetch cost and avoids missing deletes where parent/child relationships only exist in partial local caches.

## Related Issue

Closes #2486

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/issues/delete-cache.ts` — adds one shared helper for deleted-issue metadata collection, list pruning, issue-scoped cache removal, parent/child-progress invalidation, and dependent agent/task cache invalidation.
- `packages/core/issues/ws-updaters.ts` — routes `issue:deleted` websocket handling through the shared cleanup helper.
- `packages/core/issues/mutations.ts` — collects delete metadata before optimistic cache edits, rolls back list/detail/children snapshots on failure, and runs shared cleanup after successful single or full batch deletes.
- `packages/core/issues/ws-updaters.test.ts` — covers websocket delete cleanup across issue-scoped caches, workspace/My Issues lists, parent metadata sources, deleted-parent child progress, and agent task/activity caches.
- `packages/views/issues/hooks/issue-delete-mutations.test.tsx` — covers single-delete and batch-delete mutation cleanup, partial batch success invalidation, optimistic parent-children behavior, deleted-parent child progress, and rollback behavior.

## How to Test

Reproduce the bug on `main`:

1. Open a workspace with an issue that is visible in Issues or My Issues and has related cached data, such as timeline entries, labels, attachments, tasks, or child issues.
2. Open the issue detail page and related surfaces so the React Query caches are hydrated.
3. Delete the issue, or delete it from another tab/client so the current client receives `issue:deleted`.
4. Navigate to the old issue URL, or inspect Issues, My Issues, agent activity, recent work, and parent child-progress UI.
5. Before this fix, stale local cache data can continue to show the deleted issue or links to it until a later refetch or unrelated realtime invalidation.

Verify this PR:

1. Repeat the same flow after applying this PR.
2. The deleted issue should be removed from local list/detail caches immediately after successful delete or `issue:deleted` handling.
3. The old issue URL should refetch instead of rendering stale hydrated issue data.
4. Agent activity/recent work/task caches and parent child-progress data should be invalidated so they cannot keep stable links or progress rows for the deleted entity.

Automated verification run locally:

- [x] `pnpm --filter @multica/core exec vitest run issues/ws-updaters.test.ts inbox/ws-updaters.test.ts` — 2 files, 13 tests passed
- [x] `pnpm --filter @multica/views exec vitest run issues/hooks/issue-delete-mutations.test.tsx issues/components/issue-detail.test.tsx agents/components/tabs/activity-tab.test.ts` — 3 files, 30 tests passed
- [x] `pnpm --filter @multica/core typecheck`
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/core lint` — passed with one existing warning in `packages/core/platform/auth-initializer.tsx`
- [x] `pnpm --filter @multica/views lint` — passed with existing warnings in unrelated files
- [x] `pnpm exec turbo build typecheck lint test --filter='!@multica/docs'` — 16/16 tasks successful
- [x] `cd server && go run ./cmd/migrate up`
- [x] `cd server && go test ./...`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no visual component or layout change; cache behavior is covered by the steps and tests above)
- [x] I have updated relevant documentation to reflect my changes (N/A: no user-facing docs or API surface changed)
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`) (N/A)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Used codebase inspection and TDD to map the issue-delete cache surfaces, add failing regression coverage for websocket and mutation delete flows, centralize the cleanup path, and verify the result with targeted tests plus the frontend CI-equivalent command.

## Screenshots (optional)

N/A — no visual component or layout changes.
