### PR TITLE
fix(repocache): strip embedded credentials from bare cache remote URL

### DIFF
--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -258,7 +258,35 @@ func gitCloneBare(url, dest string) error {
 		os.RemoveAll(dest)
 		return fmt.Errorf("configure fetch refspec: %w", err)
 	}
+	sanitizeRemoteURL(dest)
 	return nil
+}
+
+// sanitizeRemoteURL strips embedded credentials from the bare cache's
+// remote.origin.url if present. An external process (or a user-supplied
+// clone URL) may embed user:password in the URL; worktrees inherit the
+// bare cache's remote config, so credentials would leak into every
+// worktree's git environment. Best-effort: failures are silently ignored.
+func sanitizeRemoteURL(barePath string) {
+	cmd := exec.Command("git", "-C", barePath, "config", "--get", "remote.origin.url")
+	cmd.Env = gitEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return
+	}
+	raw := strings.TrimSpace(string(out))
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return // SSH scp-style or unparseable — nothing to strip
+	}
+	if u.User == nil {
+		return // no credentials embedded
+	}
+	u.User = nil
+	clean := u.String()
+	setURL := exec.Command("git", "-C", barePath, "remote", "set-url", "origin", clean)
+	setURL.Env = gitEnv()
+	_ = setURL.Run()
 }
 
 // gitFetch runs `git fetch origin` on a bare cache, migrating its fetch
@@ -408,6 +436,7 @@ func (c *Cache) CreateWorktree(params WorktreeParams) (*WorktreeResult, error) {
 			"error", err,
 		)
 	}
+	sanitizeRemoteURL(barePath)
 
 	// Determine the ref to base the worktree on. By default this is the remote's
 	// default branch (resolved internally via getRemoteDefaultBranch, which walks

--- a/server/internal/daemon/repocache/cache_test.go
+++ b/server/internal/daemon/repocache/cache_test.go
@@ -1411,6 +1411,86 @@ func TestRemoveCoAuthoredByHookPreservesUserHook(t *testing.T) {
 	}
 }
 
+// TestSanitizeRemoteURL verifies that embedded credentials in a bare cache's
+// remote.origin.url are stripped after clone or fetch.
+func TestSanitizeRemoteURL(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	cacheRoot := t.TempDir()
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	barePath := cache.Lookup("ws-1", sourceRepo)
+
+	// Inject a credential-embedded URL into the bare cache.
+	credURL := "https://user:token@github.com/org/repo.git"
+	cmd := exec.Command("git", "-C", barePath, "remote", "set-url", "origin", credURL)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("set-url failed: %s: %v", out, err)
+	}
+
+	sanitizeRemoteURL(barePath)
+
+	got := gitConfigGet(t, barePath, "remote.origin.url")
+	if strings.Contains(got, "user") || strings.Contains(got, "token") {
+		t.Fatalf("credentials not stripped: remote.origin.url = %q", got)
+	}
+	if got != "https://github.com/org/repo.git" {
+		t.Fatalf("unexpected URL after sanitize: %q", got)
+	}
+}
+
+// TestSanitizeRemoteURLNoOp verifies that a clean URL is left unchanged.
+func TestSanitizeRemoteURLNoOp(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	cacheRoot := t.TempDir()
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	barePath := cache.Lookup("ws-1", sourceRepo)
+
+	cleanURL := "https://github.com/org/repo.git"
+	cmd := exec.Command("git", "-C", barePath, "remote", "set-url", "origin", cleanURL)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("set-url failed: %s: %v", out, err)
+	}
+
+	sanitizeRemoteURL(barePath)
+
+	got := gitConfigGet(t, barePath, "remote.origin.url")
+	if got != cleanURL {
+		t.Fatalf("clean URL changed: got %q, want %q", got, cleanURL)
+	}
+}
+
+// TestSanitizeRemoteURLSSH verifies that SSH scp-style URLs are left unchanged.
+func TestSanitizeRemoteURLSSH(t *testing.T) {
+	t.Parallel()
+	sourceRepo := createTestRepo(t)
+	cacheRoot := t.TempDir()
+	cache := New(cacheRoot, testLogger())
+	if err := cache.Sync("ws-1", []RepoInfo{{URL: sourceRepo}}); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	barePath := cache.Lookup("ws-1", sourceRepo)
+
+	sshURL := "git@github.com:org/repo.git"
+	cmd := exec.Command("git", "-C", barePath, "remote", "set-url", "origin", sshURL)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("set-url failed: %s: %v", out, err)
+	}
+
+	sanitizeRemoteURL(barePath)
+
+	got := gitConfigGet(t, barePath, "remote.origin.url")
+	if got != sshURL {
+		t.Fatalf("SSH URL changed: got %q, want %q", got, sshURL)
+	}
+}
+
 // TestGetRemoteDefaultBranchAmbiguousOriginReturnsEmpty verifies step 4's
 // safe-scan gating: when the cache has multiple refs/remotes/origin/*
 // entries, none match the common defaults, and none match the bare HEAD


### PR DESCRIPTION
## Summary

Fixes #2554

Strips embedded credentials (e.g. `user:token@`) from a bare cache's `remote.origin.url` after clone and before worktree creation. This prevents credential leakage into agent-visible surfaces when an external process modifies the cache's remote URL to include authentication tokens.

## Changes

- **`cache.go`**: Add `sanitizeRemoteURL(barePath)` that reads the cached `remote.origin.url`, parses it with `net/url`, and strips any `User` info. Called:
  - After `gitCloneBare()` completes (defense against credential-embedded clone URLs)
  - In `CreateWorktree()` after fetch (defense against external mutation between clone and checkout)
  - SSH scp-style URLs (`git@host:path`) are left unchanged (no credential embedding in that form)
  - Best-effort: failures are silently ignored to avoid blocking clone/checkout

- **`cache_test.go`**: Three new tests:
  - `TestSanitizeRemoteURL` — verifies credential-embedded URL is cleaned
  - `TestSanitizeRemoteURLNoOp` — verifies clean URL is left unchanged
  - `TestSanitizeRemoteURLSSH` — verifies SSH URL is not altered

## Testing

```
go test -run TestSanitizeRemoteURL -v ./...
--- PASS: TestSanitizeRemoteURLSSH (0.27s)
--- PASS: TestSanitizeRemoteURLNoOp (0.27s)
--- PASS: TestSanitizeRemoteURL (0.28s)
PASS
```

Note: `TestCreateWorktreeInstallsCoAuthoredByHook` fails on upstream/main (pre-existing, unrelated to this change).