### PR TITLE
[codex] Add member and agent task views

### DIFF
--- a/apps/desktop/src/renderer/src/pages/member-detail-page.tsx
+++ b/apps/desktop/src/renderer/src/pages/member-detail-page.tsx
@@ -1,0 +1,18 @@
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { MemberDetailPage as SharedMemberDetailPage } from "@multica/views/members";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { memberListOptions } from "@multica/core/workspace/queries";
+import { useDocumentTitle } from "@/hooks/use-document-title";
+
+export function MemberDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const wsId = useWorkspaceId();
+  const { data: members = [] } = useQuery(memberListOptions(wsId));
+  const member = members.find((m) => m.user_id === id) ?? null;
+
+  useDocumentTitle(member?.name ?? "Member");
+
+  if (!id) return null;
+  return <SharedMemberDetailPage userId={id} />;
+}

--- a/apps/desktop/src/renderer/src/routes.tsx
+++ b/apps/desktop/src/renderer/src/routes.tsx
@@ -11,6 +11,7 @@ import { ProjectDetailPage } from "./pages/project-detail-page";
 import { AutopilotDetailPage } from "./pages/autopilot-detail-page";
 import { SkillDetailPage } from "./pages/skill-detail-page";
 import { AgentDetailPage } from "./pages/agent-detail-page";
+import { MemberDetailPage } from "./pages/member-detail-page";
 import { RuntimeDetailPage } from "./pages/runtime-detail-page";
 import { IssuesPage } from "@multica/views/issues/components";
 import { ProjectsPage } from "@multica/views/projects/components";
@@ -146,6 +147,11 @@ export const appRoutes: RouteObject[] = [
             path: "agents/:id",
             element: <AgentDetailPage />,
             handle: { title: "Agent" },
+          },
+          {
+            path: "members/:id",
+            element: <MemberDetailPage />,
+            handle: { title: "Member" },
           },
           { path: "squads", element: <SquadsPage />, handle: { title: "Squads" } },
           {

--- a/apps/web/app/[workspaceSlug]/(dashboard)/members/[id]/page.tsx
+++ b/apps/web/app/[workspaceSlug]/(dashboard)/members/[id]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { MemberDetailPage } from "@multica/views/members";
+
+export default function MemberDetailRoute({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  return <MemberDetailPage userId={id} />;
+}

--- a/packages/core/issues/stores/actor-issues-view-store.ts
+++ b/packages/core/issues/stores/actor-issues-view-store.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { persist } from "zustand/middleware";
+import {
+  type IssueViewState,
+  viewStoreSlice,
+  viewStorePersistOptions,
+  mergeViewStatePersisted,
+} from "./view-store";
+import { registerForWorkspaceRehydration } from "../../platform/workspace-storage";
+
+export type ActorIssuesScope = "assigned" | "created";
+
+export interface ActorIssuesViewState extends IssueViewState {
+  scope: ActorIssuesScope;
+  setScope: (scope: ActorIssuesScope) => void;
+}
+
+const basePersist = viewStorePersistOptions("multica_actor_issues_view");
+
+const _actorIssuesViewStore = createStore<ActorIssuesViewState>()(
+  persist(
+    (set) => ({
+      ...viewStoreSlice(set as unknown as StoreApi<IssueViewState>["setState"]),
+      scope: "assigned" as ActorIssuesScope,
+      setScope: (scope: ActorIssuesScope) => set({ scope }),
+    }),
+    {
+      name: basePersist.name,
+      storage: basePersist.storage,
+      partialize: (state: ActorIssuesViewState) => ({
+        ...basePersist.partialize(state),
+        scope: state.scope,
+      }),
+      merge: mergeViewStatePersisted<ActorIssuesViewState>,
+    },
+  ),
+);
+
+export const actorIssuesViewStore: StoreApi<ActorIssuesViewState> =
+  _actorIssuesViewStore;
+
+registerForWorkspaceRehydration(() =>
+  _actorIssuesViewStore.persist.rehydrate(),
+);

--- a/packages/core/issues/stores/index.ts
+++ b/packages/core/issues/stores/index.ts
@@ -24,6 +24,11 @@ export {
   type MyIssuesScope,
 } from "./my-issues-view-store";
 export {
+  actorIssuesViewStore,
+  type ActorIssuesViewState,
+  type ActorIssuesScope,
+} from "./actor-issues-view-store";
+export {
   useIssueViewStore,
   createIssueViewStore,
   viewStoreSlice,

--- a/packages/core/paths/paths.test.ts
+++ b/packages/core/paths/paths.test.ts
@@ -13,6 +13,7 @@ describe("paths.workspace(slug)", () => {
     expect(ws.autopilots()).toBe("/acme/autopilots");
     expect(ws.autopilotDetail("a1")).toBe("/acme/autopilots/a1");
     expect(ws.agents()).toBe("/acme/agents");
+    expect(ws.memberDetail("u1")).toBe("/acme/members/u1");
     expect(ws.inbox()).toBe("/acme/inbox");
     expect(ws.myIssues()).toBe("/acme/my-issues");
     expect(ws.runtimes()).toBe("/acme/runtimes");

--- a/packages/core/paths/paths.ts
+++ b/packages/core/paths/paths.ts
@@ -27,6 +27,7 @@ function workspaceScoped(slug: string) {
     autopilotDetail: (id: string) => `${ws}/autopilots/${encode(id)}`,
     agents: () => `${ws}/agents`,
     agentDetail: (id: string) => `${ws}/agents/${encode(id)}`,
+    memberDetail: (id: string) => `${ws}/members/${encode(id)}`,
     squads: () => `${ws}/squads`,
     squadDetail: (id: string) => `${ws}/squads/${encode(id)}`,
     inbox: () => `${ws}/inbox`,

--- a/packages/views/agents/components/agent-overview-pane.tsx
+++ b/packages/views/agents/components/agent-overview-pane.tsx
@@ -6,6 +6,7 @@ import {
   BookOpenText,
   FileText,
   KeyRound,
+  ListTodo,
   Terminal,
 } from "lucide-react";
 import type { Agent, AgentRuntime } from "@multica/core/types";
@@ -24,17 +25,20 @@ import { InstructionsTab } from "./tabs/instructions-tab";
 import { SkillsTab } from "./tabs/skills-tab";
 import { EnvTab } from "./tabs/env-tab";
 import { CustomArgsTab } from "./tabs/custom-args-tab";
+import { ActorIssuesPanel } from "../../common/actor-issues-panel";
 import { useT } from "../../i18n";
 
 type DetailTab =
   | "activity"
+  | "tasks"
   | "instructions"
   | "skills"
   | "env"
   | "custom_args";
 
-const TAB_LABEL_KEY: Record<DetailTab, "activity" | "instructions" | "skills" | "environment" | "custom_args"> = {
+const TAB_LABEL_KEY: Record<DetailTab, "activity" | "tasks" | "instructions" | "skills" | "environment" | "custom_args"> = {
   activity: "activity",
+  tasks: "tasks",
   instructions: "instructions",
   skills: "skills",
   env: "environment",
@@ -46,6 +50,7 @@ const detailTabs: {
   icon: typeof FileText;
 }[] = [
   { id: "activity", icon: Activity },
+  { id: "tasks", icon: ListTodo },
   { id: "instructions", icon: FileText },
   { id: "skills", icon: BookOpenText },
   { id: "env", icon: KeyRound },
@@ -59,10 +64,11 @@ interface AgentOverviewPaneProps {
 }
 
 /**
- * Right-pane on the agent detail page. Five tabs of equal weight:
+ * Right-pane on the agent detail page:
  *
  *   - Activity (default) — what the agent is doing now / how it's been doing /
  *     what it just finished. The "watch state" surface.
+ *   - Tasks — assigned/created issues using the shared issue board/list.
  *   - Instructions / Skills / Env / Custom Args — four editing surfaces.
  *
  * The previous Settings tab was deleted because every field on it is now
@@ -142,6 +148,11 @@ export function AgentOverviewPane({
 
       <div className="flex-1 min-h-0 overflow-y-auto">
         {activeTab === "activity" && <ActivityTab agent={agent} />}
+        {activeTab === "tasks" && (
+          <div className="flex h-full min-h-[520px] flex-col">
+            <ActorIssuesPanel actorType="agent" actorId={agent.id} />
+          </div>
+        )}
         {activeTab === "instructions" && (
           <TabContent>
             <InstructionsTab

--- a/packages/views/common/actor-avatar.tsx
+++ b/packages/views/common/actor-avatar.tsx
@@ -9,11 +9,12 @@ import {
 } from "@multica/ui/components/ui/hover-card";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useAgentPresenceDetail } from "@multica/core/agents";
-import { useCurrentWorkspace } from "@multica/core/paths";
+import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { AgentProfileCard } from "../agents/components/agent-profile-card";
 import { AgentLivePeekCard } from "../agents/components/agent-live-peek-card";
 import { MemberProfileCard } from "../members/member-profile-card";
 import { availabilityConfig } from "../agents/presence";
+import { useNavigation } from "../navigation";
 
 /**
  * Selects which agent hover-card payload to render when `enableHoverCard` is
@@ -54,10 +55,17 @@ interface ActorAvatarProps {
    * existing call sites keep their identity-card behaviour.
    */
   hoverCardVariant?: AgentHoverCardVariant;
+  /**
+   * Make the avatar click through to the actor page. Defaults on for members
+   * and agents, while picker/menu controls keep their own click behavior.
+   */
+  profileLink?: boolean;
 }
 
 const FOCUSABLE_ANCESTOR_SELECTOR =
   'a[href], button:not([disabled]), [role="button"]:not([aria-disabled="true"]), [tabindex]:not([tabindex="-1"])';
+const PROFILE_LINK_CONTROL_SELECTOR =
+  'button, [role^="menuitem"], [role="option"], [data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-checkbox-item"], [data-slot="popover-trigger"]';
 
 export function ActorAvatar({
   actorType,
@@ -67,8 +75,10 @@ export function ActorAvatar({
   enableHoverCard,
   showStatusDot,
   hoverCardVariant = "profile",
+  profileLink,
 }: ActorAvatarProps) {
   const { getActorName, getActorInitials, getActorAvatarUrl } = useActorName();
+  const paths = useWorkspacePaths();
   const avatar = (
     <ActorAvatarBase
       name={getActorName(actorType, actorId)}
@@ -95,21 +105,79 @@ export function ActorAvatar({
   ) : (
     avatar
   );
+  const shouldLinkToProfile =
+    profileLink ?? (actorType === "member" || actorType === "agent");
+  const profileHref =
+    shouldLinkToProfile && actorType === "member"
+      ? paths.memberDetail(actorId)
+      : shouldLinkToProfile && actorType === "agent"
+        ? paths.agentDetail(actorId)
+        : null;
+  const content = profileHref ? (
+    <ActorAvatarProfileLink href={profileHref}>{dotted}</ActorAvatarProfileLink>
+  ) : (
+    dotted
+  );
 
   if (!enableHoverCard) {
-    return dotted;
+    return content;
   }
   if (actorType === "agent") {
     return (
       <AgentAvatarHoverCard agentId={actorId} variant={hoverCardVariant}>
-        {dotted}
+        {content}
       </AgentAvatarHoverCard>
     );
   }
   if (actorType === "member") {
-    return <MemberAvatarHoverCard userId={actorId}>{dotted}</MemberAvatarHoverCard>;
+    return <MemberAvatarHoverCard userId={actorId}>{content}</MemberAvatarHoverCard>;
   }
-  return dotted;
+  return content;
+}
+
+function ActorAvatarProfileLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  const { push, openInNewTab } = useNavigation();
+
+  const navigate = (event: React.MouseEvent | React.KeyboardEvent) => {
+    const controlAncestor = event.currentTarget.parentElement?.closest(
+      PROFILE_LINK_CONTROL_SELECTOR,
+    );
+    if (controlAncestor) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    if (
+      "metaKey" in event &&
+      (event.metaKey || event.ctrlKey || event.shiftKey) &&
+      openInNewTab
+    ) {
+      openInNewTab(href);
+      return;
+    }
+    push(href);
+  };
+
+  return (
+    <span
+      role="link"
+      tabIndex={-1}
+      className="inline-flex cursor-pointer rounded-full"
+      onClick={navigate}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          navigate(event);
+        }
+      }}
+    >
+      {children}
+    </span>
+  );
 }
 
 // Small presence indicator overlaid on the bottom-right of an agent avatar.

--- a/packages/views/common/actor-issues-panel.tsx
+++ b/packages/views/common/actor-issues-panel.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from "react";
+import { useStore } from "zustand";
+import { toast } from "sonner";
+import { ListTodo } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import type { IssueStatus } from "@multica/core/types";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { BOARD_STATUSES } from "@multica/core/issues/config";
+import {
+  childIssueProgressOptions,
+  myIssueListOptions,
+  type MyIssuesFilter,
+} from "@multica/core/issues/queries";
+import { useUpdateIssue } from "@multica/core/issues/mutations";
+import {
+  actorIssuesViewStore,
+  type ActorIssuesScope,
+} from "@multica/core/issues/stores/actor-issues-view-store";
+import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
+import { useClearFiltersOnWorkspaceChange } from "@multica/core/issues/stores/view-store";
+import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import { Button } from "@multica/ui/components/ui/button";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@multica/ui/components/ui/tooltip";
+import { BoardView } from "../issues/components/board-view";
+import { ListView } from "../issues/components/list-view";
+import { BatchActionToolbar } from "../issues/components/batch-action-toolbar";
+import { IssueDisplayControls } from "../issues/components/issues-header";
+import { filterIssues } from "../issues/utils/filter";
+import { useT } from "../i18n";
+
+export type TaskActorType = "member" | "agent";
+
+const SCOPE_VALUES: ActorIssuesScope[] = ["assigned", "created"];
+
+export function ActorIssuesPanel({
+  actorType,
+  actorId,
+}: {
+  actorType: TaskActorType;
+  actorId: string;
+}) {
+  const { t } = useT("issues");
+  const wsId = useWorkspaceId();
+  const scope = useStore(actorIssuesViewStore, (s) => s.scope);
+  const setScope = useStore(actorIssuesViewStore, (s) => s.setScope);
+  const viewMode = useStore(actorIssuesViewStore, (s) => s.viewMode);
+  const statusFilters = useStore(actorIssuesViewStore, (s) => s.statusFilters);
+  const priorityFilters = useStore(actorIssuesViewStore, (s) => s.priorityFilters);
+  const assigneeFilters = useStore(actorIssuesViewStore, (s) => s.assigneeFilters);
+  const includeNoAssignee = useStore(actorIssuesViewStore, (s) => s.includeNoAssignee);
+  const creatorFilters = useStore(actorIssuesViewStore, (s) => s.creatorFilters);
+  const projectFilters = useStore(actorIssuesViewStore, (s) => s.projectFilters);
+  const includeNoProject = useStore(actorIssuesViewStore, (s) => s.includeNoProject);
+  const labelFilters = useStore(actorIssuesViewStore, (s) => s.labelFilters);
+
+  useClearFiltersOnWorkspaceChange(actorIssuesViewStore, wsId);
+
+  useEffect(() => {
+    useIssueSelectionStore.getState().clear();
+  }, [viewMode, scope, actorType, actorId]);
+
+  const queryFilter: MyIssuesFilter = useMemo(
+    () =>
+      scope === "assigned"
+        ? { assignee_id: actorId }
+        : { creator_id: actorId },
+    [scope, actorId],
+  );
+  const queryScope = `${actorType}:${actorId}:${scope}`;
+
+  const { data: rawIssues = [], isLoading } = useQuery(
+    myIssueListOptions(wsId, queryScope, queryFilter),
+  );
+
+  const actorIssues = useMemo(
+    () =>
+      rawIssues.filter((issue) =>
+        scope === "assigned"
+          ? issue.assignee_type === actorType && issue.assignee_id === actorId
+          : issue.creator_type === actorType && issue.creator_id === actorId,
+      ),
+    [rawIssues, scope, actorType, actorId],
+  );
+
+  const issues = useMemo(
+    () =>
+      filterIssues(actorIssues, {
+        statusFilters,
+        priorityFilters,
+        assigneeFilters,
+        includeNoAssignee,
+        creatorFilters,
+        projectFilters,
+        includeNoProject,
+        labelFilters,
+      }),
+    [
+      actorIssues,
+      statusFilters,
+      priorityFilters,
+      assigneeFilters,
+      includeNoAssignee,
+      creatorFilters,
+      projectFilters,
+      includeNoProject,
+      labelFilters,
+    ],
+  );
+
+  const { data: childProgressMap = new Map() } = useQuery(
+    childIssueProgressOptions(wsId),
+  );
+
+  const visibleStatuses = useMemo(() => {
+    if (statusFilters.length > 0) {
+      return BOARD_STATUSES.filter((s) => statusFilters.includes(s));
+    }
+    return BOARD_STATUSES;
+  }, [statusFilters]);
+
+  const hiddenStatuses = useMemo(
+    () => BOARD_STATUSES.filter((s) => !visibleStatuses.includes(s)),
+    [visibleStatuses],
+  );
+
+  const updateIssueMutation = useUpdateIssue();
+  const handleMoveIssue = useCallback(
+    (issueId: string, newStatus: IssueStatus, newPosition?: number) => {
+      const updates: Partial<{ status: IssueStatus; position: number }> = {
+        status: newStatus,
+      };
+      if (newPosition !== undefined) updates.position = newPosition;
+
+      updateIssueMutation.mutate(
+        { id: issueId, ...updates },
+        { onError: () => toast.error(t(($) => $.page.move_failed)) },
+      );
+    },
+    [updateIssueMutation, t],
+  );
+
+  if (isLoading) {
+    return <ActorIssuesSkeleton />;
+  }
+
+  return (
+    <ViewStoreProvider store={actorIssuesViewStore}>
+      <div className="flex flex-1 min-h-0 flex-col">
+        <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
+          <div className="flex items-center gap-1">
+            {SCOPE_VALUES.map((value) => (
+              <Tooltip key={value}>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className={
+                        scope === value
+                          ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                          : "text-muted-foreground"
+                      }
+                      onClick={() => setScope(value)}
+                    >
+                      {t(($) => $.actor_issues.scope[value].label)}
+                    </Button>
+                  }
+                />
+                <TooltipContent side="bottom">
+                  {t(($) => $.actor_issues.scope[value].description)}
+                </TooltipContent>
+              </Tooltip>
+            ))}
+          </div>
+          <IssueDisplayControls scopedIssues={actorIssues} />
+        </div>
+
+        {actorIssues.length === 0 ? (
+          <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-2 text-muted-foreground">
+            <ListTodo className="h-10 w-10 text-muted-foreground/40" />
+            <p className="text-sm">
+              {t(($) => $.actor_issues.empty[scope].title)}
+            </p>
+            <p className="text-xs">
+              {t(($) => $.actor_issues.empty[scope].description)}
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-1 min-h-0 flex-col">
+            {viewMode === "board" ? (
+              <BoardView
+                issues={issues}
+                visibleStatuses={visibleStatuses}
+                hiddenStatuses={hiddenStatuses}
+                onMoveIssue={handleMoveIssue}
+                childProgressMap={childProgressMap}
+                myIssuesScope={queryScope}
+                myIssuesFilter={queryFilter}
+              />
+            ) : (
+              <ListView
+                issues={issues}
+                visibleStatuses={visibleStatuses}
+                childProgressMap={childProgressMap}
+                myIssuesScope={queryScope}
+                myIssuesFilter={queryFilter}
+              />
+            )}
+          </div>
+        )}
+        {viewMode === "list" && <BatchActionToolbar />}
+      </div>
+    </ViewStoreProvider>
+  );
+}
+
+function ActorIssuesSkeleton() {
+  return (
+    <div className="flex flex-1 min-h-0 flex-col">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-8 w-20 rounded-md" />
+          <Skeleton className="h-8 w-20 rounded-md" />
+        </div>
+        <div className="flex items-center gap-1">
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+        </div>
+      </div>
+      <div className="flex flex-1 min-h-0 gap-4 overflow-hidden p-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex min-w-52 flex-1 flex-col gap-2">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-24 w-full rounded-lg" />
+            <Skeleton className="h-24 w-full rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -493,7 +493,51 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
   const { t } = useT("issues");
   const scope = useIssuesScopeStore((s) => s.scope);
   const setScope = useIssuesScopeStore((s) => s.setScope);
+  const SCOPE_LABEL_KEY: Record<IssuesScope, "all_label" | "members_label" | "agents_label"> = {
+    all: "all_label",
+    members: "members_label",
+    agents: "agents_label",
+  };
+  const SCOPE_DESC_KEY: Record<IssuesScope, "all_description" | "members_description" | "agents_description"> = {
+    all: "all_description",
+    members: "members_description",
+    agents: "agents_description",
+  };
 
+  return (
+    <div className="flex h-12 shrink-0 items-center justify-between px-4">
+      {/* Left: scope buttons */}
+      <div className="flex items-center gap-1">
+        {SCOPE_VALUES.map((s) => (
+          <Tooltip key={s}>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={
+                    scope === s
+                      ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                      : "text-muted-foreground"
+                  }
+                  onClick={() => setScope(s)}
+                >
+                  {t(($) => $.scope[SCOPE_LABEL_KEY[s]])}
+                </Button>
+              }
+            />
+            <TooltipContent side="bottom">{t(($) => $.scope[SCOPE_DESC_KEY[s]])}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+
+      <IssueDisplayControls scopedIssues={scopedIssues} />
+    </div>
+  );
+}
+
+export function IssueDisplayControls({ scopedIssues }: { scopedIssues: Issue[] }) {
+  const { t } = useT("issues");
   const viewMode = useViewStore((s) => s.viewMode);
   const statusFilters = useViewStore((s) => s.statusFilters);
   const priorityFilters = useViewStore((s) => s.priorityFilters);
@@ -539,46 +583,9 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
     childProgress: "card_child_progress",
   };
   const sortLabel = t(($) => $.display[SORT_LABEL_KEY[sortBy]]);
-  const SCOPE_LABEL_KEY: Record<IssuesScope, "all_label" | "members_label" | "agents_label"> = {
-    all: "all_label",
-    members: "members_label",
-    agents: "agents_label",
-  };
-  const SCOPE_DESC_KEY: Record<IssuesScope, "all_description" | "members_description" | "agents_description"> = {
-    all: "all_description",
-    members: "members_description",
-    agents: "agents_description",
-  };
 
   return (
-    <div className="flex h-12 shrink-0 items-center justify-between px-4">
-      {/* Left: scope buttons */}
-      <div className="flex items-center gap-1">
-        {SCOPE_VALUES.map((s) => (
-          <Tooltip key={s}>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className={
-                    scope === s
-                      ? "bg-accent text-accent-foreground hover:bg-accent/80"
-                      : "text-muted-foreground"
-                  }
-                  onClick={() => setScope(s)}
-                >
-                  {t(($) => $.scope[SCOPE_LABEL_KEY[s]])}
-                </Button>
-              }
-            />
-            <TooltipContent side="bottom">{t(($) => $.scope[SCOPE_DESC_KEY[s]])}</TooltipContent>
-          </Tooltip>
-        ))}
-      </div>
-
-      {/* Right: filter + display + view toggle */}
-      <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1">
         {/* Filter */}
         <DropdownMenu>
           <Tooltip>
@@ -893,7 +900,6 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
             </DropdownMenuGroup>
           </DropdownMenuContent>
         </DropdownMenu>
-      </div>
     </div>
   );
 }

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -186,6 +186,7 @@
   },
   "tabs": {
     "activity": "Activity",
+    "tasks": "Tasks",
     "instructions": "Instructions",
     "skills": "Skills",
     "environment": "Environment",

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -76,6 +76,28 @@
     "board": "Board",
     "list": "List"
   },
+  "actor_issues": {
+    "scope": {
+      "assigned": {
+        "label": "Assigned",
+        "description": "Issues assigned to this member or agent"
+      },
+      "created": {
+        "label": "Created",
+        "description": "Issues created by this member or agent"
+      }
+    },
+    "empty": {
+      "assigned": {
+        "title": "No assigned issues",
+        "description": "Issues assigned here will appear in this view."
+      },
+      "created": {
+        "title": "No created issues",
+        "description": "Issues created here will appear in this view."
+      }
+    }
+  },
   "list": {
     "empty_status": "No issues",
     "add_issue_tooltip": "Add issue"

--- a/packages/views/locales/en/members.json
+++ b/packages/views/locales/en/members.json
@@ -10,5 +10,12 @@
     "detail_link": "Detail →",
     "more_agents_one": "and {{count}} other agent",
     "more_agents_other": "and {{count}} other agents"
+  },
+  "detail": {
+    "workspace_fallback": "Workspace",
+    "members_breadcrumb": "Members",
+    "breadcrumb_fallback": "Member",
+    "not_found_title": "Member not found",
+    "not_found_description": "This member may have left the workspace."
   }
 }

--- a/packages/views/locales/en/search.json
+++ b/packages/views/locales/en/search.json
@@ -1,11 +1,11 @@
 {
   "title": "Search",
-  "description": "Search pages, issues, and projects",
+  "description": "Search pages, issues, projects, and members",
   "placeholder": "Type a command or search...",
   "groups": {
     "pages": "Pages",
     "commands": "Commands",
-    "switch_workspace": "Switch Workspace",
+    "members": "Members",
     "projects": "Projects",
     "issues": "Issues",
     "recent": "Recent"

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -182,6 +182,7 @@
   },
   "tabs": {
     "activity": "动态",
+    "tasks": "task",
     "instructions": "指令",
     "skills": "skill",
     "environment": "环境变量",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -75,6 +75,28 @@
     "board": "看板",
     "list": "列表"
   },
+  "actor_issues": {
+    "scope": {
+      "assigned": {
+        "label": "已分配",
+        "description": "分配给这个成员或智能体的 issue"
+      },
+      "created": {
+        "label": "已创建",
+        "description": "这个成员或智能体创建的 issue"
+      }
+    },
+    "empty": {
+      "assigned": {
+        "title": "没有已分配的 issue",
+        "description": "分配到这里的 issue 会显示在此视图中。"
+      },
+      "created": {
+        "title": "没有已创建的 issue",
+        "description": "由这里创建的 issue 会显示在此视图中。"
+      }
+    }
+  },
   "list": {
     "empty_status": "无 issue",
     "add_issue_tooltip": "新建 issue"

--- a/packages/views/locales/zh-Hans/members.json
+++ b/packages/views/locales/zh-Hans/members.json
@@ -9,5 +9,12 @@
     "agents_section": "智能体（{{count}}）",
     "detail_link": "详情 →",
     "more_agents_other": "另有 {{count}} 个智能体"
+  },
+  "detail": {
+    "workspace_fallback": "工作区",
+    "members_breadcrumb": "成员",
+    "breadcrumb_fallback": "成员",
+    "not_found_title": "未找到该成员",
+    "not_found_description": "该成员可能已经离开工作区。"
   }
 }

--- a/packages/views/locales/zh-Hans/search.json
+++ b/packages/views/locales/zh-Hans/search.json
@@ -1,11 +1,11 @@
 {
   "title": "搜索",
-  "description": "搜索页面、issue 和项目",
+  "description": "搜索页面、issue、项目和成员",
   "placeholder": "输入命令或关键词搜索...",
   "groups": {
     "pages": "页面",
     "commands": "命令",
-    "switch_workspace": "切换工作区",
+    "members": "成员",
     "projects": "项目",
     "issues": "issue",
     "recent": "最近"

--- a/packages/views/members/index.ts
+++ b/packages/views/members/index.ts
@@ -1,1 +1,2 @@
 export { MemberProfileCard } from "./member-profile-card";
+export { MemberDetailPage } from "./member-detail-page";

--- a/packages/views/members/member-detail-page.tsx
+++ b/packages/views/members/member-detail-page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { ChevronRight, UserRound } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import type { MemberRole } from "@multica/core/types";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useCurrentWorkspace } from "@multica/core/paths";
+import { memberListOptions } from "@multica/core/workspace/queries";
+import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { PageHeader } from "../layout/page-header";
+import { WorkspaceAvatar } from "../workspace/workspace-avatar";
+import { ActorIssuesPanel } from "../common/actor-issues-panel";
+import { useT } from "../i18n";
+
+export function MemberDetailPage({ userId }: { userId: string }) {
+  const { t } = useT("members");
+  const wsId = useWorkspaceId();
+  const workspace = useCurrentWorkspace();
+  const { data: members = [], isLoading } = useQuery(memberListOptions(wsId));
+  const member = members.find((m) => m.user_id === userId) ?? null;
+
+  if (isLoading && !member) {
+    return <MemberDetailSkeleton />;
+  }
+
+  if (!member) {
+    return (
+      <div className="flex flex-1 min-h-0 flex-col">
+        <MemberBreadcrumb workspaceName={workspace?.name} title={t(($) => $.detail.breadcrumb_fallback)} />
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+          <UserRound className="h-8 w-8 text-muted-foreground" />
+          <div>
+            <p className="text-sm font-medium">{t(($) => $.detail.not_found_title)}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t(($) => $.detail.not_found_description)}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const initials = member.name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+
+  return (
+    <div className="flex flex-1 min-h-0 flex-col">
+      <MemberBreadcrumb workspaceName={workspace?.name} title={member.name} />
+
+      <div className="flex shrink-0 items-center gap-3 border-b px-6 py-4">
+        <ActorAvatarBase
+          name={member.name}
+          initials={initials}
+          avatarUrl={member.avatar_url}
+          size={44}
+          className="rounded-full"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <h1 className="truncate text-base font-semibold">{member.name}</h1>
+            <RoleBadge role={member.role} />
+          </div>
+          <p className="mt-0.5 truncate text-sm text-muted-foreground">
+            {member.email}
+          </p>
+        </div>
+      </div>
+
+      <ActorIssuesPanel actorType="member" actorId={userId} />
+    </div>
+  );
+}
+
+function MemberBreadcrumb({
+  workspaceName,
+  title,
+}: {
+  workspaceName: string | undefined;
+  title: string;
+}) {
+  const { t } = useT("members");
+  return (
+    <PageHeader className="gap-1.5">
+      <WorkspaceAvatar name={workspaceName ?? "W"} size="sm" />
+      <span className="text-sm text-muted-foreground">
+        {workspaceName ?? t(($) => $.detail.workspace_fallback)}
+      </span>
+      <ChevronRight className="h-3 w-3 text-muted-foreground" />
+      <span className="text-sm text-muted-foreground">
+        {t(($) => $.detail.members_breadcrumb)}
+      </span>
+      <ChevronRight className="h-3 w-3 text-muted-foreground" />
+      <span className="truncate text-sm font-medium">{title}</span>
+    </PageHeader>
+  );
+}
+
+function RoleBadge({ role }: { role: MemberRole }) {
+  const { t } = useT("members");
+  return (
+    <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+      {role === "owner"
+        ? t(($) => $.role.owner)
+        : role === "admin"
+          ? t(($) => $.role.admin)
+          : t(($) => $.role.member)}
+    </span>
+  );
+}
+
+function MemberDetailSkeleton() {
+  return (
+    <div className="flex flex-1 min-h-0 flex-col">
+      <PageHeader className="px-5">
+        <Skeleton className="h-5 w-52" />
+      </PageHeader>
+      <div className="flex shrink-0 items-center gap-3 border-b px-6 py-4">
+        <Skeleton className="h-11 w-11 rounded-full" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-56" />
+        </div>
+      </div>
+      <div className="flex flex-1 min-h-0 gap-4 overflow-hidden p-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex min-w-52 flex-1 flex-col gap-2">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-24 w-full rounded-lg" />
+            <Skeleton className="h-24 w-full rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -25,6 +25,7 @@
     "./my-issues": "./my-issues/index.ts",
     "./skills": "./skills/index.ts",
     "./agents": "./agents/index.ts",
+    "./members": "./members/index.ts",
     "./inbox": "./inbox/index.ts",
     "./runtimes": "./runtimes/index.ts",
     "./dashboard": "./dashboard/index.ts",

--- a/packages/views/search/search-command.test.tsx
+++ b/packages/views/search/search-command.test.tsx
@@ -34,8 +34,7 @@ const {
   mockTheme,
   mockPathname,
   mockGetShareableUrl,
-  mockWorkspaces,
-  mockCurrentWorkspace,
+  mockMembers,
   mockOpenModal,
   mockToastSuccess,
   mockClipboardWrite,
@@ -49,11 +48,17 @@ const {
   mockTheme: { current: "system" as "light" | "dark" | "system" },
   mockPathname: { current: "/ws-test/issues" as string },
   mockGetShareableUrl: vi.fn((p: string) => `https://app.multica/${p}`),
-  mockWorkspaces: {
-    current: [] as Array<{ id: string; name: string; slug: string }>,
-  },
-  mockCurrentWorkspace: {
-    current: null as { id: string; name: string; slug: string } | null,
+  mockMembers: {
+    current: [] as Array<{
+      id: string;
+      workspace_id: string;
+      user_id: string;
+      role: "owner" | "admin" | "member";
+      created_at: string;
+      name: string;
+      email: string;
+      avatar_url: string | null;
+    }>,
   },
   mockOpenModal: vi.fn(),
   mockToastSuccess: vi.fn(),
@@ -92,12 +97,6 @@ vi.mock("@multica/core", () => ({
 }));
 
 vi.mock("@multica/core/paths", () => ({
-  paths: {
-    workspace: (slug: string) => ({
-      issues: () => `/${slug}/issues`,
-    }),
-  },
-  useCurrentWorkspace: () => mockCurrentWorkspace.current,
   useWorkspacePaths: () => ({
     inbox: () => "/ws-test/inbox",
     myIssues: () => "/ws-test/my-issues",
@@ -108,6 +107,7 @@ vi.mock("@multica/core/paths", () => ({
     skills: () => "/ws-test/skills",
     settings: () => "/ws-test/settings",
     issueDetail: (id: string) => `/ws-test/issues/${id}`,
+    memberDetail: (id: string) => `/ws-test/members/${id}`,
     projectDetail: (id: string) => `/ws-test/projects/${id}`,
   }),
 }));
@@ -119,7 +119,7 @@ vi.mock("@multica/core/issues/queries", () => ({
 }));
 
 vi.mock("@multica/core/workspace/queries", () => ({
-  workspaceListOptions: () => ({ queryKey: ["workspaces", "list"], enabled: false }),
+  memberListOptions: () => ({ queryKey: ["workspaces", "ws-test", "members"] }),
 }));
 
 vi.mock("@multica/core/modals", () => ({
@@ -140,7 +140,9 @@ function resolveIssue(key: readonly unknown[]) {
 vi.mock("@tanstack/react-query", () => ({
   useQuery: (opts: { queryKey: readonly unknown[]; enabled?: boolean }) => {
     const key = opts.queryKey;
-    if (key[0] === "workspaces") return { data: mockWorkspaces.current };
+    if (key[0] === "workspaces" && key[2] === "members") {
+      return { data: mockMembers.current };
+    }
     if (opts.enabled === false) return { data: undefined };
     return { data: resolveIssue(key) };
   },
@@ -175,8 +177,7 @@ describe("SearchCommand", () => {
     mockTheme.current = "system";
     mockPathname.current = "/ws-test/issues";
     mockGetShareableUrl.mockReset().mockImplementation((p: string) => `https://app.multica/${p}`);
-    mockWorkspaces.current = [];
-    mockCurrentWorkspace.current = null;
+    mockMembers.current = [];
     mockOpenModal.mockReset();
     mockToastSuccess.mockReset();
     mockClipboardWrite.mockReset().mockResolvedValue(undefined);
@@ -207,11 +208,10 @@ describe("SearchCommand", () => {
     expect(screen.queryByPlaceholderText("Type a command or search...")).not.toBeInTheDocument();
   });
 
-  it("shows only New Issue by default and hides Pages / Switch Workspace / low-frequency commands until query", () => {
+  it("shows only New Issue by default and hides Pages / low-frequency commands until query", () => {
     renderSearch();
 
     expect(screen.queryByText("Pages")).not.toBeInTheDocument();
-    expect(screen.queryByText("Switch Workspace")).not.toBeInTheDocument();
     // Only the primary creation action surfaces on empty query; everything
     // else (theme, copy, New Project) must be revealed by typing.
     expect(screen.getByText("Commands")).toBeInTheDocument();
@@ -249,6 +249,55 @@ describe("SearchCommand", () => {
     await user.click(settingsItem);
 
     expect(mockPush).toHaveBeenCalledWith("/ws-test/settings");
+    expect(useSearchStore.getState().open).toBe(false);
+  });
+
+  it("lists workspace members and navigates to the member page on selection", async () => {
+    const user = userEvent.setup();
+    mockMembers.current = [
+      {
+        id: "member-1",
+        workspace_id: "ws-test",
+        user_id: "user-1",
+        role: "member",
+        created_at: "2026-01-01T00:00:00Z",
+        name: "Alice Zhang",
+        email: "alice@example.com",
+        avatar_url: null,
+      },
+      {
+        id: "member-2",
+        workspace_id: "ws-test",
+        user_id: "user-2",
+        role: "admin",
+        created_at: "2026-01-01T00:00:00Z",
+        name: "Bob Liu",
+        email: "bob@example.com",
+        avatar_url: null,
+      },
+    ];
+    renderSearch();
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "alice");
+
+    await waitFor(() => {
+      expect(screen.getByText("Members")).toBeInTheDocument();
+      expect(
+        screen.getByText((_, el) => el?.textContent === "Alice Zhang" && el?.tagName === "DIV"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText((_, el) => el?.textContent === "alice@example.com" && el?.tagName === "DIV"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Bob Liu")).not.toBeInTheDocument();
+
+    const aliceItem = await screen.findByText(
+      (_, el) => el?.textContent === "Alice Zhang" && el?.tagName === "DIV",
+    );
+    await user.click(aliceItem);
+
+    expect(mockPush).toHaveBeenCalledWith("/ws-test/members/user-1");
     expect(useSearchStore.getState().open).toBe(false);
   });
 
@@ -405,62 +454,6 @@ describe("SearchCommand", () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByLabelText("Current theme")).toBeInTheDocument();
-  });
-
-  it("lists other workspaces under Switch Workspace and navigates on select", async () => {
-    const user = userEvent.setup();
-    mockCurrentWorkspace.current = { id: "ws-current", name: "Current", slug: "current" };
-    mockWorkspaces.current = [
-      { id: "ws-current", name: "Current", slug: "current" },
-      { id: "ws-alpha", name: "Alpha Co", slug: "alpha" },
-      { id: "ws-beta", name: "Beta Co", slug: "beta" },
-    ];
-    renderSearch();
-
-    const input = screen.getByPlaceholderText("Type a command or search...");
-    await user.type(input, "alpha");
-
-    await waitFor(() => {
-      expect(screen.getByText("Switch Workspace")).toBeInTheDocument();
-      expect(
-        screen.getByText((_, el) => el?.textContent === "Alpha Co" && el?.tagName === "SPAN"),
-      ).toBeInTheDocument();
-    });
-    expect(screen.queryByText("Beta Co")).not.toBeInTheDocument();
-    expect(screen.queryByText("Current")).not.toBeInTheDocument();
-
-    const alphaItem = await screen.findByText(
-      (_, el) => el?.textContent === "Alpha Co" && el?.tagName === "SPAN",
-    );
-    await user.click(alphaItem);
-
-    expect(mockPush).toHaveBeenCalledWith("/alpha/issues");
-    expect(useSearchStore.getState().open).toBe(false);
-  });
-
-  it("shows all other workspaces when typing 'workspace'", async () => {
-    const user = userEvent.setup();
-    mockCurrentWorkspace.current = { id: "ws-current", name: "Current", slug: "current" };
-    mockWorkspaces.current = [
-      { id: "ws-current", name: "Current", slug: "current" },
-      { id: "ws-alpha", name: "Alpha Co", slug: "alpha" },
-      { id: "ws-beta", name: "Beta Co", slug: "beta" },
-    ];
-    renderSearch();
-
-    const input = screen.getByPlaceholderText("Type a command or search...");
-    await user.type(input, "workspace");
-
-    await waitFor(() => {
-      expect(screen.getByText("Switch Workspace")).toBeInTheDocument();
-      expect(
-        screen.getByText((_, el) => el?.textContent === "Alpha Co" && el?.tagName === "SPAN"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText((_, el) => el?.textContent === "Beta Co" && el?.tagName === "SPAN"),
-      ).toBeInTheDocument();
-    });
-    expect(screen.queryByText("Current")).not.toBeInTheDocument();
   });
 
   it("filters out recent items not present in query cache", () => {

--- a/packages/views/search/search-command.tsx
+++ b/packages/views/search/search-command.tsx
@@ -20,13 +20,16 @@ import {
   Sun,
   BookOpenText,
   Settings,
-  Building2,
   type LucideIcon,
 } from "lucide-react";
 import { Command as CommandPrimitive } from "cmdk";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { SearchIssueResult, SearchProjectResult } from "@multica/core/types";
+import type {
+  MemberWithUser,
+  SearchIssueResult,
+  SearchProjectResult,
+} from "@multica/core/types";
 import { api } from "@multica/core/api";
 import {
   openCreateIssueWithPreference,
@@ -35,15 +38,16 @@ import {
 } from "@multica/core/issues/stores";
 import { issueDetailOptions } from "@multica/core/issues/queries";
 import { useWorkspaceId } from "@multica/core";
-import { paths, useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
+import { useWorkspacePaths } from "@multica/core/paths";
 import type { WorkspacePaths } from "@multica/core/paths";
 import { useModalStore } from "@multica/core/modals";
-import { workspaceListOptions } from "@multica/core/workspace/queries";
+import { memberListOptions } from "@multica/core/workspace/queries";
 import { StatusIcon } from "../issues/components";
 import { ProjectIcon } from "../projects/components/project-icon";
 import { STATUS_CONFIG } from "@multica/core/issues/config";
 import { PROJECT_STATUS_CONFIG } from "@multica/core/projects/config";
 import type { ProjectStatus } from "@multica/core/types";
+import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import {
   Dialog,
   DialogContent,
@@ -54,6 +58,7 @@ import {
 import { useTheme } from "@multica/ui/components/common/theme-provider";
 import { useNavigation } from "../navigation";
 import { useT } from "../i18n";
+import { matchesPinyin } from "../editor/extensions/pinyin-match";
 import { useSearchStore } from "./search-store";
 
 function HighlightText({ text, query }: { text: string; query: string }) {
@@ -114,6 +119,24 @@ interface NavPage {
 
 type ThemeValue = "light" | "dark" | "system";
 
+function memberInitials(name: string) {
+  return name
+    .split(" ")
+    .map((word) => word[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function matchesMember(member: MemberWithUser, query: string) {
+  return (
+    member.name.toLowerCase().includes(query) ||
+    member.email.toLowerCase().includes(query) ||
+    (query.length >= 3 && member.role.startsWith(query)) ||
+    matchesPinyin(member.name, query)
+  );
+}
+
 interface CommandItem {
   key: string;
   label: string;
@@ -147,8 +170,7 @@ export function SearchCommand() {
   const recentItems = useRecentIssuesStore(selectRecentIssues(wsId));
   const p: WorkspacePaths = useWorkspacePaths();
   const { theme, setTheme } = useTheme();
-  const currentWorkspace = useCurrentWorkspace();
-  const { data: workspaces = [] } = useQuery(workspaceListOptions());
+  const { data: members = [] } = useQuery(memberListOptions(wsId));
 
   // Resolve each recent issue via its cached detail entry. Recent items are
   // typically already in the detail cache because the user has opened them;
@@ -303,23 +325,24 @@ export function SearchCommand() {
     );
   }, [commands, query]);
 
-  // Only show workspaces different from the current one, and only after the
-  // user types >=2 chars — one char would match everything (e.g. "w").
-  const filteredWorkspaces = useMemo(() => {
+  const filteredMembers = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
-    const others = workspaces.filter((w) => w.id !== currentWorkspace?.id);
-    const wantsAll =
-      q.length >= 2 && ("workspace".startsWith(q) || "switch".startsWith(q));
-    return others.filter(
-      (w) =>
-        wantsAll ||
-        w.name.toLowerCase().includes(q) ||
-        w.slug.toLowerCase().includes(q),
-    );
-  }, [workspaces, currentWorkspace?.id, query]);
+    const wantsAllMembers =
+      q.length >= 3 &&
+      ("members".startsWith(q) ||
+        "people".startsWith(q) ||
+        "users".startsWith(q) ||
+        "team".startsWith(q));
+    return members
+      .filter((member) => wantsAllMembers || matchesMember(member, q))
+      .slice(0, 10);
+  }, [members, query]);
 
-  const hasResults = results.issues.length > 0 || results.projects.length > 0;
+  const hasResults =
+    results.issues.length > 0 ||
+    results.projects.length > 0 ||
+    filteredMembers.length > 0;
 
   // Global Cmd+K / Ctrl+K shortcut
   useEffect(() => {
@@ -437,12 +460,12 @@ export function SearchCommand() {
     [push, setOpen, p],
   );
 
-  const handleSwitchWorkspace = useCallback(
-    (slug: string) => {
-      push(paths.workspace(slug).issues());
+  const handleMemberSelect = useCallback(
+    (userId: string) => {
+      push(p.memberDetail(userId));
       setOpen(false);
     },
-    [push, setOpen],
+    [push, setOpen, p],
   );
 
   return (
@@ -523,26 +546,32 @@ export function SearchCommand() {
               </CommandPrimitive.Group>
             )}
 
-            {/* Workspaces section — switch to a different workspace, only shown when query matches */}
-            {filteredWorkspaces.length > 0 && (
+            {filteredMembers.length > 0 && (
               <CommandPrimitive.Group className="p-2">
                 <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground">
-                  {t(($) => $.groups.switch_workspace)}
+                  {t(($) => $.groups.members)}
                 </div>
-                {filteredWorkspaces.map((ws) => (
+                {filteredMembers.map((member) => (
                   <CommandPrimitive.Item
-                    key={ws.id}
-                    value={`workspace:${ws.id}`}
-                    onSelect={() => handleSwitchWorkspace(ws.slug)}
+                    key={member.user_id}
+                    value={`member:${member.user_id}`}
+                    onSelect={() => handleMemberSelect(member.user_id)}
                     className="flex cursor-default select-none items-center gap-2.5 rounded-lg px-3 py-2.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-accent"
                   >
-                    <Building2 className="size-4 shrink-0 text-muted-foreground" />
-                    <span className="truncate">
-                      <HighlightText text={ws.name} query={query} />
-                    </span>
-                    <span className="ml-auto text-xs text-muted-foreground truncate">
-                      {ws.slug}
-                    </span>
+                    <ActorAvatarBase
+                      name={member.name}
+                      initials={memberInitials(member.name)}
+                      avatarUrl={member.avatar_url}
+                      size={22}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate">
+                        <HighlightText text={member.name} query={query} />
+                      </div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        <HighlightText text={member.email} query={query} />
+                      </div>
+                    </div>
                   </CommandPrimitive.Item>
                 ))}
               </CommandPrimitive.Group>
@@ -558,8 +587,7 @@ export function SearchCommand() {
               query.trim() &&
               !hasResults &&
               filteredPages.length === 0 &&
-              filteredCommands.length === 0 &&
-              filteredWorkspaces.length === 0 && (
+              filteredCommands.length === 0 && (
                 <CommandPrimitive.Empty className="py-10 text-center text-sm text-muted-foreground">
                   {t(($) => $.empty.no_results)}
                 </CommandPrimitive.Empty>


### PR DESCRIPTION
## Summary

Adds member profile task pages so clicking a member avatar opens a dedicated page showing tasks assigned to and created by that member. The task list reuses the existing issues board/list presentation and view controls.

Also extends agent detail pages with a Tasks tab using the same reusable task panel, makes member and agent avatars link to their actor pages where appropriate, and adds member results to Cmd+K search while removing workspace switching from the command palette.

## Impact

Users can navigate directly from avatars or Cmd+K to member task pages and inspect actor-specific assigned/created work without leaving the familiar issue display model. Workspace switching is no longer exposed through Cmd+K.

## Validation

- `pnpm --filter @multica/views test -- search/search-command.test.tsx`
- `pnpm typecheck`
- `git diff --check`

A full `make check` was attempted earlier in this change set; TypeScript, Vitest, and Go tests passed, but the E2E phase hit existing login-flow/429/overlay failures unrelated to these changes.
