### PR TITLE
fix(runtimes): keep runtime name visible, truncate hostname first

### DIFF
--- a/packages/views/runtimes/components/runtime-columns.tsx
+++ b/packages/views/runtimes/components/runtime-columns.tsx
@@ -235,14 +235,14 @@ function RuntimeNameCell({ runtime }: { runtime: AgentRuntime }) {
         <ProviderLogo provider={runtime.provider} className="h-5 w-5" />
       </div>
       <div className="flex min-w-0 flex-1 items-center gap-1.5">
-        <span className="block min-w-0 truncate text-sm font-medium">
+        <span className="block min-w-0 shrink truncate text-sm font-medium">
           {baseName}
         </span>
         {hostname && (
           <Tooltip>
             <TooltipTrigger
               render={
-                <span className="block min-w-0 truncate text-xs text-muted-foreground/70">
+                <span className="block min-w-0 flex-1 basis-0 truncate text-xs text-muted-foreground/70">
                   ({hostname})
                 </span>
               }


### PR DESCRIPTION
## Summary
- Fix [MUL-2221](https://multica.app/MUL-2221): runtime list 中 base name 被括号里的 hostname 遮挡。
- 让 base name `shrink` 保留收缩兜底，hostname 的 span 改成 `flex-1 basis-0`，列宽不足时 hostname 先被截断，name 保持完整。
- 其它列、行高、徽章位置、tooltip 行为均不变。

## Test plan
- [ ] Runtimes 列表（Mine / All）下 name 完整可见
- [ ] 列变窄时优先截断 hostname，name 保持完整
- [ ] Hover 括号部分仍弹出完整 hostname tooltip
- [ ] Private/Public 徽章位置不变