### PR TITLE
fix(security): randomize POSTGRES_PASSWORD in install.sh (MUL-2355)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -298,16 +298,21 @@ setup_server() {
 
   # Generate .env if needed
   if [ ! -f .env ]; then
-    info "Creating .env with random JWT_SECRET..."
+    info "Creating .env with random secrets..."
     cp .env.example .env
-    local jwt
+    local jwt pg_pass
     jwt=$(openssl rand -hex 32)
+    pg_pass=$(openssl rand -hex 24)
     if [ "$(uname -s)" = "Darwin" ]; then
       sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
+      sed -i '' "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$pg_pass/" .env
+      sed -i '' -E "s#^(DATABASE_URL=postgres://[^:]+:)[^@]+(@.*)\$#\1${pg_pass}\2#" .env
     else
       sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
+      sed -i "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$pg_pass/" .env
+      sed -i -E "s#^(DATABASE_URL=postgres://[^:]+:)[^@]+(@.*)\$#\1${pg_pass}\2#" .env
     fi
-    ok "Generated .env with random JWT_SECRET"
+    ok "Generated .env with random JWT_SECRET and POSTGRES_PASSWORD"
   else
     ok "Using existing .env"
   fi


### PR DESCRIPTION
## What does this PR do?

  `scripts/install.sh` already randomizes `JWT_SECRET` via `openssl rand -hex 32` when creating `.env` from `.env.example`. This PR mirrors that pattern for `POSTGRES_PASSWORD` so default self-host installs no
   longer ship with the literal string `multica` as the database password.

  The change also rewrites `DATABASE_URL` to embed the new password using a position-aware regex that preserves the user/host/port/db segments — so operators who customized `.env.example` before running the
  installer keep their other settings intact.

  ## Related Issue

  Closes #2757

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `scripts/install.sh`: alongside `JWT_SECRET` generation, generate `POSTGRES_PASSWORD` via `openssl rand -hex 24` and rewrite both `POSTGRES_PASSWORD=` and the password segment inside `DATABASE_URL=`. Same
  gating as the existing JWT block (only fires when `.env` is being created from `.env.example`), so existing operators with custom passwords are unaffected.

  ## How to Test

  ```bash
  # Fresh checkout, no existing .env
  rm -f .env
  bash scripts/install.sh --with-server
  grep -E '^(POSTGRES_PASSWORD|DATABASE_URL)=' .env
  # POSTGRES_PASSWORD=<48-char hex>
  # DATABASE_URL=postgres://multica:<same hex>@localhost:5432/multica?sslmode=disable

  # Existing .env — should not be touched
  echo "POSTGRES_PASSWORD=keep-me" > .env
  bash scripts/install.sh --with-server
  grep '^POSTGRES_PASSWORD=' .env
  # POSTGRES_PASSWORD=keep-me

  Stack starts as before — the randomized password is consistent across POSTGRES_PASSWORD and DATABASE_URL, and is read by the same ${POSTGRES_PASSWORD} reference in docker-compose.selfhost.yml.

  Checklist

  - I have included a thinking path that traces from project context to this change
  - I have run tests locally and they pass
  - I have added or updated tests where applicable (shell installer; manual verification of both code paths)
  - If this change affects the UI, I have included before/after screenshots (n/a)
  - I have updated relevant documentation to reflect my changes (install docs don't reference the credential)
  - If I added a new runtime / coding tool / UI tab, I synced the change to landing copy (apps/web/features/landing/i18n/), starter-content (packages/views/onboarding/utils/starter-content-content-*.ts), and
  relevant docs (apps/docs/content/docs/) (n/a)
  - If this PR touches Chinese product copy, I checked it against apps/docs/content/docs/developers/conventions.zh.mdx (n/a)
  - I have considered and documented any risks above
  - I will address all reviewer comments before requesting merge

  AI Disclosure

  AI tool used: Claude Code

  Prompt / approach: Audited scripts/install.sh for secret handling — noticed JWT_SECRET was randomized but POSTGRES_PASSWORD was not. Mirrored the existing openssl pattern and used position-aware sed to avoid
   hardcoding URL components.

  Screenshots (optional)

  n/a — installer script change, no UI affected.