### PR TITLE
fix: add mobile sidebar trigger to settings (MUL-2361)

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -94,6 +94,14 @@ export class TestApiClient {
     this.workspaceSlug = slug;
   }
 
+  getWorkspaceId() {
+    return this.workspaceId;
+  }
+
+  getWorkspaceSlug() {
+    return this.workspaceSlug;
+  }
+
   async ensureWorkspace(name = "E2E Workspace", slug = "e2e-workspace") {
     const workspaces = await this.getWorkspaces();
     const workspace = workspaces.find((item) => item.slug === slug) ?? workspaces[0];
@@ -110,6 +118,7 @@ export class TestApiClient {
     if (res.ok) {
       const created = (await res.json()) as TestWorkspace;
       this.workspaceId = created.id;
+      this.workspaceSlug = created.slug;
       return created;
     }
 
@@ -117,6 +126,7 @@ export class TestApiClient {
     const created = refreshed.find((item) => item.slug === slug) ?? refreshed[0];
     if (created) {
       this.workspaceId = created.id;
+      this.workspaceSlug = created.slug;
       return created;
     }
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -123,6 +123,13 @@ export class TestApiClient {
     throw new Error(`Failed to ensure workspace ${slug}: ${res.status} ${res.statusText}`);
   }
 
+  async dismissStarterContent(workspaceId?: string) {
+    await this.authedFetch("/api/me/starter-content/dismiss", {
+      method: "POST",
+      body: workspaceId ? JSON.stringify({ workspace_id: workspaceId }) : undefined,
+    });
+  }
+
   async createIssue(title: string, opts?: Record<string, unknown>) {
     const res = await this.authedFetch("/api/issues", {
       method: "POST",

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -21,8 +21,7 @@ export async function loginAsDefault(page: Page): Promise<string> {
   );
 
   const token = api.getToken();
-  await page.goto("/login");
-  await page.evaluate((t) => {
+  await page.addInitScript((t) => {
     localStorage.setItem("multica_token", t);
   }, token);
   await page.goto(`/${workspace.slug}/issues`);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -21,7 +21,8 @@ export async function loginAsDefault(page: Page): Promise<string> {
   );
 
   const token = api.getToken();
-  await page.addInitScript((t) => {
+  await page.goto("/login");
+  await page.evaluate((t) => {
     localStorage.setItem("multica_token", t);
   }, token);
   await page.goto(`/${workspace.slug}/issues`);

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,7 +1,33 @@
 import { test, expect } from "@playwright/test";
-import { loginAsDefault, openWorkspaceMenu } from "./helpers";
+import { createTestApi, loginAsDefault, openWorkspaceMenu } from "./helpers";
 
 test.describe("Settings", () => {
+  test("mobile settings page can reopen sidebar and navigate away", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const api = await createTestApi();
+    const workspace = await api.ensureWorkspace("E2E Workspace", "e2e-workspace");
+    await api.dismissStarterContent(workspace.id);
+    const workspaceSlug = await loginAsDefault(page);
+    await page.goto(`/${workspaceSlug}/settings`);
+    await page.waitForURL("**/settings");
+
+    const sidebarTrigger = page.locator('[data-slot="sidebar-trigger"]').first();
+    await expect(sidebarTrigger).toBeVisible();
+
+    await sidebarTrigger.click();
+    const sidebarSheet = page.locator('[data-slot="sidebar"][data-mobile="true"]');
+    await expect(sidebarSheet).toBeVisible();
+
+    await page
+      .getByRole("dialog", { name: "Sidebar" })
+      .getByRole("link", { name: "Issues", exact: true })
+      .click();
+    await page.waitForURL("**/issues");
+    await expect(page).toHaveURL(/\/issues/);
+  });
+
   test("updating workspace name reflects in sidebar immediately", async ({
     page,
   }) => {

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -7,13 +7,25 @@ test.describe("Settings", () => {
   }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     const api = await createTestApi();
-    const workspace = await api.ensureWorkspace("E2E Workspace", "e2e-workspace");
-    await api.dismissStarterContent(workspace.id);
-    const workspaceSlug = await loginAsDefault(page);
+    const workspaceId = api.getWorkspaceId();
+    const workspaceSlug = api.getWorkspaceSlug();
+    if (!workspaceId || !workspaceSlug) {
+      throw new Error("Expected createTestApi() to ensure an E2E workspace");
+    }
+
+    // This endpoint is one-way for the shared E2E user. Keep it in this
+    // regression only to prevent the starter modal from covering the mobile
+    // sidebar trigger.
+    await api.dismissStarterContent(workspaceId);
+    await page.addInitScript((token) => {
+      localStorage.setItem("multica_token", token);
+    }, api.getToken());
     await page.goto(`/${workspaceSlug}/settings`);
     await page.waitForURL("**/settings");
 
-    const sidebarTrigger = page.locator('[data-slot="sidebar-trigger"]').first();
+    const sidebarTrigger = page.getByRole("button", {
+      name: /toggle sidebar/i,
+    });
     await expect(sidebarTrigger).toBeVisible();
 
     await sidebarTrigger.click();

--- a/packages/views/settings/components/settings-page.tsx
+++ b/packages/views/settings/components/settings-page.tsx
@@ -16,6 +16,7 @@ import { GitHubMark } from "./github-mark";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@multica/ui/components/ui/tabs";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { useNavigation } from "../../navigation";
+import { PageHeader } from "../../layout/page-header";
 import { AccountTab } from "./account-tab";
 import { PreferencesTab } from "./preferences-tab";
 import { TokensTab } from "./tokens-tab";
@@ -107,70 +108,79 @@ export function SettingsPage({ extraAccountTabs }: SettingsPageProps = {}) {
   };
 
   return (
-    <Tabs
-      value={activeTab}
-      onValueChange={handleTabChange}
-      orientation="vertical"
-      className="flex-1 min-h-0 gap-0 flex flex-col md:flex-row md:overflow-hidden overflow-y-auto"
-    >
-      {/* Left nav (stacks on top on mobile, sidebar on md+) */}
-      <div className="shrink-0 md:w-52 border-b md:border-b-0 md:border-r md:overflow-y-auto p-3 md:p-4">
-        <h1 className="text-sm font-semibold mb-4 px-2">{t(($) => $.page.title)}</h1>
-        <TabsList variant="line" className="flex-col items-stretch w-full">
-          {/* My Account group */}
-          <span className="px-2 pb-1 pt-2 text-xs font-medium text-muted-foreground">
-            {t(($) => $.page.my_account)}
-          </span>
-          {ACCOUNT_TAB_KEYS.map((key) => {
-            const Icon = ACCOUNT_TAB_ICONS[key];
-            return (
-              <TabsTrigger key={key} value={key}>
-                <Icon className="h-4 w-4" />
-                {t(($) => $.page.tabs[key])}
-              </TabsTrigger>
-            );
-          })}
-          {extraAccountTabs?.map((tab) => (
-            <TabsTrigger key={tab.value} value={tab.value}>
-              <tab.icon className="h-4 w-4" />
-              {tab.label}
-            </TabsTrigger>
-          ))}
+    <div className="flex flex-1 min-h-0 flex-col">
+      {/* Desktop settings already has a side-nav title, so only mobile needs PageHeader. */}
+      <PageHeader className="md:hidden">
+        <h1 className="text-sm font-medium">{t(($) => $.page.title)}</h1>
+      </PageHeader>
 
-          {/* Workspace group */}
-          <span className="px-2 pb-1 pt-4 text-xs font-medium text-muted-foreground truncate">
-            {workspaceName ?? t(($) => $.page.workspace_fallback)}
-          </span>
-          {WORKSPACE_TAB_KEYS.map((key) => {
-            const Icon = WORKSPACE_TAB_ICONS[key];
-            return (
-              <TabsTrigger key={key} value={WORKSPACE_TAB_VALUES[key]}>
-                <Icon className="h-4 w-4" />
-                {t(($) => $.page.tabs[key])}
+      <Tabs
+        value={activeTab}
+        onValueChange={handleTabChange}
+        orientation="vertical"
+        className="flex-1 min-h-0 gap-0 flex flex-col md:flex-row md:overflow-hidden overflow-y-auto"
+      >
+        {/* Left nav (stacks on top on mobile, sidebar on md+) */}
+        <div className="shrink-0 md:w-52 border-b md:border-b-0 md:border-r md:overflow-y-auto p-3 md:p-4">
+          <h1 className="hidden text-sm font-semibold mb-4 px-2 md:block">
+            {t(($) => $.page.title)}
+          </h1>
+          <TabsList variant="line" className="flex-col items-stretch w-full">
+            {/* My Account group */}
+            <span className="px-2 pb-1 pt-2 text-xs font-medium text-muted-foreground">
+              {t(($) => $.page.my_account)}
+            </span>
+            {ACCOUNT_TAB_KEYS.map((key) => {
+              const Icon = ACCOUNT_TAB_ICONS[key];
+              return (
+                <TabsTrigger key={key} value={key}>
+                  <Icon className="h-4 w-4" />
+                  {t(($) => $.page.tabs[key])}
+                </TabsTrigger>
+              );
+            })}
+            {extraAccountTabs?.map((tab) => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                <tab.icon className="h-4 w-4" />
+                {tab.label}
               </TabsTrigger>
-            );
-          })}
-        </TabsList>
-      </div>
+            ))}
 
-      {/* Right content */}
-      <div className="flex-1 min-w-0 md:overflow-y-auto">
-        <div className="w-full max-w-3xl mx-auto p-4 md:p-6">
-          <TabsContent value="profile"><AccountTab /></TabsContent>
-          <TabsContent value="preferences"><PreferencesTab /></TabsContent>
-          <TabsContent value="notifications"><NotificationsTab /></TabsContent>
-          <TabsContent value="tokens"><TokensTab /></TabsContent>
-          <TabsContent value="workspace"><WorkspaceTab /></TabsContent>
-          <TabsContent value="repositories"><RepositoriesTab /></TabsContent>
-          <TabsContent value="github"><GitHubTab /></TabsContent>
-          <TabsContent value="integrations"><IntegrationsTab /></TabsContent>
-          <TabsContent value="labs"><LabsTab /></TabsContent>
-          <TabsContent value="members"><MembersTab /></TabsContent>
-          {extraAccountTabs?.map((tab) => (
-            <TabsContent key={tab.value} value={tab.value}>{tab.content}</TabsContent>
-          ))}
+            {/* Workspace group */}
+            <span className="px-2 pb-1 pt-4 text-xs font-medium text-muted-foreground truncate">
+              {workspaceName ?? t(($) => $.page.workspace_fallback)}
+            </span>
+            {WORKSPACE_TAB_KEYS.map((key) => {
+              const Icon = WORKSPACE_TAB_ICONS[key];
+              return (
+                <TabsTrigger key={key} value={WORKSPACE_TAB_VALUES[key]}>
+                  <Icon className="h-4 w-4" />
+                  {t(($) => $.page.tabs[key])}
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
         </div>
-      </div>
-    </Tabs>
+
+        {/* Right content */}
+        <div className="flex-1 min-w-0 md:overflow-y-auto">
+          <div className="w-full max-w-3xl mx-auto p-4 md:p-6">
+            <TabsContent value="profile"><AccountTab /></TabsContent>
+            <TabsContent value="preferences"><PreferencesTab /></TabsContent>
+            <TabsContent value="notifications"><NotificationsTab /></TabsContent>
+            <TabsContent value="tokens"><TokensTab /></TabsContent>
+            <TabsContent value="workspace"><WorkspaceTab /></TabsContent>
+            <TabsContent value="repositories"><RepositoriesTab /></TabsContent>
+            <TabsContent value="github"><GitHubTab /></TabsContent>
+            <TabsContent value="integrations"><IntegrationsTab /></TabsContent>
+            <TabsContent value="labs"><LabsTab /></TabsContent>
+            <TabsContent value="members"><MembersTab /></TabsContent>
+            {extraAccountTabs?.map((tab) => (
+              <TabsContent key={tab.value} value={tab.value}>{tab.content}</TabsContent>
+            ))}
+          </div>
+        </div>
+      </Tabs>
+    </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a mobile Settings page navigation dead-end by reusing the shared `PageHeader`, which includes the standard mobile `SidebarTrigger`.

On mobile, Settings now shows the same sidebar toggle affordance as other dashboard pages. On desktop, the existing settings side-nav layout is preserved.

Thinking path: other dashboard pages already use `PageHeader` for the mobile sidebar trigger, while Settings rendered its tabs directly and skipped that shared header. Reusing the existing shared header keeps the interaction consistent and avoids introducing a parallel sidebar button implementation.

Context:
- Mobile Settings could be reached from the sidebar, but it did not expose a way to reopen that sidebar on small screens.
- This PR is a clean community branch against `multica-ai/multica:main`; the diff is limited to the Settings page fix and the related Playwright coverage.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/settings/components/settings-page.tsx`: adds mobile-only shared `PageHeader` so Settings renders the standard sidebar trigger; keeps the existing Settings title inside the desktop side nav only.
- `e2e/settings.spec.ts`: adds a mobile regression test that opens Settings, uses the sidebar trigger, opens the mobile sidebar, and navigates back to Issues.
- `e2e/fixtures.ts`: adds workspace id/slug accessors and `dismissStarterContent()` so the regression can reuse the cached E2E workspace and avoid being blocked by the first-workspace starter modal.

## Reviewer Feedback Addressed

- Kept token-before-navigation scoped to this Settings regression instead of changing the shared `loginAsDefault()` helper for every e2e spec.
- Removed the duplicate workspace setup and second login round-trip from the new Settings test.
- Documented that `dismissStarterContent()` is one-way for the shared E2E user and is only used here to prevent the starter modal from covering the mobile sidebar trigger.
- Replaced the fragile `[data-slot="sidebar-trigger"] .first()` path with a role-based `Toggle Sidebar` locator.
- Added an inline note explaining why Settings uses a mobile-only `PageHeader`.

## How to Test

- [x] `pnpm typecheck`
- [x] `pnpm --filter @multica/web build`
- [x] Focused mobile Playwright regression passed during validation:
  `PLAYWRIGHT_BASE_URL=http://localhost:3102 DATABASE_URL=... NEXT_PUBLIC_API_URL=http://localhost:8080 pnpm exec playwright test e2e/settings.spec.ts --grep 'mobile settings page can reopen sidebar and navigate away'`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Checklist notes:
- UI evidence: the focused mobile Playwright regression verifies the before/after behavior: Settings exposes the standard mobile sidebar trigger, opens the mobile sidebar sheet, and can navigate to `Issues`. Before this change, Settings skipped the shared header and that trigger was absent.
- Documentation: no docs content changed because this is a bugfix to an existing navigation affordance, not a user-facing feature or workflow change.
- Landing/starter-content/docs sync: N/A because this PR does not add a runtime, coding tool, or UI tab.
- Chinese copy glossary: N/A because this PR does not add or edit Chinese product copy.

## AI Disclosure

**AI tool used:** Multica coding-agent / Codex

**Prompt / approach:** Investigated the mobile Settings navigation issue, compared Settings with other dashboard pages, reused the shared `PageHeader`, preserved the focused Playwright regression, and validated the clean community branch with typecheck and web build.

## Screenshots

Before: mobile Settings rendered directly into the settings tabs and had no global sidebar trigger.

![Before - mobile Settings without sidebar trigger](https://raw.githubusercontent.com/biubiu0002/multica/assets/pr-2761-mobile-settings-screenshots/docs/pr-assets/pr-7/mobile-settings-before.png)

After: mobile Settings renders the shared PageHeader with the standard sidebar trigger in the top-left.

![After - mobile Settings with sidebar trigger](https://raw.githubusercontent.com/biubiu0002/multica/assets/pr-2761-mobile-settings-screenshots/docs/pr-assets/pr-7/mobile-settings-after.png)
