### PR TITLE
fix(layout): open usage dashboard in focused page (MUL-2262)

### DIFF
--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { cloneElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@multica/core/api";
 import { AppSidebar } from "./app-sidebar";
@@ -43,7 +45,13 @@ vi.mock("@multica/ui/components/ui/sidebar", () => ({
   SidebarGroupLabel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   SidebarHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   SidebarMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SidebarMenuButton: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+  SidebarMenuButton: ({
+    children,
+    render,
+  }: {
+    children: React.ReactNode;
+    render?: React.ReactElement<{ children?: React.ReactNode }>;
+  }) => (render ? cloneElement(render, undefined, children) : <button type="button">{children}</button>),
   SidebarMenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   SidebarRail: () => null,
 }));
@@ -70,7 +78,7 @@ vi.mock("./help-launcher", () => ({ HelpLauncher: () => null }));
 vi.mock("../auth", () => ({ useLogout: () => vi.fn() }));
 vi.mock("../issues/components/status-icon", () => ({ StatusIcon: () => <span /> }));
 vi.mock("../navigation", () => ({
-  AppLink: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+  AppLink: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => <a href={href} {...props}>{children}</a>,
   useNavigation: () => ({ pathname: "/acme/issues", push: vi.fn() }),
 }));
 vi.mock("../projects/components/project-icon", () => ({ ProjectIcon: () => <span /> }));
@@ -147,5 +155,20 @@ describe("PinRow", () => {
     detail.current = { isPending: false, isError: false, data: { identifier: "MUL-123", title: "Keep this pin", status: "todo" }, error: null };
     render(<AppSidebar />);
     expect(await screen.findByText("MUL-123 Keep this pin")).toBeInTheDocument();
+  });
+
+  it("opens the usage dashboard in a focused new page", async () => {
+    const focus = vi.fn();
+    const openedWindow = { focus, opener: null } as unknown as Window;
+    const open = vi.spyOn(window, "open").mockReturnValue(openedWindow);
+
+    const { container } = render(<AppSidebar />);
+    const usageLink = container.querySelector<HTMLAnchorElement>('a[href="/acme/usage"]');
+
+    expect(usageLink).toBeInTheDocument();
+    await userEvent.click(usageLink!);
+
+    expect(open).toHaveBeenCalledWith("/acme/usage", "_blank");
+    expect(focus).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -89,6 +89,27 @@ function isNavActive(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(href + "/");
 }
 
+function openFocusedPage(path: string): void {
+  if (typeof window === "undefined") return;
+  const desktopAPI = (
+    window as unknown as {
+      desktopAPI?: { openExternal?: (url: string) => Promise<void> | void };
+    }
+  ).desktopAPI;
+  if (desktopAPI?.openExternal) {
+    void desktopAPI.openExternal(path);
+    return;
+  }
+  const opened = window.open(path, "_blank");
+  if (!opened) return;
+  opened.focus();
+  try {
+    opened.opener = null;
+  } catch {
+    // Some browsers disallow mutating opener after navigation starts.
+  }
+}
+
 // Stable empty arrays for query defaults. Using an inline `= []` default on
 // `useQuery` creates a new array reference on every render when `data` is
 // undefined (e.g. query disabled or loading) — which in turn breaks any
@@ -341,7 +362,7 @@ interface AppSidebarProps {
 
 export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }: AppSidebarProps = {}) {
   const { t } = useT("layout");
-  const { pathname, push } = useNavigation();
+  const { pathname, push, getShareableUrl } = useNavigation();
   const user = useAuthStore((s) => s.user);
   const userId = useAuthStore((s) => s.user?.id);
   const logout = useLogout();
@@ -370,6 +391,14 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
   const sidebarScrollRef = useRef<HTMLDivElement>(null);
   const sidebarFadeStyle = useScrollFade(sidebarScrollRef, 24);
+  const handleUsageClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>, href: string) => {
+      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      event.preventDefault();
+      openFocusedPage(getShareableUrl?.(href) ?? href);
+    },
+    [getShareableUrl],
+  );
 
   // Local presentational copy of pinnedItems for drop-animation stability.
   // Follows TQ at rest; frozen during a drag gesture so a mid-drag cache
@@ -680,11 +709,22 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                 {workspaceNav.map((item) => {
                   const href = p[item.key]();
                   const isActive = isNavActive(pathname, href);
+                  const render =
+                    item.key === "usage" ? (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noreferrer"
+                        onClick={(event) => handleUsageClick(event, href)}
+                      />
+                    ) : (
+                      <AppLink href={href} />
+                    );
                   return (
                     <SidebarMenuItem key={item.key}>
                       <SidebarMenuButton
                         isActive={isActive}
-                        render={<AppLink href={href} />}
+                        render={render}
                         className="text-muted-foreground hover:not-data-active:bg-sidebar-accent/70 data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground"
                       >
                         <item.icon />


### PR DESCRIPTION
## Summary
- open the workspace Usage sidebar item in a new focused page instead of navigating the current page
- keep modified-click behavior as native browser new-tab handling
- add a regression test for the Usage sidebar item

## Test Plan
- pnpm --filter @multica/views exec vitest run layout/app-sidebar.test.tsx
- pnpm --filter @multica/views test
- pnpm typecheck

## Notes
- Local Windows run of the full frontend CI command hits a Vitest collection failure in apps/desktop/scripts/package.test.mjs (SyntaxError during collection); node --check succeeds for that file, and the latest upstream Ubuntu CI was green before this change.