### PR TITLE
fix(squads): i18n the Squad pages to unblock @multica/views#lint

### DIFF
--- a/packages/views/i18n/resources-types.ts
+++ b/packages/views/i18n/resources-types.ts
@@ -25,6 +25,7 @@ import type modals from "../locales/en/modals.json";
 import type runtimes from "../locales/en/runtimes.json";
 import type layout from "../locales/en/layout.json";
 import type usage from "../locales/en/usage.json";
+import type squads from "../locales/en/squads.json";
 
 // Module augmentation enables i18next v26 selector API across the monorepo:
 // `t($ => $.signin.title)` resolves to the value in en/auth.json.
@@ -64,6 +65,7 @@ declare global {
     runtimes: typeof runtimes;
     layout: typeof layout;
     usage: typeof usage;
+    squads: typeof squads;
   }
 }
 

--- a/packages/views/locales/en/squads.json
+++ b/packages/views/locales/en/squads.json
@@ -1,0 +1,47 @@
+{
+  "page": {
+    "title": "Squads",
+    "new_button": "New Squad",
+    "empty_no_squads": "No squads yet. Create one to get started.",
+    "empty_no_match": "No squads match your filters."
+  },
+  "inspector": {
+    "details_section": "Details",
+    "archive_button": "Archive"
+  },
+  "name_editor": {
+    "cancel": "Cancel"
+  },
+  "add_member_dialog": {
+    "title": "Add Member",
+    "description": "Add a workspace member or agent to this squad.",
+    "label_member": "Member",
+    "label_role": "Role",
+    "label_optional": "(optional)",
+    "placeholder_role_inline": "Add role…",
+    "cancel": "Cancel"
+  },
+  "description_dialog": {
+    "title": "Edit description",
+    "placeholder_empty": "Add a description",
+    "cancel": "Cancel"
+  },
+  "discard_changes_dialog": {
+    "title": "Discard unsaved changes?",
+    "description": "You have unsaved changes on this tab. Switching tabs will discard them.",
+    "keep_editing": "Keep editing",
+    "discard_button": "Discard"
+  },
+  "members_tab": {
+    "section_title": "Members",
+    "section_count_one": "{{count}} member in this squad",
+    "section_count_other": "{{count}} members in this squad",
+    "add_member_button": "Add Member",
+    "leader_chip": "Leader"
+  },
+  "instructions_tab": {
+    "description": "Squad instructions are injected into the leader agent's prompt whenever it works on an issue assigned to this squad. Use them to give the leader squad-wide guidance, working agreements, or context the leader should follow on every task.",
+    "unsaved_changes": "Unsaved changes",
+    "save_button": "Save"
+  }
+}

--- a/packages/views/locales/index.ts
+++ b/packages/views/locales/index.ts
@@ -22,6 +22,7 @@ import enRuntimes from "./en/runtimes.json";
 import enLayout from "./en/layout.json";
 import enUsage from "./en/usage.json";
 import enUi from "./en/ui.json";
+import enSquads from "./en/squads.json";
 import zhHansCommon from "./zh-Hans/common.json";
 import zhHansAuth from "./zh-Hans/auth.json";
 import zhHansSettings from "./zh-Hans/settings.json";
@@ -45,6 +46,7 @@ import zhHansRuntimes from "./zh-Hans/runtimes.json";
 import zhHansLayout from "./zh-Hans/layout.json";
 import zhHansUsage from "./zh-Hans/usage.json";
 import zhHansUi from "./zh-Hans/ui.json";
+import zhHansSquads from "./zh-Hans/squads.json";
 
 // Single source of truth for the resource bundle. Both apps (web layout +
 // desktop App.tsx) import from here so adding a locale or namespace happens
@@ -74,6 +76,7 @@ export const RESOURCES: Record<SupportedLocale, LocaleResources> = {
     layout: enLayout,
     usage: enUsage,
     ui: enUi,
+    squads: enSquads,
   },
   "zh-Hans": {
     common: zhHansCommon,
@@ -99,5 +102,6 @@ export const RESOURCES: Record<SupportedLocale, LocaleResources> = {
     layout: zhHansLayout,
     usage: zhHansUsage,
     ui: zhHansUi,
+    squads: zhHansSquads,
   },
 };

--- a/packages/views/locales/zh-Hans/squads.json
+++ b/packages/views/locales/zh-Hans/squads.json
@@ -1,0 +1,47 @@
+{
+  "page": {
+    "title": "小队",
+    "new_button": "新建小队",
+    "empty_no_squads": "还没有小队，创建一个开始吧。",
+    "empty_no_match": "没有匹配筛选条件的小队。"
+  },
+  "inspector": {
+    "details_section": "详情",
+    "archive_button": "归档"
+  },
+  "name_editor": {
+    "cancel": "取消"
+  },
+  "add_member_dialog": {
+    "title": "添加成员",
+    "description": "添加工作区成员或智能体到这个小队。",
+    "label_member": "成员",
+    "label_role": "角色",
+    "label_optional": "（可选）",
+    "placeholder_role_inline": "添加角色…",
+    "cancel": "取消"
+  },
+  "description_dialog": {
+    "title": "编辑描述",
+    "placeholder_empty": "添加描述",
+    "cancel": "取消"
+  },
+  "discard_changes_dialog": {
+    "title": "放弃未保存的修改？",
+    "description": "当前标签页有未保存的修改，切换标签会丢弃这些修改。",
+    "keep_editing": "继续编辑",
+    "discard_button": "放弃"
+  },
+  "members_tab": {
+    "section_title": "成员",
+    "section_count_one": "该小队有 {{count}} 名成员",
+    "section_count_other": "该小队有 {{count}} 名成员",
+    "add_member_button": "添加成员",
+    "leader_chip": "负责人"
+  },
+  "instructions_tab": {
+    "description": "小队指引会在 Leader 智能体处理分配给该小队的 issue 时注入到它的 prompt 中。可用来给 Leader 提供贯穿全队的指导、协作规范，或每次任务都应遵循的上下文。",
+    "unsaved_changes": "有未保存的修改",
+    "save_button": "保存"
+  }
+}

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -49,8 +49,10 @@ import {
 import { ChevronDown, UserPlus } from "lucide-react";
 import { toast } from "sonner";
 import type { Squad, SquadMember, Agent, MemberWithUser } from "@multica/core/types";
+import { useT } from "../../i18n";
 
 export function SquadDetailPage() {
+  const { t } = useT("squads");
   const workspace = useCurrentWorkspace();
   const wsId = useWorkspaceId();
   const p = useWorkspacePaths();
@@ -161,7 +163,7 @@ export function SquadDetailPage() {
         </div>
         <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive" onClick={() => { if (confirm("Archive this squad? Issues will be transferred to the leader.")) deleteMut.mutate(); }}>
           <Trash2 className="size-3.5 mr-1" />
-          Archive
+          {t(($) => $.inspector.archive_button)}
         </Button>
       </PageHeader>
 
@@ -344,6 +346,7 @@ function InlineEditPopover({
   validate?: (v: string) => string | null;
   children: (triggerProps: { onClick: (e: React.MouseEvent) => void }) => ReactNode;
 }) {
+  const { t } = useT("squads");
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(value);
   const [saving, setSaving] = useState(false);
@@ -410,7 +413,7 @@ function InlineEditPopover({
           {error && <p className="text-xs text-destructive">{error}</p>}
           <div className="flex items-center justify-end gap-2">
             <Button variant="ghost" size="sm" onClick={() => setOpen(false)} disabled={saving}>
-              Cancel
+              {t(($) => $.name_editor.cancel)}
             </Button>
             <Button size="sm" onClick={() => void commit()} disabled={saving || draft === value}>
               {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Save"}
@@ -439,6 +442,7 @@ function AddMemberDialog({
   onClose: () => void;
   onSubmit: (input: { type: "agent" | "member"; id: string; role?: string }) => Promise<void>;
 }) {
+  const { t } = useT("squads");
   const [target, setTarget] = useState<{ type: "agent" | "member"; id: string; name: string } | null>(null);
   const [role, setRole] = useState("");
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -466,13 +470,13 @@ function AddMemberDialog({
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Add Member</DialogTitle>
-          <DialogDescription>Add a workspace member or agent to this squad.</DialogDescription>
+          <DialogTitle>{t(($) => $.add_member_dialog.title)}</DialogTitle>
+          <DialogDescription>{t(($) => $.add_member_dialog.description)}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 min-w-0">
           <div>
-            <Label className="text-xs text-muted-foreground">Member</Label>
+            <Label className="text-xs text-muted-foreground">{t(($) => $.add_member_dialog.label_member)}</Label>
             <Popover open={pickerOpen} onOpenChange={(v) => { setPickerOpen(v); if (!v) setPickerFilter(""); }}>
               <PopoverTrigger className="flex w-full min-w-0 items-center gap-3 rounded-lg border border-border bg-background px-3 py-2.5 mt-1 text-left text-sm transition-colors hover:bg-muted">
                 {target ? (
@@ -545,7 +549,10 @@ function AddMemberDialog({
           </div>
 
           <div>
-            <Label className="text-xs text-muted-foreground">Role <span className="text-muted-foreground/60">(optional)</span></Label>
+            <Label className="text-xs text-muted-foreground">
+              {t(($) => $.add_member_dialog.label_role)}{" "}
+              <span className="text-muted-foreground/60">{t(($) => $.add_member_dialog.label_optional)}</span>
+            </Label>
             <Input
               type="text"
               value={role}
@@ -561,7 +568,7 @@ function AddMemberDialog({
         </div>
 
         <DialogFooter>
-          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button variant="ghost" onClick={onClose}>{t(($) => $.add_member_dialog.cancel)}</Button>
           <Button onClick={() => void handleSubmit()} disabled={!canSubmit}>
             {submitting ? <Loader2 className="size-3.5 animate-spin" /> : "Add"}
           </Button>
@@ -576,6 +583,7 @@ function AddMemberDialog({
 // commits on blur / Enter and cancels on Escape. Avoids opening a modal
 // for what is usually a one-word change.
 function RoleEditor({ value, onSave }: { value: string; onSave: (next: string) => Promise<void> }) {
+  const { t } = useT("squads");
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const [saving, setSaving] = useState(false);
@@ -621,7 +629,7 @@ function RoleEditor({ value, onSave }: { value: string; onSave: (next: string) =
       onClick={() => setEditing(true)}
       className="text-xs text-muted-foreground mt-0.5 text-left hover:text-foreground transition-colors"
     >
-      {value || <span className="italic opacity-60">Add role…</span>}
+      {value || <span className="italic opacity-60">{t(($) => $.add_member_dialog.placeholder_role_inline)}</span>}
     </button>
   );
 }
@@ -650,6 +658,7 @@ function SquadDetailInspector({
   onRename: (next: string) => Promise<void>;
   onUpdateDescription: (next: string) => Promise<void>;
 }) {
+  const { t } = useT("squads");
   const initials = squad.name
     .split(" ")
     .map((w) => w[0])
@@ -679,7 +688,7 @@ function SquadDetailInspector({
       {/* Details — read-only */}
       <div className="border-b px-5 py-4">
         <div className="mb-1 -mx-2 px-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Details
+          {t(($) => $.inspector.details_section)}
         </div>
         <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
           <InspectorRow label="Leader">
@@ -729,6 +738,7 @@ function SquadDescriptionEditor({
   value: string;
   onSave: (next: string) => Promise<void>;
 }) {
+  const { t } = useT("squads");
   const [open, setOpen] = useState(false);
   return (
     <>
@@ -740,7 +750,7 @@ function SquadDescriptionEditor({
         {value ? (
           <span className="text-muted-foreground">{value}</span>
         ) : (
-          <span className="italic text-muted-foreground/50">Add a description</span>
+          <span className="italic text-muted-foreground/50">{t(($) => $.description_dialog.placeholder_empty)}</span>
         )}
         <Pencil className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground" />
       </button>
@@ -769,6 +779,7 @@ function SquadDescriptionEditorBody({
   onSave: (next: string) => Promise<void>;
   onClose: () => void;
 }) {
+  const { t } = useT("squads");
   const [draft, setDraft] = useState(initialValue);
   const [saving, setSaving] = useState(false);
   const dirty = draft !== initialValue;
@@ -789,7 +800,7 @@ function SquadDescriptionEditorBody({
   return (
     <>
       <DialogHeader>
-        <DialogTitle>Edit description</DialogTitle>
+        <DialogTitle>{t(($) => $.description_dialog.title)}</DialogTitle>
       </DialogHeader>
       <textarea
         autoFocus
@@ -808,7 +819,7 @@ function SquadDescriptionEditorBody({
         className="w-full resize-none rounded-md border bg-transparent px-3 py-2 text-sm outline-none focus-visible:border-input"
       />
       <DialogFooter>
-        <Button variant="ghost" size="sm" onClick={onClose} disabled={saving}>Cancel</Button>
+        <Button variant="ghost" size="sm" onClick={onClose} disabled={saving}>{t(($) => $.description_dialog.cancel)}</Button>
         <Button size="sm" onClick={() => void commit()} disabled={saving || !dirty}>
           {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Save"}
         </Button>
@@ -852,6 +863,7 @@ function SquadOverviewPane({
   onSaveInstructions: (next: string) => Promise<void>;
   setLeaderPending: boolean;
 }) {
+  const { t } = useT("squads");
   const [activeTab, setActiveTab] = useState<SquadDetailTab>("members");
   const [activeDirty, setActiveDirty] = useState(false);
   const [pendingTab, setPendingTab] = useState<SquadDetailTab | null>(null);
@@ -920,15 +932,15 @@ function SquadOverviewPane({
         <AlertDialog open onOpenChange={(v) => { if (!v) setPendingTab(null); }}>
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+              <AlertDialogTitle>{t(($) => $.discard_changes_dialog.title)}</AlertDialogTitle>
               <AlertDialogDescription>
-                You have unsaved changes on this tab. Switching tabs will discard them.
+                {t(($) => $.discard_changes_dialog.description)}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Keep editing</AlertDialogCancel>
+              <AlertDialogCancel>{t(($) => $.discard_changes_dialog.keep_editing)}</AlertDialogCancel>
               <AlertDialogAction variant="destructive" onClick={commitTabChange}>
-                Discard
+                {t(($) => $.discard_changes_dialog.discard_button)}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
@@ -958,16 +970,19 @@ function SquadMembersTab({
   onUpdateRole: (m: SquadMember, role: string) => Promise<void>;
   setLeaderPending: boolean;
 }) {
+  const { t } = useT("squads");
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="text-sm font-medium">Members</h3>
-          <p className="text-xs text-muted-foreground mt-0.5">{members.length} member{members.length !== 1 ? "s" : ""} in this squad</p>
+          <h3 className="text-sm font-medium">{t(($) => $.members_tab.section_title)}</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {t(($) => $.members_tab.section_count, { count: members.length })}
+          </p>
         </div>
         <Button size="sm" variant="outline" onClick={onAddMemberClick}>
           <Plus className="size-3.5 mr-1.5" />
-          Add Member
+          {t(($) => $.members_tab.add_member_button)}
         </Button>
       </div>
 
@@ -982,7 +997,7 @@ function SquadMembersTab({
                 {isLeader(m) && (
                   <span className="inline-flex items-center gap-0.5 text-xs bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-1.5 py-0.5 rounded">
                     <Crown className="size-3" />
-                    Leader
+                    {t(($) => $.members_tab.leader_chip)}
                   </span>
                 )}
               </div>
@@ -1035,6 +1050,7 @@ function SquadInstructionsTab({
   onSave: (instructions: string) => Promise<void>;
   onDirtyChange?: (dirty: boolean) => void;
 }) {
+  const { t } = useT("squads");
   const [value, setValue] = useState(squad.instructions ?? "");
   const [saving, setSaving] = useState(false);
   const isDirty = value !== (squad.instructions ?? "");
@@ -1061,7 +1077,7 @@ function SquadInstructionsTab({
   return (
     <div className="flex h-full flex-col gap-4">
       <p className="text-xs text-muted-foreground">
-        Squad instructions are injected into the leader agent&apos;s prompt whenever it works on an issue assigned to this squad. Use them to give the leader squad-wide guidance, working agreements, or context the leader should follow on every task.
+        {t(($) => $.instructions_tab.description)}
       </p>
 
       <div className="flex-1 min-h-0 overflow-y-auto rounded-md border bg-background px-4 py-3 transition-colors focus-within:border-input">
@@ -1078,7 +1094,7 @@ function SquadInstructionsTab({
 
       <div className="flex items-center justify-end gap-3">
         {isDirty && (
-          <span className="text-xs text-muted-foreground">Unsaved changes</span>
+          <span className="text-xs text-muted-foreground">{t(($) => $.instructions_tab.unsaved_changes)}</span>
         )}
         <Button size="sm" onClick={handleSave} disabled={!isDirty || saving}>
           {saving ? (
@@ -1086,7 +1102,7 @@ function SquadInstructionsTab({
           ) : (
             <Save className="h-3.5 w-3.5" />
           )}
-          Save
+          {t(($) => $.instructions_tab.save_button)}
         </Button>
       </div>
     </div>

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -13,10 +13,12 @@ import { Input } from "@multica/ui/components/ui/input";
 import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import { useModalStore } from "@multica/core/modals";
 import type { Agent, Squad } from "@multica/core/types";
+import { useT } from "../../i18n";
 
 type Scope = "mine" | "all";
 
 export function SquadsPage() {
+  const { t } = useT("squads");
   const workspace = useCurrentWorkspace();
   const wsId = workspace?.id ?? "";
   const p = useWorkspacePaths();
@@ -65,14 +67,14 @@ export function SquadsPage() {
       <PageHeader className="justify-between px-5">
         <div className="flex items-center gap-2">
           <Users className="h-4 w-4 text-muted-foreground" />
-          <h1 className="text-sm font-medium">Squads</h1>
+          <h1 className="text-sm font-medium">{t(($) => $.page.title)}</h1>
           {!isLoading && squads.length > 0 && (
             <span className="text-xs text-muted-foreground tabular-nums">{squads.length}</span>
           )}
         </div>
         <Button size="sm" variant="outline" onClick={() => useModalStore.getState().open("create-squad")}>
           <Plus className="size-3.5 mr-1.5" />
-          New Squad
+          {t(($) => $.page.new_button)}
         </Button>
       </PageHeader>
 
@@ -82,7 +84,7 @@ export function SquadsPage() {
         ) : squads.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
             <Users className="size-10 text-muted-foreground/50" />
-            <p className="text-sm text-muted-foreground">No squads yet. Create one to get started.</p>
+            <p className="text-sm text-muted-foreground">{t(($) => $.page.empty_no_squads)}</p>
           </div>
         ) : (
           <>
@@ -104,7 +106,7 @@ export function SquadsPage() {
 
             {filtered.length === 0 ? (
               <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
-                <p className="text-sm text-muted-foreground">No squads match your filters.</p>
+                <p className="text-sm text-muted-foreground">{t(($) => $.page.empty_no_match)}</p>
               </div>
             ) : (
               <div className="flex-1 overflow-y-auto p-4">


### PR DESCRIPTION
## Why this exists

`@multica/views#lint` has been red on `main` since #2505 (Squad MVP). That PR landed 29 hardcoded English strings in JSX text nodes — concentrated in `squads-page.tsx` (4) and `squad-detail-page.tsx` (25) — which the package's eslint config enforces as **errors** via `i18next/no-literal-string`. Turbo cascades that lint failure into `@multica/web#build`, `@multica/desktop#build`, and `@multica/views#typecheck`, so every open PR's frontend CI currently goes red on `main` regardless of what the PR itself touches (this is why #2538 and #2540 both can't go green).

I considered disabling the rule for the Squad files via an eslint override, but Squad is a high-visibility surface — hiding the debt there would silently spread English-only UX into a flagship feature. Better to wire i18n up properly once and keep the lint rule as the guardrail it's meant to be.

## What changed

**New namespace plumbing**
- `packages/views/locales/en/squads.json` and `packages/views/locales/zh-Hans/squads.json` covering all 29 strings, grouped by surface (`page` / `inspector` / `name_editor` / `add_member_dialog` / `description_dialog` / `discard_changes_dialog` / `members_tab` / `instructions_tab`).
- Registered in `packages/views/locales/index.ts` and `packages/views/i18n/resources-types.ts` so `t($ => $.squads.*)` is type-safe (selector mode auto-completes).

**Component replacements**
- `squads-page.tsx` — `useT("squads")` + 4 literal swaps.
- `squad-detail-page.tsx` — `useT("squads")` added to every inner component that holds flagged text: `SquadDetailPage`, `InlineEditPopover`, `AddMemberDialog`, `RoleEditor`, `SquadDescriptionEditor`, `SquadDescriptionEditorBody`, `SquadOverviewPane`, `SquadMembersTab`, `SquadInstructionsTab`, `SquadDetailInspector`. Then literals replaced.
- Member count uses i18next's `_one` / `_other` plural suffixes via `t($ => $.members_tab.section_count, { count })` — matches the convention already in `runtimes/usage` and `agents`.

## What this doesn't fix

The eslint rule runs in `mode: "jsx-text-only"`, so it only catches **string children of JSX elements**. A handful of unflagged user-facing strings remain in Squad code:
- Tab labels living in the `squadDetailTabs` array (object-literal values, not JSX children)
- Ternary alternatives like `{saving ? <Loader/> : "Save"}` (JSX expression, not text node)
- The `confirm("Archive this squad?…")` inline prompt
- `toast.success("Leader updated")` messages

Those are real i18n gaps, but expanding scope here would turn a CI-unblock fix into a full Squad UX pass. Easy follow-up.

## Test plan
- [x] `pnpm --filter @multica/views lint` → **0 errors** (was 29). Remaining 13 warnings are pre-existing in unrelated files (search/onboarding/auth-initializer) and don't fail CI.
- [x] `pnpm typecheck` → 6/6 packages pass.
- [ ] CI green end-to-end on this branch.
- [ ] Squad pages render normally in both `en` and `zh-Hans` (manual smoke).