### PR TITLE
fix(daemon): strip Windows chcp noise from runtime version

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -581,7 +581,31 @@ func detectCLIVersion(ctx context.Context, execPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("detect version for %s: %w", execPath, err)
 	}
-	return strings.TrimSpace(string(data)), nil
+	return extractVersionLine(string(data)), nil
+}
+
+// extractVersionLine pulls the version line out of a `<cli> --version` capture,
+// discarding leading shell noise. On Windows, npm-installed CLI shims (notably
+// gemini's) emit `chcp` output like `Active code page: 65001` before the real
+// version reaches stdout, and the raw concatenation was being persisted as the
+// runtime version (see #2516).
+//
+// The heuristic: return the first non-empty line that contains a semver-shaped
+// token (matches versionRe). Full version strings like "2.1.5 (Claude Code)"
+// or "codex-cli 0.118.0" survive unchanged because the whole matching line is
+// returned. If no line carries a semver token, fall back to the trimmed raw
+// output so unusual version formats aren't silently dropped to empty.
+func extractVersionLine(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if versionRe.MatchString(line) {
+			return line
+		}
+	}
+	return strings.TrimSpace(raw)
 }
 
 // logWriter adapts a *slog.Logger to an io.Writer for capturing stderr.

--- a/server/pkg/agent/version_test.go
+++ b/server/pkg/agent/version_test.go
@@ -78,6 +78,65 @@ func TestCheckMinCLIVersion(t *testing.T) {
 	}
 }
 
+func TestExtractVersionLine(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "bare semver",
+			raw:  "0.42.0\n",
+			want: "0.42.0",
+		},
+		{
+			name: "claude full string preserved",
+			raw:  "2.1.5 (Claude Code)\n",
+			want: "2.1.5 (Claude Code)",
+		},
+		{
+			name: "codex prefix preserved",
+			raw:  "codex-cli 0.118.0\n",
+			want: "codex-cli 0.118.0",
+		},
+		// Reproduces #2516: gemini's Windows shim emits `chcp` output to stdout
+		// before the real version. The chcp line has no dotted-number form,
+		// so the semver scan skips it and picks up "0.42.0" from the next line.
+		{
+			name: "windows chcp prefix before version",
+			raw:  "Active code page: 65001\n0.42.0\n",
+			want: "0.42.0",
+		},
+		{
+			name: "windows chcp prefix CRLF",
+			raw:  "Active code page: 65001\r\n0.42.0\r\n",
+			want: "0.42.0",
+		},
+		{
+			name: "leading blank lines",
+			raw:  "\n\n  0.42.0\n",
+			want: "0.42.0",
+		},
+		{
+			name: "non-semver output falls back to trimmed raw",
+			raw:  "  some-build-id  \n",
+			want: "some-build-id",
+		},
+		{
+			name: "empty input",
+			raw:  "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractVersionLine(tt.raw); got != tt.want {
+				t.Errorf("extractVersionLine(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckMinVersion(t *testing.T) {
 	tests := []struct {
 		agentType string


### PR DESCRIPTION
## Summary

 (MUL-2140).

On Windows, the gemini CLI's npm shim emits `chcp 65001` output to stdout before the real version reaches `--version` stdout. The daemon was capturing the full output verbatim and registering the raw concatenation as the runtime version, so the runtime detail page rendered:

```
Active code page: 65001 0.42.0
```

instead of just `0.42.0`. This affects any agent CLI whose Windows shim leaks `chcp` to stdout — gemini is the one users hit but the fix sits in shared code (`detectCLIVersion`), so all backends benefit.

## Fix

`detectCLIVersion` now passes its output through `extractVersionLine`, which scans the captured text line by line and returns the first one containing a semver-shaped token. Full strings like `2.1.5 (Claude Code)` or `codex-cli 0.118.0` survive unchanged; unparseable output falls back to the trimmed raw value (so we never go silently empty).

The semver regex (`versionRe`) is the same one `parseSemver` already uses, so the gate in `CheckMinVersion` and the stored display string stay in lockstep.

## Test plan

- [x] `go test ./server/pkg/agent/...` (new `TestExtractVersionLine` covers chcp prefix, CRLF chcp prefix, codex/claude existing formats, blank-line padding, and non-semver fallback)
- [x] `go test ./server/internal/daemon/...`
- [ ] Manual verification on a Windows daemon: re-register a gemini runtime and confirm the runtime detail page shows the bare version (`0.42.0`) with no `Active code page` prefix.