### PR TITLE
fix(runtimes): price Claude IDs reported as dotted / provider-prefixed (MUL-2243)

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -53,6 +53,42 @@ describe("estimateCost", () => {
     expect(cost).toBeCloseTo(1.25, 5);
   });
 
+  it("prices a Copilot session reporting claude-opus-4.7 at the official Opus rate", () => {
+    // Copilot's `meta.agentMeta.model` is `claude-opus-4.7` (dotted). We
+    // canonicalize to the dashed catalog key so it hits the maintained $5/$25
+    // tier instead of falling through to the custom-pricing dialog.
+    const cost = estimateCost({
+      ...zeroUsage,
+      model: "claude-opus-4.7",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(5 + 25, 5);
+  });
+
+  it("prices the provider-prefixed Anthropic form (anthropic/claude-sonnet-4.6)", () => {
+    // openclaw / opencode emit `<provider>/<model>`. Same SKU as the
+    // bare form, must hit the same rate.
+    const cost = estimateCost({
+      ...zeroUsage,
+      model: "anthropic/claude-sonnet-4.6",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(3 + 15, 5);
+  });
+
+  it("prices the dated dotted Anthropic form (claude-haiku-4.5-20251001)", () => {
+    // Belt-and-braces: combine all three tolerances (provider prefix not
+    // present, but dot→dash + date strip both apply).
+    const cost = estimateCost({
+      ...zeroUsage,
+      model: "claude-haiku-4.5-20251001",
+      input_tokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(1, 5);
+  });
+
   it("prices each dotted Codex catalog SKU at its own tier, not gpt-5", () => {
     // Every dotted minor version is priced independently. The resolver does
     // exact-match-after-date-strip (no startsWith fallback), so each row
@@ -128,6 +164,34 @@ describe("isModelPriced", () => {
     expect(isModelPriced("gpt-5-mini")).toBe(true);
     expect(isModelPriced("o3")).toBe(true);
     expect(isModelPriced("totally-made-up-model")).toBe(false);
+  });
+
+  it("recognises dotted Anthropic IDs as the same SKU as their dashed canonical form", () => {
+    // GitHub Copilot reports Claude models with dots (`claude-opus-4.7`)
+    // while Anthropic's own CLIs use dashes (`claude-opus-4-7`). Both must
+    // hit the same catalog row, otherwise Copilot-routed usage gets bucketed
+    // as "unmapped" and the user has to type the price in by hand.
+    expect(isModelPriced("claude-haiku-4.5")).toBe(true);
+    expect(isModelPriced("claude-sonnet-4.5")).toBe(true);
+    expect(isModelPriced("claude-sonnet-4.6")).toBe(true);
+    expect(isModelPriced("claude-opus-4.5")).toBe(true);
+    expect(isModelPriced("claude-opus-4.6")).toBe(true);
+    expect(isModelPriced("claude-opus-4.7")).toBe(true);
+  });
+
+  it("recognises provider-prefixed Anthropic IDs (openclaw / opencode form)", () => {
+    // openclaw / opencode emit `<provider>/<model>` in `meta.agentMeta.model`.
+    // The provider prefix is routing metadata, not part of the SKU.
+    expect(isModelPriced("anthropic/claude-opus-4.7")).toBe(true);
+    expect(isModelPriced("anthropic/claude-sonnet-4-6")).toBe(true);
+  });
+
+  it("still rejects OpenAI dotted variants that don't have their own row", () => {
+    // The Anthropic dot→dash normalization is scoped to `claude-*` IDs.
+    // For OpenAI the separator is semantic — `gpt-5.4` is a different SKU
+    // from a hypothetical `gpt-5-4` — and `gpt-5.5-mini` must still surface
+    // as unmapped because OpenAI hasn't published its rate.
+    expect(isModelPriced("gpt-5.5-mini")).toBe(false);
   });
 });
 

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -179,32 +179,71 @@ const MODEL_PRICING: Record<
   "gpt-4o":             { input: 2.50, output: 10,   cacheRead: 1.25,  cacheWrite: 2.50 },
 };
 
-// Resolve a model string to its pricing tier. Exact match, with one
-// tolerance: providers ship dated snapshots (`claude-sonnet-4-5-20250929`,
-// `gpt-5-2025-08-07`) where the family is what we price and the date is
-// volatile, so we strip a trailing date / "latest" tag and try again.
-// Anything still unmapped in the maintained catalog falls back to the
-// user-supplied custom pricing store before giving up. No startsWith
-// fallback: variants like `gpt-5.5-mini` must have their own row to be
-// priced (otherwise they'd inherit `gpt-5.5`).
+// Resolve a model string to its pricing tier. Exact match, with three
+// tolerances applied in order:
+//
+//  1. Provider-prefixed IDs (`anthropic/claude-opus-4.7` from openclaw /
+//     opencode) — the `<provider>/` segment is routing metadata, not part
+//     of the SKU, so we strip it before lookup.
+//  2. Anthropic dot↔dash normalization — Claude Code reports
+//     `claude-opus-4-7`, GitHub Copilot reports `claude-opus-4.7`. Same
+//     SKU, two transports. We canonicalize `claude-*` IDs to the dashed
+//     form Anthropic itself publishes. Scoped to `claude-*` because for
+//     OpenAI the separator IS semantic (`gpt-5.4` ≠ `gpt-5-4`).
+//  3. Trailing dated snapshots (`claude-sonnet-4-5-20250929`,
+//     `gpt-5-2025-08-07`) — the family is what we price, the date is
+//     volatile, so we strip a trailing date / "latest" tag.
+//
+// Anything still unmapped falls back to the user-supplied custom pricing
+// store. No startsWith fallback: variants like `gpt-5.5-mini` must have
+// their own row to be priced (otherwise they'd inherit `gpt-5.5`).
 function resolvePricing(model: string) {
   if (!model) return undefined;
-  if (MODEL_PRICING[model]) return MODEL_PRICING[model];
 
-  const stripped = model.replace(/-(20\d{2}-\d{2}-\d{2}|20\d{6}|latest)$/, "");
-  if (stripped !== model && MODEL_PRICING[stripped]) return MODEL_PRICING[stripped];
-
-  // User-supplied override for models we don't ship a maintained rate for.
-  // Checked exact-then-stripped to mirror the catalog lookup above, so a
-  // user can either pin a dated snapshot specifically or price the family.
-  const custom = getCustomPricing(model);
-  if (custom) return custom;
-  if (stripped !== model) {
-    const customStripped = getCustomPricing(stripped);
-    if (customStripped) return customStripped;
+  for (const candidate of canonicalCandidates(model)) {
+    const hit = MODEL_PRICING[candidate];
+    if (hit) return hit;
   }
-
+  for (const candidate of canonicalCandidates(model)) {
+    const hit = getCustomPricing(candidate);
+    if (hit) return hit;
+  }
   return undefined;
+}
+
+// Generate the lookup candidates for a model string, in priority order:
+// the raw string first (preserves explicit user / catalog spellings),
+// then the canonicalized forms. Deduped so we don't repeat lookups.
+function canonicalCandidates(model: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (s: string) => {
+    if (!s || seen.has(s)) return;
+    seen.add(s);
+    out.push(s);
+  };
+  const stripDate = (s: string) =>
+    s.replace(/-(20\d{2}-\d{2}-\d{2}|20\d{6}|latest)$/, "");
+  const stripProvider = (s: string) => {
+    const i = s.indexOf("/");
+    return i > 0 && /^[a-z][a-z0-9_-]*$/i.test(s.slice(0, i)) ? s.slice(i + 1) : s;
+  };
+  // Only Anthropic IDs are dot↔dash equivalent. OpenAI separators are
+  // semantic, so we leave `gpt-5.4` etc. alone.
+  const canonAnthropic = (s: string) =>
+    s.startsWith("claude-") ? s.replace(/\./g, "-") : s;
+
+  const raw = model;
+  const noProvider = stripProvider(raw);
+  const dashed = canonAnthropic(noProvider);
+
+  push(raw);
+  push(noProvider);
+  push(dashed);
+  push(stripDate(raw));
+  push(stripDate(noProvider));
+  push(stripDate(dashed));
+  return out;
 }
 
 // Cheap predicate for the empty-state diagnostic: which model strings in a


### PR DESCRIPTION
## Summary

Linked Multica issue: MUL-2243 — "Claude Haiku/Opus/Sonnet are official models, shouldn't fall into the custom-pricing dialog."

The maintained `MODEL_PRICING` catalog in `packages/views/runtimes/utils.ts` only keyed Anthropic models by their canonical dashed form (`claude-opus-4-7`, `claude-sonnet-4-6`, ...), but the daemon emits Claude SKUs in two other shapes:

- **Dotted** — GitHub Copilot's `meta.agentMeta.model` ships `claude-opus-4.7`, `claude-sonnet-4.6`, `claude-haiku-4.5`. See `server/pkg/agent/models.go` `copilotStaticModels()` and the `copilot_test.go` fixtures.
- **Provider-prefixed** — openclaw / opencode emit `<provider>/<model>` (`anthropic/claude-opus-4.7`). See `openclaw_test.go` and `testdata/openclaw-2026.5.5-stdout.json`.

Both shapes were missing the price lookup and silently contributing $0 to cost totals, while the "Custom model pricing" dialog asked the user to enter the rate by hand.

This PR teaches `resolvePricing` two new tolerances, applied in order before the existing date strip:

1. Strip a leading `<provider>/` segment when the prefix is alphanumeric — that's routing metadata, not part of the SKU.
2. For `claude-*` IDs, normalize dots to dashes. **Scoped to Anthropic** because for OpenAI the separator is semantic (`gpt-5.4` is a distinct SKU from a hypothetical `gpt-5-4`, and `gpt-5.5-mini` should still surface as unmapped).

Existing invariants preserved:
- The maintained catalog still beats a stale custom override (covered by the existing "does NOT shadow the maintained catalog" test).
- `gpt-5.5-mini` still resolves as unmapped (no `startsWith` fallback).
- Date-stripping still works (`gpt-5-2025-08-07` → `gpt-5`).

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run runtimes/utils.test.ts` — 21 tests pass (3 new)
- [x] `pnpm --filter @multica/views exec vitest run` — full views package, 530 tests pass
- [x] `pnpm --filter @multica/views typecheck` — clean
- [ ] Reviewer: open the runtime usage dashboard while a Copilot-backed runtime is active and confirm the "Custom model pricing" banner no longer flags `claude-*` SKUs