### PR TITLE
fix(ci): refresh pnpm-lock.yaml + name test wrapper after #2665

### DIFF
--- a/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
+++ b/packages/core/realtime/use-realtime-sync-ws-instance.test.tsx
@@ -38,9 +38,11 @@ function createStores(): RealtimeSyncStores {
 }
 
 function createWrapper(qc: QueryClient) {
-  return ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-  );
+  // Named function (not arrow) so react/display-name lint rule passes —
+  // anonymous render-fn components break that rule even in test files.
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
 }
 
 describe("useRealtimeSync — ws instance change", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,9 +510,6 @@ importers:
       posthog-js:
         specifier: 'catalog:'
         version: 1.369.3
-      react:
-        specifier: 'catalog:'
-        version: 19.2.3
       react-i18next:
         specifier: 'catalog:'
         version: 17.0.6(i18next@26.0.8(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -526,12 +523,21 @@ importers:
       '@multica/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.14
       jsdom:
         specifier: 'catalog:'
         version: 29.0.1(@noble/hashes@1.8.0)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.3
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.3(react@19.2.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Why

#2665 (`MUL-2256 fix(realtime): invalidate workspace queries on WSClient instance change`) introduced two unrelated CI fail modes that the original PR didn't catch locally. Both surface as `frontend` job red on `main`, so every open PR's frontend CI has been gated since `7c8cf929`.

This PR clears both in one go.

## Failure 1 — outdated lockfile

`#2665` added two devDependencies to `packages/core/package.json` (`@testing-library/react`, `react-dom`) and moved `react` from `dependencies` → `devDependencies`, but didn't commit the regenerated `pnpm-lock.yaml`. CI runs `pnpm install` with frozen-lockfile by default and bails on the first step:

```
ERR_PNPM_OUTDATED_LOCKFILE: pnpm-lock.yaml is not up to date with packages/core/package.json
  * 2 dependencies were added: @testing-library/react@catalog:, react-dom@catalog:
```

**Fix**: `pnpm install` locally and commit the resulting lockfile (+9 / -3, no version churn).

## Failure 2 — anonymous test wrapper

Once install was unblocked, the next CI step (`@multica/core#lint`) failed too. Same root cause — the new test file `packages/core/realtime/use-realtime-sync-ws-instance.test.tsx` from #2665 returned an anonymous arrow function from `createWrapper`, which trips `react/display-name` (enforced as error in core).

```
realtime/use-realtime-sync-ws-instance.test.tsx
  41:10  error  Component definition is missing display name  react/display-name
```

**Fix**: convert the inline arrow into `function Wrapper(…)` — identical render, satisfies the rule.

## Test plan
- [x] `pnpm install` runs clean locally; lockfile delta is purely the missing specifier blocks (no transitive churn).
- [x] `pnpm --filter @multica/core lint` → **0 errors** (was 1). Remaining warning is pre-existing on `auth-initializer.tsx` and untouched.
- [x] `pnpm --filter @multica/core test realtime/use-realtime-sync-ws-instance` → 4/4 pass after the rename.
- [ ] CI green end-to-end on this branch.

## Side note

Adding a pre-commit hook that runs `pnpm install --frozen-lockfile` whenever a `package.json` is staged would prevent this exact failure from recurring (it's structural — anyone editing a `package.json` and forgetting to re-install will trip the same wire). Out of scope here, but worth a separate task.