### PR TITLE
fix(auth): add per-IP rate limiting on public auth endpoints (MUL-2251)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -205,10 +206,16 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 		})
 	}
 
-	// Auth (public)
-	r.Post("/auth/send-code", h.SendCode)
-	r.Post("/auth/verify-code", h.VerifyCode)
-	r.Post("/auth/google", h.GoogleLogin)
+	// Auth (public) — per-IP rate limiting.
+	if rdb == nil {
+		slog.Warn("rate limiting disabled: REDIS_URL not configured")
+	}
+	trustedProxies := middleware.ParseTrustedProxies(os.Getenv("RATE_LIMIT_TRUSTED_PROXIES"))
+	authRL := middleware.RateLimit(rdb, envPositiveInt("RATE_LIMIT_AUTH", 5), time.Minute, trustedProxies)
+	authVerifyRL := middleware.RateLimit(rdb, envPositiveInt("RATE_LIMIT_AUTH_VERIFY", 20), time.Minute, trustedProxies)
+	r.With(authRL).Post("/auth/send-code", h.SendCode)
+	r.With(authVerifyRL).Post("/auth/verify-code", h.VerifyCode)
+	r.With(authRL).Post("/auth/google", h.GoogleLogin)
 	r.Post("/auth/logout", h.Logout)
 
 	// Public API

--- a/server/internal/middleware/ratelimit.go
+++ b/server/internal/middleware/ratelimit.go
@@ -1,0 +1,134 @@
+package middleware
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// rateLimitScript atomically increments the counter and sets the TTL on
+// first access. Using a Lua script ensures INCR and EXPIRE cannot be
+// split by a network failure — if INCR succeeds the TTL is guaranteed
+// to be set, preventing a stuck key that acts as a permanent ban.
+var rateLimitScript = redis.NewScript(`
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return count
+`)
+
+// ParseTrustedProxies parses a comma-separated list of CIDRs into a
+// slice of *net.IPNet. Invalid entries are warned and skipped.
+// Returns nil if raw is empty (default: never trust X-Forwarded-For).
+func ParseTrustedProxies(raw string) []*net.IPNet {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	var nets []*net.IPNet
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		_, cidr, err := net.ParseCIDR(p)
+		if err != nil {
+			slog.Warn("ratelimit: invalid trusted proxy CIDR, skipping", "cidr", p, "error", err)
+			continue
+		}
+		nets = append(nets, cidr)
+	}
+	return nets
+}
+
+// RateLimit returns a per-IP fixed-window rate limiter backed by Redis.
+// If rdb is nil the middleware is a no-op (fail-open).
+//
+// trustedProxies controls X-Forwarded-For handling: when the direct
+// connection (RemoteAddr) originates from a CIDR in the list, the
+// rightmost non-trusted IP in the XFF chain is used as the client IP.
+// When the list is empty (default), XFF is never consulted — only
+// RemoteAddr is used. This matches the project's conservative trust
+// model (see health_realtime.go).
+func RateLimit(rdb *redis.Client, limit int, window time.Duration, trustedProxies []*net.IPNet) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if rdb == nil {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := extractIP(r, trustedProxies)
+			key := rateLimitKey(r.URL.Path, ip)
+			ctx := r.Context()
+
+			count, err := rateLimitScript.Run(ctx, rdb, []string{key}, int(window.Seconds())).Int64()
+			if err != nil {
+				slog.Warn("ratelimit: redis error; allowing request", "error", err, "ip", ip)
+				next.ServeHTTP(w, r)
+				return
+			}
+			if count > int64(limit) {
+				w.Header().Set("Retry-After", fmt.Sprintf("%d", int(window.Seconds())))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				json.NewEncoder(w).Encode(map[string]string{"error": "too many requests"})
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// extractIP determines the client IP for rate limiting purposes.
+// It only honors X-Forwarded-For when RemoteAddr is from a trusted proxy.
+func extractIP(r *http.Request, trustedProxies []*net.IPNet) string {
+	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		remoteHost = r.RemoteAddr
+	}
+
+	if len(trustedProxies) > 0 {
+		remoteIP := net.ParseIP(remoteHost)
+		if remoteIP != nil && isTrustedProxy(remoteIP, trustedProxies) {
+			if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+				// Walk right-to-left: the rightmost non-trusted entry is
+				// the last hop before the trusted proxy chain.
+				parts := strings.Split(xff, ",")
+				for i := len(parts) - 1; i >= 0; i-- {
+					candidate := net.ParseIP(strings.TrimSpace(parts[i]))
+					if candidate != nil && !isTrustedProxy(candidate, trustedProxies) {
+						return candidate.String()
+					}
+				}
+			}
+		}
+	}
+
+	// Default: use RemoteAddr in canonical form.
+	if ip := net.ParseIP(remoteHost); ip != nil {
+		return ip.String()
+	}
+	return remoteHost
+}
+
+func isTrustedProxy(ip net.IP, cidrs []*net.IPNet) bool {
+	for _, cidr := range cidrs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func rateLimitKey(path, ip string) string {
+	sanitized := strings.TrimPrefix(path, "/")
+	sanitized = strings.ReplaceAll(sanitized, "/", ":")
+	return fmt.Sprintf("mul:ratelimit:%s:%s", sanitized, ip)
+}

--- a/server/internal/middleware/ratelimit_test.go
+++ b/server/internal/middleware/ratelimit_test.go
@@ -1,0 +1,245 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func TestRateLimit_NilRedis(t *testing.T) {
+	mw := RateLimit(nil, 5, time.Minute, nil)
+	handler := mw(okHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "1.2.3.4:12345"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nil redis should pass through; got status %d", rec.Code)
+	}
+}
+
+func TestRateLimit_AllowsUnderLimit(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	mw := RateLimit(rdb, 3, time.Minute, nil)
+	handler := mw(okHandler)
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+		req.RemoteAddr = "10.0.0.1:9000"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, rec.Code)
+		}
+	}
+}
+
+func TestRateLimit_BlocksOverLimit(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	mw := RateLimit(rdb, 2, time.Minute, nil)
+	handler := mw(okHandler)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+		req.RemoteAddr = "10.0.0.2:9000"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, rec.Code)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "10.0.0.2:9000"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "too many requests" {
+		t.Fatalf("unexpected error message: %q", body["error"])
+	}
+}
+
+func TestRateLimit_RetryAfterHeader(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	mw := RateLimit(rdb, 1, 2*time.Minute, nil)
+	handler := mw(okHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "10.0.0.3:9000"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	req = httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "10.0.0.3:9000"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+	retryAfter := rec.Header().Get("Retry-After")
+	if retryAfter != "120" {
+		t.Fatalf("expected Retry-After=120, got %q", retryAfter)
+	}
+}
+
+func TestRateLimit_DifferentIPs(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	mw := RateLimit(rdb, 1, time.Minute, nil)
+	handler := mw(okHandler)
+
+	ips := []string{"10.0.1.1:9000", "10.0.1.2:9000", "10.0.1.3:9000"}
+	for _, addr := range ips {
+		req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+		req.RemoteAddr = addr
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("ip %s: expected 200, got %d", addr, rec.Code)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "10.0.1.1:9000"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for repeated IP, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "10.0.1.3:9000"
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for repeated IP 10.0.1.3, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// X-Forwarded-For trust model tests
+// ---------------------------------------------------------------------------
+
+func mustParseCIDR(cidr string) *net.IPNet {
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+func TestExtractIP_NoTrustedProxies_IgnoresXFF(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "203.0.113.1:9000"
+	req.Header.Set("X-Forwarded-For", "198.51.100.1, 203.0.113.1")
+
+	ip := extractIP(req, nil)
+	if ip != "203.0.113.1" {
+		t.Fatalf("with no trusted proxies, expected RemoteAddr; got %q", ip)
+	}
+}
+
+func TestExtractIP_TrustedProxy_HonorsXFF(t *testing.T) {
+	trusted := []*net.IPNet{mustParseCIDR("10.0.0.0/8")}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "10.0.0.1:9000"
+	req.Header.Set("X-Forwarded-For", "198.51.100.42, 10.0.0.5")
+
+	ip := extractIP(req, trusted)
+	// Rightmost non-trusted: 198.51.100.42 (10.0.0.5 is trusted)
+	if ip != "198.51.100.42" {
+		t.Fatalf("expected rightmost non-trusted IP; got %q", ip)
+	}
+}
+
+func TestExtractIP_UntrustedSource_IgnoresXFF(t *testing.T) {
+	trusted := []*net.IPNet{mustParseCIDR("10.0.0.0/8")}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "203.0.113.99:9000" // Not in trusted CIDR
+	req.Header.Set("X-Forwarded-For", "198.51.100.1")
+
+	ip := extractIP(req, trusted)
+	if ip != "203.0.113.99" {
+		t.Fatalf("untrusted source should use RemoteAddr; got %q", ip)
+	}
+}
+
+func TestExtractIP_IPv6Normalization(t *testing.T) {
+	req1 := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req1.RemoteAddr = "[::1]:9000"
+
+	req2 := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req2.RemoteAddr = "[0:0:0:0:0:0:0:1]:9000"
+
+	ip1 := extractIP(req1, nil)
+	ip2 := extractIP(req2, nil)
+	if ip1 != ip2 {
+		t.Fatalf("IPv6 representations should normalize to same key: %q vs %q", ip1, ip2)
+	}
+}
+
+func TestRateLimit_LuaScript_SetsTTL(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	mw := RateLimit(rdb, 10, 30*time.Second, nil)
+	handler := mw(okHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/send-code", nil)
+	req.RemoteAddr = "10.0.99.1:9000"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	key := rateLimitKey("/auth/send-code", "10.0.99.1")
+	ttl, err := rdb.TTL(req.Context(), key).Result()
+	if err != nil {
+		t.Fatalf("TTL: %v", err)
+	}
+	if ttl <= 0 || ttl > 31*time.Second {
+		t.Fatalf("expected TTL ~30s, got %v", ttl)
+	}
+}
+
+func TestParseTrustedProxies_Empty(t *testing.T) {
+	if nets := ParseTrustedProxies(""); nets != nil {
+		t.Fatalf("empty string should return nil, got %v", nets)
+	}
+	if nets := ParseTrustedProxies("  "); nets != nil {
+		t.Fatalf("whitespace should return nil, got %v", nets)
+	}
+}
+
+func TestParseTrustedProxies_Valid(t *testing.T) {
+	nets := ParseTrustedProxies("10.0.0.0/8, 172.16.0.0/12")
+	if len(nets) != 2 {
+		t.Fatalf("expected 2 CIDRs, got %d", len(nets))
+	}
+}
+
+func TestParseTrustedProxies_InvalidSkipped(t *testing.T) {
+	nets := ParseTrustedProxies("10.0.0.0/8, not-a-cidr, 172.16.0.0/12")
+	if len(nets) != 2 {
+		t.Fatalf("expected 2 valid CIDRs (invalid skipped), got %d", len(nets))
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds per-IP fixed-window rate limiting on public auth endpoints (`/auth/send-code`, `/auth/google`, `/auth/verify-code`) backed by Redis. Prevents brute-force attacks on authentication codes.

Key design decisions addressing reviewer feedback:
- **Trusted proxy CIDR allowlist**: `X-Forwarded-For` is only honored when `RemoteAddr` is from a configured trusted proxy CIDR. Default: never trust XFF (matches project's conservative model in `health_realtime.go`).
- **Atomic Lua script**: Uses `INCR` + conditional `EXPIRE` in a single Lua script to prevent the INCR/EXPIRE race where a failed EXPIRE creates a permanent sticky ban.
- **Configurable via env vars**: `RATE_LIMIT_AUTH`, `RATE_LIMIT_AUTH_VERIFY`, `RATE_LIMIT_TRUSTED_PROXIES`.
- **Fail-open**: If Redis is unavailable, rate limiting is skipped (logged warning at startup).

## Thinking Path

The project's `health_realtime.go:70-106` deliberately does NOT trust forwarding headers for security decisions. Rate limiting must follow the same conservative trust model — XFF is only honored from known proxy CIDRs, using the rightmost-untrusted algorithm to prevent client-controlled header spoofing.

For atomicity, the project already uses Lua scripts for Redis operations (`runtime_local_skills_redis_store.go:52-59`). The same pattern here prevents the INCR+EXPIRE race that could create permanent bans.

## Related Issue

Closes MUL-2251

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/middleware/ratelimit.go` — Complete rewrite: Lua script for atomic INCR+EXPIRE, `ParseTrustedProxies` for CIDR config, `extractIP` with rightmost-untrusted algorithm, IPv6 normalization via `net.ParseIP().String()`, corrected doc comment (fixed-window, not sliding-window)
- `server/internal/middleware/ratelimit_test.go` — Updated existing tests + added: `TestExtractIP_NoTrustedProxies_IgnoresXFF`, `TestExtractIP_TrustedProxy_HonorsXFF`, `TestExtractIP_UntrustedSource_IgnoresXFF`, `TestExtractIP_IPv6Normalization`, `TestRateLimit_LuaScript_SetsTTL`, `TestParseTrustedProxies_*`
- `server/cmd/server/router.go` — Added startup warning when Redis unavailable, env var config for limits and trusted proxies

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `RATE_LIMIT_TRUSTED_PROXIES` | `""` (never trust XFF) | Comma-separated CIDRs of known reverse proxies |
| `RATE_LIMIT_AUTH` | `5` | Requests/min for /auth/send-code, /auth/google |
| `RATE_LIMIT_AUTH_VERIFY` | `20` | Requests/min for /auth/verify-code |

## How to Test

1. `cd server && go test ./internal/middleware/ -run TestRateLimit -v`
2. `cd server && go test ./internal/middleware/ -run TestExtractIP -v`
3. `cd server && go test ./internal/middleware/ -run TestParseTrustedProxies -v`
4. Manual: start server with `REDIS_URL` set, hit `/auth/send-code` 6 times rapidly → 6th should get 429

## Risks

- **Misconfigured `RATE_LIMIT_TRUSTED_PROXIES`**: If a real proxy CIDR is not listed, all users behind that proxy share a rate limit bucket keyed on the proxy IP. Mitigated by conservative default (empty = never trust XFF = use direct IP).
- **Redis unavailable**: Rate limiting is disabled (fail-open). Logged at startup so operators notice.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy, starter-content, and relevant docs
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code (Opus)

**Prompt / approach:** Used Claude Code to analyze the reviewer's security concerns about XFF trust, research the project's existing patterns for header trust and Redis Lua scripts, implement the rightmost-untrusted algorithm with CIDR allowlist, and write comprehensive tests covering the XFF attack surface.