### PR TITLE
fix(realtime): invalidate per-issue token usage on task events (MUL-2298)

### DIFF
--- a/packages/core/realtime/use-realtime-sync.ts
+++ b/packages/core/realtime/use-realtime-sync.ts
@@ -262,6 +262,10 @@ export function useRealtimeSync(
         // every list-of-tasks query stale" so cache stays fresh even
         // when the relevant component isn't currently mounted.
         qc.invalidateQueries({ queryKey: ["issues", "tasks"] });
+        // Per-issue token usage card (issue-detail right rail). Same
+        // shape as the tasks invalidation above — any task lifecycle
+        // event shifts the aggregated usage numbers.
+        qc.invalidateQueries({ queryKey: ["issues", "usage"] });
       },
     };
 


### PR DESCRIPTION
## Summary

Fix the issue-detail right-rail **Token usage** card not refreshing in real time. The card is fed by `useQuery(issueUsageOptions(id))`, but the realtime `task:` handler in `packages/core/realtime/use-realtime-sync.ts` only invalidated `["issues","tasks"]`. As a result the card only refreshed on remount — consecutive runs on the same issue left the numbers stuck until the user navigated away and back.

Mirror the existing tasks invalidation with a prefix invalidation of `["issues","usage"]` so any task lifecycle event refreshes the aggregated usage numbers. No polling, no `staleTime` workarounds — matches the project's WS-driven invalidation convention.

Issue: [MUL-2298](https://github.com/multica-ai/multica/issues) — 侧边栏 token usage 显示未实时更新

## Test plan

End-to-end verification with Playwright on the local isolated env (same page session, no remount).

**With fix — 3 consecutive runs on the same issue detail page:**

| Run | `task:completed` | next `GET /usage` | Δ | returned `task_count` |
|---|---|---|---|---|
| initial mount | — | 10:31:27.977 | — | 1 |
| 1 | 10:31:41.311 | 10:31:41.451 | **+140ms** | 1 → 2 |
| 2 | 10:32:01.984 | 10:32:02.126 | **+142ms** | 2 → 3 |
| 3 | 10:32:19.206 | 10:32:19.363 | **+157ms** | 3 → 4 |

Card refreshes within ~140–160ms of each `task:completed`.

**Without fix (the invalidate line temporarily reverted, HMR applied) — 3 consecutive runs:**

| Run | `task:completed` | next `GET /usage` |
|---|---|---|
| initial mount | — | 10:32:56.180 (task_count=4) |
| 1 | 10:33:10.941 | **not triggered** |
| 2 | 10:33:27.163 | **not triggered** |
| 3 | 10:33:44.602 | **not triggered** |

Over ~50s, three runs completed and the card stayed at `task_count=4` while the backend aggregate had already advanced to 5/6/7 — exactly the user-reported "non-realtime" symptom.

Also ran:
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/core exec vitest run realtime/use-realtime-sync-ws-instance.test.tsx`
- `git diff --check`
