### PR TITLE
fix(issues): 创建 issue 通用入口读取持久化的手动/自动偏好

### DIFF
--- a/packages/core/issues/stores/create-mode-store.test.ts
+++ b/packages/core/issues/stores/create-mode-store.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  openCreateIssueWithPreference,
+  useCreateModeStore,
+} from "./create-mode-store";
+import { useModalStore } from "../../modals";
+
+describe("openCreateIssueWithPreference", () => {
+  const initialMode = useCreateModeStore.getState().lastMode;
+
+  beforeEach(() => {
+    useModalStore.getState().close();
+  });
+
+  afterEach(() => {
+    useCreateModeStore.getState().setLastMode(initialMode);
+    useModalStore.getState().close();
+  });
+
+  it("opens quick-create-issue when last mode is agent", () => {
+    useCreateModeStore.getState().setLastMode("agent");
+    openCreateIssueWithPreference();
+    expect(useModalStore.getState().modal).toBe("quick-create-issue");
+    expect(useModalStore.getState().data).toBeNull();
+  });
+
+  it("opens create-issue when last mode is manual", () => {
+    useCreateModeStore.getState().setLastMode("manual");
+    openCreateIssueWithPreference();
+    expect(useModalStore.getState().modal).toBe("create-issue");
+  });
+
+  it("forwards seed data to whichever modal is opened", () => {
+    useCreateModeStore.getState().setLastMode("manual");
+    openCreateIssueWithPreference({ project_id: "p1" });
+    expect(useModalStore.getState().modal).toBe("create-issue");
+    expect(useModalStore.getState().data).toEqual({ project_id: "p1" });
+
+    useCreateModeStore.getState().setLastMode("agent");
+    openCreateIssueWithPreference({ project_id: "p2" });
+    expect(useModalStore.getState().modal).toBe("quick-create-issue");
+    expect(useModalStore.getState().data).toEqual({ project_id: "p2" });
+  });
+});

--- a/packages/core/issues/stores/create-mode-store.ts
+++ b/packages/core/issues/stores/create-mode-store.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { defaultStorage } from "../../platform/storage";
+import { useModalStore } from "../../modals";
 
 /**
  * Last create-issue mode the user landed on. Drives the global `c` shortcut
@@ -34,3 +35,18 @@ export const useCreateModeStore = create<CreateModeState>()(
     },
   ),
 );
+
+/**
+ * Open the create-issue flow in whichever mode the user landed on last.
+ * Generic entry points (sidebar button, command palette, `c` shortcut) call
+ * this so the persisted preference actually takes effect; entry points that
+ * pre-seed manual-only fields (status, parent_issue_id) keep opening
+ * "create-issue" directly because agent mode can't honour those seeds.
+ */
+export function openCreateIssueWithPreference(
+  data?: Record<string, unknown> | null,
+) {
+  const lastMode = useCreateModeStore.getState().lastMode;
+  const modal = lastMode === "manual" ? "create-issue" : "quick-create-issue";
+  useModalStore.getState().open(modal, data ?? null);
+}

--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -1,5 +1,9 @@
 export { useIssueSelectionStore } from "./selection-store";
-export { useCreateModeStore, type CreateMode } from "./create-mode-store";
+export {
+  useCreateModeStore,
+  openCreateIssueWithPreference,
+  type CreateMode,
+} from "./create-mode-store";
 export { useIssueDraftStore } from "./draft-store";
 export {
   useRecentIssuesStore,

--- a/packages/views/layout/app-sidebar.test.tsx
+++ b/packages/views/layout/app-sidebar.test.tsx
@@ -102,7 +102,10 @@ vi.mock("@multica/core/paths", () => ({
 vi.mock("@multica/core/api", async (importOriginal) => ({ ...(await importOriginal<typeof import("@multica/core/api")>()), api: {} }));
 vi.mock("@multica/core/inbox/queries", () => ({ deduplicateInboxItems: (items: unknown[]) => items, inboxKeys: { list: () => ["inbox"] } }));
 vi.mock("@multica/core/issues/queries", () => ({ issueDetailOptions: () => ({ queryKey: ["issue"] }) }));
-vi.mock("@multica/core/issues/stores/create-mode-store", () => ({ useCreateModeStore: { getState: () => ({ lastMode: "agent" }) } }));
+vi.mock("@multica/core/issues/stores/create-mode-store", () => ({
+  useCreateModeStore: { getState: () => ({ lastMode: "agent" }) },
+  openCreateIssueWithPreference: vi.fn(),
+}));
 vi.mock("@multica/core/issues/stores/draft-store", () => ({ useIssueDraftStore: () => false }));
 vi.mock("@multica/core/modals", () => ({ useModalStore: { getState: () => ({ modal: null, open: vi.fn() }) } }));
 vi.mock("@multica/core/pins/mutations", () => ({ useDeletePin: () => ({ mutate: deletePin }), useReorderPins: () => ({ mutate: vi.fn() }) }));

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -41,7 +41,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@multica/ui/components/ui/collapsible";
 import { StatusIcon } from "../issues/components/status-icon";
 import { useIssueDraftStore } from "@multica/core/issues/stores/draft-store";
-import { useCreateModeStore } from "@multica/core/issues/stores/create-mode-store";
+import { openCreateIssueWithPreference } from "@multica/core/issues/stores/create-mode-store";
 import {
   Sidebar,
   SidebarContent,
@@ -448,16 +448,12 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
       if (isEditable) return;
       if (useModalStore.getState().modal) return;
       e.preventDefault();
-      const lastMode = useCreateModeStore.getState().lastMode;
-      if (lastMode === "manual") {
-        // Auto-fill project when on a project detail page (manual form only —
-        // agent mode lets the agent infer project from the prompt).
-        const projectMatch = pathname.match(/^\/[^/]+\/projects\/([^/]+)$/);
-        const data = projectMatch ? { project_id: projectMatch[1] } : undefined;
-        useModalStore.getState().open("create-issue", data);
-      } else {
-        useModalStore.getState().open("quick-create-issue");
-      }
+      // Auto-fill project when on a project detail page. The manual form
+      // consumes `project_id`; quick-create also honours it as a seed for
+      // its project picker, so passing it through is safe for both modes.
+      const projectMatch = pathname.match(/^\/[^/]+\/projects\/([^/]+)$/);
+      const data = projectMatch ? { project_id: projectMatch[1] } : undefined;
+      openCreateIssueWithPreference(data);
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
@@ -595,7 +591,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
             <SidebarMenuItem>
               <SidebarMenuButton
                 className="text-muted-foreground"
-                onClick={() => useModalStore.getState().open("quick-create-issue")}
+                onClick={() => openCreateIssueWithPreference()}
               >
                 <span className="relative">
                   <SquarePen />

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -82,6 +82,8 @@ vi.mock("@multica/core/issues/stores", () => {
       (wsId: string | null) =>
       (state: { byWorkspace: Record<string, typeof mockRecentItems.current> }) =>
         wsId ? (state.byWorkspace[wsId] ?? EMPTY) : EMPTY,
+    openCreateIssueWithPreference: (data?: Record<string, unknown> | null) =>
+      mockOpenModal("quick-create-issue", data ?? null),
   };
 });
 
@@ -291,7 +293,7 @@ describe("SearchCommand", () => {
     );
     await user.click(newIssue);
 
-    expect(mockOpenModal).toHaveBeenCalledWith("quick-create-issue");
+    expect(mockOpenModal).toHaveBeenCalledWith("quick-create-issue", null);
     expect(useSearchStore.getState().open).toBe(false);
   });
 

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -28,7 +28,11 @@ import { useQueries, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { SearchIssueResult, SearchProjectResult } from "@multica/core/types";
 import { api } from "@multica/core/api";
-import { selectRecentIssues, useRecentIssuesStore } from "@multica/core/issues/stores";
+import {
+  openCreateIssueWithPreference,
+  selectRecentIssues,
+  useRecentIssuesStore,
+} from "@multica/core/issues/stores";
 import { issueDetailOptions } from "@multica/core/issues/queries";
 import { useWorkspaceId } from "@multica/core";
 import { paths, useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
@@ -203,7 +207,7 @@ export function SearchCommand() {
         icon: Plus,
         keywords: ["new", "issue", "create", "add"],
         onSelect: () => {
-          useModalStore.getState().open("quick-create-issue");
+          openCreateIssueWithPreference();
           setOpen(false);
         },
       },


### PR DESCRIPTION
## 🎯 解决什么问题

用户反馈"打开创建 issue 时,手动 / 自动的选择没有被记住"——这次定位并修好了这个 bug。

## ✅ 做了什么

- 找到根因:`useCreateModeStore` 本身有持久化,但只有 `c` 快捷键真的去读 `lastMode`,sidebar 按钮 / 命令面板等 UI 入口全是硬编码模式,导致用户感受就是"没记住"
- 抽出 `openCreateIssueWithPreference(data?)` helper,3 个通用入口统一改用 helper 读偏好:`c` 快捷键、sidebar "新建 issue" 按钮、命令面板 "New Issue"
- 保留 5 个带种子的入口(inbox 失败恢复、board 列尾、list 列尾、project 详情、sub-issue)继续硬编码 manual——这些入口要预填 `status` 等字段,agent 模式不接受,改了反而砸预填
- 加了 3 个单元测试覆盖 helper 三条分支
- `typecheck` / `lint` / `test` 全过,Reviewer 独立复跑也都通过

## 📊 之前 vs 现状

- 之前:UI 上选了一次"手动",关掉重开仍然回到"自动",偏好等同于失效
- 现状:UI 上选过什么模式,下次从通用入口打开就是什么模式;带表单种子的入口依然走手动(为保留预填,符合产品直觉)

## 🔄 影响范围

- 用户感受:从通用入口("新建 issue" 按钮 / `c` / 命令面板)打开的创建对话框,模式会随上次选择切换;board / list / project 等带上下文的"+"按钮行为不变
- 兼容性 / 部署:纯前端改动,无 migration,无后端变更;localStorage key 复用既有的 `multica_create_mode`

Issue: [MUL-2234](https://multica.ai/issues/891fcc2a-c911-4781-9372-6dfd54e3c387)