### PR TITLE
MUL-2263 Fix websocket origin env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,8 +88,8 @@ LOCAL_UPLOAD_BASE_URL=http://localhost:8080
 # Security
 # Comma-separated list of allowed origins for CORS and WebSocket connections.
 # Defaults to localhost dev origins when unset.
-# Example: ALLOWED_ORIGINS=https://app.multica.ai,https://staging.multica.ai
-ALLOWED_ORIGINS=
+# Example: CORS_ALLOWED_ORIGINS=https://app.multica.ai,https://staging.multica.ai
+CORS_ALLOWED_ORIGINS=
 
 # Realtime metrics endpoint (/health/realtime) access control. See MUL-1342.
 # When unset, the endpoint only serves direct loopback (127.0.0.1 / ::1)


### PR DESCRIPTION
## Fix .env.example inconsistency
correct the documented self-host CORS/WebSocket origin env var from ALLOWED_ORIGINS to CORS_ALLOWED_ORIGINS, which aligns `docker-compose.selfhost.yml`, `SELF_HOSTING_ADVANCED.md`, and `server/cmd/server/router.go`