### PR TITLE
feat: extend pinyin search to all Agent/Member/Squad selectors

### DIFF
--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -46,6 +46,7 @@ import { availabilityConfig, availabilityOrder } from "../presence";
 import { CreateAgentDialog } from "./create-agent-dialog";
 import { type AgentRow, createAgentColumns } from "./agent-columns";
 import { useT } from "../../i18n";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
 // Filter axes:
 //
@@ -196,6 +197,7 @@ export function AgentsPage() {
       if (q) {
         if (
           !a.name.toLowerCase().includes(q) &&
+          !matchesPinyin(a.name, q) &&
           !(a.description ?? "").toLowerCase().includes(q)
         ) {
           return false;

--- a/packages/views/autopilots/components/pickers/agent-picker.tsx
+++ b/packages/views/autopilots/components/pickers/agent-picker.tsx
@@ -12,6 +12,7 @@ import {
   PickerEmpty,
 } from "../../../issues/components/pickers/property-picker";
 import { useT } from "../../../i18n";
+import { matchesPinyin } from "../../../editor/extensions/pinyin-match";
 
 export function AgentPicker({
   agentId,
@@ -36,7 +37,7 @@ export function AgentPicker({
 
   const query = filter.trim().toLowerCase();
   const filteredAgents = query
-    ? active.filter((a) => a.name.toLowerCase().includes(query))
+    ? active.filter((a) => a.name.toLowerCase().includes(query) || matchesPinyin(a.name, query))
     : active;
 
   return (

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -65,6 +65,7 @@ import {
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import type { Issue } from "@multica/core/types";
 import { useT } from "../../i18n";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
 // ---------------------------------------------------------------------------
 // HoverCheck — shadcn official pattern (PR #6862)
@@ -187,13 +188,13 @@ function ActorSubContent({
   const { data: squads = [] } = useQuery(squadListOptions(wsId));
   const query = search.trim().toLowerCase();
   const filteredMembers = members.filter((m) =>
-    m.name.toLowerCase().includes(query),
+    m.name.toLowerCase().includes(query) || matchesPinyin(m.name, query),
   );
   const filteredAgents = agents.filter((a) =>
-    !a.archived_at && a.name.toLowerCase().includes(query),
+    !a.archived_at && (a.name.toLowerCase().includes(query) || matchesPinyin(a.name, query)),
   );
   const filteredSquads = squads.filter((s) =>
-    !s.archived_at && s.name.toLowerCase().includes(query),
+    !s.archived_at && (s.name.toLowerCase().includes(query) || matchesPinyin(s.name, query)),
   );
 
   const isSelected = (type: "member" | "agent" | "squad", id: string) =>

--- a/packages/views/issues/components/pickers/assignee-picker.tsx
+++ b/packages/views/issues/components/pickers/assignee-picker.tsx
@@ -17,6 +17,7 @@ import {
   PickerEmpty,
 } from "./property-picker";
 import { useT } from "../../../i18n";
+import { matchesPinyin } from "../../../editor/extensions/pinyin-match";
 
 /**
  * Legacy boolean shape kept around for callers (e.g. `use-issue-actions.ts`)
@@ -84,13 +85,13 @@ export function AssigneePicker({
 
   const query = filter.trim().toLowerCase();
   const filteredMembers = members
-    .filter((m) => m.name.toLowerCase().includes(query))
+    .filter((m) => m.name.toLowerCase().includes(query) || matchesPinyin(m.name, query))
     .sort((a, b) => getFreq("member", b.user_id) - getFreq("member", a.user_id));
   const filteredAgents = agents
-    .filter((a) => !a.archived_at && a.name.toLowerCase().includes(query))
+    .filter((a) => !a.archived_at && (a.name.toLowerCase().includes(query) || matchesPinyin(a.name, query)))
     .sort((a, b) => getFreq("agent", b.id) - getFreq("agent", a.id));
   const filteredSquads = squads
-    .filter((s) => !s.archived_at && s.name.toLowerCase().includes(query))
+    .filter((s) => !s.archived_at && (s.name.toLowerCase().includes(query) || matchesPinyin(s.name, query)))
     .sort((a, b) => getFreq("squad", b.id) - getFreq("squad", a.id));
 
   const isSelected = (type: string, id: string) =>

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -52,6 +52,7 @@ import { PriorityIcon } from "../issues/components/priority-icon";
 import { ActorAvatar } from "../common/actor-avatar";
 import { useNavigation } from "../navigation";
 import { useT } from "../i18n";
+import { matchesPinyin } from "../editor/extensions/pinyin-match";
 import {
   useProjectStatusLabels,
   useProjectPriorityLabels,
@@ -152,9 +153,9 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
   const [leadFilter, setLeadFilter] = useState("");
 
   const leadQuery = leadFilter.toLowerCase();
-  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery));
+  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
   const filteredAgents = agents.filter(
-    (a) => !a.archived_at && a.name.toLowerCase().includes(leadQuery),
+    (a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)),
   );
 
   const leadLabel =

--- a/packages/views/modals/quick-create-issue.tsx
+++ b/packages/views/modals/quick-create-issue.tsx
@@ -47,6 +47,7 @@ import {
 } from "../editor";
 import { FileUploadButton } from "@multica/ui/components/common/file-upload-button";
 import { useT } from "../i18n";
+import { matchesPinyin } from "../editor/extensions/pinyin-match";
 
 type ActorSelection =
   | { type: "agent"; id: string }
@@ -552,11 +553,11 @@ function ActorPicker({
   const query = filter.trim().toLowerCase();
 
   const filteredAgents = useMemo(
-    () => visibleAgents.filter((a) => a.name.toLowerCase().includes(query)),
+    () => visibleAgents.filter((a) => a.name.toLowerCase().includes(query) || matchesPinyin(a.name, query)),
     [visibleAgents, query],
   );
   const filteredSquads = useMemo(
-    () => visibleSquads.filter((s) => s.name.toLowerCase().includes(query)),
+    () => visibleSquads.filter((s) => s.name.toLowerCase().includes(query) || matchesPinyin(s.name, query)),
     [visibleSquads, query],
   );
 

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -70,6 +70,7 @@ import {
 } from "@multica/ui/components/ui/alert-dialog";
 import { useT } from "../../i18n";
 import { useProjectStatusLabels, useProjectPriorityLabels } from "./labels";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
 // ---------------------------------------------------------------------------
 // Property row — sidebar property display
@@ -264,8 +265,8 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
   const [leadOpen, setLeadOpen] = useState(false);
   const [leadFilter, setLeadFilter] = useState("");
   const leadQuery = leadFilter.toLowerCase();
-  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery));
-  const filteredAgents = agents.filter((a) => !a.archived_at && a.name.toLowerCase().includes(leadQuery));
+  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
+  const filteredAgents = agents.filter((a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)));
 
   const handleUpdateField = useCallback(
     (data: Parameters<typeof updateProject.mutate>[0] extends { id: string } & infer R ? R : never) => {

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -43,6 +43,7 @@ import {
   useProjectPriorityLabels,
   useFormatRelativeDate,
 } from "./labels";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
 function ProjectRow({ project }: { project: Project }) {
   const { t } = useT("projects");
@@ -61,8 +62,8 @@ function ProjectRow({ project }: { project: Project }) {
   const [leadOpen, setLeadOpen] = useState(false);
   const [leadFilter, setLeadFilter] = useState("");
   const leadQuery = leadFilter.toLowerCase();
-  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery));
-  const filteredAgents = agents.filter((a) => !a.archived_at && a.name.toLowerCase().includes(leadQuery));
+  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
+  const filteredAgents = agents.filter((a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)));
 
   const handleUpdate = useCallback(
     (data: UpdateProjectRequest) => {

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -50,6 +50,7 @@ import { ChevronDown, UserPlus } from "lucide-react";
 import { toast } from "sonner";
 import type { Squad, SquadMember, Agent, MemberWithUser } from "@multica/core/types";
 import { useT } from "../../i18n";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
 export function SquadDetailPage() {
   const { t } = useT("squads");
@@ -450,8 +451,8 @@ function AddMemberDialog({
   const [submitting, setSubmitting] = useState(false);
 
   const query = pickerFilter.trim().toLowerCase();
-  const filteredMembers = availableMembers.filter((m) => m.name.toLowerCase().includes(query));
-  const filteredAgents = availableAgents.filter((a) => a.name.toLowerCase().includes(query));
+  const filteredMembers = availableMembers.filter((m) => m.name.toLowerCase().includes(query) || matchesPinyin(m.name, query));
+  const filteredAgents = availableAgents.filter((a) => a.name.toLowerCase().includes(query) || matchesPinyin(a.name, query));
 
   const canSubmit = !!target && !submitting;
 

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -14,6 +14,7 @@ import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/ac
 import { useModalStore } from "@multica/core/modals";
 import type { Agent, Squad } from "@multica/core/types";
 import { useT } from "../../i18n";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
 type Scope = "mine" | "all";
 
@@ -57,7 +58,7 @@ export function SquadsPage() {
     const q = search.trim().toLowerCase();
     return squads.filter((s) => {
       if (scope === "mine" && currentUser && s.creator_id !== currentUser.id) return false;
-      if (q && !s.name.toLowerCase().includes(q) && !s.description.toLowerCase().includes(q)) return false;
+      if (q && !s.name.toLowerCase().includes(q) && !matchesPinyin(s.name, q) && !s.description.toLowerCase().includes(q)) return false;
       return true;
     });
   }, [squads, scope, currentUser, search]);


### PR DESCRIPTION
Extends the existing `matchesPinyin` utility (from the editor @mention) to all components that search for Agent/Member/Squad:

- **AssigneePicker** — issue assignee selector
- **IssuesHeader** — assignee filter bar
- **AgentPicker** — autopilot agent selector
- **SquadDetailPage** — add member/agent picker
- **QuickCreateIssue** — agent/squad picker
- **CreateProject** — lead picker
- **ProjectDetail** — lead picker
- **ProjectsPage** — lead filter
- **AgentsPage** — agent search
- **SquadsPage** — squad search

Users can now search by full pinyin (e.g. `liyunlong`), initials (`lyl`), or mixed prefix (`liyu`) in all these selectors.

**Testing:**
- All existing tests pass (19 tests in 4 test files)
- Pinyin-specific tests pass (22 tests)
- Typecheck passes (only pre-existing errors)
- Lint passes (0 errors, 13 pre-existing warnings)

Closes MUL-2179 extended scope.