### PR TITLE
docs: remove reverted runtime changelog note

### DIFF
--- a/apps/web/features/landing/i18n/en.ts
+++ b/apps/web/features/landing/i18n/en.ts
@@ -299,7 +299,6 @@ export function createEnDict(allowSignup: boolean): LandingDict {
         ],
         improvements: [
           "Failed issue actions now show clearer error messages so teams can understand what happened without digging through logs",
-          "Agent runs recover more reliably from stuck commands, idle sessions, and long-running work",
           "GitHub-linked pull requests now surface CI and merge-conflict status inside Multica",
           "Self-hosted deployments get safer defaults and clearer guidance for reverse proxies, auth limits, and local-only services",
           "Search results are ranked more usefully and include better snippets",

--- a/apps/web/features/landing/i18n/zh.ts
+++ b/apps/web/features/landing/i18n/zh.ts
@@ -298,7 +298,6 @@ export function createZhDict(allowSignup: boolean): LandingDict {
         ],
         improvements: [
           "Issue 操作失败时会显示更明确的错误原因，团队不用翻日志也能理解发生了什么",
-          "Agent 运行在遇到卡住的命令、空闲会话和长时间任务时更容易恢复",
           "关联 GitHub 的 Pull Request 会在 Multica 内展示 CI 和合并冲突状态",
           "自托管部署获得更安全的默认配置，并补充反向代理、登录限制和本地服务的说明",
           "搜索结果排序更准确，也会展示更有帮助的摘要片段",


### PR DESCRIPTION
## Summary
- Remove the May 18 changelog bullet that claimed agent runs recover more reliably from stuck commands after the related watchdog work was reverted.
- Update both English and Chinese changelog copy.

## Verification
- pnpm --filter @multica/web typecheck
- pnpm --filter @multica/web lint (passes with existing login hook dependency warning)
