### PR TITLE
fix(execenv): fall back OpenClaw skills to .agent_context/skills/ and stop claiming native auto-discovery

### DIFF
--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -16,7 +16,7 @@ import (
 // Codex:    skills → handled separately in Prepare via codex-home
 // Copilot:  skills → {workDir}/.github/skills/{name}/SKILL.md  (native project-level discovery)
 // OpenCode: skills → {workDir}/.opencode/skills/{name}/SKILL.md  (native discovery)
-// OpenClaw: skills → {workDir}/.openclaw/skills/{name}/SKILL.md  (native discovery)
+// OpenClaw: skills → {workDir}/.agent_context/skills/{name}/SKILL.md  (NO native auto-discovery — see note in resolveSkillsDir)
 // Pi:       skills → {workDir}/.pi/skills/{name}/SKILL.md  (native discovery)
 // Cursor:   skills → {workDir}/.cursor/skills/{name}/SKILL.md  (native discovery)
 // Kimi:     skills → {workDir}/.kimi/skills/{name}/SKILL.md  (native discovery)
@@ -134,12 +134,6 @@ func resolveSkillsDir(workDir, provider string) (string, error) {
 	case "opencode":
 		// OpenCode natively discovers skills from .opencode/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".opencode", "skills")
-	case "openclaw":
-		// OpenClaw natively discovers skills from .openclaw/skills/ in the workdir.
-		// Without this case the provider fell through to .agent_context/skills/,
-		// where the openclaw CLI never looks — so workspace skills attached to
-		// the agent silently disappeared from chat and task runs.
-		skillsDir = filepath.Join(workDir, ".openclaw", "skills")
 	case "pi":
 		// Pi natively discovers skills from .pi/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".pi", "skills")

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -16,6 +16,7 @@ import (
 // Codex:    skills → handled separately in Prepare via codex-home
 // Copilot:  skills → {workDir}/.github/skills/{name}/SKILL.md  (native project-level discovery)
 // OpenCode: skills → {workDir}/.opencode/skills/{name}/SKILL.md  (native discovery)
+// OpenClaw: skills → {workDir}/.openclaw/skills/{name}/SKILL.md  (native discovery)
 // Pi:       skills → {workDir}/.pi/skills/{name}/SKILL.md  (native discovery)
 // Cursor:   skills → {workDir}/.cursor/skills/{name}/SKILL.md  (native discovery)
 // Kimi:     skills → {workDir}/.kimi/skills/{name}/SKILL.md  (native discovery)
@@ -133,6 +134,12 @@ func resolveSkillsDir(workDir, provider string) (string, error) {
 	case "opencode":
 		// OpenCode natively discovers skills from .opencode/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".opencode", "skills")
+	case "openclaw":
+		// OpenClaw natively discovers skills from .openclaw/skills/ in the workdir.
+		// Without this case the provider fell through to .agent_context/skills/,
+		// where the openclaw CLI never looks — so workspace skills attached to
+		// the agent silently disappeared from chat and task runs.
+		skillsDir = filepath.Join(workDir, ".openclaw", "skills")
 	case "pi":
 		// Pi natively discovers skills from .pi/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".pi", "skills")

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -802,7 +802,13 @@ func TestWriteContextFilesOpencodeNativeSkills(t *testing.T) {
 	}
 }
 
-func TestWriteContextFilesOpenclawNativeSkills(t *testing.T) {
+// OpenClaw scans its own workspaceDir (resolved from the openclaw config,
+// not the task workdir) and never reads {workDir}/.openclaw/skills/. Until
+// per-task workspace integration lands, openclaw skills fall back to
+// .agent_context/skills/ — the meta AGENTS.md content references that path
+// explicitly. This test fails closed if someone re-adds a dead-drop case to
+// resolveSkillsDir.
+func TestWriteContextFilesOpenclawFallsBackToAgentContext(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
@@ -823,15 +829,15 @@ func TestWriteContextFilesOpenclawNativeSkills(t *testing.T) {
 		t.Fatalf("writeContextFiles failed: %v", err)
 	}
 
-	skillMd, err := os.ReadFile(filepath.Join(dir, ".openclaw", "skills", "go-conventions", "SKILL.md"))
+	skillMd, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "go-conventions", "SKILL.md"))
 	if err != nil {
-		t.Fatalf("failed to read .openclaw/skills/go-conventions/SKILL.md: %v", err)
+		t.Fatalf("failed to read .agent_context/skills/go-conventions/SKILL.md: %v", err)
 	}
 	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
 		t.Error("SKILL.md missing content")
 	}
 
-	supportFile, err := os.ReadFile(filepath.Join(dir, ".openclaw", "skills", "go-conventions", "templates", "example.go"))
+	supportFile, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "go-conventions", "templates", "example.go"))
 	if err != nil {
 		t.Fatalf("failed to read supporting file: %v", err)
 	}
@@ -839,8 +845,8 @@ func TestWriteContextFilesOpenclawNativeSkills(t *testing.T) {
 		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
-		t.Error("expected .agent_context/skills/ to NOT exist for OpenClaw provider")
+	if _, err := os.Stat(filepath.Join(dir, ".openclaw", "skills")); !os.IsNotExist(err) {
+		t.Error(".openclaw/skills/ MUST NOT be written — openclaw never scans that path; writing there is a dead drop")
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -802,6 +802,48 @@ func TestWriteContextFilesOpencodeNativeSkills(t *testing.T) {
 	}
 }
 
+func TestWriteContextFilesOpenclawNativeSkills(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ctx := TaskContextForEnv{
+		IssueID: "openclaw-skill-test",
+		AgentSkills: []SkillContextForEnv{
+			{
+				Name:    "Go Conventions",
+				Content: "Follow Go conventions.",
+				Files: []SkillFileContextForEnv{
+					{Path: "templates/example.go", Content: "package main"},
+				},
+			},
+		},
+	}
+
+	if err := writeContextFiles(dir, "openclaw", ctx); err != nil {
+		t.Fatalf("writeContextFiles failed: %v", err)
+	}
+
+	skillMd, err := os.ReadFile(filepath.Join(dir, ".openclaw", "skills", "go-conventions", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("failed to read .openclaw/skills/go-conventions/SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
+		t.Error("SKILL.md missing content")
+	}
+
+	supportFile, err := os.ReadFile(filepath.Join(dir, ".openclaw", "skills", "go-conventions", "templates", "example.go"))
+	if err != nil {
+		t.Fatalf("failed to read supporting file: %v", err)
+	}
+	if string(supportFile) != "package main" {
+		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
+		t.Error("expected .agent_context/skills/ to NOT exist for OpenClaw provider")
+	}
+}
+
 func TestWriteContextFilesKiroNativeSkills(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -56,7 +56,7 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Codex:    writes {workDir}/AGENTS.md  (skills discovered natively via CODEX_HOME)
 // For Copilot:  writes {workDir}/AGENTS.md  (skills discovered natively from .github/skills/)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .opencode/skills/)
-// For OpenClaw: writes {workDir}/AGENTS.md  (skills discovered natively from .openclaw/skills/)
+// For OpenClaw: writes {workDir}/AGENTS.md  (skills fall back to .agent_context/skills/; OpenClaw does not auto-discover from workdir)
 // For Hermes:   writes {workDir}/AGENTS.md  (skills fall back to .agent_context/skills/; AGENTS.md points there)
 // For Gemini:   writes {workDir}/GEMINI.md  (discovered natively by the Gemini CLI)
 // For Pi:       writes {workDir}/AGENTS.md  (skills discovered natively from .pi/skills/)
@@ -305,12 +305,15 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro":
-			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, Kimi, and Kiro discover skills natively from their respective paths — just list names.
+		case "codex", "copilot", "opencode", "pi", "cursor", "kimi", "kiro":
+			// Codex, Copilot, OpenCode, Pi, Cursor, Kimi, and Kiro discover skills natively from their respective paths — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "gemini", "hermes":
-			// Gemini reads GEMINI.md directly; Hermes has no native skills discovery path
-			// wired up in resolveSkillsDir, so both fall back to .agent_context/skills/.
+		case "gemini", "hermes", "openclaw":
+			// Gemini reads GEMINI.md directly. Hermes has no native skills discovery
+			// path wired up in resolveSkillsDir. OpenClaw scans its own workspaceDir
+			// (resolved from the openclaw config, not the task workdir) so per-task
+			// skills written by Multica are not visible to its native loader; we
+			// fall back to .agent_context/skills/ and reference the files explicitly.
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")
 		default:
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -51,7 +51,7 @@ func gitEnv() []string {
 	)
 }
 
-var agentGitExcludePatterns = []string{".agent_context", "CLAUDE.md", "AGENTS.md", ".claude", ".opencode"}
+var agentGitExcludePatterns = []string{".agent_context", "CLAUDE.md", "AGENTS.md", ".claude", ".opencode", ".openclaw"}
 
 // RepoInfo describes a repository to cache.
 type RepoInfo struct {

--- a/server/internal/daemon/repocache/cache.go
+++ b/server/internal/daemon/repocache/cache.go
@@ -51,7 +51,7 @@ func gitEnv() []string {
 	)
 }
 
-var agentGitExcludePatterns = []string{".agent_context", "CLAUDE.md", "AGENTS.md", ".claude", ".opencode", ".openclaw"}
+var agentGitExcludePatterns = []string{".agent_context", "CLAUDE.md", "AGENTS.md", ".claude", ".opencode"}
 
 // RepoInfo describes a repository to cache.
 type RepoInfo struct {


### PR DESCRIPTION
## Summary

OpenClaw-backed agents could not see any Skills loaded for them in
Multica — neither in Chat nor in regular task runs. MUL-2213.

Two problems combined to cause the symptom:

1. `resolveSkillsDir` in `server/internal/daemon/execenv/context.go`
   had no case for `openclaw`, so skills landed in the default
   `.agent_context/skills/`. An earlier attempt routed them to
   `{workDir}/.openclaw/skills/`, but that path is not in any of
   OpenClaw's skill scan roots either — OpenClaw scans
   `<workspaceDir>/skills`, `<workspaceDir>/.agents/skills`,
   `~/.openclaw/skills`, `~/.agents/skills`, bundled, and
   `skills.load.extraDirs`, where `workspaceDir` comes from
   OpenClaw config (`agents.list[id].workspace` →
   `agents.defaults.workspace` → `~/.openclaw/workspace`), **not** the
   process cwd. `openclaw agent --local` has no `--workspace` flag and
   does not consume `OPENCLAW_WORKSPACE` at runtime, so any path
   under the Multica task workdir is a dead drop.
2. The meta AGENTS.md / runtime brief told the OpenClaw agent the
   skills were "discovered automatically", which is not true on the
   Multica side — the agent was told it had skills with no honest
   path to read them.

This PR makes the behavior honest rather than pretending native
discovery works:

- Drop the `openclaw` case from `resolveSkillsDir`; skills fall
  through to `.agent_context/skills/<name>/SKILL.md` (same as
  `hermes` / `gemini`).
- Move `openclaw` out of the "auto-discovered" branch in
  `buildMetaSkillContent` / runtime brief. The brief now tells the
  agent skills live under `.agent_context/skills/` and to reference
  them by path — no more "discovered automatically" wording.
- Remove `.openclaw` from `agentGitExcludePatterns` in
  `internal/daemon/repocache`, since we no longer write there.

Native OpenClaw skill discovery (per-task `OPENCLAW_CONFIG_PATH` or
writing into the agent's configured `workspaceDir`) is intentionally
left as follow-up; it needs per-task OpenClaw workspace integration
that is well out of scope for this fix.

## Test plan

- [x] `go test ./internal/daemon/execenv ./internal/daemon/repocache` — passes
- [x] `go test ./internal/daemon/...` — passes
- [x] `TestWriteContextFilesOpenclawFallsBackToAgentContext` covers:
      (a) SKILL.md + supporting files land under
      `.agent_context/skills/<name>/`, (b) `.openclaw/skills/` is
      **not** created (fail-closed against regressing back to the
      dead-drop path)
- [ ] Manual: create an OpenClaw agent, attach a workspace Skill,
      start a chat — verify the agent references the skill content
      via `.agent_context/skills/<name>/SKILL.md`
