### PR TITLE
MUL-2324 conditionally inject non-core rule blocks

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2199,25 +2199,31 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Repos are passed as metadata only — the agent checks them out on demand
 	// via `multica repo checkout <url>`.
 	taskCtx := execenv.TaskContextForEnv{
-		IssueID:                 task.IssueID,
-		TriggerCommentID:        task.TriggerCommentID,
-		AgentID:                 agentID,
-		AgentName:               agentName,
-		AgentInstructions:       instructions,
-		AgentSkills:             convertSkillsForEnv(skills),
-		Repos:                   convertReposForEnv(task.Repos),
-		ProjectID:               task.ProjectID,
-		ProjectTitle:            task.ProjectTitle,
-		ProjectResources:        convertProjectResourcesForEnv(task.ProjectResources),
-		ChatSessionID:           task.ChatSessionID,
-		AutopilotRunID:          task.AutopilotRunID,
-		AutopilotID:             task.AutopilotID,
-		AutopilotTitle:          task.AutopilotTitle,
-		AutopilotDescription:    task.AutopilotDescription,
-		AutopilotSource:         task.AutopilotSource,
-		AutopilotTriggerPayload: strings.TrimSpace(string(task.AutopilotTriggerPayload)),
-		QuickCreatePrompt:       task.QuickCreatePrompt,
-		IsSquadLeader:           strings.Contains(instructions, "## Squad Operating Protocol"),
+		IssueID:                      task.IssueID,
+		IssueTitle:                   task.IssueTitle,
+		IssueDescription:             task.IssueDescription,
+		TriggerCommentID:             task.TriggerCommentID,
+		TriggerCommentContent:        task.TriggerCommentContent,
+		AgentID:                      agentID,
+		AgentName:                    agentName,
+		AgentInstructions:            instructions,
+		AgentSkills:                  convertSkillsForEnv(skills),
+		Repos:                        convertReposForEnv(task.Repos),
+		ProjectID:                    task.ProjectID,
+		ProjectTitle:                 task.ProjectTitle,
+		ProjectResources:             convertProjectResourcesForEnv(task.ProjectResources),
+		HasIssueOrCommentAttachments: task.HasIssueOrCommentAttachments,
+		ChatSessionID:                task.ChatSessionID,
+		ChatMessage:                  task.ChatMessage,
+		ChatMessageAttachments:       convertAttachmentsForEnv(task.ChatMessageAttachments),
+		AutopilotRunID:               task.AutopilotRunID,
+		AutopilotID:                  task.AutopilotID,
+		AutopilotTitle:               task.AutopilotTitle,
+		AutopilotDescription:         task.AutopilotDescription,
+		AutopilotSource:              task.AutopilotSource,
+		AutopilotTriggerPayload:      strings.TrimSpace(string(task.AutopilotTriggerPayload)),
+		QuickCreatePrompt:            task.QuickCreatePrompt,
+		IsSquadLeader:                strings.Contains(instructions, "## Squad Operating Protocol"),
 	}
 
 	// Mark candidate env roots as active before any env work so the GC loop
@@ -3021,6 +3027,21 @@ func convertProjectResourcesForEnv(resources []ProjectResourceData) []execenv.Pr
 			ResourceType: r.ResourceType,
 			ResourceRef:  r.ResourceRef,
 			Label:        r.Label,
+		}
+	}
+	return result
+}
+
+func convertAttachmentsForEnv(attachments []ChatAttachmentMeta) []execenv.AttachmentContextForEnv {
+	if len(attachments) == 0 {
+		return nil
+	}
+	result := make([]execenv.AttachmentContextForEnv, len(attachments))
+	for i, a := range attachments {
+		result[i] = execenv.AttachmentContextForEnv{
+			ID:          a.ID,
+			Filename:    a.Filename,
+			ContentType: a.ContentType,
 		}
 	}
 	return result

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -43,25 +43,39 @@ type PrepareParams struct {
 
 // TaskContextForEnv is the subset of task context used for writing context files.
 type TaskContextForEnv struct {
-	IssueID                 string
-	TriggerCommentID        string // comment that triggered this task (empty for on_assign)
-	AgentID                 string // unique ID of the dispatched agent
-	AgentName               string
-	AgentInstructions       string // agent identity/persona instructions, injected into CLAUDE.md
-	AgentSkills             []SkillContextForEnv
-	Repos                   []RepoContextForEnv     // workspace repos available for checkout
-	ProjectID               string                  // issue's project, when present
-	ProjectTitle            string                  // human-readable project title
-	ProjectResources        []ProjectResourceForEnv // resources attached to the project
-	ChatSessionID           string                  // non-empty for chat tasks
-	AutopilotRunID          string                  // non-empty for autopilot run_only tasks
-	AutopilotID             string
-	AutopilotTitle          string
-	AutopilotDescription    string
-	AutopilotSource         string
-	AutopilotTriggerPayload string
-	QuickCreatePrompt       string // non-empty for quick-create tasks
-	IsSquadLeader           bool   // true when the agent is acting as a squad leader (may exit silently on no_action)
+	IssueID                      string
+	IssueTitle                   string
+	IssueDescription             string
+	TriggerCommentID             string // comment that triggered this task (empty for on_assign)
+	TriggerCommentContent        string
+	AgentID                      string // unique ID of the dispatched agent
+	AgentName                    string
+	AgentInstructions            string // agent identity/persona instructions, injected into CLAUDE.md
+	AgentSkills                  []SkillContextForEnv
+	Repos                        []RepoContextForEnv     // workspace repos available for checkout
+	ProjectID                    string                  // issue's project, when present
+	ProjectTitle                 string                  // human-readable project title
+	ProjectResources             []ProjectResourceForEnv // resources attached to the project
+	HasIssueOrCommentAttachments bool                    // true when the issue or any issue comment has attachments
+	ChatSessionID                string                  // non-empty for chat tasks
+	ChatMessage                  string
+	ChatMessageAttachments       []AttachmentContextForEnv
+	AutopilotRunID               string // non-empty for autopilot run_only tasks
+	AutopilotID                  string
+	AutopilotTitle               string
+	AutopilotDescription         string
+	AutopilotSource              string
+	AutopilotTriggerPayload      string
+	QuickCreatePrompt            string // non-empty for quick-create tasks
+	IsSquadLeader                bool   // true when the agent is acting as a squad leader (may exit silently on no_action)
+}
+
+// AttachmentContextForEnv is the minimal attachment metadata needed for
+// capability derivation. The agent fetches full metadata through the CLI.
+type AttachmentContextForEnv struct {
+	ID          string
+	Filename    string
+	ContentType string
 }
 
 // SkillContextForEnv represents a skill to be written into the execution environment.

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -592,7 +592,10 @@ func TestInjectRuntimeConfigAutopilotAdvertisesBothModes(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	if _, err := InjectRuntimeConfig(dir, "claude", TaskContextForEnv{IssueID: "issue-1"}); err != nil {
+	if _, err := InjectRuntimeConfig(dir, "claude", TaskContextForEnv{
+		IssueID:    "issue-1",
+		IssueTitle: "Create an autopilot for stale issue triage",
+	}); err != nil {
 		t.Fatalf("InjectRuntimeConfig failed: %v", err)
 	}
 
@@ -1132,6 +1135,163 @@ func TestInjectRuntimeConfigAvailableCommandsIsNeutral(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestInjectRuntimeConfigConditionalRuleBlocks(t *testing.T) {
+	t.Parallel()
+
+	render := func(t *testing.T, ctx TaskContextForEnv) string {
+		t.Helper()
+		dir := t.TempDir()
+		if _, err := InjectRuntimeConfig(dir, "claude", ctx); err != nil {
+			t.Fatalf("InjectRuntimeConfig failed: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+		if err != nil {
+			t.Fatalf("read CLAUDE.md: %v", err)
+		}
+		return string(data)
+	}
+	assertContains := func(t *testing.T, s string, wants ...string) {
+		t.Helper()
+		for _, want := range wants {
+			if !strings.Contains(s, want) {
+				t.Fatalf("runtime config missing %q\n---\n%s", want, s)
+			}
+		}
+	}
+	assertAbsent := func(t *testing.T, s string, banned ...string) {
+		t.Helper()
+		for _, ban := range banned {
+			if strings.Contains(s, ban) {
+				t.Fatalf("runtime config should not include %q\n---\n%s", ban, s)
+			}
+		}
+	}
+
+	t.Run("ordinary comment trigger gets core loop only", func(t *testing.T) {
+		s := render(t, TaskContextForEnv{
+			IssueID:               "issue-1",
+			TriggerCommentID:      "comment-1",
+			TriggerCommentContent: "Please fix the login redirect.",
+		})
+		assertContains(t, s,
+			"multica issue get issue-1 --output json",
+			"multica issue comment add issue-1",
+			"Do not create member or agent mention links unless the task explicitly requires",
+		)
+		assertAbsent(t, s,
+			"multica attachment download",
+			"multica issue label add",
+			"multica issue subscriber add",
+			"multica autopilot create",
+			"multica project resource list",
+			"side-effecting actions",
+		)
+	})
+
+	t.Run("ordinary webhook notification work does not trigger optional rule blocks", func(t *testing.T) {
+		s := render(t, TaskContextForEnv{
+			IssueID:               "issue-1",
+			IssueTitle:            "Build webhook notification delivery",
+			IssueDescription:      "Implement retry handling for webhook events and notification preferences.",
+			TriggerCommentID:      "comment-1",
+			TriggerCommentContent: "Please fix the webhook and notification code paths.",
+		})
+		assertContains(t, s,
+			"Do not create member or agent mention links unless the task explicitly requires",
+			"multica issue comment add issue-1",
+		)
+		assertAbsent(t, s,
+			"multica autopilot create",
+			"multica autopilot list",
+			"side-effecting actions",
+			"enqueues a new run for that agent",
+		)
+	})
+
+	t.Run("attachment context gets attachment block", func(t *testing.T) {
+		s := render(t, TaskContextForEnv{
+			IssueID:                      "issue-1",
+			TriggerCommentID:             "comment-1",
+			TriggerCommentContent:        "The screenshot is attached.",
+			HasIssueOrCommentAttachments: true,
+		})
+		assertContains(t, s,
+			"## Attachments",
+			"multica attachment download <id>",
+			"[--attachment <path>]",
+		)
+		assertAbsent(t, s, "multica autopilot create", "multica issue label add")
+	})
+
+	t.Run("label and subscriber request gets label subscriber block", func(t *testing.T) {
+		s := render(t, TaskContextForEnv{
+			IssueID:          "issue-1",
+			IssueTitle:       "Add bug label and subscribe Alice",
+			IssueDescription: "Please label this as regression and subscribe the reporter.",
+		})
+		assertContains(t, s,
+			"multica issue label list <issue-id> --output json",
+			"multica issue label add <issue-id> <label-id>",
+			"multica issue subscriber add <issue-id>",
+			"multica label create --name",
+		)
+		assertAbsent(t, s, "multica autopilot create", "multica attachment download")
+	})
+
+	t.Run("autopilot request gets autopilot block", func(t *testing.T) {
+		s := render(t, TaskContextForEnv{
+			IssueID:    "issue-1",
+			IssueTitle: "Create an autopilot for weekly dependency reports",
+		})
+		assertContains(t, s,
+			"multica autopilot list",
+			"multica autopilot create --title \"...\" --agent <name> --mode create_issue|run_only",
+			"multica autopilot update <id>",
+			"[--mode create_issue|run_only]",
+			"multica autopilot trigger <id>",
+		)
+		assertAbsent(t, s, "multica issue label add", "multica project resource list")
+	})
+
+	t.Run("project resources get resource block", func(t *testing.T) {
+		s := render(t, TaskContextForEnv{
+			IssueID:      "issue-1",
+			ProjectID:    "project-1",
+			ProjectTitle: "Platform",
+			ProjectResources: []ProjectResourceForEnv{
+				{
+					ID:           "resource-1",
+					ResourceType: "github_repo",
+					ResourceRef:  json.RawMessage(`{"url":"https://github.com/multica-ai/multica","default_branch_hint":"main"}`),
+				},
+			},
+		})
+		assertContains(t, s,
+			"multica project get <id> --output json",
+			"multica project resource list <project-id> --output json",
+			"## Project Context",
+			"https://github.com/multica-ai/multica",
+			"resources.json",
+		)
+		assertAbsent(t, s, "multica autopilot create", "multica issue label add")
+	})
+
+	t.Run("squad delegation gets squad block", func(t *testing.T) {
+		s := render(t, TaskContextForEnv{
+			IssueID:          "issue-1",
+			TriggerCommentID: "comment-1",
+			IsSquadLeader:    true,
+		})
+		assertContains(t, s,
+			"multica squad get <squad-id> --output json",
+			"multica squad member list <squad-id> --output json",
+			"multica squad activity <issue-id> action|no_action|failed",
+			"Squad leader rule",
+		)
+		assertAbsent(t, s, "multica autopilot create", "multica project resource list")
+	})
 }
 
 // TestInjectRuntimeConfigCodexLinuxEmphasizesStdin pins the
@@ -2654,6 +2814,11 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 		IssueID:          "issue-1",
 		TriggerCommentID: "comment-1",
 	}
+	mentionCtx := TaskContextForEnv{
+		IssueID:               "issue-1",
+		TriggerCommentID:      "comment-1",
+		TriggerCommentContent: "Please loop in [@ReviewBot](mention://agent/agent-1) for a second pass.",
+	}
 	assignmentCtx := TaskContextForEnv{IssueID: "issue-1"}
 
 	readClaudeMD := func(t *testing.T, ctx TaskContextForEnv) string {
@@ -2671,7 +2836,7 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 
 	t.Run("mentions-section-lists-loop-protocol", func(t *testing.T) {
 		t.Parallel()
-		s := readClaudeMD(t, assignmentCtx)
+		s := readClaudeMD(t, mentionCtx)
 		for _, want := range []string{
 			"side-effecting actions",
 			"enqueues a new run for that agent",
@@ -2683,6 +2848,23 @@ func TestInjectRuntimeConfigMentionLoopHardening(t *testing.T) {
 			if !strings.Contains(s, want) {
 				t.Errorf("Mentions section missing %q\n---\n%s", want, s)
 			}
+		}
+	})
+
+	t.Run("ordinary-task-keeps-minimal-mention-warning", func(t *testing.T) {
+		t.Parallel()
+		s := readClaudeMD(t, assignmentCtx)
+		for _, banned := range []string{
+			"side-effecting actions",
+			"enqueues a new run for that agent",
+			"When a mention IS appropriate",
+		} {
+			if strings.Contains(s, banned) {
+				t.Errorf("ordinary CLAUDE.md should not include full mention block %q\n---\n%s", banned, s)
+			}
+		}
+		if !strings.Contains(s, "Do not create member or agent mention links unless the task explicitly requires") {
+			t.Errorf("ordinary CLAUDE.md missing minimal mention warning\n---\n%s", s)
 		}
 	})
 

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -1210,6 +1210,23 @@ func TestInjectRuntimeConfigConditionalRuleBlocks(t *testing.T) {
 		)
 	})
 
+	t.Run("issue mention link does not trigger full mention block", func(t *testing.T) {
+		s := render(t, TaskContextForEnv{
+			IssueID:               "issue-1",
+			TriggerCommentID:      "comment-1",
+			TriggerCommentContent: "Please follow up on [MUL-123](mention://issue/issue-123) while fixing this.",
+		})
+		assertContains(t, s,
+			"Do not create member or agent mention links unless the task explicitly requires",
+			"multica issue comment add issue-1",
+		)
+		assertAbsent(t, s,
+			"side-effecting actions",
+			"enqueues a new run for that agent",
+			"When a mention IS appropriate",
+		)
+	})
+
 	t.Run("attachment context gets attachment block", func(t *testing.T) {
 		s := render(t, TaskContextForEnv{
 			IssueID:                      "issue-1",

--- a/server/internal/daemon/execenv/rule_blocks.go
+++ b/server/internal/daemon/execenv/rule_blocks.go
@@ -43,7 +43,7 @@ func deriveRuntimeCapabilities(ctx TaskContextForEnv) runtimeCapabilities {
 	if ctx.HasIssueOrCommentAttachments || len(ctx.ChatMessageAttachments) > 0 || (allowTextDrivenBlocks && containsAny(text, attachmentIntentKeywords)) {
 		caps.flags |= capabilityAttachments
 	}
-	if strings.Contains(text, "mention://") || containsAny(text, mentionIntentKeywords) || ctx.IsSquadLeader {
+	if containsSideEffectMentionLink(text) || containsAny(text, mentionIntentKeywords) || ctx.IsSquadLeader {
 		caps.flags |= capabilityFullMentions
 	}
 	if allowTextDrivenBlocks && containsAny(text, labelSubscriberIntentKeywords) {
@@ -101,6 +101,10 @@ func containsAny(text string, needles []string) bool {
 		}
 	}
 	return false
+}
+
+func containsSideEffectMentionLink(text string) bool {
+	return strings.Contains(text, "mention://member/") || strings.Contains(text, "mention://agent/")
 }
 
 var attachmentIntentKeywords = []string{

--- a/server/internal/daemon/execenv/rule_blocks.go
+++ b/server/internal/daemon/execenv/rule_blocks.go
@@ -1,0 +1,336 @@
+package execenv
+
+import (
+	"fmt"
+	"strings"
+)
+
+type taskKind string
+
+const (
+	taskKindAssignment  taskKind = "assignment"
+	taskKindComment     taskKind = "comment"
+	taskKindChat        taskKind = "chat"
+	taskKindAutopilot   taskKind = "autopilot"
+	taskKindQuickCreate taskKind = "quick_create"
+)
+
+type capabilityFlag uint64
+
+const (
+	capabilityAttachments capabilityFlag = 1 << iota
+	capabilityFullMentions
+	capabilityLabelsSubscribers
+	capabilityAutopilot
+	capabilityProjectResources
+	capabilitySquadDelegation
+)
+
+type runtimeCapabilities struct {
+	kind  taskKind
+	flags capabilityFlag
+}
+
+func (c runtimeCapabilities) Has(flag capabilityFlag) bool {
+	return c.flags&flag != 0
+}
+
+func deriveRuntimeCapabilities(ctx TaskContextForEnv) runtimeCapabilities {
+	caps := runtimeCapabilities{kind: taskKindForContext(ctx)}
+	text := capabilityIntentText(ctx)
+	allowTextDrivenBlocks := caps.kind != taskKindQuickCreate
+
+	if ctx.HasIssueOrCommentAttachments || len(ctx.ChatMessageAttachments) > 0 || (allowTextDrivenBlocks && containsAny(text, attachmentIntentKeywords)) {
+		caps.flags |= capabilityAttachments
+	}
+	if strings.Contains(text, "mention://") || containsAny(text, mentionIntentKeywords) || ctx.IsSquadLeader {
+		caps.flags |= capabilityFullMentions
+	}
+	if allowTextDrivenBlocks && containsAny(text, labelSubscriberIntentKeywords) {
+		caps.flags |= capabilityLabelsSubscribers
+	}
+	if ctx.AutopilotRunID != "" || (allowTextDrivenBlocks && containsAny(text, autopilotIntentKeywords)) {
+		caps.flags |= capabilityAutopilot
+	}
+	if len(ctx.ProjectResources) > 0 || (allowTextDrivenBlocks && containsAny(text, projectResourceIntentKeywords)) {
+		caps.flags |= capabilityProjectResources
+	}
+	if ctx.IsSquadLeader || containsAny(text, squadDelegationIntentKeywords) {
+		caps.flags |= capabilitySquadDelegation
+	}
+
+	return caps
+}
+
+func taskKindForContext(ctx TaskContextForEnv) taskKind {
+	switch {
+	case ctx.ChatSessionID != "":
+		return taskKindChat
+	case ctx.QuickCreatePrompt != "":
+		return taskKindQuickCreate
+	case ctx.AutopilotRunID != "":
+		return taskKindAutopilot
+	case ctx.TriggerCommentID != "":
+		return taskKindComment
+	default:
+		return taskKindAssignment
+	}
+}
+
+func capabilityIntentText(ctx TaskContextForEnv) string {
+	parts := []string{
+		ctx.IssueTitle,
+		ctx.IssueDescription,
+		ctx.TriggerCommentContent,
+		ctx.ChatMessage,
+		ctx.QuickCreatePrompt,
+		ctx.AutopilotTitle,
+		ctx.AutopilotDescription,
+		ctx.AutopilotTriggerPayload,
+	}
+	return strings.ToLower(strings.Join(parts, "\n"))
+}
+
+func containsAny(text string, needles []string) bool {
+	if text == "" {
+		return false
+	}
+	for _, needle := range needles {
+		if strings.Contains(text, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+var attachmentIntentKeywords = []string{
+	"attachment",
+	"attachments",
+	"attached",
+	"uploaded",
+	"uploaded file",
+	"screenshot",
+	"file attached",
+	"附件",
+	"上传",
+	"截图",
+}
+
+var mentionIntentKeywords = []string{
+	"loop someone in",
+	"mention link",
+	"member mention",
+	"agent mention",
+	"@mention",
+	"notify a member",
+	"notify an agent",
+	"notify @",
+	"cc @",
+	"提及链接",
+	"mention 链接",
+	"通知某人",
+	"拉人进来",
+	"抄送 @",
+}
+
+var labelSubscriberIntentKeywords = []string{
+	" label ",
+	" labels ",
+	"issue label",
+	"label this",
+	"relabel",
+	"subscriber",
+	"subscribers",
+	"subscribe",
+	"unsubscribe",
+	"watcher",
+	"watchers",
+	"标签",
+	"订阅",
+	"取消订阅",
+}
+
+var autopilotIntentKeywords = []string{
+	"autopilot",
+	"multica autopilot",
+	"autopilot run",
+	"autopilot runs",
+	"autopilot trigger",
+	"autopilot webhook",
+	"scheduled autopilot",
+	"create autopilot",
+	"update autopilot",
+	"delete autopilot",
+	"list autopilots",
+	"创建 autopilot",
+	"更新 autopilot",
+	"删除 autopilot",
+	"autopilot 定时",
+	"autopilot 触发",
+}
+
+var projectResourceIntentKeywords = []string{
+	"project resource",
+	"project resources",
+	"resource_count",
+	"resources.json",
+	".multica/project",
+	"项目资源",
+	"项目仓库",
+	"项目 repo",
+}
+
+var squadDelegationIntentKeywords = []string{
+	"squad delegation",
+	"squad leader",
+	"delegate to squad",
+	"squad roster",
+	"squad member",
+	"squad members",
+	"小队",
+	"班组",
+	"小队委派",
+	"小队转派",
+	"小队成员名单",
+}
+
+func writeAvailableCommands(b *strings.Builder, caps runtimeCapabilities) {
+	b.WriteString("## Available Commands\n\n")
+	b.WriteString("**Use `--output json` for structured data.** Human table output now prints routable issue keys (for example `MUL-123`) and short UUID prefixes for workspace resources; use `--full-id` on list commands when you need canonical UUIDs.\n\n")
+
+	b.WriteString("### Read\n")
+	b.WriteString("- `multica issue get <id> --output json` — Get full issue details (title, description, status, priority, assignee)\n")
+	b.WriteString("- `multica issue list [--status X] [--priority X] [--assignee X | --assignee-id <uuid>] [--limit N] [--offset N] [--full-id] [--output json]` — List issues in workspace (default limit: 50; table output uses routable issue keys; JSON output includes `total`, `has_more` — use offset to paginate when `has_more` is true). Prefer `--assignee-id <uuid>` when scripting from `multica workspace members --output json` / `multica agent list --output json` / `multica squad list --output json`.\n")
+	b.WriteString("- `multica issue comment list <issue-id> [--since <RFC3339>] --output json` — List all comments on an issue (server caps at 2000 rows). Use `--since` for incremental polling.\n")
+	if caps.Has(capabilityLabelsSubscribers) {
+		b.WriteString("- `multica issue label list <issue-id> --output json` — List labels currently attached to an issue\n")
+		b.WriteString("- `multica issue subscriber list <issue-id> --output json` — List members/agents subscribed to an issue\n")
+		b.WriteString("- `multica label list --output json` — List all labels defined in the workspace (returns id + name + color)\n")
+	}
+	b.WriteString("- `multica workspace get --output json` — Get workspace details and context\n")
+	b.WriteString("- `multica workspace members [workspace-id] --output json` — List workspace members (user IDs, names, roles)\n")
+	b.WriteString("- `multica agent list --output json` — List agents in workspace\n")
+	b.WriteString("- `multica squad list --output json` — List squads in workspace (squads are first-class assignees — assigning an issue to a squad routes it to the squad leader, who then delegates)\n")
+	if caps.Has(capabilitySquadDelegation) {
+		b.WriteString("- `multica squad get <squad-id> --output json` — Get squad details including leader and instructions\n")
+		b.WriteString("- `multica squad member list <squad-id> --output json` — List members of a squad\n")
+	}
+	b.WriteString("- `multica repo checkout <url> [--ref <branch-or-sha>]` — Check out a repository into the working directory (creates a git worktree with a dedicated branch; use `--ref` for review/QA on a specific branch, tag, or commit)\n")
+	b.WriteString("- `multica issue runs <issue-id> [--full-id] --output json` — List all execution runs for an issue (status, timestamps, errors); table task IDs are short prefixes unless `--full-id` is set\n")
+	b.WriteString("- `multica issue run-messages <task-id> [--issue <issue-id>] [--since <seq>] --output json` — List messages for a specific execution run; full task UUIDs work directly, copied short task prefixes must be scoped with `--issue <issue-id>`\n")
+	if caps.Has(capabilityAttachments) {
+		b.WriteString("- `multica attachment download <id> [-o <dir>]` — Download an attachment file locally by ID\n")
+	}
+	if caps.Has(capabilityAutopilot) {
+		b.WriteString("- `multica autopilot list [--status X] [--full-id] [--output json]` — List autopilots (scheduled/triggered agent automations) in the workspace; copied short IDs are accepted by autopilot subcommands when unique\n")
+		b.WriteString("- `multica autopilot get <id> --output json` — Get autopilot details including triggers\n")
+		b.WriteString("- `multica autopilot runs <id> [--limit N] --output json` — List execution history for an autopilot\n")
+	}
+	if caps.Has(capabilityProjectResources) {
+		b.WriteString("- `multica project get <id> --output json` — Get project details. Includes `resource_count`; the resources themselves live at the sub-collection below.\n")
+		b.WriteString("- `multica project resource list <project-id> --output json` — List resources (e.g. github_repo) attached to a project. Use this when `resource_count > 0` and you need the actual refs.\n")
+	}
+	b.WriteString("\n")
+
+	b.WriteString("### Write\n")
+	if caps.Has(capabilityAttachments) {
+		b.WriteString("- `multica issue create --title \"...\" [--description \"...\"] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--project <project-id>] [--due-date <RFC3339>] [--attachment <path>]` — Create a new issue. `--attachment` may be repeated to upload multiple local files.\n")
+	} else {
+		b.WriteString("- `multica issue create --title \"...\" [--description \"...\"] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--project <project-id>] [--due-date <RFC3339>]` — Create a new issue.\n")
+	}
+	b.WriteString("- `multica issue update <id> [--title X] [--description X] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--project <project-id>] [--due-date <RFC3339>]` — Update one or more issue fields in a single call. Use `--parent \"\"` to clear the parent.\n")
+	b.WriteString("- `multica issue status <id> <status>` — Shortcut for `issue update --status` when you only need to flip status (todo, in_progress, in_review, done, blocked, backlog, cancelled)\n")
+	b.WriteString("- `multica issue assign <id> --to <name>|--to-id <uuid>` — Assign an issue to a member, agent, or squad. `--to <name>` does fuzzy name matching; pass `--to-id <uuid>` (mutually exclusive with `--to`) to assign by canonical UUID, e.g. when names overlap. Use `--unassign` to clear the assignee.\n")
+	if caps.Has(capabilityLabelsSubscribers) {
+		b.WriteString("- Note: `multica issue create` does not accept labels or subscribers directly; attach them after creation with the commands below.\n")
+		b.WriteString("- `multica issue label add <issue-id> <label-id>` — Attach a label to an issue (look up the label id via `multica label list`)\n")
+		b.WriteString("- `multica issue label remove <issue-id> <label-id>` — Detach a label from an issue\n")
+		b.WriteString("- `multica issue subscriber add <issue-id> [--user <name>|--user-id <uuid>]` — Subscribe a member or agent to issue updates (defaults to the caller when neither flag is set; the two flags are mutually exclusive)\n")
+		b.WriteString("- `multica issue subscriber remove <issue-id> [--user <name>|--user-id <uuid>]` — Unsubscribe a member or agent\n")
+	}
+	if caps.Has(capabilityAttachments) {
+		b.WriteString("- `multica issue comment add <issue-id> [--content \"...\" | --content-stdin | --content-file <path>] [--parent <comment-id>] [--attachment <path>]` — Post a comment. `--attachment` may be repeated for local files.\n")
+	} else {
+		b.WriteString("- `multica issue comment add <issue-id> [--content \"...\" | --content-stdin | --content-file <path>] [--parent <comment-id>]` — Post a comment.\n")
+	}
+	b.WriteString("  - `--content \"...\"` for short single-line text. The CLI decodes `\\n`, `\\r`, `\\t`, `\\\\` so escaped multi-line is OK; do not embed raw newlines in the argument.\n")
+	b.WriteString("  - `--content-stdin` to pipe the body via HEREDOC. Preserves multi-line and special characters verbatim. Cleanest in `bash` / `zsh`.\n")
+	b.WriteString("  - `--content-file <path>` to read a UTF-8 file off disk. Preserves bytes verbatim regardless of the shell — use this on Windows when stdin would re-encode non-ASCII (Chinese, Japanese, Cyrillic, accents, emoji) through the console codepage and drop them as `?`.\n")
+	b.WriteString("  - Use `--parent` to reply to a specific comment")
+	if caps.Has(capabilityAttachments) {
+		b.WriteString("; `--attachment` may be repeated")
+	}
+	b.WriteString(".\n")
+	b.WriteString("- `multica issue create` / `multica issue update` accept the same three modes for `--description`: `--description \"...\"`, `--description-stdin`, or `--description-file <path>`.\n")
+	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
+	if caps.Has(capabilityLabelsSubscribers) {
+		b.WriteString("- `multica label create --name \"...\" --color \"#hex\"` — Define a new workspace label (use this only when the label you need does not exist yet; reuse existing labels via `multica label list` first)\n")
+	}
+	if caps.Has(capabilityAutopilot) {
+		b.WriteString("- `multica autopilot create --title \"...\" --agent <name> --mode create_issue|run_only [--description \"...\"]` — Create an autopilot\n")
+		b.WriteString("- `multica autopilot update <id> [--title X] [--description X] [--status active|paused] [--mode create_issue|run_only]` — Update an autopilot\n")
+		b.WriteString("- `multica autopilot trigger <id>` — Manually trigger an autopilot to run once\n")
+		b.WriteString("- `multica autopilot delete <id>` — Delete an autopilot\n")
+	}
+	if caps.Has(capabilitySquadDelegation) {
+		b.WriteString("- `multica squad activity <issue-id> action|no_action|failed [--reason \"...\"] [--output json]` — Record a squad leader evaluation decision in the issue timeline\n")
+	}
+	b.WriteString("\n")
+}
+
+func writeProjectContext(b *strings.Builder, ctx TaskContextForEnv, caps runtimeCapabilities) {
+	if !caps.Has(capabilityProjectResources) || (ctx.ProjectID == "" && len(ctx.ProjectResources) == 0) {
+		return
+	}
+
+	b.WriteString("## Project Context\n\n")
+	if ctx.ProjectTitle != "" {
+		fmt.Fprintf(b, "This issue belongs to **%s**.\n\n", ctx.ProjectTitle)
+	}
+	if len(ctx.ProjectResources) > 0 {
+		b.WriteString("Project resources (also written to `.multica/project/resources.json`):\n\n")
+		for _, r := range ctx.ProjectResources {
+			fmt.Fprintf(b, "- %s\n", formatProjectResource(r))
+		}
+		b.WriteString("\nResources are pointers — open them only when relevant to the task. ")
+		b.WriteString("For `github_repo` resources, use `multica repo checkout <url>` to fetch the code. Add `--ref <branch-or-sha>` when a task or handoff names an exact revision.\n\n")
+	} else {
+		b.WriteString("This project has no resources attached yet.\n\n")
+	}
+}
+
+func writeMentionRules(b *strings.Builder, caps runtimeCapabilities) {
+	b.WriteString("## Mentions\n\n")
+	if !caps.Has(capabilityFullMentions) {
+		b.WriteString("Do not create member or agent mention links unless the task explicitly requires notifying or delegating to someone; plain names are safe.\n\n")
+		return
+	}
+
+	b.WriteString("Mention links are **side-effecting actions**, not just formatting:\n\n")
+	b.WriteString("- `[MUL-123](mention://issue/<issue-id>)` — clickable link to an issue (safe, no side effect)\n")
+	b.WriteString("- `[@Name](mention://member/<user-id>)` — **sends a notification to a human**\n")
+	b.WriteString("- `[@Name](mention://agent/<agent-id>)` — **enqueues a new run for that agent**\n\n")
+	b.WriteString("### When NOT to use a mention link\n\n")
+	b.WriteString("- Referring to someone in prose (e.g. \"GPT-Boy is right\") — write the plain name, no link.\n")
+	b.WriteString("- **Replying to another agent that just spoke to you.** By default, do NOT put a `mention://agent/...` link anywhere in your reply. The platform already shows your comment to everyone on the issue; re-mentioning the other agent will make them run again, and if they reply with a mention back, you will be triggered again. That is a loop and it costs the user money.\n")
+	b.WriteString("- Thanking, acknowledging, wrapping up, or signing off. These are exactly the moments where an accidental `@mention` causes the other agent to reply \"you're welcome\" and restart the loop. If the work is done, **end with no mention at all**.\n\n")
+	b.WriteString("### When a mention IS appropriate\n\n")
+	b.WriteString("- Escalating to a human owner who is not yet involved.\n")
+	b.WriteString("- Delegating a concrete sub-task to another agent for the first time, with a clear request.\n")
+	b.WriteString("- The user explicitly asked you to loop someone in.\n\n")
+	b.WriteString("If you are unsure whether a mention is warranted, **don't mention**. Silence ends conversations; `@` restarts them.\n\n")
+	b.WriteString("Use `multica issue list --output json` to look up issue IDs, and `multica workspace members --output json` for member IDs.\n\n")
+}
+
+func writeAttachmentRules(b *strings.Builder, caps runtimeCapabilities) {
+	if !caps.Has(capabilityAttachments) {
+		return
+	}
+
+	b.WriteString("## Attachments\n\n")
+	b.WriteString("Issues and comments may include file attachments (images, documents, etc.).\n")
+	b.WriteString("Use the download command to fetch attachment files locally:\n\n")
+	b.WriteString("```\nmultica attachment download <attachment-id>\n```\n\n")
+	b.WriteString("This downloads the file to the current directory and prints the local path. Use `-o <dir>` to save elsewhere.\n")
+	b.WriteString("After downloading, you can read the file directly (e.g. view an image, read a document).\n\n")
+}

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -83,6 +83,7 @@ func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) (strin
 // about the Multica runtime environment and available CLI tools.
 func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	var b strings.Builder
+	caps := deriveRuntimeCapabilities(ctx)
 
 	b.WriteString("# Multica Agent Runtime\n\n")
 	b.WriteString("You are a coding agent in the Multica platform. Use the `multica` CLI to interact with the platform.\n\n")
@@ -108,66 +109,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("\n\n")
 	}
 
-	b.WriteString("## Available Commands\n\n")
-	b.WriteString("**Use `--output json` for structured data.** Human table output now prints routable issue keys (for example `MUL-123`) and short UUID prefixes for workspace resources; use `--full-id` on list commands when you need canonical UUIDs.\n\n")
-	b.WriteString("### Read\n")
-	b.WriteString("- `multica issue get <id> --output json` — Get full issue details (title, description, status, priority, assignee)\n")
-	b.WriteString("- `multica issue list [--status X] [--priority X] [--assignee X | --assignee-id <uuid>] [--limit N] [--offset N] [--full-id] [--output json]` — List issues in workspace (default limit: 50; table output uses routable issue keys; JSON output includes `total`, `has_more` — use offset to paginate when `has_more` is true). Prefer `--assignee-id <uuid>` when scripting from `multica workspace members --output json` / `multica agent list --output json` / `multica squad list --output json`.\n")
-	b.WriteString("- `multica issue comment list <issue-id> [--since <RFC3339>] --output json` — List all comments on an issue (server caps at 2000 rows). Use `--since` for incremental polling.\n")
-	b.WriteString("- `multica issue label list <issue-id> --output json` — List labels currently attached to an issue\n")
-	b.WriteString("- `multica issue subscriber list <issue-id> --output json` — List members/agents subscribed to an issue\n")
-	b.WriteString("- `multica label list --output json` — List all labels defined in the workspace (returns id + name + color)\n")
-	b.WriteString("- `multica workspace get --output json` — Get workspace details and context\n")
-	b.WriteString("- `multica workspace members [workspace-id] --output json` — List workspace members (user IDs, names, roles)\n")
-	b.WriteString("- `multica agent list --output json` — List agents in workspace\n")
-	b.WriteString("- `multica squad list --output json` — List squads in workspace (squads are first-class assignees — assigning an issue to a squad routes it to the squad leader, who then delegates)\n")
-	b.WriteString("- `multica repo checkout <url> [--ref <branch-or-sha>]` — Check out a repository into the working directory (creates a git worktree with a dedicated branch; use `--ref` for review/QA on a specific branch, tag, or commit)\n")
-	b.WriteString("- `multica issue runs <issue-id> [--full-id] --output json` — List all execution runs for an issue (status, timestamps, errors); table task IDs are short prefixes unless `--full-id` is set\n")
-	b.WriteString("- `multica issue run-messages <task-id> [--issue <issue-id>] [--since <seq>] --output json` — List messages for a specific execution run; full task UUIDs work directly, copied short task prefixes must be scoped with `--issue <issue-id>`\n")
-	b.WriteString("- `multica attachment download <id> [-o <dir>]` — Download an attachment file locally by ID\n")
-	b.WriteString("- `multica autopilot list [--status X] [--full-id] [--output json]` — List autopilots (scheduled/triggered agent automations) in the workspace; copied short IDs are accepted by autopilot subcommands when unique\n")
-	b.WriteString("- `multica autopilot get <id> --output json` — Get autopilot details including triggers\n")
-	b.WriteString("- `multica autopilot runs <id> [--limit N] --output json` — List execution history for an autopilot\n")
-	b.WriteString("- `multica project get <id> --output json` — Get project details. Includes `resource_count`; the resources themselves live at the sub-collection below.\n")
-	b.WriteString("- `multica project resource list <project-id> --output json` — List resources (e.g. github_repo) attached to a project. Use this when `resource_count > 0` and you need the actual refs.\n\n")
-
-	b.WriteString("### Write\n")
-	b.WriteString("- `multica issue create --title \"...\" [--description \"...\"] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--project <project-id>] [--due-date <RFC3339>] [--attachment <path>]` — Create a new issue. `--attachment` may be repeated to upload multiple files; labels and subscribers are not accepted here, attach them after create with the commands below.\n")
-	b.WriteString("- `multica issue update <id> [--title X] [--description X] [--priority X] [--status X] [--assignee X | --assignee-id <uuid>] [--parent <issue-id>] [--project <project-id>] [--due-date <RFC3339>]` — Update one or more issue fields in a single call. Use `--parent \"\"` to clear the parent.\n")
-	b.WriteString("- `multica issue status <id> <status>` — Shortcut for `issue update --status` when you only need to flip status (todo, in_progress, in_review, done, blocked, backlog, cancelled)\n")
-	b.WriteString("- `multica issue assign <id> --to <name>|--to-id <uuid>` — Assign an issue to a member, agent, or squad. `--to <name>` does fuzzy name matching; pass `--to-id <uuid>` (mutually exclusive with `--to`) to assign by canonical UUID, e.g. when names overlap. Use `--unassign` to clear the assignee.\n")
-	b.WriteString("- `multica issue label add <issue-id> <label-id>` — Attach a label to an issue (look up the label id via `multica label list`)\n")
-	b.WriteString("- `multica issue label remove <issue-id> <label-id>` — Detach a label from an issue\n")
-	b.WriteString("- `multica issue subscriber add <issue-id> [--user <name>|--user-id <uuid>]` — Subscribe a member or agent to issue updates (defaults to the caller when neither flag is set; the two flags are mutually exclusive)\n")
-	b.WriteString("- `multica issue subscriber remove <issue-id> [--user <name>|--user-id <uuid>]` — Unsubscribe a member or agent\n")
-	// Available Commands lists `multica issue comment add` and the
-	// description flags neutrally — three input modes, pick what fits.
-	// The previous "MUST pipe via stdin" mandate (#1795 / #1851) was
-	// originally a Codex-specific fix for codex emitting literal `\n`
-	// escapes inside `--content "..."`, but it landed in this global
-	// section and ended up steering every provider at stdin, which then
-	// burned non-ASCII bytes on Windows where the agent's shell layer
-	// (typically PowerShell) re-encodes the pipe through an ASCII /
-	// non-UTF-8 codepage and drops non-representable bytes as `?`
-	// (issues #2198 / #2236 / #2376).
-	//
-	// Strong "MUST" wording lives in the Codex-Specific section below
-	// where it actually belongs; non-Codex providers handle inline
-	// escaping correctly and can pick whichever flag suits their
-	// content. The `--content-file` line in the menu doubles as a
-	// pointer at the Windows-safe path.
-	b.WriteString("- `multica issue comment add <issue-id> [--content \"...\" | --content-stdin | --content-file <path>] [--parent <comment-id>] [--attachment <path>]` — Post a comment. Three input modes, pick whichever fits the content:\n")
-	b.WriteString("  - `--content \"...\"` for short single-line text. The CLI decodes `\\n`, `\\r`, `\\t`, `\\\\` so escaped multi-line is OK; do not embed raw newlines in the argument.\n")
-	b.WriteString("  - `--content-stdin` to pipe the body via HEREDOC. Preserves multi-line and special characters verbatim. Cleanest in `bash` / `zsh`.\n")
-	b.WriteString("  - `--content-file <path>` to read a UTF-8 file off disk. Preserves bytes verbatim regardless of the shell — use this on Windows when stdin would re-encode non-ASCII (Chinese, Japanese, Cyrillic, accents, emoji) through the console codepage and drop them as `?`.\n")
-	b.WriteString("  - Use `--parent` to reply to a specific comment; `--attachment` may be repeated.\n")
-	b.WriteString("- `multica issue create` / `multica issue update` accept the same three modes for `--description`: `--description \"...\"`, `--description-stdin`, or `--description-file <path>`.\n")
-	b.WriteString("- `multica issue comment delete <comment-id>` — Delete a comment\n")
-	b.WriteString("- `multica label create --name \"...\" --color \"#hex\"` — Define a new workspace label (use this only when the label you need does not exist yet; reuse existing labels via `multica label list` first)\n")
-	b.WriteString("- `multica autopilot create --title \"...\" --agent <name> --mode create_issue|run_only [--description \"...\"]` — Create an autopilot\n")
-	b.WriteString("- `multica autopilot update <id> [--title X] [--description X] [--status active|paused] [--mode create_issue|run_only]` — Update an autopilot\n")
-	b.WriteString("- `multica autopilot trigger <id>` — Manually trigger an autopilot to run once\n")
-	b.WriteString("- `multica autopilot delete <id>` — Delete an autopilot\n\n")
+	writeAvailableCommands(&b, caps)
 
 	if provider == "codex" {
 		b.WriteString("## Codex-Specific Comment Formatting\n\n")
@@ -193,25 +135,7 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed, and can pass `--ref` for review/QA on a non-default branch or commit.\n\n")
 	}
 
-	// Inject project-scoped context (resources attached to the issue's project).
-	// The full structured payload is also available at .multica/project/resources.json
-	// so skills can consume it programmatically.
-	if ctx.ProjectID != "" || len(ctx.ProjectResources) > 0 {
-		b.WriteString("## Project Context\n\n")
-		if ctx.ProjectTitle != "" {
-			fmt.Fprintf(&b, "This issue belongs to **%s**.\n\n", ctx.ProjectTitle)
-		}
-		if len(ctx.ProjectResources) > 0 {
-			b.WriteString("Project resources (also written to `.multica/project/resources.json`):\n\n")
-			for _, r := range ctx.ProjectResources {
-				fmt.Fprintf(&b, "- %s\n", formatProjectResource(r))
-			}
-			b.WriteString("\nResources are pointers — open them only when relevant to the task. ")
-			b.WriteString("For `github_repo` resources, use `multica repo checkout <url>` to fetch the code. Add `--ref <branch-or-sha>` when a task or handoff names an exact revision.\n\n")
-		} else {
-			b.WriteString("This project has no resources attached yet.\n\n")
-		}
-	}
+	writeProjectContext(&b, ctx, caps)
 
 	b.WriteString("### Workflow\n\n")
 
@@ -326,28 +250,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		b.WriteString("\n")
 	}
 
-	b.WriteString("## Mentions\n\n")
-	b.WriteString("Mention links are **side-effecting actions**, not just formatting:\n\n")
-	b.WriteString("- `[MUL-123](mention://issue/<issue-id>)` — clickable link to an issue (safe, no side effect)\n")
-	b.WriteString("- `[@Name](mention://member/<user-id>)` — **sends a notification to a human**\n")
-	b.WriteString("- `[@Name](mention://agent/<agent-id>)` — **enqueues a new run for that agent**\n\n")
-	b.WriteString("### When NOT to use a mention link\n\n")
-	b.WriteString("- Referring to someone in prose (e.g. \"GPT-Boy is right\") — write the plain name, no link.\n")
-	b.WriteString("- **Replying to another agent that just spoke to you.** By default, do NOT put a `mention://agent/...` link anywhere in your reply. The platform already shows your comment to everyone on the issue; re-mentioning the other agent will make them run again, and if they reply with a mention back, you will be triggered again. That is a loop and it costs the user money.\n")
-	b.WriteString("- Thanking, acknowledging, wrapping up, or signing off. These are exactly the moments where an accidental `@mention` causes the other agent to reply \"you're welcome\" and restart the loop. If the work is done, **end with no mention at all**.\n\n")
-	b.WriteString("### When a mention IS appropriate\n\n")
-	b.WriteString("- Escalating to a human owner who is not yet involved.\n")
-	b.WriteString("- Delegating a concrete sub-task to another agent for the first time, with a clear request.\n")
-	b.WriteString("- The user explicitly asked you to loop someone in.\n\n")
-	b.WriteString("If you are unsure whether a mention is warranted, **don't mention**. Silence ends conversations; `@` restarts them.\n\n")
-	b.WriteString("Use `multica issue list --output json` to look up issue IDs, and `multica workspace members --output json` for member IDs.\n\n")
-
-	b.WriteString("## Attachments\n\n")
-	b.WriteString("Issues and comments may include file attachments (images, documents, etc.).\n")
-	b.WriteString("Use the download command to fetch attachment files locally:\n\n")
-	b.WriteString("```\nmultica attachment download <attachment-id>\n```\n\n")
-	b.WriteString("This downloads the file to the current directory and prints the local path. Use `-o <dir>` to save elsewhere.\n")
-	b.WriteString("After downloading, you can read the file directly (e.g. view an image, read a document).\n\n")
+	writeMentionRules(&b, caps)
+	writeAttachmentRules(&b, caps)
 
 	b.WriteString("## Important: Always Use the `multica` CLI\n\n")
 	b.WriteString("All interactions with Multica platform resources — including issues, comments, attachments, images, files, and any other platform data — **must** go through the `multica` CLI. ")

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -33,34 +33,37 @@ type ProjectResourceData struct {
 // Task represents a claimed task from the server.
 // Agent data (name, skills) is populated by the claim endpoint.
 type Task struct {
-	ID                      string          `json:"id"`
-	AgentID                 string          `json:"agent_id"`
-	RuntimeID               string          `json:"runtime_id"`
-	IssueID                 string          `json:"issue_id"`
-	WorkspaceID             string          `json:"workspace_id"`
-	Agent                   *AgentData      `json:"agent,omitempty"`
-	Repos                   []RepoData            `json:"repos,omitempty"`
-	ProjectID               string                `json:"project_id,omitempty"`        // issue's project, when present
-	ProjectTitle            string                `json:"project_title,omitempty"`     // human-readable project title for context injection
-	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"` // project-scoped resources to expose to the agent
-	PriorSessionID          string          `json:"prior_session_id,omitempty"`          // Claude session ID from a previous task on this issue
-	PriorWorkDir            string          `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on this issue
-	TriggerCommentID        string          `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
-	TriggerCommentContent   string          `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
-	TriggerAuthorType       string          `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind for the triggering comment
-	TriggerAuthorName       string          `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
-	ChatSessionID           string          `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
-	ChatMessage             string          `json:"chat_message,omitempty"`              // user message content for chat tasks
-	ChatMessageAttachments  []ChatAttachmentMeta `json:"chat_message_attachments,omitempty"` // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
-	AutopilotRunID          string          `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot run_only tasks
-	AutopilotID             string          `json:"autopilot_id,omitempty"`              // autopilot that spawned this run
-	AutopilotTitle          string          `json:"autopilot_title,omitempty"`           // autopilot title used as task context
-	AutopilotDescription    string          `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
-	AutopilotSource         string          `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
-	AutopilotTriggerPayload json.RawMessage `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
-	QuickCreatePrompt       string          `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
-	SquadID                 string          `json:"squad_id,omitempty"`                  // when the picker was a squad, the squad's UUID; Agent is still the resolved leader
-	SquadName               string          `json:"squad_name,omitempty"`                // display name for the picker squad, used in prompt text
+	ID                           string                `json:"id"`
+	AgentID                      string                `json:"agent_id"`
+	RuntimeID                    string                `json:"runtime_id"`
+	IssueID                      string                `json:"issue_id"`
+	IssueTitle                   string                `json:"issue_title,omitempty"`
+	IssueDescription             string                `json:"issue_description,omitempty"`
+	WorkspaceID                  string                `json:"workspace_id"`
+	Agent                        *AgentData            `json:"agent,omitempty"`
+	Repos                        []RepoData            `json:"repos,omitempty"`
+	ProjectID                    string                `json:"project_id,omitempty"`                       // issue's project, when present
+	ProjectTitle                 string                `json:"project_title,omitempty"`                    // human-readable project title for context injection
+	ProjectResources             []ProjectResourceData `json:"project_resources,omitempty"`                // project-scoped resources to expose to the agent
+	HasIssueOrCommentAttachments bool                  `json:"has_issue_or_comment_attachments,omitempty"` // issue-level or issue-comment attachments exist
+	PriorSessionID               string                `json:"prior_session_id,omitempty"`                 // Claude session ID from a previous task on this issue
+	PriorWorkDir                 string                `json:"prior_work_dir,omitempty"`                   // work_dir from a previous task on this issue
+	TriggerCommentID             string                `json:"trigger_comment_id,omitempty"`               // comment that triggered this task
+	TriggerCommentContent        string                `json:"trigger_comment_content,omitempty"`          // content of the triggering comment
+	TriggerAuthorType            string                `json:"trigger_author_type,omitempty"`              // "agent" or "member" — author kind for the triggering comment
+	TriggerAuthorName            string                `json:"trigger_author_name,omitempty"`              // display name of the triggering comment author
+	ChatSessionID                string                `json:"chat_session_id,omitempty"`                  // non-empty for chat tasks
+	ChatMessage                  string                `json:"chat_message,omitempty"`                     // user message content for chat tasks
+	ChatMessageAttachments       []ChatAttachmentMeta  `json:"chat_message_attachments,omitempty"`         // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
+	AutopilotRunID               string                `json:"autopilot_run_id,omitempty"`                 // non-empty for autopilot run_only tasks
+	AutopilotID                  string                `json:"autopilot_id,omitempty"`                     // autopilot that spawned this run
+	AutopilotTitle               string                `json:"autopilot_title,omitempty"`                  // autopilot title used as task context
+	AutopilotDescription         string                `json:"autopilot_description,omitempty"`            // autopilot description used as task prompt
+	AutopilotSource              string                `json:"autopilot_source,omitempty"`                 // manual, schedule, webhook, or api
+	AutopilotTriggerPayload      json.RawMessage       `json:"autopilot_trigger_payload,omitempty"`        // optional trigger payload for webhook/api runs
+	QuickCreatePrompt            string                `json:"quick_create_prompt,omitempty"`              // user's natural-language input for quick-create tasks
+	SquadID                      string                `json:"squad_id,omitempty"`                         // when the picker was a squad, the squad's UUID; Agent is still the resolved leader
+	SquadName                    string                `json:"squad_name,omitempty"`                       // display name for the picker squad, used in prompt text
 }
 
 // ChatAttachmentMeta is the structured attachment metadata the daemon

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -134,49 +134,52 @@ type ProjectResourceData struct {
 }
 
 type AgentTaskResponse struct {
-	ID                      string                `json:"id"`
-	AgentID                 string                `json:"agent_id"`
-	RuntimeID               string                `json:"runtime_id"`
-	IssueID                 string                `json:"issue_id"`
-	WorkspaceID             string                `json:"workspace_id"`
-	Status                  string                `json:"status"`
-	Priority                int32                 `json:"priority"`
-	DispatchedAt            *string               `json:"dispatched_at"`
-	StartedAt               *string               `json:"started_at"`
-	CompletedAt             *string               `json:"completed_at"`
-	Result                  any                   `json:"result"`
-	Error                   *string               `json:"error"`
-	FailureReason           string                `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
-	Attempt                 int32                 `json:"attempt"`
-	MaxAttempts             int32                 `json:"max_attempts"`
-	ParentTaskID            *string               `json:"parent_task_id,omitempty"`
-	Agent                   *TaskAgentData        `json:"agent,omitempty"`
-	Repos                   []RepoData            `json:"repos,omitempty"`
-	ProjectID               string                `json:"project_id,omitempty"`        // issue's project, when present
-	ProjectTitle            string                `json:"project_title,omitempty"`     // for surfacing in agent context
-	ProjectResources        []ProjectResourceData `json:"project_resources,omitempty"` // resources attached to the project
-	CreatedAt               string                `json:"created_at"`
-	PriorSessionID          string                `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
-	PriorWorkDir            string                `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
-	WorkDir                 string                `json:"work_dir,omitempty"`                  // local working directory pinned for this task; populated once the daemon reports it
-	TriggerCommentID        *string               `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
-	TriggerCommentContent   string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
-	TriggerSummary          *string               `json:"trigger_summary,omitempty"`           // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
-	TriggerAuthorType       string                `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind of the triggering comment
-	TriggerAuthorName       string                `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
-	ChatSessionID           string                `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
-	ChatMessage             string                `json:"chat_message,omitempty"`              // user message for chat tasks
-	ChatMessageAttachments  []ChatAttachmentMeta  `json:"chat_message_attachments,omitempty"`  // attachments on the user message — agent calls `multica attachment download <id>` per entry
-	AutopilotRunID          string                `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot-spawned tasks
-	AutopilotID             string                `json:"autopilot_id,omitempty"`              // autopilot that spawned this task
-	AutopilotTitle          string                `json:"autopilot_title,omitempty"`           // autopilot title used as task context
-	AutopilotDescription    string                `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
-	AutopilotSource         string                `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
-	AutopilotTriggerPayload json.RawMessage       `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
-	QuickCreatePrompt       string                `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
-	SquadID                 string                `json:"squad_id,omitempty"`                  // for quick-create tasks where the picker was a squad; Agent is still the resolved leader
-	SquadName               string                `json:"squad_name,omitempty"`                // display name for the picker squad
-	Kind                    string                `json:"kind"`                                // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
+	ID                           string                `json:"id"`
+	AgentID                      string                `json:"agent_id"`
+	RuntimeID                    string                `json:"runtime_id"`
+	IssueID                      string                `json:"issue_id"`
+	IssueTitle                   string                `json:"issue_title,omitempty"`       // issue text used by daemon-side capability derivation only
+	IssueDescription             string                `json:"issue_description,omitempty"` // issue text used by daemon-side capability derivation only
+	WorkspaceID                  string                `json:"workspace_id"`
+	Status                       string                `json:"status"`
+	Priority                     int32                 `json:"priority"`
+	DispatchedAt                 *string               `json:"dispatched_at"`
+	StartedAt                    *string               `json:"started_at"`
+	CompletedAt                  *string               `json:"completed_at"`
+	Result                       any                   `json:"result"`
+	Error                        *string               `json:"error"`
+	FailureReason                string                `json:"failure_reason,omitempty"` // see TaskService.MaybeRetryFailedTask
+	Attempt                      int32                 `json:"attempt"`
+	MaxAttempts                  int32                 `json:"max_attempts"`
+	ParentTaskID                 *string               `json:"parent_task_id,omitempty"`
+	Agent                        *TaskAgentData        `json:"agent,omitempty"`
+	Repos                        []RepoData            `json:"repos,omitempty"`
+	ProjectID                    string                `json:"project_id,omitempty"`                       // issue's project, when present
+	ProjectTitle                 string                `json:"project_title,omitempty"`                    // for surfacing in agent context
+	ProjectResources             []ProjectResourceData `json:"project_resources,omitempty"`                // resources attached to the project
+	HasIssueOrCommentAttachments bool                  `json:"has_issue_or_comment_attachments,omitempty"` // issue-level or issue-comment attachments exist
+	CreatedAt                    string                `json:"created_at"`
+	PriorSessionID               string                `json:"prior_session_id,omitempty"`          // session ID from a previous task on same issue
+	PriorWorkDir                 string                `json:"prior_work_dir,omitempty"`            // work_dir from a previous task on same issue
+	WorkDir                      string                `json:"work_dir,omitempty"`                  // local working directory pinned for this task; populated once the daemon reports it
+	TriggerCommentID             *string               `json:"trigger_comment_id,omitempty"`        // comment that triggered this task
+	TriggerCommentContent        string                `json:"trigger_comment_content,omitempty"`   // content of the triggering comment
+	TriggerSummary               *string               `json:"trigger_summary,omitempty"`           // canonical short description snapshot — comment text / autopilot title — taken at task creation; survives source edits/deletes
+	TriggerAuthorType            string                `json:"trigger_author_type,omitempty"`       // "agent" or "member" — author kind of the triggering comment
+	TriggerAuthorName            string                `json:"trigger_author_name,omitempty"`       // display name of the triggering comment author
+	ChatSessionID                string                `json:"chat_session_id,omitempty"`           // non-empty for chat tasks
+	ChatMessage                  string                `json:"chat_message,omitempty"`              // user message for chat tasks
+	ChatMessageAttachments       []ChatAttachmentMeta  `json:"chat_message_attachments,omitempty"`  // attachments on the user message — agent calls `multica attachment download <id>` per entry
+	AutopilotRunID               string                `json:"autopilot_run_id,omitempty"`          // non-empty for autopilot-spawned tasks
+	AutopilotID                  string                `json:"autopilot_id,omitempty"`              // autopilot that spawned this task
+	AutopilotTitle               string                `json:"autopilot_title,omitempty"`           // autopilot title used as task context
+	AutopilotDescription         string                `json:"autopilot_description,omitempty"`     // autopilot description used as task prompt
+	AutopilotSource              string                `json:"autopilot_source,omitempty"`          // manual, schedule, webhook, or api
+	AutopilotTriggerPayload      json.RawMessage       `json:"autopilot_trigger_payload,omitempty"` // optional trigger payload for webhook/api runs
+	QuickCreatePrompt            string                `json:"quick_create_prompt,omitempty"`       // user's natural-language input for quick-create tasks
+	SquadID                      string                `json:"squad_id,omitempty"`                  // for quick-create tasks where the picker was a squad; Agent is still the resolved leader
+	SquadName                    string                `json:"squad_name,omitempty"`                // display name for the picker squad
+	Kind                         string                `json:"kind"`                                // discriminator: "comment" | "autopilot" | "chat" | "quick_create" | "direct" — used by the activity row to label tasks that have no linked issue
 }
 
 // ChatAttachmentMeta is the structured attachment metadata embedded in

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1107,6 +1107,10 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 	if task.IssueID.Valid {
 		if issue, err := h.Queries.GetIssue(r.Context(), task.IssueID); err == nil {
 			resp.WorkspaceID = uuidToString(issue.WorkspaceID)
+			resp.IssueTitle = issue.Title
+			if issue.Description.Valid {
+				resp.IssueDescription = issue.Description.String
+			}
 
 			// Squad-leader briefing injection: when the issue is assigned
 			// to a squad and the claiming agent is that squad's current
@@ -1180,6 +1184,10 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 				if json.Unmarshal(ws.Repos, &repos) == nil && len(repos) > 0 {
 					resp.Repos = repos
 				}
+			}
+
+			if urls, err := h.Queries.ListAttachmentURLsByIssueOrComments(r.Context(), task.IssueID); err == nil && len(urls) > 0 {
+				resp.HasIssueOrCommentAttachments = true
 			}
 		}
 

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1590,10 +1590,10 @@ func TestClaimTaskByRuntime_SurfacesIssueTriggerAndAttachmentSignals(t *testing.
 
 		var commentID string
 		if err := testPool.QueryRow(ctx, `
-			INSERT INTO comment (issue_id, author_type, author_id, content)
-			VALUES ($1, 'member', $2, $3)
+			INSERT INTO comment (workspace_id, issue_id, author_type, author_id, content)
+			VALUES ($1, $2, 'member', $3, $4)
 			RETURNING id
-		`, issueID, testUserID, triggerCommentBody).Scan(&commentID); err != nil {
+		`, testWorkspaceID, issueID, testUserID, triggerCommentBody).Scan(&commentID); err != nil {
 			t.Fatalf("create trigger comment: %v", err)
 		}
 

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -1548,6 +1548,135 @@ func TestClaimTask_ProjectWithoutRepos_FallsBackToWorkspaceRepos(t *testing.T) {
 	}
 }
 
+func TestClaimTaskByRuntime_SurfacesIssueTriggerAndAttachmentSignals(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+
+	runCase := func(t *testing.T, attachTo string) {
+		t.Helper()
+
+		const (
+			issueTitle          = "Claim context signal fixture"
+			issueDescription    = "Issue description used by runtime capability derivation."
+			triggerCommentBody  = "Trigger comment used by daemon context."
+			attachmentURLSuffix = "/claim-context-signal.txt"
+		)
+
+		var issueID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO issue (
+				workspace_id, title, description, status, priority, creator_id, creator_type, number, position
+			) VALUES (
+				$1, $2, $3, 'todo', 'medium', $4, 'member',
+				(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1),
+				0
+			)
+			RETURNING id
+		`, testWorkspaceID, issueTitle, issueDescription, testUserID).Scan(&issueID); err != nil {
+			t.Fatalf("create issue: %v", err)
+		}
+		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+
+		var commentID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO comment (issue_id, author_type, author_id, content)
+			VALUES ($1, 'member', $2, $3)
+			RETURNING id
+		`, issueID, testUserID, triggerCommentBody).Scan(&commentID); err != nil {
+			t.Fatalf("create trigger comment: %v", err)
+		}
+
+		switch attachTo {
+		case "issue":
+			if _, err := testPool.Exec(ctx, `
+				INSERT INTO attachment (
+					workspace_id, issue_id, uploader_type, uploader_id, filename, url, content_type, size_bytes
+				) VALUES ($1, $2, 'member', $3, 'claim-context-signal.txt', $4, 'text/plain', 12)
+			`, testWorkspaceID, issueID, testUserID, "s3://test"+attachmentURLSuffix); err != nil {
+				t.Fatalf("create issue attachment: %v", err)
+			}
+		case "comment":
+			if _, err := testPool.Exec(ctx, `
+				INSERT INTO attachment (
+					workspace_id, comment_id, uploader_type, uploader_id, filename, url, content_type, size_bytes
+				) VALUES ($1, $2, 'member', $3, 'claim-context-signal.txt', $4, 'text/plain', 12)
+			`, testWorkspaceID, commentID, testUserID, "s3://test-comment"+attachmentURLSuffix); err != nil {
+				t.Fatalf("create comment attachment: %v", err)
+			}
+		default:
+			t.Fatalf("unknown attachTo %q", attachTo)
+		}
+
+		var taskID string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO agent_task_queue (
+				agent_id, runtime_id, issue_id, status, priority, trigger_comment_id
+			) VALUES ($1, $2, $3, 'queued', 9999, $4)
+			RETURNING id
+		`, agentID, runtimeID, issueID, commentID).Scan(&taskID); err != nil {
+			t.Fatalf("create task: %v", err)
+		}
+		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+		w := httptest.NewRecorder()
+		req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "test-claim-context-signals")
+		req = withURLParam(req, "runtimeId", runtimeID)
+		testHandler.ClaimTaskByRuntime(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("ClaimTaskByRuntime: %d %s", w.Code, w.Body.String())
+		}
+
+		var resp struct {
+			Task *struct {
+				ID                           string `json:"id"`
+				IssueTitle                   string `json:"issue_title"`
+				IssueDescription             string `json:"issue_description"`
+				TriggerCommentContent        string `json:"trigger_comment_content"`
+				HasIssueOrCommentAttachments bool   `json:"has_issue_or_comment_attachments"`
+			} `json:"task"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Task == nil {
+			t.Fatal("expected task in response")
+		}
+		if resp.Task.ID != taskID {
+			t.Fatalf("claimed task id = %q, want %q", resp.Task.ID, taskID)
+		}
+		if resp.Task.IssueTitle != issueTitle {
+			t.Fatalf("issue_title = %q, want %q", resp.Task.IssueTitle, issueTitle)
+		}
+		if resp.Task.IssueDescription != issueDescription {
+			t.Fatalf("issue_description = %q, want %q", resp.Task.IssueDescription, issueDescription)
+		}
+		if resp.Task.TriggerCommentContent != triggerCommentBody {
+			t.Fatalf("trigger_comment_content = %q, want %q", resp.Task.TriggerCommentContent, triggerCommentBody)
+		}
+		if !resp.Task.HasIssueOrCommentAttachments {
+			t.Fatalf("has_issue_or_comment_attachments = false for %s attachment", attachTo)
+		}
+	}
+
+	t.Run("issue attachment", func(t *testing.T) {
+		runCase(t, "issue")
+	})
+	t.Run("comment attachment", func(t *testing.T) {
+		runCase(t, "comment")
+	})
+}
+
 // Regression test for #1276: ClaimTaskByRuntime must populate workspace_id in
 // the response for run_only autopilot tasks. Before the fix, resp.WorkspaceID
 // stayed empty because ClaimTaskByRuntime only handled IssueID and


### PR DESCRIPTION
## Summary
- split non-core runtime instructions into capability-driven rule blocks
- pass issue title/description, trigger comment text, and attachment presence through claim responses into daemon exec context
- narrow keyword-based detection to avoid webhook/notification false positives

## Tests
- go test ./... (server)