### PR TITLE
fix(autopilots): align trash icon with action buttons in webhook trigger row

### DIFF
--- a/packages/views/autopilots/components/autopilot-detail-page.tsx
+++ b/packages/views/autopilots/components/autopilot-detail-page.tsx
@@ -314,6 +314,25 @@ function TriggerRow({ trigger, autopilotId }: { trigger: AutopilotTrigger; autop
   };
 
   const Icon = isWebhook ? Webhook : isApi ? Zap : Clock;
+  const showWebhookUrlRow = isWebhook && webhookUrl;
+
+  // Delete control extracted so a webhook trigger can render it inline
+  // with Copy / Rotate on the URL action row (where the other action
+  // buttons live), while schedule / api triggers — which have no URL row
+  // — keep it pinned to the row's top-right corner. Without this the
+  // trash icon visually floats above the URL action buttons because the
+  // outer flex uses `items-start`.
+  const deleteButton = (
+    <Button
+      size="icon"
+      variant="ghost"
+      className="h-7 w-7 shrink-0"
+      onClick={() => setConfirmOpen(true)}
+      title={t(($) => $.trigger_row.delete_dialog.confirm)}
+    >
+      <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
+    </Button>
+  );
 
   return (
     <div className="flex items-start gap-3 rounded-md border px-3 py-2">
@@ -346,7 +365,7 @@ function TriggerRow({ trigger, autopilotId }: { trigger: AutopilotTrigger; autop
             {t(($) => $.trigger_row.next_label, { date: formatDate(trigger.next_run_at) })}
           </div>
         )}
-        {isWebhook && webhookUrl && (
+        {showWebhookUrlRow && (
           <div className="mt-1.5 flex items-center gap-1.5">
             <code className="flex-1 min-w-0 truncate rounded bg-muted px-2 py-1 text-xs font-mono text-foreground">
               {webhookUrl}
@@ -370,17 +389,11 @@ function TriggerRow({ trigger, autopilotId }: { trigger: AutopilotTrigger; autop
             >
               <RotateCw className={cn("h-3.5 w-3.5 text-muted-foreground", rotateToken.isPending && "animate-spin")} />
             </Button>
+            {deleteButton}
           </div>
         )}
       </div>
-      <Button
-        size="icon"
-        variant="ghost"
-        className="h-7 w-7 shrink-0"
-        onClick={() => setConfirmOpen(true)}
-      >
-        <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
-      </Button>
+      {!showWebhookUrlRow && deleteButton}
       <AlertDialog open={confirmOpen} onOpenChange={(v) => { if (!v && !deleting) setConfirmOpen(false); }}>
         <AlertDialogContent>
           <AlertDialogHeader>


### PR DESCRIPTION
## Why

The `TriggerRow` outer flex uses `items-start`, which made sense back when every trigger only had one content row (label + maybe a cron expression). #2774 added the URL action row to webhook triggers — Copy + Rotate buttons sit on a second line inside the inner column. The trash button stayed pinned to the outer flex's top-right, so it visibly floats above the URL action buttons instead of lining up with them. Reads as a layout glitch the moment you scan the list.

## What

Move the trash button into the URL action row for webhook triggers so all three action buttons (Copy / Rotate / Delete) share one flex container and align by construction. Schedule and API triggers — which have no URL row — keep the trash button pinned top-right (their bodies are short enough that the top-right reads as the row's right end).

Implementation detail: extract a `deleteButton` const so the JSX isn't duplicated. Also reuse the existing `delete_dialog.confirm` i18n string as a `title` attribute so the button gets a hover tooltip like its Copy / Rotate neighbours.

## Scope

- 1 file, +22 / -9, CSS/structure only.
- No behavioural change — same click handler, same `AlertDialog` confirm flow.
- `pnpm --filter @multica/views typecheck` clean.

## Test plan
- [ ] Webhook trigger row: trash sits inline with Copy + Rotate, all on the URL action row.
- [ ] Schedule trigger row: trash stays top-right (no URL row → previous layout preserved).
- [ ] API trigger row: same as Schedule.
- [ ] Click trash on a webhook row — confirm dialog still pops; delete still works.
- [ ] Hover trash — sees the "Delete" tooltip (new).