### PR TITLE
feat(dashboard): reuse runtime timezone picker on the usage page

### DIFF
--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -23,6 +23,10 @@ import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-sto
 import { PageHeader } from "../../layout/page-header";
 import { KpiCard } from "../../runtimes/components/shared";
 import { DailyCostChart } from "../../runtimes/components/charts";
+import {
+  TimezoneSelect,
+  browserTimezone,
+} from "../../runtimes/components/timezone-select";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { formatTokens } from "../../runtimes/utils";
@@ -109,6 +113,10 @@ export function DashboardPage() {
   const wsId = useWorkspaceId();
   const [days, setDays] = useState<TimeRange>(30);
   const [projectValue, setProjectValue] = useState<string>(ALL_PROJECTS);
+  // Local-only timezone selection. The shared TimezoneSelect lists the
+  // browser tz first; we default to it so the picker matches what the user
+  // currently sees on their clock.
+  const [timezone, setTimezone] = useState<string>(() => browserTimezone());
 
   // The user can save model prices from the runtimes page; re-render when
   // they do so the dashboard reflects the new rates.
@@ -191,6 +199,11 @@ export function DashboardPage() {
             value={days}
             onChange={setDays}
             options={TIME_RANGES.map((r) => ({ label: r.label, value: r.days }))}
+          />
+          <TimezoneSelect
+            value={timezone}
+            onValueChange={setTimezone}
+            triggerClassName="min-w-[180px]"
           />
         </div>
       </PageHeader>

--- a/packages/views/runtimes/components/runtime-detail.tsx
+++ b/packages/views/runtimes/components/runtime-detail.tsx
@@ -38,13 +38,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@multica/ui/components/ui/tooltip";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@multica/ui/components/ui/select";
+import { TimezoneSelect } from "./timezone-select";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { AppLink } from "../../navigation";
 import { availabilityConfig, workloadConfig } from "../../agents/presence";
@@ -567,54 +561,6 @@ function DiagnosticsCard({
   );
 }
 
-// Common IANA zones offered as quick picks when Intl.supportedValuesOf is not
-// available, and promoted near the top otherwise.
-const COMMON_TIMEZONES = [
-  "UTC",
-  "America/Los_Angeles",
-  "America/Denver",
-  "America/Chicago",
-  "America/New_York",
-  "America/Sao_Paulo",
-  "Europe/London",
-  "Europe/Berlin",
-  "Europe/Paris",
-  "Europe/Moscow",
-  "Africa/Cairo",
-  "Asia/Dubai",
-  "Asia/Kolkata",
-  "Asia/Bangkok",
-  "Asia/Shanghai",
-  "Asia/Singapore",
-  "Asia/Tokyo",
-  "Australia/Sydney",
-  "Pacific/Auckland",
-];
-
-function browserTimezone(): string {
-  try {
-    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return tz || "UTC";
-  } catch {
-    return "UTC";
-  }
-}
-
-type IntlWithSupportedValues = typeof Intl & {
-  supportedValuesOf?: (key: "timeZone") => string[];
-};
-
-function supportedTimezones(): string[] {
-  try {
-    const supported = (Intl as IntlWithSupportedValues).supportedValuesOf?.(
-      "timeZone",
-    );
-    return supported && supported.length > 0 ? supported : COMMON_TIMEZONES;
-  } catch {
-    return COMMON_TIMEZONES;
-  }
-}
-
 // VisibilityReadout renders a static "Private" / "Public" pill for users
 // who can't edit the runtime. The description used to sit under the chip;
 // it now lives in the hover tooltip so the Diagnostics column stays compact
@@ -755,14 +701,8 @@ function TimezoneEditor({ runtime }: { runtime: AgentRuntime }) {
   const wsId = useWorkspaceId();
   const updateRuntime = useUpdateRuntime(wsId);
   const current = runtime.timezone || "UTC";
-  const browser = browserTimezone();
-  const browserSuffix = t(($) => $.detail.timezone_browser_suffix);
 
-  const options = Array.from(
-    new Set([current, browser, ...COMMON_TIMEZONES, ...supportedTimezones()]),
-  ).filter(Boolean);
   const handleTimezoneChange = (next: string) => {
-    if (next === current) return;
     updateRuntime.mutate(
       { runtimeId: runtime.id, patch: { timezone: next } },
       {
@@ -776,26 +716,12 @@ function TimezoneEditor({ runtime }: { runtime: AgentRuntime }) {
 
   return (
     <div className="space-y-1.5">
-      <Select
+      <TimezoneSelect
         value={current}
         disabled={updateRuntime.isPending}
-        onValueChange={(next) => {
-          if (next) handleTimezoneChange(next);
-        }}
-      >
-        <SelectTrigger size="sm" className="w-full rounded-md font-mono text-xs">
-          <SelectValue>
-            {current === browser ? `${current}${browserSuffix}` : current}
-          </SelectValue>
-        </SelectTrigger>
-        <SelectContent align="start" className="max-h-72">
-          {options.map((tz) => (
-            <SelectItem key={tz} value={tz} className="font-mono text-xs">
-              {tz === browser ? `${tz}${browserSuffix}` : tz}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        onValueChange={handleTimezoneChange}
+        triggerClassName="w-full"
+      />
       <p className="text-[11px] leading-snug text-muted-foreground">
         {t(($) => $.detail.timezone_hint)}
       </p>

--- a/packages/views/runtimes/components/timezone-select.tsx
+++ b/packages/views/runtimes/components/timezone-select.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@multica/ui/components/ui/select";
+import { cn } from "@multica/ui/lib/utils";
+import { useT } from "../../i18n";
+
+// Common IANA zones offered as quick picks when Intl.supportedValuesOf is not
+// available, and promoted near the top otherwise.
+const COMMON_TIMEZONES = [
+  "UTC",
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Paris",
+  "Europe/Moscow",
+  "Africa/Cairo",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Bangkok",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+];
+
+export function browserTimezone(): string {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return tz || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+type IntlWithSupportedValues = typeof Intl & {
+  supportedValuesOf?: (key: "timeZone") => string[];
+};
+
+function supportedTimezones(): string[] {
+  try {
+    const supported = (Intl as IntlWithSupportedValues).supportedValuesOf?.(
+      "timeZone",
+    );
+    return supported && supported.length > 0 ? supported : COMMON_TIMEZONES;
+  } catch {
+    return COMMON_TIMEZONES;
+  }
+}
+
+export function buildTimezoneOptions(current: string): string[] {
+  return Array.from(
+    new Set([current, browserTimezone(), ...COMMON_TIMEZONES, ...supportedTimezones()]),
+  ).filter(Boolean);
+}
+
+export interface TimezoneSelectProps {
+  value: string;
+  onValueChange: (next: string) => void;
+  disabled?: boolean;
+  /** Custom classes applied to the trigger element. */
+  triggerClassName?: string;
+  /** Size prop forwarded to <SelectTrigger>. */
+  size?: "sm" | "default";
+}
+
+/**
+ * Controlled timezone dropdown shared between the runtime detail page and the
+ * usage page. Lists the supplied value first, then the browser's resolved
+ * zone, then a curated set of common IANA zones, and finally everything
+ * `Intl.supportedValuesOf("timeZone")` exposes — de-duplicated. The browser
+ * zone is suffixed via the `runtimes.detail.timezone_browser_suffix` string
+ * so users can see at a glance which entry matches their local clock.
+ */
+export function TimezoneSelect({
+  value,
+  onValueChange,
+  disabled,
+  triggerClassName,
+  size = "sm",
+}: TimezoneSelectProps) {
+  const { t } = useT("runtimes");
+  const current = value || "UTC";
+  const browser = browserTimezone();
+  const browserSuffix = t(($) => $.detail.timezone_browser_suffix);
+  const options = buildTimezoneOptions(current);
+
+  return (
+    <Select
+      value={current}
+      disabled={disabled}
+      onValueChange={(next) => {
+        if (next && next !== current) onValueChange(next);
+      }}
+    >
+      <SelectTrigger
+        size={size}
+        className={cn("rounded-md font-mono text-xs", triggerClassName)}
+      >
+        <SelectValue>
+          {current === browser ? `${current}${browserSuffix}` : current}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent align="start" className="max-h-72">
+        {options.map((tz) => (
+          <SelectItem key={tz} value={tz} className="font-mono text-xs">
+            {tz === browser ? `${tz}${browserSuffix}` : tz}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Reuses the runtime detail page's timezone picker on the usage page header, placed immediately to the right of the 7d / 30d / 90d segmented control.

The picker UI was buried inside `runtime-detail.tsx` (helpers + a `Select` wired to `useUpdateRuntime`). To share it without dragging the mutation along, I split it in two:

- `packages/views/runtimes/components/timezone-select.tsx` — the visual / data part. Exports a controlled `TimezoneSelect` (`value` / `onValueChange`) plus `browserTimezone()`. Same option list as before: current value → browser zone → common IANA quick picks → everything `Intl.supportedValuesOf("timeZone")` exposes, de-duplicated. The browser zone keeps its `(browser)` suffix from `runtimes.detail.timezone_browser_suffix`.
- `TimezoneEditor` in `runtime-detail.tsx` — now owns only the PATCH mutation and delegates the UI to `TimezoneSelect`.

The usage page (`DashboardPage`) gets a local `timezone` state that defaults to the browser zone and feeds the picker. Per the project's "UI-only relocation" convention I did **not** touch the dashboard queries / API / SQL — the picker is wired as local state so the visual relocation lands first and any aggregation-by-tz work can follow in a separate PR.

## Related Issue

Closes #2533

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/runtimes/components/timezone-select.tsx` (new) — shared `TimezoneSelect` + `browserTimezone()` / `buildTimezoneOptions()` helpers.
- `packages/views/runtimes/components/runtime-detail.tsx` — `TimezoneEditor` now delegates the dropdown to `TimezoneSelect`; deleted the inline `COMMON_TIMEZONES` / `browserTimezone()` / `supportedTimezones()` helpers and the `Select*` imports.
- `packages/views/dashboard/components/dashboard-page.tsx` — added `timezone` state (default = browser tz) and rendered `<TimezoneSelect>` to the right of the `Segmented` 7d/30d/90d switch in the page header.

## How to Test

1. `pnpm dev:web`, open `/{workspace}/runtimes/{id}` — confirm the timezone dropdown still renders, lists browser zone with the `(browser)` suffix, picking a new zone PATCHes the runtime and shows the success toast (i.e. the refactor preserved behavior 1:1).
2. Open `/{workspace}/usage` — confirm a timezone dropdown appears to the right of the `7d / 30d / 90d` segmented control. It should default to your local zone with the `(browser)` suffix.
3. Pick another zone in the usage page picker — the value updates locally and the dropdown re-renders with the new selection. No network call is fired (this is intentional; see PR description).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

_Re: tests — no new tests; the runtime-detail picker is a 1:1 visual+behavior preservation, and the usage-page picker is local state only. `pnpm typecheck` shows the same pre-existing errors on `upstream/main` (calendar.tsx / spinner.tsx / editor `@ts-expect-error`) — none from the changed files._

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:**
Asked Claude Code to "checkout a new branch from upstream/main and reuse the runtime detail page's timezone picker on the usage page, keeping the component's existing data shape and interaction, placed to the right of the 7d/30d/90d switch." Claude located both surfaces, split the picker into a shared `TimezoneSelect` (UI + helpers) and a thin `TimezoneEditor` wrapper (mutation only), wired the picker into the usage page header with browser-tz default, then split the work into two atomic commits.

## Screenshots (optional)

<img width="529" height="45" alt="image" src="https://github.com/user-attachments/assets/b570da15-4c23-4897-9c84-dc1468576fd7" />
