### PR TITLE
feat(views): show Total in daily token/cost chart tooltips (MUL-2282)

### DIFF
--- a/packages/ui/components/ui/chart.tsx
+++ b/packages/ui/components/ui/chart.tsx
@@ -127,6 +127,7 @@ function ChartTooltipContent({
   labelFormatter,
   labelClassName,
   formatter,
+  footer,
   color,
   nameKey,
   labelKey,
@@ -137,6 +138,16 @@ function ChartTooltipContent({
     indicator?: "line" | "dot" | "dashed"
     nameKey?: string
     labelKey?: string
+    footer?:
+      | React.ReactNode
+      | ((
+          payload: NonNullable<
+            RechartsPrimitive.DefaultTooltipContentProps<
+              TooltipValueType,
+              TooltipNameType
+            >["payload"]
+          >,
+        ) => React.ReactNode)
   } & Omit<
     RechartsPrimitive.DefaultTooltipContentProps<
       TooltipValueType,
@@ -266,6 +277,11 @@ function ChartTooltipContent({
             )
           })}
       </div>
+      {footer != null && (
+        <div className="mt-0.5 border-t border-border/50 pt-1.5">
+          {typeof footer === "function" ? footer(payload) : footer}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/views/locales/en/runtimes.json
+++ b/packages/views/locales/en/runtimes.json
@@ -154,7 +154,8 @@
   },
   "charts": {
     "heatmap_less": "Less",
-    "heatmap_more": "More"
+    "heatmap_more": "More",
+    "tooltip_total": "Total"
   },
   "list": {
     "col_runtime": "Runtime",

--- a/packages/views/locales/zh-Hans/runtimes.json
+++ b/packages/views/locales/zh-Hans/runtimes.json
@@ -149,7 +149,8 @@
   },
   "charts": {
     "heatmap_less": "少",
-    "heatmap_more": "多"
+    "heatmap_more": "多",
+    "tooltip_total": "总计"
   },
   "list": {
     "col_runtime": "运行时",

--- a/packages/views/runtimes/components/charts/daily-cost-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-cost-chart.tsx
@@ -12,6 +12,7 @@ import {
   type ChartConfig,
 } from "@multica/ui/components/ui/chart";
 import type { DailyCostStackData } from "../../utils";
+import { useT } from "../../../i18n";
 
 // Three-segment stack (input / output / cache write) — keeps the user's
 // attention on what's actually driving spend. Cache reads are excluded
@@ -29,6 +30,7 @@ export const costStackConfig = {
 } satisfies ChartConfig;
 
 export function DailyCostChart({ data }: { data: DailyCostStackData[] }) {
+  const { t } = useT("runtimes");
   // No internal empty-state — the parent decides what to show in place of
   // the chart (often a diagnostic explaining *why* there's no cost). Letting
   // recharts render an empty axis would be both ugly and uninformative.
@@ -67,7 +69,7 @@ export function DailyCostChart({ data }: { data: DailyCostStackData[] }) {
                 );
                 return (
                   <div className="flex items-center justify-between gap-2 font-medium">
-                    <span>Total</span>
+                    <span>{t(($) => $.charts.tooltip_total)}</span>
                     <span className="font-mono tabular-nums">
                       ${total.toFixed(2)}
                     </span>

--- a/packages/views/runtimes/components/charts/daily-cost-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-cost-chart.tsx
@@ -58,6 +58,22 @@ export function DailyCostChart({ data }: { data: DailyCostStackData[] }) {
                   ? `$${value.toFixed(2)} ${name}`
                   : `${value} ${name}`
               }
+              footer={(payload) => {
+                const total = payload.reduce(
+                  (sum, item) =>
+                    sum +
+                    (typeof item.value === "number" ? item.value : 0),
+                  0,
+                );
+                return (
+                  <div className="flex items-center justify-between gap-2 font-medium">
+                    <span>Total</span>
+                    <span className="font-mono tabular-nums">
+                      ${total.toFixed(2)}
+                    </span>
+                  </div>
+                );
+              }}
             />
           }
         />

--- a/packages/views/runtimes/components/charts/daily-tokens-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-tokens-chart.tsx
@@ -60,6 +60,22 @@ export function DailyTokensChart({ data }: { data: DailyTokenData[] }) {
                   ? `${formatTokens(value)} ${name}`
                   : `${value} ${name}`
               }
+              footer={(payload) => {
+                const total = payload.reduce(
+                  (sum, item) =>
+                    sum +
+                    (typeof item.value === "number" ? item.value : 0),
+                  0,
+                );
+                return (
+                  <div className="flex items-center justify-between gap-2 font-medium">
+                    <span>Total</span>
+                    <span className="font-mono tabular-nums">
+                      {total.toLocaleString()}
+                    </span>
+                  </div>
+                );
+              }}
             />
           }
         />

--- a/packages/views/runtimes/components/charts/daily-tokens-chart.tsx
+++ b/packages/views/runtimes/components/charts/daily-tokens-chart.tsx
@@ -12,6 +12,7 @@ import {
   type ChartConfig,
 } from "@multica/ui/components/ui/chart";
 import { formatTokens, type DailyTokenData } from "../../utils";
+import { useT } from "../../../i18n";
 
 // Four-segment stack — input / output / cache read / cache write. Unlike the
 // cost chart, cache reads ARE visible here: a typical day on Claude shows
@@ -32,6 +33,7 @@ export const tokenStackConfig = {
 } satisfies ChartConfig;
 
 export function DailyTokensChart({ data }: { data: DailyTokenData[] }) {
+  const { t } = useT("runtimes");
   // No internal empty-state — same convention as DailyCostChart: the parent
   // decides what to render when there's nothing to show.
   return (
@@ -69,7 +71,7 @@ export function DailyTokensChart({ data }: { data: DailyTokenData[] }) {
                 );
                 return (
                   <div className="flex items-center justify-between gap-2 font-medium">
-                    <span>Total</span>
+                    <span>{t(($) => $.charts.tooltip_total)}</span>
                     <span className="font-mono tabular-nums">
                       {total.toLocaleString()}
                     </span>


### PR DESCRIPTION
## Summary

Closes [MUL-2282](https://github.com/multica-ai/multica/issues) — show a precise Total when hovering the daily token / daily cost charts on a runtime's Usage page.

- `packages/ui/components/ui/chart.tsx`: extend `ChartTooltipContent` with an optional `footer` prop (`ReactNode | (payload) => ReactNode`), rendered below the items with a top divider. Backwards-compatible — no change when `footer` is omitted.
- `packages/views/runtimes/components/charts/daily-tokens-chart.tsx`: tooltip footer sums the stacked token segments and renders `Total {value.toLocaleString()}` (precise count, complementing the `formatTokens` abbreviations above).
- `packages/views/runtimes/components/charts/daily-cost-chart.tsx`: tooltip footer sums the stacked cost segments and renders `Total ${value.toFixed(2)}` (consistent with the per-stack `$X.XX` format).

## Test plan

- [x] `pnpm --filter @multica/ui typecheck`
- [x] `pnpm --filter @multica/views typecheck`
- [x] `git diff --check`
- [x] Manual verification in a local isolated env with seeded daily token / daily cost data: hovering each chart shows the per-stack breakdown plus a `Total xxx` / `Total $X.XX` row at the bottom. Verified by Jiayuan (LGTM).
- [x] Tooltips that don't pass `footer` (other charts using `ChartTooltipContent`) render unchanged.