### PR TITLE
feat(daemon): slot-value mapping (MULTICA_AVAILABLE_SLOTS) + ${VAR} interpolation in custom_env

### DIFF
--- a/CLI_AND_DAEMON.md
+++ b/CLI_AND_DAEMON.md
@@ -171,6 +171,7 @@ Daemon behavior is configured via flags or environment variables:
 | Agent timeout | `--agent-timeout` | `MULTICA_AGENT_TIMEOUT` | `2h` |
 | Codex semantic inactivity timeout | `--codex-semantic-inactivity-timeout` | `MULTICA_CODEX_SEMANTIC_INACTIVITY_TIMEOUT` | `10m` |
 | Max concurrent tasks | `--max-concurrent-tasks` | `MULTICA_DAEMON_MAX_CONCURRENT_TASKS` | `20` |
+| Available slot values | — | `MULTICA_AVAILABLE_SLOTS` | — |
 | Daemon ID | `--daemon-id` | `MULTICA_DAEMON_ID` | hostname |
 | Device name | `--device-name` | `MULTICA_DAEMON_DEVICE_NAME` | hostname |
 | Runtime name | `--runtime-name` | `MULTICA_AGENT_RUNTIME_NAME` | `Local Agent` |
@@ -222,6 +223,15 @@ Agent-specific overrides:
 | `MULTICA_KIRO_MODEL` | Override the Kiro model used |
 
 `MULTICA_CLAUDE_ARGS` and `MULTICA_CODEX_ARGS` are parsed with POSIX shellword quoting, so values such as `--model "gpt-5.1 codex" --sandbox read-only` are split like a shell command line. Agent arguments are applied in this order: hardcoded Multica defaults, daemon-wide env defaults, then per-agent `custom_args` from the task.
+
+The following variables are injected by the daemon into every spawned agent process at task start:
+
+| Variable | Description |
+|----------|-------------|
+| `MULTICA_TASK_SLOT` | Slot index in the daemon concurrency pool (0-based, range `[0, max_concurrent_tasks)`) |
+| `MULTICA_TASK_SLOT_VALUE` | Value from `MULTICA_AVAILABLE_SLOTS` at the slot index. Not set if `MULTICA_AVAILABLE_SLOTS` is unset or the slot index is out of range. |
+
+These can be referenced in per-agent `custom_env` values using `${VAR}` syntax (e.g. `CUDA_VISIBLE_DEVICES = ${MULTICA_TASK_SLOT_VALUE}`).
 
 ### Self-Hosted Server
 

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	AgentIdleWatchdog              time.Duration // force-stop a run when the backend goes silent this long with an empty queue (0 = disabled)
 	ClaudeArgs                     []string
 	CodexArgs                      []string
+	AvailableSlots                 []string // optional values indexed by task slot
 }
 
 // Overrides allows CLI flags to override environment variables and defaults.
@@ -213,6 +214,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	availableSlots := splitCSV(os.Getenv("MULTICA_AVAILABLE_SLOTS"))
 
 	// Host info
 	host, err := os.Hostname()
@@ -398,6 +400,7 @@ func LoadConfig(overrides Overrides) (Config, error) {
 		AgentIdleWatchdog:              agentIdleWatchdog,
 		ClaudeArgs:                     claudeArgs,
 		CodexArgs:                      codexArgs,
+		AvailableSlots:                 availableSlots,
 	}, nil
 }
 
@@ -693,4 +696,19 @@ func isSafeAgentName(s string) bool {
 		}
 	}
 	return true
+}
+
+// splitCSV splits a comma-separated string into trimmed non-empty tokens.
+func splitCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2300,6 +2300,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		"MULTICA_TASK_ID":      task.ID,
 		"MULTICA_TASK_SLOT":    strconv.Itoa(slot),
 	}
+	if slot < len(d.cfg.AvailableSlots) {
+		agentEnv["MULTICA_TASK_SLOT_VALUE"] = d.cfg.AvailableSlots[slot]
+	}
 	if task.AutopilotRunID != "" {
 		agentEnv["MULTICA_AUTOPILOT_RUN_ID"] = task.AutopilotRunID
 	}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -2347,13 +2347,23 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	// Bedrock). These are set per-agent via the agent settings UI.
 	// Critical internal variables are blocklisted to prevent accidental or
 	// malicious override of daemon-set values.
+	//
+	// Values support ${VAR} interpolation against the already-resolved agentEnv,
+	// falling back to the daemon process environment. This lets values reference
+	// daemon-injected variables such as MULTICA_TASK_ID — for example:
+	//   ANTHROPIC_API_KEY = ${MULTICA_TASK_ID}-sk-xxx
 	if task.Agent != nil {
 		for k, v := range task.Agent.CustomEnv {
 			if isBlockedEnvKey(k) {
 				d.logger.Warn("custom_env: blocked key skipped", "key", k)
 				continue
 			}
-			agentEnv[k] = v
+			agentEnv[k] = os.Expand(v, func(name string) string {
+				if val, ok := agentEnv[name]; ok {
+					return val
+				}
+				return os.Getenv(name)
+			})
 		}
 	}
 	backend, err := agent.New(provider, agent.Config{


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Adds two related daemon capabilities that together let operators assign dedicated
hardware resources (e.g. GPU devices) to each concurrent task slot without
hardcoding values.

**1. `MULTICA_AVAILABLE_SLOTS` — per-slot value mapping**

Operators set a comma-separated list of values. The daemon maps each concurrency
slot to the corresponding entry and injects it as `MULTICA_TASK_SLOT_VALUE` into
the spawned agent process. If unset, or the slot index is out of range,
`MULTICA_TASK_SLOT_VALUE` is simply not injected (safe degradation).

**2. `${VAR}` interpolation in `custom_env` values**

`custom_env` values are now expanded against the daemon-injected `agentEnv`
(which includes `MULTICA_TASK_SLOT`, `MULTICA_TASK_SLOT_VALUE`, `MULTICA_TASK_ID`,
etc.) before being passed to the agent process, with fallback to the daemon's own
environment.

**Together:** on an 8-GPU machine with `MaxConcurrentTasks=4`, set:

```bash
export MULTICA_AVAILABLE_SLOTS=1,3,5,7   # discrete, non-contiguous GPUs
```

And in the agent's Custom Env in the UI:

```
CUDA_VISIBLE_DEVICES = ${MULTICA_TASK_SLOT_VALUE}
```

Each of the 4 concurrent tasks automatically receives a unique, non-overlapping
`CUDA_VISIBLE_DEVICES` value. Changing which GPUs multica uses is a one-line env
var change — no code edits needed.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

[Closes #](https://github.com/multica-ai/multica/issues/1750)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->
- `server/internal/daemon/config.go`: add `AvailableSlots []string` to `Config`; parse `MULTICA_AVAILABLE_SLOTS` from env via new `splitCSV` helper
- `server/internal/daemon/daemon.go`: inject `MULTICA_TASK_SLOT_VALUE` when `AvailableSlots` is configured; expand `${VAR}` in `custom_env` values using `os.Expand` against `agentEnv` with daemon-env fallback
- `CLI_AND_DAEMON.md`: document `MULTICA_AVAILABLE_SLOTS` in the config table and add a new section describing daemon-injected variables (`MULTICA_TASK_SLOT`, `MULTICA_TASK_SLOT_VALUE`) and `${VAR}` interpolation

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Start a daemon with `MULTICA_AVAILABLE_SLOTS=gpu-a,gpu-b,gpu-c,gpu-d` and `MULTICA_DAEMON_MAX_CONCURRENT_TASKS=4`
2. In the Web UI, set an agent's Custom Env to `CUDA_VISIBLE_DEVICES = ${MULTICA_TASK_SLOT_VALUE}`
3. Trigger 4 concurrent tasks for that agent; verify each task process receives a distinct `CUDA_VISIBLE_DEVICES` value (`gpu-a`, `gpu-b`, `gpu-c`, `gpu-d`)
4. Verify safe degradation: unset `MULTICA_AVAILABLE_SLOTS` and confirm `MULTICA_TASK_SLOT_VALUE` is absent from the agent environment
5. Verify blocklisted keys in `custom_env` are still rejected before interpolation runs

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->
Claude Code

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->
> I'm running the Multica daemon on an 8-GPU machine with `MaxConcurrentTasks=4`,
> so up to 4 tasks run concurrently. I want each task to exclusively own one GPU
> without interfering with the others. The GPU indices may not be contiguous — for
> example, I only want Multica to use devices 1, 3, 5, and 7.
>
> The daemon already injects `MULTICA_TASK_SLOT` (a 0-based slot index) into every
> spawned agent process, but there's no way to map that index to an actual GPU
> device number, and `custom_env` values are passed through as-is with no variable
> expansion.
>
> I need two features:
>
> 1. **`MULTICA_AVAILABLE_SLOTS`** — a new daemon environment variable that accepts
>    a comma-separated list of values (e.g. `"1,3,5,7"`). The daemon maps the task's
>    slot index to the corresponding entry and injects it as `MULTICA_TASK_SLOT_VALUE`
>    into the agent process. If the variable is unset or the slot index is out of
>    range, `MULTICA_TASK_SLOT_VALUE` is simply not injected (silent degradation, no
>    error).
>
> 2. **`${VAR}` interpolation in `custom_env` values** — when the daemon starts a
>    task, each `custom_env` value is expanded against the already-resolved
>    `agentEnv` map (which includes `MULTICA_TASK_SLOT`, `MULTICA_TASK_SLOT_VALUE`,
>    `MULTICA_TASK_ID`, etc.), falling back to the daemon's own environment for any
>    variable not found there.
>
> With both features in place I can write this in the agent's Custom Env in the UI:
>
> ```
> CUDA_VISIBLE_DEVICES = ${MULTICA_TASK_SLOT_VALUE}
> ```
>
> and each of the 4 concurrent tasks will automatically receive a distinct,
> non-overlapping device index (1, 3, 5, or 7). Changing which GPUs Multica uses
> is then a single env-var change — no code edits required.
>
> Please implement both features in `server/internal/daemon/` and update
> `CLI_AND_DAEMON.md` to document `MULTICA_AVAILABLE_SLOTS` in the config table
> and add a section describing the daemon-injected variables (`MULTICA_TASK_SLOT`,
> `MULTICA_TASK_SLOT_VALUE`) and the `${VAR}` interpolation behaviour.
## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
