### PR TITLE
feat: add pinyin search to subscriber popover

### DIFF
--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -72,7 +72,90 @@ import { timeAgo } from "@multica/core/utils";
 import { cn } from "@multica/ui/lib/utils";
 
 import { ProgressRing } from "./progress-ring";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { useT } from "../../i18n";
+
+function SubscriberPopoverContent({
+  members,
+  agents,
+  subscribers,
+  toggleSubscriber,
+  t,
+}: {
+  members: { user_id: string; name: string }[];
+  agents: { id: string; name: string; archived_at?: string | null }[];
+  subscribers: { user_type: string; user_id: string }[];
+  toggleSubscriber: (id: string, type: "member" | "agent", subscribed: boolean) => void;
+  t: ActivityT;
+}) {
+  const [search, setSearch] = useState("");
+  const q = search.trim().toLowerCase();
+
+  const uniqueMembers = members.filter((m, i, arr) => arr.findIndex((x) => x.user_id === m.user_id) === i);
+  const activeAgents = agents.filter((a) => !a.archived_at);
+
+  const filteredMembers = q
+    ? uniqueMembers.filter((m) => m.name.toLowerCase().includes(q) || matchesPinyin(m.name, q))
+    : uniqueMembers;
+  const filteredAgents = q
+    ? activeAgents.filter((a) => a.name.toLowerCase().includes(q) || matchesPinyin(a.name, q))
+    : activeAgents;
+
+  return (
+    <PopoverContent align="end" className="w-64 p-0">
+      <Command shouldFilter={false}>
+        <CommandInput
+          placeholder={t(($) => $.detail.change_subscribers_placeholder)}
+          value={search}
+          onValueChange={setSearch}
+        />
+        <CommandList className="max-h-64">
+          {filteredMembers.length === 0 && filteredAgents.length === 0 && (
+            <CommandEmpty>{t(($) => $.detail.no_subscribers_results)}</CommandEmpty>
+          )}
+          {filteredMembers.length > 0 && (
+            <CommandGroup heading={t(($) => $.detail.members_group)}>
+              {filteredMembers.map((m) => {
+                const sub = subscribers.find((s) => s.user_type === "member" && s.user_id === m.user_id);
+                const isSubbed = !!sub;
+                return (
+                  <CommandItem
+                    key={`member-${m.user_id}`}
+                    onSelect={() => toggleSubscriber(m.user_id, "member", isSubbed)}
+                    className="flex items-center gap-2.5"
+                  >
+                    <Checkbox checked={isSubbed} className="pointer-events-none" />
+                    <ActorAvatar actorType="member" actorId={m.user_id} size={22} />
+                    <span className="truncate flex-1">{m.name}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          )}
+          {filteredAgents.length > 0 && (
+            <CommandGroup heading={t(($) => $.detail.agents_group)}>
+              {filteredAgents.map((a) => {
+                const sub = subscribers.find((s) => s.user_type === "agent" && s.user_id === a.id);
+                const isSubbed = !!sub;
+                return (
+                  <CommandItem
+                    key={`agent-${a.id}`}
+                    onSelect={() => toggleSubscriber(a.id, "agent", isSubbed)}
+                    className="flex items-center gap-2.5"
+                  >
+                    <Checkbox checked={isSubbed} className="pointer-events-none" />
+                    <ActorAvatar actorType="agent" actorId={a.id} size={22} showStatusDot />
+                    <span className="truncate flex-1">{a.name}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </PopoverContent>
+  );
+}
 
 function shortDate(date: string | null): string {
   if (!date) return "—";
@@ -1350,54 +1433,13 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                       </span>
                     )}
                   </PopoverTrigger>
-                  <PopoverContent align="end" className="w-64 p-0">
-                    <Command>
-                      <CommandInput placeholder={t(($) => $.detail.change_subscribers_placeholder)} />
-                      <CommandList className="max-h-64">
-                        <CommandEmpty>{t(($) => $.detail.no_subscribers_results)}</CommandEmpty>
-                        {members.length > 0 && (
-                          <CommandGroup heading={t(($) => $.detail.members_group)}>
-                            {members.filter((m, i, arr) => arr.findIndex((x) => x.user_id === m.user_id) === i).map((m) => {
-                              const sub = subscribers.find((s) => s.user_type === "member" && s.user_id === m.user_id);
-                              const isSubbed = !!sub;
-                              return (
-                                <CommandItem
-                                  key={`member-${m.user_id}`}
-                                  onSelect={() => toggleSubscriber(m.user_id, "member", isSubbed)}
-                                  className="flex items-center gap-2.5"
-                                >
-                                  <Checkbox checked={isSubbed} className="pointer-events-none" />
-                                  <ActorAvatar actorType="member" actorId={m.user_id} size={22} />
-                                  <span className="truncate flex-1">{m.name}</span>
-
-                                </CommandItem>
-                              );
-                            })}
-                          </CommandGroup>
-                        )}
-                        {agents.filter((a) => !a.archived_at).length > 0 && (
-                          <CommandGroup heading={t(($) => $.detail.agents_group)}>
-                            {agents.filter((a) => !a.archived_at).map((a) => {
-                              const sub = subscribers.find((s) => s.user_type === "agent" && s.user_id === a.id);
-                              const isSubbed = !!sub;
-                              return (
-                                <CommandItem
-                                  key={`agent-${a.id}`}
-                                  onSelect={() => toggleSubscriber(a.id, "agent", isSubbed)}
-                                  className="flex items-center gap-2.5"
-                                >
-                                  <Checkbox checked={isSubbed} className="pointer-events-none" />
-                                  <ActorAvatar actorType="agent" actorId={a.id} size={22} showStatusDot />
-                                  <span className="truncate flex-1">{a.name}</span>
-
-                                </CommandItem>
-                              );
-                            })}
-                          </CommandGroup>
-                        )}
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
+                  <SubscriberPopoverContent
+                    members={members}
+                    agents={agents}
+                    subscribers={subscribers}
+                    toggleSubscriber={toggleSubscriber}
+                    t={t}
+                  />
                 </Popover>
               </div>
             </div>


### PR DESCRIPTION
Fixes the missing matchesPinyin integration in the subscriber popover (issue-detail.tsx:1355) flagged in review of PR #2582.

Changes:
- Extracted subscriber popover into SubscriberPopoverContent component
- Added controlled search with shouldFilter={false} on Command
- Filter members/agents using matchesPinyin alongside text includes
- Consistent with all other selector/picker components