### PR TITLE
fix(security): bind all services to loopback in docker-compose files (MUL-2356)

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -18,7 +18,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-multica}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-multica}
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     restart: unless-stopped
@@ -34,7 +34,7 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "${PORT:-8080}:8080"
+      - "127.0.0.1:${PORT:-8080}:8080"
     volumes:
       - backend_uploads:/app/data/uploads
     environment:
@@ -75,7 +75,7 @@ services:
     depends_on:
       - backend
     ports:
-      - "${FRONTEND_PORT:-3000}:3000"
+      - "127.0.0.1:${FRONTEND_PORT:-3000}:3000"
     environment:
       HOSTNAME: "0.0.0.0"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-multica}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-multica}
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
 


### PR DESCRIPTION
## What does this PR do?

  Both `docker-compose.yml` and `docker-compose.selfhost.yml` bind postgres, backend, and frontend to `0.0.0.0` (all interfaces) by omitting the `host_ip` prefix on port mappings. On any VPS with a public IP,
  these services are directly reachable from the internet. Docker bypasses UFW iptables chains by default, so host-level firewall rules have no effect.

  This PR prefixes every port binding with `127.0.0.1` so services are only reachable from the host itself. This matches the documented `DATABASE_URL` (which uses `localhost`) and does not break any local dev
  or self-host workflow.

  ## Related Issue

  Closes #2756

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `docker-compose.yml`: bind postgres to `127.0.0.1:5432:5432` (was `5432:5432`)
  - `docker-compose.selfhost.yml`: bind postgres, backend, and frontend to `127.0.0.1:` prefix (was bare port mappings)

  ## How to Test

  ```bash
  # Before (on a host with a public IP):
  docker compose -f docker-compose.yml -f docker-compose.selfhost.yml up -d
  ss -tlnp | grep -E ':5432|:8080|:3000'
  # LISTEN 0.0.0.0:5432 ...   ← publicly reachable

  # After:
  docker compose -f docker-compose.yml -f docker-compose.selfhost.yml up -d
  ss -tlnp | grep -E ':5432|:8080|:3000'
  # LISTEN 127.0.0.1:5432 ...  ← loopback only

  docker compose config should show host_ip: 127.0.0.1 on every port entry.

  Checklist

  - I have included a thinking path that traces from project context to this change
  - I have run tests locally and they pass (verified merged config + actual port bindings)
  - I have added or updated tests where applicable (config-level change, no unit tests affected)
  - If this change affects the UI, I have included before/after screenshots (n/a)
  - I have updated relevant documentation to reflect my changes (no docs reference the binding behavior)
  - If I added a new runtime / coding tool / UI tab, I synced the change to landing copy (apps/web/features/landing/i18n/), starter-content (packages/views/onboarding/utils/starter-content-content-*.ts), and
  relevant docs (apps/docs/content/docs/) (n/a)
  - If this PR touches Chinese product copy, I checked it against apps/docs/content/docs/developers/conventions.zh.mdx (n/a)
  - I have considered and documented any risks above
  - I will address all reviewer comments before requesting merge

  AI Disclosure

  AI tool used: Claude Code

  Prompt / approach: Audited a self-hosted Multica deployment and noticed postgres listening on 0.0.0.0:5432. Traced the root cause to missing 127.0.0.1 prefixes in both compose files, verified the fix with
  docker compose config and ss -tlnp.

  Screenshots (optional)

  n/a — config-only change, no UI affected.