### PR TITLE
feat(desktop): silent background auto-download for updates (MUL-2224)

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,7 +1,10 @@
-import { autoUpdater } from "electron-updater";
+import { autoUpdater, UpdateDownloadedEvent } from "electron-updater";
 import { app, BrowserWindow, ipcMain } from "electron";
 
-autoUpdater.autoDownload = false;
+// Silent background updates: electron-updater downloads on its own as soon
+// as `update-available` fires; we only surface UI when the package is fully
+// downloaded and ready to install on next quit.
+autoUpdater.autoDownload = true;
 autoUpdater.autoInstallOnAppQuit = true;
 
 // Windows arm64 ships its own update metadata channel because
@@ -26,8 +29,27 @@ export type ManualUpdateCheckResult =
     }
   | { ok: false; error: string };
 
+// Single-flight guard around checkForUpdates(). With autoDownload=true the
+// startup, periodic, and manual triggers can all kick off downloads, and
+// overlapping calls have caused duplicate download warnings in the past
+// (see electronjs.org/docs/latest/api/auto-updater). Coalesce concurrent
+// callers onto the same in-flight promise.
+let inFlightCheck: Promise<unknown> | null = null;
+function checkForUpdatesOnce(): Promise<unknown> {
+  if (inFlightCheck) return inFlightCheck;
+  const p = autoUpdater
+    .checkForUpdates()
+    .finally(() => {
+      if (inFlightCheck === p) inFlightCheck = null;
+    });
+  inFlightCheck = p;
+  return p;
+}
+
 export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): void {
   autoUpdater.on("update-available", (info) => {
+    // Forwarded for renderer-side state tracking only; the notification UI
+    // does not render an "available" affordance with autoDownload=true.
     const win = getMainWindow();
     win?.webContents.send("updater:update-available", {
       version: info.version,
@@ -42,15 +64,20 @@ export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): voi
     });
   });
 
-  autoUpdater.on("update-downloaded", () => {
+  autoUpdater.on("update-downloaded", (info: UpdateDownloadedEvent) => {
     const win = getMainWindow();
-    win?.webContents.send("updater:update-downloaded");
+    win?.webContents.send("updater:update-downloaded", {
+      version: info.version,
+      releaseNotes: info.releaseNotes,
+    });
   });
 
   autoUpdater.on("error", (err) => {
     console.error("Auto-updater error:", err);
   });
 
+  // Retained for IPC back-compat with older renderer bundles. With
+  // autoDownload=true the renderer no longer triggers this path.
   ipcMain.handle("updater:download", () => {
     return autoUpdater.downloadUpdate();
   });
@@ -61,7 +88,9 @@ export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): voi
 
   ipcMain.handle("updater:check", async (): Promise<ManualUpdateCheckResult> => {
     try {
-      const result = await autoUpdater.checkForUpdates();
+      const result = (await checkForUpdatesOnce()) as
+        | { updateInfo: { version: string }; isUpdateAvailable?: boolean }
+        | null;
       const currentVersion = app.getVersion();
       // Trust electron-updater's own decision rather than re-deriving it from
       // a version-string compare. The two diverge for pre-release channels,
@@ -85,7 +114,7 @@ export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): voi
 
   // Initial check shortly after startup so we don't block boot.
   setTimeout(() => {
-    autoUpdater.checkForUpdates().catch((err) => {
+    checkForUpdatesOnce().catch((err) => {
       console.error("Failed to check for updates:", err);
     });
   }, STARTUP_CHECK_DELAY_MS);
@@ -93,7 +122,7 @@ export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): voi
   // Background poll so long-running sessions still pick up new releases
   // without requiring the user to restart the app.
   setInterval(() => {
-    autoUpdater.checkForUpdates().catch((err) => {
+    checkForUpdatesOnce().catch((err) => {
       console.error("Periodic update check failed:", err);
     });
   }, PERIODIC_CHECK_INTERVAL_MS);

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -39,6 +39,18 @@ function checkForUpdatesOnce(): Promise<unknown> {
   if (inFlightCheck) return inFlightCheck;
   const p = autoUpdater
     .checkForUpdates()
+    .then((result) => {
+      // checkForUpdates resolves as soon as metadata is fetched; the actual
+      // download (when autoDownload=true) is exposed on result.downloadPromise.
+      // Without a handler a download failure becomes an unhandled rejection
+      // in the main process — Node may terminate it on future versions.
+      void (result as { downloadPromise?: Promise<unknown> } | null)?.downloadPromise?.catch(
+        (err) => {
+          console.error("Failed to download update:", err);
+        },
+      );
+      return result;
+    })
     .finally(() => {
       if (inFlightCheck === p) inFlightCheck = null;
     });

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -84,7 +84,9 @@ interface DaemonAPI {
 interface UpdaterAPI {
   onUpdateAvailable: (callback: (info: { version: string; releaseNotes?: string }) => void) => () => void;
   onDownloadProgress: (callback: (progress: { percent: number }) => void) => () => void;
-  onUpdateDownloaded: (callback: () => void) => () => void;
+  onUpdateDownloaded: (
+    callback: (info: { version: string; releaseNotes?: string }) => void,
+  ) => () => void;
   downloadUpdate: () => Promise<void>;
   installUpdate: () => Promise<void>;
   checkForUpdates: () => Promise<

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -207,8 +207,11 @@ const updaterAPI = {
     ipcRenderer.on("updater:download-progress", handler);
     return () => ipcRenderer.removeListener("updater:download-progress", handler);
   },
-  onUpdateDownloaded: (callback: () => void) => {
-    const handler = () => callback();
+  onUpdateDownloaded: (
+    callback: (info: { version: string; releaseNotes?: string }) => void,
+  ) => {
+    const handler = (_: unknown, info: { version: string; releaseNotes?: string }) =>
+      callback(info);
     ipcRenderer.on("updater:update-downloaded", handler);
     return () => ipcRenderer.removeListener("updater:update-downloaded", handler);
   },

--- a/apps/desktop/src/renderer/src/components/update-notification.tsx
+++ b/apps/desktop/src/renderer/src/components/update-notification.tsx
@@ -1,55 +1,27 @@
-import { useCallback, useEffect, useState } from "react";
-import { ArrowDownToLine, RefreshCw, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { RefreshCw, X } from "lucide-react";
 
+// Downloads run silently in the background (main process has
+// autoDownload=true). The renderer only renders UI once the package is fully
+// downloaded and waiting for a restart.
 type UpdateState =
   | { status: "idle" }
-  | { status: "available"; version: string }
-  | { status: "downloading"; percent: number }
-  | { status: "ready" };
+  | { status: "ready"; version: string };
 
 export function UpdateNotification() {
   const [state, setState] = useState<UpdateState>({ status: "idle" });
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
-    const cleanups: (() => void)[] = [];
-
-    cleanups.push(
-      window.updater.onUpdateAvailable((info) => {
-        setState({ status: "available", version: info.version });
-        setDismissed(false);
-      }),
-    );
-
-    cleanups.push(
-      window.updater.onDownloadProgress((progress) => {
-        setState({ status: "downloading", percent: progress.percent });
-      }),
-    );
-
-    cleanups.push(
-      window.updater.onUpdateDownloaded(() => {
-        setState({ status: "ready" });
-      }),
-    );
-
-    return () => cleanups.forEach((fn) => fn());
+    const cleanup = window.updater.onUpdateDownloaded((info) => {
+      setState({ status: "ready", version: info.version });
+      setDismissed(false);
+    });
+    return cleanup;
   }, []);
 
-  const handleDownload = useCallback(() => {
-    // Prevent double-click: immediately transition to downloading state
-    if (state.status !== "available") return;
-    setState({ status: "downloading", percent: 0 });
-    window.updater.downloadUpdate();
-  }, [state.status]);
-
-  const handleInstall = useCallback(() => {
-    window.updater.installUpdate();
-  }, []);
-
-  // Only allow dismiss when update is available (not during download or ready)
   if (state.status === "idle") return null;
-  if (dismissed && state.status === "available") return null;
+  if (dismissed) return null;
 
   return (
     <div className="fixed bottom-4 right-4 z-50 w-80 rounded-lg border border-border bg-background p-4 shadow-lg animate-in slide-in-from-bottom-2 fade-in duration-300">
@@ -60,78 +32,31 @@ export function UpdateNotification() {
         <X className="size-3.5" />
       </button>
 
-      {state.status === "available" && (
-        <div className="flex items-start gap-3">
-          <div className="mt-0.5 rounded-md bg-primary/10 p-1.5">
-            <ArrowDownToLine className="size-4 text-primary" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium">New version available</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              v{state.version} is ready to download
-            </p>
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded-md bg-success/10 p-1.5">
+          <RefreshCw className="size-4 text-success" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">Update ready</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            v{state.version} will be applied on next launch.
+          </p>
+          <div className="mt-2 flex items-center gap-1.5">
             <button
-              onClick={handleDownload}
-              className="mt-2 inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              onClick={() => setDismissed(true)}
+              className="inline-flex items-center rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent transition-colors"
             >
-              Download update
+              Later
+            </button>
+            <button
+              onClick={() => window.updater.installUpdate()}
+              className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              Restart now
             </button>
           </div>
         </div>
-      )}
-
-      {state.status === "downloading" && (
-        <div className="flex items-start gap-3">
-          <div className="mt-0.5 rounded-md bg-primary/10 p-1.5">
-            <ArrowDownToLine className="size-4 text-primary animate-pulse" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium">Downloading update...</p>
-            <div className="mt-2 h-1.5 w-full rounded-full bg-muted overflow-hidden">
-              <div
-                className="h-full rounded-full bg-primary transition-all duration-300"
-                style={{ width: `${Math.round(state.percent)}%` }}
-              />
-            </div>
-            <p className="text-xs text-muted-foreground mt-1">
-              {Math.round(state.percent)}%
-            </p>
-          </div>
-        </div>
-      )}
-
-      {state.status === "ready" && (
-        <div className="flex items-start gap-3">
-          <div className="mt-0.5 rounded-md bg-success/10 p-1.5">
-            <RefreshCw className="size-4 text-success" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium">Update ready</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Restart to apply the update
-            </p>
-            <div className="mt-2 flex items-center gap-1.5">
-              {/* Secondary "See changes" — gives the user a reason to
-                  restart by surfacing what they're about to get. Opens
-                  in the default browser via the shared openExternal
-                  bridge so the URL hits the same allow-list as every
-                  other outbound link. */}
-              <button
-                onClick={() => window.desktopAPI.openExternal("https://multica.ai/changelog")}
-                className="inline-flex items-center rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent transition-colors"
-              >
-                See changes
-              </button>
-              <button
-                onClick={handleInstall}
-                className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-              >
-                Restart now
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/updates-settings-tab.tsx
+++ b/apps/desktop/src/renderer/src/components/updates-settings-tab.tsx
@@ -32,7 +32,8 @@ export function UpdatesSettingsTab() {
       <h2 className="text-lg font-semibold">Updates</h2>
       <p className="text-sm text-muted-foreground mt-1">
         The desktop app checks for new versions automatically once an hour and
-        shortly after launch.
+        shortly after launch, downloading them in the background. You&apos;ll
+        be prompted to restart once an update is ready.
       </p>
 
       <div className="mt-6 divide-y">
@@ -50,7 +51,8 @@ export function UpdatesSettingsTab() {
             <p className="text-sm font-medium">Check for updates</p>
             <p className="text-sm text-muted-foreground mt-0.5">
               Trigger a check now instead of waiting for the next automatic
-              poll. Available updates appear as a notification in the corner.
+              poll. Available updates download in the background and show a
+              restart prompt when ready.
             </p>
             {state.status === "up-to-date" && (
               <p className="text-sm text-muted-foreground mt-2 inline-flex items-center gap-1.5">
@@ -61,8 +63,8 @@ export function UpdatesSettingsTab() {
             {state.status === "available" && (
               <p className="text-sm text-muted-foreground mt-2 inline-flex items-center gap-1.5">
                 <ArrowDownToLine className="size-3.5 text-primary" />
-                v{state.latestVersion} is available — see the download prompt
-                in the corner.
+                v{state.latestVersion} is downloading in the background —
+                you&apos;ll be notified when it&apos;s ready to install.
               </p>
             )}
             {state.status === "error" && (


### PR DESCRIPTION
## Summary

Implements [MUL-2224](https://multica.app/issue/072d836a-b492-4e38-8c9c-7161d921646d) — Desktop now downloads new releases silently in the background and only surfaces a UI prompt when the update is downloaded and ready to install.

- `updater.ts`: `autoDownload = true`; `update-downloaded` IPC now carries `{ version, releaseNotes }`; single-flight guard around `checkForUpdates()` so startup / periodic / manual checks don't trigger overlapping downloads (per [electron docs warning](https://www.electronjs.org/docs/latest/api/auto-updater#autoupdatercheckforupdates)).
- `update-notification.tsx`: drops the `available` / `downloading` UI entirely; only the `ready` state renders, with `Later` and `Restart now` actions. Version is read from the download event so the prompt always shows the correct release.
- `updates-settings-tab.tsx`: settings copy updated — "downloads in background, you'll be prompted to restart".
- preload: `onUpdateDownloaded` callback now receives `{ version, releaseNotes? }` instead of being a bare void callback.
- `updater:download` IPC kept (no-op from new renderer) for back-compat with older renderer bundles in the same Electron app.

`autoInstallOnAppQuit` is unchanged, so users who never click Restart still get the update applied on the next normal quit.

## Test plan

- [x] `pnpm --filter @multica/desktop typecheck`
- [x] `pnpm --filter @multica/desktop test` (103 passed)
- [x] `pnpm --filter @multica/desktop lint` (no new warnings)
- [ ] Manual: launch desktop, wait through update flow, confirm no "Download update" prompt appears and the ready prompt shows when packaging is complete (Jiayuan acceptance in isolated env)