### PR TITLE
fix(editor): fill modal viewport in attachment preview (MUL-2431)

### DIFF
--- a/packages/views/editor/attachment-preview-modal.tsx
+++ b/packages/views/editor/attachment-preview-modal.tsx
@@ -352,7 +352,7 @@ function PreviewContent({
           <img
             src={state.mediaUrl}
             alt={state.filename}
-            className="max-h-full max-w-full rounded-lg object-contain"
+            className="h-full w-full rounded-lg object-contain"
           />
         </div>
       );
@@ -370,7 +370,7 @@ function PreviewContent({
           <video
             src={state.mediaUrl}
             controls
-            className="max-h-full max-w-full"
+            className="h-full w-full object-contain"
           />
         </div>
       );


### PR DESCRIPTION
## Summary

Closes [MUL-2431](https://multica.ai).

In the attachment preview modal, image and video previews used `max-h-full max-w-full`, which let small assets render at their natural size and leave the modal mostly empty (reporter screenshot showed a tiny image floating in a large black backdrop). Switch to `h-full w-full` so the preview fills the modal viewport; `object-contain` preserves aspect ratio without distortion.

## Changes

`packages/views/editor/attachment-preview-modal.tsx`
- L355 (image branch): `max-h-full max-w-full rounded-lg object-contain` → `h-full w-full rounded-lg object-contain`
- L373 (video branch): `max-h-full max-w-full` → `h-full w-full object-contain`

Modal outer dimensions (`max-w-6xl × 90vh`) unchanged. No JS / no new state / no icon or i18n changes. Pdf, audio, markdown, html, and text branches untouched.

## Test plan

- [x] `pnpm --filter @multica/views typecheck` — passes
- [x] `pnpm --filter @multica/views lint` — 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @multica/views test` — 683 / 683 passing
- [ ] Manual: open the attachment preview modal on a small image and on a video; both should fill the viewport with letterboxing where needed, no upscaling distortion