### PR TITLE
feat(runtimes): add Daily Runtime Duration chart (MUL-2283)

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -44,6 +44,7 @@ import type {
   RuntimeHourlyActivity,
   RuntimeUsageByAgent,
   RuntimeUsageByHour,
+  RuntimeRunDuration,
   DashboardUsageDaily,
   DashboardUsageByAgent,
   DashboardAgentRunTime,
@@ -111,6 +112,7 @@ import {
   DashboardAgentRunTimeListSchema,
   DashboardUsageByAgentListSchema,
   DashboardUsageDailyListSchema,
+  RuntimeRunDurationListSchema,
   EMPTY_AGENT_TEMPLATE_DETAIL,
   EMPTY_AGENT_TEMPLATE_SUMMARY_LIST,
   EMPTY_ATTACHMENT,
@@ -835,6 +837,23 @@ export class ApiClient {
     const search = new URLSearchParams();
     if (params?.days) search.set("days", String(params.days));
     return this.fetch(`/api/runtimes/${runtimeId}/usage/by-hour?${search}`);
+  }
+
+  async getRuntimeRunDuration(
+    runtimeId: string,
+    params?: { days?: number },
+  ): Promise<RuntimeRunDuration[]> {
+    const search = new URLSearchParams();
+    if (params?.days) search.set("days", String(params.days));
+    const raw = await this.fetch<unknown>(
+      `/api/runtimes/${runtimeId}/usage/duration?${search}`,
+    );
+    return parseWithFallback<RuntimeRunDuration[]>(
+      raw,
+      RuntimeRunDurationListSchema,
+      [],
+      { endpoint: "GET /api/runtimes/:id/usage/duration" },
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -238,6 +238,16 @@ const DashboardAgentRunTimeSchema = z.object({
 
 export const DashboardAgentRunTimeListSchema = z.array(DashboardAgentRunTimeSchema);
 
+// Daily runtime duration — one row per local-tz day, total seconds of
+// terminal runs that finished that day. The chart treats missing days as
+// zero, so a malformed row is safer to drop than to render as NaN.
+const RuntimeRunDurationSchema = z.object({
+  date: z.string(),
+  duration_seconds: z.number().default(0),
+}).loose();
+
+export const RuntimeRunDurationListSchema = z.array(RuntimeRunDurationSchema);
+
 // ---------------------------------------------------------------------------
 // Agent template catalog — `/api/agent-templates*` and the
 // create-from-template response. The desktop app's create-agent picker

--- a/packages/core/runtimes/queries.ts
+++ b/packages/core/runtimes/queries.ts
@@ -11,6 +11,8 @@ export const runtimeKeys = {
     ["runtimes", "usage", "by-agent", rid, days] as const,
   usageByHour: (rid: string, days: number) =>
     ["runtimes", "usage", "by-hour", rid, days] as const,
+  usageDuration: (rid: string, days: number) =>
+    ["runtimes", "usage", "duration", rid, days] as const,
   latestVersion: () => ["runtimes", "latestVersion"] as const,
 };
 
@@ -42,6 +44,18 @@ export function runtimeUsageByHourOptions(runtimeId: string, days: number) {
   return queryOptions({
     queryKey: runtimeKeys.usageByHour(runtimeId, days),
     queryFn: () => api.getRuntimeUsageByHour(runtimeId, { days }),
+    staleTime: 60 * 1000,
+  });
+}
+
+// Daily total run-duration (seconds) for one runtime — drives the
+// Duration metric on the Daily tab. Fetched at the top of UsageSection
+// alongside the token cache so the page-level empty-state check can
+// consider duration data (a failed / zero-token run still has duration).
+export function runtimeUsageDurationOptions(runtimeId: string, days: number) {
+  return queryOptions({
+    queryKey: runtimeKeys.usageDuration(runtimeId, days),
+    queryFn: () => api.getRuntimeRunDuration(runtimeId, { days }),
     staleTime: 60 * 1000,
   });
 }

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -359,6 +359,16 @@ export interface RuntimeUsageByHour {
   task_count: number;
 }
 
+// One day of total run-duration (seconds) for the Daily Runtime Duration
+// chart on the runtime detail page. The server aggregates terminal
+// (completed / failed) runs by completed_at-day in the runtime's local tz
+// — see GetRuntimeRunDurationByDay for the bucket semantics. Days with no
+// terminal runs are omitted; clients should treat absent dates as zero.
+export interface RuntimeRunDuration {
+  date: string;
+  duration_seconds: number;
+}
+
 // One (date, model) bucket of token usage for the workspace dashboard.
 // Same shape as RuntimeUsage but workspace-scoped (no runtime_id, no
 // provider field on the wire) and optionally narrowed to a single project

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -29,6 +29,7 @@ export type {
   RuntimeHourlyActivity,
   RuntimeUsageByAgent,
   RuntimeUsageByHour,
+  RuntimeRunDuration,
   DashboardUsageDaily,
   DashboardUsageByAgent,
   DashboardAgentRunTime,

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -187,6 +187,7 @@
     "when_tab_heatmap": "Heatmap",
     "daily_metric_cost": "Cost",
     "daily_metric_tokens": "Tokens",
+    "daily_metric_duration": "Duration",
     "heatmap_caption": "Last 26 weeks · daily $ intensity (period selector ignored here)",
     "legend_input": "Input",
     "legend_output": "Output",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -182,6 +182,7 @@
     "when_tab_heatmap": "热力图",
     "daily_metric_cost": "费用",
     "daily_metric_tokens": "Token",
+    "daily_metric_duration": "时长",
     "heatmap_caption": "最近 26 周 · 每日 $ 强度（此处忽略上方时间范围）",
     "legend_input": "输入",
     "legend_output": "输出",

--- a/packages/views/runtimes/components/charts/daily-duration-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-duration-chart.tsx
@@ -1,0 +1,74 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@multica/ui/components/ui/chart";
+import { formatDuration, type DailyDurationData } from "../../utils";
+
+// Single-series bar — total terminal-run duration per day in the runtime's
+// local tz. Y axis is hours (compact "Xh" ticks); the tooltip renders the
+// raw second count via formatDuration so sub-hour spans aren't pinned to
+// `0h` at the chart edge.
+//
+// Cache reads / writes don't apply here, so the legend in WhenChart's
+// header collapses to a single "Duration" pip — see usage-section.tsx.
+export const durationStackConfig = {
+  hours: { label: "Duration", color: "var(--chart-1)" },
+} satisfies ChartConfig;
+
+export function DailyDurationChart({ data }: { data: DailyDurationData[] }) {
+  // No internal empty-state — same convention as DailyCostChart /
+  // DailyTokensChart: the parent decides what to render when there's
+  // nothing to show.
+  return (
+    <ChartContainer config={durationStackConfig} className="aspect-[3/1] w-full">
+      <BarChart data={data} margin={{ left: 0, right: 0, top: 4, bottom: 0 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          interval="preserveStartEnd"
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(v: number) => `${v}h`}
+          width={50}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              // Read the raw `seconds` payload off the row so sub-hour
+              // spans don't get truncated to `0h` by the chart's plotted
+              // value (which is in hours).
+              formatter={(_value, _name, item) => {
+                const seconds = (item?.payload as DailyDurationData | undefined)
+                  ?.seconds;
+                return typeof seconds === "number"
+                  ? `${formatDuration(seconds)} Duration`
+                  : `${_value} Duration`;
+              }}
+            />
+          }
+        />
+        {/* Legend rendered by the parent in WhenChart's header. */}
+        <Bar
+          dataKey="hours"
+          fill="var(--color-hours)"
+          radius={[3, 3, 0, 0]}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/packages/views/runtimes/components/charts/index.ts
+++ b/packages/views/runtimes/components/charts/index.ts
@@ -1,4 +1,5 @@
 export { DailyCostChart, costStackConfig } from "./daily-cost-chart";
 export { DailyTokensChart, tokenStackConfig } from "./daily-tokens-chart";
+export { DailyDurationChart, durationStackConfig } from "./daily-duration-chart";
 export { ActivityHeatmap } from "./activity-heatmap";
 export { HourlyActivityChart } from "./hourly-activity-chart";

--- a/packages/views/runtimes/components/usage-section.tsx
+++ b/packages/views/runtimes/components/usage-section.tsx
@@ -7,11 +7,12 @@ import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { Button } from "@multica/ui/components/ui/button";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { agentListOptions } from "@multica/core/workspace/queries";
-import type { RuntimeUsage } from "@multica/core/types";
+import type { RuntimeUsage, RuntimeRunDuration } from "@multica/core/types";
 import {
   runtimeUsageOptions,
   runtimeUsageByAgentOptions,
   runtimeUsageByHourOptions,
+  runtimeUsageDurationOptions,
 } from "@multica/core/runtimes/queries";
 import { useCustomPricingStore } from "@multica/core/runtimes/custom-pricing-store";
 import {
@@ -22,6 +23,7 @@ import {
   aggregateCostByAgent,
   aggregateCostByModel,
   aggregateCostByHour,
+  buildDailyDurationSeries,
   collectUnmappedModels,
   pctChange,
   type CostByKey,
@@ -31,6 +33,7 @@ import { ActorAvatar } from "../../common/actor-avatar";
 import {
   DailyCostChart,
   DailyTokensChart,
+  DailyDurationChart,
   HourlyActivityChart,
   ActivityHeatmap,
 } from "./charts";
@@ -111,6 +114,14 @@ export function UsageSection({ runtimeId }: { runtimeId: string }) {
   const { data: usage = [], isLoading: loading } = useQuery(
     runtimeUsageOptions(runtimeId, 180),
   );
+  // Duration prefetch lives at the top so the empty-state check below
+  // doesn't trip on runtimes that have only failed / zero-token runs but
+  // still recorded execution time. Same 180d window as the token cache so
+  // WhenChart's slicing logic can stay symmetric. The downstream Daily tab
+  // reads through the same query key — TanStack dedupes.
+  const { data: duration = [] } = useQuery(
+    runtimeUsageDurationOptions(runtimeId, 180),
+  );
   const [days, setDays] = useState<TimeRange>(30);
   // Subscribe so the KPI cards (which call estimateCost at render-time, not
   // through a memo) re-evaluate when the user saves a custom rate. The
@@ -119,13 +130,14 @@ export function UsageSection({ runtimeId }: { runtimeId: string }) {
   useCustomPricingStore((s) => s.pricings);
 
   if (loading) return <UsageSkeleton />;
-  if (usage.length === 0) return <UsageEmpty />;
+  if (usage.length === 0 && duration.length === 0) return <UsageEmpty />;
 
   // Slice the cached 90-day window into the user's selected sub-window AND
   // the immediately prior window of equal length. The KPI delta ("+18% vs
   // prev") then compares like-for-like ranges instead of "this period vs
   // all of history".
   const { filtered, prevFiltered } = sliceWindow(usage, days);
+  const filteredDuration = sliceDurationWindow(duration, days);
   const totals = computeTotals(filtered);
   const prevTotals = computeTotals(prevFiltered);
 
@@ -223,6 +235,7 @@ export function UsageSection({ runtimeId }: { runtimeId: string }) {
         runtimeId={runtimeId}
         usage={usage}
         filtered={filtered}
+        duration={filteredDuration}
         days={days}
       />
 
@@ -246,17 +259,19 @@ export function UsageSection({ runtimeId }: { runtimeId: string }) {
 // ---------------------------------------------------------------------------
 
 type WhenTab = "daily" | "hourly" | "heatmap";
-type DailyMetric = "cost" | "tokens";
+type DailyMetric = "cost" | "tokens" | "duration";
 
 function WhenChart({
   runtimeId,
   usage,
   filtered,
+  duration,
   days,
 }: {
   runtimeId: string;
   usage: RuntimeUsage[];
   filtered: RuntimeUsage[];
+  duration: RuntimeRunDuration[];
   days: TimeRange;
 }) {
   const { t } = useT("runtimes");
@@ -280,6 +295,10 @@ function WhenChart({
   const { dailyCostStack, dailyTokens } = useMemo(
     () => aggregateByDate(filtered),
     [filtered, pricings],
+  );
+  const dailyDuration = useMemo(
+    () => buildDailyDurationSeries(duration),
+    [duration],
   );
   const hourlyCost = useMemo(
     () =>
@@ -318,12 +337,13 @@ function WhenChart({
                 [
                   { label: t(($) => $.usage.daily_metric_cost), value: "cost" },
                   { label: t(($) => $.usage.daily_metric_tokens), value: "tokens" },
+                  { label: t(($) => $.usage.daily_metric_duration), value: "duration" },
                 ] as const
               }
             />
           )}
         </div>
-        {tab !== "heatmap" && (
+        {tab !== "heatmap" && !(tab === "daily" && dailyMetric === "duration") && (
           <ChartLegend includeCacheRead={tab === "daily" && dailyMetric === "tokens"} />
         )}
       </div>
@@ -346,6 +366,7 @@ function WhenChart({
             metric={dailyMetric}
             costData={dailyCostStack}
             tokensData={dailyTokens}
+            durationData={dailyDuration}
             usage={filtered}
           />
         )}
@@ -360,11 +381,13 @@ function DailyTab({
   metric,
   costData,
   tokensData,
+  durationData,
   usage,
 }: {
   metric: DailyMetric;
   costData: Parameters<typeof DailyCostChart>[0]["data"];
   tokensData: Parameters<typeof DailyTokensChart>[0]["data"];
+  durationData: Parameters<typeof DailyDurationChart>[0]["data"];
   usage: RuntimeUsage[];
 }) {
   if (metric === "tokens") {
@@ -377,6 +400,15 @@ function DailyTab({
     );
     if (totalTokens === 0) return <EmptyChartState usage={usage} />;
     return <DailyTokensChart data={tokensData} />;
+  }
+  if (metric === "duration") {
+    // Duration is independent of token / cost data — show the empty hint
+    // only when no terminal run finished in-window. Unmapped-pricing
+    // diagnostics don't apply here, but EmptyChartState already handles
+    // the "no usage" copy without surfacing a pricing CTA.
+    const totalSeconds = durationData.reduce((s, d) => s + d.seconds, 0);
+    if (totalSeconds === 0) return <EmptyChartState usage={usage} />;
+    return <DailyDurationChart data={durationData} />;
   }
   const totalCost = costData.reduce((s, d) => s + d.total, 0);
   if (totalCost === 0) return <EmptyChartState usage={usage} />;
@@ -791,6 +823,16 @@ function sliceWindow(usage: RuntimeUsage[], days: number) {
       (u) => u.date >= isoPrev && u.date < isoCurrent,
     ),
   };
+}
+
+function sliceDurationWindow(
+  duration: RuntimeRunDuration[],
+  days: number,
+): RuntimeRunDuration[] {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const iso = cutoff.toISOString().slice(0, 10);
+  return duration.filter((d) => d.date >= iso);
 }
 
 interface UsageTotals {

--- a/packages/views/runtimes/utils.test.ts
+++ b/packages/views/runtimes/utils.test.ts
@@ -5,6 +5,7 @@ import {
   aggregateCostByModel,
   collectUnmappedModels,
   estimateCost,
+  formatDuration,
   isModelPriced,
 } from "./utils";
 
@@ -348,5 +349,33 @@ describe("user-supplied custom pricing", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const after = aggregateCostByModel(rows as any);
     expect(after[0]?.cost).toBeCloseTo(2, 5);
+  });
+});
+
+describe("formatDuration", () => {
+  it("renders sub-minute spans in seconds", () => {
+    expect(formatDuration(0)).toBe("0s");
+    expect(formatDuration(1)).toBe("1s");
+    expect(formatDuration(59)).toBe("59s");
+  });
+
+  it("renders minute spans with second remainder", () => {
+    expect(formatDuration(60)).toBe("1m");
+    expect(formatDuration(61)).toBe("1m 1s");
+    expect(formatDuration(3599)).toBe("59m 59s");
+  });
+
+  it("renders hour spans with minute remainder", () => {
+    expect(formatDuration(3600)).toBe("1h");
+    expect(formatDuration(3601)).toBe("1h");
+    expect(formatDuration(3660)).toBe("1h 1m");
+    // 12h 8m
+    expect(formatDuration(12 * 3600 + 8 * 60)).toBe("12h 8m");
+  });
+
+  it("guards against malformed input", () => {
+    expect(formatDuration(NaN)).toBe("0s");
+    expect(formatDuration(-1)).toBe("0s");
+    expect(formatDuration(Infinity)).toBe("0s");
   });
 });

--- a/packages/views/runtimes/utils.ts
+++ b/packages/views/runtimes/utils.ts
@@ -2,6 +2,7 @@ import type {
   RuntimeUsage,
   RuntimeUsageByAgent,
   RuntimeUsageByHour,
+  RuntimeRunDuration,
 } from "@multica/core/types";
 import { getCustomPricing } from "@multica/core/runtimes/custom-pricing-store";
 
@@ -97,6 +98,27 @@ export function isVersionNewer(latest: string, current: string): boolean {
     if (lv < cv) return false;
   }
   return false;
+}
+
+// Smart-unit duration formatter. Picks the largest unit that gives a
+// non-zero leading number so a 2-hour 3-minute span reads as `2h 3m`
+// rather than `7380s`, while sub-minute spikes keep second-precision.
+// Negative or NaN inputs collapse to `0s` so a bad row never renders as
+// `-` or `NaN`.
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "0s";
+  const s = Math.floor(seconds);
+  if (s >= 3600) {
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  }
+  if (s >= 60) {
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    return r > 0 ? `${m}m ${r}s` : `${m}m`;
+  }
+  return `${s}s`;
 }
 
 export function formatTokens(n: number): string {
@@ -345,6 +367,39 @@ export interface DailyCostStackData {
   output: number;
   cacheWrite: number;
   total: number;
+}
+
+export interface DailyDurationData {
+  date: string;
+  label: string;
+  seconds: number;
+  hours: number;
+}
+
+// Sort-and-label helper for the Daily Runtime Duration chart. Mirrors the
+// `${month}/${day}` label format used by daily-tokens / daily-cost so all
+// three metrics share an X axis at the same window. `hours` is the chart
+// payload (Recharts plots numeric series; we want a tidy Y axis like 0.5
+// rather than 1800), and the tooltip falls back to `seconds` to apply
+// `formatDuration` for human-readable spans across magnitudes.
+export function buildDailyDurationSeries(
+  rows: RuntimeRunDuration[],
+): DailyDurationData[] {
+  const formatLabel = (d: string) => {
+    const date = new Date(d + "T00:00:00");
+    return `${date.getMonth() + 1}/${date.getDate()}`;
+  };
+  return [...rows]
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .map((r) => {
+      const seconds = Math.max(0, r.duration_seconds);
+      return {
+        date: r.date,
+        label: formatLabel(r.date),
+        seconds,
+        hours: Math.round((seconds / 3600) * 100) / 100,
+      };
+    });
 }
 
 export interface ModelDistribution {

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -519,6 +519,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Get("/usage", h.GetRuntimeUsage)
 					r.Get("/usage/by-agent", h.GetRuntimeUsageByAgent)
 					r.Get("/usage/by-hour", h.GetRuntimeUsageByHour)
+					r.Get("/usage/duration", h.GetRuntimeRunDuration)
 					r.Get("/activity", h.GetRuntimeTaskActivity)
 					r.Post("/update", h.InitiateUpdate)
 					r.Get("/update/{updateId}", h.GetUpdate)

--- a/server/internal/handler/runtime.go
+++ b/server/internal/handler/runtime.go
@@ -320,6 +320,62 @@ func (h *Handler) GetRuntimeUsageByHour(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// RuntimeRunDurationResponse is one (date, duration_seconds) row of the
+// Daily Runtime Duration chart. Each row is the total wall-clock duration
+// of terminal runs (completed / failed) whose completed_at fell on `date`
+// in the runtime's local tz. See GetRuntimeRunDurationByDay query for the
+// bucket semantics — cross-midnight runs are attributed to their
+// completion day, not split.
+type RuntimeRunDurationResponse struct {
+	Date            string `json:"date"`
+	DurationSeconds int64  `json:"duration_seconds"`
+}
+
+// GetRuntimeRunDuration returns per-day total run duration for a runtime.
+// Drives the Duration metric in the runtime-detail Daily tab. The data
+// comes straight from agent_task_queue (no rollup table): the source table
+// is small enough that direct scans are fine, and the partial index from
+// migration 091 keeps the working set bounded.
+func (h *Handler) GetRuntimeRunDuration(w http.ResponseWriter, r *http.Request) {
+	runtimeID := chi.URLParam(r, "runtimeId")
+	runtimeUUID, ok := parseUUIDOrBadRequest(w, runtimeID, "runtime_id")
+	if !ok {
+		return
+	}
+
+	rt, err := h.Queries.GetAgentRuntime(r.Context(), runtimeUUID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "runtime not found")
+		return
+	}
+
+	if _, ok := h.requireWorkspaceMember(w, r, uuidToString(rt.WorkspaceID), "runtime not found"); !ok {
+		return
+	}
+
+	since := parseSinceParamInTZ(r, 90, rt.Timezone)
+
+	rows, err := h.Queries.GetRuntimeRunDurationByDay(r.Context(), db.GetRuntimeRunDurationByDayParams{
+		RuntimeID: rt.ID,
+		Tz:        rt.Timezone,
+		Since:     since,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get runtime duration")
+		return
+	}
+
+	resp := make([]RuntimeRunDurationResponse, len(rows))
+	for i, row := range rows {
+		resp[i] = RuntimeRunDurationResponse{
+			Date:            row.Day.Time.Format("2006-01-02"),
+			DurationSeconds: row.DurationSeconds,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // GetWorkspaceUsageByDay returns daily token usage aggregated by model for the workspace.
 func (h *Handler) GetWorkspaceUsageByDay(w http.ResponseWriter, r *http.Request) {
 	workspaceID := h.resolveWorkspaceID(r)

--- a/server/migrations/091_agent_task_queue_terminal_completed_index.down.sql
+++ b/server/migrations/091_agent_task_queue_terminal_completed_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS idx_agent_task_queue_terminal_completed;

--- a/server/migrations/091_agent_task_queue_terminal_completed_index.up.sql
+++ b/server/migrations/091_agent_task_queue_terminal_completed_index.up.sql
@@ -1,0 +1,21 @@
+-- Partial index supporting GetRuntimeRunDurationByDay (MUL-2283 — Daily
+-- Runtime Duration chart). The query filters by runtime_id, restricts to
+-- terminal rows ('completed' / 'failed') with non-null started_at /
+-- completed_at, and buckets by completed_at in the runtime's local tz.
+--
+-- Without a runtime-scoped partial index on completed_at the planner falls
+-- back to a runtime_id-only scan and re-evaluates the terminal-status filter
+-- per row. As terminal rows accumulate over the lifetime of a runtime this
+-- gets expensive; the partial index keeps the working set bounded to the
+-- subset the chart actually reads.
+--
+-- CONCURRENTLY because agent_task_queue is hot — a plain CREATE INDEX would
+-- take an ACCESS EXCLUSIVE lock and block the dispatch path during build.
+-- Matches the pattern in 080; the migration runner cannot mix CONCURRENTLY
+-- with other statements in the same file, so this lives in its own
+-- single-statement migration.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_task_queue_terminal_completed
+    ON agent_task_queue (runtime_id, completed_at)
+    WHERE status IN ('completed', 'failed')
+      AND started_at IS NOT NULL
+      AND completed_at IS NOT NULL;

--- a/server/pkg/db/generated/runtime_usage.sql.go
+++ b/server/pkg/db/generated/runtime_usage.sql.go
@@ -11,6 +11,64 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const getRuntimeRunDurationByDay = `-- name: GetRuntimeRunDurationByDay :many
+SELECT
+    date_trunc('day', completed_at AT TIME ZONE $2::text)::date AS day,
+    SUM(EXTRACT(EPOCH FROM (completed_at - started_at)))::bigint AS duration_seconds
+FROM agent_task_queue
+WHERE runtime_id = $1
+  AND status IN ('completed', 'failed')
+  AND started_at IS NOT NULL
+  AND completed_at IS NOT NULL
+  AND completed_at >= $3::timestamptz
+GROUP BY 1
+ORDER BY 1
+`
+
+type GetRuntimeRunDurationByDayParams struct {
+	RuntimeID pgtype.UUID        `json:"runtime_id"`
+	Tz        string             `json:"tz"`
+	Since     pgtype.Timestamptz `json:"since"`
+}
+
+type GetRuntimeRunDurationByDayRow struct {
+	Day             pgtype.Date `json:"day"`
+	DurationSeconds int64       `json:"duration_seconds"`
+}
+
+// Per-day total run duration (seconds) for a runtime since a cutoff. Powers
+// the "Daily Runtime Duration" metric on the runtime detail page. Bucket
+// semantics: each terminal run's entire (completed_at - started_at) span
+// is attributed to the day that contains its completed_at in the runtime's
+// local tz. Cross-midnight runs are NOT split across days — this aligns
+// with the dashboard's existing "completed window" treatment and avoids
+// the cost of generate_series range slicing for an outlier case.
+//
+// Only terminal rows ('completed' / 'failed') with both timestamps set
+// are counted; same eligibility as ListDashboardAgentRunTime. Backed by
+// the partial index idx_agent_task_queue_terminal_completed (migration
+// 091); make sure to keep the WHERE clause aligned with the index
+// predicate so the planner can use it.
+func (q *Queries) GetRuntimeRunDurationByDay(ctx context.Context, arg GetRuntimeRunDurationByDayParams) ([]GetRuntimeRunDurationByDayRow, error) {
+	rows, err := q.db.Query(ctx, getRuntimeRunDurationByDay, arg.RuntimeID, arg.Tz, arg.Since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetRuntimeRunDurationByDayRow{}
+	for rows.Next() {
+		var i GetRuntimeRunDurationByDayRow
+		if err := rows.Scan(&i.Day, &i.DurationSeconds); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getRuntimeTaskHourlyActivity = `-- name: GetRuntimeTaskHourlyActivity :many
 SELECT EXTRACT(HOUR FROM started_at AT TIME ZONE $2::text)::int AS hour,
        COUNT(*)::int AS count

--- a/server/pkg/db/queries/runtime_usage.sql
+++ b/server/pkg/db/queries/runtime_usage.sql
@@ -91,6 +91,32 @@ WHERE atq.runtime_id = $1
 GROUP BY atq.agent_id, tu.model
 ORDER BY atq.agent_id, tu.model;
 
+-- name: GetRuntimeRunDurationByDay :many
+-- Per-day total run duration (seconds) for a runtime since a cutoff. Powers
+-- the "Daily Runtime Duration" metric on the runtime detail page. Bucket
+-- semantics: each terminal run's entire (completed_at - started_at) span
+-- is attributed to the day that contains its completed_at in the runtime's
+-- local tz. Cross-midnight runs are NOT split across days — this aligns
+-- with the dashboard's existing "completed window" treatment and avoids
+-- the cost of generate_series range slicing for an outlier case.
+--
+-- Only terminal rows ('completed' / 'failed') with both timestamps set
+-- are counted; same eligibility as ListDashboardAgentRunTime. Backed by
+-- the partial index idx_agent_task_queue_terminal_completed (migration
+-- 091); make sure to keep the WHERE clause aligned with the index
+-- predicate so the planner can use it.
+SELECT
+    date_trunc('day', completed_at AT TIME ZONE @tz::text)::date AS day,
+    SUM(EXTRACT(EPOCH FROM (completed_at - started_at)))::bigint AS duration_seconds
+FROM agent_task_queue
+WHERE runtime_id = $1
+  AND status IN ('completed', 'failed')
+  AND started_at IS NOT NULL
+  AND completed_at IS NOT NULL
+  AND completed_at >= @since::timestamptz
+GROUP BY 1
+ORDER BY 1;
+
 -- name: GetRuntimeUsageByHour :many
 -- Per-(hour, model) token aggregates (hour ∈ 0..23) for a runtime since a
 -- cutoff. Powers the "By hour" tab — shows when in the day this runtime is


### PR DESCRIPTION
## Summary

Adds a third Daily-tab metric (**Duration**) alongside Cost / Tokens on the runtime detail page's Usage section, per [MUL-2283](mention://issue/1b4a01b5-257f-4fd7-b1c1-0a4315863270) RFC v2.

- New endpoint `GET /api/runtimes/:runtimeId/usage/duration?days=N` returns per-local-tz-day total wall-clock duration of terminal runs (`completed` / `failed`). Bucketed by `completed_at`; cross-midnight runs are attributed to their completion day, not split.
- Backed by a new partial concurrent index `idx_agent_task_queue_terminal_completed` (migration 091) scoped to terminal rows with both timestamps non-null — keeps direct-scan cost bounded as terminal rows accumulate.
- Top-level `UsageSection` now prefetches the duration series and merges it into the empty-state check, so a runtime with only failed / zero-token runs no longer renders as "no data".
- New `DailyDurationChart` mirrors the existing daily-cost / daily-tokens chart layout; Y axis in hours, tooltip uses smart-unit `formatDuration` (h / m / s).

## Test plan

- [x] `pnpm typecheck` (all packages)
- [x] `pnpm --filter @multica/views test` (552 passed, including new `formatDuration` cases and locale parity)
- [x] `pnpm --filter @multica/core test` (266 passed)
- [x] `go build ./...`
- [ ] Local manual: select Duration metric, confirm chart renders with hour-scale Y axis, tooltip covers h/m/s tiers, 7/30/90 toggle keeps X axis aligned with Daily Tokens.
- [ ] Local manual: runtime with only failed / zero-token runs no longer shows the section-level empty state.

cc [@Emacs](mention://agent/df9a06c1-877d-4761-8147-f0bc2f8060b4) for review.