### PR TITLE
fix(daemon): classify transient agent errors as retryable (MYW-1744, MUL-2362)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2050,8 +2050,15 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	if err != nil {
 		taskLog.Error("task failed", "error", err)
 		// runTask returned without a TaskResult, so we don't have a SessionID
-		// to forward — best we can do is record the failure.
-		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", "agent_error"); failErr != nil {
+		// to forward — best we can do is record the failure. Classify the
+		// error message for transient patterns so the server can retry
+		// infrastructure failures (database locked, stream interrupted, etc.)
+		// while keeping permanent errors (auth, config) non-retryable.
+		failureReason := "agent_error"
+		if tr := classifyTransientError(err.Error()); tr != "" {
+			failureReason = tr
+		}
+		if failErr := d.client.FailTask(ctx, task.ID, err.Error(), "", "", failureReason); failErr != nil {
 			taskLog.Error("fail task callback failed", "error", failErr)
 		}
 		return
@@ -2617,6 +2624,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		failureReason, _ := classifyPoisonedError(errMsg)
 		if failureReason != "" {
 			taskLog.Warn("agent failed with poisoned API error, classifying as blocked",
+				"failure_reason", failureReason,
+			)
+		} else if reason := classifyTransientError(errMsg); reason != "" {
+			failureReason = reason
+			taskLog.Warn("agent failed with transient error, classifying as blocked (retryable)",
 				"failure_reason", failureReason,
 			)
 		}

--- a/server/internal/daemon/poisoned.go
+++ b/server/internal/daemon/poisoned.go
@@ -20,6 +20,7 @@ const (
 	FailureReasonIterationLimit    = "iteration_limit"
 	FailureReasonAgentFallbackMsg  = "agent_fallback_message"
 	FailureReasonAPIInvalidRequest = "api_invalid_request"
+	FailureReasonAgentTransient    = "agent_transient"
 )
 
 // poisonedOutputMaxLen caps how long an output can be and still be
@@ -97,4 +98,52 @@ func classifyPoisonedError(errMsg string) (string, bool) {
 		return FailureReasonAPIInvalidRequest, true
 	}
 	return "", false
+}
+
+// transientErrorPatterns lists known transient error substrings that
+// should be classified as FailureReasonAgentTransient instead of the
+// generic agent_error. These are infrastructure/operational failures
+// that are likely to resolve on retry — unlike auth, config, or
+// content-policy errors which are permanent and must not be retried.
+//
+// The server-side retryableReasons map includes agent_transient, so
+// tasks carrying this reason will be auto-retried (subject to the
+// usual attempt < max_attempts guard).
+var transientErrorPatterns = []string{
+	"database is locked",
+	"database locked",
+	"sqlite_busy",
+	"broken pipe",
+	"connection reset",
+	"connection refused",
+	"no route to host",
+	"temporarily unavailable",
+	"service unavailable",
+	"stream interrupted",
+	"returned empty output",
+	"empty response",
+	"no output from",
+	"produced no output",
+}
+
+// classifyTransientError checks whether the error message indicates a
+// transient infrastructure/operational failure that is likely to resolve
+// on retry. Returns FailureReasonAgentTransient when a match is found,
+// or "" when the error should remain in the agent_error bucket.
+//
+// The classifier is intentionally conservative: it only fires on
+// well-known substrings that correspond to operational glitches, not
+// on every error. Unknown errors default to agent_error (non-retryable)
+// to avoid retry storms on auth/config/permission failures.
+func classifyTransientError(errMsg string) string {
+	if errMsg == "" {
+		return ""
+	}
+	lowered := strings.ToLower(errMsg)
+	for _, p := range transientErrorPatterns {
+		if strings.Contains(lowered, p) {
+			return FailureReasonAgentTransient
+		}
+	}
+	return ""
 }

--- a/server/internal/daemon/poisoned_test.go
+++ b/server/internal/daemon/poisoned_test.go
@@ -85,6 +85,134 @@ the matcher being too permissive on long outputs.`,
 	}
 }
 
+func TestClassifyTransientError(t *testing.T) {
+	cases := []struct {
+		name       string
+		errMsg     string
+		wantReason string
+	}{
+		{
+			name:       "database is locked",
+			errMsg:     "sqlite: database is locked",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "database locked (short form)",
+			errMsg:     "database locked (SQLITE_BUSY)",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "sqlite busy",
+			errMsg:     "SQLITE_BUSY: database is locked",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "connection reset",
+			errMsg:     "read tcp 10.0.0.1:443: connection reset by peer",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "connection refused",
+			errMsg:     "dial tcp 10.0.0.1:8080: connect: connection refused",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "no route to host",
+			errMsg:     "dial tcp: no route to host",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "broken pipe",
+			errMsg:     "write /dev/stdout: broken pipe",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "temporarily unavailable",
+			errMsg:     "resource temporarily unavailable",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "service unavailable",
+			errMsg:     "503 service unavailable",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "stream interrupted",
+			errMsg:     "stream interrupted unexpectedly during generation",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "returned empty output",
+			errMsg:     "kimi returned empty output after processing",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "empty response",
+			errMsg:     "provider returned empty response",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "no output from",
+			errMsg:     "error: no output from model after 5 retries",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "produced no output",
+			errMsg:     "agent produced no output within timeout",
+			wantReason: FailureReasonAgentTransient,
+		},
+		{
+			name:       "case insensitive matching",
+			errMsg:     "Database Is Locked: retry later",
+			wantReason: FailureReasonAgentTransient,
+		},
+		// Non-transient errors that must NOT be classified
+		{
+			name:       "auth failure is not transient",
+			errMsg:     "API Error: 401 authentication_error: invalid api key",
+			wantReason: "",
+		},
+		{
+			name:       "configuration error is not transient",
+			errMsg:     "invalid configuration: agent path not found",
+			wantReason: "",
+		},
+		{
+			name:       "content policy is not transient",
+			errMsg:     "output blocked by content policy filter",
+			wantReason: "",
+		},
+		{
+			name:       "permission denied is not transient",
+			errMsg:     "permission denied: cannot access /etc/secrets",
+			wantReason: "",
+		},
+		{
+			name:       "invalid request error is not transient",
+			errMsg:     `API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"Could not process image"}}`,
+			wantReason: "",
+		},
+		{
+			name:       "empty error message",
+			errMsg:     "",
+			wantReason: "",
+		},
+		{
+			name:       "unrelated agent error is not transient",
+			errMsg:     "failed to compile regex pattern",
+			wantReason: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason := classifyTransientError(tc.errMsg)
+			if reason != tc.wantReason {
+				t.Fatalf("classifyTransientError(%q) = %q, want %q", tc.errMsg, reason, tc.wantReason)
+			}
+		})
+	}
+}
+
 func TestClassifyPoisonedError(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1234,10 +1234,15 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 // allowed to act on. Agent-side errors (compile failures, model rejections,
 // etc.) are intentionally excluded — those are real problems that the user
 // should see, not infrastructure flakiness.
+//
+// agent_transient covers runtime-level transient failures that the daemon
+// classifies as likely to recover on retry: database-locked, stream
+// interruption, connection resets, and similar operational glitches.
 var retryableReasons = map[string]bool{
 	"runtime_offline":  true,
 	"runtime_recovery": true,
 	"timeout":          true,
+	"agent_transient":  true,
 }
 
 // MaybeRetryFailedTask spawns a fresh queued attempt for a recently-failed
@@ -1259,6 +1264,14 @@ func (s *TaskService) MaybeRetryFailedTask(ctx context.Context, parent db.AgentT
 		reason = parent.FailureReason.String
 	}
 	if !retryableReasons[reason] {
+		if parent.Attempt < parent.MaxAttempts {
+			slog.Warn("task auto-retry skipped: non-retryable failure with remaining attempts",
+				"task_id", util.UUIDToString(parent.ID),
+				"reason", reason,
+				"attempt", parent.Attempt,
+				"max_attempts", parent.MaxAttempts,
+			)
+		}
 		return nil, nil
 	}
 	if parent.Attempt >= parent.MaxAttempts {


### PR DESCRIPTION
## Summary

- 修复平台执行重试调度器完全失效的问题：当 `max_attempts > 1` 时，transient 类 agent 错误被错误归类为 `agent_error`，导致无法创建二次 attempt
- 新增 `classifyTransientError` 函数，识别 database locked、stream interrupted、empty output 等 transient 错误并分类为 `agent_transient`
- 将 `agent_transient` 加入 `retryableReasons`，确保 server 侧重试状态机正确创建后续 attempt
- 新增 `slog.Warn` 日志，当有剩余 attempts 但 retry 被跳过时记录告警

## Scope

- `server/internal/daemon/poisoned.go`: 新增 `FailureReasonAgentTransient` 常量、`transientErrorPatterns` 模式表和 `classifyTransientError` 函数
- `server/internal/daemon/daemon.go`: `classifyOutcome` default 分支和 `handleTask` error 路径使用 `classifyTransientError`
- `server/internal/service/task.go`: `retryableReasons` 新增 `agent_transient`，`MaybeRetryFailedTask` 新增跳过告警日志
- `server/internal/daemon/poisoned_test.go`: 新增 22 个 `classifyTransientError` 测试用例

## Out of Scope

- 对 7 个 affected issue 的人工补偿（需先确认是否仍需执行）
- retry TTL / orphan 判断改为 heartbeat/lease 机制（独立 story）
- retry enqueue 失败补偿机制（独立 story）
- daemon durable outbox（MYW-1457）
- server orphan sweeper（MYW-1458）
- SQLite 并发锁根因（MYW-1740）

## Implementation Summary

| 层级 | 改动 | 文件 |
|------|------|------|
| Daemon 分类 | 新增 `classifyTransientError`，匹配 14 种 transient 错误模式 | `poisoned.go` |
| Daemon 分类 | `classifyOutcome` default 分支先查 transient 再 fallback | `daemon.go:2626-2630` |
| Daemon 分类 | `handleTask` error 路径区分 transient/永久错误 | `daemon.go:2050-2058` |
| Server 重试 | `retryableReasons` 新增 `agent_transient` | `task.go:1244` |
| Server 可观测性 | retry 跳过时输出 `WARN` 级别日志（含 task_id、reason、attempt/max_attempts）| `task.go:1267-1273` |

## Tests

- `TestClassifyTransientError`: 15 个 transient 用例 + 7 个永久错误用例，全部通过
- `TestClassifyPoisonedOutput`（预存在）: 继续通过
- `TestClassifyPoisonedError`（预存在）: 继续通过
- `go test ./internal/daemon/`: 全部通过（11.9s）
- `go test ./internal/service/`: 全部通过（0.8s）
- `go vet ./internal/daemon/ ./internal/service/`: 无告警

## Risks

- **误分类风险**: `classifyTransientError` 使用保守的子串匹配，误匹配可能导致永久错误被重试。所有模式均为高度特异性的 infrastructure error 关键词（database locked、broken pipe、connection reset 等），且在 `classifyPoisonedError`（permanent）之后检查
- **新增 failure_reason 兼容性**: `agent_transient` 是新增值，前端和后端分析管道已通过 `taskFailureReason` 的 default→`"agent_error"` fallback 保证兼容
- **retry 风暴**: `agent_transient` 被纳入重试，但仍受 `attempt < max_attempts` 限制（默认 max_attempts=2），不会无限重试

## API / Schema / Data Impact

- **Schema**: 无变更
- **API**: `AgentTaskResponse` 已有 `failure_reason` 字段，新增 `agent_transient` 值
- **前端**: `TaskFailureReason` union type 需跟进（out of scope for this PR），当前前端通过 fallback 处理未知值
- **分析事件**: `AgentTaskFailed` 事件的 `failure_reason` 和 `will_retry` 字段自动覆盖新值

## Required Reviewers

- 程远 — 后端架构 review（本 issue 后端 owner）

## Linked Issues

- Parent: [MYW-1744](mention://issue/b33c417a-c206-4857-8b50-5c2d9a0aa763) — 执行重试调度器完全失效
- Child: [MYW-1745](mention://issue/345b2f84-df70-41c2-9858-d262feb938cd) — 本 PR 实现的后端修复