### PR TITLE
feat(settings): show GitHub installations

### DIFF
--- a/packages/core/api/client.test.ts
+++ b/packages/core/api/client.test.ts
@@ -259,6 +259,70 @@ describe("ApiClient", () => {
     });
   });
 
+  describe("listGitHubInstallations", () => {
+    it("returns parsed installations for a well-formed response", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              configured: true,
+              installations: [
+                {
+                  id: "gh-inst-1",
+                  workspace_id: "workspace-1",
+                  installation_id: 123456,
+                  account_login: "multica-ai",
+                  account_type: "Organization",
+                  account_avatar_url: "https://example.test/avatar.png",
+                  created_at: "2026-05-19T00:00:00Z",
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
+
+      const client = new ApiClient("https://api.example.test");
+      const response = await client.listGitHubInstallations("workspace-1");
+
+      expect(response.configured).toBe(true);
+      expect(response.installations).toHaveLength(1);
+      expect(response.installations[0]?.account_login).toBe("multica-ai");
+      expect(response.installations[0]?.account_avatar_url).toBe(
+        "https://example.test/avatar.png",
+      );
+    });
+
+    it("falls back to an empty response when the installation shape drifts", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              configured: true,
+              installations: [
+                {
+                  id: "gh-inst-1",
+                  installation_id: "123456",
+                  account_login: "multica-ai",
+                  account_type: "Organization",
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
+
+      const client = new ApiClient("https://api.example.test");
+      const response = await client.listGitHubInstallations("workspace-1");
+
+      expect(response).toEqual({ configured: false, installations: [] });
+    });
+  });
+
   describe("chat attachment wiring", () => {
     it("uploadFile includes chat_session_id in the FormData body", async () => {
       const fetchMock = vi.fn().mockResolvedValue(

--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -121,12 +121,14 @@ import {
   EMPTY_ATTACHMENT,
   EMPTY_CREATE_AGENT_FROM_TEMPLATE_RESPONSE,
   EMPTY_GROUPED_ISSUES_RESPONSE,
+  EMPTY_LIST_GITHUB_INSTALLATIONS_RESPONSE,
   EMPTY_LIST_ISSUES_RESPONSE,
   EMPTY_SQUAD_MEMBER_STATUS_LIST,
   EMPTY_TIMELINE_ENTRIES,
   EMPTY_LIST_WEBHOOK_DELIVERIES_RESPONSE,
   EMPTY_WEBHOOK_DELIVERY,
   GroupedIssuesResponseSchema,
+  ListGitHubInstallationsResponseSchema,
   ListIssuesResponseSchema,
   ListWebhookDeliveriesResponseSchema,
   OnboardingNoRuntimeBootstrapResponseSchema,
@@ -1763,7 +1765,13 @@ export class ApiClient {
   }
 
   async listGitHubInstallations(workspaceId: string): Promise<ListGitHubInstallationsResponse> {
-    return this.fetch(`/api/workspaces/${workspaceId}/github/installations`);
+    const raw = await this.fetch<unknown>(`/api/workspaces/${workspaceId}/github/installations`);
+    return parseWithFallback(
+      raw,
+      ListGitHubInstallationsResponseSchema,
+      EMPTY_LIST_GITHUB_INSTALLATIONS_RESPONSE,
+      { endpoint: "GET /api/workspaces/:id/github/installations" },
+    );
   }
 
   async deleteGitHubInstallation(workspaceId: string, installationId: string): Promise<void> {

--- a/packages/core/api/schemas.ts
+++ b/packages/core/api/schemas.ts
@@ -6,6 +6,7 @@ import type {
   Attachment,
   CreateAgentFromTemplateResponse,
   GroupedIssuesResponse,
+  ListGitHubInstallationsResponse,
   ListIssuesResponse,
   ListWebhookDeliveriesResponse,
   TimelineEntry,
@@ -413,6 +414,29 @@ export interface DuplicateIssueErrorBody {
     title: string;
   };
 }
+
+// GitHub installations: backs Settings > Integrations. This is an installed
+// desktop boundary, so the response is parsed defensively before the UI reads
+// the installation list.
+const GitHubInstallationSchema = z.object({
+  id: z.string(),
+  workspace_id: z.string(),
+  installation_id: z.number(),
+  account_login: z.string(),
+  account_type: z.string(),
+  account_avatar_url: z.string().nullable().optional().transform((v) => v ?? null),
+  created_at: z.string(),
+}).loose();
+
+export const ListGitHubInstallationsResponseSchema = z.object({
+  installations: z.array(GitHubInstallationSchema).default([]),
+  configured: z.boolean().default(false),
+}).loose();
+
+export const EMPTY_LIST_GITHUB_INSTALLATIONS_RESPONSE: ListGitHubInstallationsResponse = {
+  installations: [],
+  configured: false,
+};
 
 // ---------------------------------------------------------------------------
 // Webhook delivery schemas — backing the Autopilot Deliveries section. Enums

--- a/packages/views/locales/en/settings.json
+++ b/packages/views/locales/en/settings.json
@@ -171,6 +171,12 @@
     "connect_disabled_tooltip": "GitHub App is not configured on this server",
     "not_configured": "GitHub integration is not configured for this deployment. Operators must set",
     "not_configured_and": "and",
+    "installations_title": "Connected GitHub accounts",
+    "installations_empty": "No GitHub accounts connected yet.",
+    "installation_id": "Installation #{{id}}",
+    "account_type_user": "User",
+    "account_type_organization": "Organization",
+    "account_type_unknown": "Account",
     "manage_hint": "Only admins and owners can manage integrations.",
     "toast_not_configured": "GitHub integration is not configured for this deployment",
     "toast_open_failed": "Failed to open GitHub install"

--- a/packages/views/locales/zh-Hans/settings.json
+++ b/packages/views/locales/zh-Hans/settings.json
@@ -171,6 +171,12 @@
     "connect_disabled_tooltip": "服务端未配置 GitHub App",
     "not_configured": "当前部署没有配置 GitHub 集成。运维需要设置",
     "not_configured_and": "和",
+    "installations_title": "已连接的 GitHub 账号",
+    "installations_empty": "暂无已连接的 GitHub 账号。",
+    "installation_id": "安装 ID：{{id}}",
+    "account_type_user": "用户",
+    "account_type_organization": "组织",
+    "account_type_unknown": "账号",
     "manage_hint": "只有管理员和所有者可以管理集成。",
     "toast_not_configured": "当前部署未配置 GitHub 集成",
     "toast_open_failed": "打开 GitHub 安装页失败"

--- a/packages/views/settings/components/integrations-tab.test.tsx
+++ b/packages/views/settings/components/integrations-tab.test.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { I18nProvider } from "@multica/core/i18n/react";
+import enCommon from "../../locales/en/common.json";
+import enSettings from "../../locales/en/settings.json";
+
+const githubInstallationsRef = vi.hoisted(() => ({
+  current: {
+    configured: true,
+    installations: [
+      {
+        id: "gh-inst-1",
+        workspace_id: "workspace-1",
+        installation_id: 123456,
+        account_login: "multica-ai",
+        account_type: "Organization" as const,
+        account_avatar_url: "https://example.test/avatar.png",
+        created_at: "2026-05-19T00:00:00Z",
+      },
+    ],
+  },
+}));
+
+const membersRef = vi.hoisted(() => ({
+  current: [{ user_id: "user-1", role: "owner" as const }],
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: readonly unknown[] }) => {
+    if (queryKey[0] === "github") {
+      return { data: githubInstallationsRef.current };
+    }
+    return { data: membersRef.current };
+  },
+}));
+
+vi.mock("@multica/core/hooks", () => ({
+  useWorkspaceId: () => "workspace-1",
+}));
+
+vi.mock("@multica/core/workspace/queries", () => ({
+  memberListOptions: () => ({ queryKey: ["members"], queryFn: vi.fn() }),
+}));
+
+vi.mock("@multica/core/github/queries", () => ({
+  githubInstallationsOptions: () => ({
+    queryKey: ["github", "workspace-1", "installations"],
+    queryFn: vi.fn(),
+  }),
+}));
+
+vi.mock("@multica/core/api", () => ({
+  api: { getGitHubConnectURL: vi.fn() },
+}));
+
+vi.mock("@multica/core/auth", () => {
+  const useAuthStore = Object.assign(
+    (sel?: (s: { user: { id: string } }) => unknown) =>
+      sel ? sel({ user: { id: "user-1" } }) : { user: { id: "user-1" } },
+    { getState: () => ({ user: { id: "user-1" } }) },
+  );
+  return { useAuthStore };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+import { IntegrationsTab } from "./integrations-tab";
+
+const TEST_RESOURCES = {
+  en: { common: enCommon, settings: enSettings },
+};
+
+function I18nWrapper({ children }: { children: ReactNode }) {
+  return (
+    <I18nProvider locale="en" resources={TEST_RESOURCES}>
+      {children}
+    </I18nProvider>
+  );
+}
+
+describe("IntegrationsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    membersRef.current = [{ user_id: "user-1", role: "owner" }];
+    githubInstallationsRef.current = {
+      configured: true,
+      installations: [
+        {
+          id: "gh-inst-1",
+          workspace_id: "workspace-1",
+          installation_id: 123456,
+          account_login: "multica-ai",
+          account_type: "Organization",
+          account_avatar_url: "https://example.test/avatar.png",
+          created_at: "2026-05-19T00:00:00Z",
+        },
+      ],
+    };
+  });
+
+  it("shows connected GitHub installations to workspace admins", () => {
+    render(<IntegrationsTab />, { wrapper: I18nWrapper });
+
+    expect(screen.getByText("multica-ai")).toBeInTheDocument();
+    expect(screen.getByText("Organization")).toBeInTheDocument();
+    expect(screen.getByText("Installation #123456")).toBeInTheDocument();
+  });
+});

--- a/packages/views/settings/components/integrations-tab.tsx
+++ b/packages/views/settings/components/integrations-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Building2, UserRound } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@multica/ui/components/ui/button";
 import { Card, CardContent } from "@multica/ui/components/ui/card";
@@ -32,14 +33,22 @@ export function IntegrationsTab() {
   const currentMember = members.find((m) => m.user_id === user?.id) ?? null;
   const canManage = currentMember?.role === "owner" || currentMember?.role === "admin";
 
-  // Only used to gate the Connect button + show a "not configured" hint;
-  // we no longer render the installation list here — admins manage existing
-  // installations on GitHub directly via the Connect flow.
   const { data } = useQuery({
     ...githubInstallationsOptions(wsId),
     enabled: !!wsId && canManage,
   });
   const configured = data?.configured ?? false;
+  const installations = data?.installations ?? [];
+
+  function getAccountTypeLabel(accountType: string): string {
+    if (accountType === "Organization") {
+      return t(($) => $.integrations.account_type_organization);
+    }
+    if (accountType === "User") {
+      return t(($) => $.integrations.account_type_user);
+    }
+    return accountType || t(($) => $.integrations.account_type_unknown);
+  }
 
   async function handleConnect() {
     setConnecting(true);
@@ -100,6 +109,67 @@ export function IntegrationsTab() {
                 {t(($) => $.integrations.not_configured_and)}{" "}
                 <code className="rounded bg-muted px-1 py-0.5 text-[10px]">GITHUB_WEBHOOK_SECRET</code>.
               </p>
+            )}
+
+            {canManage && configured && (
+              <div className="border-t pt-4">
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    {t(($) => $.integrations.installations_title)}
+                  </p>
+                  <span className="text-xs tabular-nums text-muted-foreground">
+                    {installations.length}
+                  </span>
+                </div>
+
+                {installations.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    {t(($) => $.integrations.installations_empty)}
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {installations.map((installation) => {
+                      const isOrganization = installation.account_type === "Organization";
+                      const AccountIcon = isOrganization ? Building2 : UserRound;
+                      const accountTypeLabel = getAccountTypeLabel(installation.account_type);
+
+                      return (
+                        <div
+                          key={installation.id}
+                          className="flex items-center gap-3 rounded-md border bg-muted/30 px-3 py-2"
+                        >
+                          {installation.account_avatar_url ? (
+                            <img
+                              src={installation.account_avatar_url}
+                              alt=""
+                              className="h-8 w-8 rounded-full bg-muted"
+                            />
+                          ) : (
+                            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                              <AccountIcon className="h-4 w-4" />
+                            </div>
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <p className="truncate text-sm font-medium">
+                                {installation.account_login}
+                              </p>
+                              <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                                {accountTypeLabel}
+                              </span>
+                            </div>
+                            <p className="mt-0.5 text-xs text-muted-foreground">
+                              {t(($) => $.integrations.installation_id, {
+                                id: installation.installation_id,
+                              })}
+                            </p>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             )}
 
             {!canManage && (


### PR DESCRIPTION
## What does this PR do?

Settings -> Integrations now shows the connected GitHub installation accounts returned by `GET /api/workspaces/{id}/github/installations`. This lets self-hosted admins verify which GitHub user or organization is connected without checking SQL rows or backend logs.

Thinking path: the backend route, sqlc query, and core query already existed; the missing product behavior was the settings UI rendering. I kept the change scoped to the existing Integrations card, reused the existing query, and added API schema parsing because this response is consumed by installed desktop clients.

## Related Issue

Closes #2870

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/settings/components/integrations-tab.tsx`: renders connected GitHub accounts with avatar/icon, account type, and installation ID for admins/owners.
- `packages/views/settings/components/integrations-tab.test.tsx`: adds RTL coverage for displaying a connected GitHub organization installation.
- `packages/core/api/schemas.ts` and `packages/core/api/client.ts`: parse the GitHub installations response through zod with a safe fallback.
- `packages/core/api/client.test.ts`: covers well-formed and drifted GitHub installation API responses.
- `packages/views/locales/en/settings.json` and `packages/views/locales/zh-Hans/settings.json`: adds integration list copy.

## How to Test

1. Configure a workspace with at least one GitHub App installation.
2. Open Settings -> Integrations as an owner/admin.
3. Confirm the GitHub card lists the connected account login, account type, and installation ID.

Local verification run:

- `pnpm --filter @multica/views exec vitest run settings/components/integrations-tab.test.tsx`
- `pnpm --filter @multica/core exec vitest run api/client.test.ts`
- `pnpm --filter @multica/views typecheck`
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/views lint` (passes with existing warnings)
- `pnpm --filter @multica/core lint` (passes with existing warning)
- `pnpm --filter @multica/views test`
- `pnpm --filter @multica/core test`
- `pnpm exec turbo build typecheck lint test --filter='!@multica/docs'`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: low. The UI only renders data already returned by the existing endpoint. Malformed installation responses now fall back to an empty configured=false response instead of breaking the settings view.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Asked Codex to continue fixing issues by priority. I inspected the issue, confirmed existing backend/core support, added regression tests first, implemented the settings UI list, hardened the API response schema, and ran local verification.

## Screenshots (optional)

Not captured locally; rendering is covered by the new React Testing Library test with mocked installation data.
