### PR TITLE
fix: trigger squad leader agent run on squad @mention in comment

### DIFF
--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -440,6 +440,42 @@ func (h *Handler) enqueueMentionedAgentTasks(ctx context.Context, issue db.Issue
 		mentions = util.ParseMentions(parentComment.Content)
 	}
 	for _, m := range mentions {
+		if m.Type == "squad" {
+			// @squad mention → trigger the squad's leader agent.
+			squadUUID := parseUUID(m.ID)
+			squad, err := h.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
+				ID:          squadUUID,
+				WorkspaceID: issue.WorkspaceID,
+			})
+			if err != nil {
+				continue
+			}
+			leaderID := squad.LeaderID
+			// Prevent self-trigger: skip if the comment author is the leader.
+			if authorType == "agent" && authorID == uuidToString(leaderID) {
+				continue
+			}
+			// Verify leader agent is ready (has runtime, not archived).
+			agent, err := h.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+				ID:          leaderID,
+				WorkspaceID: issue.WorkspaceID,
+			})
+			if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
+				continue
+			}
+			// Dedup: skip if leader already has a pending task for this issue.
+			hasPending, err := h.Queries.HasPendingTaskForIssueAndAgent(ctx, db.HasPendingTaskForIssueAndAgentParams{
+				IssueID: issue.ID,
+				AgentID: leaderID,
+			})
+			if err != nil || hasPending {
+				continue
+			}
+			if _, err := h.TaskService.EnqueueTaskForMention(ctx, issue, leaderID, comment.ID); err != nil {
+				slog.Warn("enqueue squad leader mention task failed", "issue_id", uuidToString(issue.ID), "squad_id", m.ID, "error", err)
+			}
+			continue
+		}
 		if m.Type != "agent" {
 			continue
 		}

--- a/server/internal/handler/comment.go
+++ b/server/internal/handler/comment.go
@@ -463,6 +463,10 @@ func (h *Handler) enqueueMentionedAgentTasks(ctx context.Context, issue db.Issue
 			if err != nil || !agent.RuntimeID.Valid || agent.ArchivedAt.Valid {
 				continue
 			}
+			// Private-agent gate: prevent triggering a private leader via squad mention.
+			if !h.canAccessPrivateAgent(ctx, agent, authorType, authorID, wsID) {
+				continue
+			}
 			// Dedup: skip if leader already has a pending task for this issue.
 			hasPending, err := h.Queries.HasPendingTaskForIssueAndAgent(ctx, db.HasPendingTaskForIssueAndAgentParams{
 				IssueID: issue.ID,

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -286,3 +286,75 @@ func TestCreateComment_SquadLeaderSkipOnlyInspectsCurrentMention(t *testing.T) {
 		t.Fatalf("after plain reply: expected 1 leader task (no parent inheritance), got %d", got)
 	}
 }
+
+// TestCreateComment_SquadMentionTriggersLeader verifies that @mentioning a
+// squad in a comment triggers the squad's leader agent via the mention path,
+// even when the issue is NOT assigned to that squad.
+func TestCreateComment_SquadMentionTriggersLeader(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	// Create a squad with a leader agent.
+	var leaderID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent WHERE workspace_id = $1 ORDER BY created_at ASC LIMIT 1
+	`, testWorkspaceID).Scan(&leaderID); err != nil {
+		t.Fatalf("load leader agent: %v", err)
+	}
+
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, $2, '', $3, $4)
+		RETURNING id
+	`, testWorkspaceID, "Mention Trigger Squad", leaderID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+	})
+
+	// Create an issue NOT assigned to the squad (assigned to nobody).
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
+		VALUES ($1, 'member', $2, 'squad mention trigger test')
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	countQueued := func(agentID string) int {
+		var n int
+		if err := testPool.QueryRow(ctx,
+			`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'`,
+			issueID, agentID,
+		).Scan(&n); err != nil {
+			t.Fatalf("count tasks for %s: %v", agentID, err)
+		}
+		return n
+	}
+
+	// Post a comment that @mentions the squad.
+	w := httptest.NewRecorder()
+	r := newRequest("POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "[@Squad](mention://squad/" + squadID + ") please handle this",
+	})
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The squad's leader should have a queued task.
+	if got := countQueued(leaderID); got != 1 {
+		t.Fatalf("after @squad mention: expected 1 leader task, got %d", got)
+	}
+}

--- a/server/internal/handler/squad_comment_trigger_test.go
+++ b/server/internal/handler/squad_comment_trigger_test.go
@@ -287,6 +287,73 @@ func TestCreateComment_SquadLeaderSkipOnlyInspectsCurrentMention(t *testing.T) {
 	}
 }
 
+// TestCreateComment_SquadMentionPrivateLeaderBlocksPlainMember verifies that
+// a plain workspace member cannot trigger a private squad leader via @squad
+// mention. This is the regression test for the P1 finding: without the
+// canAccessPrivateAgent gate in the squad mention branch, a member could
+// bypass the private-agent restriction by mentioning the squad instead of
+// the agent directly.
+func TestCreateComment_SquadMentionPrivateLeaderBlocksPlainMember(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	// Use privateAgentTestFixture to get a private agent + plain member.
+	agentID, _, memberID := privateAgentTestFixture(t)
+
+	// Create a squad with the private agent as leader.
+	var squadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, description, leader_id, creator_id)
+		VALUES ($1, 'Private Leader Squad', '', $2, $3)
+		RETURNING id
+	`, testWorkspaceID, agentID, testUserID).Scan(&squadID); err != nil {
+		t.Fatalf("create squad: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM squad WHERE id = $1`, squadID)
+	})
+
+	// Create an issue.
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, creator_type, creator_id, title)
+		VALUES ($1, 'member', $2, 'private leader squad mention test')
+		RETURNING id
+	`, testWorkspaceID, memberID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM comment WHERE issue_id = $1`, issueID)
+		testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID)
+	})
+
+	// Plain member posts a comment mentioning the squad.
+	w := httptest.NewRecorder()
+	r := newRequestAs(memberID, "POST", "/api/issues/"+issueID+"/comments", map[string]any{
+		"content": "[@Squad](mention://squad/" + squadID + ") please handle",
+	})
+	r = withURLParam(r, "id", issueID)
+	testHandler.CreateComment(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateComment: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The private leader must NOT have a queued task — plain member lacks access.
+	var count int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM agent_task_queue WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued'`,
+		issueID, agentID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count tasks: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("private leader got %d queued tasks from plain member squad mention; want 0 (access denied)", count)
+	}
+}
+
 // TestCreateComment_SquadMentionTriggersLeader verifies that @mentioning a
 // squad in a comment triggers the squad's leader agent via the mention path,
 // even when the issue is NOT assigned to that squad.


### PR DESCRIPTION
## Summary

When a squad is @mentioned in a comment, the squad leader's agent run was not being triggered. This was because `enqueueMentionedAgentTasks` only handled `agent` type mentions and skipped `squad` mentions entirely.

## Changes

- Added a `squad` type branch in `enqueueMentionedAgentTasks` that resolves the squad's leader agent and enqueues a task for them
- Includes the same self-trigger prevention, runtime checks, and dedup logic as the existing agent mention path
- Added integration test `TestCreateComment_SquadMentionTriggersLeader`

## Testing

All handler tests pass.