### PR TITLE
docs(self-host): reverse-proxy guidance for loopback-only ports (MUL-2360)

### DIFF
--- a/apps/docs/content/docs/self-host-quickstart.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.mdx
@@ -127,7 +127,7 @@ multica setup self-host \
 
 A minimal Caddyfile that fronts both the frontend and the backend (with WebSocket support, which the daemon and the web app both need) on a single hostname:
 
-```caddy
+```nginx
 multica.example.com {
     # WebSocket route — must come before the catch-all
     @ws path /ws /ws/*

--- a/apps/docs/content/docs/self-host-quickstart.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.mdx
@@ -45,6 +45,10 @@ Once it's up:
 - **Frontend**: [http://localhost:3000](http://localhost:3000)
 - **Backend**: [http://localhost:8080](http://localhost:8080)
 
+<Callout type="info">
+**Ports listen on `127.0.0.1` only.** `docker-compose.selfhost.yml` binds every published port to loopback — `ss -tlnp` will not show `0.0.0.0:8080`, and the services are unreachable from other machines by design. The default `JWT_SECRET` and Postgres credentials must never sit on the open internet. For cross-machine access, front the stack with a reverse proxy that terminates TLS — see [Step 5b — Cross-machine: front with a reverse proxy](#5b-cross-machine-front-with-a-reverse-proxy).
+</Callout>
+
 ## 2. Important: keep production safety on
 
 <Callout type="warning">
@@ -99,21 +103,53 @@ Open [http://localhost:3000](http://localhost:3000):
 
 ## 5. Point the CLI at your own server
 
-The CLI install is the same as in [Cloud quickstart → 2. Install the CLI](/cloud-quickstart#2-install-the-multica-cli) — Homebrew / script / PowerShell, pick one. Once installed, **use the self-host variant of the setup command**:
+The CLI install is the same as in [Cloud quickstart → 2. Install the CLI](/cloud-quickstart#2-install-the-multica-cli) — Homebrew / script / PowerShell, pick one.
 
-```bash
-multica setup self-host --server-url http://<your-server-address>:8080 --app-url http://<your-server-address>:3000
-```
+### 5a. Same machine
 
-If you're running everything on one local machine:
+If the CLI and the server run on the same host, the defaults already work:
 
 ```bash
 multica setup self-host
 ```
 
-That defaults to `http://localhost:8080` (backend) and `http://localhost:3000` (frontend).
+That points the CLI at `http://localhost:8080` (backend) and `http://localhost:3000` (frontend), takes you through browser login, stores the PAT locally, and **starts the daemon automatically**.
 
-`setup self-host` takes you through browser login, stores the PAT locally, and **starts the daemon automatically**.
+### 5b. Cross-machine: front with a reverse proxy
+
+Because the compose stack only listens on `127.0.0.1`, a daemon on a different machine cannot reach `http://<server-ip>:8080` directly — and you do not want it to, since the default `JWT_SECRET` would otherwise be reachable from the open internet. Put a reverse proxy on the server that terminates TLS and forwards to `127.0.0.1:8080` (backend) and `127.0.0.1:3000` (frontend), then point the CLI at the public HTTPS URL:
+
+```bash
+multica setup self-host \
+  --server-url https://<your-domain> \
+  --app-url https://<your-domain>
+```
+
+A minimal Caddyfile that fronts both the frontend and the backend (with WebSocket support, which the daemon and the web app both need) on a single hostname:
+
+```caddy
+multica.example.com {
+    # WebSocket route — must come before the catch-all
+    @ws path /ws /ws/*
+    handle @ws {
+        reverse_proxy 127.0.0.1:8080 {
+            flush_interval -1
+        }
+    }
+
+    # Backend API
+    handle /api/* {
+        reverse_proxy 127.0.0.1:8080
+    }
+
+    # Everything else → frontend
+    reverse_proxy 127.0.0.1:3000
+}
+```
+
+After bringing the proxy up, set `FRONTEND_ORIGIN=https://multica.example.com` in the server's `.env` and restart the backend — otherwise the WebSocket origin check will reject the browser ([Troubleshooting → WebSocket can't connect](/troubleshooting#websocket-cant-connect)).
+
+[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) is another solid option — it gives you TLS and a public hostname without exposing any port on the host at all. An Nginx equivalent (separate `app.` / `api.` hostnames, `proxy_set_header Upgrade` for WebSockets) works just as well; the key requirements are TLS termination and forwarding the `Upgrade` header on `/ws`.
 
 ## 6. Create an agent + assign your first task
 

--- a/apps/docs/content/docs/self-host-quickstart.zh.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.zh.mdx
@@ -44,6 +44,10 @@ make selfhost
 - **前端**：[http://localhost:3000](http://localhost:3000)
 - **后端**：[http://localhost:8080](http://localhost:8080)
 
+<Callout type="info">
+**所有端口只监听 `127.0.0.1`。** `docker-compose.selfhost.yml` 把每个 publish 出来的端口都绑到 loopback —— `ss -tlnp` 不会看到 `0.0.0.0:8080`，外网/其它机器默认根本连不上。这是为了避免默认 `JWT_SECRET` 和 Postgres 凭据被直接暴露到公网。要做跨机访问，请用反向代理在前面终结 TLS，详见下方 [Step 5b —— 跨机访问：用反向代理把服务挡在前面](#5b-跨机访问用反向代理把服务挡在前面)。
+</Callout>
+
 ## 2. 重要：保持生产安全配置
 
 <Callout type="warning">
@@ -98,21 +102,53 @@ RESEND_FROM_EMAIL=noreply@yourdomain.com  # 同时作为 SMTP From: 头
 
 ## 5. 连接命令行工具到你自己的 server
 
-命令行装法和 [Cloud 快速上手 → 2. 装命令行工具](/cloud-quickstart#2-装-multica-命令行工具) 一样——Homebrew / 脚本 / PowerShell 任选。装好之后，**用 self-host 版本的 setup 命令**：
+命令行装法和 [Cloud 快速上手 → 2. 装命令行工具](/cloud-quickstart#2-装-multica-命令行工具) 一样——Homebrew / 脚本 / PowerShell 任选。
 
-```bash
-multica setup self-host --server-url http://<你的服务器地址>:8080 --app-url http://<你的服务器地址>:3000
-```
+### 5a. 同一台机器
 
-本地就是一台电脑跑整套的话：
+CLI 和 server 在同一台机器上时，默认参数就够用：
 
 ```bash
 multica setup self-host
 ```
 
-默认连 `http://localhost:8080`（backend）+ `http://localhost:3000`（frontend）。
+会自动连 `http://localhost:8080`（backend）+ `http://localhost:3000`（frontend），引导你在浏览器里登录、把 PAT 存到本地、**自动启动守护进程**。
 
-`setup self-host` 会让你在浏览器里完成登录，把 PAT 存到本地，**自动启动守护进程**。
+### 5b. 跨机访问：用反向代理把服务挡在前面
+
+因为 compose 默认只监听 `127.0.0.1`，从别的机器跑的 daemon 是连不上 `http://<server-ip>:8080` 的——这也是有意为之，否则默认 `JWT_SECRET` 等于直接暴露在公网。正确做法是在 server 上跑一个反向代理（Caddy / nginx / Cloudflare Tunnel），由它终结 TLS，再反代到 `127.0.0.1:8080`（backend）和 `127.0.0.1:3000`（frontend）。然后把 CLI 指到公开的 HTTPS 域名：
+
+```bash
+multica setup self-host \
+  --server-url https://<你的域名> \
+  --app-url https://<你的域名>
+```
+
+最小可用的 Caddyfile，单域名同时挂前后端（带 WebSocket 转发，daemon 和网页端都依赖）：
+
+```caddy
+multica.example.com {
+    # WebSocket 路由——必须在 catch-all 之前
+    @ws path /ws /ws/*
+    handle @ws {
+        reverse_proxy 127.0.0.1:8080 {
+            flush_interval -1
+        }
+    }
+
+    # Backend API
+    handle /api/* {
+        reverse_proxy 127.0.0.1:8080
+    }
+
+    # 其它请求 → 前端
+    reverse_proxy 127.0.0.1:3000
+}
+```
+
+代理起好之后，记得在 server 的 `.env` 里把 `FRONTEND_ORIGIN` 设成 `https://multica.example.com` 并重启后端，否则 WebSocket 的 origin 校验会把浏览器拒掉（见 [故障排查 → WebSocket 连不上](/troubleshooting#websocket-连不上)）。
+
+[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) 也是不错的选择——它直接给一个公开域名 + TLS，host 上不用对外暴露任何端口。Nginx 也能做（分 `app.` / `api.` 两个域名 + `proxy_set_header Upgrade` 转 WebSocket），关键就是终结 TLS、并在 `/ws` 上转发 `Upgrade` 头。
 
 ## 6. 创建智能体 + 分配第一个任务
 

--- a/apps/docs/content/docs/self-host-quickstart.zh.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.zh.mdx
@@ -126,7 +126,7 @@ multica setup self-host \
 
 最小可用的 Caddyfile，单域名同时挂前后端（带 WebSocket 转发，daemon 和网页端都依赖）：
 
-```caddy
+```nginx
 multica.example.com {
     # WebSocket 路由——必须在 catch-all 之前
     @ws path /ws /ws/*

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -1,5 +1,13 @@
 # Self-hosting Docker Compose — starts PostgreSQL, backend, and frontend.
 #
+# Services bind to 127.0.0.1 only. For cross-machine or public access, front
+# them with a reverse proxy (Caddy / nginx / Cloudflare Tunnel) that terminates
+# TLS and forwards to 127.0.0.1:8080 (backend) and 127.0.0.1:3000 (frontend).
+# Do NOT change these bindings to 0.0.0.0 — Docker bypasses host firewalls
+# (UFW/iptables) by default, so the raw ports would be exposed to the internet
+# with the default JWT_SECRET and Postgres credentials. See:
+#   apps/docs/content/docs/self-host-quickstart.mdx
+#
 # Usage:
 #   cp .env.example .env
 #   # Edit .env — change JWT_SECRET at minimum


### PR DESCRIPTION
## Summary

Follow-up to #2759 (which bound every `docker-compose.selfhost.yml` published port to `127.0.0.1`). The self-host quickstart still told cross-machine users to point the CLI at `http://<server-ip>:8080`, which after that PR no longer works — and shouldn't, because the default `JWT_SECRET` and Postgres credentials must never be reachable from the open internet.

- **`apps/docs/content/docs/self-host-quickstart.mdx`**
  - Added a Callout under step 1 explaining ports are bound to `127.0.0.1` only and why (security: default creds).
  - Split step 5 into **5a. Same machine** (defaults still work) and **5b. Cross-machine: front with a reverse proxy** with a minimal Caddyfile snippet that fronts frontend + backend on a single hostname, including the `/ws` route with `flush_interval -1`.
  - Cross-machine `multica setup self-host` example now uses `https://<your-domain>` instead of `http://<server-ip>:8080`.
  - Notes that Nginx / Cloudflare Tunnel are equivalent options and reminds users to set `FRONTEND_ORIGIN`.
- **`apps/docs/content/docs/self-host-quickstart.zh.mdx`** — mirrored the same changes.
- **`docker-compose.selfhost.yml`** — added a header comment so anyone reading the file directly understands why `ss -tlnp` no longer shows `0.0.0.0:8080` and what to do for external access. Explicitly warns against flipping the bindings back to `0.0.0.0` (Docker bypasses UFW/iptables by default).

Closes MUL-2360.

## Test plan

- [x] `docker compose -f docker-compose.selfhost.yml config --quiet` still parses cleanly after the header comment change.
- [ ] Docs preview: confirm the Callout renders, anchor `#5b-cross-machine-front-with-a-reverse-proxy` resolves on the English page, and `#5b-跨机访问用反向代理把服务挡在前面` resolves on the Chinese page.
- [ ] Visually skim both quickstart pages for the new step ordering (5a/5b) and the Caddyfile code block.