### PR TITLE
fix(squad): skip leader when a member @mentions anyone (MUL-2170)

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -274,8 +274,9 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Squad trigger: if the issue is assigned to a squad, trigger the squad leader.
-	// Skip when the comment author is a squad member (prevent internal loops).
-	if h.shouldEnqueueSquadLeaderOnComment(r.Context(), issue, authorType, authorID) {
+	// Skip when the comment author is a squad member (prevent internal loops),
+	// or when a member explicitly @mentions any agent (that agent handles it).
+	if h.shouldEnqueueSquadLeaderOnComment(r.Context(), issue, comment.Content, authorType, authorID) {
 		h.enqueueSquadLeaderTask(r.Context(), issue, comment.ID, authorType, authorID)
 	}
 

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -274,8 +274,9 @@ func (h *Handler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Squad trigger: if the issue is assigned to a squad, trigger the squad leader.
-	// Skip when the comment author is a squad member (prevent internal loops),
-	// or when a member explicitly @mentions any agent (that agent handles it).
+	// Skip when the comment author is the leader (prevent internal loops), or
+	// when a member explicitly @mentions anyone (agent/member/squad/all) — that
+	// counts as deliberate routing and the leader stays out.
 	if h.shouldEnqueueSquadLeaderOnComment(r.Context(), issue, comment.Content, authorType, authorID) {
 		h.enqueueSquadLeaderTask(r.Context(), issue, comment.ID, authorType, authorID)
 	}

--- a/server/internal/handler/squad.go
+++ b/server/internal/handler/squad.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -583,7 +584,12 @@ func (h *Handler) RecordSquadLeaderEvaluation(w http.ResponseWriter, r *http.Req
 
 // shouldEnqueueSquadLeaderOnComment returns true if the issue is assigned to a
 // squad and the comment author is NOT a member of that squad (anti-loop).
-func (h *Handler) shouldEnqueueSquadLeaderOnComment(ctx context.Context, issue db.Issue, authorType, authorID string) bool {
+// commentContent is the new comment's markdown body; when a member explicitly
+// @mentions any agent in that body, the leader is skipped so the @mentioned
+// agent handles the request directly. Agent-authored comments always go through
+// the leader (subject to the leader self-trigger guard) so agent updates still
+// drive coordination.
+func (h *Handler) shouldEnqueueSquadLeaderOnComment(ctx context.Context, issue db.Issue, commentContent, authorType, authorID string) bool {
 	if !issue.AssigneeType.Valid || issue.AssigneeType.String != "squad" || !issue.AssigneeID.Valid {
 		return false
 	}
@@ -604,6 +610,14 @@ func (h *Handler) shouldEnqueueSquadLeaderOnComment(ctx context.Context, issue d
 		return false
 	}
 
+	// Member explicitly @mentioned an agent → that agent owns the next step,
+	// skip the leader. Agent-authored comments are intentionally exempt: when
+	// an agent posts a result that @mentions another agent, the leader still
+	// needs to coordinate the thread.
+	if authorType == "member" && commentMentionsAnyAgent(commentContent) {
+		return false
+	}
+
 	// Verify leader agent is ready (has runtime, not archived).
 	agent, err := h.Queries.GetAgent(ctx, squad.LeaderID)
 	if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
@@ -611,6 +625,18 @@ func (h *Handler) shouldEnqueueSquadLeaderOnComment(ctx context.Context, issue d
 	}
 
 	return true
+}
+
+// commentMentionsAnyAgent returns true when the comment body contains at least
+// one [@Name](mention://agent/<id>) link. Only the current comment is
+// inspected — parent (thread root) mentions are NOT inherited here.
+func commentMentionsAnyAgent(content string) bool {
+	for _, m := range util.ParseMentions(content) {
+		if m.Type == "agent" {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldEnqueueSquadLeaderOnAssign returns true when assigning an issue to a

--- a/server/internal/handler/squad.go
+++ b/server/internal/handler/squad.go
@@ -585,10 +585,12 @@ func (h *Handler) RecordSquadLeaderEvaluation(w http.ResponseWriter, r *http.Req
 // shouldEnqueueSquadLeaderOnComment returns true if the issue is assigned to a
 // squad and the comment author is NOT a member of that squad (anti-loop).
 // commentContent is the new comment's markdown body; when a member explicitly
-// @mentions any agent in that body, the leader is skipped so the @mentioned
-// agent handles the request directly. Agent-authored comments always go through
-// the leader (subject to the leader self-trigger guard) so agent updates still
-// drive coordination.
+// @mentions anyone (agent, member, squad, or @all) in that body, the leader
+// is skipped — the @ marks deliberate routing and the leader would otherwise
+// just observe and record no_action. Issue cross-reference mentions
+// (mention://issue/...) are NOT a routing signal and do not suppress the
+// leader. Agent-authored comments always go through the leader (subject to
+// the leader self-trigger guard) so agent updates still drive coordination.
 func (h *Handler) shouldEnqueueSquadLeaderOnComment(ctx context.Context, issue db.Issue, commentContent, authorType, authorID string) bool {
 	if !issue.AssigneeType.Valid || issue.AssigneeType.String != "squad" || !issue.AssigneeID.Valid {
 		return false
@@ -610,11 +612,12 @@ func (h *Handler) shouldEnqueueSquadLeaderOnComment(ctx context.Context, issue d
 		return false
 	}
 
-	// Member explicitly @mentioned an agent → that agent owns the next step,
-	// skip the leader. Agent-authored comments are intentionally exempt: when
-	// an agent posts a result that @mentions another agent, the leader still
-	// needs to coordinate the thread.
-	if authorType == "member" && commentMentionsAnyAgent(commentContent) {
+	// Member explicitly @mentioned someone → that someone owns the next step,
+	// skip the leader. Covers @agent / @member / @squad / @all; issue
+	// cross-references do NOT count as routing. Agent-authored comments are
+	// intentionally exempt: when an agent posts a result that @mentions
+	// another agent, the leader still needs to coordinate the thread.
+	if authorType == "member" && commentMentionsAnyone(commentContent) {
 		return false
 	}
 
@@ -627,12 +630,15 @@ func (h *Handler) shouldEnqueueSquadLeaderOnComment(ctx context.Context, issue d
 	return true
 }
 
-// commentMentionsAnyAgent returns true when the comment body contains at least
-// one [@Name](mention://agent/<id>) link. Only the current comment is
-// inspected — parent (thread root) mentions are NOT inherited here.
-func commentMentionsAnyAgent(content string) bool {
+// commentMentionsAnyone returns true when the comment body contains at least
+// one routing-style mention — [@Name](mention://agent|member|squad|all/<id>).
+// Issue cross-references (mention://issue/...) are ignored because they are
+// not directed at a participant. Only the current comment is inspected —
+// parent (thread root) mentions are NOT inherited here.
+func commentMentionsAnyone(content string) bool {
 	for _, m := range util.ParseMentions(content) {
-		if m.Type == "agent" {
+		switch m.Type {
+		case "agent", "member", "squad", "all":
 			return true
 		}
 	}

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -1,0 +1,181 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/util"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// TestCommentMentionsAnyAgent covers the pure helper that drives the new
+// "skip leader on @agent" behavior. Kept as a unit test so it runs without
+// a database connection.
+func TestCommentMentionsAnyAgent(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "empty", content: "", want: false},
+		{name: "plain text", content: "please take a look", want: false},
+		{name: "literal at sign only", content: "ping @alice", want: false},
+		{name: "agent mention", content: "[@A](mention://agent/11111111-1111-1111-1111-111111111111) handle this", want: true},
+		{name: "member mention only", content: "[@Bob](mention://member/22222222-2222-2222-2222-222222222222)", want: false},
+		{name: "issue mention only", content: "see [MUL-1](mention://issue/33333333-3333-3333-3333-333333333333)", want: false},
+		{name: "squad mention only", content: "[@Squad](mention://squad/44444444-4444-4444-4444-444444444444)", want: false},
+		{name: "mention all", content: "[@all](mention://all/all)", want: false},
+		{name: "agent plus member", content: "[@A](mention://agent/11111111-1111-1111-1111-111111111111) cc [@B](mention://member/22222222-2222-2222-2222-222222222222)", want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commentMentionsAnyAgent(tc.content); got != tc.want {
+				t.Fatalf("commentMentionsAnyAgent(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+// squadCommentTriggerFixture wires a squad assigned to a fresh issue and
+// returns the loaded db.Issue plus the leader agent UUID for use in
+// shouldEnqueueSquadLeaderOnComment integration tests.
+type squadCommentTriggerFixture struct {
+	Issue    db.Issue
+	SquadID  string
+	LeaderID string
+	OtherID  string // second agent in workspace (with runtime), used as a non-leader @mention target
+}
+
+func newSquadCommentTriggerFixture(t *testing.T) squadCommentTriggerFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	// Reuse the seeded "Handler Test Agent" as the leader — it has a runtime.
+	var leaderID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1
+	`, testWorkspaceID).Scan(&leaderID); err != nil {
+		t.Fatalf("load leader agent: %v", err)
+	}
+
+	// Spin up a second agent in the same workspace as a non-leader mention
+	// target. createHandlerTestAgent installs a t.Cleanup row deletion.
+	otherID := createHandlerTestAgent(t, "Squad Comment Other", nil)
+
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, $2, '', $3, $4)
+		RETURNING id
+	`, testWorkspaceID, "Squad Comment Trigger", leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+	})
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title, assignee_type, assignee_id)
+		VALUES ($1, 'member', $2, $3, 'squad', $4)
+		RETURNING id
+	`, testWorkspaceID, testUserID, "squad comment trigger", squadID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	issue, err := testHandler.Queries.GetIssue(ctx, util.MustParseUUID(issueID))
+	if err != nil {
+		t.Fatalf("load issue: %v", err)
+	}
+
+	return squadCommentTriggerFixture{
+		Issue:    issue,
+		SquadID:  squadID,
+		LeaderID: leaderID,
+		OtherID:  otherID,
+	}
+}
+
+// TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyAgent
+// encodes Bohan's rule (MUL-2170): a human comment that explicitly @mentions
+// any agent — whether the leader, another squad member, or an unrelated
+// workspace agent — must not also wake the leader. The mentioned agent owns
+// the next step, so the leader stays asleep to cut queue noise.
+func TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyAgent(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	fx := newSquadCommentTriggerFixture(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name        string
+		content     string
+		authorType  string
+		authorID    string
+		want        bool
+		description string
+	}{
+		{
+			name:        "member plain comment triggers leader",
+			content:     "what is the latest on this?",
+			authorType:  "member",
+			authorID:    testUserID,
+			want:        true,
+			description: "no @agent in body → leader must coordinate as today",
+		},
+		{
+			name:        "member member-only mention still triggers leader",
+			content:     "[@" + testUserID[:8] + "](mention://member/" + testUserID + ") please weigh in",
+			authorType:  "member",
+			authorID:    testUserID,
+			want:        true,
+			description: "@member is not @agent — leader still owns routing",
+		},
+		{
+			name:        "member mentions non-leader agent skips leader",
+			content:     "[@Other](mention://agent/" + fx.OtherID + ") please take this",
+			authorType:  "member",
+			authorID:    testUserID,
+			want:        false,
+			description: "user routed directly to an agent → leader stays asleep",
+		},
+		{
+			name:        "member mentions leader skips leader on comment path",
+			content:     "[@Leader](mention://agent/" + fx.LeaderID + ") your call",
+			authorType:  "member",
+			authorID:    testUserID,
+			want:        false,
+			description: "even @leader is dispatched via the mention path; comment path must not double-enqueue",
+		},
+		{
+			name:        "agent comment with @agent still triggers leader",
+			content:     "delegating to [@Other](mention://agent/" + fx.OtherID + ")",
+			authorType:  "agent",
+			authorID:    fx.OtherID,
+			want:        true,
+			description: "agent-authored replies always reach leader so it can coordinate next step",
+		},
+		{
+			name:        "leader self-comment does NOT re-trigger leader",
+			content:     "noted",
+			authorType:  "agent",
+			authorID:    fx.LeaderID,
+			want:        false,
+			description: "existing self-trigger guard must still hold",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := testHandler.shouldEnqueueSquadLeaderOnComment(ctx, fx.Issue, tc.content, tc.authorType, tc.authorID)
+			if got != tc.want {
+				t.Fatalf("%s\n  content=%q author=%s/%s\n  got=%v want=%v",
+					tc.description, tc.content, tc.authorType, tc.authorID, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -11,10 +11,11 @@ import (
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
-// TestCommentMentionsAnyAgent covers the pure helper that drives the new
-// "skip leader on @agent" behavior. Kept as a unit test so it runs without
-// a database connection.
-func TestCommentMentionsAnyAgent(t *testing.T) {
+// TestCommentMentionsAnyone covers the pure helper that drives the
+// "skip leader on @<anyone>" behavior. Routing-style mentions
+// (agent/member/squad/all) count; issue cross-references do not. Kept as a
+// unit test so it runs without a database connection.
+func TestCommentMentionsAnyone(t *testing.T) {
 	cases := []struct {
 		name    string
 		content string
@@ -24,16 +25,18 @@ func TestCommentMentionsAnyAgent(t *testing.T) {
 		{name: "plain text", content: "please take a look", want: false},
 		{name: "literal at sign only", content: "ping @alice", want: false},
 		{name: "agent mention", content: "[@A](mention://agent/11111111-1111-1111-1111-111111111111) handle this", want: true},
-		{name: "member mention only", content: "[@Bob](mention://member/22222222-2222-2222-2222-222222222222)", want: false},
+		{name: "member mention", content: "[@Bob](mention://member/22222222-2222-2222-2222-222222222222)", want: true},
+		{name: "squad mention", content: "[@Squad](mention://squad/44444444-4444-4444-4444-444444444444)", want: true},
+		{name: "mention all", content: "[@all](mention://all/all)", want: true},
 		{name: "issue mention only", content: "see [MUL-1](mention://issue/33333333-3333-3333-3333-333333333333)", want: false},
-		{name: "squad mention only", content: "[@Squad](mention://squad/44444444-4444-4444-4444-444444444444)", want: false},
-		{name: "mention all", content: "[@all](mention://all/all)", want: false},
+		{name: "issue + plain text", content: "see [MUL-1](mention://issue/33333333-3333-3333-3333-333333333333) for context", want: false},
 		{name: "agent plus member", content: "[@A](mention://agent/11111111-1111-1111-1111-111111111111) cc [@B](mention://member/22222222-2222-2222-2222-222222222222)", want: true},
+		{name: "issue plus member", content: "blocks [MUL-1](mention://issue/33333333-3333-3333-3333-333333333333) — [@Bob](mention://member/22222222-2222-2222-2222-222222222222)", want: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := commentMentionsAnyAgent(tc.content); got != tc.want {
-				t.Fatalf("commentMentionsAnyAgent(%q) = %v, want %v", tc.content, got, tc.want)
+			if got := commentMentionsAnyone(tc.content); got != tc.want {
+				t.Fatalf("commentMentionsAnyone(%q) = %v, want %v", tc.content, got, tc.want)
 			}
 		})
 	}
@@ -102,12 +105,12 @@ func newSquadCommentTriggerFixture(t *testing.T) squadCommentTriggerFixture {
 	}
 }
 
-// TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyAgent
-// encodes Bohan's rule (MUL-2170): a human comment that explicitly @mentions
-// any agent — whether the leader, another squad member, or an unrelated
-// workspace agent — must not also wake the leader. The mentioned agent owns
-// the next step, so the leader stays asleep to cut queue noise.
-func TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyAgent(t *testing.T) {
+// TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyone
+// encodes Bohan's rule (MUL-2170): a member comment that explicitly @mentions
+// anyone — agent, member, squad, or @all — must NOT wake the squad leader.
+// Issue cross-references are not routing and do not suppress the leader.
+// Agent-authored comments are exempt: the leader still coordinates threads.
+func TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyone(t *testing.T) {
 	if testHandler == nil || testPool == nil {
 		t.Skip("database not available")
 	}
@@ -128,15 +131,23 @@ func TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyAgent(t *te
 			authorType:  "member",
 			authorID:    testUserID,
 			want:        true,
-			description: "no @agent in body → leader must coordinate as today",
+			description: "no @ in body → leader must coordinate as today",
 		},
 		{
-			name:        "member member-only mention still triggers leader",
-			content:     "[@" + testUserID[:8] + "](mention://member/" + testUserID + ") please weigh in",
+			name:        "member issue cross-reference only triggers leader",
+			content:     "blocked by [MUL-1](mention://issue/" + testUserID + ")",
 			authorType:  "member",
 			authorID:    testUserID,
 			want:        true,
-			description: "@member is not @agent — leader still owns routing",
+			description: "issue mentions are not routing — leader still owns dispatch",
+		},
+		{
+			name:        "member mentions another member skips leader",
+			content:     "[@self](mention://member/" + testUserID + ") please weigh in",
+			authorType:  "member",
+			authorID:    testUserID,
+			want:        false,
+			description: "user routed at a human — leader stays out (extended rule)",
 		},
 		{
 			name:        "member mentions non-leader agent skips leader",
@@ -144,7 +155,7 @@ func TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyAgent(t *te
 			authorType:  "member",
 			authorID:    testUserID,
 			want:        false,
-			description: "user routed directly to an agent → leader stays asleep",
+			description: "user routed at an agent — leader stays out",
 		},
 		{
 			name:        "member mentions leader skips leader on comment path",
@@ -153,6 +164,22 @@ func TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyAgent(t *te
 			authorID:    testUserID,
 			want:        false,
 			description: "even @leader is dispatched via the mention path; comment path must not double-enqueue",
+		},
+		{
+			name:        "member mention all skips leader",
+			content:     "[@all](mention://all/all) heads up",
+			authorType:  "member",
+			authorID:    testUserID,
+			want:        false,
+			description: "@all is a broadcast — leader does not need to wake to evaluate routing",
+		},
+		{
+			name:        "member mentions a squad skips leader",
+			content:     "handing to [@Other Squad](mention://squad/" + fx.SquadID + ")",
+			authorType:  "member",
+			authorID:    testUserID,
+			want:        false,
+			description: "@squad routes the issue to that squad's leader — current leader stays out",
 		},
 		{
 			name:        "agent comment with @agent still triggers leader",

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -2,6 +2,9 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/multica-ai/multica/server/internal/util"
@@ -177,5 +180,82 @@ func TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyAgent(t *te
 					tc.description, tc.content, tc.authorType, tc.authorID, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestCreateComment_SquadLeaderSkipOnlyInspectsCurrentMention drives the
+// full CreateComment handler to lock the call-site wiring (comment.go) for
+// the squad-leader-skip rule. Specifically it proves that:
+//
+//   - A member top-level comment that @mentions another agent does NOT
+//     enqueue the squad leader (the mentioned agent owns the next step).
+//   - A subsequent member REPLY in the same thread, containing no mentions
+//     of its own, DOES enqueue the squad leader — i.e. the parent's
+//     @agent mention is not inherited into the leader-skip decision.
+//
+// The matching unit test above exercises the helper in isolation; this
+// test catches a class of regression where someone refactors comment.go
+// to pass the parent's content (or the merged thread content) by mistake.
+func TestCreateComment_SquadLeaderSkipOnlyInspectsCurrentMention(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+	fx := newSquadCommentTriggerFixture(t)
+	issueID := uuidToString(fx.Issue.ID)
+
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+	})
+
+	countQueued := func(agentID string) int {
+		var n int
+		if err := testPool.QueryRow(ctx,
+			`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'`,
+			issueID, agentID,
+		).Scan(&n); err != nil {
+			t.Fatalf("count tasks for %s: %v", agentID, err)
+		}
+		return n
+	}
+
+	postMemberComment := func(body map[string]any) CommentResponse {
+		t.Helper()
+		w := httptest.NewRecorder()
+		r := newRequest("POST", "/api/issues/"+issueID+"/comments", body)
+		r = withURLParam(r, "id", issueID)
+		testHandler.CreateComment(w, r)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp CommentResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode comment: %v", err)
+		}
+		return resp
+	}
+
+	// 1. Member top-level comment mentions OtherAgent.
+	//    Leader must be skipped; OtherAgent must be enqueued via the mention path.
+	parent := postMemberComment(map[string]any{
+		"content": "[@Other](mention://agent/" + fx.OtherID + ") please take this",
+	})
+	if got := countQueued(fx.LeaderID); got != 0 {
+		t.Fatalf("after parent (@OtherAgent): expected 0 leader tasks (skipped), got %d", got)
+	}
+	if got := countQueued(fx.OtherID); got != 1 {
+		t.Fatalf("after parent (@OtherAgent): expected 1 OtherAgent task (mention path), got %d", got)
+	}
+
+	// 2. Member posts a reply in the same thread with NO mentions.
+	//    The leader-skip helper must inspect only the reply's body (empty),
+	//    NOT the parent's @OtherAgent mention. Leader must wake up.
+	postMemberComment(map[string]any{
+		"content":   "any update?",
+		"parent_id": parent.ID,
+	})
+	if got := countQueued(fx.LeaderID); got != 1 {
+		t.Fatalf("after plain reply: expected 1 leader task (no parent inheritance), got %d", got)
 	}
 }


### PR DESCRIPTION
## Summary

When a human commenter explicitly routes an issue at someone via `[@Name](mention://agent|member|squad|all/...)`, the squad leader was still being woken up to evaluate the same comment. The leader's only real options were to re-delegate to whoever the member already named, or to record `no_action` — both produce queue noise without changing the outcome.

This change skips the squad-leader enqueue when **all** of the following are true:
- the issue assignee is a squad,
- the comment author is a `member`, AND
- the comment body contains at least one routing mention: `agent`, `member`, `squad`, or `all`.

Issue cross-references (`mention://issue/...`) are not routing and do NOT suppress the leader.

Agent-authored comments are intentionally exempt: when an agent posts an update that `@mentions` another agent, the leader still needs to coordinate the thread. The existing leader-self-trigger guard is preserved, and only the current comment's body is inspected (parent / thread-root mentions are NOT inherited).

Implementation lives in the trigger routing layer (`shouldEnqueueSquadLeaderOnComment`), not in the leader's `evaluate` loop, so the work is cut before a task is enqueued rather than after.

Closes MUL-2170.

## Test plan

- [x] `go test ./internal/handler/ -run 'TestCommentMentionsAnyone|TestShouldEnqueueSquadLeaderOnComment_SkipsWhenMemberMentionsAnyone|TestCreateComment_SquadLeaderSkipOnlyInspectsCurrentMention' -v`
  - 11 unit cases on the `commentMentionsAnyone` parsing helper (agent / member / squad / @all / issue-only / mixed)
  - 9 integration cases on `shouldEnqueueSquadLeaderOnComment`:
    member plain / member @issue-only / member @member / member @non-leader-agent /
    member @leader / member @all / member @squad / agent @agent / leader self-comment
  - 1 full `CreateComment` HTTP-path regression locking the "current-comment-only, no parent inheritance" wiring
- [x] `go test ./internal/handler/ -count=1` — full handler suite green
- [x] `go test ./... -count=1` — full server suite green (run on earlier commit; current diff is test-only widening)