### PR TITLE
fix: treat empty successful daemon output as completed

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2229,12 +2229,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	switch result.Status {
 	case "completed":
 		if result.Output == "" {
-			// Even an empty-output completion may have established a real
-			// session — surface it through the blocked path so the next chat
-			// turn can still resume from where this one left off.
+			// The agent completed successfully but produced no text output.
+			// This is valid — the agent may have done all its work via tool
+			// calls (e.g. posting comments via CLI, pushing code). Treat as
+			// a normal completion so the task is not incorrectly marked as
+			// blocked.
 			return TaskResult{
-				Status:    "blocked",
-				Comment:   fmt.Sprintf("%s returned empty output", provider),
+				Status:    "completed",
+				Comment:   "",
 				SessionID: result.SessionID,
 				WorkDir:   env.WorkDir,
 				EnvRoot:   env.RootDir,


### PR DESCRIPTION
## Summary
- Treat successful agent completions with empty text output as completed instead of blocked.
- Preserve session/workdir/usage metadata for the completed path.
- Keep failed, timeout, cancelled, and poisoned-output handling unchanged.

Fixes MUL-2104

## Testing
- go test ./internal/daemon
- go test ./internal/service ./internal/handler -run 'TestCompleteTask|TestReportTaskResult'
- git diff --check origin/main...HEAD
