### PR TITLE
feat(issue-detail): inline X to clear parent on sidebar

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -976,4 +976,35 @@ describe("IssueDetail (shared)", () => {
       );
     });
   });
+
+  it("clears parent with parent_issue_id: null when the remove-parent X is clicked", async () => {
+    const parentIssue: Issue = {
+      ...mockIssue,
+      id: "parent-1",
+      identifier: "TES-99",
+      title: "Parent task",
+    };
+    const childWithParent: Issue = {
+      ...mockIssue,
+      parent_issue_id: "parent-1",
+    };
+    mockApiObj.getIssue.mockImplementation((id: string) =>
+      Promise.resolve(id === "parent-1" ? parentIssue : childWithParent),
+    );
+    mockApiObj.listIssues.mockResolvedValue({
+      issues: [childWithParent, parentIssue],
+      total: 2,
+    });
+
+    renderIssueDetail();
+
+    const removeButton = await screen.findByRole("button", { name: "Remove parent" });
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(mockApiObj.updateIssue).toHaveBeenCalledWith("issue-1", {
+        parent_issue_id: null,
+      });
+    });
+  });
 });

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -21,6 +21,7 @@ import {
   Plus,
   Tag,
   Users,
+  X,
 } from "lucide-react";
 import { PageHeader } from "../../layout/page-header";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
@@ -1153,6 +1154,12 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     setAutoOpenProp(null);
   }, [autoOpenProp]);
 
+  const handleRemoveParent = useCallback(() => {
+    if (!issue) return;
+    handleUpdateField({ parent_issue_id: null });
+    toast.success(t(($) => $.detail.remove_parent_toast_success));
+  }, [issue, handleUpdateField, t]);
+
   const handleToggleSidebar = useCallback(() => {
     if (isMobile) {
       setMobileSidebarOpen((open) => !open);
@@ -1362,14 +1369,24 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
             <ChevronRight className={`!size-3 shrink-0 stroke-[2.5] text-muted-foreground transition-transform ${parentIssueOpen ? "rotate-90" : ""}`} />
           </button>
           {parentIssueOpen && <div className="pl-2">
-            <AppLink
-              href={paths.issueDetail(parentIssue.id)}
-              className="flex items-center gap-1.5 rounded-md px-2 py-1.5 -mx-2 text-xs hover:bg-accent/50 transition-colors group"
-            >
-              <StatusIcon status={parentIssue.status} className="h-3.5 w-3.5 shrink-0" />
-              <span className="text-muted-foreground shrink-0">{parentIssue.identifier}</span>
-              <span className="truncate group-hover:text-foreground">{parentIssue.title}</span>
-            </AppLink>
+            <div className="group/parent-link flex items-center gap-1 rounded-md px-2 py-1.5 -mx-2 text-xs hover:bg-accent/50 transition-colors">
+              <AppLink
+                href={paths.issueDetail(parentIssue.id)}
+                className="group/parent-link-inner flex min-w-0 flex-1 items-center gap-1.5"
+              >
+                <StatusIcon status={parentIssue.status} className="h-3.5 w-3.5 shrink-0" />
+                <span className="text-muted-foreground shrink-0">{parentIssue.identifier}</span>
+                <span className="truncate group-hover/parent-link-inner:text-foreground">{parentIssue.title}</span>
+              </AppLink>
+              <button
+                type="button"
+                onClick={handleRemoveParent}
+                aria-label={t(($) => $.detail.remove_parent_aria)}
+                className="shrink-0 inline-flex h-5 w-5 items-center justify-center rounded-md text-muted-foreground opacity-0 group-hover/parent-link:opacity-100 focus-visible:opacity-100 hover:bg-accent hover:text-foreground transition-opacity cursor-pointer"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
           </div>}
         </div>
       )}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -141,6 +141,8 @@
     "add_sub_issue_aria": "Add sub-issue",
     "section_properties": "Properties",
     "section_parent_issue": "Parent issue",
+    "remove_parent_aria": "Remove parent",
+    "remove_parent_toast_success": "Parent removed",
     "section_pull_requests": "Pull requests",
     "section_metadata": "Metadata",
     "section_details": "Details",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -140,6 +140,8 @@
     "add_sub_issue_aria": "添加子 issue",
     "section_properties": "属性",
     "section_parent_issue": "父 issue",
+    "remove_parent_aria": "移除父 issue",
+    "remove_parent_toast_success": "已移除父 issue",
     "section_pull_requests": "Pull Request",
     "section_metadata": "元数据",
     "section_details": "详情",


### PR DESCRIPTION
## Summary

The parent-issue link in the issue detail sidebar can now be cleared from the UI. A small X reveals on hover next to the parent link and calls `updateIssue({ parent_issue_id: null })` — the shape the backend, CLI and MCP server already accept.

Before this change, the only way to clear a parent was to set a different one via the picker; there was no way to drop the link entirely without dropping to the CLI.

## What changed

- **`packages/views/issues/components/issue-detail.tsx`** — wraps the parent `AppLink` in a `group/parent-link` container with a sibling X button. The X is `opacity-0` at rest and reveals on hover or keyboard focus, so the section stays calm visually until the user reaches for it. Click routes through `useIssueActions.updateField`, which already provides optimistic updates + `onError` toast; a success toast (\"Parent removed\") is added to mirror the set-parent flow.
- **`packages/views/locales/en/issues.json` + `zh-Hans/issues.json`** — adds `remove_parent_aria` and `remove_parent_toast_success`.

The button is a sibling of `AppLink` (not nested inside it) so clicking the X never navigates to the parent.

## Test plan

- [x] New unit test in `issue-detail.test.tsx` — clicking the remove-parent button calls `api.updateIssue('issue-1', { parent_issue_id: null })`.
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views test` — all 15 tests pass.
- [ ] Manual smoke once running: hover the parent link, confirm X appears, click clears the parent + toast appears, optimistic update rolls back on simulated server error.