### PR TITLE
fix(editor): sync ContentEditor when defaultValue changes externally

### DIFF
--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 const mockFocus = vi.hoisted(() => vi.fn());
+const mockSetContent = vi.hoisted(() => vi.fn());
+const mockSetTextSelection = vi.hoisted(() => vi.fn());
+const editorState = vi.hoisted(() => ({
+  isFocused: false,
+  isDestroyed: false,
+  markdown: "",
+}));
 
 vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({}),
@@ -23,24 +30,38 @@ vi.mock("./bubble-menu", () => ({
   EditorBubbleMenu: () => null,
 }));
 
+const editorRef = vi.hoisted<{ current: unknown }>(() => ({ current: null }));
+const onCreateFired = vi.hoisted(() => ({ value: false }));
+
 vi.mock("@tiptap/react", () => ({
-  useEditor: () => ({
-    commands: {
-      focus: mockFocus,
-      clearContent: vi.fn(),
-    },
-    getMarkdown: () => "",
-    state: {
-      doc: {
-        content: {
-          size: 0,
+  useEditor: (options: { onCreate?: (args: { editor: unknown }) => void }) => {
+    if (!editorRef.current) {
+      editorRef.current = {
+        get isFocused() {
+          return editorState.isFocused;
         },
-      },
-      selection: {
-        empty: true,
-      },
-    },
-  }),
+        get isDestroyed() {
+          return editorState.isDestroyed;
+        },
+        commands: {
+          focus: mockFocus,
+          clearContent: vi.fn(),
+          setContent: mockSetContent,
+          setTextSelection: mockSetTextSelection,
+        },
+        getMarkdown: () => editorState.markdown,
+        state: {
+          doc: { content: { size: 0 } },
+          selection: { empty: true, from: 0, to: 0 },
+        },
+      };
+    }
+    if (!onCreateFired.value) {
+      onCreateFired.value = true;
+      options?.onCreate?.({ editor: editorRef.current });
+    }
+    return editorRef.current;
+  },
   EditorContent: ({ className }: { className?: string }) => (
     <div className={className} data-testid="editor-content">
       <div className="ProseMirror rich-text-editor" data-testid="prosemirror" />
@@ -53,6 +74,11 @@ import { ContentEditor } from "./content-editor";
 describe("ContentEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    editorState.isFocused = false;
+    editorState.isDestroyed = false;
+    editorState.markdown = "";
+    editorRef.current = null;
+    onCreateFired.value = false;
   });
 
   it("focuses the editor when clicking the empty container area", () => {
@@ -72,5 +98,87 @@ describe("ContentEditor", () => {
     fireEvent.mouseDown(screen.getByTestId("prosemirror"));
 
     expect(mockFocus).not.toHaveBeenCalled();
+  });
+
+  it("syncs editor content when defaultValue changes externally and editor is unfocused", () => {
+    editorState.markdown = "old content";
+    const { rerender } = render(<ContentEditor defaultValue="old content" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+
+    // Editor still holds the old, in-sync content; external value changes.
+    editorState.markdown = "old content";
+    rerender(<ContentEditor defaultValue="new content from server" />);
+
+    expect(mockSetContent).toHaveBeenCalledTimes(1);
+    expect(mockSetContent).toHaveBeenCalledWith(
+      "new content from server",
+      expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+    );
+  });
+
+  it("does not sync when editor is focused and has unsaved local edits", () => {
+    editorState.markdown = "old content";
+    const { rerender } = render(<ContentEditor defaultValue="old content" />);
+
+    // User is typing — focused AND dirty (markdown diverges from
+    // lastEmittedRef, which was seeded with "old content" by onCreate).
+    editorState.isFocused = true;
+    editorState.markdown = "user-typed-content";
+
+    rerender(<ContentEditor defaultValue="incoming external change" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("syncs even when editor is focused, as long as it is clean (focused-but-clean must not be permanently dropped)", () => {
+    // This case is the regression test for the focused-but-clean hole:
+    // user clicks into the editor (focused = true) but types nothing
+    // (markdown still equals lastEmittedRef). An external update arrives.
+    // With an unconditional `if (isFocused) return`, this sync would be lost
+    // forever because onBlur has no replay path.
+    editorState.markdown = "old content";
+    const { rerender } = render(<ContentEditor defaultValue="old content" />);
+
+    editorState.isFocused = true;
+    editorState.markdown = "old content"; // clean — no typing happened
+
+    rerender(<ContentEditor defaultValue="new content from server" />);
+
+    expect(mockSetContent).toHaveBeenCalledTimes(1);
+    expect(mockSetContent).toHaveBeenCalledWith(
+      "new content from server",
+      expect.objectContaining({ emitUpdate: false, contentType: "markdown" }),
+    );
+  });
+
+  it("does not sync when editor is unfocused but has unsaved local edits (blur-before-debounce window)", () => {
+    editorState.markdown = "old content";
+    const { rerender } = render(
+      <ContentEditor defaultValue="old content" onUpdate={() => {}} />,
+    );
+
+    // User typed locally, then blurred. Debounce hasn't flushed yet so
+    // lastEmittedRef inside the component still reflects "old content".
+    editorState.isFocused = false;
+    editorState.markdown = "user typed but unsaved";
+
+    rerender(
+      <ContentEditor
+        defaultValue="external update from another agent"
+        onUpdate={() => {}}
+      />,
+    );
+
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it("does not sync when defaultValue normalizes to the current editor markdown", () => {
+    editorState.markdown = "same content";
+    const { rerender } = render(<ContentEditor defaultValue="same content" />);
+
+    rerender(<ContentEditor defaultValue="same content" />);
+
+    expect(mockSetContent).not.toHaveBeenCalled();
   });
 });

--- a/packages/views/editor/content-editor.test.tsx
+++ b/packages/views/editor/content-editor.test.tsx
@@ -177,7 +177,10 @@ describe("ContentEditor", () => {
     editorState.markdown = "same content";
     const { rerender } = render(<ContentEditor defaultValue="same content" />);
 
-    rerender(<ContentEditor defaultValue="same content" />);
+    // Different `defaultValue` string forces the effect to re-run (the dep
+    // array sees a new value), but the trailing whitespace normalises away
+    // via `trimEnd()`, so `setContent` must still short-circuit.
+    rerender(<ContentEditor defaultValue={"same content\n"} />);
 
     expect(mockSetContent).not.toHaveBeenCalled();
   });

--- a/packages/views/editor/content-editor.tsx
+++ b/packages/views/editor/content-editor.tsx
@@ -225,6 +225,59 @@ const ContentEditor = forwardRef<ContentEditorRef, ContentEditorProps>(
       };
     }, []);
 
+    // Sync external `defaultValue` changes into the editor.
+    // Tiptap v3 `useEditor` reads `content` only at mount (ueberdosis/tiptap#5831);
+    // without this effect, a WS-driven description update keeps the editor
+    // showing stale content until the issue is closed and reopened.
+    useEffect(() => {
+      if (!editor || editor.isDestroyed) return;
+
+      const current = stripBlobUrls(editor.getMarkdown()).trimEnd();
+      // "Dirty" = user has local edits not yet flushed through the debounced
+      // `onUpdate`. `lastEmittedRef` is advanced only after a debounce fire,
+      // so a divergence means the editor holds unsaved bytes.
+      const isDirty =
+        lastEmittedRef.current !== null && current !== lastEmittedRef.current;
+
+      // Guard 1: focused AND dirty — protect bytes the user is actively
+      // typing. Focused-but-clean falls through: applying setContent is safe
+      // (no user input to lose) and necessary, because onBlur has no replay
+      // mechanism and a focused clean editor would otherwise drop this sync
+      // permanently.
+      if (editor.isFocused && isDirty) return;
+
+      // Guard 2: unfocused-but-dirty — blur happened but the debounce window
+      // (debounceMs, 1500ms for description) hasn't flushed yet. The pending
+      // onUpdate will reach the server and the cache will reconcile; skipping
+      // here avoids overwriting unsaved local edits.
+      if (isDirty) return;
+
+      const incoming = defaultValue ? preprocessMarkdown(defaultValue) : "";
+      const incomingNormalized = stripBlobUrls(incoming).trimEnd();
+      // Guard 3: normalized-equal short-circuit. Avoids a no-op transaction
+      // when the cache reflects a write this same editor just emitted.
+      if (incomingNormalized === current) return;
+
+      // Guard 4: `emitUpdate: false`. Tiptap v3's setContent defaults to
+      // `emitUpdate: true`; without this we would re-trigger onUpdate →
+      // server save → self-write loop.
+      const { from, to } = editor.state.selection;
+      editor.commands.setContent(incoming, {
+        emitUpdate: false,
+        contentType: "markdown",
+      });
+
+      // Clamp prior selection to the new doc size so the caret doesn't snap
+      // to position 0 after ProseMirror replaces the document.
+      const docSize = editor.state.doc.content.size;
+      editor.commands.setTextSelection({
+        from: Math.min(from, docSize),
+        to: Math.min(to, docSize),
+      });
+
+      lastEmittedRef.current = stripBlobUrls(editor.getMarkdown()).trimEnd();
+    }, [defaultValue, editor]);
+
     useImperativeHandle(ref, () => ({
       getMarkdown: () => stripBlobUrls(editor?.getMarkdown() ?? ""),
       clearContent: () => {


### PR DESCRIPTION
## Summary

Adds a `useEffect` in `ContentEditor` that mirrors external `defaultValue` changes into the Tiptap editor via `editor.commands.setContent()`. Tiptap v3's `useEditor` reads `content` only at mount ([ueberdosis/tiptap#5831](https://github.com/ueberdosis/tiptap/issues/5831)), so WS-driven description updates were leaving the editor stale until the issue was closed and reopened (MUL-2316).

Single-file scope plus its test. No conflict dialog, no baseline snapshot, no `onBlur` rework, no new i18n strings — this is the minimal-fix follow-up to PR #2409.

## Guards

The effect carries four guards, in order:

1. **focused AND dirty** → skip. Protects bytes the user is actively typing.
2. **unfocused AND dirty** → skip. Covers the blur → 1500ms debounce window where the editor still holds unsaved content; the pending `onUpdate` flush will reconcile via the cache.
3. **normalized-equal** → skip. Avoids no-op transactions when the cache reflects a write this editor just emitted.
4. **`emitUpdate: false`** on `setContent`. Tiptap v3 flipped the default to `true`; without this we'd re-trigger `onUpdate` → server save → self-write loop.

After `setContent` we clamp the prior selection to the new doc size so the caret doesn't snap to 0.

### Why focused-but-clean must sync

The first reviewed plan used unconditional `if (editor.isFocused) return`. Reviewer caught that this permanently drops a sync when the editor is focused but clean (user clicked in, didn't type) — `onBlur` only forwards the callback, there's no replay path, and the effect won't re-run until `defaultValue` changes again. The fix is to gate Guard 1 on `editor.isFocused && isDirty`. Falling through with `setContent` + caret clamp is safe in that state (no user input to lose).

## Test plan

- [x] `pnpm --filter @multica/views test` — 571 / 571 passing
- [x] `pnpm --filter @multica/views typecheck` — clean
- [x] `pnpm --filter @multica/views lint` — 0 errors (pre-existing warnings unrelated)
- [x] New test cases cover all five required scenarios:
  - unfocused + dirty-content → `setContent` fires
  - focused + dirty → no `setContent`
  - **focused + clean → `setContent` fires** (regression guard against the focused-but-clean hole)
  - unfocused + dirty (blur-before-debounce window) → no `setContent`
  - normalized-equal short-circuit → no `setContent`

Closes #2409

Refs MUL-2316 / MUL-2035

🤖 Generated with [Claude Code](https://claude.com/claude-code)