### PR TITLE
fix(codex): bump default exec_command stuck timeout to 3 minutes (MUL-2337)

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -37,7 +37,7 @@ const (
 	// 2026-05-18, MUL-2334). When that happens the model waits forever for
 	// the missing output; this watchdog ends the turn so the next run can
 	// recover instead of burning the overall semantic inactivity budget.
-	defaultCodexExecStuckTimeout = 2 * time.Minute
+	defaultCodexExecStuckTimeout = 3 * time.Minute
 
 	// codexExecStuckCheckInterval is how often the lifecycle loop polls for
 	// stuck exec calls. Kept short so the watchdog fires close to the


### PR DESCRIPTION
## Background

Follow-up to #2779. That PR added a per-call watchdog for Codex `exec_command`
to escape dropped `function_call_output`s; it ended the turn after 2 minutes of
no progress on any open exec item. Per discussion on MUL-2337, the default is
being relaxed to 3 minutes to leave more headroom for legitimately silent
long-running commands before treating them as stuck.

## Change

- `defaultCodexExecStuckTimeout`: `2 * time.Minute` → `3 * time.Minute` in `server/pkg/agent/codex.go`.

Semantics are unchanged: this is a *no-progress* window, not a total execution
budget. Any `outputDelta` (raw v2 `item/commandExecution/outputDelta` or legacy
`exec_command_output_delta`) still resets `LastProgressAt`, and any
completed/end event clears the open exec entry — long commands that stream
output are unaffected.

`ExecOptions.ExecCommandStuckTimeout` remains injectable for tests / future
config knobs; only the fallback default changes.

## Verification

- `go test ./pkg/agent/ -count=1` — all green.

Tests in `codex_test.go` pin watchdog behavior with explicit short timeouts
(150ms / 200ms / 2s) and do not depend on this default, so no test changes
needed.

MUL-2337