### PR TITLE
fix(runtimes): stop surfacing agent CLI version branding in machine subtitle (MUL-2309)

### DIFF
--- a/packages/views/runtimes/components/runtime-machines.test.ts
+++ b/packages/views/runtimes/components/runtime-machines.test.ts
@@ -75,6 +75,37 @@ describe("runtime machine grouping", () => {
     expect(filterRuntimeMachines(machines, "", "issues")).toHaveLength(1);
   });
 
+  it("does not surface agent CLI version branding as the machine subtitle", () => {
+    // Reproduces the bug where every machine row's subtitle read
+    // "Claude Code …" because compactDeviceInfo flipped the parenthetical
+    // of the version string "2.1.5 (Claude Code)" into the description.
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          id: "rt-claude",
+          provider: "claude",
+          name: "Claude (dev.local)",
+          device_info: "dev.local · 2.1.5 (Claude Code)",
+        }),
+        makeRuntime({
+          id: "rt-codex",
+          provider: "codex",
+          name: "Codex (dev.local)",
+          device_info: "dev.local · codex-cli 0.118.0",
+        }),
+      ],
+      { now: NOW, localDaemonId: "daemon-1" },
+    );
+
+    expect(machines).toHaveLength(1);
+    const subtitle = machines[0]?.subtitle ?? "";
+    expect(subtitle.toLowerCase()).not.toContain("claude code");
+    expect(subtitle.toLowerCase()).not.toContain("codex-cli");
+    // Falls back to the daemon-id descriptor — at minimum it must not be
+    // the runtime CLI's marketing string.
+    expect(subtitle).toMatch(/^daemon /);
+  });
+
   it("keeps cloud runtimes as cloud workers when they have no daemon", () => {
     const machines = buildRuntimeMachines(
       [

--- a/packages/views/runtimes/components/runtime-machines.ts
+++ b/packages/views/runtimes/components/runtime-machines.ts
@@ -253,15 +253,29 @@ function compactDeviceInfo(
     .split(" · ")
     .map((part) => part.trim())
     .filter(Boolean)
-    .filter((part) => part !== title);
+    .filter((part) => part !== title)
+    .filter((part) => !isAgentVersionLike(part));
   const primary = parts[0];
   if (!primary) return null;
 
-  const runtimeVersion = primary.match(/^(.+?)\s+\(([^)]+)\)$/);
-  if (runtimeVersion?.[1] && runtimeVersion[2]) {
-    return `${runtimeVersion[2]} ${runtimeVersion[1]}`;
+  // Reshape OS+arch produced by formatDeviceInfo (e.g. "macOS (x86_64)")
+  // into the more scannable "x86_64 macOS". Version strings — the only
+  // other shape that historically carried parens — are filtered out
+  // above so they can't pollute the per-machine subtitle.
+  const osArch = primary.match(/^(.+?)\s+\(([^)]+)\)$/);
+  if (osArch?.[1] && osArch[2]) {
+    return `${osArch[2]} ${osArch[1]}`;
   }
   return primary;
+}
+
+// True for parts that carry an agent CLI version, not machine info —
+// e.g. "2.1.5 (Claude Code)", "codex-cli 0.118.0", "1.0.20", "claude 1.0.0".
+// Those describe a runtime, not the host, so they should never become a
+// machine's subtitle (otherwise every claude-equipped daemon's row reads
+// "Claude Code …", drowning out actual per-machine differences).
+function isAgentVersionLike(part: string): boolean {
+  return /(?:^|\s)v?\d+\.\d+\.\d+/.test(part);
 }
 
 function latestLastSeenAt(runtimes: AgentRuntime[]): string | null {


### PR DESCRIPTION
## Summary
- Fix `compactDeviceInfo` so the agent CLI version string (e.g. `2.1.5 (Claude Code)`) no longer gets flipped into each machine's subtitle, which made every Claude-equipped machine row read "Claude Code …".
- Filter out semver-like agent CLI fragments (`v?\d+\.\d+\.\d+` …) before picking the primary descriptor. The OS+arch reshape (e.g. `macOS (x86_64)` → `x86_64 macOS`) is preserved.
- When no host descriptor remains, fall back to the existing `daemon <id>` subtitle.

Resolves [MUL-2309](mention://issue/21169e6d-d9d3-4131-85fc-4832587a9e73).

## Test plan
- [x] `pnpm --filter @multica/views exec vitest run runtimes/components/runtime-machines.test.ts` — 6/6 passed (includes new regression covering a claude + codex daemon)
- [x] `pnpm --filter @multica/views exec vitest run runtimes` — 32/32 passed
- [x] `pnpm --filter @multica/views typecheck` — clean