### PR TITLE
fix(selfhost): randomize postgres password during setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,16 +57,12 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 	@if [ ! -f .env ]; then \
 		echo "==> Creating .env from .env.example..."; \
 		cp .env.example .env; \
-		JWT=$$(openssl rand -hex 32); \
-		if [ "$$(uname)" = "Darwin" ]; then \
-			sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
-		else \
-			sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
-		fi; \
-		echo "==> Generated random JWT_SECRET"; \
+		bash scripts/selfhost-env.sh .env; \
+		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
 	@echo "==> Pulling official Multica images..."
-	@if ! docker compose -f docker-compose.selfhost.yml pull; then \
+	@set -a; . ./.env; set +a; \
+	if ! docker compose -f docker-compose.selfhost.yml pull; then \
 		echo ""; \
 		echo "Official images for tag '$${MULTICA_IMAGE_TAG:-latest}' are not published yet."; \
 		echo "If this is before the first GHCR release, build from the current checkout:"; \
@@ -74,7 +70,7 @@ selfhost: ## Create .env if needed, then pull and start the official self-hosted
 		exit 1; \
 	fi
 	@echo "==> Starting Multica via Docker Compose..."
-	docker compose -f docker-compose.selfhost.yml up -d
+	set -a; . ./.env; set +a; docker compose -f docker-compose.selfhost.yml up -d
 	@echo "==> Waiting for backend to be ready..."
 	@for i in $$(seq 1 30); do \
 		if curl -sf http://localhost:$${PORT:-8080}/health > /dev/null 2>&1; then \
@@ -107,16 +103,11 @@ selfhost-build: ## Build backend/web from the current checkout and start the sel
 	@if [ ! -f .env ]; then \
 		echo "==> Creating .env from .env.example..."; \
 		cp .env.example .env; \
-		JWT=$$(openssl rand -hex 32); \
-		if [ "$$(uname)" = "Darwin" ]; then \
-			sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
-		else \
-			sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$$JWT/" .env; \
-		fi; \
-		echo "==> Generated random JWT_SECRET"; \
+		bash scripts/selfhost-env.sh .env; \
+		echo "==> Generated random JWT_SECRET and POSTGRES_PASSWORD"; \
 	fi
 	@echo "==> Building Multica from the current checkout..."
-	docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
+	set -a; . ./.env; set +a; docker compose -f docker-compose.selfhost.yml -f docker-compose.selfhost.build.yml up -d --build
 	@echo "==> Waiting for backend to be ready..."
 	@for i in $$(seq 1 30); do \
 		if curl -sf http://localhost:$${PORT:-8080}/health > /dev/null 2>&1; then \

--- a/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.zh.mdx
@@ -51,7 +51,7 @@ cd multica
 make selfhost
 ```
 
-`make selfhost` automatically creates `.env`, generates a random `JWT_SECRET`, and starts all services via Docker Compose.
+`make selfhost` automatically creates `.env`, generates random `JWT_SECRET` and `POSTGRES_PASSWORD` values, and starts all services via Docker Compose.
 
 By default it pulls the latest stable release images from GHCR. To build the backend/web from your current checkout instead, run `make selfhost-build`.
 If the selected GHCR tag has not been published yet, `make selfhost` now tells you to fall back to `make selfhost-build`.
@@ -63,7 +63,7 @@ Once ready:
 - **Backend API:** http://localhost:8080
 
 <Callout>
-If you prefer running the Docker Compose steps manually: `cp .env.example .env`, edit `JWT_SECRET`, then `docker compose -f docker-compose.selfhost.yml pull && docker compose -f docker-compose.selfhost.yml up -d`.
+If you prefer running the Docker Compose steps manually: `cp .env.example .env`, edit `JWT_SECRET`, `POSTGRES_PASSWORD`, and the password segment in `DATABASE_URL`, then `docker compose -f docker-compose.selfhost.yml pull && docker compose -f docker-compose.selfhost.yml up -d`.
 </Callout>
 
 ### Step 2 — Log In
@@ -189,7 +189,8 @@ All configuration is done via environment variables. Copy `.env.example` as a st
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | `postgres://multica:multica@localhost:5432/multica?sslmode=disable` |
+| `DATABASE_URL` | PostgreSQL connection string. Keep its password segment in sync with `POSTGRES_PASSWORD`. | `postgres://multica:<password>@localhost:5432/multica?sslmode=disable` |
+| `POSTGRES_PASSWORD` | **Must change from default** for manual Docker Compose installs. `make selfhost` randomizes this for you. | `openssl rand -hex 24` |
 | `JWT_SECRET` | **Must change from default.** Secret key for signing JWT tokens. Use a long random string. | `openssl rand -hex 32` |
 | `FRONTEND_ORIGIN` | URL where the frontend is served (used for CORS) | `https://app.example.com` |
 

--- a/apps/docs/content/docs/self-host-quickstart.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.mdx
@@ -30,7 +30,7 @@ make selfhost
 
 `make selfhost` will:
 
-1. Generate a `.env` from `.env.example` if missing, with a **random JWT_SECRET**
+1. Generate a `.env` from `.env.example` if missing, with random `JWT_SECRET` and `POSTGRES_PASSWORD`
 2. Pull the official Docker images (PostgreSQL, Multica backend, Multica frontend)
 3. Bring up every service using `docker-compose.selfhost.yml`
 4. Wait until the backend's `/health` endpoint is ready

--- a/apps/docs/content/docs/self-host-quickstart.zh.mdx
+++ b/apps/docs/content/docs/self-host-quickstart.zh.mdx
@@ -30,7 +30,7 @@ make selfhost
 
 `make selfhost` 会：
 
-1. 如果没有 `.env` 文件，从 `.env.example` 自动生成一份并**生成随机 JWT_SECRET**
+1. 如果没有 `.env` 文件，从 `.env.example` 自动生成一份，并生成随机 `JWT_SECRET` 和 `POSTGRES_PASSWORD`
 2. 拉取官方 Docker 镜像（PostgreSQL、Multica backend、Multica frontend）
 3. 用 `docker-compose.selfhost.yml` 启动全部服务
 4. 等后端 `/health` 端点准备就绪

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -5,12 +5,12 @@
 # TLS and forwards to 127.0.0.1:8080 (backend) and 127.0.0.1:3000 (frontend).
 # Do NOT change these bindings to 0.0.0.0 — Docker bypasses host firewalls
 # (UFW/iptables) by default, so the raw ports would be exposed to the internet
-# with the default JWT_SECRET and Postgres credentials. See:
+# with default secrets if you copied .env.example without editing it. See:
 #   apps/docs/content/docs/self-host-quickstart.mdx
 #
 # Usage:
 #   cp .env.example .env
-#   # Edit .env — change JWT_SECRET at minimum
+#   # Edit .env — change JWT_SECRET, POSTGRES_PASSWORD, and DATABASE_URL
 #   docker compose -f docker-compose.selfhost.yml up -d
 #
 # Frontend: http://localhost:${FRONTEND_PORT:-3000}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -70,6 +70,38 @@ function Get-SelfHostFrontendPort {
     return Get-EnvFileValue -Path (Join-Path $InstallDir ".env") -Name "FRONTEND_PORT" -Default "3000"
 }
 
+function New-HexSecret {
+    param([int]$Bytes)
+
+    $buffer = New-Object byte[] $Bytes
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($buffer)
+    return -join ($buffer | ForEach-Object { $_.ToString("x2") })
+}
+
+function Set-GeneratedSelfHostEnv {
+    param([string]$Path)
+
+    $jwt = New-HexSecret 32
+    $postgresPassword = New-HexSecret 24
+    $content = Get-Content $Path -Raw
+    $content = [regex]::Replace(
+        $content,
+        '(?m)^JWT_SECRET=.*$',
+        "JWT_SECRET=$jwt"
+    )
+    $content = [regex]::Replace(
+        $content,
+        '(?m)^POSTGRES_PASSWORD=.*$',
+        "POSTGRES_PASSWORD=$postgresPassword"
+    )
+    $content = [regex]::Replace(
+        $content,
+        '(?m)^(DATABASE_URL=postgres(?:ql)?://[^:/@]+:)[^@]*(@.*)$',
+        { param($match) "$($match.Groups[1].Value)$postgresPassword$($match.Groups[2].Value)" }
+    )
+    Set-Content -Path $Path -Value $content -NoNewline
+}
+
 function Get-LatestVersion {
     try {
         $release = Invoke-RestMethod -Uri "https://api.github.com/repos/multica-ai/multica/releases/latest" -ErrorAction Stop
@@ -411,11 +443,10 @@ function Install-Server {
     Write-Ok "Repository ready at $InstallDir ($serverRef)"
 
     if (-not (Test-Path ".env")) {
-        Write-Info "Creating .env with random JWT_SECRET..."
+        Write-Info "Creating .env with random secrets..."
         Copy-Item ".env.example" ".env"
-        $jwt = -join ((1..32) | ForEach-Object { "{0:x2}" -f (Get-Random -Maximum 256) })
-        (Get-Content ".env") -replace '^JWT_SECRET=.*', "JWT_SECRET=$jwt" | Set-Content ".env"
-        Write-Ok "Generated .env with random JWT_SECRET"
+        Set-GeneratedSelfHostEnv ".env"
+        Write-Ok "Generated .env with random JWT_SECRET and POSTGRES_PASSWORD"
     } else {
         Write-Ok "Using existing .env"
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,6 +81,56 @@ selfhost_frontend_port() {
   env_file_value "${1:-.env}" "FRONTEND_PORT" "3000"
 }
 
+sed_in_place() {
+  local expr="$1"
+  local file="$2"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    sed -i '' -E "$expr" "$file"
+  else
+    sed -i -E "$expr" "$file"
+  fi
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+set_env_value() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local escaped
+  escaped="$(escape_sed_replacement "$value")"
+  sed_in_place "s|^${key}=.*|${key}=${escaped}|" "$file"
+}
+
+replace_database_url_password() {
+  local file="$1"
+  local password="$2"
+  local escaped
+  escaped="$(escape_sed_replacement "$password")"
+  sed_in_place "s|^(DATABASE_URL=postgres(ql)?://[^:/@]+:)[^@]*(@.*)$|\\1${escaped}\\3|" "$file"
+}
+
+randomize_generated_env() {
+  local file="$1"
+  local jwt
+  local postgres_password
+  jwt="$(openssl rand -hex 32)"
+  postgres_password="$(openssl rand -hex 24)"
+  set_env_value "$file" "JWT_SECRET" "$jwt"
+  set_env_value "$file" "POSTGRES_PASSWORD" "$postgres_password"
+  replace_database_url_password "$file" "$postgres_password"
+}
+
+load_env_file() {
+  local file="$1"
+  set -a
+  # shellcheck disable=SC1090
+  . "$file"
+  set +a
+}
+
 detect_os() {
   case "$(uname -s)" in
     Darwin) OS="darwin" ;;
@@ -357,21 +407,16 @@ setup_server() {
 
   # Generate .env if needed
   if [ ! -f .env ]; then
-    info "Creating .env with random JWT_SECRET..."
+    info "Creating .env with random secrets..."
     cp .env.example .env
-    local jwt
-    jwt=$(openssl rand -hex 32)
-    if [ "$(uname -s)" = "Darwin" ]; then
-      sed -i '' "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
-    else
-      sed -i "s/^JWT_SECRET=.*/JWT_SECRET=$jwt/" .env
-    fi
-    ok "Generated .env with random JWT_SECRET"
+    randomize_generated_env .env
+    ok "Generated .env with random JWT_SECRET and POSTGRES_PASSWORD"
   else
     ok "Using existing .env"
   fi
 
   # Start Docker Compose
+  load_env_file .env
   info "Pulling official Multica images..."
   pull_official_selfhost_images
   info "Starting Multica services (this may take a few minutes on first run)..."

--- a/scripts/selfhost-env.sh
+++ b/scripts/selfhost-env.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+env_file="${1:-.env}"
+jwt_secret="${2:-}"
+postgres_password="${3:-}"
+
+random_hex() {
+  local bytes="$1"
+  openssl rand -hex "$bytes"
+}
+
+sed_in_place() {
+  local expr="$1"
+  local file="$2"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    sed -i '' -E "$expr" "$file"
+  else
+    sed -i -E "$expr" "$file"
+  fi
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+set_env_value() {
+  local key="$1"
+  local value="$2"
+  local escaped
+  escaped="$(escape_sed_replacement "$value")"
+  sed_in_place "s|^${key}=.*|${key}=${escaped}|" "$env_file"
+}
+
+replace_database_url_password() {
+  local password="$1"
+  local escaped
+  escaped="$(escape_sed_replacement "$password")"
+  sed_in_place "s|^(DATABASE_URL=postgres(ql)?://[^:/@]+:)[^@]*(@.*)$|\\1${escaped}\\3|" "$env_file"
+}
+
+if [ ! -f "$env_file" ]; then
+  echo "env file not found: $env_file" >&2
+  exit 1
+fi
+
+if [ -z "$jwt_secret" ]; then
+  jwt_secret="$(random_hex 32)"
+fi
+if [ -z "$postgres_password" ]; then
+  postgres_password="$(random_hex 24)"
+fi
+
+set_env_value "JWT_SECRET" "$jwt_secret"
+set_env_value "POSTGRES_PASSWORD" "$postgres_password"
+replace_database_url_password "$postgres_password"

--- a/scripts/selfhost-env.test.sh
+++ b/scripts/selfhost-env.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/selfhost-env.sh"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+assert_line() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fxq "$expected" "$file"; then
+    echo "expected line not found: $expected" >&2
+    echo "--- $file ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+example_env="$tmp_dir/example.env"
+cp "$ROOT_DIR/.env.example" "$example_env"
+
+jwt="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+postgres_password="abcdef0123456789abcdef0123456789abcdef0123456789"
+
+bash "$SCRIPT" "$example_env" "$jwt" "$postgres_password"
+
+assert_line "$example_env" "JWT_SECRET=$jwt"
+assert_line "$example_env" "POSTGRES_PASSWORD=$postgres_password"
+assert_line "$example_env" "DATABASE_URL=postgres://multica:$postgres_password@localhost:5432/multica?sslmode=disable"
+
+custom_env="$tmp_dir/custom.env"
+cat > "$custom_env" <<'EOF'
+POSTGRES_USER=app_user
+POSTGRES_PASSWORD=old-password
+POSTGRES_DB=prod_db
+DATABASE_URL=postgresql://app_user:old-password@db.internal:6543/prod_db?sslmode=require
+JWT_SECRET=change-me
+EOF
+
+bash "$SCRIPT" "$custom_env" "$jwt" "$postgres_password"
+
+assert_line "$custom_env" "POSTGRES_PASSWORD=$postgres_password"
+assert_line "$custom_env" "DATABASE_URL=postgresql://app_user:$postgres_password@db.internal:6543/prod_db?sslmode=require"


### PR DESCRIPTION
## What does this PR do?

Randomizes self-hosted PostgreSQL credentials whenever Multica generates a fresh `.env` from `.env.example`, and keeps `DATABASE_URL` in sync with the generated password.

Thinking path:
- The reported failure is in first-run self-host setup: `.env.example` uses `POSTGRES_PASSWORD=multica`, while existing setup only randomized `JWT_SECRET`.
- `docker-compose.selfhost.yml` derives backend `DATABASE_URL` from `POSTGRES_PASSWORD`, but `make selfhost` also exported Makefile defaults. That meant a generated `.env` could still be overridden by `POSTGRES_PASSWORD=multica` from the make environment.
- The fix centralizes Bash `.env` secret generation, mirrors the behavior in the PowerShell installer, and reloads `.env` before Docker Compose so the generated password is the value Compose sees.

## Related Issue

Closes #2757

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added `scripts/selfhost-env.sh` to generate random `JWT_SECRET` and `POSTGRES_PASSWORD`, then update the password segment in `DATABASE_URL`.
- Added `scripts/selfhost-env.test.sh` covering `.env.example` and a custom `postgresql://...` URL shape.
- Updated `scripts/install.sh`, `scripts/install.ps1`, `make selfhost`, and `make selfhost-build` to generate both secrets for fresh `.env` files.
- Reloaded `.env` before Docker Compose in Makefile self-host targets so generated values override Makefile defaults.
- Updated self-host docs and compose comments to mention both secrets.

## How to Test

1. `bash scripts/selfhost-env.test.sh`
2. `bash -n scripts/install.sh scripts/selfhost-env.sh scripts/selfhost-env.test.sh`
3. `tmp=$(mktemp -d); cp .env.example "$tmp/.env"; bash scripts/selfhost-env.sh "$tmp/.env"; grep -E '^(JWT_SECRET|POSTGRES_PASSWORD|DATABASE_URL)=' "$tmp/.env"; rm -rf "$tmp"`
4. `pnpm --filter @multica/docs typecheck`
5. `git diff --check`

Note: I could not run a PowerShell parser locally because `pwsh` is not installed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`), **starter-content** (`packages/views/onboarding/utils/starter-content-content-*.ts`), and **relevant docs** (`apps/docs/content/docs/`)
- [x] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Investigated open installer/self-hosting bugs, reproduced the missing Postgres password randomization with a failing shell test, implemented the minimal secret-generation path, and verified shell/docs checks locally.

## Screenshots (optional)

N/A
