### PR TITLE
fix(realtime): include actor_type in WS broadcast messages

### DIFF
--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -1,7 +1,7 @@
 import type { WSMessage, WSEventType } from "../types/events";
 import { type Logger, noopLogger } from "../logger";
 
-type EventHandler = (payload: unknown, actorId?: string) => void;
+type EventHandler = (payload: unknown, actorId?: string, actorType?: string) => void;
 
 /** Identifies the WS client to the server. Sent as `client_platform`,
  *  `client_version`, and `client_os` query parameters on the upgrade URL —
@@ -84,7 +84,7 @@ export class WSClient {
       const eventHandlers = this.handlers.get(msg.type);
       if (eventHandlers) {
         for (const handler of eventHandlers) {
-          handler(msg.payload, msg.actor_id);
+          handler(msg.payload, msg.actor_id, msg.actor_type);
         }
       }
       for (const handler of this.anyHandlers) {

--- a/packages/core/realtime/hooks.ts
+++ b/packages/core/realtime/hooks.ts
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import type { WSEventType } from "../types";
 import { useWS } from "./provider";
 
-type EventHandler = (payload: unknown, actorId?: string) => void;
+type EventHandler = (payload: unknown, actorId?: string, actorType?: string) => void;
 
 /**
  * Hook that subscribes to a WebSocket event and calls the handler.

--- a/packages/core/realtime/provider.tsx
+++ b/packages/core/realtime/provider.tsx
@@ -21,7 +21,7 @@ import {
 import { createLogger } from "../logger";
 import { useRealtimeSync, type RealtimeSyncStores } from "./use-realtime-sync";
 
-type EventHandler = (payload: unknown, actorId?: string) => void;
+type EventHandler = (payload: unknown, actorId?: string, actorType?: string) => void;
 
 interface WSContextValue {
   subscribe: (event: WSEventType, handler: EventHandler) => () => void;

--- a/packages/core/types/events.ts
+++ b/packages/core/types/events.ts
@@ -82,6 +82,7 @@ export interface WSMessage<T = unknown> {
   type: WSEventType;
   payload: T;
   actor_id?: string;
+  actor_type?: string;
 }
 
 export interface IssueCreatedPayload {

--- a/server/cmd/server/listeners.go
+++ b/server/cmd/server/listeners.go
@@ -38,7 +38,7 @@ func registerListeners(bus *events.Bus, b realtime.Broadcaster) {
 		if recipientID == "" {
 			return
 		}
-		data, err := json.Marshal(map[string]any{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID})
+		data, err := json.Marshal(map[string]any{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID, "actor_type": e.ActorType})
 		if err != nil {
 			return
 		}
@@ -87,7 +87,7 @@ func registerListeners(bus *events.Bus, b realtime.Broadcaster) {
 			// Fallback for map encoding.
 			if invMap, ok := payload["invitation"].(map[string]any); ok {
 				if uid, _ := invMap["invitee_user_id"].(*string); uid != nil && *uid != "" {
-					data, err := json.Marshal(map[string]any{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID})
+					data, err := json.Marshal(map[string]any{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID, "actor_type": e.ActorType})
 					if err != nil {
 						return
 					}
@@ -98,7 +98,7 @@ func registerListeners(bus *events.Bus, b realtime.Broadcaster) {
 			return
 		}
 		if inv.InviteeUserID != nil && *inv.InviteeUserID != "" {
-			data, err := json.Marshal(map[string]any{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID})
+			data, err := json.Marshal(map[string]any{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID, "actor_type": e.ActorType})
 			if err != nil {
 				return
 			}
@@ -139,7 +139,7 @@ func registerListeners(bus *events.Bus, b realtime.Broadcaster) {
 		if userID == "" {
 			return
 		}
-		data, err := json.Marshal(map[string]any{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID})
+		data, err := json.Marshal(map[string]any{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID, "actor_type": e.ActorType})
 		if err != nil {
 			return
 		}
@@ -155,9 +155,10 @@ func registerListeners(bus *events.Bus, b realtime.Broadcaster) {
 		}
 
 		msg := map[string]any{
-			"type":     e.Type,
-			"payload":  e.Payload,
-			"actor_id": e.ActorID,
+			"type":       e.Type,
+			"payload":    e.Payload,
+			"actor_id":   e.ActorID,
+			"actor_type": e.ActorType,
 		}
 		data, err := json.Marshal(msg)
 		if err != nil {

--- a/server/cmd/server/listeners_frame_test.go
+++ b/server/cmd/server/listeners_frame_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/multica-ai/multica/server/internal/events"
+	"github.com/multica-ai/multica/server/pkg/protocol"
+)
+
+// TestRegisterListeners_FrameContainsActorType asserts that every WS frame
+// produced by registerListeners includes the top-level "actor_type" field.
+// This is a regression guard for the bug where agent operations appeared as
+// human in the web UI because the broadcast frame lacked actor_type.
+func TestRegisterListeners_FrameContainsActorType(t *testing.T) {
+	cases := []struct {
+		name      string
+		event     events.Event
+		checkUser bool // true = check SendToUser, false = check BroadcastToWorkspace
+		userID    string
+	}{
+		{
+			name: "workspace broadcast carries actor_type",
+			event: events.Event{
+				Type:        protocol.EventIssueCreated,
+				WorkspaceID: "ws-1",
+				ActorID:     "agent-abc",
+				ActorType:   "agent",
+				Payload:     map[string]any{"id": "issue-1"},
+			},
+		},
+		{
+			name: "personal event (inbox:new) carries actor_type",
+			event: events.Event{
+				Type:        protocol.EventInboxNew,
+				WorkspaceID: "ws-1",
+				ActorID:     "member-xyz",
+				ActorType:   "member",
+				Payload: map[string]any{
+					"item": map[string]any{"recipient_id": "user-1"},
+				},
+			},
+			checkUser: true,
+			userID:    "user-1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bus := events.New()
+			fb := &fakeBroadcaster{}
+			registerListeners(bus, fb)
+
+			bus.Publish(tc.event)
+
+			var raw []byte
+			if tc.checkUser {
+				if len(fb.userCalls) == 0 {
+					t.Fatal("expected SendToUser call, got none")
+				}
+				raw = fb.userCalls[0].msg
+			} else {
+				if len(fb.workspaceCalls) == 0 {
+					t.Fatal("expected BroadcastToWorkspace call, got none")
+				}
+				raw = fb.workspaceCalls[0].msg
+			}
+
+			var frame map[string]any
+			if err := json.Unmarshal(raw, &frame); err != nil {
+				t.Fatalf("failed to unmarshal frame: %v", err)
+			}
+
+			actorType, ok := frame["actor_type"]
+			if !ok {
+				t.Fatal("frame missing actor_type field")
+			}
+			if actorType != tc.event.ActorType {
+				t.Fatalf("actor_type = %q, want %q", actorType, tc.event.ActorType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix the v0.3.0 bug where Agent CLI operations are displayed as human operations in the web UI.

## Root Cause

The WebSocket broadcast message format in `server/cmd/server/listeners.go` was:
```go
{"type": e.Type, "payload": e.Payload, "actor_id": e.ActorID}
```

Missing `actor_type`. The web UI could not distinguish agent from human operations in real-time events at the top level, causing agent CLI operations to display as human operations.

## Changes

- **server/cmd/server/listeners.go**: Add `actor_type` to all broadcast messages (workspace-wide and personal/user-targeted)
- **packages/core/types/events.ts**: Add `actor_type` to `WSMessage` interface
- **packages/core/api/ws-client.ts**: Pass `actor_type` to event handlers
- **packages/core/realtime/hooks.ts**: Update `EventHandler` type signature
- **packages/core/realtime/provider.tsx**: Update `EventHandler` type signature

## Testing

- Go server builds cleanly
- All existing Go tests pass (`TestResolveActor`, `TestRegisterListeners_TaskChatGoToWorkspace`, etc.)
- TypeScript type-checks pass for `@multica/core` and `@multica/views`
- All 248 frontend unit tests pass

Fixes MUL-2260