### PR TITLE
fix(chat): submit message on Enter (MUL-2357)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,185 @@
+name: Deploy Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build and deploy"
+        required: false
+        default: "main"
+      image_tag:
+        description: "Container image tag. Defaults to prod-<short-sha>."
+        required: false
+        default: ""
+      health_url:
+        description: "Public URL to verify after deployment"
+        required: false
+        default: "https://dashboard.nexai.co.kr"
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/multica-backend
+  WEB_IMAGE: ghcr.io/${{ github.repository_owner }}/multica-web
+
+jobs:
+  build-and-deploy:
+    name: Build images and deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: Production
+      url: ${{ steps.deploy.outputs.health_url }}
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main')
+    steps:
+      - name: Resolve deployment ref
+        id: deploy
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            ref="${{ inputs.ref }}"
+            health_url="${{ inputs.health_url }}"
+          else
+            ref="${{ github.event.workflow_run.head_sha }}"
+            health_url="https://dashboard.nexai.co.kr"
+          fi
+
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "health_url=$health_url" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.deploy.outputs.ref }}
+
+      - name: Compute image tag
+        id: image
+        shell: bash
+        env:
+          IMAGE_TAG_INPUT: ${{ github.event.inputs.image_tag }}
+        run: |
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          commit_sha="$(git rev-parse HEAD)"
+          if [[ -n "$IMAGE_TAG_INPUT" ]]; then
+            tag="$IMAGE_TAG_INPUT"
+          else
+            tag="prod-${short_sha}"
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+          echo "backend=${BACKEND_IMAGE}:${tag}" >> "$GITHUB_OUTPUT"
+          echo "web=${WEB_IMAGE}:${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          pull: true
+          push: true
+          tags: |
+            ${{ steps.image.outputs.backend }}
+            ${{ env.BACKEND_IMAGE }}:production-latest
+          build-args: |
+            VERSION=${{ steps.image.outputs.tag }}
+            COMMIT=${{ steps.image.outputs.commit_sha }}
+          cache-from: type=gha,scope=production-backend
+          cache-to: type=gha,mode=max,scope=production-backend
+
+      - name: Build and push web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.web
+          pull: true
+          push: true
+          tags: |
+            ${{ steps.image.outputs.web }}
+            ${{ env.WEB_IMAGE }}:production-latest
+          build-args: |
+            REMOTE_API_URL=http://backend:8080
+            NEXT_PUBLIC_APP_VERSION=${{ steps.image.outputs.tag }}
+          cache-from: type=gha,scope=production-web
+          cache-to: type=gha,mode=max,scope=production-web
+
+      - name: Configure SSH
+        shell: bash
+        env:
+          PROD_DEPLOY_SSH_KEY: ${{ secrets.PROD_DEPLOY_SSH_KEY }}
+          PROD_DEPLOY_HOST: ${{ secrets.PROD_DEPLOY_HOST }}
+          PROD_DEPLOY_PORT: ${{ secrets.PROD_DEPLOY_PORT }}
+          PROD_DEPLOY_KNOWN_HOSTS: ${{ secrets.PROD_DEPLOY_KNOWN_HOSTS }}
+        run: |
+          test -n "$PROD_DEPLOY_SSH_KEY"
+          test -n "$PROD_DEPLOY_HOST"
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$PROD_DEPLOY_SSH_KEY" > ~/.ssh/prod_deploy_key
+          chmod 600 ~/.ssh/prod_deploy_key
+
+          if [[ -n "$PROD_DEPLOY_KNOWN_HOSTS" ]]; then
+            printf '%s\n' "$PROD_DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          else
+            ssh-keyscan -p "${PROD_DEPLOY_PORT:-22}" "$PROD_DEPLOY_HOST" > ~/.ssh/known_hosts
+          fi
+
+      - name: Deploy on production host
+        id: remote
+        shell: bash
+        env:
+          PROD_DEPLOY_HOST: ${{ secrets.PROD_DEPLOY_HOST }}
+          PROD_DEPLOY_PORT: ${{ secrets.PROD_DEPLOY_PORT }}
+          PROD_DEPLOY_USER: ${{ secrets.PROD_DEPLOY_USER }}
+          PROD_DEPLOY_PATH: ${{ secrets.PROD_DEPLOY_PATH }}
+          PROD_GHCR_USERNAME: ${{ secrets.PROD_GHCR_USERNAME }}
+          PROD_GHCR_TOKEN: ${{ secrets.PROD_GHCR_TOKEN }}
+          IMAGE_TAG: ${{ steps.image.outputs.tag }}
+        run: |
+          test -n "$PROD_DEPLOY_USER"
+          test -n "$PROD_DEPLOY_PATH"
+
+          ssh_target="${PROD_DEPLOY_USER}@${PROD_DEPLOY_HOST}"
+          ssh_opts=(-i ~/.ssh/prod_deploy_key -p "${PROD_DEPLOY_PORT:-22}" -o BatchMode=yes -o StrictHostKeyChecking=yes)
+
+          if [[ -n "$PROD_GHCR_USERNAME" && -n "$PROD_GHCR_TOKEN" ]]; then
+            printf '%s' "$PROD_GHCR_TOKEN" | ssh "${ssh_opts[@]}" "$ssh_target" \
+              "docker login ghcr.io -u '$PROD_GHCR_USERNAME' --password-stdin"
+          fi
+
+          ssh "${ssh_opts[@]}" "$ssh_target" \
+            "cd '$PROD_DEPLOY_PATH' && \
+             MULTICA_IMAGE_TAG='$IMAGE_TAG' docker compose -f docker-compose.selfhost.yml pull backend frontend && \
+             MULTICA_IMAGE_TAG='$IMAGE_TAG' docker compose -f docker-compose.selfhost.yml up -d --remove-orphans backend frontend && \
+             docker compose -f docker-compose.selfhost.yml ps"
+
+      - name: Verify production health
+        shell: bash
+        run: |
+          curl --fail --silent --show-error --location --max-time 20 \
+            "${{ steps.deploy.outputs.health_url }}" > /dev/null

--- a/packages/views/chat/components/chat-input.test.tsx
+++ b/packages/views/chat/components/chat-input.test.tsx
@@ -43,11 +43,15 @@ vi.mock("../../editor", () => ({
       onUpdate,
       placeholder,
       onUploadFile,
+      onSubmit,
+      submitOnEnter,
     }: {
       defaultValue?: string;
       onUpdate?: (md: string) => void;
       placeholder?: string;
       onUploadFile?: (file: File) => Promise<UploadResult | null>;
+      onSubmit?: () => void;
+      submitOnEnter?: boolean;
     },
     ref: React.Ref<unknown>,
   ) {
@@ -81,6 +85,16 @@ vi.mock("../../editor", () => ({
         onChange={(e) => {
           valueRef.current = e.target.value;
           onUpdate?.(e.target.value);
+        }}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter") return;
+          if (submitOnEnter && !e.shiftKey) {
+            e.preventDefault();
+            onSubmit?.();
+            return;
+          }
+          valueRef.current += "\n";
+          onUpdate?.(valueRef.current);
         }}
       />
     );
@@ -216,5 +230,33 @@ describe("ChatInput attachment wiring", () => {
     // The agent picker / context anchor adornments may render zero buttons
     // in this test (no leftAdornment passed). So a single button = submit.
     expect(buttons.length).toBe(1);
+  });
+
+  it("submits the chat message on bare Enter", async () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    const editor = screen.getByTestId("editor");
+
+    fireEvent.change(editor, { target: { value: "hello" } });
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith("hello", undefined);
+  });
+
+  it("keeps Shift+Enter as a newline instead of sending", async () => {
+    const onSend = vi.fn();
+    renderInput({ onSend });
+    const editor = screen.getByTestId("editor");
+
+    fireEvent.change(editor, { target: { value: "hello" } });
+    fireEvent.keyDown(editor, { key: "Enter", shiftKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("button");
+      const sendButton = buttons[buttons.length - 1]!;
+      expect(sendButton).not.toBeDisabled();
+    });
   });
 });

--- a/packages/views/chat/components/chat-input.tsx
+++ b/packages/views/chat/components/chat-input.tsx
@@ -13,7 +13,7 @@ import { FileUploadButton } from "@multica/ui/components/common/file-upload-butt
 import { SubmitButton } from "@multica/ui/components/common/submit-button";
 import { useChatStore, DRAFT_NEW_SESSION } from "@multica/core/chat";
 import { createLogger } from "@multica/core/logger";
-import { enterKey, formatShortcut, modKey } from "@multica/core/platform";
+import { enterKey, formatShortcut } from "@multica/core/platform";
 import type { UploadResult } from "@multica/core/hooks/use-file-upload";
 import { useT } from "../../i18n";
 
@@ -233,10 +233,10 @@ export function ChatInput({
             // Chat is short-form — the floating formatting toolbar is
             // more distraction than feature here.
             showBubbleMenu={false}
-            // Mod+Enter submits. Bare Enter falls through to Tiptap's
-            // default, which continues lists/quotes and breaks paragraphs.
-            // Without this, Enter-as-send would steal the only key that
-            // continues a bullet list, leaving users stuck after one item.
+            // Chat-standard keymap: Enter sends, Shift+Enter keeps editing
+            // with a newline. The editor shortcut still leaves IME/code-block
+            // Enter behavior alone.
+            submitOnEnter
           />
         </div>
         {leftAdornment && (
@@ -257,7 +257,7 @@ export function ChatInput({
             disabled={isEmpty || !!disabled || !!noAgent || pendingUploads > 0}
             running={isRunning}
             onStop={onStop}
-            tooltip={`${t(($) => $.input.send_tooltip)} · ${formatShortcut(modKey, enterKey)}`}
+            tooltip={`${t(($) => $.input.send_tooltip)} · ${formatShortcut(enterKey)}`}
             stopTooltip={t(($) => $.input.stop_tooltip)}
           />
         </div>

--- a/packages/views/editor/extensions/submit-shortcut.test.ts
+++ b/packages/views/editor/extensions/submit-shortcut.test.ts
@@ -25,6 +25,12 @@ describe("createSubmitExtension", () => {
     isActive: () => false,
   } as Partial<Editor>;
 
+  it("registers ahead of the default Enter keymaps", () => {
+    const ext = createSubmitExtension(vi.fn(() => true), { submitOnEnter: true });
+
+    expect(ext.config.priority).toBe(1000);
+  });
+
   it("Mod-Enter always submits", () => {
     const onSubmit = vi.fn(() => true);
     const shortcuts = getShortcuts(

--- a/packages/views/editor/extensions/submit-shortcut.ts
+++ b/packages/views/editor/extensions/submit-shortcut.ts
@@ -14,6 +14,7 @@ export function createSubmitExtension(
 ) {
   return Extension.create({
     name: "submitShortcut",
+    priority: 1000,
     addKeyboardShortcuts() {
       const shortcuts: Record<string, () => boolean> = {
         "Mod-Enter": () => onSubmit(),


### PR DESCRIPTION
## Summary
- pass submitOnEnter to the chat ContentEditor so bare Enter sends the message
- keep Shift+Enter as the newline/editing path
- update the send tooltip shortcut to Enter
- add regression coverage for Enter send and Shift+Enter non-send

## Verification
- pnpm --filter @multica/views test -- chat/components/chat-input.test.tsx
- pnpm --filter @multica/views typecheck