### PR TITLE
fix(chat): collapse chat-done flicker via inline cache write

### DIFF
--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -1,0 +1,117 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { chatKeys } from "../chat/queries";
+import type { ChatDonePayload, ChatMessage, ChatPendingTask } from "../types";
+import { applyChatDoneToCache } from "./use-realtime-sync";
+
+const sessionId = "session-1";
+const taskId = "task-1";
+const messagesKey = chatKeys.messages(sessionId);
+const pendingKey = chatKeys.pendingTask(sessionId);
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function userMessage(): ChatMessage {
+  return {
+    id: "msg-user",
+    chat_session_id: sessionId,
+    role: "user",
+    content: "hello",
+    task_id: null,
+    created_at: "2026-05-13T05:00:00Z",
+  };
+}
+
+function donePayload(overrides: Partial<ChatDonePayload> = {}): ChatDonePayload {
+  return {
+    chat_session_id: sessionId,
+    task_id: taskId,
+    message_id: "msg-assistant",
+    content: "done",
+    elapsed_ms: 1234,
+    created_at: "2026-05-13T05:00:02Z",
+    ...overrides,
+  };
+}
+
+describe("applyChatDoneToCache", () => {
+  it("writes the assistant message before clearing pending task", () => {
+    const qc = createQueryClient();
+    qc.setQueryData<ChatMessage[]>(messagesKey, [userMessage()]);
+    qc.setQueryData<ChatPendingTask>(pendingKey, {
+      task_id: taskId,
+      status: "running",
+    });
+
+    const setQueryData = vi.spyOn(qc, "setQueryData");
+
+    applyChatDoneToCache(qc, donePayload());
+
+    expect(setQueryData.mock.calls[0]?.[0]).toEqual(messagesKey);
+    expect(setQueryData.mock.calls[1]?.[0]).toEqual(pendingKey);
+    expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual({});
+    expect(qc.getQueryData<ChatMessage[]>(messagesKey)).toEqual([
+      userMessage(),
+      {
+        id: "msg-assistant",
+        chat_session_id: sessionId,
+        role: "assistant",
+        content: "done",
+        task_id: taskId,
+        created_at: "2026-05-13T05:00:02Z",
+        elapsed_ms: 1234,
+      },
+    ]);
+  });
+
+  it("does not duplicate a replayed chat done event", () => {
+    const qc = createQueryClient();
+    const assistant: ChatMessage = {
+      id: "msg-assistant",
+      chat_session_id: sessionId,
+      role: "assistant",
+      content: "done",
+      task_id: taskId,
+      created_at: "2026-05-13T05:00:02Z",
+      elapsed_ms: 1234,
+    };
+    qc.setQueryData<ChatMessage[]>(messagesKey, [userMessage(), assistant]);
+    qc.setQueryData<ChatPendingTask>(pendingKey, {
+      task_id: taskId,
+      status: "running",
+    });
+
+    applyChatDoneToCache(qc, donePayload());
+
+    expect(qc.getQueryData<ChatMessage[]>(messagesKey)).toEqual([
+      userMessage(),
+      assistant,
+    ]);
+    expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual({});
+  });
+
+  it("falls back to invalidation-only when older servers omit message fields", () => {
+    const qc = createQueryClient();
+    qc.setQueryData<ChatMessage[]>(messagesKey, [userMessage()]);
+    qc.setQueryData<ChatPendingTask>(pendingKey, {
+      task_id: taskId,
+      status: "running",
+    });
+
+    applyChatDoneToCache(
+      qc,
+      donePayload({ message_id: undefined, content: undefined }),
+    );
+
+    expect(qc.getQueryData<ChatMessage[]>(messagesKey)).toEqual([
+      userMessage(),
+    ]);
+    expect(qc.getQueryData<ChatPendingTask>(pendingKey)).toEqual({});
+  });
+});

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import type { WSClient } from "../api/ws-client";
 import type { StoreApi, UseBoundStore } from "zustand";
 import type { AuthState } from "../auth/store";
@@ -70,6 +70,42 @@ import type {
 const chatWsLogger = createLogger("chat.ws");
 
 const logger = createLogger("realtime-sync");
+
+export function applyChatDoneToCache(
+  qc: QueryClient,
+  payload: ChatDonePayload,
+) {
+  const sessionId = payload.chat_session_id;
+  const taskId = payload.task_id;
+  const messageId = payload.message_id;
+  const content = payload.content;
+  if (messageId && content !== undefined) {
+    qc.setQueryData<ChatMessage[] | undefined>(
+      chatKeys.messages(sessionId),
+      (old) => {
+        if (!old) return old; // first fetch will pick it up
+        // Idempotent against reconnect replay.
+        if (old.some((m) => m.id === messageId)) return old;
+        const assistant: ChatMessage = {
+          id: messageId,
+          chat_session_id: sessionId,
+          role: "assistant",
+          content,
+          task_id: taskId,
+          created_at: payload.created_at ?? new Date().toISOString(),
+          elapsed_ms: payload.elapsed_ms ?? null,
+        };
+        return [...old, assistant];
+      },
+    );
+  }
+  // Replacement is in the messages list now; safe to drop pending.
+  qc.setQueryData(chatKeys.pendingTask(sessionId), {});
+  // Authoritative refetch reconciles redaction / migrations / clients
+  // that took the fallback branch above.
+  qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
+  qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
+}
 
 export interface RealtimeSyncStores {
   authStore: UseBoundStore<StoreApi<AuthState>>;
@@ -583,34 +619,7 @@ export function useRealtimeSync(
       // payload (older builds). Older clients hitting a newer server also
       // work: they ignore the extra fields and rely on the invalidate
       // below, which keeps the old behavior alive.
-      const sessionId = payload.chat_session_id;
-      const taskId = payload.task_id;
-      if (payload.message_id && payload.content !== undefined) {
-        qc.setQueryData<ChatMessage[] | undefined>(
-          chatKeys.messages(sessionId),
-          (old) => {
-            if (!old) return old; // first fetch will pick it up
-            // Idempotent against reconnect replay.
-            if (old.some((m) => m.id === payload.message_id)) return old;
-            const assistant: ChatMessage = {
-              id: payload.message_id!,
-              chat_session_id: sessionId,
-              role: "assistant",
-              content: payload.content ?? "",
-              task_id: taskId,
-              created_at: payload.created_at ?? new Date().toISOString(),
-              elapsed_ms: payload.elapsed_ms ?? null,
-            };
-            return [...old, assistant];
-          },
-        );
-      }
-      // Replacement is in the messages list now; safe to drop pending.
-      qc.setQueryData(chatKeys.pendingTask(sessionId), {});
-      // Authoritative refetch reconciles redaction / migrations / clients
-      // that took the fallback branch above.
-      qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
-      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
+      applyChatDoneToCache(qc, payload);
       invalidatePendingAggregate();
       // Assistant message just landed → has_unread may have flipped to true.
       invalidateSessionLists();

--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -62,6 +62,7 @@ import type {
   TaskFailedPayload,
   TaskCancelledPayload,
   ChatDonePayload,
+  ChatMessage,
   ChatPendingTask,
   InvitationCreatedPayload,
 } from "../types";
@@ -568,13 +569,48 @@ export function useRealtimeSync(
       chatWsLogger.info("chat:done (global)", {
         task_id: payload.task_id,
         chat_session_id: payload.chat_session_id,
+        has_message: !!payload.message_id,
       });
-      // Assistant message was just written and task flipped out of 'running'.
-      // Clear pending-task cache immediately so the live-timeline-vs-assistant
-      // race window collapses to zero — the subsequent refetch will confirm.
-      qc.setQueryData(chatKeys.pendingTask(payload.chat_session_id), {});
-      qc.invalidateQueries({ queryKey: chatKeys.messages(payload.chat_session_id) });
-      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
+      // Inline-insert the assistant message into the messages cache BEFORE
+      // clearing pending-task. Both writes land in the same React render
+      // tick, so ChatMessageList sees `pendingAlreadyPersisted === true`
+      // and the live TimelineView unmounts only after AssistantMessage has
+      // mounted — no flicker window. This applies TkDodo's "combine
+      // setQueryData (active query) + invalidateQueries (others)" pattern
+      // (https://tkdodo.eu/blog/using-web-sockets-with-react-query).
+      //
+      // Falls back to invalidate-only when the server omits the message
+      // payload (older builds). Older clients hitting a newer server also
+      // work: they ignore the extra fields and rely on the invalidate
+      // below, which keeps the old behavior alive.
+      const sessionId = payload.chat_session_id;
+      const taskId = payload.task_id;
+      if (payload.message_id && payload.content !== undefined) {
+        qc.setQueryData<ChatMessage[] | undefined>(
+          chatKeys.messages(sessionId),
+          (old) => {
+            if (!old) return old; // first fetch will pick it up
+            // Idempotent against reconnect replay.
+            if (old.some((m) => m.id === payload.message_id)) return old;
+            const assistant: ChatMessage = {
+              id: payload.message_id!,
+              chat_session_id: sessionId,
+              role: "assistant",
+              content: payload.content ?? "",
+              task_id: taskId,
+              created_at: payload.created_at ?? new Date().toISOString(),
+              elapsed_ms: payload.elapsed_ms ?? null,
+            };
+            return [...old, assistant];
+          },
+        );
+      }
+      // Replacement is in the messages list now; safe to drop pending.
+      qc.setQueryData(chatKeys.pendingTask(sessionId), {});
+      // Authoritative refetch reconciles redaction / migrations / clients
+      // that took the fallback branch above.
+      qc.invalidateQueries({ queryKey: chatKeys.messages(sessionId) });
+      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(sessionId) });
       invalidatePendingAggregate();
       // Assistant message just landed → has_unread may have flipped to true.
       invalidateSessionLists();
@@ -645,9 +681,12 @@ export function useRealtimeSync(
         task_id: payload.task_id,
         chat_session_id: payload.chat_session_id,
       });
-      qc.setQueryData(chatKeys.pendingTask(payload.chat_session_id), {});
-      qc.invalidateQueries({ queryKey: chatKeys.messages(payload.chat_session_id) });
-      qc.invalidateQueries({ queryKey: chatKeys.pendingTask(payload.chat_session_id) });
+      // `chat:done` (broadcast immediately before this event in CompleteTask)
+      // already wrote the assistant message into the messages cache and
+      // cleared `chatKeys.pendingTask`. This event is now only responsible
+      // for refreshing the per-user cross-session aggregate that drives the
+      // FAB indicator — `chat:done` is per-session and doesn't carry that
+      // information.
       invalidatePendingAggregate();
     });
 

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -289,7 +289,16 @@ export interface ChatMessageEventPayload {
 export interface ChatDonePayload {
   chat_session_id: string;
   task_id: string;
+  /**
+   * Server populates these from the freshly-persisted assistant ChatMessage
+   * row so the WS handler can write it into the messages cache inline. Older
+   * servers (pre-#2123) only sent chat_session_id + task_id; treat every field
+   * below as optional and fall back to a refetch when absent.
+   */
+  message_id?: string;
   content?: string;
+  elapsed_ms?: number;
+  created_at?: string;
 }
 
 export interface ChatSessionReadPayload {

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -991,21 +991,24 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	// For chat tasks, save assistant reply and broadcast chat:done. The
 	// resume pointer was already persisted inside the transaction above.
 	if task.ChatSessionID.Valid {
+		var assistantMsg *db.ChatMessage
 		var payload protocol.TaskCompletedPayload
 		if err := json.Unmarshal(result, &payload); err == nil && payload.Output != "" {
 			// Same unescape as the issue-comment path above: literal `\n` from
 			// agent stdout becomes a real newline so the chat panel renders
 			// paragraph breaks instead of one wall of prose.
 			body := util.UnescapeBackslashEscapes(payload.Output)
-			if _, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
+			row, err := s.Queries.CreateChatMessage(ctx, db.CreateChatMessageParams{
 				ChatSessionID: task.ChatSessionID,
 				Role:          "assistant",
 				Content:       redact.Text(body),
 				TaskID:        task.ID,
 				ElapsedMs:     computeChatElapsedMs(task),
-			}); err != nil {
+			})
+			if err != nil {
 				slog.Error("failed to save assistant chat message", "task_id", util.UUIDToString(task.ID), "error", err)
 			} else {
+				assistantMsg = &row
 				// Event-driven unread: stamp unread_since on the first unread
 				// assistant message. No-op if the session already has unread.
 				// If the user is actively viewing the session, the frontend's
@@ -1015,7 +1018,7 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 				}
 			}
 		}
-		s.broadcastChatDone(ctx, task)
+		s.broadcastChatDone(ctx, task, assistantMsg)
 	}
 
 	// Reconcile agent status
@@ -1630,10 +1633,24 @@ func (s *TaskService) ResolveTaskWorkspaceID(ctx context.Context, task db.AgentT
 	return ""
 }
 
-func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQueue) {
+func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQueue, msg *db.ChatMessage) {
 	workspaceID := s.ResolveTaskWorkspaceID(ctx, task)
 	if workspaceID == "" {
 		return
+	}
+	payload := protocol.ChatDonePayload{
+		ChatSessionID: util.UUIDToString(task.ChatSessionID),
+		TaskID:        util.UUIDToString(task.ID),
+	}
+	if msg != nil {
+		payload.MessageID = util.UUIDToString(msg.ID)
+		payload.Content = msg.Content
+		if msg.CreatedAt.Valid {
+			payload.CreatedAt = msg.CreatedAt.Time.UTC().Format(time.RFC3339Nano)
+		}
+		if msg.ElapsedMs.Valid {
+			payload.ElapsedMs = msg.ElapsedMs.Int64
+		}
 	}
 	s.Bus.Publish(events.Event{
 		Type:          protocol.EventChatDone,
@@ -1641,10 +1658,7 @@ func (s *TaskService) broadcastChatDone(ctx context.Context, task db.AgentTaskQu
 		ActorType:     "system",
 		ActorID:       "",
 		ChatSessionID: util.UUIDToString(task.ChatSessionID),
-		Payload: protocol.ChatDonePayload{
-			ChatSessionID: util.UUIDToString(task.ChatSessionID),
-			TaskID:        util.UUIDToString(task.ID),
-		},
+		Payload:       payload,
 	})
 }
 

--- a/server/pkg/protocol/messages.go
+++ b/server/pkg/protocol/messages.go
@@ -74,11 +74,18 @@ type ChatMessagePayload struct {
 	CreatedAt     string `json:"created_at"`
 }
 
-// ChatDonePayload is broadcast when an agent finishes responding to a chat message.
+// ChatDonePayload is broadcast when an agent finishes responding to a chat
+// message. Carries the freshly-persisted assistant ChatMessage so the client
+// can write it into the messages cache inline — avoids a refetch round-trip
+// during the live-timeline → AssistantMessage handoff that previously caused
+// a visible flicker (#2123).
 type ChatDonePayload struct {
 	ChatSessionID string `json:"chat_session_id"`
 	TaskID        string `json:"task_id"`
-	Content       string `json:"content"`
+	MessageID     string `json:"message_id,omitempty"`
+	Content       string `json:"content,omitempty"`
+	ElapsedMs     int64  `json:"elapsed_ms,omitempty"`
+	CreatedAt     string `json:"created_at,omitempty"`
 }
 
 // ChatSessionReadPayload is broadcast when the creator marks a session as read.


### PR DESCRIPTION
## Summary

修 chat 完成时聊天面板的闪屏:展开的 live `TimelineView` 当帧 unmount → 空窗 + 滚动跳 → 持久化 `AssistantMessage` 后到达再 mount(默认收起)。

**根因(对照 [TkDodo 官方实践](https://tkdodo.eu/blog/using-web-sockets-with-react-query)):** `chat:done` handler 同步 `setQueryData(pendingTask, {})` 立刻让 `chat-message-list.tsx:62-68` 的 `pendingAlreadyPersisted` 翻为 false → live timeline 当帧 unmount;但替代它的持久化 `AssistantMessage` 要等 `invalidateQueries(messages)` 的 ~50–200ms refetch 才会 mount。空窗就是闪屏。

**修复:** 应用 TkDodo "combine setQueryData (active) + invalidate (others)" 模式 —— 把新写入的 assistant message **inline 写入** `chatKeys.messages` 缓存,然后才清 pending,两次写入落在同一 React render tick。`pendingAlreadyPersisted` 在那一帧已为 true,live timeline 让位发生在 `AssistantMessage` 已挂载之后。

**配套清理:** `task:completed` 的 chat 分支瘦身到只刷 FAB 跨 session 聚合 —— 同事务的 `chat:done` 已经完成了 messages/pending 的更新,去掉重复 invalidate 调用。

## Changes

- `server/pkg/protocol/messages.go` — `ChatDonePayload` 增加 `MessageID` / `Content` / `ElapsedMs` / `CreatedAt`(均 `omitempty`,旧客户端忽略,旧服务器侧字段为空时前端走 fallback)。
- `server/internal/service/task.go` — `broadcastChatDone` 接受新创建的 `db.ChatMessage` 行,填入 payload;`CompleteTask` 调用点改用单参→双参签名。
- `packages/core/types/events.ts` — TS `ChatDonePayload` 同步扩字段,带注释说明 server pre-#2123 兼容路径。
- `packages/core/realtime/use-realtime-sync.ts`:
  - `chat:done` handler 改成 "setQueryData(messages) → setQueryData(pendingTask, {}) → invalidate 兜底" 的固定顺序,带 `payload.message_id` 去重(reconnect 重放幂等)
  - `task:completed` chat 分支只保留 `invalidatePendingAggregate()`

## Compatibility

- **新前端 vs 旧服务器**:payload 缺新字段 → handler 跳过 setQueryData(messages),走回原本的 invalidate 路径,无回归(只是没有 flicker 优化效果)。
- **旧前端 vs 新服务器**:多出来的字段对旧 TS 类型是结构子集,无副作用。
- **Reconnect 重放 chat:done**:`payload.message_id` 去重,不会插重复 assistant message。

## Test plan

- [ ] 本地连发 5 轮对话,肉眼检查 live timeline 与 `AssistantMessage` 的切换有没有空窗 / 滚动跳。
- [ ] 现有 `pnpm typecheck` 与 `make test` 已本地通过。
- [ ] 与 `task:failed` 相对照:本 PR 不动 `task:failed` 路径(同类问题但本 issue 不涉及,留待后续闭环)。
- [ ] 跨工作区切换 / FAB 跨 session 计数:`invalidatePendingAggregate` 仍在 `task:completed` 触发,无回归。

Fixes MUL-2123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)