### PR TITLE
refactor(editor): revert image render styling churn to pure DOM port

### DIFF
--- a/packages/views/editor/attachment.tsx
+++ b/packages/views/editor/attachment.tsx
@@ -215,10 +215,12 @@ export function Attachment({
 // ImageAttachmentView — inline image with hover toolbar
 // ---------------------------------------------------------------------------
 //
-// Self-contained Tailwind: works inside the editor surface (where the legacy
-// `.rich-text-editor .image-figure` CSS in content-editor.css continues to
-// apply for backward compatibility) AND in standalone surfaces (chat
-// messages, comment-card AttachmentList) that don't carry that scope.
+// DOM and styling are intentionally a direct port of the original
+// extensions/image-view.tsx <figure> structure. All visual styles live in
+// content-editor.css under `.image-figure / .image-content / .image-toolbar`
+// — the unification step de-scoped those rules from `.rich-text-editor` so
+// standalone surfaces (chat messages, AttachmentList) get identical visuals
+// without each component carrying its own Tailwind tax.
 
 interface ImageAttachmentViewProps {
   src: string;
@@ -254,83 +256,52 @@ function ImageAttachmentView({
     }
   };
 
-  // Click on figure opens the preview only in non-editor surfaces — inside
-  // the editor we let ProseMirror own the click for selection / cursor
-  // placement and route preview through the explicit Maximize button.
-  const figureOnClick = !editable && !uploading ? onView : undefined;
+  // Click on figure opens the preview only in non-editor / non-uploading
+  // surfaces — inside the editor we let ProseMirror own the click for
+  // selection / cursor placement and route preview through the explicit
+  // Maximize button. The CSS rule `.image-figure[data-clickable="true"] {
+  // cursor: zoom-in }` keys off this same flag for the cursor affordance.
+  const clickable = !editable && !uploading;
 
+  // DOM mirrors the original ReadonlyImage (span-only chain so it stays
+  // valid HTML5 when rendered inside a markdown <p>). In editor surfaces
+  // the NodeViewWrapper still emits its own outer .image-node div around
+  // this — the duplicate `image-node` class is harmless.
   return (
-    <span
-      className={cn(
-        "image-node group/image relative inline-block max-w-full",
-        className,
-      )}
-    >
+    <span className="image-node">
       <span
         className={cn(
-          "image-figure relative inline-block max-w-full rounded-md transition-shadow",
-          selected && editable && "image-selected ring-2 ring-primary",
-          !editable && !uploading && "cursor-zoom-in",
+          "image-figure",
+          selected && editable && "image-selected",
+          className,
         )}
-        onClick={figureOnClick}
+        data-clickable={clickable || undefined}
+        contentEditable={false}
+        onClick={clickable ? onView : undefined}
       >
-        {src ? (
-          <img
-            src={src}
-            alt={alt}
-            className={cn(
-              "image-content block max-w-full rounded-md",
-              uploading && "image-uploading opacity-60",
-            )}
-            draggable={false}
-          />
-        ) : (
-          // Defensive: an image input without a URL is degenerate, but
-          // emitting nothing leaves no anchor for the toolbar. Render a
-          // small placeholder so the surface is still recognizable.
-          <span className="block h-20 w-32 rounded-md bg-muted" />
-        )}
+        <img
+          src={src || undefined}
+          alt={alt}
+          className={cn("image-content", uploading && "image-uploading")}
+          draggable={false}
+        />
         {!uploading && src && (
           <span
-            className="image-toolbar absolute right-2 top-2 flex items-center gap-0.5 rounded-md border border-border bg-background/95 p-0.5 opacity-0 shadow-sm transition-opacity group-hover/image:opacity-100"
+            className="image-toolbar"
             onMouseDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
           >
-            <button
-              type="button"
-              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title={t(($) => $.image.view)}
-              aria-label={t(($) => $.image.view)}
-              onClick={onView}
-            >
+            <button type="button" onClick={onView} title={t(($) => $.image.view)}>
               <Maximize2 className="size-3.5" />
             </button>
-            <button
-              type="button"
-              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title={t(($) => $.image.download)}
-              aria-label={t(($) => $.image.download)}
-              onClick={onDownload}
-            >
+            <button type="button" onClick={onDownload} title={t(($) => $.image.download)}>
               <Download className="size-3.5" />
             </button>
-            <button
-              type="button"
-              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title={t(($) => $.image.copy_link)}
-              aria-label={t(($) => $.image.copy_link)}
-              onClick={handleCopyLink}
-            >
+            <button type="button" onClick={handleCopyLink} title={t(($) => $.image.copy_link)}>
               <LinkIcon className="size-3.5" />
             </button>
             {editable && onDelete && (
-              <button
-                type="button"
-                className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                title={t(($) => $.image.delete)}
-                aria-label={t(($) => $.image.delete)}
-                onClick={onDelete}
-              >
+              <button type="button" onClick={onDelete} title={t(($) => $.image.delete)}>
                 <Trash2 className="size-3.5" />
               </button>
             )}

--- a/packages/views/editor/content-editor.css
+++ b/packages/views/editor/content-editor.css
@@ -502,32 +502,34 @@
   margin: 0.5rem 0;
 }
 
-/* Image NodeView — centered block with max-width cap */
-.rich-text-editor .image-node {
-  display: block !important;
-  text-align: center;
-}
+/* Image — shared by the editor NodeView AND standalone surfaces (chat
+ * messages, comment-card AttachmentList). De-scoped from `.rich-text-editor`
+ * during the <Attachment> unification so every call site renders identical
+ * visuals without each component carrying its own Tailwind override. */
 
-.rich-text-editor .image-figure {
+.image-figure {
   position: relative;
   display: inline-block;
-  max-width: min(100%, 640px);
   margin: 0.75rem 0;
 }
 
-.rich-text-editor .image-figure.image-selected .image-content {
+.image-figure[data-clickable="true"] {
+  cursor: zoom-in;
+}
+
+.image-figure.image-selected .image-content {
   outline: 2px solid var(--brand);
   outline-offset: 2px;
 }
 
-.rich-text-editor .image-content {
+.image-content {
   display: block;
   width: 100%;
   height: auto;
   border-radius: var(--radius);
 }
 
-.rich-text-editor .image-uploading {
+.image-uploading {
   opacity: 0.5;
   animation: rte-upload-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
@@ -537,13 +539,7 @@
   50% { opacity: 0.3; }
 }
 
-/* Readonly — zoom cursor on clickable images */
-.rich-text-editor.readonly .image-figure {
-  cursor: zoom-in;
-}
-
-/* Image toolbar — dark pill, top-right corner, appears on hover */
-.rich-text-editor .image-toolbar {
+.image-toolbar {
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
@@ -562,7 +558,7 @@
   opacity: 1;
 }
 
-.rich-text-editor .image-toolbar button {
+.image-toolbar button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -573,8 +569,20 @@
   transition: background 0.15s;
 }
 
-.rich-text-editor .image-toolbar button:hover {
+.image-toolbar button:hover {
   background: color-mix(in srgb, white 15%, transparent);
+}
+
+/* Editor-only overrides: center the figure inside the NodeView and cap
+ * width so an oversize paste doesn't blow out the editor column. */
+
+.rich-text-editor .image-node {
+  display: block !important;
+  text-align: center;
+}
+
+.rich-text-editor .image-figure {
+  max-width: min(100%, 640px);
 }
 
 /* Bubble menu — floating toolbar pill */

--- a/packages/views/editor/extensions/image-view.tsx
+++ b/packages/views/editor/extensions/image-view.tsx
@@ -17,8 +17,10 @@ function ImageView({ node, editor, selected, deleteNode }: NodeViewProps) {
   const alt = (node.attrs.alt as string) || "";
   const uploading = node.attrs.uploading as boolean;
 
+  // <Attachment> emits its own .image-node wrapper, so the NodeViewWrapper
+  // stays unclassed — no double image-node.
   return (
-    <NodeViewWrapper className="image-node">
+    <NodeViewWrapper>
       <Attachment
         attachment={{
           kind: "url",


### PR DESCRIPTION
## Summary

Follow-up to #2850 (already merged). That PR landed the unified `<Attachment>` dispatcher but the image renderer dragged in a Tailwind override stack ("ring", "rounded-md", "transition-shadow", "bg-background/95", "hover:bg-muted" on buttons, etc.) to compensate for `.image-*` CSS being scoped to `.rich-text-editor`. The legacy CSS wasn't removed, so both layers applied in the editor and produced:

- Visible **double-stroke selection ring** (CSS outline + Tailwind ring)
- **Light hover bg on the dark-glass toolbar** in the editor (Tailwind hover:bg-muted on top of `color-mix(black 75% transparent)`)
- Several other redundant style declarations

The fix is to do the unification "the simple way": port the DOM exactly and let one CSS layer drive every surface.

## What changed

**`packages/views/editor/attachment.tsx` — `ImageAttachmentView`**
- Reverted to the original `ReadonlyImage` span-only DOM: `<span.image-node> > <span.image-figure> > <img.image-content>` + `<span.image-toolbar>` with naked `<button>` children
- Removed all Tailwind class additions (ring, rounded-md, transition-shadow, bg-background/95, button hover, padding/positioning duplicates)
- Added a small `data-clickable` attribute to drive the cursor affordance from a single CSS rule

**`packages/views/editor/content-editor.css`**
- De-scoped the `.image-figure / .image-content / .image-toolbar / .image-uploading / .image-selected` rules from `.rich-text-editor` so they apply globally
- Restored `.image-figure.image-selected .image-content { outline ... }` (deleted in #2850)
- Replaced the `.rich-text-editor.readonly .image-figure { cursor: zoom-in }` scope with the new `.image-figure[data-clickable="true"] { cursor: zoom-in }` selector
- Editor-only behavior (640px width cap, `.image-node` centering) stays under `.rich-text-editor` scope

**`packages/views/editor/extensions/image-view.tsx`**
- `NodeViewWrapper` no longer adds `className="image-node"` because `<Attachment>` already emits one; the duplicate was harmless but redundant

## Visual

- **Editor + readonly comments**: identical to the state before the unification PR landed (single-stroke selection outline, dark-glass toolbar)
- **Chat / AttachmentList standalone images**: same visual as editor (one CSS layer now drives all three surfaces); previously rendered a gray file card in #2850's parent state, then a Tailwind-tax variant after #2850

## Why a separate PR

#2850 is already merged. This is the minimal patch to undo the styling churn while keeping the dispatcher unification.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm test` — 98 attachment-related tests pass
- [ ] Manual smoke:
  - [ ] Click an image in the editor → single-stroke selection outline (not double)
  - [ ] Hover toolbar over editor image → dark glass pill, white-tint hover on buttons (not light bg)
  - [ ] Comment readonly with image → centered, single-stroke when selected
  - [ ] Chat message with image attachment → same visual as editor (consistent toolbar style)
  - [ ] Standalone AttachmentList (P0 from #2850) still renders real image, not gray card

🤖 Generated with [Claude Code](https://claude.com/claude-code)