### PR TITLE
feat(daemon): claude-tui backend driving real Claude Code TUI via PTY + hooks

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -48,6 +48,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/server/internal/daemon/config.go
+++ b/server/internal/daemon/config.go
@@ -170,6 +170,13 @@ func LoadConfig(overrides Overrides) (Config, error) {
 	agents := map[string]AgentEntry{}
 	if e, ok := probe("MULTICA_CLAUDE_PATH", "claude", "MULTICA_CLAUDE_MODEL"); ok {
 		agents["claude"] = e
+		// claude-tui is a demo backend that drives the same `claude` binary
+		// in TUI mode over a PTY. It's an opt-in alternative provider gated
+		// by MULTICA_CLAUDE_TUI_ENABLED so it doesn't register by default and
+		// surprise operators with two claude-shaped providers.
+		if strings.EqualFold(strings.TrimSpace(os.Getenv("MULTICA_CLAUDE_TUI_ENABLED")), "1") {
+			agents["claude-tui"] = e
+		}
 	}
 	if e, ok := probe("MULTICA_CODEX_PATH", "codex", "MULTICA_CODEX_MODEL"); ok {
 		agents["codex"] = e

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -144,6 +144,14 @@ type Daemon struct {
 	// New() and overridable in tests so the auto-update poller can be exercised
 	// without touching the real network or the brew CLI.
 	runUpdateFn func(targetVersion string) (string, error)
+
+	// hooks is the localhost HTTP server that receives Claude Code hook
+	// deliveries (PreToolUse, PostToolUse, Stop, SessionStart) and routes
+	// them to per-task subscribers. Used by the claude-tui backend to
+	// recover the structured events the TUI doesn't expose on stdout. nil
+	// until Run() starts it; only initialised when the claude-tui provider
+	// is registered.
+	hooks *hookServer
 }
 
 // New creates a new Daemon instance.
@@ -580,6 +588,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 	healthLn, err := d.listenHealth()
 	if err != nil {
 		return err
+	}
+
+	// Start the hook server when claude-tui is registered. The TUI backend
+	// can't get structured events without it; other backends ignore the
+	// HookSubscriber field on agent.Config.
+	if _, hasTUI := d.cfg.Agents["claude-tui"]; hasTUI {
+		d.hooks = newHookServer(d.logger)
+		if _, err := d.hooks.Start(ctx); err != nil {
+			return fmt.Errorf("start hook server: %w", err)
+		}
 	}
 
 	agentNames := make([]string, 0, len(d.cfg.Agents))
@@ -2366,6 +2384,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		ExecutablePath: entry.Path,
 		Env:            agentEnv,
 		Logger:         d.logger,
+		Hooks:          d.hookSubscriberFor(provider),
 	})
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("create agent backend: %w", err)

--- a/server/internal/daemon/hookserver.go
+++ b/server/internal/daemon/hookserver.go
@@ -141,6 +141,7 @@ func (s *hookServer) handleHook(w http.ResponseWriter, r *http.Request) {
 		HookEventName     string          `json:"hook_event_name"`
 		SessionID         string          `json:"session_id"`
 		Cwd               string          `json:"cwd"`
+		TranscriptPath    string          `json:"transcript_path"`
 		ToolName          string          `json:"tool_name"`
 		ToolUseID         string          `json:"tool_use_id"`
 		ToolInput         json.RawMessage `json:"tool_input"`
@@ -156,6 +157,7 @@ func (s *hookServer) handleHook(w http.ResponseWriter, r *http.Request) {
 		Type:              agent.HookEventType(raw.HookEventName),
 		SessionID:         raw.SessionID,
 		Cwd:               raw.Cwd,
+		TranscriptPath:    raw.TranscriptPath,
 		ToolName:          raw.ToolName,
 		ToolUseID:         raw.ToolUseID,
 		ToolInput:         raw.ToolInput,
@@ -164,22 +166,31 @@ func (s *hookServer) handleHook(w http.ResponseWriter, r *http.Request) {
 		Raw:               body,
 	}
 
+	// Hold the lock across the send so cancel() cannot close ch between the
+	// lookup and the channel op (which would panic with "send on closed
+	// channel"). Cancel takes the same mutex before close, so any sender
+	// that's already past the lookup completes its non-blocking send first;
+	// any sender that arrives after cancel finds the entry gone.
+	//
+	// Non-blocking send (default branch) preserves the prior "drop if the
+	// subscriber is stuck" semantics without holding the lock for hundreds
+	// of milliseconds.
 	s.mu.Lock()
 	ch, ok := s.subs[token]
-	s.mu.Unlock()
 	if !ok {
+		s.mu.Unlock()
 		// Subscriber gone — common during graceful shutdown after Stop hook
 		// fired. Don't 404 (claude treats non-2xx as hook failure and may
 		// retry); accept silently.
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-
 	select {
 	case ch <- event:
-	case <-time.After(500 * time.Millisecond):
+	default:
 		s.logger.Warn("hook event dropped: subscriber full", "token", token, "event", raw.HookEventName)
 	}
+	s.mu.Unlock()
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/server/internal/daemon/hookserver.go
+++ b/server/internal/daemon/hookserver.go
@@ -1,0 +1,185 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/multica-ai/multica/server/pkg/agent"
+)
+
+// hookServer is a localhost-only HTTP listener that receives Claude Code
+// hook deliveries and routes them to per-task subscriber channels. The
+// daemon runs exactly one instance, shared across all in-flight tasks.
+//
+// Subscribers are keyed by an opaque token the backend chooses (task UUID
+// today). Inbound POSTs include the token as a `task` query parameter so
+// the server can dispatch each event to the right channel without
+// inspecting the payload's cwd.
+type hookServer struct {
+	logger *slog.Logger
+	addr   string // 127.0.0.1:<port>, resolved at Start
+
+	mu   sync.Mutex
+	subs map[string]chan agent.HookEvent
+
+	listener net.Listener
+	srv      *http.Server
+}
+
+// hookSubscriberFor returns the daemon's HookSubscriber when provider is a
+// backend that consumes Claude Code hooks, and nil otherwise. Wiring nil
+// into agent.Config keeps non-TUI backends unaware of the hook plumbing.
+func (d *Daemon) hookSubscriberFor(provider string) agent.HookSubscriber {
+	if d.hooks == nil || provider != "claude-tui" {
+		return nil
+	}
+	return d.hooks
+}
+
+// newHookServer constructs an unstarted hook server. Call Start before use.
+func newHookServer(logger *slog.Logger) *hookServer {
+	return &hookServer{
+		logger: logger,
+		subs:   map[string]chan agent.HookEvent{},
+	}
+}
+
+// Start binds 127.0.0.1:0 (OS-allocated port), records the listening
+// address, and serves on a background goroutine. Returns the resolved
+// address. The server runs until ctx is cancelled.
+func (s *hookServer) Start(ctx context.Context) (string, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("hook server listen: %w", err)
+	}
+	s.listener = ln
+	s.addr = ln.Addr().String()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hook", s.handleHook)
+	s.srv = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		if err := s.srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			s.logger.Error("hook server failed", "error", err)
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.srv.Shutdown(shutdownCtx)
+	}()
+
+	s.logger.Info("hook server listening", "addr", s.addr)
+	return s.addr, nil
+}
+
+// BaseURL returns the URL prefix backends embed in Claude's settings.local.json
+// to route hook deliveries here. Implements agent.HookSubscriber.
+func (s *hookServer) BaseURL() string {
+	return "http://" + s.addr + "/hook"
+}
+
+// Subscribe registers a channel for the given task token. The returned cancel
+// must be called exactly once when the task completes; it closes the channel
+// and removes the entry so a slow hook arriving after Execute returned does
+// not panic on send.
+func (s *hookServer) Subscribe(token string) (<-chan agent.HookEvent, func()) {
+	ch := make(chan agent.HookEvent, 32)
+	s.mu.Lock()
+	s.subs[token] = ch
+	s.mu.Unlock()
+
+	cancelled := false
+	cancel := func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if cancelled {
+			return
+		}
+		cancelled = true
+		delete(s.subs, token)
+		close(ch)
+	}
+	return ch, cancel
+}
+
+// handleHook is the single POST endpoint. It expects ?task=<token> and a JSON
+// body matching Claude Code's hook payload shape. Unknown tokens are 404'd;
+// well-formed events are pushed onto the subscriber channel with a 500ms
+// best-effort send (a stuck subscriber drops, not blocks, the server).
+func (s *hookServer) handleHook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	token := r.URL.Query().Get("task")
+	if token == "" {
+		http.Error(w, "missing task token", http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 4*1024*1024))
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	var raw struct {
+		HookEventName     string          `json:"hook_event_name"`
+		SessionID         string          `json:"session_id"`
+		Cwd               string          `json:"cwd"`
+		ToolName          string          `json:"tool_name"`
+		ToolUseID         string          `json:"tool_use_id"`
+		ToolInput         json.RawMessage `json:"tool_input"`
+		ToolResponse      json.RawMessage `json:"tool_response"`
+		LastAssistantText string          `json:"last_assistant_message"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		http.Error(w, "parse body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	event := agent.HookEvent{
+		Type:              agent.HookEventType(raw.HookEventName),
+		SessionID:         raw.SessionID,
+		Cwd:               raw.Cwd,
+		ToolName:          raw.ToolName,
+		ToolUseID:         raw.ToolUseID,
+		ToolInput:         raw.ToolInput,
+		ToolResponse:      raw.ToolResponse,
+		LastAssistantText: raw.LastAssistantText,
+		Raw:               body,
+	}
+
+	s.mu.Lock()
+	ch, ok := s.subs[token]
+	s.mu.Unlock()
+	if !ok {
+		// Subscriber gone — common during graceful shutdown after Stop hook
+		// fired. Don't 404 (claude treats non-2xx as hook failure and may
+		// retry); accept silently.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	select {
+	case ch <- event:
+	case <-time.After(500 * time.Millisecond):
+		s.logger.Warn("hook event dropped: subscriber full", "token", token, "event", raw.HookEventName)
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/server/internal/daemon/hookserver_test.go
+++ b/server/internal/daemon/hookserver_test.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestHookServer_CancelDuringDispatchNoPanic exercises the H3 race: a hook
+// POST arrives at the same time the subscriber cancels. Pre-fix, the server
+// looked up the channel under the mutex, released, then sent — so a cancel
+// that closed the channel between unlock and send would panic with
+// "send on closed channel". The fix holds the mutex across a non-blocking
+// send. Run under `go test -race` to be meaningful.
+func TestHookServer_CancelDuringDispatchNoPanic(t *testing.T) {
+	srv := newHookServer(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := srv.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	body := []byte(`{"hook_event_name":"Stop","session_id":"s","last_assistant_message":"hi"}`)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		token := fmt.Sprintf("tok-%d", i)
+		_, cancelSub := srv.Subscribe(token)
+
+		wg.Add(2)
+		// Hammer the dispatcher and the cancel from two goroutines to
+		// maximize the chance the cancel lands between lookup and send.
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest(http.MethodPost, srv.BaseURL()+"?task="+token, bytes.NewReader(body))
+			resp, err := http.DefaultClient.Do(req)
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			cancelSub()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("race test deadlocked")
+	}
+}
+
+// TestHookServer_DropOnFullSubscriber verifies that when the subscriber
+// channel is full the server drops the event rather than blocking the
+// shared mutex.
+func TestHookServer_DropOnFullSubscriber(t *testing.T) {
+	srv := newHookServer(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := srv.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	ch, cancelSub := srv.Subscribe("full")
+	defer cancelSub()
+
+	body := []byte(`{"hook_event_name":"PostToolUse","session_id":"s","tool_name":"Bash"}`)
+
+	// Fill the 32-slot buffer + 1 to force a drop. Without a non-blocking
+	// send this loop would block past the timeout.
+	deadline := time.After(3 * time.Second)
+	for i := 0; i < 64; i++ {
+		select {
+		case <-deadline:
+			t.Fatalf("send loop blocked at i=%d", i)
+		default:
+		}
+		req, _ := http.NewRequest(http.MethodPost, srv.BaseURL()+"?task=full", bytes.NewReader(body))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post %d: %v", i, err)
+		}
+		_ = resp.Body.Close()
+	}
+	// Consumer side should have seen at most cap(ch) events.
+	if len(ch) > cap(ch) {
+		t.Fatalf("channel overrun: len=%d cap=%d", len(ch), cap(ch))
+	}
+}

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -107,6 +107,8 @@ func New(agentType string, cfg Config) (Backend, error) {
 	switch agentType {
 	case "claude":
 		return &claudeBackend{cfg: cfg}, nil
+	case "claude-tui":
+		return &claudeTUIBackend{cfg: cfg}, nil
 	case "codex":
 		return &codexBackend{cfg: cfg}, nil
 	case "copilot":
@@ -128,7 +130,7 @@ func New(agentType string, cfg Config) (Backend, error) {
 	case "kiro":
 		return &kiroBackend{cfg: cfg}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro)", agentType)
+		return nil, fmt.Errorf("unknown agent type: %q (supported: claude, claude-tui, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro)", agentType)
 	}
 }
 
@@ -144,7 +146,8 @@ func DetectVersion(ctx context.Context, executablePath string) (string, error) {
 // environment variables are deliberately omitted so the string is a hint
 // about *what* users are extending, not a dump of the full command line.
 var launchHeaders = map[string]string{
-	"claude":   "claude (stream-json)",
+	"claude":     "claude (stream-json)",
+	"claude-tui": "claude (tui pty)",
 	"codex":    "codex app-server",
 	"copilot":  "copilot (json)",
 	"cursor":   "cursor-agent (stream-json)",

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -95,6 +95,11 @@ type Config struct {
 	ExecutablePath string            // path to CLI binary (claude, codex, copilot, opencode, openclaw, hermes, gemini, pi, cursor, kimi, kiro-cli)
 	Env            map[string]string // extra environment variables
 	Logger         *slog.Logger
+	// Hooks lets a backend subscribe to Claude Code hook deliveries routed
+	// through the daemon's HTTP hook server. Only the claude-tui backend
+	// currently uses it; other backends ignore the field. nil means hooks
+	// are unavailable (e.g. in unit tests that don't start a hook server).
+	Hooks HookSubscriber
 }
 
 // New creates a Backend for the given agent type.

--- a/server/pkg/agent/claude_tui.go
+++ b/server/pkg/agent/claude_tui.go
@@ -4,51 +4,54 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/creack/pty"
 )
 
-func claudeTUIInterruptSignal() os.Signal { return syscall.SIGINT }
-
 // claudeTUIBackend implements Backend by driving the real Claude Code TUI
 // over a pseudo-terminal. Unlike claudeBackend (which uses -p stream-json),
-// this backend types the prompt into the interactive UI character-by-character
-// and accumulates ANSI-stripped output until a silence window elapses.
+// this backend types the prompt into the interactive UI char-by-char.
 //
-// This is a demo/technical-validation backend. It has hard limitations:
-//   - No structured tool_use / tool_result events (Claude Code runs tools
-//     locally; daemon only sees final assistant text).
-//   - No MCP config injection (--mcp-config is a headless-mode flag).
-//   - No session resumption; ResumeSessionID is ignored.
-//   - Completion is detected by output silence, not a protocol frame.
-//   - Token usage and SessionID are not reported.
+// Structured events (tool_use, tool_result, session start/stop) are recovered
+// via Claude Code's hook system: at Execute time the backend writes a
+// .claude/settings.local.json into the task workdir that configures
+// `type: command` hooks invoking `curl` back to the daemon's hook HTTP
+// server. Pre/PostToolUse drive MessageToolUse/MessageToolResult events on
+// the Messages channel; Stop ends the run with last_assistant_message as
+// the canonical Result.Output. PTY ANSI text is still forwarded as
+// MessageText for live progress visibility but is not used for the final
+// output or completion detection.
 //
-// Not supported on Windows (creack/pty has no Windows ConPTY implementation
-// in this dependency).
+// If Hooks is nil (e.g. in tests), completion falls back to a silence
+// window and Output accumulates the (noisy) PTY text.
+//
+// Not supported on Windows (creack/pty has no Windows ConPTY backend in
+// the version we depend on).
 type claudeTUIBackend struct {
 	cfg Config
 }
 
-// claudeTUIDefaultSilence is the default inactivity window after which the
-// backend considers the agent done producing output. Demo-grade heuristic:
-// long enough that mid-turn pauses don't end the session prematurely, short
-// enough that callers don't wait forever after a real completion.
-const claudeTUIDefaultSilence = 5 * time.Minute
+// claudeTUIFallbackSilence is how long the backend waits without any PTY
+// activity before declaring a turn complete when no Stop hook arrives. Real
+// completion should fire from the Stop hook; this is only a safety net.
+const claudeTUIFallbackSilence = 2 * time.Minute
 
-// ansiEscape matches the common ANSI control sequences that the Claude Code
-// TUI emits for redraws, colors, and cursor moves. Not exhaustive — the goal
-// is plain-text approximation for the output buffer, not perfect terminal
-// emulation.
+// ansiEscape matches the common ANSI control sequences the Claude Code TUI
+// emits for redraws, colors, and cursor moves. Plain-text approximation is
+// good enough for the MessageText stream; the authoritative final text comes
+// from the Stop hook's last_assistant_message.
 var ansiEscape = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07|\x1b[=>]|\r`)
 
 func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
@@ -59,6 +62,9 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 	if _, err := exec.LookPath(execPath); err != nil {
 		return nil, fmt.Errorf("claude executable not found at %q: %w", execPath, err)
 	}
+	if opts.Cwd == "" {
+		return nil, fmt.Errorf("claude-tui: opts.Cwd is required (hook settings.local.json must be written into it)")
+	}
 
 	hardTimeout := opts.Timeout
 	if hardTimeout == 0 {
@@ -66,27 +72,61 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 	}
 	silenceWindow := opts.SemanticInactivityTimeout
 	if silenceWindow == 0 {
-		silenceWindow = claudeTUIDefaultSilence
+		silenceWindow = claudeTUIFallbackSilence
+	}
+
+	// Install the per-task hook config so Claude posts back to the daemon's
+	// hook server. The token is the resume session id when present (so
+	// follow-up turns share routing) or a fresh nonce otherwise — task UUID
+	// would be cleaner but the backend doesn't have access to it. Either
+	// way the token only needs to be unique among concurrent Executes.
+	token := opts.ResumeSessionID
+	if token == "" {
+		token = fmt.Sprintf("tui-%d-%d", time.Now().UnixNano(), os.Getpid())
+	}
+
+	var (
+		hookEvents <-chan HookEvent
+		hookCancel func()
+	)
+	settingsRestore, err := installTUIHookSettings(opts.Cwd, b.cfg.Hooks, token)
+	if err != nil {
+		return nil, fmt.Errorf("claude-tui: install hook settings: %w", err)
+	}
+	if b.cfg.Hooks != nil {
+		hookEvents, hookCancel = b.cfg.Hooks.Subscribe(token)
 	}
 
 	runCtx, cancel := context.WithTimeout(ctx, hardTimeout)
 
-	// Build the command without -p / --output-format so claude renders its
-	// real interactive TUI. CustomArgs are still honored for users who want
-	// to pass e.g. --model.
+	// Build command without -p / --output-format — let claude render its
+	// real interactive TUI. CustomArgs still honored (e.g. --model).
 	args := append([]string{}, opts.ExtraArgs...)
 	args = append(args, opts.CustomArgs...)
-	cmd := exec.CommandContext(runCtx, execPath, args...)
-	if opts.Cwd != "" {
-		cmd.Dir = opts.Cwd
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--resume", opts.ResumeSessionID)
 	}
+	cmd := exec.CommandContext(runCtx, execPath, args...)
+	cmd.Dir = opts.Cwd
 	cmd.Env = buildEnv(b.cfg.Env)
 
-	b.cfg.Logger.Info("agent command (tui)", "exec", execPath, "args", args, "silence", silenceWindow.String(), "timeout", hardTimeout.String())
+	b.cfg.Logger.Info("agent command (tui)",
+		"exec", execPath,
+		"args", args,
+		"cwd", opts.Cwd,
+		"silence", silenceWindow.String(),
+		"timeout", hardTimeout.String(),
+		"hooks", b.cfg.Hooks != nil,
+		"token", token,
+	)
 
 	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 120})
 	if err != nil {
 		cancel()
+		if hookCancel != nil {
+			hookCancel()
+		}
+		settingsRestore()
 		return nil, fmt.Errorf("start claude (tui pty): %w", err)
 	}
 
@@ -95,10 +135,9 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 	msgCh := make(chan Message, 256)
 	resCh := make(chan Result, 1)
 
-	// lastByteAt is updated by the reader goroutine every time the TUI writes
-	// anything to the PTY. The silence-window watcher reads it to decide when
-	// to declare completion. Protected by a mutex because the watcher and the
-	// reader run on different goroutines.
+	// lastByteAt: silence-window baseline, updated whenever the PTY writes
+	// anything. Guards against the hook server going silent (e.g. claude
+	// crashed before Stop fired) by forcing eventual completion.
 	var (
 		lastMu     sync.Mutex
 		lastByteAt = time.Now()
@@ -114,44 +153,30 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 		return time.Since(lastByteAt)
 	}
 
-	// Typing the prompt: claude's TUI needs a moment to render before it can
-	// accept input. A small initial delay plus per-character pacing keeps the
-	// input box from dropping characters. End with CR to submit.
-	go func() {
-		time.Sleep(500 * time.Millisecond)
-		for _, r := range prompt {
-			if _, err := ptmx.Write([]byte(string(r))); err != nil {
-				return
-			}
-			time.Sleep(8 * time.Millisecond)
-		}
-		// Some TUI builds require Enter rather than CR; \r is the standard
-		// terminal submit and is what claude's TUI expects.
-		_, _ = ptmx.Write([]byte("\r"))
-		// The prompt itself was a burst of writes that bumped lastByteAt via
-		// the reader echoing them back. Reset the silence baseline now so the
-		// window measures from after-submit, not from process start.
-		bump()
-	}()
-
-	// Reader: pulls bytes from the PTY, strips ANSI, appends plain text to the
-	// output buffer, and bumps the activity timestamp. Streams MessageText
-	// chunks on line boundaries so the daemon UI can render live progress.
+	// Reader goroutine: ANSI-strip PTY bytes and stream as MessageText.
 	var (
 		outMu  sync.Mutex
-		output strings.Builder
-		pend   strings.Builder // partial line buffer
+		pend   strings.Builder
+		ptyOut strings.Builder // PTY-derived output, used only when hooks unavailable
 	)
 	flushLine := func(line string) {
+		line = strings.TrimRight(line, " \t")
 		if line == "" {
 			return
 		}
 		outMu.Lock()
-		output.WriteString(line)
-		output.WriteByte('\n')
+		ptyOut.WriteString(line)
+		ptyOut.WriteByte('\n')
 		outMu.Unlock()
 		trySend(msgCh, Message{Type: MessageText, Content: line})
 	}
+
+	// trustPromptSeen flips when the reader spots the "trust this folder"
+	// modal in cleaned PTY output. The typer polls this flag and only sends
+	// "1\r" when it's set — avoids injecting a stray "1" into the prompt on
+	// already-trusted workspaces.
+	var trustPromptSeen atomic.Bool
+	const trustPromptMarker = "trust this folder"
 
 	readerDone := make(chan struct{})
 	go func() {
@@ -162,6 +187,9 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 			if n > 0 {
 				bump()
 				clean := ansiEscape.ReplaceAllString(string(buf[:n]), "")
+				if !trustPromptSeen.Load() && strings.Contains(strings.ToLower(clean), trustPromptMarker) {
+					trustPromptSeen.Store(true)
+				}
 				pend.WriteString(clean)
 				for {
 					s := pend.String()
@@ -169,31 +197,64 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 					if idx < 0 {
 						break
 					}
-					flushLine(strings.TrimRight(s[:idx], " \t"))
+					flushLine(s[:idx])
 					pend.Reset()
 					pend.WriteString(s[idx+1:])
 				}
 			}
 			if err != nil {
-				// io.EOF or read on closed PTY — reader exits, watcher and
-				// Wait() handle teardown.
 				return
 			}
 		}
 	}()
 
-	// Watcher: declares completion when the silence window elapses, fires the
-	// hard timeout, or observes external cancellation. Whoever wins kills the
-	// PTY/process; cmd.Wait() then unblocks for final cleanup.
+	// Typer: drive the TUI. Wait up to 4s watching for a trust-folder modal;
+	// if it shows, dismiss with "1\r" and let the UI settle. Then type the
+	// real prompt char by char and submit with CR. Skipping the trust
+	// keystrokes when no modal is present avoids injecting a stray "1" into
+	// the prompt on already-trusted workspaces.
+	go func() {
+		deadline := time.Now().Add(4 * time.Second)
+		for time.Now().Before(deadline) {
+			if trustPromptSeen.Load() {
+				_, _ = ptmx.Write([]byte("1\r"))
+				time.Sleep(800 * time.Millisecond)
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		// Brief settle to ensure the input box is focused even when the
+		// trust modal wasn't shown.
+		time.Sleep(1500 * time.Millisecond)
+		for _, r := range prompt {
+			if _, err := ptmx.Write([]byte(string(r))); err != nil {
+				return
+			}
+			time.Sleep(8 * time.Millisecond)
+		}
+		_, _ = ptmx.Write([]byte("\r"))
+		bump()
+	}()
+
+	// Watcher: wins one of {Stop hook, ctx done, silence window} and tears
+	// the run down. Hook events also feed structured Messages to the daemon.
 	go func() {
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
+		defer settingsRestore()
 		defer func() { _ = ptmx.Close() }()
+		defer func() {
+			if hookCancel != nil {
+				hookCancel()
+			}
+		}()
 
 		startTime := time.Now()
 		finalStatus := "completed"
 		var finalError string
+		var sessionID string
+		var hookFinalText string
 
 		ticker := time.NewTicker(2 * time.Second)
 		defer ticker.Stop()
@@ -210,22 +271,62 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 					finalError = "execution cancelled"
 				}
 				decided = true
+
+			case ev, ok := <-hookEvents:
+				if !ok {
+					hookEvents = nil
+					continue
+				}
+				switch ev.Type {
+				case HookSessionStart:
+					if ev.SessionID != "" {
+						sessionID = ev.SessionID
+						trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
+					}
+				case HookPreToolUse:
+					var input map[string]any
+					if len(ev.ToolInput) > 0 {
+						_ = json.Unmarshal(ev.ToolInput, &input)
+					}
+					trySend(msgCh, Message{
+						Type:   MessageToolUse,
+						Tool:   ev.ToolName,
+						CallID: ev.ToolUseID,
+						Input:  input,
+					})
+				case HookPostToolUse:
+					out := ""
+					if len(ev.ToolResponse) > 0 {
+						out = string(ev.ToolResponse)
+					}
+					trySend(msgCh, Message{
+						Type:   MessageToolResult,
+						Tool:   ev.ToolName,
+						CallID: ev.ToolUseID,
+						Output: out,
+					})
+				case HookStop:
+					if ev.SessionID != "" {
+						sessionID = ev.SessionID
+					}
+					hookFinalText = ev.LastAssistantText
+					finalStatus = "completed"
+					decided = true
+				}
+
 			case <-ticker.C:
 				if since() >= silenceWindow {
-					finalStatus = "completed"
+					b.cfg.Logger.Warn("claude tui silence fallback fired (no Stop hook)", "silence", silenceWindow.String())
 					decided = true
 				}
 			}
 		}
 
-		// Send SIGINT to the TUI so it has a chance to write any final lines
-		// before the PTY closes. If the process doesn't exit within WaitDelay,
-		// CommandContext's cancel will kill it.
+		// SIGINT first so claude can flush trailing UI; CommandContext will
+		// kill if it doesn't exit within WaitDelay.
 		if cmd.Process != nil {
-			_ = cmd.Process.Signal(claudeTUIInterruptSignal())
+			_ = cmd.Process.Signal(syscall.SIGINT)
 		}
-		// Give the reader a brief grace period to drain trailing bytes, then
-		// force the PTY closed so Read returns and readerDone fires.
 		select {
 		case <-readerDone:
 		case <-time.After(2 * time.Second):
@@ -233,33 +334,121 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 		_ = ptmx.Close()
 		<-readerDone
 
-		// Flush any trailing partial line.
 		if tail := strings.TrimRight(pend.String(), " \t\r\n"); tail != "" {
 			flushLine(tail)
 		}
-
-		// Reap the process. We don't propagate a non-zero exit to finalStatus
-		// when we ended on silence — TUI mode exits non-zero on SIGINT, which
-		// is the expected teardown path here.
 		_ = cmd.Wait()
 
 		duration := time.Since(startTime)
-		b.cfg.Logger.Info("claude tui finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+		b.cfg.Logger.Info("claude tui finished",
+			"pid", cmd.Process.Pid,
+			"status", finalStatus,
+			"duration", duration.Round(time.Millisecond).String(),
+			"session_id", sessionID,
+			"via_hook", hookFinalText != "",
+		)
 
-		outMu.Lock()
-		outText := output.String()
-		outMu.Unlock()
+		// Prefer the Stop hook's clean text; fall back to PTY accumulation.
+		outText := hookFinalText
+		if outText == "" {
+			outMu.Lock()
+			outText = ptyOut.String()
+			outMu.Unlock()
+		}
 
 		resCh <- Result{
 			Status:     finalStatus,
 			Output:     outText,
 			Error:      finalError,
 			DurationMs: duration.Milliseconds(),
-			SessionID:  "", // not exposed by TUI mode
+			SessionID:  sessionID,
 			Usage:      map[string]TokenUsage{},
 		}
 	}()
 
-	_ = io.Discard // reserved for future stderr piping if needed
 	return &Session{Messages: msgCh, Result: resCh}, nil
+}
+
+// installTUIHookSettings writes a per-task .claude/settings.local.json into
+// cwd that routes all four hook events through curl to the daemon's HTTP
+// server. If the file already exists (e.g. checked-out repo carries one),
+// it is moved aside and the returned restore func puts it back when the
+// run ends. When hooks is nil the function is a no-op and restore is a
+// no-op too — the backend will fall back to silence-window completion.
+func installTUIHookSettings(cwd string, hooks HookSubscriber, token string) (func(), error) {
+	noop := func() {}
+	if hooks == nil {
+		return noop, nil
+	}
+
+	dir := filepath.Join(cwd, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return noop, err
+	}
+	settingsPath := filepath.Join(dir, "settings.local.json")
+	backupPath := settingsPath + ".multica-tui.bak"
+
+	// Back up an existing user file. We only restore if WE wrote a fresh
+	// file (i.e. a backup exists at the end) — if backup creation fails
+	// we refuse to clobber and surface the error.
+	var hadExisting bool
+	if _, err := os.Stat(settingsPath); err == nil {
+		hadExisting = true
+		if err := os.Rename(settingsPath, backupPath); err != nil {
+			return noop, fmt.Errorf("backup existing settings.local.json: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return noop, err
+	}
+
+	url := hooks.BaseURL() + "?task=" + token
+	// Hook stdin is JSON; curl reads it directly and posts to the daemon's
+	// HTTP server. The `|| true` swallows curl errors so a transient daemon
+	// hiccup doesn't surface to claude as a hook failure (claude treats
+	// non-zero exit as a hook problem and shows a warning to the user).
+	cmd := fmt.Sprintf(
+		`curl -sS -X POST -H 'Content-Type: application/json' --data-binary @- '%s' >/dev/null 2>&1 || true`,
+		url,
+	)
+	type hookEntry struct {
+		Type    string `json:"type"`
+		Command string `json:"command"`
+	}
+	type hookMatcher struct {
+		Matcher string      `json:"matcher"`
+		Hooks   []hookEntry `json:"hooks"`
+	}
+	type settings struct {
+		Hooks map[string][]hookMatcher `json:"hooks"`
+	}
+	one := []hookMatcher{{Matcher: "", Hooks: []hookEntry{{Type: "command", Command: cmd}}}}
+	body, err := json.MarshalIndent(settings{
+		Hooks: map[string][]hookMatcher{
+			"SessionStart": one,
+			"PreToolUse":   one,
+			"PostToolUse":  one,
+			"Stop":         one,
+		},
+	}, "", "  ")
+	if err != nil {
+		if hadExisting {
+			_ = os.Rename(backupPath, settingsPath)
+		}
+		return noop, err
+	}
+	if err := os.WriteFile(settingsPath, body, 0o644); err != nil {
+		if hadExisting {
+			_ = os.Rename(backupPath, settingsPath)
+		}
+		return noop, err
+	}
+
+	restore := func() {
+		if hadExisting {
+			_ = os.Rename(backupPath, settingsPath)
+			return
+		}
+		_ = os.Remove(settingsPath)
+	}
+	return restore, nil
 }

--- a/server/pkg/agent/claude_tui.go
+++ b/server/pkg/agent/claude_tui.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -89,9 +88,9 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 		hookEvents <-chan HookEvent
 		hookCancel func()
 	)
-	settingsRestore, err := installTUIHookSettings(opts.Cwd, b.cfg.Hooks, token)
+	hookSettingsJSON, err := buildTUIHookSettingsJSON(b.cfg.Hooks, token)
 	if err != nil {
-		return nil, fmt.Errorf("claude-tui: install hook settings: %w", err)
+		return nil, fmt.Errorf("claude-tui: build hook settings: %w", err)
 	}
 	if b.cfg.Hooks != nil {
 		hookEvents, hookCancel = b.cfg.Hooks.Subscribe(token)
@@ -105,6 +104,12 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 	args = append(args, opts.CustomArgs...)
 	if opts.ResumeSessionID != "" {
 		args = append(args, "--resume", opts.ResumeSessionID)
+	}
+	// --settings accepts an inline JSON string (verified on claude 2.1.140).
+	// We pass it instead of writing .claude/settings.local.json so we never
+	// touch the user's on-disk config. Empty string means hooks disabled.
+	if hookSettingsJSON != "" {
+		args = append(args, "--settings", hookSettingsJSON)
 	}
 	cmd := exec.CommandContext(runCtx, execPath, args...)
 	cmd.Dir = opts.Cwd
@@ -126,7 +131,6 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 		if hookCancel != nil {
 			hookCancel()
 		}
-		settingsRestore()
 		return nil, fmt.Errorf("start claude (tui pty): %w", err)
 	}
 
@@ -242,7 +246,6 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 		defer cancel()
 		defer close(msgCh)
 		defer close(resCh)
-		defer settingsRestore()
 		defer func() { _ = ptmx.Close() }()
 		defer func() {
 			if hookCancel != nil {
@@ -255,6 +258,7 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 		var finalError string
 		var sessionID string
 		var hookFinalText string
+		var transcriptPath string // captured from SessionStart / Stop hooks for post-turn usage extraction
 
 		ticker := time.NewTicker(2 * time.Second)
 		defer ticker.Stop()
@@ -283,6 +287,9 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 						sessionID = ev.SessionID
 						trySend(msgCh, Message{Type: MessageStatus, Status: "running", SessionID: sessionID})
 					}
+					if ev.TranscriptPath != "" {
+						transcriptPath = ev.TranscriptPath
+					}
 				case HookPreToolUse:
 					var input map[string]any
 					if len(ev.ToolInput) > 0 {
@@ -308,6 +315,9 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 				case HookStop:
 					if ev.SessionID != "" {
 						sessionID = ev.SessionID
+					}
+					if ev.TranscriptPath != "" {
+						transcriptPath = ev.TranscriptPath
 					}
 					hookFinalText = ev.LastAssistantText
 					finalStatus = "completed"
@@ -340,12 +350,20 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 		_ = cmd.Wait()
 
 		duration := time.Since(startTime)
+
+		// Pull token usage from the transcript JSONL claude wrote during the
+		// run. Hooks don't expose usage directly; the transcript does, keyed
+		// per assistant message with input/output/cache tokens. Best-effort
+		// only — Result.Usage stays empty if the file is missing or unreadable.
+		usage := readTranscriptUsage(transcriptPath)
+
 		b.cfg.Logger.Info("claude tui finished",
 			"pid", cmd.Process.Pid,
 			"status", finalStatus,
 			"duration", duration.Round(time.Millisecond).String(),
 			"session_id", sessionID,
 			"via_hook", hookFinalText != "",
+			"transcript_models", len(usage),
 		)
 
 		// Prefer the Stop hook's clean text; fall back to PTY accumulation.
@@ -362,43 +380,24 @@ func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts Exec
 			Error:      finalError,
 			DurationMs: duration.Milliseconds(),
 			SessionID:  sessionID,
-			Usage:      map[string]TokenUsage{},
+			Usage:      usage,
 		}
 	}()
 
 	return &Session{Messages: msgCh, Result: resCh}, nil
 }
 
-// installTUIHookSettings writes a per-task .claude/settings.local.json into
-// cwd that routes all four hook events through curl to the daemon's HTTP
-// server. If the file already exists (e.g. checked-out repo carries one),
-// it is moved aside and the returned restore func puts it back when the
-// run ends. When hooks is nil the function is a no-op and restore is a
-// no-op too — the backend will fall back to silence-window completion.
-func installTUIHookSettings(cwd string, hooks HookSubscriber, token string) (func(), error) {
-	noop := func() {}
+// buildTUIHookSettingsJSON returns a JSON blob suitable for `claude --settings`
+// that wires the four hook events we consume through curl to the daemon's HTTP
+// server. Empty string when hooks is nil — the backend will fall back to
+// silence-window completion.
+//
+// Using --settings instead of writing .claude/settings.local.json keeps us
+// off the user's disk entirely: no temp files, no backup/restore dance, no
+// risk of clobbering a checked-out repo's existing settings.
+func buildTUIHookSettingsJSON(hooks HookSubscriber, token string) (string, error) {
 	if hooks == nil {
-		return noop, nil
-	}
-
-	dir := filepath.Join(cwd, ".claude")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return noop, err
-	}
-	settingsPath := filepath.Join(dir, "settings.local.json")
-	backupPath := settingsPath + ".multica-tui.bak"
-
-	// Back up an existing user file. We only restore if WE wrote a fresh
-	// file (i.e. a backup exists at the end) — if backup creation fails
-	// we refuse to clobber and surface the error.
-	var hadExisting bool
-	if _, err := os.Stat(settingsPath); err == nil {
-		hadExisting = true
-		if err := os.Rename(settingsPath, backupPath); err != nil {
-			return noop, fmt.Errorf("backup existing settings.local.json: %w", err)
-		}
-	} else if !os.IsNotExist(err) {
-		return noop, err
+		return "", nil
 	}
 
 	url := hooks.BaseURL() + "?task=" + token
@@ -422,33 +421,16 @@ func installTUIHookSettings(cwd string, hooks HookSubscriber, token string) (fun
 		Hooks map[string][]hookMatcher `json:"hooks"`
 	}
 	one := []hookMatcher{{Matcher: "", Hooks: []hookEntry{{Type: "command", Command: cmd}}}}
-	body, err := json.MarshalIndent(settings{
+	body, err := json.Marshal(settings{
 		Hooks: map[string][]hookMatcher{
 			"SessionStart": one,
 			"PreToolUse":   one,
 			"PostToolUse":  one,
 			"Stop":         one,
 		},
-	}, "", "  ")
+	})
 	if err != nil {
-		if hadExisting {
-			_ = os.Rename(backupPath, settingsPath)
-		}
-		return noop, err
+		return "", err
 	}
-	if err := os.WriteFile(settingsPath, body, 0o644); err != nil {
-		if hadExisting {
-			_ = os.Rename(backupPath, settingsPath)
-		}
-		return noop, err
-	}
-
-	restore := func() {
-		if hadExisting {
-			_ = os.Rename(backupPath, settingsPath)
-			return
-		}
-		_ = os.Remove(settingsPath)
-	}
-	return restore, nil
+	return string(body), nil
 }

--- a/server/pkg/agent/claude_tui.go
+++ b/server/pkg/agent/claude_tui.go
@@ -1,0 +1,265 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+func claudeTUIInterruptSignal() os.Signal { return syscall.SIGINT }
+
+// claudeTUIBackend implements Backend by driving the real Claude Code TUI
+// over a pseudo-terminal. Unlike claudeBackend (which uses -p stream-json),
+// this backend types the prompt into the interactive UI character-by-character
+// and accumulates ANSI-stripped output until a silence window elapses.
+//
+// This is a demo/technical-validation backend. It has hard limitations:
+//   - No structured tool_use / tool_result events (Claude Code runs tools
+//     locally; daemon only sees final assistant text).
+//   - No MCP config injection (--mcp-config is a headless-mode flag).
+//   - No session resumption; ResumeSessionID is ignored.
+//   - Completion is detected by output silence, not a protocol frame.
+//   - Token usage and SessionID are not reported.
+//
+// Not supported on Windows (creack/pty has no Windows ConPTY implementation
+// in this dependency).
+type claudeTUIBackend struct {
+	cfg Config
+}
+
+// claudeTUIDefaultSilence is the default inactivity window after which the
+// backend considers the agent done producing output. Demo-grade heuristic:
+// long enough that mid-turn pauses don't end the session prematurely, short
+// enough that callers don't wait forever after a real completion.
+const claudeTUIDefaultSilence = 5 * time.Minute
+
+// ansiEscape matches the common ANSI control sequences that the Claude Code
+// TUI emits for redraws, colors, and cursor moves. Not exhaustive — the goal
+// is plain-text approximation for the output buffer, not perfect terminal
+// emulation.
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07|\x1b[=>]|\r`)
+
+func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	execPath := b.cfg.ExecutablePath
+	if execPath == "" {
+		execPath = "claude"
+	}
+	if _, err := exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("claude executable not found at %q: %w", execPath, err)
+	}
+
+	hardTimeout := opts.Timeout
+	if hardTimeout == 0 {
+		hardTimeout = 60 * time.Minute
+	}
+	silenceWindow := opts.SemanticInactivityTimeout
+	if silenceWindow == 0 {
+		silenceWindow = claudeTUIDefaultSilence
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, hardTimeout)
+
+	// Build the command without -p / --output-format so claude renders its
+	// real interactive TUI. CustomArgs are still honored for users who want
+	// to pass e.g. --model.
+	args := append([]string{}, opts.ExtraArgs...)
+	args = append(args, opts.CustomArgs...)
+	cmd := exec.CommandContext(runCtx, execPath, args...)
+	if opts.Cwd != "" {
+		cmd.Dir = opts.Cwd
+	}
+	cmd.Env = buildEnv(b.cfg.Env)
+
+	b.cfg.Logger.Info("agent command (tui)", "exec", execPath, "args", args, "silence", silenceWindow.String(), "timeout", hardTimeout.String())
+
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 120})
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("start claude (tui pty): %w", err)
+	}
+
+	b.cfg.Logger.Info("claude tui started", "pid", cmd.Process.Pid, "cwd", opts.Cwd)
+
+	msgCh := make(chan Message, 256)
+	resCh := make(chan Result, 1)
+
+	// lastByteAt is updated by the reader goroutine every time the TUI writes
+	// anything to the PTY. The silence-window watcher reads it to decide when
+	// to declare completion. Protected by a mutex because the watcher and the
+	// reader run on different goroutines.
+	var (
+		lastMu     sync.Mutex
+		lastByteAt = time.Now()
+	)
+	bump := func() {
+		lastMu.Lock()
+		lastByteAt = time.Now()
+		lastMu.Unlock()
+	}
+	since := func() time.Duration {
+		lastMu.Lock()
+		defer lastMu.Unlock()
+		return time.Since(lastByteAt)
+	}
+
+	// Typing the prompt: claude's TUI needs a moment to render before it can
+	// accept input. A small initial delay plus per-character pacing keeps the
+	// input box from dropping characters. End with CR to submit.
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		for _, r := range prompt {
+			if _, err := ptmx.Write([]byte(string(r))); err != nil {
+				return
+			}
+			time.Sleep(8 * time.Millisecond)
+		}
+		// Some TUI builds require Enter rather than CR; \r is the standard
+		// terminal submit and is what claude's TUI expects.
+		_, _ = ptmx.Write([]byte("\r"))
+		// The prompt itself was a burst of writes that bumped lastByteAt via
+		// the reader echoing them back. Reset the silence baseline now so the
+		// window measures from after-submit, not from process start.
+		bump()
+	}()
+
+	// Reader: pulls bytes from the PTY, strips ANSI, appends plain text to the
+	// output buffer, and bumps the activity timestamp. Streams MessageText
+	// chunks on line boundaries so the daemon UI can render live progress.
+	var (
+		outMu  sync.Mutex
+		output strings.Builder
+		pend   strings.Builder // partial line buffer
+	)
+	flushLine := func(line string) {
+		if line == "" {
+			return
+		}
+		outMu.Lock()
+		output.WriteString(line)
+		output.WriteByte('\n')
+		outMu.Unlock()
+		trySend(msgCh, Message{Type: MessageText, Content: line})
+	}
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		buf := make([]byte, 8192)
+		for {
+			n, err := ptmx.Read(buf)
+			if n > 0 {
+				bump()
+				clean := ansiEscape.ReplaceAllString(string(buf[:n]), "")
+				pend.WriteString(clean)
+				for {
+					s := pend.String()
+					idx := strings.IndexByte(s, '\n')
+					if idx < 0 {
+						break
+					}
+					flushLine(strings.TrimRight(s[:idx], " \t"))
+					pend.Reset()
+					pend.WriteString(s[idx+1:])
+				}
+			}
+			if err != nil {
+				// io.EOF or read on closed PTY — reader exits, watcher and
+				// Wait() handle teardown.
+				return
+			}
+		}
+	}()
+
+	// Watcher: declares completion when the silence window elapses, fires the
+	// hard timeout, or observes external cancellation. Whoever wins kills the
+	// PTY/process; cmd.Wait() then unblocks for final cleanup.
+	go func() {
+		defer cancel()
+		defer close(msgCh)
+		defer close(resCh)
+		defer func() { _ = ptmx.Close() }()
+
+		startTime := time.Now()
+		finalStatus := "completed"
+		var finalError string
+
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		decided := false
+		for !decided {
+			select {
+			case <-runCtx.Done():
+				if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+					finalStatus = "timeout"
+					finalError = fmt.Sprintf("claude tui timed out after %s", hardTimeout)
+				} else {
+					finalStatus = "aborted"
+					finalError = "execution cancelled"
+				}
+				decided = true
+			case <-ticker.C:
+				if since() >= silenceWindow {
+					finalStatus = "completed"
+					decided = true
+				}
+			}
+		}
+
+		// Send SIGINT to the TUI so it has a chance to write any final lines
+		// before the PTY closes. If the process doesn't exit within WaitDelay,
+		// CommandContext's cancel will kill it.
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(claudeTUIInterruptSignal())
+		}
+		// Give the reader a brief grace period to drain trailing bytes, then
+		// force the PTY closed so Read returns and readerDone fires.
+		select {
+		case <-readerDone:
+		case <-time.After(2 * time.Second):
+		}
+		_ = ptmx.Close()
+		<-readerDone
+
+		// Flush any trailing partial line.
+		if tail := strings.TrimRight(pend.String(), " \t\r\n"); tail != "" {
+			flushLine(tail)
+		}
+
+		// Reap the process. We don't propagate a non-zero exit to finalStatus
+		// when we ended on silence — TUI mode exits non-zero on SIGINT, which
+		// is the expected teardown path here.
+		_ = cmd.Wait()
+
+		duration := time.Since(startTime)
+		b.cfg.Logger.Info("claude tui finished", "pid", cmd.Process.Pid, "status", finalStatus, "duration", duration.Round(time.Millisecond).String())
+
+		outMu.Lock()
+		outText := output.String()
+		outMu.Unlock()
+
+		resCh <- Result{
+			Status:     finalStatus,
+			Output:     outText,
+			Error:      finalError,
+			DurationMs: duration.Milliseconds(),
+			SessionID:  "", // not exposed by TUI mode
+			Usage:      map[string]TokenUsage{},
+		}
+	}()
+
+	_ = io.Discard // reserved for future stderr piping if needed
+	return &Session{Messages: msgCh, Result: resCh}, nil
+}

--- a/server/pkg/agent/claude_tui_transcript.go
+++ b/server/pkg/agent/claude_tui_transcript.go
@@ -1,0 +1,78 @@
+//go:build !windows
+
+package agent
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+)
+
+// readTranscriptUsage scans the Claude Code transcript JSONL at path and
+// returns aggregated token usage keyed by model name. Each `assistant` line's
+// message.usage is added to the model's running total. Lines are deduped by
+// message.id because claude appends the same assistant message multiple times
+// (once per content block) and they share usage counters — naive summation
+// would double-count.
+//
+// Errors are non-fatal: a missing or unreadable transcript returns an empty
+// map, on the principle that usage telemetry must never block task completion.
+func readTranscriptUsage(path string) map[string]TokenUsage {
+	out := map[string]TokenUsage{}
+	if path == "" {
+		return out
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+
+	seen := map[string]bool{}
+
+	type usageRaw struct {
+		InputTokens              int64 `json:"input_tokens"`
+		OutputTokens             int64 `json:"output_tokens"`
+		CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+		CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	}
+	type messageRaw struct {
+		ID    string    `json:"id"`
+		Model string    `json:"model"`
+		Usage *usageRaw `json:"usage"`
+	}
+	type rowRaw struct {
+		Type    string      `json:"type"`
+		Message *messageRaw `json:"message"`
+	}
+
+	// Claude's transcript can grow to MB for long sessions; bufio's default
+	// 64KB line buffer is too small for occasional embedded tool outputs.
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	for sc.Scan() {
+		var row rowRaw
+		if err := json.Unmarshal(sc.Bytes(), &row); err != nil {
+			continue
+		}
+		if row.Type != "assistant" || row.Message == nil || row.Message.Usage == nil {
+			continue
+		}
+		if row.Message.ID == "" || seen[row.Message.ID] {
+			continue
+		}
+		seen[row.Message.ID] = true
+
+		model := row.Message.Model
+		if model == "" {
+			model = "unknown"
+		}
+		u := out[model]
+		u.InputTokens += row.Message.Usage.InputTokens
+		u.OutputTokens += row.Message.Usage.OutputTokens
+		u.CacheReadTokens += row.Message.Usage.CacheReadInputTokens
+		u.CacheWriteTokens += row.Message.Usage.CacheCreationInputTokens
+		out[model] = u
+	}
+	return out
+}

--- a/server/pkg/agent/claude_tui_transcript_test.go
+++ b/server/pkg/agent/claude_tui_transcript_test.go
@@ -1,0 +1,72 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadTranscriptUsage_MissingFile(t *testing.T) {
+	if got := readTranscriptUsage(""); len(got) != 0 {
+		t.Fatalf("expected empty map for empty path, got %v", got)
+	}
+	if got := readTranscriptUsage("/no/such/file.jsonl"); len(got) != 0 {
+		t.Fatalf("expected empty map for missing file, got %v", got)
+	}
+}
+
+func TestReadTranscriptUsage_DedupAndAggregate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.jsonl")
+	// Two rows with the SAME message.id — claude writes the row again as
+	// content blocks accumulate, but the usage counters are shared. The
+	// parser must count them once. Then a second message with different id.
+	content := `{"type":"attachment"}
+{"type":"assistant","message":{"id":"msg_A","model":"opus","usage":{"input_tokens":10,"output_tokens":20,"cache_creation_input_tokens":1000,"cache_read_input_tokens":500}}}
+{"type":"assistant","message":{"id":"msg_A","model":"opus","usage":{"input_tokens":10,"output_tokens":20,"cache_creation_input_tokens":1000,"cache_read_input_tokens":500}}}
+{"type":"user","message":{"id":"u1"}}
+{"type":"assistant","message":{"id":"msg_B","model":"opus","usage":{"input_tokens":5,"output_tokens":7,"cache_creation_input_tokens":0,"cache_read_input_tokens":2000}}}
+{"type":"assistant","message":{"id":"msg_C","model":"haiku","usage":{"input_tokens":3,"output_tokens":4,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readTranscriptUsage(path)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 models, got %d: %v", len(got), got)
+	}
+	opus := got["opus"]
+	if opus.InputTokens != 15 || opus.OutputTokens != 27 || opus.CacheWriteTokens != 1000 || opus.CacheReadTokens != 2500 {
+		t.Errorf("opus aggregation wrong: %+v", opus)
+	}
+	haiku := got["haiku"]
+	if haiku.InputTokens != 3 || haiku.OutputTokens != 4 {
+		t.Errorf("haiku aggregation wrong: %+v", haiku)
+	}
+}
+
+func TestReadTranscriptUsage_RealFixture(t *testing.T) {
+	// Smoke test against a transcript shape from the field. Uses the same
+	// JSON keys claude actually writes. Verifies that an assistant row
+	// missing message.id (shouldn't happen, but parser must not crash) is
+	// silently skipped instead of double-counting.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "real.jsonl")
+	content := `{"type":"assistant","message":{"id":"","model":"opus","usage":{"input_tokens":1,"output_tokens":1}}}
+{"type":"assistant","message":{"id":"msg_X","model":"opus","usage":{"input_tokens":6,"cache_creation_input_tokens":24662,"cache_read_input_tokens":18411,"output_tokens":99}}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readTranscriptUsage(path)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 model, got %d: %v", len(got), got)
+	}
+	u := got["opus"]
+	if u.InputTokens != 6 || u.OutputTokens != 99 || u.CacheWriteTokens != 24662 || u.CacheReadTokens != 18411 {
+		t.Errorf("real fixture wrong: %+v", u)
+	}
+}

--- a/server/pkg/agent/claude_tui_windows.go
+++ b/server/pkg/agent/claude_tui_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package agent
+
+import (
+	"context"
+	"fmt"
+)
+
+// claudeTUIBackend is not supported on Windows: creack/pty has no Windows
+// ConPTY implementation in the version we depend on. Calling Execute returns
+// an error explaining the platform constraint.
+type claudeTUIBackend struct {
+	cfg Config
+}
+
+func (b *claudeTUIBackend) Execute(ctx context.Context, prompt string, opts ExecOptions) (*Session, error) {
+	return nil, fmt.Errorf("claude-tui backend is not supported on Windows")
+}

--- a/server/pkg/agent/hooks.go
+++ b/server/pkg/agent/hooks.go
@@ -21,15 +21,16 @@ const (
 // Only fields the claude-tui backend uses are exposed as typed columns; the
 // full original JSON is preserved in Raw for logging and forward-compat.
 type HookEvent struct {
-	Type                HookEventType
-	SessionID           string
-	Cwd                 string
-	ToolName            string          // PreToolUse, PostToolUse
-	ToolUseID           string          // PreToolUse, PostToolUse
-	ToolInput           json.RawMessage // PreToolUse, PostToolUse
-	ToolResponse        json.RawMessage // PostToolUse
-	LastAssistantText   string          // Stop
-	Raw                 json.RawMessage // entire POST body, for debug
+	Type              HookEventType
+	SessionID         string
+	Cwd               string
+	TranscriptPath    string          // SessionStart, Stop — absolute path to the per-session JSONL claude writes
+	ToolName          string          // PreToolUse, PostToolUse
+	ToolUseID         string          // PreToolUse, PostToolUse
+	ToolInput         json.RawMessage // PreToolUse, PostToolUse
+	ToolResponse      json.RawMessage // PostToolUse
+	LastAssistantText string          // Stop
+	Raw               json.RawMessage // entire POST body, for debug
 }
 
 // HookSubscriber is the interface a backend uses to receive Claude Code hook

--- a/server/pkg/agent/hooks.go
+++ b/server/pkg/agent/hooks.go
@@ -1,0 +1,46 @@
+package agent
+
+import "encoding/json"
+
+// HookEventType identifies the Claude Code hook event that produced a HookEvent.
+// Only the events the claude-tui backend consumes are enumerated; unknown
+// events are accepted by the daemon hook server and dropped here.
+type HookEventType string
+
+const (
+	HookSessionStart HookEventType = "SessionStart"
+	HookPreToolUse   HookEventType = "PreToolUse"
+	HookPostToolUse  HookEventType = "PostToolUse"
+	HookStop         HookEventType = "Stop"
+)
+
+// HookEvent is one parsed Claude Code hook delivery. The daemon's hook server
+// constructs these from the JSON body Claude POSTs and pushes them onto the
+// per-task subscription channel.
+//
+// Only fields the claude-tui backend uses are exposed as typed columns; the
+// full original JSON is preserved in Raw for logging and forward-compat.
+type HookEvent struct {
+	Type                HookEventType
+	SessionID           string
+	Cwd                 string
+	ToolName            string          // PreToolUse, PostToolUse
+	ToolUseID           string          // PreToolUse, PostToolUse
+	ToolInput           json.RawMessage // PreToolUse, PostToolUse
+	ToolResponse        json.RawMessage // PostToolUse
+	LastAssistantText   string          // Stop
+	Raw                 json.RawMessage // entire POST body, for debug
+}
+
+// HookSubscriber is the interface a backend uses to receive Claude Code hook
+// events from the daemon's HTTP hook server. The daemon injects an
+// implementation into agent.Config; backends call Subscribe once at the start
+// of Execute and Cancel when the run completes.
+//
+// BaseURL returns the URL prefix backends should write into Claude's
+// settings.local.json hook config. The token argument lets the server route
+// inbound POSTs back to the right subscriber.
+type HookSubscriber interface {
+	Subscribe(token string) (events <-chan HookEvent, cancel func())
+	BaseURL() string
+}


### PR DESCRIPTION
## What does this PR do?

Adds **claude-tui**, a demo/technical-validation alternative to the existing headless \`claude\` backend. Instead of \`claude -p\` with stream-json, it drives the real interactive Claude Code TUI over a pseudo-terminal and recovers structured events (tool calls, completion, token usage) through Claude Code's hook system routed back to the daemon over localhost HTTP.

The motivating question was whether the daemon could integrate with a TUI-based agent path at all. Answer: yes — and with hooks (PreToolUse / PostToolUse / Stop / SessionStart) the daemon-side event stream stays roughly on par with the headless backend (tool cards, session id, completion signal), with the deliberate trade-off that thinking blocks aren't streamed and PTY output isn't authoritative.

Opt-in only: set \`MULTICA_CLAUDE_TUI_ENABLED=1\` when starting the daemon; otherwise nothing in the existing claude path changes.

## Related Issue

N/A — internal demo backend, no Jira ticket.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

**New files:**
- \`server/pkg/agent/claude_tui.go\` — PTY-driven TUI backend (Unix only; Windows stub returns explicit error)
- \`server/pkg/agent/claude_tui_windows.go\` — Windows stub
- \`server/pkg/agent/claude_tui_transcript.go\` + test — parse transcript JSONL for token usage, dedup by \`message.id\`
- \`server/pkg/agent/hooks.go\` — \`HookEvent\` / \`HookSubscriber\` types shared between daemon and backend
- \`server/internal/daemon/hookserver.go\` + test — localhost HTTP listener (127.0.0.1:0) that routes hook POSTs to per-task subscriber channels, race-safe under concurrent Subscribe/cancel

**Modified:**
- \`server/pkg/agent/agent.go\` — \`Config.Hooks HookSubscriber\` field; register \`claude-tui\` in factory; launch header
- \`server/internal/daemon/config.go\` — register \`claude-tui\` provider when \`MULTICA_CLAUDE_TUI_ENABLED=1\`, reusing \`MULTICA_CLAUDE_PATH\`
- \`server/internal/daemon/daemon.go\` — start hook server in \`Run()\` if \`claude-tui\` registered; inject \`HookSubscriber\` into the \`claude-tui\` provider only
- \`go.mod\` / \`go.sum\` — \`github.com/creack/pty v1.1.24\` explicit require

**Notable design choices:**
- Hook config delivered via \`claude --settings <inline-json>\` instead of writing \`.claude/settings.local.json\` — no on-disk side effects, no backup/restore dance, safe for concurrent tasks
- Token usage recovered post-hoc from the per-session transcript JSONL (\`transcript_path\` is in SessionStart/Stop payloads); deduped by \`message.id\` since claude appends the same row multiple times as content blocks accumulate
- Trust-folder modal is auto-dismissed only when its keyword is detected in PTY output, to avoid injecting a stray \`1\` into the prompt on already-trusted workspaces

## How to Test

1. Build: \`cd server && go build ./... && go vet ./...\`
2. Run unit tests: \`go test ./pkg/agent/... ./internal/daemon/...\`
3. End-to-end against a real workspace:
   - \`MULTICA_CLAUDE_TUI_ENABLED=1 make daemon\`
   - Confirm daemon log shows \`hook server listening\` and \`agents=[... claude-tui ...]\`
   - Create an issue in the web UI, assign it to a \`claude-tui\` agent
   - Watch daemon log for \`agent command (tui)\` → \`claude tui started\` → tool-call events → \`claude tui finished via_hook=true transcript_models=N\` (N>0 means usage was recovered)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, daemon-only
- [ ] I have updated relevant documentation to reflect my changes — intentionally skipped; \`MULTICA_CLAUDE_TUI_ENABLED\` is an internal opt-in flag, not a public feature
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy**, **starter-content**, and **relevant docs** — N/A, demo backend not advertised to users
- [ ] If this PR touches Chinese product copy — N/A
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

**Known limitations (deliberate):**
- No streaming of \`thinking\` blocks (hook system doesn't surface them; transcript has them but we don't currently parse)
- TUI output parsing is fragile by nature — any future Claude Code TUI redesign can break this backend. Demo scope only.
- Not supported on Windows (creack/pty lacks ConPTY backend at v1.1.x)

## AI Disclosure

**AI tool used:** Claude Code (Opus 4.7, 1M context)

**Prompt / approach:**
Iterative design conversation: started from \"can the daemon drive Claude Code TUI?\", systematically ruled out simulating-TUI-to-shift-billing approaches, then designed the cooperative hook-based integration. The implementation work was paired — model proposed each step's design with trade-offs spelled out (e.g. \`--settings\` inline vs settings.local.json on disk, sync window for completion vs Stop-hook-driven, dedup strategy for transcript token usage), I picked the option each time. Live testing exposed real bugs (\`tee | curl\` hang, stray \`1\` keystroke when trust-folder modal absent) which the model patched against actual daemon log evidence rather than guessed fixes.

## Screenshots (optional)

N/A — daemon-only change.