### PR TITLE
fix(daemon): retry with fresh session on stale thinking-block signature

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2189,7 +2189,16 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Fallback: if session resume failed before establishing a session, retry
 	// with a fresh session. We check SessionID == "" to distinguish a resume
 	// failure (no session established) from a failure during actual execution.
-	if result.Status == "failed" && task.PriorSessionID != "" && result.SessionID == "" {
+	//
+	// Also retry when the resumed session was established but the very first
+	// API call failed because the stored history carries a `thinking` block
+	// (extended thinking) whose signature is no longer valid in this run —
+	// Anthropic ties that signature to (model, api key, request_id), so any
+	// retry after a model swap, key rotation, or attempt boundary will 400
+	// on the first turn forever. The session file is unrecoverable; the only
+	// way out is to drop the resume and start fresh.
+	resumeUnrecoverable := result.SessionID == "" || isStaleResumeError(result.Error)
+	if result.Status == "failed" && task.PriorSessionID != "" && resumeUnrecoverable {
 		firstUsage := result.Usage
 		taskLog.Warn("session resume failed, retrying with fresh session", "error", result.Error)
 		execOpts.ResumeSessionID = ""
@@ -2530,6 +2539,24 @@ func (d *Daemon) executeAndDrain(ctx context.Context, backend agent.Backend, pro
 			Error:  "agent did not produce result within drain timeout",
 		}, toolCount.Load(), nil
 	}
+}
+
+// isStaleResumeError reports whether result.Error indicates the resumed
+// session carries an Anthropic `thinking` block (extended thinking) whose
+// signature is no longer valid in this run. The signature is bound to
+// (model_version, api_key, request_id) and never re-validates across model
+// swaps, key rotations, or attempt boundaries — so the only viable recovery
+// is to drop --resume and start a fresh session.
+//
+// The matched substring is what Claude Code prints verbatim when it relays
+// the upstream Anthropic 400. See XIM-615 for the failing run that motivated
+// this check.
+func isStaleResumeError(errMsg string) bool {
+	if errMsg == "" {
+		return false
+	}
+	return strings.Contains(errMsg, "Invalid `signature` in `thinking` block") ||
+		strings.Contains(errMsg, "Invalid `signature` in `redacted_thinking` block")
 }
 
 func mergeUsage(a, b map[string]agent.TokenUsage) map[string]agent.TokenUsage {

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -841,13 +841,137 @@ func TestExecuteAndDrain_NoRetryWhenSessionEstablished(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// SessionID is set → session was established → should NOT retry.
-	shouldRetry := result.Status == "failed" && result.SessionID == ""
+	// SessionID is set and the error is not a stale-resume signal → should NOT retry.
+	resumeUnrecoverable := result.SessionID == "" || isStaleResumeError(result.Error)
+	shouldRetry := result.Status == "failed" && resumeUnrecoverable
 	if shouldRetry {
-		t.Fatal("should not retry when SessionID is present")
+		t.Fatal("should not retry when SessionID is present and error is not a stale-resume signal")
 	}
 	if int(fb.idx.Load()) != 1 {
 		t.Fatalf("expected 1 call, got %d", fb.idx.Load())
+	}
+}
+
+// TestExecuteAndDrain_StaleThinkingBlockFallback covers the case where the
+// resumed session is established (claude emits a session_id) but the very
+// first turn fails with Anthropic 400 "Invalid `signature` in `thinking`
+// block" — the saved history carries a thinking block whose signature is
+// tied to a different model/key/turn boundary. The session is unrecoverable;
+// the daemon must retry with --resume "". Regression coverage for XIM-615.
+func TestExecuteAndDrain_StaleThinkingBlockFallback(t *testing.T) {
+	t.Parallel()
+
+	d := newTestDaemon(t)
+	ctx := context.Background()
+	taskLog := slog.Default()
+
+	staleSessionErr := "API Error: 400 {\"type\":\"error\",\"error\":{" +
+		"\"type\":\"invalid_request_error\"," +
+		"\"message\":\"messages.1.content.0: Invalid `signature` in `thinking` block\"" +
+		"}, \"request_id\":\"req_011CayMypaLNs8duFTfpgLdt\"}"
+
+	fb := &fakeBackend{
+		results: []agent.Result{
+			// First attempt: resume lands (SessionID populated), API errors on
+			// the stale thinking-block signature.
+			{Status: "failed", Error: staleSessionErr, SessionID: "stale-but-loaded-sess",
+				Usage: map[string]agent.TokenUsage{
+					"m1": {InputTokens: 5},
+				}},
+			// Retry with --resume "" succeeds.
+			{Status: "completed", Output: "done", SessionID: "fresh-sess",
+				Usage: map[string]agent.TokenUsage{
+					"m1": {InputTokens: 10, OutputTokens: 20},
+				}},
+		},
+	}
+
+	priorSessionID := "stale-but-loaded-sess"
+	opts := agent.ExecOptions{ResumeSessionID: priorSessionID}
+	result, _, err := d.executeAndDrain(ctx, fb, "prompt", opts, taskLog, "task-1")
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+	if result.Status != "failed" || result.SessionID != "stale-but-loaded-sess" {
+		t.Fatalf("expected failed result with stale SessionID, got %+v", result)
+	}
+
+	// Mirror the runTask gate: SessionID set BUT error is stale-resume → retry.
+	resumeUnrecoverable := result.SessionID == "" || isStaleResumeError(result.Error)
+	if !resumeUnrecoverable {
+		t.Fatal("expected resumeUnrecoverable=true for thinking-block signature error")
+	}
+	if result.Status == "failed" && priorSessionID != "" && resumeUnrecoverable {
+		firstUsage := result.Usage
+		opts.ResumeSessionID = ""
+		retryResult, _, retryErr := d.executeAndDrain(ctx, fb, "prompt", opts, taskLog, "task-1")
+		if retryErr != nil {
+			t.Fatalf("retry error: %v", retryErr)
+		}
+		result = retryResult
+		result.Usage = mergeUsage(firstUsage, result.Usage)
+	}
+
+	if result.Status != "completed" || result.Output != "done" {
+		t.Fatalf("expected completed result after retry, got %+v", result)
+	}
+	if result.SessionID != "fresh-sess" {
+		t.Fatalf("expected fresh-sess, got %s", result.SessionID)
+	}
+	if u := result.Usage["m1"]; u.InputTokens != 15 || u.OutputTokens != 20 {
+		t.Fatalf("expected merged usage {15,20}, got %+v", u)
+	}
+	if fb.calls[1].ResumeSessionID != "" {
+		t.Fatal("retry should not have ResumeSessionID")
+	}
+}
+
+func TestIsStaleResumeError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  string
+		want bool
+	}{
+		{
+			name: "thinking block invalid signature",
+			err:  "API Error: 400 {\"error\":{\"message\":\"messages.1.content.0: Invalid `signature` in `thinking` block\"}}",
+			want: true,
+		},
+		{
+			name: "redacted_thinking block invalid signature",
+			err:  "messages.2.content.0: Invalid `signature` in `redacted_thinking` block",
+			want: true,
+		},
+		{
+			name: "unrelated 400",
+			err:  "API Error: 400 {\"error\":{\"message\":\"messages.0.content: Empty text\"}}",
+			want: false,
+		},
+		{
+			name: "rate limit",
+			err:  "API Error: 429 Rate limit reached for requests",
+			want: false,
+		},
+		{
+			name: "session not found",
+			err:  "No conversation found with session ID: abc-123",
+			want: false,
+		},
+		{
+			name: "empty",
+			err:  "",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStaleResumeError(tc.err); got != tc.want {
+				t.Fatalf("isStaleResumeError(%q) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Multica daemon resumes agent sessions via `--resume <sid>`. The underlying CLI (Claude Code, for the `claude` provider) restores saved conversation history before its first API call. When that history contains an Anthropic `thinking` block whose signature is no longer valid in this run, the call fails with:

> API Error: 400 messages.N.content.M: Invalid `signature` in `thinking` block

The signature is bound to (`model_version`, `api_key`, `request_id`) and never re-validates across model swaps, key rotations, or attempt boundaries.

Today `runTask`'s fallback retries with `--resume ""` only when `SessionID == ""` (resume never landed). For the stale-signature case the session *is* established, so the fallback never triggers and the task fails permanently — every subsequent attempt also reads the corrupted session file.

This PR extends the fallback gate: also retry when `result.Error` matches the stale thinking / redacted_thinking signature pattern. The first retry loses historical context (session starts fresh) but the alternative is a hard loop on every future attempt; the session file is unrecoverable either way.

## What changed

`server/internal/daemon/daemon.go`:
- New `isStaleResumeError(errMsg string) bool` helper — substring match against the two strings Claude Code relays verbatim from the upstream Anthropic 400.
- `runTask` fallback condition: `result.SessionID == ""` → `result.SessionID == "" || isStaleResumeError(result.Error)`.

`server/internal/daemon/daemon_test.go`:
- `TestExecuteAndDrain_StaleThinkingBlockFallback` — replays the real failing payload (request_id `req_011CayMypaLNs8duFTfpgLdt`) and asserts retry uses `ResumeSessionID == ""`.
- `TestIsStaleResumeError` — 6 cases: thinking, redacted_thinking, unrelated 400, 429 rate limit, "session not found" (falls through to old path), empty.
- `TestExecuteAndDrain_NoRetryWhenSessionEstablished` mirrors the new gate.

## Test plan

- [x] `go test ./internal/daemon/...` (full daemon package) — passes
- [x] `go test ./internal/daemon/... -run TestExecuteAndDrain_StaleThinkingBlockFallback -v` — passes
- [x] `go test ./internal/daemon/... -run TestIsStaleResumeError -v` — 6/6 sub-cases pass
- [x] `go vet ./internal/daemon/...` — clean
- [ ] Manual: re-run the failing agent task on a workspace that has a corrupted session file → expect single retry with fresh session, no infinite 400 loop

## Risks

- Detection is substring-based. If Anthropic changes the 400 message, we degrade to the pre-PR behavior and the original bug returns. The strings have been stable for years but this is the monitoring point.
- First retry of an affected task loses historical context. Acceptable — corrupted session is unrecoverable either way.

## Context

Originally reported as XIM-615 in our internal Multica workspace. The motivating failure was request_id `req_011CayMypaLNs8duFTfpgLdt`: a previously-failed run from 2026-05-05 left a session file with a thinking block signed by a since-rotated key; a retry on 2026-05-12 against the same session looped on the 400 until we shipped this fix locally.
