### PR TITLE
feat(agents): list-only tasks panel with issue search (MUL-2391)

### DIFF
--- a/packages/core/issues/stores/actor-issues-view-store.ts
+++ b/packages/core/issues/stores/actor-issues-view-store.ts
@@ -23,6 +23,8 @@ const _actorIssuesViewStore = createStore<ActorIssuesViewState>()(
   persist(
     (set) => ({
       ...viewStoreSlice(set as unknown as StoreApi<IssueViewState>["setState"]),
+      // Actor tasks panel is list-only; override the slice's "board" default.
+      viewMode: "list",
       scope: "assigned" as ActorIssuesScope,
       setScope: (scope: ActorIssuesScope) => set({ scope }),
     }),

--- a/packages/views/common/actor-issues-panel.tsx
+++ b/packages/views/common/actor-issues-panel.tsx
@@ -1,21 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useStore } from "zustand";
-import { toast } from "sonner";
-import { ListTodo } from "lucide-react";
+import { ListTodo, Search } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import type { UpdateIssueRequest } from "@multica/core/types";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { BOARD_STATUSES } from "@multica/core/issues/config";
 import {
   childIssueProgressOptions,
-  myIssueAssigneeGroupsOptions,
   myIssueListOptions,
-  type AssigneeGroupedIssuesFilter,
   type MyIssuesFilter,
 } from "@multica/core/issues/queries";
-import { useUpdateIssue } from "@multica/core/issues/mutations";
 import {
   actorIssuesViewStore,
   type ActorIssuesScope,
@@ -24,13 +19,14 @@ import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-st
 import { useClearFiltersOnWorkspaceChange } from "@multica/core/issues/stores/view-store";
 import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
 import { Button } from "@multica/ui/components/ui/button";
+import { Input } from "@multica/ui/components/ui/input";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@multica/ui/components/ui/tooltip";
-import { BoardView } from "../issues/components/board-view";
 import { ListView } from "../issues/components/list-view";
 import { BatchActionToolbar } from "../issues/components/batch-action-toolbar";
 import { IssueDisplayControls } from "../issues/components/issues-header";
 import { filterIssues } from "../issues/utils/filter";
+import { matchesPinyin } from "../editor/extensions/pinyin-match";
 import { useT } from "../i18n";
 
 export type TaskActorType = "member" | "agent";
@@ -48,8 +44,7 @@ export function ActorIssuesPanel({
   const wsId = useWorkspaceId();
   const scope = useStore(actorIssuesViewStore, (s) => s.scope);
   const setScope = useStore(actorIssuesViewStore, (s) => s.setScope);
-  const viewMode = useStore(actorIssuesViewStore, (s) => s.viewMode);
-  const grouping = useStore(actorIssuesViewStore, (s) => s.grouping);
+  const setViewMode = useStore(actorIssuesViewStore, (s) => s.setViewMode);
   const statusFilters = useStore(actorIssuesViewStore, (s) => s.statusFilters);
   const priorityFilters = useStore(actorIssuesViewStore, (s) => s.priorityFilters);
   const assigneeFilters = useStore(actorIssuesViewStore, (s) => s.assigneeFilters);
@@ -59,11 +54,19 @@ export function ActorIssuesPanel({
   const includeNoProject = useStore(actorIssuesViewStore, (s) => s.includeNoProject);
   const labelFilters = useStore(actorIssuesViewStore, (s) => s.labelFilters);
 
+  const [search, setSearch] = useState("");
+
   useClearFiltersOnWorkspaceChange(actorIssuesViewStore, wsId);
+
+  // The actor tasks panel is list-only; clear any persisted "board" state
+  // so list-only affordances (e.g. BatchActionToolbar) render correctly.
+  useEffect(() => {
+    setViewMode("list");
+  }, [setViewMode]);
 
   useEffect(() => {
     useIssueSelectionStore.getState().clear();
-  }, [viewMode, scope, actorType, actorId]);
+  }, [scope, actorType, actorId]);
 
   const queryFilter: MyIssuesFilter = useMemo(
     () =>
@@ -73,73 +76,25 @@ export function ActorIssuesPanel({
     [scope, actorId],
   );
   const queryScope = `${actorType}:${actorId}:${scope}`;
-  const usesAssigneeBoard = viewMode === "board" && grouping === "assignee";
 
-  const assigneeGroupFilter = useMemo<AssigneeGroupedIssuesFilter>(() => {
-    const filter: AssigneeGroupedIssuesFilter = {
-      ...queryFilter,
-      statuses: statusFilters.length > 0 ? statusFilters : [...BOARD_STATUSES],
-      priorities: priorityFilters,
-      assignee_filters: assigneeFilters,
-      include_no_assignee: includeNoAssignee,
-      creator_filters: creatorFilters,
-      project_ids: projectFilters,
-      include_no_project: includeNoProject,
-      label_ids: labelFilters,
-    };
-    if (scope === "assigned") {
-      filter.assignee_types = [actorType];
-    }
-    return filter;
-  }, [
-    actorType,
-    assigneeFilters,
-    creatorFilters,
-    includeNoAssignee,
-    includeNoProject,
-    labelFilters,
-    priorityFilters,
-    projectFilters,
-    queryFilter,
-    scope,
-    statusFilters,
-  ]);
-  const assigneeGroupsOptions = myIssueAssigneeGroupsOptions(
-    wsId,
-    queryScope,
-    assigneeGroupFilter,
-  );
-  const rawIssuesQuery = useQuery({
-    ...myIssueListOptions(wsId, queryScope, queryFilter),
-    enabled: !usesAssigneeBoard,
-  });
-  const assigneeGroupsQuery = useQuery({
-    ...assigneeGroupsOptions,
-    enabled: usesAssigneeBoard,
-  });
+  const rawIssuesQuery = useQuery(myIssueListOptions(wsId, queryScope, queryFilter));
   const rawIssues = useMemo(
     () => rawIssuesQuery.data ?? [],
     [rawIssuesQuery.data],
   );
-  const groupedIssues = useMemo(
-    () => assigneeGroupsQuery.data?.groups.flatMap((group) => group.issues) ?? [],
-    [assigneeGroupsQuery.data],
-  );
-  const isLoading = usesAssigneeBoard
-    ? assigneeGroupsQuery.isLoading
-    : rawIssuesQuery.isLoading;
+  const isLoading = rawIssuesQuery.isLoading;
 
   const actorIssues = useMemo(
     () =>
-      (usesAssigneeBoard ? groupedIssues : rawIssues).filter((issue) =>
+      rawIssues.filter((issue) =>
         scope === "assigned"
           ? issue.assignee_type === actorType && issue.assignee_id === actorId
           : issue.creator_type === actorType && issue.creator_id === actorId,
       ),
-    [actorId, actorType, groupedIssues, rawIssues, scope, usesAssigneeBoard],
+    [actorId, actorType, rawIssues, scope],
   );
 
-  const issues = useMemo(
+  const filteredIssues = useMemo(
     () =>
       filterIssues(actorIssues, {
         statusFilters,
@@ -164,6 +119,19 @@ export function ActorIssuesPanel({
     ],
   );
 
+  const issues = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return filteredIssues;
+    return filteredIssues.filter((issue) => {
+      const title = issue.title ?? "";
+      return (
+        title.toLowerCase().includes(query) ||
+        issue.identifier.toLowerCase().includes(query) ||
+        matchesPinyin(title, query)
+      );
+    });
+  }, [filteredIssues, search]);
+
   const { data: childProgressMap = new Map() } = useQuery(
     childIssueProgressOptions(wsId),
   );
@@ -175,29 +143,6 @@ export function ActorIssuesPanel({
     return BOARD_STATUSES;
   }, [statusFilters]);
 
-  const hiddenStatuses = useMemo(
-    () => BOARD_STATUSES.filter((s) => !visibleStatuses.includes(s)),
-    [visibleStatuses],
-  );
-
-  const updateIssueMutation = useUpdateIssue();
-  const handleMoveIssue = useCallback(
-    (issueId: string, updates: Pick<UpdateIssueRequest, "status" | "assignee_type" | "assignee_id" | "position">) => {
-      updateIssueMutation.mutate(
-        { id: issueId, ...updates },
-        {
-          onError: (err) =>
-            toast.error(
-              err instanceof Error && err.message
-                ? err.message
-                : t(($) => $.page.move_failed),
-            ),
-        },
-      );
-    },
-    [updateIssueMutation, t],
-  );
-
   if (isLoading) {
     return <ActorIssuesSkeleton />;
   }
@@ -205,33 +150,44 @@ export function ActorIssuesPanel({
   return (
     <ViewStoreProvider store={actorIssuesViewStore}>
       <div className="flex flex-1 min-h-0 flex-col">
-        <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
-          <div className="flex items-center gap-1">
-            {SCOPE_VALUES.map((value) => (
-              <Tooltip key={value}>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className={
-                        scope === value
-                          ? "bg-accent text-accent-foreground hover:bg-accent/80"
-                          : "text-muted-foreground"
-                      }
-                      onClick={() => setScope(value)}
-                    >
-                      {t(($) => $.actor_issues.scope[value].label)}
-                    </Button>
-                  }
-                />
-                <TooltipContent side="bottom">
-                  {t(($) => $.actor_issues.scope[value].description)}
-                </TooltipContent>
-              </Tooltip>
-            ))}
+        <div className="flex h-12 shrink-0 items-center justify-between gap-3 border-b px-4">
+          <div className="flex items-center gap-3">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t(($) => $.actor_issues.search_placeholder)}
+                className="h-8 w-64 pl-8 text-sm"
+              />
+            </div>
+            <div className="flex items-center gap-1">
+              {SCOPE_VALUES.map((value) => (
+                <Tooltip key={value}>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className={
+                          scope === value
+                            ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                            : "text-muted-foreground"
+                        }
+                        onClick={() => setScope(value)}
+                      >
+                        {t(($) => $.actor_issues.scope[value].label)}
+                      </Button>
+                    }
+                  />
+                  <TooltipContent side="bottom">
+                    {t(($) => $.actor_issues.scope[value].description)}
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
           </div>
-          <IssueDisplayControls scopedIssues={actorIssues} />
+          <IssueDisplayControls scopedIssues={actorIssues} hideViewToggle />
         </div>
 
         {actorIssues.length === 0 ? (
@@ -244,33 +200,23 @@ export function ActorIssuesPanel({
               {t(($) => $.actor_issues.empty[scope].description)}
             </p>
           </div>
+        ) : issues.length === 0 ? (
+          <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-2 text-muted-foreground">
+            <Search className="h-10 w-10 text-muted-foreground/40" />
+            <p className="text-sm">{t(($) => $.actor_issues.search_empty)}</p>
+          </div>
         ) : (
           <div className="flex flex-1 min-h-0 flex-col">
-            {viewMode === "board" ? (
-              <BoardView
-                issues={usesAssigneeBoard ? actorIssues : issues}
-                assigneeGroups={usesAssigneeBoard ? assigneeGroupsQuery.data?.groups : undefined}
-                assigneeGroupQueryKey={usesAssigneeBoard ? assigneeGroupsOptions.queryKey : undefined}
-                assigneeGroupFilter={usesAssigneeBoard ? assigneeGroupFilter : undefined}
-                visibleStatuses={visibleStatuses}
-                hiddenStatuses={hiddenStatuses}
-                onMoveIssue={handleMoveIssue}
-                childProgressMap={childProgressMap}
-                myIssuesScope={queryScope}
-                myIssuesFilter={queryFilter}
-              />
-            ) : (
-              <ListView
-                issues={issues}
-                visibleStatuses={visibleStatuses}
-                childProgressMap={childProgressMap}
-                myIssuesScope={queryScope}
-                myIssuesFilter={queryFilter}
-              />
-            )}
+            <ListView
+              issues={issues}
+              visibleStatuses={visibleStatuses}
+              childProgressMap={childProgressMap}
+              myIssuesScope={queryScope}
+              myIssuesFilter={queryFilter}
+            />
           </div>
         )}
-        {viewMode === "list" && <BatchActionToolbar />}
+        <BatchActionToolbar />
       </div>
     </ViewStoreProvider>
   );
@@ -280,23 +226,19 @@ function ActorIssuesSkeleton() {
   return (
     <div className="flex flex-1 min-h-0 flex-col">
       <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-64 rounded-md" />
           <Skeleton className="h-8 w-20 rounded-md" />
           <Skeleton className="h-8 w-20 rounded-md" />
         </div>
         <div className="flex items-center gap-1">
-          <Skeleton className="h-8 w-8 rounded-md" />
           <Skeleton className="h-8 w-8 rounded-md" />
           <Skeleton className="h-8 w-8 rounded-md" />
         </div>
       </div>
-      <div className="flex flex-1 min-h-0 gap-4 overflow-hidden p-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="flex min-w-52 flex-1 flex-col gap-2">
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-24 w-full rounded-lg" />
-            <Skeleton className="h-24 w-full rounded-lg" />
-          </div>
+      <div className="flex flex-1 min-h-0 flex-col gap-2 p-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full rounded-md" />
         ))}
       </div>
     </div>

--- a/packages/views/common/actor-issues-panel.tsx
+++ b/packages/views/common/actor-issues-panel.tsx
@@ -200,7 +200,7 @@ export function ActorIssuesPanel({
               {t(($) => $.actor_issues.empty[scope].description)}
             </p>
           </div>
-        ) : issues.length === 0 ? (
+        ) : search.trim() !== "" && issues.length === 0 ? (
           <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-2 text-muted-foreground">
             <Search className="h-10 w-10 text-muted-foreground/40" />
             <p className="text-sm">{t(($) => $.actor_issues.search_empty)}</p>

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -537,7 +537,13 @@ export function IssuesHeader({ scopedIssues }: { scopedIssues: Issue[] }) {
   );
 }
 
-export function IssueDisplayControls({ scopedIssues }: { scopedIssues: Issue[] }) {
+export function IssueDisplayControls({
+  scopedIssues,
+  hideViewToggle = false,
+}: {
+  scopedIssues: Issue[];
+  hideViewToggle?: boolean;
+}) {
   const { t } = useT("issues");
   const viewMode = useViewStore((s) => s.viewMode);
   const statusFilters = useViewStore((s) => s.statusFilters);
@@ -908,41 +914,43 @@ export function IssueDisplayControls({ scopedIssues }: { scopedIssues: Issue[] }
         </Popover>
 
         {/* View toggle */}
-        <DropdownMenu>
-          <Tooltip>
-            <DropdownMenuTrigger
-              render={
-                <TooltipTrigger
-                  render={
-                    <Button variant="outline" size="icon-sm" className="text-muted-foreground">
-                      {viewMode === "board" ? (
-                        <Columns3 className="size-4" />
-                      ) : (
-                        <List className="size-4" />
-                      )}
-                    </Button>
-                  }
-                />
-              }
-            />
-            <TooltipContent side="bottom">
-              {viewMode === "board" ? t(($) => $.view.tooltip_board) : t(($) => $.view.tooltip_list)}
-            </TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent align="end" className="w-auto">
-            <DropdownMenuGroup>
-              <DropdownMenuLabel>{t(($) => $.view.section)}</DropdownMenuLabel>
-              <DropdownMenuItem onClick={() => act.setViewMode("board")}>
-                <Columns3 />
-                {t(($) => $.view.board)}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => act.setViewMode("list")}>
-                <List />
-                {t(($) => $.view.list)}
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {!hideViewToggle && (
+          <DropdownMenu>
+            <Tooltip>
+              <DropdownMenuTrigger
+                render={
+                  <TooltipTrigger
+                    render={
+                      <Button variant="outline" size="icon-sm" className="text-muted-foreground">
+                        {viewMode === "board" ? (
+                          <Columns3 className="size-4" />
+                        ) : (
+                          <List className="size-4" />
+                        )}
+                      </Button>
+                    }
+                  />
+                }
+              />
+              <TooltipContent side="bottom">
+                {viewMode === "board" ? t(($) => $.view.tooltip_board) : t(($) => $.view.tooltip_list)}
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" className="w-auto">
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>{t(($) => $.view.section)}</DropdownMenuLabel>
+                <DropdownMenuItem onClick={() => act.setViewMode("board")}>
+                  <Columns3 />
+                  {t(($) => $.view.board)}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => act.setViewMode("list")}>
+                  <List />
+                  {t(($) => $.view.list)}
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
     </div>
   );
 }

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -101,7 +101,9 @@
         "title": "No created issues",
         "description": "Issues created here will appear in this view."
       }
-    }
+    },
+    "search_placeholder": "Search issues...",
+    "search_empty": "No issues match your search."
   },
   "list": {
     "empty_status": "No issues",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -100,7 +100,9 @@
         "title": "没有已创建的 issue",
         "description": "由这里创建的 issue 会显示在此视图中。"
       }
-    }
+    },
+    "search_placeholder": "搜索 issue...",
+    "search_empty": "没有匹配的 issue。"
   },
   "list": {
     "empty_status": "无 issue",


### PR DESCRIPTION
## Summary
- Agent detail tasks panel now renders only the list view; the board/list toggle is gone.
- Added an Issue search bar at the top of the tasks list — filters by title, identifier (e.g. `MUL-123`), or pinyin.
- `IssueDisplayControls` gains a `hideViewToggle` prop so the main `/issues` page is unaffected.
- Closes [MUL-2391](mention://issue/8497c4ed-c3b5-4b7f-b594-4ad5d4bde4a2).

## Test plan
- [ ] Open an agent detail page and confirm the tasks tab shows the search bar + scope buttons; no view-mode toggle.
- [ ] Type a query — list filters by title / identifier / pinyin.
- [ ] Confirm the global `/issues` page still has the board/list toggle.
- [ ] zh-Hans + en strings render correctly.