### PR TITLE
fix(chat): make session dropdown width track its trigger (MUL-2223)

### DIFF
--- a/packages/views/chat/components/chat-window.tsx
+++ b/packages/views/chat/components/chat-window.tsx
@@ -907,7 +907,7 @@ function SessionDropdown({
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger className="flex items-center gap-1.5 min-w-0 rounded-md px-1.5 py-1 transition-colors hover:bg-accent aria-expanded:bg-accent">
+        <DropdownMenuTrigger className="flex max-w-96 min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 transition-colors hover:bg-accent aria-expanded:bg-accent">
           {triggerAgent && (
             <ActorAvatar
               actorType="agent"
@@ -917,7 +917,7 @@ function SessionDropdown({
               showStatusDot
             />
           )}
-          <span className="truncate text-sm font-medium">{title}</span>
+          <span className="min-w-0 truncate text-sm font-medium">{title}</span>
           {otherSessionRunning ? (
             <span
               aria-label={t(($) => $.window.another_running)}
@@ -933,7 +933,10 @@ function SessionDropdown({
           ) : null}
           <ChevronDown className="size-3 text-muted-foreground shrink-0" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="max-h-96 w-auto min-w-64 max-w-80 overflow-y-auto">
+        <DropdownMenuContent
+          align="start"
+          className="max-h-96 w-auto min-w-[max(16rem,var(--anchor-width,16rem))] max-w-96 overflow-y-auto"
+        >
           {sessions.length === 0 ? (
             <div className="px-2 py-1.5 text-xs text-muted-foreground">
               {t(($) => $.window.no_previous)}


### PR DESCRIPTION
## Summary
- Cap `SessionDropdown` trigger at `max-w-96` so very long chat titles do not let the trigger grow indefinitely.
- Let `DropdownMenuContent` track the trigger width via `--anchor-width` (with a 16rem floor and 24rem ceiling), removing the visual gap where the popup was visibly narrower than the trigger.
- Add `min-w-0` to the title `<span>` so truncation works inside the flex trigger.

Closes [MUL-2223](https://multica-app.copilothub.ai/issues/MUL-2223).

## Test plan
- [ ] Open chat with a short title — dropdown shows at 16rem floor, no regression.
- [ ] Open chat with a long title — trigger and dropdown both cap at 24rem with `...` truncation, no visual gap.
- [ ] Verify dropdown items render correctly at the new widths.