### PR TITLE
Fix stale Done replies on comment follow-ups

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -1933,7 +1933,7 @@ func gcMetaForTask(task Task) (execenv.GCMeta, bool) {
 
 func providerNeedsInlineSystemPrompt(provider string) bool {
 	switch provider {
-	case "openclaw", "hermes", "kiro", "kimi":
+	case "openclaw", "kiro", "kimi":
 		return true
 	default:
 		return false
@@ -2166,9 +2166,6 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// write into the task workdir:
 	//   - openclaw loads bootstrap files (AGENTS.md, SOUL.md, ...) from its own
 	//     workspace dir rather than the task workdir.
-	//   - hermes is driven through ACP and starts from a long-lived Hermes home;
-	//     deployments that cross a wrapper/container boundary can miss the
-	//     task-workdir AGENTS.md even when the prompt itself is delivered.
 	//   - kiro and kimi are wrapped through their own CLIs whose cwd handling
 	//     is opaque enough that we can't trust the file-based path either.
 	// Pass the full runtime brief inline (CLI catalog + workflow steps + agent
@@ -2177,6 +2174,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// these providers silently miss the workflow section and never call
 	// `multica issue status` / `multica issue comment add`, leaving issues
 	// stuck in `todo`.
+	//
+	// Hermes is intentionally excluded: ACP sessions start in the task cwd and
+	// Hermes loads AGENTS.md / .agent_context itself. Prepending the full runtime
+	// brief into the ACP user prompt duplicates that context, bloats every turn,
+	// and has triggered upstream safety filters on harmless tasks.
 	if providerNeedsInlineSystemPrompt(provider) {
 		execOpts.SystemPrompt = runtimeBrief
 	}

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -185,7 +185,10 @@ func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
 		want     bool
 	}{
 		{provider: "openclaw", want: true},
-		{provider: "hermes", want: true},
+		// Hermes ACP starts in the task cwd and loads AGENTS.md / .agent_context
+		// directly. Inlining the full runtime brief duplicates that context and
+		// can trip upstream provider safety filters on otherwise harmless tasks.
+		{provider: "hermes", want: false},
 		{provider: "kiro", want: true},
 		{provider: "kimi", want: true},
 		{provider: "codex", want: false},

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1189,21 +1189,23 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		// Look up the prior session for this (agent, issue) pair so the daemon
 		// can resume the Claude Code conversation context.
 		//
-		// Skip the lookup when the task was flagged as a manual rerun: the
-		// user just judged the prior output bad, so the daemon must start a
+		// Skip the session resume when the task was flagged as a manual rerun:
+		// the user just judged the prior output bad, so the daemon must start a
 		// fresh agent session instead of resuming the same conversation that
-		// produced that output.
-		if !task.ForceFreshSession {
-			if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
-				AgentID: task.AgentID,
-				IssueID: task.IssueID,
-			}); err == nil && prior.SessionID.Valid {
-				if prior.RuntimeID == task.RuntimeID {
-					resp.PriorSessionID = prior.SessionID.String
-				}
-				if prior.WorkDir.Valid {
-					resp.PriorWorkDir = prior.WorkDir.String
-				}
+		// produced that output. Also skip session resume for comment-triggered
+		// follow-ups: resumed issue conversations often inherit the prior final
+		// assistant message (for example "Done.") and answer a new human comment
+		// with that stale completion marker instead of the comment itself. Keep
+		// reusing the workdir so follow-up tasks still see the same checkout.
+		if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
+			AgentID: task.AgentID,
+			IssueID: task.IssueID,
+		}); err == nil && prior.SessionID.Valid {
+			if !task.ForceFreshSession && !task.TriggerCommentID.Valid && prior.RuntimeID == task.RuntimeID {
+				resp.PriorSessionID = prior.SessionID.String
+			}
+			if prior.WorkDir.Valid {
+				resp.PriorWorkDir = prior.WorkDir.String
 			}
 		}
 	}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1189,23 +1189,26 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 		// Look up the prior session for this (agent, issue) pair so the daemon
 		// can resume the Claude Code conversation context.
 		//
-		// Skip the session resume when the task was flagged as a manual rerun:
+		// Skip all prior state when the task was flagged as a manual rerun:
 		// the user just judged the prior output bad, so the daemon must start a
-		// fresh agent session instead of resuming the same conversation that
-		// produced that output. Also skip session resume for comment-triggered
-		// follow-ups: resumed issue conversations often inherit the prior final
-		// assistant message (for example "Done.") and answer a new human comment
-		// with that stale completion marker instead of the comment itself. Keep
-		// reusing the workdir so follow-up tasks still see the same checkout.
-		if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
-			AgentID: task.AgentID,
-			IssueID: task.IssueID,
-		}); err == nil && prior.SessionID.Valid {
-			if !task.ForceFreshSession && !task.TriggerCommentID.Valid && prior.RuntimeID == task.RuntimeID {
-				resp.PriorSessionID = prior.SessionID.String
-			}
-			if prior.WorkDir.Valid {
-				resp.PriorWorkDir = prior.WorkDir.String
+		// fresh agent session in a fresh workdir instead of resuming anything
+		// from the same conversation that produced that output. For
+		// comment-triggered follow-ups, skip only the session resume: resumed
+		// issue conversations often inherit the prior final assistant message
+		// (for example "Done.") and answer a new human comment with that stale
+		// completion marker instead of the comment itself. Keep reusing the
+		// workdir for comment follow-ups so the agent still sees the same checkout.
+		if !task.ForceFreshSession {
+			if prior, err := h.Queries.GetLastTaskSession(r.Context(), db.GetLastTaskSessionParams{
+				AgentID: task.AgentID,
+				IssueID: task.IssueID,
+			}); err == nil && prior.SessionID.Valid {
+				if !task.TriggerCommentID.Valid && prior.RuntimeID == task.RuntimeID {
+					resp.PriorSessionID = prior.SessionID.String
+				}
+				if prior.WorkDir.Valid {
+					resp.PriorWorkDir = prior.WorkDir.String
+				}
 			}
 		}
 	}

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1904,6 +1904,140 @@ func TestCompleteTask_CommentTriggered_SkipsSynthesisWhenAgentAlreadyCommented(t
 	}
 }
 
+func TestCompleteTask_CommentTriggered_SuppressesTrivialDoneOutput(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'trivial-done-suppression fixture', 'in_progress', 'none', $2, 'member', 81200, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var triggerCommentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'member', $3, 'please follow up', 'comment')
+		RETURNING id
+	`, issueID, testWorkspaceID, testUserID).Scan(&triggerCommentID); err != nil {
+		t.Fatalf("setup: create trigger comment: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, trigger_comment_id,
+			status, priority, started_at
+		)
+		VALUES ($1, $2, $3, $4, 'running', 0, now())
+		RETURNING id
+	`, agentID, runtimeID, issueID, triggerCommentID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create comment-triggered task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
+		map[string]any{"output": "Done."},
+		testWorkspaceID, "legit-daemon")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", taskID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.CompleteTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var count int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM comment
+		WHERE issue_id = $1 AND author_type = 'agent' AND author_id = $2
+	`, issueID, agentID).Scan(&count); err != nil {
+		t.Fatalf("count agent comments: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no synthesized agent comment for trivial Done output, got %d", count)
+	}
+}
+
+func TestCompleteTask_AssignmentTriggered_DoesNotSuppressTrivialDoneOutput(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT a.id, a.runtime_id FROM agent a WHERE a.workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("setup: get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'assignment-trivial-done fixture', 'in_progress', 'none', $2, 'member', 81201, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("setup: create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id,
+			status, priority, started_at
+		)
+		VALUES ($1, $2, $3, 'running', 0, now())
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("setup: create assignment-triggered task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/tasks/"+taskID+"/complete",
+		map[string]any{"output": "Done."},
+		testWorkspaceID, "legit-daemon")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("taskId", taskID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	testHandler.CompleteTask(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("CompleteTask: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var content string
+	if err := testPool.QueryRow(ctx, `
+		SELECT content FROM comment
+		WHERE issue_id = $1 AND author_type = 'agent' AND author_id = $2
+		ORDER BY created_at DESC LIMIT 1
+	`, issueID, agentID).Scan(&content); err != nil {
+		t.Fatalf("query synthesized comment: %v", err)
+	}
+	if content != "Done." {
+		t.Fatalf("synthesized comment content = %q, want Done.", content)
+	}
+}
+
 type claimRuntimeGuardTask struct {
 	PriorSessionID string `json:"prior_session_id"`
 	PriorWorkDir   string `json:"prior_work_dir"`
@@ -2198,6 +2332,96 @@ func TestClaimTask_IssuePriorSessionRuntimeGuard(t *testing.T) {
 	}
 	if task.PriorWorkDir != "/tmp/same-runtime-workdir" {
 		t.Fatalf("runtime match: expected PriorWorkDir='/tmp/same-runtime-workdir', got %q", task.PriorWorkDir)
+	}
+
+	var commentIssueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'comment-triggered-session-skip fixture', 'in_progress', 'none', $2, 'member', 81205, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&commentIssueID); err != nil {
+		t.Fatalf("setup: create comment-triggered issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, commentIssueID) })
+
+	var triggerCommentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO comment (issue_id, workspace_id, author_type, author_id, content, type)
+		VALUES ($1, $2, 'member', $3, 'please follow up', 'comment')
+		RETURNING id
+	`, commentIssueID, testWorkspaceID, testUserID).Scan(&triggerCommentID); err != nil {
+		t.Fatalf("setup: create trigger comment: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id,
+			status, priority, started_at, completed_at,
+			session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'completed', 0, now(), now(), 'comment-prior-session', '/tmp/comment-prior-workdir')
+	`, agentID, runtimeID, commentIssueID); err != nil {
+		t.Fatalf("setup: create comment-trigger prior task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, trigger_comment_id,
+			status, priority
+		)
+		VALUES ($1, $2, $3, $4, 'queued', 0)
+	`, agentID, runtimeID, commentIssueID, triggerCommentID); err != nil {
+		t.Fatalf("setup: create comment-triggered task: %v", err)
+	}
+
+	task = claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "" {
+		t.Fatalf("comment trigger: expected empty PriorSessionID, got %q", task.PriorSessionID)
+	}
+	if task.PriorWorkDir != "/tmp/comment-prior-workdir" {
+		t.Fatalf("comment trigger: expected PriorWorkDir='/tmp/comment-prior-workdir', got %q", task.PriorWorkDir)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE agent_task_queue
+		SET status = 'completed', completed_at = now()
+		WHERE issue_id = $1 AND status IN ('dispatched', 'running')
+	`, commentIssueID); err != nil {
+		t.Fatalf("setup: complete claimed comment-trigger task: %v", err)
+	}
+
+	var freshIssueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, status, priority, creator_id, creator_type, number, position)
+		VALUES ($1, 'force-fresh-session fixture', 'in_progress', 'none', $2, 'member', 81206, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&freshIssueID); err != nil {
+		t.Fatalf("setup: create force-fresh issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, freshIssueID) })
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id,
+			status, priority, started_at, completed_at,
+			session_id, work_dir
+		)
+		VALUES ($1, $2, $3, 'completed', 0, now(), now(), 'force-fresh-prior-session', '/tmp/force-fresh-prior-workdir')
+	`, agentID, runtimeID, freshIssueID); err != nil {
+		t.Fatalf("setup: create force-fresh prior task: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id,
+			status, priority, force_fresh_session
+		)
+		VALUES ($1, $2, $3, 'queued', 0, TRUE)
+	`, agentID, runtimeID, freshIssueID); err != nil {
+		t.Fatalf("setup: create force-fresh task: %v", err)
+	}
+
+	task = claimTaskForRuntimeGuard(t, runtimeID, daemonID)
+	if task.PriorSessionID != "" {
+		t.Fatalf("force fresh: expected empty PriorSessionID, got %q", task.PriorSessionID)
+	}
+	if task.PriorWorkDir != "" {
+		t.Fatalf("force fresh: expected empty PriorWorkDir, got %q", task.PriorWorkDir)
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -106,6 +106,12 @@ func NewTaskService(q *db.Queries, tx TxStarter, hub *realtime.Hub, bus *events.
 	return &TaskService{Queries: q, TxStarter: tx, Hub: hub, Bus: bus, Wakeup: wakeup}
 }
 
+func isTrivialDoneOutput(output string) bool {
+	normalized := strings.TrimSpace(strings.ToLower(output))
+	normalized = strings.Trim(normalized, ".!。 ")
+	return normalized == "done" || normalized == "готово"
+}
+
 func (s *TaskService) captureTaskQueued(ctx context.Context, task db.AgentTaskQueue) {
 	s.captureTaskEvent(ctx, analytics.AgentTaskQueued(s.taskAnalyticsContext(ctx, task)))
 }
@@ -972,7 +978,15 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 					// decoded into real newlines before the comment hits the DB. See
 					// util.UnescapeBackslashEscapes for the exact contract.
 					body := util.UnescapeBackslashEscapes(payload.Output)
-					s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(body), "comment", task.TriggerCommentID)
+					if task.TriggerCommentID.Valid && isTrivialDoneOutput(body) {
+						slog.Warn("suppressing trivial comment-trigger fallback output",
+							"task_id", util.UUIDToString(task.ID),
+							"issue_id", util.UUIDToString(task.IssueID),
+							"agent_id", util.UUIDToString(task.AgentID),
+						)
+					} else {
+						s.createAgentComment(ctx, task.IssueID, task.AgentID, redact.Text(body), "comment", task.TriggerCommentID)
+					}
 				}
 			}
 		}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -106,10 +106,24 @@ func NewTaskService(q *db.Queries, tx TxStarter, hub *realtime.Hub, bus *events.
 	return &TaskService{Queries: q, TxStarter: tx, Hub: hub, Bus: bus, Wakeup: wakeup}
 }
 
+var trivialDoneMarkers = []string{
+	"done",
+	"готово",
+	"готова",
+	"сделано",
+	"完成",
+	"完了",
+}
+
 func isTrivialDoneOutput(output string) bool {
 	normalized := strings.TrimSpace(strings.ToLower(output))
-	normalized = strings.Trim(normalized, ".!。 ")
-	return normalized == "done" || normalized == "готово"
+	normalized = strings.Trim(normalized, ".!！。… ")
+	for _, marker := range trivialDoneMarkers {
+		if normalized == marker {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *TaskService) captureTaskQueued(ctx context.Context, task db.AgentTaskQueue) {

--- a/server/internal/service/trivial_done_test.go
+++ b/server/internal/service/trivial_done_test.go
@@ -1,0 +1,32 @@
+package service
+
+import "testing"
+
+func TestIsTrivialDoneOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"plain english", "done", true},
+		{"english punctuation", " Done. ", true},
+		{"russian", "Готово!", true},
+		{"russian feminine", "готова…", true},
+		{"russian done", "Сделано", true},
+		{"chinese", "完成！", true},
+		{"japanese", "完了。", true},
+		{"not only marker", "done, see PR", false},
+		{"not acknowledgement", "好的", false},
+		{"real answer", "I fixed the issue", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTrivialDoneOutput(tt.in); got != tt.want {
+				t.Fatalf("isTrivialDoneOutput(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -22,8 +22,11 @@ type Backend interface {
 
 // ExecOptions configures a single execution.
 type ExecOptions struct {
-	Cwd                       string
-	Model                     string
+	Cwd   string
+	Model string
+	// SystemPrompt is consumed only by providers that can pass or safely inline
+	// developer/system instructions. Hermes ACP intentionally ignores it and
+	// relies on cwd-scoped context files such as AGENTS.md instead.
 	SystemPrompt              string
 	MaxTurns                  int
 	Timeout                   time.Duration

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -50,8 +52,16 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	cmd := exec.CommandContext(runCtx, execPath, hermesArgs...)
 	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", hermesArgs)
+	agentsMDPresent := false
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
+		if _, err := os.Stat(filepath.Join(opts.Cwd, "AGENTS.md")); err == nil {
+			agentsMDPresent = true
+		}
+	}
+	b.cfg.Logger.Info("hermes acp starting", "cwd", opts.Cwd, "agents_md_present", agentsMDPresent)
+	if opts.SystemPrompt != "" {
+		b.cfg.Logger.Debug("hermes ignoring ExecOptions.SystemPrompt; using cwd-scoped context files", "cwd", opts.Cwd)
 	}
 
 	env := buildEnv(b.cfg.Env)
@@ -271,15 +281,13 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			b.cfg.Logger.Info("hermes session model set", "model", opts.Model)
 		}
 
-		// 4. Build the prompt content.
+		// 4. Send the prompt and wait for PromptResponse.
 		//
 		// Do NOT prepend opts.SystemPrompt here. Hermes ACP loads project/context
 		// files from cwd (AGENTS.md, .agent_context, etc.) itself; duplicating the
 		// full runtime brief in the user prompt makes the request much larger and
 		// has triggered upstream safety filters on otherwise ordinary tasks.
-		userText := prompt
-
-		// 5. Send the prompt and wait for PromptResponse. Flip the gate
+		// Flip the gate
 		// just before the request so any history replay flushed during
 		// initialize / session setup stays dropped, but every notification
 		// belonging to this turn is processed.
@@ -287,7 +295,7 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 		_, err = c.request(runCtx, "session/prompt", map[string]any{
 			"sessionId": sessionID,
 			"prompt": []map[string]any{
-				{"type": "text", "text": userText},
+				{"type": "text", "text": prompt},
 			},
 		})
 		if err != nil {

--- a/server/pkg/agent/hermes.go
+++ b/server/pkg/agent/hermes.go
@@ -271,11 +271,13 @@ func (b *hermesBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 			b.cfg.Logger.Info("hermes session model set", "model", opts.Model)
 		}
 
-		// 4. Build the prompt content. If we have a system prompt, prepend it.
+		// 4. Build the prompt content.
+		//
+		// Do NOT prepend opts.SystemPrompt here. Hermes ACP loads project/context
+		// files from cwd (AGENTS.md, .agent_context, etc.) itself; duplicating the
+		// full runtime brief in the user prompt makes the request much larger and
+		// has triggered upstream safety filters on otherwise ordinary tasks.
 		userText := prompt
-		if opts.SystemPrompt != "" {
-			userText = opts.SystemPrompt + "\n\n---\n\n" + prompt
-		}
 
 		// 5. Send the prompt and wait for PromptResponse. Flip the gate
 		// just before the request so any history replay flushed during


### PR DESCRIPTION
## Summary

Fixes comment-triggered follow-up tasks sometimes replying with only `Done.` instead of addressing the new user comment.

Also fixes a Hermes ACP regression found while dogfooding this branch locally: the daemon was inlining the full runtime brief into Hermes' ACP user prompt. Hermes already starts the ACP session in the task cwd and loads `AGENTS.md` / `.agent_context` itself, so the inline path duplicated a very large prompt. On an ordinary non-security legal/business question this triggered the upstream provider safety filter (`possible cybersecurity risk`). Hermes is now excluded from `providerNeedsInlineSystemPrompt`; OpenClaw/Kiro/Kimi keep the inline runtime brief behavior.

## Problem

When a user adds a new comment to an already completed issue, Multica creates a follow-up agent task with `trigger_comment_id`. The daemon claim response currently reuses the last `(agent_id, issue_id)` session via `prior_session_id` for these tasks.

That works well for normal issue continuation, but for comment-triggered follow-ups it can poison the next turn: the resumed agent conversation often ends with the previous terminal assistant message (for example `Done.`). In practice, the agent may treat the follow-up as another completed turn and finish with `Done.` instead of answering the newly embedded trigger comment.

Because `CompleteTask` synthesizes a fallback issue comment from final task output when the agent did not post one explicitly, that stale `Done.` then becomes the visible reply to the user.

Observed behavior:

1. User assigns an issue to an agent.
2. Agent completes the task successfully.
3. User adds a new comment/question on the completed issue.
4. Follow-up task is queued and resumes the previous session.
5. Agent completes with output `Done.`.
6. Multica creates a fallback comment containing only `Done.`.

## Solution

This PR changes comment-triggered issue tasks to start a fresh agent conversation while still reusing the previous workdir:

- `prior_session_id` is no longer returned for tasks with `trigger_comment_id`.
- `prior_work_dir` is still returned so the agent can reuse the same checkout/workspace state.
- Manual rerun behavior remains unchanged: `force_fresh_session` still prevents session resume.
- Normal assignment-triggered issue tasks still resume the prior session as before.

It also adds a defensive guard in task completion:

- If a comment-triggered task did not post its own comment and its final output is only a trivial completion marker (`Done`, `Done.`, `Готово`, `Готово.`), Multica suppresses the synthesized fallback comment instead of showing that to the user.
- Non-trivial final output is still synthesized as before.

Hermes ACP adjustment:

- `providerNeedsInlineSystemPrompt("hermes")` now returns `false`.
- The Hermes ACP backend no longer prepends `opts.SystemPrompt` into the `session/prompt` user text.
- Rationale: Hermes ACP uses the task cwd and loads runtime files itself; inlining duplicates the runtime brief, inflates the prompt, and can trip provider safety filters on harmless tasks.

## Why this approach

The trigger comment content is already embedded directly into the task prompt, and the workdir still gives the agent access to the previous checkout. For a new human comment, the most important thing is preventing stale conversational state from overriding the new turn.

This keeps useful filesystem continuity without carrying forward the old final assistant response pattern.

For Hermes specifically, keeping the task prompt small is safer than duplicating the full runtime brief. Providers that still need inline injection (`openclaw`, `kiro`, `kimi`) are unchanged.

## Testing

Ran targeted Go tests via Docker because the host does not have `go` installed:

```bash
docker run --rm -v "$PWD":/src -w /src/server golang:1.26-alpine \
  sh -lc 'apk add --no-cache git >/dev/null; export PATH=/usr/local/go/bin:$PATH; go test ./internal/daemon ./pkg/agent'
```

Result:

```text
ok  github.com/multica-ai/multica/server/internal/daemon  7.471s
ok  github.com/multica-ai/multica/server/pkg/agent        5.056s
```

Dogfood verification on self-host:

- Before the Hermes ACP fix, an ordinary Russian legal/business issue failed with:
  `API call failed after 3 retries: This content was flagged for possible cybersecurity risk`.
- After excluding Hermes from inline runtime brief injection and rebuilding the local backend, the same issue completed and posted a normal substantive answer.
