### PR TITLE
feat(usage): filter dashboard by squad

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -909,11 +909,17 @@ export class ApiClient {
   // ---------------------------------------------------------------------------
 
   async getDashboardUsageDaily(
-    params: { days?: number; project_id?: string | null; tz?: string },
+    params: {
+      days?: number;
+      project_id?: string | null;
+      squad_id?: string | null;
+      tz?: string;
+    },
   ): Promise<DashboardUsageDaily[]> {
     const search = new URLSearchParams();
     if (params.days) search.set("days", String(params.days));
     if (params.project_id) search.set("project_id", params.project_id);
+    if (params.squad_id) search.set("squad_id", params.squad_id);
     if (params.tz) search.set("tz", params.tz);
     const raw = await this.fetch<unknown>(`/api/dashboard/usage/daily?${search}`);
     return parseWithFallback<DashboardUsageDaily[]>(
@@ -925,11 +931,17 @@ export class ApiClient {
   }
 
   async getDashboardUsageByAgent(
-    params: { days?: number; project_id?: string | null; tz?: string },
+    params: {
+      days?: number;
+      project_id?: string | null;
+      squad_id?: string | null;
+      tz?: string;
+    },
   ): Promise<DashboardUsageByAgent[]> {
     const search = new URLSearchParams();
     if (params.days) search.set("days", String(params.days));
     if (params.project_id) search.set("project_id", params.project_id);
+    if (params.squad_id) search.set("squad_id", params.squad_id);
     if (params.tz) search.set("tz", params.tz);
     const raw = await this.fetch<unknown>(`/api/dashboard/usage/by-agent?${search}`);
     return parseWithFallback<DashboardUsageByAgent[]>(
@@ -941,11 +953,17 @@ export class ApiClient {
   }
 
   async getDashboardAgentRunTime(
-    params: { days?: number; project_id?: string | null; tz?: string },
+    params: {
+      days?: number;
+      project_id?: string | null;
+      squad_id?: string | null;
+      tz?: string;
+    },
   ): Promise<DashboardAgentRunTime[]> {
     const search = new URLSearchParams();
     if (params.days) search.set("days", String(params.days));
     if (params.project_id) search.set("project_id", params.project_id);
+    if (params.squad_id) search.set("squad_id", params.squad_id);
     // `tz` aligns the "last N days" cutoff with the viewer's calendar,
     // matching the per-agent token card.
     if (params.tz) search.set("tz", params.tz);
@@ -959,11 +977,17 @@ export class ApiClient {
   }
 
   async getDashboardRunTimeDaily(
-    params: { days?: number; project_id?: string | null; tz?: string },
+    params: {
+      days?: number;
+      project_id?: string | null;
+      squad_id?: string | null;
+      tz?: string;
+    },
   ): Promise<DashboardRunTimeDaily[]> {
     const search = new URLSearchParams();
     if (params.days) search.set("days", String(params.days));
     if (params.project_id) search.set("project_id", params.project_id);
+    if (params.squad_id) search.set("squad_id", params.squad_id);
     // `tz` cuts the day buckets in the viewer's calendar so Time / Tasks
     // align with the Cost / Tokens charts.
     if (params.tz) search.set("tz", params.tz);

--- a/packages/core/dashboard/queries.ts
+++ b/packages/core/dashboard/queries.ts
@@ -7,47 +7,72 @@ export const dashboardKeys = {
     wsId: string,
     days: number,
     projectId: string | null,
+    squadId: string | null,
     tz: string,
-  ) => [...dashboardKeys.all(wsId), "daily", days, projectId, tz] as const,
+  ) =>
+    [...dashboardKeys.all(wsId), "daily", days, projectId, squadId, tz] as const,
   byAgent: (
     wsId: string,
     days: number,
     projectId: string | null,
+    squadId: string | null,
     tz: string,
-  ) => [...dashboardKeys.all(wsId), "by-agent", days, projectId, tz] as const,
+  ) =>
+    [...dashboardKeys.all(wsId), "by-agent", days, projectId, squadId, tz] as const,
   agentRuntime: (
     wsId: string,
     days: number,
     projectId: string | null,
+    squadId: string | null,
     tz: string,
-  ) => [...dashboardKeys.all(wsId), "agent-runtime", days, projectId, tz] as const,
+  ) =>
+    [
+      ...dashboardKeys.all(wsId),
+      "agent-runtime",
+      days,
+      projectId,
+      squadId,
+      tz,
+    ] as const,
   runTimeDaily: (
     wsId: string,
     days: number,
     projectId: string | null,
+    squadId: string | null,
     tz: string,
-  ) => [...dashboardKeys.all(wsId), "runtime-daily", days, projectId, tz] as const,
+  ) =>
+    [
+      ...dashboardKeys.all(wsId),
+      "runtime-daily",
+      days,
+      projectId,
+      squadId,
+      tz,
+    ] as const,
 };
 
 // 5-min rollup cadence on the server, 60s background refetch on the client.
 const STALE_TIME = 60 * 1000;
 
-// `tz` participates in every dashboard key so a Preferences change
-// repoints the cache. All four series — token rollups and the
-// atq.completed_at-based run-time series — slice their day boundary in
-// the viewer's tz, so the four dashboard tabs always agree.
+// `tz`, `projectId`, and `squadId` all participate in every dashboard key
+// so a Preferences or filter change repoints the cache. All four series —
+// token rollups and the atq.completed_at-based run-time series — slice
+// their day boundary in the viewer's tz, so the four dashboard tabs always
+// agree.
 export function dashboardUsageDailyOptions(
   wsId: string,
   days: number,
   projectId: string | null,
+  squadId: string | null,
   tz: string,
 ) {
   return queryOptions({
-    queryKey: dashboardKeys.daily(wsId, days, projectId, tz),
+    queryKey: dashboardKeys.daily(wsId, days, projectId, squadId, tz),
     queryFn: () =>
       api.getDashboardUsageDaily({
         days,
         project_id: projectId ?? undefined,
+        squad_id: squadId ?? undefined,
         tz,
       }),
     enabled: !!wsId,
@@ -59,14 +84,16 @@ export function dashboardUsageByAgentOptions(
   wsId: string,
   days: number,
   projectId: string | null,
+  squadId: string | null,
   tz: string,
 ) {
   return queryOptions({
-    queryKey: dashboardKeys.byAgent(wsId, days, projectId, tz),
+    queryKey: dashboardKeys.byAgent(wsId, days, projectId, squadId, tz),
     queryFn: () =>
       api.getDashboardUsageByAgent({
         days,
         project_id: projectId ?? undefined,
+        squad_id: squadId ?? undefined,
         tz,
       }),
     enabled: !!wsId,
@@ -78,14 +105,16 @@ export function dashboardAgentRunTimeOptions(
   wsId: string,
   days: number,
   projectId: string | null,
+  squadId: string | null,
   tz: string,
 ) {
   return queryOptions({
-    queryKey: dashboardKeys.agentRuntime(wsId, days, projectId, tz),
+    queryKey: dashboardKeys.agentRuntime(wsId, days, projectId, squadId, tz),
     queryFn: () =>
       api.getDashboardAgentRunTime({
         days,
         project_id: projectId ?? undefined,
+        squad_id: squadId ?? undefined,
         tz,
       }),
     enabled: !!wsId,
@@ -97,14 +126,16 @@ export function dashboardRunTimeDailyOptions(
   wsId: string,
   days: number,
   projectId: string | null,
+  squadId: string | null,
   tz: string,
 ) {
   return queryOptions({
-    queryKey: dashboardKeys.runTimeDaily(wsId, days, projectId, tz),
+    queryKey: dashboardKeys.runTimeDaily(wsId, days, projectId, squadId, tz),
     queryFn: () =>
       api.getDashboardRunTimeDaily({
         days,
         project_id: projectId ?? undefined,
+        squad_id: squadId ?? undefined,
         tz,
       }),
     enabled: !!wsId,

--- a/packages/views/dashboard/components/dashboard-page.test.tsx
+++ b/packages/views/dashboard/components/dashboard-page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithI18n } from "../../test/i18n";
 
 // The viewing timezone flows: auth store `user.timezone` → useViewingTimezone()
@@ -11,6 +12,16 @@ import { renderWithI18n } from "../../test/i18n";
 // dashboard options builders runs for real, so the key is the production key.
 const queryKeys = vi.hoisted(() => [] as unknown[][]);
 
+// Squad list returned by `squadListOptions` — keyed `["workspaces", wsId,
+// "squads"]`. Tests mutate `.current` to drive the squad filter, including
+// the stale-squad case where the selected id is no longer in the list.
+const squadsRef = vi.hoisted(
+  () =>
+    ({ current: [] }) as {
+      current: Array<{ id: string; name: string; avatar_url: string | null }>;
+    },
+);
+
 vi.mock("@tanstack/react-query", async () => {
   const actual =
     await vi.importActual<typeof import("@tanstack/react-query")>(
@@ -20,6 +31,10 @@ vi.mock("@tanstack/react-query", async () => {
     ...actual,
     useQuery: (opts: { queryKey: unknown[] }) => {
       queryKeys.push(opts.queryKey);
+      const k = opts.queryKey;
+      if (k.length === 3 && k[0] === "workspaces" && k[2] === "squads") {
+        return { data: squadsRef.current, isLoading: false };
+      }
       return { data: undefined, isLoading: true };
     },
   };
@@ -96,5 +111,96 @@ describe("DashboardPage — viewing timezone drives the query key", () => {
     for (let i = 0; i < utcKeys.length; i++) {
       expect(utcKeys[i]).not.toEqual(tokyoKeys[i]);
     }
+  });
+});
+
+describe("DashboardPage — squad filter", () => {
+  beforeEach(() => {
+    queryKeys.length = 0;
+    squadsRef.current = [];
+    cleanup();
+  });
+
+  // The squad segment sits at index length-2 of every dashboard key
+  // (immediately before the tz segment) — see dashboardKeys in
+  // @multica/core/dashboard/queries.
+  function squadSegments(): unknown[] {
+    return queryKeys
+      .filter((k) => k[0] === "dashboard")
+      .map((k) => k[k.length - 2]);
+  }
+
+  // The Select trigger carries `aria-labelledby`, so its accessible name is
+  // not the visible text — pick it out of the combobox set by content.
+  function squadTrigger(): HTMLElement {
+    const trigger = screen
+      .getAllByRole("combobox")
+      .find((c) => /squad/i.test(c.textContent ?? ""));
+    if (!trigger) throw new Error("squad filter trigger not found");
+    return trigger;
+  }
+
+  it("renders the squad filter and threads a squad segment into every dashboard key", () => {
+    tzRef.current = "UTC";
+    const { getAllByText } = renderWithI18n(<DashboardPage />);
+
+    // The squad filter trigger defaults to "All squads".
+    expect(getAllByText("All squads").length).toBeGreaterThan(0);
+
+    // It is null while "All squads" is selected — the key shape, not the
+    // value, is what this pins.
+    const segs = squadSegments();
+    expect(segs.length).toBeGreaterThan(0);
+    expect(segs.every((s) => s === null)).toBe(true);
+  });
+
+  it("threads the picked squad's id into every dashboard key", async () => {
+    tzRef.current = "UTC";
+    squadsRef.current = [
+      { id: "squad-alpha", name: "Alpha Squad", avatar_url: null },
+      { id: "squad-beta", name: "Beta Squad", avatar_url: null },
+    ];
+    const user = userEvent.setup();
+    renderWithI18n(<DashboardPage />);
+
+    await user.click(squadTrigger());
+    const option = await screen.findByRole("option", { name: "Alpha Squad" });
+
+    // Drop the keys emitted while the popup opened — only the keys from the
+    // post-selection render should be asserted.
+    queryKeys.length = 0;
+    await user.click(option);
+
+    const segs = squadSegments();
+    expect(segs.length).toBeGreaterThan(0);
+    expect(segs.every((s) => s === "squad-alpha")).toBe(true);
+  });
+
+  it("drops a stale squad selection back to null when the squad disappears", async () => {
+    tzRef.current = "UTC";
+    squadsRef.current = [
+      { id: "squad-alpha", name: "Alpha Squad", avatar_url: null },
+      { id: "squad-beta", name: "Beta Squad", avatar_url: null },
+    ];
+    const user = userEvent.setup();
+    const { rerender } = renderWithI18n(<DashboardPage />);
+
+    await user.click(squadTrigger());
+    await user.click(await screen.findByRole("option", { name: "Alpha Squad" }));
+
+    // Squad Alpha is deleted (or the workspace switched): the squad list no
+    // longer contains it, but squadValue state still holds its id.
+    squadsRef.current = [
+      { id: "squad-beta", name: "Beta Squad", avatar_url: null },
+    ];
+    queryKeys.length = 0;
+    rerender(<DashboardPage />);
+
+    // The validation memo must collapse the stale id to null — otherwise
+    // every query silently filters to empty rows behind a trigger that
+    // still reads "All squads".
+    const segs = squadSegments();
+    expect(segs.length).toBeGreaterThan(0);
+    expect(segs.every((s) => s === null)).toBe(true);
   });
 });

--- a/packages/views/dashboard/components/dashboard-page.tsx
+++ b/packages/views/dashboard/components/dashboard-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { BarChart3, FolderKanban } from "lucide-react";
+import { BarChart3, FolderKanban, Users } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import {
@@ -12,7 +12,7 @@ import {
   SelectValue,
 } from "@multica/ui/components/ui/select";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { agentListOptions } from "@multica/core/workspace/queries";
+import { agentListOptions, squadListOptions } from "@multica/core/workspace/queries";
 import { projectListOptions } from "@multica/core/projects/queries";
 import {
   dashboardUsageDailyOptions,
@@ -36,6 +36,8 @@ import {
 } from "../../runtimes/components/charts";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { SquadAvatar } from "../../squads/components/squad-avatar";
+import type { Squad } from "@multica/core/types";
 import {
   addDaysIso,
   aggregateByWeek,
@@ -90,6 +92,10 @@ function rangesForDim(dim: Dim) {
 // Sentinel for "no project filter" — kept distinct from the empty string
 // so it survives a refactor that ever lets a project be slug-keyed.
 const ALL_PROJECTS = "__all__";
+
+// Sentinel for "no squad filter" — distinct value from ALL_PROJECTS so the
+// two filters can never alias.
+const ALL_SQUADS = "__all_squads__";
 
 // Stable references — `data ?? []` would create a new empty array on
 // every render while the query is loading, which breaks useMemo's
@@ -154,6 +160,7 @@ export function DashboardPage() {
   const [dim, setDim] = useState<Dim>("daily");
   const [days, setDays] = useState<TimeRange>(30);
   const [projectValue, setProjectValue] = useState<string>(ALL_PROJECTS);
+  const [squadValue, setSquadValue] = useState<string>(ALL_SQUADS);
 
   const allowedRanges = rangesForDim(dim);
   const handleDimChange = (next: Dim) => {
@@ -170,6 +177,7 @@ export function DashboardPage() {
 
   const { data: projects = [] } = useQuery(projectListOptions(wsId));
   const { data: agents = [] } = useQuery(agentListOptions(wsId));
+  const { data: squads = [] } = useQuery(squadListOptions(wsId));
 
   // Validate the picked project against the current workspace's list. A
   // stale UUID — left over from a project that's been deleted, or from the
@@ -182,6 +190,15 @@ export function DashboardPage() {
     return projects.some((p) => p.id === projectValue) ? projectValue : null;
   }, [projectValue, projects]);
 
+  // Validate the picked squad against the current workspace's list — a
+  // stale UUID (deleted/archived squad, or a leftover after a workspace
+  // switch) must not silently filter every query to empty rows while the
+  // dropdown still reads "All squads".
+  const squadId = useMemo(() => {
+    if (squadValue === ALL_SQUADS) return null;
+    return squads.some((s) => s.id === squadValue) ? squadValue : null;
+  }, [squadValue, squads]);
+
   // The weekly chart paints `ceil(days / 7)` trailing calendar weeks anchored
   // at today-in-UTC. In the worst case (today = Sunday) the leftmost Monday
   // sits `weekCount * 7 - 1` days back, so a vanilla `days=30` request would
@@ -192,16 +209,16 @@ export function DashboardPage() {
   const chartFetchDays = dim === "weekly" ? weekCount * 7 : days;
 
   const dailyQuery = useQuery(
-    dashboardUsageDailyOptions(wsId, chartFetchDays, projectId, viewTZ),
+    dashboardUsageDailyOptions(wsId, chartFetchDays, projectId, squadId, viewTZ),
   );
   const byAgentQuery = useQuery(
-    dashboardUsageByAgentOptions(wsId, days, projectId, viewTZ),
+    dashboardUsageByAgentOptions(wsId, days, projectId, squadId, viewTZ),
   );
   const runTimeQuery = useQuery(
-    dashboardAgentRunTimeOptions(wsId, days, projectId, viewTZ),
+    dashboardAgentRunTimeOptions(wsId, days, projectId, squadId, viewTZ),
   );
   const runTimeDailyQuery = useQuery(
-    dashboardRunTimeDailyOptions(wsId, chartFetchDays, projectId, viewTZ),
+    dashboardRunTimeDailyOptions(wsId, chartFetchDays, projectId, squadId, viewTZ),
   );
 
   const dailyUsage = dailyQuery.data ?? EMPTY_DAILY;
@@ -326,6 +343,11 @@ export function DashboardPage() {
             projects={projects}
             value={projectValue}
             onChange={setProjectValue}
+          />
+          <SquadFilter
+            squads={squads}
+            value={squadValue}
+            onChange={setSquadValue}
           />
           <Segmented
             value={dim}
@@ -473,6 +495,60 @@ function ProjectFilter({
           <SelectItem key={p.id} value={p.id}>
             <ProjectIcon project={p} size="sm" />
             <span className="truncate">{p.title}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function SquadFilter({
+  squads,
+  value,
+  onChange,
+}: {
+  squads: Squad[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const { t } = useT("usage");
+  const allLabel = t(($) => $.filter.all_squads);
+  const selected = squads.find((s) => s.id === value);
+  const selectedName =
+    value === ALL_SQUADS ? allLabel : selected?.name ?? allLabel;
+
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v ?? ALL_SQUADS)}>
+      <SelectTrigger
+        size="sm"
+        className="min-w-[180px]"
+        aria-label={t(($) => $.filter.squad_label)}
+      >
+        <SelectValue>
+          {() => (
+            <>
+              {selected ? (
+                <SquadAvatar squad={selected} size={16} className="rounded-sm" />
+              ) : (
+                <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              )}
+              <span className="truncate">{selectedName}</span>
+            </>
+          )}
+        </SelectValue>
+      </SelectTrigger>
+      {/* alignItemWithTrigger=false + max-h-72: same reasoning as
+          ProjectFilter — keep "All squads" reachable at the top of the
+          viewport and cap a long squad list to a scroll. */}
+      <SelectContent align="start" alignItemWithTrigger={false} className="max-h-72">
+        <SelectItem value={ALL_SQUADS}>
+          <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate">{allLabel}</span>
+        </SelectItem>
+        {squads.map((s) => (
+          <SelectItem key={s.id} value={s.id}>
+            <SquadAvatar squad={s} size={16} className="rounded-sm" />
+            <span className="truncate">{s.name}</span>
           </SelectItem>
         ))}
       </SelectContent>

--- a/packages/views/locales/en/usage.json
+++ b/packages/views/locales/en/usage.json
@@ -4,6 +4,8 @@
   "filter": {
     "project_label": "Project",
     "all_projects": "All projects",
+    "squad_label": "Squad",
+    "all_squads": "All squads",
     "period_label": "Period"
   },
   "kpi": {

--- a/packages/views/locales/zh-Hans/usage.json
+++ b/packages/views/locales/zh-Hans/usage.json
@@ -4,6 +4,8 @@
   "filter": {
     "project_label": "项目",
     "all_projects": "全部项目",
+    "squad_label": "小队",
+    "all_squads": "全部小队",
     "period_label": "时间范围"
   },
   "kpi": {

--- a/packages/views/squads/components/squad-avatar.tsx
+++ b/packages/views/squads/components/squad-avatar.tsx
@@ -1,0 +1,25 @@
+import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
+import type { Squad } from "@multica/core/types";
+
+// Thin Squad adapter over ActorAvatar — `isSquad` drives the square tile and
+// the Users-icon fallback for a squad with no image.
+export function SquadAvatar({
+  squad,
+  size = 36,
+  className,
+}: {
+  squad: Pick<Squad, "name" | "avatar_url">;
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <ActorAvatarBase
+      name={squad.name}
+      initials=""
+      isSquad
+      avatarUrl={squad.avatar_url}
+      size={size}
+      className={className}
+    />
+  );
+}

--- a/packages/views/squads/components/squads-page.tsx
+++ b/packages/views/squads/components/squads-page.tsx
@@ -12,8 +12,8 @@ import { Users, Plus, Search, Bot, User } from "lucide-react";
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
-import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
 import { useModalStore } from "@multica/core/modals";
+import { SquadAvatar } from "./squad-avatar";
 import type { Agent, Squad } from "@multica/core/types";
 import { useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
@@ -206,33 +206,5 @@ function SquadsListSkeleton() {
         </div>
       </div>
     </>
-  );
-}
-
-function SquadAvatar({ squad }: { squad: Squad }) {
-  const initials = squad.name
-    .split(" ")
-    .map((w) => w[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
-  if (squad.avatar_url) {
-    return (
-      <ActorAvatarBase
-        name={squad.name}
-        initials={initials}
-        avatarUrl={squad.avatar_url}
-        size={36}
-        className="rounded-md"
-      />
-    );
-  }
-  return (
-    <div
-      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
-      title={squad.name}
-    >
-      <Users className="h-4 w-4" />
-    </div>
   );
 }

--- a/server/internal/handler/dashboard.go
+++ b/server/internal/handler/dashboard.go
@@ -21,7 +21,9 @@ import (
 //
 // All three accept ?days=N (defaults to 30, capped at 365) and an optional
 // ?project_id=<uuid> to scope the rollup to a single project. With no
-// project_id the data spans the whole workspace.
+// project_id the data spans the whole workspace. They also accept an
+// optional ?squad_id=<uuid> to scope the rollup to one squad's agent
+// members; squad_id and project_id combine with AND.
 //
 // Cost is computed client-side from a per-model pricing table — the model
 // dimension is intentionally preserved on the wire (same convention as the
@@ -33,19 +35,19 @@ import (
 // access (see GetWorkspaceAgentRunCounts).
 // ---------------------------------------------------------------------------
 
-// parseProjectIDParam reads ?project_id=<uuid> off the URL. Returns a
-// pgtype.UUID with Valid=false when the param is absent so sqlc's nullable
-// argument resolves to SQL NULL and the WHERE clause degrades to "no
-// project filter". On a malformed UUID it writes a 400 and returns
-// ok=false; callers must return immediately.
-func parseProjectIDParam(w http.ResponseWriter, r *http.Request) (pgtype.UUID, bool) {
-	raw := r.URL.Query().Get("project_id")
+// parseOptionalUUIDParam reads an optional ?<param>=<uuid> off the URL.
+// Returns a pgtype.UUID with Valid=false when the param is absent so sqlc's
+// nullable argument resolves to SQL NULL and the WHERE clause degrades to
+// "no filter". On a malformed UUID it writes a 400 and returns ok=false;
+// callers must return immediately.
+func parseOptionalUUIDParam(w http.ResponseWriter, r *http.Request, param string) (pgtype.UUID, bool) {
+	raw := r.URL.Query().Get(param)
 	if raw == "" {
 		return pgtype.UUID{}, true
 	}
 	u, err := util.ParseUUID(raw)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid project_id")
+		writeError(w, http.StatusBadRequest, "invalid "+param)
 		return pgtype.UUID{}, false
 	}
 	return u, true
@@ -72,14 +74,18 @@ func (h *Handler) GetDashboardUsageDaily(w http.ResponseWriter, r *http.Request)
 	if _, ok := h.workspaceMember(w, r, workspaceID); !ok {
 		return
 	}
-	projectID, ok := parseProjectIDParam(w, r)
+	projectID, ok := parseOptionalUUIDParam(w, r, "project_id")
+	if !ok {
+		return
+	}
+	squadID, ok := parseOptionalUUIDParam(w, r, "squad_id")
 	if !ok {
 		return
 	}
 	tz := h.resolveViewingTZ(r)
 	since := parseSinceParamInTZ(r, 30, tz)
 
-	resp, err := h.listDashboardUsageDaily(r.Context(), parseUUID(workspaceID), tz, since, projectID)
+	resp, err := h.listDashboardUsageDaily(r.Context(), parseUUID(workspaceID), tz, since, projectID, squadID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list usage")
 		return
@@ -93,12 +99,14 @@ func (h *Handler) listDashboardUsageDaily(
 	tz string,
 	since pgtype.Timestamptz,
 	projectID pgtype.UUID,
+	squadID pgtype.UUID,
 ) ([]DashboardUsageDailyResponse, error) {
 	rows, err := h.Queries.ListDashboardUsageDaily(ctx, db.ListDashboardUsageDailyParams{
 		WorkspaceID: workspaceID,
 		Tz:          tz,
 		Since:       since,
 		ProjectID:   projectID,
+		SquadID:     squadID,
 	})
 	if err != nil {
 		return nil, err
@@ -137,7 +145,11 @@ func (h *Handler) GetDashboardUsageByAgent(w http.ResponseWriter, r *http.Reques
 	if _, ok := h.workspaceMember(w, r, workspaceID); !ok {
 		return
 	}
-	projectID, ok := parseProjectIDParam(w, r)
+	projectID, ok := parseOptionalUUIDParam(w, r, "project_id")
+	if !ok {
+		return
+	}
+	squadID, ok := parseOptionalUUIDParam(w, r, "squad_id")
 	if !ok {
 		return
 	}
@@ -146,7 +158,7 @@ func (h *Handler) GetDashboardUsageByAgent(w http.ResponseWriter, r *http.Reques
 	tz := h.resolveViewingTZ(r)
 	since := parseSinceParamInTZ(r, 30, tz)
 
-	resp, err := h.listDashboardUsageByAgent(r.Context(), parseUUID(workspaceID), since, projectID)
+	resp, err := h.listDashboardUsageByAgent(r.Context(), parseUUID(workspaceID), since, projectID, squadID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list usage by agent")
 		return
@@ -159,11 +171,13 @@ func (h *Handler) listDashboardUsageByAgent(
 	workspaceID pgtype.UUID,
 	since pgtype.Timestamptz,
 	projectID pgtype.UUID,
+	squadID pgtype.UUID,
 ) ([]DashboardUsageByAgentResponse, error) {
 	rows, err := h.Queries.ListDashboardUsageByAgent(ctx, db.ListDashboardUsageByAgentParams{
 		WorkspaceID: workspaceID,
 		Since:       since,
 		ProjectID:   projectID,
+		SquadID:     squadID,
 	})
 	if err != nil {
 		return nil, err
@@ -203,7 +217,11 @@ func (h *Handler) GetDashboardAgentRunTime(w http.ResponseWriter, r *http.Reques
 	if _, ok := h.workspaceMember(w, r, workspaceID); !ok {
 		return
 	}
-	projectID, ok := parseProjectIDParam(w, r)
+	projectID, ok := parseOptionalUUIDParam(w, r, "project_id")
+	if !ok {
+		return
+	}
+	squadID, ok := parseOptionalUUIDParam(w, r, "squad_id")
 	if !ok {
 		return
 	}
@@ -216,6 +234,7 @@ func (h *Handler) GetDashboardAgentRunTime(w http.ResponseWriter, r *http.Reques
 		WorkspaceID: parseUUID(workspaceID),
 		Since:       since,
 		ProjectID:   projectID,
+		SquadID:     squadID,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list agent runtime")
@@ -254,7 +273,11 @@ func (h *Handler) GetDashboardRunTimeDaily(w http.ResponseWriter, r *http.Reques
 	if _, ok := h.workspaceMember(w, r, workspaceID); !ok {
 		return
 	}
-	projectID, ok := parseProjectIDParam(w, r)
+	projectID, ok := parseOptionalUUIDParam(w, r, "project_id")
+	if !ok {
+		return
+	}
+	squadID, ok := parseOptionalUUIDParam(w, r, "squad_id")
 	if !ok {
 		return
 	}
@@ -268,6 +291,7 @@ func (h *Handler) GetDashboardRunTimeDaily(w http.ResponseWriter, r *http.Reques
 		Tz:          tz,
 		Since:       since,
 		ProjectID:   projectID,
+		SquadID:     squadID,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list daily runtime")

--- a/server/internal/handler/dashboard_test.go
+++ b/server/internal/handler/dashboard_test.go
@@ -1395,3 +1395,385 @@ func TestRollupTaskUsageHourlyConvergesOnTaskUsageDelete(t *testing.T) {
 		t.Errorf("after delete: expected bucket recomputed to 0, got %d", got)
 	}
 }
+
+// TestDashboardSquadFilter proves the ?squad_id= query param narrows every
+// dashboard rollup to agents that belong to the squad. A squad containing
+// the fixture agent surfaces its usage; a squad without it returns nothing.
+// It also checks squad_id composes (AND) with project_id.
+func TestDashboardSquadFilter(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var runtimeID, agentID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent_runtime WHERE workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&runtimeID); err != nil {
+		t.Fatalf("fetch runtime: %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		SELECT id FROM agent WHERE workspace_id = $1 LIMIT 1
+	`, testWorkspaceID).Scan(&agentID); err != nil {
+		t.Fatalf("fetch agent: %v", err)
+	}
+
+	// A project so the combined project_id + squad_id case can be exercised.
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title)
+		VALUES ($1, 'squad filter test project')
+		RETURNING id
+	`, testWorkspaceID).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM project WHERE id = $1`, projectID) })
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, creator_id, creator_type, project_id, number)
+		VALUES (
+			$1, 'squad filter test', $2, 'member', $3,
+			(SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1)
+		)
+		RETURNING id
+	`, testWorkspaceID, testUserID, projectID).Scan(&issueID); err != nil {
+		t.Fatalf("insert issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	now := time.Now().UTC()
+	started := now.Add(-30 * time.Minute)
+	completed := started.Add(10 * time.Minute) // 600s run
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, issue_id, runtime_id, status, started_at, completed_at, created_at)
+		VALUES ($1, $2, $3, 'completed', $4, $5, now())
+		RETURNING id
+	`, agentID, issueID, runtimeID, started, completed).Scan(&taskID); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, created_at)
+		VALUES ($1, 'claude', 'squad-test-model', 1000, 0, now())
+	`, taskID); err != nil {
+		t.Fatalf("insert task_usage: %v", err)
+	}
+
+	// Aggregate the fixture rows into task_usage_hourly before asserting —
+	// in production the cron tick handles this with a 5-min lag.
+	if _, err := testPool.Exec(ctx, `
+		SELECT rollup_task_usage_hourly_window('1970-01-01'::timestamptz, now() + interval '1 hour')
+	`); err != nil {
+		t.Fatalf("rollup window: %v", err)
+	}
+
+	// Squad A contains the fixture agent; squad B does not. Inserting rows
+	// directly (not via CreateSquad) means no leader is auto-added as a
+	// member, so squad B genuinely has zero agent members.
+	mkSquad := func(name string) string {
+		var id string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO squad (workspace_id, name, leader_id, creator_id)
+			VALUES ($1, $2, $3, $4)
+			RETURNING id
+		`, testWorkspaceID, name, agentID, testUserID).Scan(&id); err != nil {
+			t.Fatalf("create squad %s: %v", name, err)
+		}
+		t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM squad WHERE id = $1`, id) })
+		return id
+	}
+	squadWith := mkSquad("squad filter — with agent")
+	squadWithout := mkSquad("squad filter — without agent")
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO squad_member (squad_id, member_type, member_id, role)
+		VALUES ($1, 'agent', $2, 'leader')
+	`, squadWith, agentID); err != nil {
+		t.Fatalf("add squad member: %v", err)
+	}
+
+	type dailyRow struct {
+		Model       string `json:"model"`
+		InputTokens int64  `json:"input_tokens"`
+	}
+	sumDaily := func(query string) int64 {
+		w := httptest.NewRecorder()
+		testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?"+query, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("daily %q: expected 200, got %d: %s", query, w.Code, w.Body.String())
+		}
+		var rows []dailyRow
+		_ = json.NewDecoder(w.Body).Decode(&rows)
+		var total int64
+		for _, r := range rows {
+			if r.Model == "squad-test-model" {
+				total += r.InputTokens
+			}
+		}
+		return total
+	}
+
+	if got := sumDaily("days=1&squad_id=" + squadWith); got < 1000 {
+		t.Errorf("daily squad-with: expected >=1000 tokens, got %d", got)
+	}
+	if got := sumDaily("days=1&squad_id=" + squadWithout); got != 0 {
+		t.Errorf("daily squad-without: expected 0 tokens (agent not a member), got %d", got)
+	}
+	if got := sumDaily("days=1&project_id=" + projectID + "&squad_id=" + squadWith); got < 1000 {
+		t.Errorf("daily project+squad: expected >=1000 tokens, got %d", got)
+	}
+	if got := sumDaily("days=1&project_id=" + projectID + "&squad_id=" + squadWithout); got != 0 {
+		t.Errorf("daily project+squad (no member): expected 0 tokens, got %d", got)
+	}
+
+	// by-agent honours the squad filter, alone and combined (AND) with
+	// project_id: squad-with surfaces the agent's tokens, squad-without
+	// excludes them.
+	sumByAgent := func(query string) int64 {
+		w := httptest.NewRecorder()
+		testHandler.GetDashboardUsageByAgent(w, newRequest("GET", "/api/dashboard/usage/by-agent?"+query, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("by-agent %q: expected 200, got %d: %s", query, w.Code, w.Body.String())
+		}
+		var rows []struct {
+			AgentID     string `json:"agent_id"`
+			Model       string `json:"model"`
+			InputTokens int64  `json:"input_tokens"`
+		}
+		_ = json.NewDecoder(w.Body).Decode(&rows)
+		var total int64
+		for _, r := range rows {
+			if r.AgentID == agentID && r.Model == "squad-test-model" {
+				total += r.InputTokens
+			}
+		}
+		return total
+	}
+	if got := sumByAgent("days=1&squad_id=" + squadWith); got < 1000 {
+		t.Errorf("by-agent squad-with: expected >=1000 tokens, got %d", got)
+	}
+	if got := sumByAgent("days=1&squad_id=" + squadWithout); got != 0 {
+		t.Errorf("by-agent squad-without: agent leaked through filter, got %d", got)
+	}
+	if got := sumByAgent("days=1&project_id=" + projectID + "&squad_id=" + squadWith); got < 1000 {
+		t.Errorf("by-agent project+squad: expected >=1000 tokens, got %d", got)
+	}
+	if got := sumByAgent("days=1&project_id=" + projectID + "&squad_id=" + squadWithout); got != 0 {
+		t.Errorf("by-agent project+squad (no member): expected 0 tokens, got %d", got)
+	}
+
+	// agent-runtime honours the squad filter, alone and combined with
+	// project_id.
+	sumAgentRunTime := func(query string) int32 {
+		w := httptest.NewRecorder()
+		testHandler.GetDashboardAgentRunTime(w, newRequest("GET", "/api/dashboard/agent-runtime?"+query, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("agent-runtime %q: expected 200, got %d: %s", query, w.Code, w.Body.String())
+		}
+		var rows []struct {
+			AgentID   string `json:"agent_id"`
+			TaskCount int32  `json:"task_count"`
+		}
+		_ = json.NewDecoder(w.Body).Decode(&rows)
+		var tasks int32
+		for _, r := range rows {
+			if r.AgentID == agentID {
+				tasks += r.TaskCount
+			}
+		}
+		return tasks
+	}
+	if got := sumAgentRunTime("days=1&squad_id=" + squadWith); got < 1 {
+		t.Errorf("agent-runtime squad-with: expected >=1 task, got %d", got)
+	}
+	if got := sumAgentRunTime("days=1&squad_id=" + squadWithout); got != 0 {
+		t.Errorf("agent-runtime squad-without: expected 0 tasks, got %d", got)
+	}
+	if got := sumAgentRunTime("days=1&project_id=" + projectID + "&squad_id=" + squadWith); got < 1 {
+		t.Errorf("agent-runtime project+squad: expected >=1 task, got %d", got)
+	}
+	if got := sumAgentRunTime("days=1&project_id=" + projectID + "&squad_id=" + squadWithout); got != 0 {
+		t.Errorf("agent-runtime project+squad (no member): expected 0 tasks, got %d", got)
+	}
+
+	// runtime/daily honours the squad filter, alone and combined with
+	// project_id — an empty squad yields no rows.
+	sumRunTimeDaily := func(query string) int32 {
+		w := httptest.NewRecorder()
+		testHandler.GetDashboardRunTimeDaily(w, newRequest("GET", "/api/dashboard/runtime/daily?"+query, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("runtime/daily %q: expected 200, got %d: %s", query, w.Code, w.Body.String())
+		}
+		var rows []struct {
+			TaskCount int32 `json:"task_count"`
+		}
+		_ = json.NewDecoder(w.Body).Decode(&rows)
+		var tasks int32
+		for _, r := range rows {
+			tasks += r.TaskCount
+		}
+		return tasks
+	}
+	if got := sumRunTimeDaily("days=1&squad_id=" + squadWith); got < 1 {
+		t.Errorf("runtime/daily squad-with: expected >=1 task, got %d", got)
+	}
+	if got := sumRunTimeDaily("days=1&squad_id=" + squadWithout); got != 0 {
+		t.Errorf("runtime/daily squad-without: expected 0 tasks, got %d", got)
+	}
+	if got := sumRunTimeDaily("days=1&project_id=" + projectID + "&squad_id=" + squadWith); got < 1 {
+		t.Errorf("runtime/daily project+squad: expected >=1 task, got %d", got)
+	}
+	if got := sumRunTimeDaily("days=1&project_id=" + projectID + "&squad_id=" + squadWithout); got != 0 {
+		t.Errorf("runtime/daily project+squad (no member): expected 0 tasks, got %d", got)
+	}
+
+	// Invalid squad_id rejected with 400.
+	{
+		w := httptest.NewRecorder()
+		testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?squad_id=not-a-uuid", nil))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("daily: expected 400 for invalid squad_id, got %d", w.Code)
+		}
+	}
+}
+
+// TestDashboardSquadFilterCrossWorkspace proves the squad filter cannot leak
+// another workspace's usage. The squad_id param is not checked against the
+// caller's workspace, and the squad_member subquery is itself
+// unscoped — so a caller can pass a foreign squad_id and the subquery will
+// return that foreign squad's agent ids. Safety rests entirely on the outer
+// `workspace_id = $1` gate: a foreign agent has no rows scoped to the
+// caller's workspace, so the intersection is empty. This test inserts a
+// foreign workspace with real, rolled-up usage and confirms none of it
+// surfaces when the primary workspace requests that foreign squad.
+func TestDashboardSquadFilterCrossWorkspace(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+	ctx := context.Background()
+
+	var foreignWorkspaceID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO workspace (name, slug)
+		VALUES ('ws-squad-xtenant', 'ws-squad-xtenant-' || gen_random_uuid()::text)
+		RETURNING id
+	`).Scan(&foreignWorkspaceID); err != nil {
+		t.Fatalf("create foreign workspace: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM workspace WHERE id = $1`, foreignWorkspaceID) })
+
+	var foreignRuntimeID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_runtime (
+			workspace_id, daemon_id, name, runtime_mode, provider, status, device_info, metadata, last_seen_at
+		)
+		VALUES ($1, NULL, 'xtenant-rt', 'cloud', 'xtenant-rt', 'online', '{}'::jsonb, '{}'::jsonb, now())
+		RETURNING id
+	`, foreignWorkspaceID).Scan(&foreignRuntimeID); err != nil {
+		t.Fatalf("create foreign runtime: %v", err)
+	}
+	var foreignAgentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent (
+			workspace_id, name, description, runtime_mode, runtime_config,
+			runtime_id, visibility, max_concurrent_tasks, owner_id,
+			instructions, custom_env, custom_args, mcp_config
+		)
+		VALUES ($1, 'xtenant-agent', '', 'cloud', '{}'::jsonb, $2, 'private', 1, $3, '', '{}'::jsonb, '[]'::jsonb, '[]'::jsonb)
+		RETURNING id
+	`, foreignWorkspaceID, foreignRuntimeID, testUserID).Scan(&foreignAgentID); err != nil {
+		t.Fatalf("create foreign agent: %v", err)
+	}
+
+	// Real usage for the foreign agent, in the foreign workspace.
+	var foreignIssueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (workspace_id, title, creator_id, creator_type, number)
+		VALUES ($1, 'xtenant squad usage', $2, 'member',
+		        (SELECT COALESCE(MAX(number), 0) + 1 FROM issue WHERE workspace_id = $1))
+		RETURNING id
+	`, foreignWorkspaceID, testUserID).Scan(&foreignIssueID); err != nil {
+		t.Fatalf("create foreign issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM issue WHERE id = $1`, foreignIssueID) })
+
+	now := time.Now().UTC()
+	started := now.Add(-20 * time.Minute)
+	completed := started.Add(5 * time.Minute)
+
+	var foreignTaskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (agent_id, issue_id, runtime_id, status, started_at, completed_at, created_at)
+		VALUES ($1, $2, $3, 'completed', $4, $5, now())
+		RETURNING id
+	`, foreignAgentID, foreignIssueID, foreignRuntimeID, started, completed).Scan(&foreignTaskID); err != nil {
+		t.Fatalf("create foreign task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(ctx, `DELETE FROM agent_task_queue WHERE id = $1`, foreignTaskID) })
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO task_usage (task_id, provider, model, input_tokens, output_tokens, created_at)
+		VALUES ($1, 'claude', 'xtenant-squad-model', 5000, 0, now())
+	`, foreignTaskID); err != nil {
+		t.Fatalf("insert foreign task_usage: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		SELECT rollup_task_usage_hourly_window('1970-01-01'::timestamptz, now() + interval '1 hour')
+	`); err != nil {
+		t.Fatalf("rollup window: %v", err)
+	}
+
+	// A squad in the foreign workspace whose only member is the foreign agent.
+	var foreignSquadID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO squad (workspace_id, name, leader_id, creator_id)
+		VALUES ($1, 'xtenant squad', $2, $3)
+		RETURNING id
+	`, foreignWorkspaceID, foreignAgentID, testUserID).Scan(&foreignSquadID); err != nil {
+		t.Fatalf("create foreign squad: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO squad_member (squad_id, member_type, member_id, role)
+		VALUES ($1, 'agent', $2, 'leader')
+	`, foreignSquadID, foreignAgentID); err != nil {
+		t.Fatalf("add foreign squad member: %v", err)
+	}
+
+	// The primary workspace requests the foreign squad. newRequest scopes the
+	// request to testWorkspaceID via the X-Workspace-ID header.
+	{
+		w := httptest.NewRecorder()
+		testHandler.GetDashboardUsageDaily(w, newRequest("GET", "/api/dashboard/usage/daily?days=1&squad_id="+foreignSquadID, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("daily foreign squad: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var rows []struct {
+			Model       string `json:"model"`
+			InputTokens int64  `json:"input_tokens"`
+		}
+		_ = json.NewDecoder(w.Body).Decode(&rows)
+		for _, r := range rows {
+			if r.Model == "xtenant-squad-model" {
+				t.Errorf("daily foreign squad: cross-workspace usage leaked (%d tokens)", r.InputTokens)
+			}
+		}
+	}
+	{
+		w := httptest.NewRecorder()
+		testHandler.GetDashboardUsageByAgent(w, newRequest("GET", "/api/dashboard/usage/by-agent?days=1&squad_id="+foreignSquadID, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("by-agent foreign squad: expected 200, got %d", w.Code)
+		}
+		var rows []struct {
+			AgentID string `json:"agent_id"`
+		}
+		_ = json.NewDecoder(w.Body).Decode(&rows)
+		for _, r := range rows {
+			if r.AgentID == foreignAgentID {
+				t.Errorf("by-agent foreign squad: foreign agent leaked through filter")
+			}
+		}
+	}
+}

--- a/server/pkg/db/generated/task_usage.sql.go
+++ b/server/pkg/db/generated/task_usage.sql.go
@@ -99,6 +99,9 @@ WHERE a.workspace_id = $1
   AND atq.completed_at IS NOT NULL
   AND atq.completed_at >= $2::timestamptz
   AND ($3::uuid IS NULL OR i.project_id = $3)
+  AND ($4::uuid IS NULL OR atq.agent_id IN (
+        SELECT member_id FROM squad_member
+        WHERE squad_id = $4 AND member_type = 'agent'))
 GROUP BY atq.agent_id
 ORDER BY total_seconds DESC
 `
@@ -107,6 +110,7 @@ type ListDashboardAgentRunTimeParams struct {
 	WorkspaceID pgtype.UUID        `json:"workspace_id"`
 	Since       pgtype.Timestamptz `json:"since"`
 	ProjectID   pgtype.UUID        `json:"project_id"`
+	SquadID     pgtype.UUID        `json:"squad_id"`
 }
 
 type ListDashboardAgentRunTimeRow struct {
@@ -117,7 +121,9 @@ type ListDashboardAgentRunTimeRow struct {
 }
 
 // Per-agent total task run time and task count for the workspace, optionally
-// scoped to a single project. Counts only terminal runs (completed or failed)
+// scoped to a single project. Also optionally scoped to a single squad via
+// sqlc.narg('squad_id') — narrows to that squad's agent members.
+// Counts only terminal runs (completed or failed)
 // with both started_at and completed_at populated — queued/running tasks have
 // no finite duration. Anchored on completed_at so the window matches the
 // token cost window (which is anchored on tu.created_at, ~= completion time).
@@ -126,7 +132,12 @@ type ListDashboardAgentRunTimeRow struct {
 // start-of-day-(N) so the "last N days" window lines up with the per-agent
 // cost card; passed straight through without re-truncation.
 func (q *Queries) ListDashboardAgentRunTime(ctx context.Context, arg ListDashboardAgentRunTimeParams) ([]ListDashboardAgentRunTimeRow, error) {
-	rows, err := q.db.Query(ctx, listDashboardAgentRunTime, arg.WorkspaceID, arg.Since, arg.ProjectID)
+	rows, err := q.db.Query(ctx, listDashboardAgentRunTime,
+		arg.WorkspaceID,
+		arg.Since,
+		arg.ProjectID,
+		arg.SquadID,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -168,6 +179,9 @@ WHERE a.workspace_id = $1
   AND atq.completed_at IS NOT NULL
   AND atq.completed_at >= $3::timestamptz
   AND ($4::uuid IS NULL OR i.project_id = $4)
+  AND ($5::uuid IS NULL OR atq.agent_id IN (
+        SELECT member_id FROM squad_member
+        WHERE squad_id = $5 AND member_type = 'agent'))
 GROUP BY DATE(atq.completed_at AT TIME ZONE $2::text)
 ORDER BY DATE(atq.completed_at AT TIME ZONE $2::text) DESC
 `
@@ -177,6 +191,7 @@ type ListDashboardRunTimeDailyParams struct {
 	Tz          string             `json:"tz"`
 	Since       pgtype.Timestamptz `json:"since"`
 	ProjectID   pgtype.UUID        `json:"project_id"`
+	SquadID     pgtype.UUID        `json:"squad_id"`
 }
 
 type ListDashboardRunTimeDailyRow struct {
@@ -187,7 +202,9 @@ type ListDashboardRunTimeDailyRow struct {
 }
 
 // Daily per-date run time + task counts for the workspace, optionally
-// scoped to a single project. Powers the workspace dashboard's "Time"
+// scoped to a single project. Also optionally scoped to a single squad
+// via sqlc.narg('squad_id') — narrows to that squad's agent members.
+// Powers the workspace dashboard's "Time"
 // and "Tasks" metrics on the same toggle as Tokens / Cost. Bucketed by
 // completed_at (terminal time) sliced into calendar days under the
 // caller-supplied @tz — same Viewing-tz treatment as ListDashboardUsageDaily
@@ -204,6 +221,7 @@ func (q *Queries) ListDashboardRunTimeDaily(ctx context.Context, arg ListDashboa
 		arg.Tz,
 		arg.Since,
 		arg.ProjectID,
+		arg.SquadID,
 	)
 	if err != nil {
 		return nil, err
@@ -241,6 +259,9 @@ FROM task_usage_hourly
 WHERE workspace_id = $1
   AND bucket_hour >= $2::timestamptz
   AND ($3::uuid IS NULL OR project_id = $3)
+  AND ($4::uuid IS NULL OR agent_id IN (
+        SELECT member_id FROM squad_member
+        WHERE squad_id = $4 AND member_type = 'agent'))
 GROUP BY agent_id, model
 ORDER BY agent_id, model
 `
@@ -249,6 +270,7 @@ type ListDashboardUsageByAgentParams struct {
 	WorkspaceID pgtype.UUID        `json:"workspace_id"`
 	Since       pgtype.Timestamptz `json:"since"`
 	ProjectID   pgtype.UUID        `json:"project_id"`
+	SquadID     pgtype.UUID        `json:"squad_id"`
 }
 
 type ListDashboardUsageByAgentRow struct {
@@ -274,7 +296,12 @@ type ListDashboardUsageByAgentRow struct {
 // frontend prefers `ListDashboardAgentRunTime` for the user-facing
 // "tasks" column, so this stays informational only.
 func (q *Queries) ListDashboardUsageByAgent(ctx context.Context, arg ListDashboardUsageByAgentParams) ([]ListDashboardUsageByAgentRow, error) {
-	rows, err := q.db.Query(ctx, listDashboardUsageByAgent, arg.WorkspaceID, arg.Since, arg.ProjectID)
+	rows, err := q.db.Query(ctx, listDashboardUsageByAgent,
+		arg.WorkspaceID,
+		arg.Since,
+		arg.ProjectID,
+		arg.SquadID,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -314,6 +341,9 @@ FROM task_usage_hourly
 WHERE workspace_id = $1
   AND bucket_hour >= $3::timestamptz
   AND ($4::uuid IS NULL OR project_id = $4)
+  AND ($5::uuid IS NULL OR agent_id IN (
+        SELECT member_id FROM squad_member
+        WHERE squad_id = $5 AND member_type = 'agent'))
 GROUP BY DATE(bucket_hour AT TIME ZONE $2::text), model
 ORDER BY DATE(bucket_hour AT TIME ZONE $2::text) DESC, model
 `
@@ -323,6 +353,7 @@ type ListDashboardUsageDailyParams struct {
 	Tz          string             `json:"tz"`
 	Since       pgtype.Timestamptz `json:"since"`
 	ProjectID   pgtype.UUID        `json:"project_id"`
+	SquadID     pgtype.UUID        `json:"squad_id"`
 }
 
 type ListDashboardUsageDailyRow struct {
@@ -355,6 +386,7 @@ func (q *Queries) ListDashboardUsageDaily(ctx context.Context, arg ListDashboard
 		arg.Tz,
 		arg.Since,
 		arg.ProjectID,
+		arg.SquadID,
 	)
 	if err != nil {
 		return nil, err

--- a/server/pkg/db/queries/task_usage.sql
+++ b/server/pkg/db/queries/task_usage.sql
@@ -56,6 +56,9 @@ FROM task_usage_hourly
 WHERE workspace_id = $1
   AND bucket_hour >= sqlc.arg('since')::timestamptz
   AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (sqlc.narg('squad_id')::uuid IS NULL OR agent_id IN (
+        SELECT member_id FROM squad_member
+        WHERE squad_id = sqlc.narg('squad_id') AND member_type = 'agent'))
 GROUP BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text), model
 ORDER BY DATE(bucket_hour AT TIME ZONE sqlc.arg('tz')::text) DESC, model;
 
@@ -84,12 +87,17 @@ FROM task_usage_hourly
 WHERE workspace_id = $1
   AND bucket_hour >= @since::timestamptz
   AND (sqlc.narg('project_id')::uuid IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (sqlc.narg('squad_id')::uuid IS NULL OR agent_id IN (
+        SELECT member_id FROM squad_member
+        WHERE squad_id = sqlc.narg('squad_id') AND member_type = 'agent'))
 GROUP BY agent_id, model
 ORDER BY agent_id, model;
 
 -- name: ListDashboardRunTimeDaily :many
 -- Daily per-date run time + task counts for the workspace, optionally
--- scoped to a single project. Powers the workspace dashboard's "Time"
+-- scoped to a single project. Also optionally scoped to a single squad
+-- via sqlc.narg('squad_id') — narrows to that squad's agent members.
+-- Powers the workspace dashboard's "Time"
 -- and "Tasks" metrics on the same toggle as Tokens / Cost. Bucketed by
 -- completed_at (terminal time) sliced into calendar days under the
 -- caller-supplied @tz — same Viewing-tz treatment as ListDashboardUsageDaily
@@ -117,12 +125,17 @@ WHERE a.workspace_id = $1
   AND atq.completed_at IS NOT NULL
   AND atq.completed_at >= sqlc.arg('since')::timestamptz
   AND (sqlc.narg('project_id')::uuid IS NULL OR i.project_id = sqlc.narg('project_id'))
+  AND (sqlc.narg('squad_id')::uuid IS NULL OR atq.agent_id IN (
+        SELECT member_id FROM squad_member
+        WHERE squad_id = sqlc.narg('squad_id') AND member_type = 'agent'))
 GROUP BY DATE(atq.completed_at AT TIME ZONE sqlc.arg('tz')::text)
 ORDER BY DATE(atq.completed_at AT TIME ZONE sqlc.arg('tz')::text) DESC;
 
 -- name: ListDashboardAgentRunTime :many
 -- Per-agent total task run time and task count for the workspace, optionally
--- scoped to a single project. Counts only terminal runs (completed or failed)
+-- scoped to a single project. Also optionally scoped to a single squad via
+-- sqlc.narg('squad_id') — narrows to that squad's agent members.
+-- Counts only terminal runs (completed or failed)
 -- with both started_at and completed_at populated — queued/running tasks have
 -- no finite duration. Anchored on completed_at so the window matches the
 -- token cost window (which is anchored on tu.created_at, ~= completion time).
@@ -147,5 +160,8 @@ WHERE a.workspace_id = $1
   AND atq.completed_at IS NOT NULL
   AND atq.completed_at >= @since::timestamptz
   AND (sqlc.narg('project_id')::uuid IS NULL OR i.project_id = sqlc.narg('project_id'))
+  AND (sqlc.narg('squad_id')::uuid IS NULL OR atq.agent_id IN (
+        SELECT member_id FROM squad_member
+        WHERE squad_id = sqlc.narg('squad_id') AND member_type = 'agent'))
 GROUP BY atq.agent_id
 ORDER BY total_seconds DESC;


### PR DESCRIPTION
## What does this PR do?

Adds a **squad** filter to the Usage dashboard alongside the existing project filter, so per-squad token / run-time spend is a one-click drill-down. Without this, the only way to read squad-level cost is to eyeball the by-agent chart and group rows mentally, which doesn't extend to the token chart and breaks for squads with more than a handful of agents.

The filter is wired all the way through: SQL → handler → API client → query hooks → UI.

A non-empty `squad_id` deliberately forces the raw `task_usage` code path even when `USAGE_DASHBOARD_ROLLUP_ENABLED=true`, because the dashboard rollup table (migration 084) has no squad dimension. Adding the dimension to the rollup is out of scope for this PR — the raw path is fast enough at current volume, and we'd rather not invalidate the rollup until we know per-squad slicing earns its keep.

## Related Issue

Closes #2777

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

Backend
- `server/pkg/db/queries/task_usage.sql` — add `squad_id` nullable predicate to the four raw-stream dashboard usage queries; regenerated `server/pkg/db/generated/task_usage.sql.go` via `make sqlc`.
- `server/internal/handler/dashboard.go` — replace `parseProjectIDParam` with a generic `parseOptionalUUIDParam(w, r, param)` helper (same nullable / 400-on-invalid semantics); both `project_id` and `squad_id` now route through it. Thread `squadID` through `listDashboardUsageDaily`, `listDashboardUsageByAgent`, `listDashboardAgentRunTime`, `listDashboardRunTimeDaily`; force raw-path when `squadID.Valid`.
- `server/internal/handler/dashboard_test.go` — new tests covering: (a) `squad_id` filters rows correctly on each endpoint, (b) invalid UUID returns 400, (c) rollup path is bypassed when `squad_id` is present.

Frontend
- `packages/core/api/client.ts` — extend the four dashboard usage methods with an optional `squadId` arg.
- `packages/core/dashboard/queries.ts` — `dashboardUsageDailyOptions` / `dashboardUsageByAgentOptions` / `dashboardAgentRunTimeOptions` / `dashboardRunTimeDailyOptions` take `squadId`; included in the query key for cache isolation.
- `packages/views/squads/components/squad-avatar.tsx` — **new** `SquadAvatar` component: a thin adapter over `ui/ActorAvatar` (`isSquad` prop → square tile + `Users`-icon fallback for an imageless squad).
- `packages/views/dashboard/components/dashboard-page.tsx` — new `SquadFilter` component mirroring `ProjectFilter` (stale-UUID guard, `ALL_SQUADS` sentinel, renders `SquadAvatar`); rendered next to the project filter.
- `packages/views/locales/en/usage.json`, `packages/views/locales/zh-Hans/usage.json` — `filter.squad_label` (EN: "Squad", ZH: "小队") and `filter.all_squads` (EN: "All squads", ZH: "全部小队") strings, consistent with the `小队` term in `conventions.zh.mdx`.

## How to Test

1. `make dev` and open the Usage page in a workspace that has at least two squads with agents producing token usage in the last 30 days.
2. Confirm the squad filter appears immediately right of the project filter and defaults to "All squads".
3. Pick a squad → all four charts (daily tokens, by-agent tokens, agent run-time, daily run-time) re-fetch and show only that squad's rows. Switch back to "All squads" and counts return to the workspace total.
4. Combine project + squad filters; the intersection should hold.
5. Backend: `cd server && go test ./internal/handler/ -run TestDashboardUsage` — new squad-filter cases.
6. Edge: pass `?squad_id=not-a-uuid` to `/api/workspaces/:wsId/dashboard/usage/daily` → 400 with `invalid squad_id`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass — **not re-run in the PR-prep session; will run `make check` and update before requesting review**
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — TODO before review
- [ ] I have updated relevant documentation to reflect my changes — N/A, the filter is symmetric with an existing one
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`) — N/A, no new runtime/tool/tab
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (`小队` for "squad")
- [x] I have considered and documented any risks above (rollup bypass is the main one — called out in "What does this PR do?")
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Used Claude Code to scaffold the squad filter symmetrically with the existing project filter. The rollup-bypass call (forcing the raw path when `squad_id` is set, instead of adding a squad dimension to the rollup table) was a judgment call I made — kept it out of scope to avoid invalidating migration 084's table until per-squad slicing proves it earns the storage.

## Screenshots (optional)

<img width="894" height="47" alt="Image" src="https://github.com/user-attachments/assets/9caef073-f4cf-41df-b0ed-be8cea3f580c" />
