### PR TITLE
[codex] Add inbox read filter

### DIFF
--- a/packages/views/inbox/components/inbox-display.test.ts
+++ b/packages/views/inbox/components/inbox-display.test.ts
@@ -4,6 +4,7 @@ import {
   filterInboxItemsByReadState,
   getInboxDisplayTitle,
   getQuickCreateFailureDetail,
+  keepSelectedInboxItemVisible,
   stripQuickCreatePrefix,
 } from "./inbox-display";
 
@@ -87,5 +88,17 @@ describe("inbox display helpers", () => {
     expect(filterInboxItemsByReadState(items, "all")).toEqual(items);
     expect(filterInboxItemsByReadState(items, "unread")).toEqual([unread]);
     expect(filterInboxItemsByReadState(items, "read")).toEqual([read]);
+  });
+
+  it("keeps the selected inbox item visible when filters hide it", () => {
+    const newest = item({ id: "newest", read: false });
+    const selected = item({ id: "selected", read: true });
+    const oldest = item({ id: "oldest", read: false });
+    const items = [newest, selected, oldest];
+    const unreadItems = [newest, oldest];
+
+    expect(
+      keepSelectedInboxItemVisible(items, unreadItems, selected.id),
+    ).toEqual(items);
   });
 });

--- a/packages/views/inbox/components/inbox-display.test.ts
+++ b/packages/views/inbox/components/inbox-display.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { InboxItem } from "@multica/core/types";
 import {
+  filterInboxItemsByReadState,
   getInboxDisplayTitle,
   getQuickCreateFailureDetail,
   stripQuickCreatePrefix,
@@ -76,5 +77,15 @@ describe("inbox display helpers", () => {
     expect(getQuickCreateFailureDetail(failedItem)).toBe(
       "CLI failed with exit status 1",
     );
+  });
+
+  it("filters inbox items by read state", () => {
+    const unread = item({ id: "unread", read: false });
+    const read = item({ id: "read", read: true });
+    const items = [unread, read];
+
+    expect(filterInboxItemsByReadState(items, "all")).toEqual(items);
+    expect(filterInboxItemsByReadState(items, "unread")).toEqual([unread]);
+    expect(filterInboxItemsByReadState(items, "read")).toEqual([read]);
   });
 });

--- a/packages/views/inbox/components/inbox-display.ts
+++ b/packages/views/inbox/components/inbox-display.ts
@@ -58,3 +58,18 @@ export function filterInboxItemsByReadState(
   if (filter === "read") return items.filter((item) => item.read);
   return items;
 }
+
+export function keepSelectedInboxItemVisible(
+  items: InboxItem[],
+  filteredItems: InboxItem[],
+  selectedItemId: string | null | undefined,
+): InboxItem[] {
+  if (!selectedItemId) return filteredItems;
+
+  const filteredIds = new Set(filteredItems.map((item) => item.id));
+  if (filteredIds.has(selectedItemId)) return filteredItems;
+
+  return items.filter(
+    (item) => filteredIds.has(item.id) || item.id === selectedItemId,
+  );
+}

--- a/packages/views/inbox/components/inbox-display.ts
+++ b/packages/views/inbox/components/inbox-display.ts
@@ -1,5 +1,7 @@
 import type { InboxItem } from "@multica/core/types";
 
+export type InboxReadFilter = "all" | "unread" | "read";
+
 function singleLine(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
 }
@@ -46,4 +48,13 @@ export function getInboxDisplayTitle(item: InboxItem): string {
 export function getQuickCreateFailureDetail(item: InboxItem): string {
   const details = item.details ?? {};
   return singleLine(details.error) || singleLine(item.body);
+}
+
+export function filterInboxItemsByReadState(
+  items: InboxItem[],
+  filter: InboxReadFilter,
+): InboxItem[] {
+  if (filter === "unread") return items.filter((item) => !item.read);
+  if (filter === "read") return items.filter((item) => item.read);
+  return items;
 }

--- a/packages/views/inbox/components/inbox-list-item.tsx
+++ b/packages/views/inbox/components/inbox-list-item.tsx
@@ -30,11 +30,13 @@ export function InboxListItem({
   isSelected,
   onClick,
   onArchive,
+  isFilteredOut = false,
 }: {
   item: InboxItem;
   isSelected: boolean;
   onClick: () => void;
   onArchive: () => void;
+  isFilteredOut?: boolean;
 }) {
   const { t } = useT("inbox");
   const timeAgo = useTimeAgo();
@@ -45,7 +47,7 @@ export function InboxListItem({
       onClick={onClick}
       className={`group flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${
         isSelected ? "bg-accent" : "hover:bg-accent/50"
-      }`}
+      } ${isFilteredOut ? "opacity-60" : ""}`}
     >
       <ActorAvatar
         actorType={item.actor_type ?? item.recipient_type}

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -60,6 +60,7 @@ import { useTypeLabels } from "./inbox-detail-label";
 import {
   filterInboxItemsByReadState,
   getInboxDisplayTitle,
+  keepSelectedInboxItemVisible,
   type InboxReadFilter,
 } from "./inbox-display";
 import { useT } from "../../i18n";
@@ -87,6 +88,14 @@ export function InboxPage() {
   );
 
   const selected = items.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
+  const filteredItemIds = useMemo(
+    () => new Set(filteredItems.map((item) => item.id)),
+    [filteredItems],
+  );
+  const listItems = useMemo(
+    () => keepSelectedInboxItemVisible(items, filteredItems, selected?.id),
+    [filteredItems, items, selected?.id],
+  );
 
   // Track the last key we actually resolved against the inbox list. Lets the
   // fallback effect distinguish "shared-link to a notification not in our
@@ -137,6 +146,7 @@ export function InboxPage() {
   const timeAgo = useTimeAgo();
   const typeLabels = useTypeLabels();
   const hasActiveReadFilter = readFilter !== "all";
+  const filterTooltip = t(($) => $.filter.tooltip);
 
 
   // Auto-mark-read whenever a selected item is unread — covers both click-
@@ -223,7 +233,8 @@ export function InboxPage() {
               <Button
                 variant="ghost"
                 size="icon-sm"
-                title={t(($) => $.filter.tooltip)}
+                title={filterTooltip}
+                aria-label={filterTooltip}
                 className="relative text-muted-foreground"
               />
             }
@@ -287,7 +298,7 @@ export function InboxPage() {
     </PageHeader>
   );
 
-  const listBody = filteredItems.length === 0 ? (
+  const listBody = listItems.length === 0 ? (
     <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
       <Inbox className="mb-3 h-8 w-8 text-muted-foreground/50" />
       <p className="text-sm">
@@ -298,11 +309,12 @@ export function InboxPage() {
     </div>
   ) : (
     <div>
-      {filteredItems.map((item) => (
+      {listItems.map((item) => (
         <InboxListItem
           key={item.id}
           item={item}
           isSelected={(item.issue_id ?? item.id) === selectedKey}
+          isFilteredOut={!filteredItemIds.has(item.id)}
           onClick={() => handleSelect(item)}
           onArchive={() => handleArchive(item.id)}
         />

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -47,6 +47,7 @@ import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
@@ -245,21 +246,23 @@ export function InboxPage() {
             )}
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-40">
-            <DropdownMenuLabel>{t(($) => $.filter.label)}</DropdownMenuLabel>
-            <DropdownMenuRadioGroup
-              value={readFilter}
-              onValueChange={(value) => setReadFilter(value as InboxReadFilter)}
-            >
-              <DropdownMenuRadioItem value="all">
-                {t(($) => $.filter.all)}
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="unread">
-                {t(($) => $.filter.unread)}
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="read">
-                {t(($) => $.filter.read)}
-              </DropdownMenuRadioItem>
-            </DropdownMenuRadioGroup>
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>{t(($) => $.filter.label)}</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={readFilter}
+                onValueChange={(value) => setReadFilter(value as InboxReadFilter)}
+              >
+                <DropdownMenuRadioItem value="all">
+                  {t(($) => $.filter.all)}
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="unread">
+                  {t(($) => $.filter.unread)}
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="read">
+                  {t(($) => $.filter.read)}
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuGroup>
           </DropdownMenuContent>
         </DropdownMenu>
         <DropdownMenu>

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -33,6 +33,7 @@ import {
   BookCheck,
   ListChecks,
   ArrowLeft,
+  Filter,
 } from "lucide-react";
 import type { InboxItem } from "@multica/core/types";
 import { Button } from "@multica/ui/components/ui/button";
@@ -47,13 +48,20 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
 } from "@multica/ui/components/ui/dropdown-menu";
 import { useIsMobile } from "@multica/ui/hooks/use-mobile";
 import { PageHeader } from "../../layout/page-header";
 import { InboxListItem, useTimeAgo } from "./inbox-list-item";
 import { useTypeLabels } from "./inbox-detail-label";
-import { getInboxDisplayTitle } from "./inbox-display";
+import {
+  filterInboxItemsByReadState,
+  getInboxDisplayTitle,
+  type InboxReadFilter,
+} from "./inbox-display";
 import { useT } from "../../i18n";
 
 export function InboxPage() {
@@ -63,6 +71,7 @@ export function InboxPage() {
   const wsPaths = useWorkspacePaths();
 
   const [selectedKey, setSelectedKeyState] = useState(() => urlIssue);
+  const [readFilter, setReadFilter] = useState<InboxReadFilter>("all");
 
   // Sync from URL when searchParams change (e.g. navigation)
   useEffect(() => {
@@ -72,6 +81,10 @@ export function InboxPage() {
   const wsId = useWorkspaceId();
   const { data: rawItems = [], isLoading: loading } = useQuery(inboxListOptions(wsId));
   const items = useMemo(() => deduplicateInboxItems(rawItems), [rawItems]);
+  const filteredItems = useMemo(
+    () => filterInboxItemsByReadState(items, readFilter),
+    [items, readFilter],
+  );
 
   const selected = items.find((i) => (i.issue_id ?? i.id) === selectedKey) ?? null;
 
@@ -123,6 +136,7 @@ export function InboxPage() {
   const archiveCompletedMutation = useArchiveCompletedInbox();
   const timeAgo = useTimeAgo();
   const typeLabels = useTypeLabels();
+  const hasActiveReadFilter = readFilter !== "all";
 
 
   // Auto-mark-read whenever a selected item is unread — covers both click-
@@ -202,49 +216,89 @@ export function InboxPage() {
           </span>
         )}
       </div>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="text-muted-foreground"
-            />
-          }
-        >
-          <MoreHorizontal className="h-4 w-4" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-auto">
-          <DropdownMenuItem onClick={handleMarkAllRead}>
-            <CheckCheck className="h-4 w-4" />
-            {t(($) => $.menu.mark_all_read)}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={handleArchiveAll}>
-            <Archive className="h-4 w-4" />
-            {t(($) => $.menu.archive_all)}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleArchiveAllRead}>
-            <BookCheck className="h-4 w-4" />
-            {t(($) => $.menu.archive_all_read)}
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleArchiveCompleted}>
-            <ListChecks className="h-4 w-4" />
-            {t(($) => $.menu.archive_completed)}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <div className="flex items-center gap-1">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                title={t(($) => $.filter.tooltip)}
+                className="relative text-muted-foreground"
+              />
+            }
+          >
+            <Filter className="h-4 w-4" />
+            {hasActiveReadFilter && (
+              <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-brand" />
+            )}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuLabel>{t(($) => $.filter.label)}</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={readFilter}
+              onValueChange={(value) => setReadFilter(value as InboxReadFilter)}
+            >
+              <DropdownMenuRadioItem value="all">
+                {t(($) => $.filter.all)}
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="unread">
+                {t(($) => $.filter.unread)}
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="read">
+                {t(($) => $.filter.read)}
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground"
+              />
+            }
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-auto">
+            <DropdownMenuItem onClick={handleMarkAllRead}>
+              <CheckCheck className="h-4 w-4" />
+              {t(($) => $.menu.mark_all_read)}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={handleArchiveAll}>
+              <Archive className="h-4 w-4" />
+              {t(($) => $.menu.archive_all)}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleArchiveAllRead}>
+              <BookCheck className="h-4 w-4" />
+              {t(($) => $.menu.archive_all_read)}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={handleArchiveCompleted}>
+              <ListChecks className="h-4 w-4" />
+              {t(($) => $.menu.archive_completed)}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
     </PageHeader>
   );
 
-  const listBody = items.length === 0 ? (
+  const listBody = filteredItems.length === 0 ? (
     <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
       <Inbox className="mb-3 h-8 w-8 text-muted-foreground/50" />
-      <p className="text-sm">{t(($) => $.list.empty)}</p>
+      <p className="text-sm">
+        {items.length === 0
+          ? t(($) => $.list.empty)
+          : t(($) => $.list.empty_filter)}
+      </p>
     </div>
   ) : (
     <div>
-      {items.map((item) => (
+      {filteredItems.map((item) => (
         <InboxListItem
           key={item.id}
           item={item}

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -9,8 +9,16 @@
     "archive_all_read": "Archive all read",
     "archive_completed": "Archive completed"
   },
+  "filter": {
+    "tooltip": "Filter inbox",
+    "label": "Filter",
+    "all": "All",
+    "unread": "Unread",
+    "read": "Read"
+  },
   "list": {
     "empty": "No notifications",
+    "empty_filter": "No notifications match this filter",
     "mark_done_tooltip": "Mark as done",
     "archive_tooltip": "Archive",
     "time": {

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -9,8 +9,16 @@
     "archive_all_read": "归档全部已读",
     "archive_completed": "归档已完成"
   },
+  "filter": {
+    "tooltip": "筛选收件箱",
+    "label": "筛选",
+    "all": "全部",
+    "unread": "未读",
+    "read": "已读"
+  },
   "list": {
     "empty": "暂无通知",
+    "empty_filter": "当前筛选下没有通知",
     "mark_done_tooltip": "标为已完成",
     "archive_tooltip": "归档",
     "time": {


### PR DESCRIPTION
## Summary

Adds a read-state filter to the Inbox list so users can switch between all, unread, and read notifications from the Inbox header.

## Changes

- Added an Inbox filter menu with All, Unread, and Read options.
- Applied the filter to the displayed list while keeping selection/detail behavior backed by the full inbox list.
- Added localized English and Simplified Chinese filter labels and filtered-empty copy.
- Covered the read-state filter helper with a focused unit test.

## Validation

- `pnpm --filter @multica/views test inbox/components/inbox-display.test.ts`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/views lint` exited 0 with existing warnings outside the touched Inbox files.
