### PR TITLE
fix(ui): vertically center SelectItem content (MUL-2351)

### DIFF
--- a/packages/ui/components/ui/select.tsx
+++ b/packages/ui/components/ui/select.tsx
@@ -122,7 +122,7 @@ function SelectItem({
       )}
       {...props}
     >
-      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 items-center gap-2 whitespace-nowrap">
         {children}
       </SelectPrimitive.ItemText>
       <SelectPrimitive.ItemIndicator


### PR DESCRIPTION
## What does this PR do?

Adds `items-center` to the `SelectPrimitive.ItemText` inside `SelectItem`, so dropdown options that combine an icon with a text label render with the icon and label vertically centered — matching how the trigger already renders the same content.

`SelectTrigger` applies `items-center` to its value container via the `*:data-[slot=select-value]:items-center` selector, which is why the trigger already looks correct. Dropdown items had no equivalent, so icon-sized children (14px) top-aligned against text-sm labels (~20px line-height) inside `ItemText`. The cleanest fix is at the shared component, so every consumer benefits and call sites stay free of wrapper `<span>`s.

## Related Issue

Closes #2781

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/ui/components/ui/select.tsx` — add `items-center` to `SelectPrimitive.ItemText`'s className.

## How to Test

1. `pnpm dev:web` and open `/{workspaceSlug}/usage`.
2. Click the project filter; confirm every option's icon and label sit on the same horizontal centerline.
3. Open any other `Select` dropdown (e.g. timezone select) to verify text-only options still render correctly with no regression.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Claude Code

**Prompt / approach:** Spotted the misalignment on the Usage page's project filter. First proposed wrapping each `SelectItem`'s children in a `flex items-center` span at the call site; reviewer pointed out the upcoming squad filter on the same page uses the identical structure, so a call-site wrapper would leave the page inconsistent and the squad filter still broken. Walked the cause back to `ItemText` and fixed it at the shared component instead.

## Screenshots (optional)
<img width="459" height="173" alt="image" src="https://github.com/user-attachments/assets/9c8bbaf7-900c-4207-bbfa-9526194b2ec8" />
