### PR TITLE
fix(agent): use openclaw agent id instead of name for --agent flag

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -869,19 +869,28 @@ func openclawEntriesToModels(entries []openclawAgentEntry) []Model {
 	models := make([]Model, 0, len(entries))
 	seen := map[string]bool{}
 	for _, e := range entries {
-		name := e.Name
-		if name == "" {
-			name = e.ID
+		// Use ID as the model identifier because openclaw resolves
+		// --agent by id, not by display name. Names may contain spaces
+		// (e.g. "Sub2API OPS") which openclaw's normalizeAgentId would
+		// mangle into a different string ("sub2api-ops"), causing a
+		// lookup miss and "no parseable output" errors.
+		id := e.ID
+		if id == "" {
+			id = e.Name
 		}
-		if name == "" || seen[name] {
+		if id == "" || seen[id] {
 			continue
 		}
-		seen[name] = true
-		label := name
-		if e.Model != "" {
-			label = name + " (" + e.Model + ")"
+		seen[id] = true
+		displayName := e.Name
+		if displayName == "" {
+			displayName = id
 		}
-		models = append(models, Model{ID: name, Label: label, Provider: "openclaw"})
+		label := displayName
+		if e.Model != "" {
+			label = displayName + " (" + e.Model + ")"
+		}
+		models = append(models, Model{ID: id, Label: label, Provider: "openclaw"})
 	}
 	return models
 }

--- a/server/pkg/agent/models_test.go
+++ b/server/pkg/agent/models_test.go
@@ -407,6 +407,26 @@ func TestParseOpenclawAgentsJSONWrapped(t *testing.T) {
 	}
 }
 
+func TestOpenclawEntriesToModelsUsesIDOverName(t *testing.T) {
+	// When both id and name are present, Model.ID should use the id field
+	// because openclaw resolves --agent by id. Names with spaces (e.g.
+	// "Sub2API OPS") would be mangled by openclaw's normalizeAgentId.
+	input := []byte(`[{"id": "sub2api", "name": "Sub2API OPS", "model": "gpt-4o"}]`)
+	models, ok := parseOpenclawAgentsJSON(input)
+	if !ok {
+		t.Fatal("expected parseOpenclawAgentsJSON to accept array")
+	}
+	if len(models) != 1 {
+		t.Fatalf("got %d models, want 1", len(models))
+	}
+	if models[0].ID != "sub2api" {
+		t.Errorf("Model.ID = %q, want %q (should use id, not name)", models[0].ID, "sub2api")
+	}
+	if models[0].Label != "Sub2API OPS (gpt-4o)" {
+		t.Errorf("Model.Label = %q, want %q (should use name for display)", models[0].Label, "Sub2API OPS (gpt-4o)")
+	}
+}
+
 func TestParseOpenclawAgentsJSONRejectsGarbage(t *testing.T) {
 	if _, ok := parseOpenclawAgentsJSON([]byte("not json")); ok {
 		t.Error("expected ok=false for non-JSON")


### PR DESCRIPTION
## What

Fix OpenClaw agent name with spaces (e.g. "Sub2API OPS") causing "openclaw returned no parseable output" error.

## Related Issue

Closes #2714

## Type

- [x] Bug fix

## Changes

`openclawEntriesToModels()` used the agent **Name** (which may contain spaces) as `Model.ID`. This ID is passed to the openclaw CLI via `--agent`, where `normalizeAgentId` mangles spaces into hyphens — e.g. `"Sub2API OPS"` becomes `"sub2api-ops"`, which does not match the registered agent id `"sub2api"`.

**Fix:** Prefer agent `ID` for `Model.ID` (used in `--agent` flag); use `Name` only for the display `Label`. When `ID` is empty, fall back to `Name` for backward compatibility.

### Files changed

- `server/pkg/agent/models.go` — `openclawEntriesToModels`: ID-first priority for model identifier
- `server/pkg/agent/models_test.go` — Added `TestOpenclawEntriesToModelsUsesIDOverName` verifying ID is used over Name with spaces

## How to Test

1. Register an OpenClaw agent with `"id": "sub2api", "name": "Sub2API OPS"`
2. In Multica, select this agent and send a chat message
3. Before fix: "openclaw returned no parseable output" after 10s
4. After fix: agent responds correctly (passes `--agent sub2api`)

```bash
cd server && go test ./pkg/agent/ -run TestOpenclawEntries -v
cd server && go test ./pkg/agent/ -run TestParseOpenclawAgents -v
```

## Checklist

- [x] Changes are limited to the bug fix
- [x] Existing tests pass
- [x] New test added for the fix
- [x] `go vet` clean

## AI Disclosure

This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent.

## Thinking path

1. Issue reports agent name with space fails → traced the data flow:
   - `discoverOpenclawAgents` → `parseOpenclawAgentsJSON` → `openclawEntriesToModels` → `Model.ID` = Name
   - `buildOpenclawArgs` passes `Model.ID` (= Name with spaces) to `--agent` flag
   - OpenClaw's `normalizeAgentId` converts spaces to hyphens → ID mismatch → lookup failure
2. Confirmed by reading OpenClaw source: `VALID_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i`, `INVALID_CHARS_RE = /[^a-z0-9_-]+/g` — spaces are invalid chars replaced with `-`
3. Fix: use agent ID (no spaces) for CLI identification, Name for human-readable labels only