### PR TITLE
feat(views): refine navigation progress bar with brand color and glow (MUL-2269)

### DIFF
--- a/packages/ui/styles/base.css
+++ b/packages/ui/styles/base.css
@@ -114,17 +114,18 @@
   animation: chat-text-shimmer 2.5s linear infinite;
 }
 
-/* Navigation progress bar: 1px brand-tinted indeterminate sweep that shows
- * across the top of the dashboard while a transition-wrapped push/replace is
- * committing. Driven by useIsNavigating(); independent of the actual network,
- * so it disappears the moment React commits the new route. */
+/* Navigation progress bar: 2px brand-colored indeterminate sweep with a
+ * right-edge glow that shows across the top of the dashboard while a
+ * transition-wrapped push/replace is committing. Driven by useIsNavigating();
+ * independent of the actual network, so it disappears the moment React commits
+ * the new route. */
 @keyframes nav-progress-sweep {
   0% { transform: translateX(-100%); }
   100% { transform: translateX(100%); }
 }
 
 .animate-nav-progress-sweep {
-  animation: nav-progress-sweep 1.1s ease-in-out infinite;
+  animation: nav-progress-sweep 1.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
 
 /* Border beam: a brand-tinted highlight sweeps continuously around the

--- a/packages/views/layout/navigation-progress.tsx
+++ b/packages/views/layout/navigation-progress.tsx
@@ -1,27 +1,45 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 import { useIsNavigating } from "../navigation";
 
 // 2px top-of-content progress bar shown while a transition-wrapped
 // push/replace is mid-flight. Indeterminate by design — we don't know
-// when the next route will commit, just that it's coming. Always mounted
-// so the container can fade out (200ms) instead of disappearing in one
-// frame, which previously felt abrupt.
+// when the next route will commit, just that it's coming.
+//
+// The container stays mounted so it can fade out over 200ms instead of
+// vanishing in one frame. The inner sweep is mounted only while navigating
+// (plus the fade-out tail); leaving its `infinite` keyframe animation
+// running while hidden would burn paints on every dashboard view.
 export function NavigationProgress() {
   const isNavigating = useIsNavigating();
+  const [renderSweep, setRenderSweep] = useState(false);
+
+  useEffect(() => {
+    if (isNavigating) setRenderSweep(true);
+  }, [isNavigating]);
+
   return (
     <div
       aria-hidden
       data-visible={isNavigating ? "true" : "false"}
+      onTransitionEnd={(event) => {
+        if (event.propertyName === "opacity" && !isNavigating) {
+          setRenderSweep(false);
+        }
+      }}
       className="pointer-events-none absolute inset-x-0 top-0 z-50 h-0.5 overflow-hidden opacity-0 transition-opacity duration-200 data-[visible=true]:opacity-100"
     >
-      <div
-        className="h-full w-1/3 animate-nav-progress-sweep bg-brand"
-        style={{
-          boxShadow:
-            "0 0 8px color-mix(in oklab, var(--brand) 60%, transparent), 0 0 2px color-mix(in oklab, var(--brand) 80%, transparent)",
-        }}
-      />
+      {renderSweep && (
+        <div
+          className="h-full w-1/3 animate-nav-progress-sweep bg-brand"
+          style={{
+            boxShadow:
+              "0 0 8px color-mix(in oklab, var(--brand) 60%, transparent), 0 0 2px color-mix(in oklab, var(--brand) 80%, transparent)",
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/packages/views/layout/navigation-progress.tsx
+++ b/packages/views/layout/navigation-progress.tsx
@@ -2,18 +2,26 @@
 
 import { useIsNavigating } from "../navigation";
 
-// 1px top-of-content progress bar shown while a transition-wrapped
+// 2px top-of-content progress bar shown while a transition-wrapped
 // push/replace is mid-flight. Indeterminate by design — we don't know
-// when the next route will commit, just that it's coming.
+// when the next route will commit, just that it's coming. Always mounted
+// so the container can fade out (200ms) instead of disappearing in one
+// frame, which previously felt abrupt.
 export function NavigationProgress() {
   const isNavigating = useIsNavigating();
-  if (!isNavigating) return null;
   return (
     <div
       aria-hidden
-      className="pointer-events-none absolute inset-x-0 top-0 z-50 h-px overflow-hidden"
+      data-visible={isNavigating ? "true" : "false"}
+      className="pointer-events-none absolute inset-x-0 top-0 z-50 h-0.5 overflow-hidden opacity-0 transition-opacity duration-200 data-[visible=true]:opacity-100"
     >
-      <div className="h-full w-1/3 animate-nav-progress-sweep bg-primary" />
+      <div
+        className="h-full w-1/3 animate-nav-progress-sweep bg-brand"
+        style={{
+          boxShadow:
+            "0 0 8px color-mix(in oklab, var(--brand) 60%, transparent), 0 0 2px color-mix(in oklab, var(--brand) 80%, transparent)",
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Polish the dashboard navigation progress bar shipped in #2677. The previous 1px `bg-primary` bar read as near-black on light theme and snapped on/off in a single frame, so users said it looked unrefined. SpecOwner locked the visual spec (Linear / nprogress-inspired); this PR is the pure UI follow-up.

- `packages/views/layout/navigation-progress.tsx`
  - `h-px` (1px) → `h-0.5` (2px)
  - `bg-primary` (neutral near-black) → `bg-brand` (existing brand-blue token)
  - Added two-layer `box-shadow` glow via `color-mix(in oklab, var(--brand) …, transparent)` so the thin bar reads softly without dropping alpha
  - Removed `return null` — container is always mounted and toggles `opacity` with `transition-opacity duration-200`, giving a 200ms fade-out instead of a single-frame disappear
- `packages/ui/styles/base.css` (`@keyframes nav-progress-sweep` / `.animate-nav-progress-sweep`)
  - Cycle 1.1s → 1.4s
  - Easing `ease-in-out` → `cubic-bezier(0.4, 0, 0.2, 1)` (Material standard) for a calmer feel

Zero new design tokens (reuses existing `--brand`), zero `tailwind.config.*` changes, zero API changes. Desktop unaffected — `NavigationProgress` lives in `packages/views/` and desktop's adapter has no `prefetch`, so behavior is unchanged.

Closes the UI-polish follow-up on [MUL-2269](https://github.com/multica-ai/multica/issues).

## Test plan

- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/web typecheck`
- [x] `pnpm --filter @multica/desktop typecheck`
- [x] `pnpm --filter @multica/views test` — 545/545 pass
- [x] `pnpm lint` — clean (1 pre-existing warning, no new findings)
- [ ] Visual check in web dev: navigate between dashboard pages and confirm the bar is brand-blue, 2px, with a soft right-edge glow and a 200ms fade on completion
- [ ] Desktop visual check: confirm no regression (bar should not appear on desktop since adapter has no `prefetch`/`useTransition` pending state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)