### PR TITLE
feat(editor): bump HTML iframe preview default height to 480px (MUL-2419)

### DIFF
--- a/packages/views/editor/code-block-iframe.tsx
+++ b/packages/views/editor/code-block-iframe.tsx
@@ -29,7 +29,7 @@ interface CodeBlockIframeProps {
   /** Iframe title for accessibility. */
   title: string;
   className?: string;
-  /** Tailwind height token; defaults to h-[320px]. */
+  /** Tailwind height token; defaults to h-[480px]. */
   heightClassName?: string;
 }
 
@@ -37,7 +37,7 @@ export function CodeBlockIframe({
   html,
   title,
   className,
-  heightClassName = "h-[320px]",
+  heightClassName = "h-[480px]",
 }: CodeBlockIframeProps) {
   return (
     <iframe

--- a/packages/views/editor/extensions/code-block-view.tsx
+++ b/packages/views/editor/extensions/code-block-view.tsx
@@ -18,7 +18,7 @@ import { CodeBlockIframe } from "../code-block-iframe";
 // keystroke causes the iframe to re-load and flicker.
 const PREVIEW_DEBOUNCE_MS = 200;
 
-const HTML_PREVIEW_HEIGHT = "h-[320px]";
+const HTML_PREVIEW_HEIGHT = "h-[480px]";
 
 function useDebouncedValue<T>(value: T, delayMs: number): T {
   const [debounced, setDebounced] = useState(value);

--- a/packages/views/editor/html-block-preview.tsx
+++ b/packages/views/editor/html-block-preview.tsx
@@ -22,7 +22,7 @@ import { useT } from "../i18n";
 import { CodeBlockIframe } from "./code-block-iframe";
 import { CodeBlockStatic } from "./code-block-static";
 
-const CODE_BLOCK_IFRAME_HEIGHT = "h-[320px]";
+const CODE_BLOCK_IFRAME_HEIGHT = "h-[480px]";
 
 // Label shown in the code-block header. Not a translatable string — it's a
 // language identifier (matches the `lang === "html"` token below).


### PR DESCRIPTION
## What does this PR do?

Bumps the default height of the HTML iframe preview from **320px** to **480px**. The previous value felt cramped for typical rendered HTML content (charts, dashboards, formatted documents). The new value also matches the existing HTML attachment preview height, giving both iframe surfaces consistent visual behavior.

## Related Issue

Closes [MUL-2419](mention://issue/72f7f369-22c2-4985-85cc-bf1d8c9971eb) — 增加 HTML iframe 预览的默认高度

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Breaking Change

None.

## Changes Made

Single shared default constant raised from `320` → `480`, applied to all three iframe surfaces that read it:

- `packages/views/editor/code-block-iframe.tsx`
- `packages/views/editor/extensions/code-block-view.tsx`
- `packages/views/editor/html-block-preview.tsx`

Affects readonly fenced ```html``` blocks, the editable code block view, and the standalone `CodeBlockIframe` consumers.

## How to Test

1. Open any document containing an HTML fenced code block or HTML preview.
2. Verify the iframe renders at 480px tall by default (previously 320px).
3. Confirm the HTML attachment preview and the HTML iframe preview now share the same default height.

## Checklist

- [x] Tests run locally and pass
- [x] No new runtime / tool / tab — no landing/starter/doc sync required
- [x] No Chinese product copy touched

### Verification

- `pnpm --filter @multica/views typecheck` passed
- `pnpm --filter @multica/views test` passed (75 files / 651 tests, verified by reviewer)

## AI Disclosure

**AI tool used:** Multica Agent (Lambda + Emacs review)

**Prompt / approach:** Implemented per agent task MUL-2419 — locate the HTML iframe preview default height and raise it to a more reasonable value aligned with the HTML attachment preview. Emacs agent reviewed and verified typecheck + vitest before opening this PR.
