### PR TITLE
docs(agent): clarify openclaw agent id vs name semantics

### DIFF
--- a/server/pkg/agent/models.go
+++ b/server/pkg/agent/models.go
@@ -830,10 +830,14 @@ func discoverOpenclawAgents(ctx context.Context, executablePath string) ([]Model
 }
 
 // openclawAgentEntry is the shape parseOpenclawAgentsJSON expects
-// from `openclaw agents list --json`. Both `name` and `id` are
-// accepted as the identifier (different openclaw versions ship
-// different field names); `model` is optional and only used to
-// enrich the dropdown label.
+// from `openclaw agents list --json`. `id` is the routing key
+// passed to `openclaw agent --agent <id>`; `name` is the human
+// display label set via `openclaw agents set-identity --name` and
+// is only used to enrich the dropdown label. The two are not
+// interchangeable — see openclawEntriesToModels for the mapping.
+// Older openclaw versions may emit only `name`; in that case we
+// fall back to using it as the id for backward compatibility.
+// `model` is optional and only used to enrich the dropdown label.
 type openclawAgentEntry struct {
 	Name  string `json:"name"`
 	ID    string `json:"id"`

--- a/server/pkg/agent/openclaw.go
+++ b/server/pkg/agent/openclaw.go
@@ -178,10 +178,12 @@ func buildOpenclawArgs(prompt, sessionID string, opts ExecOptions, logger *slog.
 	}
 	// OpenClaw binds models to pre-registered agents at `openclaw agents
 	// add/update --model` time; the daemon selects one at runtime by
-	// passing --agent <name>. The model dropdown populates its list from
-	// `openclaw agents list`, so opts.Model here is an agent name. Only
-	// inject when the user hasn't already set --agent via custom_args —
-	// custom_args wins for backward compatibility with existing configs.
+	// passing --agent <id>. The model dropdown populates its list from
+	// `openclaw agents list`, so opts.Model here is an agent id (see
+	// openclawEntriesToModels — the agent's display name lives in the
+	// dropdown label, not in opts.Model). Only inject when the user
+	// hasn't already set --agent via custom_args — custom_args wins for
+	// backward compatibility with existing configs.
 	customArgs := filterCustomArgs(opts.CustomArgs, openclawBlockedArgs, logger)
 	if opts.Model != "" && !customArgsContains(customArgs, "--agent") {
 		args = append(args, "--agent", opts.Model)


### PR DESCRIPTION
## Summary

Follow-up to #2716 — addresses two stale comments flagged as nits in the review of that PR.

- `server/pkg/agent/models.go` — `openclawAgentEntry` docstring previously said `name` and `id` were interchangeable identifiers. Updated to state that `id` is the routing key (`openclaw agent --agent <id>`) and `name` is the human display label set via `openclaw agents set-identity --name`. Notes the legacy-shape fallback (older openclaw outputs only emit `name`).
- `server/pkg/agent/openclaw.go` — `buildOpenclawArgs` comment previously described `--agent <name>` and called `opts.Model` an agent name. Updated to `--agent <id>` / agent id, with a pointer back to `openclawEntriesToModels` for the mapping.

No behavior change; comments only.

Relates to MUL-2292.

## Test plan

- [x] `go build ./pkg/agent/...`
- [x] `go vet ./pkg/agent/...`
- [x] `go test ./pkg/agent -run 'TestOpenclawEntries|TestParseOpenclawAgents' -count=1`