### PR TITLE
docs(changelog): add May 14 release notes

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -285,13 +285,12 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
-        version: "0.2.33",
+        version: "0.3.0",
         date: "2026-05-14",
-        title: "Squads, Agent Templates & Attachment Previews",
+        title: "Squads & Attachment Previews",
         changes: [],
         features: [
           "Squads let teams assign work to a group, with a leader agent coordinating the next step",
-          "Create agents from a richer template gallery, including lightweight prompt-only starters for engineering, product, design, writing, communication, and productivity",
           "Attachments can be previewed in place for PDFs, audio, video, markdown, code, logs, and plain text",
           "Chinese names can be found by pinyin across mentions, assignees, subscribers, agents, projects, and squads",
         ],

--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -285,6 +285,31 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.33",
+        date: "2026-05-14",
+        title: "Squads, Agent Templates & Attachment Previews",
+        changes: [],
+        features: [
+          "Squads let teams assign work to a group, with a leader agent coordinating the next step",
+          "Create agents from a richer template gallery, including lightweight prompt-only starters for engineering, product, design, writing, communication, and productivity",
+          "Attachments can be previewed in place for PDFs, audio, video, markdown, code, logs, and plain text",
+          "Chinese names can be found by pinyin across mentions, assignees, subscribers, agents, projects, and squads",
+        ],
+        improvements: [
+          "Squad pages now include member management, faster agent creation from a squad, clearer row actions, and a wider detail layout",
+          "Quick-create and picker flows are easier to search and now include squad-aware routing",
+          "Usage charts can switch between cost and token views, with the same timezone controls used by runtimes",
+          "Workspace operators get command-line controls for managing squads and stopping a runaway issue run",
+          "Shared interface labels are translated more consistently in English and Chinese",
+        ],
+        fixes: [
+          "Squad leaders stay quiet when a human already routed the conversation to someone specific",
+          "Mentioning a squad now wakes the right leader while preserving private-agent access rules",
+          "Issue lists stay fresher after deletes and follow-up comments no longer trigger stale Done replies",
+          "Attachment previews keep working for files added while writing or editing issues and comments",
+        ],
+      },
+      {
         version: "0.2.32",
         date: "2026-05-13",
         title: "Usage Insights, Chat Renaming & Smoother Desktop Flows",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -285,6 +285,31 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.2.33",
+        date: "2026-05-14",
+        title: "Squads、Agent 模板与附件预览",
+        changes: [],
+        features: [
+          "Squads 支持把任务交给一个小组，由 leader agent 负责协调下一步",
+          "创建 Agent 时可以从更丰富的模板库开始，覆盖工程、产品、设计、写作、沟通和效率场景，也支持纯指令模板",
+          "附件可以直接预览，支持 PDF、音频、视频、Markdown、代码、日志和纯文本",
+          "中文姓名支持用拼音搜索，适用于 mention、负责人、订阅人、agents、projects 和 squads",
+        ],
+        improvements: [
+          "Squad 页面补齐成员管理、从 squad 内快速创建 agent、清晰的成员操作按钮，以及更宽的详情布局",
+          "快速创建和各类选择器更容易搜索，并能识别 squad 相关的指派和提及",
+          "Usage 图表可以在费用和 token 视图之间切换，并复用 runtime 的时区控制",
+          "工作区管理员可以通过命令行管理 squads，并在必要时停止失控的 issue 执行",
+          "共享界面文案的中英文翻译更完整",
+        ],
+        fixes: [
+          "当成员已经明确把讨论指向某个人或小组时，Squad leader 不再重复发言",
+          "提及 squad 时会正确唤起对应 leader，同时保留私有 agent 的访问限制",
+          "删除 Issue 后列表刷新更准确，后续评论也不再触发过期的 Done 回复",
+          "在撰写或编辑 issue 和评论时新增的附件，也可以稳定使用预览",
+        ],
+      },
+      {
         version: "0.2.32",
         date: "2026-05-13",
         title: "用量洞察、聊天重命名与桌面体验优化",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -285,13 +285,12 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
-        version: "0.2.33",
+        version: "0.3.0",
         date: "2026-05-14",
-        title: "Squads、Agent 模板与附件预览",
+        title: "Squads 与附件预览",
         changes: [],
         features: [
           "Squads 支持把任务交给一个小组，由 leader agent 负责协调下一步",
-          "创建 Agent 时可以从更丰富的模板库开始，覆盖工程、产品、设计、写作、沟通和效率场景，也支持纯指令模板",
           "附件可以直接预览，支持 PDF、音频、视频、Markdown、代码、日志和纯文本",
           "中文姓名支持用拼音搜索，适用于 mention、负责人、订阅人、agents、projects 和 squads",
         ],


### PR DESCRIPTION
Summary:
- Add the v0.3.0 / 2026-05-14 changelog entry in English and Chinese.
- Cover today's release highlights in product language: Squads, attachment previews, pinyin search, usage updates, squad routing fixes, and operator controls.

Testing:
- pnpm install --frozen-lockfile
- pnpm --filter @multica/web typecheck
- git diff --check

MUL-2205
