### PR TITLE
fix(views): narrow agent/squad create dialogs to max-w-4xl

### DIFF
--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -225,7 +225,7 @@ export function CreateAgentDialog({
 
   return (
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
-      <DialogContent className="p-0 gap-0 flex flex-col overflow-hidden !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !w-full !max-w-5xl !h-[85vh]">
+      <DialogContent className="p-0 gap-0 flex flex-col overflow-hidden !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !w-full !max-w-4xl !h-[85vh]">
         <DialogHeader className="border-b px-5 py-3 space-y-0">
           <DialogTitle className="text-base font-semibold">{headerTitle}</DialogTitle>
           {isDuplicate && template && (

--- a/packages/views/modals/create-squad.tsx
+++ b/packages/views/modals/create-squad.tsx
@@ -142,7 +142,7 @@ export function CreateSquadModal({ onClose }: { onClose: () => void }) {
 
   return (
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
-      <DialogContent className="p-0 gap-0 flex flex-col overflow-hidden !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !w-full !max-w-5xl !h-[85vh]">
+      <DialogContent className="p-0 gap-0 flex flex-col overflow-hidden !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !w-full !max-w-4xl !h-[85vh]">
         <DialogHeader className="border-b px-5 py-3 space-y-0">
           <DialogTitle className="text-base font-semibold">
             {t(($) => $.create_squad.title)}


### PR DESCRIPTION
## Summary
- Agent 创建和小队创建两个弹窗当前是 `!max-w-5xl`(1024px),过宽
- 改为 `!max-w-4xl`(896px),对齐仓库现有 create-project / create-issue(expanded)的宽度约定
- 两个弹窗宽度保持一致;仅改宽度,不动布局/字段

Closes [MUL-2280](mention://issue/19fdd6ef-5899-4491-b9c0-ff97be62d729)

## Test plan
- [ ] 打开 Agent 创建弹窗,确认宽度更合适
- [ ] 打开小队创建弹窗,确认宽度与 Agent 创建一致
- [ ] 表单内字段排版无溢出

🤖 Generated with [Claude Code](https://claude.com/claude-code)