### PR TITLE
feat(squads): add agent live peek hover card on member avatars

### DIFF
--- a/packages/views/agents/components/agent-live-peek-card.test.tsx
+++ b/packages/views/agents/components/agent-live-peek-card.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enAgents from "../../locales/en/agents.json";
+
+const TEST_RESOURCES = { en: { common: enCommon, agents: enAgents } };
+
+// useWorkspaceId is a Context-backed hook in core; stub it to a static id so
+// the card runs outside a WorkspaceIdProvider in tests.
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "ws-1",
+}));
+
+// Paths only needs issueDetail for the "Now on" link. A simple stub keeps the
+// test free of WorkspaceSlugProvider wiring.
+vi.mock("@multica/core/paths", () => ({
+  useWorkspacePaths: () => ({
+    issueDetail: (id: string) => `/test/issues/${id}`,
+  }),
+}));
+
+// AppLink is just a plain anchor here — wiring the navigation adapter would
+// add nothing to these assertions.
+vi.mock("../../navigation", () => ({
+  AppLink: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// Each test sets these up via beforeEach.
+const mockAgents = vi.hoisted(() => ({ current: [] as unknown[] }));
+const mockSnapshot = vi.hoisted(() => ({ current: [] as unknown[] }));
+const mockIssue = vi.hoisted(() => ({ current: null as unknown }));
+const mockPresence = vi.hoisted(
+  () => ({ current: "loading" as unknown }),
+);
+
+// Distinguish queries by the function reference of the queryFn — the agent
+// list, snapshot, and issue detail are all `queryOptions(...)` records that
+// the component spreads into useQuery. Match on `queryKey[2]` which we know
+// is unique per query factory.
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>(
+    "@tanstack/react-query",
+  );
+  return {
+    ...actual,
+    useQuery: (opts: { queryKey: readonly unknown[]; enabled?: boolean }) => {
+      const key = opts.queryKey;
+      // Distinguish by the third segment which is the factory tag:
+      //   ["workspaces", wsId, "agents"]                       — agent list
+      //   ["workspaces", wsId, "agent-task-snapshot", "list"]  — snapshot
+      //   ["issues",     wsId, "detail", id]                   — issue detail
+      const root = key[0];
+      const marker = key[2];
+      if (root === "workspaces" && marker === "agents") {
+        return { data: mockAgents.current, isLoading: false };
+      }
+      if (root === "workspaces" && marker === "agent-task-snapshot") {
+        return { data: mockSnapshot.current, isLoading: false };
+      }
+      if (root === "issues" && marker === "detail") {
+        return {
+          data: opts.enabled ? mockIssue.current : undefined,
+          isLoading: false,
+        };
+      }
+      return { data: undefined, isLoading: false };
+    },
+  };
+});
+
+vi.mock("@multica/core/agents", async () => {
+  const actual =
+    await vi.importActual<typeof import("@multica/core/agents")>(
+      "@multica/core/agents",
+    );
+  return {
+    ...actual,
+    useAgentPresenceDetail: () => mockPresence.current,
+  };
+});
+
+import { AgentLivePeekCard } from "./agent-live-peek-card";
+
+function makeAgent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "agent-1",
+    workspace_id: "ws-1",
+    runtime_id: "rt-1",
+    name: "Squirtle",
+    description: "",
+    instructions: "",
+    avatar_url: null,
+    runtime_mode: "local" as const,
+    runtime_config: {},
+    custom_env: {},
+    custom_args: [],
+    custom_env_redacted: false,
+    visibility: "private" as const,
+    status: "idle" as const,
+    max_concurrent_tasks: 1,
+    model: "",
+    owner_id: "user-me",
+    skills: [],
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+    archived_at: null,
+    archived_by: null,
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Record<string, unknown>) {
+  return {
+    id: "task-x",
+    agent_id: "agent-1",
+    runtime_id: "rt-1",
+    issue_id: "",
+    status: "completed" as const,
+    priority: 0,
+    dispatched_at: null,
+    started_at: null,
+    completed_at: null,
+    result: null,
+    error: null,
+    created_at: "2026-05-14T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderCard() {
+  return render(
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      <AgentLivePeekCard agentId="agent-1" />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+  mockAgents.current = [makeAgent()];
+  mockSnapshot.current = [];
+  mockIssue.current = null;
+  mockPresence.current = {
+    availability: "online",
+    workload: "idle",
+    runningCount: 0,
+    queuedCount: 0,
+    capacity: 1,
+  };
+});
+
+describe("AgentLivePeekCard", () => {
+  it("renders Working state with the linked current issue", () => {
+    mockSnapshot.current = [
+      makeTask({
+        id: "task-running",
+        status: "running",
+        issue_id: "issue-42",
+        started_at: "2026-05-14T08:00:00Z",
+      }),
+    ];
+    mockIssue.current = {
+      id: "issue-42",
+      identifier: "MUL-42",
+      title: "Wire up live peek",
+    };
+    mockPresence.current = {
+      availability: "online",
+      workload: "working",
+      runningCount: 1,
+      queuedCount: 0,
+      capacity: 1,
+    };
+
+    renderCard();
+
+    expect(screen.getByText("Working")).toBeInTheDocument();
+    // identifier + title both render under the same link.
+    const link = screen.getByRole("link", { name: /MUL-42/ });
+    expect(link).toHaveAttribute("href", "/test/issues/issue-42");
+    expect(link.textContent).toContain("Wire up live peek");
+  });
+
+  it("renders Idle + empty issue copy when nothing is running", () => {
+    mockPresence.current = {
+      availability: "online",
+      workload: "idle",
+      runningCount: 0,
+      queuedCount: 0,
+      capacity: 1,
+    };
+    mockSnapshot.current = [
+      makeTask({
+        id: "task-done",
+        status: "completed",
+        completed_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      }),
+    ];
+
+    renderCard();
+
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByText(enAgents.live_peek.no_current_issue)).toBeInTheDocument();
+    // "5m ago" — proves last activity falls back to the most recent terminal
+    // task in the snapshot.
+    expect(screen.getByText(/5m ago/)).toBeInTheDocument();
+    // No failed indicator on a completed terminal state.
+    expect(screen.queryByText(enAgents.live_peek.failed_indicator)).toBeNull();
+  });
+
+  it("shows the failed indicator on the last-activity row when the most recent terminal task failed", () => {
+    mockPresence.current = {
+      availability: "online",
+      // Per the project's deliberate split, workload is current-only — so
+      // a failed terminal task does NOT flip workload to anything besides
+      // idle / queued / working.
+      workload: "idle",
+      runningCount: 0,
+      queuedCount: 0,
+      capacity: 1,
+    };
+    mockSnapshot.current = [
+      makeTask({
+        id: "task-failed",
+        status: "failed",
+        completed_at: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+      }),
+    ];
+
+    renderCard();
+
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByText(enAgents.live_peek.failed_indicator)).toBeInTheDocument();
+  });
+});

--- a/packages/views/agents/components/agent-live-peek-card.tsx
+++ b/packages/views/agents/components/agent-live-peek-card.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useWorkspacePaths } from "@multica/core/paths";
+import { agentListOptions } from "@multica/core/workspace/queries";
+import {
+  agentTaskSnapshotOptions,
+  useAgentPresenceDetail,
+} from "@multica/core/agents";
+import { issueDetailOptions } from "@multica/core/issues";
+import { timeAgo } from "@multica/core/utils";
+import type { AgentTask } from "@multica/core/types";
+import { AlertTriangle } from "lucide-react";
+import { AppLink } from "../../navigation";
+import { useT } from "../../i18n";
+import { workloadConfig } from "../presence";
+
+interface AgentLivePeekCardProps {
+  agentId: string;
+}
+
+// Live "peek" card for an agent avatar — shows the three live signals the
+// squad members tab cares about (workload, current issue, last activity).
+// Companion to AgentProfileCard, which surfaces static identity (description,
+// runtime, skills, owner). Keeping them separate avoids polluting the 23+
+// existing AgentProfileCard call sites with live-only concerns.
+export function AgentLivePeekCard({ agentId }: AgentLivePeekCardProps) {
+  const { t } = useT("agents");
+  const wsId = useWorkspaceId();
+  const p = useWorkspacePaths();
+  const { data: agents = [], isLoading: agentsLoading } = useQuery(
+    agentListOptions(wsId),
+  );
+  const { data: snapshot = [] } = useQuery(agentTaskSnapshotOptions(wsId));
+  const presence = useAgentPresenceDetail(wsId, agentId);
+
+  const agent = agents.find((a) => a.id === agentId);
+
+  if (agentsLoading && !agent) {
+    return (
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-full" />
+        <div className="flex-1 space-y-1.5">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!agent) {
+    return (
+      <div className="text-xs text-muted-foreground">
+        {t(($) => $.profile_card.unavailable)}
+      </div>
+    );
+  }
+
+  const agentTasks = snapshot.filter((t) => t.agent_id === agentId);
+  const runningTask = agentTasks.find(
+    (t) => t.status === "running" && !!t.issue_id,
+  );
+  const currentIssueId = runningTask?.issue_id ?? null;
+  const lastTerminal = pickLatestTerminal(agentTasks);
+
+  const initials = agent.name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+
+  const workload = presence === "loading" ? null : presence.workload;
+  const workloadVisual = workload ? workloadConfig[workload] : null;
+
+  return (
+    <div className="flex flex-col gap-3 text-left">
+      {/* Header — avatar + name. */}
+      <div className="flex items-start gap-3">
+        <ActorAvatarBase
+          name={agent.name}
+          initials={initials}
+          avatarUrl={agent.avatar_url}
+          isAgent
+          size={40}
+          className="rounded-md"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold">{agent.name}</p>
+          <div className="mt-0.5 inline-flex items-center gap-1.5">
+            {workloadVisual ? (
+              <>
+                <workloadVisual.icon
+                  className={`h-3 w-3 shrink-0 ${workloadVisual.textClass}`}
+                />
+                <span className={`text-xs ${workloadVisual.textClass}`}>
+                  {t(($) => $.workload[workload!])}
+                </span>
+              </>
+            ) : (
+              <Skeleton className="h-3 w-12" />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Meta rows. */}
+      <div className="flex flex-col gap-1.5 text-xs">
+        <CurrentIssueRow
+          wsId={wsId}
+          issueId={currentIssueId}
+          label={t(($) => $.live_peek.current_issue_label)}
+          emptyLabel={t(($) => $.live_peek.no_current_issue)}
+          issueHref={(id) => p.issueDetail(id)}
+        />
+        <LastActivityRow
+          task={lastTerminal}
+          label={t(($) => $.live_peek.last_activity_label)}
+          emptyLabel={t(($) => $.live_peek.no_recent_activity)}
+          failedLabel={t(($) => $.live_peek.failed_indicator)}
+        />
+      </div>
+    </div>
+  );
+}
+
+// Pick the most recent terminal task for last-activity display. Snapshot
+// already caps this to one terminal row per agent (see queries.ts header),
+// but a defensive max-by-completed_at keeps the card honest if that shape
+// ever changes.
+function pickLatestTerminal(tasks: readonly AgentTask[]): AgentTask | null {
+  let best: AgentTask | null = null;
+  for (const t of tasks) {
+    if (t.status !== "completed" && t.status !== "failed" && t.status !== "cancelled") {
+      continue;
+    }
+    if (!t.completed_at) continue;
+    if (!best || (best.completed_at && t.completed_at > best.completed_at)) {
+      best = t;
+    }
+  }
+  return best;
+}
+
+function CurrentIssueRow({
+  wsId,
+  issueId,
+  label,
+  emptyLabel,
+  issueHref,
+}: {
+  wsId: string;
+  issueId: string | null;
+  label: string;
+  emptyLabel: string;
+  issueHref: (id: string) => string;
+}) {
+  // Lazy issue detail — only enabled while the card is mounted AND we have
+  // a running issue id. snapshot already gives us the id; this hook just
+  // resolves the human identifier (MUL-123) + title.
+  const { data: issue } = useQuery({
+    ...issueDetailOptions(wsId, issueId ?? ""),
+    enabled: !!issueId,
+  });
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="w-16 shrink-0 text-muted-foreground">{label}</span>
+      {issueId ? (
+        issue ? (
+          <AppLink
+            href={issueHref(issueId)}
+            className="min-w-0 truncate text-brand hover:underline"
+            title={`${issue.identifier} ${issue.title}`}
+          >
+            <span className="mr-1 font-mono text-[11px]">{issue.identifier}</span>
+            <span>{issue.title}</span>
+          </AppLink>
+        ) : (
+          <Skeleton className="h-3 w-24" />
+        )
+      ) : (
+        <span className="text-muted-foreground">{emptyLabel}</span>
+      )}
+    </div>
+  );
+}
+
+function LastActivityRow({
+  task,
+  label,
+  emptyLabel,
+  failedLabel,
+}: {
+  task: AgentTask | null;
+  label: string;
+  emptyLabel: string;
+  failedLabel: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="w-16 shrink-0 text-muted-foreground">{label}</span>
+      {task && task.completed_at ? (
+        <span className="inline-flex min-w-0 items-center gap-1 truncate">
+          <span className="truncate">{timeAgo(task.completed_at)}</span>
+          {task.status === "failed" && (
+            // Failed terminal state shows here only — workload above stays a
+            // clean "what's on the plate now" reading (working/queued/idle),
+            // matching the project's deliberate split between current and
+            // historical state.
+            <span
+              className="inline-flex items-center gap-0.5 rounded bg-warning/10 px-1 py-0.5 text-[10px] font-medium text-warning"
+              title={failedLabel}
+            >
+              <AlertTriangle className="h-2.5 w-2.5" />
+              {failedLabel}
+            </span>
+          )}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">{emptyLabel}</span>
+      )}
+    </div>
+  );
+}

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -11,8 +11,23 @@ import { useActorName } from "@multica/core/workspace/hooks";
 import { useAgentPresenceDetail } from "@multica/core/agents";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { AgentProfileCard } from "../agents/components/agent-profile-card";
+import { AgentLivePeekCard } from "../agents/components/agent-live-peek-card";
 import { MemberProfileCard } from "../members/member-profile-card";
 import { availabilityConfig } from "../agents/presence";
+
+/**
+ * Selects which agent hover-card payload to render when `enableHoverCard` is
+ * on. Two surfaces, two intents:
+ * - `"profile"` (default) — static identity (description, runtime, skills,
+ *   owner). Used by 20+ "who is this agent?" surfaces (comment authors,
+ *   pickers, list rows).
+ * - `"live"` — live activity peek (workload, current issue, last activity).
+ *   Used where the user already knows the identity and wants the live state,
+ *   e.g. the squad members tab.
+ *
+ * Has no effect for non-agent actors (members always render the member card).
+ */
+export type AgentHoverCardVariant = "profile" | "live";
 
 interface ActorAvatarProps {
   actorType: string;
@@ -33,6 +48,12 @@ interface ActorAvatarProps {
    * popover inside the dropdown.
    */
   showStatusDot?: boolean;
+  /**
+   * When `enableHoverCard` is on for an agent, choose which payload to
+   * render. See {@link AgentHoverCardVariant}. Defaults to `"profile"` so
+   * existing call sites keep their identity-card behaviour.
+   */
+  hoverCardVariant?: AgentHoverCardVariant;
 }
 
 const FOCUSABLE_ANCESTOR_SELECTOR =
@@ -45,6 +66,7 @@ export function ActorAvatar({
   className,
   enableHoverCard,
   showStatusDot,
+  hoverCardVariant = "profile",
 }: ActorAvatarProps) {
   const { getActorName, getActorInitials, getActorAvatarUrl } = useActorName();
   const avatar = (
@@ -78,7 +100,11 @@ export function ActorAvatar({
     return dotted;
   }
   if (actorType === "agent") {
-    return <AgentAvatarHoverCard agentId={actorId}>{dotted}</AgentAvatarHoverCard>;
+    return (
+      <AgentAvatarHoverCard agentId={actorId} variant={hoverCardVariant}>
+        {dotted}
+      </AgentAvatarHoverCard>
+    );
   }
   if (actorType === "member") {
     return <MemberAvatarHoverCard userId={actorId}>{dotted}</MemberAvatarHoverCard>;
@@ -116,13 +142,21 @@ function AgentStatusDot({ agentId, size }: { agentId: string; size?: number }) {
  */
 function AgentAvatarHoverCard({
   agentId,
+  variant,
   children,
 }: {
   agentId: string;
+  variant: AgentHoverCardVariant;
   children: React.ReactNode;
 }) {
+  const content =
+    variant === "live" ? (
+      <AgentLivePeekCard agentId={agentId} />
+    ) : (
+      <AgentProfileCard agentId={agentId} />
+    );
   return (
-    <ActorAvatarHoverCardShell content={<AgentProfileCard agentId={agentId} />}>
+    <ActorAvatarHoverCardShell content={content}>
       {children}
     </ActorAvatarHoverCardShell>
   );

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -403,6 +403,13 @@
     "owner_label": "Owner",
     "unknown_runtime": "Unknown runtime"
   },
+  "live_peek": {
+    "current_issue_label": "Now on",
+    "no_current_issue": "No task",
+    "last_activity_label": "Last seen",
+    "no_recent_activity": "No recent activity",
+    "failed_indicator": "Failed"
+  },
   "transcript": {
     "dialog_title": "Agent Execution Transcript",
     "status_running": "Running",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -392,6 +392,13 @@
     "owner_label": "所有者",
     "unknown_runtime": "未知运行时"
   },
+  "live_peek": {
+    "current_issue_label": "正在处理",
+    "no_current_issue": "暂无任务",
+    "last_activity_label": "最近活动",
+    "no_recent_activity": "暂无活动",
+    "failed_indicator": "失败"
+  },
   "transcript": {
     "dialog_title": "智能体执行记录",
     "status_running": "进行中",

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -1077,7 +1077,7 @@ function SquadMembersTab({
               actorId={m.member_id}
               size={32}
               showStatusDot
-              enableHoverCard
+              enableHoverCard={m.member_type === "agent"}
               hoverCardVariant="live"
             />
             <div className="flex-1 min-w-0">

--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -1072,7 +1072,14 @@ function SquadMembersTab({
       <div className="space-y-2">
         {members.map((m) => (
           <div key={m.id} className="group flex items-start gap-3 rounded-lg border p-3">
-            <ActorAvatar actorType={m.member_type} actorId={m.member_id} size={32} showStatusDot />
+            <ActorAvatar
+              actorType={m.member_type}
+              actorId={m.member_id}
+              size={32}
+              showStatusDot
+              enableHoverCard
+              hoverCardVariant="live"
+            />
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium">{getEntityName(m.member_type, m.member_id)}</span>


### PR DESCRIPTION
## Summary

- New `AgentLivePeekCard` shows workload, current issue (clickable), and last activity when hovering/focusing an agent avatar in the squad members tab.
- `ActorAvatar` gains an optional `hoverCardVariant?: "profile" | "live"` prop, defaulting to `"profile"` so all existing call sites keep the identity card. Only the squad members row opts into `"live"`.
- `failed` terminal state surfaces as a small ⚠ on the last-activity line; workload stays current-only (working/queued/idle) per the deliberate split documented in `core/agents/types.ts`.

## Data

- Zero backend changes. The card reuses `agentTaskSnapshotOptions` (already fetched by the presence dot) and lazily resolves the running issue's identifier/title via `issueDetailOptions` only while the card is mounted.

## Test plan

- [x] `pnpm typecheck` (all packages)
- [x] `pnpm --filter @multica/views test` (485/485)
- [x] New `agent-live-peek-card.test.tsx` covers Working+link, Idle+empty, and the Failed indicator branch.
- [ ] Manual: hover an agent avatar in the squad detail Members tab → workload + current issue (if running) + "X ago" all render. Tab key reaches the trigger. The MUL-2196 hover/focus button group still works.

Tracking issue: [MUL-2201](https://multica.ai/issues/ce810556-34bf-4ba3-a081-ed03f3393ecd)