### PR TITLE
docs: install-agent-runtime page + onboarding link

### DIFF
--- a/apps/docs/content/docs/install-agent-runtime.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.mdx
@@ -1,0 +1,169 @@
+---
+title: Install an agent runtime
+description: Multica drives whichever AI coding tools you have on your machine. This page shows you how to install each of the 11 supported tools so the daemon can detect them.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+A **runtime** in Multica is the daemon on your machine paired with one AI coding tool the daemon found on your `PATH`. If the onboarding "Connect a runtime" step shows **No supported tools detected**, it means the daemon scanned `PATH` and didn't find any of the 11 tools it knows how to drive. Install one (or several) of the tools below, then come back to the step and re-scan — the runtime will show up within a few seconds.
+
+This page is the install-side companion to:
+
+- [Daemon and runtimes](/daemon-runtimes) — how detection works
+- [AI coding tools matrix](/providers) — what each tool can and can't do (session resumption, MCP, model selection)
+
+<Callout type="info">
+The Multica server never sees your API keys or the tools themselves. Everything below — installation, authentication, model access — lives on your local machine. If something fails, it's almost always a local problem.
+</Callout>
+
+## Before you start
+
+Two prerequisites apply to **every** tool below:
+
+1. **The Multica daemon must be running.** Either run `multica daemon start` after installing the [Multica CLI](/cli), or use the [Multica desktop app](/desktop-app), which launches the daemon automatically. Without a running daemon there is nothing to detect tools.
+2. **The tool's binary must be reachable on `PATH`.** The daemon shells out to each tool by name (see the **Daemon looks for** column in each section). If `which <name>` doesn't find it in your terminal, the daemon won't find it either. After installing, open a fresh terminal (or restart the daemon) so the new `PATH` entry is picked up.
+
+After installing a tool, restart the daemon:
+
+```bash
+multica daemon restart
+```
+
+Or, in the desktop app, just relaunch the app. The daemon re-scans `PATH` on every start.
+
+## The 11 supported tools
+
+Listed roughly from most to least common. Pick whichever ones you already have credentials for — you don't need all 11.
+
+### Claude Code (Anthropic)
+
+The most complete integration. Session resumption works, MCP works, and it's the **only one of the 11 that actually consumes the `mcp_config` field** on agents (see the [matrix](/providers#mcp-configuration-only-claude-code-actually-reads-it)).
+
+| | |
+|---|---|
+| Daemon looks for | `claude` |
+| Install | Follow the official guide at [claude.com/claude-code](https://www.claude.com/claude-code). The standard route is the npm package `@anthropic-ai/claude-code` (Node.js 18+ required). |
+| Authentication | Run `claude` once and follow the in-CLI login flow, or set `ANTHROPIC_API_KEY`. |
+| Notes | First-choice recommendation for new users. |
+
+### Codex (OpenAI)
+
+JSON-RPC 2.0 transport with finer-grained approval gates. **Session resumption code exists but is currently unreachable** — pick Claude Code or one of the ACP family if you need resume.
+
+| | |
+|---|---|
+| Daemon looks for | `codex` |
+| Install | Follow the official guide at [github.com/openai/codex](https://github.com/openai/codex). The standard route is the npm package `@openai/codex`. |
+| Authentication | `codex login` (browser-based) or `OPENAI_API_KEY`. |
+
+### Cursor (Anysphere)
+
+The CLI counterpart to the Cursor editor. **Session resumption is broken** — Cursor's CLI doesn't return a session id, so the value you pass on resume is always invalid.
+
+| | |
+|---|---|
+| Daemon looks for | `cursor-agent` |
+| Install | Install the [Cursor editor](https://cursor.com/) and then the CLI per their docs at [docs.cursor.com](https://docs.cursor.com/). The binary name is `cursor-agent`, not `cursor`. |
+| Authentication | Sign in through the Cursor editor; the CLI reuses that session. |
+
+### GitHub Copilot
+
+Model routing goes through your GitHub account entitlement — the tool doesn't pick a model itself; GitHub decides which model you get.
+
+| | |
+|---|---|
+| Daemon looks for | `copilot` |
+| Install | See GitHub's CLI docs at [github.com/github/copilot-cli](https://github.com/github/copilot-cli). |
+| Authentication | Browser-based GitHub login through the CLI. |
+| Notes | Requires an active GitHub Copilot subscription on the signed-in account. |
+
+### Gemini (Google)
+
+Supports the Gemini 2.5 and 3 series. No session resumption, no MCP — suitable for one-shot tasks.
+
+| | |
+|---|---|
+| Daemon looks for | `gemini` |
+| Install | Follow the official guide at [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli). The standard route is the npm package `@google/gemini-cli`. |
+| Authentication | `gemini` will prompt for a Google account login, or set `GEMINI_API_KEY`. |
+
+### OpenCode (SST)
+
+Open-source CLI agent. Dynamically discovers available models from its own configuration file — good fit for users who want to bring their own model catalog.
+
+| | |
+|---|---|
+| Daemon looks for | `opencode` |
+| Install | Follow the official guide at [opencode.ai](https://opencode.ai/) or the GitHub repo at [github.com/sst/opencode](https://github.com/sst/opencode). The typical route is the install script or the npm package. |
+| Authentication | Configure your model provider(s) per OpenCode's docs (Anthropic, OpenAI, etc.). |
+
+### Kiro CLI (Amazon)
+
+ACP-over-stdio transport. Session resumption works through ACP `session/load`; skills are copied into `.kiro/skills/`.
+
+| | |
+|---|---|
+| Daemon looks for | `kiro-cli` |
+| Install | See the Kiro docs at [kiro.dev](https://kiro.dev/). The binary name is `kiro-cli`, not `kiro`. |
+| Authentication | AWS-account-based; follow Kiro's own onboarding. |
+
+### Kimi (Moonshot)
+
+ACP-protocol agent, primarily aimed at the Chinese market. Skills live under `.kimi/skills/` (native discovery).
+
+| | |
+|---|---|
+| Daemon looks for | `kimi` |
+| Install | Follow the official guide at [github.com/MoonshotAI/kimi-cli](https://github.com/MoonshotAI/kimi-cli). |
+| Authentication | Moonshot API key, configured per the vendor's docs. |
+
+### Hermes (Nous Research)
+
+ACP-protocol agent (shares the transport with Kimi). Session resumption works. The skill injection path falls back to the generic `.agent_context/skills/` — verify your skills are loading before relying on them.
+
+| | |
+|---|---|
+| Daemon looks for | `hermes` |
+| Install | See Nous Research's repository at [github.com/NousResearch](https://github.com/NousResearch) for the latest CLI distribution. |
+| Authentication | Per the vendor's docs. |
+
+### OpenClaw
+
+Open-source CLI agent orchestrator. **Model is bound at the agent layer** (`openclaw agents add --model`) — it can't be overridden per task, and you can't pass `--model` or `--system-prompt` from Multica.
+
+| | |
+|---|---|
+| Daemon looks for | `openclaw` |
+| Install | See the project at [github.com/openclaw-org/openclaw](https://github.com/openclaw-org/openclaw) (community-maintained). |
+| Authentication | Configure the underlying model provider per OpenClaw's docs. |
+
+### Pi (Inflection AI)
+
+Minimalist. **Session resumption is unusual** — the resume id is the path to a session file on disk, not a string id.
+
+| | |
+|---|---|
+| Daemon looks for | `pi` |
+| Install | See Inflection's CLI docs at [pi.ai](https://pi.ai/). |
+| Authentication | Per the vendor's docs. |
+
+## After installing
+
+1. **Confirm the binary is on `PATH`.** Open a fresh terminal and run `which <name>` (for example `which claude`, `which cursor-agent`, `which kiro-cli`). If it prints a path, the daemon will find it. If it prints nothing, fix your shell `PATH` first (the typical cause is a per-shell rc file that wasn't reloaded).
+2. **Restart the daemon.** `multica daemon restart`, or relaunch the desktop app. The daemon only scans `PATH` at startup.
+3. **Check the Runtimes page.** In the Multica UI, the **Runtimes** page should now list one row per `(workspace × tool)` combination. If the row says "offline", see [Daemon and runtimes → When a runtime is marked offline](/daemon-runtimes#when-a-runtime-is-marked-offline).
+4. **Go back to onboarding.** The "Connect a runtime" step polls and will pick up the new runtime within a few seconds — no need to refresh.
+
+## Troubleshooting
+
+- **`which` finds the binary but the daemon doesn't.** The daemon was started with an older `PATH`. Restart it.
+- **The binary exists but launching fails.** Run the tool's own `--version` or `--help` once from the terminal — most failures here are missing auth, expired tokens, or a Node.js / runtime mismatch.
+- **The Runtimes page shows the row, but tasks fail immediately.** Check `multica daemon logs -f` while triggering a task. The daemon surfaces the tool's own error output.
+
+For broader symptoms, see the [Troubleshooting guide](/troubleshooting).
+
+## Next
+
+- [Daemon and runtimes](/daemon-runtimes) — how detection, heartbeats, and offline handling work
+- [AI coding tools matrix](/providers) — capability differences once a tool is connected
+- [Creating and configuring agents](/agents-create) — pick a tool for your agent and start running tasks

--- a/apps/docs/content/docs/install-agent-runtime.zh.mdx
+++ b/apps/docs/content/docs/install-agent-runtime.zh.mdx
@@ -1,0 +1,169 @@
+---
+title: 安装一个 Agent 运行时
+description: Multica 驱动本机上已安装的 AI 编程工具。这一页讲清楚怎么安装目前支持的 11 款工具，让守护进程能扫到。
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+在 Multica 里，一个**运行时**（runtime）就是你机器上的守护进程，配上守护进程在 `PATH` 里扫到的某一款 AI 编程工具。如果 onboarding 的 "连接运行时" 这一步显示 **未检测到支持的工具**，说明守护进程扫了 `PATH`，但 11 款它认得的工具一个都没找到。装下面任意一款（或几款），回到这一步重新扫描，几秒内运行时就会出现。
+
+这一页是装机的入口，和它配套的是：
+
+- [守护进程与运行时](/zh/daemon-runtimes) — 检测是怎么工作的
+- [AI 编程工具矩阵](/zh/providers) — 每款工具的能力差异（会话续接、MCP、模型选择）
+
+<Callout type="info">
+Multica 服务器从不接触你的 API key，也不接触工具本身。下面这些操作 —— 安装、登录、模型访问 —— 全部发生在你本机。出问题几乎都是本地问题。
+</Callout>
+
+## 开始前
+
+下面每一款工具都有两个共同前提：
+
+1. **Multica 守护进程在运行。** 装完 [Multica CLI](/zh/cli) 后跑 `multica daemon start`；或者用 [Multica 桌面端](/zh/desktop-app)，它启动时自动拉起守护进程。守护进程没起来，就没人去扫工具。
+2. **工具的可执行文件在 `PATH` 上。** 守护进程通过名字 shell out 调起工具（见每一节里 **守护进程扫描** 那行的命令名）。终端里 `which <名字>` 找不到，守护进程也找不到。装完后打开新终端（或者重启守护进程），让新的 `PATH` 生效。
+
+装完一款工具后，重启守护进程：
+
+```bash
+multica daemon restart
+```
+
+桌面端的话，重启 app 即可。守护进程只在启动时扫一次 `PATH`。
+
+## 11 款支持的工具
+
+大致按常见程度排序。挑你已经有账号 / API key 的那几款就行 —— 不需要 11 个全装。
+
+### Claude Code（Anthropic）
+
+集成最完整的一款。会话续接好用，MCP 好用，而且 **11 款里只有它真正会读 agent 配置里的 `mcp_config` 字段**（见[矩阵](/zh/providers)）。
+
+| | |
+|---|---|
+| 守护进程扫描 | `claude` |
+| 安装 | 看官方指引 [claude.com/claude-code](https://www.claude.com/claude-code)。常见装法是 npm 包 `@anthropic-ai/claude-code`（需要 Node.js 18+）。 |
+| 认证 | 跑一次 `claude`，跟着 CLI 里的登录流程走；或者设置 `ANTHROPIC_API_KEY`。 |
+| 备注 | 新用户首选。 |
+
+### Codex（OpenAI）
+
+JSON-RPC 2.0 传输，审批粒度更细。**会话续接的代码在，但调不到** —— 要续接的话选 Claude Code 或 ACP 系列。
+
+| | |
+|---|---|
+| 守护进程扫描 | `codex` |
+| 安装 | 看官方指引 [github.com/openai/codex](https://github.com/openai/codex)。常见装法是 npm 包 `@openai/codex`。 |
+| 认证 | `codex login`（浏览器登录），或 `OPENAI_API_KEY`。 |
+
+### Cursor（Anysphere）
+
+Cursor 编辑器的 CLI 对应物。**会话续接是坏的** —— Cursor CLI 不返回 session id，你传过去的续接 id 永远无效。
+
+| | |
+|---|---|
+| 守护进程扫描 | `cursor-agent` |
+| 安装 | 先装 [Cursor 编辑器](https://cursor.com/)，再按 [docs.cursor.com](https://docs.cursor.com/) 的说明装 CLI。可执行文件叫 `cursor-agent`，不是 `cursor`。 |
+| 认证 | 在 Cursor 编辑器里登录，CLI 复用同一份会话。 |
+
+### GitHub Copilot
+
+模型走的是你 GitHub 账号的 entitlement —— 工具自己不挑模型，GitHub 决定你拿到哪个模型。
+
+| | |
+|---|---|
+| 守护进程扫描 | `copilot` |
+| 安装 | 看 GitHub 的 CLI 文档 [github.com/github/copilot-cli](https://github.com/github/copilot-cli)。 |
+| 认证 | CLI 里走 GitHub 浏览器登录。 |
+| 备注 | 登录账号必须有有效的 GitHub Copilot 订阅。 |
+
+### Gemini（Google）
+
+支持 Gemini 2.5 和 3 系列。没有会话续接，没有 MCP —— 适合一次性、无需上下文记忆的任务。
+
+| | |
+|---|---|
+| 守护进程扫描 | `gemini` |
+| 安装 | 看官方指引 [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli)。常见装法是 npm 包 `@google/gemini-cli`。 |
+| 认证 | 跑 `gemini` 会提示 Google 账号登录，或设置 `GEMINI_API_KEY`。 |
+
+### OpenCode（SST）
+
+开源 CLI agent。会从自己的配置文件里动态发现可用模型 —— 适合想自己掌控模型清单的用户。
+
+| | |
+|---|---|
+| 守护进程扫描 | `opencode` |
+| 安装 | 看官方指引 [opencode.ai](https://opencode.ai/) 或仓库 [github.com/sst/opencode](https://github.com/sst/opencode)。一般是装脚本或 npm 包。 |
+| 认证 | 按 OpenCode 的文档配你自己的模型供应商（Anthropic、OpenAI 等）。 |
+
+### Kiro CLI（Amazon）
+
+ACP-over-stdio 传输。会话续接通过 ACP `session/load` 工作；skills 拷到 `.kiro/skills/`。
+
+| | |
+|---|---|
+| 守护进程扫描 | `kiro-cli` |
+| 安装 | 看 Kiro 的文档 [kiro.dev](https://kiro.dev/)。可执行文件叫 `kiro-cli`，不是 `kiro`。 |
+| 认证 | 基于 AWS 账号，按 Kiro 自己的引导走。 |
+
+### Kimi（Moonshot）
+
+ACP 协议 agent，主要面向中国市场。Skills 放在 `.kimi/skills/`（原生发现路径）。
+
+| | |
+|---|---|
+| 守护进程扫描 | `kimi` |
+| 安装 | 看官方指引 [github.com/MoonshotAI/kimi-cli](https://github.com/MoonshotAI/kimi-cli)。 |
+| 认证 | Moonshot API key，按厂商文档配置。 |
+
+### Hermes（Nous Research）
+
+ACP 协议 agent（和 Kimi 共享传输层）。会话续接可用。Skill 注入用的是通用回退路径 `.agent_context/skills/` —— 用之前先验证 skills 真的被加载了。
+
+| | |
+|---|---|
+| 守护进程扫描 | `hermes` |
+| 安装 | 看 Nous Research 的仓库 [github.com/NousResearch](https://github.com/NousResearch) 获取最新 CLI。 |
+| 认证 | 按厂商文档。 |
+
+### OpenClaw
+
+开源 CLI agent 编排器。**模型绑在 agent 层**（`openclaw agents add --model`）—— 不能按任务覆盖，从 Multica 也传不了 `--model` / `--system-prompt`。
+
+| | |
+|---|---|
+| 守护进程扫描 | `openclaw` |
+| 安装 | 看项目 [github.com/openclaw-org/openclaw](https://github.com/openclaw-org/openclaw)（社区维护）。 |
+| 认证 | 按 OpenClaw 的文档配底层模型供应商。 |
+
+### Pi（Inflection AI）
+
+极简风格。**会话续接的方式不太一样** —— resume id 是磁盘上的会话文件路径，不是字符串 id。
+
+| | |
+|---|---|
+| 守护进程扫描 | `pi` |
+| 安装 | 看 Inflection 的 CLI 文档 [pi.ai](https://pi.ai/)。 |
+| 认证 | 按厂商文档。 |
+
+## 装完之后
+
+1. **确认可执行文件在 `PATH` 上。** 开一个新终端，跑 `which <名字>`（比如 `which claude`、`which cursor-agent`、`which kiro-cli`）。打印出路径，守护进程就找得到；什么都不打印，先修 shell 的 `PATH`（最常见原因是 rc 文件没重新加载）。
+2. **重启守护进程。** `multica daemon restart`，或者重启桌面端。守护进程只在启动时扫一次 `PATH`。
+3. **看 Runtimes 页面。** Multica UI 的 **Runtimes** 页应该会出现一行 `(工作区 × 工具)`。如果显示 "offline"，看[守护进程与运行时 → 运行时何时被标记为离线](/zh/daemon-runtimes#运行时何时被标记为离线)。
+4. **回到 onboarding。** "连接运行时" 这一步会一直轮询，几秒内就能扫到新运行时，不需要手动刷新。
+
+## 排错
+
+- **`which` 找得到，但守护进程找不到。** 守护进程是用旧 `PATH` 启的，重启它。
+- **可执行文件在，但启动就失败。** 在终端单独跑一次工具的 `--version` 或 `--help`，绝大多数失败都是登录没做、token 过期、Node.js / 运行时版本不对。
+- **Runtimes 页面看到行，但任务一跑就失败。** 一边触发任务一边跑 `multica daemon logs -f`。守护进程会把工具自己的报错原样吐出来。
+
+更宽的症状看[排错指南](/zh/troubleshooting)。
+
+## 接下来
+
+- [守护进程与运行时](/zh/daemon-runtimes) — 检测、心跳、离线处理
+- [AI 编程工具矩阵](/zh/providers) — 工具连上之后的能力差异
+- [创建并配置智能体](/zh/agents-create) — 给你的 agent 挑一款工具，开始跑任务

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -19,6 +19,7 @@
     "squads",
     "---How agents run---",
     "daemon-runtimes",
+    "install-agent-runtime",
     "tasks",
     "providers",
     "---Collaborating with agents---",

--- a/packages/views/locales/en/onboarding.json
+++ b/packages/views/locales/en/onboarding.json
@@ -254,6 +254,7 @@
     "empty_waitlist_subtitle": "We'll host the runtime for you — no local install, no setup. Not live yet; click to leave your email and get notified.",
     "empty_waitlist_action": "Join waitlist",
     "empty_waitlist_done": "On the waitlist",
+    "empty_install_link": "Install an agent runtime →",
     "dialog_title": "Join the cloud runtime waitlist",
     "dialog_description": "Cloud runtimes aren't live yet. Leave your email and we'll email you when they are.",
     "dialog_close": "Close",

--- a/packages/views/locales/zh-Hans/onboarding.json
+++ b/packages/views/locales/zh-Hans/onboarding.json
@@ -253,6 +253,7 @@
     "empty_waitlist_subtitle": "由 Multica 托管运行时 —— 无需本地安装，无需配置。尚未上线，点击留下邮箱。",
     "empty_waitlist_action": "加入候补",
     "empty_waitlist_done": "已在候补",
+    "empty_install_link": "安装一个 Agent 运行时 →",
     "dialog_title": "加入云运行时候补名单",
     "dialog_description": "云运行时尚未上线。留下邮箱，上线时通过邮件通知你。",
     "dialog_close": "关闭",

--- a/packages/views/onboarding/steps/step-runtime-connect.tsx
+++ b/packages/views/onboarding/steps/step-runtime-connect.tsx
@@ -448,6 +448,15 @@ function EmptyView({
         />
       </div>
 
+      <a
+        href="https://multica.ai/docs/install-agent-runtime"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-5 inline-block self-start text-[13px] text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+      >
+        {t(($) => $.step_runtime.empty_install_link)}
+      </a>
+
       <Dialog
         open={waitlistOpen}
         onOpenChange={(o) => (o ? null : setWaitlistOpen(false))}


### PR DESCRIPTION
## Summary

- New docs page **Install an agent runtime** covering all 11 supported AI coding tools — vendor, install pointers, the exact binary the daemon scans for on `PATH`, and a brief auth note. EN + zh-Hans, registered under *How agents run* in the docs sidebar.
- The onboarding *Connect a runtime* empty state ("no supported tools detected") now shows an **Install an agent runtime →** link that opens the new doc, so users have a discoverable path beyond *Skip* and *Join waitlist*.

Per [MUL-2320](https://github.com/multica-ai/multica/issues/2320) — comment by @jiayuan suggesting the empty state should link to install docs.

## Files

- `apps/docs/content/docs/install-agent-runtime.mdx` (new)
- `apps/docs/content/docs/install-agent-runtime.zh.mdx` (new)
- `apps/docs/content/docs/meta.json` — sidebar entry
- `packages/views/locales/{en,zh-Hans}/onboarding.json` — `step_runtime.empty_install_link`
- `packages/views/onboarding/steps/step-runtime-connect.tsx` — link in `EmptyView`

## Test plan

- [x] i18n parity test passes (`vitest run locales/parity.test.ts`)
- [x] Onboarding step tests pass (`vitest run onboarding/steps`)
- [ ] Visual check: trigger the empty state on a machine with no supported tools installed and confirm the link renders + opens the new doc in a new tab
- [ ] Docs site: confirm the new page renders at `/docs/install-agent-runtime` and `/docs/zh/install-agent-runtime`, and that the sidebar shows it under *How agents run*