### PR TITLE
feat(agents): add AI skill finder and draft flows

### DIFF
--- a/apps/mobile/app/(app)/[workspace]/(tabs)/inbox.tsx
+++ b/apps/mobile/app/(app)/[workspace]/(tabs)/inbox.tsx
@@ -28,7 +28,7 @@ import {
 import { useWorkspaceStore } from "@/data/workspace-store";
 import { useColorScheme } from "@/lib/use-color-scheme";
 import { THEME } from "@/lib/theme";
-import { deduplicateInboxItems } from "@/lib/inbox-display";
+import { deduplicateInboxItems, getInboxStringDetail } from "@/lib/inbox-display";
 
 export default function Inbox() {
   const wsId = useWorkspaceStore((s) => s.currentWorkspaceId);
@@ -64,7 +64,7 @@ export default function Inbox() {
         params: {
           workspace: wsSlug,
           id: item.issue_id,
-          highlight: item.details?.comment_id,
+          highlight: getInboxStringDetail(item, "comment_id"),
           h: String(Date.now()),
         },
       });

--- a/apps/mobile/components/inbox/detail-label.tsx
+++ b/apps/mobile/components/inbox/detail-label.tsx
@@ -23,6 +23,7 @@ import { StatusIcon } from "@/components/ui/status-icon";
 import { PriorityIcon } from "@/components/ui/priority-icon";
 import { useActorLookup } from "@/data/use-actor-name";
 import { cn } from "@/lib/utils";
+import { getInboxStringDetail } from "@/lib/inbox-display";
 
 // Mirrors STATUS_CONFIG.label in packages/core/issues/config/status.ts
 const STATUS_LABEL: Record<IssueStatus, string> = {
@@ -64,6 +65,10 @@ const TYPE_LABEL: Record<InboxItemType, string> = {
   reaction_added: "Reaction added",
   quick_create_done: "Quick-create done",
   quick_create_failed: "Quick-create failed",
+  agent_draft_done: "Agent draft ready",
+  agent_draft_failed: "Agent draft failed",
+  skill_find_done: "Skill recommendations ready",
+  skill_find_failed: "Skill finder failed",
 };
 
 // due_date is a calendar day — format timezone-safely (no offset day shift).
@@ -83,11 +88,11 @@ export function InboxDetailLabel({
   className?: string;
 }) {
   const { getName } = useActorLookup();
-  const details = item.details ?? {};
+  const detail = (key: string) => getInboxStringDetail(item, key);
 
   // Cases with inline icons → Row layout.
-  if (item.type === "status_changed" && details.to) {
-    const status = details.to as IssueStatus;
+  if (item.type === "status_changed" && detail("to")) {
+    const status = detail("to") as IssueStatus;
     return (
       <View className={cn("flex-row items-center gap-1", className)}>
         <Text className="text-xs text-muted-foreground">Set status to</Text>
@@ -99,8 +104,8 @@ export function InboxDetailLabel({
     );
   }
 
-  if (item.type === "priority_changed" && details.to) {
-    const priority = details.to as IssuePriority;
+  if (item.type === "priority_changed" && detail("to")) {
+    const priority = detail("to") as IssuePriority;
     return (
       <View className={cn("flex-row items-center gap-1", className)}>
         <Text className="text-xs text-muted-foreground">Set priority to</Text>
@@ -116,34 +121,42 @@ export function InboxDetailLabel({
   const text = (() => {
     switch (item.type) {
       case "issue_assigned":
-      case "assignee_changed":
-        if (details.new_assignee_id) {
+      case "assignee_changed": {
+        const assigneeID = detail("new_assignee_id");
+        if (assigneeID) {
           const name = getName(
-            (details.new_assignee_type ?? "member") as "member" | "agent",
-            details.new_assignee_id,
+            (detail("new_assignee_type") || "member") as "member" | "agent",
+            assigneeID,
           );
           return `Assigned to ${name}`;
         }
         return TYPE_LABEL[item.type];
+      }
       case "unassigned":
         return "Removed assignee";
-      case "due_date_changed":
-        return details.to
-          ? `Set due date to ${shortDate(details.to)}`
+      case "due_date_changed": {
+        const to = detail("to");
+        return to
+          ? `Set due date to ${shortDate(to)}`
           : "Removed due date";
+      }
       case "new_comment":
         return singleLine(item.body) || TYPE_LABEL[item.type];
-      case "reaction_added":
-        return details.emoji
-          ? `Reacted with ${details.emoji}`
+      case "reaction_added": {
+        const emoji = detail("emoji");
+        return emoji
+          ? `Reacted with ${emoji}`
           : TYPE_LABEL[item.type];
-      case "quick_create_done":
-        return details.identifier
-          ? `Created with agent: ${details.identifier}`
+      }
+      case "quick_create_done": {
+        const identifier = detail("identifier");
+        return identifier
+          ? `Created with agent: ${identifier}`
           : TYPE_LABEL[item.type];
+      }
       case "quick_create_failed": {
-        const detail = singleLine(details.error) || singleLine(item.body);
-        return detail ? `Failed: ${detail}` : TYPE_LABEL[item.type];
+        const failureDetail = singleLine(detail("error")) || singleLine(item.body);
+        return failureDetail ? `Failed: ${failureDetail}` : TYPE_LABEL[item.type];
       }
       default:
         return TYPE_LABEL[item.type] ?? item.type;

--- a/apps/mobile/lib/inbox-display.ts
+++ b/apps/mobile/lib/inbox-display.ts
@@ -12,6 +12,11 @@ function singleLine(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
 }
 
+export function getInboxStringDetail(item: InboxItem, key: string): string {
+  const value = item.details?.[key];
+  return typeof value === "string" ? value : "";
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -34,15 +39,28 @@ export function stripQuickCreatePrefix(
 }
 
 export function getInboxDisplayTitle(item: InboxItem): string {
-  const details = item.details ?? {};
   if (item.type === "quick_create_done") {
-    const cleanedTitle = stripQuickCreatePrefix(item.title, details.identifier);
+    const cleanedTitle = stripQuickCreatePrefix(item.title, getInboxStringDetail(item, "identifier"));
     if (cleanedTitle) return cleanedTitle;
-    const prompt = singleLine(details.original_prompt);
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
     if (prompt) return prompt;
   }
   if (item.type === "quick_create_failed") {
-    const prompt = singleLine(details.original_prompt);
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
+    if (prompt) return prompt;
+  }
+  if (item.type === "skill_find_done") {
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
+    if (prompt) return prompt;
+  }
+  if (item.type === "agent_draft_done") {
+    const name = singleLine(getInboxStringDetail(item, "drafted_agent_name") || getInboxStringDetail(item, "name"));
+    if (name) return name;
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
+    if (prompt) return prompt;
+  }
+  if (item.type === "agent_draft_failed") {
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
     if (prompt) return prompt;
   }
   return item.title;

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -12,6 +12,7 @@ import type {
   ListIssuesParams,
   ListGroupedIssuesParams,
   Agent,
+  AITaskQueuedResponse,
   CreateAgentRequest,
   AgentTemplate,
   AgentTemplateSummary,
@@ -45,6 +46,8 @@ import type {
   CreateSkillRequest,
   UpdateSkillRequest,
   SetAgentSkillsRequest,
+  DraftAgentWithAIRequest,
+  FindSkillsWithAIRequest,
   PersonalAccessToken,
   CreatePersonalAccessTokenRequest,
   CreatePersonalAccessTokenResponse,
@@ -149,6 +152,7 @@ import { parseWithFallback } from "./schema";
 import {
   AgentTemplateSchema,
   AgentTemplateSummaryListSchema,
+  AITaskQueuedResponseSchema,
   AttachmentResponseSchema,
   CancelTaskResponseSchema,
   ChildIssuesResponseSchema,
@@ -166,10 +170,14 @@ import {
   EMPTY_AGENT_TEMPLATE_SUMMARY_LIST,
   EMPTY_APP_CONFIG,
   EMPTY_ATTACHMENT,
+  EMPTY_AI_TASK_QUEUED_RESPONSE,
   EMPTY_CLOUD_RUNTIME_NODE,
   EMPTY_CLOUD_RUNTIME_NODE_LIST,
   EMPTY_CREATE_AGENT_FROM_TEMPLATE_RESPONSE,
+  EMPTY_GITHUB_CONNECT_RESPONSE,
+  EMPTY_GITHUB_INSTALLATIONS_RESPONSE,
   EMPTY_GROUPED_ISSUES_RESPONSE,
+  EMPTY_ISSUE_PULL_REQUESTS_RESPONSE,
   EMPTY_LIST_ISSUES_RESPONSE,
   EMPTY_SEARCH_ISSUES_RESPONSE,
   EMPTY_SEARCH_PROJECTS_RESPONSE,
@@ -182,7 +190,10 @@ import {
   EMPTY_WEBHOOK_DELIVERY,
   AppConfigSchema,
   type AppConfigResponse,
+  GitHubConnectResponseSchema,
   GroupedIssuesResponseSchema,
+  IssuePullRequestsResponseSchema,
+  ListGitHubInstallationsResponseSchema,
   ListAutopilotsResponseSchema,
   EMPTY_LIST_AUTOPILOTS_RESPONSE,
   ListIssuesResponseSchema,
@@ -854,6 +865,16 @@ export class ApiClient {
     return this.fetch("/api/agents", {
       method: "POST",
       body: JSON.stringify(data),
+    });
+  }
+
+  async draftAgentWithAI(data: DraftAgentWithAIRequest): Promise<AITaskQueuedResponse> {
+    const raw = await this.fetch<unknown>("/api/agents/ai-draft", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+    return parseWithFallback(raw, AITaskQueuedResponseSchema, EMPTY_AI_TASK_QUEUED_RESPONSE, {
+      endpoint: "POST /api/agents/ai-draft",
     });
   }
 
@@ -1686,6 +1707,16 @@ export class ApiClient {
     });
   }
 
+  async findSkillsWithAI(data: FindSkillsWithAIRequest): Promise<AITaskQueuedResponse> {
+    const raw = await this.fetch<unknown>("/api/skills/find", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+    return parseWithFallback(raw, AITaskQueuedResponseSchema, EMPTY_AI_TASK_QUEUED_RESPONSE, {
+      endpoint: "POST /api/skills/find",
+    });
+  }
+
   async listAgentSkills(agentId: string): Promise<SkillSummary[]> {
     return this.fetch(`/api/agents/${agentId}/skills`);
   }
@@ -2291,11 +2322,23 @@ export class ApiClient {
 
   // GitHub integration
   async getGitHubConnectURL(workspaceId: string): Promise<GitHubConnectResponse> {
-    return this.fetch(`/api/workspaces/${workspaceId}/github/connect`);
+    const raw = await this.fetch<unknown>(`/api/workspaces/${workspaceId}/github/connect`);
+    return parseWithFallback(
+      raw,
+      GitHubConnectResponseSchema,
+      EMPTY_GITHUB_CONNECT_RESPONSE,
+      { endpoint: "GET /api/workspaces/:id/github/connect" },
+    );
   }
 
   async listGitHubInstallations(workspaceId: string): Promise<ListGitHubInstallationsResponse> {
-    return this.fetch(`/api/workspaces/${workspaceId}/github/installations`);
+    const raw = await this.fetch<unknown>(`/api/workspaces/${workspaceId}/github/installations`);
+    return parseWithFallback(
+      raw,
+      ListGitHubInstallationsResponseSchema,
+      EMPTY_GITHUB_INSTALLATIONS_RESPONSE,
+      { endpoint: "GET /api/workspaces/:id/github/installations" },
+    );
   }
 
   async deleteGitHubInstallation(workspaceId: string, installationId: string): Promise<void> {
@@ -2305,7 +2348,13 @@ export class ApiClient {
   }
 
   async listIssuePullRequests(issueId: string): Promise<{ pull_requests: GitHubPullRequest[] }> {
-    return this.fetch(`/api/issues/${issueId}/pull-requests`);
+    const raw = await this.fetch<unknown>(`/api/issues/${issueId}/pull-requests`);
+    return parseWithFallback(
+      raw,
+      IssuePullRequestsResponseSchema,
+      EMPTY_ISSUE_PULL_REQUESTS_RESPONSE,
+      { endpoint: "GET /api/issues/:id/pull-requests" },
+    );
   }
 
   // Lark integration

--- a/packages/core/api/schema.test.ts
+++ b/packages/core/api/schema.test.ts
@@ -235,6 +235,121 @@ describe("ApiClient schema fallback", () => {
     });
   });
 
+  describe("skill finder", () => {
+    it("parses the queued task response", async () => {
+      stubFetchJson({ task_id: "task-1" });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.findSkillsWithAI({
+        agent_id: "agent-1",
+        prompt: "Find React performance skills",
+      });
+      expect(res).toEqual({ task_id: "task-1" });
+    });
+
+    it("falls back to an empty task id when the response is malformed", async () => {
+      stubFetchJson({ task_id: 123 });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.findSkillsWithAI({
+        agent_id: "agent-1",
+        prompt: "Find React performance skills",
+      });
+      expect(res).toEqual({ task_id: "" });
+    });
+  });
+
+  describe("agent draft", () => {
+    it("parses the queued task response", async () => {
+      stubFetchJson({ task_id: "task-2" });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.draftAgentWithAI({
+        host_agent_id: "agent-1",
+        prompt: "Create a frontend review agent",
+      });
+      expect(res).toEqual({ task_id: "task-2" });
+    });
+  });
+  describe("github integration", () => {
+    it("accepts a configured GitHub connect URL response", async () => {
+      stubFetchJson({
+        configured: true,
+        url: "https://github.com/apps/multica/installations/new",
+      });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.getGitHubConnectURL("ws-1");
+      expect(res).toEqual({
+        configured: true,
+        url: "https://github.com/apps/multica/installations/new",
+      });
+    });
+
+    it("falls back to unconfigured when GitHub connect configured has the wrong type", async () => {
+      stubFetchJson({ configured: "yes", url: "https://github.com/apps/multica/installations/new" });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.getGitHubConnectURL("ws-1");
+      expect(res).toEqual({ configured: false });
+    });
+
+    it("defaults GitHub installations to [] when the field is missing", async () => {
+      stubFetchJson({ configured: true });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.listGitHubInstallations("ws-1");
+      expect(res).toEqual({ configured: true, installations: [] });
+    });
+
+    it("falls back to an unconfigured empty GitHub installations response when installations is not an array", async () => {
+      stubFetchJson({ configured: true, installations: "not-an-array" });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.listGitHubInstallations("ws-1");
+      expect(res).toEqual({ configured: false, installations: [] });
+    });
+
+    it("accepts future pull request state, mergeability, and checks values", async () => {
+      stubFetchJson({
+        pull_requests: [
+          {
+            id: "pr-1",
+            workspace_id: "ws-1",
+            repo_owner: "acme",
+            repo_name: "widget",
+            number: 42,
+            title: "Future PR",
+            state: "queued_for_merge",
+            html_url: "https://github.com/acme/widget/pull/42",
+            branch: "feat/future",
+            author_login: "octocat",
+            author_avatar_url: null,
+            merged_at: null,
+            closed_at: null,
+            pr_created_at: "2026-01-01T00:00:00Z",
+            pr_updated_at: "2026-01-02T00:00:00Z",
+            mergeable_state: "future_state",
+            checks_conclusion: "waiting",
+          },
+        ],
+      });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.listIssuePullRequests("issue-1");
+      expect(res.pull_requests).toHaveLength(1);
+      expect(res.pull_requests[0]?.state).toBe("queued_for_merge");
+      expect(res.pull_requests[0]?.mergeable_state).toBe("future_state");
+      expect(res.pull_requests[0]?.checks_conclusion).toBe("waiting");
+    });
+
+    it("defaults pull_requests to [] when the field is missing", async () => {
+      stubFetchJson({});
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.listIssuePullRequests("issue-1");
+      expect(res).toEqual({ pull_requests: [] });
+    });
+
+    it("falls back to an empty pull request list when pull_requests is not an array", async () => {
+      stubFetchJson({ pull_requests: "not-an-array" });
+      const client = new ApiClient("https://api.example.test");
+      const res = await client.listIssuePullRequests("issue-1");
+      expect(res).toEqual({ pull_requests: [] });
+    });
+  });
+
   // Agent template catalog is hit by the desktop create-agent picker.
   // Installed desktop builds outlive any given server, so the shape MUST
   // survive future field renames / wrapping without crashing. Each test

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -3,6 +3,7 @@ import type {
   Agent,
   AgentTemplate,
   AgentTemplateSummary,
+  AITaskQueuedResponse,
   Attachment,
   BillingBalance,
   BillingBatchesPage,
@@ -14,9 +15,12 @@ import type {
   CreateAgentFromTemplateResponse,
   CreateBillingCheckoutSessionResponse,
   CreateBillingPortalSessionResponse,
+  GitHubConnectResponse,
+  GitHubPullRequest,
   GroupedIssuesResponse,
   InboxWorkspaceUnread,
   ListIssuesResponse,
+  ListGitHubInstallationsResponse,
   ListWebhookDeliveriesResponse,
   SearchIssuesResponse,
   SearchProjectsResponse,
@@ -112,6 +116,13 @@ export const AttachmentResponseSchema = z.object({
   chat_message_id: z.string().nullable().optional(),
 }).loose();
 
+export const AITaskQueuedResponseSchema = z.object({
+  task_id: z.string(),
+}).loose();
+
+export const EMPTY_AI_TASK_QUEUED_RESPONSE: AITaskQueuedResponse = {
+  task_id: "",
+};
 export const EMPTY_ATTACHMENT: Attachment = {
   id: "",
   workspace_id: "",
@@ -774,6 +785,81 @@ export const SquadMemberStatusListResponseSchema = z.object({
 }).loose();
 
 export const EMPTY_SQUAD_MEMBER_STATUS_LIST = { members: [] };
+
+// ---------------------------------------------------------------------------
+// GitHub integration schemas — settings integration state and issue PR rows.
+//
+// These endpoints are consumed by web and installed desktop builds. GitHub's
+// server-facing enum-like strings (`state`, `mergeable_state`,
+// `checks_conclusion`) must stay forward-compatible: a future value should
+// render through the UI fallback path rather than fail schema validation.
+// ---------------------------------------------------------------------------
+
+const nullableString = z.string().nullable().optional().transform((v) => v ?? null);
+const numberWithZeroDefault = z.number().nullable().optional().transform((v) => v ?? 0);
+
+export const GitHubConnectResponseSchema = z.object({
+  configured: z.boolean(),
+  url: z.string().optional(),
+}).loose();
+
+export const EMPTY_GITHUB_CONNECT_RESPONSE: GitHubConnectResponse = {
+  configured: false,
+};
+
+const GitHubInstallationSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  installation_id: z.number(),
+  account_login: z.string(),
+  account_type: z.string(),
+  account_avatar_url: nullableString,
+  created_at: z.string(),
+}).loose();
+
+export const ListGitHubInstallationsResponseSchema = z.object({
+  installations: z.array(GitHubInstallationSchema).default([]),
+  configured: z.boolean().default(false),
+}).loose();
+
+export const EMPTY_GITHUB_INSTALLATIONS_RESPONSE: ListGitHubInstallationsResponse = {
+  configured: false,
+  installations: [],
+};
+
+const GitHubPullRequestSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  repo_owner: z.string(),
+  repo_name: z.string(),
+  number: z.number(),
+  title: z.string(),
+  state: z.string(),
+  html_url: z.string(),
+  branch: nullableString,
+  author_login: nullableString,
+  author_avatar_url: nullableString,
+  merged_at: nullableString,
+  closed_at: nullableString,
+  pr_created_at: z.string(),
+  pr_updated_at: z.string(),
+  mergeable_state: nullableString,
+  checks_conclusion: nullableString,
+  checks_passed: numberWithZeroDefault,
+  checks_failed: numberWithZeroDefault,
+  checks_pending: numberWithZeroDefault,
+  additions: numberWithZeroDefault,
+  deletions: numberWithZeroDefault,
+  changed_files: numberWithZeroDefault,
+}).loose();
+
+export const IssuePullRequestsResponseSchema = z.object({
+  pull_requests: z.array(GitHubPullRequestSchema).default([]),
+}).loose();
+
+export const EMPTY_ISSUE_PULL_REQUESTS_RESPONSE: { pull_requests: GitHubPullRequest[] } = {
+  pull_requests: [],
+};
 
 // ---------------------------------------------------------------------------
 // Structured error body — POST /api/workspaces/:wsId/issues 409 conflict.

--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -257,7 +257,7 @@ export interface AgentTask {
    * tasks that have no linked issue (so e.g. quick-create tasks render
    * with a meaningful title instead of falling through to "Untracked").
    */
-  kind?: "comment" | "autopilot" | "chat" | "quick_create" | "direct";
+  kind?: "comment" | "autopilot" | "chat" | "quick_create" | "ai_task" | "direct";
   /**
    * Local working directory pinned for this task by the daemon. Empty until
    * the daemon reports a work_dir (typically once execution starts). This is
@@ -396,6 +396,33 @@ export interface AgentSkillSummary {
   description: string;
 }
 
+export interface FindSkillsWithAIRequest {
+  prompt: string;
+  agent_id: string;
+}
+
+export interface DraftAgentWithAIRequest {
+  prompt: string;
+  host_agent_id: string;
+}
+
+export interface AITaskQueuedResponse {
+  task_id: string;
+}
+
+export interface SkillFindRecommendation {
+  name: string;
+  description: string;
+  source_url: string;
+  reason: string;
+}
+
+export interface AgentDraftResult {
+  agent_id: string;
+  name: string;
+  summary: string;
+  skill_source_urls: string[];
+}
 export interface CreateAgentRequest {
   name: string;
   description?: string;

--- a/packages/core/types/github.ts
+++ b/packages/core/types/github.ts
@@ -1,9 +1,11 @@
-export type GitHubPullRequestState = "open" | "closed" | "merged" | "draft";
+export type GitHubKnownPullRequestState = "open" | "closed" | "merged" | "draft";
+export type GitHubPullRequestState = GitHubKnownPullRequestState | (string & {});
 
 /** Aggregated CI status for a PR's current head SHA, computed server-side from
  * the latest check_suite per app. `null` when no completed suite has been seen
  * yet (e.g. PR just opened, or repository has no CI configured). */
-export type GitHubPullRequestChecksConclusion = "passed" | "failed" | "pending";
+export type GitHubKnownPullRequestChecksConclusion = "passed" | "failed" | "pending";
+export type GitHubPullRequestChecksConclusion = GitHubKnownPullRequestChecksConclusion | (string & {});
 
 /** Raw mirror of GitHub's `mergeable_state`. The UI only surfaces `clean` and
  * `dirty`; the other values (`blocked`, `behind`, `unstable`, `unknown`,
@@ -19,7 +21,7 @@ export interface GitHubInstallation {
    * integrations (see `ListGitHubInstallationsResponse.can_manage`). */
   installation_id?: number;
   account_login: string;
-  account_type: "User" | "Organization";
+  account_type: string;
   account_avatar_url: string | null;
   created_at: string;
   /** Display name of the workspace member who connected this installation.

--- a/packages/core/types/inbox.ts
+++ b/packages/core/types/inbox.ts
@@ -20,7 +20,11 @@ export type InboxItemType =
   | "agent_completed"
   | "reaction_added"
   | "quick_create_done"
-  | "quick_create_failed";
+  | "quick_create_failed"
+  | "agent_draft_done"
+  | "agent_draft_failed"
+  | "skill_find_done"
+  | "skill_find_failed";
 
 /**
  * One workspace's unread inbox count in the cross-workspace summary
@@ -49,5 +53,5 @@ export interface InboxItem {
   read: boolean;
   archived: boolean;
   created_at: string;
-  details: Record<string, string> | null;
+  details: Record<string, unknown> | null;
 }

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -19,6 +19,11 @@ export type {
   CreateRuntimeProfileRequest,
   UpdateRuntimeProfileRequest,
   CreateAgentRequest,
+  DraftAgentWithAIRequest,
+  FindSkillsWithAIRequest,
+  AITaskQueuedResponse,
+  SkillFindRecommendation,
+  AgentDraftResult,
   AgentTemplate,
   AgentTemplateSummary,
   AgentTemplateSkillRef,
@@ -111,6 +116,8 @@ export type {
 export type { PinnedItem, PinnedItemType, CreatePinRequest, ReorderPinsRequest } from "./pin";
 export type {
   GitHubInstallation,
+  GitHubKnownPullRequestChecksConclusion,
+  GitHubKnownPullRequestState,
   GitHubMergeableState,
   GitHubPullRequest,
   GitHubPullRequestChecksConclusion,

--- a/packages/views/agents/components/agent-draft-dialog.tsx
+++ b/packages/views/agents/components/agent-draft-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, Loader2, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+import { api } from "@multica/core/api";
+import type { Agent, AgentRuntime } from "@multica/core/types";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@multica/ui/components/ui/dialog";
+import { Label } from "@multica/ui/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@multica/ui/components/ui/select";
+import { Textarea } from "@multica/ui/components/ui/textarea";
+import { useT } from "../../i18n";
+
+export function AgentDraftDialog({
+  agents,
+  runtimesById,
+  onClose,
+}: {
+  agents: Agent[];
+  runtimesById: Map<string, AgentRuntime>;
+  onClose: () => void;
+}) {
+  const { t } = useT("agents");
+  const eligibleAgents = useMemo(
+    () => agents.filter((agent) => runtimesById.get(agent.runtime_id)?.status === "online"),
+    [agents, runtimesById],
+  );
+  const [hostAgentId, setHostAgentId] = useState(eligibleAgents[0]?.id ?? "");
+  const [prompt, setPrompt] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!hostAgentId && eligibleAgents[0]) setHostAgentId(eligibleAgents[0].id);
+  }, [hostAgentId, eligibleAgents]);
+
+  const selectedAgent = eligibleAgents.find((agent) => agent.id === hostAgentId) ?? null;
+  const canSubmit = !!selectedAgent && prompt.trim().length > 0 && !loading;
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setLoading(true);
+    setError("");
+    try {
+      await api.draftAgentWithAI({
+        host_agent_id: selectedAgent.id,
+        prompt: prompt.trim(),
+      });
+      toast.success(t(($) => $.ai_draft.toast_queued));
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t(($) => $.ai_draft.fallback_error));
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="flex max-h-[82vh] w-[min(560px,calc(100vw-2rem))] flex-col overflow-hidden p-0">
+        <div className="flex items-center gap-3 border-b px-5 py-4">
+          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-brand/10 text-brand">
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <div>
+            <DialogTitle className="text-sm font-semibold">
+              {t(($) => $.ai_draft.title)}
+            </DialogTitle>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t(($) => $.ai_draft.subtitle)}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4 overflow-y-auto px-5 py-4">
+          {eligibleAgents.length === 0 ? (
+            <div className="flex items-start gap-2 rounded-md bg-warning/10 px-3 py-2 text-xs text-muted-foreground">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
+              <span>{t(($) => $.ai_draft.no_agents)}</span>
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">
+                {t(($) => $.ai_draft.host_agent_label)}
+              </Label>
+              <Select value={hostAgentId} onValueChange={(v) => setHostAgentId(v ?? "")}>
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {() => selectedAgent?.name ?? t(($) => $.ai_draft.host_agent_placeholder)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent align="start" alignItemWithTrigger={false} className="max-h-72">
+                  {eligibleAgents.map((agent) => {
+                    const runtime = runtimesById.get(agent.runtime_id);
+                    return (
+                      <SelectItem key={agent.id} value={agent.id}>
+                        <span className="truncate">{agent.name}</span>
+                        {runtime?.provider && (
+                          <span className="text-xs text-muted-foreground">{runtime.provider}</span>
+                        )}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="agent-draft-prompt" className="text-xs text-muted-foreground">
+              {t(($) => $.ai_draft.prompt_label)}
+            </Label>
+            <Textarea
+              id="agent-draft-prompt"
+              value={prompt}
+              onChange={(e) => {
+                setPrompt(e.target.value);
+                setError("");
+              }}
+              placeholder={t(($) => $.ai_draft.prompt_placeholder)}
+              rows={5}
+              className="resize-none"
+              autoFocus
+            />
+          </div>
+
+          {error && (
+            <div role="alert" className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t bg-muted/30 px-5 py-3">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={loading}>
+            {t(($) => $.ai_draft.cancel)}
+          </Button>
+          <Button type="button" size="sm" onClick={submit} disabled={!canSubmit}>
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+            {t(($) => $.ai_draft.submit)}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/views/agents/components/agents-page.tsx
+++ b/packages/views/agents/components/agents-page.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   Lock,
   Plus,
+  Sparkles,
   X,
 } from "lucide-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -76,6 +77,7 @@ import { useNavigation, useRowLink } from "../../navigation";
 import { ActorAvatar } from "../../common/actor-avatar";
 import { PageHeader } from "../../layout/page-header";
 import { availabilityConfig } from "../presence";
+import { AgentDraftDialog } from "./agent-draft-dialog";
 import { CreateAgentDialog } from "./create-agent-dialog";
 import { AgentRowActions } from "./agent-row-actions";
 import {
@@ -196,9 +198,11 @@ export interface AgentsPageProps {
 function PageHeaderBar({
   totalCount,
   onCreate,
+  onDraft,
 }: {
   totalCount: number;
   onCreate: () => void;
+  onDraft?: () => void;
 }) {
   const { t } = useT("agents");
   return (
@@ -223,19 +227,38 @@ function PageHeaderBar({
           </a>
         </p>
       </div>
-      {/* Quiet chrome button (outline, icon-only below md) — primary is
-          reserved for the empty state's CTA. */}
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
-        aria-label={t(($) => $.page.new_agent)}
-        onClick={onCreate}
-      >
-        <Plus className="h-3.5 w-3.5" />
-        <span className="hidden md:inline">{t(($) => $.page.new_agent)}</span>
-      </Button>
+      <div className="flex items-center gap-2">
+        {onDraft && (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
+            aria-label={t(($) => $.page.ai_draft)}
+            onClick={onDraft}
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            <span className="hidden md:inline">
+              {t(($) => $.page.ai_draft)}
+            </span>
+          </Button>
+        )}
+        {/* Quiet chrome button (outline, icon-only below md) — primary is
+            reserved for the empty state's CTA. */}
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
+          aria-label={t(($) => $.page.new_agent)}
+          onClick={onCreate}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          <span className="hidden md:inline">
+            {t(($) => $.page.new_agent)}
+          </span>
+        </Button>
+      </div>
     </PageHeader>
   );
 }
@@ -829,6 +852,7 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
   const { byAgent: activityMap } = useWorkspaceActivityMap(wsId);
 
   const [showCreate, setShowCreate] = useState(false);
+  const [showAIDraft, setShowAIDraft] = useState(false);
   const [duplicateTemplate, setDuplicateTemplate] = useState<Agent | null>(
     null,
   );
@@ -1097,6 +1121,7 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
       <PageHeaderBar
         totalCount={totalCount}
         onCreate={() => setShowCreate(true)}
+        onDraft={() => setShowAIDraft(true)}
       />
 
       {isLoading ? (
@@ -1244,6 +1269,14 @@ export function AgentsPage(_props: AgentsPageProps = {}) {
         rows={selectedRows}
         onClear={() => setSelectedIds(new Set())}
       />
+
+      {showAIDraft && (
+        <AgentDraftDialog
+          agents={agents}
+          runtimesById={runtimesById}
+          onClose={() => setShowAIDraft(false)}
+        />
+      )}
 
       {showCreate && (
         <CreateAgentDialog

--- a/packages/views/agents/components/tabs/activity-tab.tsx
+++ b/packages/views/agents/components/tabs/activity-tab.tsx
@@ -394,7 +394,9 @@ function TaskRow({
       ? isTerminalStatus
         ? t(($) => $.tab_body.activity.source_quick_create)
         : t(($) => $.tab_body.activity.source_creating_issue)
-      : task.chat_session_id
+      : task.kind === "ai_task"
+        ? t(($) => $.tab_body.activity.source_ai_task)
+        : task.chat_session_id
         ? t(($) => $.tab_body.activity.source_chat_session)
         : task.autopilot_run_id
           ? t(($) => $.tab_body.activity.source_autopilot_run)

--- a/packages/views/inbox/components/agent-draft-result.tsx
+++ b/packages/views/inbox/components/agent-draft-result.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Bot, ExternalLink, Sparkles } from "lucide-react";
+import type { InboxItem } from "@multica/core/types";
+import { Button } from "@multica/ui/components/ui/button";
+import { useWorkspacePaths } from "@multica/core/paths";
+import { useNavigation } from "../../navigation";
+import {
+  getInboxStringArrayDetail,
+  getInboxStringDetail,
+} from "./inbox-display";
+import { useT } from "../../i18n";
+
+export function AgentDraftResult({ item }: { item: InboxItem }) {
+  const { t } = useT("inbox");
+  const navigation = useNavigation();
+  const paths = useWorkspacePaths();
+  const agentId = getInboxStringDetail(item, "drafted_agent_id") || getInboxStringDetail(item, "agent_id");
+  const name = getInboxStringDetail(item, "drafted_agent_name") || getInboxStringDetail(item, "name");
+  const summary = getInboxStringDetail(item, "summary") || item.body;
+  const prompt = getInboxStringDetail(item, "original_prompt");
+  const skillURLs = getInboxStringArrayDetail(item, "skill_source_urls");
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-card p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <Bot className="h-3.5 w-3.5 shrink-0 text-brand" />
+              <span className="truncate">{name || t(($) => $.detail.agent_draft_fallback_name)}</span>
+            </div>
+            {summary && (
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-foreground/80">
+                {summary}
+              </p>
+            )}
+          </div>
+          {agentId && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              onClick={() => navigation.push(paths.agentDetail(agentId))}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              {t(($) => $.detail.open_agent)}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {skillURLs.length > 0 && (
+        <div className="rounded-md border bg-muted/30 p-3">
+          <p className="text-xs font-medium text-muted-foreground">
+            {t(($) => $.detail.attached_skills)}
+          </p>
+          <div className="mt-2 grid gap-1.5">
+            {skillURLs.map((url) => (
+              <a
+                key={url}
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex min-w-0 items-center gap-1.5 text-xs text-foreground hover:underline"
+              >
+                <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
+                <span className="truncate">{url}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {prompt && (
+        <div className="rounded-md border bg-muted/40 p-3">
+          <p className="text-xs font-medium text-muted-foreground">
+            {t(($) => $.detail.original_input)}
+          </p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{prompt}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/views/inbox/components/inbox-detail-label.tsx
+++ b/packages/views/inbox/components/inbox-detail-label.tsx
@@ -5,7 +5,7 @@ import { formatDateOnly } from "@multica/core/issues/date";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { StatusIcon, PriorityIcon } from "../../issues/components";
 import type { InboxItem, InboxItemType, IssueStatus, IssuePriority } from "@multica/core/types";
-import { getQuickCreateFailureDetail } from "./inbox-display";
+import { getInboxStringDetail, getQuickCreateFailureDetail } from "./inbox-display";
 import { useT } from "../../i18n";
 
 // Hook returning the inbox-item type → human label map. Replaces the
@@ -32,6 +32,10 @@ export function useTypeLabels(): Record<InboxItemType, string> {
     reaction_added: t(($) => $.types.reaction_added),
     quick_create_done: t(($) => $.types.quick_create_done),
     quick_create_failed: t(($) => $.types.quick_create_failed),
+    agent_draft_done: t(($) => $.types.agent_draft_done),
+    agent_draft_failed: t(($) => $.types.agent_draft_failed),
+    skill_find_done: t(($) => $.types.skill_find_done),
+    skill_find_failed: t(($) => $.types.skill_find_failed),
   };
 }
 
@@ -45,51 +49,59 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
   const { t } = useT("inbox");
   const typeLabels = useTypeLabels();
   const { getActorName } = useActorName();
-  const details = item.details ?? {};
+  const detail = (key: string) => getInboxStringDetail(item, key);
 
   switch (item.type) {
     case "status_changed": {
-      if (!details.to) return <span>{typeLabels[item.type]}</span>;
-      const label = STATUS_CONFIG[details.to as IssueStatus]?.label ?? details.to;
+      const to = detail("to");
+      if (!to) return <span>{typeLabels[item.type]}</span>;
+      const label = STATUS_CONFIG[to as IssueStatus]?.label ?? to;
       return (
         <span className="inline-flex items-center gap-1">
           {t(($) => $.labels.set_status_to)}
-          <StatusIcon status={details.to as IssueStatus} className="h-3 w-3" />
+          <StatusIcon status={to as IssueStatus} className="h-3 w-3" />
           {label}
         </span>
       );
     }
     case "priority_changed": {
-      if (!details.to) return <span>{typeLabels[item.type]}</span>;
-      const label = PRIORITY_CONFIG[details.to as IssuePriority]?.label ?? details.to;
+      const to = detail("to");
+      if (!to) return <span>{typeLabels[item.type]}</span>;
+      const label = PRIORITY_CONFIG[to as IssuePriority]?.label ?? to;
       return (
         <span className="inline-flex items-center gap-1">
           {t(($) => $.labels.set_priority_to)}
-          <PriorityIcon priority={details.to as IssuePriority} className="h-3 w-3" />
+          <PriorityIcon priority={to as IssuePriority} className="h-3 w-3" />
           {label}
         </span>
       );
     }
     case "issue_assigned": {
-      if (details.new_assignee_id) {
-        return <span>{t(($) => $.labels.assigned_to, { name: getActorName(details.new_assignee_type ?? "member", details.new_assignee_id) })}</span>;
+      const assigneeID = detail("new_assignee_id");
+      if (assigneeID) {
+        const assigneeType = detail("new_assignee_type") || "member";
+        return <span>{t(($) => $.labels.assigned_to, { name: getActorName(assigneeType, assigneeID) })}</span>;
       }
       return <span>{typeLabels[item.type]}</span>;
     }
     case "unassigned":
       return <span>{t(($) => $.labels.removed_assignee)}</span>;
     case "assignee_changed": {
-      if (details.new_assignee_id) {
-        return <span>{t(($) => $.labels.assigned_to, { name: getActorName(details.new_assignee_type ?? "member", details.new_assignee_id) })}</span>;
+      const assigneeID = detail("new_assignee_id");
+      if (assigneeID) {
+        const assigneeType = detail("new_assignee_type") || "member";
+        return <span>{t(($) => $.labels.assigned_to, { name: getActorName(assigneeType, assigneeID) })}</span>;
       }
       return <span>{typeLabels[item.type]}</span>;
     }
     case "start_date_changed": {
-      if (details.to) return <span>{t(($) => $.labels.set_start_date_to, { date: shortDate(details.to) })}</span>;
+      const to = detail("to");
+      if (to) return <span>{t(($) => $.labels.set_start_date_to, { date: shortDate(to) })}</span>;
       return <span>{t(($) => $.labels.removed_start_date)}</span>;
     }
     case "due_date_changed": {
-      if (details.to) return <span>{t(($) => $.labels.set_due_date_to, { date: shortDate(details.to) })}</span>;
+      const to = detail("to");
+      if (to) return <span>{t(($) => $.labels.set_due_date_to, { date: shortDate(to) })}</span>;
       return <span>{t(($) => $.labels.removed_due_date)}</span>;
     }
     case "new_comment": {
@@ -97,12 +109,12 @@ export function InboxDetailLabel({ item }: { item: InboxItem }) {
       return <span>{typeLabels[item.type]}</span>;
     }
     case "reaction_added": {
-      const emoji = details.emoji;
+      const emoji = detail("emoji");
       if (emoji) return <span>{t(($) => $.labels.reacted_to_comment, { emoji })}</span>;
       return <span>{typeLabels[item.type]}</span>;
     }
     case "quick_create_done": {
-      const identifier = details.identifier;
+      const identifier = detail("identifier");
       if (identifier) return <span>{t(($) => $.labels.created_with_agent, { identifier })}</span>;
       return <span>{typeLabels[item.type]}</span>;
     }

--- a/packages/views/inbox/components/inbox-display.test.ts
+++ b/packages/views/inbox/components/inbox-display.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { InboxItem } from "@multica/core/types";
 import {
+  getAgentDraftResult,
   getInboxDisplayTitle,
   getQuickCreateFailureDetail,
+  getSkillFindRecommendations,
   stripQuickCreatePrefix,
 } from "./inbox-display";
 
@@ -76,5 +78,64 @@ describe("inbox display helpers", () => {
     expect(getQuickCreateFailureDetail(failedItem)).toBe(
       "CLI failed with exit status 1",
     );
+  });
+  it("uses the original prompt as the skill finder row title", () => {
+    const skillFindItem = item({
+      type: "skill_find_done",
+      title: "2 skill recommendations ready",
+      issue_id: null,
+      details: { original_prompt: "Need React performance help" },
+    });
+
+    expect(getInboxDisplayTitle(skillFindItem)).toBe("Need React performance help");
+  });
+
+  it("uses the drafted agent name as the agent draft row title", () => {
+    const draftItem = item({
+      type: "agent_draft_done",
+      title: "Agent draft ready: Frontend Reviewer",
+      issue_id: null,
+      details: {
+        drafted_agent_id: "agent-2",
+        drafted_agent_name: "Frontend Reviewer",
+        summary: "Created a review agent.",
+        skill_source_urls: ["https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices"],
+      },
+    });
+
+    expect(getInboxDisplayTitle(draftItem)).toBe("Frontend Reviewer");
+    expect(getAgentDraftResult(draftItem)).toEqual({
+      agent_id: "agent-2",
+      name: "Frontend Reviewer",
+      summary: "Created a review agent.",
+      skill_source_urls: ["https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices"],
+    });
+  });
+
+  it("extracts skill finder recommendations defensively", () => {
+    const skillFindItem = item({
+      type: "skill_find_done",
+      issue_id: null,
+      details: {
+        recommendations: [
+          {
+            name: "react-best-practices",
+            description: "React guidance",
+            source_url: "https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices",
+            reason: "Matches rendering work.",
+          },
+          { name: "bad" },
+        ],
+      },
+    });
+
+    expect(getSkillFindRecommendations(skillFindItem)).toEqual([
+      {
+        name: "react-best-practices",
+        description: "React guidance",
+        source_url: "https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices",
+        reason: "Matches rendering work.",
+      },
+    ]);
   });
 });

--- a/packages/views/inbox/components/inbox-display.ts
+++ b/packages/views/inbox/components/inbox-display.ts
@@ -1,4 +1,4 @@
-import type { InboxItem } from "@multica/core/types";
+import type { AgentDraftResult, InboxItem, SkillFindRecommendation } from "@multica/core/types";
 
 function singleLine(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
@@ -6,6 +6,46 @@ function singleLine(value: string | null | undefined): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function getInboxStringDetail(item: InboxItem, key: string): string {
+  const value = item.details?.[key];
+  return typeof value === "string" ? value : "";
+}
+
+export function getInboxStringArrayDetail(item: InboxItem, key: string): string[] {
+  const value = item.details?.[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+}
+
+function toSkillFindRecommendation(value: unknown): SkillFindRecommendation | null {
+  if (!isRecord(value)) return null;
+  const name = typeof value.name === "string" ? value.name : "";
+  const description = typeof value.description === "string" ? value.description : "";
+  const source_url = typeof value.source_url === "string" ? value.source_url : "";
+  const reason = typeof value.reason === "string" ? value.reason : "";
+  if (!name || !source_url) return null;
+  return { name, description, source_url, reason };
+}
+
+export function getSkillFindRecommendations(item: InboxItem): SkillFindRecommendation[] {
+  const raw = item.details?.recommendations;
+  if (!Array.isArray(raw)) return [];
+  return raw.map(toSkillFindRecommendation).filter((rec): rec is SkillFindRecommendation => rec !== null);
+}
+
+export function getAgentDraftResult(item: InboxItem): AgentDraftResult | null {
+  const agent_id = getInboxStringDetail(item, "drafted_agent_id") || getInboxStringDetail(item, "agent_id");
+  const name = getInboxStringDetail(item, "drafted_agent_name") || getInboxStringDetail(item, "name");
+  const summary = getInboxStringDetail(item, "summary");
+  const skill_source_urls = getInboxStringArrayDetail(item, "skill_source_urls");
+  if (!agent_id || !name) return null;
+  return { agent_id, name, summary, skill_source_urls };
 }
 
 export function stripQuickCreatePrefix(title: string, identifier?: string): string {
@@ -25,18 +65,33 @@ export function stripQuickCreatePrefix(title: string, identifier?: string): stri
 }
 
 export function getInboxDisplayTitle(item: InboxItem): string {
-  const details = item.details ?? {};
-
   if (item.type === "quick_create_done") {
-    const cleanedTitle = stripQuickCreatePrefix(item.title, details.identifier);
+    const cleanedTitle = stripQuickCreatePrefix(item.title, getInboxStringDetail(item, "identifier"));
     if (cleanedTitle) return cleanedTitle;
 
-    const prompt = singleLine(details.original_prompt);
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
     if (prompt) return prompt;
   }
 
   if (item.type === "quick_create_failed") {
-    const prompt = singleLine(details.original_prompt);
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
+    if (prompt) return prompt;
+  }
+
+  if (item.type === "skill_find_done") {
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
+    if (prompt) return prompt;
+  }
+
+  if (item.type === "agent_draft_done") {
+    const name = singleLine(getInboxStringDetail(item, "drafted_agent_name") || getInboxStringDetail(item, "name"));
+    if (name) return name;
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
+    if (prompt) return prompt;
+  }
+
+  if (item.type === "agent_draft_failed") {
+    const prompt = singleLine(getInboxStringDetail(item, "original_prompt"));
     if (prompt) return prompt;
   }
 
@@ -44,6 +99,5 @@ export function getInboxDisplayTitle(item: InboxItem): string {
 }
 
 export function getQuickCreateFailureDetail(item: InboxItem): string {
-  const details = item.details ?? {};
-  return singleLine(details.error) || singleLine(item.body);
+  return singleLine(getInboxStringDetail(item, "error")) || singleLine(item.body);
 }

--- a/packages/views/inbox/components/inbox-page.tsx
+++ b/packages/views/inbox/components/inbox-page.tsx
@@ -53,7 +53,9 @@ import { useIsMobile } from "@multica/ui/hooks/use-mobile";
 import { PageHeader } from "../../layout/page-header";
 import { InboxListItem, useTimeAgo } from "./inbox-list-item";
 import { useTypeLabels } from "./inbox-detail-label";
-import { getInboxDisplayTitle } from "./inbox-display";
+import { getInboxDisplayTitle, getInboxStringDetail } from "./inbox-display";
+import { AgentDraftResult } from "./agent-draft-result";
+import { SkillFindResult } from "./skill-find-result";
 import { useT } from "../../i18n";
 
 export function InboxPage() {
@@ -297,7 +299,7 @@ export function InboxPage() {
         issueId={selected.issue_id}
         defaultSidebarOpen={false}
         layoutId="multica_inbox_issue_detail_layout"
-        highlightCommentId={selected.details?.comment_id ?? undefined}
+        highlightCommentId={getInboxStringDetail(selected, "comment_id") || undefined}
         onDelete={() => {
           // Issue deletion CASCADE-deletes the inbox item server-side, and the
           // issue:deleted WS event prunes it from the inbox cache. Just clear
@@ -321,12 +323,22 @@ export function InboxPage() {
           {selected.body}
         </div>
       )}
-      {selected.type === "quick_create_failed" && selected.details?.original_prompt && (
+      {selected.type === "quick_create_failed" && getInboxStringDetail(selected, "original_prompt") && (
         <div className="mt-4 rounded-md border bg-muted/40 p-3">
           <p className="text-xs font-medium text-muted-foreground">
             {t(($) => $.detail.original_input)}
           </p>
-          <p className="mt-1 whitespace-pre-wrap text-sm">{selected.details.original_prompt}</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{getInboxStringDetail(selected, "original_prompt")}</p>
+        </div>
+      )}
+      {selected.type === "skill_find_done" && (
+        <div className="mt-4">
+          <SkillFindResult item={selected} />
+        </div>
+      )}
+      {selected.type === "agent_draft_done" && (
+        <div className="mt-4">
+          <AgentDraftResult item={selected} />
         </div>
       )}
       <div className="mt-4 flex gap-2">
@@ -338,8 +350,8 @@ export function InboxPage() {
               // user can recover their input in the full editor instead of
               // retyping. The agent picker hint becomes the assignee
               // candidate (still editable).
-              const prompt = selected.details?.original_prompt ?? "";
-              const agentId = selected.details?.agent_id;
+              const prompt = getInboxStringDetail(selected, "original_prompt");
+              const agentId = getInboxStringDetail(selected, "agent_id");
               useIssueDraftStore.getState().setDraft({
                 description: prompt,
                 ...(agentId

--- a/packages/views/inbox/components/skill-find-result.tsx
+++ b/packages/views/inbox/components/skill-find-result.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { ExternalLink, Sparkles } from "lucide-react";
+import type { InboxItem } from "@multica/core/types";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  getInboxStringDetail,
+  getSkillFindRecommendations,
+} from "./inbox-display";
+import { useT } from "../../i18n";
+
+export function SkillFindResult({ item }: { item: InboxItem }) {
+  const { t } = useT("inbox");
+  const recommendations = getSkillFindRecommendations(item);
+  const prompt = getInboxStringDetail(item, "original_prompt");
+
+  return (
+    <div className="space-y-4">
+      {prompt && (
+        <div className="rounded-md border bg-muted/40 p-3">
+          <p className="text-xs font-medium text-muted-foreground">
+            {t(($) => $.detail.original_input)}
+          </p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{prompt}</p>
+        </div>
+      )}
+      {recommendations.length === 0 ? (
+        <div className="rounded-md border bg-muted/40 p-4 text-sm text-muted-foreground">
+          {t(($) => $.detail.skill_find_empty)}
+        </div>
+      ) : (
+        <div className="grid gap-2">
+          {recommendations.map((rec) => (
+            <div key={rec.source_url} className="rounded-md border bg-card p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <Sparkles className="h-3.5 w-3.5 shrink-0 text-brand" />
+                    <span className="truncate">{rec.name}</span>
+                  </div>
+                  {rec.description && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {rec.description}
+                    </p>
+                  )}
+                </div>
+                <Button
+                  render={<a href={rec.source_url} target="_blank" rel="noreferrer" />}
+                  variant="ghost"
+                  size="icon-sm"
+                  className="shrink-0"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              {rec.reason && (
+                <p className="mt-3 text-sm leading-relaxed text-foreground/80">
+                  {rec.reason}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/views/issues/components/pull-request-list.test.tsx
+++ b/packages/views/issues/components/pull-request-list.test.tsx
@@ -115,6 +115,24 @@ describe("PullRequestList sidebar rows", () => {
     expect(screen.getByText("Ready to merge")).toBeInTheDocument();
   });
 
+  it("renders unknown future PR state with the raw state label", async () => {
+    mockPRs = [makePR({ title: "Future state", state: "constructor" })];
+    renderList();
+    await waitForRender();
+    expect(screen.getByText("Future state")).toBeInTheDocument();
+    expect(screen.getByText(/constructor/)).toBeInTheDocument();
+  });
+
+  it("ignores unknown checks conclusions instead of rendering a known checks badge", async () => {
+    mockPRs = [makePR({ title: "Future checks", checks_conclusion: "toString" })];
+    renderList();
+    await waitForRender();
+    expect(screen.getByText("Future checks")).toBeInTheDocument();
+    expect(screen.queryByText("Checks passed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Checks failed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Checks pending")).not.toBeInTheDocument();
+  });
+
   it("renders Merged status for merged PRs, suppressing conflict/check text", async () => {
     mockPRs = [
       makePR({

--- a/packages/views/issues/components/pull-request-list.tsx
+++ b/packages/views/issues/components/pull-request-list.tsx
@@ -22,6 +22,8 @@ import {
   type PullRequestProgressSegment,
 } from "@multica/core/github";
 import type {
+  GitHubKnownPullRequestChecksConclusion,
+  GitHubKnownPullRequestState,
   GitHubPullRequest,
   GitHubPullRequestChecksConclusion,
   GitHubPullRequestState,
@@ -35,24 +37,24 @@ type IssuesT = ReturnType<typeof useT<"issues">>["t"];
 // collapse the rest once the section reaches 4 rows.
 const PR_LIMIT_BEFORE_COLLAPSE = 4;
 
-const STATE_ICON: Record<
-  GitHubPullRequestState,
-  { icon: React.ComponentType<{ className?: string }>; className: string }
-> = {
+const STATE_ICON = {
   open: { icon: GitPullRequestArrow, className: "text-emerald-600 dark:text-emerald-400" },
   draft: { icon: GitPullRequestDraft, className: "text-muted-foreground" },
   merged: { icon: GitMerge, className: "text-violet-600 dark:text-violet-400" },
   closed: { icon: GitPullRequestClosed, className: "text-rose-600 dark:text-rose-400" },
-};
-
-const CHECKS_ICON: Record<
-  GitHubPullRequestChecksConclusion,
+} satisfies Record<
+  GitHubKnownPullRequestState,
   { icon: React.ComponentType<{ className?: string }>; className: string }
-> = {
+>;
+
+const CHECKS_ICON = {
   passed: { icon: CheckCircle2, className: "text-emerald-600 dark:text-emerald-400" },
   failed: { icon: XCircle, className: "text-rose-600 dark:text-rose-400" },
   pending: { icon: CircleDashed, className: "text-amber-600 dark:text-amber-400" },
-};
+} satisfies Record<
+  GitHubKnownPullRequestChecksConclusion,
+  { icon: React.ComponentType<{ className?: string }>; className: string }
+>;
 
 export function PullRequestList({ issueId }: { issueId: string }) {
   const { t } = useT("issues");
@@ -106,7 +108,9 @@ export function PullRequestList({ issueId }: { issueId: string }) {
 
 function PullRequestRow({ pr }: { pr: GitHubPullRequest }) {
   const { t } = useT("issues");
-  const cfg = STATE_ICON[pr.state] ?? { icon: GitPullRequest, className: "" };
+  const cfg = isKnownPullRequestState(pr.state)
+    ? STATE_ICON[pr.state]
+    : { icon: GitPullRequest, className: "" };
   const StateIcon = cfg.icon;
   const kind = derivePullRequestStatusKind({
     state: pr.state,
@@ -284,18 +288,30 @@ function getChecksBadge(
   t: IssuesT,
 ): PullRequestBadgeConfig | null {
   const checks = pr.checks_conclusion ?? null;
-  return checks && CHECKS_ICON[checks]
-    ? {
-        icon: CHECKS_ICON[checks].icon,
-        className: CHECKS_ICON[checks].className,
-        label:
-          checks === "passed"
-            ? t(($) => $.detail.pull_request_checks_passed)
-            : checks === "failed"
-              ? t(($) => $.detail.pull_request_checks_failed)
-              : t(($) => $.detail.pull_request_checks_pending),
-      }
-    : null;
+  if (!checks || !isKnownPullRequestChecksConclusion(checks)) return null;
+  const cfg = CHECKS_ICON[checks];
+  return {
+    icon: cfg.icon,
+    className: cfg.className,
+    label:
+      checks === "passed"
+        ? t(($) => $.detail.pull_request_checks_passed)
+        : checks === "failed"
+          ? t(($) => $.detail.pull_request_checks_failed)
+          : t(($) => $.detail.pull_request_checks_pending),
+  };
+}
+
+function isKnownPullRequestState(
+  state: GitHubPullRequestState,
+): state is GitHubKnownPullRequestState {
+  return Object.prototype.hasOwnProperty.call(STATE_ICON, state);
+}
+
+function isKnownPullRequestChecksConclusion(
+  checks: GitHubPullRequestChecksConclusion,
+): checks is GitHubKnownPullRequestChecksConclusion {
+  return Object.prototype.hasOwnProperty.call(CHECKS_ICON, checks);
 }
 
 function getStateLabel(

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -9,7 +9,8 @@
     "of_total": "{{visible}} of {{total}}",
     "list_load_failed": "Couldn't load agents",
     "list_load_failed_default": "Something went wrong fetching the agent list.",
-    "try_again": "Try again"
+    "try_again": "Try again",
+    "ai_draft": "AI draft"
   },
   "scope": {
     "mine": "Mine",
@@ -444,7 +445,8 @@
       "cancel_failed_toast": "Failed to cancel task",
       "started_prefix": "Started {{when}}",
       "dispatched_prefix": "Dispatched {{when}}",
-      "queued_prefix": "Queued {{when}}"
+      "queued_prefix": "Queued {{when}}",
+      "source_ai_task": "AI task"
     }
   },
   "char_counter": {
@@ -558,5 +560,18 @@
     "selected_one": "{{count}} selected",
     "selected_other": "{{count}} selected",
     "clear_selection": "Clear selection"
+  },
+  "ai_draft": {
+    "title": "Draft agent with AI",
+    "subtitle": "Ask an online agent to create a configured teammate for this workspace.",
+    "host_agent_label": "Host agent",
+    "host_agent_placeholder": "Select an online agent",
+    "no_agents": "No online agents are available. Start a runtime-backed agent first.",
+    "prompt_label": "What should this agent do?",
+    "prompt_placeholder": "e.g. Create a frontend review agent for React performance, accessibility, and regression testing.",
+    "cancel": "Cancel",
+    "submit": "Draft agent",
+    "toast_queued": "Agent draft started. Results will arrive in Inbox.",
+    "fallback_error": "Failed to start agent draft"
   }
 }

--- a/packages/views/locales/en/inbox.json
+++ b/packages/views/locales/en/inbox.json
@@ -25,7 +25,11 @@
     "empty": "Your inbox is empty",
     "original_input": "Original input",
     "edit_advanced": "Edit as advanced form",
-    "archive": "Archive"
+    "archive": "Archive",
+    "skill_find_empty": "No valid recommendations were returned.",
+    "agent_draft_fallback_name": "New agent",
+    "open_agent": "Open agent",
+    "attached_skills": "Attached skills"
   },
   "types": {
     "issue_assigned": "Assigned",
@@ -45,7 +49,11 @@
     "agent_completed": "Agent completed",
     "reaction_added": "Reacted",
     "quick_create_done": "Created with agent",
-    "quick_create_failed": "Create with agent failed"
+    "quick_create_failed": "Create with agent failed",
+    "skill_find_done": "Skill recommendations",
+    "skill_find_failed": "Skill finder failed",
+    "agent_draft_done": "Agent draft",
+    "agent_draft_failed": "Agent draft failed"
   },
   "labels": {
     "set_status_to": "Set status to",

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -6,10 +6,22 @@
     "new_skill": "New skill",
     "search_placeholder": "Search skills…",
     "scopes": {
-      "all": { "label": "All", "description": "All skills in this workspace" },
-      "used": { "label": "In use", "description": "Skills assigned to at least one agent" },
-      "unused": { "label": "Unused", "description": "Skills not assigned to any agent" },
-      "mine": { "label": "Created by me", "description": "Skills you created" }
+      "all": {
+        "label": "All",
+        "description": "All skills in this workspace"
+      },
+      "used": {
+        "label": "In use",
+        "description": "Skills assigned to at least one agent"
+      },
+      "unused": {
+        "label": "Unused",
+        "description": "Skills not assigned to any agent"
+      },
+      "mine": {
+        "label": "Created by me",
+        "description": "Skills you created"
+      }
     },
     "empty": {
       "title": "No skills yet",
@@ -305,5 +317,19 @@
     "no_content": "*No content yet*",
     "markdown_placeholder": "Write markdown content...",
     "raw_placeholder": "File content..."
+  },
+  "finder": {
+    "action": "Find with AI",
+    "title": "Find skills with AI",
+    "subtitle": "Ask an online agent to recommend workspace skills.",
+    "agent_label": "Agent",
+    "agent_placeholder": "Choose an agent",
+    "prompt_label": "What should the skill help with?",
+    "prompt_placeholder": "Example: Improve React render performance and avoid unnecessary re-renders",
+    "no_agents": "No online agent is available for skill finding.",
+    "cancel": "Cancel",
+    "submit": "Find skills",
+    "toast_queued": "Skill finder started. Results will appear in your inbox.",
+    "fallback_error": "Failed to start skill finder"
   }
 }

--- a/packages/views/locales/ja/agents.json
+++ b/packages/views/locales/ja/agents.json
@@ -9,7 +9,8 @@
     "of_total": "{{total}} 件中 {{visible}} 件",
     "list_load_failed": "エージェントを読み込めませんでした",
     "list_load_failed_default": "エージェント一覧の取得中に問題が発生しました。",
-    "try_again": "再試行"
+    "try_again": "再試行",
+    "ai_draft": "AI 下書き"
   },
   "scope": {
     "mine": "自分のもの",
@@ -423,8 +424,22 @@
       "cancel_failed_toast": "タスクをキャンセルできませんでした",
       "started_prefix": "{{when}} に開始",
       "dispatched_prefix": "{{when}} にディスパッチ",
-      "queued_prefix": "{{when}} に待機開始"
+      "queued_prefix": "{{when}} に待機開始",
+      "source_ai_task": "AI タスク"
     }
+  },
+  "ai_draft": {
+    "title": "AI でエージェントの下書きを作成",
+    "subtitle": "オンラインのエージェントに、このワークスペース向けのチームメイト構成を依頼します。",
+    "host_agent_label": "ホストエージェント",
+    "host_agent_placeholder": "オンラインのエージェントを選択",
+    "no_agents": "利用可能なオンラインエージェントがありません。先にランタイム連携エージェントを起動してください。",
+    "prompt_label": "このエージェントに何をさせますか？",
+    "prompt_placeholder": "例: React のパフォーマンス、アクセシビリティ、回帰テストを確認するフロントエンドレビューエージェントを作成してください。",
+    "cancel": "キャンセル",
+    "submit": "エージェントの下書きを作成",
+    "toast_queued": "エージェント下書きタスクを開始しました。結果はインボックスに届きます。",
+    "fallback_error": "エージェント下書きタスクを開始できませんでした"
   },
   "char_counter": {
     "over_limit": " · 制限を {{count}} 文字超過"

--- a/packages/views/locales/ja/inbox.json
+++ b/packages/views/locales/ja/inbox.json
@@ -25,7 +25,11 @@
     "empty": "インボックスは空です",
     "original_input": "元の入力",
     "edit_advanced": "詳細フォームで編集",
-    "archive": "アーカイブ"
+    "archive": "アーカイブ",
+    "skill_find_empty": "有効なおすすめは返されませんでした。",
+    "agent_draft_fallback_name": "新規エージェント",
+    "open_agent": "エージェントを開く",
+    "attached_skills": "添付されたスキル"
   },
   "types": {
     "issue_assigned": "割り当て済み",
@@ -45,7 +49,11 @@
     "agent_completed": "エージェントが完了",
     "reaction_added": "リアクションあり",
     "quick_create_done": "エージェントで作成",
-    "quick_create_failed": "エージェントでの作成に失敗"
+    "quick_create_failed": "エージェントでの作成に失敗",
+    "skill_find_done": "スキルのおすすめ",
+    "skill_find_failed": "スキル検索に失敗",
+    "agent_draft_done": "エージェント下書き",
+    "agent_draft_failed": "エージェント下書きに失敗"
   },
   "labels": {
     "set_status_to": "ステータスを変更:",

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -89,6 +89,20 @@
     "direction_desc": "降順",
     "section_columns": "表示する列"
   },
+  "finder": {
+    "action": "AI で検索",
+    "title": "AI でスキルを検索",
+    "subtitle": "オンラインのエージェントにワークスペースのスキル推薦を依頼します。",
+    "agent_label": "エージェント",
+    "agent_placeholder": "エージェントを選択",
+    "prompt_label": "スキルは何を支援するべきですか？",
+    "prompt_placeholder": "例: React のレンダリング性能を改善し、不要な再レンダリングを避ける",
+    "no_agents": "スキル検索に使用できるオンラインエージェントがありません。",
+    "cancel": "キャンセル",
+    "submit": "スキルを検索",
+    "toast_queued": "スキル検索を開始しました。結果はインボックスに表示されます。",
+    "fallback_error": "スキル検索を開始できませんでした"
+  },
   "detail": {
     "all_skills": "すべてのスキル",
     "read_only": "読み取り専用",

--- a/packages/views/locales/ko/agents.json
+++ b/packages/views/locales/ko/agents.json
@@ -9,7 +9,8 @@
     "of_total": "{{total}}개 중 {{visible}}개",
     "list_load_failed": "에이전트 목록을 불러오지 못했습니다",
     "list_load_failed_default": "에이전트 목록을 가져오는 중 문제가 발생했습니다.",
-    "try_again": "다시 시도"
+    "try_again": "다시 시도",
+    "ai_draft": "AI 초안"
   },
   "scope": {
     "mine": "내 것",
@@ -431,7 +432,8 @@
       "cancel_failed_toast": "작업을 취소하지 못했습니다",
       "started_prefix": "{{when}} 시작됨",
       "dispatched_prefix": "{{when}} 디스패치됨",
-      "queued_prefix": "{{when}} 대기 시작"
+      "queued_prefix": "{{when}} 대기 시작",
+      "source_ai_task": "AI 작업"
     }
   },
   "char_counter": {
@@ -540,5 +542,18 @@
   "actions": {
     "selected_other": "{{count}}개 선택됨",
     "clear_selection": "선택 해제"
+  },
+  "ai_draft": {
+    "title": "AI로 에이전트 초안 만들기",
+    "subtitle": "온라인 에이전트에게 이 워크스페이스에 맞는 팀원을 구성해 달라고 요청하세요.",
+    "host_agent_label": "호스트 에이전트",
+    "host_agent_placeholder": "온라인 에이전트 선택",
+    "no_agents": "사용 가능한 온라인 에이전트가 없습니다. 먼저 런타임 기반 에이전트를 시작하세요.",
+    "prompt_label": "이 에이전트는 무엇을 해야 하나요?",
+    "prompt_placeholder": "예: React 성능, 접근성, 회귀 테스트를 검토하는 프론트엔드 리뷰 에이전트를 만들어 주세요.",
+    "cancel": "취소",
+    "submit": "에이전트 초안 만들기",
+    "toast_queued": "에이전트 초안 작업을 시작했습니다. 결과는 인박스에 도착합니다.",
+    "fallback_error": "에이전트 초안 작업을 시작하지 못했습니다"
   }
 }

--- a/packages/views/locales/ko/inbox.json
+++ b/packages/views/locales/ko/inbox.json
@@ -25,7 +25,11 @@
     "empty": "인박스가 비어 있습니다",
     "original_input": "원본 입력",
     "edit_advanced": "고급 양식으로 수정",
-    "archive": "보관"
+    "archive": "보관",
+    "skill_find_empty": "유효한 추천 결과가 반환되지 않았습니다.",
+    "agent_draft_fallback_name": "새 에이전트",
+    "open_agent": "에이전트 열기",
+    "attached_skills": "연결된 스킬"
   },
   "types": {
     "issue_assigned": "할당됨",
@@ -45,7 +49,11 @@
     "agent_completed": "에이전트 완료됨",
     "reaction_added": "반응 추가됨",
     "quick_create_done": "에이전트로 생성됨",
-    "quick_create_failed": "에이전트 생성 실패"
+    "quick_create_failed": "에이전트 생성 실패",
+    "skill_find_done": "스킬 추천",
+    "skill_find_failed": "스킬 찾기 실패",
+    "agent_draft_done": "에이전트 초안",
+    "agent_draft_failed": "에이전트 초안 실패"
   },
   "labels": {
     "set_status_to": "상태 변경:",

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -297,5 +297,19 @@
     "no_content": "*아직 내용이 없습니다*",
     "markdown_placeholder": "Markdown 내용 작성...",
     "raw_placeholder": "파일 내용..."
+  },
+  "finder": {
+    "action": "AI로 찾기",
+    "title": "AI로 스킬 찾기",
+    "subtitle": "온라인 에이전트에게 워크스페이스 스킬을 추천해 달라고 요청하세요.",
+    "agent_label": "에이전트",
+    "agent_placeholder": "에이전트 선택",
+    "prompt_label": "스킬이 어떤 일을 도와야 하나요?",
+    "prompt_placeholder": "예: React 렌더링 성능을 개선하고 불필요한 리렌더링을 피하기",
+    "no_agents": "스킬 찾기에 사용할 수 있는 온라인 에이전트가 없습니다.",
+    "cancel": "취소",
+    "submit": "스킬 찾기",
+    "toast_queued": "스킬 찾기를 시작했습니다. 결과는 인박스에 표시됩니다.",
+    "fallback_error": "스킬 찾기를 시작하지 못했습니다"
   }
 }

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -9,7 +9,8 @@
     "of_total": "{{visible}} / {{total}}",
     "list_load_failed": "无法加载智能体列表",
     "list_load_failed_default": "获取智能体列表时出错。",
-    "try_again": "重试"
+    "try_again": "重试",
+    "ai_draft": "AI 起草"
   },
   "scope": {
     "mine": "我的",
@@ -431,7 +432,8 @@
       "cancel_failed_toast": "取消 task 失败",
       "started_prefix": "{{when}}启动",
       "dispatched_prefix": "{{when}}派发",
-      "queued_prefix": "{{when}}排队"
+      "queued_prefix": "{{when}}排队",
+      "source_ai_task": "AI task"
     }
   },
   "char_counter": {
@@ -540,5 +542,18 @@
   "actions": {
     "selected_other": "已选 {{count}} 项",
     "clear_selection": "清除选择"
+  },
+  "ai_draft": {
+    "title": "用 AI 起草智能体",
+    "subtitle": "让一个在线智能体为当前工作区创建并配置新的队友。",
+    "host_agent_label": "执行智能体",
+    "host_agent_placeholder": "选择一个在线智能体",
+    "no_agents": "当前没有可用的在线智能体。请先启动带运行时的智能体。",
+    "prompt_label": "这个智能体应该做什么？",
+    "prompt_placeholder": "例如：创建一个前端审查智能体，关注 React 性能、可访问性和回归测试。",
+    "cancel": "取消",
+    "submit": "起草智能体",
+    "toast_queued": "智能体起草已开始，结果会进入收件箱。",
+    "fallback_error": "启动智能体起草失败"
   }
 }

--- a/packages/views/locales/zh-Hans/inbox.json
+++ b/packages/views/locales/zh-Hans/inbox.json
@@ -25,7 +25,11 @@
     "empty": "收件箱为空",
     "original_input": "原始输入",
     "edit_advanced": "在完整表单中编辑",
-    "archive": "归档"
+    "archive": "归档",
+    "skill_find_empty": "没有返回有效推荐。",
+    "agent_draft_fallback_name": "新智能体",
+    "open_agent": "打开智能体",
+    "attached_skills": "已关联 skill"
   },
   "types": {
     "issue_assigned": "已分配",
@@ -45,7 +49,11 @@
     "agent_completed": "智能体已完成",
     "reaction_added": "添加了表情反应",
     "quick_create_done": "通过智能体创建",
-    "quick_create_failed": "通过智能体创建失败"
+    "quick_create_failed": "通过智能体创建失败",
+    "skill_find_done": "skill 推荐",
+    "skill_find_failed": "skill 查找失败",
+    "agent_draft_done": "智能体起草",
+    "agent_draft_failed": "智能体起草失败"
   },
   "labels": {
     "set_status_to": "状态设为",

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -309,5 +309,19 @@
     "no_content": "*暂无内容*",
     "markdown_placeholder": "输入 Markdown 内容...",
     "raw_placeholder": "文件内容..."
+  },
+  "finder": {
+    "action": "AI 查找",
+    "title": "用 AI 查找 skill",
+    "subtitle": "让在线智能体根据目标推荐工作区 skill。",
+    "agent_label": "智能体",
+    "agent_placeholder": "选择智能体",
+    "prompt_label": "这个 skill 需要帮你做什么？",
+    "prompt_placeholder": "例如：优化 React 渲染性能，避免不必要的重渲染",
+    "no_agents": "当前没有可用于查找 skill 的在线智能体。",
+    "cancel": "取消",
+    "submit": "查找 skill",
+    "toast_queued": "skill 查找已开始，结果会进入收件箱。",
+    "fallback_error": "启动 skill 查找失败"
   }
 }

--- a/packages/views/skills/components/skill-finder-dialog.tsx
+++ b/packages/views/skills/components/skill-finder-dialog.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, Loader2, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+import { api } from "@multica/core/api";
+import type { Agent, AgentRuntime } from "@multica/core/types";
+import { Button } from "@multica/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@multica/ui/components/ui/dialog";
+import { Label } from "@multica/ui/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@multica/ui/components/ui/select";
+import { Textarea } from "@multica/ui/components/ui/textarea";
+import { useT } from "../../i18n";
+
+export function SkillFinderDialog({
+  agents,
+  runtimesById,
+  onClose,
+}: {
+  agents: Agent[];
+  runtimesById: Map<string, AgentRuntime>;
+  onClose: () => void;
+}) {
+  const { t } = useT("skills");
+  const eligibleAgents = useMemo(
+    () => agents.filter((agent) => runtimesById.get(agent.runtime_id)?.status === "online"),
+    [agents, runtimesById],
+  );
+  const [agentId, setAgentId] = useState(eligibleAgents[0]?.id ?? "");
+  const [prompt, setPrompt] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!agentId && eligibleAgents[0]) setAgentId(eligibleAgents[0].id);
+  }, [agentId, eligibleAgents]);
+
+  const selectedAgent = eligibleAgents.find((agent) => agent.id === agentId) ?? null;
+  const canSubmit = !!selectedAgent && prompt.trim().length > 0 && !loading;
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setLoading(true);
+    setError("");
+    try {
+      await api.findSkillsWithAI({ agent_id: selectedAgent.id, prompt: prompt.trim() });
+      toast.success(t(($) => $.finder.toast_queued));
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t(($) => $.finder.fallback_error));
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="flex max-h-[82vh] w-[min(560px,calc(100vw-2rem))] flex-col overflow-hidden p-0">
+        <div className="flex items-center gap-3 border-b px-5 py-4">
+          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-brand/10 text-brand">
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <div>
+            <DialogTitle className="text-sm font-semibold">
+              {t(($) => $.finder.title)}
+            </DialogTitle>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t(($) => $.finder.subtitle)}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4 overflow-y-auto px-5 py-4">
+          {eligibleAgents.length === 0 ? (
+            <div className="flex items-start gap-2 rounded-md bg-warning/10 px-3 py-2 text-xs text-muted-foreground">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
+              <span>{t(($) => $.finder.no_agents)}</span>
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">
+                {t(($) => $.finder.agent_label)}
+              </Label>
+              <Select value={agentId} onValueChange={(v) => setAgentId(v ?? "")}>
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {() => selectedAgent?.name ?? t(($) => $.finder.agent_placeholder)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent align="start" alignItemWithTrigger={false} className="max-h-72">
+                  {eligibleAgents.map((agent) => {
+                    const runtime = runtimesById.get(agent.runtime_id);
+                    return (
+                      <SelectItem key={agent.id} value={agent.id}>
+                        <span className="truncate">{agent.name}</span>
+                        {runtime?.provider && (
+                          <span className="text-xs text-muted-foreground">{runtime.provider}</span>
+                        )}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="skill-finder-prompt" className="text-xs text-muted-foreground">
+              {t(($) => $.finder.prompt_label)}
+            </Label>
+            <Textarea
+              id="skill-finder-prompt"
+              value={prompt}
+              onChange={(e) => {
+                setPrompt(e.target.value);
+                setError("");
+              }}
+              placeholder={t(($) => $.finder.prompt_placeholder)}
+              rows={5}
+              className="resize-none"
+              autoFocus
+            />
+          </div>
+
+          {error && (
+            <div role="alert" className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t bg-muted/30 px-5 py-3">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={loading}>
+            {t(($) => $.finder.cancel)}
+          </Button>
+          <Button type="button" size="sm" onClick={submit} disabled={!canSubmit}>
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+            {t(($) => $.finder.submit)}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -10,6 +10,7 @@ import {
   Lock,
   Pencil,
   Plus,
+  Sparkles,
 } from "lucide-react";
 import type {
   Agent,
@@ -55,6 +56,7 @@ import { PageHeader } from "../../layout/page-header";
 import { canEditSkill } from "../hooks/use-can-edit-skill";
 import { readOrigin, type OriginInfo } from "../lib/origin";
 import { CreateSkillDialog } from "./create-skill-dialog";
+import { SkillFinderDialog } from "./skill-finder-dialog";
 import {
   useSkillsViewStore,
   DEFAULT_HIDDEN_COLUMNS,
@@ -162,9 +164,11 @@ export interface SkillRow {
 function PageHeaderBar({
   totalCount,
   onCreate,
+  onFind,
 }: {
   totalCount: number;
   onCreate: () => void;
+  onFind?: () => void;
 }) {
   const { t } = useT("skills");
   return (
@@ -189,19 +193,38 @@ function PageHeaderBar({
           </a>
         </p>
       </div>
-      {/* Quiet chrome button (outline, icon-only below md) — primary is
-          reserved for the empty state's single CTA. */}
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
-        aria-label={t(($) => $.page.new_skill)}
-        onClick={onCreate}
-      >
-        <Plus className="h-3.5 w-3.5" />
-        <span className="hidden md:inline">{t(($) => $.page.new_skill)}</span>
-      </Button>
+      <div className="flex items-center gap-2">
+        {onFind && (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
+            aria-label={t(($) => $.finder.action)}
+            onClick={onFind}
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            <span className="hidden md:inline">
+              {t(($) => $.finder.action)}
+            </span>
+          </Button>
+        )}
+        {/* Quiet chrome button (outline, icon-only below md) — primary is
+            reserved for the empty state's single CTA. */}
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 w-8 gap-1 px-0 md:w-auto md:px-2.5"
+          aria-label={t(($) => $.page.new_skill)}
+          onClick={onCreate}
+        >
+          <Plus className="h-3.5 w-3.5" />
+          <span className="hidden md:inline">
+            {t(($) => $.page.new_skill)}
+          </span>
+        </Button>
+      </div>
     </PageHeader>
   );
 }
@@ -598,6 +621,7 @@ export default function SkillsPage() {
   );
 
   const [createOpen, setCreateOpen] = useState(false);
+  const [finderOpen, setFinderOpen] = useState(false);
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(
     new Set(),
   );
@@ -763,7 +787,11 @@ export default function SkillsPage() {
   if (listError) {
     return (
       <div className="flex flex-1 min-h-0 flex-col">
-        <PageHeaderBar totalCount={0} onCreate={() => setCreateOpen(true)} />
+        <PageHeaderBar
+          totalCount={0}
+          onCreate={() => setCreateOpen(true)}
+          onFind={() => setFinderOpen(true)}
+        />
         <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-16 text-center">
           <AlertCircle className="h-8 w-8 text-destructive" />
           <div>
@@ -813,6 +841,7 @@ export default function SkillsPage() {
       <PageHeaderBar
         totalCount={totalCount}
         onCreate={() => setCreateOpen(true)}
+        onFind={() => setFinderOpen(true)}
       />
 
       {supportingQueryDown && (
@@ -946,6 +975,14 @@ export default function SkillsPage() {
         <CreateSkillDialog
           onClose={() => setCreateOpen(false)}
           onCreated={handleCreated}
+        />
+      )}
+
+      {finderOpen && (
+        <SkillFinderDialog
+          agents={agents}
+          runtimesById={runtimesById}
+          onClose={() => setFinderOpen(false)}
         />
       )}
     </div>

--- a/server/cmd/multica/cmd_agent.go
+++ b/server/cmd/multica/cmd_agent.go
@@ -42,6 +42,12 @@ var agentCreateCmd = &cobra.Command{
 	RunE:  runAgentCreate,
 }
 
+var agentDraftCmd = &cobra.Command{
+	Use:   "draft",
+	Short: "Record structured AI agent draft output",
+	RunE:  runAgentDraft,
+}
+
 var agentUpdateCmd = &cobra.Command{
 	Use:   "update <id>",
 	Short: "Update an agent",
@@ -134,6 +140,7 @@ func init() {
 	agentCmd.AddCommand(agentListCmd)
 	agentCmd.AddCommand(agentGetCmd)
 	agentCmd.AddCommand(agentCreateCmd)
+	agentCmd.AddCommand(agentDraftCmd)
 	agentCmd.AddCommand(agentUpdateCmd)
 	agentCmd.AddCommand(agentArchiveCmd)
 	agentCmd.AddCommand(agentRestoreCmd)
@@ -177,6 +184,9 @@ func init() {
 	agentCreateCmd.Flags().StringSlice("public-to-member", nil, "public_to: allow the given member user id(s) to invoke this agent. Repeatable.")
 	agentCreateCmd.Flags().Int32("max-concurrent-tasks", 6, "Maximum concurrent tasks")
 	agentCreateCmd.Flags().String("output", "json", "Output format: table or json")
+
+	// agent draft
+	agentDraftCmd.Flags().String("output-results", "", "Structured JSON agent draft result for AI task capture")
 
 	// agent update
 	agentUpdateCmd.Flags().String("name", "", "New name")
@@ -240,6 +250,18 @@ func init() {
 	agentEnvSetCmd.Flags().Bool("custom-env-stdin", false, "Read the replacement custom_env JSON object from stdin. Keeps secrets out of shell history and 'ps'. Mutually exclusive with --custom-env and --custom-env-file.")
 	agentEnvSetCmd.Flags().String("custom-env-file", "", "Read the replacement custom_env JSON object from a file path (suggested mode: 0600). Mutually exclusive with --custom-env and --custom-env-stdin.")
 	agentEnvSetCmd.Flags().String("output", "json", "Output format: json or table")
+}
+
+func runAgentDraft(cmd *cobra.Command, _ []string) error {
+	outputResults, _ := cmd.Flags().GetString("output-results")
+	if strings.TrimSpace(outputResults) == "" {
+		return fmt.Errorf("--output-results is required")
+	}
+	if err := writeStructuredAIResult(outputResults); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, "Agent draft captured")
+	return nil
 }
 
 // resolveProfile returns the --profile flag value (empty string means default profile).

--- a/server/cmd/multica/cmd_agent_draft_test.go
+++ b/server/cmd/multica/cmd_agent_draft_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRunAgentDraftWritesStructuredOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ai-task-output.json")
+	t.Setenv(aiTaskOutputPathEnv, path)
+	cmd := freshAgentDraftCmdForTest()
+	cmd.SetArgs([]string{"--output-results", `{"agent_id":"00000000-0000-0000-0000-000000000123","name":"A","summary":"B","skill_source_urls":[]}`})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("agent draft failed: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(data) == "" {
+		t.Fatal("expected output file to be written")
+	}
+}
+
+func freshAgentDraftCmdForTest() *cobra.Command {
+	cmd := &cobra.Command{Use: "draft", RunE: runAgentDraft}
+	cmd.Flags().String("output-results", "", "Structured JSON agent draft result for AI task capture")
+	return cmd
+}

--- a/server/cmd/multica/cmd_ai_output.go
+++ b/server/cmd/multica/cmd_ai_output.go
@@ -15,7 +15,7 @@ func writeStructuredAIResult(raw string) error {
 	if outputPath == "" {
 		return fmt.Errorf("%s is not set; this command is only available inside an AI task", aiTaskOutputPathEnv)
 	}
-	if strings.Contains(outputPath, "..") {
+	if hasParentDirSegment(outputPath) {
 		return fmt.Errorf("%s must not contain path traversal", aiTaskOutputPathEnv)
 	}
 	clean := filepath.Clean(outputPath)
@@ -36,4 +36,13 @@ func writeStructuredAIResult(raw string) error {
 		return fmt.Errorf("write AI task output: %w", err)
 	}
 	return nil
+}
+
+func hasParentDirSegment(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }

--- a/server/cmd/multica/cmd_ai_output.go
+++ b/server/cmd/multica/cmd_ai_output.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const aiTaskOutputPathEnv = "MULTICA_AI_TASK_OUTPUT_PATH"
+
+func writeStructuredAIResult(raw string) error {
+	outputPath := strings.TrimSpace(os.Getenv(aiTaskOutputPathEnv))
+	if outputPath == "" {
+		return fmt.Errorf("%s is not set; this command is only available inside an AI task", aiTaskOutputPathEnv)
+	}
+	if strings.Contains(outputPath, "..") {
+		return fmt.Errorf("%s must not contain path traversal", aiTaskOutputPathEnv)
+	}
+	clean := filepath.Clean(outputPath)
+	if !filepath.IsAbs(clean) {
+		return fmt.Errorf("%s must be an absolute path", aiTaskOutputPathEnv)
+	}
+	if filepath.Base(clean) != "ai-task-output.json" {
+		return fmt.Errorf("%s must point to ai-task-output.json", aiTaskOutputPathEnv)
+	}
+	payload := strings.TrimSpace(raw)
+	if payload == "" {
+		return fmt.Errorf("--output-results is required")
+	}
+	if !json.Valid([]byte(payload)) {
+		return fmt.Errorf("--output-results must be valid JSON")
+	}
+	if err := os.WriteFile(clean, []byte(payload), 0o600); err != nil {
+		return fmt.Errorf("write AI task output: %w", err)
+	}
+	return nil
+}

--- a/server/cmd/multica/cmd_skill.go
+++ b/server/cmd/multica/cmd_skill.go
@@ -63,6 +63,12 @@ var skillImportCmd = &cobra.Command{
 	RunE:  runSkillImport,
 }
 
+var skillFindCmd = &cobra.Command{
+	Use:   "find",
+	Short: "Write AI skill finder results",
+	RunE:  runSkillFind,
+}
+
 var skillSearchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search for installable skills",
@@ -105,6 +111,7 @@ func init() {
 	skillCmd.AddCommand(skillUpdateCmd)
 	skillCmd.AddCommand(skillDeleteCmd)
 	skillCmd.AddCommand(skillImportCmd)
+	skillCmd.AddCommand(skillFindCmd)
 	skillCmd.AddCommand(skillSearchCmd)
 	skillCmd.AddCommand(skillFilesCmd)
 
@@ -148,6 +155,9 @@ func init() {
 	// skill search
 	skillSearchCmd.Flags().String("output", "json", "Output format: table or json")
 
+	// skill find
+	skillFindCmd.Flags().String("output-results", "", "Structured recommendation JSON to return to the AI task")
+
 	// skill files list
 	skillFilesListCmd.Flags().String("output", "table", "Output format: table or json")
 
@@ -157,6 +167,15 @@ func init() {
 	skillFilesUpsertCmd.Flags().Bool("content-stdin", false, "Read file content from stdin. Mutually exclusive with --content and --content-file.")
 	skillFilesUpsertCmd.Flags().String("content-file", "", "Read file content from a UTF-8 file. Mutually exclusive with --content and --content-stdin.")
 	skillFilesUpsertCmd.Flags().String("output", "json", "Output format: table or json")
+}
+
+func runSkillFind(cmd *cobra.Command, _ []string) error {
+	results, _ := cmd.Flags().GetString("output-results")
+	if err := writeStructuredAIResult(results); err != nil {
+		return err
+	}
+	fmt.Println("Skill recommendations captured")
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/server/cmd/multica/cmd_skill_find_test.go
+++ b/server/cmd/multica/cmd_skill_find_test.go
@@ -51,7 +51,7 @@ func TestWriteStructuredAIResultRequiresTaskOutputEnv(t *testing.T) {
 }
 
 func TestWriteStructuredAIResultRejectsPathTraversal(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "subdir") + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "ai-task-output.json"
+	path := t.TempDir() + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "ai-task-output.json"
 	t.Setenv(aiTaskOutputPathEnv, path)
 
 	err := writeStructuredAIResult(`[]`)

--- a/server/cmd/multica/cmd_skill_find_test.go
+++ b/server/cmd/multica/cmd_skill_find_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteStructuredAIResultWritesValidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ai-task-output.json")
+	t.Setenv(aiTaskOutputPathEnv, path)
+	payload := `[{"name":"react","description":"React help","source_url":"https://example.test/react","reason":"fits"}]`
+
+	if err := writeStructuredAIResult(payload); err != nil {
+		t.Fatalf("writeStructuredAIResult() error = %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("written payload = %s, want %s", got, payload)
+	}
+}
+
+func TestWriteStructuredAIResultRejectsInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ai-task-output.json")
+	t.Setenv(aiTaskOutputPathEnv, path)
+
+	if err := writeStructuredAIResult(`{"missing"`); err == nil {
+		t.Fatal("expected invalid JSON to fail")
+	}
+}
+
+func TestWriteStructuredAIResultRequiresTaskOutputEnv(t *testing.T) {
+	old, had := os.LookupEnv(aiTaskOutputPathEnv)
+	os.Unsetenv(aiTaskOutputPathEnv)
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(aiTaskOutputPathEnv, old)
+		} else {
+			os.Unsetenv(aiTaskOutputPathEnv)
+		}
+	})
+
+	err := writeStructuredAIResult(`[]`)
+	if err == nil || !strings.Contains(err.Error(), aiTaskOutputPathEnv) {
+		t.Fatalf("expected missing env error, got %v", err)
+	}
+}
+
+func TestWriteStructuredAIResultRejectsPathTraversal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "subdir") + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "ai-task-output.json"
+	t.Setenv(aiTaskOutputPathEnv, path)
+
+	err := writeStructuredAIResult(`[]`)
+	if err == nil || !strings.Contains(err.Error(), "path traversal") {
+		t.Fatalf("expected path traversal error, got %v", err)
+	}
+}

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1121,6 +1121,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 			r.Route("/api/agents", func(r chi.Router) {
 				r.Get("/", h.ListAgents)
 				r.Post("/", h.CreateAgent)
+				r.Post("/ai-draft", h.DraftAgentWithAI)
 				// Agent templates: pre-configured instructions + skill refs.
 				// Picking a template imports the referenced skills into the
 				// workspace (find-or-create by name) and creates the agent
@@ -1158,6 +1159,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 				r.Get("/", h.ListSkills)
 				r.Post("/", h.CreateSkill)
 				r.Get("/search", h.SearchSkills)
+				r.Post("/find", h.FindSkillsWithAI)
 				r.Post("/import", h.ImportSkill)
 				r.Route("/{id}", func(r chi.Router) {
 					r.Get("/", h.GetSkill)

--- a/server/internal/agentdraft/validate.go
+++ b/server/internal/agentdraft/validate.go
@@ -1,0 +1,76 @@
+package agentdraft
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/multica-ai/multica/server/internal/skillindex"
+	"github.com/multica-ai/multica/server/internal/util"
+)
+
+const MaxSummaryRunes = 500
+
+type Result struct {
+	AgentID         string   `json:"agent_id"`
+	Name            string   `json:"name"`
+	Summary         string   `json:"summary"`
+	SkillSourceURLs []string `json:"skill_source_urls,omitempty"`
+}
+
+func NormalizeAgentDraftResult(raw []byte) ([]byte, Result, error) {
+	var result Result
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&result); err != nil {
+		return nil, Result{}, fmt.Errorf("agent draft result must be a JSON object: %w", err)
+	}
+
+	result.AgentID = strings.TrimSpace(result.AgentID)
+	result.Name = strings.TrimSpace(result.Name)
+	result.Summary = strings.TrimSpace(result.Summary)
+	if result.AgentID == "" {
+		return nil, Result{}, fmt.Errorf("agent draft result has empty agent_id")
+	}
+	if _, err := util.ParseUUID(result.AgentID); err != nil {
+		return nil, Result{}, fmt.Errorf("agent draft result has invalid agent_id: %w", err)
+	}
+	if result.Name == "" {
+		return nil, Result{}, fmt.Errorf("agent draft result has empty name")
+	}
+	if result.Summary == "" {
+		return nil, Result{}, fmt.Errorf("agent draft result has empty summary")
+	}
+	if len([]rune(result.Summary)) > MaxSummaryRunes {
+		return nil, Result{}, fmt.Errorf("agent draft summary is too long")
+	}
+
+	allowed, err := skillindex.SourceURLSet()
+	if err != nil {
+		return nil, Result{}, err
+	}
+	seen := map[string]struct{}{}
+	urls := make([]string, 0, len(result.SkillSourceURLs))
+	for i, sourceURL := range result.SkillSourceURLs {
+		sourceURL = strings.TrimSpace(sourceURL)
+		if sourceURL == "" {
+			return nil, Result{}, fmt.Errorf("agent draft skill_source_urls[%d] is empty", i)
+		}
+		if _, ok := allowed[sourceURL]; !ok {
+			return nil, Result{}, fmt.Errorf("agent draft skill_source_urls[%d] is outside curated index", i)
+		}
+		if _, ok := seen[sourceURL]; ok {
+			continue
+		}
+		seen[sourceURL] = struct{}{}
+		urls = append(urls, sourceURL)
+	}
+	result.SkillSourceURLs = urls
+
+	normalized, err := json.Marshal(result)
+	if err != nil {
+		return nil, Result{}, fmt.Errorf("marshal normalized agent draft result: %w", err)
+	}
+	return normalized, result, nil
+}

--- a/server/internal/agentdraft/validate_test.go
+++ b/server/internal/agentdraft/validate_test.go
@@ -1,0 +1,65 @@
+package agentdraft
+
+import (
+	"strings"
+	"testing"
+)
+
+const testAgentID = "00000000-0000-0000-0000-000000000123"
+
+func TestNormalizeAgentDraftResultValid(t *testing.T) {
+	raw := []byte(`{
+		"agent_id":" 00000000-0000-0000-0000-000000000123 ",
+		"name":" Frontend Maintainer ",
+		"summary":" Created a focused frontend agent. ",
+		"skill_source_urls":["https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices","https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices"]
+	}`)
+
+	normalized, result, err := NormalizeAgentDraftResult(raw)
+	if err != nil {
+		t.Fatalf("NormalizeAgentDraftResult returned error: %v", err)
+	}
+	if result.AgentID != testAgentID {
+		t.Fatalf("agent id was not trimmed/kept: %q", result.AgentID)
+	}
+	if result.Name != "Frontend Maintainer" {
+		t.Fatalf("name was not trimmed: %q", result.Name)
+	}
+	if len(result.SkillSourceURLs) != 1 {
+		t.Fatalf("expected duplicate skill URL to be collapsed, got %d", len(result.SkillSourceURLs))
+	}
+	if !strings.Contains(string(normalized), `"agent_id":"00000000-0000-0000-0000-000000000123"`) {
+		t.Fatalf("normalized JSON did not contain normalized agent id: %s", normalized)
+	}
+}
+
+func TestNormalizeAgentDraftResultRejectsInvalidAgentID(t *testing.T) {
+	_, _, err := NormalizeAgentDraftResult([]byte(`{"agent_id":"not-a-uuid","name":"A","summary":"B"}`))
+	if err == nil {
+		t.Fatal("expected invalid agent_id to fail")
+	}
+}
+
+func TestNormalizeAgentDraftResultRejectsUnknownSkillURL(t *testing.T) {
+	_, _, err := NormalizeAgentDraftResult([]byte(`{
+		"agent_id":"00000000-0000-0000-0000-000000000123",
+		"name":"A",
+		"summary":"B",
+		"skill_source_urls":["https://example.com/skill"]
+	}`))
+	if err == nil {
+		t.Fatal("expected unknown skill URL to fail")
+	}
+}
+
+func TestNormalizeAgentDraftResultRejectsUnknownFields(t *testing.T) {
+	_, _, err := NormalizeAgentDraftResult([]byte(`{
+		"agent_id":"00000000-0000-0000-0000-000000000123",
+		"name":"A",
+		"summary":"B",
+		"extra":true
+	}`))
+	if err == nil {
+		t.Fatal("expected unknown field to fail")
+	}
+}

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -18,9 +18,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/multica-ai/multica/server/internal/agentdraft"
 	"github.com/multica-ai/multica/server/internal/cli"
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
+	"github.com/multica-ai/multica/server/internal/skillindex"
 	"github.com/multica-ai/multica/server/pkg/agent"
 	"github.com/multica-ai/multica/server/pkg/skillbundle"
 	"github.com/multica-ai/multica/server/pkg/taskfailure"
@@ -3534,6 +3536,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		AutopilotSource:                  task.AutopilotSource,
 		AutopilotTriggerPayload:          strings.TrimSpace(string(task.AutopilotTriggerPayload)),
 		QuickCreatePrompt:                task.QuickCreatePrompt,
+		AITaskType:                       task.AITaskType,
+		AITaskPrompt:                     task.AITaskPrompt,
 		HandoffNote:                      task.HandoffNote,
 		IsSquadLeader:                    strings.Contains(instructions, "## Squad Operating Protocol"),
 		RequestingUserName:               task.RequestingUserName,
@@ -3633,6 +3637,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 	taskTempDir, err := ensureTaskTempDir(env.RootDir, task.ID)
 	if err != nil {
 		return TaskResult{}, fmt.Errorf("prepare task temp dir: %w", err)
+	}
+	aiOutputPath := ""
+	if task.AITaskType != "" {
+		aiOutputPath = filepath.Join(env.WorkDir, "ai-task-output.json")
 	}
 
 	// Issue #3999 race A: now that env.WorkDir is on disk, transition the
@@ -3738,6 +3746,10 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 				taskLog.Warn("quick-create attachment ids: marshal failed; skipping env injection", "error", err)
 			}
 		}
+	}
+	if aiOutputPath != "" {
+		agentEnv["MULTICA_AI_TASK_TYPE"] = task.AITaskType
+		agentEnv["MULTICA_AI_TASK_OUTPUT_PATH"] = aiOutputPath
 	}
 	// Ensure the multica CLI is on PATH inside the agent's environment.
 	// Some runtimes (e.g. Codex) run in an isolated sandbox that may not
@@ -3968,6 +3980,44 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 			CacheReadTokens:  u.CacheReadTokens,
 			CacheWriteTokens: u.CacheWriteTokens,
 		})
+	}
+
+	if result.Status == "completed" && task.AITaskType != "" {
+		raw, err := os.ReadFile(aiOutputPath)
+		if err != nil {
+			taskLog.Warn("ai task completed without structured output", "type", task.AITaskType, "error", err)
+			return TaskResult{
+				Status:        "blocked",
+				Comment:       "AI task did not write structured output",
+				SessionID:     result.SessionID,
+				WorkDir:       env.WorkDir,
+				EnvRoot:       env.RootDir,
+				FailureReason: "agent_error",
+				Usage:         usageEntries,
+			}, nil
+		}
+		var normalized []byte
+		switch task.AITaskType {
+		case "skill-find":
+			normalized, _, err = skillindex.NormalizeSkillFindResult(raw)
+		case "agent-create":
+			normalized, _, err = agentdraft.NormalizeAgentDraftResult(raw)
+		default:
+			err = fmt.Errorf("unsupported ai task type %q", task.AITaskType)
+		}
+		if err != nil {
+			taskLog.Warn("ai task wrote invalid structured output", "type", task.AITaskType, "error", err)
+			return TaskResult{
+				Status:        "blocked",
+				Comment:       "AI task wrote invalid structured output",
+				SessionID:     result.SessionID,
+				WorkDir:       env.WorkDir,
+				EnvRoot:       env.RootDir,
+				FailureReason: "agent_error",
+				Usage:         usageEntries,
+			}, nil
+		}
+		result.Output = string(normalized)
 	}
 
 	switch result.Status {

--- a/server/internal/daemon/execenv/context.go
+++ b/server/internal/daemon/execenv/context.go
@@ -556,6 +556,9 @@ func renderIssueContext(provider string, ctx TaskContextForEnv) string {
 	if ctx.QuickCreatePrompt != "" {
 		return renderQuickCreateContext(ctx)
 	}
+	if ctx.AITaskType != "" {
+		return renderAITaskContext(ctx)
+	}
 
 	var b strings.Builder
 
@@ -614,6 +617,24 @@ func renderQuickCreateContext(ctx TaskContextForEnv) string {
 	return b.String()
 }
 
+// renderAITaskContext renders issue_context.md for generic no-parent AI tasks.
+func renderAITaskContext(ctx TaskContextForEnv) string {
+	var b strings.Builder
+	b.WriteString("# AI Task\n\n")
+	fmt.Fprintf(&b, "**Task type:** %s\n\n", ctx.AITaskType)
+	b.WriteString("## User input\n\n")
+	b.WriteString("> ")
+	b.WriteString(ctx.AITaskPrompt)
+	b.WriteString("\n\n")
+	if len(ctx.AgentSkills) > 0 {
+		b.WriteString("## Agent Skills\n\n")
+		for _, skill := range ctx.AgentSkills {
+			fmt.Fprintf(&b, "- **%s**\n", skill.Name)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
 func renderAutopilotContext(ctx TaskContextForEnv) string {
 	var b strings.Builder
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -88,6 +88,8 @@ type TaskContextForEnv struct {
 	AutopilotSource         string
 	AutopilotTriggerPayload string
 	QuickCreatePrompt       string // non-empty for quick-create tasks
+	AITaskType              string // non-empty for generic no-parent AI tasks
+	AITaskPrompt            string // user's input for generic no-parent AI tasks
 	HandoffNote             string // assignment handoff instruction; rendered into issue_context.md (MUL-3375)
 	IsSquadLeader           bool   // true when the agent is acting as a squad leader (may exit silently on no_action)
 	// WorkspaceContext is the workspace-level system prompt (workspace.context

--- a/server/internal/daemon/prompt.go
+++ b/server/internal/daemon/prompt.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/multica-ai/multica/server/internal/daemon/execenv"
+	"github.com/multica-ai/multica/server/internal/skillindex"
 )
 
 // BuildPrompt constructs the task prompt for an agent CLI.
@@ -24,6 +25,12 @@ func BuildPrompt(task Task, provider string) string {
 	if task.AutopilotRunID != "" {
 		return buildAutopilotPrompt(task)
 	}
+	if task.AITaskType == "skill-find" {
+		return buildSkillFindPrompt(task)
+	}
+	if task.AITaskType == "agent-create" {
+		return buildAgentCreatePrompt(task)
+	}
 	if task.QuickCreatePrompt != "" {
 		return buildQuickCreatePrompt(task)
 	}
@@ -42,6 +49,53 @@ func BuildPrompt(task Task, provider string) string {
 	return b.String()
 }
 
+// buildSkillFindPrompt asks the agent to map a user goal to the curated
+// skill catalog and persist a structured result through the multica CLI.
+func buildSkillFindPrompt(task Task) string {
+	var b strings.Builder
+	b.WriteString("You are running as an AI skill finder for a Multica workspace.\n\n")
+	b.WriteString("A user wants help finding reusable agent skills. Recommend only skills from the curated index below.\n\n")
+	fmt.Fprintf(&b, "User goal:\n> %s\n\n", task.AITaskPrompt)
+	b.WriteString("Curated skill index JSON:\n")
+	b.WriteString("```json\n")
+	b.WriteString(skillindex.MustJSON())
+	b.WriteString("\n```\n\n")
+	b.WriteString("Selection rules:\n")
+	b.WriteString("- Return 1 to 5 recommendations.\n")
+	b.WriteString("- Do not invent URLs, names, or skills. Every source_url must exactly match one source_url in the curated index.\n")
+	b.WriteString("- Prefer specific matches over broad skills. If no skill is a strong fit, choose the closest safe option and explain the limitation in reason.\n")
+	b.WriteString("- Keep each reason concise and tied to the user's goal.\n\n")
+	b.WriteString("Output rules:\n")
+	b.WriteString("- Produce a JSON array of objects with exactly these fields: name, description, source_url, reason.\n")
+	b.WriteString("- Then run exactly one command to hand the JSON to Multica: `multica skill find --output-results '<json-array>'`.\n")
+	b.WriteString("- Do not create or install skills in this task. Do not print extra commentary after the command succeeds.\n")
+	return b.String()
+}
+// buildAgentCreatePrompt asks the agent to create a workspace agent from a
+// natural-language goal, optionally importing curated skills first.
+func buildAgentCreatePrompt(task Task) string {
+	var b strings.Builder
+	b.WriteString("You are running as an AI agent draft assistant for a Multica workspace.\n\n")
+	b.WriteString("A user wants a new Multica agent. Create the agent directly with the multica CLI, using the curated skill index below when skills would help.\n\n")
+	fmt.Fprintf(&b, "User goal:\n> %s\n\n", task.AITaskPrompt)
+	b.WriteString("Curated skill index JSON:\n")
+	b.WriteString("```json\n")
+	b.WriteString(skillindex.MustJSON())
+	b.WriteString("\n```\n\n")
+	b.WriteString("Workflow rules:\n")
+	b.WriteString("- Choose a concise agent name, a short description, and useful instructions from the user goal.\n")
+	b.WriteString("- If curated skills help, import each chosen skill with `multica skill import --url <source_url> --output json`, collect the returned skill ids, and then assign them with `multica agent skills set <agent-id> --skill-ids <ids> --output json`.\n")
+	b.WriteString("- Do not invent skill URLs. Every imported URL must exactly match a source_url from the curated index.\n")
+	b.WriteString("- Create the agent with exactly one `multica agent create --runtime-id \"$MULTICA_AGENT_RUNTIME_ID\" --output json` invocation. Do not use any other runtime id for this task.\n")
+	b.WriteString("- Prefer `--visibility workspace` only when the user asks for a team/workspace agent; otherwise use the CLI default.\n\n")
+	b.WriteString("Structured output rules:\n")
+	b.WriteString("- After the agent and any skill assignments are complete, produce a JSON object with exactly these fields: agent_id, name, summary, skill_source_urls.\n")
+	b.WriteString("- summary should describe what was created and any skills attached, in 1-3 concise sentences.\n")
+	b.WriteString("- skill_source_urls must be an array of curated source_url strings that were actually imported/assigned, or an empty array.\n")
+	b.WriteString("- Then run exactly one command to hand the JSON to Multica: `multica agent draft --output-results '<json-object>'`.\n")
+	b.WriteString("- Do not create an issue or post a comment. Do not print extra commentary after the command succeeds.\n")
+	return b.String()
+}
 // buildQuickCreatePrompt constructs a prompt for quick-create tasks. The
 // user typed a single natural-language sentence in the create-issue modal;
 // the agent's job is to translate it into one `multica issue create` CLI

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -5,6 +5,40 @@ import (
 	"testing"
 )
 
+func TestBuildSkillFindPrompt(t *testing.T) {
+	out := buildSkillFindPrompt(Task{AITaskPrompt: "improve React rendering performance"})
+	mustContain := []string{
+		"improve React rendering performance",
+		"Curated skill index JSON",
+		"https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices",
+		"multica skill find --output-results",
+		"Do not invent URLs",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("buildSkillFindPrompt output missing %q\n--- output ---\n%s", s, out)
+		}
+	}
+}
+
+func TestBuildAgentCreatePrompt(t *testing.T) {
+	out := buildAgentCreatePrompt(Task{AITaskPrompt: "create a frontend review agent"})
+	mustContain := []string{
+		"create a frontend review agent",
+		"Curated skill index JSON",
+		"multica agent create --runtime-id",
+		"multica skill import --url",
+		"multica agent skills set",
+		"multica agent draft --output-results",
+		"agent_id, name, summary, skill_source_urls",
+		"Do not invent skill URLs",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("buildAgentCreatePrompt output missing %q\n--- output ---\n%s", s, out)
+		}
+	}
+}
 // TestBuildQuickCreatePromptRules locks in the rules that govern how the
 // quick-create agent is allowed to translate raw user input into the issue
 // description body. Each substring corresponds to a concrete failure mode

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -90,6 +90,9 @@ type Task struct {
 	AutopilotSource          string                `json:"autopilot_source,omitempty"`            // manual, schedule, webhook, or api
 	AutopilotTriggerPayload  json.RawMessage       `json:"autopilot_trigger_payload,omitempty"`   // optional trigger payload for webhook/api runs
 	QuickCreatePrompt        string                `json:"quick_create_prompt,omitempty"`         // user's natural-language input for quick-create tasks
+	AITaskType               string                `json:"ai_task_type,omitempty"`                // generic no-parent AI task type, e.g. skill-find
+	AITaskPrompt             string                `json:"ai_task_prompt,omitempty"`              // user's natural-language input for AI tasks
+	AITaskVersion            int                   `json:"ai_task_version,omitempty"`             // AI task context version
 	QuickCreateAttachmentIDs []string              `json:"quick_create_attachment_ids,omitempty"` // attachments uploaded in the quick-create prompt and bound by issue create
 	HandoffNote              string                `json:"handoff_note,omitempty"`                // assignment handoff instruction; rendered into the opening prompt + issue_context.md
 

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -330,6 +330,9 @@ type AgentTaskResponse struct {
 	AutopilotSource          string               `json:"autopilot_source,omitempty"`            // manual, schedule, webhook, or api
 	AutopilotTriggerPayload  json.RawMessage      `json:"autopilot_trigger_payload,omitempty"`   // optional trigger payload for webhook/api runs
 	QuickCreatePrompt        string               `json:"quick_create_prompt,omitempty"`         // user's natural-language input for quick-create tasks
+	AITaskType               string               `json:"ai_task_type,omitempty"`                // generic no-parent AI task type, e.g. skill-find
+	AITaskPrompt             string               `json:"ai_task_prompt,omitempty"`              // user's natural-language input for AI tasks
+	AITaskVersion            int                  `json:"ai_task_version,omitempty"`             // AI task context version
 	QuickCreateAttachmentIDs []string             `json:"quick_create_attachment_ids,omitempty"` // attachment ids uploaded in the quick-create prompt and bound on issue create
 	HandoffNote              string               `json:"handoff_note,omitempty"`                // assignment handoff instruction; rendered into the run's opening prompt + issue_context.md (omitempty so old daemons ignore it)
 	SquadID                  string               `json:"squad_id,omitempty"`                    // for quick-create tasks where the picker was a squad; Agent is still the resolved leader

--- a/server/internal/handler/agent_draft.go
+++ b/server/internal/handler/agent_draft.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/service"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+type DraftAgentWithAIRequest struct {
+	Prompt      string `json:"prompt"`
+	HostAgentID string `json:"host_agent_id"`
+}
+
+func (h *Handler) DraftAgentWithAI(w http.ResponseWriter, r *http.Request) {
+	var req DraftAgentWithAIRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	prompt := strings.TrimSpace(req.Prompt)
+	if prompt == "" {
+		writeError(w, http.StatusBadRequest, "prompt is required")
+		return
+	}
+	if strings.TrimSpace(req.HostAgentID) == "" {
+		writeError(w, http.StatusBadRequest, "host_agent_id is required")
+		return
+	}
+	workspaceID := h.resolveWorkspaceID(r)
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id is required")
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
+	requesterID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	requesterUUID, ok := parseUUIDOrBadRequest(w, requesterID, "requester_id")
+	if !ok {
+		return
+	}
+	hostAgent, hostAgentUUID, ok := h.validateHostAgentForAITask(w, r, workspaceID, req.HostAgentID)
+	if !ok {
+		return
+	}
+	runtime, err := h.Queries.GetAgentRuntimeForWorkspace(r.Context(), db.GetAgentRuntimeForWorkspaceParams{
+		ID:          hostAgent.RuntimeID,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		writeAgentUnavailable(w, "agent runtime is unavailable")
+		return
+	}
+	member, ok := h.workspaceMember(w, r, workspaceID)
+	if !ok {
+		return
+	}
+	if !canUseRuntimeForAgent(member, runtime) {
+		writeError(w, http.StatusForbidden, "this runtime is private; only its owner or a workspace admin can draft agents on it")
+		return
+	}
+	task, err := h.TaskService.EnqueueAITask(r.Context(), service.AITaskContextTypeAgentCreate, wsUUID, requesterUUID, hostAgentUUID, prompt)
+	if err != nil {
+		slog.Warn("agent-draft enqueue failed", append(logger.RequestAttrs(r), "error", err)...)
+		writeError(w, http.StatusInternalServerError, "failed to enqueue agent draft task")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, AITaskQueuedResponse{TaskID: uuidToString(task.ID)})
+}

--- a/server/internal/handler/ai_task.go
+++ b/server/internal/handler/ai_task.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	db "github.com/multica-ai/multica/server/pkg/db/generated"
+)
+
+// validateHostAgentForAITask applies the same agent dispatch boundary used by
+// issue assignment and quick-create before a no-parent AI task is queued.
+func (h *Handler) validateHostAgentForAITask(w http.ResponseWriter, r *http.Request, workspaceID, agentID string) (db.Agent, pgtype.UUID, bool) {
+	agentUUID, ok := parseUUIDOrBadRequest(w, strings.TrimSpace(agentID), "agent_id")
+	if !ok {
+		return db.Agent{}, pgtype.UUID{}, false
+	}
+	if status, msg := h.validateAssigneePair(
+		r.Context(), r, workspaceID,
+		pgtype.Text{String: "agent", Valid: true},
+		agentUUID,
+	); status != 0 {
+		writeError(w, status, msg)
+		return db.Agent{}, pgtype.UUID{}, false
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return db.Agent{}, pgtype.UUID{}, false
+	}
+	agent, err := h.Queries.GetAgentInWorkspace(r.Context(), db.GetAgentInWorkspaceParams{
+		ID:          agentUUID,
+		WorkspaceID: wsUUID,
+	})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "agent not found")
+		return db.Agent{}, pgtype.UUID{}, false
+	}
+	if !agent.RuntimeID.Valid {
+		writeAgentUnavailable(w, "agent has no runtime")
+		return db.Agent{}, pgtype.UUID{}, false
+	}
+	if !h.isRuntimeOnline(r.Context(), agent.RuntimeID) {
+		writeAgentUnavailable(w, "agent's runtime is offline")
+		return db.Agent{}, pgtype.UUID{}, false
+	}
+	return agent, agentUUID, true
+}

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1976,6 +1976,19 @@ func (h *Handler) ClaimTaskByRuntime(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+		if ai, ok := service.ParseAITaskContext(task.Context); ok {
+			resp.AITaskType = ai.Type
+			resp.AITaskPrompt = ai.Prompt
+			resp.AITaskVersion = ai.Version
+			resp.ThreadName = ai.Prompt
+			resp.WorkspaceID = ai.WorkspaceID
+			if ws, err := h.Queries.GetWorkspace(r.Context(), parseUUID(ai.WorkspaceID)); err == nil && ws.Repos != nil {
+				var repos []RepoData
+				if json.Unmarshal(ws.Repos, &repos) == nil && len(repos) > 0 {
+					resp.Repos = repos
+				}
+			}
+		}
 	}
 
 	// Workspace isolation check: the daemon uses this response's workspace_id

--- a/server/internal/handler/skill_find.go
+++ b/server/internal/handler/skill_find.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/multica-ai/multica/server/internal/logger"
+	"github.com/multica-ai/multica/server/internal/service"
+)
+
+type FindSkillsWithAIRequest struct {
+	Prompt  string `json:"prompt"`
+	AgentID string `json:"agent_id"`
+}
+
+type AITaskQueuedResponse struct {
+	TaskID string `json:"task_id"`
+}
+
+func (h *Handler) FindSkillsWithAI(w http.ResponseWriter, r *http.Request) {
+	var req FindSkillsWithAIRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	prompt := strings.TrimSpace(req.Prompt)
+	if prompt == "" {
+		writeError(w, http.StatusBadRequest, "prompt is required")
+		return
+	}
+	if strings.TrimSpace(req.AgentID) == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+	workspaceID := h.resolveWorkspaceID(r)
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id is required")
+		return
+	}
+	wsUUID, ok := parseUUIDOrBadRequest(w, workspaceID, "workspace_id")
+	if !ok {
+		return
+	}
+	requesterID, ok := requireUserID(w, r)
+	if !ok {
+		return
+	}
+	requesterUUID, ok := parseUUIDOrBadRequest(w, requesterID, "requester_id")
+	if !ok {
+		return
+	}
+	_, agentUUID, ok := h.validateHostAgentForAITask(w, r, workspaceID, req.AgentID)
+	if !ok {
+		return
+	}
+	task, err := h.TaskService.EnqueueAITask(r.Context(), service.AITaskContextTypeSkillFind, wsUUID, requesterUUID, agentUUID, prompt)
+	if err != nil {
+		slog.Warn("skill-find enqueue failed", append(logger.RequestAttrs(r), "error", err)...)
+		writeError(w, http.StatusInternalServerError, "failed to enqueue skill finder task")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, AITaskQueuedResponse{TaskID: uuidToString(task.ID)})
+}

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/multica-ai/multica/server/internal/agentdraft"
 	"github.com/multica-ai/multica/server/internal/analytics"
 	"github.com/multica-ai/multica/server/internal/events"
 	"github.com/multica-ai/multica/server/internal/featureflags"
 	obsmetrics "github.com/multica-ai/multica/server/internal/metrics"
 	"github.com/multica-ai/multica/server/internal/realtime"
 	"github.com/multica-ai/multica/server/internal/runtimeapps"
+	"github.com/multica-ai/multica/server/internal/skillindex"
 	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 	"github.com/multica-ai/multica/server/pkg/featureflag"
@@ -874,6 +876,41 @@ type QuickCreateContext struct {
 // QuickCreateContextType marks a task as a quick-create job.
 const QuickCreateContextType = "quick_create"
 
+const (
+	AITaskContextTypeSkillFind   = "skill-find"
+	AITaskContextTypeAgentCreate = "agent-create"
+)
+
+// AITaskContext is a generic no-parent task payload. The daemon dispatches by
+// Type while preserving the prompt and requester/workspace identity for inbox
+// completion notifications.
+type AITaskContext struct {
+	Type        string `json:"type"`
+	Version     int    `json:"version"`
+	Prompt      string `json:"prompt"`
+	RequesterID string `json:"requester_id"`
+	WorkspaceID string `json:"workspace_id"`
+}
+
+func ParseAITaskContext(raw []byte) (AITaskContext, bool) {
+	if len(raw) == 0 {
+		return AITaskContext{}, false
+	}
+	var ctx AITaskContext
+	if err := json.Unmarshal(raw, &ctx); err != nil {
+		return AITaskContext{}, false
+	}
+	if ctx.Version != 1 {
+		return AITaskContext{}, false
+	}
+	switch ctx.Type {
+	case AITaskContextTypeSkillFind, AITaskContextTypeAgentCreate:
+		return ctx, true
+	default:
+		return AITaskContext{}, false
+	}
+}
+
 // EnqueueQuickCreateTask creates a queued task that has no issue / chat /
 // autopilot link — the user's natural-language prompt is stored in the
 // task's context JSONB and the agent is expected to translate it into a
@@ -961,6 +998,53 @@ func (s *TaskService) EnqueueQuickCreateTask(ctx context.Context, workspaceID, r
 	// cycle. Without this the user perceives "quick create never
 	// triggered" because the modal closes immediately and the task
 	// sits in 'queued' until the next sleepWithContextOrWakeup tick.
+	s.NotifyTaskEnqueued(ctx, task)
+	return task, nil
+}
+
+// EnqueueAITask creates a queued no-parent task whose behavior is selected by
+// its context type.
+func (s *TaskService) EnqueueAITask(ctx context.Context, kind string, workspaceID, requesterID, agentID pgtype.UUID, prompt string) (db.AgentTaskQueue, error) {
+	switch kind {
+	case AITaskContextTypeSkillFind, AITaskContextTypeAgentCreate:
+	default:
+		return db.AgentTaskQueue{}, fmt.Errorf("unsupported ai task type %q", kind)
+	}
+	agent, err := s.Queries.GetAgent(ctx, agentID)
+	if err != nil {
+		return db.AgentTaskQueue{}, fmt.Errorf("load agent: %w", err)
+	}
+	if agent.ArchivedAt.Valid {
+		return db.AgentTaskQueue{}, fmt.Errorf("agent is archived")
+	}
+	if !agent.RuntimeID.Valid {
+		return db.AgentTaskQueue{}, fmt.Errorf("agent has no runtime")
+	}
+	payload := AITaskContext{
+		Type:        kind,
+		Version:     1,
+		Prompt:      prompt,
+		RequesterID: util.UUIDToString(requesterID),
+		WorkspaceID: util.UUIDToString(workspaceID),
+	}
+	contextJSON, err := json.Marshal(payload)
+	if err != nil {
+		return db.AgentTaskQueue{}, fmt.Errorf("marshal ai task context: %w", err)
+	}
+	runtimeMCPOverlay := s.buildRuntimeMCPOverlay(ctx, requesterID, agent)
+	task, err := s.Queries.CreateQuickCreateTask(ctx, db.CreateQuickCreateTaskParams{
+		AgentID:              agentID,
+		RuntimeID:            agent.RuntimeID,
+		Priority:             priorityToInt("high"),
+		Context:              contextJSON,
+		OriginatorUserID:     requesterID,
+		RuntimeMcpOverlay:    runtimeMCPOverlay.Overlay,
+		RuntimeConnectedApps: runtimeMCPOverlay.ConnectedApps,
+	})
+	if err != nil {
+		return db.AgentTaskQueue{}, fmt.Errorf("create ai task: %w", err)
+	}
+	s.broadcastTaskEvent(ctx, protocol.EventTaskQueued, task)
 	s.NotifyTaskEnqueued(ctx, task)
 	return task, nil
 }
@@ -1713,6 +1797,9 @@ func (s *TaskService) CompleteTask(ctx context.Context, taskID pgtype.UUID, resu
 	if qc, ok := s.parseQuickCreateContext(task); ok {
 		s.notifyQuickCreateCompleted(ctx, task, qc)
 	}
+	if ai, ok := ParseAITaskContext(task.Context); ok {
+		s.notifyAITaskCompleted(ctx, task, ai, result)
+	}
 
 	// For chat tasks, save assistant reply and broadcast chat:done. The
 	// resume pointer was already persisted inside the transaction above.
@@ -1884,6 +1971,9 @@ func (s *TaskService) FailTask(ctx context.Context, taskID pgtype.UUID, errMsg, 
 	if retried == nil {
 		if qc, ok := s.parseQuickCreateContext(task); ok {
 			s.notifyQuickCreateFailed(ctx, task, qc, errMsg)
+		}
+		if ai, ok := ParseAITaskContext(task.Context); ok {
+			s.notifyAITaskFailed(ctx, task, ai, errMsg)
 		}
 	}
 	// Reconcile agent status
@@ -2580,6 +2670,9 @@ func (s *TaskService) ResolveTaskWorkspaceID(ctx context.Context, task db.AgentT
 	if qc, ok := s.parseQuickCreateContext(task); ok {
 		return qc.WorkspaceID
 	}
+	if ai, ok := ParseAITaskContext(task.Context); ok {
+		return ai.WorkspaceID
+	}
 	return ""
 }
 
@@ -2790,6 +2883,188 @@ func (s *TaskService) parseQuickCreateContext(task db.AgentTaskQueue) (QuickCrea
 		return QuickCreateContext{}, false
 	}
 	return qc, true
+}
+
+func (s *TaskService) notifyAITaskCompleted(ctx context.Context, task db.AgentTaskQueue, ai AITaskContext, result []byte) {
+	switch ai.Type {
+	case AITaskContextTypeSkillFind:
+		s.notifySkillFindCompleted(ctx, task, ai, result)
+	case AITaskContextTypeAgentCreate:
+		s.notifyAgentDraftCompleted(ctx, task, ai, result)
+	}
+}
+
+func (s *TaskService) notifySkillFindCompleted(ctx context.Context, task db.AgentTaskQueue, ai AITaskContext, result []byte) {
+	requesterID, err := util.ParseUUID(ai.RequesterID)
+	if err != nil {
+		slog.Warn("skill-find completion: invalid requester id", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	workspaceID, err := util.ParseUUID(ai.WorkspaceID)
+	if err != nil {
+		slog.Warn("skill-find completion: invalid workspace id", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	var payload protocol.TaskCompletedPayload
+	if err := json.Unmarshal(result, &payload); err != nil {
+		s.notifyAITaskFailed(ctx, task, ai, "agent completed with an unreadable result")
+		return
+	}
+	normalized, recs, err := skillindex.NormalizeSkillFindResult([]byte(payload.Output))
+	if err != nil {
+		slog.Warn("skill-find completion: invalid structured output", "task_id", util.UUIDToString(task.ID), "error", err)
+		s.notifyAITaskFailed(ctx, task, ai, "agent returned invalid skill recommendations")
+		return
+	}
+	var recommendations []map[string]any
+	if err := json.Unmarshal(normalized, &recommendations); err != nil {
+		s.notifyAITaskFailed(ctx, task, ai, "agent returned invalid skill recommendations")
+		return
+	}
+	details, _ := json.Marshal(map[string]any{
+		"task_id":         util.UUIDToString(task.ID),
+		"agent_id":        util.UUIDToString(task.AgentID),
+		"original_prompt": ai.Prompt,
+		"recommendations": recommendations,
+	})
+	title := "Skill recommendations ready"
+	if len(recs) == 1 {
+		title = "1 skill recommendation ready"
+	} else if len(recs) > 1 {
+		title = fmt.Sprintf("%d skill recommendations ready", len(recs))
+	}
+	item, err := s.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+		WorkspaceID:   workspaceID,
+		RecipientType: "member",
+		RecipientID:   requesterID,
+		Type:          "skill_find_done",
+		Severity:      "info",
+		IssueID:       pgtype.UUID{},
+		Title:         title,
+		Body:          pgtype.Text{String: redact.Text(ai.Prompt), Valid: ai.Prompt != ""},
+		ActorType:     pgtype.Text{String: "agent", Valid: true},
+		ActorID:       task.AgentID,
+		Details:       details,
+	})
+	if err != nil {
+		slog.Error("skill-find completion: inbox write failed", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	s.publishQuickCreateInbox(item, ai.WorkspaceID, util.UUIDToString(task.AgentID), "")
+}
+
+func (s *TaskService) notifyAgentDraftCompleted(ctx context.Context, task db.AgentTaskQueue, ai AITaskContext, result []byte) {
+	requesterID, err := util.ParseUUID(ai.RequesterID)
+	if err != nil {
+		slog.Warn("agent-draft completion: invalid requester id", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	workspaceID, err := util.ParseUUID(ai.WorkspaceID)
+	if err != nil {
+		slog.Warn("agent-draft completion: invalid workspace id", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	var payload protocol.TaskCompletedPayload
+	if err := json.Unmarshal(result, &payload); err != nil {
+		s.notifyAITaskFailed(ctx, task, ai, "agent completed with an unreadable result")
+		return
+	}
+	normalized, draft, err := agentdraft.NormalizeAgentDraftResult([]byte(payload.Output))
+	if err != nil {
+		slog.Warn("agent-draft completion: invalid structured output", "task_id", util.UUIDToString(task.ID), "error", err)
+		s.notifyAITaskFailed(ctx, task, ai, "agent returned invalid agent draft details")
+		return
+	}
+	draftedAgentID, err := util.ParseUUID(draft.AgentID)
+	if err != nil {
+		s.notifyAITaskFailed(ctx, task, ai, "agent returned invalid agent id")
+		return
+	}
+	if _, err := s.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{ID: draftedAgentID, WorkspaceID: workspaceID}); err != nil {
+		slog.Warn("agent-draft completion: drafted agent not found in workspace", "task_id", util.UUIDToString(task.ID), "drafted_agent_id", draft.AgentID, "error", err)
+		s.notifyAITaskFailed(ctx, task, ai, "agent draft was not created in this workspace")
+		return
+	}
+	var details map[string]any
+	if err := json.Unmarshal(normalized, &details); err != nil {
+		s.notifyAITaskFailed(ctx, task, ai, "agent returned invalid agent draft details")
+		return
+	}
+	details["task_id"] = util.UUIDToString(task.ID)
+	details["host_agent_id"] = util.UUIDToString(task.AgentID)
+	details["drafted_agent_id"] = draft.AgentID
+	details["drafted_agent_name"] = draft.Name
+	details["original_prompt"] = ai.Prompt
+	detailsJSON, _ := json.Marshal(details)
+	item, err := s.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+		WorkspaceID:   workspaceID,
+		RecipientType: "member",
+		RecipientID:   requesterID,
+		Type:          "agent_draft_done",
+		Severity:      "info",
+		IssueID:       pgtype.UUID{},
+		Title:         fmt.Sprintf("Agent draft ready: %s", draft.Name),
+		Body:          pgtype.Text{String: redact.Text(draft.Summary), Valid: draft.Summary != ""},
+		ActorType:     pgtype.Text{String: "agent", Valid: true},
+		ActorID:       task.AgentID,
+		Details:       detailsJSON,
+	})
+	if err != nil {
+		slog.Error("agent-draft completion: inbox write failed", "task_id", util.UUIDToString(task.ID), "error", err)
+		return
+	}
+	s.publishQuickCreateInbox(item, ai.WorkspaceID, util.UUIDToString(task.AgentID), "")
+}
+
+func (s *TaskService) notifyAITaskFailed(ctx context.Context, task db.AgentTaskQueue, ai AITaskContext, errMsg string) {
+	if ai.Type != AITaskContextTypeSkillFind && ai.Type != AITaskContextTypeAgentCreate {
+		return
+	}
+	requesterID, err := util.ParseUUID(ai.RequesterID)
+	if err != nil {
+		return
+	}
+	workspaceID, err := util.ParseUUID(ai.WorkspaceID)
+	if err != nil {
+		return
+	}
+	if strings.TrimSpace(errMsg) == "" {
+		if ai.Type == AITaskContextTypeAgentCreate {
+			errMsg = "AI agent draft did not finish successfully"
+		} else {
+			errMsg = "AI skill finder did not finish successfully"
+		}
+	}
+	itemType := "skill_find_failed"
+	title := "AI skill finder failed"
+	if ai.Type == AITaskContextTypeAgentCreate {
+		itemType = "agent_draft_failed"
+		title = "AI agent draft failed"
+	}
+	details, _ := json.Marshal(map[string]any{
+		"task_id":         util.UUIDToString(task.ID),
+		"agent_id":        util.UUIDToString(task.AgentID),
+		"original_prompt": ai.Prompt,
+		"error":           redact.Text(errMsg),
+	})
+	item, err := s.Queries.CreateInboxItem(ctx, db.CreateInboxItemParams{
+		WorkspaceID:   workspaceID,
+		RecipientType: "member",
+		RecipientID:   requesterID,
+		Type:          itemType,
+		Severity:      "action_required",
+		IssueID:       pgtype.UUID{},
+		Title:         title,
+		Body:          pgtype.Text{String: redact.Text(errMsg), Valid: true},
+		ActorType:     pgtype.Text{String: "agent", Valid: true},
+		ActorID:       task.AgentID,
+		Details:       details,
+	})
+	if err != nil {
+		slog.Error("ai task failure: inbox write failed", "task_id", util.UUIDToString(task.ID), "type", ai.Type, "error", err)
+		return
+	}
+	s.publishQuickCreateInbox(item, ai.WorkspaceID, util.UUIDToString(task.AgentID), "")
 }
 
 // notifyQuickCreateCompleted writes a success inbox notification to the

--- a/server/internal/skillindex/index.go
+++ b/server/internal/skillindex/index.go
@@ -1,0 +1,57 @@
+package skillindex
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+)
+
+//go:embed index.json
+var files embed.FS
+
+type Entry struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	SourceURL   string   `json:"source_url"`
+	Tags        []string `json:"tags"`
+	Category    string   `json:"category,omitempty"`
+}
+
+func List() ([]Entry, error) {
+	data, err := files.ReadFile("index.json")
+	if err != nil {
+		return nil, fmt.Errorf("read skill index: %w", err)
+	}
+	var entries []Entry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parse skill index: %w", err)
+	}
+	return entries, nil
+}
+
+func MustJSON() string {
+	entries, err := List()
+	if err != nil {
+		panic(err)
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+func SourceURLSet() (map[string]Entry, error) {
+	entries, err := List()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]Entry, len(entries))
+	for _, entry := range entries {
+		if entry.SourceURL == "" {
+			return nil, fmt.Errorf("skill index entry %q has empty source_url", entry.Name)
+		}
+		out[entry.SourceURL] = entry
+	}
+	return out, nil
+}

--- a/server/internal/skillindex/index.json
+++ b/server/internal/skillindex/index.json
@@ -1,0 +1,79 @@
+[
+  {
+    "name": "vercel-react-best-practices",
+    "description": "React and Next.js performance optimization guidelines from Vercel Engineering.",
+    "source_url": "https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices",
+    "tags": [
+      "react",
+      "nextjs",
+      "performance"
+    ],
+    "category": "Engineering"
+  },
+  {
+    "name": "web-artifacts-builder",
+    "description": "Build polished browser-rendered HTML artifacts and interactive web outputs.",
+    "source_url": "https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder",
+    "tags": [
+      "html",
+      "frontend",
+      "artifacts"
+    ],
+    "category": "Design"
+  },
+  {
+    "name": "canvas-design",
+    "description": "Design visual canvases, layouts, and presentation-like compositions.",
+    "source_url": "https://github.com/anthropics/skills/tree/main/skills/canvas-design",
+    "tags": [
+      "design",
+      "canvas",
+      "visual"
+    ],
+    "category": "Design"
+  },
+  {
+    "name": "webapp-testing",
+    "description": "Test web applications with browser-driven checks and user-visible regression coverage.",
+    "source_url": "https://github.com/anthropics/skills/tree/main/skills/webapp-testing",
+    "tags": [
+      "testing",
+      "browser",
+      "playwright"
+    ],
+    "category": "Engineering"
+  },
+  {
+    "name": "frontend-design",
+    "description": "Create frontend UI with careful layout, visual hierarchy, responsiveness, and interaction states.",
+    "source_url": "https://github.com/anthropics/skills/tree/main/skills/frontend-design",
+    "tags": [
+      "frontend",
+      "ui",
+      "design"
+    ],
+    "category": "Design"
+  },
+  {
+    "name": "web-design-guidelines",
+    "description": "Guidelines for high-quality web page composition and visual design.",
+    "source_url": "https://github.com/vercel-labs/agent-skills/tree/main/skills/web-design-guidelines",
+    "tags": [
+      "web",
+      "design",
+      "guidelines"
+    ],
+    "category": "Design"
+  },
+  {
+    "name": "internal-comms",
+    "description": "Draft concise internal communications, updates, and email-style replies.",
+    "source_url": "https://github.com/anthropics/skills/tree/main/skills/internal-comms",
+    "tags": [
+      "writing",
+      "email",
+      "communication"
+    ],
+    "category": "Writing"
+  }
+]

--- a/server/internal/skillindex/validate.go
+++ b/server/internal/skillindex/validate.go
@@ -1,0 +1,62 @@
+package skillindex
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	MaxSkillFindRecommendations = 5
+	MaxReasonRunes              = 320
+)
+
+type Recommendation struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	SourceURL   string `json:"source_url"`
+	Reason      string `json:"reason"`
+}
+
+func NormalizeSkillFindResult(raw []byte) ([]byte, []Recommendation, error) {
+	var recs []Recommendation
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&recs); err != nil {
+		return nil, nil, fmt.Errorf("skill-find result must be a JSON array: %w", err)
+	}
+	if len(recs) == 0 {
+		return nil, nil, fmt.Errorf("skill-find result must include at least one recommendation")
+	}
+	if len(recs) > MaxSkillFindRecommendations {
+		return nil, nil, fmt.Errorf("skill-find result has %d recommendations, max %d", len(recs), MaxSkillFindRecommendations)
+	}
+	allowed, err := SourceURLSet()
+	if err != nil {
+		return nil, nil, err
+	}
+	for i := range recs {
+		recs[i].Name = strings.TrimSpace(recs[i].Name)
+		recs[i].Description = strings.TrimSpace(recs[i].Description)
+		recs[i].SourceURL = strings.TrimSpace(recs[i].SourceURL)
+		recs[i].Reason = strings.TrimSpace(recs[i].Reason)
+		if recs[i].Name == "" {
+			return nil, nil, fmt.Errorf("recommendation %d has empty name", i+1)
+		}
+		if recs[i].SourceURL == "" {
+			return nil, nil, fmt.Errorf("recommendation %d has empty source_url", i+1)
+		}
+		if _, ok := allowed[recs[i].SourceURL]; !ok {
+			return nil, nil, fmt.Errorf("recommendation %d uses source_url outside curated index", i+1)
+		}
+		if len([]rune(recs[i].Reason)) > MaxReasonRunes {
+			return nil, nil, fmt.Errorf("recommendation %d reason is too long", i+1)
+		}
+	}
+	normalized, err := json.Marshal(recs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal normalized skill-find result: %w", err)
+	}
+	return normalized, recs, nil
+}

--- a/server/internal/skillindex/validate_test.go
+++ b/server/internal/skillindex/validate_test.go
@@ -1,0 +1,87 @@
+package skillindex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func firstEntry(t *testing.T) Entry {
+	t.Helper()
+	entries, err := List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("skill index is empty")
+	}
+	return entries[0]
+}
+
+func recommendationJSON(t *testing.T, recs []Recommendation) []byte {
+	t.Helper()
+	data, err := json.Marshal(recs)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return data
+}
+
+func TestNormalizeSkillFindResultValid(t *testing.T) {
+	entry := firstEntry(t)
+	raw := recommendationJSON(t, []Recommendation{{
+		Name:        "  " + entry.Name + "  ",
+		Description: entry.Description,
+		SourceURL:   "  " + entry.SourceURL + "  ",
+		Reason:      " Fits the requested React performance work. ",
+	}})
+
+	normalized, recs, err := NormalizeSkillFindResult(raw)
+	if err != nil {
+		t.Fatalf("NormalizeSkillFindResult() error = %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d recs, want 1", len(recs))
+	}
+	if recs[0].Name != entry.Name || recs[0].SourceURL != entry.SourceURL {
+		t.Fatalf("recommendation was not normalized: %+v", recs[0])
+	}
+	if !json.Valid(normalized) {
+		t.Fatalf("normalized output is not valid JSON: %s", normalized)
+	}
+}
+
+func TestNormalizeSkillFindResultRejectsNonArray(t *testing.T) {
+	if _, _, err := NormalizeSkillFindResult([]byte(`{"name":"x"}`)); err == nil {
+		t.Fatal("expected non-array JSON to fail")
+	}
+}
+
+func TestNormalizeSkillFindResultRejectsEmptyArray(t *testing.T) {
+	if _, _, err := NormalizeSkillFindResult([]byte(`[]`)); err == nil {
+		t.Fatal("expected empty array to fail")
+	}
+}
+
+func TestNormalizeSkillFindResultRejectsUnknownSourceURL(t *testing.T) {
+	raw := recommendationJSON(t, []Recommendation{{
+		Name:      "unknown",
+		SourceURL: "https://example.test/skills/unknown",
+		Reason:    "Looks useful.",
+	}})
+	if _, _, err := NormalizeSkillFindResult(raw); err == nil {
+		t.Fatal("expected unknown source_url to fail")
+	}
+}
+
+func TestNormalizeSkillFindResultRejectsOverlongReason(t *testing.T) {
+	entry := firstEntry(t)
+	raw := recommendationJSON(t, []Recommendation{{
+		Name:      entry.Name,
+		SourceURL: entry.SourceURL,
+		Reason:    strings.Repeat("x", MaxReasonRunes+1),
+	}})
+	if _, _, err := NormalizeSkillFindResult(raw); err == nil {
+		t.Fatal("expected overlong reason to fail")
+	}
+}

--- a/server/pkg/db/generated/agent.sql.go
+++ b/server/pkg/db/generated/agent.sql.go
@@ -1397,6 +1397,59 @@ func (q *Queries) CreateQuickCreateTask(ctx context.Context, arg CreateQuickCrea
 	return i, err
 }
 
+const createContextTask = `-- name: CreateContextTask :one
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, context)
+VALUES ($1, $2, NULL, 'queued', $3, $4)
+RETURNING id, agent_id, issue_id, status, priority, dispatched_at, started_at, completed_at, result, error, created_at, context, runtime_id, session_id, work_dir, trigger_comment_id, chat_session_id, autopilot_run_id, attempt, max_attempts, parent_task_id, failure_reason, trigger_summary, force_fresh_session, is_leader_task
+`
+
+type CreateContextTaskParams struct {
+	AgentID   pgtype.UUID `json:"agent_id"`
+	RuntimeID pgtype.UUID `json:"runtime_id"`
+	Priority  int32       `json:"priority"`
+	Context   []byte      `json:"context"`
+}
+
+// Context tasks have no issue / chat / autopilot link; the entire job
+// description lives in context JSONB and is dispatched by context.type.
+func (q *Queries) CreateContextTask(ctx context.Context, arg CreateContextTaskParams) (AgentTaskQueue, error) {
+	row := q.db.QueryRow(ctx, createContextTask,
+		arg.AgentID,
+		arg.RuntimeID,
+		arg.Priority,
+		arg.Context,
+	)
+	var i AgentTaskQueue
+	err := row.Scan(
+		&i.ID,
+		&i.AgentID,
+		&i.IssueID,
+		&i.Status,
+		&i.Priority,
+		&i.DispatchedAt,
+		&i.StartedAt,
+		&i.CompletedAt,
+		&i.Result,
+		&i.Error,
+		&i.CreatedAt,
+		&i.Context,
+		&i.RuntimeID,
+		&i.SessionID,
+		&i.WorkDir,
+		&i.TriggerCommentID,
+		&i.ChatSessionID,
+		&i.AutopilotRunID,
+		&i.Attempt,
+		&i.MaxAttempts,
+		&i.ParentTaskID,
+		&i.FailureReason,
+		&i.TriggerSummary,
+		&i.ForceFreshSession,
+		&i.IsLeaderTask,
+	)
+	return i, err
+}
+
 const createRetryTask = `-- name: CreateRetryTask :one
 INSERT INTO agent_task_queue (
     agent_id, runtime_id, issue_id, chat_session_id, autopilot_run_id,

--- a/server/pkg/db/queries/agent.sql
+++ b/server/pkg/db/queries/agent.sql
@@ -225,6 +225,13 @@ VALUES (
 )
 RETURNING *;
 
+-- name: CreateContextTask :one
+-- Context tasks have no issue / chat / autopilot link; the entire job
+-- description lives in context JSONB and is dispatched by context.type.
+INSERT INTO agent_task_queue (agent_id, runtime_id, issue_id, status, priority, context)
+VALUES ($1, $2, NULL, 'queued', $3, $4)
+RETURNING *;
+
 -- name: LinkTaskToIssue :exec
 -- Attaches the issue a quick-create task produced back to the task row, once
 -- the agent has finished and the issue exists. Guarded by `issue_id IS NULL`


### PR DESCRIPTION
## What does this PR do?

Adds two daemon-backed AI workflows and hardens GitHub API response handling at the installed-client boundary.

Thinking path: Multica already routes long-running AI work through daemon tasks and Inbox notifications, while `packages/core` owns API contracts used by both web and desktop. This change keeps the new AI flows on that existing async path: the backend enqueues typed AI tasks, the daemon writes structured output, the CLI captures/validates it, and the shared views render the result from Inbox without adding app-specific state.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/core/api/*`, `packages/core/types/github.ts`: add schema-backed GitHub response parsing and drift-tolerant enum handling for issue / pull request responses.
- `packages/views/issues/components/pull-request-list.tsx`: render PR states and checks with fallback labels and own-property guards.
- `server/internal/skillindex/*`, `server/internal/handler/skill_find.go`, `server/cmd/multica/cmd_skill.go`: add curated skill lookup, `/api/skills/find`, and structured CLI output capture.
- `server/internal/agentdraft/*`, `server/internal/handler/agent_draft.go`, `server/cmd/multica/cmd_agent.go`: add AI agent draft validation, runtime permission checks, `/api/agents/ai-draft`, and CLI result capture.
- `server/internal/service/task.go`, `server/internal/daemon/*`: support typed AI task contexts, structured daemon output files, and Inbox completion/failure notifications for the new flows.
- `packages/views/skills/*`, `packages/views/agents/*`, `packages/views/inbox/*`, `packages/views/locales/*`: add Skills / Agents entry points, result cards, and en / zh-Hans copy.

## How to Test

1. Open Skills, start the AI skill finder, and verify the result appears in Inbox with matching curated skill recommendations.
2. Open Agents, start the AI draft flow against an accessible runtime, and verify the resulting draft notification includes valid agent fields and imported skills.
3. Feed malformed or future-shaped GitHub issue / PR responses through the client schemas and verify the UI falls back instead of throwing.
4. Run `pnpm typecheck`, `pnpm test`, and `make test` in a fully provisioned local environment.

Verification performed in this agent environment:

- [x] `git diff --check`
- [x] `git diff --cached --check` before commit
- [x] JSON parse check for locale/catalog files
- [x] `superpowers` / `docs/superpowers` diff checks returned empty for the submitted commit
- [ ] `pnpm typecheck` / `pnpm test` — blocked here by Corepack registry DNS access (`ENOTFOUND registry.npmjs.org`)
- [ ] `make test ENV_FILE=.env.worktree` — blocked here by unavailable Docker socket

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`) — N/A, no new runtime / coding tool / UI tab
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Used Codex to inspect the repository conventions, identify high-value AI workflow and GitHub API compatibility work, implement backend / daemon / CLI / frontend slices, run available verification, and revise the branch so the submitted commit excludes `docs/superpowers/specs/*` planning files.

## Screenshots (optional)

Not included. The UI paths are shared view components, but the local app could not be run in this agent environment because frontend dependencies and Docker-backed services were unavailable.
