### PR TITLE
feat(cli): add `multica issue cancel-task <task-id>` command

### DIFF
--- a/server/cmd/multica/cmd_issue.go
+++ b/server/cmd/multica/cmd_issue.go
@@ -204,6 +204,16 @@ var issueRerunCmd = &cobra.Command{
 	RunE:  runIssueRerun,
 }
 
+var issueCancelTaskCmd = &cobra.Command{
+	Use:   "cancel-task <task-id>",
+	Short: "Cancel a running or queued task (interrupts in-flight agent)",
+	Long: "Cancel a single task by its ID. Accepts the short ID prefix shown by `issue runs`. " +
+		"Use --issue to scope short-ID resolution to a specific issue when ambiguous. " +
+		"Triggers daemon-side interrupt of any in-flight agent so it stops emitting tool calls promptly.",
+	Args: exactArgs(1),
+	RunE: runIssueCancelTask,
+}
+
 var issueSearchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search issues by title or description",
@@ -227,6 +237,7 @@ func init() {
 	issueCmd.AddCommand(issueRunsCmd)
 	issueCmd.AddCommand(issueRunMessagesCmd)
 	issueCmd.AddCommand(issueRerunCmd)
+	issueCmd.AddCommand(issueCancelTaskCmd)
 	issueCmd.AddCommand(issueSearchCmd)
 
 	issueCommentCmd.AddCommand(issueCommentListCmd)
@@ -299,7 +310,9 @@ func init() {
 
 	// issue rerun
 	issueRerunCmd.Flags().String("output", "json", "Output format: table or json")
-
+	// issue cancel-task
+	issueCancelTaskCmd.Flags().String("output", "json", "Output format: table or json")
+	issueCancelTaskCmd.Flags().String("issue", "", "Issue ID/key to scope short task ID prefix resolution")
 	// issue run-messages
 	issueRunMessagesCmd.Flags().String("output", "json", "Output format: table or json")
 	issueRunMessagesCmd.Flags().Int("since", 0, "Only return messages after this sequence number")
@@ -1153,6 +1166,51 @@ func runIssueRerun(cmd *cobra.Command, args []string) error {
 	}
 	agent := loadActorDisplayLookup(ctx, client).agent(strVal(task, "agent_id"))
 	fmt.Fprintf(os.Stdout, "Re-enqueued task %s on agent %s\n", strVal(task, "id"), agent)
+	return nil
+}
+
+// runIssueCancelTask cancels a single task by ID. It accepts the short ID
+// prefix shown by `issue runs` (resolved through resolveTaskRunID), and uses
+// /api/tasks/{taskId}/cancel which both updates the DB row to status=cancelled
+// and triggers the daemon-side interrupt path (#2107) so an in-flight agent
+// stops emitting tool calls promptly instead of running until its own timeout.
+func runIssueCancelTask(cmd *cobra.Command, args []string) error {
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	issueScope := ""
+	if issueInput, _ := cmd.Flags().GetString("issue"); issueInput != "" {
+		issueRef, err := resolveIssueRef(ctx, client, issueInput)
+		if err != nil {
+			return fmt.Errorf("resolve issue: %w", err)
+		}
+		issueScope = issueRef.ID
+	}
+	taskRef, err := resolveTaskRunID(ctx, client, issueScope, args[0])
+	if err != nil {
+		return fmt.Errorf("resolve task run: %w", err)
+	}
+
+	var result map[string]any
+	path := "/api/tasks/" + url.PathEscape(taskRef.ID) + "/cancel"
+	if err := client.PostJSON(ctx, path, map[string]any{}, &result); err != nil {
+		return fmt.Errorf("cancel task: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "json" {
+		return cli.PrintJSON(os.Stdout, result)
+	}
+	status := strVal(result, "status")
+	if status == "" {
+		status = "cancelled"
+	}
+	fmt.Fprintf(os.Stdout, "Task %s -> status=%s\n", taskRef.ID, status)
 	return nil
 }
 


### PR DESCRIPTION
## What

Adds a CLI subcommand to cancel a single agent task by ID:

```bash
multica issue cancel-task <task-id> [--issue <id>] [--output json|table]
```

## Why

The backend already exposes `POST /api/tasks/{taskId}/cancel` (`Handler.CancelTaskByUser` in `server/internal/handler/chat.go`), and #2107 made the daemon side actually interrupt the in-flight agent on cancel. Until now there was no CLI surface for it — operators had to hand-craft an authenticated curl, or set the whole issue to `cancelled` (which is broader and harder to recover from).

Concrete trigger: an agent on our fork pushed 14 commits in 1h20min on a single PR while we tried to stop it. The only available knobs (`issue rerun`, `issue assign --unassign`, `issue status done`) all act on the issue or queue new work; none of them stop an already-running task. We ended up admin-bypassing branch protection just to get the PR off our screen. `cancel-task` is the smallest CLI addition that closes that gap.

## How

- New cobra command `issueCancelTaskCmd`, mirroring `issueRerunCmd` and `issueRunMessagesCmd`:
  - Accepts the same short task-ID prefix that `issue runs` and `run-messages` accept (`resolveTaskRunID`).
  - Optional `--issue <id>` to scope the prefix lookup when the user has more than one issue with the same prefix.
  - `--output json` for scripting.
- Wired into `init()` next to `rerun`.
- Calls the existing `POST /api/tasks/{id}/cancel` endpoint via `client.PostJSON`. No new backend code, no new schema.

Total diff: 1 file, +59/-1.

## Test

- `go build ./server/...` ✓
- `go vet ./server/...` ✓
- `go test ./server/internal/...` ✓ (full server suite passes locally)
- Manual: ran against a live workspace, confirmed status flips `running` → `cancelled` and the daemon stops emitting tool calls within seconds (the #2107 path).

## Compatibility

- No new flags or env vars.
- No DB changes.
- Pure additive CLI command — does not change behavior of any existing command.

## Out of scope (happy to follow up)

- A `cancel-tasks-for-issue` batch wrapper. The same effect is one jq away today (`multica issue runs ... | jq | xargs cancel-task`); a dedicated subcommand can land later if the pipeline pattern proves common.
- Cancel by chat session ID. The backend handler already supports this code path (`task.ChatSessionID.Valid`), but `resolveTaskRunID` is currently issue-scoped; a separate flag could be added when needed.