### PR TITLE
fix(paths): add squads to consistency-test expected set (unblock CI)

### DIFF
--- a/packages/core/paths/consistency.test.ts
+++ b/packages/core/paths/consistency.test.ts
@@ -26,6 +26,7 @@ describe("paths.workspace() shape", () => {
         "myIssues",
         "runtimes",
         "skills",
+        "squads",
         "settings",
       ]),
     );
@@ -45,6 +46,7 @@ describe("paths.workspace() shape", () => {
       ["myIssues", "my-issues"],
       ["runtimes", "runtimes"],
       ["skills", "skills"],
+      ["squads", "squads"],
       ["settings", "settings"],
     ];
     const wsAsAny = ws as unknown as Record<string, () => string>;

--- a/packages/core/paths/paths.test.ts
+++ b/packages/core/paths/paths.test.ts
@@ -18,6 +18,8 @@ describe("paths.workspace(slug)", () => {
     expect(ws.runtimes()).toBe("/acme/runtimes");
     expect(ws.skills()).toBe("/acme/skills");
     expect(ws.skillDetail("skl_123")).toBe("/acme/skills/skl_123");
+    expect(ws.squads()).toBe("/acme/squads");
+    expect(ws.squadDetail("sq_1")).toBe("/acme/squads/sq_1");
     expect(ws.settings()).toBe("/acme/settings");
   });
 


### PR DESCRIPTION
## Summary

CI's been red on `main` since #2505 (`29082f7c feat: implement Squad feature MVP`). That PR added `paths.workspace(slug).squads()` / `.squadDetail(id)` to `packages/core/paths/paths.ts` but did not update `packages/core/paths/consistency.test.ts`, whose first test enumerates **all** parameterless workspace route methods and `expect(...).toEqual(...)` against an explicit `Set`. Since `squads` is parameterless, it shows up in the actual set, the expected set doesn't have it, and the test fails:

```
expected Set{ 'root', 'usage', 'issues', …(9) } to deeply equal Set{ 'root', 'usage', 'issues', …(8) }
+   "squads",
```

This is the only failing test in the frontend job (verified against run `25794495479` on `c6ccc496`).

## Changes

Test files only — no source changes. The `squads()` / `squadDetail()` route helpers themselves already exist on main and behave correctly; the assertions just needed to catch up.

- `consistency.test.ts` — add `"squads"` to the expected-Set in `exposes the expected parameterless workspace route methods` (the failing test).
- `consistency.test.ts` — add `["squads", "squads"]` to the `expectedSegments` array in `each parameterless route emits /{slug}/{segment}` (was silently skipping squads, now covered).
- `paths.test.ts` — add `ws.squads()` / `ws.squadDetail("sq_1")` expectations to the `builds workspace paths with slug prefix` smoke test, mirroring how every other route is asserted.

## Test plan
- [x] `pnpm --filter @multica/core test paths/` → 12 passed (was 11/12 with 1 fail).
- [ ] CI green on this branch.