### PR TITLE
fix(agent): set Codex standalone session source

### DIFF
--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -25,7 +25,8 @@ import (
 // stripped separately by filterCodexCustomConfigOverrides because they
 // share the `-c` flag with legitimate non-MCP overrides like `-c model=…`.
 var codexBlockedArgs = map[string]blockedArgMode{
-	"--listen": blockedWithValue, // stdio:// transport for daemon communication
+	"--listen":         blockedWithValue, // stdio:// transport for daemon communication
+	"--session-source": blockedWithValue, // Multica-owned Codex Desktop classification when supported
 }
 
 // codexStderrTailBytes bounds the stderr tail captured for inclusion in
@@ -74,8 +75,11 @@ type codexBackend struct {
 	cfg Config
 }
 
-func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
+func buildCodexArgs(execPath string, opts ExecOptions, logger *slog.Logger) []string {
 	args := []string{"app-server", "--listen", "stdio://"}
+	if isStandaloneCodexAppServer(execPath) {
+		args = []string{"--listen", "stdio://", "--session-source", "multica-agent-sdk"}
+	}
 	extra := filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger)
 	custom := filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger)
 	// Only claim ownership of the `mcp_servers` namespace when the agent
@@ -92,6 +96,11 @@ func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
 	args = append(args, extra...)
 	args = append(args, custom...)
 	return args
+}
+
+func isStandaloneCodexAppServer(execPath string) bool {
+	base := filepath.Base(execPath)
+	return base == "codex-app-server" || base == "codex-app-server.exe"
 }
 
 // hasManagedCodexMcpConfig reports whether the agent's mcp_config field is
@@ -494,7 +503,8 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 	if execPath == "" {
 		execPath = "codex"
 	}
-	if _, err := exec.LookPath(execPath); err != nil {
+	resolvedPath, err := exec.LookPath(execPath)
+	if err != nil {
 		return nil, fmt.Errorf("codex executable not found at %q: %w", execPath, err)
 	}
 
@@ -537,7 +547,7 @@ func (b *codexBackend) Execute(ctx context.Context, prompt string, opts ExecOpti
 		return nil, fmt.Errorf("codex: mcp_config is set but CODEX_HOME env var is not configured; cannot apply managed MCP")
 	}
 
-	codexArgs := buildCodexArgs(opts, b.cfg.Logger)
+	codexArgs := buildCodexArgs(resolvedPath, opts, b.cfg.Logger)
 	cmd := exec.CommandContext(runCtx, execPath, codexArgs...)
 	hideAgentWindow(cmd)
 	b.cfg.Logger.Info("agent command", "exec", execPath, "args", codexArgs)

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -1420,8 +1420,24 @@ func TestWithAgentStderrAppendsHint(t *testing.T) {
 	}
 }
 
+func TestBuildCodexArgsUsesUmbrellaCodexSubcommand(t *testing.T) {
+	args := buildCodexArgs("/usr/local/bin/codex", ExecOptions{}, slog.Default())
+	want := []string{"app-server", "--listen", "stdio://"}
+	if !stringSlicesEqual(args, want) {
+		t.Fatalf("got %v, want %v", args, want)
+	}
+}
+
+func TestBuildCodexArgsUsesStandaloneAppServerSessionSource(t *testing.T) {
+	args := buildCodexArgs("/usr/local/bin/codex-app-server", ExecOptions{}, slog.Default())
+	want := []string{"--listen", "stdio://", "--session-source", "multica-agent-sdk"}
+	if !stringSlicesEqual(args, want) {
+		t.Fatalf("got %v, want %v", args, want)
+	}
+}
+
 func TestBuildCodexArgsExtraArgsBeforeCustomArgsAndFiltersBoth(t *testing.T) {
-	args := buildCodexArgs(ExecOptions{
+	args := buildCodexArgs("/usr/local/bin/codex", ExecOptions{
 		ExtraArgs:  []string{"--listen", "tcp://evil", "--sandbox", "read-only"},
 		CustomArgs: []string{"--sandbox", "workspace-write", "--listen=bad"},
 	}, slog.Default())
@@ -1452,7 +1468,7 @@ func TestBuildCodexArgsDoesNotLeakMcpToArgv(t *testing.T) {
 	// test pins the contract: even with a non-empty mcp_config, no -c /
 	// --config / mcp_servers.* entry shows up in buildCodexArgs output.
 	raw := json.RawMessage(`{"mcpServers":{"fetch":{"command":"uvx","env":{"SECRET":"hunter2"}}}}`)
-	args := buildCodexArgs(ExecOptions{
+	args := buildCodexArgs("/usr/local/bin/codex", ExecOptions{
 		McpConfig:  raw,
 		CustomArgs: []string{"-c", `model="o3"`},
 	}, slog.Default())
@@ -1561,7 +1577,7 @@ func TestBuildCodexArgsPreservesCustomMcpOverridesWhenUnmanaged(t *testing.T) {
 	// alone — silently dropping them would break the only way those
 	// users had to configure MCP. We only claim the `mcp_servers`
 	// namespace once an admin opts in via the MCP Tab.
-	args := buildCodexArgs(ExecOptions{
+	args := buildCodexArgs("/usr/local/bin/codex", ExecOptions{
 		CustomArgs: []string{"-c", `mcp_servers.fetch={ command = "uvx" }`, "-c", `model="o3"`},
 	}, slog.Default())
 	foundMcp := false
@@ -1583,7 +1599,7 @@ func TestBuildCodexArgsDropsCustomMcpOverridesWhenManaged(t *testing.T) {
 	// `-c` is last-wins, so any `-c mcp_servers.…` left in custom_args
 	// would silently shadow the saved managed entries.
 	raw := json.RawMessage(`{"mcpServers":{"managed":{"command":"managed-cmd"}}}`)
-	args := buildCodexArgs(ExecOptions{
+	args := buildCodexArgs("/usr/local/bin/codex", ExecOptions{
 		McpConfig:  raw,
 		CustomArgs: []string{"-c", `mcp_servers.fetch={ command = "evil" }`, "-c", `model="o3"`},
 	}, slog.Default())
@@ -1971,4 +1987,31 @@ func TestHasManagedCodexMcpConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildCodexArgsStandaloneFiltersSessionSourceOverrides(t *testing.T) {
+	args := buildCodexArgs("/usr/local/bin/codex-app-server", ExecOptions{
+		ExtraArgs:  []string{"--session-source", "vscode", "--sandbox", "read-only"},
+		CustomArgs: []string{"--session-source=cli", "--sandbox", "workspace-write"},
+	}, slog.Default())
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "vscode") || strings.Contains(joined, "--session-source=cli") {
+		t.Fatalf("session source overrides should be filtered: %v", args)
+	}
+	wantPrefix := []string{"--listen", "stdio://", "--session-source", "multica-agent-sdk"}
+	if len(args) < len(wantPrefix) || !stringSlicesEqual(args[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("got %v, want prefix %v", args, wantPrefix)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the Multica-side stopgap discussed in #2746 for Codex Desktop history pollution.

Multica still launches the regular umbrella `codex` binary as `codex app-server --listen stdio://`, because that subcommand currently does not expose a session-source flag upstream. When the configured executable resolves to the standalone `codex-app-server` binary, this PR now launches it directly as `codex-app-server --listen stdio:// --session-source multica-agent-sdk`, matching Multica's existing JSON-RPC `clientInfo.name` and avoiding the default `vscode` classification for users who install/configure the standalone app server.

The daemon also treats `--session-source` as a blocked custom arg so user-provided `MULTICA_CODEX_ARGS` / custom runtime args cannot override Multica's session classification.

## Related Issue

Closes #2746

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/codex.go`: detect standalone `codex-app-server` by resolved executable basename and build direct app-server args with `--session-source multica-agent-sdk`.
- `server/pkg/agent/codex.go`: keep the existing umbrella `codex app-server --listen stdio://` launch path unchanged.
- `server/pkg/agent/codex.go`: block `--session-source` from custom args so runtime/user config cannot override Multica-owned classification.
- `server/pkg/agent/codex_test.go`: add coverage for umbrella args, standalone args, and session-source override filtering.

## How to Test

1. Configure a Codex runtime with `MULTICA_CODEX_PATH` pointing at a standalone `codex-app-server` binary.
2. Start a Codex-backed Multica task.
3. Verify the spawned command uses `--listen stdio:// --session-source multica-agent-sdk` without the `app-server` subcommand.
4. Verify sessions created through the standalone binary are no longer tagged with the default `vscode` source in Codex Desktop metadata.

Local verification run:

- [x] `PATH=/private/tmp/go1.26.1/go/bin:$PATH go test -count=1 ./...` from `server/`
- [x] `PATH=/private/tmp/go1.26.1/go/bin:$PATH go vet ./...` from `server/`
- [x] `git diff --check`
- [x] submitted file list excludes `superpowers` / `docs/superpowers`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`) — N/A, no new runtime / coding tool / UI tab
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`) — N/A, no product copy changes
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Continued open-issue triage, selected #2746 after excluding issues with existing open PRs, followed the maintainer-confirmed stopgap design from the issue comments, added failing argument-builder tests first, implemented the narrow Codex launch-path change, then verified with full server Go tests, go vet, diff checks, and submitted-file inspection.

## Screenshots (optional)

Not applicable; daemon launch-argument behavior only.
