### PR TITLE
fix(editor): preserve pasted mentions in instruction editor

### DIFF
--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -89,9 +89,11 @@ interface ContentEditorProps {
    */
   currentIssueId?: string;
   /**
-   * When true, the @mention extension is not registered. Use for editors
-   * where mentioning members/agents has no business meaning (e.g. agent
-   * system prompts, where the content is fed to an LLM as plain text).
+   * When true, the `@` suggestion picker is disabled but the mention node
+   * type remains in the schema, so existing mentions pasted in from other
+   * Multica editors still render as the normal pill. Use for editors where
+   * *creating* a new mention has no business meaning (e.g. agent system
+   * prompts) but *preserving* an existing one still matters.
    */
   disableMentions?: boolean;
   /**

--- a/packages/views/editor/extensions/index.ts
+++ b/packages/views/editor/extensions/index.ts
@@ -86,11 +86,12 @@ export interface EditorExtensionsOptions {
   /** When true, bare Enter also submits (chat-style). Default false. */
   submitOnEnter?: boolean;
   /**
-   * When true, the @mention extension is not registered at all. Use for
-   * editors where mentioning members/agents has no business meaning (e.g.
-   * agent system prompts) — typing `@` becomes inert and any pre-existing
-   * `[@user](mention://...)` markdown renders as plain text instead of being
-   * parsed into a mention node.
+   * When true, the `@` suggestion picker is not attached. The mention node
+   * type is still registered in the schema so any mention pasted in from
+   * another Multica editor renders as the normal mention pill instead of
+   * being silently dropped by ProseMirror's schema check. Use for editors
+   * where *creating* a new mention has no business meaning (e.g. agent
+   * system prompts) but *preserving* an existing one still matters.
    */
   disableMentions?: boolean;
 }
@@ -128,16 +129,14 @@ export function createEditorExtensions(
     // so users can copy rich content out as the original Markdown.
     createMarkdownCopyExtension(),
     FileCardExtension,
-    ...(options.disableMentions
-      ? []
-      : [
-          BaseMentionExtension.configure({
-            HTMLAttributes: { class: "mention" },
-            ...(options.queryClient
-              ? { suggestion: createMentionSuggestion(options.queryClient) }
-              : {}),
-          }),
-        ]),
+    BaseMentionExtension.configure({
+      HTMLAttributes: { class: "mention" },
+      ...(options.disableMentions
+        ? { suggestion: { allow: () => false } }
+        : options.queryClient
+          ? { suggestion: createMentionSuggestion(options.queryClient) }
+          : {}),
+    }),
     Typography,
     Placeholder.configure({ placeholder: placeholderText }),
     createMarkdownPasteExtension(),


### PR DESCRIPTION
## Summary

- Keep `BaseMentionExtension` registered in all editors. `disableMentions=true` now configures an inert suggestion (`allow: () => false`) instead of skipping the extension, so the `mention` node type stays in the schema.
- This stops ProseMirror from silently dropping mention nodes (and the surrounding inline text glued to them) when a slice from another Multica editor is pasted into the agent instruction editor.
- Typing `@` in instruction editors still does NOT pop the picker — original product intent unchanged.

## Why this approach

Previous attempt #2477 patched the paste classifier in `markdown-paste.ts` to reroute mention-bearing payloads through the Markdown path. That still lost text in practice (`mention://` is not in the markdown link protocol whitelist, the link validator dropped the label) and was reverted in #2510.

Removing `mention` from the schema is the actual root cause. Once the node type exists, the native `data-pm-slice` paste path Just Works, no paste-side intervention needed.

## Test plan

- [ ] `pnpm typecheck` — passes (verified locally)
- [ ] `pnpm --filter @multica/views exec vitest run editor` — 49 editor tests pass (verified locally)
- [ ] Manual: copy a paragraph containing `@SomeAgent` / `@SomeUser` / `MUL-xxx` mentions from an issue description, paste into Agents → Instructions editor → mention pills render normally, surrounding text intact
- [ ] Manual: in the same Instructions editor, type `@` → no picker appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)