### PR TITLE
feat(desktop): foreground new tab for explicit Open-in-new-tab CTAs (MUL-2434)

### DIFF
--- a/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
+++ b/apps/desktop/src/renderer/src/components/pageview-tracker.test.tsx
@@ -128,10 +128,11 @@ describe("PageviewTracker", () => {
     const { rerender } = render(<PageviewTracker />);
     state.capturePageview.mockClear();
 
-    // Simulate a foreground new-tab action (e.g. cmd+k → "Open in new tab"
-    // that explicitly switches focus) — tC is appended AND becomes active.
-    // Note: `openInNewTab` itself opens tabs in the background and does NOT
-    // change `activeTabId`, so it does not trigger this path on its own.
+    // Simulate a foreground new-tab action (e.g. an explicit "Open in new
+    // tab" toolbar button that passes `{ activate: true }`) — tC is
+    // appended AND becomes active. `openInNewTab` defaults to background
+    // (no `setActiveTab`); only the `activate: true` branch produces the
+    // state change this test exercises.
     state.byWorkspace = {
       acme: {
         activeTabId: "tC",

--- a/apps/desktop/src/renderer/src/platform/navigation.test.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.test.tsx
@@ -137,6 +137,22 @@ describe("DesktopNavigationProvider.openInNewTab", () => {
     expect(state.switchWorkspace).not.toHaveBeenCalled();
   });
 
+  it("activates the new tab when opts.activate is true (foreground)", () => {
+    let adapter: ReturnType<typeof useNavigation> | null = null;
+    const Probe = captureAdapter((a) => {
+      adapter = a;
+    });
+    render(
+      <DesktopNavigationProvider>
+        <Probe />
+      </DesktopNavigationProvider>,
+    );
+    adapter!.openInNewTab!("/acme/agents", "Agents", { activate: true });
+    expect(state.openTab).toHaveBeenCalledWith("/acme/agents", "Agents", "File");
+    expect(state.setActiveTab).toHaveBeenCalledWith("tNew");
+    expect(state.switchWorkspace).not.toHaveBeenCalled();
+  });
+
   it("delegates to switchWorkspace for a cross-workspace path", () => {
     let adapter: ReturnType<typeof useNavigation> | null = null;
     const Probe = captureAdapter((a) => {
@@ -155,7 +171,7 @@ describe("DesktopNavigationProvider.openInNewTab", () => {
 });
 
 describe("TabNavigationProvider.openInNewTab", () => {
-  it("opens a background tab (no setActiveTab) for a same-workspace path", () => {
+  function renderTabProvider() {
     let adapter: ReturnType<typeof useNavigation> | null = null;
     const Probe = captureAdapter((a) => {
       adapter = a;
@@ -170,9 +186,22 @@ describe("TabNavigationProvider.openInNewTab", () => {
         <Probe />
       </TabNavigationProvider>,
     );
-    adapter!.openInNewTab!("/acme/agents", "Agents");
+    return () => adapter!;
+  }
+
+  it("opens a background tab (no setActiveTab) for a same-workspace path", () => {
+    const getAdapter = renderTabProvider();
+    getAdapter().openInNewTab!("/acme/agents", "Agents");
     expect(state.openTab).toHaveBeenCalledWith("/acme/agents", "Agents", "File");
     expect(state.setActiveTab).not.toHaveBeenCalled();
+    expect(state.switchWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("activates the new tab when opts.activate is true (foreground)", () => {
+    const getAdapter = renderTabProvider();
+    getAdapter().openInNewTab!("/acme/agents", "Agents", { activate: true });
+    expect(state.openTab).toHaveBeenCalledWith("/acme/agents", "Agents", "File");
+    expect(state.setActiveTab).toHaveBeenCalledWith("tNew");
     expect(state.switchWorkspace).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/src/platform/navigation.tsx
+++ b/apps/desktop/src/renderer/src/platform/navigation.tsx
@@ -178,11 +178,16 @@ export function DesktopNavigationProvider({
       },
       pathname: location.pathname,
       searchParams: new URLSearchParams(location.search),
-      openInNewTab: (path: string, title?: string) => {
+      openInNewTab: (
+        path: string,
+        title?: string,
+        opts?: { activate?: boolean },
+      ) => {
         // Cross-workspace "open in new tab" switches workspace and opens
-        // the path there; same-workspace just adds a background tab. The
-        // type contract (NavigationAdapter.openInNewTab) is explicitly a
-        // background-tab operation — focus stays on the current tab.
+        // the path there (focus follows the user); same-workspace defaults
+        // to background tab (browser cmd+click semantics). Callers that
+        // represent an explicit "Open in new tab" CTA pass `activate: true`
+        // to bring the new tab to the foreground.
         const slug = extractWorkspaceSlug(path);
         const store = useTabStore.getState();
         if (slug && slug !== store.activeWorkspaceSlug) {
@@ -190,7 +195,10 @@ export function DesktopNavigationProvider({
           return;
         }
         const icon = resolveRouteIcon(path);
-        store.openTab(path, title ?? path, icon);
+        const newId = store.openTab(path, title ?? path, icon);
+        if (opts?.activate && newId) {
+          store.setActiveTab(newId);
+        }
       },
       getShareableUrl: (path: string) => `${appUrl}${path}`,
     }),
@@ -242,7 +250,11 @@ export function TabNavigationProvider({
       back: () => router.navigate(-1),
       pathname: location.pathname,
       searchParams: new URLSearchParams(location.search),
-      openInNewTab: (path: string, title?: string) => {
+      openInNewTab: (
+        path: string,
+        title?: string,
+        opts?: { activate?: boolean },
+      ) => {
         const slug = extractWorkspaceSlug(path);
         const store = useTabStore.getState();
         if (slug && slug !== store.activeWorkspaceSlug) {
@@ -250,7 +262,10 @@ export function TabNavigationProvider({
           return;
         }
         const icon = resolveRouteIcon(path);
-        store.openTab(path, title ?? path, icon);
+        const newId = store.openTab(path, title ?? path, icon);
+        if (opts?.activate && newId) {
+          store.setActiveTab(newId);
+        }
       },
       getShareableUrl: (path: string) => `${appUrl}${path}`,
     }),

--- a/packages/views/editor/attachment-preview-modal.test.tsx
+++ b/packages/views/editor/attachment-preview-modal.test.tsx
@@ -419,6 +419,7 @@ describe("AttachmentPreviewModal — open-in-new-tab (HTML only)", () => {
     expect(openInNewTabMock).toHaveBeenCalledWith(
       "/acme/attachments/att-1/preview?name=report.html",
       "report.html",
+      { activate: true },
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/views/editor/attachment-preview-modal.tsx
+++ b/packages/views/editor/attachment-preview-modal.tsx
@@ -221,7 +221,7 @@ export function AttachmentPreviewModal({
       : "";
     const path = `${paths.workspace(slug).attachmentPreview(state.attachmentId)}${nameQuery}`;
     if (navigation.openInNewTab) {
-      navigation.openInNewTab(path, state.filename);
+      navigation.openInNewTab(path, state.filename, { activate: true });
     } else {
       const url = navigation.getShareableUrl(path);
       window.open(url, "_blank", "noopener,noreferrer");

--- a/packages/views/editor/html-attachment-preview.test.tsx
+++ b/packages/views/editor/html-attachment-preview.test.tsx
@@ -202,6 +202,7 @@ describe("HtmlAttachmentPreview — toolbar actions", () => {
     expect(openInNewTabMock).toHaveBeenCalledWith(
       "/acme/attachments/att-1/preview?name=report.html",
       "report.html",
+      { activate: true },
     );
   });
 

--- a/packages/views/editor/html-attachment-preview.tsx
+++ b/packages/views/editor/html-attachment-preview.tsx
@@ -73,7 +73,7 @@ export function HtmlAttachmentPreview({
     const nameQuery = filename ? `?name=${encodeURIComponent(filename)}` : "";
     const path = `${paths.workspace(slug).attachmentPreview(attachmentId)}${nameQuery}`;
     if (navigation.openInNewTab) {
-      navigation.openInNewTab(path, filename);
+      navigation.openInNewTab(path, filename, { activate: true });
       return;
     }
     const url = navigation.getShareableUrl(path);

--- a/packages/views/navigation/types.ts
+++ b/packages/views/navigation/types.ts
@@ -4,8 +4,20 @@ export interface NavigationAdapter {
   back(): void;
   pathname: string;
   searchParams: URLSearchParams;
-  /** Desktop only: open a path in a new background tab. Optional title overrides the default. */
-  openInNewTab?: (path: string, title?: string) => void;
+  /**
+   * Desktop only: open a path in a new tab. Optional `title` overrides the
+   * default tab label. `opts.activate` controls focus:
+   *   - `false` / omitted → background tab (browser cmd+click semantics; what
+   *     modifier-click on links and mentions should use).
+   *   - `true` → foreground tab (explicit "Open in new tab" toolbar buttons,
+   *     where the user is asking to move into the new context).
+   * Cross-workspace paths always switch workspace, regardless of `activate`.
+   */
+  openInNewTab?: (
+    path: string,
+    title?: string,
+    opts?: { activate?: boolean },
+  ) => void;
   /** Return a shareable URL for a path. Web: origin + path. Desktop: public web URL of the connected environment. */
   getShareableUrl: (path: string) => string;
   /**


### PR DESCRIPTION
## Summary

- Adds optional `opts.activate` to `NavigationAdapter.openInNewTab`. Default `false` keeps cmd/ctrl+click on links / mentions / actor avatars as background tabs (browser semantics).
- The two explicit "Open in new tab" toolbar buttons — HTML attachment preview modal and inline HTML attachment preview — now pass `{ activate: true }`, so after the modal closes the user's focus moves to the new tab. Fixes reporter's complaint that "modal pops but doesn't actually jump".
- Both desktop providers (`DesktopNavigationProvider` + `TabNavigationProvider`) consume the tab id returned by `store.openTab` and call `setActiveTab` only when `activate` is true.
- No change to web (`window.open(..., "_blank")` already opens foreground), to `shell.openExternal` flows, or to PR #2854's modal `onClose()` behavior. cmd+click callsites continue to omit the third arg → background.

Issue: [MUL-2434](https://app.multica.ai/issues/ef4cd8ba-9f6f-434e-aa91-a72a486cdfe7)

Plan: comment `d6a252e5-b07a-4257-baa4-dbfd43520a35` (Reviewer APPROVE `81b8123f`).

## Files touched

- `packages/views/navigation/types.ts` — extend signature + JSDoc.
- `apps/desktop/src/renderer/src/platform/navigation.tsx` — two symmetric `activate` branches.
- `packages/views/editor/attachment-preview-modal.tsx` — callsite passes `{ activate: true }`.
- `packages/views/editor/html-attachment-preview.tsx` — callsite passes `{ activate: true }`.
- Vitest updates: `navigation.test.tsx` (new activate-true cases for both providers), `attachment-preview-modal.test.tsx` + `html-attachment-preview.test.tsx` (assert third arg), `pageview-tracker.test.tsx` (comment updated for the new default-vs-activate split).

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 670/670 views tests + all desktop tests pass
- [x] `pnpm lint` — 0 errors (15 pre-existing warnings, unrelated)
- [ ] Manual: in desktop dev, open an HTML attachment preview → click "Open in new tab" → modal closes AND focus moves to the new tab
- [ ] Manual: cmd+click on a mention / `<AppLink>` → still opens as a background tab (no focus theft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)