### PR TITLE
Isolate OpenCode data home per task

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2356,6 +2356,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			agentEnv[k] = v
 		}
 	}
+	// OpenCode stores opencode.db below XDG_DATA_HOME. Apply this after
+	// custom_env so the per-task state isolation cannot be overwritten by
+	// agent settings.
+	applyOpenCodeDataHome(agentEnv, env)
 	backend, err := agent.New(provider, agent.Config{
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,
@@ -3129,6 +3133,13 @@ func composeOpenclawIncludeRoots(addRoot, userValue string) (string, bool) {
 		parts = append(parts, p)
 	}
 	return strings.Join(parts, string(os.PathListSeparator)), true
+}
+
+func applyOpenCodeDataHome(agentEnv map[string]string, env *execenv.Environment) {
+	if env == nil || env.OpenCodeDataHome == "" {
+		return
+	}
+	agentEnv["XDG_DATA_HOME"] = env.OpenCodeDataHome
 }
 
 // isBlockedEnvKey returns true if the key must not be overridden by user-

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
 	"github.com/multica-ai/multica/server/pkg/agent"
 )
@@ -276,6 +277,21 @@ func TestComposeOpenclawIncludeRoots(t *testing.T) {
 				t.Errorf("got = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestApplyOpenCodeDataHome(t *testing.T) {
+	t.Parallel()
+
+	agentEnv := map[string]string{
+		"XDG_DATA_HOME": "/custom/data",
+	}
+	applyOpenCodeDataHome(agentEnv, &execenv.Environment{
+		OpenCodeDataHome: "/task/opencode-data",
+	})
+
+	if got := agentEnv["XDG_DATA_HOME"]; got != "/task/opencode-data" {
+		t.Fatalf("XDG_DATA_HOME = %q, want per-task OpenCode data home", got)
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -85,6 +85,11 @@ type Environment struct {
 	WorkDir string
 	// CodexHome is the path to the per-task CODEX_HOME directory (set only for codex provider).
 	CodexHome string
+	// OpenCodeDataHome is the per-task XDG_DATA_HOME used by OpenCode.
+	// OpenCode stores its SQLite state DB under XDG_DATA_HOME/opencode/,
+	// so sharing the daemon user's default data home across parallel tasks
+	// can surface as cross-task "database is locked" failures.
+	OpenCodeDataHome string
 	// OpenclawConfigPath is the path to the per-task synthesized OpenClaw
 	// config (set only for openclaw provider). The daemon exports this as
 	// OPENCLAW_CONFIG_PATH on the openclaw subprocess so its native skill
@@ -166,6 +171,17 @@ func Prepare(params PrepareParams, logger *slog.Logger) (*Environment, error) {
 		env.CodexHome = codexHome
 	}
 
+	// OpenCode stores mutable runtime state, including opencode.db, under
+	// XDG_DATA_HOME. Give each task its own data home so concurrent OpenCode
+	// tasks do not contend on the user's global SQLite database.
+	if params.Provider == "opencode" {
+		dataHome, err := ensureOpenCodeDataHome(envRoot)
+		if err != nil {
+			return nil, fmt.Errorf("execenv: prepare opencode data home: %w", err)
+		}
+		env.OpenCodeDataHome = dataHome
+	}
+
 	// For OpenClaw, synthesize a per-task config that pins workspace to
 	// workDir. The skill scanner then reads {workDir}/skills/ (written by
 	// writeContextFiles above). Fail closed on errors: a malformed user
@@ -229,6 +245,15 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 		}
 	}
 
+	if params.Provider == "opencode" {
+		dataHome, err := ensureOpenCodeDataHome(env.RootDir)
+		if err != nil {
+			logger.Warn("execenv: refresh opencode data home failed", "error", err)
+			return nil
+		}
+		env.OpenCodeDataHome = dataHome
+	}
+
 	// Refresh the per-task OpenClaw config on reuse — the user may have
 	// added/removed agents or rotated providers since the prior task ran,
 	// and the workspace override always re-targets the current workDir.
@@ -247,6 +272,14 @@ func Reuse(params ReuseParams, logger *slog.Logger) *Environment {
 
 	logger.Info("execenv: reusing env", "workdir", params.WorkDir)
 	return env
+}
+
+func ensureOpenCodeDataHome(envRoot string) (string, error) {
+	dataHome := filepath.Join(envRoot, "opencode-data")
+	if err := os.MkdirAll(dataHome, 0o755); err != nil {
+		return "", err
+	}
+	return dataHome, nil
 }
 
 // hydrateCodexSkills populates the per-task CODEX_HOME/skills directory with

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1002,6 +1002,75 @@ func TestPrepareWithRepoContextOpencode(t *testing.T) {
 	}
 }
 
+func TestPrepareOpencodeSetsDataHome(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-test-oc-data",
+		TaskID:         "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		AgentName:      "OpenCode Agent",
+		Provider:       "opencode",
+		Task:           TaskContextForEnv{IssueID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	want := filepath.Join(env.RootDir, "opencode-data")
+	if env.OpenCodeDataHome != want {
+		t.Fatalf("OpenCodeDataHome = %q, want %q", env.OpenCodeDataHome, want)
+	}
+	if fi, err := os.Stat(want); err != nil {
+		t.Fatalf("OpenCodeDataHome should exist: %v", err)
+	} else if !fi.IsDir() {
+		t.Fatalf("OpenCodeDataHome should be a directory")
+	}
+}
+
+func TestReuseOpencodeRestoresDataHome(t *testing.T) {
+	t.Parallel()
+	workspacesRoot := t.TempDir()
+
+	env, err := Prepare(PrepareParams{
+		WorkspacesRoot: workspacesRoot,
+		WorkspaceID:    "ws-test-oc-reuse",
+		TaskID:         "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+		AgentName:      "OpenCode Agent",
+		Provider:       "opencode",
+		Task:           TaskContextForEnv{IssueID: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"},
+	}, testLogger())
+	if err != nil {
+		t.Fatalf("Prepare failed: %v", err)
+	}
+	defer env.Cleanup(true)
+
+	if err := os.RemoveAll(env.OpenCodeDataHome); err != nil {
+		t.Fatalf("remove OpenCodeDataHome: %v", err)
+	}
+
+	reused := Reuse(ReuseParams{
+		WorkDir:  env.WorkDir,
+		Provider: "opencode",
+		Task:     TaskContextForEnv{IssueID: "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"},
+	}, testLogger())
+	if reused == nil {
+		t.Fatal("Reuse returned nil")
+	}
+
+	want := filepath.Join(env.RootDir, "opencode-data")
+	if reused.OpenCodeDataHome != want {
+		t.Fatalf("OpenCodeDataHome = %q, want %q", reused.OpenCodeDataHome, want)
+	}
+	if fi, err := os.Stat(want); err != nil {
+		t.Fatalf("OpenCodeDataHome should be recreated on reuse: %v", err)
+	} else if !fi.IsDir() {
+		t.Fatalf("OpenCodeDataHome should be a directory")
+	}
+}
+
 // TestInjectRuntimeConfigRequiresExplicitCommentPost ensures the injected
 // workflow makes "post a comment with results" an explicit, unmissable step in
 // both the assignment- and comment-triggered branches, plus hard-warns in the


### PR DESCRIPTION
## Summary
- add a per-task OpenCode data home under the exec environment root
- export it as XDG_DATA_HOME for OpenCode after custom_env injection, so task isolation wins
- restore and recreate the OpenCode data home on execenv reuse

## Verification
- go test ./internal/daemon/execenv
- go test ./internal/daemon -run 'TestApplyOpenCodeDataHome|TestComposeOpenclawIncludeRoots'
- go test ./internal/daemon

## Notes
- Multica issue: MYW-1741
- Opened from fork because the active GitHub account has READ permission on multica-ai/multica