### PR TITLE
feat(workspace): add per-workspace logo upload

### DIFF
--- a/apps/mobile/data/schemas.ts
+++ b/apps/mobile/data/schemas.ts
@@ -467,6 +467,7 @@ export const WorkspaceSchema: z.ZodType<Workspace> = z.object({
   settings: z.record(z.string(), z.unknown()).default({}),
   repos: z.array(z.object({ url: z.string() }).loose()).default([]),
   issue_prefix: z.string().default(""),
+  avatar_url: z.string().nullable().default(null),
   created_at: z.string().default(""),
   updated_at: z.string().default(""),
 }).loose();

--- a/apps/web/app/auth/callback/page.test.tsx
+++ b/apps/web/app/auth/callback/page.test.tsx
@@ -134,6 +134,7 @@ describe("CallbackPage", () => {
         settings: {},
         repos: [],
         issue_prefix: "ACME",
+        avatar_url: null,
         created_at: "",
         updated_at: "",
       },

--- a/apps/web/test/helpers.tsx
+++ b/apps/web/test/helpers.tsx
@@ -31,6 +31,7 @@ export const mockWorkspace: Workspace = {
   settings: {},
   repos: [],
   issue_prefix: "TES",
+  avatar_url: null,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
 };

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1385,7 +1385,7 @@ export class ApiClient {
     });
   }
 
-  async updateWorkspace(id: string, data: { name?: string; description?: string; context?: string; settings?: Record<string, unknown>; repos?: WorkspaceRepo[]; issue_prefix?: string }): Promise<Workspace> {
+  async updateWorkspace(id: string, data: { name?: string; description?: string; context?: string; settings?: Record<string, unknown>; repos?: WorkspaceRepo[]; issue_prefix?: string; avatar_url?: string }): Promise<Workspace> {
     return this.fetch(`/api/workspaces/${id}`, {
       method: "PATCH",
       body: JSON.stringify(data),

--- a/packages/core/paths/resolve.test.ts
+++ b/packages/core/paths/resolve.test.ts
@@ -13,6 +13,7 @@ function makeWs(slug: string): Workspace {
     settings: {},
     repos: [],
     issue_prefix: slug.toUpperCase(),
+    avatar_url: null,
     created_at: "",
     updated_at: "",
   };

--- a/packages/core/realtime/use-realtime-sync.test.ts
+++ b/packages/core/realtime/use-realtime-sync.test.ts
@@ -139,6 +139,7 @@ describe("applyWorkspaceUpdatedToCache", () => {
       settings: {},
       repos: [],
       issue_prefix: "TES",
+      avatar_url: null,
       created_at: "2026-05-18T00:00:00Z",
       updated_at: "2026-05-18T00:00:00Z",
       ...overrides,

--- a/packages/core/types/workspace.ts
+++ b/packages/core/types/workspace.ts
@@ -14,6 +14,7 @@ export interface Workspace {
   settings: Record<string, unknown>;
   repos: WorkspaceRepo[];
   issue_prefix: string;
+  avatar_url: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/packages/views/invitations/invitations-page.test.tsx
+++ b/packages/views/invitations/invitations-page.test.tsx
@@ -97,6 +97,7 @@ const mkWs = (id: string, slug: string) => ({
   settings: {},
   repos: [],
   issue_prefix: slug.toUpperCase(),
+  avatar_url: null,
   created_at: "",
   updated_at: "",
 });

--- a/packages/views/issues/hooks/issue-delete-mutations.test.tsx
+++ b/packages/views/issues/hooks/issue-delete-mutations.test.tsx
@@ -40,6 +40,7 @@ const workspace: Workspace = {
   settings: {},
   repos: [],
   issue_prefix: "TST",
+  avatar_url: null,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",
 };

--- a/packages/views/layout/app-sidebar.tsx
+++ b/packages/views/layout/app-sidebar.tsx
@@ -474,7 +474,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                   render={
                     <SidebarMenuButton>
                       <span className="relative">
-                        <WorkspaceAvatar name={workspace?.name ?? "M"} size="sm" />
+                        <WorkspaceAvatar name={workspace?.name ?? "M"} avatarUrl={workspace?.avatar_url} size="sm" />
                         {myInvitations.length > 0 && (
                           <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-brand ring-1 ring-sidebar" />
                         )}
@@ -520,7 +520,7 @@ export function AppSidebar({ topSlot, searchSlot, headerClassName, headerStyle }
                           <AppLink href={paths.workspace(ws.slug).issues()} />
                         }
                       >
-                        <WorkspaceAvatar name={ws.name} size="sm" />
+                        <WorkspaceAvatar name={ws.name} avatarUrl={ws.avatar_url} size="sm" />
                         <span className="flex-1 truncate">{ws.name}</span>
                         {ws.id === workspace?.id && (
                           <Check className="h-3.5 w-3.5 text-primary" />

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -122,6 +122,10 @@
   },
   "workspace": {
     "section_general": "General",
+    "change_logo_aria": "Change workspace logo",
+    "click_logo_hint": "Click the logo to upload a new image",
+    "toast_logo_updated": "Workspace logo updated",
+    "toast_logo_failed": "Failed to upload workspace logo",
     "name_label": "Name",
     "description_label": "Description",
     "description_placeholder": "What does this workspace focus on?",

--- a/packages/views/locales/ko/settings.json
+++ b/packages/views/locales/ko/settings.json
@@ -122,6 +122,10 @@
   },
   "workspace": {
     "section_general": "일반",
+    "change_logo_aria": "워크스페이스 로고 변경",
+    "click_logo_hint": "로고를 클릭하여 새 이미지를 업로드하세요",
+    "toast_logo_updated": "워크스페이스 로고를 업데이트했습니다",
+    "toast_logo_failed": "워크스페이스 로고를 업로드하지 못했습니다",
     "name_label": "이름",
     "description_label": "설명",
     "description_placeholder": "이 워크스페이스는 무엇에 집중하나요?",

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -122,6 +122,10 @@
   },
   "workspace": {
     "section_general": "通用",
+    "change_logo_aria": "更换工作区图标",
+    "click_logo_hint": "点击图标上传新图片",
+    "toast_logo_updated": "工作区图标已更新",
+    "toast_logo_failed": "上传工作区图标失败",
     "name_label": "名称",
     "description_label": "描述",
     "description_placeholder": "这个工作区主要做什么？",

--- a/packages/views/members/member-detail-page.tsx
+++ b/packages/views/members/member-detail-page.tsx
@@ -28,7 +28,7 @@ export function MemberDetailPage({ userId }: { userId: string }) {
   if (!member) {
     return (
       <div className="flex flex-1 min-h-0 flex-col">
-        <MemberBreadcrumb workspaceName={workspace?.name} title={t(($) => $.detail.breadcrumb_fallback)} />
+        <MemberBreadcrumb workspaceName={workspace?.name} workspaceAvatarUrl={workspace?.avatar_url} title={t(($) => $.detail.breadcrumb_fallback)} />
         <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-16 text-center">
           <UserRound className="h-8 w-8 text-muted-foreground" />
           <div>
@@ -51,7 +51,7 @@ export function MemberDetailPage({ userId }: { userId: string }) {
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      <MemberBreadcrumb workspaceName={workspace?.name} title={member.name} />
+      <MemberBreadcrumb workspaceName={workspace?.name} workspaceAvatarUrl={workspace?.avatar_url} title={member.name} />
 
       <div className="flex shrink-0 items-center gap-3 border-b px-6 py-4">
         <ActorAvatarBase
@@ -79,15 +79,17 @@ export function MemberDetailPage({ userId }: { userId: string }) {
 
 function MemberBreadcrumb({
   workspaceName,
+  workspaceAvatarUrl,
   title,
 }: {
   workspaceName: string | undefined;
+  workspaceAvatarUrl?: string | null;
   title: string;
 }) {
   const { t } = useT("members");
   return (
     <PageHeader className="gap-1.5">
-      <WorkspaceAvatar name={workspaceName ?? "W"} size="sm" />
+      <WorkspaceAvatar name={workspaceName ?? "W"} avatarUrl={workspaceAvatarUrl} size="sm" />
       <span className="text-sm text-muted-foreground">
         {workspaceName ?? t(($) => $.detail.workspace_fallback)}
       </span>

--- a/packages/views/onboarding/steps/step-workspace.test.tsx
+++ b/packages/views/onboarding/steps/step-workspace.test.tsx
@@ -36,6 +36,10 @@ vi.mock("@multica/core/workspace/mutations", () => ({
   useCreateWorkspace: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
+vi.mock("@multica/core/api", () => ({
+  api: { getBaseUrl: () => "http://127.0.0.1:8080" },
+}));
+
 import { StepWorkspace } from "./step-workspace";
 
 function I18nWrapper({ children }: { children: ReactNode }) {

--- a/packages/views/onboarding/steps/step-workspace.tsx
+++ b/packages/views/onboarding/steps/step-workspace.tsx
@@ -438,7 +438,7 @@ function ExistingWorkspaceCard({
           : "hover:border-foreground/20 hover:bg-accent/30",
       )}
     >
-      <WorkspaceAvatar name={workspace.name} size="lg" />
+      <WorkspaceAvatar name={workspace.name} avatarUrl={workspace.avatar_url} size="lg" />
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="truncate text-[14.5px] font-medium text-foreground">
           {workspace.name}

--- a/packages/views/settings/components/workspace-tab.test.tsx
+++ b/packages/views/settings/components/workspace-tab.test.tsx
@@ -62,7 +62,7 @@ vi.mock("@multica/core/workspace/mutations", () => ({
 }));
 
 vi.mock("@multica/core/api", () => ({
-  api: { updateWorkspace: mockUpdateWorkspace },
+  api: { updateWorkspace: mockUpdateWorkspace, getBaseUrl: () => "http://127.0.0.1:8080" },
 }));
 
 vi.mock("@multica/core/auth", () => {

--- a/packages/views/settings/components/workspace-tab.tsx
+++ b/packages/views/settings/components/workspace-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Save, LogOut } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Camera, Loader2, Save, LogOut } from "lucide-react";
 import { Input } from "@multica/ui/components/ui/input";
 import { Textarea } from "@multica/ui/components/ui/textarea";
 import { Label } from "@multica/ui/components/ui/label";
@@ -29,6 +29,8 @@ import {
 } from "@multica/core/workspace/queries";
 import { issueKeys } from "@multica/core/issues/queries";
 import { api } from "@multica/core/api";
+import { useFileUpload } from "@multica/core/hooks/use-file-upload";
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import {
   resolvePostAuthDestination,
   useCurrentWorkspace,
@@ -121,12 +123,17 @@ export function WorkspaceTab() {
   const isSoleOwner = isOwner && ownerCount <= 1;
   const isSoleMember = members.length <= 1;
 
+  // Reset form state only when the user switches to a different workspace.
+  // Keying on workspace?.id (not the object ref) avoids wiping unsaved edits
+  // when an unrelated mutation — e.g. avatar/logo upload — replaces the
+  // cached Workspace object via setQueryData.
   useEffect(() => {
     setName(workspace?.name ?? "");
     setDescription(workspace?.description ?? "");
     setContext(workspace?.context ?? "");
     setIssuePrefix(workspace?.issue_prefix ?? "");
-  }, [workspace]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed on id only; see comment above
+  }, [workspace?.id]);
 
   // Letters + digits only, uppercase, capped at 10 chars. The backend
   // uppercases and trims on its side too — this is purely a UX guardrail
@@ -185,6 +192,28 @@ export function WorkspaceTab() {
     void performSave(false);
   };
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { upload, uploading } = useFileUpload(api);
+
+  const handleLogoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!workspace) return;
+    const file = e.target.files?.[0];
+    if (!file) return;
+    // Reset input so the same file can be re-selected
+    e.target.value = "";
+    try {
+      const result = await upload(file);
+      if (!result) return;
+      const updated = await api.updateWorkspace(workspace.id, { avatar_url: result.link });
+      qc.setQueryData(workspaceKeys.list(), (old: Workspace[] | undefined) =>
+        old?.map((ws) => (ws.id === updated.id ? updated : ws)),
+      );
+      toast.success(t(($) => $.workspace.toast_logo_updated));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t(($) => $.workspace.toast_logo_failed));
+    }
+  };
+
   const handleLeaveWorkspace = () => {
     if (!workspace) return;
     setConfirmAction({
@@ -225,6 +254,8 @@ export function WorkspaceTab() {
 
   if (!workspace) return null;
 
+  const logoUrl = resolvePublicFileUrl(workspace.avatar_url);
+
   return (
     <div className="space-y-8">
       {/* Workspace settings */}
@@ -233,6 +264,46 @@ export function WorkspaceTab() {
 
         <Card>
           <CardContent className="space-y-3">
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                className="group relative h-16 w-16 shrink-0 overflow-hidden rounded-md bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading || !canManageWorkspace}
+                aria-label={t(($) => $.workspace.change_logo_aria)}
+              >
+                {logoUrl ? (
+                  <img
+                    src={logoUrl}
+                    alt={workspace.name}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <span className="flex h-full w-full items-center justify-center text-lg font-semibold text-muted-foreground">
+                    {workspace.name.charAt(0).toUpperCase()}
+                  </span>
+                )}
+                {canManageWorkspace && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+                    {uploading ? (
+                      <Loader2 className="h-5 w-5 animate-spin text-white" />
+                    ) : (
+                      <Camera className="h-5 w-5 text-white" />
+                    )}
+                  </div>
+                )}
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                className="hidden"
+                onChange={handleLogoUpload}
+              />
+              <div className="text-xs text-muted-foreground">
+                {t(($) => $.workspace.click_logo_hint)}
+              </div>
+            </div>
             <div>
               <Label className="text-xs text-muted-foreground">{t(($) => $.workspace.name_label)}</Label>
               <Input

--- a/packages/views/workspace/paths-hooks.test.tsx
+++ b/packages/views/workspace/paths-hooks.test.tsx
@@ -24,6 +24,7 @@ function makeWorkspace(over: Partial<Workspace>): Workspace {
     settings: {},
     repos: [],
     issue_prefix: "DEF",
+    avatar_url: null,
     created_at: "",
     updated_at: "",
     ...over,

--- a/packages/views/workspace/workspace-avatar.tsx
+++ b/packages/views/workspace/workspace-avatar.tsx
@@ -1,3 +1,4 @@
+import { resolvePublicFileUrl } from "@multica/core/workspace/avatar-url";
 import { cn } from "@multica/ui/lib/utils";
 
 const sizeMap = {
@@ -8,11 +9,22 @@ const sizeMap = {
 
 interface WorkspaceAvatarProps {
   name: string;
+  avatarUrl?: string | null;
   size?: keyof typeof sizeMap;
   className?: string;
 }
 
-function WorkspaceAvatar({ name, size = "sm", className }: WorkspaceAvatarProps) {
+function WorkspaceAvatar({ name, avatarUrl, size = "sm", className }: WorkspaceAvatarProps) {
+  const resolvedUrl = resolvePublicFileUrl(avatarUrl);
+  if (resolvedUrl) {
+    return (
+      <img
+        src={resolvedUrl}
+        alt={name}
+        className={cn("inline-block shrink-0 border object-cover", sizeMap[size], className)}
+      />
+    );
+  }
   return (
     <span
       className={cn(

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -41,6 +41,7 @@ type WorkspaceResponse struct {
 	Settings    any     `json:"settings"`
 	Repos       any     `json:"repos"`
 	IssuePrefix string  `json:"issue_prefix"`
+	AvatarURL   *string `json:"avatar_url"`
 	CreatedAt   string  `json:"created_at"`
 	UpdatedAt   string  `json:"updated_at"`
 }
@@ -69,6 +70,7 @@ func workspaceToResponse(w db.Workspace) WorkspaceResponse {
 		Settings:    settings,
 		Repos:       repos,
 		IssuePrefix: w.IssuePrefix,
+		AvatarURL:   textToPtr(w.AvatarUrl),
 		CreatedAt:   timestampToString(w.CreatedAt),
 		UpdatedAt:   timestampToString(w.UpdatedAt),
 	}
@@ -243,6 +245,7 @@ type UpdateWorkspaceRequest struct {
 	Settings    any     `json:"settings"`
 	Repos       any     `json:"repos"`
 	IssuePrefix *string `json:"issue_prefix"`
+	AvatarURL   *string `json:"avatar_url"`
 }
 
 func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
@@ -288,6 +291,9 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 		if prefix != "" {
 			params.IssuePrefix = pgtype.Text{String: prefix, Valid: true}
 		}
+	}
+	if req.AvatarURL != nil {
+		params.AvatarUrl = pgtype.Text{String: *req.AvatarURL, Valid: true}
 	}
 
 	ws, err := h.Queries.UpdateWorkspace(r.Context(), params)

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -215,6 +216,90 @@ VALUES ($1, $2, 'owner')
 	}
 	if exists {
 		t.Fatal("workspace still exists after owner DELETE")
+	}
+}
+
+// TestUpdateWorkspace_AvatarURL covers the avatar_url field added to
+// UpdateWorkspaceRequest: a PATCH with avatar_url is persisted and surfaced
+// back on the response, and partial updates leave other fields untouched.
+// Route-level authorization (owner/admin) is enforced by middleware in
+// router.go; the handler test calls UpdateWorkspace directly to verify the
+// payload wiring.
+func TestUpdateWorkspace_AvatarURL(t *testing.T) {
+	ctx := context.Background()
+
+	const slug = "handler-tests-avatar-url"
+	_, _ = testPool.Exec(ctx, `DELETE FROM workspace WHERE slug = $1`, slug)
+
+	var wsID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO workspace (name, slug, description)
+VALUES ($1, $2, $3)
+RETURNING id
+`, "Handler Test Avatar URL", slug, "UpdateWorkspace avatar_url test").Scan(&wsID); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, wsID)
+	})
+
+	if _, err := testPool.Exec(ctx, `
+INSERT INTO member (workspace_id, user_id, role)
+VALUES ($1, $2, 'owner')
+`, wsID, testUserID); err != nil {
+		t.Fatalf("create owner member: %v", err)
+	}
+
+	const avatarURL = "https://cdn.example.com/workspaces/abc/logo.png"
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+wsID, map[string]any{
+		"avatar_url": avatarURL,
+	})
+	req = withURLParam(req, "id", wsID)
+	testHandler.UpdateWorkspace(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from UpdateWorkspace, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp WorkspaceResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.AvatarURL == nil || *resp.AvatarURL != avatarURL {
+		t.Fatalf("expected avatar_url %q in response, got %v", avatarURL, resp.AvatarURL)
+	}
+	if resp.Name != "Handler Test Avatar URL" {
+		t.Fatalf("name should be unchanged by avatar-only update, got %q", resp.Name)
+	}
+
+	var dbAvatar *string
+	if err := testPool.QueryRow(ctx, `SELECT avatar_url FROM workspace WHERE id = $1`, wsID).Scan(&dbAvatar); err != nil {
+		t.Fatalf("read avatar_url back: %v", err)
+	}
+	if dbAvatar == nil || *dbAvatar != avatarURL {
+		t.Fatalf("expected avatar_url %q persisted, got %v", avatarURL, dbAvatar)
+	}
+
+	// A follow-up update that doesn't include avatar_url must leave it alone.
+	w2 := httptest.NewRecorder()
+	req2 := newRequest("PATCH", "/api/workspaces/"+wsID, map[string]any{
+		"description": "new description",
+	})
+	req2 = withURLParam(req2, "id", wsID)
+	testHandler.UpdateWorkspace(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200 from second UpdateWorkspace, got %d: %s", w2.Code, w2.Body.String())
+	}
+
+	var resp2 WorkspaceResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp2); err != nil {
+		t.Fatalf("decode second response: %v", err)
+	}
+	if resp2.AvatarURL == nil || *resp2.AvatarURL != avatarURL {
+		t.Fatalf("avatar_url should be preserved by partial update, got %v", resp2.AvatarURL)
 	}
 }
 

--- a/server/migrations/111_workspace_avatar.down.sql
+++ b/server/migrations/111_workspace_avatar.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workspace DROP COLUMN IF EXISTS avatar_url;

--- a/server/migrations/111_workspace_avatar.up.sql
+++ b/server/migrations/111_workspace_avatar.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workspace ADD COLUMN avatar_url TEXT;

--- a/server/pkg/db/generated/models.go
+++ b/server/pkg/db/generated/models.go
@@ -654,6 +654,7 @@ type Workspace struct {
 	Repos        []byte             `json:"repos"`
 	IssuePrefix  string             `json:"issue_prefix"`
 	IssueCounter int32              `json:"issue_counter"`
+	AvatarUrl    pgtype.Text        `json:"avatar_url"`
 }
 
 type WorkspaceInvitation struct {

--- a/server/pkg/db/generated/workspace.sql.go
+++ b/server/pkg/db/generated/workspace.sql.go
@@ -14,7 +14,7 @@ import (
 const createWorkspace = `-- name: CreateWorkspace :one
 INSERT INTO workspace (name, slug, description, context, issue_prefix)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter
+RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter, avatar_url
 `
 
 type CreateWorkspaceParams struct {
@@ -46,6 +46,7 @@ func (q *Queries) CreateWorkspace(ctx context.Context, arg CreateWorkspaceParams
 		&i.Repos,
 		&i.IssuePrefix,
 		&i.IssueCounter,
+		&i.AvatarUrl,
 	)
 	return i, err
 }
@@ -60,7 +61,7 @@ func (q *Queries) DeleteWorkspace(ctx context.Context, id pgtype.UUID) error {
 }
 
 const getWorkspace = `-- name: GetWorkspace :one
-SELECT id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter FROM workspace
+SELECT id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter, avatar_url FROM workspace
 WHERE id = $1
 `
 
@@ -79,12 +80,13 @@ func (q *Queries) GetWorkspace(ctx context.Context, id pgtype.UUID) (Workspace, 
 		&i.Repos,
 		&i.IssuePrefix,
 		&i.IssueCounter,
+		&i.AvatarUrl,
 	)
 	return i, err
 }
 
 const getWorkspaceBySlug = `-- name: GetWorkspaceBySlug :one
-SELECT id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter FROM workspace
+SELECT id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter, avatar_url FROM workspace
 WHERE slug = $1
 `
 
@@ -103,6 +105,7 @@ func (q *Queries) GetWorkspaceBySlug(ctx context.Context, slug string) (Workspac
 		&i.Repos,
 		&i.IssuePrefix,
 		&i.IssueCounter,
+		&i.AvatarUrl,
 	)
 	return i, err
 }
@@ -123,7 +126,7 @@ func (q *Queries) IncrementIssueCounter(ctx context.Context, id pgtype.UUID) (in
 const listWorkspaces = `-- name: ListWorkspaces :many
 SELECT w.id, w.name, w.slug, w.description, w.settings,
        w.created_at, w.updated_at, w.context, w.repos,
-       w.issue_prefix, w.issue_counter
+       w.issue_prefix, w.issue_counter, w.avatar_url
 FROM member m
 JOIN workspace w ON w.id = m.workspace_id
 WHERE m.user_id = $1
@@ -151,6 +154,7 @@ func (q *Queries) ListWorkspaces(ctx context.Context, userID pgtype.UUID) ([]Wor
 			&i.Repos,
 			&i.IssuePrefix,
 			&i.IssueCounter,
+			&i.AvatarUrl,
 		); err != nil {
 			return nil, err
 		}
@@ -170,9 +174,10 @@ UPDATE workspace SET
     settings = COALESCE($5, settings),
     repos = COALESCE($6, repos),
     issue_prefix = COALESCE($7, issue_prefix),
+    avatar_url = COALESCE($8, avatar_url),
     updated_at = now()
 WHERE id = $1
-RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter
+RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter, avatar_url
 `
 
 type UpdateWorkspaceParams struct {
@@ -183,6 +188,7 @@ type UpdateWorkspaceParams struct {
 	Settings    []byte      `json:"settings"`
 	Repos       []byte      `json:"repos"`
 	IssuePrefix pgtype.Text `json:"issue_prefix"`
+	AvatarUrl   pgtype.Text `json:"avatar_url"`
 }
 
 func (q *Queries) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams) (Workspace, error) {
@@ -194,6 +200,7 @@ func (q *Queries) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams
 		arg.Settings,
 		arg.Repos,
 		arg.IssuePrefix,
+		arg.AvatarUrl,
 	)
 	var i Workspace
 	err := row.Scan(
@@ -208,6 +215,7 @@ func (q *Queries) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams
 		&i.Repos,
 		&i.IssuePrefix,
 		&i.IssueCounter,
+		&i.AvatarUrl,
 	)
 	return i, err
 }

--- a/server/pkg/db/queries/workspace.sql
+++ b/server/pkg/db/queries/workspace.sql
@@ -1,7 +1,7 @@
 -- name: ListWorkspaces :many
 SELECT w.id, w.name, w.slug, w.description, w.settings,
        w.created_at, w.updated_at, w.context, w.repos,
-       w.issue_prefix, w.issue_counter
+       w.issue_prefix, w.issue_counter, w.avatar_url
 FROM member m
 JOIN workspace w ON w.id = m.workspace_id
 WHERE m.user_id = $1
@@ -28,6 +28,7 @@ UPDATE workspace SET
     settings = COALESCE(sqlc.narg('settings'), settings),
     repos = COALESCE(sqlc.narg('repos'), repos),
     issue_prefix = COALESCE(sqlc.narg('issue_prefix'), issue_prefix),
+    avatar_url = COALESCE(sqlc.narg('avatar_url'), avatar_url),
     updated_at = now()
 WHERE id = $1
 RETURNING *;


### PR DESCRIPTION
## Summary

Adds a per-workspace logo (`avatar_url`) that members see across the app. Mirrors the squad-avatar pattern (migration 086) — schema/code uses `avatar_url` (consistent with `user.avatar_url` and `squad.avatar_url`), while user-facing strings use "logo" because that's the natural noun for an org-level entity.

### What changed

- **DB:** migration `111_workspace_avatar` adds a nullable `avatar_url TEXT` column.
- **Backend:** `UpdateWorkspace` sqlc query + handler accept `avatar_url`; `WorkspaceResponse` exposes it; `ListWorkspaces` selects it. Authorization is enforced at the router (`RequireWorkspaceRoleFromURL("owner", "admin")`), no handler-level change needed.
- **Types:** `Workspace.avatar_url: string | null` in `packages/core/types/workspace.ts`; `api.updateWorkspace` signature widened. Mobile's `WorkspaceSchema` (`apps/mobile/data/schemas.ts`) gains the matching Zod field so it still conforms to the shared type.
- **UI:**
  - `WorkspaceAvatar` renders an `<img>` when a logo is set, falling back to the initial-letter span. The URL is resolved through `resolvePublicFileUrl()` so relative server URLs render correctly on desktop (matches the user-avatar handling from MUL-2746).
  - Surfaces threaded through: sidebar header + dropdown, member-detail breadcrumb, onboarding workspace selector.
  - `workspace-tab.tsx` gains a click-to-upload logo editor at the top of the General settings card. Uses the existing `useFileUpload` hook; `accept="image/png,image/jpeg,image/webp"`. Disabled for non-admin members. The settings preview also goes through `resolvePublicFileUrl()`.
  - Form-state effect keys on `workspace?.id` (not the full workspace object) so an avatar-only mutation doesn't clobber unsaved name/description/context edits.
- **i18n:** `workspace.change_logo_aria`, `workspace.click_logo_hint`, `workspace.toast_logo_updated`, `workspace.toast_logo_failed` in `en`, `zh-Hans`, and `ko`.
- **Tests:** new `TestUpdateWorkspace_AvatarURL` (set + partial-update preservation); `Workspace` fixtures updated with the new field.

> Note: the issues-list and my-issues-list breadcrumbs were dropped as surfaces — upstream #3510 ("unify detail/list headers") replaced those workspace breadcrumbs with a `ListTodo` icon, so there's no longer a breadcrumb there to host the logo.

### Verified locally

- `pnpm typecheck` green across all packages (incl. `@multica/mobile`).
- `pnpm lint` green (0 errors), `pnpm test` green (TS).
- `go build ./...` / `go vet` clean; `go test ./internal/handler/` green incl. `TestUpdateWorkspace_AvatarURL`; migration `111` applies cleanly.
- CI green: frontend, backend, mobile, installers.

## Test plan

- [ ] Apply migration 111 against a workspace DB.
- [ ] As an owner/admin, upload a PNG/JPEG/WebP in workspace Settings → General → confirm the toast, sidebar update.
- [ ] Hard-reload → confirm the logo persists (DB-backed) and renders on desktop (relative URL resolution).
- [ ] As a regular member, confirm the editor is disabled and the server returns 403 on a forged PATCH.
- [ ] Type into the Name field, then upload a logo without clicking Save → confirm the typed text is preserved.
- [ ] Switch workspaces → confirm the form resets to the new workspace's values (id-based effect dependency).
