### PR TITLE
feat(daemon): expose runtime/model/trigger via MULTICA_* env

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2285,6 +2285,11 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 
 	prompt := BuildPrompt(task, provider)
 
+	// Resolve the model now (same two-tier rule used for ExecOptions below) so
+	// it can be surfaced to the spawned agent via MULTICA_MODEL. Resolving in
+	// one place keeps the env-var and the CLI flag in sync.
+	resolvedModel := resolveTaskModel(task, entry.Model)
+
 	// Pass the daemon's auth credentials and context so the spawned agent CLI
 	// can call the Multica API and the local daemon (e.g. `multica repo checkout`).
 	// MULTICA_TASK_SLOT is allocated from the daemon-wide concurrency pool, not
@@ -2299,6 +2304,15 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"MULTICA_AGENT_ID":     task.AgentID,
 		"MULTICA_TASK_ID":      task.ID,
 		"MULTICA_TASK_SLOT":    strconv.Itoa(slot),
+		// Runtime self-introspection: expose the resolved provider, model, and
+		// trigger origin so skills and run-traces no longer need to grep CLI
+		// configs or inspect file markers to know what they are. Autopilot IDs
+		// follow further down for runs that have one.
+		"MULTICA_RUNTIME":        provider,
+		"MULTICA_TRIGGER_SOURCE": triggerSource(task),
+	}
+	if resolvedModel != "" {
+		agentEnv["MULTICA_MODEL"] = resolvedModel
 	}
 	if task.AutopilotRunID != "" {
 		agentEnv["MULTICA_AUTOPILOT_RUN_ID"] = task.AutopilotRunID
@@ -2393,14 +2407,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// default, codex app-server's account-scoped default, etc.).
 	// Baking a Go-side "recommended default" here is how the
 	// cursor regression happened — static guesses drift from
-	// whatever the upstream CLI actually accepts.
-	model := ""
-	if task.Agent != nil && task.Agent.Model != "" {
-		model = task.Agent.Model
-	}
-	if model == "" {
-		model = entry.Model
-	}
+	// whatever the upstream CLI actually accepts. Resolved earlier
+	// in this function (resolvedModel) and reused here so the
+	// MULTICA_MODEL env var and the --model flag never diverge.
+	model := resolvedModel
 	execOpts := agent.ExecOptions{
 		Cwd:                       env.WorkDir,
 		Model:                     model,
@@ -3144,6 +3154,45 @@ func isBlockedEnvKey(key string) bool {
 		return true
 	}
 	return false
+}
+
+// resolveTaskModel returns the model string the daemon should pass to both
+// the agent CLI (`--model`) and the spawned agent's environment
+// (MULTICA_MODEL). It mirrors the two-tier rule documented at the
+// ExecOptions call-site: an explicit agent.model wins over the daemon-wide
+// MULTICA_<PROVIDER>_MODEL default (which the caller has already resolved
+// into entry.Model). Empty means "let the CLI pick its own default" — the
+// caller MUST treat "" as "don't set the env var" rather than as the
+// literal string.
+func resolveTaskModel(task Task, entryModel string) string {
+	if task.Agent != nil && task.Agent.Model != "" {
+		return task.Agent.Model
+	}
+	return entryModel
+}
+
+// triggerSource derives the MULTICA_TRIGGER_SOURCE value from the task
+// payload. The agent uses this to short-circuit "why am I running?"
+// introspection (autopilot debugging, chat-vs-issue tracing, squad routing
+// audits) without having to grep its own context files.
+//
+// Discrimination order matches the daemon's own dispatch precedence:
+// autopilot > chat > quick_create > squad > manual. The default "manual"
+// covers comment- and assignment-triggered runs where no specialised
+// pathway tagged the task.
+func triggerSource(task Task) string {
+	switch {
+	case task.AutopilotRunID != "":
+		return "autopilot"
+	case task.ChatSessionID != "":
+		return "chat"
+	case task.QuickCreatePrompt != "":
+		return "quick_create"
+	case task.SquadID != "":
+		return "squad"
+	default:
+		return "manual"
+	}
 }
 
 func defaultArgsForProvider(cfg Config, provider string) []string {

--- a/server/internal/daemon/trigger_env_test.go
+++ b/server/internal/daemon/trigger_env_test.go
@@ -1,0 +1,112 @@
+package daemon
+
+import "testing"
+
+func TestResolveTaskModel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		task       Task
+		entryModel string
+		want       string
+	}{
+		{
+			name:       "agent override wins",
+			task:       Task{Agent: &AgentData{Model: "claude-opus-4-7"}},
+			entryModel: "claude-sonnet-4-6",
+			want:       "claude-opus-4-7",
+		},
+		{
+			name:       "entry default used when agent omits model",
+			task:       Task{Agent: &AgentData{}},
+			entryModel: "claude-sonnet-4-6",
+			want:       "claude-sonnet-4-6",
+		},
+		{
+			name:       "nil agent falls through to entry default",
+			task:       Task{},
+			entryModel: "gpt-5",
+			want:       "gpt-5",
+		},
+		{
+			name:       "both empty returns empty",
+			task:       Task{Agent: &AgentData{}},
+			entryModel: "",
+			want:       "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveTaskModel(tc.task, tc.entryModel); got != tc.want {
+				t.Fatalf("resolveTaskModel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTriggerSource(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		task Task
+		want string
+	}{
+		{
+			name: "default is manual",
+			task: Task{ID: "t1"},
+			want: "manual",
+		},
+		{
+			name: "autopilot wins over every other marker",
+			task: Task{
+				AutopilotRunID:    "ar-1",
+				ChatSessionID:     "chat-1",
+				QuickCreatePrompt: "draft me a release note",
+				SquadID:           "squad-1",
+			},
+			want: "autopilot",
+		},
+		{
+			name: "chat wins over quick_create and squad",
+			task: Task{
+				ChatSessionID:     "chat-1",
+				QuickCreatePrompt: "draft me a release note",
+				SquadID:           "squad-1",
+			},
+			want: "chat",
+		},
+		{
+			name: "quick_create wins over squad",
+			task: Task{
+				QuickCreatePrompt: "draft me a release note",
+				SquadID:           "squad-1",
+			},
+			want: "quick_create",
+		},
+		{
+			name: "squad routes to squad",
+			task: Task{SquadID: "squad-1"},
+			want: "squad",
+		},
+		{
+			name: "comment-triggered manual run",
+			task: Task{
+				IssueID:               "issue-1",
+				TriggerCommentID:      "comment-1",
+				TriggerCommentContent: "please fix",
+			},
+			want: "manual",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := triggerSource(tc.task); got != tc.want {
+				t.Fatalf("triggerSource = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Spawned agents currently have to grep CLI config files (Hermes `config.yaml`, Claude settings) to learn which runtime and model they're running on. Autopilot-triggered runs surface `MULTICA_AUTOPILOT_ID` but no generic trigger-source marker, so `env | grep AUTOPILOT` returns empty for chat / quick-create / squad-routed runs and every skill that wants a structured run-trace ends up writing its own per-runtime introspection.

This adds three daemon-set env vars next to the existing `MULTICA_TASK_ID` / `MULTICA_AUTOPILOT_ID` block in `runTask`:

| Var | Value | Notes |
|-----|-------|-------|
| `MULTICA_RUNTIME` | `claude`, `hermes`, `gemini`, … | Always set — same `provider` string used by `agent.New`. |
| `MULTICA_MODEL` | Resolved model string | Same value passed as `--model`; omitted when both `task.Agent.Model` and `entry.Model` are empty (matches the existing "let the CLI pick its default" behaviour). |
| `MULTICA_TRIGGER_SOURCE` | `autopilot` \| `chat` \| `quick_create` \| `squad` \| `manual` | Derived from existing `Task` fields, no schema change. |

The two-tier model resolution (`task.Agent.Model` wins over `entry.Model`) is extracted into `resolveTaskModel` so the env var and `ExecOptions.Model` can never drift. The discrimination order in `triggerSource` mirrors the daemon's dispatch precedence: `autopilot > chat > quick_create > squad > manual`.

`MULTICA_*` keys are already protected from `custom_env` override by `isBlockedEnvKey`, so user-supplied env can't shadow these.

## Why

- Skills can write runtime- and trigger-aware logic without grepping config files.
- Run-traces can record `model` and `trigger_source` deterministically.
- Cost / latency attribution per autopilot becomes straightforward.
- Debugging: an agent immediately knows whether it was spawned by a comment, an autopilot, or a chat message.

## Test plan

- [x] `go test ./internal/daemon/...` — 275 pass, including 10 new table-driven cases in `trigger_env_test.go` (4 for `resolveTaskModel`, 6 for `triggerSource`).
- [x] `go vet ./...` clean.
- [x] `go build ./server/...` clean.
- [ ] Manual: assign an issue to a Claude agent, confirm `env | grep MULTICA_` in the spawned task shows `MULTICA_RUNTIME=claude`, `MULTICA_MODEL=<resolved>`, `MULTICA_TRIGGER_SOURCE=manual`.
- [ ] Manual: trigger an autopilot run, confirm `MULTICA_TRIGGER_SOURCE=autopilot` alongside the existing `MULTICA_AUTOPILOT_ID` / `MULTICA_AUTOPILOT_RUN_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)