### PR TITLE
feat(skills): support 2-segment skills.sh URL for batch importing all skills from a repo

### DIFF
--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -792,10 +792,14 @@ func parseSkillsShParts(raw string) (owner, repo, skillName string, err error) {
 		return "", "", "", fmt.Errorf("invalid URL: %w", err)
 	}
 	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(parts) != 3 {
-		return "", "", "", fmt.Errorf("expected URL format: skills.sh/{owner}/{repo}/{skill-name}, got: %s", parsed.Path)
+	switch len(parts) {
+	case 2:
+		return parts[0], parts[1], "", nil
+	case 3:
+		return parts[0], parts[1], parts[2], nil
+	default:
+		return "", "", "", fmt.Errorf("expected URL format: skills.sh/{owner}/{repo} or skills.sh/{owner}/{repo}/{skill-name}, got: %s", parsed.Path)
 	}
-	return parts[0], parts[1], parts[2], nil
 }
 
 func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, error) {
@@ -920,6 +924,115 @@ func fetchFromSkillsSh(httpClient *http.Client, rawURL string) (*importedSkill, 
 	}
 
 	return result, nil
+}
+
+func fetchAllFromSkillsSh(httpClient *http.Client, rawURL string) ([]*importedSkill, error) {
+	owner, repo, _, err := parseSkillsShParts(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultBranch := fetchGitHubDefaultBranch(httpClient, owner, repo)
+	rawPrefix := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/git/trees/%s?recursive=1",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(defaultBranch))
+	resp, err := doGitHubAPIGet(httpClient, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect repository %s/%s: %w", owner, repo, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to inspect repository %s/%s: HTTP %d", owner, repo, resp.StatusCode)
+	}
+
+	var tree githubTreeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
+		return nil, fmt.Errorf("failed to inspect repository %s/%s: %w", owner, repo, err)
+	}
+
+	skillPaths := extractSkillMdPaths(tree.Tree)
+	if len(skillPaths) == 0 {
+		return nil, fmt.Errorf("no SKILL.md files found in repository %s/%s", owner, repo)
+	}
+
+	var results []*importedSkill
+	for _, skillPath := range skillPaths {
+		skillDir := skillDirFromSkillFilePath(skillPath)
+		body, err := fetchRawFile(httpClient, buildRawGitHubURL(rawPrefix, skillPath))
+		if err != nil {
+			slog.Warn("batch import: failed to download SKILL.md", "path", skillPath, "error", err)
+			continue
+		}
+
+		name, description := parseSkillFrontmatter(string(body))
+		if name == "" {
+			// Derive name from directory
+			if skillDir != "" {
+				parts := strings.Split(skillDir, "/")
+				name = parts[len(parts)-1]
+			} else {
+				name = repo
+			}
+		}
+
+		result := &importedSkill{
+			name:        name,
+			description: description,
+			content:     string(body),
+			origin: map[string]any{
+				"type":       "skills_sh",
+				"source_url": rawURL,
+				"owner":      owner,
+				"repo":       repo,
+				"skill":      name,
+			},
+		}
+
+		// Collect supporting files
+		contentsURL := buildGitHubContentsURL(owner, repo, skillDir, defaultBranch)
+		dirResp, err := doGitHubAPIGet(httpClient, contentsURL)
+		if err == nil && dirResp.StatusCode == http.StatusOK {
+			var entries []githubContentEntry
+			if err := json.NewDecoder(dirResp.Body).Decode(&entries); err == nil {
+				var allFiles []githubContentEntry
+				collectGitHubFiles(httpClient, entries, &allFiles, contentsURL)
+				basePath := ""
+				if skillDir != "" {
+					basePath = skillDir + "/"
+				}
+				for _, entry := range allFiles {
+					if entry.DownloadURL == "" {
+						continue
+					}
+					fileBody, err := fetchRawFile(httpClient, entry.DownloadURL)
+					if err != nil {
+						if isCapError(err) {
+							slog.Warn("batch import: file too large", "path", entry.Path, "error", err)
+							break
+						}
+						continue
+					}
+					relPath := strings.TrimPrefix(entry.Path, basePath)
+					if err := result.addFile(relPath, string(fileBody)); err != nil {
+						slog.Warn("batch import: addFile failed", "path", relPath, "error", err)
+						break
+					}
+				}
+			}
+			dirResp.Body.Close()
+		} else if dirResp != nil {
+			dirResp.Body.Close()
+		}
+
+		results = append(results, result)
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("failed to import any skills from repository %s/%s", owner, repo)
+	}
+	return results, nil
 }
 
 func resolveGitHubSkillDirByName(httpClient *http.Client, owner, repo, defaultBranch, rawPrefix, skillName string) (string, []byte, error) {
@@ -1611,6 +1724,66 @@ func (h *Handler) ImportSkill(w http.ResponseWriter, r *http.Request) {
 	case sourceClawHub:
 		imported, err = fetchFromClawHub(httpClient, normalized)
 	case sourceSkillsSh:
+		// Check if this is a 2-segment URL (batch import all skills from repo)
+		_, _, skillName, _ := parseSkillsShParts(normalized)
+		if skillName == "" {
+			allImported, err := fetchAllFromSkillsSh(httpClient, normalized)
+			if err != nil {
+				writeError(w, http.StatusBadGateway, err.Error())
+				return
+			}
+
+			type batchResult struct {
+				Imported []any    `json:"imported"`
+				Errors   []string `json:"errors"`
+			}
+			result := batchResult{
+				Imported: make([]any, 0, len(allImported)),
+				Errors:   make([]string, 0),
+			}
+
+			actorType, actorID := h.resolveActor(r, creatorID, workspaceID)
+			for _, imp := range allImported {
+				files := make([]CreateSkillFileRequest, 0, len(imp.files))
+				for _, f := range imp.files {
+					if !validateFilePath(f.path) {
+						continue
+					}
+					files = append(files, CreateSkillFileRequest{
+						Path:    f.path,
+						Content: f.content,
+					})
+				}
+
+				config := map[string]any{}
+				if imp.origin != nil {
+					config["origin"] = imp.origin
+				}
+
+				resp, err := h.createSkillWithFiles(r.Context(), skillCreateInput{
+					WorkspaceID: workspaceUUID,
+					CreatorID:   creatorUUID,
+					Name:        imp.name,
+					Description: imp.description,
+					Content:     imp.content,
+					Config:      config,
+					Files:       files,
+				})
+				if err != nil {
+					if isUniqueViolation(err) {
+						result.Errors = append(result.Errors, fmt.Sprintf("skill %q: already exists", imp.name))
+					} else {
+						result.Errors = append(result.Errors, fmt.Sprintf("skill %q: %s", imp.name, err.Error()))
+					}
+					continue
+				}
+				h.publish(protocol.EventSkillCreated, workspaceID, actorType, actorID, map[string]any{"skill": resp})
+				result.Imported = append(result.Imported, resp)
+			}
+
+			writeJSON(w, http.StatusCreated, result)
+			return
+		}
 		imported, err = fetchFromSkillsSh(httpClient, normalized)
 	case sourceGitHub:
 		imported, err = fetchFromGitHub(httpClient, normalized)

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -1226,3 +1226,36 @@ func containsString(values []string, want string) bool {
 	}
 	return false
 }
+
+func TestParseSkillsShParts_TwoSegments(t *testing.T) {
+	owner, repo, skillName, err := parseSkillsShParts("https://skills.sh/acme/tools")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "acme" || repo != "tools" || skillName != "" {
+		t.Fatalf("got owner=%q repo=%q skill=%q, want acme/tools/empty", owner, repo, skillName)
+	}
+}
+
+func TestParseSkillsShParts_ThreeSegments(t *testing.T) {
+	owner, repo, skillName, err := parseSkillsShParts("https://skills.sh/acme/tools/linter")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "acme" || repo != "tools" || skillName != "linter" {
+		t.Fatalf("got owner=%q repo=%q skill=%q, want acme/tools/linter", owner, repo, skillName)
+	}
+}
+
+func TestParseSkillsShParts_InvalidSegments(t *testing.T) {
+	for _, input := range []string{
+		"https://skills.sh/onlyone",
+		"https://skills.sh/a/b/c/d",
+		"https://skills.sh/",
+	} {
+		_, _, _, err := parseSkillsShParts(input)
+		if err == nil {
+			t.Errorf("expected error for %q, got nil", input)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds support for 2-segment `skills.sh` URLs (`https://skills.sh/{owner}/{repo}`) to batch-import **all skills** from a repository at once. Previously, only the 3-segment format (`https://skills.sh/{owner}/{repo}/{skill-name}`) was accepted.

When a 2-segment URL is provided, the import handler:
1. Fetches the repository tree via GitHub API
2. Finds all `SKILL.md` files using the existing `extractSkillMdPaths` helper
3. Downloads each skill content + supporting files
4. Creates all skills in the workspace, with partial failure handling

## Related Issue

Closes #2653

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/skill.go`:
  - Modified `parseSkillsShParts` to accept 2-segment paths (returns empty `skillName`)
  - Added `fetchAllFromSkillsSh` function that discovers all SKILL.md files in a repo using the git tree API and imports each as a separate skill
  - Updated `ImportSkill` handler to detect 2-segment URLs and use the batch import path
  - Batch response returns `{ imported: [...], errors: [...] }` for partial failure transparency

- `server/internal/handler/skill_test.go`:
  - Added 3 tests for `parseSkillsShParts`: 2-segment, 3-segment, and invalid segment counts

## How to Test

1. Import a single skill (existing behavior, unchanged):
   ```
   POST /api/skills/import { "url": "https://skills.sh/acme/tools/linter" }
   ```
2. Import all skills from a repo (new):
   ```
   POST /api/skills/import { "url": "https://skills.sh/acme/tools" }
   ```
3. Verify partial failures are reported in the `errors` array while successful imports appear in `imported`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy**, **starter-content**, and **relevant docs**
- [ ] If this PR touches Chinese product copy, I checked it against conventions
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

### Thinking path

Issue #2653 identified that `parseSkillsShParts` rejects 2-segment URLs with a hard error. The fix extends the parser to accept 2 segments, then adds a batch import code path that reuses existing infrastructure (`extractSkillMdPaths`, `fetchRawFile`, `collectGitHubFiles`, `buildGitHubContentsURL`) to discover and import all skills. The handler branches early on segment count to keep the existing single-import path unchanged.

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Provided issue context, target file analysis, and existing helper functions to reuse. Claude Code implemented the parser change, batch fetch function, and handler integration.

## Risks

- **GitHub API rate limits**: Batch importing from large repos with many skills could hit unauthenticated GitHub API limits (60 req/hr). The tree API call is a single request, but each skill requires additional requests for content + supporting files.
- **Response shape change**: Batch import returns `{ imported, errors }` instead of a single skill object. Frontend may need to handle this new shape for 2-segment URLs.
