### PR TITLE
fix(projects): make GitHub repo list scrollable in Add Resource popovers

### DIFF
--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -464,7 +464,7 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
                 {t(($) => $.create_project.repos_heading)}
               </div>
               {workspaceRepos.length > 0 ? (
-                <div className="space-y-1">
+                <div className="space-y-1 max-h-48 overflow-y-auto">
                   {workspaceRepos.map((repo) => {
                     const checked = selectedRepos.includes(repo.url);
                     return (

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -117,7 +117,7 @@ export function ProjectResourcesSection({ projectId }: { projectId: string }) {
                 {t(($) => $.resources.popover_title)}
               </div>
               {workspace?.repos && workspace.repos.length > 0 && (
-                <div className="space-y-1">
+                <div className="space-y-1 max-h-48 overflow-y-auto">
                   {workspace.repos.map((repo) => {
                     const isAttached = attachedUrls.has(repo.url);
                     const isDisabled = isAttached || createResource.isPending;


### PR DESCRIPTION
## What does this PR do?

When a workspace has many GitHub repositories, the repo list inside the "Add Resource" popover renders at full height with no scrollbar, making it impossible to reach repositories that fall below the visible fold. This PR adds `max-h-48 overflow-y-auto` to the repos container `div` so users can scroll through the full list.

## Related Issue

Closes #2489

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `packages/views/projects/components/project-resources-section.tsx`: Added `max-h-48 overflow-y-auto` to the `div` wrapping the GitHub repos list inside the Add Resource popover.

## How to Test

1. Connect many GitHub repos to a workspace (enough to overflow the popover height).
2. Open any project and click "+ Add resource" in the Resources section.
3. Verify the repo list is now scrollable.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] If this change affects the UI, I have included before/after screenshots

## AI Disclosure

**AI tool used:** Multica Agent (Claude Sonnet 4.6 via Claude Code)

**Prompt / approach:** Assigned this fix via a Multica issue. The agent identified the missing `overflow-y-auto` + `max-height` on the repos container and applied a minimal targeted fix.

## Screenshots (optional)

Before: repo list grows unbounded inside the popover, no scroll.
<img width="1842" height="967" alt="image" src="https://github.com/user-attachments/assets/d6366a67-55a8-48ae-85d2-5e41a010c4ec" />
<img width="1848" height="967" alt="Google Chrome 2026-05-12 22 07 46" src="https://github.com/user-attachments/assets/a11b407d-4eb2-4d6c-adf0-dbc6733a2bd7" />


After: list is capped at `max-h-48` and scrollable when overflowing.
<img width="1851" height="1007" alt="Xnip2026-05-12_21-58-22" src="https://github.com/user-attachments/assets/db8452b3-abe9-438c-868f-58df4831be22" />
<img width="1850" height="961" alt="Xnip2026-05-12_22-14-45" src="https://github.com/user-attachments/assets/b71e528e-5ca7-42ff-970e-e398060d3d58" />

