### PR TITLE
fix(skills): synthesize SKILL.md frontmatter when content omits it

### DIFF
--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -1546,7 +1546,7 @@ func (s *TaskService) LoadAgentSkills(ctx context.Context, agentID pgtype.UUID) 
 
 	result := make([]AgentSkillData, 0, len(skills))
 	for _, sk := range skills {
-		data := AgentSkillData{Name: sk.Name, Content: sk.Content}
+		data := AgentSkillData{Name: sk.Name, Content: ensureSkillFrontmatter(sk.Name, sk.Description, sk.Content)}
 		files, _ := s.Queries.ListSkillFiles(ctx, sk.ID)
 		for _, f := range files {
 			data.Files = append(data.Files, AgentSkillFileData{Path: f.Path, Content: f.Content})
@@ -1554,6 +1554,33 @@ func (s *TaskService) LoadAgentSkills(ctx context.Context, agentID pgtype.UUID) 
 		result = append(result, data)
 	}
 	return result
+}
+
+// ensureSkillFrontmatter guarantees the SKILL.md body sent to the daemon starts
+// with valid YAML frontmatter (`name`, `description`). Without this, Claude
+// Code's skill autoloader silently ignores the file. If the stored content
+// already starts with `---`, we trust the author's frontmatter and return it
+// untouched. Otherwise we synthesize a minimal block from the DB columns —
+// covering the common UI mistake of pasting the body into the description
+// field and leaving content empty.
+func ensureSkillFrontmatter(name, description, content string) string {
+	trimmed := strings.TrimLeft(content, " \t\r\n")
+	if strings.HasPrefix(trimmed, "---") {
+		return content
+	}
+	safeName := strings.ReplaceAll(strings.TrimSpace(name), "\n", " ")
+	if safeName == "" {
+		safeName = "skill"
+	}
+	safeDesc := strings.ReplaceAll(strings.TrimSpace(description), "\n", " ")
+	if safeDesc == "" {
+		safeDesc = safeName
+	}
+	body := content
+	if body != "" && !strings.HasPrefix(body, "\n") {
+		body = "\n" + body
+	}
+	return "---\nname: " + safeName + "\ndescription: " + safeDesc + "\n---\n" + body
 }
 
 // AgentSkillData represents a skill for task execution responses.


### PR DESCRIPTION
## Summary

Claude Code's skill autoloader requires every `.claude/skills/*/SKILL.md` to begin with a YAML frontmatter block containing `name` and `description`. When a user creates a skill in the Multica UI and accidentally pastes the body into the **Description** field (instead of **Content**), the resulting row has `content=''` and the staged SKILL.md is a zero-byte file — Claude silently ignores it, and the user sees agents "not reading the skill" with no error.

This patch adds `ensureSkillFrontmatter` in `LoadAgentSkills`: if `content` already starts with `---` it is passed through unchanged; otherwise a minimal frontmatter block is synthesized from the `name` and `description` columns and prepended. The fix is server-side, so existing broken rows are repaired transparently — users don't have to re-edit their skills.

## Repro

1. Create a skill via the UI; paste the SKILL.md body into the Description field, leave Content empty.
2. Attach the skill to an agent and send a chat message that should invoke it.
3. Before this change: the staged file under `<workdir>/.claude/skills/<name>/SKILL.md` is empty, Claude never references the skill.
4. After this change: the staged file begins with a valid `---\nname: …\ndescription: …\n---` block; Claude discovers and uses the skill.

## Test plan

- [x] Manual: reverted an affected skill to `content=''`, sent a fresh task, confirmed the daemon writes a SKILL.md with synthesized frontmatter and Claude follows it.
- [ ] CI / existing tests should pass — change is additive and only affects rows whose content was already broken.

## Follow-up (out of scope)

Worth a UI tweak so the Description / Content fields are unambiguous (placeholder text, or required-non-empty validation on Content). Filed separately so this fix can land.