### PR TITLE
fix(chat): commit rename only on real outside click, not on hover

### DIFF
--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -1019,11 +1019,16 @@ function SessionDropdown({
 /**
  * Inline editor for a session title. Mounts focused with the existing
  * title pre-selected so the user can either replace it outright or arrow
- * into the existing text. Enter commits, Escape / blur cancels.
+ * into the existing text. Enter commits, Escape cancels, a real click
+ * outside the input also commits.
  *
- * Lives inside a DropdownMenuItem; we stop propagation on keys and clicks
- * so Base UI's menu doesn't intercept arrow / space / enter for navigation
- * while the user is typing.
+ * We do NOT commit on the input's `blur` event: Base UI's Menu uses
+ * focus-follows-cursor (hovering a sibling row drags DOM focus there),
+ * so a blur handler would fire on every mouse-move and "save" the user's
+ * half-typed title without them clicking anywhere. Instead a document-
+ * level `pointerdown` listener — registered in capture phase so it runs
+ * before Base UI's outside-click close handler — commits when the user
+ * actually clicks outside the input.
  */
 function SessionRenameInput({
   initialValue,
@@ -1037,10 +1042,32 @@ function SessionRenameInput({
   const { t } = useT("chat");
   const [value, setValue] = useState(initialValue);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Hold the latest value + callback in refs so the mount-only effect's
+  // listener always sees fresh state without re-subscribing on every
+  // keystroke (which would briefly leave a window where pointerdown isn't
+  // observed).
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
 
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
+
+    const handlePointerDown = (e: PointerEvent) => {
+      const input = inputRef.current;
+      if (!input) return;
+      if (input.contains(e.target as Node)) return;
+      onSubmitRef.current(valueRef.current);
+    };
+    // Capture phase — Base UI registers its own outside-click handler in
+    // bubble; running first lets us commit before the menu starts to
+    // close (and unmount this component).
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
   }, []);
 
   return (
@@ -1064,7 +1091,6 @@ function SessionRenameInput({
           onCancel();
         }
       }}
-      onBlur={() => onSubmit(value)}
       className="w-full rounded-sm bg-background px-1 py-0.5 text-sm outline-none ring-1 ring-border focus-visible:ring-brand"
     />
   );


### PR DESCRIPTION
## Summary

Follow-up to #2522. Fixes the auto-save-on-hover bug reported in MUL-2110: after clicking the pencil to edit, moving the mouse over a sibling row was committing the half-typed title.

**Root cause.** Base UI's `Menu` uses focus-follows-cursor — hovering a sibling row programmatically moves DOM focus to that row, which fires `blur` on the rename input. The old `onBlur={() => onSubmit(value)}` handler couldn't tell a real "click somewhere else" from a hover-driven focus shift, so it committed on every mouse-move.

**Fix.** Drop the blur handler. Instead, register a document-level `pointerdown` listener in capture phase while the editor is mounted, and commit only when the click target is outside the input. Capture phase runs before Base UI's outside-click close handler, so we commit before the menu starts closing.

After this:
- `Enter` → commits (unchanged)
- `Escape` → cancels (unchanged)
- Click outside the input → commits ✓
- Mouse hover only → no-op ✓ (was the bug)

Base PR: #2522. Once #2522 merges, this PR's base auto-switches to `main`.

## Test plan

- [x] `pnpm typecheck`, `pnpm test` (393 tests), `pnpm lint` (0 errors)
- [ ] Manual: click pencil on a session row, type a partial title, hover over other rows → no save fires. Then click on the chat window background → title commits. Then re-edit, press Escape → original title restored.

MUL-2110