### PR TITLE
fix: make quick-create output prefix agnostic

### DIFF
--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -98,10 +98,11 @@ func buildQuickCreatePrompt(task Task) string {
 
 	// output format
 	b.WriteString("Output format:\n")
-	b.WriteString("- Run exactly one `multica issue create` invocation. Do not retry for any reason — even on non-zero exit. The issue may already exist; another attempt would create a duplicate.\n")
-	b.WriteString("- After success, print exactly one line: `Created MUL-<n>: <title>` and exit. No commentary, no follow-up tool calls.\n")
+	b.WriteString("- Run exactly one `multica issue create --output json` invocation. Do not retry for any reason — even on non-zero exit. The issue may already exist; another attempt would create a duplicate.\n")
+	b.WriteString("- Parse the JSON response to read the created issue's `identifier` (preferred) or `id` (fallback). Do not scrape human output and do not assume any workspace issue prefix such as `MUL-`; workspaces can use custom prefixes like `KCA-`.\n")
+	b.WriteString("- After success, print exactly one line: `Created <identifier-or-id>: <title>` and exit. No commentary, no follow-up tool calls.\n")
 	b.WriteString("- Do NOT call `multica issue get` or `multica issue comment add` — there is no issue to query or comment on.\n")
-	b.WriteString("- On CLI error, exit with the error as the only output. The platform writes a failure notification automatically.\n")
+	b.WriteString("- On CLI error or JSON parse error, exit with the error as the only output. The platform writes a failure notification automatically.\n")
 	return b.String()
 }
 

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -30,6 +30,16 @@ func TestBuildQuickCreatePromptRules(t *testing.T) {
 		// context section is conditional and must not be an apology log
 		"include ONLY when the input cited external resources",
 		"never use it as an apology log",
+		// output/reporting must be workspace-prefix agnostic. A K3 Lens
+		// production run regressed when the prompt told quick-create agents
+		// to print `Created MUL-<n>`; the workspace used KCA-* identifiers,
+		// so the wrapper produced `Created : ...` despite a successful create.
+		"multica issue create --output json",
+		"JSON response",
+		"identifier",
+		"Do not scrape human output",
+		"do not assume any workspace issue prefix",
+		"Created <identifier-or-id>: <title>",
 		// hard rules
 		"never invent requirements",
 		"never reduce multi-sentence input",


### PR DESCRIPTION
## Summary
- Updates the quick-create prompt to require `multica issue create --output json`.
- Tells agents to parse `identifier`/`id` from JSON instead of scraping human output or assuming `MUL-*`.
- Locks the prefix-agnostic output contract in `TestBuildQuickCreatePromptRules`.

## Why
A K3 Lens quick-create run successfully created an issue in a workspace whose prefix is `KCA`, but the prompt required `Created MUL-<n>`. The agent's wrapper grepped for `MUL-[0-9]+`, then produced malformed output (`Created : ...`) even though the backend accepted, claimed, and completed the task. The prompt should not encode a workspace-specific prefix.

## Test Plan
- `docker run --rm -v "$PWD:/src" -w /src/server golang:1.26 sh -lc 'export PATH=/usr/local/go/bin:$PATH; gofmt -w internal/daemon/prompt.go internal/daemon/prompt_test.go && go test ./internal/daemon'`
