### PR TITLE
fix(runtimes): exempt CLI command literals in Connect Remote dialog from i18n rule

### DIFF
--- a/packages/views/runtimes/components/connect-remote-dialog.tsx
+++ b/packages/views/runtimes/components/connect-remote-dialog.tsx
@@ -233,12 +233,16 @@ function TroubleshootingDetails() {
         <ul className="space-y-1">
           <li className="flex items-center gap-1.5">
             <span>{t(($) => $.connect.trouble_check_status)}</span>
+            {/* CLI command — literal shell string, not i18n content. */}
+            {/* eslint-disable-next-line i18next/no-literal-string */}
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground">
               multica daemon status
             </code>
           </li>
           <li className="flex items-center gap-1.5">
             <span>{t(($) => $.connect.trouble_view_logs)}</span>
+            {/* CLI command — literal shell string, not i18n content. */}
+            {/* eslint-disable-next-line i18next/no-literal-string */}
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground">
               multica daemon logs -f
             </code>


### PR DESCRIPTION
## Why

`@multica/views#lint` has been red on `main` since the Connect Remote dialog landed — two `<code>` blocks in the "having trouble?" disclosure render literal shell commands (`multica daemon status`, `multica daemon logs -f`) and trip `i18next/no-literal-string`. Turbo cascades the lint failure into the typecheck + web/desktop builds, so the whole `frontend` job goes red.

These strings are inherently locale-agnostic — they are the actual commands users type into a shell, identical in every language. Wrapping them in `t()` would be wrong: translators would have no source-of-truth about whether the binary name `multica` or the subcommand `daemon` could be translated (the answer is "never"). Exempting them with an inline disable + a one-line comment is the right move.

## What

Add `// eslint-disable-next-line i18next/no-literal-string` (with a one-line "CLI command — literal shell string" comment) above each of the two `<code>` blocks. No behavioural change, no copy change.

## Test plan
- [x] `pnpm --filter @multica/views lint` → **0 errors** (was 2). 13 remaining warnings are pre-existing in other files.
- [ ] CI green end-to-end on this branch.

## Note

The cascaded `@multica/views#typecheck` failure that also shows in CI logs is downstream of the lint task in turbo's DAG — once lint passes, typecheck (and the web/desktop builds) will run from a clean state.