### PR TITLE
feat(workspaces): default assignee for unassigned new issues (ARV-45)

### DIFF
--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -46,11 +46,44 @@ var workspaceUpdateCmd = &cobra.Command{
 	RunE:  runWorkspaceUpdate,
 }
 
+var workspaceSettingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "Manage workspace settings (admin/owner only)",
+}
+
+var workspaceSettingsSetCmd = &cobra.Command{
+	Use:   "set <key> <value>",
+	Short: "Set a workspace setting (kebab-case key, e.g. default-unassigned-to)",
+	Long: `Set a workspace setting.
+
+Keys are accepted in kebab-case and normalized to snake_case server-side.
+Use --workspace-id or MULTICA_WORKSPACE_ID to target a workspace.
+
+Available keys:
+  default-unassigned-to    UUID of the agent to auto-assign new issues that
+                            arrive without an assignee.
+
+Example:
+  multica workspace settings set default-unassigned-to 5c6c59b8-3d1a-4ec1-a1f0-9547934cf440`,
+	Args: cobra.ExactArgs(2),
+	RunE: runWorkspaceSettingsSet,
+}
+
+var workspaceSettingsUnsetCmd = &cobra.Command{
+	Use:   "unset <key>",
+	Short: "Clear a workspace setting, restoring the default behaviour",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runWorkspaceSettingsUnset,
+}
+
 func init() {
 	workspaceCmd.AddCommand(workspaceListCmd)
 	workspaceCmd.AddCommand(workspaceGetCmd)
 	workspaceCmd.AddCommand(workspaceMembersCmd)
 	workspaceCmd.AddCommand(workspaceUpdateCmd)
+	workspaceCmd.AddCommand(workspaceSettingsCmd)
+	workspaceSettingsCmd.AddCommand(workspaceSettingsSetCmd)
+	workspaceSettingsCmd.AddCommand(workspaceSettingsUnsetCmd)
 
 	workspaceGetCmd.Flags().String("output", "json", "Output format: table or json")
 	workspaceMembersCmd.Flags().String("output", "table", "Output format: table or json")
@@ -62,6 +95,9 @@ func init() {
 	workspaceUpdateCmd.Flags().Bool("context-stdin", false, "Read context from stdin (preserves multi-line content verbatim)")
 	workspaceUpdateCmd.Flags().String("issue-prefix", "", "New issue prefix (uppercased server-side)")
 	workspaceUpdateCmd.Flags().String("output", "json", "Output format: table or json")
+
+	workspaceSettingsSetCmd.Flags().String("output", "json", "Output format: table or json")
+	workspaceSettingsUnsetCmd.Flags().String("output", "json", "Output format: table or json")
 }
 
 func runWorkspaceList(cmd *cobra.Command, _ []string) error {
@@ -276,4 +312,83 @@ func runWorkspaceMembers(cmd *cobra.Command, args []string) error {
 	}
 	cli.PrintTable(os.Stdout, headers, rows)
 	return nil
+}
+
+// normalizeSettingKey converts the kebab-case keys the CLI accepts (e.g.
+// "default-unassigned-to") into the snake_case keys the server stores.
+// Doing the swap in one place keeps the two naming conventions cleanly
+// separated: kebab in the CLI surface, snake on the wire and in the DB.
+func normalizeSettingKey(key string) string {
+	return strings.ReplaceAll(strings.TrimSpace(key), "-", "_")
+}
+
+func runWorkspaceSettingsSet(cmd *cobra.Command, args []string) error {
+	wsID := resolveWorkspaceID(cmd)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: pass --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+	key := normalizeSettingKey(args[0])
+	if key == "" {
+		return fmt.Errorf("setting key is required")
+	}
+	value := args[1]
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	body := map[string]any{
+		"key":   key,
+		"value": value,
+	}
+	var ws map[string]any
+	if err := client.PatchJSON(ctx, "/api/workspaces/"+wsID+"/settings", body, &ws); err != nil {
+		return fmt.Errorf("update workspace setting: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		fmt.Fprintf(os.Stdout, "Setting %s updated for workspace %s\n", key, wsID)
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, ws)
+}
+
+func runWorkspaceSettingsUnset(cmd *cobra.Command, args []string) error {
+	wsID := resolveWorkspaceID(cmd)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: pass --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+	key := normalizeSettingKey(args[0])
+	if key == "" {
+		return fmt.Errorf("setting key is required")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	body := map[string]any{
+		"key":   key,
+		"value": nil,
+	}
+	var ws map[string]any
+	if err := client.PatchJSON(ctx, "/api/workspaces/"+wsID+"/settings", body, &ws); err != nil {
+		return fmt.Errorf("clear workspace setting: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		fmt.Fprintf(os.Stdout, "Setting %s cleared for workspace %s\n", key, wsID)
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, ws)
 }

--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -83,6 +83,35 @@ var workspaceUpdateCmd = &cobra.Command{
 	RunE:  runWorkspaceUpdate,
 }
 
+var workspaceSettingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "Manage workspace settings (admin/owner only)",
+}
+
+var workspaceSettingsSetCmd = &cobra.Command{
+	Use:   "set <key> <value>",
+	Short: "Set a workspace setting (kebab-case key, e.g. default-unassigned-to)",
+	Long: `Set a workspace setting.
+
+Keys are accepted in kebab-case and normalized to snake_case server-side.
+Use --workspace-id or MULTICA_WORKSPACE_ID to target a workspace.
+
+Available keys:
+  default-unassigned-to    UUID of the agent to auto-assign new issues that
+                            arrive without an assignee.
+
+Example:
+  multica workspace settings set default-unassigned-to 5c6c59b8-3d1a-4ec1-a1f0-9547934cf440`,
+	Args: cobra.ExactArgs(2),
+	RunE: runWorkspaceSettingsSet,
+}
+
+var workspaceSettingsUnsetCmd = &cobra.Command{
+	Use:   "unset <key>",
+	Short: "Clear a workspace setting, restoring the default behaviour",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runWorkspaceSettingsUnset,
+}
 var workspaceSwitchCmd = &cobra.Command{
 	Use:   "switch <workspace-id|slug|prefix>",
 	Short: "Set the default workspace for this profile",
@@ -164,6 +193,10 @@ func init() {
 	workspaceMemberCmd.AddCommand(workspaceMemberListCmd)
 	workspaceMemberCmd.AddCommand(workspaceMemberInviteCmd)
 	workspaceCmd.AddCommand(workspaceUpdateCmd)
+	workspaceCmd.AddCommand(workspaceSettingsCmd)
+	workspaceSettingsCmd.AddCommand(workspaceSettingsSetCmd)
+	workspaceSettingsCmd.AddCommand(workspaceSettingsUnsetCmd)
+
 	workspaceCmd.AddCommand(workspaceSwitchCmd)
 	workspaceCmd.AddCommand(workspaceMcpCmd)
 	workspaceMcpCmd.AddCommand(workspaceMcpListCmd)
@@ -194,6 +227,8 @@ func init() {
 	workspaceUpdateCmd.Flags().String("issue-prefix", "", "New issue prefix (uppercased server-side)")
 	workspaceUpdateCmd.Flags().String("output", "json", "Output format: table or json")
 
+	workspaceSettingsSetCmd.Flags().String("output", "json", "Output format: table or json")
+	workspaceSettingsUnsetCmd.Flags().String("output", "json", "Output format: table or json")
 	workspaceMcpListCmd.Flags().String("output", "json", "Output format: table or json")
 	// Same three mutually-exclusive secret-safe channels as `agent update`,
 	// resolved by the shared resolveMcpJSONObject so every surface agrees on
@@ -824,6 +859,84 @@ func runWorkspaceMembers(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// normalizeSettingKey converts the kebab-case keys the CLI accepts (e.g.
+// "default-unassigned-to") into the snake_case keys the server stores.
+// Doing the swap in one place keeps the two naming conventions cleanly
+// separated: kebab in the CLI surface, snake on the wire and in the DB.
+func normalizeSettingKey(key string) string {
+	return strings.ReplaceAll(strings.TrimSpace(key), "-", "_")
+}
+
+func runWorkspaceSettingsSet(cmd *cobra.Command, args []string) error {
+	wsID := resolveWorkspaceID(cmd)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: pass --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+	key := normalizeSettingKey(args[0])
+	if key == "" {
+		return fmt.Errorf("setting key is required")
+	}
+	value := args[1]
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	body := map[string]any{
+		"key":   key,
+		"value": value,
+	}
+	var ws map[string]any
+	if err := client.PatchJSON(ctx, "/api/workspaces/"+wsID+"/settings", body, &ws); err != nil {
+		return fmt.Errorf("update workspace setting: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		fmt.Fprintf(os.Stdout, "Setting %s updated for workspace %s\n", key, wsID)
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, ws)
+}
+
+func runWorkspaceSettingsUnset(cmd *cobra.Command, args []string) error {
+	wsID := resolveWorkspaceID(cmd)
+	if wsID == "" {
+		return fmt.Errorf("workspace ID is required: pass --workspace-id or set MULTICA_WORKSPACE_ID")
+	}
+	key := normalizeSettingKey(args[0])
+	if key == "" {
+		return fmt.Errorf("setting key is required")
+	}
+
+	client, err := newAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := cli.APIContext(context.Background())
+	defer cancel()
+
+	body := map[string]any{
+		"key":   key,
+		"value": nil,
+	}
+	var ws map[string]any
+	if err := client.PatchJSON(ctx, "/api/workspaces/"+wsID+"/settings", body, &ws); err != nil {
+		return fmt.Errorf("clear workspace setting: %w", err)
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	if output == "table" {
+		fmt.Fprintf(os.Stdout, "Setting %s cleared for workspace %s\n", key, wsID)
+		return nil
+	}
+	return cli.PrintJSON(os.Stdout, ws)
+}
 func runWorkspaceMemberInvite(cmd *cobra.Command, args []string) error {
 	email := strings.ToLower(strings.TrimSpace(args[0]))
 	if email == "" {

--- a/server/cmd/multica/cmd_workspace_test.go
+++ b/server/cmd/multica/cmd_workspace_test.go
@@ -152,3 +152,19 @@ func TestBuildWorkspaceUpdateBody(t *testing.T) {
 		}
 	})
 }
+
+// TestNormalizeSettingKey pins the kebab-on-CLI / snake-on-wire boundary so
+// the two naming conventions stay confined to their own layer.
+func TestNormalizeSettingKey(t *testing.T) {
+	cases := map[string]string{
+		"default-unassigned-to":   "default_unassigned_to",
+		"default_unassigned_to":   "default_unassigned_to",
+		"  default-unassigned-to": "default_unassigned_to",
+		"":                        "",
+	}
+	for in, want := range cases {
+		if got := normalizeSettingKey(in); got != want {
+			t.Errorf("normalizeSettingKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/server/cmd/multica/cmd_workspace_test.go
+++ b/server/cmd/multica/cmd_workspace_test.go
@@ -678,6 +678,21 @@ func TestBuildWorkspaceUpdateBody(t *testing.T) {
 	})
 }
 
+// TestNormalizeSettingKey pins the kebab-on-CLI / snake-on-wire boundary so
+// the two naming conventions stay confined to their own layer.
+func TestNormalizeSettingKey(t *testing.T) {
+	cases := map[string]string{
+		"default-unassigned-to":   "default_unassigned_to",
+		"default_unassigned_to":   "default_unassigned_to",
+		"  default-unassigned-to": "default_unassigned_to",
+		"":                        "",
+	}
+	for in, want := range cases {
+		if got := normalizeSettingKey(in); got != want {
+			t.Errorf("normalizeSettingKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
 func newWorkspaceMemberInviteTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "invite"}
 	cmd.Flags().String("server-url", "", "")

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -288,6 +288,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Use(middleware.RequireWorkspaceRoleFromURL(queries, "id", "owner", "admin"))
 					r.Put("/", h.UpdateWorkspace)
 					r.Patch("/", h.UpdateWorkspace)
+					r.Patch("/settings", h.UpdateWorkspaceSetting)
 					r.Post("/members", h.CreateInvitation)
 					r.Route("/members/{memberId}", func(r chi.Router) {
 						r.Patch("/", h.UpdateMember)

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1176,6 +1176,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Use(middleware.RequireWorkspaceRoleFromURL(queries, "id", "owner", "admin"))
 					r.Put("/", h.UpdateWorkspace)
 					r.Patch("/", h.UpdateWorkspace)
+					r.Patch("/settings", h.UpdateWorkspaceSetting)
 					r.Post("/members", h.CreateInvitation)
 					r.Route("/members/{memberId}", func(r chi.Router) {
 						r.Patch("/", h.UpdateMember)

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -1588,6 +1588,18 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		assigneeID = id
 	}
 
+	// When the request carries no assignee, fall back to the workspace's
+	// default_unassigned_to setting if configured. The helper soft-fails on
+	// stale config (missing / archived / private agent), so an admin's
+	// misconfiguration cannot block issue creation — the issue lands as
+	// unassigned, matching the legacy behaviour.
+	if !assigneeType.Valid && !assigneeID.Valid {
+		if t, id, ok := h.defaultAssigneeForUnassignedIssue(r.Context(), r, wsUUID, workspaceID); ok {
+			assigneeType = t
+			assigneeID = id
+		}
+	}
+
 	if status, msg := h.validateAssigneePair(r.Context(), r, workspaceID, assigneeType, assigneeID); status != 0 {
 		writeError(w, status, msg)
 		return

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -2495,6 +2495,18 @@ func (h *Handler) CreateIssue(w http.ResponseWriter, r *http.Request) {
 		assigneeID = id
 	}
 
+	// When the request carries no assignee, fall back to the workspace's
+	// default_unassigned_to setting if configured. The helper soft-fails on
+	// stale config (missing / archived / private agent), so an admin's
+	// misconfiguration cannot block issue creation — the issue lands as
+	// unassigned, matching the legacy behaviour.
+	if !assigneeType.Valid && !assigneeID.Valid {
+		if t, id, ok := h.defaultAssigneeForUnassignedIssue(r.Context(), r, wsUUID, workspaceID); ok {
+			assigneeType = t
+			assigneeID = id
+		}
+	}
+
 	if status, msg := h.validateAssigneePair(r.Context(), r, workspaceID, assigneeType, assigneeID); status != 0 {
 		writeError(w, status, msg)
 		return

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -290,6 +292,174 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	h.publish(protocol.EventWorkspaceUpdated, uuidToString(ws.ID), "member", userID, map[string]any{"workspace": workspaceToResponse(ws)})
 
 	writeJSON(w, http.StatusOK, workspaceToResponse(ws))
+}
+
+// SettingKeyDefaultUnassignedTo is the workspace setting that controls which
+// agent receives newly created issues that arrive without an assignee. The
+// stored value is the agent's UUID as a JSON string. Absence (or null) keeps
+// the legacy behaviour of leaving the issue unassigned.
+const SettingKeyDefaultUnassignedTo = "default_unassigned_to"
+
+// settingsKeyAllowlist is the set of workspace.settings keys writable through
+// the dedicated PATCH endpoint. Any other key is rejected so a typo or a
+// rogue caller cannot mint arbitrary settings; this also lets the read-side
+// auto-fill logic in CreateIssue assume each known key has been validated.
+var settingsKeyAllowlist = map[string]struct{}{
+	SettingKeyDefaultUnassignedTo: {},
+}
+
+type UpdateWorkspaceSettingRequest struct {
+	Key   string `json:"key"`
+	// Value is the new value for the setting. JSON null deletes the key,
+	// restoring the unset default. Anything else is validated per-key
+	// before being merged in.
+	Value json.RawMessage `json:"value"`
+}
+
+// UpdateWorkspaceSetting writes a single key into workspace.settings using
+// an atomic server-side jsonb merge. Strict write validation is intentional:
+// a stale value (archived/private/missing agent) becomes invisible noise on
+// the read side (CreateIssue logs and falls back to unassigned to avoid
+// blocking issue creation), so admin mistakes must be caught here, at the
+// moment they are made.
+func (h *Handler) UpdateWorkspaceSetting(w http.ResponseWriter, r *http.Request) {
+	id := workspaceIDFromURL(r, "id")
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "workspace id")
+	if !ok {
+		return
+	}
+
+	var req UpdateWorkspaceSettingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	key := strings.TrimSpace(req.Key)
+	if key == "" {
+		writeError(w, http.StatusBadRequest, "key is required")
+		return
+	}
+	if _, allowed := settingsKeyAllowlist[key]; !allowed {
+		writeError(w, http.StatusBadRequest, "unknown setting key: "+key)
+		return
+	}
+
+	// Treat absent / explicit null as a delete. json.RawMessage is nil for an
+	// omitted field and exactly the four bytes of "null" for an explicit one.
+	deleteSetting := len(req.Value) == 0 || string(req.Value) == "null"
+
+	if !deleteSetting {
+		if status, msg := h.validateSettingValue(r.Context(), r, id, key, req.Value); status != 0 {
+			writeError(w, status, msg)
+			return
+		}
+	}
+
+	var ws db.Workspace
+	var err error
+	if deleteSetting {
+		ws, err = h.Queries.DeleteWorkspaceSetting(r.Context(), db.DeleteWorkspaceSettingParams{
+			ID:  idUUID,
+			Key: key,
+		})
+	} else {
+		ws, err = h.Queries.MergeWorkspaceSetting(r.Context(), db.MergeWorkspaceSettingParams{
+			ID:    idUUID,
+			Key:   key,
+			Value: []byte(req.Value),
+		})
+	}
+	if err != nil {
+		slog.Warn("update workspace setting failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", id, "key", key)...)
+		writeError(w, http.StatusInternalServerError, "failed to update workspace setting")
+		return
+	}
+
+	slog.Info("workspace setting updated", append(logger.RequestAttrs(r), "workspace_id", id, "key", key, "deleted", deleteSetting)...)
+	userID := requestUserID(r)
+	h.publish(protocol.EventWorkspaceUpdated, uuidToString(ws.ID), "member", userID, map[string]any{"workspace": workspaceToResponse(ws)})
+
+	writeJSON(w, http.StatusOK, workspaceToResponse(ws))
+}
+
+// validateSettingValue runs per-key write validation. Returning a non-zero
+// status code signals rejection; the caller surfaces the message verbatim.
+// Keep validation here (not in the SQL layer) so we can reuse handler-side
+// helpers like canAccessPrivateAgent that depend on the request actor.
+func (h *Handler) validateSettingValue(ctx context.Context, r *http.Request, workspaceID, key string, raw json.RawMessage) (int, string) {
+	switch key {
+	case SettingKeyDefaultUnassignedTo:
+		var agentID string
+		if err := json.Unmarshal(raw, &agentID); err != nil {
+			return http.StatusBadRequest, "default_unassigned_to must be a string agent id"
+		}
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			return http.StatusBadRequest, "default_unassigned_to cannot be empty; pass null to clear"
+		}
+		// Reuse validateAssigneePair so the write-side rules match the
+		// runtime rules CreateIssue applies to an explicit assignee — same
+		// allow/deny set, same error vocabulary.
+		assigneeUUID, err := util.ParseUUID(agentID)
+		if err != nil {
+			return http.StatusBadRequest, "default_unassigned_to is not a valid uuid"
+		}
+		assigneeType := pgtype.Text{String: "agent", Valid: true}
+		if status, msg := h.validateAssigneePair(ctx, r, workspaceID, assigneeType, assigneeUUID); status != 0 {
+			return status, msg
+		}
+		return 0, ""
+	default:
+		// settingsKeyAllowlist guards reachability — a key landing here
+		// without a case is a wiring bug, not user input.
+		return http.StatusInternalServerError, "no validator registered for setting key"
+	}
+}
+
+// defaultAssigneeForUnassignedIssue resolves the workspace's
+// default_unassigned_to setting into a validated (type, id) pair, suitable
+// for substituting into CreateIssue when the request itself carries no
+// assignee. Stale configuration (missing / archived / private agent) is
+// logged and treated as "no default" — the read path must never block
+// issue creation on an admin's misconfiguration.
+//
+// Returns ok=false when no default is configured, when the configured
+// agent is no longer eligible, or on any underlying lookup error.
+func (h *Handler) defaultAssigneeForUnassignedIssue(ctx context.Context, r *http.Request, wsUUID pgtype.UUID, workspaceID string) (pgtype.Text, pgtype.UUID, bool) {
+	ws, err := h.Queries.GetWorkspace(ctx, wsUUID)
+	if err != nil {
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	var settings map[string]any
+	if len(ws.Settings) > 0 {
+		if err := json.Unmarshal(ws.Settings, &settings); err != nil {
+			return pgtype.Text{}, pgtype.UUID{}, false
+		}
+	}
+	raw, found := settings[SettingKeyDefaultUnassignedTo]
+	if !found || raw == nil {
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	agentIDStr, isString := raw.(string)
+	if !isString || strings.TrimSpace(agentIDStr) == "" {
+		slog.Warn("default_unassigned_to is not a valid string; skipping",
+			append(logger.RequestAttrs(r), "workspace_id", workspaceID, "raw", raw)...)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	assigneeUUID, err := util.ParseUUID(strings.TrimSpace(agentIDStr))
+	if err != nil {
+		slog.Warn("default_unassigned_to is not a valid uuid; skipping",
+			append(logger.RequestAttrs(r), "workspace_id", workspaceID, "value", agentIDStr, "error", err)...)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	assigneeType := pgtype.Text{String: "agent", Valid: true}
+	if status, msg := h.validateAssigneePair(ctx, r, workspaceID, assigneeType, assigneeUUID); status != 0 {
+		slog.Warn("default_unassigned_to agent is not eligible; falling back to unassigned",
+			append(logger.RequestAttrs(r), "workspace_id", workspaceID, "agent_id", agentIDStr, "status", status, "reason", msg)...)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	return assigneeType, assigneeUUID, true
 }
 
 func (h *Handler) ListMembers(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/workspace.go
+++ b/server/internal/handler/workspace.go
@@ -17,6 +17,7 @@ import (
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/logger"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/protocol"
 )
@@ -448,6 +449,174 @@ func (h *Handler) UpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, h.workspaceToResponse(ws))
+}
+
+// SettingKeyDefaultUnassignedTo is the workspace setting that controls which
+// agent receives newly created issues that arrive without an assignee. The
+// stored value is the agent's UUID as a JSON string. Absence (or null) keeps
+// the legacy behaviour of leaving the issue unassigned.
+const SettingKeyDefaultUnassignedTo = "default_unassigned_to"
+
+// settingsKeyAllowlist is the set of workspace.settings keys writable through
+// the dedicated PATCH endpoint. Any other key is rejected so a typo or a
+// rogue caller cannot mint arbitrary settings; this also lets the read-side
+// auto-fill logic in CreateIssue assume each known key has been validated.
+var settingsKeyAllowlist = map[string]struct{}{
+	SettingKeyDefaultUnassignedTo: {},
+}
+
+type UpdateWorkspaceSettingRequest struct {
+	Key string `json:"key"`
+	// Value is the new value for the setting. JSON null deletes the key,
+	// restoring the unset default. Anything else is validated per-key
+	// before being merged in.
+	Value json.RawMessage `json:"value"`
+}
+
+// UpdateWorkspaceSetting writes a single key into workspace.settings using
+// an atomic server-side jsonb merge. Strict write validation is intentional:
+// a stale value (archived/private/missing agent) becomes invisible noise on
+// the read side (CreateIssue logs and falls back to unassigned to avoid
+// blocking issue creation), so admin mistakes must be caught here, at the
+// moment they are made.
+func (h *Handler) UpdateWorkspaceSetting(w http.ResponseWriter, r *http.Request) {
+	id := workspaceIDFromURL(r, "id")
+	idUUID, ok := parseUUIDOrBadRequest(w, id, "workspace id")
+	if !ok {
+		return
+	}
+
+	var req UpdateWorkspaceSettingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	key := strings.TrimSpace(req.Key)
+	if key == "" {
+		writeError(w, http.StatusBadRequest, "key is required")
+		return
+	}
+	if _, allowed := settingsKeyAllowlist[key]; !allowed {
+		writeError(w, http.StatusBadRequest, "unknown setting key: "+key)
+		return
+	}
+
+	// Treat absent / explicit null as a delete. json.RawMessage is nil for an
+	// omitted field and exactly the four bytes of "null" for an explicit one.
+	deleteSetting := len(req.Value) == 0 || string(req.Value) == "null"
+
+	if !deleteSetting {
+		if status, msg := h.validateSettingValue(r.Context(), r, id, key, req.Value); status != 0 {
+			writeError(w, status, msg)
+			return
+		}
+	}
+
+	var ws db.Workspace
+	var err error
+	if deleteSetting {
+		ws, err = h.Queries.DeleteWorkspaceSetting(r.Context(), db.DeleteWorkspaceSettingParams{
+			ID:  idUUID,
+			Key: key,
+		})
+	} else {
+		ws, err = h.Queries.MergeWorkspaceSetting(r.Context(), db.MergeWorkspaceSettingParams{
+			ID:    idUUID,
+			Key:   key,
+			Value: []byte(req.Value),
+		})
+	}
+	if err != nil {
+		slog.Warn("update workspace setting failed", append(logger.RequestAttrs(r), "error", err, "workspace_id", id, "key", key)...)
+		writeError(w, http.StatusInternalServerError, "failed to update workspace setting")
+		return
+	}
+
+	slog.Info("workspace setting updated", append(logger.RequestAttrs(r), "workspace_id", id, "key", key, "deleted", deleteSetting)...)
+	userID := requestUserID(r)
+	h.publish(protocol.EventWorkspaceUpdated, uuidToString(ws.ID), "member", userID, map[string]any{"workspace": h.workspaceToResponse(ws)})
+
+	writeJSON(w, http.StatusOK, h.workspaceToResponse(ws))
+}
+
+// validateSettingValue runs per-key write validation. Returning a non-zero
+// status code signals rejection; the caller surfaces the message verbatim.
+// Keep validation here (not in the SQL layer) so we can reuse handler-side
+// helpers like canAccessPrivateAgent that depend on the request actor.
+func (h *Handler) validateSettingValue(ctx context.Context, r *http.Request, workspaceID, key string, raw json.RawMessage) (int, string) {
+	switch key {
+	case SettingKeyDefaultUnassignedTo:
+		var agentID string
+		if err := json.Unmarshal(raw, &agentID); err != nil {
+			return http.StatusBadRequest, "default_unassigned_to must be a string agent id"
+		}
+		agentID = strings.TrimSpace(agentID)
+		if agentID == "" {
+			return http.StatusBadRequest, "default_unassigned_to cannot be empty; pass null to clear"
+		}
+		// Reuse validateAssigneePair so the write-side rules match the
+		// runtime rules CreateIssue applies to an explicit assignee — same
+		// allow/deny set, same error vocabulary.
+		assigneeUUID, err := util.ParseUUID(agentID)
+		if err != nil {
+			return http.StatusBadRequest, "default_unassigned_to is not a valid uuid"
+		}
+		assigneeType := pgtype.Text{String: "agent", Valid: true}
+		if status, msg := h.validateAssigneePair(ctx, r, workspaceID, assigneeType, assigneeUUID); status != 0 {
+			return status, msg
+		}
+		return 0, ""
+	default:
+		// settingsKeyAllowlist guards reachability — a key landing here
+		// without a case is a wiring bug, not user input.
+		return http.StatusInternalServerError, "no validator registered for setting key"
+	}
+}
+
+// defaultAssigneeForUnassignedIssue resolves the workspace's
+// default_unassigned_to setting into a validated (type, id) pair, suitable
+// for substituting into CreateIssue when the request itself carries no
+// assignee. Stale configuration (missing / archived / private agent) is
+// logged and treated as "no default" — the read path must never block
+// issue creation on an admin's misconfiguration.
+//
+// Returns ok=false when no default is configured, when the configured
+// agent is no longer eligible, or on any underlying lookup error.
+func (h *Handler) defaultAssigneeForUnassignedIssue(ctx context.Context, r *http.Request, wsUUID pgtype.UUID, workspaceID string) (pgtype.Text, pgtype.UUID, bool) {
+	ws, err := h.Queries.GetWorkspace(ctx, wsUUID)
+	if err != nil {
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	var settings map[string]any
+	if len(ws.Settings) > 0 {
+		if err := json.Unmarshal(ws.Settings, &settings); err != nil {
+			return pgtype.Text{}, pgtype.UUID{}, false
+		}
+	}
+	raw, found := settings[SettingKeyDefaultUnassignedTo]
+	if !found || raw == nil {
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	agentIDStr, isString := raw.(string)
+	if !isString || strings.TrimSpace(agentIDStr) == "" {
+		slog.Warn("default_unassigned_to is not a valid string; skipping",
+			append(logger.RequestAttrs(r), "workspace_id", workspaceID, "raw", raw)...)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	assigneeUUID, err := util.ParseUUID(strings.TrimSpace(agentIDStr))
+	if err != nil {
+		slog.Warn("default_unassigned_to is not a valid uuid; skipping",
+			append(logger.RequestAttrs(r), "workspace_id", workspaceID, "value", agentIDStr, "error", err)...)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	assigneeType := pgtype.Text{String: "agent", Valid: true}
+	if status, msg := h.validateAssigneePair(ctx, r, workspaceID, assigneeType, assigneeUUID); status != 0 {
+		slog.Warn("default_unassigned_to agent is not eligible; falling back to unassigned",
+			append(logger.RequestAttrs(r), "workspace_id", workspaceID, "agent_id", agentIDStr, "status", status, "reason", msg)...)
+		return pgtype.Text{}, pgtype.UUID{}, false
+	}
+	return assigneeType, assigneeUUID, true
 }
 
 func (h *Handler) ListMembers(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -469,5 +470,350 @@ INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'admin') RETURN
 	}
 	if memberExists {
 		t.Fatal("member row was not deleted")
+	}
+}
+
+// handlerTestAgentID returns the agent created by the shared fixture in
+// setupHandlerTestFixture (handler_test.go). Tests that need an agent ID
+// without creating their own should reach for this — duplicate fixtures
+// have caused races against the shared workspace before.
+func handlerTestAgentID(t *testing.T) string {
+	t.Helper()
+	var agentID string
+	err := testPool.QueryRow(context.Background(),
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+	return agentID
+}
+
+// resetWorkspaceSettings empties the test workspace's settings JSONB so a
+// test can start from a known state. The default-unassigned-to feature is
+// stateful per workspace, so leakage between tests would mask bugs.
+func resetWorkspaceSettings(t *testing.T) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE workspace SET settings = '{}'::jsonb WHERE id = $1`,
+		testWorkspaceID,
+	); err != nil {
+		t.Fatalf("reset workspace settings: %v", err)
+	}
+}
+
+func TestUpdateWorkspaceSetting_RejectsUnknownKey(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "totally_made_up",
+		"value": "x",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown key, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateWorkspaceSetting_RejectsInvalidAgentUUID(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": "not-a-uuid",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed uuid, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateWorkspaceSetting_RejectsNonexistentAgent(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": "00000000-0000-0000-0000-000000000000",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing agent, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateWorkspaceSetting_PersistsAndClearsAgent(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+	agentID := handlerTestAgentID(t)
+
+	// Set the value.
+	wSet := httptest.NewRecorder()
+	reqSet := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": agentID,
+	})
+	reqSet = withURLParam(reqSet, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(wSet, reqSet)
+	if wSet.Code != http.StatusOK {
+		t.Fatalf("PATCH settings: expected 200, got %d: %s", wSet.Code, wSet.Body.String())
+	}
+
+	// Verify persisted in DB.
+	var raw []byte
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT settings FROM workspace WHERE id = $1`,
+		testWorkspaceID,
+	).Scan(&raw); err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var stored map[string]any
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal settings: %v", err)
+	}
+	if stored["default_unassigned_to"] != agentID {
+		t.Fatalf("expected default_unassigned_to=%q, got %v", agentID, stored)
+	}
+
+	// Clear with explicit null.
+	wClear := httptest.NewRecorder()
+	reqClear := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": nil,
+	})
+	reqClear = withURLParam(reqClear, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(wClear, reqClear)
+	if wClear.Code != http.StatusOK {
+		t.Fatalf("PATCH settings (clear): expected 200, got %d: %s", wClear.Code, wClear.Body.String())
+	}
+
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT settings FROM workspace WHERE id = $1`,
+		testWorkspaceID,
+	).Scan(&raw); err != nil {
+		t.Fatalf("read settings post-clear: %v", err)
+	}
+	var stored2 map[string]any
+	if err := json.Unmarshal(raw, &stored2); err != nil {
+		t.Fatalf("unmarshal settings post-clear: %v", err)
+	}
+	if _, exists := stored2["default_unassigned_to"]; exists {
+		t.Fatalf("expected key removed, still present: %v", stored2)
+	}
+}
+
+func TestUpdateWorkspaceSetting_RejectsArchivedAgent(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	// Spin up a dedicated archived agent so we don't poison the shared
+	// fixture's "Handler Test Agent" used by every other test.
+	var archivedAgentID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO agent (workspace_id, name, description, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id, archived_at)
+VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4, now())
+RETURNING id
+`, testWorkspaceID, "Handler Archived Default Assignee", testRuntimeID, testUserID).Scan(&archivedAgentID); err != nil {
+		t.Fatalf("create archived agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, archivedAgentID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": archivedAgentID,
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for archived agent, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateIssue_DefaultAssigneeAppliedWhenMissing covers acceptance #3:
+// when the workspace setting is configured and the request itself omits an
+// assignee, the issue is created with assignee = configured agent.
+func TestCreateIssue_DefaultAssigneeAppliedWhenMissing(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+	agentID := handlerTestAgentID(t)
+
+	if _, err := testPool.Exec(ctx,
+		`UPDATE workspace SET settings = jsonb_build_object('default_unassigned_to', $2::text) WHERE id = $1`,
+		testWorkspaceID, agentID,
+	); err != nil {
+		t.Fatalf("seed default_unassigned_to: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Default-assignee feature: no assignee in request",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+	})
+
+	if created.AssigneeType == nil || *created.AssigneeType != "agent" {
+		t.Fatalf("expected assignee_type=agent, got %v", created.AssigneeType)
+	}
+	if created.AssigneeID == nil || *created.AssigneeID != agentID {
+		t.Fatalf("expected assignee_id=%s, got %v", agentID, created.AssigneeID)
+	}
+}
+
+// TestCreateIssue_ExplicitAssigneeBeatsDefault covers the contract that an
+// explicit assignee in the request must always win. Without this guard, the
+// auto-fill could silently rewrite a member assignment to an agent.
+func TestCreateIssue_ExplicitAssigneeBeatsDefault(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+	agentID := handlerTestAgentID(t)
+
+	if _, err := testPool.Exec(ctx,
+		`UPDATE workspace SET settings = jsonb_build_object('default_unassigned_to', $2::text) WHERE id = $1`,
+		testWorkspaceID, agentID,
+	); err != nil {
+		t.Fatalf("seed default_unassigned_to: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "Default-assignee feature: explicit assignee wins",
+		"assignee_type": "member",
+		"assignee_id":   testUserID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+	})
+
+	if created.AssigneeType == nil || *created.AssigneeType != "member" {
+		t.Fatalf("expected assignee_type=member, got %v", created.AssigneeType)
+	}
+	if created.AssigneeID == nil || *created.AssigneeID != testUserID {
+		t.Fatalf("expected assignee_id=%s, got %v", testUserID, created.AssigneeID)
+	}
+}
+
+// TestCreateIssue_StaleDefaultAssigneeFallsBackUnassigned covers the soft
+// fallback property: if the configured agent is archived (or otherwise
+// invisible) by the time an issue is created, the issue is created
+// unassigned rather than 4xx-failing the caller. Acceptance #5.
+func TestCreateIssue_StaleDefaultAssigneeFallsBackUnassigned(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	// Create an agent that exists at config-time, then archive it before the
+	// issue create — simulating the "admin set it, agent later went away"
+	// scenario. The PATCH validator would have rejected an archived agent at
+	// write time; this test exercises only the read-path soft fallback.
+	var staleAgentID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO agent (workspace_id, name, description, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id)
+VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4)
+RETURNING id
+`, testWorkspaceID, "Handler Stale Default Assignee", testRuntimeID, testUserID).Scan(&staleAgentID); err != nil {
+		t.Fatalf("create stale agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, staleAgentID)
+	})
+
+	if _, err := testPool.Exec(ctx,
+		`UPDATE workspace SET settings = jsonb_build_object('default_unassigned_to', $2::text) WHERE id = $1`,
+		testWorkspaceID, staleAgentID,
+	); err != nil {
+		t.Fatalf("seed default_unassigned_to: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET archived_at = now() WHERE id = $1`, staleAgentID); err != nil {
+		t.Fatalf("archive agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Default-assignee feature: stale config falls back",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201 (soft fallback, not 4xx), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+	})
+
+	if created.AssigneeType != nil || created.AssigneeID != nil {
+		t.Fatalf("expected unassigned issue from stale config, got type=%v id=%v", created.AssigneeType, created.AssigneeID)
+	}
+}
+
+// TestCreateIssue_NoSettingLeavesUnassigned is the regression guard for
+// acceptance #5 ("留空时退回未指派"): the legacy unassigned path must keep
+// working when no setting is configured. Without this, an over-eager
+// auto-fill could surface a default that the user never asked for.
+func TestCreateIssue_NoSettingLeavesUnassigned(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+	resetWorkspaceSettings(t) // make doubly sure we start from {}.
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Default-assignee feature: no setting, no assignee",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+	})
+
+	if created.AssigneeType != nil || created.AssigneeID != nil {
+		t.Fatalf("expected unassigned, got type=%v id=%v", created.AssigneeType, created.AssigneeID)
 	}
 }

--- a/server/internal/handler/workspace_test.go
+++ b/server/internal/handler/workspace_test.go
@@ -1366,6 +1366,351 @@ INSERT INTO member (workspace_id, user_id, role) VALUES ($1, $2, 'admin') RETURN
 	}
 }
 
+// handlerTestAgentID returns the agent created by the shared fixture in
+// setupHandlerTestFixture (handler_test.go). Tests that need an agent ID
+// without creating their own should reach for this — duplicate fixtures
+// have caused races against the shared workspace before.
+func handlerTestAgentID(t *testing.T) string {
+	t.Helper()
+	var agentID string
+	err := testPool.QueryRow(context.Background(),
+		`SELECT id FROM agent WHERE workspace_id = $1 AND name = $2`,
+		testWorkspaceID, "Handler Test Agent",
+	).Scan(&agentID)
+	if err != nil {
+		t.Fatalf("failed to find test agent: %v", err)
+	}
+	return agentID
+}
+
+// resetWorkspaceSettings empties the test workspace's settings JSONB so a
+// test can start from a known state. The default-unassigned-to feature is
+// stateful per workspace, so leakage between tests would mask bugs.
+func resetWorkspaceSettings(t *testing.T) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(),
+		`UPDATE workspace SET settings = '{}'::jsonb WHERE id = $1`,
+		testWorkspaceID,
+	); err != nil {
+		t.Fatalf("reset workspace settings: %v", err)
+	}
+}
+
+func TestUpdateWorkspaceSetting_RejectsUnknownKey(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "totally_made_up",
+		"value": "x",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown key, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateWorkspaceSetting_RejectsInvalidAgentUUID(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": "not-a-uuid",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed uuid, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateWorkspaceSetting_RejectsNonexistentAgent(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": "00000000-0000-0000-0000-000000000000",
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing agent, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateWorkspaceSetting_PersistsAndClearsAgent(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+	agentID := handlerTestAgentID(t)
+
+	// Set the value.
+	wSet := httptest.NewRecorder()
+	reqSet := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": agentID,
+	})
+	reqSet = withURLParam(reqSet, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(wSet, reqSet)
+	if wSet.Code != http.StatusOK {
+		t.Fatalf("PATCH settings: expected 200, got %d: %s", wSet.Code, wSet.Body.String())
+	}
+
+	// Verify persisted in DB.
+	var raw []byte
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT settings FROM workspace WHERE id = $1`,
+		testWorkspaceID,
+	).Scan(&raw); err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var stored map[string]any
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal settings: %v", err)
+	}
+	if stored["default_unassigned_to"] != agentID {
+		t.Fatalf("expected default_unassigned_to=%q, got %v", agentID, stored)
+	}
+
+	// Clear with explicit null.
+	wClear := httptest.NewRecorder()
+	reqClear := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": nil,
+	})
+	reqClear = withURLParam(reqClear, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(wClear, reqClear)
+	if wClear.Code != http.StatusOK {
+		t.Fatalf("PATCH settings (clear): expected 200, got %d: %s", wClear.Code, wClear.Body.String())
+	}
+
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT settings FROM workspace WHERE id = $1`,
+		testWorkspaceID,
+	).Scan(&raw); err != nil {
+		t.Fatalf("read settings post-clear: %v", err)
+	}
+	var stored2 map[string]any
+	if err := json.Unmarshal(raw, &stored2); err != nil {
+		t.Fatalf("unmarshal settings post-clear: %v", err)
+	}
+	if _, exists := stored2["default_unassigned_to"]; exists {
+		t.Fatalf("expected key removed, still present: %v", stored2)
+	}
+}
+
+func TestUpdateWorkspaceSetting_RejectsArchivedAgent(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	// Spin up a dedicated archived agent so we don't poison the shared
+	// fixture's "Handler Test Agent" used by every other test.
+	var archivedAgentID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO agent (workspace_id, name, description, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id, archived_at)
+VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4, now())
+RETURNING id
+`, testWorkspaceID, "Handler Archived Default Assignee", testRuntimeID, testUserID).Scan(&archivedAgentID); err != nil {
+		t.Fatalf("create archived agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, archivedAgentID)
+	})
+
+	w := httptest.NewRecorder()
+	req := newRequest("PATCH", "/api/workspaces/"+testWorkspaceID+"/settings", map[string]any{
+		"key":   "default_unassigned_to",
+		"value": archivedAgentID,
+	})
+	req = withURLParam(req, "id", testWorkspaceID)
+	testHandler.UpdateWorkspaceSetting(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for archived agent, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestCreateIssue_DefaultAssigneeAppliedWhenMissing covers acceptance #3:
+// when the workspace setting is configured and the request itself omits an
+// assignee, the issue is created with assignee = configured agent.
+func TestCreateIssue_DefaultAssigneeAppliedWhenMissing(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+	agentID := handlerTestAgentID(t)
+
+	if _, err := testPool.Exec(ctx,
+		`UPDATE workspace SET settings = jsonb_build_object('default_unassigned_to', $2::text) WHERE id = $1`,
+		testWorkspaceID, agentID,
+	); err != nil {
+		t.Fatalf("seed default_unassigned_to: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Default-assignee feature: no assignee in request",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+	})
+
+	if created.AssigneeType == nil || *created.AssigneeType != "agent" {
+		t.Fatalf("expected assignee_type=agent, got %v", created.AssigneeType)
+	}
+	if created.AssigneeID == nil || *created.AssigneeID != agentID {
+		t.Fatalf("expected assignee_id=%s, got %v", agentID, created.AssigneeID)
+	}
+}
+
+// TestCreateIssue_ExplicitAssigneeBeatsDefault covers the contract that an
+// explicit assignee in the request must always win. Without this guard, the
+// auto-fill could silently rewrite a member assignment to an agent.
+func TestCreateIssue_ExplicitAssigneeBeatsDefault(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+	agentID := handlerTestAgentID(t)
+
+	if _, err := testPool.Exec(ctx,
+		`UPDATE workspace SET settings = jsonb_build_object('default_unassigned_to', $2::text) WHERE id = $1`,
+		testWorkspaceID, agentID,
+	); err != nil {
+		t.Fatalf("seed default_unassigned_to: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title":         "Default-assignee feature: explicit assignee wins",
+		"assignee_type": "member",
+		"assignee_id":   testUserID,
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+	})
+
+	if created.AssigneeType == nil || *created.AssigneeType != "member" {
+		t.Fatalf("expected assignee_type=member, got %v", created.AssigneeType)
+	}
+	if created.AssigneeID == nil || *created.AssigneeID != testUserID {
+		t.Fatalf("expected assignee_id=%s, got %v", testUserID, created.AssigneeID)
+	}
+}
+
+// TestCreateIssue_StaleDefaultAssigneeFallsBackUnassigned covers the soft
+// fallback property: if the configured agent is archived (or otherwise
+// invisible) by the time an issue is created, the issue is created
+// unassigned rather than 4xx-failing the caller. Acceptance #5.
+func TestCreateIssue_StaleDefaultAssigneeFallsBackUnassigned(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+
+	// Create an agent that exists at config-time, then archive it before the
+	// issue create — simulating the "admin set it, agent later went away"
+	// scenario. The PATCH validator would have rejected an archived agent at
+	// write time; this test exercises only the read-path soft fallback.
+	var staleAgentID string
+	if err := testPool.QueryRow(ctx, `
+INSERT INTO agent (workspace_id, name, description, runtime_mode, runtime_config, runtime_id, visibility, max_concurrent_tasks, owner_id)
+VALUES ($1, $2, '', 'cloud', '{}'::jsonb, $3, 'workspace', 1, $4)
+RETURNING id
+`, testWorkspaceID, "Handler Stale Default Assignee", testRuntimeID, testUserID).Scan(&staleAgentID); err != nil {
+		t.Fatalf("create stale agent: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM agent WHERE id = $1`, staleAgentID)
+	})
+
+	if _, err := testPool.Exec(ctx,
+		`UPDATE workspace SET settings = jsonb_build_object('default_unassigned_to', $2::text) WHERE id = $1`,
+		testWorkspaceID, staleAgentID,
+	); err != nil {
+		t.Fatalf("seed default_unassigned_to: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `UPDATE agent SET archived_at = now() WHERE id = $1`, staleAgentID); err != nil {
+		t.Fatalf("archive agent: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Default-assignee feature: stale config falls back",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201 (soft fallback, not 4xx), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+	})
+
+	if created.AssigneeType != nil || created.AssigneeID != nil {
+		t.Fatalf("expected unassigned issue from stale config, got type=%v id=%v", created.AssigneeType, created.AssigneeID)
+	}
+}
+
+// TestCreateIssue_NoSettingLeavesUnassigned is the regression guard for
+// acceptance #5 ("留空时退回未指派"): the legacy unassigned path must keep
+// working when no setting is configured. Without this, an over-eager
+// auto-fill could surface a default that the user never asked for.
+func TestCreateIssue_NoSettingLeavesUnassigned(t *testing.T) {
+	t.Cleanup(func() { resetWorkspaceSettings(t) })
+	resetWorkspaceSettings(t) // make doubly sure we start from {}.
+
+	w := httptest.NewRecorder()
+	req := newRequest("POST", "/api/issues?workspace_id="+testWorkspaceID, map[string]any{
+		"title": "Default-assignee feature: no setting, no assignee",
+	})
+	testHandler.CreateIssue(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateIssue: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var created IssueResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupReq := newRequest("DELETE", "/api/issues/"+created.ID, nil)
+		cleanupReq = withURLParam(cleanupReq, "id", created.ID)
+		testHandler.DeleteIssue(httptest.NewRecorder(), cleanupReq)
+	})
+
+	if created.AssigneeType != nil || created.AssigneeID != nil {
+		t.Fatalf("expected unassigned, got type=%v id=%v", created.AssigneeType, created.AssigneeID)
+	}
+}
+
 // TestDefaultIssuePrefixFromSlug pins the derivation new workspaces get
 // (MUL-6050): alphanumerics of the slug, first 4, uppercased. The Chinese
 // cases are the point of the change — under the old name-based derivation

--- a/server/pkg/db/generated/workspace.sql.go
+++ b/server/pkg/db/generated/workspace.sql.go
@@ -208,3 +208,74 @@ func (q *Queries) UpdateWorkspace(ctx context.Context, arg UpdateWorkspaceParams
 	)
 	return i, err
 }
+
+const mergeWorkspaceSetting = `-- name: MergeWorkspaceSetting :one
+UPDATE workspace
+SET settings = settings || jsonb_build_object($2::text, $3::jsonb),
+    updated_at = now()
+WHERE id = $1
+RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter
+`
+
+type MergeWorkspaceSettingParams struct {
+	ID    pgtype.UUID `json:"id"`
+	Key   string      `json:"key"`
+	Value []byte      `json:"value"`
+}
+
+// MergeWorkspaceSetting upserts a single key into workspace.settings.
+// jsonb || jsonb is a server-side merge so concurrent PATCH requests for
+// different keys do not clobber each other (unlike a client-side
+// read / modify / write through UpdateWorkspace.settings).
+func (q *Queries) MergeWorkspaceSetting(ctx context.Context, arg MergeWorkspaceSettingParams) (Workspace, error) {
+	row := q.db.QueryRow(ctx, mergeWorkspaceSetting, arg.ID, arg.Key, arg.Value)
+	var i Workspace
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.Settings,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Context,
+		&i.Repos,
+		&i.IssuePrefix,
+		&i.IssueCounter,
+	)
+	return i, err
+}
+
+const deleteWorkspaceSetting = `-- name: DeleteWorkspaceSetting :one
+UPDATE workspace
+SET settings = settings - $2::text,
+    updated_at = now()
+WHERE id = $1
+RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter
+`
+
+type DeleteWorkspaceSettingParams struct {
+	ID  pgtype.UUID `json:"id"`
+	Key string      `json:"key"`
+}
+
+// DeleteWorkspaceSetting removes a single key from workspace.settings,
+// restoring the unset behaviour without touching other keys.
+func (q *Queries) DeleteWorkspaceSetting(ctx context.Context, arg DeleteWorkspaceSettingParams) (Workspace, error) {
+	row := q.db.QueryRow(ctx, deleteWorkspaceSetting, arg.ID, arg.Key)
+	var i Workspace
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.Settings,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Context,
+		&i.Repos,
+		&i.IssuePrefix,
+		&i.IssueCounter,
+	)
+	return i, err
+}

--- a/server/pkg/db/generated/workspace.sql.go
+++ b/server/pkg/db/generated/workspace.sql.go
@@ -186,6 +186,42 @@ func (q *Queries) DeleteWorkspace(ctx context.Context, id pgtype.UUID) error {
 	return err
 }
 
+const deleteWorkspaceSetting = `-- name: DeleteWorkspaceSetting :one
+UPDATE workspace
+SET settings = settings - $2::text,
+    updated_at = now()
+WHERE id = $1
+RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter, avatar_url, attribution_fail_closed
+`
+
+type DeleteWorkspaceSettingParams struct {
+	ID  pgtype.UUID `json:"id"`
+	Key string      `json:"key"`
+}
+
+// DeleteWorkspaceSetting removes a single key from workspace.settings,
+// restoring the unset behaviour without touching other keys.
+func (q *Queries) DeleteWorkspaceSetting(ctx context.Context, arg DeleteWorkspaceSettingParams) (Workspace, error) {
+	row := q.db.QueryRow(ctx, deleteWorkspaceSetting, arg.ID, arg.Key)
+	var i Workspace
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.Settings,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Context,
+		&i.Repos,
+		&i.IssuePrefix,
+		&i.IssueCounter,
+		&i.AvatarUrl,
+		&i.AttributionFailClosed,
+	)
+	return i, err
+}
+
 const getDaemonWorkspace = `-- name: GetDaemonWorkspace :one
 SELECT id, name
 FROM workspace
@@ -408,6 +444,45 @@ func (q *Queries) LockWorkspaceForDelete(ctx context.Context, id pgtype.UUID) (p
 	var id_2 pgtype.UUID
 	err := row.Scan(&id_2)
 	return id_2, err
+}
+
+const mergeWorkspaceSetting = `-- name: MergeWorkspaceSetting :one
+UPDATE workspace
+SET settings = settings || jsonb_build_object($2::text, $3::jsonb),
+    updated_at = now()
+WHERE id = $1
+RETURNING id, name, slug, description, settings, created_at, updated_at, context, repos, issue_prefix, issue_counter, avatar_url, attribution_fail_closed
+`
+
+type MergeWorkspaceSettingParams struct {
+	ID    pgtype.UUID `json:"id"`
+	Key   string      `json:"key"`
+	Value []byte      `json:"value"`
+}
+
+// MergeWorkspaceSetting upserts a single key into workspace.settings.
+// jsonb || jsonb is a server-side merge so concurrent PATCH requests for
+// different keys do not clobber each other (unlike a client-side
+// read / modify / write through UpdateWorkspace.settings).
+func (q *Queries) MergeWorkspaceSetting(ctx context.Context, arg MergeWorkspaceSettingParams) (Workspace, error) {
+	row := q.db.QueryRow(ctx, mergeWorkspaceSetting, arg.ID, arg.Key, arg.Value)
+	var i Workspace
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.Description,
+		&i.Settings,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Context,
+		&i.Repos,
+		&i.IssuePrefix,
+		&i.IssueCounter,
+		&i.AvatarUrl,
+		&i.AttributionFailClosed,
+	)
+	return i, err
 }
 
 const updateWorkspace = `-- name: UpdateWorkspace :one

--- a/server/pkg/db/queries/workspace.sql
+++ b/server/pkg/db/queries/workspace.sql
@@ -34,5 +34,25 @@ UPDATE workspace SET issue_counter = issue_counter + 1
 WHERE id = $1
 RETURNING issue_counter;
 
+-- MergeWorkspaceSetting upserts a single key into workspace.settings.
+-- jsonb || jsonb is a server-side merge so concurrent PATCH requests for
+-- different keys do not clobber each other (unlike a client-side
+-- read / modify / write through UpdateWorkspace.settings).
+-- name: MergeWorkspaceSetting :one
+UPDATE workspace
+SET settings = settings || jsonb_build_object(sqlc.arg('key')::text, sqlc.arg('value')::jsonb),
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- DeleteWorkspaceSetting removes a single key from workspace.settings,
+-- restoring the unset behaviour without touching other keys.
+-- name: DeleteWorkspaceSetting :one
+UPDATE workspace
+SET settings = settings - sqlc.arg('key')::text,
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
+
 -- name: DeleteWorkspace :exec
 DELETE FROM workspace WHERE id = $1;

--- a/server/pkg/db/queries/workspace.sql
+++ b/server/pkg/db/queries/workspace.sql
@@ -62,6 +62,25 @@ UPDATE workspace SET issue_counter = issue_counter + 1
 WHERE id = $1
 RETURNING issue_counter;
 
+-- MergeWorkspaceSetting upserts a single key into workspace.settings.
+-- jsonb || jsonb is a server-side merge so concurrent PATCH requests for
+-- different keys do not clobber each other (unlike a client-side
+-- read / modify / write through UpdateWorkspace.settings).
+-- name: MergeWorkspaceSetting :one
+UPDATE workspace
+SET settings = settings || jsonb_build_object(sqlc.arg('key')::text, sqlc.arg('value')::jsonb),
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
+
+-- DeleteWorkspaceSetting removes a single key from workspace.settings,
+-- restoring the unset behaviour without touching other keys.
+-- name: DeleteWorkspaceSetting :one
+UPDATE workspace
+SET settings = settings - sqlc.arg('key')::text,
+    updated_at = now()
+WHERE id = $1
+RETURNING *;
 -- name: LockWorkspaceForDelete :one
 -- Taken first by DeleteWorkspace, before it enumerates the workspace's chat
 -- sessions. LockChatSessionsByWorkspace only covers sessions that exist when it


### PR DESCRIPTION
Add a per-workspace setting `default_unassigned_to` that auto-assigns new issues to the configured agent when the request omits an assignee. Lets arvin (and any other workspace) route incoming issues to its Triage agent without each caller having to pass the assignee explicitly.

- queries/workspace.sql: MergeWorkspaceSetting / DeleteWorkspaceSetting, using server-side jsonb merges so concurrent PATCHes for different keys do not clobber each other.
- handler.UpdateWorkspaceSetting: PATCH /api/workspaces/{id}/settings. Strict write-side validation (the agent must exist, be visible, and not be archived) so admin misconfiguration is caught at write time. Allowlisted keys only — unknown keys 400.
- handler.CreateIssue: when the request omits an assignee, auto-fill from default_unassigned_to. The read path is intentionally tolerant — stale config (missing/archived/private agent) is logged and falls back to unassigned, so an admin's mistake never blocks issue creation.
- cmd/multica: `multica workspace settings set|unset <key> <value>`, with kebab→snake key normalization confined to the CLI layer.

Tests cover all four CreateIssue branches (default applied, explicit wins, stale falls back, no-setting regression) plus PATCH happy/sad paths against the real DB.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
