### PR TITLE
feat: Add project list responsive compact and comfortable views (MUL-2464)

### DIFF
--- a/packages/core/projects/index.ts
+++ b/packages/core/projects/index.ts
@@ -1,7 +1,7 @@
 export { projectKeys, projectListOptions, projectDetailOptions } from "./queries";
 export { useCreateProject, useUpdateProject, useDeleteProject } from "./mutations";
 export { useProjectDraftStore } from "./draft-store";
-export { useProjectViewStore } from "./view-store";
+export { useProjectViewStore } from "./stores/view-store";
 export {
   projectResourceKeys,
   projectResourcesOptions,

--- a/packages/core/projects/index.ts
+++ b/packages/core/projects/index.ts
@@ -1,6 +1,7 @@
 export { projectKeys, projectListOptions, projectDetailOptions } from "./queries";
 export { useCreateProject, useUpdateProject, useDeleteProject } from "./mutations";
 export { useProjectDraftStore } from "./draft-store";
+export { useProjectViewStore } from "./view-store";
 export {
   projectResourceKeys,
   projectResourcesOptions,

--- a/packages/core/projects/stores/view-store.test.ts
+++ b/packages/core/projects/stores/view-store.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { useProjectViewStore } from "./view-store";
+import { setCurrentWorkspace } from "../../platform/workspace-storage";
+
+const flush = () => new Promise((resolve) => queueMicrotask(() => resolve(null)));
+
+// Node 25 ships a partial `localStorage` shim under jsdom that's missing
+// `clear`/`removeItem`; replace it with a real in-memory Storage so persist
+// can round-trip values.
+beforeAll(() => {
+  if (typeof globalThis.localStorage?.clear !== "function") {
+    const values = new Map<string, string>();
+    const storage: Storage = {
+      get length() { return values.size; },
+      clear: () => values.clear(),
+      getItem: (k) => values.get(k) ?? null,
+      key: (i) => Array.from(values.keys())[i] ?? null,
+      removeItem: (k) => { values.delete(k); },
+      setItem: (k, v) => { values.set(k, v); },
+    };
+    Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+    Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  }
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  useProjectViewStore.setState({ viewMode: "comfortable" });
+  setCurrentWorkspace(null, null);
+});
+
+afterEach(() => {
+  setCurrentWorkspace(null, null);
+});
+
+describe("useProjectViewStore", () => {
+  it("defaults to 'comfortable'", () => {
+    expect(useProjectViewStore.getState().viewMode).toBe("comfortable");
+  });
+
+  it("setViewMode mutates the store", () => {
+    useProjectViewStore.getState().setViewMode("compact");
+    expect(useProjectViewStore.getState().viewMode).toBe("compact");
+  });
+
+  it("partialize persists only viewMode under the workspace-namespaced key", async () => {
+    setCurrentWorkspace("acme", "ws_a");
+    await flush();
+    useProjectViewStore.getState().setViewMode("compact");
+
+    const raw = localStorage.getItem("multica_projects_view:acme");
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.state).toEqual({ viewMode: "compact" });
+  });
+
+  it("rehydrates a different saved viewMode on workspace switch", async () => {
+    localStorage.setItem(
+      "multica_projects_view:acme",
+      JSON.stringify({ state: { viewMode: "compact" }, version: 0 }),
+    );
+    localStorage.setItem(
+      "multica_projects_view:beta",
+      JSON.stringify({ state: { viewMode: "comfortable" }, version: 0 }),
+    );
+
+    setCurrentWorkspace("acme", "ws_a");
+    await flush();
+    await flush();
+    expect(useProjectViewStore.getState().viewMode).toBe("compact");
+
+    setCurrentWorkspace("beta", "ws_b");
+    await flush();
+    await flush();
+    expect(useProjectViewStore.getState().viewMode).toBe("comfortable");
+  });
+
+  it("resets to 'comfortable' when switching to a workspace with no persisted value", async () => {
+    localStorage.setItem(
+      "multica_projects_view:acme",
+      JSON.stringify({ state: { viewMode: "compact" }, version: 0 }),
+    );
+
+    setCurrentWorkspace("acme", "ws_a");
+    await flush();
+    await flush();
+    expect(useProjectViewStore.getState().viewMode).toBe("compact");
+
+    setCurrentWorkspace("beta", "ws_b");
+    await flush();
+    await flush();
+    expect(useProjectViewStore.getState().viewMode).toBe("comfortable");
+    expect(localStorage.getItem("multica_projects_view:acme")).not.toBeNull();
+  });
+});

--- a/packages/core/projects/stores/view-store.ts
+++ b/packages/core/projects/stores/view-store.ts
@@ -2,8 +2,8 @@
 
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../platform/workspace-storage";
-import { defaultStorage } from "../platform/storage";
+import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
+import { defaultStorage } from "../../platform/storage";
 
 export type ProjectViewMode = "compact" | "comfortable";
 

--- a/packages/core/projects/view-store.ts
+++ b/packages/core/projects/view-store.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../platform/workspace-storage";
+import { defaultStorage } from "../platform/storage";
+
+export type ProjectViewMode = "compact" | "comfortable";
+
+export interface ProjectViewState {
+  viewMode: ProjectViewMode;
+  setViewMode: (mode: ProjectViewMode) => void;
+}
+
+export const useProjectViewStore = create<ProjectViewState>()(
+  persist(
+    (set) => ({
+      viewMode: "comfortable",
+      setViewMode: (mode) => set({ viewMode: mode }),
+    }),
+    {
+      name: "multica_projects_view",
+      storage: createJSONStorage(() => createWorkspaceAwareStorage(defaultStorage)),
+      partialize: (state) => ({ viewMode: state.viewMode }),
+      merge: (persisted, current) => {
+        if (!persisted) return { ...current, viewMode: "comfortable" };
+        return { ...current, ...(persisted as Partial<ProjectViewState>) };
+      },
+    }
+  )
+);
+
+registerForWorkspaceRehydration(() => useProjectViewStore.persist.rehydrate());

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -3,7 +3,9 @@
     "title": "Projects",
     "new_project": "New project",
     "empty": "No projects yet",
-    "create_first": "Create your first project"
+    "create_first": "Create your first project",
+    "view_compact": "Compact",
+    "view_comfortable": "Comfortable"
   },
   "table": {
     "name": "Name",
@@ -57,6 +59,7 @@
     "empty_issues_title": "No issues linked",
     "empty_issues_hint": "Create a new issue or assign existing ones to this project.",
     "empty_issues_new_button": "New Issue",
+    "no_issues_yet": "No issues yet",
     "toast_link_copied": "Link copied",
     "toast_project_deleted": "Project deleted",
     "toast_move_issue_failed": "Failed to move issue"

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -5,7 +5,8 @@
     "empty": "No projects yet",
     "create_first": "Create your first project",
     "view_compact": "Compact",
-    "view_comfortable": "Comfortable"
+    "view_comfortable": "Comfortable",
+    "search_placeholder": "Search projects..."
   },
   "table": {
     "name": "Name",

--- a/packages/views/locales/en/projects.json
+++ b/packages/views/locales/en/projects.json
@@ -6,7 +6,8 @@
     "create_first": "Create your first project",
     "view_compact": "Compact",
     "view_comfortable": "Comfortable",
-    "search_placeholder": "Search projects..."
+    "search_placeholder": "Search projects...",
+    "no_search_results": "No results match your search"
   },
   "table": {
     "name": "Name",

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -6,7 +6,8 @@
     "create_first": "创建第一个项目",
     "view_compact": "紧凑视图",
     "view_comfortable": "舒适视图",
-    "search_placeholder": "搜索项目..."
+    "search_placeholder": "搜索项目...",
+    "no_search_results": "未找到匹配的项目"
   },
   "table": {
     "name": "名称",

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -5,7 +5,8 @@
     "empty": "还没有项目",
     "create_first": "创建第一个项目",
     "view_compact": "紧凑视图",
-    "view_comfortable": "舒适视图"
+    "view_comfortable": "舒适视图",
+    "search_placeholder": "搜索项目..."
   },
   "table": {
     "name": "名称",

--- a/packages/views/locales/zh-Hans/projects.json
+++ b/packages/views/locales/zh-Hans/projects.json
@@ -3,7 +3,9 @@
     "title": "项目",
     "new_project": "新建项目",
     "empty": "还没有项目",
-    "create_first": "创建第一个项目"
+    "create_first": "创建第一个项目",
+    "view_compact": "紧凑视图",
+    "view_comfortable": "舒适视图"
   },
   "table": {
     "name": "名称",
@@ -57,6 +59,7 @@
     "empty_issues_title": "还没有关联的 issue",
     "empty_issues_hint": "新建一个 issue，或把已有的 issue 关联到这个项目。",
     "empty_issues_new_button": "新建 issue",
+    "no_issues_yet": "目前还没有 issue",
     "toast_link_copied": "已复制链接",
     "toast_project_deleted": "已删除项目",
     "toast_move_issue_failed": "移动 issue 失败"

--- a/packages/views/projects/components/project-badge.tsx
+++ b/packages/views/projects/components/project-badge.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Check } from "lucide-react";
-import { 
-  PROJECT_STATUS_CONFIG, 
+import {
+  PROJECT_STATUS_CONFIG,
   PROJECT_STATUS_ORDER,
   PROJECT_PRIORITY_CONFIG,
   PROJECT_PRIORITY_ORDER
@@ -21,7 +21,7 @@ import { useProjectStatusLabels, useProjectPriorityLabels } from "./labels";
 export function ProjectStatusBadge({ project, handleUpdate, triggerClassName, align = "end" }: { project: Project; handleUpdate: (data: UpdateProjectRequest) => void; triggerClassName?: string; align?: "start" | "end" | "center" }) {
   const statusLabels = useProjectStatusLabels();
   const statusCfg = PROJECT_STATUS_CONFIG[project.status];
-  
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -51,7 +51,7 @@ export function ProjectStatusBadge({ project, handleUpdate, triggerClassName, al
 export function ProjectPriorityBadge({ project, handleUpdate, triggerClassName, align = "end" }: { project: Project; handleUpdate: (data: UpdateProjectRequest) => void; triggerClassName?: string; align?: "start" | "end" | "center" }) {
   const priorityLabels = useProjectPriorityLabels();
   const priorityCfg = PROJECT_PRIORITY_CONFIG[project.priority];
-  
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger

--- a/packages/views/projects/components/project-badge.tsx
+++ b/packages/views/projects/components/project-badge.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Check } from "lucide-react";
+import { 
+  PROJECT_STATUS_CONFIG, 
+  PROJECT_STATUS_ORDER,
+  PROJECT_PRIORITY_CONFIG,
+  PROJECT_PRIORITY_ORDER
+} from "@multica/core/projects/config";
+import { cn } from "@multica/ui/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@multica/ui/components/ui/dropdown-menu";
+import type { Project, ProjectStatus, ProjectPriority, UpdateProjectRequest } from "@multica/core/types";
+import { PriorityIcon } from "../../issues/components/priority-icon";
+import { useProjectStatusLabels, useProjectPriorityLabels } from "./labels";
+
+export function ProjectStatusBadge({ project, handleUpdate, triggerClassName, align = "end" }: { project: Project; handleUpdate: (data: UpdateProjectRequest) => void; triggerClassName?: string; align?: "start" | "end" | "center" }) {
+  const statusLabels = useProjectStatusLabels();
+  const statusCfg = PROJECT_STATUS_CONFIG[project.status];
+  
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button type="button" className={cn(
+            "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:opacity-80 transition-opacity",
+            statusCfg.badgeBg, statusCfg.badgeText,
+            triggerClassName
+          )}>
+            {statusLabels[project.status]}
+          </button>
+        }
+      />
+      <DropdownMenuContent align={align} className="w-44">
+        {PROJECT_STATUS_ORDER.map((s) => (
+          <DropdownMenuItem key={s} onClick={() => handleUpdate({ status: s as ProjectStatus })}>
+            <span className={cn("size-2 rounded-full", PROJECT_STATUS_CONFIG[s].dotColor)} />
+            <span>{statusLabels[s]}</span>
+            {s === project.status && <Check className="ml-auto h-3.5 w-3.5" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function ProjectPriorityBadge({ project, handleUpdate, triggerClassName, align = "end" }: { project: Project; handleUpdate: (data: UpdateProjectRequest) => void; triggerClassName?: string; align?: "start" | "end" | "center" }) {
+  const priorityLabels = useProjectPriorityLabels();
+  const priorityCfg = PROJECT_PRIORITY_CONFIG[project.priority];
+  
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button type="button" className={cn(
+            "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium hover:bg-accent/60 transition-colors cursor-pointer",
+            triggerClassName
+          )}>
+            <PriorityIcon priority={project.priority} />
+            <span className={cn("text-xs", priorityCfg.color)}>{priorityLabels[project.priority]}</span>
+          </button>
+        }
+      />
+      <DropdownMenuContent align={align} className="w-44">
+        {PROJECT_PRIORITY_ORDER.map((p) => (
+          <DropdownMenuItem key={p} onClick={() => handleUpdate({ priority: p as ProjectPriority })}>
+            <PriorityIcon priority={p} />
+            <span>{priorityLabels[p]}</span>
+            {p === project.priority && <Check className="ml-auto h-3.5 w-3.5" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/views/projects/components/project-lead-picker.tsx
+++ b/packages/views/projects/components/project-lead-picker.tsx
@@ -12,9 +12,9 @@ import { useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 import { ActorAvatar } from "../../common/actor-avatar";
 
-export function ProjectLeadPicker({ project, handleUpdate, renderTrigger, align = "start" }: { 
-  project: Project; 
-  handleUpdate: (data: UpdateProjectRequest) => void; 
+export function ProjectLeadPicker({ project, handleUpdate, renderTrigger, align = "start" }: {
+  project: Project;
+  handleUpdate: (data: UpdateProjectRequest) => void;
   renderTrigger: (leadName: string | null) => React.ReactElement;
   align?: "start" | "end" | "center"
 }) {
@@ -27,10 +27,10 @@ export function ProjectLeadPicker({ project, handleUpdate, renderTrigger, align 
   const [leadOpen, setLeadOpen] = useState(false);
   const [leadFilter, setLeadFilter] = useState("");
   const leadQuery = leadFilter.toLowerCase();
-  
+
   const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
   const filteredAgents = agents.filter((a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)));
-  
+
   const leadId = project.lead_id;
   const leadType = project.lead_type;
   const leadName = leadId && leadType ? getActorName(leadType, leadId) : null;

--- a/packages/views/projects/components/project-lead-picker.tsx
+++ b/packages/views/projects/components/project-lead-picker.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { UserMinus } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
+import { useWorkspaceId } from "@multica/core/hooks";
+import { useActorName } from "@multica/core/workspace/hooks";
+import { Popover, PopoverContent, PopoverTrigger } from "@multica/ui/components/ui/popover";
+import type { Project, UpdateProjectRequest } from "@multica/core/types";
+import { useT } from "../../i18n";
+import { matchesPinyin } from "../../editor/extensions/pinyin-match";
+import { ActorAvatar } from "../../common/actor-avatar";
+
+export function ProjectLeadPicker({ project, handleUpdate, renderTrigger, align = "start" }: { 
+  project: Project; 
+  handleUpdate: (data: UpdateProjectRequest) => void; 
+  renderTrigger: (leadName: string | null) => React.ReactElement;
+  align?: "start" | "end" | "center"
+}) {
+  const { t } = useT("projects");
+  const wsId = useWorkspaceId();
+  const { getActorName } = useActorName();
+  const { data: members = [] } = useQuery(memberListOptions(wsId));
+  const { data: agents = [] } = useQuery(agentListOptions(wsId));
+
+  const [leadOpen, setLeadOpen] = useState(false);
+  const [leadFilter, setLeadFilter] = useState("");
+  const leadQuery = leadFilter.toLowerCase();
+  
+  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
+  const filteredAgents = agents.filter((a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)));
+  
+  const leadId = project.lead_id;
+  const leadType = project.lead_type;
+  const leadName = leadId && leadType ? getActorName(leadType, leadId) : null;
+
+  return (
+    <Popover open={leadOpen} onOpenChange={(v) => { setLeadOpen(v); if (!v) setLeadFilter(""); }}>
+      <PopoverTrigger render={renderTrigger(leadName)} />
+      <PopoverContent align={align} className="w-52 p-0">
+        <div className="px-2 py-1.5 border-b">
+          <input
+            type="text"
+            value={leadFilter}
+            onChange={(e) => setLeadFilter(e.target.value)}
+            placeholder={t(($) => $.lead.assign_placeholder)}
+            className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
+          />
+        </div>
+        <div className="p-1 max-h-48 overflow-y-auto">
+          <button
+            type="button"
+            onClick={() => { handleUpdate({ lead_type: null, lead_id: null }); setLeadOpen(false); }}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+          >
+            <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-muted-foreground">{t(($) => $.lead.no_lead)}</span>
+          </button>
+          {filteredMembers.length > 0 && (
+            <>
+              <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">{t(($) => $.lead.members_group)}</div>
+              {filteredMembers.map((m) => (
+                <button
+                  type="button"
+                  key={m.user_id}
+                  onClick={() => { handleUpdate({ lead_type: "member", lead_id: m.user_id }); setLeadOpen(false); }}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                >
+                  <ActorAvatar actorType="member" actorId={m.user_id} size={16} />
+                  <span>{m.name}</span>
+                </button>
+              ))}
+            </>
+          )}
+          {filteredAgents.length > 0 && (
+            <>
+              <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">{t(($) => $.lead.agents_group)}</div>
+              {filteredAgents.map((a) => (
+                <button
+                  type="button"
+                  key={a.id}
+                  onClick={() => { handleUpdate({ lead_type: "agent", lead_id: a.id }); setLeadOpen(false); }}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                >
+                  <ActorAvatar actorType="agent" actorId={a.id} size={16} showStatusDot />
+                  <span>{a.name}</span>
+                </button>
+              ))}
+            </>
+          )}
+          {filteredMembers.length === 0 && filteredAgents.length === 0 && leadFilter && (
+            <div className="px-2 py-3 text-center text-sm text-muted-foreground">{t(($) => $.lead.no_results)}</div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -141,7 +141,7 @@ function ProjectCard({ project }: { project: Project }) {
             </span>
           </div>
         ) : (
-          <span className="text-[10px] text-muted-foreground pt-2 flex justify-end">No issues yet</span>
+          <span className="text-[10px] text-muted-foreground pt-2 flex justify-end">{t(($) => $.detail.no_issues_yet)}</span>
         )}
       </div>
 
@@ -470,20 +470,20 @@ export function ProjectsPage() {
                     />
                   }
                 />
-                <TooltipContent side="bottom">
-                  {isCompact ? "Compact" : "Comfortable"}
-                </TooltipContent>
+              <TooltipContent side="bottom">
+                {isCompact ? t(($) => $.page.view_compact) : t(($) => $.page.view_comfortable)}
+              </TooltipContent>
               </Tooltip>
               <DropdownMenuContent align="end" className="w-auto">
                 <DropdownMenuGroup>
-                  <DropdownMenuItem onClick={() => setViewMode("compact")}>
-                    <Rows3 className="mr-2 h-4 w-4" />
-                    Compact
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => setViewMode("comfortable")}>
-                    <LayoutGrid className="mr-2 h-4 w-4" />
-                    Comfortable
-                  </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setViewMode("compact")}>
+                  <Rows3 className="mr-2 h-4 w-4" />
+                  {t(($) => $.page.view_compact)}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setViewMode("comfortable")}>
+                  <LayoutGrid className="mr-2 h-4 w-4" />
+                  {t(($) => $.page.view_comfortable)}
+                </DropdownMenuItem>
                 </DropdownMenuGroup>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -91,8 +91,8 @@ function ProjectCard({ project }: { project: Project }) {
       </div>
 
       <div className="flex items-center justify-between px-3 pb-3 border-t mt-0 pt-2">
-        <ProjectLeadPicker 
-          project={project} 
+        <ProjectLeadPicker
+          project={project}
           handleUpdate={handleUpdate}
           renderTrigger={(leadName) => (
             <button type="button" className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -mx-1.5 hover:bg-accent/60 transition-colors cursor-pointer">
@@ -153,8 +153,8 @@ function ProjectCardCompact({ project }: { project: Project }) {
         {project.issue_count > 0 ? `${project.done_count}/${project.issue_count}` : "--"}
       </span>
 
-      <ProjectLeadPicker 
-        project={project} 
+      <ProjectLeadPicker
+        project={project}
         handleUpdate={handleUpdate}
         align="start"
         renderTrigger={(leadName) => (
@@ -193,7 +193,7 @@ export function ProjectsPage() {
   const filteredProjects = useMemo(() => {
     const q = search.trim().toLowerCase();
     if (!q) return projects;
-    return projects.filter((p) => 
+    return projects.filter((p) =>
       p.title.toLowerCase().includes(q) || matchesPinyin(p.title, q)
     );
   }, [projects, search]);
@@ -226,7 +226,7 @@ export function ProjectsPage() {
                 className="h-8 w-full sm:w-64 pl-8 text-sm"
               />
             </div>
-            
+
             <div className="flex items-center gap-2 sm:gap-4 shrink-0">
               <span className="hidden sm:inline-block font-mono text-xs tabular-nums text-muted-foreground/70">
                 {filteredProjects.length} / {projects.length}
@@ -259,7 +259,7 @@ export function ProjectsPage() {
           </div>
         )}
 
-        <div className="flex-1 overflow-y-auto">
+        <div key={viewMode} className={cn("flex-1", isCompact ? "overflow-hidden flex flex-col" : "overflow-y-auto")}>
           {isLoading ? (
             isCompact ? (
               <div className="pt-4 mx-5 overflow-x-auto rounded-md border pb-4 mb-5">
@@ -304,29 +304,36 @@ export function ProjectsPage() {
                 {t(($) => $.page.create_first)}
               </Button>
             </div>
-          ) : isCompact ? (
-            <div className="mt-4 mx-5 overflow-x-auto rounded-md border mb-5">
-              <div className={cn(COMPACT_GRID, "h-8 shrink-0 items-center gap-2 px-4 text-xs font-medium text-muted-foreground border-b bg-muted/30 sticky top-0 z-10")}>
-                <span />
-                <span className="text-left">{t(($) => $.table.name)}</span>
-                <span className="text-left">{t(($) => $.table.priority)}</span>
-                <span className="text-left">{t(($) => $.table.status)}</span>
-                <span className="text-left">{t(($) => $.table.progress)}</span>
-                <span className="text-left">{t(($) => $.table.lead)}</span>
-                <span className="text-left">{t(($) => $.table.created)}</span>
-              </div>
-            <div className="pb-4">
-              {filteredProjects.map((project) => (
-                <ProjectCardCompact key={project.id} project={project} />
-              ))}
+          ) : filteredProjects.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-24 text-muted-foreground">
+              <Search className="h-10 w-10 mb-3 opacity-30" />
+              <p className="text-sm">{t(($) => $.page.no_search_results)}</p>
             </div>
+          ) : isCompact ? (
+            <div className="mt-4 mx-5 rounded-md border mb-5 overflow-auto flex-1">
+              <div className="min-w-[740px]">
+                <div className={cn(COMPACT_GRID, "h-8 shrink-0 items-center gap-2 px-4 text-xs font-medium text-muted-foreground border-b bg-muted/30 sticky top-0 z-10")}>
+                  <span />
+                  <span className="text-left">{t(($) => $.table.name)}</span>
+                  <span className="text-left">{t(($) => $.table.priority)}</span>
+                  <span className="text-left">{t(($) => $.table.status)}</span>
+                  <span className="text-left">{t(($) => $.table.progress)}</span>
+                  <span className="text-left">{t(($) => $.table.lead)}</span>
+                  <span className="text-left">{t(($) => $.table.created)}</span>
+                </div>
+                <div className="pb-4">
+                  {filteredProjects.map((project) => (
+                    <ProjectCardCompact key={project.id} project={project} />
+                  ))}
+                </div>
+              </div>
             </div>
           ) : (
-          <div className="pt-4 pb-5 px-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-            {filteredProjects.map((project) => (
-              <ProjectCard key={project.id} project={project} />
-            ))}
-          </div>
+            <div className="pt-4 pb-5 px-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              {filteredProjects.map((project) => (
+                <ProjectCard key={project.id} project={project} />
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Plus, FolderKanban, UserMinus, Check } from "lucide-react";
+import { Plus, FolderKanban, UserMinus, Check, Rows3, LayoutGrid } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { useUpdateProject } from "@multica/core/projects/mutations";
@@ -24,6 +24,7 @@ import { cn } from "@multica/ui/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@multica/ui/components/ui/dropdown-menu";
@@ -44,8 +45,9 @@ import {
   useFormatRelativeDate,
 } from "./labels";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
+import { useProjectViewStore } from "@multica/core/projects";
 
-function ProjectRow({ project }: { project: Project }) {
+function ProjectCard({ project }: { project: Project }) {
   const { t } = useT("projects");
   const wsId = useWorkspaceId();
   const wsPaths = useWorkspacePaths();
@@ -72,93 +74,289 @@ function ProjectRow({ project }: { project: Project }) {
     [project.id, updateProject],
   );
 
+  const progressPercent = project.issue_count > 0 ? Math.round((project.done_count / project.issue_count) * 100) : 0;
+
   return (
-    <div className="group/row flex h-11 items-center gap-2 px-5 text-sm transition-colors hover:bg-accent/40">
-      {/* Icon + Name (navigates to detail) */}
-      <AppLink
-        href={wsPaths.projectDetail(project.id)}
-        className="flex min-w-0 flex-1 items-center gap-2"
-      >
-        <ProjectIcon project={project} size="md" />
-        <span className="min-w-0 flex-1 truncate font-medium">{project.title}</span>
-      </AppLink>
+    <div className="group/card flex flex-col rounded-md border bg-card hover:border-primary/50 transition-colors">
+      <div className="p-3 pb-2">
+        <div className="flex items-center gap-2">
+          <AppLink
+            href={wsPaths.projectDetail(project.id)}
+            className="flex items-center gap-2 min-w-0 flex-1"
+          >
+            <ProjectIcon project={project} size="sm" />
+            <h3 className="font-medium text-sm truncate">{project.title}</h3>
+          </AppLink>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <button type="button" className={cn(
+                  "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:opacity-80 transition-opacity shrink-0",
+                  statusCfg.badgeBg, statusCfg.badgeText,
+                )}>
+                  {statusLabels[project.status]}
+                </button>
+              }
+            />
+            <DropdownMenuContent align="end" className="w-44">
+              {PROJECT_STATUS_ORDER.map((s) => (
+                <DropdownMenuItem key={s} onClick={() => handleUpdate({ status: s as ProjectStatus })}>
+                  <span className={cn("size-2 rounded-full", PROJECT_STATUS_CONFIG[s].dotColor)} />
+                  <span>{statusLabels[s]}</span>
+                  {s === project.status && <Check className="ml-auto h-3.5 w-3.5" />}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
 
-      {/* Priority — dropdown */}
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <button type="button" className="flex w-24 items-center justify-center gap-1 shrink-0 rounded px-1 py-0.5 hover:bg-accent/60 transition-colors cursor-pointer">
-              <PriorityIcon priority={project.priority} />
-              <span className={cn("text-xs", priorityCfg.color)}>{priorityLabels[project.priority]}</span>
-            </button>
-          }
-        />
-        <DropdownMenuContent align="start" className="w-44">
-          {PROJECT_PRIORITY_ORDER.map((p) => (
-            <DropdownMenuItem key={p} onClick={() => handleUpdate({ priority: p as ProjectPriority })}>
-              <PriorityIcon priority={p} />
-              <span>{priorityLabels[p]}</span>
-              {p === project.priority && <Check className="ml-auto h-3.5 w-3.5" />}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      {/* Status — dropdown */}
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <button type="button" className={cn(
-              "inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium shrink-0 w-28 justify-center cursor-pointer hover:opacity-80 transition-opacity",
-              statusCfg.badgeBg, statusCfg.badgeText,
-            )}>
-              {statusLabels[project.status]}
-            </button>
-          }
-        />
-        <DropdownMenuContent align="start" className="w-44">
-          {PROJECT_STATUS_ORDER.map((s) => (
-            <DropdownMenuItem key={s} onClick={() => handleUpdate({ status: s as ProjectStatus })}>
-              <span className={cn("size-2 rounded-full", PROJECT_STATUS_CONFIG[s].dotColor)} />
-              <span>{statusLabels[s]}</span>
-              {s === project.status && <Check className="ml-auto h-3.5 w-3.5" />}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      {/* Progress (read-only) */}
-      <span className="flex w-24 items-center justify-center gap-1.5 shrink-0">
         {project.issue_count > 0 ? (
-          <>
-            <span className="relative h-1.5 w-12 rounded-full bg-muted overflow-hidden">
-              <span
-                className="absolute inset-y-0 left-0 rounded-full bg-emerald-500 transition-all"
-                style={{ width: `${Math.round((project.done_count / project.issue_count) * 100)}%` }}
-              />
-            </span>
-            <span className="text-xs text-muted-foreground tabular-nums">
+          <div className="flex justify-end items-center gap-1.5 pt-2">
+            <div className="relative h-4 w-4">
+              <svg className="h-4 w-4 -rotate-90" viewBox="0 0 16 16">
+                <circle
+                  className="text-muted"
+                  strokeWidth="2"
+                  stroke="currentColor"
+                  fill="none"
+                  r="6"
+                  cx="8"
+                  cy="8"
+                />
+                <circle
+                  className="text-emerald-500"
+                  strokeWidth="2"
+                  stroke="currentColor"
+                  fill="none"
+                  r="6"
+                  cx="8"
+                  cy="8"
+                  strokeDasharray={`${progressPercent * 0.377} 37.7`}
+                  strokeLinecap="round"
+                />
+              </svg>
+            </div>
+            <span className="text-[10px] text-muted-foreground tabular-nums">
               {project.done_count}/{project.issue_count}
             </span>
-          </>
+          </div>
         ) : (
-          <span className="text-xs text-muted-foreground">--</span>
+          <span className="text-[10px] text-muted-foreground pt-2 flex justify-end">No issues yet</span>
         )}
+      </div>
+
+      <div className="flex items-center justify-between px-3 pb-3 border-t mt-0 pt-2">
+        <Popover open={leadOpen} onOpenChange={(v) => { setLeadOpen(v); if (!v) setLeadFilter(""); }}>
+          <PopoverTrigger
+            render={
+              <button type="button" className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -mx-1.5 hover:bg-accent/60 transition-colors cursor-pointer">
+                {project.lead_type && project.lead_id ? (
+                  <Tooltip>
+                    <TooltipTrigger render={<span><ActorAvatar actorType={project.lead_type} actorId={project.lead_id} size={20} enableHoverCard /></span>} />
+                    <TooltipContent side="bottom">{getActorName(project.lead_type, project.lead_id)}</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <span className="inline-flex h-5 w-5 rounded-full border border-dashed border-muted-foreground/30" />
+                )}
+                <span className="text-[10px] text-muted-foreground truncate max-w-[60px]">
+                  {project.lead_type && project.lead_id ? getActorName(project.lead_type, project.lead_id) : t(($) => $.lead.no_lead)}
+                </span>
+              </button>
+            }
+          />
+          <PopoverContent align="start" className="w-52 p-0">
+            <div className="px-2 py-1.5 border-b">
+              <input
+                type="text"
+                value={leadFilter}
+                onChange={(e) => setLeadFilter(e.target.value)}
+                placeholder={t(($) => $.lead.assign_placeholder)}
+                className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
+              />
+            </div>
+            <div className="p-1 max-h-48 overflow-y-auto">
+              <button
+                type="button"
+                onClick={() => { handleUpdate({ lead_type: null, lead_id: null }); setLeadOpen(false); }}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+              >
+                <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-muted-foreground">{t(($) => $.lead.no_lead)}</span>
+              </button>
+              {filteredMembers.length > 0 && (
+                <>
+                  <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">{t(($) => $.lead.members_group)}</div>
+                  {filteredMembers.map((m) => (
+                    <button
+                      type="button"
+                      key={m.user_id}
+                      onClick={() => { handleUpdate({ lead_type: "member", lead_id: m.user_id }); setLeadOpen(false); }}
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                    >
+                      <ActorAvatar actorType="member" actorId={m.user_id} size={16} />
+                      <span>{m.name}</span>
+                    </button>
+                  ))}
+                </>
+              )}
+              {filteredAgents.length > 0 && (
+                <>
+                  <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">{t(($) => $.lead.agents_group)}</div>
+                  {filteredAgents.map((a) => (
+                    <button
+                      type="button"
+                      key={a.id}
+                      onClick={() => { handleUpdate({ lead_type: "agent", lead_id: a.id }); setLeadOpen(false); }}
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
+                    >
+                      <ActorAvatar actorType="agent" actorId={a.id} size={16} showStatusDot />
+                      <span>{a.name}</span>
+                    </button>
+                  ))}
+                </>
+              )}
+              {filteredMembers.length === 0 && filteredAgents.length === 0 && leadFilter && (
+                <div className="px-2 py-3 text-center text-sm text-muted-foreground">{t(($) => $.lead.no_results)}</div>
+              )}
+            </div>
+          </PopoverContent>
+        </Popover>
+
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <button type="button" className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium hover:bg-accent/60 transition-colors cursor-pointer">
+                  <PriorityIcon priority={project.priority} />
+                  <span className={cn("text-xs", priorityCfg.color)}>{priorityLabels[project.priority]}</span>
+                </button>
+              }
+            />
+            <DropdownMenuContent align="start" className="w-44">
+              {PROJECT_PRIORITY_ORDER.map((p) => (
+                <DropdownMenuItem key={p} onClick={() => handleUpdate({ priority: p as ProjectPriority })}>
+                  <PriorityIcon priority={p} />
+                  <span>{priorityLabels[p]}</span>
+                  {p === project.priority && <Check className="ml-auto h-3.5 w-3.5" />}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <span className="text-[10px] text-muted-foreground">
+            {formatRelativeDate(project.created_at)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+function ProjectCardCompact({ project }: { project: Project }) {
+  const { t } = useT("projects");
+  const wsId = useWorkspaceId();
+  const wsPaths = useWorkspacePaths();
+  const statusLabels = useProjectStatusLabels();
+  const priorityLabels = useProjectPriorityLabels();
+  const formatRelativeDate = useFormatRelativeDate();
+  const statusCfg = PROJECT_STATUS_CONFIG[project.status];
+  const priorityCfg = PROJECT_PRIORITY_CONFIG[project.priority];
+  const updateProject = useUpdateProject();
+  const { getActorName } = useActorName();
+  const { data: members = [] } = useQuery(memberListOptions(wsId));
+  const { data: agents = [] } = useQuery(agentListOptions(wsId));
+
+  const [leadOpen, setLeadOpen] = useState(false);
+  const [leadFilter, setLeadFilter] = useState("");
+  const leadQuery = leadFilter.toLowerCase();
+  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
+  const filteredAgents = agents.filter((a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)));
+
+  const handleUpdate = useCallback(
+    (data: UpdateProjectRequest) => {
+      updateProject.mutate({ id: project.id, ...data });
+    },
+    [project.id, updateProject],
+  );
+
+  const leadId = project.lead_id;
+  const leadType = project.lead_type;
+  const leadName = leadId && leadType ? getActorName(leadType, leadId) : null;
+
+  return (
+    <div className="grid w-full min-w-[740px] grid-cols-[24px_minmax(200px,1fr)_96px_96px_80px_80px_80px] h-10 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/40 border-b">
+      <ProjectIcon project={project} size="sm" />
+      <AppLink
+        href={wsPaths.projectDetail(project.id)}
+        className="flex items-center justify-start gap-2 min-w-0 overflow-hidden"
+      >
+        <span className="font-medium truncate text-left">{project.title}</span>
+      </AppLink>
+
+      <div className="flex items-center justify-start">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <button type="button" className="flex items-center justify-start gap-1 rounded px-1 py-0.5 hover:bg-accent/60 transition-colors cursor-pointer">
+                <PriorityIcon priority={project.priority} />
+                <span className={cn("text-xs", priorityCfg.color)}>{priorityLabels[project.priority]}</span>
+              </button>
+            }
+          />
+          <DropdownMenuContent align="start" className="w-44">
+            {PROJECT_PRIORITY_ORDER.map((p) => (
+              <DropdownMenuItem key={p} onClick={() => handleUpdate({ priority: p as ProjectPriority })}>
+                <PriorityIcon priority={p} />
+                <span>{priorityLabels[p]}</span>
+                {p === project.priority && <Check className="ml-auto h-3.5 w-3.5" />}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex items-center justify-start">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <button type="button" className={cn(
+                "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:opacity-80 transition-opacity",
+                statusCfg.badgeBg, statusCfg.badgeText,
+              )}>
+                {statusLabels[project.status]}
+              </button>
+            }
+          />
+          <DropdownMenuContent align="start" className="w-44">
+            {PROJECT_STATUS_ORDER.map((s) => (
+              <DropdownMenuItem key={s} onClick={() => handleUpdate({ status: s as ProjectStatus })}>
+                <span className={cn("size-2 rounded-full", PROJECT_STATUS_CONFIG[s].dotColor)} />
+                <span>{statusLabels[s]}</span>
+                {s === project.status && <Check className="ml-auto h-3.5 w-3.5" />}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <span className="flex items-center justify-start gap-1.5 text-xs text-muted-foreground tabular-nums">
+        {project.issue_count > 0 ? `${project.done_count}/${project.issue_count}` : "--"}
       </span>
 
-      {/* Lead — popover */}
       <Popover open={leadOpen} onOpenChange={(v) => { setLeadOpen(v); if (!v) setLeadFilter(""); }}>
         <PopoverTrigger
           render={
-            <button type="button" className="flex w-10 items-center justify-center shrink-0 rounded-full hover:ring-2 hover:ring-accent transition-all cursor-pointer">
-              {project.lead_type && project.lead_id ? (
-                <Tooltip>
-                  <TooltipTrigger render={<span><ActorAvatar actorType={project.lead_type} actorId={project.lead_id} size={22} enableHoverCard /></span>} />
-                  <TooltipContent side="bottom">{getActorName(project.lead_type, project.lead_id)}</TooltipContent>
-                </Tooltip>
-              ) : (
-                <span className="h-[22px] w-[22px] rounded-full border border-dashed border-muted-foreground/30" />
-              )}
+            <button type="button" className="flex items-center justify-start gap-1.5 rounded px-1 py-0.5 hover:bg-accent/60 transition-colors cursor-pointer">
+              <span className="shrink-0">
+                {project.lead_type && project.lead_id ? (
+                  <ActorAvatar actorType={project.lead_type} actorId={project.lead_id} size={20} enableHoverCard />
+                ) : (
+                  <span className="inline-flex h-5 w-5 rounded-full border border-dashed border-muted-foreground/30" />
+                )}
+              </span>
+              <span className="text-xs text-muted-foreground truncate max-w-[50px]">
+                {leadName ?? t(($) => $.lead.no_lead)}
+              </span>
             </button>
           }
         />
@@ -172,7 +370,7 @@ function ProjectRow({ project }: { project: Project }) {
               className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
             />
           </div>
-          <div className="p-1 max-h-60 overflow-y-auto">
+          <div className="p-1 max-h-48 overflow-y-auto">
             <button
               type="button"
               onClick={() => { handleUpdate({ lead_type: null, lead_id: null }); setLeadOpen(false); }}
@@ -220,8 +418,7 @@ function ProjectRow({ project }: { project: Project }) {
         </PopoverContent>
       </Popover>
 
-      {/* Created */}
-      <span className="w-20 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+      <span className="text-left text-xs text-muted-foreground tabular-nums">
         {formatRelativeDate(project.created_at)}
       </span>
     </div>
@@ -232,12 +429,15 @@ function ProjectRow({ project }: { project: Project }) {
 export function ProjectsPage() {
   const { t } = useT("projects");
   const wsId = useWorkspaceId();
+  const viewMode = useProjectViewStore((s) => s.viewMode);
+  const setViewMode = useProjectViewStore((s) => s.setViewMode);
+  const isCompact = viewMode === "compact";
+  const gridClass = isCompact ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3";
   const { data: projects = [], isLoading } = useQuery(projectListOptions(wsId));
   const openCreateProject = () => useModalStore.getState().open("create-project");
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header bar */}
       <PageHeader className="justify-between px-5">
         <div className="flex items-center gap-2">
           <FolderKanban className="h-4 w-4 text-muted-foreground" />
@@ -246,31 +446,85 @@ export function ProjectsPage() {
             <span className="text-xs text-muted-foreground tabular-nums">{projects.length}</span>
           )}
         </div>
-        <Button size="sm" variant="outline" onClick={openCreateProject}>
-          <Plus className="h-3.5 w-3.5 mr-1" />
-          {t(($) => $.page.new_project)}
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={openCreateProject}>
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            {t(($) => $.page.new_project)}
+          </Button>
+        </div>
       </PageHeader>
 
-      {/* Table */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto flex flex-col">
+        {(projects.length > 0 || isLoading) && (
+          <div className="flex justify-end px-5 pt-4 -mb-2">
+            <DropdownMenu>
+              <Tooltip>
+                <DropdownMenuTrigger
+                  render={
+                    <TooltipTrigger
+                      render={
+                        <Button variant="ghost" size="icon-sm" className="text-muted-foreground">
+                          {isCompact ? <Rows3 className="size-4" /> : <LayoutGrid className="size-4" />}
+                        </Button>
+                      }
+                    />
+                  }
+                />
+                <TooltipContent side="bottom">
+                  {isCompact ? "Compact" : "Comfortable"}
+                </TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="end" className="w-auto">
+                <DropdownMenuGroup>
+                  <DropdownMenuItem onClick={() => setViewMode("compact")}>
+                    <Rows3 className="mr-2 h-4 w-4" />
+                    Compact
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setViewMode("comfortable")}>
+                    <LayoutGrid className="mr-2 h-4 w-4" />
+                    Comfortable
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
         {isLoading ? (
-          <>
-            <div className="sticky top-0 z-[1] flex h-8 items-center gap-2 border-b bg-muted/30 px-5">
-              <span className="shrink-0 w-[24px]" />
-              <Skeleton className="h-3 w-12 flex-1 max-w-[48px]" />
-              <Skeleton className="h-3 w-12 shrink-0" />
-              <Skeleton className="h-3 w-12 shrink-0" />
-              <Skeleton className="h-3 w-12 shrink-0" />
-              <Skeleton className="h-3 w-8 shrink-0" />
-              <Skeleton className="h-3 w-12 shrink-0" />
+          isCompact ? (
+            <div className="pt-4 overflow-x-auto">
+              <div className="min-w-[600px]">
+                <div className="flex h-10 items-center gap-2 px-4 border-b">
+                  <Skeleton className="h-6 w-6 rounded" />
+                  <Skeleton className="h-4 w-48" />
+                </div>
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="flex h-10 items-center gap-2 px-4 border-b">
+                    <Skeleton className="h-6 w-6 rounded" />
+                    <Skeleton className="h-4 w-48" />
+                  </div>
+                ))}
+              </div>
             </div>
-            <div className="p-5 pt-1 space-y-1">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <Skeleton key={i} className="h-11 w-full" />
+          ) : (
+            <div className={cn("pt-4 grid px-5", gridClass)}>
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className={cn("flex flex-col rounded-md border p-3 gap-2")}>
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-8 w-8 rounded" />
+                    <Skeleton className="h-4 w-3/4" />
+                  </div>
+                  <div className="flex gap-1.5">
+                    <Skeleton className="h-5 w-16 rounded" />
+                    <Skeleton className="h-5 w-20 rounded" />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <Skeleton className="h-5 w-5 rounded-full" />
+                    <Skeleton className="h-3 w-12" />
+                  </div>
+                </div>
               ))}
             </div>
-          </>
+          )
         ) : projects.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-24 text-muted-foreground">
             <FolderKanban className="h-10 w-10 mb-3 opacity-30" />
@@ -279,24 +533,29 @@ export function ProjectsPage() {
               {t(($) => $.page.create_first)}
             </Button>
           </div>
-        ) : (
-          <>
-            {/* Column headers */}
-            <div className="sticky top-0 z-[1] flex h-8 items-center gap-2 border-b bg-muted/30 px-5 text-xs font-medium text-muted-foreground">
-              {/* Icon spacer + Name */}
-              <span className="shrink-0 w-[24px]" />
-              <span className="min-w-0 flex-1">{t(($) => $.table.name)}</span>
-              <span className="w-24 text-center shrink-0">{t(($) => $.table.priority)}</span>
-              <span className="w-28 text-center shrink-0">{t(($) => $.table.status)}</span>
-              <span className="w-24 text-center shrink-0">{t(($) => $.table.progress)}</span>
-              <span className="w-10 text-center shrink-0">{t(($) => $.table.lead)}</span>
-              <span className="w-20 text-right shrink-0">{t(($) => $.table.created)}</span>
+        ) : isCompact ? (
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border mt-4 mx-5">
+            <div className="flex min-h-0 flex-1 flex-col overflow-auto min-w-0 pb-4">
+              <div className="grid w-full min-w-[740px] grid-cols-[24px_minmax(200px,1fr)_96px_96px_80px_80px_80px] h-8 shrink-0 items-center gap-2 px-4 text-xs font-medium text-muted-foreground border-b bg-muted/30 sticky top-0 z-10">
+                <span />
+                <span className="text-left">{t(($) => $.table.name)}</span>
+                <span className="text-left">{t(($) => $.table.priority)}</span>
+                <span className="text-left">{t(($) => $.table.status)}</span>
+                <span className="text-left">{t(($) => $.table.progress)}</span>
+                <span className="text-left">{t(($) => $.table.lead)}</span>
+                <span className="text-left">{t(($) => $.table.created)}</span>
+              </div>
+              {projects.map((project) => (
+                <ProjectCardCompact key={project.id} project={project} />
+              ))}
             </div>
-            {/* Rows */}
+          </div>
+        ) : (
+          <div className={cn("pt-4 pb-5 px-5 grid", gridClass)}>
             {projects.map((project) => (
-              <ProjectRow key={project.id} project={project} />
+              <ProjectCard key={project.id} project={project} />
             ))}
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/packages/views/projects/components/projects-page.tsx
+++ b/packages/views/projects/components/projects-page.tsx
@@ -1,71 +1,36 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { Plus, FolderKanban, UserMinus, Check, Rows3, LayoutGrid } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { Plus, FolderKanban, Rows3, LayoutGrid, Search } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { projectListOptions } from "@multica/core/projects/queries";
 import { useUpdateProject } from "@multica/core/projects/mutations";
-import {
-  PROJECT_STATUS_CONFIG,
-  PROJECT_STATUS_ORDER,
-  PROJECT_PRIORITY_CONFIG,
-  PROJECT_PRIORITY_ORDER,
-} from "@multica/core/projects/config";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
-import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import { useModalStore } from "@multica/core/modals";
 import { AppLink } from "../../navigation";
 import { ActorAvatar } from "../../common/actor-avatar";
-import { useActorName } from "@multica/core/workspace/hooks";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { Button } from "@multica/ui/components/ui/button";
+import { Input } from "@multica/ui/components/ui/input";
 import { cn } from "@multica/ui/lib/utils";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@multica/ui/components/ui/dropdown-menu";
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@multica/ui/components/ui/popover";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
-import type { Project, ProjectStatus, ProjectPriority, UpdateProjectRequest } from "@multica/core/types";
+import type { Project, UpdateProjectRequest } from "@multica/core/types";
 import { PageHeader } from "../../layout/page-header";
-import { PriorityIcon } from "../../issues/components/priority-icon";
 import { ProjectIcon } from "./project-icon";
 import { useT } from "../../i18n";
-import {
-  useProjectStatusLabels,
-  useProjectPriorityLabels,
-  useFormatRelativeDate,
-} from "./labels";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
+import { useFormatRelativeDate } from "./labels";
 import { useProjectViewStore } from "@multica/core/projects";
+import { ProjectStatusBadge, ProjectPriorityBadge } from "./project-badge";
+import { ProjectLeadPicker } from "./project-lead-picker";
+
+const COMPACT_GRID = "grid w-full min-w-[740px] grid-cols-[24px_minmax(200px,1fr)_96px_96px_80px_80px_80px]";
 
 function ProjectCard({ project }: { project: Project }) {
   const { t } = useT("projects");
-  const wsId = useWorkspaceId();
   const wsPaths = useWorkspacePaths();
-  const statusLabels = useProjectStatusLabels();
-  const priorityLabels = useProjectPriorityLabels();
   const formatRelativeDate = useFormatRelativeDate();
-  const statusCfg = PROJECT_STATUS_CONFIG[project.status];
-  const priorityCfg = PROJECT_PRIORITY_CONFIG[project.priority];
   const updateProject = useUpdateProject();
-  const { data: members = [] } = useQuery(memberListOptions(wsId));
-  const { data: agents = [] } = useQuery(agentListOptions(wsId));
-  const { getActorName } = useActorName();
-
-  const [leadOpen, setLeadOpen] = useState(false);
-  const [leadFilter, setLeadFilter] = useState("");
-  const leadQuery = leadFilter.toLowerCase();
-  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
-  const filteredAgents = agents.filter((a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)));
 
   const handleUpdate = useCallback(
     (data: UpdateProjectRequest) => {
@@ -87,27 +52,7 @@ function ProjectCard({ project }: { project: Project }) {
             <ProjectIcon project={project} size="sm" />
             <h3 className="font-medium text-sm truncate">{project.title}</h3>
           </AppLink>
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <button type="button" className={cn(
-                  "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:opacity-80 transition-opacity shrink-0",
-                  statusCfg.badgeBg, statusCfg.badgeText,
-                )}>
-                  {statusLabels[project.status]}
-                </button>
-              }
-            />
-            <DropdownMenuContent align="end" className="w-44">
-              {PROJECT_STATUS_ORDER.map((s) => (
-                <DropdownMenuItem key={s} onClick={() => handleUpdate({ status: s as ProjectStatus })}>
-                  <span className={cn("size-2 rounded-full", PROJECT_STATUS_CONFIG[s].dotColor)} />
-                  <span>{statusLabels[s]}</span>
-                  {s === project.status && <Check className="ml-auto h-3.5 w-3.5" />}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <ProjectStatusBadge project={project} handleUpdate={handleUpdate} triggerClassName="shrink-0" />
         </div>
 
         {project.issue_count > 0 ? (
@@ -146,102 +91,25 @@ function ProjectCard({ project }: { project: Project }) {
       </div>
 
       <div className="flex items-center justify-between px-3 pb-3 border-t mt-0 pt-2">
-        <Popover open={leadOpen} onOpenChange={(v) => { setLeadOpen(v); if (!v) setLeadFilter(""); }}>
-          <PopoverTrigger
-            render={
-              <button type="button" className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -mx-1.5 hover:bg-accent/60 transition-colors cursor-pointer">
-                {project.lead_type && project.lead_id ? (
-                  <Tooltip>
-                    <TooltipTrigger render={<span><ActorAvatar actorType={project.lead_type} actorId={project.lead_id} size={20} enableHoverCard /></span>} />
-                    <TooltipContent side="bottom">{getActorName(project.lead_type, project.lead_id)}</TooltipContent>
-                  </Tooltip>
-                ) : (
-                  <span className="inline-flex h-5 w-5 rounded-full border border-dashed border-muted-foreground/30" />
-                )}
-                <span className="text-[10px] text-muted-foreground truncate max-w-[60px]">
-                  {project.lead_type && project.lead_id ? getActorName(project.lead_type, project.lead_id) : t(($) => $.lead.no_lead)}
-                </span>
-              </button>
-            }
-          />
-          <PopoverContent align="start" className="w-52 p-0">
-            <div className="px-2 py-1.5 border-b">
-              <input
-                type="text"
-                value={leadFilter}
-                onChange={(e) => setLeadFilter(e.target.value)}
-                placeholder={t(($) => $.lead.assign_placeholder)}
-                className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
-              />
-            </div>
-            <div className="p-1 max-h-48 overflow-y-auto">
-              <button
-                type="button"
-                onClick={() => { handleUpdate({ lead_type: null, lead_id: null }); setLeadOpen(false); }}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-              >
-                <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="text-muted-foreground">{t(($) => $.lead.no_lead)}</span>
-              </button>
-              {filteredMembers.length > 0 && (
-                <>
-                  <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">{t(($) => $.lead.members_group)}</div>
-                  {filteredMembers.map((m) => (
-                    <button
-                      type="button"
-                      key={m.user_id}
-                      onClick={() => { handleUpdate({ lead_type: "member", lead_id: m.user_id }); setLeadOpen(false); }}
-                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                    >
-                      <ActorAvatar actorType="member" actorId={m.user_id} size={16} />
-                      <span>{m.name}</span>
-                    </button>
-                  ))}
-                </>
+        <ProjectLeadPicker 
+          project={project} 
+          handleUpdate={handleUpdate}
+          renderTrigger={(leadName) => (
+            <button type="button" className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -mx-1.5 hover:bg-accent/60 transition-colors cursor-pointer">
+              {project.lead_type && project.lead_id ? (
+                <ActorAvatar actorType={project.lead_type} actorId={project.lead_id} size={20} enableHoverCard />
+              ) : (
+                <span className="inline-flex h-5 w-5 rounded-full border border-dashed border-muted-foreground/30" />
               )}
-              {filteredAgents.length > 0 && (
-                <>
-                  <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">{t(($) => $.lead.agents_group)}</div>
-                  {filteredAgents.map((a) => (
-                    <button
-                      type="button"
-                      key={a.id}
-                      onClick={() => { handleUpdate({ lead_type: "agent", lead_id: a.id }); setLeadOpen(false); }}
-                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                    >
-                      <ActorAvatar actorType="agent" actorId={a.id} size={16} showStatusDot />
-                      <span>{a.name}</span>
-                    </button>
-                  ))}
-                </>
-              )}
-              {filteredMembers.length === 0 && filteredAgents.length === 0 && leadFilter && (
-                <div className="px-2 py-3 text-center text-sm text-muted-foreground">{t(($) => $.lead.no_results)}</div>
-              )}
-            </div>
-          </PopoverContent>
-        </Popover>
+              <span className="text-[10px] text-muted-foreground truncate max-w-[60px]">
+                {leadName ?? t(($) => $.lead.no_lead)}
+              </span>
+            </button>
+          )}
+        />
 
         <div className="flex items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <button type="button" className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium hover:bg-accent/60 transition-colors cursor-pointer">
-                  <PriorityIcon priority={project.priority} />
-                  <span className={cn("text-xs", priorityCfg.color)}>{priorityLabels[project.priority]}</span>
-                </button>
-              }
-            />
-            <DropdownMenuContent align="start" className="w-44">
-              {PROJECT_PRIORITY_ORDER.map((p) => (
-                <DropdownMenuItem key={p} onClick={() => handleUpdate({ priority: p as ProjectPriority })}>
-                  <PriorityIcon priority={p} />
-                  <span>{priorityLabels[p]}</span>
-                  {p === project.priority && <Check className="ml-auto h-3.5 w-3.5" />}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <ProjectPriorityBadge project={project} handleUpdate={handleUpdate} align="start" />
           <span className="text-[10px] text-muted-foreground">
             {formatRelativeDate(project.created_at)}
           </span>
@@ -251,26 +119,10 @@ function ProjectCard({ project }: { project: Project }) {
   );
 }
 
-
 function ProjectCardCompact({ project }: { project: Project }) {
-  const { t } = useT("projects");
-  const wsId = useWorkspaceId();
   const wsPaths = useWorkspacePaths();
-  const statusLabels = useProjectStatusLabels();
-  const priorityLabels = useProjectPriorityLabels();
   const formatRelativeDate = useFormatRelativeDate();
-  const statusCfg = PROJECT_STATUS_CONFIG[project.status];
-  const priorityCfg = PROJECT_PRIORITY_CONFIG[project.priority];
   const updateProject = useUpdateProject();
-  const { getActorName } = useActorName();
-  const { data: members = [] } = useQuery(memberListOptions(wsId));
-  const { data: agents = [] } = useQuery(agentListOptions(wsId));
-
-  const [leadOpen, setLeadOpen] = useState(false);
-  const [leadFilter, setLeadFilter] = useState("");
-  const leadQuery = leadFilter.toLowerCase();
-  const filteredMembers = members.filter((m) => m.name.toLowerCase().includes(leadQuery) || matchesPinyin(m.name, leadQuery));
-  const filteredAgents = agents.filter((a) => !a.archived_at && (a.name.toLowerCase().includes(leadQuery) || matchesPinyin(a.name, leadQuery)));
 
   const handleUpdate = useCallback(
     (data: UpdateProjectRequest) => {
@@ -279,12 +131,8 @@ function ProjectCardCompact({ project }: { project: Project }) {
     [project.id, updateProject],
   );
 
-  const leadId = project.lead_id;
-  const leadType = project.lead_type;
-  const leadName = leadId && leadType ? getActorName(leadType, leadId) : null;
-
   return (
-    <div className="grid w-full min-w-[740px] grid-cols-[24px_minmax(200px,1fr)_96px_96px_80px_80px_80px] h-10 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/40 border-b">
+    <div className={cn(COMPACT_GRID, "h-10 items-center gap-2 px-4 text-sm transition-colors hover:bg-accent/40 border-b")}>
       <ProjectIcon project={project} size="sm" />
       <AppLink
         href={wsPaths.projectDetail(project.id)}
@@ -294,129 +142,36 @@ function ProjectCardCompact({ project }: { project: Project }) {
       </AppLink>
 
       <div className="flex items-center justify-start">
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <button type="button" className="flex items-center justify-start gap-1 rounded px-1 py-0.5 hover:bg-accent/60 transition-colors cursor-pointer">
-                <PriorityIcon priority={project.priority} />
-                <span className={cn("text-xs", priorityCfg.color)}>{priorityLabels[project.priority]}</span>
-              </button>
-            }
-          />
-          <DropdownMenuContent align="start" className="w-44">
-            {PROJECT_PRIORITY_ORDER.map((p) => (
-              <DropdownMenuItem key={p} onClick={() => handleUpdate({ priority: p as ProjectPriority })}>
-                <PriorityIcon priority={p} />
-                <span>{priorityLabels[p]}</span>
-                {p === project.priority && <Check className="ml-auto h-3.5 w-3.5" />}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <ProjectPriorityBadge project={project} handleUpdate={handleUpdate} align="start" />
       </div>
 
       <div className="flex items-center justify-start">
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <button type="button" className={cn(
-                "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:opacity-80 transition-opacity",
-                statusCfg.badgeBg, statusCfg.badgeText,
-              )}>
-                {statusLabels[project.status]}
-              </button>
-            }
-          />
-          <DropdownMenuContent align="start" className="w-44">
-            {PROJECT_STATUS_ORDER.map((s) => (
-              <DropdownMenuItem key={s} onClick={() => handleUpdate({ status: s as ProjectStatus })}>
-                <span className={cn("size-2 rounded-full", PROJECT_STATUS_CONFIG[s].dotColor)} />
-                <span>{statusLabels[s]}</span>
-                {s === project.status && <Check className="ml-auto h-3.5 w-3.5" />}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <ProjectStatusBadge project={project} handleUpdate={handleUpdate} align="start" />
       </div>
 
       <span className="flex items-center justify-start gap-1.5 text-xs text-muted-foreground tabular-nums">
         {project.issue_count > 0 ? `${project.done_count}/${project.issue_count}` : "--"}
       </span>
 
-      <Popover open={leadOpen} onOpenChange={(v) => { setLeadOpen(v); if (!v) setLeadFilter(""); }}>
-        <PopoverTrigger
-          render={
-            <button type="button" className="flex items-center justify-start gap-1.5 rounded px-1 py-0.5 hover:bg-accent/60 transition-colors cursor-pointer">
-              <span className="shrink-0">
-                {project.lead_type && project.lead_id ? (
-                  <ActorAvatar actorType={project.lead_type} actorId={project.lead_id} size={20} enableHoverCard />
-                ) : (
-                  <span className="inline-flex h-5 w-5 rounded-full border border-dashed border-muted-foreground/30" />
-                )}
-              </span>
-              <span className="text-xs text-muted-foreground truncate max-w-[50px]">
-                {leadName ?? t(($) => $.lead.no_lead)}
-              </span>
-            </button>
-          }
-        />
-        <PopoverContent align="start" className="w-52 p-0">
-          <div className="px-2 py-1.5 border-b">
-            <input
-              type="text"
-              value={leadFilter}
-              onChange={(e) => setLeadFilter(e.target.value)}
-              placeholder={t(($) => $.lead.assign_placeholder)}
-              className="w-full bg-transparent text-sm placeholder:text-muted-foreground outline-none"
-            />
-          </div>
-          <div className="p-1 max-h-48 overflow-y-auto">
-            <button
-              type="button"
-              onClick={() => { handleUpdate({ lead_type: null, lead_id: null }); setLeadOpen(false); }}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-            >
-              <UserMinus className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="text-muted-foreground">{t(($) => $.lead.no_lead)}</span>
-            </button>
-            {filteredMembers.length > 0 && (
-              <>
-                <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">{t(($) => $.lead.members_group)}</div>
-                {filteredMembers.map((m) => (
-                  <button
-                    type="button"
-                    key={m.user_id}
-                    onClick={() => { handleUpdate({ lead_type: "member", lead_id: m.user_id }); setLeadOpen(false); }}
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                  >
-                    <ActorAvatar actorType="member" actorId={m.user_id} size={16} />
-                    <span>{m.name}</span>
-                  </button>
-                ))}
-              </>
-            )}
-            {filteredAgents.length > 0 && (
-              <>
-                <div className="px-2 pt-2 pb-1 text-xs font-medium text-muted-foreground uppercase tracking-wider">{t(($) => $.lead.agents_group)}</div>
-                {filteredAgents.map((a) => (
-                  <button
-                    type="button"
-                    key={a.id}
-                    onClick={() => { handleUpdate({ lead_type: "agent", lead_id: a.id }); setLeadOpen(false); }}
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent transition-colors"
-                  >
-                    <ActorAvatar actorType="agent" actorId={a.id} size={16} showStatusDot />
-                    <span>{a.name}</span>
-                  </button>
-                ))}
-              </>
-            )}
-            {filteredMembers.length === 0 && filteredAgents.length === 0 && leadFilter && (
-              <div className="px-2 py-3 text-center text-sm text-muted-foreground">{t(($) => $.lead.no_results)}</div>
-            )}
-          </div>
-        </PopoverContent>
-      </Popover>
+      <ProjectLeadPicker 
+        project={project} 
+        handleUpdate={handleUpdate}
+        align="start"
+        renderTrigger={(leadName) => (
+          <button type="button" className="flex items-center justify-start gap-1.5 rounded px-1 py-0.5 hover:bg-accent/60 transition-colors cursor-pointer">
+            <span className="shrink-0">
+              {project.lead_type && project.lead_id ? (
+                <ActorAvatar actorType={project.lead_type} actorId={project.lead_id} size={20} enableHoverCard />
+              ) : (
+                <span className="inline-flex h-5 w-5 rounded-full border border-dashed border-muted-foreground/30" />
+              )}
+            </span>
+            <span className="text-xs text-muted-foreground truncate max-w-[50px]">
+              {leadName ?? "--"}
+            </span>
+          </button>
+        )}
+      />
 
       <span className="text-left text-xs text-muted-foreground tabular-nums">
         {formatRelativeDate(project.created_at)}
@@ -425,19 +180,26 @@ function ProjectCardCompact({ project }: { project: Project }) {
   );
 }
 
-
 export function ProjectsPage() {
   const { t } = useT("projects");
   const wsId = useWorkspaceId();
   const viewMode = useProjectViewStore((s) => s.viewMode);
   const setViewMode = useProjectViewStore((s) => s.setViewMode);
   const isCompact = viewMode === "compact";
-  const gridClass = isCompact ? "grid-cols-1" : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3";
   const { data: projects = [], isLoading } = useQuery(projectListOptions(wsId));
   const openCreateProject = () => useModalStore.getState().open("create-project");
 
+  const [search, setSearch] = useState("");
+  const filteredProjects = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return projects;
+    return projects.filter((p) => 
+      p.title.toLowerCase().includes(q) || matchesPinyin(p.title, q)
+    );
+  }, [projects, search]);
+
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex flex-1 min-h-0 flex-col">
       <PageHeader className="justify-between px-5">
         <div className="flex items-center gap-2">
           <FolderKanban className="h-4 w-4 text-muted-foreground" />
@@ -446,97 +208,105 @@ export function ProjectsPage() {
             <span className="text-xs text-muted-foreground tabular-nums">{projects.length}</span>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <Button size="sm" variant="outline" onClick={openCreateProject}>
-            <Plus className="h-3.5 w-3.5 mr-1" />
-            {t(($) => $.page.new_project)}
-          </Button>
-        </div>
+        <Button size="sm" variant="outline" onClick={openCreateProject}>
+          <Plus className="h-3.5 w-3.5 mr-1" />
+          {t(($) => $.page.new_project)}
+        </Button>
       </PageHeader>
 
-      <div className="flex-1 overflow-y-auto flex flex-col">
+      <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
         {(projects.length > 0 || isLoading) && (
-          <div className="flex justify-end px-5 pt-4 -mb-2">
-            <DropdownMenu>
-              <Tooltip>
-                <DropdownMenuTrigger
-                  render={
-                    <TooltipTrigger
-                      render={
-                        <Button variant="ghost" size="icon-sm" className="text-muted-foreground">
-                          {isCompact ? <Rows3 className="size-4" /> : <LayoutGrid className="size-4" />}
-                        </Button>
-                      }
-                    />
-                  }
-                />
-              <TooltipContent side="bottom">
-                {isCompact ? t(($) => $.page.view_compact) : t(($) => $.page.view_comfortable)}
-              </TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="end" className="w-auto">
-                <DropdownMenuGroup>
-                <DropdownMenuItem onClick={() => setViewMode("compact")}>
-                  <Rows3 className="mr-2 h-4 w-4" />
-                  {t(($) => $.page.view_compact)}
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => setViewMode("comfortable")}>
-                  <LayoutGrid className="mr-2 h-4 w-4" />
-                  {t(($) => $.page.view_comfortable)}
-                </DropdownMenuItem>
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
+          <div className="flex h-12 shrink-0 items-center justify-between border-b px-4 gap-2 sm:gap-3">
+            <div className="relative flex-1 sm:flex-none">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t(($) => $.page.search_placeholder)}
+                className="h-8 w-full sm:w-64 pl-8 text-sm"
+              />
+            </div>
+            
+            <div className="flex items-center gap-2 sm:gap-4 shrink-0">
+              <span className="hidden sm:inline-block font-mono text-xs tabular-nums text-muted-foreground/70">
+                {filteredProjects.length} / {projects.length}
+              </span>
+              <div className="flex items-center gap-0.5 rounded-md bg-muted p-0.5">
+                <button
+                  type="button"
+                  onClick={() => setViewMode("compact")}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded p-1 sm:px-2.5 sm:py-1 text-xs font-medium transition-colors",
+                    isCompact ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  <Rows3 className="size-3.5" />
+                  <span className="hidden sm:inline-block">{t(($) => $.page.view_compact)}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setViewMode("comfortable")}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded p-1 sm:px-2.5 sm:py-1 text-xs font-medium transition-colors",
+                    !isCompact ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  <LayoutGrid className="size-3.5" />
+                  <span className="hidden sm:inline-block">{t(($) => $.page.view_comfortable)}</span>
+                </button>
+              </div>
+            </div>
           </div>
         )}
-        {isLoading ? (
-          isCompact ? (
-            <div className="pt-4 overflow-x-auto">
-              <div className="min-w-[600px]">
-                <div className="flex h-10 items-center gap-2 px-4 border-b">
-                  <Skeleton className="h-6 w-6 rounded" />
-                  <Skeleton className="h-4 w-48" />
-                </div>
-                {Array.from({ length: 6 }).map((_, i) => (
-                  <div key={i} className="flex h-10 items-center gap-2 px-4 border-b">
+
+        <div className="flex-1 overflow-y-auto">
+          {isLoading ? (
+            isCompact ? (
+              <div className="pt-4 mx-5 overflow-x-auto rounded-md border pb-4 mb-5">
+                <div className="min-w-[740px]">
+                  <div className={cn(COMPACT_GRID, "h-10 items-center gap-2 px-4 border-b")}>
                     <Skeleton className="h-6 w-6 rounded" />
                     <Skeleton className="h-4 w-48" />
                   </div>
+                  {Array.from({ length: 6 }).map((_, i) => (
+                    <div key={i} className={cn(COMPACT_GRID, "h-10 items-center gap-2 px-4 border-b")}>
+                      <Skeleton className="h-6 w-6 rounded" />
+                      <Skeleton className="h-4 w-48" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div className="pt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 px-5">
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <div key={i} className="flex flex-col rounded-md border p-3 gap-2">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-8 w-8 rounded" />
+                      <Skeleton className="h-4 w-3/4" />
+                    </div>
+                    <div className="flex gap-1.5">
+                      <Skeleton className="h-5 w-16 rounded" />
+                      <Skeleton className="h-5 w-20 rounded" />
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <Skeleton className="h-5 w-5 rounded-full" />
+                      <Skeleton className="h-3 w-12" />
+                    </div>
+                  </div>
                 ))}
               </div>
+            )
+          ) : projects.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-24 text-muted-foreground">
+              <FolderKanban className="h-10 w-10 mb-3 opacity-30" />
+              <p className="text-sm">{t(($) => $.page.empty)}</p>
+              <Button size="sm" variant="outline" className="mt-3" onClick={openCreateProject}>
+                {t(($) => $.page.create_first)}
+              </Button>
             </div>
-          ) : (
-            <div className={cn("pt-4 grid px-5", gridClass)}>
-              {Array.from({ length: 8 }).map((_, i) => (
-                <div key={i} className={cn("flex flex-col rounded-md border p-3 gap-2")}>
-                  <div className="flex items-center gap-2">
-                    <Skeleton className="h-8 w-8 rounded" />
-                    <Skeleton className="h-4 w-3/4" />
-                  </div>
-                  <div className="flex gap-1.5">
-                    <Skeleton className="h-5 w-16 rounded" />
-                    <Skeleton className="h-5 w-20 rounded" />
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <Skeleton className="h-5 w-5 rounded-full" />
-                    <Skeleton className="h-3 w-12" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          )
-        ) : projects.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-24 text-muted-foreground">
-            <FolderKanban className="h-10 w-10 mb-3 opacity-30" />
-            <p className="text-sm">{t(($) => $.page.empty)}</p>
-            <Button size="sm" variant="outline" className="mt-3" onClick={openCreateProject}>
-              {t(($) => $.page.create_first)}
-            </Button>
-          </div>
-        ) : isCompact ? (
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border mt-4 mx-5">
-            <div className="flex min-h-0 flex-1 flex-col overflow-auto min-w-0 pb-4">
-              <div className="grid w-full min-w-[740px] grid-cols-[24px_minmax(200px,1fr)_96px_96px_80px_80px_80px] h-8 shrink-0 items-center gap-2 px-4 text-xs font-medium text-muted-foreground border-b bg-muted/30 sticky top-0 z-10">
+          ) : isCompact ? (
+            <div className="mt-4 mx-5 overflow-x-auto rounded-md border mb-5">
+              <div className={cn(COMPACT_GRID, "h-8 shrink-0 items-center gap-2 px-4 text-xs font-medium text-muted-foreground border-b bg-muted/30 sticky top-0 z-10")}>
                 <span />
                 <span className="text-left">{t(($) => $.table.name)}</span>
                 <span className="text-left">{t(($) => $.table.priority)}</span>
@@ -545,18 +315,20 @@ export function ProjectsPage() {
                 <span className="text-left">{t(($) => $.table.lead)}</span>
                 <span className="text-left">{t(($) => $.table.created)}</span>
               </div>
-              {projects.map((project) => (
+            <div className="pb-4">
+              {filteredProjects.map((project) => (
                 <ProjectCardCompact key={project.id} project={project} />
               ))}
             </div>
-          </div>
-        ) : (
-          <div className={cn("pt-4 pb-5 px-5 grid", gridClass)}>
-            {projects.map((project) => (
+            </div>
+          ) : (
+          <div className="pt-4 pb-5 px-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+            {filteredProjects.map((project) => (
               <ProjectCard key={project.id} project={project} />
             ))}
           </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

Fixes mobile usability for projects page where the project name cannot be seem, and add 2 kind of views, comfortable that uses for spaces and compact view, keeping the old table behavior but with horizontal scroll fixes.

## Related Issue

Closes #2720

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- **Projects Page Layout (`packages/views/projects/components/projects-page.tsx`)**: Refactored the generic HTML `<table/>` to use a responsive `div`-based Flex/Grid layout. 
- **View Modes**: Added a new view toggle (Compact vs. Comfortable) positioned intuitively above the project list.
- **Horizontal Scrolling Fix**: Re-implemented the Compact view as a `grid` inside an `overflow-x-auto` container with a strict `min-w-[740px]`. This ensures table borders stretch properly across the entire container on mobile without cutting off, while still allowing the project name column (`minmax(200px, 1fr)`) to truncate correctly when needed.
- **View Persistence (`packages/core/projects/stores/view-store.ts`)**: Created a new Zustand store leveraging `createWorkspaceAwareStorage` to persist the user's view preference locally on a per-workspace basis.
- **UI Polish**: Standardized column alignment (left-aligned) across all headers and rows in the compact view, fixed the empty state circular avatar styling (`inline-flex`), and added appropriate padding constraints to the comfortable grid view.

## How to Test

1. Navigate to `{{url}}/{{workspace}}/projects`
2. Create 1 or many projects
3. Check comfortable view
4. Click on the icon to change view mode
5. Check compact view
6. Refresh the page to see if the last selected view is persisted
7. Check if navigating to a project works
8. Back to project list, check if assignment works
9. Check if priority change works
10. Check if status change works
11. Check if number of tasks and progress works

## Checklist

- [X] I have included a thinking path that traces from project context to this change
- [X] I have run tests locally and they pass
- [X] I have added or updated tests where applicable
- [X] If this change affects the UI, I have included before/after screenshots
- [X] I have updated relevant documentation to reflect my changes
- [X] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [X] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [X] I have considered and documented any risks above
- [X] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Opencode

**Prompt / approach:**

```
Objective: 

Convert the projects page from a legacy <table> to a responsive div-based layout. Add "Compact" (list) and "Comfortable" (card) view modes.

1. State Management
- Create a Zustand store in packages/core/projects/stores/view-store.ts to track the selected view mode.
- It must persist the user's choice on a per-workspace basis using our createWorkspaceAwareStorage utility.
- Export this store correctly from the core package index.

2. Layout & UI Structure

View Toggle: Move the view mode toggle icon out of the main page header. Place it right-aligned directly above the project list/grid area.

Comfortable View: Render project cards in a responsive grid. Ensure the container has proper padding around the edges.

Compact View (Table Replacement): 
- Rebuild the table using CSS Grid for the rows/headers.
- Wrap the entire grid in a horizontal scroll container for mobile support.
- Critical: Apply a minimum width to the grid so row borders stretch fully across the scrollable area on mobile. Set the "Name" column to flexibly shrink and truncate long text.

3. Strict Styling Rules
- Alignment: ALL columns (Name, Priority, Status, Progress, Lead, Created) must be left-aligned for both headers and cell contents. Do not center or right-align anything.
- Empty Avatars: Ensure the dashed-circle placeholder for unassigned leads uses inline-flex so it doesn't collapse or 
- lose its circular shape in the grid.
```

## Screenshots (optional)

<img width="377" height="840" alt="Screenshot 2026-05-20 at 20 41 21" src="https://github.com/user-attachments/assets/01f53b8b-edde-436e-8a33-8ec5b13f0aca" />

<img width="378" height="197" alt="Screenshot 2026-05-20 at 20 41 35" src="https://github.com/user-attachments/assets/79127b9c-c01a-4313-a99e-abc99ee56e7e" />

<img width="380" height="840" alt="Screenshot 2026-05-20 at 20 41 28" src="https://github.com/user-attachments/assets/57f0d26a-a616-4537-9964-bf842c0cccb1" />

<img width="383" height="334" alt="Screenshot 2026-05-20 at 20 41 42" src="https://github.com/user-attachments/assets/875d1bb9-472b-4d5a-8d7d-e0a0e43f3c90" />

