### PR TITLE
fix(my-issues): rename tab 3 label to include squads (MUL-2397)

### DIFF
--- a/packages/views/locales/en/my-issues.json
+++ b/packages/views/locales/en/my-issues.json
@@ -11,7 +11,7 @@
       "assigned_description": "Issues assigned to me",
       "created_label": "Created",
       "created_description": "Issues I created",
-      "agents_label": "My Agents",
+      "agents_label": "My Agents and Squads",
       "agents_description": "Issues assigned to my agents"
     },
     "filter_button": "Filter",

--- a/packages/views/locales/zh-Hans/my-issues.json
+++ b/packages/views/locales/zh-Hans/my-issues.json
@@ -11,7 +11,7 @@
       "assigned_description": "分配给我的 issue",
       "created_label": "我创建的",
       "created_description": "我创建的 issue",
-      "agents_label": "我的智能体",
+      "agents_label": "我的智能体和小队",
       "agents_description": "分配给我的智能体的 issue"
     },
     "filter_button": "筛选",


### PR DESCRIPTION
## Summary
- Tab 3 on `/my-issues` now includes squad assignees (landed in #2829), but the label still said "我的智能体" / "My Agents" — under-described the new scope.
- Renames the label only: `agents_label` → "我的智能体和小队" / "My Agents and Squads" in both locales.
- Filter logic, SQL, descriptions, tab 1 / tab 2 names, icons, and layout are untouched per scope.

Closes [MUL-2397](https://multica.app/issues/MUL-2397) wording follow-up.

## Test plan
- [x] `pnpm --filter @multica/views exec vitest run locales/parity.test.ts` — 51 passed
- [x] `pnpm typecheck` — 6/6 successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)