### PR TITLE
feat(execenv): native OpenClaw skill discovery via per-task config (MUL-2219)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2142,6 +2142,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if env.CodexHome != "" {
 		agentEnv["CODEX_HOME"] = env.CodexHome
 	}
+	// Point OpenClaw at the per-task synthesized config. The config pins
+	// agents.defaults.workspace (and any agents.list[].workspace) to the
+	// task workdir, so the CLI's native skill scanner picks up the per-task
+	// skills written under {workDir}/skills/. Falls back silently when the
+	// preparer didn't run (non-openclaw provider, or write failure).
+	if env.OpenclawConfigPath != "" {
+		agentEnv["OPENCLAW_CONFIG_PATH"] = env.OpenclawConfigPath
+	}
 	// Inject user-configured custom environment variables (e.g. ANTHROPIC_API_KEY,
 	// ANTHROPIC_BASE_URL for router/proxy mode, or CLAUDE_CODE_USE_BEDROCK for
 	// Bedrock). These are set per-agent via the agent settings UI.
@@ -2723,7 +2731,7 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	switch upper {
-	case "HOME", "PATH", "USER", "SHELL", "TERM", "CODEX_HOME":
+	case "HOME", "PATH", "USER", "SHELL", "TERM", "CODEX_HOME", "OPENCLAW_CONFIG_PATH":
 		return true
 	}
 	return false

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2161,6 +2161,14 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	if env.OpenclawConfigPath != "" {
 		agentEnv["OPENCLAW_CONFIG_PATH"] = env.OpenclawConfigPath
 	}
+	// Grant the wrapper config permission to $include the user's active
+	// config across directories. OpenClaw's $include defaults to confining
+	// resolution to the wrapper's own directory; without this, the
+	// wrapper-out-of-envRoot $include into ~/.openclaw/openclaw.json is
+	// rejected and the run boots with no user-registered agents.
+	if rootsValue, ok := composeOpenclawIncludeRoots(env.OpenclawIncludeRoot, os.Getenv("OPENCLAW_INCLUDE_ROOTS")); ok {
+		agentEnv["OPENCLAW_INCLUDE_ROOTS"] = rootsValue
+	}
 	// Inject user-configured custom environment variables (e.g. ANTHROPIC_API_KEY,
 	// ANTHROPIC_BASE_URL for router/proxy mode, or CLAUDE_CODE_USE_BEDROCK for
 	// Bedrock). These are set per-agent via the agent settings UI.
@@ -2737,6 +2745,40 @@ func convertSkillsForEnv(skills []SkillData) []execenv.SkillContextForEnv {
 	return result
 }
 
+// composeOpenclawIncludeRoots returns the value the daemon should set for
+// OPENCLAW_INCLUDE_ROOTS on the child openclaw process so its `$include`
+// loader will follow the wrapper's reference out of envRoot into the
+// user's active config directory.
+//
+// addRoot is the directory we must grant (typically dirname of the user's
+// active openclaw.json). userValue is whatever the daemon's own
+// environment already has under OPENCLAW_INCLUDE_ROOTS — the user's own
+// cross-directory layout. We prepend addRoot, dedupe by string equality,
+// drop empty path segments, and return ok=false when there's nothing to
+// grant (addRoot is empty — fresh install case), so callers can leave the
+// env var alone in that case.
+//
+// Path separator is the OS-native list separator (`:` on Unix, `;` on
+// Windows) to match how OpenClaw splits the env var.
+func composeOpenclawIncludeRoots(addRoot, userValue string) (string, bool) {
+	if addRoot == "" {
+		return "", false
+	}
+	parts := []string{addRoot}
+	seen := map[string]struct{}{addRoot: {}}
+	for _, p := range strings.Split(userValue, string(os.PathListSeparator)) {
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		parts = append(parts, p)
+	}
+	return strings.Join(parts, string(os.PathListSeparator)), true
+}
+
 // isBlockedEnvKey returns true if the key must not be overridden by user-
 // configured custom_env. This prevents accidental or malicious override of
 // daemon-internal variables and critical system paths.
@@ -2746,7 +2788,7 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	switch upper {
-	case "HOME", "PATH", "USER", "SHELL", "TERM", "CODEX_HOME", "OPENCLAW_CONFIG_PATH":
+	case "HOME", "PATH", "USER", "SHELL", "TERM", "CODEX_HOME", "OPENCLAW_CONFIG_PATH", "OPENCLAW_INCLUDE_ROOTS":
 		return true
 	}
 	return false

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2065,8 +2065,18 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Try to reuse the workdir from a previous task on the same (agent, issue) pair.
 	var env *execenv.Environment
 	codexVersion := d.agentVersion("codex")
+	openclawBin := ""
+	if provider == "openclaw" {
+		openclawBin = entry.Path
+	}
 	if task.PriorWorkDir != "" {
-		env = execenv.Reuse(task.PriorWorkDir, provider, codexVersion, taskCtx, d.logger)
+		env = execenv.Reuse(execenv.ReuseParams{
+			WorkDir:      task.PriorWorkDir,
+			Provider:     provider,
+			CodexVersion: codexVersion,
+			OpenclawBin:  openclawBin,
+			Task:         taskCtx,
+		}, d.logger)
 	}
 	if env == nil {
 		var err error
@@ -2077,6 +2087,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			AgentName:      agentName,
 			Provider:       provider,
 			CodexVersion:   codexVersion,
+			OpenclawBin:    openclawBin,
 			Task:           taskCtx,
 		}, d.logger)
 		if err != nil {
@@ -2221,8 +2232,12 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	}
 	// Some providers do not reliably load the per-task runtime config files we
 	// write into the task workdir:
-	//   - openclaw loads bootstrap files (AGENTS.md, SOUL.md, ...) from its own
-	//     workspace dir rather than the task workdir.
+	//   - openclaw is pinned to the task workdir via the per-task config we
+	//     synthesize (see prepareOpenclawConfig), so AGENTS.md / .agent_context/
+	//     in the workdir ARE picked up by the CLI. Inline injection is retained
+	//     as a belt-and-suspenders for older openclaw releases until that load
+	//     path stabilises in production; remove this once a release tracks the
+	//     workdir bootstrap reliably end-to-end.
 	//   - kiro and kimi are wrapped through their own CLIs whose cwd handling
 	//     is opaque enough that we can't trust the file-based path either.
 	// Pass the full runtime brief inline (CLI catalog + workflow steps + agent

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -205,6 +205,80 @@ func TestProviderNeedsInlineSystemPrompt(t *testing.T) {
 	}
 }
 
+// TestComposeOpenclawIncludeRoots — the Elon must-fix regression: the
+// daemon must grant OpenClaw permission to follow the wrapper's $include
+// link from envRoot into the user's active config dir, while preserving
+// any roots the user already configured in their shell env so their own
+// cross-directory layouts keep working.
+func TestComposeOpenclawIncludeRoots(t *testing.T) {
+	t.Parallel()
+
+	sep := string(os.PathListSeparator)
+	cases := []struct {
+		name    string
+		add     string
+		user    string
+		want    string
+		wantSet bool
+	}{
+		{
+			// Fresh install — preparer emits no $include, so daemon
+			// shouldn't touch OPENCLAW_INCLUDE_ROOTS at all.
+			name:    "fresh_install_no_root_to_grant",
+			add:     "",
+			user:    "/some/user/dir",
+			wantSet: false,
+		},
+		{
+			// User has no existing value — output is just the granted dir.
+			name:    "no_user_value",
+			add:     "/home/alice/.openclaw",
+			user:    "",
+			want:    "/home/alice/.openclaw",
+			wantSet: true,
+		},
+		{
+			// User has their own include roots — daemon must prepend
+			// granted dir AND preserve user's entries verbatim.
+			name:    "preserves_user_value",
+			add:     "/home/alice/.openclaw",
+			user:    "/etc/openclaw" + sep + "/opt/openclaw/shared",
+			want:    "/home/alice/.openclaw" + sep + "/etc/openclaw" + sep + "/opt/openclaw/shared",
+			wantSet: true,
+		},
+		{
+			// User's value already contains the granted dir — daemon
+			// must dedupe rather than emit a redundant entry that would
+			// trip OpenClaw confused-deputy heuristics.
+			name:    "dedupes_when_user_already_grants_same_dir",
+			add:     "/home/alice/.openclaw",
+			user:    "/home/alice/.openclaw" + sep + "/etc/openclaw",
+			want:    "/home/alice/.openclaw" + sep + "/etc/openclaw",
+			wantSet: true,
+		},
+		{
+			// Stray empty segments from a malformed user env are skipped.
+			name:    "skips_empty_segments_in_user_value",
+			add:     "/home/alice/.openclaw",
+			user:    "" + sep + "/etc/openclaw" + sep + "",
+			want:    "/home/alice/.openclaw" + sep + "/etc/openclaw",
+			wantSet: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := composeOpenclawIncludeRoots(tc.add, tc.user)
+			if ok != tc.wantSet {
+				t.Fatalf("ok = %v, want %v (got = %q)", ok, tc.wantSet, got)
+			}
+			if got != tc.want {
+				t.Errorf("got = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildPromptContainsIssueID(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -16,7 +16,7 @@ import (
 // Codex:    skills → handled separately in Prepare via codex-home
 // Copilot:  skills → {workDir}/.github/skills/{name}/SKILL.md  (native project-level discovery)
 // OpenCode: skills → {workDir}/.opencode/skills/{name}/SKILL.md  (native discovery)
-// OpenClaw: skills → {workDir}/.agent_context/skills/{name}/SKILL.md  (NO native auto-discovery — see note in resolveSkillsDir)
+// OpenClaw: skills → {workDir}/skills/{name}/SKILL.md  (native discovery — paired with a per-task synthesized openclaw-config.json that pins agents.defaults.workspace to workDir; see openclaw_config.go)
 // Pi:       skills → {workDir}/.pi/skills/{name}/SKILL.md  (native discovery)
 // Cursor:   skills → {workDir}/.cursor/skills/{name}/SKILL.md  (native discovery)
 // Kimi:     skills → {workDir}/.kimi/skills/{name}/SKILL.md  (native discovery)
@@ -134,6 +134,14 @@ func resolveSkillsDir(workDir, provider string) (string, error) {
 	case "opencode":
 		// OpenCode natively discovers skills from .opencode/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".opencode", "skills")
+	case "openclaw":
+		// OpenClaw's native skill scanner reads <workspaceDir>/skills/. The
+		// daemon pairs this with a per-task synthesized openclaw-config.json
+		// (see openclaw_config.go) that pins agents.defaults.workspace to
+		// workDir, so writing here is what the CLI actually scans. Before
+		// MUL-2219 this used to fall back to .agent_context/skills/, which
+		// no openclaw scan path ever inspected.
+		skillsDir = filepath.Join(workDir, "skills")
 	case "pi":
 		// Pi natively discovers skills from .pi/skills/ in the workdir.
 		skillsDir = filepath.Join(workDir, ".pi", "skills")

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -84,6 +84,11 @@ type Environment struct {
 	WorkDir string
 	// CodexHome is the path to the per-task CODEX_HOME directory (set only for codex provider).
 	CodexHome string
+	// OpenclawConfigPath is the path to the per-task synthesized OpenClaw
+	// config (set only for openclaw provider). The daemon exports this as
+	// OPENCLAW_CONFIG_PATH on the openclaw subprocess so its native skill
+	// scanner pins workspaceDir to WorkDir.
+	OpenclawConfigPath string
 
 	logger *slog.Logger // for cleanup logging
 }
@@ -152,6 +157,20 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		env.CodexHome = codexHome
 	}
 
+	// For OpenClaw, synthesize a per-task config that pins workspace to
+	// workDir. The skill scanner then reads {workDir}/skills/ (written by
+	// writeContextFiles above). Best-effort: a write failure logs and the
+	// agent falls back to the inline runtime brief, which still references
+	// the skill file paths so they're not lost.
+	if params.Provider == "openclaw" {
+		cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+		if err != nil {
+			logger.Warn("execenv: prepare openclaw config failed", "error", err)
+		} else {
+			env.OpenclawConfigPath = cfgPath
+		}
+	}
+
 	logger.Info("execenv: prepared env", "root", envRoot, "repos_available", len(params.Task.Repos))
 	return env, nil
 }
@@ -190,6 +209,17 @@ func Reuse(workDir, provider, codexVersion string, task TaskContextForEnv, logge
 			if err := hydrateCodexSkills(codexHome, task.AgentSkills, logger); err != nil {
 				logger.Warn("execenv: refresh codex skills failed", "error", err)
 			}
+		}
+	}
+
+	// Refresh the per-task OpenClaw config on reuse — the user may have
+	// added/removed agents or rotated providers since the prior task ran,
+	// and the workspace override always re-targets the current workDir.
+	if provider == "openclaw" {
+		if cfgPath, err := prepareOpenclawConfig(env.RootDir, workDir); err != nil {
+			logger.Warn("execenv: refresh openclaw config failed", "error", err)
+		} else {
+			env.OpenclawConfigPath = cfgPath
 		}
 	}
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -90,6 +90,14 @@ type Environment struct {
 	// OPENCLAW_CONFIG_PATH on the openclaw subprocess so its native skill
 	// scanner pins workspaceDir to WorkDir.
 	OpenclawConfigPath string
+	// OpenclawIncludeRoot is the directory of the user's active OpenClaw
+	// config (set only for openclaw provider with an on-disk user config).
+	// The daemon must prepend it to OPENCLAW_INCLUDE_ROOTS so OpenClaw is
+	// allowed to follow the wrapper's `$include` link out of envRoot into
+	// the user's config — by default OpenClaw confines `$include` to the
+	// directory holding the wrapper file. Empty when no $include is
+	// emitted (fresh install).
+	OpenclawIncludeRoot string
 
 	logger *slog.Logger // for cleanup logging
 }
@@ -165,11 +173,12 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 	// silently degrading to a minimal config would mask it by booting
 	// OpenClaw without the agents / providers / API keys it expects.
 	if params.Provider == "openclaw" {
-		cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: params.OpenclawBin})
+		result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: params.OpenclawBin})
 		if err != nil {
 			return nil, fmt.Errorf("execenv: prepare openclaw config: %w", err)
 		}
-		env.OpenclawConfigPath = cfgPath
+		env.OpenclawConfigPath = result.ConfigPath
+		env.OpenclawIncludeRoot = result.IncludeRoot
 	}
 
 	logger.Info("execenv: prepared env", "root", envRoot, "repos_available", len(params.Task.Repos))
@@ -227,12 +236,13 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 	// reuse rather than degrade to a minimal config that boots OpenClaw
 	// without the registered agents.
 	if params.Provider == "openclaw" {
-		cfgPath, err := prepareOpenclawConfig(env.RootDir, params.WorkDir, OpenclawConfigPrep{OpenclawBin: params.OpenclawBin})
+		result, err := prepareOpenclawConfig(env.RootDir, params.WorkDir, OpenclawConfigPrep{OpenclawBin: params.OpenclawBin})
 		if err != nil {
 			logger.Warn("execenv: refresh openclaw config failed", "error", err)
 			return nil
 		}
-		env.OpenclawConfigPath = cfgPath
+		env.OpenclawConfigPath = result.ConfigPath
+		env.OpenclawIncludeRoot = result.IncludeRoot
 	}
 
 	logger.Info("execenv: reusing env", "workdir", params.WorkDir)

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -37,6 +37,7 @@ type PrepareParams struct {
 	AgentName      string            // for git branch naming only
 	Provider       string            // agent provider (determines runtime config and skill injection paths)
 	CodexVersion   string            // detected Codex CLI version (only used when Provider == "codex")
+	OpenclawBin    string            // resolved openclaw CLI path (only used when Provider == "openclaw"); empty = look up on PATH
 	Task           TaskContextForEnv // context data for writing files
 }
 
@@ -159,54 +160,61 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 
 	// For OpenClaw, synthesize a per-task config that pins workspace to
 	// workDir. The skill scanner then reads {workDir}/skills/ (written by
-	// writeContextFiles above). Best-effort: a write failure logs and the
-	// agent falls back to the inline runtime brief, which still references
-	// the skill file paths so they're not lost.
+	// writeContextFiles above). Fail closed on errors: a malformed user
+	// config that the openclaw CLI can't read is a real problem and
+	// silently degrading to a minimal config would mask it by booting
+	// OpenClaw without the agents / providers / API keys it expects.
 	if params.Provider == "openclaw" {
-		cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+		cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: params.OpenclawBin})
 		if err != nil {
-			logger.Warn("execenv: prepare openclaw config failed", "error", err)
-		} else {
-			env.OpenclawConfigPath = cfgPath
+			return nil, fmt.Errorf("execenv: prepare openclaw config: %w", err)
 		}
+		env.OpenclawConfigPath = cfgPath
 	}
 
 	logger.Info("execenv: prepared env", "root", envRoot, "repos_available", len(params.Task.Repos))
 	return env, nil
 }
 
+// ReuseParams describes the inputs to Reuse. It mirrors PrepareParams for
+// the per-provider knobs (CodexVersion, OpenclawBin) so callers can pass
+// the same resolved binary path on both first-run and reuse paths.
+type ReuseParams struct {
+	WorkDir      string
+	Provider     string
+	CodexVersion string            // only used when Provider == "codex"
+	OpenclawBin  string            // only used when Provider == "openclaw"; empty = PATH lookup
+	Task         TaskContextForEnv // refreshed context files / skills
+}
+
 // Reuse wraps an existing workdir into an Environment and refreshes context files.
 // Returns nil if the workdir does not exist (caller should fall back to Prepare).
-//
-// codexVersion is the detected Codex CLI version, used (only when provider is
-// "codex") to pick the right sandbox policy for the per-task config.toml.
-// Pass an empty string when the version is unknown.
-func Reuse(workDir, provider, codexVersion string, task TaskContextForEnv, logger *slog.Logger) *Environment {
-	if _, err := os.Stat(workDir); err != nil {
+func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
+	if _, err := os.Stat(params.WorkDir); err != nil {
 		return nil
 	}
 
 	env := &Environment{
-		RootDir: filepath.Dir(workDir),
-		WorkDir: workDir,
+		RootDir: filepath.Dir(params.WorkDir),
+		WorkDir: params.WorkDir,
 		logger:  logger,
 	}
 
 	// Refresh context files (issue_context.md, skills).
-	if err := writeContextFiles(workDir, provider, task); err != nil {
+	if err := writeContextFiles(params.WorkDir, params.Provider, params.Task); err != nil {
 		logger.Warn("execenv: refresh context files failed", "error", err)
 	}
 
 	// Restore CodexHome for Codex provider — the per-task codex-home directory
 	// lives alongside the workdir. Re-run prepareCodexHomeWithOpts to ensure
 	// config (especially sandbox/network access) is up to date.
-	if provider == "codex" {
+	if params.Provider == "codex" {
 		codexHome := filepath.Join(env.RootDir, "codex-home")
-		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: codexVersion}, logger); err != nil {
+		if err := prepareCodexHomeWithOpts(codexHome, CodexHomeOptions{CodexVersion: params.CodexVersion}, logger); err != nil {
 			logger.Warn("execenv: refresh codex-home failed", "error", err)
 		} else {
 			env.CodexHome = codexHome
-			if err := hydrateCodexSkills(codexHome, task.AgentSkills, logger); err != nil {
+			if err := hydrateCodexSkills(codexHome, params.Task.AgentSkills, logger); err != nil {
 				logger.Warn("execenv: refresh codex skills failed", "error", err)
 			}
 		}
@@ -215,15 +223,19 @@ func Reuse(workDir, provider, codexVersion string, task TaskContextForEnv, logge
 	// Refresh the per-task OpenClaw config on reuse — the user may have
 	// added/removed agents or rotated providers since the prior task ran,
 	// and the workspace override always re-targets the current workDir.
-	if provider == "openclaw" {
-		if cfgPath, err := prepareOpenclawConfig(env.RootDir, workDir); err != nil {
+	// Fail closed: a user config that can no longer be parsed should block
+	// reuse rather than degrade to a minimal config that boots OpenClaw
+	// without the registered agents.
+	if params.Provider == "openclaw" {
+		cfgPath, err := prepareOpenclawConfig(env.RootDir, params.WorkDir, OpenclawConfigPrep{OpenclawBin: params.OpenclawBin})
+		if err != nil {
 			logger.Warn("execenv: refresh openclaw config failed", "error", err)
-		} else {
-			env.OpenclawConfigPath = cfgPath
+			return nil
 		}
+		env.OpenclawConfigPath = cfgPath
 	}
 
-	logger.Info("execenv: reusing env", "workdir", workDir)
+	logger.Info("execenv: reusing env", "workdir", params.WorkDir)
 	return env
 }
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -802,13 +802,13 @@ func TestWriteContextFilesOpencodeNativeSkills(t *testing.T) {
 	}
 }
 
-// OpenClaw scans its own workspaceDir (resolved from the openclaw config,
-// not the task workdir) and never reads {workDir}/.openclaw/skills/. Until
-// per-task workspace integration lands, openclaw skills fall back to
-// .agent_context/skills/ — the meta AGENTS.md content references that path
-// explicitly. This test fails closed if someone re-adds a dead-drop case to
-// resolveSkillsDir.
-func TestWriteContextFilesOpenclawFallsBackToAgentContext(t *testing.T) {
+// OpenClaw's native skill scanner reads {workspaceDir}/skills/. The daemon
+// pairs writeContextFiles with a per-task synthesized openclaw-config.json
+// (see openclaw_config.go) that pins agents.defaults.workspace to workDir,
+// so writing skills to {workDir}/skills/ is what the CLI actually scans.
+// This test pins the post-MUL-2219 write path; the previous fallback into
+// .agent_context/skills/ was a dead drop the openclaw scanner never read.
+func TestWriteContextFilesOpenclawNativeSkills(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
@@ -829,15 +829,15 @@ func TestWriteContextFilesOpenclawFallsBackToAgentContext(t *testing.T) {
 		t.Fatalf("writeContextFiles failed: %v", err)
 	}
 
-	skillMd, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "go-conventions", "SKILL.md"))
+	skillMd, err := os.ReadFile(filepath.Join(dir, "skills", "go-conventions", "SKILL.md"))
 	if err != nil {
-		t.Fatalf("failed to read .agent_context/skills/go-conventions/SKILL.md: %v", err)
+		t.Fatalf("failed to read skills/go-conventions/SKILL.md: %v", err)
 	}
 	if !strings.Contains(string(skillMd), "Follow Go conventions.") {
 		t.Error("SKILL.md missing content")
 	}
 
-	supportFile, err := os.ReadFile(filepath.Join(dir, ".agent_context", "skills", "go-conventions", "templates", "example.go"))
+	supportFile, err := os.ReadFile(filepath.Join(dir, "skills", "go-conventions", "templates", "example.go"))
 	if err != nil {
 		t.Fatalf("failed to read supporting file: %v", err)
 	}
@@ -845,6 +845,10 @@ func TestWriteContextFilesOpenclawFallsBackToAgentContext(t *testing.T) {
 		t.Errorf("supporting file content = %q, want %q", string(supportFile), "package main")
 	}
 
+	// The pre-MUL-2219 fallback path must NOT be written: openclaw never scans it.
+	if _, err := os.Stat(filepath.Join(dir, ".agent_context", "skills")); !os.IsNotExist(err) {
+		t.Error(".agent_context/skills/ MUST NOT be written for openclaw — the scanner does not read that path")
+	}
 	if _, err := os.Stat(filepath.Join(dir, ".openclaw", "skills")); !os.IsNotExist(err) {
 		t.Error(".openclaw/skills/ MUST NOT be written — openclaw never scans that path; writing there is a dead drop")
 	}

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1918,7 +1918,7 @@ func TestReuseRestoresCodexHome(t *testing.T) {
 	}
 
 	// Reuse should restore CodexHome.
-	reused := Reuse(env.WorkDir, "codex", "", TaskContextForEnv{IssueID: "reuse-test"}, testLogger())
+	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-test"}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -1968,7 +1968,7 @@ func TestReuseRestoresCodexPluginCache(t *testing.T) {
 		t.Fatalf("remove codex plugins dir: %v", err)
 	}
 
-	reused := Reuse(env.WorkDir, "codex", "", TaskContextForEnv{IssueID: "reuse-plugin-test"}, testLogger())
+	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{IssueID: "reuse-plugin-test"}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -2006,7 +2006,7 @@ func TestReuseWritesMissingCodexWorkspaceSkills(t *testing.T) {
 		t.Fatalf("remove codex skills dir: %v", err)
 	}
 
-	reused := Reuse(env.WorkDir, "codex", "", TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-skill-test",
 		AgentSkills: []SkillContextForEnv{
 			{
@@ -2015,7 +2015,7 @@ func TestReuseWritesMissingCodexWorkspaceSkills(t *testing.T) {
 				Files:   []SkillFileContextForEnv{{Path: "examples/example.md", Content: "Example"}},
 			},
 		},
-	}, testLogger())
+	}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -2065,7 +2065,7 @@ func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
 	}
 	defer env.Cleanup(true)
 
-	reused := Reuse(env.WorkDir, "codex", "", TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-skill-update-test",
 		AgentSkills: []SkillContextForEnv{
 			{
@@ -2074,7 +2074,7 @@ func TestReuseUpdatesCodexWorkspaceSkills(t *testing.T) {
 				Files:   []SkillFileContextForEnv{{Path: "examples/example.md", Content: "Updated example"}},
 			},
 		},
-	}, testLogger())
+	}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -2332,9 +2332,9 @@ func TestReuseSeedsUserSkillUpdates(t *testing.T) {
 		t.Fatalf("update user SKILL.md: %v", err)
 	}
 
-	reused := Reuse(env.WorkDir, "codex", "", TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "user-skill-reuse-test",
-	}, testLogger())
+	}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -2387,12 +2387,12 @@ func TestReuseClearsUserSkillResidueOnWorkspaceConflict(t *testing.T) {
 		t.Fatalf("user support file should be seeded in round 1: %v", err)
 	}
 
-	reused := Reuse(env.WorkDir, "codex", "", TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-conflict-test",
 		AgentSkills: []SkillContextForEnv{
 			{Name: "Writing", Content: "workspace writing"},
 		},
-	}, testLogger())
+	}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}
@@ -2449,9 +2449,9 @@ func TestReuseClearsRemovedUserSkill(t *testing.T) {
 		t.Fatalf("remove user skill: %v", err)
 	}
 
-	reused := Reuse(env.WorkDir, "codex", "", TaskContextForEnv{
+	reused := Reuse(ReuseParams{WorkDir: env.WorkDir, Provider: "codex", Task: TaskContextForEnv{
 		IssueID: "reuse-remove-test",
-	}, testLogger())
+	}}, testLogger())
 	if reused == nil {
 		t.Fatal("Reuse returned nil")
 	}

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -1,0 +1,129 @@
+package execenv
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// openclawConfigFile is the per-task synthesized OpenClaw config the daemon
+// points the openclaw CLI at via OPENCLAW_CONFIG_PATH. It sits in the env
+// root (alongside workdir/, output/, logs/) so the GC reaper sweeps it with
+// the rest of the task env.
+const openclawConfigFile = "openclaw-config.json"
+
+// prepareOpenclawConfig writes a per-task OpenClaw config to envRoot and
+// returns its absolute path. The daemon sets OPENCLAW_CONFIG_PATH to this
+// path on the spawned openclaw subprocess so the CLI resolves its
+// `agents.defaults.workspace` (and any `agents.list[].workspace`) to the
+// task workdir — which is what makes OpenClaw's native skill scanner pick
+// up the per-task skills we write under `<workDir>/skills/`.
+//
+// We deep-copy the user's existing config (priority: $OPENCLAW_CONFIG_PATH
+// > ~/.openclaw/openclaw.json) and only override workspace fields. This
+// preserves everything the openclaw CLI needs to actually run a task —
+// registered agents in `agents.list[]`, model providers, gateway settings,
+// channels — while pinning workspace to the per-task workdir.
+//
+// Missing or malformed user configs are non-fatal: we synthesize a minimal
+// config with just the workspace override. Older openclaw versions that
+// require additional fields will surface their own validation errors when
+// the CLI starts; this preparer never blocks task startup on config IO.
+func prepareOpenclawConfig(envRoot, workDir string) (string, error) {
+	cfg, err := loadUserOpenclawConfig()
+	if err != nil {
+		// Fall through to a fresh config rather than failing the task —
+		// "no native skill discovery" is a tolerable degradation, "task
+		// won't start because we can't parse your existing config" is not.
+		cfg = map[string]any{}
+	}
+
+	overrideOpenclawWorkspace(cfg, workDir)
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal openclaw config: %w", err)
+	}
+	outPath := filepath.Join(envRoot, openclawConfigFile)
+	// 0o600 — the config may carry the user's openclaw gateway auth token
+	// and provider API keys. Match the permissions OpenClaw uses for its
+	// own ~/.openclaw/openclaw.json.
+	if err := os.WriteFile(outPath, data, 0o600); err != nil {
+		return "", fmt.Errorf("write openclaw config: %w", err)
+	}
+	return outPath, nil
+}
+
+// loadUserOpenclawConfig reads the user's existing OpenClaw config so the
+// per-task synthesized copy inherits registered agents, model providers,
+// and gateway settings. Resolution order matches the CLI:
+//
+//  1. $OPENCLAW_CONFIG_PATH (lets a parent process — e.g. another daemon
+//     wrapper — already redirect openclaw at a custom file)
+//  2. ~/.openclaw/openclaw.json (the CLI's default)
+//
+// Returns an empty config (not an error) when neither source exists, so a
+// fresh openclaw install can still get a per-task workspace override.
+func loadUserOpenclawConfig() (map[string]any, error) {
+	var path string
+	if v := os.Getenv("OPENCLAW_CONFIG_PATH"); v != "" {
+		path = v
+	} else if home, err := os.UserHomeDir(); err == nil {
+		path = filepath.Join(home, ".openclaw", "openclaw.json")
+	}
+	if path == "" {
+		return map[string]any{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, fmt.Errorf("read openclaw config %s: %w", path, err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse openclaw config %s: %w", path, err)
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	return cfg, nil
+}
+
+// overrideOpenclawWorkspace pins agents.defaults.workspace AND every
+// agents.list[].workspace to workDir. OpenClaw's workspace resolution order
+// is `agents.list[id].workspace → agents.defaults.workspace → ~/.openclaw/
+// workspace`, so a per-agent workspace in the user config would otherwise
+// silently win and bypass our override.
+//
+// Mutates cfg in place. Safe to call with any subset of agents/defaults/list
+// missing — intermediate maps are created on demand.
+func overrideOpenclawWorkspace(cfg map[string]any, workDir string) {
+	agents, _ := cfg["agents"].(map[string]any)
+	if agents == nil {
+		agents = map[string]any{}
+		cfg["agents"] = agents
+	}
+
+	defaults, _ := agents["defaults"].(map[string]any)
+	if defaults == nil {
+		defaults = map[string]any{}
+		agents["defaults"] = defaults
+	}
+	defaults["workspace"] = workDir
+
+	// `agents.list` is an array of agent entries per the openclaw schema. We
+	// rewrite each entry's workspace so per-agent overrides don't silently
+	// re-route the scan paths back to the user's shared workspace.
+	if list, ok := agents["list"].([]any); ok {
+		for _, item := range list {
+			entry, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			entry["workspace"] = workDir
+		}
+	}
+}

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -34,12 +34,24 @@ type OpenclawConfigPrep struct {
 	Timeout time.Duration
 }
 
+// OpenclawConfigResult is what prepareOpenclawConfig returns to its callers
+// in execenv.go. ConfigPath is the wrapper file the daemon points
+// OPENCLAW_CONFIG_PATH at. IncludeRoot is the directory the daemon must add
+// to OPENCLAW_INCLUDE_ROOTS so OpenClaw will follow the $include link out
+// of envRoot into the user's active config; it is empty when no $include
+// is emitted (fresh install).
+type OpenclawConfigResult struct {
+	ConfigPath  string
+	IncludeRoot string
+}
+
 // prepareOpenclawConfig writes a per-task OpenClaw config to envRoot and
-// returns its absolute path. The daemon sets OPENCLAW_CONFIG_PATH to this
-// path on the spawned openclaw subprocess so the CLI resolves its
-// `agents.defaults.workspace` (and every `agents.list[].workspace`) to the
-// task workdir — which is what makes OpenClaw's native skill scanner pick
-// up the per-task skills we write under `<workDir>/skills/`.
+// returns its absolute path along with the include root the daemon must
+// grant. The daemon sets OPENCLAW_CONFIG_PATH to the path on the spawned
+// openclaw subprocess so the CLI resolves its `agents.defaults.workspace`
+// (and every `agents.list[].workspace`) to the task workdir — which is
+// what makes OpenClaw's native skill scanner pick up the per-task skills
+// we write under `<workDir>/skills/`.
 //
 // Strategy: delegate JSON5 / $include / env-substitution / state-dir
 // resolution to the openclaw CLI itself rather than re-implementing the
@@ -57,6 +69,16 @@ type OpenclawConfigPrep struct {
 //     workDir. The original config bytes are not mutated — they are loaded
 //     by openclaw's own loader through the $include link, which preserves
 //     comments, secrets, and nested $include chains verbatim.
+//
+// **Cross-directory $include confinement.** OpenClaw confines `$include`
+// resolution to the directory containing the wrapper file unless the
+// target's parent is listed in `OPENCLAW_INCLUDE_ROOTS`. Our wrapper lives
+// in envRoot but $includes the user's active config (typically
+// `~/.openclaw/openclaw.json`) — a cross-directory hop. We surface
+// `filepath.Dir(activePath)` as IncludeRoot so the daemon can prepend it
+// to whatever the user already has in OPENCLAW_INCLUDE_ROOTS; without
+// this, OpenClaw refuses to follow the link and the wrapper boots with no
+// user config. Fresh install emits no $include, so IncludeRoot is "".
 //
 // **Intentional task isolation.** The override of every per-agent workspace
 // is deliberate. OpenClaw's resolution order is
@@ -79,7 +101,7 @@ type OpenclawConfigPrep struct {
 // agent or failing to authenticate. The only "synthesize minimal" case
 // kept is a fresh install where the CLI reports a path but no file exists
 // — there is no user data to lose in that case.
-func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (string, error) {
+func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (OpenclawConfigResult, error) {
 	bin := opts.OpenclawBin
 	if bin == "" {
 		bin = "openclaw"
@@ -91,14 +113,14 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (st
 
 	activePath, exists, err := openclawActiveConfigPath(bin, timeout)
 	if err != nil {
-		return "", fmt.Errorf("locate openclaw active config: %w", err)
+		return OpenclawConfigResult{}, fmt.Errorf("locate openclaw active config: %w", err)
 	}
 
 	var resolvedList []any
 	if exists {
 		resolvedList, err = openclawResolvedAgentsList(bin, timeout)
 		if err != nil {
-			return "", fmt.Errorf("read openclaw agents.list: %w", err)
+			return OpenclawConfigResult{}, fmt.Errorf("read openclaw agents.list: %w", err)
 		}
 	}
 
@@ -106,16 +128,24 @@ func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (st
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("marshal openclaw config: %w", err)
+		return OpenclawConfigResult{}, fmt.Errorf("marshal openclaw config: %w", err)
 	}
 	outPath := filepath.Join(envRoot, openclawConfigFile)
 	// 0o600 — defense in depth. The wrapper itself carries no secrets (the
 	// $include link is just a filesystem path), but the file lives next to
 	// task scratch and we keep the same posture as ~/.openclaw/openclaw.json.
 	if err := os.WriteFile(outPath, data, 0o600); err != nil {
-		return "", fmt.Errorf("write openclaw config: %w", err)
+		return OpenclawConfigResult{}, fmt.Errorf("write openclaw config: %w", err)
 	}
-	return outPath, nil
+	result := OpenclawConfigResult{ConfigPath: outPath}
+	if exists {
+		// Only emit an include root when we actually emit a $include line
+		// (i.e. the user has an on-disk config). On fresh install the
+		// wrapper is self-contained and OpenClaw never needs to step out
+		// of envRoot, so no extra root is required.
+		result.IncludeRoot = filepath.Dir(activePath)
+	}
+	return result, nil
 }
 
 // buildPerTaskOpenclawConfig assembles the wrapper map that goes on disk.

--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -1,10 +1,15 @@
 package execenv
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
 )
 
 // openclawConfigFile is the per-task synthesized OpenClaw config the daemon
@@ -13,117 +18,285 @@ import (
 // the rest of the task env.
 const openclawConfigFile = "openclaw-config.json"
 
+// openclawCLITimeout caps each `openclaw config ...` invocation during task
+// setup. The CLI is fast (<200ms normal); 5s leaves headroom for a cold
+// node start without letting a hung CLI stall task dispatch indefinitely.
+const openclawCLITimeout = 5 * time.Second
+
+// OpenclawConfigPrep is the input to prepareOpenclawConfig. Only OpenclawBin
+// is meaningful in production — Timeout is here for tests that need a tight
+// cap to assert error paths.
+type OpenclawConfigPrep struct {
+	// OpenclawBin is the openclaw CLI binary to invoke for config introspection.
+	// Empty means resolve "openclaw" from PATH at exec time.
+	OpenclawBin string
+	// Timeout caps each CLI invocation. Zero falls back to openclawCLITimeout.
+	Timeout time.Duration
+}
+
 // prepareOpenclawConfig writes a per-task OpenClaw config to envRoot and
 // returns its absolute path. The daemon sets OPENCLAW_CONFIG_PATH to this
 // path on the spawned openclaw subprocess so the CLI resolves its
-// `agents.defaults.workspace` (and any `agents.list[].workspace`) to the
+// `agents.defaults.workspace` (and every `agents.list[].workspace`) to the
 // task workdir — which is what makes OpenClaw's native skill scanner pick
 // up the per-task skills we write under `<workDir>/skills/`.
 //
-// We deep-copy the user's existing config (priority: $OPENCLAW_CONFIG_PATH
-// > ~/.openclaw/openclaw.json) and only override workspace fields. This
-// preserves everything the openclaw CLI needs to actually run a task —
-// registered agents in `agents.list[]`, model providers, gateway settings,
-// channels — while pinning workspace to the per-task workdir.
+// Strategy: delegate JSON5 / $include / env-substitution / state-dir
+// resolution to the openclaw CLI itself rather than re-implementing the
+// spec. We:
 //
-// Missing or malformed user configs are non-fatal: we synthesize a minimal
-// config with just the workspace override. Older openclaw versions that
-// require additional fields will surface their own validation errors when
-// the CLI starts; this preparer never blocks task startup on config IO.
-func prepareOpenclawConfig(envRoot, workDir string) (string, error) {
-	cfg, err := loadUserOpenclawConfig()
-	if err != nil {
-		// Fall through to a fresh config rather than failing the task —
-		// "no native skill discovery" is a tolerable degradation, "task
-		// won't start because we can't parse your existing config" is not.
-		cfg = map[string]any{}
+//  1. Run `openclaw config file` to find the user's active config path
+//     (handles OPENCLAW_CONFIG_PATH, OPENCLAW_STATE_DIR, OPENCLAW_HOME, and
+//     the default location).
+//  2. Run `openclaw config get agents.list --json` to enumerate every
+//     registered agent ID with its resolved fields. The CLI parses JSON5,
+//     follows $include, and substitutes ${VAR} for us.
+//  3. Write a wrapper config to envRoot/openclaw-config.json that
+//     `$include`s the active path and overrides
+//     `agents.defaults.workspace` plus every `agents.list[].workspace` to
+//     workDir. The original config bytes are not mutated — they are loaded
+//     by openclaw's own loader through the $include link, which preserves
+//     comments, secrets, and nested $include chains verbatim.
+//
+// **Intentional task isolation.** The override of every per-agent workspace
+// is deliberate. OpenClaw's resolution order is
+// `agents.list[id].workspace → agents.defaults.workspace → ~/.openclaw/
+// workspace`. Pinning only the default would let a per-agent workspace the
+// user configured at host scope silently re-route the scanner back to the
+// shared workspace, defeating the per-task skill discovery this whole flow
+// exists for. The cost is that any per-agent SOUL.md / MEMORY.md / standing
+// orders the user laid in `<host-agent-workspace>/` are NOT visible to the
+// in-task openclaw run — task isolation wins over host carry-over. The
+// user's on-disk config is untouched; this only affects the wrapper used
+// for this single task.
+//
+// **Fail closed.** Missing openclaw binary, CLI errors, malformed CLI
+// output, or any IO error during write surfaces as an error to the caller
+// rather than degrading to a minimal config. An earlier version silently
+// synthesized a minimal config on parse failure; that masked broken user
+// configs by starting OpenClaw without the registered agents / model
+// providers / API keys it expects, which led to tasks routing to the wrong
+// agent or failing to authenticate. The only "synthesize minimal" case
+// kept is a fresh install where the CLI reports a path but no file exists
+// — there is no user data to lose in that case.
+func prepareOpenclawConfig(envRoot, workDir string, opts OpenclawConfigPrep) (string, error) {
+	bin := opts.OpenclawBin
+	if bin == "" {
+		bin = "openclaw"
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = openclawCLITimeout
 	}
 
-	overrideOpenclawWorkspace(cfg, workDir)
+	activePath, exists, err := openclawActiveConfigPath(bin, timeout)
+	if err != nil {
+		return "", fmt.Errorf("locate openclaw active config: %w", err)
+	}
+
+	var resolvedList []any
+	if exists {
+		resolvedList, err = openclawResolvedAgentsList(bin, timeout)
+		if err != nil {
+			return "", fmt.Errorf("read openclaw agents.list: %w", err)
+		}
+	}
+
+	cfg := buildPerTaskOpenclawConfig(activePath, exists, resolvedList, workDir)
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("marshal openclaw config: %w", err)
 	}
 	outPath := filepath.Join(envRoot, openclawConfigFile)
-	// 0o600 — the config may carry the user's openclaw gateway auth token
-	// and provider API keys. Match the permissions OpenClaw uses for its
-	// own ~/.openclaw/openclaw.json.
+	// 0o600 — defense in depth. The wrapper itself carries no secrets (the
+	// $include link is just a filesystem path), but the file lives next to
+	// task scratch and we keep the same posture as ~/.openclaw/openclaw.json.
 	if err := os.WriteFile(outPath, data, 0o600); err != nil {
 		return "", fmt.Errorf("write openclaw config: %w", err)
 	}
 	return outPath, nil
 }
 
-// loadUserOpenclawConfig reads the user's existing OpenClaw config so the
-// per-task synthesized copy inherits registered agents, model providers,
-// and gateway settings. Resolution order matches the CLI:
+// buildPerTaskOpenclawConfig assembles the wrapper map that goes on disk.
 //
-//  1. $OPENCLAW_CONFIG_PATH (lets a parent process — e.g. another daemon
-//     wrapper — already redirect openclaw at a custom file)
-//  2. ~/.openclaw/openclaw.json (the CLI's default)
+// Exists=true: emit a $include link to the user's active config plus the
+// workspace overrides as siblings. OpenClaw deep-merges sibling object keys
+// after includes, so agents.defaults.workspace lands correctly. The
+// agents.list override is emitted as a full replacement carrying every
+// field of every resolved entry (id, model, prompts, tools, …) verbatim
+// with only `workspace` rewritten — this is robust regardless of whether
+// the runtime merges the sibling array or replaces it, because either way
+// the resulting list is shape-equivalent to the user's minus workspace.
 //
-// Returns an empty config (not an error) when neither source exists, so a
-// fresh openclaw install can still get a per-task workspace override.
-func loadUserOpenclawConfig() (map[string]any, error) {
-	var path string
-	if v := os.Getenv("OPENCLAW_CONFIG_PATH"); v != "" {
-		path = v
-	} else if home, err := os.UserHomeDir(); err == nil {
-		path = filepath.Join(home, ".openclaw", "openclaw.json")
+// Exists=false: a fresh install with no on-disk config. Emit a minimal
+// config containing only the workspace override. There is no user data to
+// $include here, so this is not the silent-fallback case the reviewer
+// flagged.
+func buildPerTaskOpenclawConfig(activePath string, exists bool, resolvedList []any, workDir string) map[string]any {
+	agents := map[string]any{
+		"defaults": map[string]any{"workspace": workDir},
 	}
-	if path == "" {
-		return map[string]any{}, nil
+	if rewritten := rewriteAgentsListWorkspaces(resolvedList, workDir); rewritten != nil {
+		agents["list"] = rewritten
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return map[string]any{}, nil
-		}
-		return nil, fmt.Errorf("read openclaw config %s: %w", path, err)
+	cfg := map[string]any{
+		"agents": agents,
 	}
-	var cfg map[string]any
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parse openclaw config %s: %w", path, err)
+	if exists {
+		// Array form (not single-file form) so OpenClaw deep-merges the
+		// included object with our sibling keys rather than letting the
+		// include replace the whole containing object.
+		cfg["$include"] = []any{activePath}
 	}
-	if cfg == nil {
-		cfg = map[string]any{}
-	}
-	return cfg, nil
+	return cfg
 }
 
-// overrideOpenclawWorkspace pins agents.defaults.workspace AND every
-// agents.list[].workspace to workDir. OpenClaw's workspace resolution order
-// is `agents.list[id].workspace → agents.defaults.workspace → ~/.openclaw/
-// workspace`, so a per-agent workspace in the user config would otherwise
-// silently win and bypass our override.
+// rewriteAgentsListWorkspaces copies every entry of the resolved agents.list
+// and pins its `workspace` field to workDir. Returns nil when the input is
+// nil or empty so buildPerTaskOpenclawConfig can omit the key entirely
+// (avoiding an empty `agents.list: []` that would replace whatever the
+// include carries).
+func rewriteAgentsListWorkspaces(list []any, workDir string) []any {
+	if len(list) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(list))
+	for _, item := range list {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			// Shape we don't recognize — skip rather than guess. Worst case
+			// the user loses native skill discovery on that one agent; we
+			// still won't crash the wrapper.
+			continue
+		}
+		copyEntry := make(map[string]any, len(entry)+1)
+		for k, v := range entry {
+			copyEntry[k] = v
+		}
+		copyEntry["workspace"] = workDir
+		out = append(out, copyEntry)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// openclawActiveConfigPath runs `openclaw config file` to discover the path
+// the openclaw CLI considers active. Returns (absolutePath, exists, error).
 //
-// Mutates cfg in place. Safe to call with any subset of agents/defaults/list
-// missing — intermediate maps are created on demand.
-func overrideOpenclawWorkspace(cfg map[string]any, workDir string) {
-	agents, _ := cfg["agents"].(map[string]any)
-	if agents == nil {
-		agents = map[string]any{}
-		cfg["agents"] = agents
+// The CLI handles the full resolution chain — OPENCLAW_CONFIG_PATH, the
+// state directory (OPENCLAW_STATE_DIR / OPENCLAW_HOME / default), legacy
+// migration, and `~` expansion — so we don't re-implement it here.
+//
+// The reported path uses `~` shorthand for the user's home; we expand it
+// so the $include reference we write is unambiguous absolute.
+func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	out, err := openclawExec(ctx, bin, "config", "file")
+	if err != nil {
+		return "", false, err
 	}
-
-	defaults, _ := agents["defaults"].(map[string]any)
-	if defaults == nil {
-		defaults = map[string]any{}
-		agents["defaults"] = defaults
+	path := strings.TrimSpace(out)
+	if path == "" {
+		return "", false, fmt.Errorf("`openclaw config file` returned empty output")
 	}
-	defaults["workspace"] = workDir
-
-	// `agents.list` is an array of agent entries per the openclaw schema. We
-	// rewrite each entry's workspace so per-agent overrides don't silently
-	// re-route the scan paths back to the user's shared workspace.
-	if list, ok := agents["list"].([]any); ok {
-		for _, item := range list {
-			entry, ok := item.(map[string]any)
-			if !ok {
-				continue
-			}
-			entry["workspace"] = workDir
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			return "", false, fmt.Errorf("expand `~` in openclaw config path: %w", herr)
+		}
+		if path == "~" {
+			path = home
+		} else {
+			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
 		}
 	}
+	if !filepath.IsAbs(path) {
+		return "", false, fmt.Errorf("openclaw reported non-absolute config path %q", path)
+	}
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return path, false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("stat openclaw config %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return "", false, fmt.Errorf("openclaw config path %s is a directory, not a file", path)
+	}
+	return path, true, nil
+}
+
+// openclawResolvedAgentsList fetches the user's resolved agents.list via
+// `openclaw config get agents.list --json`. The CLI returns the post-
+// include, post-env-substitution view of the array, which is exactly the
+// shape we need to rewrite each entry's workspace.
+//
+// Returns nil (not an error) when agents.list is unset.
+func openclawResolvedAgentsList(bin string, timeout time.Duration) ([]any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	out, err := openclawExec(ctx, bin, "config", "get", "agents.list", "--json")
+	if err != nil {
+		if isOpenclawKeyMissing(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" || trimmed == "null" {
+		return nil, nil
+	}
+	var list []any
+	if err := json.Unmarshal([]byte(trimmed), &list); err != nil {
+		return nil, fmt.Errorf("parse `openclaw config get agents.list --json` output: %w", err)
+	}
+	return list, nil
+}
+
+// openclawExec is the runtime hook prepareOpenclawConfig uses to invoke the
+// openclaw CLI. Production points at execOpenclawCLI; tests swap in a stub
+// to avoid spawning a real binary. Production code never reassigns it.
+var openclawExec = execOpenclawCLI
+
+// execOpenclawCLI executes an openclaw subcommand and returns its stdout.
+// The daemon's environment is inherited so OPENCLAW_CONFIG_PATH /
+// OPENCLAW_STATE_DIR / OPENCLAW_HOME / OPENCLAW_INCLUDE_ROOTS pass through.
+//
+// stderr is captured separately and appended to error messages — failures
+// here surface up to the daemon log, and a `openclaw doctor` hint there is
+// more useful than just an exit code.
+func execOpenclawCLI(ctx context.Context, bin string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = os.Environ()
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	raw, err := cmd.Output()
+	if err != nil {
+		stderrMsg := strings.TrimSpace(stderr.String())
+		if stderrMsg != "" {
+			return "", fmt.Errorf("openclaw %s: %w (stderr: %s)", strings.Join(args, " "), err, stderrMsg)
+		}
+		return "", fmt.Errorf("openclaw %s: %w", strings.Join(args, " "), err)
+	}
+	return string(raw), nil
+}
+
+// isOpenclawKeyMissing returns true when the CLI error indicates the asked-
+// for path simply isn't set, as opposed to a real failure (bad config,
+// CLI bug, missing binary). The CLI's "key not found" exit text has varied
+// across versions, so we match on a handful of substrings rather than the
+// exit code alone.
+func isOpenclawKeyMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "No value at ") ||
+		strings.Contains(msg, "not set") ||
+		strings.Contains(msg, "missing key") ||
+		strings.Contains(msg, "Path not found")
 }

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -1,0 +1,328 @@
+package execenv
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPrepareOpenclawConfigOverridesWorkspace pins that the per-task config
+// writes agents.defaults.workspace = workDir and rewrites every
+// agents.list[].workspace. The upstream scanner resolves
+// `agents.list[id].workspace → agents.defaults.workspace → ~/.openclaw/
+// workspace`, so leaving per-agent workspaces alone would silently bypass
+// the override on agents the user has explicitly configured.
+func TestPrepareOpenclawConfigOverridesWorkspace(t *testing.T) {
+	// Not parallel: mutates HOME / OPENCLAW_CONFIG_PATH.
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	// Seed a user config that mimics a real install: defaults.workspace
+	// pointed at the shared ~/.openclaw/workspace AND a per-agent workspace
+	// override that would otherwise win.
+	userHome := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(userHome, ".openclaw"), 0o755); err != nil {
+		t.Fatalf("mkdir user home: %v", err)
+	}
+	userCfg := map[string]any{
+		"agents": map[string]any{
+			"defaults": map[string]any{
+				"workspace": "/Users/alice/.openclaw/workspace",
+				"model": map[string]any{
+					"primary": "deepseek/deepseek-chat",
+				},
+			},
+			"list": []any{
+				map[string]any{
+					"id":        "coding-bot",
+					"workspace": "/Users/alice/projects/coding-bot",
+					"model":     "anthropic/claude-sonnet-4",
+				},
+				map[string]any{
+					"id":    "scout",
+					"model": "openai/gpt-5",
+				},
+			},
+		},
+		"gateway": map[string]any{
+			"port": float64(18789),
+		},
+	}
+	data, err := json.MarshalIndent(userCfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal user cfg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(userHome, ".openclaw", "openclaw.json"), data, 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	t.Setenv("HOME", userHome)
+	t.Setenv("OPENCLAW_CONFIG_PATH", "") // force the HOME fallback
+
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	if cfgPath != filepath.Join(envRoot, openclawConfigFile) {
+		t.Errorf("cfgPath = %q, want %q", cfgPath, filepath.Join(envRoot, openclawConfigFile))
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read synthesized cfg: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("parse synthesized cfg: %v", err)
+	}
+
+	agents := got["agents"].(map[string]any)
+	defaults := agents["defaults"].(map[string]any)
+	if defaults["workspace"] != workDir {
+		t.Errorf("agents.defaults.workspace = %v, want %q", defaults["workspace"], workDir)
+	}
+
+	// User's other defaults fields (model, etc.) must survive the override.
+	model, ok := defaults["model"].(map[string]any)
+	if !ok || model["primary"] != "deepseek/deepseek-chat" {
+		t.Errorf("agents.defaults.model not preserved: %v", defaults["model"])
+	}
+
+	list := agents["list"].([]any)
+	if len(list) != 2 {
+		t.Fatalf("agents.list length = %d, want 2", len(list))
+	}
+	for i, item := range list {
+		entry := item.(map[string]any)
+		if entry["workspace"] != workDir {
+			t.Errorf("agents.list[%d].workspace = %v, want %q (per-agent overrides must be rewritten so they don't beat defaults)", i, entry["workspace"], workDir)
+		}
+	}
+
+	// Non-agents top-level fields must survive (gateway, models, providers).
+	gw, ok := got["gateway"].(map[string]any)
+	if !ok || gw["port"].(float64) != 18789 {
+		t.Errorf("gateway section not preserved: %v", got["gateway"])
+	}
+}
+
+// TestPrepareOpenclawConfigMissingUserConfig — a fresh openclaw install with
+// no ~/.openclaw/openclaw.json must not break task startup. We synthesize a
+// minimal config containing just the workspace override so the scanner at
+// least picks up {workDir}/skills/.
+func TestPrepareOpenclawConfigMissingUserConfig(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	emptyHome := t.TempDir()
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read synthesized cfg: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("parse synthesized cfg: %v", err)
+	}
+	agents := got["agents"].(map[string]any)
+	defaults := agents["defaults"].(map[string]any)
+	if defaults["workspace"] != workDir {
+		t.Errorf("agents.defaults.workspace = %v, want %q", defaults["workspace"], workDir)
+	}
+}
+
+// TestPrepareOpenclawConfigFollowsEnvVar — when $OPENCLAW_CONFIG_PATH is
+// already set on the daemon's environment (e.g. wrapping another tool that
+// redirected openclaw at a custom file), the preparer reads from that path
+// rather than ~/.openclaw/openclaw.json. The per-task synthesized copy then
+// inherits everything from the redirected source.
+func TestPrepareOpenclawConfigFollowsEnvVar(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "alt-openclaw.json")
+	srcCfg := map[string]any{
+		"agents": map[string]any{
+			"defaults": map[string]any{
+				"workspace": "/should/be/overwritten",
+			},
+		},
+		"meta": map[string]any{
+			"marker": "from-env-var-source",
+		},
+	}
+	data, err := json.MarshalIndent(srcCfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal src cfg: %v", err)
+	}
+	if err := os.WriteFile(srcPath, data, 0o600); err != nil {
+		t.Fatalf("write src cfg: %v", err)
+	}
+
+	t.Setenv("OPENCLAW_CONFIG_PATH", srcPath)
+
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	raw, _ := os.ReadFile(cfgPath)
+	var got map[string]any
+	_ = json.Unmarshal(raw, &got)
+
+	meta := got["meta"].(map[string]any)
+	if meta["marker"] != "from-env-var-source" {
+		t.Errorf("synthesized cfg should inherit from $OPENCLAW_CONFIG_PATH source; got meta = %v", meta)
+	}
+	agents := got["agents"].(map[string]any)
+	defaults := agents["defaults"].(map[string]any)
+	if defaults["workspace"] != workDir {
+		t.Errorf("workspace = %v, want %q (override must replace the source's value)", defaults["workspace"], workDir)
+	}
+}
+
+// TestPrepareOpenclawSkillWriteMatchesScanPath is the regression test the
+// MUL-2219 DoD calls out: the directory Multica writes skills into MUST be
+// the same directory the OpenClaw scanner reads from. We assert this by
+// resolving the workspaceDir the way OpenClaw does (agents.defaults.workspace
+// from the synthesized config) and proving {workspaceDir}/skills/ holds the
+// skill we wrote. Previous fixes asserted "we wrote a file" without checking
+// the scanner would ever see it; that's why MUL-2213 / #2621 needed a
+// follow-up.
+func TestPrepareOpenclawSkillWriteMatchesScanPath(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	for _, sub := range []string{workDir, filepath.Join(envRoot, "output"), filepath.Join(envRoot, "logs")} {
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+
+	skills := []SkillContextForEnv{
+		{Name: "Issue Review", Content: "Review issues thoroughly."},
+		{Name: "Local Dev", Content: "Spin up the local dev env."},
+	}
+
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	if err := writeContextFiles(workDir, "openclaw", TaskContextForEnv{
+		IssueID:     "issue-1",
+		AgentSkills: skills,
+	}); err != nil {
+		t.Fatalf("writeContextFiles: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read synthesized cfg: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse synthesized cfg: %v", err)
+	}
+	wsDir := cfg["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"].(string)
+
+	// Scan path #1 the openclaw runtime would inspect: <workspaceDir>/skills/
+	for _, s := range skills {
+		want := filepath.Join(wsDir, "skills", sanitizeSkillName(s.Name), "SKILL.md")
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("openclaw scan target %s missing — Multica's write path and the openclaw scanner are out of sync: %v", want, err)
+		}
+	}
+}
+
+// TestPrepareEnvironmentOpenclawWiresConfigPath — end-to-end: Prepare sets
+// env.OpenclawConfigPath so the daemon can export OPENCLAW_CONFIG_PATH, and
+// the path resolves to a file with the correct workspace override.
+func TestPrepareEnvironmentOpenclawWiresConfigPath(t *testing.T) {
+	wsRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: wsRoot,
+		WorkspaceID:    "ws-1",
+		TaskID:         "11111111-2222-3333-4444-555555555555",
+		AgentName:      "scout",
+		Provider:       "openclaw",
+		Task: TaskContextForEnv{
+			IssueID: "issue-1",
+		},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if env.OpenclawConfigPath == "" {
+		t.Fatal("Prepare(openclaw) did not set OpenclawConfigPath")
+	}
+	if _, err := os.Stat(env.OpenclawConfigPath); err != nil {
+		t.Fatalf("OpenclawConfigPath does not exist: %v", err)
+	}
+	raw, _ := os.ReadFile(env.OpenclawConfigPath)
+	var cfg map[string]any
+	_ = json.Unmarshal(raw, &cfg)
+	got := cfg["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"]
+	if got != env.WorkDir {
+		t.Errorf("agents.defaults.workspace = %v, want %q", got, env.WorkDir)
+	}
+}
+
+// TestPrepareEnvironmentNonOpenclawSkipsConfig — non-openclaw providers
+// must not get a synthesized openclaw config (it would be dead weight on
+// disk and confuse the GC reaper's idea of what an env contains).
+func TestPrepareEnvironmentNonOpenclawSkipsConfig(t *testing.T) {
+	wsRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+
+	taskIDs := map[string]string{
+		"claude":   "aaaaaaaa-1111-2222-3333-444444444444",
+		"opencode": "bbbbbbbb-1111-2222-3333-444444444444",
+		"hermes":   "cccccccc-1111-2222-3333-444444444444",
+		"kiro":     "dddddddd-1111-2222-3333-444444444444",
+	}
+	for provider, taskID := range taskIDs {
+		t.Run(provider, func(t *testing.T) {
+			env, err := Prepare(PrepareParams{
+				WorkspacesRoot: wsRoot,
+				WorkspaceID:    "ws-1",
+				TaskID:         taskID,
+				AgentName:      "scout",
+				Provider:       provider,
+				Task:           TaskContextForEnv{IssueID: "issue-1"},
+			}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			if err != nil {
+				t.Fatalf("Prepare(%s): %v", provider, err)
+			}
+			if env.OpenclawConfigPath != "" {
+				t.Errorf("provider %s should not get an OpenclawConfigPath, got %q", provider, env.OpenclawConfigPath)
+			}
+			if _, err := os.Stat(filepath.Join(env.RootDir, openclawConfigFile)); !os.IsNotExist(err) {
+				t.Errorf("provider %s left a stray openclaw-config.json", provider)
+			}
+		})
+	}
+}

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -116,10 +116,11 @@ func TestPrepareOpenclawConfigDelegatesParsingToCLI(t *testing.T) {
 		]`},
 	})
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
+	cfgPath := result.ConfigPath
 	if cfgPath != filepath.Join(envRoot, openclawConfigFile) {
 		t.Errorf("cfgPath = %q, want %q", cfgPath, filepath.Join(envRoot, openclawConfigFile))
 	}
@@ -131,6 +132,14 @@ func TestPrepareOpenclawConfigDelegatesParsingToCLI(t *testing.T) {
 	include, ok := got["$include"].([]any)
 	if !ok || len(include) != 1 || include[0] != userConfigPath {
 		t.Errorf("$include = %v, want [%q]", got["$include"], userConfigPath)
+	}
+
+	// The wrapper $includes a path that lives outside envRoot. OpenClaw
+	// confines $include resolution to the wrapper file's own directory
+	// unless OPENCLAW_INCLUDE_ROOTS lists the target. Surface the user
+	// config's dirname so the daemon can grant it.
+	if result.IncludeRoot != userConfigDir {
+		t.Errorf("IncludeRoot = %q, want %q (dirname of active config so wrapper can $include across dirs)", result.IncludeRoot, userConfigDir)
 	}
 
 	agents := got["agents"].(map[string]any)
@@ -242,10 +251,11 @@ func TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty(t *testing.T) {
 		"config get agents.list --json": {err: errors.New("openclaw: No value at agents.list")},
 	})
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
+	cfgPath := result.ConfigPath
 	got := mustReadJSON(t, cfgPath)
 	if _, present := got["agents"].(map[string]any)["list"]; present {
 		t.Errorf("agents.list should be omitted when user has none, got %v", got["agents"])
@@ -275,16 +285,23 @@ func TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig(t *testing.T) {
 		// the stub will fail "unexpected args" if it is.
 	})
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
+	cfgPath := result.ConfigPath
 	got := mustReadJSON(t, cfgPath)
 	if _, present := got["$include"]; present {
 		t.Errorf("$include should be absent for fresh install, got %v", got["$include"])
 	}
 	if got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"] != workDir {
 		t.Errorf("defaults.workspace not set on fresh-install wrapper")
+	}
+	// Fresh install emits no $include, so no extra include root is needed
+	// — the wrapper never steps outside envRoot. Daemon should leave the
+	// user's OPENCLAW_INCLUDE_ROOTS alone.
+	if result.IncludeRoot != "" {
+		t.Errorf("IncludeRoot = %q on fresh install, want empty (no $include emitted)", result.IncludeRoot)
 	}
 }
 
@@ -313,14 +330,101 @@ func TestPrepareOpenclawConfigExpandsTilde(t *testing.T) {
 		"config get agents.list --json": {stdout: "null"},
 	})
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
+	cfgPath := result.ConfigPath
 	got := mustReadJSON(t, cfgPath)
 	include := got["$include"].([]any)
 	if include[0] != realPath {
 		t.Errorf("$include[0] = %v, want %q (tilde must be expanded to absolute)", include[0], realPath)
+	}
+	// IncludeRoot must also use the expanded absolute dirname, otherwise
+	// the daemon would export a `~/.openclaw`-shaped root that OpenClaw
+	// would not match against the resolved absolute include target.
+	wantRoot := filepath.Join(fakeHome, ".openclaw")
+	if result.IncludeRoot != wantRoot {
+		t.Errorf("IncludeRoot = %q, want %q (must be expanded absolute dirname)", result.IncludeRoot, wantRoot)
+	}
+}
+
+// TestPrepareOpenclawConfigWrapperLoadableUnderIncludeConfinement is the
+// regression test for the Elon include-confinement blocker. OpenClaw
+// resolves `$include` only inside the wrapper file's own directory unless
+// the target's parent dir is granted via OPENCLAW_INCLUDE_ROOTS. The
+// previous PR wrote a wrapper at envRoot that $included
+// `~/.openclaw/openclaw.json` (cross-directory) but never surfaced the
+// dirname; OpenClaw would have refused to follow the link at runtime.
+//
+// This test simulates the same confinement check OpenClaw performs:
+//
+//   - For every `$include` target, assert filepath.Dir(target) is either
+//     the wrapper's own dir OR matches the IncludeRoot we surface for the
+//     daemon to grant.
+//
+// It does NOT shell out to a real openclaw binary — the spec is small and
+// stable enough that mirroring it in-test is more reliable than depending
+// on the CLI being installed in CI. If this assertion ever drifts from the
+// real loader, the upstream docs are the source of truth:
+// https://github.com/openclaw/openclaw/blob/main/docs/gateway/configuration.md
+func TestPrepareOpenclawConfigWrapperLoadableUnderIncludeConfinement(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	// User's active config sits in its own dir, not envRoot. This is the
+	// realistic shape (~/.openclaw/openclaw.json is never inside the task
+	// workspace) and is the exact case the bug paper-trail flagged.
+	userConfigDir := t.TempDir()
+	userConfigPath := filepath.Join(userConfigDir, "openclaw.json")
+	if err := os.WriteFile(userConfigPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: userConfigPath},
+		"config get agents.list --json": {stdout: "null"},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+
+	got := mustReadJSON(t, result.ConfigPath)
+	rawIncludes, ok := got["$include"].([]any)
+	if !ok || len(rawIncludes) == 0 {
+		t.Fatalf("wrapper has no $include entries, but a user config is present: %v", got)
+	}
+
+	// Mirror OpenClaw's confinement check: every cross-dir $include target
+	// must have its dirname covered by either the wrapper's own dir or the
+	// IncludeRoot we surface.
+	wrapperDir := filepath.Dir(result.ConfigPath)
+	granted := []string{wrapperDir}
+	if result.IncludeRoot != "" {
+		granted = append(granted, result.IncludeRoot)
+	}
+	for _, raw := range rawIncludes {
+		target, ok := raw.(string)
+		if !ok {
+			t.Fatalf("$include entry is not a string: %T %v", raw, raw)
+		}
+		targetDir := filepath.Dir(target)
+		allowed := false
+		for _, g := range granted {
+			if targetDir == g {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			t.Errorf("$include target %q has dirname %q which is not in granted include roots %v — OpenClaw would refuse to load it",
+				target, targetDir, granted)
+		}
 	}
 }
 
@@ -352,10 +456,11 @@ func TestPrepareOpenclawSkillWriteMatchesScanPath(t *testing.T) {
 		{Name: "Local Dev", Content: "Spin up the local dev env."},
 	}
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
+	cfgPath := result.ConfigPath
 	if err := writeContextFiles(workDir, "openclaw", TaskContextForEnv{
 		IssueID:     "issue-1",
 		AgentSkills: skills,
@@ -406,6 +511,47 @@ func TestPrepareEnvironmentOpenclawWiresConfigPath(t *testing.T) {
 	workspace := got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"]
 	if workspace != env.WorkDir {
 		t.Errorf("agents.defaults.workspace = %v, want %q", workspace, env.WorkDir)
+	}
+	// Fresh install path emits no $include, so the Environment should
+	// leave OpenclawIncludeRoot empty — the daemon must NOT spuriously
+	// grant include roots when no cross-dir hop is being made.
+	if env.OpenclawIncludeRoot != "" {
+		t.Errorf("OpenclawIncludeRoot = %q on fresh install, want empty", env.OpenclawIncludeRoot)
+	}
+}
+
+// TestPrepareEnvironmentOpenclawWiresIncludeRoot — when the user has an
+// on-disk active config (the common non-fresh-install case), Prepare must
+// surface the active config's dirname on the Environment so the daemon
+// can export OPENCLAW_INCLUDE_ROOTS. Without this, the wrapper's
+// $include into ~/.openclaw/openclaw.json is rejected at runtime.
+func TestPrepareEnvironmentOpenclawWiresIncludeRoot(t *testing.T) {
+	wsRoot := t.TempDir()
+
+	userCfgDir := t.TempDir()
+	userCfgPath := filepath.Join(userCfgDir, "openclaw.json")
+	if err := os.WriteFile(userCfgPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: userCfgPath},
+		"config get agents.list --json": {stdout: "null"},
+	})
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: wsRoot,
+		WorkspaceID:    "ws-1",
+		TaskID:         "33333333-2222-3333-4444-555555555555",
+		AgentName:      "scout",
+		Provider:       "openclaw",
+		OpenclawBin:    stub.bin,
+		Task:           TaskContextForEnv{IssueID: "issue-1"},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if env.OpenclawIncludeRoot != userCfgDir {
+		t.Errorf("OpenclawIncludeRoot = %q, want %q (dirname of active config so daemon can grant OPENCLAW_INCLUDE_ROOTS)", env.OpenclawIncludeRoot, userCfgDir)
 	}
 }
 

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -1,71 +1,122 @@
 package execenv
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// TestPrepareOpenclawConfigOverridesWorkspace pins that the per-task config
-// writes agents.defaults.workspace = workDir and rewrites every
-// agents.list[].workspace. The upstream scanner resolves
-// `agents.list[id].workspace → agents.defaults.workspace → ~/.openclaw/
-// workspace`, so leaving per-agent workspaces alone would silently bypass
-// the override on agents the user has explicitly configured.
-func TestPrepareOpenclawConfigOverridesWorkspace(t *testing.T) {
-	// Not parallel: mutates HOME / OPENCLAW_CONFIG_PATH.
+// openclawCLIStub captures one or more (subcommand, response) pairs and
+// installs itself into the package-level openclawExec hook for the duration
+// of a test. Each call records the args it saw so assertions can verify the
+// preparer hit `config file` and `config get agents.list --json`.
+type openclawCLIStub struct {
+	t         *testing.T
+	bin       string
+	responses map[string]openclawResponse
+	calls     []openclawCall
+}
+
+type openclawCall struct {
+	bin  string
+	args []string
+}
+
+type openclawResponse struct {
+	stdout string
+	err    error
+}
+
+func installOpenclawStub(t *testing.T, responses map[string]openclawResponse) *openclawCLIStub {
+	t.Helper()
+	stub := &openclawCLIStub{
+		t:         t,
+		bin:       "/test/stub/openclaw",
+		responses: responses,
+	}
+	prev := openclawExec
+	openclawExec = stub.exec
+	t.Cleanup(func() { openclawExec = prev })
+	return stub
+}
+
+func (s *openclawCLIStub) exec(_ context.Context, bin string, args ...string) (string, error) {
+	s.calls = append(s.calls, openclawCall{bin: bin, args: append([]string(nil), args...)})
+	key := strings.Join(args, " ")
+	resp, ok := s.responses[key]
+	if !ok {
+		return "", fmt.Errorf("openclawCLIStub: unexpected args %q", key)
+	}
+	return resp.stdout, resp.err
+}
+
+func mustReadJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read synthesized cfg: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("parse synthesized cfg: %v", err)
+	}
+	return got
+}
+
+// TestPrepareOpenclawConfigDelegatesParsingToCLI is the headline assertion
+// for the Elon must-fix: instead of re-parsing the user's openclaw.json
+// with encoding/json (which can't read JSON5 / $include / env-var
+// substitution), we delegate the read to the openclaw CLI. The wrapper
+// $includes the user's active path so OpenClaw's own loader handles the
+// JSON5 / $include resolution; we only emit workspace overrides.
+func TestPrepareOpenclawConfigDelegatesParsingToCLI(t *testing.T) {
 	envRoot := t.TempDir()
 	workDir := filepath.Join(envRoot, "workdir")
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		t.Fatalf("mkdir workdir: %v", err)
 	}
 
-	// Seed a user config that mimics a real install: defaults.workspace
-	// pointed at the shared ~/.openclaw/workspace AND a per-agent workspace
-	// override that would otherwise win.
-	userHome := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(userHome, ".openclaw"), 0o755); err != nil {
-		t.Fatalf("mkdir user home: %v", err)
-	}
-	userCfg := map[string]any{
-		"agents": map[string]any{
-			"defaults": map[string]any{
-				"workspace": "/Users/alice/.openclaw/workspace",
-				"model": map[string]any{
-					"primary": "deepseek/deepseek-chat",
-				},
-			},
-			"list": []any{
-				map[string]any{
-					"id":        "coding-bot",
-					"workspace": "/Users/alice/projects/coding-bot",
-					"model":     "anthropic/claude-sonnet-4",
-				},
-				map[string]any{
-					"id":    "scout",
-					"model": "openai/gpt-5",
-				},
-			},
-		},
-		"gateway": map[string]any{
-			"port": float64(18789),
-		},
-	}
-	data, err := json.MarshalIndent(userCfg, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal user cfg: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(userHome, ".openclaw", "openclaw.json"), data, 0o600); err != nil {
+	// JSON5 user config — comments and trailing commas would break the old
+	// encoding/json reader. The stub doesn't actually parse this; it just
+	// proves the wrapper points the $include at the right file regardless
+	// of its on-disk syntax.
+	userConfigDir := t.TempDir()
+	userConfigPath := filepath.Join(userConfigDir, "openclaw.json")
+	json5Body := `// User config with JSON5 features the old parser couldn't read
+{
+  agents: {
+    defaults: {
+      workspace: "/Users/alice/.openclaw/workspace",
+      model: { primary: "anthropic/claude-sonnet-4-6" },
+    },
+    list: [
+      { id: "scout", workspace: "/Users/alice/projects/scout", },
+      { id: "coder", model: "openai/gpt-5", },
+    ],
+  },
+  gateway: { port: 18789 }, // trailing comma
+}
+`
+	if err := os.WriteFile(userConfigPath, []byte(json5Body), 0o600); err != nil {
 		t.Fatalf("write user cfg: %v", err)
 	}
 
-	t.Setenv("HOME", userHome)
-	t.Setenv("OPENCLAW_CONFIG_PATH", "") // force the HOME fallback
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {stdout: userConfigPath + "\n"},
+		"config get agents.list --json": {stdout: `[
+			{ "id": "scout", "workspace": "/Users/alice/projects/scout" },
+			{ "id": "coder", "model": "openai/gpt-5" }
+		]`},
+	})
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -73,13 +124,13 @@ func TestPrepareOpenclawConfigOverridesWorkspace(t *testing.T) {
 		t.Errorf("cfgPath = %q, want %q", cfgPath, filepath.Join(envRoot, openclawConfigFile))
 	}
 
-	raw, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("read synthesized cfg: %v", err)
-	}
-	var got map[string]any
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Fatalf("parse synthesized cfg: %v", err)
+	got := mustReadJSON(t, cfgPath)
+
+	// $include must reference the user's active config so OpenClaw's own
+	// loader does the JSON5 / $include / env-substitution work.
+	include, ok := got["$include"].([]any)
+	if !ok || len(include) != 1 || include[0] != userConfigPath {
+		t.Errorf("$include = %v, want [%q]", got["$include"], userConfigPath)
 	}
 
 	agents := got["agents"].(map[string]any)
@@ -88,12 +139,9 @@ func TestPrepareOpenclawConfigOverridesWorkspace(t *testing.T) {
 		t.Errorf("agents.defaults.workspace = %v, want %q", defaults["workspace"], workDir)
 	}
 
-	// User's other defaults fields (model, etc.) must survive the override.
-	model, ok := defaults["model"].(map[string]any)
-	if !ok || model["primary"] != "deepseek/deepseek-chat" {
-		t.Errorf("agents.defaults.model not preserved: %v", defaults["model"])
-	}
-
+	// Per-agent workspaces must be rewritten so a host-scope agents.list[].
+	// workspace cannot silently win over our defaults override. This is
+	// intentional per-task isolation (see prepareOpenclawConfig doc).
 	list := agents["list"].([]any)
 	if len(list) != 2 {
 		t.Fatalf("agents.list length = %d, want 2", len(list))
@@ -104,99 +152,175 @@ func TestPrepareOpenclawConfigOverridesWorkspace(t *testing.T) {
 			t.Errorf("agents.list[%d].workspace = %v, want %q (per-agent overrides must be rewritten so they don't beat defaults)", i, entry["workspace"], workDir)
 		}
 	}
-
-	// Non-agents top-level fields must survive (gateway, models, providers).
-	gw, ok := got["gateway"].(map[string]any)
-	if !ok || gw["port"].(float64) != 18789 {
-		t.Errorf("gateway section not preserved: %v", got["gateway"])
+	// Non-workspace fields per entry are carried over so a sibling-replace
+	// merge in OpenClaw's $include semantics doesn't silently lose them.
+	if list[0].(map[string]any)["id"] != "scout" {
+		t.Errorf("agents.list[0].id lost in carryover: %v", list[0])
+	}
+	if list[1].(map[string]any)["model"] != "openai/gpt-5" {
+		t.Errorf("agents.list[1].model lost in carryover: %v", list[1])
 	}
 }
 
-// TestPrepareOpenclawConfigMissingUserConfig — a fresh openclaw install with
-// no ~/.openclaw/openclaw.json must not break task startup. We synthesize a
-// minimal config containing just the workspace override so the scanner at
-// least picks up {workDir}/skills/.
-func TestPrepareOpenclawConfigMissingUserConfig(t *testing.T) {
+// TestPrepareOpenclawConfigFailsClosedOnCLIError — the headline regression
+// for Elon's review. When the openclaw CLI fails (broken config, missing
+// binary, etc.), prepareOpenclawConfig MUST surface the error rather than
+// silently synthesize a minimal config that would mask the user's broken
+// state and boot OpenClaw without their registered agents.
+func TestPrepareOpenclawConfigFailsClosedOnCLIError(t *testing.T) {
 	envRoot := t.TempDir()
 	workDir := filepath.Join(envRoot, "workdir")
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		t.Fatalf("mkdir workdir: %v", err)
 	}
 
-	emptyHome := t.TempDir()
-	t.Setenv("HOME", emptyHome)
-	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {err: errors.New("exec: openclaw: no such file or directory")},
+	})
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
-	if err != nil {
-		t.Fatalf("prepareOpenclawConfig: %v", err)
+	_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err == nil {
+		t.Fatal("prepareOpenclawConfig succeeded on CLI failure; expected fail closed")
+	}
+	if !strings.Contains(err.Error(), "locate openclaw active config") {
+		t.Errorf("error message %q does not name the failed step", err.Error())
 	}
 
-	raw, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("read synthesized cfg: %v", err)
-	}
-	var got map[string]any
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Fatalf("parse synthesized cfg: %v", err)
-	}
-	agents := got["agents"].(map[string]any)
-	defaults := agents["defaults"].(map[string]any)
-	if defaults["workspace"] != workDir {
-		t.Errorf("agents.defaults.workspace = %v, want %q", defaults["workspace"], workDir)
+	// No stale wrapper left behind.
+	if _, err := os.Stat(filepath.Join(envRoot, openclawConfigFile)); !os.IsNotExist(err) {
+		t.Errorf("wrapper config should not exist after fail-closed; got err = %v", err)
 	}
 }
 
-// TestPrepareOpenclawConfigFollowsEnvVar — when $OPENCLAW_CONFIG_PATH is
-// already set on the daemon's environment (e.g. wrapping another tool that
-// redirected openclaw at a custom file), the preparer reads from that path
-// rather than ~/.openclaw/openclaw.json. The per-task synthesized copy then
-// inherits everything from the redirected source.
-func TestPrepareOpenclawConfigFollowsEnvVar(t *testing.T) {
+// TestPrepareOpenclawConfigFailsClosedOnMalformedAgentsList — the second
+// fail-closed surface. When `openclaw config get agents.list --json`
+// returns junk we can't parse, we fail rather than guess.
+func TestPrepareOpenclawConfigFailsClosedOnMalformedAgentsList(t *testing.T) {
 	envRoot := t.TempDir()
 	workDir := filepath.Join(envRoot, "workdir")
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		t.Fatalf("mkdir workdir: %v", err)
 	}
 
-	srcDir := t.TempDir()
-	srcPath := filepath.Join(srcDir, "alt-openclaw.json")
-	srcCfg := map[string]any{
-		"agents": map[string]any{
-			"defaults": map[string]any{
-				"workspace": "/should/be/overwritten",
-			},
-		},
-		"meta": map[string]any{
-			"marker": "from-env-var-source",
-		},
-	}
-	data, err := json.MarshalIndent(srcCfg, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal src cfg: %v", err)
-	}
-	if err := os.WriteFile(srcPath, data, 0o600); err != nil {
-		t.Fatalf("write src cfg: %v", err)
+	userConfigPath := filepath.Join(t.TempDir(), "openclaw.json")
+	if err := os.WriteFile(userConfigPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
 	}
 
-	t.Setenv("OPENCLAW_CONFIG_PATH", srcPath)
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: userConfigPath},
+		"config get agents.list --json": {stdout: "<<<garbage>>>"},
+	})
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+	_, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err == nil {
+		t.Fatal("prepareOpenclawConfig succeeded on malformed agents.list output; expected fail closed")
+	}
+	if !strings.Contains(err.Error(), "agents.list") {
+		t.Errorf("error message %q does not name the failed step", err.Error())
+	}
+}
+
+// TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty — `config get` exits
+// non-zero when a path is unset. That is not a failure; the user simply has
+// no agents.list. We must produce a valid wrapper with just the defaults
+// override.
+func TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	userConfigPath := filepath.Join(t.TempDir(), "openclaw.json")
+	if err := os.WriteFile(userConfigPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: userConfigPath},
+		"config get agents.list --json": {err: errors.New("openclaw: No value at agents.list")},
+	})
+
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
-	raw, _ := os.ReadFile(cfgPath)
-	var got map[string]any
-	_ = json.Unmarshal(raw, &got)
-
-	meta := got["meta"].(map[string]any)
-	if meta["marker"] != "from-env-var-source" {
-		t.Errorf("synthesized cfg should inherit from $OPENCLAW_CONFIG_PATH source; got meta = %v", meta)
+	got := mustReadJSON(t, cfgPath)
+	if _, present := got["agents"].(map[string]any)["list"]; present {
+		t.Errorf("agents.list should be omitted when user has none, got %v", got["agents"])
 	}
-	agents := got["agents"].(map[string]any)
-	defaults := agents["defaults"].(map[string]any)
-	if defaults["workspace"] != workDir {
-		t.Errorf("workspace = %v, want %q (override must replace the source's value)", defaults["workspace"], workDir)
+	if got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"] != workDir {
+		t.Errorf("defaults.workspace not set when agents.list missing")
+	}
+}
+
+// TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig — the only legitimate
+// "synthesize minimal" case. `openclaw config file` reports a path (the
+// default) but the file does not exist yet. We emit a wrapper with the
+// workspace override and NO $include (there is nothing to include).
+func TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	// CLI reports a default path that doesn't exist (fresh install).
+	missingPath := filepath.Join(t.TempDir(), "openclaw.json")
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {stdout: missingPath},
+		// `config get` should not be called when the file does not exist;
+		// the stub will fail "unexpected args" if it is.
+	})
+
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, cfgPath)
+	if _, present := got["$include"]; present {
+		t.Errorf("$include should be absent for fresh install, got %v", got["$include"])
+	}
+	if got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"] != workDir {
+		t.Errorf("defaults.workspace not set on fresh-install wrapper")
+	}
+}
+
+// TestPrepareOpenclawConfigExpandsTilde — `openclaw config file` reports
+// paths with `~` shortened. The $include in our wrapper must be absolute so
+// the loader resolves it unambiguously.
+func TestPrepareOpenclawConfigExpandsTilde(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	if err := os.MkdirAll(filepath.Join(fakeHome, ".openclaw"), 0o755); err != nil {
+		t.Fatalf("mkdir home/.openclaw: %v", err)
+	}
+	realPath := filepath.Join(fakeHome, ".openclaw", "openclaw.json")
+	if err := os.WriteFile(realPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: "~/.openclaw/openclaw.json\n"},
+		"config get agents.list --json": {stdout: "null"},
+	})
+
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	got := mustReadJSON(t, cfgPath)
+	include := got["$include"].([]any)
+	if include[0] != realPath {
+		t.Errorf("$include[0] = %v, want %q (tilde must be expanded to absolute)", include[0], realPath)
 	}
 }
 
@@ -206,7 +330,7 @@ func TestPrepareOpenclawConfigFollowsEnvVar(t *testing.T) {
 // resolving the workspaceDir the way OpenClaw does (agents.defaults.workspace
 // from the synthesized config) and proving {workspaceDir}/skills/ holds the
 // skill we wrote. Previous fixes asserted "we wrote a file" without checking
-// the scanner would ever see it; that's why MUL-2213 / #2621 needed a
+// the scanner would ever see it; that is why MUL-2213 / #2621 needed a
 // follow-up.
 func TestPrepareOpenclawSkillWriteMatchesScanPath(t *testing.T) {
 	envRoot := t.TempDir()
@@ -216,15 +340,19 @@ func TestPrepareOpenclawSkillWriteMatchesScanPath(t *testing.T) {
 			t.Fatalf("mkdir %s: %v", sub, err)
 		}
 	}
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		// Fresh install — no user config on disk. Wrapper carries only the
+		// workspace override, which is what the scanner reads.
+		"config file": {stdout: filepath.Join(t.TempDir(), "absent-openclaw.json")},
+	})
 
 	skills := []SkillContextForEnv{
 		{Name: "Issue Review", Content: "Review issues thoroughly."},
 		{Name: "Local Dev", Content: "Spin up the local dev env."},
 	}
 
-	cfgPath, err := prepareOpenclawConfig(envRoot, workDir)
+	cfgPath, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
 	if err != nil {
 		t.Fatalf("prepareOpenclawConfig: %v", err)
 	}
@@ -235,17 +363,8 @@ func TestPrepareOpenclawSkillWriteMatchesScanPath(t *testing.T) {
 		t.Fatalf("writeContextFiles: %v", err)
 	}
 
-	raw, err := os.ReadFile(cfgPath)
-	if err != nil {
-		t.Fatalf("read synthesized cfg: %v", err)
-	}
-	var cfg map[string]any
-	if err := json.Unmarshal(raw, &cfg); err != nil {
-		t.Fatalf("parse synthesized cfg: %v", err)
-	}
+	cfg := mustReadJSON(t, cfgPath)
 	wsDir := cfg["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"].(string)
-
-	// Scan path #1 the openclaw runtime would inspect: <workspaceDir>/skills/
 	for _, s := range skills {
 		want := filepath.Join(wsDir, "skills", sanitizeSkillName(s.Name), "SKILL.md")
 		if _, err := os.Stat(want); err != nil {
@@ -256,11 +375,15 @@ func TestPrepareOpenclawSkillWriteMatchesScanPath(t *testing.T) {
 
 // TestPrepareEnvironmentOpenclawWiresConfigPath — end-to-end: Prepare sets
 // env.OpenclawConfigPath so the daemon can export OPENCLAW_CONFIG_PATH, and
-// the path resolves to a file with the correct workspace override.
+// the path resolves to a file with the correct workspace override. With
+// fail-closed semantics, Prepare itself errors when the CLI is unavailable;
+// a stub here keeps the happy path observable.
 func TestPrepareEnvironmentOpenclawWiresConfigPath(t *testing.T) {
 	wsRoot := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {stdout: filepath.Join(t.TempDir(), "absent.json")},
+	})
 
 	env, err := Prepare(PrepareParams{
 		WorkspacesRoot: wsRoot,
@@ -268,6 +391,7 @@ func TestPrepareEnvironmentOpenclawWiresConfigPath(t *testing.T) {
 		TaskID:         "11111111-2222-3333-4444-555555555555",
 		AgentName:      "scout",
 		Provider:       "openclaw",
+		OpenclawBin:    stub.bin,
 		Task: TaskContextForEnv{
 			IssueID: "issue-1",
 		},
@@ -278,25 +402,49 @@ func TestPrepareEnvironmentOpenclawWiresConfigPath(t *testing.T) {
 	if env.OpenclawConfigPath == "" {
 		t.Fatal("Prepare(openclaw) did not set OpenclawConfigPath")
 	}
-	if _, err := os.Stat(env.OpenclawConfigPath); err != nil {
-		t.Fatalf("OpenclawConfigPath does not exist: %v", err)
+	got := mustReadJSON(t, env.OpenclawConfigPath)
+	workspace := got["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"]
+	if workspace != env.WorkDir {
+		t.Errorf("agents.defaults.workspace = %v, want %q", workspace, env.WorkDir)
 	}
-	raw, _ := os.ReadFile(env.OpenclawConfigPath)
-	var cfg map[string]any
-	_ = json.Unmarshal(raw, &cfg)
-	got := cfg["agents"].(map[string]any)["defaults"].(map[string]any)["workspace"]
-	if got != env.WorkDir {
-		t.Errorf("agents.defaults.workspace = %v, want %q", got, env.WorkDir)
+}
+
+// TestPrepareEnvironmentOpenclawFailsClosed — when the openclaw CLI errors
+// during Prepare, the whole call must fail. Previously the preparer logged
+// a warning and continued with no config; we have removed that path.
+func TestPrepareEnvironmentOpenclawFailsClosed(t *testing.T) {
+	wsRoot := t.TempDir()
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file": {err: errors.New("openclaw config validation failed")},
+	})
+
+	_, err := Prepare(PrepareParams{
+		WorkspacesRoot: wsRoot,
+		WorkspaceID:    "ws-1",
+		TaskID:         "22222222-2222-3333-4444-555555555555",
+		AgentName:      "scout",
+		Provider:       "openclaw",
+		OpenclawBin:    stub.bin,
+		Task:           TaskContextForEnv{IssueID: "issue-1"},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err == nil {
+		t.Fatal("Prepare(openclaw) succeeded when CLI errored; expected fail closed")
+	}
+	if !strings.Contains(err.Error(), "prepare openclaw config") {
+		t.Errorf("error message %q does not name the openclaw config step", err.Error())
 	}
 }
 
 // TestPrepareEnvironmentNonOpenclawSkipsConfig — non-openclaw providers
 // must not get a synthesized openclaw config (it would be dead weight on
-// disk and confuse the GC reaper's idea of what an env contains).
+// disk and confuse the GC reaper's idea of what an env contains). They
+// also must NOT shell out to the openclaw CLI, so the stub here records
+// zero calls.
 func TestPrepareEnvironmentNonOpenclawSkipsConfig(t *testing.T) {
 	wsRoot := t.TempDir()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("OPENCLAW_CONFIG_PATH", "")
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{})
 
 	taskIDs := map[string]string{
 		"claude":   "aaaaaaaa-1111-2222-3333-444444444444",
@@ -324,5 +472,8 @@ func TestPrepareEnvironmentNonOpenclawSkipsConfig(t *testing.T) {
 				t.Errorf("provider %s left a stray openclaw-config.json", provider)
 			}
 		})
+	}
+	if len(stub.calls) != 0 {
+		t.Errorf("non-openclaw providers shelled out to openclaw CLI %d times: %+v", len(stub.calls), stub.calls)
 	}
 }

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -56,7 +56,7 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Codex:    writes {workDir}/AGENTS.md  (skills discovered natively via CODEX_HOME)
 // For Copilot:  writes {workDir}/AGENTS.md  (skills discovered natively from .github/skills/)
 // For OpenCode: writes {workDir}/AGENTS.md  (skills discovered natively from .opencode/skills/)
-// For OpenClaw: writes {workDir}/AGENTS.md  (skills fall back to .agent_context/skills/; OpenClaw does not auto-discover from workdir)
+// For OpenClaw: writes {workDir}/AGENTS.md  (skills discovered natively from {workDir}/skills/ via per-task openclaw-config.json that pins agents.defaults.workspace)
 // For Hermes:   writes {workDir}/AGENTS.md  (skills fall back to .agent_context/skills/; AGENTS.md points there)
 // For Gemini:   writes {workDir}/GEMINI.md  (discovered natively by the Gemini CLI)
 // For Pi:       writes {workDir}/AGENTS.md  (skills discovered natively from .pi/skills/)
@@ -305,15 +305,17 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		case "claude":
 			// Claude discovers skills natively from .claude/skills/ — just list names.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "codex", "copilot", "opencode", "pi", "cursor", "kimi", "kiro":
-			// Codex, Copilot, OpenCode, Pi, Cursor, Kimi, and Kiro discover skills natively from their respective paths — just list names.
+		case "codex", "copilot", "opencode", "openclaw", "pi", "cursor", "kimi", "kiro":
+			// Codex, Copilot, OpenCode, OpenClaw, Pi, Cursor, Kimi, and Kiro discover skills
+			// natively from their respective paths. For OpenClaw, the daemon also writes a
+			// per-task openclaw-config.json (exported via OPENCLAW_CONFIG_PATH) that pins
+			// agents.defaults.workspace to the task workdir so the CLI's scanner picks up
+			// {workDir}/skills/.
 			b.WriteString("You have the following skills installed (discovered automatically):\n\n")
-		case "gemini", "hermes", "openclaw":
+		case "gemini", "hermes":
 			// Gemini reads GEMINI.md directly. Hermes has no native skills discovery
-			// path wired up in resolveSkillsDir. OpenClaw scans its own workspaceDir
-			// (resolved from the openclaw config, not the task workdir) so per-task
-			// skills written by Multica are not visible to its native loader; we
-			// fall back to .agent_context/skills/ and reference the files explicitly.
+			// path wired up in resolveSkillsDir; both fall back to referencing the
+			// files explicitly under .agent_context/skills/.
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")
 		default:
 			b.WriteString("Detailed skill instructions are in `.agent_context/skills/`. Each subdirectory contains a `SKILL.md`.\n\n")


### PR DESCRIPTION
## Summary

- Synthesize a per-task `openclaw-config.json` that uses `$include` to load the user's active config through OpenClaw's own loader, then layers workspace overrides as siblings: `agents.defaults.workspace` and every `agents.list[].workspace` pin to the task workdir.
- Discover the user's active config and resolved `agents.list` via the openclaw CLI (`openclaw config file` and `openclaw config get agents.list --json`) — JSON5, `$include` chains, `${VAR}` substitution, and `OPENCLAW_STATE_DIR` / `OPENCLAW_HOME` / legacy resolution are all delegated to OpenClaw itself instead of being re-implemented in Go.
- Write workspace skills to `{workDir}/skills/<name>/SKILL.md` — the first path OpenClaw's native scanner walks under `workspaceDir`.
- Update the AGENTS.md branding so OpenClaw joins the "discovered automatically" list, alongside Claude / Codex / OpenCode / etc.

## Why

[MUL-2213](https://github.com/multica-ai/multica/pull/2621) stopped advertising auto-discovery for OpenClaw and routed its skills to `.agent_context/skills/`, but that path is **not** in OpenClaw's scan list (verified against upstream `src/agents/skills/refresh.ts`). Multica-loaded skills were still invisible to the runtime; only the AGENTS.md path-reference workaround survived.

OpenClaw resolves `workspaceDir` as `agents.list[id].workspace → agents.defaults.workspace → ~/.openclaw/workspace` — there is no CLI flag and no env var consumed by the agent runtime. The only knob is the config file. So we redirect the CLI at a per-task config with workspaces rewritten, and write the skills where the scanner looks.

## Why parsing is delegated to the openclaw CLI

Elon's review on the v1 of this PR flagged that the original `encoding/json` reader could not parse the real OpenClaw config format. OpenClaw configs are JSON5 (comments, trailing commas, unquoted keys) and support `$include` for splitting config across files, plus `${VAR}` substitution and an `OPENCLAW_STATE_DIR` / `OPENCLAW_HOME` / legacy resolution chain. The first version of this preparer silently fell back to a minimal config on any parse failure, which could have booted OpenClaw without the user's registered agents / model providers / API keys.

This revision delegates all of that to the source of truth — the openclaw CLI itself:

- `openclaw config file` resolves the active config path (honours `OPENCLAW_CONFIG_PATH` / `OPENCLAW_STATE_DIR` / `OPENCLAW_HOME` / the default location, plus `~` expansion).
- `openclaw config get agents.list --json` returns the post-`$include`, post-env-substitution `agents.list`, which is all we need to know which agent IDs and field shapes to carry forward.
- The wrapper we write uses `$include` to point at the user's active config. OpenClaw's own loader then parses the JSON5 / nested `$include` / secrets verbatim. The user's bytes are never mutated.

**Fail closed.** Any CLI error, malformed output, or write failure now surfaces as a hard error from `Prepare` / `Reuse` rather than degrading to a minimal config. The only "synthesize minimal" path left is a fresh install — when the CLI reports a default path but the file does not yet exist — and that case has no user data to lose.

## Intentional task isolation: per-agent workspaces are also rewritten

The override rewrites every `agents.list[].workspace`, not just `agents.defaults.workspace`. This is deliberate. OpenClaw's resolution order is `agents.list[id].workspace → agents.defaults.workspace → ~/.openclaw/workspace`, so pinning only the default would let a host-scope per-agent workspace silently re-route the scanner back to the user's shared workspace and defeat per-task skill discovery.

The cost is that any per-agent SOUL.md / MEMORY.md / standing orders the user laid in `<host-agent-workspace>/` are NOT visible to the in-task openclaw run — task isolation wins over host carry-over. The user's on-disk config is untouched; this only affects the wrapper used for this single task. Documented inline in `prepareOpenclawConfig`.

## Drive-by cleanup of stale comments Elon flagged

- `daemon.go` (the `providerNeedsInlineSystemPrompt` block) no longer claims OpenClaw cannot load bootstrap files from the task workdir. With the per-task config pinning workspace to workdir, OpenClaw does pick up AGENTS.md / .agent_context/ from there. The inline brief is now described as a belt-and-suspenders carryover until the workdir bootstrap is stable across all releases.
- `execenv.go` openclaw block no longer says "the inline brief still references skill file paths" — the brief uses "discovered automatically" now, with no path mentions.

## Definition of Done — MUL-2219

- [x] OpenClaw skills are reachable through native scanning, not by agent-side path reads.
- [x] Regression test asserts the **scanner's** view: `workspaceDir` from the synthesized config + Multica's write path are the same directory (`TestPrepareOpenclawSkillWriteMatchesScanPath`). The previous attempt only proved "we wrote a file," which is how the `.openclaw/skills/` dead drop slipped through.
- [x] AGENTS.md / runtime brief flips OpenClaw back to "discovered automatically."
- [x] JSON5 / `$include` / active-config-path resolution: delegated to the openclaw CLI; the preparer never re-parses on-disk config bytes.
- [x] Fail-closed on CLI / parse / write failure — no silent minimal-config synthesis.

## Test plan

- [x] `go test ./internal/daemon/... -count=1` — all daemon + execenv tests pass on this branch.
- [x] `TestPrepareOpenclawConfigDelegatesParsingToCLI` — wrapper `$include`s the user's active config (JSON5 / trailing commas in the fixture), and per-agent workspaces are rewritten without losing other fields.
- [x] `TestPrepareOpenclawConfigFailsClosedOnCLIError` — CLI failure during `config file` surfaces as a hard error; no wrapper left on disk.
- [x] `TestPrepareOpenclawConfigFailsClosedOnMalformedAgentsList` — malformed `config get` output also fails closed.
- [x] `TestPrepareOpenclawConfigKeyMissingTreatedAsEmpty` — "key not found" exit is not a failure; wrapper omits `agents.list`.
- [x] `TestPrepareOpenclawConfigFreshInstallNoOnDiskConfig` — the only synthesize-minimal case; wrapper has no `$include`.
- [x] `TestPrepareOpenclawConfigExpandsTilde` — `~/.openclaw/openclaw.json` from the CLI is expanded to absolute before going into `$include`.
- [x] `TestPrepareEnvironmentOpenclawFailsClosed` — `Prepare` itself errors when openclaw config can't be set up.
- [x] `TestPrepareEnvironmentOpenclawWiresConfigPath` / `TestPrepareEnvironmentNonOpenclawSkipsConfig` — happy path + non-openclaw providers don't shell out to the openclaw CLI at all.

## Manual verification (recommended for staging)

1. Attach a Multica skill to an openclaw-backed agent.
2. Trigger a task on that agent.
3. In the spawned openclaw process, the skill should show up via `openclaw skill list` / equivalent listing — not just as a referenced path in AGENTS.md.

MUL-2219
