### PR TITLE
fix(daemon): bypass Gemini folder-trust gate in headless mode

### DIFF
--- a/server/pkg/agent/gemini.go
+++ b/server/pkg/agent/gemini.go
@@ -41,7 +41,7 @@ func (b *geminiBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	if opts.Cwd != "" {
 		cmd.Dir = opts.Cwd
 	}
-	cmd.Env = buildEnv(b.cfg.Env)
+	cmd.Env = buildGeminiEnv(b.cfg.Env)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -264,4 +264,30 @@ func buildGeminiArgs(prompt string, opts ExecOptions, logger *slog.Logger) []str
 	}
 	args = append(args, filterCustomArgs(opts.CustomArgs, geminiBlockedArgs, logger)...)
 	return args
+}
+
+// buildGeminiEnv wraps buildEnv and defaults GEMINI_CLI_TRUST_WORKSPACE=true so
+// gemini's folder-trust gate doesn't fail every headless daemon invocation with
+// exit code 55 (FatalUntrustedWorkspaceError). When a user has enabled
+// `security.folderTrust.enabled` in `~/.gemini/settings.json` and the daemon
+// spawns gemini in a worktree that isn't pre-listed in `trustedFolders.json`,
+// the CLI throws during startup warnings with no interactive prompt available,
+// so the run fails after ~10s with no useful output (see #2516).
+//
+// The env-var bypass is gemini's own documented escape hatch (mirrors the
+// `--skip-trust` CLI flag) and has been in place for the entire folder-trust
+// feature lifetime, so this works on every gemini version that can produce the
+// crash. If the caller explicitly sets the same key in cfg.Env it wins,
+// preserving the ability to opt back into the check.
+func buildGeminiEnv(extra map[string]string) []string {
+	const trustKey = "GEMINI_CLI_TRUST_WORKSPACE"
+	if _, ok := extra[trustKey]; ok {
+		return buildEnv(extra)
+	}
+	merged := make(map[string]string, len(extra)+1)
+	for k, v := range extra {
+		merged[k] = v
+	}
+	merged[trustKey] = "true"
+	return buildEnv(merged)
 }

--- a/server/pkg/agent/gemini_test.go
+++ b/server/pkg/agent/gemini_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -88,6 +89,64 @@ func TestBuildGeminiArgsPassesThroughCustomArgs(t *testing.T) {
 
 	if args[len(args)-1] != "--sandbox" {
 		t.Fatalf("expected --sandbox at end of args, got %v", args)
+	}
+}
+
+// envLookup returns the value of key in an env slice, or ("", false) if absent.
+// When the key appears multiple times the last occurrence wins, mirroring how
+// libc's getenv resolves duplicates on the daemon's supported platforms — the
+// caller-supplied override therefore takes precedence over our default.
+func envLookup(env []string, key string) (string, bool) {
+	prefix := key + "="
+	var value string
+	var found bool
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			value = strings.TrimPrefix(entry, prefix)
+			found = true
+		}
+	}
+	return value, found
+}
+
+func TestBuildGeminiEnvSetsTrustWorkspaceDefault(t *testing.T) {
+	t.Parallel()
+
+	env := buildGeminiEnv(nil)
+	got, ok := envLookup(env, "GEMINI_CLI_TRUST_WORKSPACE")
+	if !ok {
+		t.Fatalf("expected GEMINI_CLI_TRUST_WORKSPACE to be set, got env=%v", env)
+	}
+	if got != "true" {
+		t.Fatalf("expected GEMINI_CLI_TRUST_WORKSPACE=true, got %q", got)
+	}
+}
+
+func TestBuildGeminiEnvRespectsExplicitOverride(t *testing.T) {
+	t.Parallel()
+
+	// Users who deliberately set the value (e.g. to "false" to opt back into
+	// gemini's folder-trust gate, or to a future-proofed value) must win over
+	// our daemon default.
+	env := buildGeminiEnv(map[string]string{"GEMINI_CLI_TRUST_WORKSPACE": "false"})
+	got, ok := envLookup(env, "GEMINI_CLI_TRUST_WORKSPACE")
+	if !ok {
+		t.Fatalf("expected GEMINI_CLI_TRUST_WORKSPACE to be set, got env=%v", env)
+	}
+	if got != "false" {
+		t.Fatalf("expected caller's GEMINI_CLI_TRUST_WORKSPACE=false to win, got %q", got)
+	}
+}
+
+func TestBuildGeminiEnvPreservesOtherExtras(t *testing.T) {
+	t.Parallel()
+
+	env := buildGeminiEnv(map[string]string{"GEMINI_API_KEY": "secret"})
+	if got, ok := envLookup(env, "GEMINI_API_KEY"); !ok || got != "secret" {
+		t.Fatalf("expected GEMINI_API_KEY=secret to pass through, got %q (ok=%v)", got, ok)
+	}
+	if got, ok := envLookup(env, "GEMINI_CLI_TRUST_WORKSPACE"); !ok || got != "true" {
+		t.Fatalf("expected default GEMINI_CLI_TRUST_WORKSPACE=true, got %q (ok=%v)", got, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the agent-execution side of #2516 (MUL-2140). Companion to #2521 which fixes the runtime-version display.

The screenshot in #2516 also shows a failed run with `gemini exited with error: exit status 55` after ~11s. That exit code is `FatalUntrustedWorkspaceError` in gemini-cli (`packages/core/src/utils/errors.ts:117` — `super(message, 55)`). It's thrown from `userStartupWarnings.ts:98` when:

1. The user has `security.folderTrust.enabled` set in `~/.gemini/settings.json`, **and**
2. The cwd isn't in `~/.gemini/trustedFolders.json`, **and**
3. The process is headless (no TTY → no interactive trust prompt).

The daemon spawns gemini with `-p` + `--yolo` in freshly-checked-out worktrees the user has never trusted interactively, so all three conditions hold every run and gemini exits 55 before any stdout is produced. `--yolo` only auto-accepts tool calls — it does **not** bypass folder trust.

## Fix

Default `GEMINI_CLI_TRUST_WORKSPACE=true` on the child env. This short-circuits `checkPathTrust` in gemini-core (`packages/core/src/utils/trust.ts:47`) before the folder-trust gate runs — gemini's own documented headless escape hatch, equivalent to passing `--skip-trust` on the command line. Picked the env var over the flag because:

- The env-var check has been in `trust.ts` for the entire folder-trust feature lifetime, so the fix works on every gemini version that can produce the crash (the `--skip-trust` flag is newer).
- Doesn't show up in `agent command` log noise alongside the user's `custom_args`.
- Can't collide with arg parsing if a user supplies custom args.

Callers that deliberately set the same key in `cfg.Env` win, so anyone wanting the gate back on can opt in.

## Test plan

- [x] `go test ./server/pkg/agent/... ./server/internal/daemon/...` (new `TestBuildGeminiEnvSetsTrustWorkspaceDefault`, `TestBuildGeminiEnvRespectsExplicitOverride`, `TestBuildGeminiEnvPreservesOtherExtras`)
- [ ] Manual: enable `security.folderTrust.enabled` in `~/.gemini/settings.json`, run a gemini-backed agent through the daemon in a non-trusted worktree, confirm the run completes instead of exiting 55.