### PR TITLE
fix(chat): commit rename only on real outside click, not on hover (re-target #2524 to main)

### DIFF
--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -1019,11 +1019,16 @@ function SessionDropdown({
 /**
  * Inline editor for a session title. Mounts focused with the existing
  * title pre-selected so the user can either replace it outright or arrow
- * into the existing text. Enter commits, Escape / blur cancels.
+ * into the existing text. Enter commits, Escape cancels, a real click
+ * outside the input also commits.
  *
- * Lives inside a DropdownMenuItem; we stop propagation on keys and clicks
- * so Base UI's menu doesn't intercept arrow / space / enter for navigation
- * while the user is typing.
+ * We do NOT commit on the input's `blur` event: Base UI's Menu uses
+ * focus-follows-cursor (hovering a sibling row drags DOM focus there),
+ * so a blur handler would fire on every mouse-move and "save" the user's
+ * half-typed title without them clicking anywhere. Instead a document-
+ * level `pointerdown` listener — registered in capture phase so it runs
+ * before Base UI's outside-click close handler — commits when the user
+ * actually clicks outside the input.
  */
 function SessionRenameInput({
   initialValue,
@@ -1037,10 +1042,32 @@ function SessionRenameInput({
   const { t } = useT("chat");
   const [value, setValue] = useState(initialValue);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Hold the latest value + callback in refs so the mount-only effect's
+  // listener always sees fresh state without re-subscribing on every
+  // keystroke (which would briefly leave a window where pointerdown isn't
+  // observed).
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
 
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
+
+    const handlePointerDown = (e: PointerEvent) => {
+      const input = inputRef.current;
+      if (!input) return;
+      if (input.contains(e.target as Node)) return;
+      onSubmitRef.current(valueRef.current);
+    };
+    // Capture phase — Base UI registers its own outside-click handler in
+    // bubble; running first lets us commit before the menu starts to
+    // close (and unmount this component).
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
   }, []);
 
   return (
@@ -1064,7 +1091,6 @@ function SessionRenameInput({
           onCancel();
         }
       }}
-      onBlur={() => onSubmit(value)}
       className="w-full rounded-sm bg-background px-1 py-0.5 text-sm outline-none ring-1 ring-border focus-visible:ring-brand"
     />
   );


### PR DESCRIPTION
## Summary

PR #2524 was set up with `agent/j/db056e6b` (the work branch behind #2522) as its base, with the expectation that the base would auto-switch to `main` once #2522 landed. That switch never happened — GitHub merged the PR into the stale work branch instead of `main`, so `main` still ships the buggy `onBlur` rename handler.

This PR re-applies the exact same fix (cherry-pick of `84824d18`, the underlying commit from #2524) directly on `main` so users can actually receive it. No new logic; only the targeting is corrected.

## What the fix does (verbatim from #2524)

Base UI's `Menu` uses focus-follows-cursor — hovering a sibling row drags DOM focus to that row, which made the rename input's `onBlur=save` fire just from moving the mouse. Clicking the pencil and then nudging the cursor would silently commit a half-typed title (MUL-2110).

The fix drops the blur handler and instead registers a document-level `pointerdown` listener in capture phase while the editor is mounted. The listener commits only when the click target is outside the input. Capture phase runs before Base UI's outside-click handler, so we commit before the menu starts unmounting the editor.

After this:
- `Enter` → commits (unchanged)
- `Escape` → cancels (unchanged)
- Real click outside the input → commits ✓
- Mouse hover only → no-op ✓ (was the bug)

## Test plan
- [ ] Click the pencil on a session row, type a partial title, hover over other rows → no save fires.
- [ ] Click on the chat-window background → title commits.
- [ ] Re-edit, press Escape → original title restored.
- [ ] `pnpm typecheck` clean (cherry-pick is a strict subset of #2524 which already passed all checks).