### PR TITLE
fix(chat): eliminate Skeleton flash on new-chat first message

### DIFF
--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -210,6 +210,12 @@ export function ChatWindow() {
   // session-dropdown's existing localized `window.untitled` fallback kicks
   // in. A follow-up task may back-fill the real title from the first user
   // message — until then this keeps the session list scannable across locales.
+  //
+  // NOTE: ensureSession does NOT flip `activeSessionId` itself. Callers must
+  // seed `chatKeys.messages(sessionId)` in the Query cache BEFORE calling
+  // `setActiveSession(sessionId)`, otherwise the first useQuery subscription
+  // for the new key reports `isLoading: true` and renders ChatMessageSkeleton
+  // for one frame (the "new-chat first-message" white flash).
   const sessionPromiseRef = useRef<Promise<string | null> | null>(null);
   const ensureSession = useCallback(
     async (titleSeed: string): Promise<string | null> => {
@@ -223,7 +229,6 @@ export function ChatWindow() {
             agent_id: activeAgent.id,
             title: titleSeed.slice(0, 50),
           });
-          setActiveSession(session.id);
           return session.id;
         } finally {
           sessionPromiseRef.current = null;
@@ -232,16 +237,25 @@ export function ChatWindow() {
       sessionPromiseRef.current = promise;
       return promise;
     },
-    [activeSessionId, activeAgent, createSession, setActiveSession],
+    [activeSessionId, activeAgent, createSession],
   );
 
   const handleUploadFile = useCallback(
     async (file: File) => {
       const sessionId = await ensureSession("");
       if (!sessionId) return null;
+      // Prime the messages cache as empty before flipping activeSessionId so
+      // ChatMessageList mounts directly (no Skeleton frame). Skip the write
+      // when an entry already exists — a concurrent handleSend may have
+      // seeded an optimistic message we must not clobber.
+      qc.setQueryData<ChatMessage[]>(
+        chatKeys.messages(sessionId),
+        (old) => old ?? [],
+      );
+      setActiveSession(sessionId);
       return uploadWithToast(file, { chatSessionId: sessionId });
     },
-    [ensureSession, uploadWithToast],
+    [ensureSession, uploadWithToast, qc, setActiveSession],
   );
 
   const handleSend = useCallback(
@@ -287,6 +301,12 @@ export function ChatWindow() {
         task_id: null,
         created_at: sentAt,
       };
+      // Seed cache BEFORE flipping activeSessionId. If we set the active
+      // session first, useQuery's first subscription to the new key sees no
+      // cached data and renders ChatMessageSkeleton for one frame — the
+      // "new-chat first-message" white flash. Priming the cache first means
+      // the very first read after activeSessionId flips hits data
+      // synchronously and ChatMessageList mounts directly.
       qc.setQueryData<ChatMessage[]>(
         chatKeys.messages(sessionId),
         (old) => (old ? [...old, optimistic] : [optimistic]),
@@ -301,6 +321,9 @@ export function ChatWindow() {
         status: "queued",
         created_at: sentAt,
       });
+      // Cache primed → safe to publish the new active session. Idempotent
+      // when the session was already active (existing-conversation send).
+      setActiveSession(sessionId);
       apiLogger.debug("sendChatMessage.optimistic", { sessionId, optimisticId: optimistic.id });
 
       const result = await api.sendChatMessage(sessionId, finalContent, attachmentIds);
@@ -325,6 +348,7 @@ export function ChatWindow() {
       anchorCandidate,
       ensureSession,
       qc,
+      setActiveSession,
     ],
   );
 


### PR DESCRIPTION
## Summary

- Fixes [MUL-2133](mention://issue/6f598053-21ac-4a53-9a9c-1139b4b9a8ec): in a new chat (no active session), the first send rendered `ChatMessageSkeleton` for one frame (visible white flash) before the optimistic user message appeared. Second-and-later messages were unaffected.
- Root cause: `ensureSession` flipped `activeSessionId` immediately after creating the session, *before* `handleSend` wrote the optimistic message to `chatKeys.messages(sessionId)`. `useQuery`'s first subscription to the new key saw no data → `isLoading: true` → `showSkeleton` rendered for one frame.
- Fix: apply TanStack Query's "[seed the cache before subscription](https://tkdodo.eu/blog/seeding-the-query-cache)" pattern. Move `setActiveSession` out of `ensureSession` into the callers, after they prime the cache. `handleSend` writes the optimistic message first, then flips; `handleUploadFile` seeds an empty array first, then flips.
- Distinct race from the chat-done flicker fixed in #2509 (unmount/mount on reply completion); both share the same prime-before-subscribe shape.

## Test plan

- [ ] Open chat panel, click `+` for a new conversation, send first message → no white flash, optimistic user message appears immediately.
- [ ] Within the same session, send a second message → still no flash (regression check for existing-session path).
- [ ] Drop a file into a new conversation (no active session) → no flash; attachment lands on the freshly-created session.
- [ ] Send another message after navigating to a starter prompt → no flash.
- [ ] `pnpm --filter @multica/views typecheck` passes.
- [ ] `pnpm --filter @multica/views exec vitest run chat/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)