### PR TITLE
fix(tests): add squad mocks to unblock views test suite

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -66,6 +66,10 @@ vi.mock("@multica/core/workspace/queries", () => ({
     queryKey: ["workspaces", "ws-1", "agents"],
     queryFn: () => Promise.resolve([]),
   }),
+  squadListOptions: () => ({
+    queryKey: ["workspaces", "ws-1", "squads"],
+    queryFn: () => Promise.resolve([]),
+  }),
   assigneeFrequencyOptions: () => ({
     queryKey: ["workspaces", "ws-1", "assignee-frequency"],
     queryFn: () => Promise.resolve([]),

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -90,6 +90,7 @@ vi.mock("@multica/core/paths", () => ({
     projects: () => "/acme/projects",
     autopilots: () => "/acme/autopilots",
     agents: () => "/acme/agents",
+    squads: () => "/acme/squads",
     usage: () => "/acme/usage",
     runtimes: () => "/acme/runtimes",
     skills: () => "/acme/skills",


### PR DESCRIPTION
## Summary
- Restores 13 failing tests on `main` caused by missing squad mocks after [#2505](https://github.com/multica-ai/multica/pull/2505) (Squad MVP).
- `issues/components/issue-detail.test.tsx`: adds `squadListOptions` to the `@multica/core/workspace/queries` mock — AssigneePicker now reads it and crashed at render under the prior mock (10/14 cases red).
- `layout/app-sidebar.test.tsx`: adds `squads: () => "/acme/squads"` to the `useWorkspacePaths` mock — the workspace nav now references `p.squads()`, so all 3 PinRow cases hit `TypeError: p[item.key] is not a function`.
- No production code changes. Pure test-fixture catch-up.

Issue: [MUL-2158](https://multica.copilothub.ai/multica/issues/MUL-2158)

## Test plan
- [x] `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx` — 14/14 green
- [x] `pnpm --filter @multica/views exec vitest run layout/app-sidebar.test.tsx` — 3/3 green
- [x] `pnpm --filter @multica/views test` — full suite 436/436 green