### PR TITLE
feat(squads): add tooltips and agent detail link to squad member row

### DIFF
--- a/packages/views/locales/en/squads.json
+++ b/packages/views/locales/en/squads.json
@@ -38,7 +38,10 @@
     "section_count_other": "{{count}} members in this squad",
     "add_member_button": "Add Member",
     "create_agent_button": "Create Agent",
-    "leader_chip": "Leader"
+    "leader_chip": "Leader",
+    "view_agent_tooltip": "Open agent detail",
+    "make_leader_tooltip": "Make squad leader",
+    "remove_member_tooltip": "Remove from squad"
   },
   "instructions_tab": {
     "description": "Squad instructions are injected into the leader agent's prompt whenever it works on an issue assigned to this squad. Use them to give the leader squad-wide guidance, working agreements, or context the leader should follow on every task.",

--- a/packages/views/locales/zh-Hans/squads.json
+++ b/packages/views/locales/zh-Hans/squads.json
@@ -38,7 +38,10 @@
     "section_count_other": "该小队有 {{count}} 名成员",
     "add_member_button": "添加成员",
     "create_agent_button": "创建智能体",
-    "leader_chip": "负责人"
+    "leader_chip": "负责人",
+    "view_agent_tooltip": "打开智能体详情",
+    "make_leader_tooltip": "设为小队负责人",
+    "remove_member_tooltip": "从小队移除"
   },
   "instructions_tab": {
     "description": "小队指引会在 Leader 智能体处理分配给该小队的 issue 时注入到它的 prompt 中。可用来给 Leader 提供贯穿全队的指导、协作规范，或每次任务都应遵循的上下文。",

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -236,7 +236,6 @@ export function SquadDetailPage() {
           onCreateAgentClick={isWorkspaceAdmin ? () => setShowCreateAgent(true) : undefined}
           onSetLeader={(id) => setLeaderMut.mutate(id)}
           onRemoveMember={(m) => removeMemberMut.mutate(m)}
-          onViewAgent={(agentId) => push(p.agentDetail(agentId))}
           onUpdateRole={async (m, role) => { await updateRoleMut.mutateAsync({ member: m, role }); }}
           onSaveInstructions={async (next) => { await updateSquadMut.mutateAsync({ instructions: next }); toast.success("Instructions saved"); }}
           setLeaderPending={setLeaderMut.isPending}
@@ -916,7 +915,6 @@ function SquadOverviewPane({
   onSetLeader,
   onRemoveMember,
   onUpdateRole,
-  onViewAgent,
   onSaveInstructions,
   setLeaderPending,
 }: {
@@ -932,7 +930,6 @@ function SquadOverviewPane({
   onSetLeader: (agentId: string) => void;
   onRemoveMember: (m: SquadMember) => void;
   onUpdateRole: (m: SquadMember, role: string) => Promise<void>;
-  onViewAgent: (agentId: string) => void;
   onSaveInstructions: (next: string) => Promise<void>;
   setLeaderPending: boolean;
 }) {
@@ -987,7 +984,6 @@ function SquadOverviewPane({
               onSetLeader={onSetLeader}
               onRemoveMember={onRemoveMember}
               onUpdateRole={onUpdateRole}
-              onViewAgent={onViewAgent}
               setLeaderPending={setLeaderPending}
             />
           </div>
@@ -1035,7 +1031,6 @@ function SquadMembersTab({
   onSetLeader,
   onRemoveMember,
   onUpdateRole,
-  onViewAgent,
   setLeaderPending,
 }: {
   members: SquadMember[];
@@ -1047,10 +1042,10 @@ function SquadMembersTab({
   onSetLeader: (agentId: string) => void;
   onRemoveMember: (m: SquadMember) => void;
   onUpdateRole: (m: SquadMember, role: string) => Promise<void>;
-  onViewAgent: (agentId: string) => void;
   setLeaderPending: boolean;
 }) {
   const { t } = useT("squads");
+  const p = useWorkspacePaths();
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -1094,20 +1089,18 @@ function SquadMembersTab({
                 onSave={async (next) => { await onUpdateRole(m, next); }}
               />
             </div>
-            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
               {m.member_type === "agent" && (
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="text-muted-foreground hover:text-foreground h-8 w-8 p-0"
-                        onClick={() => onViewAgent(m.member_id)}
+                      <AppLink
+                        href={p.agentDetail(m.member_id)}
+                        className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
                         aria-label={t(($) => $.members_tab.view_agent_tooltip)}
                       >
                         <ArrowUpRight className="size-3.5" />
-                      </Button>
+                      </AppLink>
                     }
                   />
                   <TooltipContent>

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -14,7 +14,7 @@ import { CreateAgentDialog } from "../../agents/components/create-agent-dialog";
 import { useNavigation } from "../../navigation";
 import { AppLink } from "../../navigation";
 import { PageHeader } from "../../layout/page-header";
-import { Users, Plus, Trash2, ArrowLeft, Crown, Camera, Loader2, Pencil, FileText, Save } from "lucide-react";
+import { Users, Plus, Trash2, ArrowLeft, ArrowUpRight, Crown, Camera, Loader2, Pencil, FileText, Save } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
@@ -23,6 +23,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@multica/ui/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@multica/ui/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -231,6 +236,7 @@ export function SquadDetailPage() {
           onCreateAgentClick={isWorkspaceAdmin ? () => setShowCreateAgent(true) : undefined}
           onSetLeader={(id) => setLeaderMut.mutate(id)}
           onRemoveMember={(m) => removeMemberMut.mutate(m)}
+          onViewAgent={(agentId) => push(p.agentDetail(agentId))}
           onUpdateRole={async (m, role) => { await updateRoleMut.mutateAsync({ member: m, role }); }}
           onSaveInstructions={async (next) => { await updateSquadMut.mutateAsync({ instructions: next }); toast.success("Instructions saved"); }}
           setLeaderPending={setLeaderMut.isPending}
@@ -910,6 +916,7 @@ function SquadOverviewPane({
   onSetLeader,
   onRemoveMember,
   onUpdateRole,
+  onViewAgent,
   onSaveInstructions,
   setLeaderPending,
 }: {
@@ -925,6 +932,7 @@ function SquadOverviewPane({
   onSetLeader: (agentId: string) => void;
   onRemoveMember: (m: SquadMember) => void;
   onUpdateRole: (m: SquadMember, role: string) => Promise<void>;
+  onViewAgent: (agentId: string) => void;
   onSaveInstructions: (next: string) => Promise<void>;
   setLeaderPending: boolean;
 }) {
@@ -979,6 +987,7 @@ function SquadOverviewPane({
               onSetLeader={onSetLeader}
               onRemoveMember={onRemoveMember}
               onUpdateRole={onUpdateRole}
+              onViewAgent={onViewAgent}
               setLeaderPending={setLeaderPending}
             />
           </div>
@@ -1026,6 +1035,7 @@ function SquadMembersTab({
   onSetLeader,
   onRemoveMember,
   onUpdateRole,
+  onViewAgent,
   setLeaderPending,
 }: {
   members: SquadMember[];
@@ -1037,6 +1047,7 @@ function SquadMembersTab({
   onSetLeader: (agentId: string) => void;
   onRemoveMember: (m: SquadMember) => void;
   onUpdateRole: (m: SquadMember, role: string) => Promise<void>;
+  onViewAgent: (agentId: string) => void;
   setLeaderPending: boolean;
 }) {
   const { t } = useT("squads");
@@ -1084,28 +1095,66 @@ function SquadMembersTab({
               />
             </div>
             <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+              {m.member_type === "agent" && (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-muted-foreground hover:text-foreground h-8 w-8 p-0"
+                        onClick={() => onViewAgent(m.member_id)}
+                        aria-label={t(($) => $.members_tab.view_agent_tooltip)}
+                      >
+                        <ArrowUpRight className="size-3.5" />
+                      </Button>
+                    }
+                  />
+                  <TooltipContent>
+                    {t(($) => $.members_tab.view_agent_tooltip)}
+                  </TooltipContent>
+                </Tooltip>
+              )}
               {m.member_type === "agent" && !isLeader(m) && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="text-muted-foreground hover:text-amber-600 h-8 px-2"
-                  title="Make leader"
-                  onClick={() => onSetLeader(m.member_id)}
-                  disabled={setLeaderPending}
-                >
-                  <Crown className="size-3.5" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-muted-foreground hover:text-amber-600 h-8 w-8 p-0"
+                        onClick={() => onSetLeader(m.member_id)}
+                        disabled={setLeaderPending}
+                        aria-label={t(($) => $.members_tab.make_leader_tooltip)}
+                      >
+                        <Crown className="size-3.5" />
+                      </Button>
+                    }
+                  />
+                  <TooltipContent>
+                    {t(($) => $.members_tab.make_leader_tooltip)}
+                  </TooltipContent>
+                </Tooltip>
               )}
               {!isLeader(m) && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="text-muted-foreground hover:text-destructive h-8 w-8 p-0"
-                  title="Remove from squad"
-                  onClick={() => onRemoveMember(m)}
-                >
-                  <Trash2 className="size-3.5" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-muted-foreground hover:text-destructive h-8 w-8 p-0"
+                        onClick={() => onRemoveMember(m)}
+                        aria-label={t(($) => $.members_tab.remove_member_tooltip)}
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    }
+                  />
+                  <TooltipContent>
+                    {t(($) => $.members_tab.remove_member_tooltip)}
+                  </TooltipContent>
+                </Tooltip>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Replaced native HTML `title` attributes on the make-leader and remove buttons in the squad member row with proper `Tooltip` components.
- Added a new icon button (`ArrowUpRight`) on agent rows that navigates to the agent detail page; also wrapped in a `Tooltip`.
- Added i18n strings for all three tooltips (en + zh-Hans).

## Test plan
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views exec vitest run locales/parity.test.ts`
- [ ] Manually verify in the squad detail page that tooltips appear on hover and the agent-detail button navigates to the correct page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)