### PR TITLE
feat(auth): cache workspace membership for daemon heartbeat path (MUL-2247)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -164,6 +164,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 	daemonTokenCache := auth.NewDaemonTokenCache(rdb)
 	h.PATCache = patCache
 	h.DaemonTokenCache = daemonTokenCache
+	h.MembershipCache = auth.NewMembershipCache(rdb)
 
 	// Empty-claim cache: lets the daemon poll path skip a Postgres
 	// scan when a recent check confirmed the runtime had no queued

--- a/server/internal/auth/membership_cache.go
+++ b/server/internal/auth/membership_cache.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const membershipCachePrefix = "mul:auth:member:"
+
+// MembershipCacheTTL bounds how long a workspace membership lookup stays
+// cached before the handler goes back to Postgres. Short enough that a
+// removed member loses access within minutes; long enough that a
+// high-frequency caller (daemon heartbeat every ~15s) collapses from one
+// DB round-trip per request to one per TTL window.
+const MembershipCacheTTL = 5 * time.Minute
+
+// MembershipCache caches workspace membership existence checks in Redis.
+// It tracks ONLY whether a user is a member of a workspace — it does NOT
+// store role information. Authorization decisions that depend on role
+// (requireWorkspaceRole, RequireWorkspaceRoleFromURL) MUST always query
+// the database directly.
+//
+// Revocation latency: a removed member may retain cached access for up to
+// MembershipCacheTTL (5 min). Combined with PATCache (10 min), the
+// worst-case revocation delay is max(10m, 5m) = 10 min — consistent with
+// the original PATCache design decision.
+//
+// A nil *MembershipCache is safe to use — every method becomes a no-op or
+// reports a cache miss, and the caller degrades to direct DB lookups.
+type MembershipCache struct {
+	rdb *redis.Client
+}
+
+// NewMembershipCache returns a cache backed by rdb. Pass nil to disable
+// caching; the returned *MembershipCache is safe to call but never hits
+// Redis.
+func NewMembershipCache(rdb *redis.Client) *MembershipCache {
+	if rdb == nil {
+		return nil
+	}
+	return &MembershipCache{rdb: rdb}
+}
+
+func membershipKey(userID, workspaceID string) string {
+	return membershipCachePrefix + userID + ":" + workspaceID
+}
+
+// Get returns whether the user is a cached member of the workspace.
+// Returns false on miss or any Redis error.
+func (c *MembershipCache) Get(ctx context.Context, userID, workspaceID string) (ok bool) {
+	if c == nil {
+		return false
+	}
+	_, err := c.rdb.Get(ctx, membershipKey(userID, workspaceID)).Result()
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			slog.Warn("membership_cache: get failed; falling back to DB", "error", err)
+		}
+		return false
+	}
+	return true
+}
+
+// Set caches the existence of membership for the given user+workspace pair.
+func (c *MembershipCache) Set(ctx context.Context, userID, workspaceID string) {
+	if c == nil {
+		return
+	}
+	if err := c.rdb.Set(ctx, membershipKey(userID, workspaceID), "1", MembershipCacheTTL).Err(); err != nil {
+		slog.Warn("membership_cache: set failed", "error", err)
+	}
+}
+
+// Invalidate removes the cached entry for a specific user+workspace.
+func (c *MembershipCache) Invalidate(ctx context.Context, userID, workspaceID string) {
+	if c == nil {
+		return
+	}
+	if err := c.rdb.Del(ctx, membershipKey(userID, workspaceID)).Err(); err != nil {
+		slog.Warn("membership_cache: invalidate failed", "error", err)
+	}
+}

--- a/server/internal/auth/membership_cache_test.go
+++ b/server/internal/auth/membership_cache_test.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMembershipCache_NilSafe(t *testing.T) {
+	var c *MembershipCache // nil
+	ctx := context.Background()
+
+	if c.Get(ctx, "any-user", "any-workspace") {
+		t.Fatal("nil cache must miss")
+	}
+	c.Set(ctx, "any-user", "any-workspace") // no panic
+	c.Invalidate(ctx, "any-user", "any-workspace") // no panic
+}
+
+func TestNewMembershipCache_NilRedisReturnsNil(t *testing.T) {
+	if c := NewMembershipCache(nil); c != nil {
+		t.Fatalf("NewMembershipCache(nil) must return nil, got %#v", c)
+	}
+}
+
+func TestMembershipCache_SetGetInvalidate(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	c := NewMembershipCache(rdb)
+	if c == nil {
+		t.Fatal("NewMembershipCache returned nil")
+	}
+	ctx := context.Background()
+
+	if c.Get(ctx, "user-1", "ws-1") {
+		t.Fatal("expected miss before set")
+	}
+
+	c.Set(ctx, "user-1", "ws-1")
+	if !c.Get(ctx, "user-1", "ws-1") {
+		t.Fatal("expected hit after set")
+	}
+
+	c.Invalidate(ctx, "user-1", "ws-1")
+	if c.Get(ctx, "user-1", "ws-1") {
+		t.Fatal("expected miss after invalidate")
+	}
+}
+
+func TestMembershipCache_TTL(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	c := NewMembershipCache(rdb)
+	if c == nil {
+		t.Fatal("NewMembershipCache returned nil")
+	}
+	ctx := context.Background()
+
+	c.Set(ctx, "user-T", "ws-T")
+	ttl, err := rdb.TTL(ctx, membershipKey("user-T", "ws-T")).Result()
+	if err != nil {
+		t.Fatalf("TTL: %v", err)
+	}
+	if ttl <= 0 || ttl > MembershipCacheTTL+time.Second {
+		t.Fatalf("unexpected TTL %v (want ~%v)", ttl, MembershipCacheTTL)
+	}
+}
+
+func TestMembershipCache_IsolatesKeysByUser(t *testing.T) {
+	rdb := newRedisTestClient(t)
+	c := NewMembershipCache(rdb)
+	if c == nil {
+		t.Fatal("NewMembershipCache returned nil")
+	}
+	ctx := context.Background()
+
+	c.Set(ctx, "user-A", "ws-1")
+	c.Set(ctx, "user-B", "ws-1")
+
+	if !c.Get(ctx, "user-A", "ws-1") {
+		t.Fatal("user-A should be cached")
+	}
+	if !c.Get(ctx, "user-B", "ws-1") {
+		t.Fatal("user-B should be cached")
+	}
+
+	c.Invalidate(ctx, "user-A", "ws-1")
+	if c.Get(ctx, "user-A", "ws-1") {
+		t.Fatal("user-A should be invalidated")
+	}
+	if !c.Get(ctx, "user-B", "ws-1") {
+		t.Fatal("user-B should still be cached")
+	}
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -48,8 +48,18 @@ func (h *Handler) requireDaemonWorkspaceAccess(w http.ResponseWriter, r *http.Re
 		return true
 	}
 
-	// PAT/JWT fallback: verify user is a member of the workspace.
+	// PAT/JWT fallback: check membership cache before hitting DB.
+	userID := requestUserID(r)
+	if userID != "" {
+		if h.MembershipCache.Get(r.Context(), userID, workspaceID) {
+			return true
+		}
+	}
+
 	_, ok := h.requireWorkspaceMember(w, r, workspaceID, "not found")
+	if ok && userID != "" {
+		h.MembershipCache.Set(r.Context(), userID, workspaceID)
+	}
 	return ok
 }
 
@@ -125,8 +135,15 @@ func (h *Handler) verifyDaemonWorkspaceAccess(r *http.Request, workspaceID strin
 	if userID == "" {
 		return false
 	}
+	if h.MembershipCache.Get(r.Context(), userID, workspaceID) {
+		return true
+	}
 	_, err := h.getWorkspaceMember(r.Context(), userID, workspaceID)
-	return err == nil
+	if err != nil {
+		return false
+	}
+	h.MembershipCache.Set(r.Context(), userID, workspaceID)
+	return true
 }
 
 // ---------------------------------------------------------------------------

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -2916,28 +2917,94 @@ func TestGetTaskGCCheck(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // Membership Cache Integration Tests
+//
+// These tests don't just exercise the cache primitive (that's covered in
+// auth/membership_cache_test.go). They prove two things that the unit tests
+// can't:
+//
+//  1. requireDaemonWorkspaceAccess actually short-circuits the DB on a cache
+//     hit (the "ghost user" trick below).
+//  2. Each handler that mutates membership actually calls
+//     h.MembershipCache.Invalidate(...) — so a future refactor that drops
+//     one of those calls will fail CI instead of silently leaking a stale
+//     authorization grant for up to MembershipCacheTTL.
 // ---------------------------------------------------------------------------
 
-func TestRequireDaemonWorkspaceAccess_CacheHit(t *testing.T) {
-	if testHandler == nil {
-		t.Skip("database not available")
-	}
+// installFreshMembershipCache swaps in a Redis-backed MembershipCache against
+// a freshly-flushed Redis DB for the test, restoring the original on cleanup.
+func installFreshMembershipCache(t *testing.T) {
+	t.Helper()
 	rdb := newRedisTestClient(t)
 	origCache := testHandler.MembershipCache
 	testHandler.MembershipCache = auth.NewMembershipCache(rdb)
 	t.Cleanup(func() { testHandler.MembershipCache = origCache })
+}
 
+// createEphemeralUser inserts a throwaway user with a unique email and
+// deletes it on test cleanup. Returns the user id as a string.
+func createEphemeralUser(t *testing.T, label string) string {
+	t.Helper()
+	email := fmt.Sprintf("membership-cache-%s-%s@multica.ai", label, uuid.NewString())
+	var userID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO "user" (name, email) VALUES ($1, $2) RETURNING id
+	`, "Membership Cache Test "+label, email).Scan(&userID); err != nil {
+		t.Fatalf("create ephemeral user: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM "user" WHERE id = $1`, userID)
+	})
+	return userID
+}
+
+// createEphemeralMember creates a throwaway user AND a member row in the
+// given workspace. Returns (userID, memberID). Both rows are cleaned up on
+// test exit.
+func createEphemeralMember(t *testing.T, workspaceID, label, role string) (string, string) {
+	t.Helper()
+	userID := createEphemeralUser(t, label)
+	var memberID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, $3) RETURNING id
+	`, workspaceID, userID, role).Scan(&memberID); err != nil {
+		t.Fatalf("create ephemeral member: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM member WHERE id = $1`, memberID)
+	})
+	return userID, memberID
+}
+
+// TestRequireDaemonWorkspaceAccess_CacheHit proves the cache lookup actually
+// short-circuits the DB query. The trick: the request actor is a "ghost"
+// user with NO member row in the workspace. With an empty cache the access
+// check must fail; after priming the cache it must succeed. If a future
+// change ever bypasses the cache and falls through to the DB, the priming
+// step stops mattering and the second assertion catches it.
+func TestRequireDaemonWorkspaceAccess_CacheHit(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	installFreshMembershipCache(t)
 	ctx := context.Background()
-	testHandler.MembershipCache.Set(ctx, testUserID, testWorkspaceID)
 
-	// Request with user context (PAT/JWT path, not daemon token).
-	req := newRequest("GET", "/api/daemon/workspaces/"+testWorkspaceID+"/repos", nil)
+	ghostUserID := createEphemeralUser(t, "ghost")
+
+	// Baseline: with an empty cache the ghost has no path to access.
+	req := newRequestAsUser(ghostUserID, "GET", "/api/daemon/workspaces/"+testWorkspaceID+"/repos", nil)
 	w := httptest.NewRecorder()
+	if testHandler.requireDaemonWorkspaceAccess(w, req, testWorkspaceID) {
+		t.Fatal("setup: ghost user must not be allowed without cache priming")
+	}
 
-	// Should succeed via cache hit without needing a full handler call.
-	ok := testHandler.requireDaemonWorkspaceAccess(w, req, testWorkspaceID)
-	if !ok {
-		t.Fatalf("expected access granted via cache hit, got denied (status %d)", w.Code)
+	// Priming the cache is the only thing that changes — the access check
+	// must now succeed via the cache short-circuit.
+	testHandler.MembershipCache.Set(ctx, ghostUserID, testWorkspaceID)
+
+	req = newRequestAsUser(ghostUserID, "GET", "/api/daemon/workspaces/"+testWorkspaceID+"/repos", nil)
+	w = httptest.NewRecorder()
+	if !testHandler.requireDaemonWorkspaceAccess(w, req, testWorkspaceID) {
+		t.Fatalf("expected access via cache hit, got denied (status %d)", w.Code)
 	}
 }
 
@@ -2945,10 +3012,7 @@ func TestRequireDaemonWorkspaceAccess_CacheMissBackfills(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
-	rdb := newRedisTestClient(t)
-	origCache := testHandler.MembershipCache
-	testHandler.MembershipCache = auth.NewMembershipCache(rdb)
-	t.Cleanup(func() { testHandler.MembershipCache = origCache })
+	installFreshMembershipCache(t)
 
 	ctx := context.Background()
 
@@ -2960,8 +3024,7 @@ func TestRequireDaemonWorkspaceAccess_CacheMissBackfills(t *testing.T) {
 	// Make a request that triggers DB lookup.
 	req := newRequest("GET", "/api/daemon/workspaces/"+testWorkspaceID+"/repos", nil)
 	w := httptest.NewRecorder()
-	ok := testHandler.requireDaemonWorkspaceAccess(w, req, testWorkspaceID)
-	if !ok {
+	if !testHandler.requireDaemonWorkspaceAccess(w, req, testWorkspaceID) {
 		t.Fatalf("expected access granted via DB lookup, got denied (status %d)", w.Code)
 	}
 
@@ -2971,28 +3034,142 @@ func TestRequireDaemonWorkspaceAccess_CacheMissBackfills(t *testing.T) {
 	}
 }
 
-func TestMembershipCache_InvalidatedOnMemberRemoval(t *testing.T) {
+// TestMembershipCache_InvalidatedOnDeleteMember drives a real DeleteMember
+// HTTP handler call and asserts the cache entry for the removed member is
+// gone afterwards. Guards against future refactors that move or drop the
+// h.MembershipCache.Invalidate(...) line in workspace.go.
+func TestMembershipCache_InvalidatedOnDeleteMember(t *testing.T) {
 	if testHandler == nil {
 		t.Skip("database not available")
 	}
-	rdb := newRedisTestClient(t)
-	origCache := testHandler.MembershipCache
-	testHandler.MembershipCache = auth.NewMembershipCache(rdb)
-	t.Cleanup(func() { testHandler.MembershipCache = origCache })
-
+	installFreshMembershipCache(t)
 	ctx := context.Background()
 
-	// Pre-populate cache.
-	testHandler.MembershipCache.Set(ctx, testUserID, testWorkspaceID)
-	if !testHandler.MembershipCache.Get(ctx, testUserID, testWorkspaceID) {
-		t.Fatal("expected cache hit after set")
+	targetUserID, targetMemberID := createEphemeralMember(t, testWorkspaceID, "delete", "admin")
+	testHandler.MembershipCache.Set(ctx, targetUserID, testWorkspaceID)
+	if !testHandler.MembershipCache.Get(ctx, targetUserID, testWorkspaceID) {
+		t.Fatal("setup: expected cache hit after Set")
 	}
 
-	// Directly call Invalidate (simulates what DeleteMember/LeaveWorkspace do).
-	testHandler.MembershipCache.Invalidate(ctx, testUserID, testWorkspaceID)
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/workspaces/"+testWorkspaceID+"/members/"+targetMemberID, nil)
+	req = withURLParams(req, "id", testWorkspaceID, "memberId", targetMemberID)
+	testHandler.DeleteMember(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DeleteMember: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
 
-	// Cache entry should be gone.
-	if testHandler.MembershipCache.Get(ctx, testUserID, testWorkspaceID) {
-		t.Fatal("expected cache miss after invalidation")
+	if testHandler.MembershipCache.Get(ctx, targetUserID, testWorkspaceID) {
+		t.Fatal("DeleteMember handler did not invalidate membership cache for removed user")
+	}
+}
+
+// TestMembershipCache_InvalidatedOnUpdateMember drives a real UpdateMember
+// (role change) call and asserts the cache entry is invalidated. The cache
+// stores only the existence of membership, but UpdateMember still flushes
+// the entry so any downstream caller that did add role-aware caching later
+// would not silently see a stale role.
+func TestMembershipCache_InvalidatedOnUpdateMember(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	installFreshMembershipCache(t)
+	ctx := context.Background()
+
+	targetUserID, targetMemberID := createEphemeralMember(t, testWorkspaceID, "update", "admin")
+	testHandler.MembershipCache.Set(ctx, targetUserID, testWorkspaceID)
+
+	w := httptest.NewRecorder()
+	req := newRequest("PUT", "/api/workspaces/"+testWorkspaceID+"/members/"+targetMemberID,
+		map[string]any{"role": "member"})
+	req = withURLParams(req, "id", testWorkspaceID, "memberId", targetMemberID)
+	testHandler.UpdateMember(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UpdateMember: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if testHandler.MembershipCache.Get(ctx, targetUserID, testWorkspaceID) {
+		t.Fatal("UpdateMember handler did not invalidate membership cache for updated user")
+	}
+}
+
+// TestMembershipCache_InvalidatedOnLeaveWorkspace exercises the self-removal
+// path (LeaveWorkspace, not DeleteMember). Both handlers route through
+// revokeAndRemoveMember, but the Invalidate call lives in the handler — a
+// refactor that consolidates them could drop one invalidation without the
+// other test catching it.
+func TestMembershipCache_InvalidatedOnLeaveWorkspace(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	installFreshMembershipCache(t)
+	ctx := context.Background()
+
+	targetUserID, _ := createEphemeralMember(t, testWorkspaceID, "leave", "admin")
+	testHandler.MembershipCache.Set(ctx, targetUserID, testWorkspaceID)
+
+	w := httptest.NewRecorder()
+	req := newRequestAsUser(targetUserID, "DELETE", "/api/workspaces/"+testWorkspaceID+"/leave", nil)
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.LeaveWorkspace(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("LeaveWorkspace: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if testHandler.MembershipCache.Get(ctx, targetUserID, testWorkspaceID) {
+		t.Fatal("LeaveWorkspace handler did not invalidate membership cache for leaver")
+	}
+}
+
+// TestMembershipCache_InvalidatedOnDeleteWorkspace exercises the bulk
+// invalidation path: when the workspace is deleted, every member's cache
+// entry must be flushed. We create an isolated workspace with two members
+// (owner + extra) so the shared testWorkspace stays intact.
+func TestMembershipCache_InvalidatedOnDeleteWorkspace(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	installFreshMembershipCache(t)
+	ctx := context.Background()
+
+	const slug = "membership-cache-delete-ws"
+	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
+	var wsID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ($1, $2, $3, $4) RETURNING id
+	`, "Membership Cache Delete WS", slug, "DeleteWorkspace cache invalidation test", "MCD").Scan(&wsID); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	// testUser must be an owner of the isolated workspace to call
+	// DeleteWorkspace.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'owner')
+	`, wsID, testUserID); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+
+	extraUserID, _ := createEphemeralMember(t, wsID, "ws-delete-extra", "admin")
+
+	testHandler.MembershipCache.Set(ctx, testUserID, wsID)
+	testHandler.MembershipCache.Set(ctx, extraUserID, wsID)
+
+	w := httptest.NewRecorder()
+	req := newRequest("DELETE", "/api/workspaces/"+wsID, nil)
+	req = withURLParam(req, "id", wsID)
+	testHandler.DeleteWorkspace(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DeleteWorkspace: expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if testHandler.MembershipCache.Get(ctx, testUserID, wsID) {
+		t.Fatal("DeleteWorkspace handler did not invalidate owner cache entry")
+	}
+	if testHandler.MembershipCache.Get(ctx, extraUserID, wsID) {
+		t.Fatal("DeleteWorkspace handler did not invalidate extra-member cache entry")
 	}
 }

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/multica-ai/multica/server/internal/auth"
 	"github.com/multica-ai/multica/server/internal/daemonws"
 	"github.com/multica-ai/multica/server/internal/middleware"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -2910,5 +2911,88 @@ func TestGetTaskGCCheck(t *testing.T) {
 	}
 	if resp.CompletedAt == "" {
 		t.Fatal("expected completed_at to be set for completed task")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Membership Cache Integration Tests
+// ---------------------------------------------------------------------------
+
+func TestRequireDaemonWorkspaceAccess_CacheHit(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	rdb := newRedisTestClient(t)
+	origCache := testHandler.MembershipCache
+	testHandler.MembershipCache = auth.NewMembershipCache(rdb)
+	t.Cleanup(func() { testHandler.MembershipCache = origCache })
+
+	ctx := context.Background()
+	testHandler.MembershipCache.Set(ctx, testUserID, testWorkspaceID)
+
+	// Request with user context (PAT/JWT path, not daemon token).
+	req := newRequest("GET", "/api/daemon/workspaces/"+testWorkspaceID+"/repos", nil)
+	w := httptest.NewRecorder()
+
+	// Should succeed via cache hit without needing a full handler call.
+	ok := testHandler.requireDaemonWorkspaceAccess(w, req, testWorkspaceID)
+	if !ok {
+		t.Fatalf("expected access granted via cache hit, got denied (status %d)", w.Code)
+	}
+}
+
+func TestRequireDaemonWorkspaceAccess_CacheMissBackfills(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	rdb := newRedisTestClient(t)
+	origCache := testHandler.MembershipCache
+	testHandler.MembershipCache = auth.NewMembershipCache(rdb)
+	t.Cleanup(func() { testHandler.MembershipCache = origCache })
+
+	ctx := context.Background()
+
+	// Cache is empty — verify miss.
+	if testHandler.MembershipCache.Get(ctx, testUserID, testWorkspaceID) {
+		t.Fatal("expected cache miss before request")
+	}
+
+	// Make a request that triggers DB lookup.
+	req := newRequest("GET", "/api/daemon/workspaces/"+testWorkspaceID+"/repos", nil)
+	w := httptest.NewRecorder()
+	ok := testHandler.requireDaemonWorkspaceAccess(w, req, testWorkspaceID)
+	if !ok {
+		t.Fatalf("expected access granted via DB lookup, got denied (status %d)", w.Code)
+	}
+
+	// Cache should now be backfilled.
+	if !testHandler.MembershipCache.Get(ctx, testUserID, testWorkspaceID) {
+		t.Fatal("expected cache to be backfilled after DB hit")
+	}
+}
+
+func TestMembershipCache_InvalidatedOnMemberRemoval(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	rdb := newRedisTestClient(t)
+	origCache := testHandler.MembershipCache
+	testHandler.MembershipCache = auth.NewMembershipCache(rdb)
+	t.Cleanup(func() { testHandler.MembershipCache = origCache })
+
+	ctx := context.Background()
+
+	// Pre-populate cache.
+	testHandler.MembershipCache.Set(ctx, testUserID, testWorkspaceID)
+	if !testHandler.MembershipCache.Get(ctx, testUserID, testWorkspaceID) {
+		t.Fatal("expected cache hit after set")
+	}
+
+	// Directly call Invalidate (simulates what DeleteMember/LeaveWorkspace do).
+	testHandler.MembershipCache.Invalidate(ctx, testUserID, testWorkspaceID)
+
+	// Cache entry should be gone.
+	if testHandler.MembershipCache.Get(ctx, testUserID, testWorkspaceID) {
+		t.Fatal("expected cache miss after invalidation")
 	}
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -110,6 +110,7 @@ type Handler struct {
 	Analytics             analytics.Client
 	PATCache              *auth.PATCache
 	DaemonTokenCache      *auth.DaemonTokenCache
+	MembershipCache       *auth.MembershipCache
 	WebhookRateLimiter    WebhookRateLimiter
 	WebhookIPRateLimiter  WebhookRateLimiter
 	cfg                   Config

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -523,6 +523,8 @@ func (h *Handler) UpdateMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.MembershipCache.Invalidate(r.Context(), uuidToString(target.UserID), workspaceID)
+
 	user, err := h.Queries.GetUser(r.Context(), updatedMember.UserID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to load member")
@@ -580,6 +582,8 @@ func (h *Handler) DeleteMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.MembershipCache.Invalidate(r.Context(), uuidToString(target.UserID), workspaceID)
+
 	wsIDStr := uuidToString(requester.WorkspaceID)
 	logRevocation(result, wsIDStr, uuidToString(target.UserID))
 	h.publishRevocation(r.Context(), result, wsIDStr, "member", requesterUserID)
@@ -620,6 +624,8 @@ func (h *Handler) LeaveWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.MembershipCache.Invalidate(r.Context(), uuidToString(member.UserID), workspaceID)
+
 	userID := requestUserID(r)
 	logRevocation(result, workspaceID, uuidToString(member.UserID))
 	h.publishRevocation(r.Context(), result, workspaceID, "member", userID)
@@ -648,6 +654,16 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	if requester.Role != "owner" {
 		writeError(w, http.StatusForbidden, "insufficient permissions")
 		return
+	}
+
+	// Invalidate membership cache for all workspace members before deletion.
+	// After CASCADE deletes the member rows, cache entries become harmless
+	// orphans (downstream lookups for the deleted workspace will fail), but
+	// proactive invalidation prevents any stale-access window up to TTL.
+	if members, err := h.Queries.ListMembers(r.Context(), requester.WorkspaceID); err == nil {
+		for _, m := range members {
+			h.MembershipCache.Invalidate(r.Context(), uuidToString(m.UserID), workspaceID)
+		}
 	}
 
 	// At this point workspaceMember has resolved → workspaceID is a valid UUID


### PR DESCRIPTION
## What does this PR do?

Caches workspace membership checks in Redis for the daemon heartbeat path, reducing database round-trips on the hot path (every 30s per daemon). The cache stores existence only (not role) to avoid a stale-role authorization footgun.

Key design decisions addressing reviewer feedback:
- **Existence-only cache**: Stores sentinel `"1"` instead of role. Both call sites discard the role (`_, ok := ...`), and caching role creates a latent cache-aside race for future developers. Role-based authorization (`requireWorkspaceRole`) always hits the DB.
- **DeleteWorkspace invalidation**: Proactively invalidates all member cache entries before workspace deletion to prevent stale access during the 5-min TTL window.
- **Handler-level tests**: Added integration tests verifying cache hit/miss/backfill behavior and invalidation on member removal.

## Thinking Path

The PATCache already stores actual data (userID) with a 10-min TTL. For membership, both call sites only check existence — they don't use the role. Storing role would create a latent footgun: if a future developer adds role-based logic using the cached value, they'd get stale roles for up to 5 min after a role change. Existence-only eliminates this class of bug entirely.

Revocation latency: a removed member may retain cached access for up to `MembershipCacheTTL` (5 min). Combined with PATCache (10 min), the worst-case revocation delay is `max(10m, 5m) = 10 min` — consistent with the original PATCache design decision. This is acceptable for the daemon heartbeat path.

Negative caching limitation: non-members hitting the heartbeat path still take a DB query per request. This is acceptable — daemons must have valid workspace-scoped tokens to reach the heartbeat endpoint, making the non-member scenario rare.

## Related Issue

Closes MUL-2247

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/auth/membership_cache.go` — Simplified API: `Get` returns `bool` (not `(string, bool)`), `Set` takes no role param, stores sentinel "1". Added comprehensive doc comment documenting revocation latency trade-off.
- `server/internal/auth/membership_cache_test.go` — Updated for new signatures, added key isolation test
- `server/internal/handler/daemon.go` — Updated `requireDaemonWorkspaceAccess` and `verifyDaemonWorkspaceAccess` call sites for new API
- `server/internal/handler/workspace.go` — Added proactive cache invalidation in `DeleteWorkspace` for all workspace members
- `server/internal/handler/daemon_test.go` — Added 3 handler-level tests: cache hit, cache miss + backfill, invalidation on member removal

## How to Test

1. `cd server && go test ./internal/auth/ -run TestMembershipCache -v` — unit tests for cache logic
2. `cd server && go test ./internal/handler/ -run TestRequireDaemonWorkspaceAccess -v` — handler integration tests
3. `cd server && go test ./internal/handler/ -run TestMembershipCache_Invalidated -v` — invalidation test
4. Manual: start daemon, observe heartbeat requests hit Redis cache instead of Postgres for membership checks (visible in query logs)

## Risks

- **Revocation latency**: Max 5 min stale access after member removal. Acceptable for daemon heartbeat path; role-based authorization always hits DB directly.
- **Redis unavailable**: Cache methods are nil-safe (same pattern as PATCache). Falls back to DB-only behavior with no degradation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy, starter-content, and relevant docs
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code (Opus)

**Prompt / approach:** Used Claude Code to analyze reviewer feedback about role-caching footguns and missing invalidation, research the project's existing nil-safe Redis cache patterns (PATCache), simplify the API to existence-only, implement DeleteWorkspace invalidation, and write handler-level integration tests following the project's existing spy/mock patterns.