### PR TITLE
feat(issues): show project segment in issue breadcrumb (MUL-2422)

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -219,6 +219,8 @@ const mockApiObj = vi.hoisted(() => ({
   removeCommentReaction: vi.fn(),
   listMembers: vi.fn().mockResolvedValue([{ user_id: "user-1", name: "Test User", email: "test@test.com", role: "admin" }]),
   listAgents: vi.fn().mockResolvedValue([]),
+  getProject: vi.fn(),
+  listProjects: vi.fn().mockResolvedValue({ projects: [] }),
 }));
 
 vi.mock("@multica/core/api", () => ({
@@ -508,6 +510,9 @@ describe("IssueDetail (shared)", () => {
       { user_id: "user-1", name: "Test User", email: "test@test.com", role: "admin" },
     ]);
     mockApiObj.listAgents.mockResolvedValue([]);
+    // Reset project mock — individual tests override per case. Default fixture
+    // has project_id: null so getProject is not invoked.
+    mockApiObj.getProject.mockReset();
   });
 
   it("shows loading skeleton while data is loading", () => {
@@ -541,6 +546,60 @@ describe("IssueDetail (shared)", () => {
     // After the URL-driven workspace refactor, issue paths are scoped under
     // /<workspaceSlug>/issues.
     expect(wsLink.closest("a")).toHaveAttribute("href", "/test/issues");
+  });
+
+  it("omits the project breadcrumb segment when the issue has no project_id", async () => {
+    // Default fixture has project_id: null.
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Test WS")).toBeInTheDocument();
+    });
+
+    // Project should not have been fetched.
+    expect(mockApiObj.getProject).not.toHaveBeenCalled();
+    expect(screen.queryByText("Unknown project")).not.toBeInTheDocument();
+  });
+
+  it("renders the project breadcrumb segment when the issue belongs to a project", async () => {
+    mockApiObj.getIssue.mockResolvedValue({ ...mockIssue, project_id: "p-1" });
+    mockApiObj.getProject.mockResolvedValue({
+      id: "p-1",
+      workspace_id: "ws-1",
+      title: "Marketing site refresh",
+      description: null,
+      icon: "🚀",
+      status: "in_progress",
+      priority: "none",
+      lead_type: null,
+      lead_id: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      issue_count: 0,
+      done_count: 0,
+      resource_count: 0,
+    });
+
+    renderIssueDetail();
+
+    const projectLink = await screen.findByText("Marketing site refresh");
+    // The whole project segment is a single AppLink pointing at the project
+    // detail route under the active workspace slug.
+    expect(projectLink.closest("a")).toHaveAttribute("href", "/test/projects/p-1");
+  });
+
+  it("shows an Unknown project placeholder when the project query fails", async () => {
+    mockApiObj.getIssue.mockResolvedValue({ ...mockIssue, project_id: "p-missing" });
+    mockApiObj.getProject.mockRejectedValue(new Error("not found"));
+
+    renderIssueDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText("Unknown project")).toBeInTheDocument();
+    });
+    // Placeholder is non-interactive — no link wraps the text.
+    const placeholder = screen.getByText("Unknown project");
+    expect(placeholder.closest("a")).toBeNull();
   });
 
   it("renders properties sidebar with all core rows plus set optional rows", async () => {

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -1516,10 +1516,10 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 {breadcrumbProject ? (
                   <AppLink
                     href={paths.projectDetail(breadcrumbProject.id)}
-                    className="flex items-center gap-1 min-w-0 text-muted-foreground hover:text-foreground transition-colors"
+                    className="flex items-center gap-1 min-w-0 max-w-72 text-muted-foreground hover:text-foreground transition-colors"
                   >
                     <ProjectIcon project={breadcrumbProject} size="sm" />
-                    <span className="truncate">{breadcrumbProject.title}</span>
+                    <span className="min-w-0 truncate">{breadcrumbProject.title}</span>
                   </AppLink>
                 ) : breadcrumbProjectError ? (
                   <span className="italic text-muted-foreground/70 shrink-0">

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -61,6 +61,8 @@ import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions, issueAttachmentsOptions } from "@multica/core/issues/queries";
+import { projectDetailOptions } from "@multica/core/projects/queries";
+import { ProjectIcon } from "../../projects/components/project-icon";
 import { issueLabelsOptions } from "@multica/core/labels";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import { useRecentIssuesStore } from "@multica/core/issues/stores";
@@ -951,6 +953,14 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     enabled: !!parentIssueId,
     initialData: () => allIssues.find((i) => i.id === parentIssueId),
   });
+
+  // Project segment in the breadcrumb. The issue's project_id is the source of
+  // truth — same URL renders the same breadcrumb regardless of entry path.
+  const issueProjectId = issue?.project_id;
+  const { data: breadcrumbProject = null, isError: breadcrumbProjectError } = useQuery({
+    ...projectDetailOptions(wsId, issueProjectId ?? ""),
+    enabled: !!issueProjectId,
+  });
   const { data: childIssues = [] } = useQuery({
     ...childIssuesOptions(wsId, id),
     enabled: !!issue,
@@ -1498,6 +1508,26 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
                 >
                   {workspace.name}
                 </AppLink>
+                <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
+              </>
+            )}
+            {issueProjectId && (
+              <>
+                {breadcrumbProject ? (
+                  <AppLink
+                    href={paths.projectDetail(breadcrumbProject.id)}
+                    className="flex items-center gap-1 min-w-0 text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <ProjectIcon project={breadcrumbProject} size="sm" />
+                    <span className="truncate">{breadcrumbProject.title}</span>
+                  </AppLink>
+                ) : breadcrumbProjectError ? (
+                  <span className="italic text-muted-foreground/70 shrink-0">
+                    {t(($) => $.detail.breadcrumb_project_unknown)}
+                  </span>
+                ) : (
+                  <Skeleton className="h-3.5 w-20 shrink-0" />
+                )}
                 <ChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
               </>
             )}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -119,6 +119,7 @@
   },
   "detail": {
     "not_found": "This issue does not exist or has been deleted in this workspace.",
+    "breadcrumb_project_unknown": "Unknown project",
     "back_to_issues": "Back to Issues",
     "title_placeholder": "Issue title",
     "desc_placeholder": "Add description...",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -118,6 +118,7 @@
   },
   "detail": {
     "not_found": "这个 issue 不存在或已在该工作区被删除。",
+    "breadcrumb_project_unknown": "未知项目",
     "back_to_issues": "返回 issue 列表",
     "title_placeholder": "issue 标题",
     "desc_placeholder": "添加描述...",


### PR DESCRIPTION
## Summary
- Add a Project segment between Workspace and ParentIssue in the issue detail breadcrumb, rendered by `issue.project_id` (attribution-based, independent of entry path).
- States: loading -> `Skeleton`; success -> `ProjectIcon` + title linking to `paths.projectDetail`; error / deleted -> grey italic `Unknown project` (non-clickable).
- Cap Project crumb to `max-w-72` (matches `ProjectChip`) with title span `min-w-0 truncate` so the flex compression order follows RFC sec.5 / sec.9 (Project / Parent shrink before the current Issue title).
- Reuses `projectDetailOptions(wsId, id)` (`enabled: !!project_id`) - no new query.

Tracks [MUL-2422](mention://issue/91d2359e-6f88-4a9e-9a51-27d19dc8c841).

## Test plan
- [x] `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx` (19 passed, includes 3 new cases: null project_id, success render, error fallback)
- [x] `pnpm typecheck`
- [ ] Manual: open an issue with a project, no project, and a project that 404s; verify breadcrumb renders correctly and long titles do not push the current Issue title out.