### PR TITLE
feat: add Aone Cloud CLI runtime

### DIFF
--- a/docs/aone-cloud-cli-runtime-only.md
+++ b/docs/aone-cloud-cli-runtime-only.md
@@ -1,0 +1,295 @@
+# Aone Cloud CLI Remote Runtime-Only Design
+
+## 背景
+
+Multica 当前把每个本机 agent CLI 都注册成一个 runtime：daemon 启动时扫描 `claude`、`codex`、`copilot`、`opencode`、`openclaw`、`hermes`、`gemini`、`pi`、`cursor-agent`、`kimi`、`kiro-cli`，然后按 provider 写入 `agent_runtime`。任务执行时，server 根据 agent 绑定的 `runtime_id` 派发给 daemon，daemon 再按 runtime 的 `provider` 选择 Go 侧 agent backend。
+
+Aone Cloud CLI 在这个集成里应该被视为远端智能体运行时，而不是 Multica daemon 需要在本机探测、启动和托管的 CLI。也就是说，Multica 不再直接面对 Claude、Codex、Cursor、Gemini 等 provider，也不再假设 agent 执行发生在本机 `cwd`。Multica 的边界应该收敛为唯一的远端 runtime：
+
+```mermaid
+flowchart LR
+  UI["Multica UI"] --> API["Multica server"]
+  API --> Queue["agent_task_queue"]
+  Queue --> Daemon["Multica daemon / remote-runtime relay"]
+  Daemon --> Remote["Aone Cloud CLI remote runtime"]
+  Remote --> Provider["Remote agent/provider orchestration"]
+  Provider --> Remote
+  Remote --> Daemon
+  Daemon --> API
+```
+
+第一阶段可以保留 Multica daemon 作为现有任务队列的 relay，降低改造成本；但 daemon 不再负责启动本地 Aone Cloud CLI 进程。更长期可以把 `aone_cloud_cli` backend 移到 server worker，由 Multica server 直接调用远端 runtime。
+
+## 目标
+
+1. Multica 只注册一个 runtime：`provider = "aone_cloud_cli"`。
+2. 这个 runtime 的 location 是 remote，不是本机 CLI binary。
+3. Multica UI 不再让用户选择 Claude、Codex、Cursor 等 runtime provider；这些是 Aone Cloud CLI 远端运行时内部能力。
+4. Multica 继续管理任务生命周期、issue/comment/chat/autopilot、runtime ownership、usage rollup 和团队协作语义。
+5. Aone Cloud CLI 远端 runtime 负责真实 agent 执行、provider 差异、session resume、权限事件、工具事件和结果归一。
+
+## 当前落地
+
+本分支已经实现第一阶段的可运行闭环：
+
+- Aone Cloud CLI 新增 headless runtime API：
+  - `GET /api/runtime/health`
+  - `GET /api/runtime/capabilities`
+  - `POST /api/runtime/execute`
+- Multica 新增 `aone_cloud_cli` backend，`ExecutablePath` 表示 Aone runtime URL，不再表示本地 binary。
+- 当 `MULTICA_AONE_RUNTIME_URL` 存在时，Multica daemon 的 agent 配置只保留一个 `aone_cloud_cli` runtime；未设置该变量时仍保留旧的本机 CLI 探测逻辑，方便回退和并行验证。
+- Aone runtime execute 输出 `application/x-ndjson`，事件形态为 `message` / `result`；Multica 会把 Aone normalized message 映射成 `agent.Message`，最终 `result` 映射成 `agent.Result`。
+- 本地联调可用 `AONE_RUNTIME_SMOKE=1` 让 Aone Cloud CLI 返回确定性 smoke 结果，不依赖真实 Claude/Codex 凭证。
+
+本地联调环境变量：
+
+```bash
+# Aone Cloud CLI
+SERVER_PORT=3211 \
+HOST=127.0.0.1 \
+AONE_RUNTIME_SMOKE=1 \
+AONE_RUNTIME_TOKEN=dev-runtime-token \
+API_KEY=dev-runtime-token \
+CODE_PRIVATE_TOKEN=dev-private-token \
+npm run server
+
+# Multica daemon / backend
+MULTICA_AONE_RUNTIME_URL=http://127.0.0.1:3211
+MULTICA_AONE_RUNTIME_TOKEN=dev-runtime-token
+MULTICA_AONE_RUNTIME_PROFILE=smoke
+MULTICA_AONE_RUNTIME_MODEL=default
+```
+
+## 非目标
+
+- 不把 Multica server 迁进 Aone Cloud CLI。
+- 不让 Aone Cloud CLI 直接写 Multica DB。
+- 不在 Multica 继续维护 Claude/Codex/Cursor/Gemini 多套 provider backend。
+- 不把远端 runtime 简化成一个需要 daemon 本机启动的 `aone-cloud-cli start` 进程。
+- 不在第一阶段解决完整代码同步和远端工作区产品体验；但协议必须为这个问题留出字段。
+
+## 当前代码锚点
+
+Multica 侧：
+
+- `server/internal/daemon/config.go`：现在扫描多 provider CLI，后续应改成读取 Aone remote runtime endpoint 配置。
+- `server/internal/daemon/daemon.go`：`registerRuntimesForWorkspace` 现在按 `cfg.Agents` 注册多 runtime；`runTask` 现在按 `provider` 创建 `agent.New(...)`。
+- `server/pkg/agent/agent.go`：Go 侧 provider backend registry，后续只需要保留 `aone_cloud_cli` 这个执行 backend。
+- `server/internal/handler/daemon.go`：`DaemonRegister` 信任 daemon 上报的 `runtime.Type`，写入 `agent_runtime.provider`。
+- `server/pkg/db/queries/runtime.sql`：`UNIQUE (workspace_id, daemon_id, provider)`，天然支持同一 daemon 下只保留一个 `aone_cloud_cli` runtime。
+- `packages/views/runtimes/components/provider-logo.tsx`、`packages/views/agents/components/create-agent-dialog.tsx`、`packages/views/onboarding/components/use-runtime-picker.ts`：前端展示和选择 runtime。
+
+Aone Cloud CLI 侧：
+
+- Aone Cloud CLI 是远端智能体运行时入口，需要对 Multica 暴露稳定的 runtime API。
+- 既有 provider registry、normalized message、session resume、permission/event 模型可以作为远端 runtime 内部实现。
+- Multica 不应直接依赖 Aone Cloud CLI 的本地 UI server 或浏览器 WebSocket 消息格式。
+
+## 推荐方案
+
+### 1. Multica 新增唯一远端 runtime provider
+
+新增常量：
+
+```go
+const AoneCloudCLIProvider = "aone_cloud_cli"
+```
+
+Multica daemon 的 provider 检测从多 CLI 扫描改成读取远端 runtime 配置：
+
+- `MULTICA_AONE_RUNTIME_URL`：Aone Cloud CLI 远端 runtime API endpoint。
+- `MULTICA_AONE_RUNTIME_TOKEN`：访问远端 runtime 的 token 或短期凭证。
+- `MULTICA_AONE_RUNTIME_TENANT` / `MULTICA_AONE_RUNTIME_WORKSPACE`：可选，用于绑定租户、项目或运行时命名空间。
+- health/version 检测：`GET /api/runtime/health` 或 `GET /api/runtime/version`。
+- runtime 名称：`Aone Cloud CLI Remote Runtime`。
+- runtime provider：`aone_cloud_cli`。
+- runtime metadata：记录 remote endpoint host、runtime version、capabilities、region、tenant/workspace binding，不写入明文 token。
+
+这样 `registerRuntimesForWorkspace` 仍然可以复用原有 `DaemonRegister` 流程，但 `runtimes` 数组固定只有一个元素。
+
+### 2. 执行链路改成远端任务委托
+
+在 `server/pkg/agent` 新增 `aone_cloud_cli` backend，实现现有 `Backend` 接口。第一阶段为了少改架构，可以仍由 daemon 执行这个 backend；但 backend 的含义变成调用远端 runtime API，而不是启动本机 agent：
+
+```go
+type Backend interface {
+    Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error)
+}
+```
+
+这个 backend 负责：
+
+- 检查远端 Aone runtime 可连接、版本和 capabilities 满足最低要求。
+- 把 Multica 的 task、agent config、workspace ref、session id、model hint、system prompt、MCP/工具配置引用传给远端 runtime。
+- 把远端 streaming event 映射成 Multica `agent.Message`。
+- 把最终状态、输出、remote session id、usage、artifact refs 映射成 Multica `agent.Result`。
+
+注意：远端 runtime 不能可靠使用 Multica daemon 本机的 `cwd`。协议必须显式表达 workspace 来源，例如 git ref、snapshot、artifact bundle、remote workspace id，或者由 Aone runtime 自己完成 workspace materialization。
+
+### 3. Aone Cloud CLI 提供远端 runtime API
+
+建议 Aone Cloud CLI 对 Multica 暴露稳定的 headless API，而不是让 Multica daemon 模拟 UI WebSocket 消息。
+
+最小协议：
+
+```http
+POST /api/runtime/execute
+Authorization: Bearer <runtime-token>
+Content-Type: application/json
+Accept: application/x-ndjson
+```
+
+Request：
+
+```json
+{
+  "prompt": "...",
+  "workspace": {
+    "kind": "git",
+    "repo": "https://...",
+    "ref": "refs/heads/feature-x",
+    "baseCommit": "..."
+  },
+  "sessionId": "optional remote session id",
+  "agentProfile": "optional profile or policy name",
+  "modelHint": "optional model preference",
+  "systemPrompt": "optional injected runtime brief",
+  "permissionMode": "controlled",
+  "mcpConfigRef": "optional config reference",
+  "secretRefs": ["multica-token", "repo-token"],
+  "metadata": {
+    "source": "multica",
+    "taskId": "...",
+    "agentId": "...",
+    "workspaceId": "..."
+  }
+}
+```
+
+NDJSON events：
+
+```json
+{"type":"message","message":{"kind":"text","content":"..."}}
+{"type":"message","message":{"kind":"tool_use","toolName":"Bash","toolInput":{}}}
+{"type":"artifact","artifact":{"kind":"patch","ref":"artifact://..."}}
+{"type":"result","status":"completed","sessionId":"...","output":"...","usage":{"model":"...","inputTokens":1,"outputTokens":2}}
+```
+
+Multica 不需要在 request 里强制传 `provider = "claude"` 或 `provider = "codex"`。如果 Aone 需要保留多 provider 能力，应通过 `agentProfile`、`modelHint` 或 Aone 自己的策略选择实现，而不是重新暴露成 Multica runtime provider。
+
+### 4. Workspace 和产物同步
+
+远端 runtime 接入的核心不是 CLI path，而是 workspace materialization。至少需要明确一种策略：
+
+1. **Git ref 策略**：Multica 传 repo/ref/baseCommit，Aone runtime 自己 checkout，并把 patch/artifact 返回给 Multica。
+2. **Snapshot 策略**：Multica daemon 把本地 workspace 打包成 snapshot 上传，Aone runtime 在远端执行后返回 patch。
+3. **Remote workspace id 策略**：Aone runtime 已经拥有对应工作区，Multica 只传 remote workspace id。
+
+推荐第一阶段采用 Git ref 策略，如果 Multica 当前 workspace 不是干净 git 状态，再降级为明确错误；后续再补 snapshot。
+
+产物回传也要标准化：
+
+- `patch`：代码改动，Multica 可展示或应用。
+- `logs`：执行日志和工具事件。
+- `artifacts`：报告、截图、测试结果等。
+- `sessionId`：Aone remote runtime opaque session id，Multica 只保存不解析。
+
+### 5. Multica UI 收敛 runtime 选择
+
+UI 行为变化：
+
+- Runtime 列表只展示 `Aone Cloud CLI Remote Runtime`。
+- Runtime 状态展示 remote health、region、capabilities、last checked。
+- Create Agent dialog 不再以 runtime provider 作为 agent 类型信号，只选唯一 runtime。
+- Provider logo 增加 `aone_cloud_cli`，文案用 `Aone Cloud CLI`。
+- Onboarding 的 runtime detected 事件不再统计 `has_claude` / `has_codex`，改成 `has_aone_cloud_cli` 或只统计 `runtime_count`。
+- Model dropdown 后续从 Aone remote capabilities 透传 profile/model 列表，但 UI 语义应该是 profile/model，不是 runtime provider。
+
+### 6. 数据迁移和兼容策略
+
+由于 `agent_runtime` 已经按 `(workspace_id, daemon_id, provider)` 去重，新增 `aone_cloud_cli` runtime 不需要表结构变更。
+
+需要一个收敛策略：
+
+1. 新 daemon 只注册 `aone_cloud_cli`。
+2. `CreateAgent` / `UpdateAgent` 拒绝绑定非 `aone_cloud_cli` runtime。
+3. Runtime list 默认隐藏旧 provider runtime，或者把旧 runtime 标记为 offline 并只保留历史 usage 可见。
+4. 对已有 agents，建议在远端 runtime health check 成功后做一次 workspace 内 rebind：
+   - 仅迁移同一 workspace、同一 owner/daemon 下旧 local runtime 绑定的 agent。
+   - 保留 agent 的 `model`、`custom_env`、`custom_args`，但把 provider 专属含义降级为 Aone runtime profile/model hint。
+   - 如果旧 runtime 已有 running task，不抢占；新任务走新 runtime。
+
+如果当前部署尚未正式承载生产数据，可以更激进：隐藏旧 runtime、禁止旧 runtime 执行，让用户重新创建 agent。
+
+## 分阶段落地
+
+### Phase 1: Multica 只注册 Aone remote runtime
+
+- 改 `LoadConfig`：当 `MULTICA_AONE_RUNTIME_URL` 存在时，不再扫描本机 Claude/Codex 等 CLI，只读取 Aone remote runtime 配置。
+- 改错误提示和 env example。
+- 加 `agent.New("aone_cloud_cli")` backend，先做 health check，并在 execute 时调用远端 runtime API。
+- 前端增加 logo/文案，创建 agent 只接受 `aone_cloud_cli` runtime。
+- 测试：config detection、daemon register payload、CreateAgent 非 aone runtime 拒绝。
+
+### Phase 2: Aone remote runtime execution API
+
+- Aone Cloud CLI 增加 `/api/runtime/execute`、`/api/runtime/health`、`/api/runtime/capabilities`。
+- 输出稳定 NDJSON event。
+- 支持 `workspace`、`sessionId`、`agentProfile`、`modelHint`、`systemPrompt`、`mcpConfigRef`、`secretRefs`。
+- 增加鉴权、租户隔离、审计日志和长连接恢复能力。
+
+### Phase 3: Multica Aone backend 接入执行
+
+- `aone_cloud_cli` backend 调用远端 execute API。
+- 映射 normalized events 到 Multica task message。
+- 映射 result 到 `TaskResult`。
+- usage 写入仍用 Multica `task_usage`，provider 字段写 `aone_cloud_cli`，model 字段写 Aone 返回的 opaque model/profile 名称。
+- patch/artifact 以远端 artifact ref 形式落入 task 结果，是否自动应用由 Multica 产品策略决定。
+
+### Phase 4: 清理旧 provider runtime
+
+- 删除或停用 `server/pkg/agent/claude.go`、`codex.go` 等 direct backend。
+- 删除多 provider CLI env：`MULTICA_CLAUDE_PATH`、`MULTICA_CODEX_PATH` 等。
+- 清理 UI 中 provider-specific onboarding metrics 和文案。
+- 文档改成只配置 Aone remote runtime。
+
+## 关键风险
+
+1. **workspace 不再等于本机 cwd**：远端 runtime 无法直接读取 daemon 本地路径。必须先定义 git ref、snapshot 或 remote workspace id。
+2. **双层 session 语义**：Multica 保存的 `session_id` 应是 Aone 返回的 opaque remote session id，不解释内部 provider session。
+3. **鉴权和租户边界**：runtime token、repo token、Multica token 都不能写入 runtime metadata 明文；远端 API 要有最小权限和审计。
+4. **长任务网络稳定性**：远端 NDJSON/WebSocket stream 需要断线重连或 resume event cursor，否则长任务容易丢状态。
+5. **工具权限归属**：Multica 的 task 权限和 Aone remote runtime 的 permission mode 不能互相绕过。默认使用 controlled mode。
+6. **消息归一丢语义**：Aone event 可能比 Multica `agent.Message` 更丰富。Multica backend 映射时要保留 `tool_use`、`tool_result`、`thinking`、`error`、`status`，未知类型降级为 log。
+7. **旧 agents 迁移**：如果直接隐藏旧 runtime，已有 agent 可能变成不可运行。需要在产品上决定是自动 rebind 还是要求用户重建。
+
+## 推荐的最终形态
+
+Multica 只管理任务系统和团队协作语义；Aone Cloud CLI 作为唯一远端智能体运行时，管理 agent 执行、provider 编排、会话、权限和工具事件。代码边界是：
+
+```mermaid
+flowchart TB
+  subgraph Multica
+    A["Issue / Chat / Autopilot"]
+    B["Task Queue"]
+    C["Daemon or Server Worker"]
+    D["AoneCloudCLIRemoteBackend"]
+  end
+
+  subgraph AoneRemoteRuntime["Aone Cloud CLI Remote Runtime"]
+    E["Runtime Execute API"]
+    F["Workspace Materialization"]
+    G["Agent Orchestration"]
+    H["Provider / Model Policy"]
+    I["Artifacts / Patch Results"]
+  end
+
+  A --> B --> C --> D --> E
+  E --> F
+  E --> G
+  G --> H
+  G --> I
+  I --> D --> C --> B
+```
+
+这个方向的好处是 Multica 不再追逐每个 provider 的 SDK/CLI 协议变化，也不再把本机 CLI 可用性当成 runtime 可用性。以后 Aone Cloud CLI 远端运行时支持新 provider、新执行沙箱或新权限策略，Multica 仍然只有一个 runtime。

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	CLIVersion                     string                // multica CLI version (e.g. "0.1.13")
 	LaunchedBy                     string                // "desktop" when spawned by the Electron app, empty for standalone
 	Profile                        string                // profile name (empty = default)
-	Agents                         map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro
+	Agents                         map[string]AgentEntry // keyed by provider: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, aone_cloud_cli
 	WorkspacesRoot                 string                // base path for execution envs (default: ~/multica_workspaces)
 	KeepEnvAfterTask               bool                  // preserve env after task for debugging
 	HealthPort                     int                   // local HTTP port for health checks (default: 19514)
@@ -95,87 +95,96 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		return Config{}, err
 	}
 
-	// Probe available agent CLIs
 	agents := map[string]AgentEntry{}
-	claudePath := envOrDefault("MULTICA_CLAUDE_PATH", "claude")
-	if _, err := exec.LookPath(claudePath); err == nil {
-		agents["claude"] = AgentEntry{
-			Path:  claudePath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_CLAUDE_MODEL")),
+	if aoneRuntimeURL := strings.TrimSpace(os.Getenv("MULTICA_AONE_RUNTIME_URL")); aoneRuntimeURL != "" {
+		agents["aone_cloud_cli"] = AgentEntry{
+			Path:    aoneRuntimeURL,
+			Model:   strings.TrimSpace(os.Getenv("MULTICA_AONE_RUNTIME_MODEL")),
+			Token:   strings.TrimSpace(os.Getenv("MULTICA_AONE_RUNTIME_TOKEN")),
+			Profile: strings.TrimSpace(os.Getenv("MULTICA_AONE_RUNTIME_PROFILE")),
 		}
-	}
-	codexPath := envOrDefault("MULTICA_CODEX_PATH", "codex")
-	if _, err := exec.LookPath(codexPath); err == nil {
-		agents["codex"] = AgentEntry{
-			Path:  codexPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_CODEX_MODEL")),
+	} else {
+		// Probe available agent CLIs.
+		claudePath := envOrDefault("MULTICA_CLAUDE_PATH", "claude")
+		if _, err := exec.LookPath(claudePath); err == nil {
+			agents["claude"] = AgentEntry{
+				Path:  claudePath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_CLAUDE_MODEL")),
+			}
 		}
-	}
-	opencodePath := envOrDefault("MULTICA_OPENCODE_PATH", "opencode")
-	if _, err := exec.LookPath(opencodePath); err == nil {
-		agents["opencode"] = AgentEntry{
-			Path:  opencodePath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCODE_MODEL")),
+		codexPath := envOrDefault("MULTICA_CODEX_PATH", "codex")
+		if _, err := exec.LookPath(codexPath); err == nil {
+			agents["codex"] = AgentEntry{
+				Path:  codexPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_CODEX_MODEL")),
+			}
 		}
-	}
-	openclawPath := envOrDefault("MULTICA_OPENCLAW_PATH", "openclaw")
-	if _, err := exec.LookPath(openclawPath); err == nil {
-		agents["openclaw"] = AgentEntry{
-			Path:  openclawPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
+		opencodePath := envOrDefault("MULTICA_OPENCODE_PATH", "opencode")
+		if _, err := exec.LookPath(opencodePath); err == nil {
+			agents["opencode"] = AgentEntry{
+				Path:  opencodePath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCODE_MODEL")),
+			}
 		}
-	}
-	hermesPath := envOrDefault("MULTICA_HERMES_PATH", "hermes")
-	if _, err := exec.LookPath(hermesPath); err == nil {
-		agents["hermes"] = AgentEntry{
-			Path:  hermesPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+		openclawPath := envOrDefault("MULTICA_OPENCLAW_PATH", "openclaw")
+		if _, err := exec.LookPath(openclawPath); err == nil {
+			agents["openclaw"] = AgentEntry{
+				Path:  openclawPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_OPENCLAW_MODEL")),
+			}
 		}
-	}
-	geminiPath := envOrDefault("MULTICA_GEMINI_PATH", "gemini")
-	if _, err := exec.LookPath(geminiPath); err == nil {
-		agents["gemini"] = AgentEntry{
-			Path:  geminiPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_GEMINI_MODEL")),
+		hermesPath := envOrDefault("MULTICA_HERMES_PATH", "hermes")
+		if _, err := exec.LookPath(hermesPath); err == nil {
+			agents["hermes"] = AgentEntry{
+				Path:  hermesPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_HERMES_MODEL")),
+			}
 		}
-	}
-	piPath := envOrDefault("MULTICA_PI_PATH", "pi")
-	if _, err := exec.LookPath(piPath); err == nil {
-		agents["pi"] = AgentEntry{
-			Path:  piPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_PI_MODEL")),
+		geminiPath := envOrDefault("MULTICA_GEMINI_PATH", "gemini")
+		if _, err := exec.LookPath(geminiPath); err == nil {
+			agents["gemini"] = AgentEntry{
+				Path:  geminiPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_GEMINI_MODEL")),
+			}
 		}
-	}
-	cursorPath := envOrDefault("MULTICA_CURSOR_PATH", "cursor-agent")
-	if _, err := exec.LookPath(cursorPath); err == nil {
-		agents["cursor"] = AgentEntry{
-			Path:  cursorPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_CURSOR_MODEL")),
+		piPath := envOrDefault("MULTICA_PI_PATH", "pi")
+		if _, err := exec.LookPath(piPath); err == nil {
+			agents["pi"] = AgentEntry{
+				Path:  piPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_PI_MODEL")),
+			}
 		}
-	}
-	copilotPath := envOrDefault("MULTICA_COPILOT_PATH", "copilot")
-	if _, err := exec.LookPath(copilotPath); err == nil {
-		agents["copilot"] = AgentEntry{
-			Path:  copilotPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_COPILOT_MODEL")),
+		cursorPath := envOrDefault("MULTICA_CURSOR_PATH", "cursor-agent")
+		if _, err := exec.LookPath(cursorPath); err == nil {
+			agents["cursor"] = AgentEntry{
+				Path:  cursorPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_CURSOR_MODEL")),
+			}
 		}
-	}
-	kimiPath := envOrDefault("MULTICA_KIMI_PATH", "kimi")
-	if _, err := exec.LookPath(kimiPath); err == nil {
-		agents["kimi"] = AgentEntry{
-			Path:  kimiPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_KIMI_MODEL")),
+		copilotPath := envOrDefault("MULTICA_COPILOT_PATH", "copilot")
+		if _, err := exec.LookPath(copilotPath); err == nil {
+			agents["copilot"] = AgentEntry{
+				Path:  copilotPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_COPILOT_MODEL")),
+			}
 		}
-	}
-	kiroPath := envOrDefault("MULTICA_KIRO_PATH", "kiro-cli")
-	if _, err := exec.LookPath(kiroPath); err == nil {
-		agents["kiro"] = AgentEntry{
-			Path:  kiroPath,
-			Model: strings.TrimSpace(os.Getenv("MULTICA_KIRO_MODEL")),
+		kimiPath := envOrDefault("MULTICA_KIMI_PATH", "kimi")
+		if _, err := exec.LookPath(kimiPath); err == nil {
+			agents["kimi"] = AgentEntry{
+				Path:  kimiPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_KIMI_MODEL")),
+			}
+		}
+		kiroPath := envOrDefault("MULTICA_KIRO_PATH", "kiro-cli")
+		if _, err := exec.LookPath(kiroPath); err == nil {
+			agents["kiro"] = AgentEntry{
+				Path:  kiroPath,
+				Model: strings.TrimSpace(os.Getenv("MULTICA_KIRO_MODEL")),
+			}
 		}
 	}
 	if len(agents) == 0 {
-		return Config{}, fmt.Errorf("no agent CLI found: install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, or kiro-cli and ensure it is on PATH")
+		return Config{}, fmt.Errorf("no agent CLI found: set MULTICA_AONE_RUNTIME_URL or install claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor-agent, kimi, or kiro-cli and ensure it is on PATH")
 	}
 
 	claudeArgs, err := shellArgsFromEnv("MULTICA_CLAUDE_ARGS")

--- a/server/internal/daemon/config_test.go
+++ b/server/internal/daemon/config_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
@@ -25,5 +26,30 @@ func TestPatternsFromEnv_DropsSeparatorBearingEntries(t *testing.T) {
 	want := []string{"node_modules", ".next", "target"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestLoadConfigAoneRuntimeOverridesLocalAgents(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MULTICA_AONE_RUNTIME_URL", "http://127.0.0.1:3211")
+	t.Setenv("MULTICA_AONE_RUNTIME_TOKEN", "secret")
+	t.Setenv("MULTICA_AONE_RUNTIME_PROFILE", "smoke")
+	t.Setenv("MULTICA_AONE_RUNTIME_MODEL", "default")
+	t.Setenv("PATH", os.Getenv("PATH"))
+
+	cfg, err := LoadConfig(Overrides{DaemonID: "daemon-test"})
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("agents = %#v, want exactly one aone runtime", cfg.Agents)
+	}
+	entry, ok := cfg.Agents["aone_cloud_cli"]
+	if !ok {
+		t.Fatalf("agents = %#v, missing aone_cloud_cli", cfg.Agents)
+	}
+	if entry.Path != "http://127.0.0.1:3211" || entry.Token != "secret" || entry.Profile != "smoke" || entry.Model != "default" {
+		t.Fatalf("entry = %+v", entry)
 	}
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -35,8 +35,9 @@ var (
 	// real agent helpers so tests can run the registration path without
 	// shelling out to a real CLI. Mirrors the pattern used for the brew
 	// helpers above.
-	detectAgentVersion   = agent.DetectVersion
-	checkAgentMinVersion = agent.CheckMinVersion
+	detectAgentVersion       = agent.DetectVersion
+	detectAoneRuntimeVersion = agent.DetectAoneRuntimeVersion
+	checkAgentMinVersion     = agent.CheckMinVersion
 )
 
 // workspaceState tracks registered runtimes for a single workspace.
@@ -598,7 +599,13 @@ func (d *Daemon) findRuntime(id string) *Runtime {
 func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID string) (*RegisterResponse, error) {
 	var runtimes []map[string]string
 	for name, entry := range d.cfg.Agents {
-		version, err := detectAgentVersion(ctx, entry.Path)
+		var version string
+		var err error
+		if name == agent.AoneCloudCLIProvider {
+			version, err = detectAoneRuntimeVersion(ctx, entry.Path, entry.Token)
+		} else {
+			version, err = detectAgentVersion(ctx, entry.Path)
+		}
 		if err != nil {
 			d.logger.Warn("skip registering runtime", "name", name, "error", err)
 			continue
@@ -609,6 +616,9 @@ func (d *Daemon) registerRuntimesForWorkspace(ctx context.Context, workspaceID s
 		}
 		d.setAgentVersion(name, version)
 		displayName := strings.ToUpper(name[:1]) + name[1:]
+		if name == agent.AoneCloudCLIProvider {
+			displayName = "Aone Cloud CLI"
+		}
 		if d.cfg.DeviceName != "" {
 			displayName = fmt.Sprintf("%s (%s)", displayName, d.cfg.DeviceName)
 		}
@@ -2106,6 +2116,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			}
 			agentEnv[k] = v
 		}
+	}
+	if provider == agent.AoneCloudCLIProvider {
+		if entry.Token != "" {
+			agentEnv["AONE_RUNTIME_TOKEN"] = entry.Token
+		}
+		if entry.Profile != "" {
+			agentEnv["AONE_RUNTIME_PROFILE"] = entry.Profile
+		}
+		agentEnv["AONE_RUNTIME_URL"] = entry.Path
 	}
 	backend, err := agent.New(provider, agent.Config{
 		ExecutablePath: entry.Path,

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -4,8 +4,10 @@ import "encoding/json"
 
 // AgentEntry describes a single available agent CLI.
 type AgentEntry struct {
-	Path  string // path to CLI binary
-	Model string // model override (optional)
+	Path    string // path to CLI binary, or remote runtime URL
+	Model   string // model override (optional)
+	Token   string // remote runtime token (optional)
+	Profile string // remote runtime profile (optional)
 }
 
 // Runtime represents a registered daemon runtime.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -1,6 +1,6 @@
 // Package agent provides a unified interface for executing prompts via
 // coding agents (Claude Code, Codex, Copilot, OpenCode, OpenClaw, Hermes,
-// Gemini, Pi, Cursor, Kimi, Kiro). It mirrors the happy-cli AgentBackend
+// Gemini, Pi, Cursor, Kimi, Kiro, Aone Cloud CLI). It mirrors the happy-cli AgentBackend
 // pattern, translated to idiomatic Go.
 package agent
 
@@ -87,15 +87,17 @@ type Result struct {
 	Usage      map[string]TokenUsage // keyed by model name
 }
 
+const AoneCloudCLIProvider = "aone_cloud_cli"
+
 // Config configures a Backend instance.
 type Config struct {
-	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli)
+	ExecutablePath string            // path to CLI binary, or Aone Cloud CLI runtime URL for aone_cloud_cli
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
 }
 
 // New creates a Backend for the given agent type.
-// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro".
+// Supported types: "claude", "codex", "copilot", "opencode", "openclaw", "hermes", "gemini", "pi", "cursor", "kimi", "kiro", "aone_cloud_cli".
 func New(agentType string, cfg Config) (Backend, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -124,8 +126,10 @@ func New(agentType string, cfg Config) (Backend, error) {
 		return &kimiBackend{cfg: cfg}, nil
 	case "kiro":
 		return &kiroBackend{cfg: cfg}, nil
+	case AoneCloudCLIProvider:
+		return &aoneCloudCLIBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro, aone_cloud_cli)", agentType)
 	}
 }
 
@@ -141,17 +145,18 @@ func DetectVersion(ctx context.Context, executablePath string) (string, error) {
 // environment variables are deliberately omitted so the string is a hint
 // about *what* users are extending, not a dump of the full command line.
 var launchHeaders = map[string]string{
-	"claude":   "claude (stream-json)",
-	"codex":    "codex app-server",
-	"copilot":  "copilot (json)",
-	"cursor":   "cursor-agent (stream-json)",
-	"gemini":   "gemini (stream-json)",
-	"hermes":   "hermes acp",
-	"openclaw": "openclaw agent (json)",
-	"opencode": "opencode run (json)",
-	"pi":       "pi (json mode)",
-	"kimi":     "kimi acp",
-	"kiro":     "kiro-cli acp",
+	"claude":             "claude (stream-json)",
+	"codex":              "codex app-server",
+	"copilot":            "copilot (json)",
+	"cursor":             "cursor-agent (stream-json)",
+	"gemini":             "gemini (stream-json)",
+	"hermes":             "hermes acp",
+	"openclaw":           "openclaw agent (json)",
+	"opencode":           "opencode run (json)",
+	"pi":                 "pi (json mode)",
+	"kimi":               "kimi acp",
+	"kiro":               "kiro-cli acp",
+	AoneCloudCLIProvider: "aone-cloud-cli remote runtime",
 }
 
 // LaunchHeader returns the user-visible launch skeleton for agentType, or an

--- a/server/pkg/agent/agent_test.go
+++ b/server/pkg/agent/agent_test.go
@@ -27,6 +27,17 @@ func TestNewReturnsCodexBackend(t *testing.T) {
 	}
 }
 
+func TestNewReturnsAoneCloudCLIBackend(t *testing.T) {
+	t.Parallel()
+	b, err := New(AoneCloudCLIProvider, Config{ExecutablePath: "http://127.0.0.1:3001"})
+	if err != nil {
+		t.Fatalf("New(aone_cloud_cli) error: %v", err)
+	}
+	if _, ok := b.(*aoneCloudCLIBackend); !ok {
+		t.Fatalf("expected *aoneCloudCLIBackend, got %T", b)
+	}
+}
+
 func TestNewReturnsCopilotBackend(t *testing.T) {
 	t.Parallel()
 	b, err := New("copilot", Config{ExecutablePath: "/nonexistent/copilot"})
@@ -71,6 +82,7 @@ func TestLaunchHeaderCoversAllSupportedBackends(t *testing.T) {
 	// runtime the daemon actually spawns. If a new backend is added, add an
 	// entry to launchHeaders in agent.go and extend this list.
 	supported := []string{
+		AoneCloudCLIProvider,
 		"claude", "codex", "copilot", "cursor", "gemini",
 		"hermes", "kimi", "kiro", "openclaw", "opencode", "pi",
 	}

--- a/server/pkg/agent/aone_cloud_cli.go
+++ b/server/pkg/agent/aone_cloud_cli.go
@@ -1,0 +1,423 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type aoneCloudCLIBackend struct {
+	cfg Config
+}
+
+type aoneRuntimeExecuteRequest struct {
+	Prompt         string            `json:"prompt"`
+	Workspace      aoneWorkspace     `json:"workspace"`
+	SessionID      string            `json:"sessionId,omitempty"`
+	AgentProfile   string            `json:"agentProfile,omitempty"`
+	ModelHint      string            `json:"modelHint,omitempty"`
+	SystemPrompt   string            `json:"systemPrompt,omitempty"`
+	PermissionMode string            `json:"permissionMode,omitempty"`
+	McpConfig      json.RawMessage   `json:"mcpConfig,omitempty"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+}
+
+type aoneWorkspace struct {
+	Kind string `json:"kind"`
+	Path string `json:"path"`
+}
+
+type aoneRuntimeEvent struct {
+	Type       string                     `json:"type"`
+	Message    json.RawMessage            `json:"message"`
+	Status     string                     `json:"status"`
+	Output     string                     `json:"output"`
+	Error      string                     `json:"error"`
+	SessionID  string                     `json:"sessionId"`
+	DurationMs int64                      `json:"durationMs"`
+	Usage      map[string]json.RawMessage `json:"usage"`
+}
+
+type aoneNormalizedMessage struct {
+	Kind            string `json:"kind"`
+	Content         string `json:"content"`
+	Text            string `json:"text"`
+	Status          string `json:"status"`
+	SessionID       string `json:"sessionId"`
+	NewSessionID    string `json:"newSessionId"`
+	ActualSessionID string `json:"actualSessionId"`
+	ToolName        string `json:"toolName"`
+	ToolID          string `json:"toolId"`
+	ToolInput       any    `json:"toolInput"`
+	IsError         bool   `json:"isError"`
+}
+
+func (b *aoneCloudCLIBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	baseURL, err := normalizeAoneRuntimeBaseURL(b.cfg.ExecutablePath)
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 20 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+
+		startTime := time.Now()
+		var output strings.Builder
+		var sessionID string
+		var lastError string
+
+		reqBody := aoneRuntimeExecuteRequest{
+			Prompt: prompt,
+			Workspace: aoneWorkspace{
+				Kind: "local_path",
+				Path: opts.Cwd,
+			},
+			SessionID:      opts.ResumeSessionID,
+			AgentProfile:   b.cfg.Env["AONE_RUNTIME_PROFILE"],
+			ModelHint:      opts.Model,
+			SystemPrompt:   opts.SystemPrompt,
+			PermissionMode: "controlled",
+			McpConfig:      opts.McpConfig,
+			Metadata:       aoneMetadataFromEnv(b.cfg.Env),
+		}
+
+		body, err := json.Marshal(reqBody)
+		if err != nil {
+			resCh <- Result{Status: "failed", Error: fmt.Sprintf("marshal aone runtime request: %v", err), DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+
+		req, err := http.NewRequestWithContext(runCtx, http.MethodPost, baseURL+"/api/runtime/execute", bytes.NewReader(body))
+		if err != nil {
+			resCh <- Result{Status: "failed", Error: fmt.Sprintf("build aone runtime request: %v", err), DurationMs: time.Since(startTime).Milliseconds()}
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/x-ndjson")
+		setAoneRuntimeAuthHeaders(req, b.cfg.Env["AONE_RUNTIME_TOKEN"])
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			resCh <- aoneContextResult(runCtx, "call aone runtime", err, time.Since(startTime))
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			tail, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			resCh <- Result{
+				Status:     "failed",
+				Error:      fmt.Sprintf("aone runtime returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(tail))),
+				DurationMs: time.Since(startTime).Milliseconds(),
+			}
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			result, done := b.handleRuntimeLine(line, msgCh, &output, &sessionID, &lastError, startTime)
+			if done {
+				resCh <- result
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			resCh <- aoneContextResult(runCtx, "read aone runtime stream", err, time.Since(startTime))
+			return
+		}
+
+		status := "completed"
+		if lastError != "" {
+			status = "failed"
+		}
+		resCh <- Result{
+			Status:     status,
+			Output:     output.String(),
+			Error:      lastError,
+			DurationMs: time.Since(startTime).Milliseconds(),
+			SessionID:  sessionID,
+			Usage:      map[string]TokenUsage{},
+		}
+	}()
+
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+func (b *aoneCloudCLIBackend) handleRuntimeLine(line string, msgCh chan<- Message, output *strings.Builder, sessionID *string, lastError *string, started time.Time) (Result, bool) {
+	var event aoneRuntimeEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		*lastError = fmt.Sprintf("parse aone runtime event: %v", err)
+		trySend(msgCh, Message{Type: MessageError, Content: *lastError})
+		return Result{}, false
+	}
+
+	switch event.Type {
+	case "message":
+		b.handleRuntimeMessage(event.Message, msgCh, output, sessionID, lastError)
+		return Result{}, false
+	case "result":
+		if event.SessionID != "" {
+			*sessionID = event.SessionID
+		}
+		status := event.Status
+		if status == "" {
+			status = "completed"
+		}
+		resultOutput := event.Output
+		if resultOutput == "" {
+			resultOutput = output.String()
+		}
+		resultError := event.Error
+		if resultError == "" {
+			resultError = *lastError
+		}
+		duration := event.DurationMs
+		if duration == 0 {
+			duration = time.Since(started).Milliseconds()
+		}
+		return Result{
+			Status:     status,
+			Output:     resultOutput,
+			Error:      resultError,
+			DurationMs: duration,
+			SessionID:  *sessionID,
+			Usage:      parseAoneUsage(event.Usage),
+		}, true
+	default:
+		b.handleRuntimeMessage([]byte(line), msgCh, output, sessionID, lastError)
+		return Result{}, false
+	}
+}
+
+func (b *aoneCloudCLIBackend) handleRuntimeMessage(raw json.RawMessage, msgCh chan<- Message, output *strings.Builder, sessionID *string, lastError *string) {
+	if len(raw) == 0 {
+		return
+	}
+	var msg aoneNormalizedMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		var text string
+		if err := json.Unmarshal(raw, &text); err == nil && text != "" {
+			output.WriteString(text)
+			trySend(msgCh, Message{Type: MessageText, Content: text})
+		}
+		return
+	}
+
+	if msg.ActualSessionID != "" {
+		*sessionID = msg.ActualSessionID
+	} else if msg.NewSessionID != "" {
+		*sessionID = msg.NewSessionID
+	} else if msg.SessionID != "" {
+		*sessionID = msg.SessionID
+	}
+
+	switch msg.Kind {
+	case "session_created":
+		trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: *sessionID})
+	case "status":
+		status := msg.Text
+		if status == "" {
+			status = msg.Status
+		}
+		if status == "" {
+			status = "running"
+		}
+		trySend(msgCh, Message{Type: MessageStatus, Status: status, SessionID: *sessionID})
+	case "text", "stream_delta":
+		if msg.Content != "" {
+			output.WriteString(msg.Content)
+			trySend(msgCh, Message{Type: MessageText, Content: msg.Content, SessionID: *sessionID})
+		}
+	case "thinking":
+		if msg.Content != "" {
+			trySend(msgCh, Message{Type: MessageThinking, Content: msg.Content, SessionID: *sessionID})
+		}
+	case "tool_use":
+		trySend(msgCh, Message{
+			Type:      MessageToolUse,
+			Tool:      msg.ToolName,
+			CallID:    msg.ToolID,
+			Input:     aoneToolInput(msg.ToolInput),
+			SessionID: *sessionID,
+		})
+	case "tool_result":
+		trySend(msgCh, Message{
+			Type:      MessageToolResult,
+			CallID:    msg.ToolID,
+			Output:    msg.Content,
+			SessionID: *sessionID,
+		})
+	case "error":
+		*lastError = msg.Content
+		trySend(msgCh, Message{Type: MessageError, Content: msg.Content, SessionID: *sessionID})
+	}
+}
+
+func DetectAoneRuntimeVersion(ctx context.Context, endpoint, token string) (string, error) {
+	baseURL, err := normalizeAoneRuntimeBaseURL(endpoint)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/runtime/health", nil)
+	if err != nil {
+		return "", err
+	}
+	setAoneRuntimeAuthHeaders(req, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		tail, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return "", fmt.Errorf("aone runtime health returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(tail)))
+	}
+
+	var health struct {
+		Version string `json:"version"`
+		Runtime struct {
+			Version string `json:"version"`
+		} `json:"runtime"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(health.Version) != "" {
+		return strings.TrimSpace(health.Version), nil
+	}
+	if strings.TrimSpace(health.Runtime.Version) != "" {
+		return strings.TrimSpace(health.Runtime.Version), nil
+	}
+	return "unknown", nil
+}
+
+func normalizeAoneRuntimeBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("aone_cloud_cli runtime URL is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid aone_cloud_cli runtime URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("aone_cloud_cli runtime URL must use http or https")
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	base := strings.TrimRight(u.String(), "/")
+	base = strings.TrimSuffix(base, "/api/runtime")
+	base = strings.TrimSuffix(base, "/api")
+	return base, nil
+}
+
+func setAoneRuntimeAuthHeaders(req *http.Request, token string) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Runtime-Token", token)
+	req.Header.Set("X-API-Key", token)
+}
+
+func aoneMetadataFromEnv(env map[string]string) map[string]string {
+	metadata := map[string]string{"source": "multica"}
+	for _, key := range []string{
+		"MULTICA_TASK_ID",
+		"MULTICA_AGENT_ID",
+		"MULTICA_AGENT_NAME",
+		"MULTICA_WORKSPACE_ID",
+		"MULTICA_AUTOPILOT_RUN_ID",
+		"MULTICA_AUTOPILOT_ID",
+	} {
+		if value := strings.TrimSpace(env[key]); value != "" {
+			metadata[key] = value
+		}
+	}
+	return metadata
+}
+
+func aoneToolInput(value any) map[string]any {
+	if value == nil {
+		return nil
+	}
+	if m, ok := value.(map[string]any); ok {
+		return m
+	}
+	return map[string]any{"value": value}
+}
+
+func parseAoneUsage(raw map[string]json.RawMessage) map[string]TokenUsage {
+	if len(raw) == 0 {
+		return map[string]TokenUsage{}
+	}
+	out := make(map[string]TokenUsage, len(raw))
+	for model, data := range raw {
+		var fields map[string]int64
+		if err := json.Unmarshal(data, &fields); err != nil {
+			continue
+		}
+		out[model] = TokenUsage{
+			InputTokens:      firstInt64(fields, "inputTokens", "input_tokens"),
+			OutputTokens:     firstInt64(fields, "outputTokens", "output_tokens"),
+			CacheReadTokens:  firstInt64(fields, "cacheReadTokens", "cache_read_tokens"),
+			CacheWriteTokens: firstInt64(fields, "cacheWriteTokens", "cache_write_tokens"),
+		}
+	}
+	return out
+}
+
+func firstInt64(fields map[string]int64, keys ...string) int64 {
+	for _, key := range keys {
+		if value, ok := fields[key]; ok {
+			return value
+		}
+	}
+	return 0
+}
+
+func aoneContextResult(ctx context.Context, prefix string, err error, duration time.Duration) Result {
+	status := "failed"
+	message := fmt.Sprintf("%s: %v", prefix, err)
+	if ctx.Err() != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			status = "timeout"
+			message = fmt.Sprintf("%s timed out: %v", prefix, err)
+		} else if errors.Is(ctx.Err(), context.Canceled) {
+			status = "cancelled"
+			message = fmt.Sprintf("%s cancelled: %v", prefix, err)
+		}
+	}
+	return Result{
+		Status:     status,
+		Error:      message,
+		DurationMs: duration.Milliseconds(),
+		Usage:      map[string]TokenUsage{},
+	}
+}

--- a/server/pkg/agent/aone_cloud_cli_test.go
+++ b/server/pkg/agent/aone_cloud_cli_test.go
@@ -1,0 +1,151 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAoneCloudCLIBackendExecuteStreamsNDJSON(t *testing.T) {
+	t.Parallel()
+
+	var sawAuth bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/runtime/execute" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") == "Bearer secret" && r.Header.Get("X-Runtime-Token") == "secret" && r.Header.Get("X-API-Key") == "secret" {
+			sawAuth = true
+		}
+		var req aoneRuntimeExecuteRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Prompt != "say hi" {
+			t.Fatalf("prompt = %q, want say hi", req.Prompt)
+		}
+		if req.Workspace.Kind != "local_path" || req.Workspace.Path != "/tmp/work" {
+			t.Fatalf("workspace = %+v", req.Workspace)
+		}
+		if req.AgentProfile != "smoke" {
+			t.Fatalf("agentProfile = %q, want smoke", req.AgentProfile)
+		}
+
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprintln(w, `{"type":"message","message":{"kind":"session_created","sessionId":"s1","newSessionId":"s1","provider":"claude"}}`)
+		fmt.Fprintln(w, `{"type":"message","message":{"kind":"text","sessionId":"s1","content":"hello","provider":"claude"}}`)
+		fmt.Fprintln(w, `{"type":"result","status":"completed","sessionId":"s1","output":"hello","usage":{"test-model":{"inputTokens":1,"outputTokens":2}}}`)
+	}))
+	defer server.Close()
+
+	backend, err := New(AoneCloudCLIProvider, Config{
+		ExecutablePath: server.URL,
+		Env: map[string]string{
+			"AONE_RUNTIME_TOKEN":   "secret",
+			"AONE_RUNTIME_PROFILE": "smoke",
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "say hi", ExecOptions{Cwd: "/tmp/work", Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var texts []string
+	var pinnedSession string
+	for msg := range session.Messages {
+		switch msg.Type {
+		case MessageStatus:
+			pinnedSession = msg.SessionID
+		case MessageText:
+			texts = append(texts, msg.Content)
+		}
+	}
+	result := <-session.Result
+
+	if !sawAuth {
+		t.Fatal("expected runtime auth headers")
+	}
+	if pinnedSession != "s1" {
+		t.Fatalf("pinned session = %q, want s1", pinnedSession)
+	}
+	if strings.Join(texts, "") != "hello" {
+		t.Fatalf("texts = %q, want hello", strings.Join(texts, ""))
+	}
+	if result.Status != "completed" || result.Output != "hello" || result.SessionID != "s1" {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := result.Usage["test-model"].OutputTokens; got != 2 {
+		t.Fatalf("output tokens = %d, want 2", got)
+	}
+}
+
+func TestDetectAoneRuntimeVersion(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/runtime/health" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("X-Runtime-Token") != "secret" {
+			t.Fatalf("missing runtime token header")
+		}
+		_, _ = w.Write([]byte(`{"status":"ok","version":"1.2.3"}`))
+	}))
+	defer server.Close()
+
+	version, err := DetectAoneRuntimeVersion(context.Background(), server.URL+"/api/runtime", "secret")
+	if err != nil {
+		t.Fatalf("DetectAoneRuntimeVersion: %v", err)
+	}
+	if version != "1.2.3" {
+		t.Fatalf("version = %q, want 1.2.3", version)
+	}
+}
+
+func TestAoneCloudCLIBackendLiveSmoke(t *testing.T) {
+	if os.Getenv("MULTICA_AONE_RUNTIME_LIVE_TEST") != "1" {
+		t.Skip("set MULTICA_AONE_RUNTIME_LIVE_TEST=1 to run against a local Aone Cloud CLI runtime")
+	}
+	endpoint := os.Getenv("MULTICA_AONE_RUNTIME_URL")
+	if endpoint == "" {
+		t.Fatal("MULTICA_AONE_RUNTIME_URL is required")
+	}
+
+	backend, err := New(AoneCloudCLIProvider, Config{
+		ExecutablePath: endpoint,
+		Env: map[string]string{
+			"AONE_RUNTIME_TOKEN":   os.Getenv("MULTICA_AONE_RUNTIME_TOKEN"),
+			"AONE_RUNTIME_PROFILE": os.Getenv("MULTICA_AONE_RUNTIME_PROFILE"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	session, err := backend.Execute(context.Background(), "hello from multica", ExecOptions{
+		Cwd:     t.TempDir(),
+		Timeout: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for range session.Messages {
+	}
+	result := <-session.Result
+	if result.Status != "completed" {
+		t.Fatalf("status = %q error = %q output = %q", result.Status, result.Error, result.Output)
+	}
+	if !strings.Contains(result.Output, "Aone runtime smoke task completed") {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+}

--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -81,6 +81,8 @@ func ListModels(ctx context.Context, providerType, executablePath string) ([]Mod
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverKiroModels(ctx, executablePath)
 		})
+	case AoneCloudCLIProvider:
+		return aoneCloudCLIStaticModels(), nil
 	case "opencode":
 		return cachedDiscovery(providerType, func() ([]Model, error) {
 			return discoverOpenCodeModels(ctx, executablePath)
@@ -135,6 +137,12 @@ func cachedDiscovery(key string, fn func() ([]Model, error)) ([]Model, error) {
 }
 
 // ── Static catalogs ──
+
+func aoneCloudCLIStaticModels() []Model {
+	return []Model{
+		{ID: "default", Label: "Aone Cloud CLI default", Provider: "aone-cloud-cli", Default: true},
+	}
+}
 
 // claudeStaticModels reflects the Claude Code CLI's accepted --model
 // values. Keep this list short and current; stale entries here


### PR DESCRIPTION
## Summary
- add an `aone_cloud_cli` remote runtime backend that calls Aone Cloud CLI over HTTP/NDJSON
- register only the Aone runtime when `MULTICA_AONE_RUNTIME_URL` is configured
- document the runtime-only integration and smoke-test flow

## Verification
- `go test ./pkg/agent -run 'TestNewReturnsAoneCloudCLIBackend|TestLaunchHeaderCoversAllSupportedBackends|TestAoneCloudCLIBackendExecuteStreamsNDJSON|TestDetectAoneRuntimeVersion' -count=1`
- `go test ./internal/daemon -run 'TestLoadConfigAoneRuntimeOverridesLocalAgents' -count=1`
- live smoke against a local Aone Cloud CLI runtime: `TestAoneCloudCLIBackendLiveSmoke`

Note: this requires a companion Aone Cloud CLI runtime API deployment that exposes `/api/runtime/health` and `/api/runtime/execute`.
