### PR TITLE
fix: squad leader no_action rule for member-triggered comments

### DIFF
--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -128,9 +128,9 @@ func buildCommentPrompt(task Task, provider string) string {
 		fmt.Fprintf(&b, "> %s\n\n", task.TriggerCommentContent)
 		if task.TriggerAuthorType == "agent" {
 			b.WriteString("⚠️ The triggering comment was posted by another agent. Decide whether a reply is warranted. If you produced actual work this turn (investigated, fixed something, answered a real question), post the result as a normal reply — that is NOT a noise comment, and the standard rule that final results must be delivered via comment still applies. If the triggering comment was a pure acknowledgment, thanks, or sign-off AND you produced no work this turn, do NOT reply — and do NOT post a comment saying 'No reply needed' or similar. Simply exit with no output. Silence is the preferred way to end agent-to-agent threads. If you do reply, do not @mention the other agent as a sign-off (that re-triggers them and starts a loop).\n\n")
-			if task.Agent != nil && strings.Contains(task.Agent.Instructions, "## Squad Operating Protocol") {
-				fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise.\n\n", task.IssueID)
-			}
+		}
+		if task.Agent != nil && strings.Contains(task.Agent.Instructions, "## Squad Operating Protocol") {
+			fmt.Fprintf(&b, "⚠️ **Squad leader no_action rule:** If you decide no action is needed, call `multica squad activity %s no_action --reason \"...\"` and EXIT. DO NOT post any comment — not even one that says \"no action needed\" or \"exiting silently\". The squad activity call records your decision; a comment is redundant noise.\n\n", task.IssueID)
 		}
 	}
 	fmt.Fprintf(&b, "Start by running `multica issue get %s --output json` to understand your task, then decide how to proceed.\n\n", task.IssueID)

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -94,3 +94,68 @@ func TestBuildQuickCreatePromptProjectPinning(t *testing.T) {
 		t.Errorf("buildQuickCreatePrompt without project must NOT mention --project, got:\n%s", plain)
 	}
 }
+
+// TestBuildPromptSquadLeaderNoActionForMemberTrigger verifies that the
+// squad leader no_action prohibition is injected in the per-turn prompt
+// regardless of whether the triggering comment was posted by an agent or
+// a member. This was the root cause of the "LGTM is a pure acknowledgment
+// — no reply needed. Exiting silently." noise comment: the prohibition
+// only fired for agent-triggered comments, so member-triggered ones
+// (like "LGTM") bypassed it.
+func TestBuildPromptSquadLeaderNoActionForMemberTrigger(t *testing.T) {
+	task := Task{
+		IssueID:               "issue-123",
+		TriggerCommentID:      "comment-456",
+		TriggerCommentContent: "LGTM",
+		TriggerAuthorType:     "member",
+		TriggerAuthorName:     "Bohan",
+		Agent: &AgentData{
+			Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
+		},
+	}
+	out := BuildPrompt(task, "claude")
+	if !strings.Contains(out, "Squad leader no_action rule") {
+		t.Errorf("buildCommentPrompt must inject squad leader no_action rule for member-triggered comments, got:\n%s", out)
+	}
+	if !strings.Contains(out, "DO NOT post any comment") {
+		t.Errorf("buildCommentPrompt must contain DO NOT post prohibition for member-triggered squad leader, got:\n%s", out)
+	}
+}
+
+// TestBuildPromptSquadLeaderNoActionForAgentTrigger verifies the rule also
+// fires for agent-triggered comments (the original path that already worked).
+func TestBuildPromptSquadLeaderNoActionForAgentTrigger(t *testing.T) {
+	task := Task{
+		IssueID:               "issue-123",
+		TriggerCommentID:      "comment-456",
+		TriggerCommentContent: "Deploy complete.",
+		TriggerAuthorType:     "agent",
+		TriggerAuthorName:     "deploy-boy",
+		Agent: &AgentData{
+			Instructions: "Some instructions\n\n## Squad Operating Protocol\n\nYou are the LEADER...",
+		},
+	}
+	out := BuildPrompt(task, "claude")
+	if !strings.Contains(out, "Squad leader no_action rule") {
+		t.Errorf("buildCommentPrompt must inject squad leader no_action rule for agent-triggered comments, got:\n%s", out)
+	}
+}
+
+// TestBuildPromptNonSquadLeaderNoRule verifies that non-squad-leader agents
+// do NOT get the squad leader no_action rule injected.
+func TestBuildPromptNonSquadLeaderNoRule(t *testing.T) {
+	task := Task{
+		IssueID:               "issue-123",
+		TriggerCommentID:      "comment-456",
+		TriggerCommentContent: "LGTM",
+		TriggerAuthorType:     "member",
+		TriggerAuthorName:     "Bohan",
+		Agent: &AgentData{
+			Instructions: "Some instructions without the squad marker",
+		},
+	}
+	out := BuildPrompt(task, "claude")
+	if strings.Contains(out, "Squad leader no_action rule") {
+		t.Errorf("buildCommentPrompt must NOT inject squad leader no_action rule for non-squad-leader agents, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

PR #2573 fixed the squad leader no_action prohibition for **agent-triggered** comments but missed the case where a **member** (human) posts the triggering comment. The per-turn prompt in `buildCommentPrompt()` only injected the prohibition inside the `if task.TriggerAuthorType == "agent"` block.

## Root Cause

When a member posted "LGTM" (04:46:10), the squad leader was triggered but the per-turn prompt did NOT include the no_action prohibition because `TriggerAuthorType == "member"`. The model then posted "LGTM is a pure acknowledgment — no reply needed. Exiting silently." (04:46:26) — exactly the noise comment we're trying to prevent.

The `runtime_config.go` step 4 already has the rule regardless of author type, but the per-turn prompt (last thing the model sees, strongest influence) was missing it for member triggers.

## Fix

Move the squad leader no_action rule outside the agent-only block so it fires for ALL trigger types.

## Additional findings

- Daemon does NOT need restart — instructions are fetched per-task from the server via ClaimTask
- The server was already running the new code (deployed at 04:39:45)
- The issue was purely that the per-turn prompt condition was too narrow

## Tests

- Added `TestBuildPromptSquadLeaderNoActionForMemberTrigger`
- Added `TestBuildPromptSquadLeaderNoActionForAgentTrigger`
- Added `TestBuildPromptNonSquadLeaderNoRule`
- All existing tests pass: `go test ./internal/daemon/... -count=1`