### PR TITLE
feat(attachments): support .excalidraw vendor MIME type

### DIFF
--- a/server/internal/handler/file.go
+++ b/server/internal/handler/file.go
@@ -19,12 +19,13 @@ import (
 // extContentTypes overrides http.DetectContentType for extensions it gets wrong.
 // Go's sniffer returns text/xml for SVG, text/plain for CSS/JS, etc.
 var extContentTypes = map[string]string{
-	".svg":  "image/svg+xml",
-	".css":  "text/css",
-	".js":   "application/javascript",
-	".mjs":  "application/javascript",
-	".json": "application/json",
-	".wasm": "application/wasm",
+	".svg":        "image/svg+xml",
+	".css":        "text/css",
+	".js":         "application/javascript",
+	".mjs":        "application/javascript",
+	".json":       "application/json",
+	".wasm":       "application/wasm",
+	".excalidraw": "application/vnd.excalidraw+json",
 }
 
 const maxUploadSize = 100 << 20 // 100 MB

--- a/server/internal/handler/file_test.go
+++ b/server/internal/handler/file_test.go
@@ -290,6 +290,81 @@ func TestUploadFile_AttachesToChatSession(t *testing.T) {
 	})
 }
 
+// TestUploadFile_ExcalidrawContentType is the regression test for CAR-711:
+// .excalidraw uploads must land with content_type
+// "application/vnd.excalidraw+json", not the sniffer's "text/plain" /
+// "application/json" guess. Without the extension override, the file would
+// still roundtrip, but the frontend can't distinguish it from a regular JSON
+// upload — which breaks the Excalidraw modal trigger.
+func TestUploadFile_ExcalidrawContentType(t *testing.T) {
+	store := &mockStorage{}
+	origStorage := testHandler.Storage
+	testHandler.Storage = store
+	defer func() { testHandler.Storage = origStorage }()
+
+	payload := []byte(`{"type":"excalidraw","version":2,"source":"https://excalidraw.com","elements":[],"appState":{},"files":{}}`)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "diagram.excalidraw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	writer.Close()
+
+	req := httptest.NewRequest("POST", "/api/upload-file", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("X-User-ID", testUserID)
+	req.Header.Set("X-Workspace-ID", testWorkspaceID)
+
+	w := httptest.NewRecorder()
+	testHandler.UploadFile(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("UploadFile: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp AttachmentResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body: %s", err, w.Body.String())
+	}
+	if want := "application/vnd.excalidraw+json"; resp.ContentType != want {
+		t.Errorf("content_type = %q, want %q", resp.ContentType, want)
+	}
+	if resp.Filename != "diagram.excalidraw" {
+		t.Errorf("filename = %q, want %q", resp.Filename, "diagram.excalidraw")
+	}
+	if int(resp.SizeBytes) != len(payload) {
+		t.Errorf("size_bytes = %d, want %d", resp.SizeBytes, len(payload))
+	}
+
+	// Verify the file went to storage bit-identical (no JSON re-marshal,
+	// no pretty-print, no BOM injection).
+	stored, err := io.ReadAll(mustGetReader(t, store, store.KeyFromURL(resp.URL)))
+	if err != nil {
+		t.Fatalf("read stored body: %v", err)
+	}
+	if !bytes.Equal(stored, payload) {
+		t.Errorf("stored body diverged from uploaded payload\n got:  %q\n want: %q", stored, payload)
+	}
+
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM attachment WHERE id = $1`, resp.ID)
+	})
+}
+
+func mustGetReader(t *testing.T, s *mockStorage, key string) io.Reader {
+	t.Helper()
+	rc, err := s.GetReader(context.Background(), key)
+	if err != nil {
+		t.Fatalf("mockStorage.GetReader(%q): %v", key, err)
+	}
+	t.Cleanup(func() { rc.Close() })
+	return rc
+}
+
 // TestUploadFile_RejectsForeignChatSession verifies a chat_session in another
 // workspace (or owned by another user) is rejected with 403/404, preventing
 // cross-tenant attachment binding.

--- a/server/internal/storage/local.go
+++ b/server/internal/storage/local.go
@@ -184,13 +184,25 @@ func (s *LocalStorage) ServeFile(w http.ResponseWriter, r *http.Request, filenam
 	// UUID + extension) instead of the human-readable name the uploader
 	// chose. Uploads from before the sidecar landed have no .meta.json on
 	// disk and fall through to the existing behavior.
-	if meta, ok := readLocalMeta(filePath); ok && meta.Filename != "" {
-		safe := sanitizeFilename(meta.Filename)
-		disposition := "attachment"
-		if isInlineContentType(meta.ContentType) {
-			disposition = "inline"
+	//
+	// Also restore Content-Type from the sidecar. http.ServeFile falls back
+	// to mime.TypeByExtension(ext) for unknown extensions and otherwise
+	// sniffs the body — for vendor types like application/vnd.excalidraw+json
+	// both paths return the wrong header (text/plain for JSON-looking bytes,
+	// empty for unknown extensions). The uploader-sniffed content_type is
+	// authoritative; surface it so clients see the exact MIME they uploaded.
+	if meta, ok := readLocalMeta(filePath); ok {
+		if meta.ContentType != "" {
+			w.Header().Set("Content-Type", meta.ContentType)
 		}
-		w.Header().Set("Content-Disposition", fmt.Sprintf(`%s; filename="%s"`, disposition, safe))
+		if meta.Filename != "" {
+			safe := sanitizeFilename(meta.Filename)
+			disposition := "attachment"
+			if isInlineContentType(meta.ContentType) {
+				disposition = "inline"
+			}
+			w.Header().Set("Content-Disposition", fmt.Sprintf(`%s; filename="%s"`, disposition, safe))
+		}
 	}
 
 	// Use http.ServeFile which has built-in path traversal protection

--- a/server/internal/storage/local_test.go
+++ b/server/internal/storage/local_test.go
@@ -280,6 +280,64 @@ func TestLocalStorage_ServeFile_ContentDispositionFromSidecar(t *testing.T) {
 	}
 }
 
+// TestLocalStorage_ServeFile_ContentTypeFromSidecar guards CAR-711: vendor
+// MIME types like application/vnd.excalidraw+json must round-trip through
+// ServeFile. http.ServeFile alone falls back to mime.TypeByExtension (empty
+// for .excalidraw) and then sniffs the body (text/plain for JSON-looking
+// bytes), so the uploader-sniffed content_type from the sidecar has to win.
+func TestLocalStorage_ServeFile_ContentTypeFromSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("LOCAL_UPLOAD_DIR", tmpDir)
+
+	store := NewLocalStorageFromEnv()
+	if store == nil {
+		t.Fatal("NewLocalStorageFromEnv returned nil")
+	}
+
+	cases := []struct {
+		name        string
+		key         string
+		contentType string
+		filename    string
+		body        []byte
+	}{
+		{
+			name:        "excalidraw vendor type",
+			key:         "workspaces/ws-1/diagram.excalidraw",
+			contentType: "application/vnd.excalidraw+json",
+			filename:    "system-flow.excalidraw",
+			body:        []byte(`{"type":"excalidraw","version":2,"elements":[]}`),
+		},
+		{
+			name:        "spreadsheet vendor type",
+			key:         "workspaces/ws-1/sheet.xlsx",
+			contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+			filename:    "report.xlsx",
+			body:        []byte("PK\x03\x04binary-bytes"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if _, err := store.Upload(ctx, tc.key, tc.body, tc.contentType, tc.filename); err != nil {
+				t.Fatalf("Upload failed: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/uploads/"+tc.key, nil)
+			rec := httptest.NewRecorder()
+			store.ServeFile(rec, req, tc.key)
+
+			if got := rec.Header().Get("Content-Type"); got != tc.contentType {
+				t.Errorf("Content-Type = %q, want %q", got, tc.contentType)
+			}
+			if got := rec.Body.Bytes(); string(got) != string(tc.body) {
+				t.Errorf("body bytes mismatch: got %q, want %q", got, tc.body)
+			}
+		})
+	}
+}
+
 // TestLocalStorage_ServeFile_NoSidecarFallback documents the graceful
 // degradation path: files uploaded before the sidecar landed (or written
 // out-of-band) have no .meta.json on disk and ServeFile must not set


### PR DESCRIPTION
## Summary

- Adds `.excalidraw` → `application/vnd.excalidraw+json` to the upload extension override so attachments uploaded through `POST /api/upload-file` are stored and surfaced with the correct vendor MIME type, instead of falling back to the sniffer's `text/plain` / `application/json` guess.
- Local storage's `ServeFile` now restores `Content-Type` from the sidecar `meta.json`. Without this, `/uploads/<key>.excalidraw` would serve the wrong header because `http.ServeFile` only knows the standard `mime` DB. The S3 backend already sets `ContentType` on `PutObject`, so the fix is local-only.
- Roundtrip is bit-identical: bytes go through `[]byte` → `os.WriteFile` / `s3.PutObject` with no re-encoding or pretty-print. Existing tests already cover that path; the new tests pin the MIME contract.

Context: this unblocks the Excalidraw integration (CAR-708) — the frontend modal trigger keys on the exact content type.

## Test plan

- [ ] `go test ./internal/storage/...` (added `TestLocalStorage_ServeFile_ContentTypeFromSidecar`)
- [ ] `go test ./internal/handler/...` (added `TestUploadFile_ExcalidrawContentType`; requires PG test DB like the rest of the suite)
- [ ] Manual: upload a `.excalidraw` file via the API, verify `GET /api/attachments/<id>` returns `content_type: "application/vnd.excalidraw+json"` and the served file carries that header