### PR TITLE
docs: add May 18 changelog entry

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -285,6 +285,34 @@ export function createEnDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.3.2",
+        date: "2026-05-18",
+        title:
+          "Webhook Autopilots, Clearer Workboards & Better Runtime Control",
+        changes: [],
+        features: [
+          "Autopilots can now start from webhook events, show delivery history, and replay a delivery when a connected system needs another attempt",
+          "Issue boards can group work by assignee, show linked pull request status, and include start dates for clearer planning",
+          "Runtime pages now have a redesigned machine view plus time and task trends in usage charts",
+          "Skills can be copied from local runtimes in bulk, making workspace setup faster",
+          "HTML attachments and HTML code blocks can be previewed directly inside issue discussions",
+        ],
+        improvements: [
+          "Failed issue actions now show clearer error messages so teams can understand what happened without digging through logs",
+          "Agent runs recover more reliably from stuck commands, idle sessions, and long-running work",
+          "GitHub-linked pull requests now surface CI and merge-conflict status inside Multica",
+          "Self-hosted deployments get safer defaults and clearer guidance for reverse proxies, auth limits, and local-only services",
+          "Search results are ranked more usefully and include better snippets",
+        ],
+        fixes: [
+          "Autopilot-created issues can repeat reliably and are attributed to the right assignee agent",
+          "Runtime setup now prefers the local machine by default and uses cleaner labels in machine lists",
+          "Squad pages scroll correctly and show which members are already working",
+          "Desktop zoom shortcuts work again across the common keyboard combinations",
+          "Auth, dependency, and local-service updates improve the safety of hosted and self-hosted deployments",
+        ],
+      },
+      {
         version: "0.3.1",
         date: "2026-05-15",
         title: "Faster Navigation, Background Updates & More Reliable Squads",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -285,6 +285,33 @@ export function createZhDict(allowSignup: boolean): LandingDict {
     },
     entries: [
       {
+        version: "0.3.2",
+        date: "2026-05-18",
+        title: "Webhook 自动任务、更清晰的工作看板与更稳的运行环境",
+        changes: [],
+        features: [
+          "Autopilot 现在可以由 webhook 事件触发，并能查看投递记录，在外部系统需要时重新投递一次",
+          "Issue 看板支持按负责人分组，展示关联 Pull Request 状态，并加入开始日期，排期更清楚",
+          "Runtime 页面升级了机器视图，并在用量图表中加入时间和任务趋势",
+          "Skills 支持从本地 runtime 批量复制到 workspace，团队初始化更快",
+          "HTML 附件和 HTML 代码块可以直接在 Issue 讨论中预览",
+        ],
+        improvements: [
+          "Issue 操作失败时会显示更明确的错误原因，团队不用翻日志也能理解发生了什么",
+          "Agent 运行在遇到卡住的命令、空闲会话和长时间任务时更容易恢复",
+          "关联 GitHub 的 Pull Request 会在 Multica 内展示 CI 和合并冲突状态",
+          "自托管部署获得更安全的默认配置，并补充反向代理、登录限制和本地服务的说明",
+          "搜索结果排序更准确，也会展示更有帮助的摘要片段",
+        ],
+        fixes: [
+          "Autopilot 创建 Issue 时可以稳定重复触发，并正确归属到负责的 assignee agent",
+          "Runtime 设置默认优先选择本地机器，机器列表中的名称也更清晰",
+          "Squad 页面可以正常滚动，并能看到成员当前是否已经在处理工作",
+          "桌面端缩放快捷键在常见组合下恢复正常",
+          "登录、安全补丁和本地服务配置更新，让托管版和自托管部署都更安全",
+        ],
+      },
+      {
         version: "0.3.1",
         date: "2026-05-15",
         title: "更快的导航、后台更新与更可靠的小队协作",


### PR DESCRIPTION
Summary:
- Add English and Chinese 0.3.2 changelog entries for the May 18 release.
- Highlight webhook autopilots, issue board planning, runtime usage, skill import, HTML previews, reliability, and security improvements.

Testing:
- pnpm --filter @multica/web typecheck
- pnpm --filter @multica/web lint (passes with one existing warning in apps/web/app/(auth)/login/page.tsx)