### PR TITLE
feat(squads): two-phase loading + in-dialog retry on squad-join failure (MUL-2178)

### DIFF
--- a/packages/views/agents/components/create-agent-dialog.test.tsx
+++ b/packages/views/agents/components/create-agent-dialog.test.tsx
@@ -294,6 +294,40 @@ describe("CreateAgentDialog runtime visibility gate", () => {
     expect(onCreateMock.mock.calls[0]?.[0].runtime_id).toBe("rt-mine");
   });
 
+  it("ignores Enter on the name input while a submit is already in flight", async () => {
+    // The Create button is disabled while creating, but the Input's
+    // own onKeyDown calls handleSubmit() directly. Without the
+    // in-flight guard inside handleSubmit, a quick Enter during the
+    // create-then-add window fires a duplicate onCreate / addSquadMember
+    // pair — which is the exact bug GPT-Boy flagged on PR #2595.
+    const mine = makeRuntime({
+      id: "rt-mine",
+      name: "My Runtime",
+      owner_id: ME,
+      visibility: "private",
+    });
+    const onCreate = vi.fn(
+      () => new Promise<Agent | void>(() => undefined),
+    );
+    renderDialog([mine], { onCreate });
+
+    const nameInput = screen.getByPlaceholderText(
+      /Deep Research Agent/i,
+    ) as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Phase Test Agent" } });
+    // Initial submit via Enter to mirror the user-reported path —
+    // they typed a name and hit Enter to fire the first request.
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+
+    // Second Enter during the in-flight window must be a no-op.
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
   it("disables Cancel and Create while a submit is in flight", async () => {
     const mine = makeRuntime({
       id: "rt-mine",

--- a/packages/views/agents/components/create-agent-dialog.test.tsx
+++ b/packages/views/agents/components/create-agent-dialog.test.tsx
@@ -3,7 +3,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import type { Agent, MemberWithUser, RuntimeDevice } from "@multica/core/types";
+import type { Agent, CreateAgentRequest, MemberWithUser, RuntimeDevice } from "@multica/core/types";
 import { I18nProvider } from "@multica/core/i18n/react";
 import { WorkspaceSlugProvider } from "@multica/core/paths";
 import { NavigationProvider, type NavigationAdapter } from "../../navigation";
@@ -42,7 +42,16 @@ vi.mock("../../common/actor-avatar", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+// Squad-join tests reach into api.addSquadMember; stub only the surface
+// we exercise so the test doesn't touch the real fetch helper.
+const addSquadMemberMock = vi.fn();
+vi.mock("@multica/core/api", () => ({
+  api: {
+    addSquadMember: (...args: unknown[]) => addSquadMemberMock(...args),
+  },
 }));
 
 import { CreateAgentDialog } from "./create-agent-dialog";
@@ -122,11 +131,23 @@ function makeTemplate(runtimeId: string): Agent {
   };
 }
 
-function renderDialog(runtimes: RuntimeDevice[], template?: Agent) {
+function renderDialog(
+  runtimes: RuntimeDevice[],
+  options: {
+    template?: Agent;
+    squadId?: string;
+    onCreate?: (data: CreateAgentRequest) => Promise<Agent | void>;
+  } = {},
+) {
+  const { template, squadId } = options;
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  const onCreate = vi.fn().mockResolvedValue(undefined);
+  // The renderDialog return value is used by tests to inspect mock calls
+  // (`.mock.calls[0]`). Default to a fresh vi.fn so existing tests still
+  // see Mock methods; explicit overrides come from the caller already
+  // typed as a function so we don't need the Mock surface for those.
+  const onCreate = options.onCreate ?? vi.fn().mockResolvedValue(undefined);
   const onClose = vi.fn();
   render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
@@ -138,6 +159,7 @@ function renderDialog(runtimes: RuntimeDevice[], template?: Agent) {
             members={members}
             currentUserId={ME}
             template={template}
+            squadId={squadId}
             onClose={onClose}
             onCreate={onCreate}
           />
@@ -153,7 +175,7 @@ function renderDialog(runtimes: RuntimeDevice[], template?: Agent) {
   if (!template) {
     fireEvent.click(screen.getByText(enAgents.create_dialog.chooser.blank_title));
   }
-  return { onCreate, onClose };
+  return { onCreate, onClose, queryClient };
 }
 
 describe("CreateAgentDialog runtime visibility gate", () => {
@@ -255,7 +277,7 @@ describe("CreateAgentDialog runtime visibility gate", () => {
       visibility: "private",
     });
     const template = makeTemplate("rt-others-private");
-    const { onCreate } = renderDialog([othersPrivate, mine], template);
+    const { onCreate } = renderDialog([othersPrivate, mine], { template });
 
     expect(
       screen.getByText("My Runtime", { selector: "span.truncate" }),
@@ -267,8 +289,39 @@ describe("CreateAgentDialog runtime visibility gate", () => {
     // Sanity check: with a usable selection seeded, Create should submit.
     fireEvent.click(screen.getByText("Create"));
     await new Promise((r) => setTimeout(r, 0));
-    expect(onCreate).toHaveBeenCalledTimes(1);
-    expect(onCreate.mock.calls[0]?.[0].runtime_id).toBe("rt-mine");
+    const onCreateMock = onCreate as ReturnType<typeof vi.fn>;
+    expect(onCreateMock).toHaveBeenCalledTimes(1);
+    expect(onCreateMock.mock.calls[0]?.[0].runtime_id).toBe("rt-mine");
+  });
+
+  it("disables Cancel and Create while a submit is in flight", async () => {
+    const mine = makeRuntime({
+      id: "rt-mine",
+      name: "My Runtime",
+      owner_id: ME,
+      visibility: "private",
+    });
+    // onCreate never resolves so the dialog stays in the "creating-agent"
+    // phase — exactly the window where a hasty backdrop click would
+    // previously have dismissed the dialog mid-flight.
+    const onCreate = vi.fn(
+      () => new Promise<Agent | void>(() => undefined),
+    );
+    renderDialog([mine], { onCreate });
+    fireEvent.change(screen.getByPlaceholderText(/Deep Research Agent/i), {
+      target: { value: "Phase Test Agent" },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const cancelBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent === "Cancel") as HTMLButtonElement;
+    expect(cancelBtn.disabled).toBe(true);
+    const submitBtn = screen
+      .getAllByRole("button")
+      .find((b) => b.textContent?.includes("Creating")) as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
   });
 
   it("disables Create when the selected runtime is locked (template + no usable fallback)", () => {
@@ -285,7 +338,7 @@ describe("CreateAgentDialog runtime visibility gate", () => {
     // visible — that's the scope where the selected-but-locked state
     // can persist after the initial seed search returns nothing.
     const template = makeTemplate("rt-only-others-private");
-    renderDialog([onlyOthersPrivate], template);
+    renderDialog([onlyOthersPrivate], { template });
 
     // The Create button is rendered by lucide-free CTA text "Create".
     const createBtn = screen
@@ -293,5 +346,104 @@ describe("CreateAgentDialog runtime visibility gate", () => {
       .find((b) => b.textContent === "Create");
     expect(createBtn).toBeDefined();
     expect((createBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("CreateAgentDialog squad-join recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addSquadMemberMock.mockReset();
+  });
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  const fillFormAndSubmit = (agentName = "Squad Agent") => {
+    fireEvent.change(screen.getByPlaceholderText(/Deep Research Agent/i), {
+      target: { value: agentName },
+    });
+    fireEvent.click(screen.getByText("Create"));
+  };
+
+  it("keeps the dialog open and shows a retry CTA when addSquadMember fails", async () => {
+    const mine = makeRuntime({
+      id: "rt-mine",
+      name: "My Runtime",
+      owner_id: ME,
+      visibility: "private",
+    });
+    const created: Agent = { ...makeTemplate("rt-mine"), id: "new-agent-id", name: "Squad Agent" };
+    const onCreate = vi.fn().mockResolvedValue(created);
+    addSquadMemberMock.mockRejectedValueOnce(new Error("forbidden"));
+    const { onClose } = renderDialog([mine], {
+      squadId: "squad-1",
+      onCreate,
+    });
+
+    fillFormAndSubmit();
+    // Two awaits: one for onCreate's microtask, one for addSquadMember.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(addSquadMemberMock).toHaveBeenCalledWith("squad-1", {
+      member_type: "agent",
+      member_id: "new-agent-id",
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    // The retry title appears in both the dialog header and the body
+    // card — either is enough proof we're in the retry view.
+    expect(
+      screen.getAllByText(enAgents.create_dialog.squad_join_retry.title).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByText(enAgents.create_dialog.squad_join_retry.retry_button),
+    ).toBeInTheDocument();
+  });
+
+  it("retries addSquadMember and closes the dialog on success", async () => {
+    const mine = makeRuntime({
+      id: "rt-mine",
+      name: "My Runtime",
+      owner_id: ME,
+      visibility: "private",
+    });
+    const created: Agent = { ...makeTemplate("rt-mine"), id: "new-agent-id", name: "Squad Agent" };
+    const onCreate = vi.fn().mockResolvedValue(created);
+    addSquadMemberMock
+      .mockRejectedValueOnce(new Error("forbidden"))
+      .mockResolvedValueOnce({
+        id: "sm-1",
+        squad_id: "squad-1",
+        member_type: "agent",
+        member_id: "new-agent-id",
+        role: "",
+        created_at: "2026-05-14T00:00:00Z",
+      });
+    const { onClose, queryClient } = renderDialog([mine], {
+      squadId: "squad-1",
+      onCreate,
+    });
+
+    fillFormAndSubmit();
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Trigger the retry button now that the failure view is on screen.
+    fireEvent.click(
+      screen.getByText(enAgents.create_dialog.squad_join_retry.retry_button),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(addSquadMemberMock).toHaveBeenCalledTimes(2);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // Optimistic insert: the squad members cache should contain the new
+    // agent the moment the join resolves, without a refetch.
+    const cached = queryClient.getQueryData<
+      Array<{ member_id: string; member_type: string }>
+    >(["workspaces", "ws-1", "squads", "squad-1", "members"]);
+    expect(cached?.[0]?.member_id).toBe("new-agent-id");
+    expect(cached?.[0]?.member_type).toBe("agent");
   });
 });

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -308,6 +308,11 @@ export function CreateAgentDialog({
   // and the banner there reports the bad URLs; on any other error we
   // surface a toast and reset the spinner so they can retry.
   const quickCreateFromTemplate = async (tmpl: AgentTemplateSummary) => {
+    // Re-entry guard: TemplateDetail already disables its CTA while
+    // `creating` is true, but a parallel keyboard path (Enter on the
+    // template card during animation) could still slip in. Bail before
+    // we issue a second createAgentFromTemplate against the same form.
+    if (creating) return;
     if (!selectedRuntime || selectedRuntimeLocked) {
       toast.error(t(($) => $.create_dialog.no_runtime_toast));
       return;
@@ -386,6 +391,14 @@ export function CreateAgentDialog({
   };
 
   const handleSubmit = async () => {
+    // In-flight re-entry guard. The Create button is disabled while
+    // `creating` is true, but the name input's Enter handler (and any
+    // future keyboard shortcut) calls handleSubmit directly — without
+    // this guard a quick Enter during the Create-then-AddSquadMember
+    // window would fire a duplicate createAgent / addSquadMember,
+    // which is exactly the two-phase-submit bug MUL-2178 set out to
+    // prevent.
+    if (creating) return;
     if (!name.trim() || !selectedRuntime || selectedRuntimeLocked) return;
     setFailedURLs(null);
     setPhase("creating-agent");
@@ -520,9 +533,12 @@ export function CreateAgentDialog({
   // Back is hidden in the squad-join retry state: the agent already
   // exists, so navigating back to a step that mutates the form would
   // imply the user is still composing the agent. Recovery is forward-
-  // only — retry the join or close out.
+  // only — retry the join or close out. It's also hidden while a
+  // submit is in flight, so the user can't re-mount the form mid-
+  // request (which would lose the create-agent context).
   const showBackButton =
     !squadJoinRetry &&
+    !creating &&
     (step.kind === "template-picker" ||
       step.kind === "template-detail" ||
       step.kind === "blank-form");
@@ -703,7 +719,19 @@ export function CreateAgentDialog({
         {!squadJoinRetry && isFormStep(step) && (
           <>
             <div className="flex-1 overflow-y-auto p-5">
-              <div className="space-y-4 min-w-0">
+              {/* fieldset[disabled] is the user-agent's native escape
+                  hatch for "freeze this form": every native control
+                  inside (input, button, select, textarea) is disabled
+                  by the browser, so a stray Enter key on the name
+                  input or click on the visibility toggle can't slip
+                  through while we're waiting on createAgent /
+                  addSquadMember. The visual neutralisations
+                  (border-0 p-0 m-0) keep fieldset's default chrome
+                  out of the layout. */}
+              <fieldset
+                disabled={creating}
+                className="space-y-4 min-w-0 border-0 p-0 m-0 disabled:opacity-60"
+              >
                 {/* failedURLs banner lives in TemplateDetail — it's the
                     only step that can trigger a 422, and rendering the
                     error there keeps the user where the action was. */}
@@ -838,7 +866,7 @@ export function CreateAgentDialog({
 
                 {/* Avatar moved up next to Name — see the identity row at
                     the top of the form. */}
-              </div>
+              </fieldset>
             </div>
 
             {/* Inline footer instead of <DialogFooter>: the shipped

--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from "react";
 import {
+  AlertTriangle,
   ArrowLeft,
   FileText,
   Globe,
+  Loader2,
   Lock,
   PenLine,
 } from "lucide-react";
@@ -28,6 +30,7 @@ import type {
   RuntimeDevice,
   MemberWithUser,
   CreateAgentRequest,
+  SquadMember,
 } from "@multica/core/types";
 import { isImeComposing } from "@multica/core/utils";
 import {
@@ -178,7 +181,20 @@ export function CreateAgentDialog({
   const [selectedSkillIds, setSelectedSkillIds] = useState<Set<string>>(
     () => new Set(template?.skills.map((s) => s.id) ?? []),
   );
-  const [creating, setCreating] = useState(false);
+  // Submit progresses through phases so the action button can show
+  // accurate copy ("Creating..." → "Adding to squad...") instead of a
+  // generic spinner. Phases are mutually exclusive — only one network
+  // call is in flight at a time.
+  type SubmitPhase = "idle" | "creating-agent" | "adding-to-squad";
+  const [phase, setPhase] = useState<SubmitPhase>("idle");
+  const creating = phase !== "idle";
+  // When the agent was created but addSquadMember failed, we hold the
+  // agent here so the dialog can stay open with a Retry button —
+  // closing in that state would orphan the agent (created but not in
+  // the squad), which is the exact bug GPT-Boy flagged on MUL-2178.
+  const [squadJoinRetry, setSquadJoinRetry] = useState<
+    { agentId: string; displayName: string } | null
+  >(null);
   const [failedURLs, setFailedURLs] = useState<string[] | null>(null);
 
   // Duplicate-mode pre-fill: clone lands on the source agent's runtime so
@@ -217,19 +233,39 @@ export function CreateAgentDialog({
     setStep({ kind: "blank-form" });
   };
 
-  // Shared squad-join follow-up. Returns nothing — the caller has
-  // already shown its create-success toast; we only need to surface a
-  // warning when the agent landed but the squad-join failed. Cache
-  // invalidation for the squad's members list rides along so the
-  // Members tab re-renders without a manual refetch.
-  const attachToSquad = async (agentId: string, displayName: string) => {
-    if (!squadId) return;
+  // Shared squad-join follow-up. Returns `true` when the agent landed
+  // in the squad, `false` when AddSquadMember failed — the form path
+  // and the template path both use this signal to decide whether to
+  // close the dialog (success) or keep it open with a retry CTA
+  // (failure). On success we optimistically insert the SquadMember
+  // into the cache so the Members tab shows the new agent the instant
+  // the dialog closes, instead of leaving an empty-feeling beat while
+  // a background refetch lands. The invalidation still rides along so
+  // server-side joins (member metadata, role) reconcile in the
+  // background.
+  const attachToSquad = async (
+    agentId: string,
+    displayName: string,
+  ): Promise<boolean> => {
+    if (!squadId) return true;
+    setPhase("adding-to-squad");
     try {
-      await api.addSquadMember(squadId, {
+      const newMember = await api.addSquadMember(squadId, {
         member_type: "agent",
         member_id: agentId,
       });
       if (wsId) {
+        queryClient.setQueryData<SquadMember[]>(
+          [...workspaceKeys.squads(wsId), squadId, "members"],
+          (current = []) => {
+            const exists = current.some(
+              (m) =>
+                m.member_type === newMember.member_type &&
+                m.member_id === newMember.member_id,
+            );
+            return exists ? current : [...current, newMember];
+          },
+        );
         queryClient.invalidateQueries({
           queryKey: [...workspaceKeys.squads(wsId), squadId, "members"],
         });
@@ -237,14 +273,32 @@ export function CreateAgentDialog({
           queryKey: [...workspaceKeys.squads(wsId), squadId],
         });
       }
+      setSquadJoinRetry(null);
+      return true;
     } catch (err) {
+      setSquadJoinRetry({ agentId, displayName });
       toast.warning(
         t(($) => $.create_dialog.squad_join_failed_toast, {
           name: displayName,
           error: err instanceof Error ? err.message : "unknown error",
         }),
       );
+      return false;
+    } finally {
+      setPhase("idle");
     }
+  };
+
+  // Retry handler for the squad-join-failed state. Reuses attachToSquad
+  // so a second failure stays in the same UI; a success closes the
+  // dialog like the happy path.
+  const handleRetrySquadJoin = async () => {
+    if (!squadJoinRetry) return;
+    const ok = await attachToSquad(
+      squadJoinRetry.agentId,
+      squadJoinRetry.displayName,
+    );
+    if (ok) onClose();
   };
 
   // Template path is one-click — picker card click goes straight to the
@@ -267,7 +321,7 @@ export function CreateAgentDialog({
     }
 
     setFailedURLs(null);
-    setCreating(true);
+    setPhase("creating-agent");
     try {
       const resp = await api.createAgentFromTemplate({
         template_slug: tmpl.slug,
@@ -295,10 +349,15 @@ export function CreateAgentDialog({
       // Squad context: attach the freshly created agent to the squad
       // before closing — and skip the agent-detail navigation so the
       // user lands back on the squad page where they triggered the
-      // flow. Failures here are non-fatal; the agent exists and can be
-      // added manually if the join call 4xxs.
+      // flow. If the join fails the dialog stays open in the retry
+      // state (attachToSquad sets squadJoinRetry); we do NOT close
+      // here, otherwise the user can't recover without re-opening
+      // Members and adding manually.
       if (squadId && resp.agent.id) {
-        await attachToSquad(resp.agent.id, candidate);
+        const joined = await attachToSquad(resp.agent.id, candidate);
+        if (!joined) return;
+        onClose();
+        return;
       }
       onClose();
       // Land on the new agent's detail page so the user can verify or
@@ -308,8 +367,9 @@ export function CreateAgentDialog({
       // fallback) we skip the navigation: the agent was created server-
       // side, the list-invalidation above will surface it, and a push
       // to `/agents/` would land on a broken detail page. Squad-context
-      // entry also skips the push — the user wants to stay on Members.
-      if (resp.agent.id && !squadId) {
+      // entry has already returned above — its navigation stays on
+      // Members.
+      if (resp.agent.id) {
         navigation.push(paths.agentDetail(resp.agent.id));
       }
     } catch (err) {
@@ -321,14 +381,14 @@ export function CreateAgentDialog({
           err instanceof Error ? err.message : t(($) => $.create_dialog.create_failed_toast),
         );
       }
-      setCreating(false);
+      setPhase("idle");
     }
   };
 
   const handleSubmit = async () => {
     if (!name.trim() || !selectedRuntime || selectedRuntimeLocked) return;
     setFailedURLs(null);
-    setCreating(true);
+    setPhase("creating-agent");
 
     // Template path goes through quickCreateFromTemplate directly from
     // the picker — no form step. So handleSubmit only fires for blank /
@@ -399,35 +459,43 @@ export function CreateAgentDialog({
       }
       // Squad context: attach the agent after skills land so the
       // squad's Members tab shows the agent with its skills already
-      // in place. Atomicity is best-effort by design (see plan in
-      // MUL-2178) — a partial failure surfaces a warning toast and
-      // the user can retry from the Add Member dialog.
+      // in place. The dialog only closes when AddSquadMember succeeds
+      // — on failure attachToSquad parks the agent in squadJoinRetry
+      // so the user can retry without re-creating the agent (the
+      // alternative was a warning toast that the user could miss and
+      // end up with an orphan agent not in the squad).
       if (createdAgent && squadId) {
-        await attachToSquad(createdAgent.id, createdAgent.name);
+        const joined = await attachToSquad(createdAgent.id, createdAgent.name);
+        if (!joined) return;
       }
       onClose();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t(($) => $.create_dialog.create_failed_toast));
-      setCreating(false);
+      setPhase("idle");
     }
   };
 
   // Header title — narrowed by step.kind, so reads on `step.template` are
-  // type-safe and there's no fallback string compilation needed.
-  const headerTitle = (() => {
-    switch (step.kind) {
-      case "chooser":
-        return t(($) => $.create_dialog.title_create);
-      case "blank-form":
-        return t(($) => $.create_dialog.title_create);
-      case "duplicate-form":
-        return t(($) => $.create_dialog.title_duplicate);
-      case "template-picker":
-        return t(($) => $.create_dialog.template_picker.title);
-      case "template-detail":
-        return step.template.name;
-    }
-  })();
+  // type-safe and there's no fallback string compilation needed. When
+  // the squad-join retry takes over, the title reflects the new task
+  // ("Couldn't add agent...") so the user isn't staring at "Create
+  // Agent" while looking at a failure recovery screen.
+  const headerTitle = squadJoinRetry
+    ? t(($) => $.create_dialog.squad_join_retry.title)
+    : (() => {
+        switch (step.kind) {
+          case "chooser":
+            return t(($) => $.create_dialog.title_create);
+          case "blank-form":
+            return t(($) => $.create_dialog.title_create);
+          case "duplicate-form":
+            return t(($) => $.create_dialog.title_duplicate);
+          case "template-picker":
+            return t(($) => $.create_dialog.template_picker.title);
+          case "template-detail":
+            return step.template.name;
+        }
+      })();
 
   // Back navigation — each kind maps to one previous kind. Duplicate-form
   // and chooser have no back (duplicate enters from a row action, chooser
@@ -449,13 +517,27 @@ export function CreateAgentDialog({
     }
   };
 
+  // Back is hidden in the squad-join retry state: the agent already
+  // exists, so navigating back to a step that mutates the form would
+  // imply the user is still composing the agent. Recovery is forward-
+  // only — retry the join or close out.
   const showBackButton =
-    step.kind === "template-picker" ||
-    step.kind === "template-detail" ||
-    step.kind === "blank-form";
+    !squadJoinRetry &&
+    (step.kind === "template-picker" ||
+      step.kind === "template-detail" ||
+      step.kind === "blank-form");
 
   return (
-    <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
+    <Dialog
+      open
+      onOpenChange={(v) => {
+        // Don't let backdrop / Escape dismiss the dialog while a network
+        // call is in flight — closing mid-flight would either drop the
+        // user before AddSquadMember finishes (silent partial success)
+        // or orphan the agent if the join request is still pending.
+        if (!v && !creating) onClose();
+      }}
+    >
       <DialogContent className={agentDialogContentClass(step)}>
         <DialogHeader className="border-b px-5 py-3 space-y-0">
           <div className="flex items-center gap-2">
@@ -471,20 +553,73 @@ export function CreateAgentDialog({
             )}
             <DialogTitle className="text-base font-semibold">{headerTitle}</DialogTitle>
           </div>
-          {step.kind === "chooser" && (
+          {!squadJoinRetry && step.kind === "chooser" && (
             <DialogDescription className="mt-1 text-xs">
               {t(($) => $.create_dialog.description_create)}
             </DialogDescription>
           )}
-          {step.kind === "duplicate-form" && template && (
+          {!squadJoinRetry && step.kind === "duplicate-form" && template && (
             <DialogDescription className="mt-1 text-xs">
               {t(($) => $.create_dialog.description_duplicate, { name: template.name })}
             </DialogDescription>
           )}
         </DialogHeader>
 
+        {/* ---------- Squad-join retry view ----------
+            Agent already exists; AddSquadMember failed. We replace the
+            entire step body with a focused recover screen instead of
+            wedging a banner into the form — leaving the create form
+            visible would imply the user is still creating something,
+            but the agent is already created and any further form edits
+            would be ignored. Retry runs AddSquadMember on the existing
+            agent; Close drops the user back to Members where Add Member
+            still works. */}
+        {squadJoinRetry && (
+          <div className="flex flex-1 flex-col">
+            <div className="flex flex-1 items-center justify-center p-8">
+              <div className="flex max-w-md flex-col items-center gap-4 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                  <AlertTriangle className="h-6 w-6" />
+                </div>
+                <div className="space-y-2">
+                  <div className="text-base font-semibold">
+                    {t(($) => $.create_dialog.squad_join_retry.title)}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {t(($) => $.create_dialog.squad_join_retry.description, {
+                      name: squadJoinRetry.displayName,
+                    })}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center justify-end gap-2 border-t bg-background px-5 py-3">
+              <Button
+                variant="ghost"
+                onClick={onClose}
+                disabled={phase === "adding-to-squad"}
+              >
+                {t(($) => $.create_dialog.squad_join_retry.close_button)}
+              </Button>
+              <Button
+                onClick={() => void handleRetrySquadJoin()}
+                disabled={phase === "adding-to-squad"}
+              >
+                {phase === "adding-to-squad" ? (
+                  <>
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    {t(($) => $.create_dialog.squad_join_retry.retrying)}
+                  </>
+                ) : (
+                  t(($) => $.create_dialog.squad_join_retry.retry_button)
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
         {/* ---------- Step 1: Chooser (two large cards, vertically centred) ---------- */}
-        {step.kind === "chooser" && (
+        {!squadJoinRetry && step.kind === "chooser" && (
           <div className="flex flex-1 items-center justify-center p-8">
             <div className="grid w-full max-w-3xl grid-cols-2 gap-4">
               <button
@@ -529,7 +664,7 @@ export function CreateAgentDialog({
         {/* ---------- Step 2: Template Picker — click a card opens the
             detail preview so the user can review instructions / skills
             before committing. ---------- */}
-        {step.kind === "template-picker" && (
+        {!squadJoinRetry && step.kind === "template-picker" && (
           <TemplatePicker
             onSelect={(tmpl) => setStep({ kind: "template-detail", template: tmpl })}
           />
@@ -540,11 +675,16 @@ export function CreateAgentDialog({
             create with default settings (name auto-deduped, first usable
             runtime, private visibility); the user customises further on
             the agent detail page if needed. ---------- */}
-        {step.kind === "template-detail" && (
+        {!squadJoinRetry && step.kind === "template-detail" && (
           <TemplateDetail
             template={step.template}
             onUse={quickCreateFromTemplate}
             creating={creating}
+            creatingLabel={
+              phase === "adding-to-squad"
+                ? t(($) => $.create_dialog.adding_to_squad)
+                : undefined
+            }
             failedURLs={failedURLs}
             runtimes={runtimes}
             runtimesLoading={runtimesLoading}
@@ -560,7 +700,7 @@ export function CreateAgentDialog({
         )}
 
         {/* ---------- Form step (blank / duplicate / template) ---------- */}
-        {isFormStep(step) && (
+        {!squadJoinRetry && isFormStep(step) && (
           <>
             <div className="flex-1 overflow-y-auto p-5">
               <div className="space-y-4 min-w-0">
@@ -708,7 +848,7 @@ export function CreateAgentDialog({
                 the dialog. A plain flex row anchored by `border-t` keeps
                 the visual rhythm without the overflow bug. */}
             <div className="flex items-center justify-end gap-2 border-t bg-background px-5 py-3">
-              <Button variant="ghost" onClick={onClose}>
+              <Button variant="ghost" onClick={onClose} disabled={creating}>
                 {t(($) => $.create_dialog.cancel)}
               </Button>
               <Button
@@ -722,7 +862,14 @@ export function CreateAgentDialog({
                     : undefined
                 }
               >
-                {creating ? t(($) => $.create_dialog.creating) : t(($) => $.create_dialog.create)}
+                {creating && (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                )}
+                {phase === "adding-to-squad"
+                  ? t(($) => $.create_dialog.adding_to_squad)
+                  : phase === "creating-agent"
+                    ? t(($) => $.create_dialog.creating)
+                    : t(($) => $.create_dialog.create)}
               </Button>
             </div>
           </>

--- a/packages/views/agents/components/template-detail.tsx
+++ b/packages/views/agents/components/template-detail.tsx
@@ -23,6 +23,11 @@ interface TemplateDetailProps {
   /** True while the parent's create request is in flight; we disable the
    *  Use button so the user can't double-click. */
   creating?: boolean;
+  /** Overrides the in-flight button label. Squad-context create runs a
+   *  follow-up AddSquadMember after createAgentFromTemplate; the parent
+   *  pipes "Adding to squad..." through here so the CTA mirrors that
+   *  phase instead of stuck on "Creating...". */
+  creatingLabel?: string;
   /** Upstream URLs the server reported as unreachable on the most recent
    *  create attempt. Surfaces an inline error banner so the user knows
    *  *why* Create didn't navigate. The detail step is the only place
@@ -60,6 +65,7 @@ export function TemplateDetail({
   template,
   onUse,
   creating = false,
+  creatingLabel,
   failedURLs,
   runtimes,
   runtimesLoading,
@@ -215,7 +221,7 @@ export function TemplateDetail({
           {creating ? (
             <>
               <Loader2 className="h-4 w-4 animate-spin" />
-              {t(($) => $.create_dialog.template_detail.creating)}
+              {creatingLabel ?? t(($) => $.create_dialog.template_detail.creating)}
             </>
           ) : (
             <>

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -216,6 +216,7 @@
     "duplicate_copy_suffix": " (Copy)",
     "create": "Create",
     "creating": "Creating...",
+    "adding_to_squad": "Adding to squad...",
     "cancel": "Cancel",
     "create_failed_toast": "Failed to create agent",
     "back_aria": "Back",
@@ -225,6 +226,13 @@
     "template_created_with_reuse_toast_other": "Agent \"{{name}}\" created. Reused {{count}} existing skills.",
     "skill_attach_failed_toast": "Agent created, but failed to attach skills: {{error}}",
     "squad_join_failed_toast": "Agent \"{{name}}\" was created but couldn't join the squad: {{error}}. You can add it manually from Members.",
+    "squad_join_retry": {
+      "title": "Couldn't add agent to this squad",
+      "description": "Agent \"{{name}}\" was created, but adding it to this squad failed. Retry, or close and add it manually from Members.",
+      "retry_button": "Retry adding to squad",
+      "retrying": "Adding to squad...",
+      "close_button": "Close"
+    },
     "chooser": {
       "blank_title": "Start blank",
       "blank_desc": "Write everything yourself.",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -212,6 +212,7 @@
     "duplicate_copy_suffix": "（副本）",
     "create": "创建",
     "creating": "创建中...",
+    "adding_to_squad": "正在加入小队...",
     "cancel": "取消",
     "create_failed_toast": "创建智能体失败",
     "back_aria": "返回",
@@ -220,6 +221,13 @@
     "template_created_with_reuse_toast_other": "智能体「{{name}}」已创建。复用了 {{count}} 个现有 skill。",
     "skill_attach_failed_toast": "智能体已创建，但 skill 关联失败：{{error}}",
     "squad_join_failed_toast": "智能体「{{name}}」已创建，但加入小队失败：{{error}}。你可以在 Members 标签里手动添加。",
+    "squad_join_retry": {
+      "title": "未能将智能体加入小队",
+      "description": "智能体「{{name}}」已创建，但加入小队失败。你可以重试，也可以关闭弹窗后在 Members 标签里手动添加。",
+      "retry_button": "重试加入小队",
+      "retrying": "正在加入小队...",
+      "close_button": "关闭"
+    },
     "chooser": {
       "blank_title": "从零开始",
       "blank_desc": "全部由你来填写。",


### PR DESCRIPTION
## Summary

Follow-up to #2579, addressing the rough edges Bohan caught on dev and the minimum-change list GPT-Boy recommended:

- **Two-phase loading** — submit button shows a spinner and the phase-accurate label (`Creating...` → `Adding to squad...`) on both the manual form and the template path, instead of a static "Create".
- **Wait for the join before closing** — the dialog keeps the user in place until `addSquadMember` resolves. No more empty Members list while a background refetch lands.
- **Optimistic SquadMember insert** — the server-returned `SquadMember` is written straight into `workspaceKeys.squads(wsId)/<squadId>/members` so the new agent is on screen the instant the dialog disappears. A background invalidation still reconciles role/metadata.
- **In-dialog retry on failure** — when `addSquadMember` 4xxs, the dialog stays open with a focused recovery view: title, description that names the orphan agent, and a `Retry adding to squad` CTA. Retry runs `attachToSquad` again on the existing agent; success closes like the happy path. Close drops the user back to Members where Add Member still works.
- **Mid-flight dismissal guard** — backdrop / Escape / Cancel are all disabled while a network call is in flight, so an accidental click can't tear the dialog down mid-AddSquadMember.

## Test plan

- [x] `pnpm typecheck` — clean across all packages
- [x] `pnpm test` — 485 tests pass (482 existing + 3 new: Cancel/Create disabled mid-submit; retry view appears when AddSquadMember rejects without calling onClose; retry on success closes the dialog AND leaves the new SquadMember in the cache)
- [ ] Manual on Squad detail → Create Agent: confirm `Creating...` then `Adding to squad...` text, then Members list updates without the empty-beat
- [ ] Manual: simulate AddSquadMember 4xx (revoke admin role mid-flight) → confirm retry view renders inside the dialog, Retry button works, Close still available

MUL-2178