### PR TITLE
fix(daemon): seed Claude image attachments (MUL-3907)

### DIFF
--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -925,6 +925,60 @@ func (c *Client) postJSONViaWithRetry(ctx context.Context, httpClient *http.Clie
 	}
 }
 
+type AttachmentResponse struct {
+	ID          string `json:"id"`
+	DownloadURL string `json:"download_url"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	SizeBytes   int64  `json:"size_bytes"`
+}
+
+func (c *Client) DownloadAttachment(ctx context.Context, attachmentID string) (*AttachmentResponse, []byte, error) {
+	var att AttachmentResponse
+	if err := c.getJSON(ctx, fmt.Sprintf("/api/attachments/%s", attachmentID), &att); err != nil {
+		return nil, nil, err
+	}
+	if att.DownloadURL == "" {
+		return nil, nil, fmt.Errorf("attachment %s has no download_url", attachmentID)
+	}
+	data, err := c.downloadFile(ctx, att.DownloadURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &att, data, nil
+}
+
+func (c *Client) downloadFile(ctx context.Context, downloadURL string) ([]byte, error) {
+	isRelative := !strings.HasPrefix(downloadURL, "http://") && !strings.HasPrefix(downloadURL, "https://")
+	if isRelative {
+		if c.baseURL == "" {
+			return nil, fmt.Errorf("download URL %q is relative but client has no base URL", downloadURL)
+		}
+		downloadURL = c.baseURL + downloadURL
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if isRelative && c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		c.setIdentityHeaders(req)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, &requestError{Method: http.MethodGet, Path: downloadURL, StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(data))}
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 100*1024*1024+1))
+}
+
 func (c *Client) postJSON(ctx context.Context, path string, reqBody any, respBody any) error {
 	return c.postJSONVia(ctx, c.client, path, reqBody, respBody)
 }

--- a/server/internal/daemon/client.go
+++ b/server/internal/daemon/client.go
@@ -934,18 +934,12 @@ type AttachmentResponse struct {
 }
 
 func (c *Client) DownloadAttachment(ctx context.Context, attachmentID string) (*AttachmentResponse, []byte, error) {
-	var att AttachmentResponse
-	if err := c.getJSON(ctx, fmt.Sprintf("/api/attachments/%s", attachmentID), &att); err != nil {
-		return nil, nil, err
-	}
-	if att.DownloadURL == "" {
-		return nil, nil, fmt.Errorf("attachment %s has no download_url", attachmentID)
-	}
-	data, err := c.downloadFile(ctx, att.DownloadURL)
+	path := fmt.Sprintf("/api/attachments/%s/download", attachmentID)
+	data, err := c.downloadFile(ctx, path)
 	if err != nil {
 		return nil, nil, err
 	}
-	return &att, data, nil
+	return &AttachmentResponse{ID: attachmentID}, data, nil
 }
 
 func (c *Client) downloadFile(ctx context.Context, downloadURL string) ([]byte, error) {

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -362,28 +362,19 @@ func TestDefaultTerminalRetrySchedule_MatchesAgreedPlan(t *testing.T) {
 	}
 }
 
-func TestClient_DownloadAttachmentDownloadsRelativeURLWithAuthHeaders(t *testing.T) {
+func TestClient_DownloadAttachmentUsesDownloadEndpointWithAuthHeaders(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/attachments/att-1":
+		case "/api/attachments/att-1/download":
 			if got := r.Header.Get("Authorization"); got != "Bearer tok" {
-				t.Errorf("metadata request Authorization = %q, want Bearer tok", got)
-			}
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{
-				"id":           "att-1",
-				"download_url": "/download/att-1",
-				"filename":     "shot.png",
-				"content_type": "image/png",
-			})
-		case "/download/att-1":
-			if got := r.Header.Get("Authorization"); got != "Bearer tok" {
-				t.Errorf("download request Authorization = %q, want Bearer tok", got)
+				t.Errorf("attachment download Authorization = %q, want Bearer tok", got)
 			}
 			if got := r.Header.Get("X-Client-Platform"); got != "daemon" {
-				t.Errorf("download request X-Client-Platform = %q, want daemon", got)
+				t.Errorf("attachment download X-Client-Platform = %q, want daemon", got)
 			}
 			w.Write([]byte("png-bytes"))
+		case "/api/attachments/att-1":
+			t.Fatal("DownloadAttachment must not fetch member-scoped attachment metadata")
 		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
 			http.NotFound(w, r)
@@ -398,7 +389,7 @@ func TestClient_DownloadAttachmentDownloadsRelativeURLWithAuthHeaders(t *testing
 	if err != nil {
 		t.Fatalf("DownloadAttachment: %v", err)
 	}
-	if meta.Filename != "shot.png" || meta.ContentType != "image/png" {
+	if meta.ID != "att-1" {
 		t.Fatalf("unexpected attachment metadata: %+v", meta)
 	}
 	if string(data) != "png-bytes" {

--- a/server/internal/daemon/client_test.go
+++ b/server/internal/daemon/client_test.go
@@ -362,6 +362,74 @@ func TestDefaultTerminalRetrySchedule_MatchesAgreedPlan(t *testing.T) {
 	}
 }
 
+func TestClient_DownloadAttachmentDownloadsRelativeURLWithAuthHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/attachments/att-1":
+			if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+				t.Errorf("metadata request Authorization = %q, want Bearer tok", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":           "att-1",
+				"download_url": "/download/att-1",
+				"filename":     "shot.png",
+				"content_type": "image/png",
+			})
+		case "/download/att-1":
+			if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+				t.Errorf("download request Authorization = %q, want Bearer tok", got)
+			}
+			if got := r.Header.Get("X-Client-Platform"); got != "daemon" {
+				t.Errorf("download request X-Client-Platform = %q, want daemon", got)
+			}
+			w.Write([]byte("png-bytes"))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	c.SetToken("tok")
+
+	meta, data, err := c.DownloadAttachment(context.Background(), "att-1")
+	if err != nil {
+		t.Fatalf("DownloadAttachment: %v", err)
+	}
+	if meta.Filename != "shot.png" || meta.ContentType != "image/png" {
+		t.Fatalf("unexpected attachment metadata: %+v", meta)
+	}
+	if string(data) != "png-bytes" {
+		t.Fatalf("downloaded data = %q, want png-bytes", string(data))
+	}
+}
+
+func TestClient_DownloadFileAbsoluteURLOmitsAuthHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("absolute download Authorization = %q, want empty", got)
+		}
+		if got := r.Header.Get("X-Client-Platform"); got != "" {
+			t.Errorf("absolute download X-Client-Platform = %q, want empty", got)
+		}
+		w.Write([]byte("image-data"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("https://api.example.test")
+	c.SetToken("tok")
+
+	data, err := c.downloadFile(context.Background(), srv.URL+"/signed")
+	if err != nil {
+		t.Fatalf("downloadFile: %v", err)
+	}
+	if string(data) != "image-data" {
+		t.Fatalf("downloaded data = %q, want image-data", string(data))
+	}
+}
+
 func TestNormalizeGOOS(t *testing.T) {
 	cases := map[string]string{
 		"darwin":  "macos",

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3507,6 +3507,56 @@ func providerNeedsInlineSystemPrompt(provider string) bool {
 	}
 }
 
+const (
+	maxClaudeInitialImages     = 4
+	maxClaudeInitialImageBytes = 10 * 1024 * 1024
+)
+
+func (d *Daemon) claudeInitialImages(ctx context.Context, task Task, taskLog *slog.Logger) []agent.InputImage {
+	attachments := make([]AttachmentMeta, 0, len(task.IssueAttachments)+len(task.ChatMessageAttachments))
+	attachments = append(attachments, task.IssueAttachments...)
+	attachments = append(attachments, task.ChatMessageAttachments...)
+	if len(attachments) == 0 {
+		return nil
+	}
+
+	images := make([]agent.InputImage, 0, min(len(attachments), maxClaudeInitialImages))
+	for _, attachment := range attachments {
+		if len(images) >= maxClaudeInitialImages {
+			break
+		}
+		if attachment.ID == "" || !strings.HasPrefix(strings.ToLower(attachment.ContentType), "image/") {
+			continue
+		}
+		meta, data, err := d.client.DownloadAttachment(ctx, attachment.ID)
+		if err != nil {
+			taskLog.Warn("claude initial image download failed", "attachment_id", attachment.ID, "error", err)
+			continue
+		}
+		if len(data) == 0 || len(data) > maxClaudeInitialImageBytes {
+			taskLog.Warn("claude initial image skipped due to size", "attachment_id", attachment.ID, "bytes", len(data))
+			continue
+		}
+		mediaType := attachment.ContentType
+		if meta != nil && meta.ContentType != "" {
+			mediaType = meta.ContentType
+		}
+		if !strings.HasPrefix(strings.ToLower(mediaType), "image/") {
+			continue
+		}
+		filename := attachment.Filename
+		if meta != nil && meta.Filename != "" {
+			filename = meta.Filename
+		}
+		images = append(images, agent.InputImage{
+			Filename:  filename,
+			MediaType: mediaType,
+			Data:      data,
+		})
+	}
+	return images
+}
+
 // gateResumeToReusedWorkdir clears the task's prior session unless the task
 // runs in the exact workdir the session was recorded against, and reports
 // whether that workdir was reused. CLI backends key their session stores to
@@ -4389,6 +4439,9 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		McpConfig:      mcpConfig,
 		ThinkingLevel:  thinkingLevel,
 		OpenclawMode:   openclawMode,
+	}
+	if provider == "claude" {
+		execOpts.InitialImages = d.claudeInitialImages(ctx, task, taskLog)
 	}
 	// Some providers do not reliably load the per-task runtime config files we
 	// write into the task workdir:

--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3512,6 +3512,10 @@ const (
 	maxClaudeInitialImageBytes = 10 * 1024 * 1024
 )
 
+func shouldSeedClaudeInitialImages(provider string, task Task) bool {
+	return provider == "claude" && task.PriorSessionID == ""
+}
+
 func (d *Daemon) claudeInitialImages(ctx context.Context, task Task, taskLog *slog.Logger) []agent.InputImage {
 	attachments := make([]AttachmentMeta, 0, len(task.IssueAttachments)+len(task.ChatMessageAttachments))
 	attachments = append(attachments, task.IssueAttachments...)
@@ -3525,10 +3529,10 @@ func (d *Daemon) claudeInitialImages(ctx context.Context, task Task, taskLog *sl
 		if len(images) >= maxClaudeInitialImages {
 			break
 		}
-		if attachment.ID == "" || !strings.HasPrefix(strings.ToLower(attachment.ContentType), "image/") {
+		if attachment.ID == "" || !isClaudeInitialImageMediaType(attachment.ContentType) {
 			continue
 		}
-		meta, data, err := d.client.DownloadAttachment(ctx, attachment.ID)
+		_, data, err := d.client.DownloadAttachment(ctx, attachment.ID)
 		if err != nil {
 			taskLog.Warn("claude initial image download failed", "attachment_id", attachment.ID, "error", err)
 			continue
@@ -3538,16 +3542,7 @@ func (d *Daemon) claudeInitialImages(ctx context.Context, task Task, taskLog *sl
 			continue
 		}
 		mediaType := attachment.ContentType
-		if meta != nil && meta.ContentType != "" {
-			mediaType = meta.ContentType
-		}
-		if !strings.HasPrefix(strings.ToLower(mediaType), "image/") {
-			continue
-		}
 		filename := attachment.Filename
-		if meta != nil && meta.Filename != "" {
-			filename = meta.Filename
-		}
 		images = append(images, agent.InputImage{
 			Filename:  filename,
 			MediaType: mediaType,
@@ -3555,6 +3550,15 @@ func (d *Daemon) claudeInitialImages(ctx context.Context, task Task, taskLog *sl
 		})
 	}
 	return images
+}
+
+func isClaudeInitialImageMediaType(mediaType string) bool {
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return true
+	default:
+		return false
+	}
 }
 
 // gateResumeToReusedWorkdir clears the task's prior session unless the task
@@ -4440,7 +4444,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		ThinkingLevel:  thinkingLevel,
 		OpenclawMode:   openclawMode,
 	}
-	if provider == "claude" {
+	if shouldSeedClaudeInitialImages(provider, task) {
 		execOpts.InitialImages = d.claudeInitialImages(ctx, task, taskLog)
 	}
 	// Some providers do not reliably load the per-task runtime config files we

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1117,15 +1117,7 @@ func TestClaudeInitialImagesDownloadsImageAttachments(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/attachments/img-1":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{
-				"id":           "img-1",
-				"download_url": "/files/img-1",
-				"filename":     "server-shot.png",
-				"content_type": "image/png",
-			})
-		case "/files/img-1":
+		case "/api/attachments/img-1/download":
 			w.Write([]byte("image-bytes"))
 		default:
 			http.NotFound(w, r)
@@ -1145,8 +1137,49 @@ func TestClaudeInitialImagesDownloadsImageAttachments(t *testing.T) {
 		t.Fatalf("initial images length = %d, want 1", len(images))
 	}
 	got := images[0]
-	if got.Filename != "server-shot.png" || got.MediaType != "image/png" || string(got.Data) != "image-bytes" {
+	if got.Filename != "client-shot.png" || got.MediaType != "image/png" || string(got.Data) != "image-bytes" {
 		t.Fatalf("unexpected initial image: %+v data=%q", got, string(got.Data))
+	}
+}
+
+func TestClaudeInitialImagesSkipsUnsupportedImageTypes(t *testing.T) {
+	t.Parallel()
+
+	var downloadCalled atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downloadCalled.Store(true)
+		w.Write([]byte("image-bytes"))
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+	images := d.claudeInitialImages(context.Background(), Task{
+		IssueAttachments: []AttachmentMeta{
+			{ID: "svg-1", Filename: "diagram.svg", ContentType: "image/svg+xml"},
+			{ID: "bmp-1", Filename: "bitmap.bmp", ContentType: "image/bmp"},
+			{ID: "ico-1", Filename: "favicon.ico", ContentType: "image/x-icon"},
+		},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if len(images) != 0 {
+		t.Fatalf("initial images length = %d, want 0", len(images))
+	}
+	if downloadCalled.Load() {
+		t.Fatal("unsupported image attachments should be skipped before download")
+	}
+}
+
+func TestShouldSeedClaudeInitialImagesOnlyForColdClaudeTasks(t *testing.T) {
+	t.Parallel()
+
+	if !shouldSeedClaudeInitialImages("claude", Task{}) {
+		t.Fatal("cold Claude task should seed initial images")
+	}
+	if shouldSeedClaudeInitialImages("claude", Task{PriorSessionID: "sess-123"}) {
+		t.Fatal("resumed Claude task should not seed initial images")
+	}
+	if shouldSeedClaudeInitialImages("codex", Task{}) {
+		t.Fatal("non-Claude task should not seed initial images")
 	}
 }
 

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1112,6 +1112,44 @@ func TestWatchTaskCancellation_RunningTaskNotInterrupted(t *testing.T) {
 	}
 }
 
+func TestClaudeInitialImagesDownloadsImageAttachments(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/attachments/img-1":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":           "img-1",
+				"download_url": "/files/img-1",
+				"filename":     "server-shot.png",
+				"content_type": "image/png",
+			})
+		case "/files/img-1":
+			w.Write([]byte("image-bytes"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	d := &Daemon{client: NewClient(srv.URL), logger: slog.Default()}
+	images := d.claudeInitialImages(context.Background(), Task{
+		IssueAttachments: []AttachmentMeta{
+			{ID: "img-1", Filename: "client-shot.png", ContentType: "image/png"},
+			{ID: "txt-1", Filename: "notes.txt", ContentType: "text/plain"},
+		},
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if len(images) != 1 {
+		t.Fatalf("initial images length = %d, want 1", len(images))
+	}
+	got := images[0]
+	if got.Filename != "server-shot.png" || got.MediaType != "image/png" || string(got.Data) != "image-bytes" {
+		t.Fatalf("unexpected initial image: %+v data=%q", got, string(got.Data))
+	}
+}
+
 func TestMergeUsage(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/daemon/prompt_test.go
+++ b/server/internal/daemon/prompt_test.go
@@ -275,7 +275,7 @@ func TestBuildChatPromptAttachmentIDsCanBeBoundToCreatedIssues(t *testing.T) {
 	task := Task{
 		ChatSessionID: "sess-1",
 		ChatMessage:   "please create an issue with this screenshot",
-		ChatMessageAttachments: []ChatAttachmentMeta{
+		ChatMessageAttachments: []AttachmentMeta{
 			{ID: "019ec09d-6222-722b-bdfa-427b105d80be", Filename: "shot.png", ContentType: "image/png"},
 		},
 	}

--- a/server/internal/daemon/types.go
+++ b/server/internal/daemon/types.go
@@ -87,11 +87,12 @@ type Task struct {
 	TriggerAuthorName        string                 `json:"trigger_author_name,omitempty"`         // display name of the triggering comment author
 	NewCommentCount          int                    `json:"new_comment_count,omitempty"`           // issue-wide comments since this agent's last run (excludes its own and the injected trigger); 0/omitted for old daemons or cold start
 	NewCommentsSince         string                 `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; empty on cold start
+	IssueAttachments         []AttachmentMeta       `json:"issue_attachments,omitempty"`           // attachments linked to the issue; Claude embeds image attachments directly when possible
 	ChatSessionID            string                 `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
 	ChatChannelType          string                 `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Drives the channel-awareness block in the prompt
 	ChatInThread             bool                   `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; selects which read command the prompt tells the agent to start with
 	ChatMessage              string                 `json:"chat_message,omitempty"`                // user message content for chat tasks
-	ChatMessageAttachments   []ChatAttachmentMeta   `json:"chat_message_attachments,omitempty"`    // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
+	ChatMessageAttachments   []AttachmentMeta       `json:"chat_message_attachments,omitempty"`    // attachments linked to the chat message; agent uses these to `multica attachment download <id>`
 	ChatIntro                bool                   `json:"chat_intro,omitempty"`                  // true for the agent's proactive self-introduction chat (no user message); selects the self-introduction prompt in buildChatPrompt
 	AutopilotRunID           string                 `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot run_only tasks
 	AutopilotID              string                 `json:"autopilot_id,omitempty"`                // autopilot that spawned this run
@@ -140,12 +141,11 @@ type Task struct {
 	AuthToken string `json:"auth_token,omitempty"`
 }
 
-// ChatAttachmentMeta is the structured attachment metadata the daemon
-// hands to the agent for chat tasks. We pass id + filename + content_type
-// so the chat prompt can list them explicitly and instruct the agent to
-// run `multica attachment download <id>` instead of guessing from a
-// signed CDN URL (which expires).
-type ChatAttachmentMeta struct {
+// AttachmentMeta is the structured attachment metadata the daemon receives
+// in claim responses. We pass id + filename + content_type so prompts can
+// list attachments explicitly, and Claude can embed image files directly in
+// the initial user message instead of going through the Read tool_result path.
+type AttachmentMeta struct {
 	ID          string `json:"id"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type,omitempty"`

--- a/server/internal/handler/agent.go
+++ b/server/internal/handler/agent.go
@@ -322,11 +322,12 @@ type AgentTaskResponse struct {
 	TriggerAuthorName        string                 `json:"trigger_author_name,omitempty"`         // display name of the triggering comment author
 	NewCommentCount          int                    `json:"new_comment_count,omitempty"`           // trigger-thread comments since last run; excludes injected trigger + own comments; omitempty so old daemons ignore it
 	NewCommentsSince         string                 `json:"new_comments_since,omitempty"`          // RFC3339 anchor (last run's started_at) the count is measured from; omitempty so old daemons ignore it
+	IssueAttachments         []AttachmentMeta       `json:"issue_attachments,omitempty"`           // attachments linked to the issue
 	ChatSessionID            string                 `json:"chat_session_id,omitempty"`             // non-empty for chat tasks
 	ChatChannelType          string                 `json:"chat_channel_type,omitempty"`           // "slack" when the chat session is backed by an IM channel; empty for a web-only chat. Makes the agent channel-aware (read history from the channel, not Multica)
 	ChatInThread             bool                   `json:"chat_in_thread,omitempty"`              // true when the latest @mention was a thread reply; tells the agent to start with `multica chat thread` vs `multica chat history`
 	ChatMessage              string                 `json:"chat_message,omitempty"`                // user message for chat tasks
-	ChatMessageAttachments   []ChatAttachmentMeta   `json:"chat_message_attachments,omitempty"`    // attachments on the user message — agent calls `multica attachment download <id>` per entry
+	ChatMessageAttachments   []AttachmentMeta       `json:"chat_message_attachments,omitempty"`    // attachments on the user message — agent calls `multica attachment download <id>` per entry
 	ChatIntro                bool                   `json:"chat_intro,omitempty"`                  // true for the agent's proactive self-introduction chat (is_agent_intro session, no user message); the daemon builds an intro prompt instead of a reply prompt
 	AutopilotRunID           string                 `json:"autopilot_run_id,omitempty"`            // non-empty for autopilot-spawned tasks
 	AutopilotID              string                 `json:"autopilot_id,omitempty"`                // autopilot that spawned this task
@@ -522,13 +523,13 @@ func attributionsOf(resps []AgentTaskResponse) []*TaskAttribution {
 	return out
 }
 
-// ChatAttachmentMeta is the structured attachment metadata embedded in
-// claim responses for chat tasks. The agent uses these to run
-// `multica attachment download <id>` rather than guessing from the
-// markdown URL (which is signed and 30-min expiring on private CDN).
+// AttachmentMeta is the structured attachment metadata embedded in
+// claim responses. The daemon uses these to embed image attachments directly
+// for Claude or to tell agents which IDs they can download through the CLI
+// rather than guessing from signed markdown URLs.
 // The mirror struct on the daemon side lives in internal/daemon/types.go
 // and uses the same JSON field names.
-type ChatAttachmentMeta struct {
+type AttachmentMeta struct {
 	ID          string `json:"id"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type,omitempty"`

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -1814,6 +1814,20 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 					resp.Repos = repos
 				}
 			}
+
+			if atts, attErr := h.Queries.ListAttachmentsByIssue(r.Context(), db.ListAttachmentsByIssueParams{
+				IssueID:     issue.ID,
+				WorkspaceID: issue.WorkspaceID,
+			}); attErr == nil && len(atts) > 0 {
+				resp.IssueAttachments = make([]AttachmentMeta, len(atts))
+				for j, a := range atts {
+					resp.IssueAttachments[j] = AttachmentMeta{
+						ID:          uuidToString(a.ID),
+						Filename:    a.Filename,
+						ContentType: a.ContentType,
+					}
+				}
+			}
 		}
 
 		// Load every planned input as one chronological, de-duplicated set.
@@ -2151,7 +2165,7 @@ func (h *Handler) buildClaimedTaskResponse(r *http.Request, task *db.AgentTaskQu
 					WorkspaceID:   parseUUID(resp.WorkspaceID),
 				}); attErr == nil && len(atts) > 0 {
 					for _, a := range atts {
-						resp.ChatMessageAttachments = append(resp.ChatMessageAttachments, ChatAttachmentMeta{
+						resp.ChatMessageAttachments = append(resp.ChatMessageAttachments, AttachmentMeta{
 							ID:          uuidToString(a.ID),
 							Filename:    a.Filename,
 							ContentType: a.ContentType,

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -2528,6 +2528,81 @@ func TestClaimTask_ProjectDescriptionInjected(t *testing.T) {
 	}
 }
 
+func TestClaimTask_IncludesIssueAttachments(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	ctx := context.Background()
+
+	var agentID, runtimeID string
+	if err := testPool.QueryRow(ctx,
+		`SELECT id, runtime_id FROM agent WHERE workspace_id = $1 LIMIT 1`,
+		testWorkspaceID,
+	).Scan(&agentID, &runtimeID); err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+
+	var issueID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO issue (
+			workspace_id, title, status, priority, creator_id, creator_type, number, position
+		) VALUES ($1, 'issue with image attachment', 'todo', 'medium', $2, 'member', 88011, 0)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&issueID); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM issue WHERE id = $1`, issueID) })
+
+	var attachmentID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO attachment (
+			workspace_id, issue_id, uploader_type, uploader_id, filename, url, content_type, size_bytes
+		) VALUES ($1, $2, 'member', $3, 'screenshot.png', 'https://static.example.test/screenshot.png', 'image/png', 123)
+		RETURNING id
+	`, testWorkspaceID, issueID, testUserID).Scan(&attachmentID); err != nil {
+		t.Fatalf("create attachment: %v", err)
+	}
+
+	var taskID string
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO agent_task_queue (
+			agent_id, runtime_id, issue_id, status, priority
+		) VALUES ($1, $2, $3, 'queued', 0)
+		RETURNING id
+	`, agentID, runtimeID, issueID).Scan(&taskID); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	t.Cleanup(func() { testPool.Exec(context.Background(), `DELETE FROM agent_task_queue WHERE id = $1`, taskID) })
+
+	w := httptest.NewRecorder()
+	req := newDaemonTokenRequest("POST", "/api/daemon/runtimes/"+runtimeID+"/claim", nil, testWorkspaceID, "test-claim-issue-attachments")
+	req = withURLParam(req, "runtimeId", runtimeID)
+	testHandler.ClaimTaskByRuntime(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ClaimTaskByRuntime: %d %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Task *struct {
+			IssueAttachments []AttachmentMeta `json:"issue_attachments"`
+		} `json:"task"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Task == nil {
+		t.Fatal("expected task in response")
+	}
+	if len(resp.Task.IssueAttachments) != 1 {
+		t.Fatalf("issue_attachments length = %d, want 1", len(resp.Task.IssueAttachments))
+	}
+	got := resp.Task.IssueAttachments[0]
+	if got.ID != attachmentID || got.Filename != "screenshot.png" || got.ContentType != "image/png" {
+		t.Fatalf("unexpected issue attachment metadata: %+v", got)
+	}
+}
+
 // The quick-create path resolves its project from the task context JSONB
 // (not an issue row), so its project_description wiring is a separate branch
 // in the claim handler and needs its own boundary assertion.

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -74,7 +74,16 @@ type ExecOptions struct {
 	// see server/internal/daemon/execenv/openclaw_config.go). Other backends
 	// ignore this field, mirroring ThinkingLevel's renderer-side fall-through
 	// pattern. See issue #3260.
-	OpenclawMode string
+	OpenclawMode  string
+	InitialImages []InputImage // image blocks to include in Claude's initial user message; ignored by text-only backends
+}
+
+// InputImage is an image attachment that a backend can embed directly in the
+// initial user message instead of relying on an agent-side file Read tool.
+type InputImage struct {
+	Filename  string
+	MediaType string
+	Data      []byte
 }
 
 // runContext derives the execution context for an agent subprocess from the

--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -120,7 +121,7 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 	// timeout.
 	writeDone := make(chan error, 1)
 	go func() {
-		err := writeClaudeInput(stdin, prompt)
+		err := writeClaudeInput(stdin, prompt, opts.InitialImages)
 		if err != nil {
 			closeStdin()
 		}
@@ -647,8 +648,8 @@ func buildClaudeArgs(opts ExecOptions, logger *slog.Logger) []string {
 	return args
 }
 
-func writeClaudeInput(w io.Writer, prompt string) error {
-	data, err := buildClaudeInput(prompt)
+func writeClaudeInput(w io.Writer, prompt string, images []InputImage) error {
+	data, err := buildClaudeInput(prompt, images)
 	if err != nil {
 		return err
 	}
@@ -658,17 +659,44 @@ func writeClaudeInput(w io.Writer, prompt string) error {
 	return nil
 }
 
-func buildClaudeInput(prompt string) ([]byte, error) {
+func buildClaudeInput(prompt string, images []InputImage) ([]byte, error) {
+	content := []map[string]any{
+		{
+			"type": "text",
+			"text": prompt,
+		},
+	}
+	for _, image := range images {
+		if len(image.Data) == 0 || image.MediaType == "" {
+			continue
+		}
+		label := "Attached image"
+		if image.Filename != "" {
+			label = fmt.Sprintf("Attached image %q", image.Filename)
+		}
+		if image.MediaType != "" {
+			label += fmt.Sprintf(" (%s)", image.MediaType)
+		}
+		content = append(content,
+			map[string]any{
+				"type": "text",
+				"text": label + ":",
+			},
+			map[string]any{
+				"type": "image",
+				"source": map[string]string{
+					"type":       "base64",
+					"media_type": image.MediaType,
+					"data":       base64.StdEncoding.EncodeToString(image.Data),
+				},
+			},
+		)
+	}
 	payload := map[string]any{
 		"type": "user",
 		"message": map[string]any{
-			"role": "user",
-			"content": []map[string]string{
-				{
-					"type": "text",
-					"text": prompt,
-				},
-			},
+			"role":    "user",
+			"content": content,
 		},
 	}
 	data, err := json.Marshal(payload)

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -538,7 +538,7 @@ func TestBuildClaudeArgsFiltersBlockedCustomArgs(t *testing.T) {
 func TestBuildClaudeInputEncodesUserMessage(t *testing.T) {
 	t.Parallel()
 
-	data, err := buildClaudeInput("say pong")
+	data, err := buildClaudeInput("say pong", nil)
 	if err != nil {
 		t.Fatalf("buildClaudeInput: %v", err)
 	}
@@ -572,6 +572,45 @@ func TestBuildClaudeInputEncodesUserMessage(t *testing.T) {
 	}
 	if block["type"] != "text" || block["text"] != "say pong" {
 		t.Fatalf("unexpected content block: %v", block)
+	}
+}
+
+func TestBuildClaudeInputEncodesInitialImages(t *testing.T) {
+	t.Parallel()
+
+	data, err := buildClaudeInput("describe the attachment", []InputImage{
+		{
+			Filename:  "screenshot.png",
+			MediaType: "image/png",
+			Data:      []byte("png-bytes"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildClaudeInput: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(data), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	message := payload["message"].(map[string]any)
+	content := message["content"].([]any)
+	if len(content) != 3 {
+		t.Fatalf("expected prompt text + image label + image block, got %v", content)
+	}
+
+	label := content[1].(map[string]any)
+	if label["type"] != "text" || !strings.Contains(label["text"].(string), "screenshot.png") {
+		t.Fatalf("unexpected image label block: %v", label)
+	}
+
+	image := content[2].(map[string]any)
+	if image["type"] != "image" {
+		t.Fatalf("expected image block, got %v", image)
+	}
+	source := image["source"].(map[string]any)
+	if source["type"] != "base64" || source["media_type"] != "image/png" || source["data"] != "cG5nLWJ5dGVz" {
+		t.Fatalf("unexpected image source: %v", source)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes Claude-backed daemon tasks not reliably understanding image attachments. The root cause is that Claude was asked to download/read issue images through the CLI/Read tool path, which can degrade into a text-only tool_result flow. This PR puts image attachments into Claude's initial user message as native image content blocks while keeping the existing CLI attachment download path as fallback/context.

## Related Issue

Closes #2400

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/daemon.go`: include issue attachment metadata in daemon task claims.
- `server/internal/daemon/client.go`: add daemon-side attachment metadata/download helper, matching the existing signed-url download behavior.
- `server/internal/daemon/daemon.go`: for Claude runtimes, download eligible image attachments and pass up to 4 images (max 10 MB each) into execution options.
- `server/pkg/agent/claude.go`: encode those images as Claude JSONL initial user-message image blocks.
- Added tests for claim metadata, daemon image hydration, attachment download behavior, and Claude input encoding.

## How to Test

1. `cd server && go test ./pkg/agent ./internal/daemon ./internal/handler -count=1`
2. Create or use an issue with an image attachment and assign it to a Claude runtime.
3. Confirm the daemon claim includes `issue_attachments` and Claude receives native image blocks in the initial message.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Used a systematic debugging path: traced #2400 from issue/task claims through daemon prompt construction and Claude JSONL input, identified the local-path/Read-tool image path as the failing boundary, then added a minimal native image-block path for Claude with focused Go tests.

## Screenshots (optional)

N/A - daemon/backend change only.
