### PR TITLE
fix(autopilot): attribute agent-created autopilots

### DIFF
--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -466,6 +466,7 @@ func (h *Handler) CreateAutopilot(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	creatorType, creatorID := h.resolveActor(r, userID, workspaceID)
 
 	assigneeUUID, ok := parseUUIDOrBadRequest(w, req.AssigneeID, "assignee_id")
 	if !ok {
@@ -513,8 +514,8 @@ func (h *Handler) CreateAutopilot(w http.ResponseWriter, r *http.Request) {
 		AssigneeID:         assigneeUUID,
 		Status:             "active",
 		ExecutionMode:      req.ExecutionMode,
-		CreatedByType:      "member",
-		CreatedByID:        parseUUID(userID),
+		CreatedByType:      creatorType,
+		CreatedByID:        parseUUID(creatorID),
 		Description:        ptrToText(req.Description),
 		IssueTitleTemplate: ptrToText(req.IssueTitleTemplate),
 		ProjectID:          projectID,
@@ -544,7 +545,7 @@ func (h *Handler) CreateAutopilot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := autopilotToResponse(autopilot, subs)
-	h.publish(protocol.EventAutopilotCreated, workspaceID, "member", userID, map[string]any{"autopilot": resp})
+	h.publish(protocol.EventAutopilotCreated, workspaceID, creatorType, creatorID, map[string]any{"autopilot": resp})
 	obsmetrics.RecordEvent(h.Analytics, h.Metrics, analytics.AutopilotCreated(
 		userID,
 		workspaceID,

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1418,6 +1418,53 @@ func TestUpdateAutopilotCanSetAndClearProject(t *testing.T) {
 	}
 }
 
+func TestCreateAutopilotAttributesTrustedAgentActor(t *testing.T) {
+	ctx := context.Background()
+	agentID := createHandlerTestAgent(t, fmt.Sprintf("Autopilot Actor Agent %d", time.Now().UnixNano()), nil)
+	taskID := createHandlerTestTaskForAgent(t, agentID)
+	var autopilotID string
+	t.Cleanup(func() {
+		if autopilotID != "" {
+			testPool.Exec(ctx, `DELETE FROM autopilot WHERE id = $1`, autopilotID)
+		}
+	})
+
+	req := newRequest("POST", "/api/autopilots?workspace_id="+testWorkspaceID, map[string]any{
+		"title":          "Agent-authored autopilot",
+		"assignee_id":    agentID,
+		"execution_mode": "run_only",
+	})
+	req.Header.Set("X-Agent-ID", agentID)
+	req.Header.Set("X-Task-ID", taskID)
+	w := httptest.NewRecorder()
+
+	testHandler.CreateAutopilot(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("CreateAutopilot: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var autopilot AutopilotResponse
+	if err := json.NewDecoder(w.Body).Decode(&autopilot); err != nil {
+		t.Fatalf("decode autopilot: %v", err)
+	}
+	autopilotID = autopilot.ID
+	if autopilot.CreatedByType != "agent" || autopilot.CreatedByID != agentID {
+		t.Fatalf("autopilot created_by = %s/%s, want agent/%s", autopilot.CreatedByType, autopilot.CreatedByID, agentID)
+	}
+
+	var creatorType, creatorID string
+	if err := testPool.QueryRow(ctx, `
+		SELECT created_by_type, created_by_id
+		FROM autopilot
+		WHERE id = $1
+	`, autopilotID).Scan(&creatorType, &creatorID); err != nil {
+		t.Fatalf("load autopilot creator: %v", err)
+	}
+	if creatorType != "agent" || creatorID != agentID {
+		t.Fatalf("stored autopilot created_by = %s/%s, want agent/%s", creatorType, creatorID, agentID)
+	}
+}
+
 // TestCreateIssueRejectsNonexistentMemberAssignee covers the bug where any
 // well-formed UUID was accepted as assignee_id without checking workspace
 // membership.


### PR DESCRIPTION
## What does this PR do?

Fixes autopilot creator attribution for daemon task flows where an agent runs `multica autopilot create`. The API now reuses the existing trusted actor resolution (`X-Agent-ID` + `X-Task-ID`) instead of always stamping the authenticated daemon token user as the creator.

Human-created autopilots still record `created_by_type=member`; trusted agent-created autopilots now record `created_by_type=agent` and publish the matching `autopilot:created` actor.

## Related Issue

Closes #2513

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/autopilot.go`: use `resolveActor` in `CreateAutopilot` and publish the resolved actor for `autopilot:created`.
- `server/internal/handler/handler_test.go`: add a regression test for trusted agent headers creating an autopilot.

## How to Test

1. `cd server && go test ./internal/cli -count=1`
2. `cd server && go test ./cmd/multica -run 'TestAutopilot|TestResolve|TestInject|TestCLI|TestAPI|TestCompat' -count=1`\n3. `cd server && go test ./internal/handler -run TestCreateAutopilotAttributesTrustedAgentActor -count=1 -v`\n\nLocal note: command 3 compiled, but this machine has no local Postgres or Docker daemon, so `handler` TestMain skipped the DB-backed assertion with `database not reachable`. CI should execute it against the configured test DB.\n\n## Checklist\n\n- [x] I have included a thinking path that traces from project context to this change\n- [x] I have run tests locally and they pass where local services are available\n- [x] I have added or updated tests where applicable\n- [x] If this change affects the UI, I have included before/after screenshots (not applicable)\n- [x] I have updated relevant documentation to reflect my changes (not applicable)\n- [x] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy, starter-content, and relevant docs (not applicable)\n- [x] If this PR touches Chinese product copy, I checked it against the conventions (not applicable)\n- [x] I have considered and documented any risks above\n- [x] I will address all reviewer comments before requesting merge\n\n## AI Disclosure\n\n**AI tool used:** Codex\n\n**Prompt / approach:** Investigated #2513 end-to-end from daemon CLI headers through handler attribution, confirmed existing issue/comment flows already use `resolveActor`, then applied the same actor resolution to autopilot creation with a focused regression test.\n\n## Screenshots (optional)\n\nN/A\n