### PR TITLE
fix(views): narrow agent/squad create dialogs to max-w-2xl

### DIFF
--- a/packages/views/agents/components/create-agent-dialog.tsx
+++ b/packages/views/agents/components/create-agent-dialog.tsx
@@ -225,7 +225,7 @@ export function CreateAgentDialog({
 
   return (
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
-      <DialogContent className="p-0 gap-0 flex flex-col overflow-hidden !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !w-full !max-w-4xl !h-[85vh]">
+      <DialogContent className="p-0 gap-0 flex flex-col overflow-hidden !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !w-full !max-w-2xl !h-[85vh]">
         <DialogHeader className="border-b px-5 py-3 space-y-0">
           <DialogTitle className="text-base font-semibold">{headerTitle}</DialogTitle>
           {isDuplicate && template && (

--- a/packages/views/modals/create-squad.tsx
+++ b/packages/views/modals/create-squad.tsx
@@ -142,7 +142,7 @@ export function CreateSquadModal({ onClose }: { onClose: () => void }) {
 
   return (
     <Dialog open onOpenChange={(v) => { if (!v) onClose(); }}>
-      <DialogContent className="p-0 gap-0 flex flex-col overflow-hidden !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !w-full !max-w-4xl !h-[85vh]">
+      <DialogContent className="p-0 gap-0 flex flex-col overflow-hidden !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !w-full !max-w-2xl !h-[85vh]">
         <DialogHeader className="border-b px-5 py-3 space-y-0">
           <DialogTitle className="text-base font-semibold">
             {t(($) => $.create_squad.title)}


### PR DESCRIPTION
## Summary
- Change agent/squad creation dialogs from `!max-w-4xl` to `!max-w-2xl`; both stay consistent.

Follow-up to #2688 per [MUL-2288](https://github.com/multica-ai/multica/issues).

## Test plan
- [ ] Open agent creation dialog — width is narrower (max-w-2xl).
- [ ] Open squad creation dialog — same width as agent dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)