### PR TITLE
feat(chat): add GET /api/chats mobile list endpoint (BUR-990)

### DIFF
--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -599,6 +599,11 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			// Workspace-wide 30-day run counts per agent for the Agents-list RUNS column.
 			r.Get("/api/agent-run-counts", h.GetWorkspaceAgentRunCounts)
 
+			// Mobile chat list (BUR-990): mobile uses a different URL +
+			// response shape than the web /api/chat/sessions endpoint.
+			// Paginated, enriched with agent_name + last_message per row.
+			r.Get("/api/chats", h.ListChats)
+
 			r.Route("/api/chat/sessions", func(r chi.Router) {
 				r.Post("/", h.CreateChatSession)
 				r.Get("/", h.ListChatSessions)

--- a/server/internal/handler/chat.go
+++ b/server/internal/handler/chat.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -18,6 +19,35 @@ import (
 // chatSessionTitleMaxLen caps the rename input. Long enough to fit a
 // meaningful summary, short enough to keep the dropdown row scannable.
 const chatSessionTitleMaxLen = 200
+
+// Mobile chat list pagination bounds. defaultChatListLimit matches the page
+// size BUR-989 settled on for the MessagesScreen, max keeps a malicious or
+// buggy client from pulling the entire table in one request.
+const (
+	defaultChatListLimit = 20
+	maxChatListLimit     = 100
+)
+
+// MobileChatSession is the per-row payload returned by ListChats. Distinct
+// from ChatSessionResponse: mobile needs agent_name + last_message for the
+// row preview but does not need workspace_id / creator_id / status (already
+// implied by the request scope or hidden in the mobile UI).
+type MobileChatSession struct {
+	ID            string  `json:"id"`
+	Title         string  `json:"title"`
+	AgentID       string  `json:"agent_id"`
+	AgentName     string  `json:"agent_name"`
+	LastMessage   *string `json:"last_message,omitempty"`
+	LastMessageAt *string `json:"last_message_at,omitempty"`
+	CreatedAt     string  `json:"created_at"`
+}
+
+// ChatListResponse is the GET /api/chats envelope expected by mobile.
+type ChatListResponse struct {
+	Sessions []MobileChatSession `json:"sessions"`
+	Total    int64               `json:"total"`
+	HasMore  bool                `json:"has_more"`
+}
 
 // ---------------------------------------------------------------------------
 // Chat Sessions
@@ -172,6 +202,110 @@ func (h *Handler) ListChatSessions(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// ListChats is the mobile-facing chat list endpoint mounted at GET /api/chats.
+// It differs from ListChatSessions (web) in three ways:
+//
+//   - Paginated: returns { sessions, total, has_more } so the mobile
+//     MessagesScreen can fetch one page at a time over a slower link.
+//   - Enriched: each row carries agent_name + last_message + last_message_at,
+//     resolved in a single DB round-trip via the LEFT JOIN in
+//     ListChatsForMobile, so the client renders the list without a follow-up
+//     fan-out per session.
+//   - Scoped: results are filtered to the authenticated user's sessions in
+//     the workspace resolved by the workspace middleware (?workspace_slug
+//     from the mobile axios interceptor). A foreign workspace returns 0 rows.
+//
+// Sessions of any status are included (active + archived) — the mobile UI is
+// the read-only history surface and intentionally shows both.
+func (h *Handler) ListChats(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	workspaceID := ctxWorkspaceID(r.Context())
+	workspaceUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace id")
+	if !ok {
+		return
+	}
+	userUUID, ok := parseUUIDOrBadRequest(w, userID, "user id")
+	if !ok {
+		return
+	}
+
+	limit := parseChatListQueryInt(r, "limit", defaultChatListLimit)
+	if limit <= 0 {
+		limit = defaultChatListLimit
+	}
+	if limit > maxChatListLimit {
+		limit = maxChatListLimit
+	}
+	offset := parseChatListQueryInt(r, "offset", 0)
+	if offset < 0 {
+		offset = 0
+	}
+
+	rows, err := h.Queries.ListChatsForMobile(r.Context(), db.ListChatsForMobileParams{
+		WorkspaceID: workspaceUUID,
+		CreatorID:   userUUID,
+		RowOffset:   int32(offset),
+		LimitCount:  int32(limit),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list chats")
+		return
+	}
+
+	total, err := h.Queries.CountChatSessionsByCreator(r.Context(), db.CountChatSessionsByCreatorParams{
+		WorkspaceID: workspaceUUID,
+		CreatorID:   userUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to count chats")
+		return
+	}
+
+	sessions := make([]MobileChatSession, len(rows))
+	for i, row := range rows {
+		s := MobileChatSession{
+			ID:        uuidToString(row.ID),
+			Title:     row.Title,
+			AgentID:   uuidToString(row.AgentID),
+			AgentName: row.AgentName,
+			CreatedAt: timestampToString(row.CreatedAt),
+		}
+		if row.LastMessage.Valid {
+			content := row.LastMessage.String
+			s.LastMessage = &content
+		}
+		if row.LastMessageAt.Valid {
+			ts := timestampToString(row.LastMessageAt)
+			s.LastMessageAt = &ts
+		}
+		sessions[i] = s
+	}
+
+	writeJSON(w, http.StatusOK, ChatListResponse{
+		Sessions: sessions,
+		Total:    total,
+		HasMore:  int64(offset)+int64(len(sessions)) < total,
+	})
+}
+
+// parseChatListQueryInt reads an integer query param, returning the fallback
+// when the param is missing or unparseable. Negative values and overflow are
+// the caller's responsibility to clamp.
+func parseChatListQueryInt(r *http.Request, name string, fallback int) int {
+	raw := r.URL.Query().Get(name)
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	return v
 }
 
 func (h *Handler) loadChatSessionForUser(w http.ResponseWriter, r *http.Request, userID, workspaceID, sessionID string) (db.ChatSession, bool) {

--- a/server/internal/handler/chat_test.go
+++ b/server/internal/handler/chat_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
 	"github.com/multica-ai/multica/server/internal/util"
@@ -160,6 +163,263 @@ func TestUpdateChatSession_RejectsBlank(t *testing.T) {
 	testHandler.UpdateChatSession(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("UpdateChatSession blank: expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// withMobileChatCtx is the equivalent of withChatTestWorkspaceCtx but for an
+// arbitrary workspace ID — used by TestListChats_WrongWorkspace to inject a
+// different workspace context than the one the seeded sessions belong to.
+// Falls back to a zero db.Member when no membership row exists (e.g. the
+// "other" workspace the user has no role in), since ListChats reads only the
+// workspace ID from context and never inspects the member row.
+func withMobileChatCtx(t *testing.T, req *http.Request, workspaceID string) *http.Request {
+	t.Helper()
+	memberRow, _ := testHandler.Queries.GetMemberByUserAndWorkspace(context.Background(), db.GetMemberByUserAndWorkspaceParams{
+		UserID:      util.MustParseUUID(testUserID),
+		WorkspaceID: util.MustParseUUID(workspaceID),
+	})
+	return req.WithContext(middleware.SetMemberContext(req.Context(), workspaceID, memberRow))
+}
+
+// createListChatsTestSession seeds a chat_session row owned by testUserID with
+// an explicit updated_at so ORDER BY updated_at DESC is deterministic across
+// rows created in the same test (without the explicit value, two rows inserted
+// in rapid succession can share a now() timestamp).
+func createListChatsTestSession(t *testing.T, workspaceID, agentID, title string, updatedAt time.Time) string {
+	t.Helper()
+	var sessionID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO chat_session (workspace_id, agent_id, creator_id, title, status, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, 'active', $5, $5)
+		RETURNING id
+	`, workspaceID, agentID, testUserID, title, updatedAt).Scan(&sessionID); err != nil {
+		t.Fatalf("failed to create test chat session: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM chat_session WHERE id = $1`, sessionID)
+	})
+	return sessionID
+}
+
+// seedChatMessage inserts a chat_message row for the given session, returning
+// the message id. Used by ListChats tests to verify last_message enrichment.
+func seedChatMessage(t *testing.T, sessionID, content string, createdAt time.Time) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO chat_message (chat_session_id, role, content, created_at)
+		VALUES ($1, 'user', $2, $3)
+	`, sessionID, content, createdAt); err != nil {
+		t.Fatalf("failed to seed chat_message: %v", err)
+	}
+}
+
+// TestListChats_Empty: no sessions for this user → empty array, total=0,
+// has_more=false. Empty sessions slice rather than null is part of the
+// contract — the mobile client relies on .length being defined.
+func TestListChats_Empty(t *testing.T) {
+	// Use a freshly created agent so no prior test's sessions leak in.
+	_ = createHandlerTestAgent(t, "ListChatsEmptyAgent", []byte("[]"))
+
+	req := httptest.NewRequest("GET", "/api/chats", nil)
+	req.Header.Set("X-User-ID", testUserID)
+	req = withChatTestWorkspaceCtx(t, req)
+	w := httptest.NewRecorder()
+	testHandler.ListChats(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListChats empty: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ChatListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Total != 0 {
+		t.Fatalf("expected total=0, got %d", resp.Total)
+	}
+	if resp.HasMore {
+		t.Fatal("expected has_more=false for empty result")
+	}
+	if len(resp.Sessions) != 0 {
+		t.Fatalf("expected 0 sessions, got %d", len(resp.Sessions))
+	}
+	// Marshalled JSON should serialize sessions as [], never null — the
+	// mobile client iterates blindly and would crash on null.
+	if !strings.Contains(w.Body.String(), `"sessions":[]`) {
+		t.Fatalf("expected sessions:[] in body, got %s", w.Body.String())
+	}
+}
+
+// TestListChats_PopulatedReturnsEnrichedRows confirms the mobile-specific
+// fields are present: each row carries agent_name (from the joined agent) and
+// last_message / last_message_at (from the latest chat_message). Ordering is
+// updated_at DESC.
+func TestListChats_PopulatedReturnsEnrichedRows(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ListChatsEnrichAgent", []byte("[]"))
+
+	older := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Millisecond)
+	newer := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Millisecond)
+	olderSession := createListChatsTestSession(t, testWorkspaceID, agentID, "Older Session", older)
+	newerSession := createListChatsTestSession(t, testWorkspaceID, agentID, "Newer Session", newer)
+	// Seed a message on the newer session only — the older session should
+	// still appear in the list, just with last_message=nil. This proves the
+	// LEFT JOIN preserves message-less sessions.
+	seedChatMessage(t, newerSession, "hello mobile", newer)
+
+	req := httptest.NewRequest("GET", "/api/chats", nil)
+	req.Header.Set("X-User-ID", testUserID)
+	req = withChatTestWorkspaceCtx(t, req)
+	w := httptest.NewRecorder()
+	testHandler.ListChats(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListChats populated: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ChatListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Total != 2 {
+		t.Fatalf("expected total=2, got %d (sessions: %+v)", resp.Total, resp.Sessions)
+	}
+	if resp.HasMore {
+		t.Fatal("expected has_more=false (one page covers both sessions)")
+	}
+	if len(resp.Sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(resp.Sessions))
+	}
+	// updated_at DESC → newerSession first.
+	if resp.Sessions[0].ID != newerSession {
+		t.Fatalf("expected newerSession (%s) first, got %s", newerSession, resp.Sessions[0].ID)
+	}
+	if resp.Sessions[1].ID != olderSession {
+		t.Fatalf("expected olderSession (%s) second, got %s", olderSession, resp.Sessions[1].ID)
+	}
+	// Enriched fields on the first row.
+	if resp.Sessions[0].AgentName != "ListChatsEnrichAgent" {
+		t.Fatalf("expected agent_name=ListChatsEnrichAgent, got %q", resp.Sessions[0].AgentName)
+	}
+	if resp.Sessions[0].LastMessage == nil || *resp.Sessions[0].LastMessage != "hello mobile" {
+		t.Fatalf("expected last_message=\"hello mobile\", got %v", resp.Sessions[0].LastMessage)
+	}
+	if resp.Sessions[0].LastMessageAt == nil {
+		t.Fatal("expected last_message_at to be populated")
+	}
+	// Older session has no messages → last_message / last_message_at omitted.
+	if resp.Sessions[1].LastMessage != nil {
+		t.Fatalf("expected last_message=nil for message-less session, got %q", *resp.Sessions[1].LastMessage)
+	}
+	if resp.Sessions[1].LastMessageAt != nil {
+		t.Fatalf("expected last_message_at=nil for message-less session, got %q", *resp.Sessions[1].LastMessageAt)
+	}
+}
+
+// TestListChats_ScopedToWorkspace confirms a request that resolves to a
+// different workspace cannot see this user's sessions from testWorkspaceID.
+// Mirrors the production guarantee that ?workspace_slug=A and ?workspace_slug=B
+// each see only their own sessions.
+func TestListChats_ScopedToWorkspace(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ListChatsScopeAgent", []byte("[]"))
+	_ = createListChatsTestSession(t, testWorkspaceID, agentID, "Session In Main WS", time.Now().UTC())
+
+	// Stand up a second workspace owned by the same user, then call ListChats
+	// with that workspace's context. The seeded session is in testWorkspaceID,
+	// so the response should be empty.
+	var otherWorkspaceID string
+	otherSlug := "list-chats-other-" + fmt.Sprint(time.Now().UnixNano())
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO workspace (name, slug, description, issue_prefix)
+		VALUES ('Other WS', $1, 'Foreign workspace for scoping test', 'OTH')
+		RETURNING id
+	`, otherSlug).Scan(&otherWorkspaceID); err != nil {
+		t.Fatalf("create other workspace: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM workspace WHERE id = $1`, otherWorkspaceID)
+	})
+
+	req := httptest.NewRequest("GET", "/api/chats", nil)
+	req.Header.Set("X-User-ID", testUserID)
+	req = withMobileChatCtx(t, req, otherWorkspaceID)
+	w := httptest.NewRecorder()
+	testHandler.ListChats(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ListChats scope: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp ChatListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Total != 0 {
+		t.Fatalf("expected total=0 from foreign workspace, got %d", resp.Total)
+	}
+	if len(resp.Sessions) != 0 {
+		t.Fatalf("expected 0 sessions from foreign workspace, got %d", len(resp.Sessions))
+	}
+}
+
+// TestListChats_Pagination: 3 sessions, limit=2 offset=0 → page 1 with
+// has_more=true; offset=2 → page 2 with has_more=false. total stays at 3
+// across both pages.
+func TestListChats_Pagination(t *testing.T) {
+	agentID := createHandlerTestAgent(t, "ListChatsPageAgent", []byte("[]"))
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	s1 := createListChatsTestSession(t, testWorkspaceID, agentID, "Page Session 1", now.Add(-3*time.Minute))
+	s2 := createListChatsTestSession(t, testWorkspaceID, agentID, "Page Session 2", now.Add(-2*time.Minute))
+	s3 := createListChatsTestSession(t, testWorkspaceID, agentID, "Page Session 3", now.Add(-1*time.Minute))
+
+	// Page 1: limit=2 offset=0 → s3, s2 (DESC); has_more=true.
+	req := httptest.NewRequest("GET", "/api/chats?limit=2&offset=0", nil)
+	req.Header.Set("X-User-ID", testUserID)
+	req = withChatTestWorkspaceCtx(t, req)
+	w := httptest.NewRecorder()
+	testHandler.ListChats(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("page 1: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var page1 ChatListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &page1); err != nil {
+		t.Fatalf("decode page 1: %v", err)
+	}
+	if page1.Total != 3 {
+		t.Fatalf("page 1 total: expected 3, got %d", page1.Total)
+	}
+	if !page1.HasMore {
+		t.Fatal("page 1 has_more: expected true")
+	}
+	if len(page1.Sessions) != 2 {
+		t.Fatalf("page 1 len: expected 2, got %d", len(page1.Sessions))
+	}
+	if page1.Sessions[0].ID != s3 || page1.Sessions[1].ID != s2 {
+		t.Fatalf("page 1 order: expected [%s, %s], got [%s, %s]",
+			s3, s2, page1.Sessions[0].ID, page1.Sessions[1].ID)
+	}
+
+	// Page 2: limit=2 offset=2 → s1 (only one row left); has_more=false.
+	req = httptest.NewRequest("GET", "/api/chats?limit=2&offset=2", nil)
+	req.Header.Set("X-User-ID", testUserID)
+	req = withChatTestWorkspaceCtx(t, req)
+	w = httptest.NewRecorder()
+	testHandler.ListChats(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("page 2: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var page2 ChatListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &page2); err != nil {
+		t.Fatalf("decode page 2: %v", err)
+	}
+	if page2.Total != 3 {
+		t.Fatalf("page 2 total: expected 3, got %d", page2.Total)
+	}
+	if page2.HasMore {
+		t.Fatal("page 2 has_more: expected false")
+	}
+	if len(page2.Sessions) != 1 {
+		t.Fatalf("page 2 len: expected 1, got %d", len(page2.Sessions))
+	}
+	if page2.Sessions[0].ID != s1 {
+		t.Fatalf("page 2 id: expected %s, got %s", s1, page2.Sessions[0].ID)
 	}
 }
 

--- a/server/pkg/db/generated/chat.sql.go
+++ b/server/pkg/db/generated/chat.sql.go
@@ -11,6 +11,26 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countChatSessionsByCreator = `-- name: CountChatSessionsByCreator :one
+SELECT COUNT(*) AS total
+FROM chat_session
+WHERE workspace_id = $1 AND creator_id = $2
+`
+
+type CountChatSessionsByCreatorParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	CreatorID   pgtype.UUID `json:"creator_id"`
+}
+
+// Total session count for the same scope as ListChatsForMobile, used to drive
+// the has_more flag on the mobile pagination response.
+func (q *Queries) CountChatSessionsByCreator(ctx context.Context, arg CountChatSessionsByCreatorParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countChatSessionsByCreator, arg.WorkspaceID, arg.CreatorID)
+	var total int64
+	err := row.Scan(&total)
+	return total, err
+}
+
 const createChatMessage = `-- name: CreateChatMessage :one
 INSERT INTO chat_message (chat_session_id, role, content, task_id, failure_reason, elapsed_ms)
 VALUES ($1, $2, $3, $4, $5, $6)
@@ -435,6 +455,87 @@ func (q *Queries) ListChatSessionsByCreator(ctx context.Context, arg ListChatSes
 			&i.UnreadSince,
 			&i.RuntimeID,
 			&i.HasUnread,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listChatsForMobile = `-- name: ListChatsForMobile :many
+SELECT
+  cs.id,
+  cs.title,
+  cs.agent_id,
+  a.name AS agent_name,
+  lm.content AS last_message,
+  lm.created_at AS last_message_at,
+  cs.created_at,
+  cs.updated_at
+FROM chat_session cs
+JOIN agent a ON a.id = cs.agent_id
+LEFT JOIN chat_message lm ON lm.id = (
+  SELECT id FROM chat_message
+  WHERE chat_session_id = cs.id
+  ORDER BY created_at DESC
+  LIMIT 1
+)
+WHERE cs.workspace_id = $1 AND cs.creator_id = $2
+ORDER BY cs.updated_at DESC
+LIMIT $4 OFFSET $3
+`
+
+type ListChatsForMobileParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	CreatorID   pgtype.UUID `json:"creator_id"`
+	RowOffset   int32       `json:"row_offset"`
+	LimitCount  int32       `json:"limit_count"`
+}
+
+type ListChatsForMobileRow struct {
+	ID            pgtype.UUID        `json:"id"`
+	Title         string             `json:"title"`
+	AgentID       pgtype.UUID        `json:"agent_id"`
+	AgentName     string             `json:"agent_name"`
+	LastMessage   pgtype.Text        `json:"last_message"`
+	LastMessageAt pgtype.Timestamptz `json:"last_message_at"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
+}
+
+// Paginated chat list for the mobile MessagesScreen. Joins the agent for the
+// display name and pulls the latest chat_message (if any) via a LEFT JOIN on
+// a correlated subquery that resolves the latest message id per session. The
+// direct LEFT JOIN on chat_message (rather than a LATERAL derived row) makes
+// sqlc infer pgtype.Text / pgtype.Timestamptz (nullable) for lm.content /
+// lm.created_at — same pattern as ListInboxItems' LEFT JOIN on issue.
+func (q *Queries) ListChatsForMobile(ctx context.Context, arg ListChatsForMobileParams) ([]ListChatsForMobileRow, error) {
+	rows, err := q.db.Query(ctx, listChatsForMobile,
+		arg.WorkspaceID,
+		arg.CreatorID,
+		arg.RowOffset,
+		arg.LimitCount,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListChatsForMobileRow{}
+	for rows.Next() {
+		var i ListChatsForMobileRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Title,
+			&i.AgentID,
+			&i.AgentName,
+			&i.LastMessage,
+			&i.LastMessageAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/server/pkg/db/queries/chat.sql
+++ b/server/pkg/db/queries/chat.sql
@@ -138,3 +138,38 @@ WHERE id = $1;
 -- unread boundary stable across multiple incoming replies.
 UPDATE chat_session SET unread_since = now()
 WHERE id = $1 AND unread_since IS NULL;
+
+-- name: ListChatsForMobile :many
+-- Paginated chat list for the mobile MessagesScreen. Joins the agent for the
+-- display name and pulls the latest chat_message (if any) via a LEFT JOIN on
+-- a correlated subquery that resolves the latest message id per session. The
+-- direct LEFT JOIN on chat_message (rather than a LATERAL derived row) makes
+-- sqlc infer pgtype.Text / pgtype.Timestamptz (nullable) for lm.content /
+-- lm.created_at — same pattern as ListInboxItems' LEFT JOIN on issue.
+SELECT
+  cs.id,
+  cs.title,
+  cs.agent_id,
+  a.name AS agent_name,
+  lm.content AS last_message,
+  lm.created_at AS last_message_at,
+  cs.created_at,
+  cs.updated_at
+FROM chat_session cs
+JOIN agent a ON a.id = cs.agent_id
+LEFT JOIN chat_message lm ON lm.id = (
+  SELECT id FROM chat_message
+  WHERE chat_session_id = cs.id
+  ORDER BY created_at DESC
+  LIMIT 1
+)
+WHERE cs.workspace_id = @workspace_id AND cs.creator_id = @creator_id
+ORDER BY cs.updated_at DESC
+LIMIT @limit_count OFFSET @row_offset;
+
+-- name: CountChatSessionsByCreator :one
+-- Total session count for the same scope as ListChatsForMobile, used to drive
+-- the has_more flag on the mobile pagination response.
+SELECT COUNT(*) AS total
+FROM chat_session
+WHERE workspace_id = @workspace_id AND creator_id = @creator_id;


### PR DESCRIPTION
## Summary

- Adds `GET /api/chats`, the mobile-shaped chat list the moana `MessagesScreen` (BUR-989, moana PR #38) calls. Returns `{ sessions, total, has_more }` with each row enriched by `agent_name`, `last_message`, and `last_message_at`.
- New SQL `ListChatsForMobile` (paginated, LEFT JOIN on `agent` + latest `chat_message`) and `CountChatSessionsByCreator` (drives `has_more`).
- Limit clamped to `[1, 100]` with a default of `20`; offset coerced to `>= 0`. Workspace + creator scoping comes from the existing workspace middleware — no middleware changes needed.

## Why a new endpoint instead of extending `GET /api/chat/sessions`

The web endpoint returns a flat `[]ChatSessionResponse` array, doesn't paginate, and exposes fields (`workspace_id`, `creator_id`, `has_unread`, `status`) the mobile list row doesn't need. Inverting it into the mobile shape would be a breaking change for the web client and a fan-out per row to resolve `agent_name` / `last_message`. `GET /api/chats` is the clean split.

## SQL nullability note

`chat_message.content` is `NOT NULL` on the column. To make sqlc infer the per-row `last_message` as nullable (sessions with zero messages), the join is written as `LEFT JOIN chat_message lm ON lm.id = (correlated subquery)` rather than a `LEFT JOIN LATERAL` — sqlc's LEFT JOIN inference does the right thing for direct column references but not for derived rows.

## Test plan

- [ ] `go build ./...` — passes locally
- [ ] `go vet ./...` — passes locally
- [ ] DB-backed integration tests added (require a live `DATABASE_URL`; verified compile-clean):
  - empty result → `{ sessions: [], total: 0, has_more: false }`
  - 2 sessions, one with a message → both returned, ordered by `updated_at DESC`, enrichment fields populated correctly (and `last_message`/`last_message_at` omitted on the message-less row)
  - foreign workspace context → 0 rows
  - 3 sessions, `limit=2 offset=0` → `has_more=true`; `offset=2` → `has_more=false`

## Out of scope

- Mobile changes — moana PR #38 is already merged and calls the right path.
- Private-agent gate (the existing `ListChatSessions` filters sessions whose target agent the caller has lost access to). Not in the BUR-990 spec; happy to add in a follow-up if Eng wants the same guarantee on mobile.

Refs: BUR-990, BUR-989 (mobile), BUR-987 (parent)