### PR TITLE
feat(skill): support private-repo imports via GITHUB_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,15 @@ ALLOWED_ORIGINS=
 GITHUB_APP_SLUG=
 GITHUB_WEBHOOK_SECRET=
 
+# GitHub token for skill import (POST /api/skills/import).
+# When set, the server attaches `Authorization: Bearer <token>` to outbound
+# api.github.com and raw.githubusercontent.com requests. Required to import
+# skills from private repositories; for public repos it only matters for
+# avoiding the 60-req/hour unauthenticated rate limit. Use a fine-grained
+# PAT with read-only access to the repos you want to import from, or a
+# GitHub App installation token. Never exposed to clients.
+# GITHUB_TOKEN=
+
 # Frontend
 FRONTEND_PORT=3000
 FRONTEND_ORIGIN=http://localhost:3000

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -1207,7 +1207,10 @@ var errGitHubAPIBlocked = errors.New("github API blocked (rate limit or auth)")
 // GITHUB_TOKEN bearer header when the env var is set. Unauthenticated GitHub
 // API requests are capped at 60/hour per IP, which is trivially exhausted on
 // shared self-hosted servers and surfaces to users as 403 errors during
-// skill imports. Setting GITHUB_TOKEN raises the limit to 5000/hour.
+// skill imports. Setting GITHUB_TOKEN raises the limit to 5000/hour and is
+// also what makes private-repo imports possible: GitHub returns 404 to
+// unauthenticated callers on private resources, which propagates as a
+// confusing "could not resolve ref" error from resolveGitHubRefAndPath.
 func doGitHubAPIGet(httpClient *http.Client, apiURL string) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
 	if err != nil {
@@ -1511,8 +1514,23 @@ func fetchFromGitHub(httpClient *http.Client, rawURL string) (*importedSkill, er
 // fetchRawFile downloads a URL and returns the body bytes. Returns an error
 // if the response exceeds maxImportFileSize so we never silently truncate a
 // half-downloaded skill file into the workspace.
+//
+// For raw.githubusercontent.com URLs the GITHUB_TOKEN bearer header is
+// attached when the env var is set. This is what unlocks private-repo skill
+// imports: unauthenticated raw requests against a private repo return 404,
+// which surfaces to the caller as "SKILL.md not found" even when the file
+// exists. Authenticated requests resolve correctly. Other hosts (clawhub.ai,
+// skills.sh, etc.) are untouched so we never leak a GitHub PAT to a
+// third-party origin.
 func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
-	resp, err := httpClient.Get(fileURL)
+	req, err := http.NewRequest(http.MethodGet, fileURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if isGitHubRawHost(req.URL.Host) {
+		addGitHubAuthHeader(req)
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1528,6 +1546,14 @@ func fetchRawFile(httpClient *http.Client, fileURL string) ([]byte, error) {
 		return nil, fmt.Errorf("%w: file exceeds %d byte limit", errImportCapExceeded, maxImportFileSize)
 	}
 	return body, nil
+}
+
+// isGitHubRawHost reports whether host serves raw GitHub blob content.
+// Used by fetchRawFile to decide whether to attach the GITHUB_TOKEN bearer
+// header; non-GitHub hosts (clawhub.ai, etc.) must never see the token.
+func isGitHubRawHost(host string) bool {
+	host = strings.ToLower(host)
+	return host == "raw.githubusercontent.com"
 }
 
 // escapeRefPath percent-encodes each segment of a git ref individually so

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -1146,6 +1146,90 @@ func TestFetchFromGitHub_SendsAuthHeaderWhenTokenSet(t *testing.T) {
 	}
 }
 
+// Private-repo skill import depends on raw.githubusercontent.com receiving
+// the GITHUB_TOKEN bearer header; without it, GitHub returns 404 and the
+// import fails with a misleading "could not resolve ref" message. This test
+// pins that contract: every raw.githubusercontent.com request must carry
+// the bearer header when GITHUB_TOKEN is set.
+func TestFetchFromGitHub_SendsAuthHeaderOnRawGitHubURLs(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_raw_token_456")
+	var (
+		mu         sync.Mutex
+		rawAuthHdr []string
+	)
+	client, _ := newGitHubFixtureClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Test-Original-Host") == "raw.githubusercontent.com" {
+			mu.Lock()
+			rawAuthHdr = append(rawAuthHdr, r.Header.Get("Authorization"))
+			mu.Unlock()
+		}
+		switch r.Header.Get("X-Test-Original-Host") {
+		case "api.github.com":
+			switch r.URL.Path {
+			case "/repos/acme/private-skills/commits/main/skills/foo",
+				"/repos/acme/private-skills/commits/main/skills":
+				http.NotFound(w, r)
+			case "/repos/acme/private-skills/commits/main":
+				w.Write([]byte("deadbeef"))
+			case "/repos/acme/private-skills/contents/skills/foo":
+				writeJSON(w, http.StatusOK, []githubContentEntry{})
+			default:
+				http.NotFound(w, r)
+			}
+		case "raw.githubusercontent.com":
+			switch r.URL.Path {
+			case "/acme/private-skills/main/skills/foo/SKILL.md":
+				w.Write([]byte("---\nname: foo\n---\nbody"))
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	if _, err := fetchFromGitHub(client, "https://github.com/acme/private-skills/tree/main/skills/foo"); err != nil {
+		t.Fatalf("fetchFromGitHub: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(rawAuthHdr) == 0 {
+		t.Fatal("expected at least one raw.githubusercontent.com request")
+	}
+	for i, h := range rawAuthHdr {
+		if h != "Bearer ghp_raw_token_456" {
+			t.Fatalf("raw request %d Authorization = %q, want Bearer ghp_raw_token_456", i, h)
+		}
+	}
+}
+
+// fetchRawFile must never leak the GitHub PAT to non-GitHub origins like
+// clawhub.ai. The skill import endpoint accepts URLs from multiple sources
+// and the same helper is used to download files from all of them.
+func TestFetchRawFile_DoesNotLeakTokenToNonGitHubHost(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_should_not_leak")
+	var (
+		mu       sync.Mutex
+		gotAuths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuths = append(gotAuths, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.Write([]byte("ok"))
+	}))
+	t.Cleanup(server.Close)
+	if _, err := fetchRawFile(server.Client(), server.URL+"/skills/foo/file"); err != nil {
+		t.Fatalf("fetchRawFile: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for i, h := range gotAuths {
+		if h != "" {
+			t.Fatalf("non-GitHub request %d carried Authorization = %q, want empty", i, h)
+		}
+	}
+}
+
 type rewriteGitHubTransport struct {
 	target *url.URL
 	base   http.RoundTripper


### PR DESCRIPTION
## Problem

`multica skill import --url <github-url>` only works against public repositories today. Pointing it at any private repo, e.g.

```
multica skill import --url https://github.com/<org>/<private-skills-repo>/tree/main/skills/foo
```

surfaces as:

```
POST /api/skills/import returned 502:
{"error":"could not resolve ref in github.com/<org>/<private-skills-repo> URL — tried: main/skills/foo, main/skills, main. ..."}
```

Root cause: GitHub returns 404 to unauthenticated callers on private resources. `resolveGitHubRefAndPath` interprets every probe as "ref does not exist," walks each shorter prefix, and ultimately fails with a misleading error message. Even if ref resolution somehow succeeded, the follow-up `raw.githubusercontent.com` fetch for `SKILL.md` would also 404 for the same reason.

`GITHUB_TOKEN` is already plumbed into outbound `api.github.com` requests via `addGitHubAuthHeader` (originally added for rate-limit avoidance, ref `doGitHubAPIGet`), but `fetchRawFile` — used for every blob download — does not use it. So even with `GITHUB_TOKEN` set today, private repos still fail.

## Fix

Attach the existing `GITHUB_TOKEN` bearer header to `raw.githubusercontent.com` requests as well, gated by host so the token is never leaked to `clawhub.ai`, `skills.sh`, or any other origin that `fetchRawFile` may download from. Existing api.github.com auth flow is unchanged. No new env var, no new config surface — the same `GITHUB_TOKEN` that already controlled rate-limit headroom now also unlocks private-repo imports.

## Before / after

```bash
# Before — fails on any private repo
$ multica skill import --url https://github.com/acme/private-skills/tree/main/skills/foo
Error: 502: could not resolve ref in github.com/acme/private-skills URL — tried: main/skills/foo, main/skills, main

# After — operator sets GITHUB_TOKEN once on the backend
$ GITHUB_TOKEN=ghp_xxx multica server  # (or set in .env / compose env)
$ multica skill import --url https://github.com/acme/private-skills/tree/main/skills/foo
Imported skill: foo
```

Public-repo imports are unaffected — same code path, same behavior, the auth header is simply absent when the env var is unset.

## What's in this PR

- `server/internal/handler/skill.go` (28 LOC) — route `raw.githubusercontent.com` requests in `fetchRawFile` through `addGitHubAuthHeader`. Add a `isGitHubRawHost` host gate so non-GitHub origins (clawhub.ai, skills.sh wrapper) never see the token. Update the `doGitHubAPIGet` doc comment to mention private-repo access alongside rate-limit relief.
- `server/internal/handler/skill_test.go` (84 LOC) — two new tests using the existing `rewriteGitHubTransport` / `newGitHubFixtureClient` fixtures:
  - `TestFetchFromGitHub_SendsAuthHeaderOnRawGitHubURLs` pins that every `raw.githubusercontent.com` request issued during a github import carries the `Bearer` header when `GITHUB_TOKEN` is set.
  - `TestFetchRawFile_DoesNotLeakTokenToNonGitHubHost` pins the blast-radius guarantee — a plain non-GitHub `httptest.Server` must never see the token.
- `.env.example` (9 LOC) — document `GITHUB_TOKEN` adjacent to the existing GitHub App config block.

## Out of scope

- `marketplace.json` parsing for multi-skill aggregator repositories. That's a separate, larger feature; treating this PR as a stepping stone unblocks the simple "import one private skill by URL" case first.
- Per-request `Authorization` header passthrough from the CLI. I didn't find an existing pattern for the import endpoint to consume request-scoped credentials, and adding one felt like scope creep. Happy to follow up if maintainers want it.

## Test plan

- [x] `go test ./internal/handler/ -run "GitHub|Skill|ClawHub|Import|RawFile" -count=1` — green
- [x] Full handler test suite (`go test ./internal/handler/ -count=1`) — green
- [x] `go build ./...` — green
- [x] `go vet ./internal/handler/` — clean
- [ ] Maintainers: smoke-test against a real private repo with a fine-grained PAT

## Notes for maintainers

- The change touches one helper (`fetchRawFile`) and adds one tiny gate (`isGitHubRawHost`). Both are deliberately narrow so the diff stays auditable.
- I left the existing "blocked by GitHub API (rate limit or auth); falling back to optimistic single-segment ref" warning intact — it now also covers the "private repo without token" case, which is the most informative actionable hint for users hitting that path. We could tighten the error message further in a follow-up if you want it to mention `GITHUB_TOKEN` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)