### PR TITLE
fix(skills): keep skill title input transparent in dark mode

### DIFF
--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -679,7 +679,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
               readOnly={!canEdit}
               onChange={(e) => setName(e.target.value)}
               placeholder={t(($) => $.detail.name_placeholder)}
-              className="h-9 border-0 bg-transparent px-0 text-lg font-semibold shadow-none focus-visible:ring-0 read-only:cursor-default"
+              className="h-9 border-0 bg-transparent px-0 text-lg font-semibold shadow-none focus-visible:ring-0 read-only:cursor-default dark:bg-transparent"
               aria-label={t(($) => $.detail.name_aria)}
             />
             <div className="space-y-1">


### PR DESCRIPTION
## Summary

The Skill name `<Input>` on the skill detail editor (`packages/views/skills/components/skill-detail-page.tsx`) renders as flush, chrome-less text via `bg-transparent px-0`. The base `Input` component also applies `dark:bg-input/30`, which Tailwind keeps because it lives under the `dark:` variant. In dark mode this exposes a 30% white fill that sits flush against the text — visually it looks like the title is missing left padding.

This change appends `dark:bg-transparent` to the caller's className so the override wins in both color modes. Light mode keeps its existing `bg-transparent px-0` behavior unchanged.

## Repro

1. Open any Skill from the sidebar (`/<runtime>/skills/<skill-id>`).
2. Switch to dark mode.
3. The Skill name title input shows a faint filled background flush against the text.

<img width="950" height="344" alt="CleanShot 2026-05-16 at 07 13 15@2x" src="https://github.com/user-attachments/assets/38e493d3-e55f-46d3-883c-1c3efedbaef7" />

After the fix the title input is fully transparent in dark mode, matching light mode.

## Scope

- Single-line className change on the title `<Input>` only.
- `Input` component base class and other inputs are untouched.
- Follows the same `dark:bg-transparent` override pattern already used in `input-group.tsx`.

## Test plan

- [x] Verified diff scoped to the Skill name input.
- [x] `git diff --check` clean.
- [x] Visual check in dark mode on `/<runtime>/skills/<skill-id>`.