### PR TITLE
refactor(runtimes): declutter the runtimes page (MUL-2407)

### DIFF
--- a/packages/views/runtimes/components/runtime-columns.tsx
+++ b/packages/views/runtimes/components/runtime-columns.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from "react";
 import {
   ArrowUpCircle,
   Globe,
-  Lock,
   MoreHorizontal,
   Trash2,
 } from "lucide-react";
@@ -231,36 +230,22 @@ function RuntimeNameCell({ runtime }: { runtime: AgentRuntime }) {
   );
 }
 
-// VisibilityBadge — small chip next to the runtime name showing whether
-// the runtime is shareable (public) or owner-only (private). Older backends
-// that don't ship the visibility field render the strict default (private).
+// Only public is worth a badge — private is the default and rendering a
+// `🔒 Private` chip on every row turns the whole column into noise.
 function VisibilityBadge({ runtime }: { runtime: AgentRuntime }) {
   const { t } = useT("runtimes");
-  const isPublic = runtime.visibility === "public";
-  const Icon = isPublic ? Globe : Lock;
-  const label = isPublic
-    ? t(($) => $.detail.visibility_label.public)
-    : t(($) => $.detail.visibility_label.private);
-  const tooltip = isPublic
-    ? t(($) => $.detail.visibility_hint.public)
-    : t(($) => $.detail.visibility_hint.private);
+  if (runtime.visibility !== "public") return null;
   return (
     <Tooltip>
       <TooltipTrigger
         render={
-          <span
-            className={`shrink-0 inline-flex items-center gap-0.5 rounded px-1 text-[10px] font-medium ${
-              isPublic
-                ? "bg-info/10 text-info"
-                : "bg-muted text-muted-foreground"
-            }`}
-          >
-            <Icon className="h-2.5 w-2.5" />
-            {label}
+          <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-info/10 px-1 text-[10px] font-medium text-info">
+            <Globe className="h-2.5 w-2.5" />
+            {t(($) => $.detail.visibility_label.public)}
           </span>
         }
       />
-      <TooltipContent>{tooltip}</TooltipContent>
+      <TooltipContent>{t(($) => $.detail.visibility_hint.public)}</TooltipContent>
     </Tooltip>
   );
 }
@@ -424,11 +409,6 @@ function CliCell({
 
   return (
     <div className="flex min-w-0 items-center gap-1 text-xs">
-      {isManaged && (
-        <span className="shrink-0 rounded-sm bg-muted px-1 py-0.5 text-[10px] font-medium text-muted-foreground">
-          {t(($) => $.list.cli_managed_badge)}
-        </span>
-      )}
       <span
         className={`truncate font-mono ${
           hasUpdate ? "text-warning" : "text-muted-foreground"

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -466,7 +466,11 @@ function MachineRow({
         <span className="flex min-w-0 items-center gap-1.5">
           <span
             className="truncate text-sm font-medium"
-            title={machine.subtitle ?? undefined}
+            title={
+              machine.daemonId
+                ? `daemon ${machine.daemonId}`
+                : (machine.subtitle ?? undefined)
+            }
           >
             {machine.title}
           </span>
@@ -574,9 +578,9 @@ function MachineDetail({
   const metaParts: React.ReactNode[] = [
     <span key="runtimes">
       <span className="font-medium tabular-nums text-foreground">
-        {runtimeTotal}
-      </span>{" "}
-      {runtimesMeta}
+        {t(($) => $.machine.runtime_count, { count: runtimeTotal })}
+      </span>
+      {runtimeTotal > 0 && <> · {runtimesMeta}</>}
     </span>,
     <span key="workload" className={busyCount > 0 ? "text-primary" : undefined}>
       {workloadLabel}

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -271,17 +271,6 @@ function PageHeaderBar({
             {totalCount}
           </span>
         )}
-        <p className="ml-2 hidden text-xs text-muted-foreground md:block">
-          {t(($) => $.page.tagline)}{" "}
-          <a
-            href="https://multica.ai/docs/daemon-runtimes"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline decoration-muted-foreground/30 underline-offset-4 transition-colors hover:text-foreground"
-          >
-            {t(($) => $.page.learn_more)}
-          </a>
-        </p>
       </div>
       <Button type="button" size="sm" onClick={onConnectRemote}>
         <Plus className="h-3 w-3" />
@@ -475,19 +464,19 @@ function MachineRow({
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-center gap-1.5">
-          <span className="truncate text-sm font-medium">{machine.title}</span>
+          <span
+            className="truncate text-sm font-medium"
+            title={machine.subtitle ?? undefined}
+          >
+            {machine.title}
+          </span>
           {machine.isCurrent && (
             <span className="shrink-0 rounded bg-foreground px-1.5 py-0.5 text-[10px] font-medium text-background">
               {t(($) => $.machine.this_machine)}
             </span>
           )}
         </span>
-        {machine.subtitle && (
-          <span className="mt-0.5 block truncate font-mono text-xs text-muted-foreground">
-            {machine.subtitle}
-          </span>
-        )}
-        <span className="mt-2 flex min-w-0 items-center gap-1.5">
+        <span className="mt-1.5 flex min-w-0 items-center gap-1.5">
           <ProviderIconStack providers={machine.providerNames} />
           {busyCount > 0 ? (
             <span className="ml-auto shrink-0 text-xs font-medium text-primary">
@@ -567,89 +556,78 @@ function MachineDetail({
     );
   }
 
-  const onlineRuntimeCount = machine.onlineCount;
-  const issueCount = machine.issueCount;
+  const runtimeTotal = machine.runtimes.length;
+  const busyCount = machine.runningCount + machine.queuedCount;
   const workloadLabel =
-    machine.runningCount > 0 || machine.queuedCount > 0
+    busyCount > 0
       ? t(($) => $.machine.metrics.workload_hint, {
           running: machine.runningCount,
           queued: machine.queuedCount,
         })
       : t(($) => $.machine.metrics.workload_idle);
-  const runtimeTotal = machine.runtimes.length;
-  const metaItems = [machine.subtitle].filter(Boolean);
+  const runtimesMeta = t(($) => $.machine.metrics.runtimes_hint, {
+    count: machine.onlineCount,
+  });
+  // Single inline meta strip replaces the old 4-card grid. Health is already
+  // shown as a chip in the title row; CLI / daemon id are scanning-grade
+  // info, not headline numbers — they belong in muted secondary text.
+  const metaParts: React.ReactNode[] = [
+    <span key="runtimes">
+      <span className="font-medium tabular-nums text-foreground">
+        {runtimeTotal}
+      </span>{" "}
+      {runtimesMeta}
+    </span>,
+    <span key="workload" className={busyCount > 0 ? "text-primary" : undefined}>
+      {workloadLabel}
+    </span>,
+  ];
+  if (machine.cliVersion) {
+    metaParts.push(
+      <span key="cli" className="font-mono">
+        {machine.cliVersion}
+      </span>,
+    );
+  }
+  if (machine.subtitle) {
+    metaParts.push(
+      <span key="subtitle" className="truncate font-mono">
+        {machine.subtitle}
+      </span>,
+    );
+  }
 
   return (
     <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-      <div className="shrink-0 border-b bg-background px-5 py-5">
-        <div className="flex min-w-0 flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div className="shrink-0 border-b bg-background px-5 py-4">
+        <div className="flex min-w-0 flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="min-w-0">
             <div className="flex min-w-0 flex-wrap items-center gap-2">
               <h2 className="truncate text-xl font-semibold tracking-tight">
                 {machine.title}
               </h2>
-              <span className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-0.5 text-xs text-muted-foreground">
                 <HealthIcon health={machine.health} />
                 {healthLabel(machine.health)}
               </span>
               {machine.isCurrent && (
-                <span className="rounded-md bg-foreground px-2 py-1 text-xs font-medium text-background">
+                <span className="rounded-md bg-foreground px-2 py-0.5 text-xs font-medium text-background">
                   {t(($) => $.machine.local_badge)}
                 </span>
               )}
-              <span className="rounded-md border bg-muted px-2 py-1 text-xs text-muted-foreground">
-                {machine.section === "cloud"
-                  ? t(($) => $.machine.section_cloud)
-                  : machine.section === "local"
-                    ? t(($) => $.machine.section_local)
-                    : t(($) => $.machine.section_remote)}
-              </span>
             </div>
-            {metaItems.length > 0 && (
-              <p className="mt-2 max-w-4xl truncate text-xs text-muted-foreground">
-                {metaItems.join(" · ")}
-              </p>
-            )}
+            <div className="mt-2 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              {metaParts.map((part, idx) => (
+                <React.Fragment key={idx}>
+                  {idx > 0 && (
+                    <span className="text-muted-foreground/40">·</span>
+                  )}
+                  {part}
+                </React.Fragment>
+              ))}
+            </div>
           </div>
           {actions && <div className="shrink-0">{actions}</div>}
-        </div>
-
-        <div className="mt-5 grid overflow-hidden rounded-lg border bg-muted/20 sm:grid-cols-2 lg:grid-cols-4">
-          <MachineMetric
-            label={t(($) => $.machine.metrics.runtimes)}
-            value={String(runtimeTotal)}
-            hint={t(($) => $.machine.metrics.runtimes_hint, {
-              count: onlineRuntimeCount,
-            })}
-          />
-          <MachineMetric
-            label={t(($) => $.machine.metrics.health)}
-            value={healthLabel(machine.health)}
-            hint={
-              issueCount > 0
-                ? t(($) => $.machine.metrics.health_issues, { count: issueCount })
-                : t(($) => $.machine.metrics.health_clear)
-            }
-          />
-          <MachineMetric
-            label={t(($) => $.machine.metrics.workload)}
-            value={
-              machine.runningCount > 0 || machine.queuedCount > 0
-                ? String(machine.runningCount + machine.queuedCount)
-                : t(($) => $.machine.metrics.workload_value_idle)
-            }
-            hint={workloadLabel}
-          />
-          <MachineMetric
-            label={t(($) => $.machine.metrics.cli)}
-            value={machine.cliVersion ?? "—"}
-            hint={
-              machine.mode === "cloud"
-                ? t(($) => $.machine.metrics.cloud_worker)
-                : t(($) => $.machine.metrics.local_daemon)
-            }
-            mono={!!machine.cliVersion}
-          />
         </div>
       </div>
 
@@ -659,35 +637,6 @@ function MachineDetail({
         now={now}
       />
     </main>
-  );
-}
-
-function MachineMetric({
-  label,
-  value,
-  hint,
-  mono,
-}: {
-  label: string;
-  value: string;
-  hint: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className="min-w-0 border-b px-4 py-3 last:border-b-0 sm:odd:border-r lg:border-b-0 lg:border-r lg:last:border-r-0">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-        {label}
-      </div>
-      <div
-        className={cn(
-          "mt-1 truncate text-base font-semibold tabular-nums",
-          mono && "font-mono text-sm",
-        )}
-      >
-        {value}
-      </div>
-      <div className="mt-1 truncate text-xs text-muted-foreground">{hint}</div>
-    </div>
   );
 }
 
@@ -748,12 +697,7 @@ function RuntimesPageSkeleton() {
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="border-b p-5">
             <Skeleton className="h-6 w-64 rounded-md" />
-            <Skeleton className="mt-3 h-4 w-full max-w-2xl rounded-md" />
-            <div className="mt-5 grid gap-px overflow-hidden rounded-lg border sm:grid-cols-2 lg:grid-cols-4">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <Skeleton key={i} className="h-24 rounded-none" />
-              ))}
-            </div>
+            <Skeleton className="mt-3 h-4 w-full max-w-md rounded-md" />
           </div>
           <div className="h-12 border-b px-4 py-2">
             <Skeleton className="h-8 w-40 rounded-full" />


### PR DESCRIPTION
## Summary

Targets the top three sources of visual noise on the Runtimes page (see [MUL-2407](mention://issue/519efd25-0042-4f17-aefd-fa8f40ca1db4) for the full analysis):

- **MachineDetail header**: drop the 4-card metric grid (RUNTIMES / HEALTH / WORKLOAD / CLI). RUNTIMES duplicates the count next to the title, HEALTH duplicates the title chip, and CLI is scanning-grade info, not a headline number. Replaced with a single inline meta strip.
- **PageHeaderBar**: remove the inline tagline + "Learn more" link. Header is now icon + title + count + connect button.
- **VisibilityBadge**: only render the `Public` chip. `Private` is the default, so a column of `🔒 Private` badges on every row was pure noise.
- **CliCell**: drop the per-row `Desktop` managed badge — the same string on every desktop row carries near-zero information.
- **MachineSidebar row**: hide the truncated daemon-id subtitle (still available on hover via `title`, still shown in the detail header meta strip).

## Test plan

- [x] `pnpm typecheck` — all packages green
- [x] `pnpm --filter @multica/views test` — 644/644 pass
- [ ] Manual: open Runtimes page; confirm header is one short row, detail panel no longer shows the 4-card grid, runtime rows don't show `Private`, and `Desktop` is gone from the CLI column