### PR TITLE
test(runtimes): pin combined provider+dotted+dated Claude normalization (MUL-2243)

### DIFF
--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -89,6 +89,20 @@ describe("estimateCost", () => {
     expect(cost).toBeCloseTo(1, 5);
   });
 
+  it("prices the full provider+dotted+dated form (anthropic/claude-opus-4.7-20251001)", () => {
+    // All three normalization steps must compose: strip `anthropic/`,
+    // dot→dash on the Claude ID, and trim the date stamp. Pins the
+    // combined path so a future change to candidate ordering can't
+    // silently drop one tolerance.
+    const cost = estimateCost({
+      ...zeroUsage,
+      model: "anthropic/claude-opus-4.7-20251001",
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+    });
+    expect(cost).toBeCloseTo(5 + 25, 5);
+  });
+
   it("prices each dotted Codex catalog SKU at its own tier, not gpt-5", () => {
     // Every dotted minor version is priced independently. The resolver does
     // exact-match-after-date-strip (no startsWith fallback), so each row


### PR DESCRIPTION
## Summary

- Follow-up to #2654. Adds the three-step composition test case Elon raised as a nit in second review of [MUL-2243](mention://issue/19e129f7-ba66-4285-8b0d-4fffa0babc52): `anthropic/claude-opus-4.7-20251001` exercises provider strip + Claude dot→dash + date trim simultaneously.
- Each step was already covered pairwise; this pins the composition so a future change to `canonicalCandidates` ordering can't silently drop a step and regress to $0 pricing.

## Test plan

- [x] `pnpm --dir packages/views exec vitest run runtimes/utils.test.ts` — 22 passed (1 new)
- [x] `pnpm --filter @multica/views typecheck` — clean