### PR TITLE
feat(desktop): forward renderer console + crash events to main stderr in dev

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -200,6 +200,57 @@ function createWindow(): void {
     }
   });
 
+  // Dev-mode renderer diagnostics. When the renderer crashes hard enough
+  // that DevTools can't be opened (white screen with no clickable surface),
+  // the only way to recover the actual JS error is to forward it from the
+  // main process to the terminal running `make dev`. Without these, the
+  // user sees only the daemon-manager polling noise (`Render frame was
+  // disposed before WebFrameMain could be accessed`) which is a downstream
+  // symptom, not the cause.
+  //
+  // Gated by `is.dev` to keep production stderr clean — packaged builds
+  // don't have a terminal anyway, and we ship to crash-reporting separately.
+  if (is.dev) {
+    const log = (tag: string, ...args: unknown[]) =>
+      process.stderr.write(`[renderer ${tag}] ${args.map(String).join(" ")}\n`);
+
+    // Forward every renderer-side console.* call. The detail object also
+    // carries source URL + line — included so a thrown stack trace from
+    // window.onerror is traceable back to a file.
+    mainWindow.webContents.on("console-message", (details) => {
+      const { level, message, sourceId, lineNumber } = details;
+      log(level, `${message} (${sourceId}:${lineNumber})`);
+    });
+
+    // Fires when the renderer process dies for any reason (OOM, crash,
+    // killed). `details.reason` is the discriminator: "crashed", "oom",
+    // "killed", "abnormal-exit", "launch-failed", etc.
+    mainWindow.webContents.on("render-process-gone", (_event, details) => {
+      log("process-gone", JSON.stringify(details));
+    });
+
+    // Fires when loadURL / loadFile can't reach its target (dev server
+    // not up yet, network blip, file missing). errorCode is a Chromium
+    // net error number; -3 = ABORTED is normal during HMR and skipped.
+    mainWindow.webContents.on(
+      "did-fail-load",
+      (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+        if (errorCode === -3) return;
+        log(
+          "did-fail-load",
+          `code=${errorCode} desc=${errorDescription} url=${validatedURL} mainFrame=${isMainFrame}`,
+        );
+      },
+    );
+
+    // Fires when the preload script throws before the renderer can boot.
+    // This is the one error class that NEVER reaches DevTools (preload
+    // runs before any window) — without this listener it's invisible.
+    mainWindow.webContents.on("preload-error", (_event, preloadPath, error) => {
+      log("preload-error", `path=${preloadPath} err=${error?.stack ?? error}`);
+    });
+  }
+
   installContextMenu(mainWindow.webContents);
 
   if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {


### PR DESCRIPTION
## Why

When the renderer crashes hard enough to leave a white window (React boundary unrecoverable, syntax error during initial mount, preload script throw), DevTools can't be opened and the only signal in the `make dev` terminal is the daemon-manager's 5s polling complaint:

```
Error sending from webFrameMain: Error: Render frame was disposed before WebFrameMain could be accessed
  at sendStatus (apps/desktop/out/main/index.js:338:31)
  at Timeout.pollOnce (apps/desktop/out/main/index.js:790:2)
```

That's a **downstream symptom**, not the cause. The actual renderer JS error is unreachable, so the developer has no path to diagnose without restarting the renderer — which loses the failure mode entirely. We hit this loop 4+ times in one session trying to debug local white-screens.

## What

Four `webContents` listeners on the main `BrowserWindow`, all gated by `is.dev`:

| Listener | Purpose |
|---|---|
| `console-message` | forward every renderer `console.*` to main's stderr with file:line — surfaces React error boundaries, `window.onerror`, and unhandled-rejection handlers |
| `render-process-gone` | serialise the `GoneDetails` (`crashed` / `oom` / `killed` / `launch-failed`) so the user sees *why* the renderer died, not just that it did |
| `did-fail-load` | catch `loadURL`/`loadFile` failures. Skip `errorCode === -3 (ABORTED)` — that's the normal HMR-induced navigation abort and would spam |
| `preload-error` | the one error class DevTools can never show (preload runs before the window owns a console). Without this, preload throws are completely invisible |

All output is prefixed with `[renderer <tag>]` so it greps cleanly distinct from main's own logs.

## Scope

- 1 file, +51 lines, all behind `if (is.dev)`.
- No behavioural change in production: packaged builds keep their existing stderr untouched.
- `pnpm --filter @multica/desktop typecheck` clean.

## Test plan
- [ ] Start `make dev`. Open DevTools, paste `console.error("test from renderer")` — terminal shows `[renderer error] test from renderer (...:...)`.
- [ ] Trigger a renderer crash (e.g. open DevTools → `throw new Error("test crash")` in console — well actually that's caught by React; better: edit a component to `throw` at mount). Terminal shows `[renderer process-gone] {...}` with the reason.
- [ ] Stop the dev server while a navigation is in flight — confirm `[renderer did-fail-load]` does NOT fire for code `-3` but does for genuine load failures.
- [ ] `make build` (production) — verify no `[renderer ...]` lines appear in the packaged app's stderr (or wherever Electron's production logs go).