### PR TITLE
fix(runtimes): prefer Local machine as default selection (MUL-2359)

### DIFF
--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDefaultLayout } from "react-resizable-panels";
 import {
   Cloud,
@@ -85,6 +85,14 @@ export function RuntimesPage({
   const [selectedMachineId, setSelectedMachineId] = useState<string | null>(
     null,
   );
+  // Tracks whether the user has explicitly picked a machine. Until then,
+  // auto-default keeps preferring the Local section (which on desktop may
+  // appear later than remotes — `localDaemonId` is fetched async).
+  const userSelectedRef = useRef(false);
+  const handleSelectMachine = useCallback((id: string) => {
+    userSelectedRef.current = true;
+    setSelectedMachineId(id);
+  }, []);
   const [showConnectDialog, setShowConnectDialog] = useState(false);
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "multica_runtimes_layout",
@@ -133,9 +141,16 @@ export function RuntimesPage({
       if (selectedMachineId !== null) setSelectedMachineId(null);
       return;
     }
-    if (!selectedMachineId || !filteredMachines.some((m) => m.id === selectedMachineId)) {
-      setSelectedMachineId(filteredMachines[0]?.id ?? null);
-    }
+    const stillValid =
+      !!selectedMachineId &&
+      filteredMachines.some((m) => m.id === selectedMachineId);
+    // Honor an explicit user pick. Otherwise re-evaluate the default so the
+    // Local machine wins as soon as it shows up, even if a remote was the
+    // first-paint default.
+    if (userSelectedRef.current && stillValid) return;
+    const local = filteredMachines.find((m) => m.section === "local");
+    const nextId = local?.id ?? filteredMachines[0]?.id ?? null;
+    if (nextId !== selectedMachineId) setSelectedMachineId(nextId);
   }, [filteredMachines, selectedMachineId]);
 
   const selectedMachine =
@@ -170,7 +185,7 @@ export function RuntimesPage({
             setSearch={setMachineSearch}
             filter={machineFilter}
             setFilter={setMachineFilter}
-            onSelect={setSelectedMachineId}
+            onSelect={handleSelectMachine}
           />
           <MachineDetail
             machine={selectedMachine}
@@ -206,7 +221,7 @@ export function RuntimesPage({
                 setSearch={setMachineSearch}
                 filter={machineFilter}
                 setFilter={setMachineFilter}
-                onSelect={setSelectedMachineId}
+                onSelect={handleSelectMachine}
                 className="h-full border-b-0 border-r"
               />
             </ResizablePanel>


### PR DESCRIPTION
## Summary

Runtime 页面的左侧列表当本地（Local）和远程（Remote）都存在时，默认仍可能选中第一个 Remote 项，而不是 Local 项。这是因为在 Desktop 上 `localDaemonId` 是异步获取的——首次渲染时仅有 remotes 加载完成，自动选择落到 `filteredMachines[0]`（一个 remote），随后选择被"粘住"，本地 daemon 注册进来后也不会再切换。

修复：

- 当机器列表更新时重新评估默认值，优先选中 `section === "local"` 的机器；
- 用 `userSelectedRef` 跟踪用户是否手动选择，一旦用户主动点选过则尊重其选择。

Closes MUL-2359

## Test plan

- [x] `pnpm --filter @multica/views typecheck`
- [ ] Desktop：打开 Runtime 页面，首次进入直接选中本地（this Mac）
- [ ] Desktop：手动点选某个远程项后，刷新数据时该选择保持不变
- [ ] Web：行为无回归（无 Local 时仍选中首项）