### PR TITLE
feat(auth): make auth token TTL configurable via AUTH_TOKEN_TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,14 @@ LOCAL_UPLOAD_BASE_URL=http://localhost:8080
 # Example: ALLOWED_ORIGINS=https://app.multica.ai,https://staging.multica.ai
 ALLOWED_ORIGINS=
 
+# AUTH_TOKEN_TTL — lifetime applied to JWTs and session cookies.
+# Go duration string (e.g. "720h" = 30 days, "8760h" = 365 days). Default
+# is 30 days. Self-hosted deployments on trusted networks may extend this
+# to reduce magic-link re-auth frequency; SaaS-style deployments should
+# leave it at the default. Invalid or non-positive values fall back to
+# 30 days with a warning in the server log.
+# AUTH_TOKEN_TTL=8760h
+
 # Realtime metrics endpoint (/health/realtime) access control. See MUL-1342.
 # When unset, the endpoint only serves direct loopback (127.0.0.1 / ::1)
 # callers with no forwarding headers and returns 404 to everything else —

--- a/server/internal/auth/cookie.go
+++ b/server/internal/auth/cookie.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	AuthCookieName   = "multica_auth"
-	CSRFCookieName   = "multica_csrf"
-	defaultAuthTTL   = 30 * 24 * time.Hour // 30 days
+	AuthCookieName = "multica_auth"
+	CSRFCookieName = "multica_csrf"
+	defaultAuthTTL = 30 * 24 * time.Hour // 30 days
 )
 
 var ipCookieDomainWarnOnce sync.Once

--- a/server/internal/auth/cookie.go
+++ b/server/internal/auth/cookie.go
@@ -18,10 +18,29 @@ import (
 const (
 	AuthCookieName   = "multica_auth"
 	CSRFCookieName   = "multica_csrf"
-	authCookieMaxAge = 30 * 24 * 60 * 60 // 30 days in seconds
+	defaultAuthTTL   = 30 * 24 * time.Hour // 30 days
 )
 
 var ipCookieDomainWarnOnce sync.Once
+
+// AuthTokenTTL returns the auth token TTL from the AUTH_TOKEN_TTL environment
+// variable (Go duration format, e.g. "8760h" for 1 year). Falls back to 30 days.
+func AuthTokenTTL() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("AUTH_TOKEN_TTL"))
+	if raw == "" {
+		return defaultAuthTTL
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		slog.Warn("AUTH_TOKEN_TTL is not a valid Go duration, using default 30d", "value", raw, "error", err)
+		return defaultAuthTTL
+	}
+	if d <= 0 {
+		slog.Warn("AUTH_TOKEN_TTL must be positive, using default 30d", "value", raw)
+		return defaultAuthTTL
+	}
+	return d
+}
 
 // cookieDomain returns the trimmed COOKIE_DOMAIN env value, or "" if it looks
 // like an IP address. RFC 6265 §4.1.2.3 forbids IP literals in the cookie
@@ -84,14 +103,15 @@ func generateCSRFToken(authToken string) (string, error) {
 func SetAuthCookies(w http.ResponseWriter, token string) error {
 	secure := isSecureCookie()
 	domain := cookieDomain()
+	ttl := AuthTokenTTL()
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     AuthCookieName,
 		Value:    token,
 		Path:     "/",
 		Domain:   domain,
-		MaxAge:   authCookieMaxAge,
-		Expires:  time.Now().Add(30 * 24 * time.Hour),
+		MaxAge:   int(ttl.Seconds()),
+		Expires:  time.Now().Add(ttl),
 		HttpOnly: true,
 		Secure:   secure,
 		SameSite: http.SameSiteStrictMode,
@@ -107,8 +127,8 @@ func SetAuthCookies(w http.ResponseWriter, token string) error {
 		Value:    csrfToken,
 		Path:     "/",
 		Domain:   domain,
-		MaxAge:   authCookieMaxAge,
-		Expires:  time.Now().Add(30 * 24 * time.Hour),
+		MaxAge:   int(ttl.Seconds()),
+		Expires:  time.Now().Add(ttl),
 		HttpOnly: false,
 		Secure:   secure,
 		SameSite: http.SameSiteStrictMode,

--- a/server/internal/auth/cookie_test.go
+++ b/server/internal/auth/cookie_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestIsSecureCookie(t *testing.T) {
@@ -77,6 +78,48 @@ func TestSetAuthCookies_HTTPSelfHost(t *testing.T) {
 		}
 		if c.Domain != "" {
 			t.Errorf("cookie %q has Domain=%q; IP-address Domain would be rejected by the browser (RFC 6265)", c.Name, c.Domain)
+		}
+	}
+}
+
+func TestAuthTokenTTL(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset → 30 days", "", 30 * 24 * time.Hour},
+		{"whitespace → 30 days", "   ", 30 * 24 * time.Hour},
+		{"explicit 1 year", "8760h", 8760 * time.Hour},
+		{"30 minutes", "30m", 30 * time.Minute},
+		{"malformed → 30 days", "not-a-duration", 30 * 24 * time.Hour},
+		{"zero → 30 days", "0s", 30 * 24 * time.Hour},
+		{"negative → 30 days", "-1h", 30 * 24 * time.Hour},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AUTH_TOKEN_TTL", tc.env)
+			if got := AuthTokenTTL(); got != tc.want {
+				t.Errorf("AuthTokenTTL() = %v, want %v (AUTH_TOKEN_TTL=%q)", got, tc.want, tc.env)
+			}
+		})
+	}
+}
+
+func TestSetAuthCookies_RespectsAuthTokenTTL(t *testing.T) {
+	t.Setenv("FRONTEND_ORIGIN", "https://app.example.com")
+	t.Setenv("COOKIE_DOMAIN", "app.example.com")
+	t.Setenv("AUTH_TOKEN_TTL", "8760h")
+
+	rec := httptest.NewRecorder()
+	if err := SetAuthCookies(rec, "test-token"); err != nil {
+		t.Fatalf("SetAuthCookies: %v", err)
+	}
+
+	wantSeconds := int((8760 * time.Hour).Seconds())
+	for _, c := range rec.Result().Cookies() {
+		if c.MaxAge != wantSeconds {
+			t.Errorf("cookie %q MaxAge = %d, want %d", c.Name, c.MaxAge, wantSeconds)
 		}
 	}
 }

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -139,7 +139,7 @@ func (h *Handler) issueJWT(user db.User) (string, error) {
 		"sub":   uuidToString(user.ID),
 		"email": user.Email,
 		"name":  user.Name,
-		"exp":   time.Now().Add(30 * 24 * time.Hour).Unix(),
+		"exp":   time.Now().Add(auth.AuthTokenTTL()).Unix(),
 		"iat":   time.Now().Unix(),
 	})
 	return token.SignedString(auth.JWTSecret())

--- a/server/internal/handler/auth.go
+++ b/server/internal/handler/auth.go
@@ -393,7 +393,7 @@ func (h *Handler) VerifyCode(w http.ResponseWriter, r *http.Request) {
 
 	// Set CloudFront signed cookies for CDN access.
 	if h.CFSigner != nil {
-		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(30 * 24 * time.Hour)) {
+		for _, cookie := range h.CFSigner.SignedCookies(time.Now().Add(auth.AuthTokenTTL())) {
 			http.SetCookie(w, cookie)
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

让 auth token / session cookie 的有效期可由环境变量 `AUTH_TOKEN_TTL` 控制，不再硬编码 30 天。自部署在受信任内网时，可以拉长到 1 年，避免每月一次跨设备 magic-link 倒手；SaaS 部署不设此变量则行为完全不变。

唯一可调维度是 TTL 数值，鉴权流程、cookie 安全属性（HttpOnly/Secure/SameSite）、CSRF 配对、CloudFront signed cookie 的签发都保持原状。

## Related Issue

Closes #

<!-- 上游暂未建对应 issue；动机讨论见 fork 内部 tracker [AGE-11](mention://issue/d4e6dc02-baf4-4a80-905b-94311214973f)。 -->

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `.env.example` — 新增 `AUTH_TOKEN_TTL` 注释 + 示例（默认 30d，建议值 `8760h`）。
- `server/internal/auth/cookie.go` — 删除常量 `authCookieMaxAge`，新增 `AuthTokenTTL()`：读 `AUTH_TOKEN_TTL`（Go duration），空 / 非法 / 非正值都回退到 30 天默认并打 `slog.Warn`。`SetAuthCookies` 中 auth cookie 与 CSRF cookie 的 `MaxAge` / `Expires` 都改用此函数。
- `server/internal/handler/auth.go` — `issueJWT` 的 `exp` claim、`VerifyCode` 中 CloudFront signed cookie 的过期时间，都改用 `auth.AuthTokenTTL()`，与 cookie 寿命对齐。
- `server/internal/auth/cookie_test.go` — 新增 `TestAuthTokenTTL`（unset / 空白 / 显式 / 非法 / 0 / 负数 6 个分支）和 `TestSetAuthCookies_RespectsAuthTokenTTL`（验证 cookie `MaxAge` 跟随 env 变化）。

## How to Test

1. 默认行为不变：`unset AUTH_TOKEN_TTL && cd server && go test ./internal/auth/... ./internal/handler/...` 全绿；签发的 cookie `MaxAge` 仍为 `2592000`（30d）。
2. 拉长寿命：`AUTH_TOKEN_TTL=8760h` 后启动 server，登录 → DevTools 看 `multica_auth` / `multica_csrf` cookie `Expires` ≈ now + 365d；JWT `exp` 与之一致。
3. 容错：`AUTH_TOKEN_TTL=garbage`、`AUTH_TOKEN_TTL=0s`、`AUTH_TOKEN_TTL=-1h` 启动后均回落到 30d 并在 stdout 看到 `slog.Warn` 一行。

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots <!-- 不涉及 UI -->
- [ ] I have updated relevant documentation to reflect my changes <!-- 仅 .env.example 内联说明，未触及 apps/docs；如需独立文档请 reviewer 指明 -->
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy / starter-content / docs <!-- 不涉及 -->
- [ ] If this PR touches Chinese product copy, I checked it against conventions.zh.mdx <!-- 不涉及产品文案 -->
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

**风险记录：**
- TTL 拉长到 1 年意味着 token 泄露后失效窗口同步拉长；建议自部署同时配 `COOKIE_DOMAIN` 收紧作用域，并在 README 注明。
- `AUTH_TOKEN_TTL` 仅影响新签发的 token，老 cookie 走它们当时签发的 30d 寿命，自然过渡，无需迁移。

## AI Disclosure

**AI tool used:** Multica Agent（Claude）

**Prompt / approach:** 在自部署 Multica 时遇到「每加一台新设备就要去 docker logs 抓验证码」的痛点，agent 排查后发现根因之一是 30d 寿命太短、跨设备倒手频次高；先做最小改动把 TTL 做成可配置以缓解再频繁登录，后续再考虑设备配对等更大改动。改动范围严格限定在 cookie / JWT / signed cookie 三处过期时间，不动鉴权流程与安全属性。

## Screenshots (optional)

N/A