### PR TITLE
fix(squad): align squad detail tab width with agent detail

### DIFF
--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -969,7 +969,7 @@ function SquadOverviewPane({
 
       <div className="flex-1 min-h-0 overflow-y-auto">
         {activeTab === "members" && (
-          <div className="mx-auto flex h-full max-w-2xl flex-col p-4 md:p-6">
+          <div className="flex h-full flex-col p-4 md:p-6">
             <SquadMembersTab
               members={members}
               isLeader={isLeader}
@@ -984,7 +984,7 @@ function SquadOverviewPane({
           </div>
         )}
         {activeTab === "instructions" && (
-          <div className="mx-auto flex h-full max-w-2xl flex-col p-4 md:p-6">
+          <div className="flex h-full flex-col p-4 md:p-6">
             <SquadInstructionsTab
               squad={squad}
               onSave={onSaveInstructions}


### PR DESCRIPTION
## Summary
- Squad detail right-pane tabs (Members, Instructions) were wrapped in `mx-auto flex h-full max-w-2xl flex-col p-4 md:p-6`, capping their width at `max-w-2xl` while the agent detail page's `TabContent` is full-width (`flex h-full flex-col p-4 md:p-6`).
- Drop the `mx-auto` + `max-w-2xl` wrappers so squad tab content fills the available width, matching agent detail.

## Test plan
- [ ] Open a squad detail page; Members tab list spans the full right pane.
- [ ] Switch to Instructions tab; editor spans the full right pane.
- [ ] Compare side-by-side with agent detail — widths match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)