### PR TITLE
Revert "fix: preserve mention markdown in instruction paste (#2477)"

### DIFF
--- a/packages/views/editor/extensions/markdown-paste.test.ts
+++ b/packages/views/editor/extensions/markdown-paste.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
 import { Markdown } from "@tiptap/markdown";
 import { createMarkdownPasteExtension } from "./markdown-paste";
 
@@ -191,59 +190,5 @@ describe("markdownPaste — code block context", () => {
 
     expectLiteralPaste(editor, text);
     expect(parseJsonSpy).not.toHaveBeenCalled();
-  });
-
-  it("preserves markdown mention links when the mention extension is disabled", () => {
-    const element = document.createElement("div");
-    document.body.appendChild(element);
-    editor = new Editor({
-      element,
-      extensions: [
-        StarterKit.configure({ link: false }),
-        Link.configure({
-          openOnClick: false,
-          autolink: true,
-          linkOnPaste: true,
-        }),
-        Markdown,
-        createMarkdownPasteExtension(),
-      ],
-      content: { type: "doc", content: [{ type: "paragraph" }] },
-    });
-
-    const text =
-      "[@copilot-test](mention://agent/e542a1b9-3c88-4f12-a7d1-123456789abc)";
-    const handled = paste(editor, text);
-
-    expect(handled).toBe(true);
-    expect(editor.getMarkdown()).toBe(text);
-  });
-
-  it("uses markdown text for copied editor mentions when the mention extension is disabled", () => {
-    const element = document.createElement("div");
-    document.body.appendChild(element);
-    editor = new Editor({
-      element,
-      extensions: [
-        StarterKit.configure({ link: false }),
-        Link.configure({
-          openOnClick: false,
-          autolink: true,
-          linkOnPaste: true,
-        }),
-        Markdown,
-        createMarkdownPasteExtension(),
-      ],
-      content: { type: "doc", content: [{ type: "paragraph" }] },
-    });
-
-    const text =
-      "[@copilot-test](mention://agent/e542a1b9-3c88-4f12-a7d1-123456789abc)";
-    const html =
-      '<p data-pm-slice="1 1 []"><span data-type="mention" data-mention-type="agent" data-mention-id="e542a1b9-3c88-4f12-a7d1-123456789abc">@copilot-test</span></p>';
-    const handled = paste(editor, text, html);
-
-    expect(handled).toBe(true);
-    expect(editor.getMarkdown()).toBe(text);
   });
 });

--- a/packages/views/editor/extensions/markdown-paste.ts
+++ b/packages/views/editor/extensions/markdown-paste.ts
@@ -39,7 +39,6 @@ interface PasteClassificationInput {
   html: string;
   hasFiles: boolean;
   isInsideCodeBlock: boolean;
-  canParseMentions: boolean;
 }
 
 function isJsonDocumentText(text: string): boolean {
@@ -63,26 +62,16 @@ function isStructuredPlainText(text: string): boolean {
   return isJsonDocumentText(text);
 }
 
-function hasMentionProtocol(text: string): boolean {
-  return text.includes("mention://");
-}
-
 function classifyPaste({
   text,
   html,
   hasFiles,
   isInsideCodeBlock,
-  canParseMentions,
 }: PasteClassificationInput): PasteMode {
   if (hasFiles) return "native";
   if (!text) return "native";
   if (isInsideCodeBlock) return "literal";
-  if (html && html.includes("data-pm-slice")) {
-    // Instructions disable mention nodes. If the source slice contains one,
-    // parse the Markdown text/plain channel instead of ProseMirror HTML.
-    if (!canParseMentions && hasMentionProtocol(text)) return "markdown";
-    return "native";
-  }
+  if (html && html.includes("data-pm-slice")) return "native";
   if (text.length > LARGE_PASTE_TEXT_THRESHOLD) return "literal";
   if (isStructuredPlainText(text)) return "literal";
   return "markdown";
@@ -110,7 +99,6 @@ export function createMarkdownPasteExtension() {
                 html,
                 hasFiles: Boolean(clipboard.files?.length),
                 isInsideCodeBlock: $from.parent.type.name === "codeBlock",
-                canParseMentions: Boolean(editor.schema.nodes.mention),
               });
 
               if (mode === "native") return false;


### PR DESCRIPTION
## Summary

Reverts PR #2477 per [MUL-2101](https://github.com/multica-ai/multica/issues) (Agent Instructions paste fix).

User-visible result of #2477 turned out to still drop mention text on paste — verification screenshot in the issue shows pasted content rendered as `你好,请关联,协作人。` with all `@TestAgent` / `MUL-2101` / `@TestUser` segments missing. The PM-slice + Markdown-fallback path didn't actually preserve the mention text in practice.

Reverting to unblock further investigation; the original bug is back on the table and needs a new fix.

## Test plan
- [ ] Confirm `git revert` is the only change (diff vs. main shows the inverse of PR #2477's 13-line edit + test additions)
- [ ] CI green