### PR TITLE
squad_briefing: hard rule requiring mention link for delegation (MUL-2252)

### DIFF
--- a/server/internal/handler/squad_briefing.go
+++ b/server/internal/handler/squad_briefing.go
@@ -60,6 +60,11 @@ Your responsibilities, in order:
    record ` + "`" + `no_action` + "`" + ` and exit silently.
 
 Hard rules:
+- EVERY delegation MUST use the full mention markdown syntax
+  ` + "`" + `[@Name](mention://<type>/<UUID>)` + "`" + ` exactly as shown in the Squad
+  Roster. A plain "@name" or bare name does NOT trigger the agent —
+  if you skip the mention link, the task is never delivered and the
+  issue stalls. This is non-negotiable: no mention link = no delegation.
 - Do NOT restate the issue body or prior comments in your delegation —
   the assignee already has them. Repeating context is noise that
   buries the actual instruction.


### PR DESCRIPTION
Adds a hard rule to `squadOperatingProtocol` mandating the full `[@Name](mention://<type>/<UUID>)` markdown syntax for every delegation. Plain `@name` does not trigger agents — this rule makes that crystal clear so the leader model never forgets.

**Tests:** 4 briefing-content tests pass. 2 ClaimTask tests fail due to pre-existing missing DB column (`is_leader_task`), unrelated to this change.