### PR TITLE
fix(repos): accept scp shorthand in repo URL inputs (MUL-2250)

### DIFF
--- a/packages/views/locales/en/modals.json
+++ b/packages/views/locales/en/modals.json
@@ -90,7 +90,7 @@
     "repos_pill_count_other": "{{count}} repos",
     "repos_heading": "Attach GitHub repos to this project",
     "repos_empty": "No workspace-level repos yet. Paste a URL below to attach one ad-hoc.",
-    "repos_url_placeholder": "https://github.com/owner/repo",
+    "repos_url_placeholder": "https://github.com/owner/repo or git@github.com:owner/repo.git",
     "repos_add": "Add",
     "repos_selected": "Selected"
   },

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -68,7 +68,7 @@
     "popover_title": "Attach a GitHub repo",
     "attached_badge": "attached",
     "remove_tooltip": "Remove",
-    "url_placeholder": "https://github.com/owner/repo",
+    "url_placeholder": "https://github.com/owner/repo or git@github.com:owner/repo.git",
     "url_submit": "Add",
     "toast_attached": "Repository attached",
     "toast_attach_failed": "Failed to attach",

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -174,7 +174,7 @@
   "repositories": {
     "section_title": "Repositories",
     "description": "Git repositories associated with this workspace. Agents use these to clone and work on code.",
-    "url_placeholder": "https://git.example.com/org/repo.git",
+    "url_placeholder": "https://git.example.com/org/repo.git or git@git.example.com:org/repo.git",
     "url_empty": "(empty URL)",
     "description_placeholder": "Description (e.g. Go backend + Next.js frontend)",
     "add": "Add repository",

--- a/packages/views/locales/zh-Hans/modals.json
+++ b/packages/views/locales/zh-Hans/modals.json
@@ -90,7 +90,7 @@
     "repos_pill_count_other": "{{count}} 个仓库",
     "repos_heading": "为此项目关联 GitHub 仓库",
     "repos_empty": "还没有工作区级别的仓库。可以在下方粘贴 URL 临时关联一个。",
-    "repos_url_placeholder": "https://github.com/owner/repo",
+    "repos_url_placeholder": "https://github.com/owner/repo 或 git@github.com:owner/repo.git",
     "repos_add": "添加",
     "repos_selected": "已选"
   },

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -68,7 +68,7 @@
     "popover_title": "关联 GitHub 仓库",
     "attached_badge": "已关联",
     "remove_tooltip": "移除",
-    "url_placeholder": "https://github.com/owner/repo",
+    "url_placeholder": "https://github.com/owner/repo 或 git@github.com:owner/repo.git",
     "url_submit": "添加",
     "toast_attached": "已关联仓库",
     "toast_attach_failed": "关联失败",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -174,7 +174,7 @@
   "repositories": {
     "section_title": "代码仓库",
     "description": "与该工作区关联的 Git 仓库。智能体会从这里 clone 代码并完成工作。",
-    "url_placeholder": "https://git.example.com/org/repo.git",
+    "url_placeholder": "https://git.example.com/org/repo.git 或 git@git.example.com:org/repo.git",
     "url_empty": "（空 URL）",
     "description_placeholder": "描述（例如：Go 后端 + Next.js 前端）",
     "add": "添加仓库",

--- a/packages/views/modals/create-project.tsx
+++ b/packages/views/modals/create-project.tsx
@@ -503,7 +503,7 @@ export function CreateProjectModal({ onClose }: { onClose: () => void }) {
                 className="flex items-center gap-1.5 pt-1 border-t"
               >
                 <input
-                  type="url"
+                  type="text"
                   value={customRepoUrl}
                   onChange={(e) => setCustomRepoUrl(e.target.value)}
                   placeholder={t(($) => $.create_project.repos_url_placeholder)}

--- a/packages/views/projects/components/project-resources-section.tsx
+++ b/packages/views/projects/components/project-resources-section.tsx
@@ -248,7 +248,7 @@ function CustomRepoForm({
   return (
     <form onSubmit={handle} className="flex items-center gap-1.5 pt-1 border-t">
       <input
-        type="url"
+        type="text"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         placeholder={t(($) => $.resources.url_placeholder)}

--- a/packages/views/settings/components/repositories-tab.test.tsx
+++ b/packages/views/settings/components/repositories-tab.test.tsx
@@ -197,6 +197,36 @@ describe("RepositoriesTab — view/edit toggle", () => {
     expect(screen.getByRole("button", { name: /^Save$/ })).toBeDisabled();
   });
 
+  it("accepts scp-like shorthand without browser URL validation blocking submit", async () => {
+    const user = userEvent.setup();
+    mockUpdateWorkspace.mockImplementation(
+      async (_id: string, payload: { repos: { url: string }[] }) => {
+        workspaceRef.current = { ...workspaceRef.current, repos: payload.repos };
+        return workspaceRef.current;
+      },
+    );
+
+    render(<RepositoriesTab />, { wrapper: I18nWrapper });
+
+    await user.click(screen.getByRole("button", { name: "Edit repository" }));
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, "git@github.com:multica-ai/multica.git");
+
+    // type="text" (not "url") so the browser does not run native URL
+    // validation; the value reaches the server which has the real check.
+    expect(input.type).toBe("text");
+    expect(input.validity.valid).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: /^Save$/ }));
+
+    await waitFor(() => {
+      expect(mockUpdateWorkspace).toHaveBeenCalledWith("workspace-1", {
+        repos: [{ url: "git@github.com:multica-ai/multica.git" }],
+      });
+    });
+  });
+
   it("deleting a row shifts tracked edit indices so the wrong row doesn't open", async () => {
     workspaceRef.current = {
       ...workspaceRef.current,

--- a/packages/views/settings/components/repositories-tab.tsx
+++ b/packages/views/settings/components/repositories-tab.tsx
@@ -128,7 +128,7 @@ export function RepositoriesTab() {
                 >
                   {isEditing ? (
                     <Input
-                      type="url"
+                      type="text"
                       value={repo.url}
                       onChange={(e) => handleRepoChange(index, e.target.value)}
                       disabled={!canManageWorkspace}


### PR DESCRIPTION
## Summary

Backend PR #2492 (MUL-2112) made `validateGithubRepoRef` accept `http`/`https`/`ssh`/`git` schemes plus the scp-like `git@host:owner/repo.git` shorthand. The frontend still had three `<input type="url">` fields where the browser's native URL validation pre-empts the backend and shows "Please enter a URL" for scp shorthand:

- `packages/views/projects/components/project-resources-section.tsx` — project resources picker
- `packages/views/settings/components/repositories-tab.tsx` — workspace repositories tab
- `packages/views/modals/create-project.tsx` — create-project repo picker (same bug, not in the original scope but fixed for consistency)

This PR switches those three to `type="text"`, extends the en/zh placeholders to show a scp shorthand example alongside the existing https one, and adds a `repositories-tab` test that types `git@github.com:multica-ai/multica.git`, asserts the input is text-type, passes `validity.valid`, and reaches the `updateWorkspace` mutation.

Backend validation (`isValidGitRepoURL` in `server/internal/handler/project_resource.go`) remains the source of truth for what's accepted; no client-side URL check is added.

MUL-2250 (follow-up from MUL-2245)

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run settings/components/repositories-tab.test.tsx modals/create-project.test.tsx` — 11/11 pass
- [x] `pnpm --filter @multica/views typecheck` — clean
- [ ] Manual sanity: paste `git@github.com:owner/repo.git` into each of the three inputs and confirm submit no longer blocked