### PR TITLE
feat(autopilots): webhook deliveries tab + replay button (MUL-2334)

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -89,6 +89,8 @@ import type {
   ListAutopilotsResponse,
   GetAutopilotResponse,
   ListAutopilotRunsResponse,
+  ListWebhookDeliveriesResponse,
+  WebhookDelivery,
   NotificationPreferenceResponse,
   NotificationPreferences,
   GitHubPullRequest,
@@ -120,10 +122,14 @@ import {
   EMPTY_GROUPED_ISSUES_RESPONSE,
   EMPTY_LIST_ISSUES_RESPONSE,
   EMPTY_TIMELINE_ENTRIES,
+  EMPTY_LIST_WEBHOOK_DELIVERIES_RESPONSE,
+  EMPTY_WEBHOOK_DELIVERY,
   GroupedIssuesResponseSchema,
   ListIssuesResponseSchema,
+  ListWebhookDeliveriesResponseSchema,
   SubscribersListSchema,
   TimelineEntriesSchema,
+  WebhookDeliveryResponseSchema,
 } from "./schemas";
 
 /** Identifies the calling client to the server.
@@ -1610,6 +1616,64 @@ export class ApiClient {
     return this.fetch(
       `/api/autopilots/${autopilotId}/triggers/${triggerId}/rotate-webhook-token`,
       { method: "POST" },
+    );
+  }
+
+  // Webhook deliveries — list is slim (no raw_body / selected_headers /
+  // response_body); detail returns the full row. Both responses are parsed
+  // through a lenient schema so an unknown server-side `status` /
+  // `signature_status` value degrades to a generic row instead of dropping
+  // the whole list.
+  async listAutopilotDeliveries(
+    autopilotId: string,
+    params?: { limit?: number; offset?: number },
+  ): Promise<ListWebhookDeliveriesResponse> {
+    const search = new URLSearchParams();
+    if (params?.limit) search.set("limit", params.limit.toString());
+    if (params?.offset) search.set("offset", params.offset.toString());
+    const raw = await this.fetch<unknown>(
+      `/api/autopilots/${autopilotId}/deliveries?${search}`,
+    );
+    return parseWithFallback(
+      raw,
+      ListWebhookDeliveriesResponseSchema,
+      EMPTY_LIST_WEBHOOK_DELIVERIES_RESPONSE,
+      { endpoint: "GET /api/autopilots/:id/deliveries" },
+    );
+  }
+
+  async getAutopilotDelivery(
+    autopilotId: string,
+    deliveryId: string,
+  ): Promise<WebhookDelivery> {
+    const raw = await this.fetch<unknown>(
+      `/api/autopilots/${autopilotId}/deliveries/${deliveryId}`,
+    );
+    return parseWithFallback(
+      raw,
+      WebhookDeliveryResponseSchema,
+      { ...EMPTY_WEBHOOK_DELIVERY, id: deliveryId, autopilot_id: autopilotId },
+      { endpoint: "GET /api/autopilots/:id/deliveries/:deliveryId" },
+    );
+  }
+
+  // Replay creates a NEW delivery row referencing the original via
+  // `replayed_from_delivery_id`. Server rejects replays of
+  // signature-invalid / rejected deliveries with 400 — the UI keeps the
+  // button disabled for those rows, but the server is the source of truth.
+  async replayAutopilotDelivery(
+    autopilotId: string,
+    deliveryId: string,
+  ): Promise<WebhookDelivery> {
+    const raw = await this.fetch<unknown>(
+      `/api/autopilots/${autopilotId}/deliveries/${deliveryId}/replay`,
+      { method: "POST" },
+    );
+    return parseWithFallback(
+      raw,
+      WebhookDeliveryResponseSchema,
+      { ...EMPTY_WEBHOOK_DELIVERY, autopilot_id: autopilotId },
+      { endpoint: "POST /api/autopilots/:id/deliveries/:deliveryId/replay" },
     );
   }
 

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -198,6 +198,68 @@ describe("ApiClient schema fallback", () => {
     });
   });
 
+  describe("listAutopilotDeliveries", () => {
+    it("falls back to an empty list when the body is null", async () => {
+      stubFetchJson(null);
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.listAutopilotDeliveries("ap-1");
+      expect(res).toEqual({ deliveries: [], total: 0 });
+    });
+
+    it("falls back to an empty list when `deliveries` is not an array", async () => {
+      stubFetchJson({ deliveries: "not-an-array", total: 0 });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.listAutopilotDeliveries("ap-1");
+      expect(res).toEqual({ deliveries: [], total: 0 });
+    });
+
+    it("accepts an unknown future status value rather than dropping the row", async () => {
+      // Server-side enum drift (e.g. new `quarantined` state). The list
+      // must still surface the row; downstream UI code's `default` arm
+      // handles unknown values with a generic visual.
+      stubFetchJson({
+        deliveries: [
+          {
+            id: "d-1",
+            workspace_id: "ws-1",
+            autopilot_id: "ap-1",
+            trigger_id: "t-1",
+            provider: "github",
+            event: "pull_request.opened",
+            dedupe_key: "abc",
+            dedupe_source: "x-github-delivery",
+            signature_status: "valid",
+            status: "quarantined",
+            attempt_count: 1,
+            content_type: "application/json",
+            response_status: 200,
+            autopilot_run_id: null,
+            replayed_from_delivery_id: null,
+            error: null,
+            received_at: "2026-01-01T00:00:00Z",
+            last_attempt_at: "2026-01-01T00:00:00Z",
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        total: 1,
+      });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.listAutopilotDeliveries("ap-1");
+      expect(res.deliveries).toHaveLength(1);
+      expect(res.deliveries[0]?.status).toBe("quarantined");
+    });
+  });
+
+  describe("getAutopilotDelivery", () => {
+    it("falls back to a placeholder carrying the requested id", async () => {
+      stubFetchJson({ wrong: "shape" });
+      const client = new ApiClient("https://api.example.test");
+      const detail = await client.getAutopilotDelivery("ap-1", "d-1");
+      expect(detail.id).toBe("d-1");
+      expect(detail.autopilot_id).toBe("ap-1");
+    });
+  });
+
   describe("createAgentFromTemplate", () => {
     it("falls back to an empty agent when the response is malformed", async () => {
       // The agent was created server-side even though the client can't

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -7,7 +7,9 @@ import type {
   CreateAgentFromTemplateResponse,
   GroupedIssuesResponse,
   ListIssuesResponse,
+  ListWebhookDeliveriesResponse,
   TimelineEntry,
+  WebhookDelivery,
 } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -332,4 +334,74 @@ export const EMPTY_CREATE_AGENT_FROM_TEMPLATE_RESPONSE: CreateAgentFromTemplateR
   agent: { id: "" } as Agent,
   imported_skill_ids: [],
   reused_skill_ids: [],
+};
+
+// ---------------------------------------------------------------------------
+// Webhook delivery schemas — backing the Autopilot Deliveries section. Enums
+// (`status`, `signature_status`, `provider`) are kept as `z.string()` so a
+// future server-side value (e.g. a Stripe provider, a new dedupe state)
+// degrades to a generic UI fallback rather than collapsing the list into
+// the empty array. `.loose()` lets unknown fields pass through, matching
+// the rule used by every other endpoint here.
+// ---------------------------------------------------------------------------
+
+const WebhookDeliverySchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  autopilot_id: z.string(),
+  trigger_id: z.string(),
+  provider: z.string(),
+  event: z.string(),
+  dedupe_key: z.string().nullable(),
+  dedupe_source: z.string().nullable(),
+  signature_status: z.string(),
+  status: z.string(),
+  attempt_count: z.number().default(0),
+  content_type: z.string().nullable(),
+  response_status: z.number().nullable(),
+  autopilot_run_id: z.string().nullable(),
+  replayed_from_delivery_id: z.string().nullable(),
+  error: z.string().nullable(),
+  received_at: z.string(),
+  last_attempt_at: z.string(),
+  created_at: z.string(),
+  // Detail-only fields. The list endpoint omits them; the detail endpoint
+  // populates raw_body / selected_headers / response_body.
+  selected_headers: z.record(z.string(), z.unknown()).nullable().optional(),
+  raw_body: z.string().nullable().optional(),
+  response_body: z.string().nullable().optional(),
+}).loose();
+
+export const ListWebhookDeliveriesResponseSchema = z.object({
+  deliveries: z.array(WebhookDeliverySchema).default([]),
+  total: z.number().default(0),
+}).loose();
+
+export const WebhookDeliveryResponseSchema = WebhookDeliverySchema;
+
+export const EMPTY_LIST_WEBHOOK_DELIVERIES_RESPONSE: ListWebhookDeliveriesResponse = {
+  deliveries: [],
+  total: 0,
+};
+
+export const EMPTY_WEBHOOK_DELIVERY: WebhookDelivery = {
+  id: "",
+  workspace_id: "",
+  autopilot_id: "",
+  trigger_id: "",
+  provider: "",
+  event: "",
+  dedupe_key: null,
+  dedupe_source: null,
+  signature_status: "not_required",
+  status: "queued",
+  attempt_count: 0,
+  content_type: null,
+  response_status: null,
+  autopilot_run_id: null,
+  replayed_from_delivery_id: null,
+  error: null,
+  received_at: "",
+  last_attempt_at: "",
+  created_at: "",
 };

--- a/packages/core/autopilots/index.ts
+++ b/packages/core/autopilots/index.ts
@@ -1,4 +1,11 @@
-export { autopilotKeys, autopilotListOptions, autopilotDetailOptions, autopilotRunsOptions } from "./queries";
+export {
+  autopilotKeys,
+  autopilotListOptions,
+  autopilotDetailOptions,
+  autopilotRunsOptions,
+  autopilotDeliveriesOptions,
+  autopilotDeliveryOptions,
+} from "./queries";
 export {
   useCreateAutopilot,
   useUpdateAutopilot,
@@ -8,5 +15,6 @@ export {
   useUpdateAutopilotTrigger,
   useDeleteAutopilotTrigger,
   useRotateAutopilotTriggerWebhookToken,
+  useReplayAutopilotDelivery,
 } from "./mutations";
 export { buildAutopilotWebhookUrl } from "./webhook";

--- a/packages/core/autopilots/mutations.ts
+++ b/packages/core/autopilots/mutations.ts
@@ -140,3 +140,20 @@ export function useRotateAutopilotTriggerWebhookToken() {
     },
   });
 }
+
+// Replay re-dispatches a previously-recorded delivery. The server creates
+// a new delivery row (with `replayed_from_delivery_id`) and synchronously
+// kicks off a new autopilot run. We invalidate both deliveries and runs so
+// the new delivery and any resulting run show up immediately.
+export function useReplayAutopilotDelivery() {
+  const qc = useQueryClient();
+  const wsId = useWorkspaceId();
+  return useMutation({
+    mutationFn: ({ autopilotId, deliveryId }: { autopilotId: string; deliveryId: string }) =>
+      api.replayAutopilotDelivery(autopilotId, deliveryId),
+    onSettled: (_data, _err, vars) => {
+      qc.invalidateQueries({ queryKey: autopilotKeys.deliveries(wsId, vars.autopilotId) });
+      qc.invalidateQueries({ queryKey: autopilotKeys.runs(wsId, vars.autopilotId) });
+    },
+  });
+}

--- a/packages/core/autopilots/queries.ts
+++ b/packages/core/autopilots/queries.ts
@@ -10,6 +10,10 @@ export const autopilotKeys = {
     [...autopilotKeys.all(wsId), "runs", id] as const,
   run: (wsId: string, autopilotId: string, runId: string) =>
     [...autopilotKeys.all(wsId), "runs", autopilotId, runId] as const,
+  deliveries: (wsId: string, id: string) =>
+    [...autopilotKeys.all(wsId), "deliveries", id] as const,
+  delivery: (wsId: string, autopilotId: string, deliveryId: string) =>
+    [...autopilotKeys.all(wsId), "deliveries", autopilotId, deliveryId] as const,
 };
 
 export function autopilotListOptions(wsId: string) {
@@ -48,6 +52,38 @@ export function autopilotRunOptions(
   return queryOptions({
     queryKey: autopilotKeys.run(wsId, autopilotId, runId),
     queryFn: () => api.getAutopilotRun(autopilotId, runId),
+    enabled: options?.enabled ?? true,
+  });
+}
+
+// autopilotDeliveriesOptions powers the Deliveries section in the autopilot
+// detail page. The list is slim — raw_body / selected_headers / response_body
+// are omitted server-side. Detail rows are fetched on-demand when the user
+// expands a row (see autopilotDeliveryOptions).
+export function autopilotDeliveriesOptions(
+  wsId: string,
+  autopilotId: string,
+  options?: { enabled?: boolean },
+) {
+  return queryOptions({
+    queryKey: autopilotKeys.deliveries(wsId, autopilotId),
+    queryFn: () => api.listAutopilotDeliveries(autopilotId),
+    select: (data) => data.deliveries,
+    enabled: options?.enabled ?? true,
+  });
+}
+
+// autopilotDeliveryOptions fetches the full delivery row including raw_body
+// and headers subset. Used by the detail dialog opened from a list row.
+export function autopilotDeliveryOptions(
+  wsId: string,
+  autopilotId: string,
+  deliveryId: string,
+  options?: { enabled?: boolean },
+) {
+  return queryOptions({
+    queryKey: autopilotKeys.delivery(wsId, autopilotId, deliveryId),
+    queryFn: () => api.getAutopilotDelivery(autopilotId, deliveryId),
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/core/types/autopilot.ts
+++ b/packages/core/types/autopilot.ts
@@ -117,3 +117,52 @@ export interface ListAutopilotRunsResponse {
   runs: AutopilotRun[];
   total: number;
 }
+
+// Webhook delivery enum is server-canonical. The frontend MUST `default`
+// any switch on it to a generic fallback — see API Response Compatibility
+// rules in CLAUDE.md. PR1 collapsed `skipped` into `dispatched` (the run
+// itself carries the skip state); a future server may add new values.
+export type WebhookDeliveryStatus =
+  | "queued"
+  | "dispatched"
+  | "rejected"
+  | "ignored"
+  | "failed";
+
+export type WebhookSignatureStatus =
+  | "not_required"
+  | "valid"
+  | "invalid"
+  | "missing";
+
+export interface WebhookDelivery {
+  id: string;
+  workspace_id: string;
+  autopilot_id: string;
+  trigger_id: string;
+  provider: string;
+  event: string;
+  dedupe_key: string | null;
+  dedupe_source: string | null;
+  signature_status: WebhookSignatureStatus;
+  status: WebhookDeliveryStatus;
+  attempt_count: number;
+  content_type: string | null;
+  response_status: number | null;
+  autopilot_run_id: string | null;
+  replayed_from_delivery_id: string | null;
+  error: string | null;
+  received_at: string;
+  last_attempt_at: string;
+  created_at: string;
+  // Detail-only fields. The list endpoint omits these to keep the wire
+  // size bounded (raw_body alone can be up to 256 KiB per delivery).
+  selected_headers?: Record<string, unknown> | null;
+  raw_body?: string | null;
+  response_body?: string | null;
+}
+
+export interface ListWebhookDeliveriesResponse {
+  deliveries: WebhookDelivery[];
+  total: number;
+}

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -102,6 +102,10 @@ export type {
   ListAutopilotsResponse,
   GetAutopilotResponse,
   ListAutopilotRunsResponse,
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+  WebhookSignatureStatus,
+  ListWebhookDeliveriesResponse,
 } from "./autopilot";
 export type {
   Squad,

--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -56,6 +56,7 @@ import { ReadonlyContent } from "../../editor";
 import { TranscriptButton } from "../../common/task-transcript";
 import { AutopilotDialog } from "./autopilot-dialog";
 import { WebhookPayloadPreview } from "./webhook-payload-preview";
+import { WebhookDeliveriesSection } from "./webhook-deliveries-section";
 import { useT } from "../../i18n";
 
 function formatDate(date: string): string {
@@ -738,6 +739,14 @@ export function AutopilotDetailPage({ autopilotId }: { autopilotId: string }) {
               </div>
             )}
           </section>
+
+          {/* Webhook deliveries — only renders when at least one webhook
+              trigger is configured. The component does its own fetch so
+              schedule-only autopilots don't pay for an empty list query. */}
+          <WebhookDeliveriesSection
+            autopilotId={autopilotId}
+            hasWebhookTrigger={triggers.some((trig) => trig.kind === "webhook")}
+          />
 
           {/* Run History */}
           <section className="space-y-3">

--- a/packages/views/autopilots/components/webhook-deliveries-section.tsx
+++ b/packages/views/autopilots/components/webhook-deliveries-section.tsx
@@ -1,0 +1,549 @@
+"use client";
+
+import { useState } from "react";
+import {
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Ban,
+  AlertTriangle,
+  ShieldOff,
+  RotateCw,
+  Copy,
+  Check,
+  Webhook,
+} from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  autopilotDeliveriesOptions,
+  autopilotDeliveryOptions,
+  useReplayAutopilotDelivery,
+} from "@multica/core/autopilots";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
+import { Button } from "@multica/ui/components/ui/button";
+import { Badge } from "@multica/ui/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@multica/ui/components/ui/dialog";
+import { cn } from "@multica/ui/lib/utils";
+import { toast } from "sonner";
+import { useT } from "../../i18n";
+import type {
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+  WebhookSignatureStatus,
+} from "@multica/core/types";
+
+// --- Status visuals -------------------------------------------------------
+
+// Mapping is exhaustive over the current backend enum but every consumer
+// site falls back to a generic "unknown" visual when the server adds a new
+// value — see the API Response Compatibility rules in CLAUDE.md.
+type StatusVisual = {
+  color: string;
+  icon: typeof CheckCircle2;
+  spin?: boolean;
+};
+
+const STATUS_VISUAL: Record<WebhookDeliveryStatus, StatusVisual> = {
+  queued: { color: "text-blue-500", icon: Loader2, spin: true },
+  dispatched: { color: "text-emerald-500", icon: CheckCircle2 },
+  // Signature failures and pre-flight bouncebacks land here. Read as a
+  // failure visually, the dialog footer explains the reason.
+  rejected: { color: "text-destructive", icon: ShieldOff },
+  // Ignored covers paused/disabled/archived autopilots — same payload was
+  // received but no run was created. Muted so it doesn't look like a bug.
+  ignored: { color: "text-muted-foreground", icon: Ban },
+  failed: { color: "text-destructive", icon: XCircle },
+};
+
+const UNKNOWN_VISUAL: StatusVisual = {
+  color: "text-muted-foreground",
+  icon: AlertTriangle,
+};
+
+function visualForStatus(status: string): StatusVisual {
+  return (STATUS_VISUAL as Record<string, StatusVisual>)[status] ?? UNKNOWN_VISUAL;
+}
+
+// --- Helpers --------------------------------------------------------------
+
+function formatDate(value: string): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// A delivery is replayable when (a) the server allows it (signature is not
+// invalid AND the delivery itself wasn't rejected) and (b) we have something
+// to replay (raw_body / received). We mirror the server's rule rather than
+// rely on the response — keeping the button disabled saves a 400 round-trip.
+function canReplay(delivery: WebhookDelivery): boolean {
+  if (delivery.signature_status === "invalid") return false;
+  if (delivery.status === "rejected") return false;
+  // `queued` deliveries are mid-flight on the server; replay would race the
+  // synchronous dispatch path. Once they settle, the user can replay.
+  if (delivery.status === "queued") return false;
+  return true;
+}
+
+// --- Section --------------------------------------------------------------
+
+export function WebhookDeliveriesSection({
+  autopilotId,
+  hasWebhookTrigger,
+}: {
+  autopilotId: string;
+  hasWebhookTrigger: boolean;
+}) {
+  const { t } = useT("autopilots");
+  const wsId = useWorkspaceId();
+
+  const { data: deliveries = [], isLoading } = useQuery(
+    autopilotDeliveriesOptions(wsId, autopilotId, {
+      enabled: hasWebhookTrigger,
+    }),
+  );
+
+  // No webhook trigger configured → the entire section is irrelevant. We hide
+  // it rather than render an empty card to keep the detail page short for
+  // schedule-only autopilots.
+  if (!hasWebhookTrigger) return null;
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+        {t(($) => $.deliveries.section_title)}
+      </h2>
+      {isLoading ? (
+        <div className="space-y-1">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : deliveries.length === 0 ? (
+        <div className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+          {t(($) => $.deliveries.empty)}
+        </div>
+      ) : (
+        <div className="rounded-md border overflow-hidden">
+          {deliveries.map((delivery) => (
+            <DeliveryRow
+              key={delivery.id}
+              delivery={delivery}
+              autopilotId={autopilotId}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// --- Row ------------------------------------------------------------------
+
+function DeliveryRow({
+  delivery,
+  autopilotId,
+}: {
+  delivery: WebhookDelivery;
+  autopilotId: string;
+}) {
+  const { t } = useT("autopilots");
+  const [open, setOpen] = useState(false);
+
+  const visual = visualForStatus(delivery.status);
+  const StatusIcon = visual.icon;
+  const statusLabel =
+    t(($) => $.deliveries.status[delivery.status as WebhookDeliveryStatus]) ??
+    delivery.status;
+  const providerLabel = delivery.provider || "—";
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent/30 transition-colors"
+      >
+        <StatusIcon
+          className={cn(
+            "h-4 w-4 shrink-0",
+            visual.color,
+            visual.spin && "animate-spin",
+          )}
+        />
+        <span className={cn("w-24 shrink-0 text-xs font-medium", visual.color)}>
+          {statusLabel}
+        </span>
+        <span className="w-20 shrink-0 text-xs text-muted-foreground truncate">
+          {providerLabel}
+        </span>
+        <span className="flex-1 min-w-0 text-xs text-muted-foreground truncate font-mono">
+          {delivery.event || t(($) => $.webhook_payload.unknown_event)}
+        </span>
+        {delivery.replayed_from_delivery_id && (
+          <Badge variant="secondary" className="shrink-0">
+            <RotateCw className="h-3 w-3" />
+            {t(($) => $.deliveries.row.replay_badge)}
+          </Badge>
+        )}
+        {delivery.attempt_count > 1 && (
+          <Badge variant="outline" className="shrink-0">
+            {t(($) => $.deliveries.row.attempts, {
+              count: delivery.attempt_count,
+            })}
+          </Badge>
+        )}
+        <span className="w-32 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+          {formatDate(delivery.received_at || delivery.created_at)}
+        </span>
+      </button>
+      {open && (
+        <DeliveryDetailDialog
+          open={open}
+          onOpenChange={setOpen}
+          autopilotId={autopilotId}
+          delivery={delivery}
+        />
+      )}
+    </>
+  );
+}
+
+// --- Detail dialog --------------------------------------------------------
+
+function DeliveryDetailDialog({
+  open,
+  onOpenChange,
+  autopilotId,
+  delivery,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  autopilotId: string;
+  delivery: WebhookDelivery;
+}) {
+  const { t } = useT("autopilots");
+  const wsId = useWorkspaceId();
+  const { data: detail, isLoading } = useQuery(
+    autopilotDeliveryOptions(wsId, autopilotId, delivery.id, { enabled: open }),
+  );
+  // Use the detail row when loaded, otherwise the slim row from the list.
+  // The slim row is missing raw_body / response_body / selected_headers; the
+  // dialog renders skeleton placeholders for those sections while detail is
+  // still loading.
+  const full = detail ?? delivery;
+  const visual = visualForStatus(full.status);
+  const StatusIcon = visual.icon;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogTitle className="flex items-center gap-2">
+          <Webhook className="h-4 w-4 text-muted-foreground" />
+          {t(($) => $.deliveries.detail.title)}
+        </DialogTitle>
+        <div className="space-y-4 pt-1">
+          {/* Header row — status / provider / event */}
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-2">
+              <StatusIcon
+                className={cn(
+                  "h-4 w-4 shrink-0",
+                  visual.color,
+                  visual.spin && "animate-spin",
+                )}
+              />
+              <span className={cn("text-sm font-medium", visual.color)}>
+                {t(($) => $.deliveries.status[full.status as WebhookDeliveryStatus]) ??
+                  full.status}
+              </span>
+            </div>
+            <Badge variant="outline">{full.provider || "—"}</Badge>
+            <code className="rounded bg-muted px-2 py-0.5 text-xs font-mono">
+              {full.event || t(($) => $.webhook_payload.unknown_event)}
+            </code>
+            <SignatureBadge status={full.signature_status as WebhookSignatureStatus} />
+          </div>
+
+          {/* Meta grid */}
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+            <MetaRow
+              label={t(($) => $.deliveries.detail.received_at)}
+              value={formatDate(full.received_at)}
+            />
+            <MetaRow
+              label={t(($) => $.deliveries.detail.last_attempt_at)}
+              value={formatDate(full.last_attempt_at)}
+            />
+            <MetaRow
+              label={t(($) => $.deliveries.detail.attempt_count)}
+              value={String(full.attempt_count)}
+            />
+            <MetaRow
+              label={t(($) => $.deliveries.detail.response_status)}
+              value={full.response_status != null ? String(full.response_status) : "—"}
+            />
+            <MetaRow
+              label={t(($) => $.deliveries.detail.dedupe_key)}
+              value={full.dedupe_key ?? "—"}
+              mono
+            />
+            <MetaRow
+              label={t(($) => $.deliveries.detail.dedupe_source)}
+              value={full.dedupe_source ?? "—"}
+            />
+            {full.content_type && (
+              <MetaRow
+                label={t(($) => $.deliveries.detail.content_type)}
+                value={full.content_type}
+                mono
+              />
+            )}
+            {full.replayed_from_delivery_id && (
+              <MetaRow
+                label={t(($) => $.deliveries.detail.replayed_from)}
+                value={full.replayed_from_delivery_id}
+                mono
+              />
+            )}
+          </dl>
+
+          {full.error && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+              <div className="font-medium">
+                {t(($) => $.deliveries.detail.error_label)}
+              </div>
+              <div className="mt-0.5 font-mono break-all">{full.error}</div>
+            </div>
+          )}
+
+          {/* Raw body + response body + headers, all loaded lazily */}
+          <DetailSections detail={detail} isLoading={isLoading} />
+
+          {/* Replay button */}
+          <div className="flex items-center justify-between pt-2">
+            <ReplayHint delivery={full} />
+            <ReplayButton
+              autopilotId={autopilotId}
+              delivery={full}
+              onSuccess={() => onOpenChange(false)}
+            />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function MetaRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex flex-col">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd
+        className={cn(
+          "truncate text-foreground",
+          mono && "font-mono",
+        )}
+        title={value}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function SignatureBadge({ status }: { status: WebhookSignatureStatus | string }) {
+  const { t } = useT("autopilots");
+  let variant: "default" | "secondary" | "destructive" | "outline" = "outline";
+  if (status === "valid") variant = "default";
+  else if (status === "invalid") variant = "destructive";
+  else if (status === "missing") variant = "secondary";
+  return (
+    <Badge variant={variant}>
+      {t(($) => $.deliveries.signature[status as WebhookSignatureStatus]) ?? status}
+    </Badge>
+  );
+}
+
+function DetailSections({
+  detail,
+  isLoading,
+}: {
+  detail: WebhookDelivery | undefined;
+  isLoading: boolean;
+}) {
+  const { t } = useT("autopilots");
+  if (isLoading && !detail) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    );
+  }
+  if (!detail) return null;
+  return (
+    <div className="space-y-3">
+      {detail.raw_body && (
+        <CodeBlock
+          label={t(($) => $.deliveries.detail.raw_body)}
+          value={detail.raw_body}
+        />
+      )}
+      {detail.selected_headers && Object.keys(detail.selected_headers).length > 0 && (
+        <CodeBlock
+          label={t(($) => $.deliveries.detail.selected_headers)}
+          value={JSON.stringify(detail.selected_headers, null, 2)}
+        />
+      )}
+      {detail.response_body && (
+        <CodeBlock
+          label={t(($) => $.deliveries.detail.response_body)}
+          value={detail.response_body}
+        />
+      )}
+    </div>
+  );
+}
+
+function CodeBlock({ label, value }: { label: string; value: string }) {
+  const { t } = useT("autopilots");
+  const [copied, setCopied] = useState(false);
+  // Truncate in-DOM display for very large bodies; the Copy button still
+  // yields the full string. 4 KiB is large enough for typical webhook
+  // payloads while keeping the dialog responsive.
+  const TRUNCATE_AT = 4096;
+  const isTruncated = value.length > TRUNCATE_AT;
+  const display = isTruncated ? value.slice(0, TRUNCATE_AT) : value;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      toast.success(t(($) => $.webhook_payload.copied));
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error(t(($) => $.webhook_payload.copy_failed));
+    }
+  };
+
+  return (
+    <div className="rounded-md border bg-background">
+      <div className="flex items-center justify-between border-b px-3 py-1.5 text-[11px]">
+        <span className="font-medium text-muted-foreground">{label}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex items-center gap-1 rounded px-2 py-0.5 hover:bg-accent transition-colors"
+        >
+          {copied ? (
+            <Check className="h-3 w-3 text-emerald-500" />
+          ) : (
+            <Copy className="h-3 w-3" />
+          )}
+          {copied
+            ? t(($) => $.webhook_payload.copied_short)
+            : t(($) => $.webhook_payload.copy)}
+        </button>
+      </div>
+      <pre className="max-h-48 overflow-auto bg-muted/40 px-3 py-2 text-xs font-mono leading-relaxed">
+        {display}
+        {isTruncated && (
+          <span className="block pt-2 text-muted-foreground/70">
+            {t(($) => $.webhook_payload.truncated_marker)}
+          </span>
+        )}
+      </pre>
+    </div>
+  );
+}
+
+function ReplayHint({ delivery }: { delivery: WebhookDelivery }) {
+  const { t } = useT("autopilots");
+  if (delivery.signature_status === "invalid") {
+    return (
+      <span className="text-xs text-muted-foreground">
+        {t(($) => $.deliveries.replay.disabled_invalid_signature)}
+      </span>
+    );
+  }
+  if (delivery.status === "rejected") {
+    return (
+      <span className="text-xs text-muted-foreground">
+        {t(($) => $.deliveries.replay.disabled_rejected)}
+      </span>
+    );
+  }
+  if (delivery.status === "queued") {
+    return (
+      <span className="text-xs text-muted-foreground">
+        {t(($) => $.deliveries.replay.disabled_queued)}
+      </span>
+    );
+  }
+  return null;
+}
+
+function ReplayButton({
+  autopilotId,
+  delivery,
+  onSuccess,
+}: {
+  autopilotId: string;
+  delivery: WebhookDelivery;
+  onSuccess: () => void;
+}) {
+  const { t } = useT("autopilots");
+  const replay = useReplayAutopilotDelivery();
+  const enabled = canReplay(delivery) && !replay.isPending;
+
+  const handleClick = async () => {
+    try {
+      await replay.mutateAsync({ autopilotId, deliveryId: delivery.id });
+      toast.success(t(($) => $.deliveries.replay.toast_success));
+      onSuccess();
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error
+          ? e.message
+          : t(($) => $.deliveries.replay.toast_failed);
+      toast.error(message);
+    }
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={handleClick}
+      disabled={!enabled}
+    >
+      <RotateCw
+        className={cn(
+          "h-3.5 w-3.5 mr-1",
+          replay.isPending && "animate-spin",
+        )}
+      />
+      {replay.isPending
+        ? t(($) => $.deliveries.replay.in_progress)
+        : t(($) => $.deliveries.replay.action)}
+    </Button>
+  );
+}

--- a/packages/views/locales/en/autopilots.json
+++ b/packages/views/locales/en/autopilots.json
@@ -151,6 +151,51 @@
       "deleting": "Deleting..."
     }
   },
+  "deliveries": {
+    "section_title": "Webhook Deliveries",
+    "empty": "No webhook deliveries yet. Send a POST to the webhook URL to see entries here.",
+    "row": {
+      "attempts": "{{count}}× attempts",
+      "replay_badge": "Replay"
+    },
+    "status": {
+      "queued": "Queued",
+      "dispatched": "Dispatched",
+      "rejected": "Rejected",
+      "ignored": "Ignored",
+      "failed": "Failed"
+    },
+    "signature": {
+      "not_required": "No signature",
+      "valid": "Signature valid",
+      "invalid": "Signature invalid",
+      "missing": "Signature missing"
+    },
+    "detail": {
+      "title": "Delivery",
+      "received_at": "Received",
+      "last_attempt_at": "Last attempt",
+      "attempt_count": "Attempts",
+      "response_status": "Response",
+      "dedupe_key": "Dedupe key",
+      "dedupe_source": "Dedupe source",
+      "content_type": "Content-Type",
+      "replayed_from": "Replayed from",
+      "error_label": "Error",
+      "raw_body": "Raw body",
+      "selected_headers": "Headers",
+      "response_body": "Response body"
+    },
+    "replay": {
+      "action": "Replay",
+      "in_progress": "Replaying...",
+      "toast_success": "Delivery replayed",
+      "toast_failed": "Replay failed",
+      "disabled_invalid_signature": "Can't replay — signature was invalid",
+      "disabled_rejected": "Can't replay a rejected delivery",
+      "disabled_queued": "Still queued — replay once it settles"
+    }
+  },
   "add_trigger_dialog": {
     "title": "Add Trigger",
     "type_label": "Type",

--- a/packages/views/locales/zh-Hans/autopilots.json
+++ b/packages/views/locales/zh-Hans/autopilots.json
@@ -151,6 +151,51 @@
       "deleting": "删除中..."
     }
   },
+  "deliveries": {
+    "section_title": "Webhook 投递",
+    "empty": "暂无 Webhook 投递记录。向 Webhook URL 发送一次 POST 后会显示在这里。",
+    "row": {
+      "attempts": "{{count}} 次尝试",
+      "replay_badge": "重放"
+    },
+    "status": {
+      "queued": "排队中",
+      "dispatched": "已分发",
+      "rejected": "已拒绝",
+      "ignored": "已忽略",
+      "failed": "失败"
+    },
+    "signature": {
+      "not_required": "无需签名",
+      "valid": "签名通过",
+      "invalid": "签名无效",
+      "missing": "缺少签名"
+    },
+    "detail": {
+      "title": "投递详情",
+      "received_at": "接收时间",
+      "last_attempt_at": "最近一次尝试",
+      "attempt_count": "尝试次数",
+      "response_status": "响应状态码",
+      "dedupe_key": "去重 Key",
+      "dedupe_source": "去重来源",
+      "content_type": "Content-Type",
+      "replayed_from": "重放自",
+      "error_label": "错误信息",
+      "raw_body": "原始 Body",
+      "selected_headers": "保留的请求头",
+      "response_body": "响应 Body"
+    },
+    "replay": {
+      "action": "重放",
+      "in_progress": "重放中...",
+      "toast_success": "已重放该投递",
+      "toast_failed": "重放失败",
+      "disabled_invalid_signature": "无法重放 — 签名校验失败",
+      "disabled_rejected": "无法重放已拒绝的投递",
+      "disabled_queued": "投递仍在排队，处理完成后再重放"
+    }
+  },
   "add_trigger_dialog": {
     "title": "添加触发器",
     "type_label": "类型",


### PR DESCRIPTION
## Summary

PR2 in the webhook system rewrite ([MUL-2334](mention://issue/cc22fa74-e001-438d-8ee7-87cf92f7b0db)). Wires the frontend onto the PR1 webhook delivery layer ([#2774](https://github.com/multica-ai/multica/pull/2774)) so operators can see deliveries land in real time and replay them.

> Stacked on [#2774](https://github.com/multica-ai/multica/pull/2774). Will be retargeted to `main` once that lands.

**What's in:**

- New **Webhook Deliveries** section on the autopilot detail page (only renders when at least one webhook trigger exists, so schedule-only autopilots don't pay for an empty list query).
- Status-coded row UI matching the converged PR1 enum: `queued` / `dispatched` / `rejected` / `ignored` / `failed`. Unknown future values render a generic fallback row instead of dropping.
- Click-to-open detail dialog with raw body, headers subset, response body, signature status, error, dedupe key/source, attempt count, and replay metadata.
- **Replay** button on the detail dialog. Disabled client-side (with an explanatory hint) for `signature_status === "invalid"` / `status === "rejected"` / `status === "queued"` — mirroring the server's 400 so the user gets immediate feedback.
- API client + zod schemas: `listAutopilotDeliveries`, `getAutopilotDelivery`, `replayAutopilotDelivery`. Schemas keep enums as `z.string()` so server-side enum drift degrades to a generic UI fallback rather than crashing the parse.
- TanStack Query plumbing: `autopilotDeliveriesOptions` for the list, `autopilotDeliveryOptions` for lazy detail loading, `useReplayAutopilotDelivery` invalidating both deliveries and runs on settle.
- i18n parity: keys added to both `en` and `zh-Hans` autopilots namespaces.

**What's deliberately not in:**

- No Stripe / Slack / Shopify provider preset UI.
- No signing-secret management UI (server-side endpoint exists; surfacing it lands in a follow-up trigger-config patch).
- No token rotate grace window UI.
- No TTL / cleanup affordance.

These all sit outside the converged PR1 scope and stay deferred per the original plan review.

## Test plan

- [x] `pnpm typecheck` — all 6 packages clean.
- [x] `pnpm test` — 575 view tests + 24 core schema tests + 103 desktop + 20 web all green.
- [x] Schema fallback test: malformed `deliveries` payload yields `{ deliveries: [], total: 0 }`; unknown `status` value still surfaces the row.
- [x] Locale parity test passes (51/51).
- [ ] Manual smoke once PR1 lands and is deployed to staging: post a delivery, verify list updates, open detail, replay, observe new delivery row with `replayed_from_delivery_id` set.