### PR TITLE
feat(projects): scheduled-only Gantt data source + WS reactivity (MUL-1881)

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -545,6 +545,7 @@ export class ApiClient {
     if (params?.project_id) search.set("project_id", params.project_id);
     if (params?.involves_user_id) search.set("involves_user_id", params.involves_user_id);
     if (params?.open_only) search.set("open_only", "true");
+    if (params?.scheduled) search.set("scheduled", "true");
     const path = `/api/issues?${search}`;
     const raw = await this.fetch<unknown>(path);
     return parseWithFallback(raw, ListIssuesResponseSchema, EMPTY_LIST_ISSUES_RESPONSE, {

--- a/packages/core/issues/delete-cache.ts
+++ b/packages/core/issues/delete-cache.ts
@@ -162,5 +162,9 @@ export function cleanupDeletedIssueCaches(
   qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
+  // Project Gantt cache lives outside `myAll`, so it needs an explicit
+  // refresh when an issue is removed — the deleted row may have been a
+  // scheduled bar visible right now.
+  qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
   invalidateDeletedIssueDependentCaches(qc, wsId);
 }

--- a/packages/core/issues/mutations.ts
+++ b/packages/core/issues/mutations.ts
@@ -4,7 +4,6 @@ import { api } from "../api";
 import {
   issueKeys,
   ISSUE_PAGE_SIZE,
-  PAGINATED_STATUSES,
   type AssigneeGroupedIssuesFilter,
   type MyIssuesFilter,
 } from "./queries";
@@ -104,75 +103,6 @@ export function useLoadMoreByStatus(
   return { loadMore, hasMore, isLoading, total };
 }
 
-/**
- * Drain every remaining paginated page across all statuses into the cache.
- * Used by surfaces that can't paginate per-column (e.g. the Project Gantt
- * view) and need the full project issue set up-front. Each iteration appends
- * one ISSUE_PAGE_SIZE page per status that still has unfetched rows; loops
- * until the cache totals match the server.
- */
-export function useLoadAllRemaining(
-  myIssues?: { scope: string; filter: MyIssuesFilter },
-) {
-  const qc = useQueryClient();
-  const wsId = useWorkspaceId();
-  const [isLoading, setIsLoading] = useState(false);
-
-  const queryKey = myIssues
-    ? issueKeys.myList(wsId, myIssues.scope, myIssues.filter)
-    : issueKeys.list(wsId);
-
-  const loadAll = useCallback(async () => {
-    if (isLoading) return;
-    setIsLoading(true);
-    try {
-      // Round-trip the cache rather than caching `loaded` locally so a
-      // concurrent WS-driven update or another loadMore can't make us
-      // re-fetch an already-loaded page.
-      for (;;) {
-        const cache = qc.getQueryData<ListIssuesCache>(queryKey);
-        if (!cache) return;
-        const pending = PAGINATED_STATUSES.filter((status) => {
-          const bucket = cache.byStatus[status];
-          if (!bucket) return false;
-          return bucket.issues.length < bucket.total;
-        });
-        if (pending.length === 0) return;
-        const results = await Promise.all(
-          pending.map((status) =>
-            api
-              .listIssues({
-                status,
-                limit: ISSUE_PAGE_SIZE,
-                offset: cache.byStatus[status]!.issues.length,
-                ...myIssues?.filter,
-              })
-              .then((res) => ({ status, res })),
-          ),
-        );
-        qc.setQueryData<ListIssuesCache>(queryKey, (old) => {
-          if (!old) return old;
-          let next = old;
-          for (const { status, res } of results) {
-            const prev = getBucket(next, status);
-            const existingIds = new Set(prev.issues.map((i) => i.id));
-            const appended = res.issues.filter((i) => !existingIds.has(i.id));
-            next = setBucket(next, status, {
-              issues: [...prev.issues, ...appended],
-              total: res.total,
-            });
-          }
-          return next;
-        });
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isLoading, qc, queryKey, myIssues?.filter]);
-
-  return { loadAll, isLoading };
-}
-
 export function useLoadMoreByAssigneeGroup(
   group: Pick<IssueAssigneeGroup, "id" | "assignee_type" | "assignee_id">,
   queryKey: QueryKey,
@@ -251,6 +181,7 @@ export function useCreateIssue() {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
     },
   });
 }
@@ -327,6 +258,7 @@ export function useUpdateIssue() {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
       // Refresh the issue's attachments cache when the description editor
       // bound new uploads — the description editor reads `issueAttachments`
       // to resolve text-preview Eye gates, and unlike other mutations this
@@ -410,6 +342,7 @@ export function useDeleteIssue() {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
       if (ctx?.metadata) invalidateDeletedIssueParentCaches(qc, wsId, ctx.metadata);
     },
   });
@@ -469,6 +402,7 @@ export function useBatchUpdateIssues() {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
       if (ctx?.affectedParentIds && ctx.affectedParentIds.size > 0) {
         for (const parentId of ctx.affectedParentIds) {
           qc.invalidateQueries({
@@ -571,6 +505,7 @@ export function useBatchDeleteIssues() {
       qc.invalidateQueries({ queryKey: issueKeys.list(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
       qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+      qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
       if (ctx?.parentIssueIds && ctx.parentIssueIds.size > 0) {
         invalidateDeletedIssueParentCaches(qc, wsId, {
           parentIssueIds: Array.from(ctx.parentIssueIds),

--- a/packages/core/issues/queries.test.ts
+++ b/packages/core/issues/queries.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+
+import { setApiInstance } from "../api";
+import type { ApiClient } from "../api/client";
+import type { Issue, ListIssuesParams, ListIssuesResponse } from "../types";
+import {
+  PROJECT_GANTT_MAX_ISSUES,
+  PROJECT_GANTT_PAGE_LIMIT,
+  issueKeys,
+  projectGanttIssuesOptions,
+} from "./queries";
+
+const WS_ID = "ws-1";
+const PROJECT_ID = "project-1";
+
+function makeIssue(idx: number): Issue {
+  return {
+    id: `issue-${idx}`,
+    workspace_id: WS_ID,
+    number: idx,
+    identifier: `MUL-${idx}`,
+    title: `Issue ${idx}`,
+    description: null,
+    status: "todo",
+    priority: "none",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: null,
+    project_id: PROJECT_ID,
+    position: idx,
+    start_date: "2026-05-01T00:00:00Z",
+    due_date: null,
+    labels: [],
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// Type-only shim — only the methods the queries.ts code path under test calls.
+function installFakeApi(listIssues: (params?: ListIssuesParams) => Promise<ListIssuesResponse>) {
+  setApiInstance({ listIssues } as unknown as ApiClient);
+}
+
+describe("projectGanttIssuesOptions", () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  afterEach(() => {
+    qc.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the first page directly when it fits under PROJECT_GANTT_PAGE_LIMIT", async () => {
+    const listIssues = vi
+      .fn<(params?: ListIssuesParams) => Promise<ListIssuesResponse>>()
+      .mockResolvedValue({
+        issues: [makeIssue(1), makeIssue(2)],
+        total: 2,
+      });
+    installFakeApi(listIssues);
+
+    const data = await qc.fetchQuery(projectGanttIssuesOptions(WS_ID, PROJECT_ID));
+
+    expect(listIssues).toHaveBeenCalledTimes(1);
+    expect(listIssues).toHaveBeenCalledWith({
+      project_id: PROJECT_ID,
+      scheduled: true,
+      limit: PROJECT_GANTT_PAGE_LIMIT,
+      offset: 0,
+    });
+    expect(data).toHaveLength(2);
+  });
+
+  it("loops through pages until total is satisfied (no silent truncation)", async () => {
+    const total = PROJECT_GANTT_PAGE_LIMIT + 7;
+    const firstPage = Array.from({ length: PROJECT_GANTT_PAGE_LIMIT }, (_, i) =>
+      makeIssue(i),
+    );
+    const secondPage = Array.from({ length: 7 }, (_, i) =>
+      makeIssue(PROJECT_GANTT_PAGE_LIMIT + i),
+    );
+
+    const listIssues = vi
+      .fn<(params?: ListIssuesParams) => Promise<ListIssuesResponse>>()
+      .mockImplementation(async (params) => {
+        if (!params) throw new Error("expected params");
+        const offset = params.offset ?? 0;
+        if (offset === 0)
+          return { issues: firstPage, total };
+        if (offset === PROJECT_GANTT_PAGE_LIMIT)
+          return { issues: secondPage, total };
+        throw new Error(`unexpected offset ${offset}`);
+      });
+    installFakeApi(listIssues);
+
+    const data = await qc.fetchQuery(projectGanttIssuesOptions(WS_ID, PROJECT_ID));
+
+    expect(listIssues).toHaveBeenCalledTimes(2);
+    expect(data).toHaveLength(total);
+  });
+
+  it("stops looping when the server reports a smaller-than-limit page (safety net for total drift)", async () => {
+    // Server says `total` is huge but only ever returns short pages — the
+    // loop must terminate on the first short page to avoid an infinite fetch.
+    const listIssues = vi
+      .fn<(params?: ListIssuesParams) => Promise<ListIssuesResponse>>()
+      .mockResolvedValue({
+        issues: [makeIssue(1)],
+        total: PROJECT_GANTT_MAX_ISSUES,
+      });
+    installFakeApi(listIssues);
+
+    const data = await qc.fetchQuery(projectGanttIssuesOptions(WS_ID, PROJECT_ID));
+
+    expect(listIssues).toHaveBeenCalledTimes(1);
+    expect(data).toHaveLength(1);
+  });
+
+  it("uses the project-scoped Gantt cache key", () => {
+    const options = projectGanttIssuesOptions(WS_ID, PROJECT_ID);
+    expect(options.queryKey).toEqual(issueKeys.projectGantt(WS_ID, PROJECT_ID));
+  });
+});

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -154,29 +154,55 @@ export function myIssueListOptions(
 }
 
 /**
- * One-shot fetch of every scheduled issue (`start_date` or `due_date` set)
- * for a project. The Project Gantt view consumes this directly — no status
- * bucketing, no client-side pagination, no Load-all affordance — because
- * the scheduled subset is bounded enough to come back in a single request.
- *
- * Backed by `GET /api/issues?scheduled=true&project_id=…`; the SQL filter
- * mirrors the same `(start_date IS NOT NULL OR due_date IS NOT NULL)`
- * predicate the Gantt view applies on the client.
+ * Page size for the scheduled-issue fetch. The Gantt view always pulls every
+ * scheduled issue (no client pagination), so this is just the chunk size we
+ * use to walk the server's `(limit, offset)` window until we hit `total`.
  */
 export const PROJECT_GANTT_PAGE_LIMIT = 500;
 
+/**
+ * Paranoia cap on the loop in {@link fetchProjectGanttIssues}. Real projects
+ * shouldn't come close to this — a single project carrying 50k scheduled
+ * issues is already a product problem, not a Gantt-rendering one — but the
+ * guard prevents a buggy server `total` from spinning the loop forever.
+ */
+export const PROJECT_GANTT_MAX_ISSUES = 10_000;
+
+async function fetchProjectGanttIssues(projectId: string) {
+  const issues = [];
+  let offset = 0;
+  while (offset < PROJECT_GANTT_MAX_ISSUES) {
+    const res = await api.listIssues({
+      project_id: projectId,
+      scheduled: true,
+      limit: PROJECT_GANTT_PAGE_LIMIT,
+      offset,
+    });
+    issues.push(...res.issues);
+    if (res.issues.length < PROJECT_GANTT_PAGE_LIMIT) break;
+    if (issues.length >= res.total) break;
+    offset += PROJECT_GANTT_PAGE_LIMIT;
+  }
+  return issues;
+}
+
+/**
+ * One-shot fetch of every scheduled issue (`start_date` or `due_date` set)
+ * for a project. The Project Gantt view consumes this directly — no status
+ * bucketing, no client-side pagination, no Load-all affordance — because
+ * the scheduled subset is bounded enough to come back in a small handful of
+ * requests.
+ *
+ * Backed by `GET /api/issues?scheduled=true&project_id=…`; the SQL filter
+ * mirrors the same `(start_date IS NOT NULL OR due_date IS NOT NULL)`
+ * predicate the Gantt view applies on the client. Pages are walked until
+ * `total` is reached so an oversized project can't silently lose bars past
+ * the first page.
+ */
 export function projectGanttIssuesOptions(wsId: string, projectId: string) {
   return queryOptions({
     queryKey: issueKeys.projectGantt(wsId, projectId),
-    queryFn: () =>
-      api
-        .listIssues({
-          project_id: projectId,
-          scheduled: true,
-          limit: PROJECT_GANTT_PAGE_LIMIT,
-          offset: 0,
-        })
-        .then((res) => res.issues),
+    queryFn: () => fetchProjectGanttIssues(projectId),
   });
 }
 

--- a/packages/core/issues/queries.ts
+++ b/packages/core/issues/queries.ts
@@ -28,6 +28,17 @@ export const issueKeys = {
     scope: string,
     filter: AssigneeGroupedIssuesFilter,
   ) => [...issueKeys.myAssigneeGroupsAll(wsId), scope, filter] as const,
+  /** All Project Gantt queries — prefix-match key for cross-project invalidation. */
+  projectGanttAll: (wsId: string) =>
+    [...issueKeys.all(wsId), "project-gantt"] as const,
+  /**
+   * Per-project Gantt issue list (scheduled-only). Uses its own cache key
+   * rather than reusing the bucketed `myList` cache so WS handlers and
+   * cache helpers don't have to special-case a non-bucketed shape under
+   * the `my` prefix.
+   */
+  projectGantt: (wsId: string, projectId: string) =>
+    [...issueKeys.projectGanttAll(wsId), projectId] as const,
   detail: (wsId: string, id: string) =>
     [...issueKeys.all(wsId), "detail", id] as const,
   children: (wsId: string, id: string) =>
@@ -77,34 +88,6 @@ export function flattenIssueBuckets(data: ListIssuesCache) {
     if (bucket) out.push(...bucket.issues);
   }
   return out;
-}
-
-export interface IssueListPagination {
-  loaded: number;
-  total: number;
-  hasMore: boolean;
-}
-
-/**
- * Aggregate the bucketed cache totals so non-paginated consumers (e.g. the
- * Gantt view, which doesn't have a per-status load-more affordance) can tell
- * whether the cache is missing pages and warn the user instead of silently
- * rendering an incomplete schedule.
- */
-export function summarizeIssueListPagination(
-  data: ListIssuesCache | undefined,
-): IssueListPagination {
-  if (!data) return { loaded: 0, total: 0, hasMore: false };
-  let loaded = 0;
-  let total = 0;
-  for (const status of PAGINATED_STATUSES) {
-    const bucket = data.byStatus[status];
-    if (bucket) {
-      loaded += bucket.issues.length;
-      total += bucket.total;
-    }
-  }
-  return { loaded, total, hasMore: loaded < total };
 }
 
 async function fetchFirstPages(filter: MyIssuesFilter = {}): Promise<ListIssuesCache> {
@@ -171,20 +154,29 @@ export function myIssueListOptions(
 }
 
 /**
- * Same cache entry as {@link myIssueListOptions} (shared queryKey + queryFn —
- * TanStack Query dedupes), but `select` derives a pagination summary instead
- * of the flat issue list. Use this alongside the list query when a consumer
- * needs to know how many issues live behind unfetched pages.
+ * One-shot fetch of every scheduled issue (`start_date` or `due_date` set)
+ * for a project. The Project Gantt view consumes this directly — no status
+ * bucketing, no client-side pagination, no Load-all affordance — because
+ * the scheduled subset is bounded enough to come back in a single request.
+ *
+ * Backed by `GET /api/issues?scheduled=true&project_id=…`; the SQL filter
+ * mirrors the same `(start_date IS NOT NULL OR due_date IS NOT NULL)`
+ * predicate the Gantt view applies on the client.
  */
-export function myIssueListPaginationOptions(
-  wsId: string,
-  scope: string,
-  filter: MyIssuesFilter,
-) {
+export const PROJECT_GANTT_PAGE_LIMIT = 500;
+
+export function projectGanttIssuesOptions(wsId: string, projectId: string) {
   return queryOptions({
-    queryKey: issueKeys.myList(wsId, scope, filter),
-    queryFn: () => fetchFirstPages(filter),
-    select: summarizeIssueListPagination,
+    queryKey: issueKeys.projectGantt(wsId, projectId),
+    queryFn: () =>
+      api
+        .listIssues({
+          project_id: projectId,
+          scheduled: true,
+          limit: PROJECT_GANTT_PAGE_LIMIT,
+          offset: 0,
+        })
+        .then((res) => res.issues),
   });
 }
 

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -156,6 +156,25 @@ describe("onIssueLabelsChanged", () => {
     const detail = qc.getQueryData<Issue>(issueKeys.detail(WS_ID, ISSUE_ID));
     expect(detail?.labels).toEqual([labelB]);
   });
+
+  it("patches the Project Gantt cache so label filters react in place", () => {
+    const PROJECT_ID = "project-1";
+    qc.setQueryData<Issue[]>(issueKeys.projectGantt(WS_ID, PROJECT_ID), [
+      baseIssue,
+      otherIssue,
+    ]);
+
+    onIssueLabelsChanged(qc, WS_ID, ISSUE_ID, [labelB]);
+
+    const gantt = qc.getQueryData<Issue[]>(
+      issueKeys.projectGantt(WS_ID, PROJECT_ID),
+    );
+    expect(gantt?.find((i) => i.id === ISSUE_ID)?.labels).toEqual([labelB]);
+    // Other issues in the same cache must not have their labels mutated.
+    expect(gantt?.find((i) => i.id === OTHER_ISSUE_ID)?.labels).toEqual([
+      labelA,
+    ]);
+  });
 });
 
 describe("onIssueDeleted", () => {

--- a/packages/core/issues/ws-updaters.test.ts
+++ b/packages/core/issues/ws-updaters.test.ts
@@ -6,7 +6,12 @@ import {
   agentTaskSnapshotKeys,
   agentTasksKeys,
 } from "../agents/queries";
-import { onIssueDeleted, onIssueLabelsChanged } from "./ws-updaters";
+import {
+  onIssueCreated,
+  onIssueDeleted,
+  onIssueLabelsChanged,
+  onIssueUpdated,
+} from "./ws-updaters";
 import { issueKeys } from "./queries";
 import { labelKeys } from "../labels/queries";
 import type {
@@ -390,5 +395,40 @@ describe("onIssueDeleted", () => {
     expectInvalidated(qc, agentRunCountsKeys.last30d(WS_ID));
     expectInvalidated(qc, agentTasksKeys.detail(WS_ID, AGENT_ID));
     expect(qc.getQueryData(issueKeys.tasks(ISSUE_ID))).toBeUndefined();
+  });
+});
+
+// Regression coverage for the Project Gantt cache. The Gantt view rides its
+// own dedicated cache (server-filtered to `scheduled=true`); every WS-driven
+// path that can shift Gantt membership has to invalidate the prefix or the
+// timeline goes stale.
+describe("project gantt cache invalidation", () => {
+  const PROJECT_ID = "project-1";
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient();
+    qc.setQueryData<Issue[]>(
+      issueKeys.projectGantt(WS_ID, PROJECT_ID),
+      [baseIssue],
+    );
+  });
+
+  it("invalidates the project Gantt cache on issue:created", () => {
+    onIssueCreated(qc, WS_ID, otherIssue);
+    expectInvalidated(qc, issueKeys.projectGantt(WS_ID, PROJECT_ID));
+  });
+
+  it("invalidates the project Gantt cache on issue:updated", () => {
+    onIssueUpdated(qc, WS_ID, {
+      id: ISSUE_ID,
+      start_date: "2026-01-01T00:00:00Z",
+    });
+    expectInvalidated(qc, issueKeys.projectGantt(WS_ID, PROJECT_ID));
+  });
+
+  it("invalidates the project Gantt cache on issue:deleted", () => {
+    onIssueDeleted(qc, WS_ID, ISSUE_ID);
+    expectInvalidated(qc, issueKeys.projectGantt(WS_ID, PROJECT_ID));
   });
 });

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -114,6 +114,20 @@ export function onIssueLabelsChanged(
   qc.setQueryData<IssueLabelsResponse>(labelKeys.byIssue(wsId, issueId), (old) =>
     old ? { ...old, labels } : old,
   );
+  // Patch the Project Gantt caches in-place: the Gantt view applies
+  // `labelFilters` to the row data, so a stale `labels` array would silently
+  // hide or surface bars after another tab/agent attached or detached a
+  // label. Mutating in place (instead of invalidating) avoids a refetch of
+  // the entire scheduled set on every label toggle.
+  for (const [key, data] of qc.getQueriesData<Issue[]>({
+    queryKey: issueKeys.projectGanttAll(wsId),
+  })) {
+    if (!data) continue;
+    const next = data.map((issue) =>
+      issue.id === issueId ? { ...issue, labels } : issue,
+    );
+    qc.setQueryData<Issue[]>(key, next);
+  }
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });

--- a/packages/core/issues/ws-updaters.ts
+++ b/packages/core/issues/ws-updaters.ts
@@ -21,6 +21,11 @@ export function onIssueCreated(
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+  // Refresh every Project Gantt cache that might be observing this issue.
+  // We invalidate the whole prefix rather than the issue's own project
+  // because a fresh issue isn't necessarily scheduled yet; the active Gantt
+  // page (if any) will refetch and pick it up if it qualifies.
+  qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
   if (issue.parent_issue_id) {
     qc.invalidateQueries({ queryKey: issueKeys.children(wsId, issue.parent_issue_id) });
     qc.invalidateQueries({ queryKey: issueKeys.childProgress(wsId) });
@@ -52,6 +57,12 @@ export function onIssueUpdated(
   qc.invalidateQueries({ queryKey: issueKeys.myAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.assigneeGroupsAll(wsId) });
   qc.invalidateQueries({ queryKey: issueKeys.myAssigneeGroupsAll(wsId) });
+  // Any field change can shift Gantt membership — start_date / due_date may
+  // have moved in or out of the `scheduled` set, project_id may have
+  // changed, or the row that is in the cache may need to mirror updated
+  // metadata (title, status, assignee). Cheaper to invalidate the prefix
+  // than to mirror the server filter here.
+  qc.invalidateQueries({ queryKey: issueKeys.projectGanttAll(wsId) });
   qc.setQueryData<Issue>(issueKeys.detail(wsId, issue.id), (old) =>
     old ? { ...old, ...issue } : old,
   );

--- a/packages/core/types/api.ts
+++ b/packages/core/types/api.ts
@@ -55,6 +55,13 @@ export interface ListIssuesParams {
    */
   involves_user_id?: string;
   open_only?: boolean;
+  /**
+   * Restrict the result to issues with at least one of `start_date` /
+   * `due_date` set. Used by the Project Gantt view so it doesn't have to
+   * page through every issue on the project just to discard the unscheduled
+   * majority on the client.
+   */
+  scheduled?: boolean;
 }
 
 export interface IssueActorRef {

--- a/packages/views/issues/components/gantt-view.tsx
+++ b/packages/views/issues/components/gantt-view.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRight, Info, Loader2 } from "lucide-react";
 import { useWorkspaceId } from "@multica/core/hooks";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useViewStore, useViewStoreApi } from "@multica/core/issues/stores/view-store-context";
@@ -436,59 +435,11 @@ function ScheduledRow({
   );
 }
 
-function UnscheduledRow({ issue }: { issue: Issue }) {
-  const p = useWorkspacePaths();
-  return (
-    <IssueActionsContextMenu issue={issue}>
-      <AppLink
-        href={p.issueDetail(issue.id)}
-        className="sticky left-0 z-[1] flex items-center gap-2 bg-background px-3 py-1.5 text-sm hover:bg-accent/40 transition-colors border-b border-foreground/5"
-        style={{ width: LEFT_COL_WIDTH }}
-      >
-        <StatusIcon status={issue.status} className="h-3.5 w-3.5" />
-        <PriorityIcon priority={issue.priority} />
-        <span className="w-14 shrink-0 text-xs text-muted-foreground tabular-nums truncate">
-          {issue.identifier}
-        </span>
-        <span className="truncate flex-1">{issue.title}</span>
-        {issue.assignee_type && issue.assignee_id && (
-          <ActorAvatar
-            actorType={issue.assignee_type}
-            actorId={issue.assignee_id}
-            size={18}
-            enableHoverCard
-          />
-        )}
-      </AppLink>
-    </IssueActionsContextMenu>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // GanttView — public component
 // ---------------------------------------------------------------------------
 
-/**
- * Pagination meta surfaced by the host so the Gantt can warn the user when
- * the in-memory issue list is incomplete. Unlike Board/List, Gantt has no
- * column-level load-more, so without this it would silently render a
- * partial schedule.
- */
-export interface GanttPaginationProps {
-  loaded: number;
-  total: number;
-  hasMore: boolean;
-  isLoadingMore: boolean;
-  onLoadAll: () => void | Promise<void>;
-}
-
-export function GanttView({
-  issues,
-  pagination,
-}: {
-  issues: Issue[];
-  pagination?: GanttPaginationProps;
-}) {
+export function GanttView({ issues }: { issues: Issue[] }) {
   const { t } = useT("issues");
   const zoom = useViewStore((s) => s.ganttZoom);
   const showCompleted = useViewStore((s) => s.ganttShowCompleted);
@@ -499,24 +450,21 @@ export function GanttView({
   const today = useMemo(() => startOfDayUTC(new Date()), []);
   const dayPx = DAY_PX_BY_ZOOM[zoom];
 
-  const visibleIssues = useMemo(() => {
+  // The data source only delivers scheduled issues (server-side
+  // `scheduled=true`), but a row can still arrive here without a date — for
+  // example, a WS-driven optimistic patch that just cleared start_date /
+  // due_date and is waiting for the cache to refetch. Filter defensively so
+  // the timeline never renders a blank lane in that brief window.
+  const scheduled = useMemo(() => {
+    const dated = issues.filter((i) => i.start_date || i.due_date);
     const filtered = showCompleted
-      ? issues
-      : issues.filter((i) => i.status !== "done" && i.status !== "cancelled");
+      ? dated
+      : dated.filter((i) => i.status !== "done" && i.status !== "cancelled");
     // "position" makes no sense on a gantt — default to start_date asc when
     // the user hasn't picked a more specific sort.
     const sortField = sortBy === "position" ? "start_date" : sortBy;
     return sortIssues(filtered, sortField, sortDirection);
   }, [issues, showCompleted, sortBy, sortDirection]);
-
-  const scheduled = useMemo(
-    () => visibleIssues.filter((i) => i.start_date || i.due_date),
-    [visibleIssues],
-  );
-  const unscheduled = useMemo(
-    () => visibleIssues.filter((i) => !i.start_date && !i.due_date),
-    [visibleIssues],
-  );
 
   const range = useMemo(
     () => computeRange(scheduled, today, zoom),
@@ -534,20 +482,13 @@ export function GanttView({
     el.scrollLeft = target;
   }, [todayOffsetDays, dayPx]);
 
-  const [unscheduledOpen, setUnscheduledOpen] = useState(false);
-
-  if (visibleIssues.length === 0) {
+  if (scheduled.length === 0) {
     return (
       <div className="flex-1 min-h-0 flex items-center justify-center text-sm text-muted-foreground">
         {t(($) => $.gantt.empty)}
       </div>
     );
   }
-
-  const hiddenCount =
-    pagination && pagination.hasMore
-      ? Math.max(0, pagination.total - pagination.loaded)
-      : 0;
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -587,30 +528,6 @@ export function GanttView({
         </Button>
       </div>
 
-      {hiddenCount > 0 && pagination && (
-        <div className="flex shrink-0 items-center gap-2 border-b bg-warning/10 px-3 py-1.5 text-xs">
-          <Info className="size-3.5 shrink-0 text-warning" />
-          <span className="text-muted-foreground">
-            {t(($) => $.gantt.pagination_warning, { hidden: hiddenCount })}
-          </span>
-          <div className="flex-1" />
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-6 text-xs"
-            disabled={pagination.isLoadingMore}
-            onClick={() => {
-              void pagination.onLoadAll();
-            }}
-          >
-            {pagination.isLoadingMore && (
-              <Loader2 className="size-3 animate-spin" />
-            )}
-            {t(($) => $.gantt.load_all)}
-          </Button>
-        </div>
-      )}
-
       {/* Body — single scroll container drives both vertical + horizontal */}
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto">
         <div style={{ minWidth: LEFT_COL_WIDTH + timelineWidth }}>
@@ -634,64 +551,30 @@ export function GanttView({
           </div>
 
           {/* Scheduled rows + background overlay */}
-          {scheduled.length > 0 ? (
-            <div className="relative">
-              {/* Background gridlines + today line spanning all rows. Positioned
-                  starting after the left label column. */}
-              <div
-                className="pointer-events-none absolute top-0"
-                style={{ left: LEFT_COL_WIDTH, width: timelineWidth }}
-              >
-                <BackgroundLayer
-                  range={range}
-                  dayPx={dayPx}
-                  height={scheduled.length * ROW_HEIGHT}
-                  todayOffsetDays={todayOffsetDays}
-                />
-              </div>
-              {scheduled.map((issue) => (
-                <ScheduledRow
-                  key={issue.id}
-                  issue={issue}
-                  range={range}
-                  dayPx={dayPx}
-                  totalDays={totalDays}
-                />
-              ))}
-            </div>
-          ) : (
+          <div className="relative">
+            {/* Background gridlines + today line spanning all rows. Positioned
+                starting after the left label column. */}
             <div
-              className="flex items-center py-10 text-sm text-muted-foreground border-b"
-              style={{ paddingLeft: LEFT_COL_WIDTH + 12 }}
+              className="pointer-events-none absolute top-0"
+              style={{ left: LEFT_COL_WIDTH, width: timelineWidth }}
             >
-              {t(($) => $.gantt.no_scheduled)}
+              <BackgroundLayer
+                range={range}
+                dayPx={dayPx}
+                height={scheduled.length * ROW_HEIGHT}
+                todayOffsetDays={todayOffsetDays}
+              />
             </div>
-          )}
-
-          {/* Unscheduled section */}
-          {unscheduled.length > 0 && (
-            <div className="border-t bg-muted/15">
-              <button
-                className="sticky left-0 z-[1] flex items-center gap-2 px-3 py-2 text-left text-xs font-medium hover:bg-accent/40 transition-colors w-full bg-muted/15"
-                onClick={() => setUnscheduledOpen((v) => !v)}
-                style={{ width: LEFT_COL_WIDTH }}
-              >
-                <ChevronRight
-                  className={cn(
-                    "size-3.5 text-muted-foreground transition-transform",
-                    unscheduledOpen && "rotate-90",
-                  )}
-                />
-                <span className="text-muted-foreground">
-                  {t(($) => $.gantt.unscheduled_section, { count: unscheduled.length })}
-                </span>
-              </button>
-              {unscheduledOpen &&
-                unscheduled.map((issue) => (
-                  <UnscheduledRow key={issue.id} issue={issue} />
-                ))}
-            </div>
-          )}
+            {scheduled.map((issue) => (
+              <ScheduledRow
+                key={issue.id}
+                issue={issue}
+                range={range}
+                dayPx={dayPx}
+                totalDays={totalDays}
+              />
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -89,11 +89,7 @@
     "zoom_week": "Week",
     "zoom_month": "Month",
     "show_completed": "Show completed",
-    "empty": "No issues to chart.",
-    "no_scheduled": "No issues have a start or due date yet — set one to see it on the timeline.",
-    "unscheduled_section": "Unscheduled · {{count}}",
-    "pagination_warning": "{{hidden}} more issue(s) haven't been loaded — the schedule is incomplete.",
-    "load_all": "Load all",
+    "empty": "No scheduled issues yet — set a start or due date on any issue to see it on the timeline.",
     "inverted_dates_warning": "Start date is after due date — bar shown from min to max."
   },
   "actor_issues": {

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -88,11 +88,7 @@
     "zoom_week": "周",
     "zoom_month": "月",
     "show_completed": "显示已完成",
-    "empty": "暂无可展示的 issue。",
-    "no_scheduled": "暂无 issue 设置了开始或截止日期 — 设置后会显示在时间轴上。",
-    "unscheduled_section": "未排期 · {{count}}",
-    "pagination_warning": "还有 {{hidden}} 个 issue 未加载 — 排期可能不完整。",
-    "load_all": "加载全部",
+    "empty": "暂无已排期的 issue — 给任意 issue 设置开始或截止日期，即可显示在时间轴上。",
     "inverted_dates_warning": "开始日期晚于截止日期 — 已按区间最小/最大端绘制。"
   },
   "actor_issues": {

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -180,7 +180,12 @@ function ProjectIssuesContent({
     [updateIssueMutation, t],
   );
 
-  if (projectIssues.length === 0) {
+  // Gantt has its own data source (scheduled-only) and its own empty axis —
+  // we never short-circuit it here, otherwise an unscheduled-but-non-empty
+  // project would surface a misleading "no issues" CTA. For Board/List the
+  // bucketed cache really is the ground truth, so an empty result means an
+  // empty project.
+  if (viewMode !== "gantt" && projectIssues.length === 0) {
     return (
       <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-3 text-muted-foreground">
         <ListTodo className="h-10 w-10 text-muted-foreground/40" />
@@ -252,6 +257,7 @@ function ProjectIssuesSurface({
   const creatorFilters = useViewStore((s) => s.creatorFilters);
   const labelFilters = useViewStore((s) => s.labelFilters);
   const usesAssigneeBoard = viewMode === "board" && grouping === "assignee";
+  const usesGantt = viewMode === "gantt";
   const assigneeGroupFilter = useMemo<AssigneeGroupedIssuesFilter>(
     () => ({
       ...filter,
@@ -269,27 +275,36 @@ function ProjectIssuesSurface({
     scope,
     assigneeGroupFilter,
   );
+  // Each view owns exactly one data source. Board/List ride the bucketed
+  // `myIssueListOptions` cache; the assignee-grouped board uses the grouped
+  // endpoint; Gantt has its own scheduled-only fetch. We gate `enabled` on
+  // the current view so switching to Gantt doesn't re-trigger the full
+  // per-status fetch in the background.
   const statusIssuesQuery = useQuery({
     ...myIssueListOptions(wsId, scope, filter),
-    enabled: !usesAssigneeBoard,
+    enabled: !usesAssigneeBoard && !usesGantt,
   });
   const assigneeGroupsQuery = useQuery({
     ...assigneeGroupsOptions,
     enabled: usesAssigneeBoard,
   });
-  // Gantt has its own data source — a single fetch of every scheduled issue
-  // in the project (server-side `scheduled=true` filter). Independent from
-  // the bucketed Board/List cache so it isn't bottlenecked by per-status
-  // pagination and reacts in isolation to WS updates that move issues into
-  // or out of the scheduled set.
+  // Gantt has its own data source — a single (paginated) fetch of every
+  // scheduled issue in the project. Independent from the bucketed Board/List
+  // cache so it isn't bottlenecked by per-status pagination and reacts in
+  // isolation to WS updates that move issues into or out of the scheduled
+  // set.
   const ganttIssuesQuery = useQuery({
     ...projectGanttIssuesOptions(wsId, projectId),
-    enabled: viewMode === "gantt",
+    enabled: usesGantt,
   });
-  const projectIssues = usesAssigneeBoard
+  const bucketedIssues = usesAssigneeBoard
     ? (assigneeGroupsQuery.data?.groups.flatMap((group) => group.issues) ?? [])
     : (statusIssuesQuery.data ?? []);
   const ganttIssues = ganttIssuesQuery.data ?? [];
+  // What the header empty-state check looks at depends on the view: Gantt
+  // would otherwise be blamed for an empty Board cache, even though it has
+  // its own (potentially non-empty) scheduled cache.
+  const projectIssues = usesGantt ? ganttIssues : bucketedIssues;
 
   return (
     <>

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -15,12 +15,12 @@ import { useCreatePin, useDeletePin } from "@multica/core/pins";
 import {
   myIssueAssigneeGroupsOptions,
   myIssueListOptions,
-  myIssueListPaginationOptions,
+  projectGanttIssuesOptions,
   childIssueProgressOptions,
   type AssigneeGroupedIssuesFilter,
   type MyIssuesFilter,
 } from "@multica/core/issues/queries";
-import { useLoadAllRemaining, useUpdateIssue } from "@multica/core/issues/mutations";
+import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useModalStore } from "@multica/core/modals";
 import { memberListOptions, agentListOptions } from "@multica/core/workspace/queries";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -40,7 +40,7 @@ import { ProjectResourcesSection } from "./project-resources-section";
 import { IssuesHeader } from "../../issues/components/issues-header";
 import { BoardView } from "../../issues/components/board-view";
 import { ListView } from "../../issues/components/list-view";
-import { GanttView, type GanttPaginationProps } from "../../issues/components/gantt-view";
+import { GanttView } from "../../issues/components/gantt-view";
 import { BatchActionToolbar } from "../../issues/components/batch-action-toolbar";
 import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import { Button } from "@multica/ui/components/ui/button";
@@ -115,7 +115,7 @@ function ProjectIssuesContent({
   assigneeGroupFilter,
   scope,
   filter,
-  ganttPagination,
+  ganttIssues,
 }: {
   projectId: string;
   projectIssues: Issue[];
@@ -124,7 +124,7 @@ function ProjectIssuesContent({
   assigneeGroupFilter?: AssigneeGroupedIssuesFilter;
   scope: string;
   filter: MyIssuesFilter;
-  ganttPagination: GanttPaginationProps | undefined;
+  ganttIssues: Issue[];
 }) {
   const { t } = useT("projects");
   const wsId = useWorkspaceId();
@@ -139,6 +139,14 @@ function ProjectIssuesContent({
   const issues = useMemo(
     () => filterIssues(projectIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters: [], includeNoProject: false, labelFilters }),
     [projectIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters],
+  );
+
+  // Gantt rides its own dedicated query (scheduled-only) so it doesn't have
+  // to wait for every status bucket to paginate in. View-store filters still
+  // apply so toggling priority / assignee / label hides the same bars.
+  const filteredGanttIssues = useMemo(
+    () => filterIssues(ganttIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters: [], includeNoProject: false, labelFilters }),
+    [ganttIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, labelFilters],
   );
 
   const { data: childProgressMap = new Map() } = useQuery(childIssueProgressOptions(wsId));
@@ -220,9 +228,7 @@ function ProjectIssuesContent({
           projectId={projectId}
         />
       )}
-      {viewMode === "gantt" && (
-        <GanttView issues={issues} pagination={ganttPagination} />
-      )}
+      {viewMode === "gantt" && <GanttView issues={filteredGanttIssues} />}
     </div>
   );
 }
@@ -271,32 +277,19 @@ function ProjectIssuesSurface({
     ...assigneeGroupsOptions,
     enabled: usesAssigneeBoard,
   });
-  // Subscribes to the same cache as statusIssuesQuery and just selects a
-  // pagination summary instead of the flat issue array — used by Gantt to
-  // warn when issues are hidden behind unfetched pages (Board/List have
-  // per-column load-more affordances; Gantt does not).
-  const paginationQuery = useQuery({
-    ...myIssueListPaginationOptions(wsId, scope, filter),
-    enabled: !usesAssigneeBoard,
+  // Gantt has its own data source — a single fetch of every scheduled issue
+  // in the project (server-side `scheduled=true` filter). Independent from
+  // the bucketed Board/List cache so it isn't bottlenecked by per-status
+  // pagination and reacts in isolation to WS updates that move issues into
+  // or out of the scheduled set.
+  const ganttIssuesQuery = useQuery({
+    ...projectGanttIssuesOptions(wsId, projectId),
+    enabled: viewMode === "gantt",
   });
-  const { loadAll, isLoading: isLoadingMore } = useLoadAllRemaining({ scope, filter });
   const projectIssues = usesAssigneeBoard
     ? (assigneeGroupsQuery.data?.groups.flatMap((group) => group.issues) ?? [])
     : (statusIssuesQuery.data ?? []);
-
-  // Gantt can't paginate per-column, so we surface a banner + Load-all
-  // affordance when the cache is missing pages. Skip when the surface is
-  // using the assignee-grouped query — that uses a different cache shape.
-  const ganttPagination: GanttPaginationProps | undefined =
-    !usesAssigneeBoard && paginationQuery.data
-      ? {
-          loaded: paginationQuery.data.loaded,
-          total: paginationQuery.data.total,
-          hasMore: paginationQuery.data.hasMore,
-          isLoadingMore,
-          onLoadAll: loadAll,
-        }
-      : undefined;
+  const ganttIssues = ganttIssuesQuery.data ?? [];
 
   return (
     <>
@@ -309,7 +302,7 @@ function ProjectIssuesSurface({
         assigneeGroupFilter={usesAssigneeBoard ? assigneeGroupFilter : undefined}
         scope={scope}
         filter={filter}
-        ganttPagination={ganttPagination}
+        ganttIssues={ganttIssues}
       />
       <BatchActionToolbar />
     </>

--- a/server/internal/handler/issue.go
+++ b/server/internal/handler/issue.go
@@ -812,6 +812,14 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		statusFilter = pgtype.Text{String: s, Valid: true}
 	}
 
+	// scheduled=true restricts the result to issues that have at least one of
+	// start_date / due_date set. Used by the Project Gantt view, which only
+	// renders schedulable rows and shouldn't pay for the full project list.
+	var scheduledFilter pgtype.Bool
+	if r.URL.Query().Get("scheduled") == "true" {
+		scheduledFilter = pgtype.Bool{Bool: true, Valid: true}
+	}
+
 	issues, err := h.Queries.ListIssues(ctx, db.ListIssuesParams{
 		WorkspaceID:    wsUUID,
 		Limit:          int32(limit),
@@ -823,6 +831,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		CreatorID:      creatorFilter,
 		ProjectID:      projectFilter,
 		InvolvesUserID: involvesUserFilter,
+		Scheduled:      scheduledFilter,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list issues")
@@ -839,6 +848,7 @@ func (h *Handler) ListIssues(w http.ResponseWriter, r *http.Request) {
 		CreatorID:      creatorFilter,
 		ProjectID:      projectFilter,
 		InvolvesUserID: involvesUserFilter,
+		Scheduled:      scheduledFilter,
 	})
 	if err != nil {
 		total = int64(len(issues))

--- a/server/internal/handler/issue_scheduled_test.go
+++ b/server/internal/handler/issue_scheduled_test.go
@@ -1,0 +1,104 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Backs the Project Gantt view: only issues with at least one of
+// start_date / due_date should come back when scheduled=true, regardless of
+// status or assignee. The unfiltered call must keep returning everything.
+func TestListIssues_ScheduledFilter(t *testing.T) {
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+
+	// Seed three issues in a fresh project — one with start_date only, one
+	// with due_date only, and one with neither. Using a dedicated project so
+	// the assertion isn't polluted by other issues seeded by parallel tests.
+	var projectID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO project (workspace_id, title) VALUES ($1, $2) RETURNING id
+	`, testWorkspaceID, fmt.Sprintf("Gantt Scheduled %d", suffix)).Scan(&projectID); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM project WHERE id = $1`, projectID) })
+
+	insertIssue := func(title string, startDate, dueDate *time.Time) string {
+		var number int
+		if err := testPool.QueryRow(ctx, `
+			UPDATE workspace
+			SET issue_counter = GREATEST(issue_counter, (SELECT COALESCE(MAX(number), 0) FROM issue WHERE workspace_id = $1)) + 1
+			WHERE id = $1 RETURNING issue_counter
+		`, testWorkspaceID).Scan(&number); err != nil {
+			t.Fatalf("next issue number: %v", err)
+		}
+		var id string
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO issue (workspace_id, title, status, priority, creator_type, creator_id, position, number, project_id, start_date, due_date)
+			VALUES ($1, $2, 'todo', 'none', 'member', $3, 0, $4, $5, $6, $7) RETURNING id
+		`, testWorkspaceID, title, testUserID, number, projectID, startDate, dueDate).Scan(&id); err != nil {
+			t.Fatalf("create issue %q: %v", title, err)
+		}
+		t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, id) })
+		return id
+	}
+
+	start := time.Now().UTC().Truncate(24 * time.Hour)
+	due := start.Add(72 * time.Hour)
+	withStart := insertIssue(fmt.Sprintf("with-start-%d", suffix), &start, nil)
+	withDue := insertIssue(fmt.Sprintf("with-due-%d", suffix), nil, &due)
+	withBoth := insertIssue(fmt.Sprintf("with-both-%d", suffix), &start, &due)
+	noDates := insertIssue(fmt.Sprintf("no-dates-%d", suffix), nil, nil)
+
+	list := func(query string) (ids []string, total int64) {
+		path := fmt.Sprintf("/api/issues?workspace_id=%s&project_id=%s&limit=500%s",
+			testWorkspaceID, projectID, query)
+		w := httptest.NewRecorder()
+		testHandler.ListIssues(w, newRequest("GET", path, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("ListIssues: expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Issues []IssueResponse `json:"issues"`
+			Total  int64           `json:"total"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode list response: %v", err)
+		}
+		for _, iss := range resp.Issues {
+			ids = append(ids, iss.ID)
+		}
+		return ids, resp.Total
+	}
+
+	// Without the filter every project issue comes back.
+	allIDs, allTotal := list("")
+	for _, want := range []string{withStart, withDue, withBoth, noDates} {
+		if !containsIssueID(allIDs, want) {
+			t.Fatalf("baseline list missing %s — all=%v", want, allIDs)
+		}
+	}
+	if allTotal != 4 {
+		t.Fatalf("baseline total: want 4, got %d", allTotal)
+	}
+
+	// With scheduled=true only the three dated issues should surface, and
+	// CountIssues must agree so the frontend pagination logic stays sane.
+	scheduledIDs, scheduledTotal := list("&scheduled=true")
+	for _, want := range []string{withStart, withDue, withBoth} {
+		if !containsIssueID(scheduledIDs, want) {
+			t.Fatalf("scheduled list missing %s — got %v", want, scheduledIDs)
+		}
+	}
+	if containsIssueID(scheduledIDs, noDates) {
+		t.Fatalf("scheduled list unexpectedly includes undated issue %s", noDates)
+	}
+	if scheduledTotal != 3 {
+		t.Fatalf("scheduled total: want 3, got %d", scheduledTotal)
+	}
+}

--- a/server/pkg/db/generated/issue.sql.go
+++ b/server/pkg/db/generated/issue.sql.go
@@ -102,12 +102,13 @@ WHERE i.workspace_id = $1
   AND ($5::uuid[] IS NULL OR i.assignee_id = ANY($5::uuid[]))
   AND ($6::uuid IS NULL OR i.creator_id = $6)
   AND ($7::uuid IS NULL OR i.project_id = $7)
+  AND ($8::bool IS NULL OR (i.start_date IS NOT NULL OR i.due_date IS NOT NULL))
   AND (
-    $8::uuid IS NULL
+    $9::uuid IS NULL
     OR (i.assignee_type = 'agent' AND i.assignee_id IN (
           SELECT a.id FROM agent a
            WHERE a.workspace_id = $1
-             AND a.owner_id     = $8::uuid
+             AND a.owner_id     = $9::uuid
     ))
     OR (i.assignee_type = 'squad' AND i.assignee_id IN (
           SELECT sm.squad_id
@@ -115,14 +116,14 @@ WHERE i.workspace_id = $1
             JOIN squad s ON s.id = sm.squad_id
            WHERE s.workspace_id = $1
              AND sm.member_type = 'member'
-             AND sm.member_id   = $8::uuid
+             AND sm.member_id   = $9::uuid
           UNION
           SELECT s.id
             FROM squad s
             JOIN agent a ON a.id = s.leader_id
            WHERE s.workspace_id = $1
              AND a.workspace_id = $1
-             AND a.owner_id     = $8::uuid
+             AND a.owner_id     = $9::uuid
           UNION
           SELECT sm.squad_id
             FROM squad_member sm
@@ -131,7 +132,7 @@ WHERE i.workspace_id = $1
            WHERE s.workspace_id = $1
              AND sm.member_type = 'agent'
              AND a.workspace_id = $1
-             AND a.owner_id     = $8::uuid
+             AND a.owner_id     = $9::uuid
     ))
   )
 `
@@ -144,6 +145,7 @@ type CountIssuesParams struct {
 	AssigneeIds    []pgtype.UUID `json:"assignee_ids"`
 	CreatorID      pgtype.UUID   `json:"creator_id"`
 	ProjectID      pgtype.UUID   `json:"project_id"`
+	Scheduled      pgtype.Bool   `json:"scheduled"`
 	InvolvesUserID pgtype.UUID   `json:"involves_user_id"`
 }
 
@@ -157,6 +159,7 @@ func (q *Queries) CountIssues(ctx context.Context, arg CountIssuesParams) (int64
 		arg.AssigneeIds,
 		arg.CreatorID,
 		arg.ProjectID,
+		arg.Scheduled,
 		arg.InvolvesUserID,
 	)
 	var count int64
@@ -613,13 +616,14 @@ WHERE i.workspace_id = $1
   AND ($7::uuid[] IS NULL OR i.assignee_id = ANY($7::uuid[]))
   AND ($8::uuid IS NULL OR i.creator_id = $8)
   AND ($9::uuid IS NULL OR i.project_id = $9)
+  AND ($10::bool IS NULL OR (i.start_date IS NOT NULL OR i.due_date IS NOT NULL))
   AND (
-    $10::uuid IS NULL
+    $11::uuid IS NULL
     -- (1) assignee is an agent owned by the user
     OR (i.assignee_type = 'agent' AND i.assignee_id IN (
           SELECT a.id FROM agent a
            WHERE a.workspace_id = $1
-             AND a.owner_id     = $10::uuid
+             AND a.owner_id     = $11::uuid
     ))
     -- (2)(3)(4) assignee is a squad related to the user — three relations
     OR (i.assignee_type = 'squad' AND i.assignee_id IN (
@@ -629,7 +633,7 @@ WHERE i.workspace_id = $1
             JOIN squad s ON s.id = sm.squad_id
            WHERE s.workspace_id = $1
              AND sm.member_type = 'member'
-             AND sm.member_id   = $10::uuid
+             AND sm.member_id   = $11::uuid
           UNION
           -- (3) the squad's canonical leader is an agent owned by the user.
           -- We read squad.leader_id directly rather than relying on a
@@ -640,7 +644,7 @@ WHERE i.workspace_id = $1
             JOIN agent a ON a.id = s.leader_id
            WHERE s.workspace_id = $1
              AND a.workspace_id = $1
-             AND a.owner_id     = $10::uuid
+             AND a.owner_id     = $11::uuid
           UNION
           -- (4) the squad has an agent member owned by the user
           SELECT sm.squad_id
@@ -650,7 +654,7 @@ WHERE i.workspace_id = $1
            WHERE s.workspace_id = $1
              AND sm.member_type = 'agent'
              AND a.workspace_id = $1
-             AND a.owner_id     = $10::uuid
+             AND a.owner_id     = $11::uuid
     ))
   )
 ORDER BY i.position ASC, i.created_at DESC
@@ -667,6 +671,7 @@ type ListIssuesParams struct {
 	AssigneeIds    []pgtype.UUID `json:"assignee_ids"`
 	CreatorID      pgtype.UUID   `json:"creator_id"`
 	ProjectID      pgtype.UUID   `json:"project_id"`
+	Scheduled      pgtype.Bool   `json:"scheduled"`
 	InvolvesUserID pgtype.UUID   `json:"involves_user_id"`
 }
 
@@ -708,6 +713,7 @@ func (q *Queries) ListIssues(ctx context.Context, arg ListIssuesParams) ([]ListI
 		arg.AssigneeIds,
 		arg.CreatorID,
 		arg.ProjectID,
+		arg.Scheduled,
 		arg.InvolvesUserID,
 	)
 	if err != nil {

--- a/server/pkg/db/queries/issue.sql
+++ b/server/pkg/db/queries/issue.sql
@@ -16,6 +16,7 @@ WHERE i.workspace_id = $1
   AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR i.assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
   AND (sqlc.narg('creator_id')::uuid IS NULL OR i.creator_id = sqlc.narg('creator_id'))
   AND (sqlc.narg('project_id')::uuid IS NULL OR i.project_id = sqlc.narg('project_id'))
+  AND (sqlc.narg('scheduled')::bool IS NULL OR (i.start_date IS NOT NULL OR i.due_date IS NOT NULL))
   AND (
     sqlc.narg('involves_user_id')::uuid IS NULL
     -- (1) assignee is an agent owned by the user
@@ -189,6 +190,7 @@ WHERE i.workspace_id = $1
   AND (sqlc.narg('assignee_ids')::uuid[] IS NULL OR i.assignee_id = ANY(sqlc.narg('assignee_ids')::uuid[]))
   AND (sqlc.narg('creator_id')::uuid IS NULL OR i.creator_id = sqlc.narg('creator_id'))
   AND (sqlc.narg('project_id')::uuid IS NULL OR i.project_id = sqlc.narg('project_id'))
+  AND (sqlc.narg('scheduled')::bool IS NULL OR (i.start_date IS NOT NULL OR i.due_date IS NOT NULL))
   AND (
     sqlc.narg('involves_user_id')::uuid IS NULL
     OR (i.assignee_type = 'agent' AND i.assignee_id IN (


### PR DESCRIPTION
## Summary
- New `GET /api/issues?scheduled=true` filter — Project Gantt fetches only issues with `start_date` or `due_date` set, no pagination required.
- WS handlers (`issue:created` / `issue:updated` / `issue:deleted`) and the local mutations invalidate a dedicated `projectGantt` cache, so the timeline reacts in real-time when start / due dates change in another tab (or this one).
- Removes the Unscheduled drawer and the pagination warning + Load-all banner from the Gantt view; deletes the now-dead `useLoadAllRemaining`, `myIssueListPaginationOptions`, and `summarizeIssueListPagination` helpers and their locale strings.

Follow-up to #2843 — addresses the "115 个未加载" issue surfaced after the original ship.

Related: MUL-1881

## Test plan
- [x] `pnpm typecheck` — green across all packages.
- [x] `pnpm test --run` — all 1100+ TS unit tests pass (incl. new `projectGantt` invalidation cases in `ws-updaters.test.ts`).
- [x] `pnpm lint` — 0 errors, only pre-existing warnings.
- [x] `go test ./internal/handler/` — new `TestListIssues_ScheduledFilter` passes; existing involves tests still green.
- [x] `go build ./...` — clean.
- [ ] Manual: visit Project Gantt with mixed-date issues, confirm only scheduled rows render and no banner appears.
- [ ] Manual: in another tab/window, set a `due_date` on a previously undated issue and confirm the bar shows up live without a refresh.
- [ ] Manual: clear both dates on a Gantt-visible issue, confirm it disappears from the timeline live.