### PR TITLE
docs(issue-template): clarify deployment type options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,10 +7,10 @@ body:
     id: deployment
     attributes:
       label: Deployment type
-      description: Are you using the hosted version or a self-hosted instance?
+      description: Are you using the Official App (multica.ai) or a self-hosted instance?
       options:
-        - multica.ai (hosted)
-        - Self-hosted
+        - Official App
+        - self-host
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,10 +7,10 @@ body:
     id: deployment
     attributes:
       label: Deployment type
-      description: Are you using the hosted version or a self-hosted instance?
+      description: Are you using the Official App (multica.ai) or a self-hosted instance?
       options:
-        - multica.ai (hosted)
-        - Self-hosted
+        - Official App
+        - self-host
     validations:
       required: true
 


### PR DESCRIPTION
## Summary
- Rename the **Deployment type** dropdown options in both bug and feature issue templates from `multica.ai (hosted)` / `Self-hosted` to `Official App` / `self-host` so reporters pick the right one without guessing.
- Updated the field description to match.

## Test plan
- [ ] GitHub renders the new options correctly on the issue creation page.

MUL-2212