### PR TITLE
feat(autopilots): support header-auth webhooks

### DIFF
--- a/packages/core/types/autopilot.ts
+++ b/packages/core/types/autopilot.ts
@@ -50,6 +50,14 @@ export interface AutopilotTrigger {
   // server-side. Clients fall back to composing from getBaseUrl/origin +
   // webhook_path when this is missing.
   webhook_url?: string | null;
+  // Non-secret URL/path variant keyed by trigger ID. Send the secret in
+  // Authorization: Bearer, X-Multica-Webhook-Secret, or a valid HMAC
+  // signature instead of embedding it in the URL path.
+  webhook_header_path?: string | null;
+  webhook_header_url?: string | null;
+  provider?: string | null;
+  has_signing_secret?: boolean;
+  signing_secret_hint?: string | null;
   label: string | null;
   last_fired_at: string | null;
   created_at: string;

--- a/server/internal/handler/autopilot.go
+++ b/server/internal/handler/autopilot.go
@@ -56,6 +56,14 @@ type AutopilotTriggerResponse struct {
 	// configured; clients then build the URL themselves from webhook_path
 	// plus their API base / current origin.
 	WebhookURL *string `json:"webhook_url"`
+	// WebhookHeaderPath is a non-secret ingress path using the trigger ID
+	// instead of the bearer token. Callers authenticate it with
+	// Authorization: Bearer <webhook_token>, X-Multica-Webhook-Secret, or a
+	// valid HMAC signature. Nil for non-webhook triggers.
+	WebhookHeaderPath *string `json:"webhook_header_path"`
+	// WebhookHeaderURL is the absolute form of WebhookHeaderPath when
+	// MULTICA_PUBLIC_URL is configured.
+	WebhookHeaderURL *string `json:"webhook_header_url"`
 	// Provider names the per-endpoint signing/dedupe convention. For now:
 	// "generic" (bearer URL only, Idempotency-Key for dedupe) or "github"
 	// (X-Hub-Signature-256 + X-GitHub-Delivery). Omitted for non-webhook
@@ -129,9 +137,13 @@ func (h *Handler) triggerToResponse(t db.AutopilotTrigger) AutopilotTriggerRespo
 	if t.Kind == "webhook" && t.WebhookToken.Valid && t.WebhookToken.String != "" {
 		path := webhookPathForToken(t.WebhookToken.String)
 		resp.WebhookPath = &path
+		headerPath := webhookHeaderPathForTriggerID(uuidToString(t.ID))
+		resp.WebhookHeaderPath = &headerPath
 		if h.cfg.PublicURL != "" {
 			full := h.cfg.PublicURL + path
 			resp.WebhookURL = &full
+			headerFull := h.cfg.PublicURL + headerPath
+			resp.WebhookHeaderURL = &headerFull
 		}
 		provider := t.Provider
 		if provider == "" {
@@ -163,6 +175,10 @@ func signingSecretHint(secret string) string {
 // expected URLs without instantiating a Handler can call it.
 func webhookPathForToken(token string) string {
 	return "/api/webhooks/autopilots/" + token
+}
+
+func webhookHeaderPathForTriggerID(triggerID string) string {
+	return "/api/webhooks/autopilots/" + triggerID
 }
 
 func runToResponse(r db.AutopilotRun) AutopilotRunResponse {

--- a/server/internal/handler/autopilot_webhook.go
+++ b/server/internal/handler/autopilot_webhook.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/multica-ai/multica/server/internal/middleware"
+	"github.com/multica-ai/multica/server/internal/util"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
 )
 
@@ -35,6 +36,11 @@ const maxWebhookBodyBytes = 256 * 1024
 // URL-safe base64 (no padding) is 43 chars, so a full token is "awt_" + 43 = 47
 // chars. URL-safe base64 keeps the token URL-friendly without escaping.
 const webhookTokenPrefix = "awt_"
+
+// Multica's timestamped HMAC scheme accepts five minutes of clock skew.
+// That is wide enough for common self-host VM drift while still preventing
+// captured requests from being replayed long after the original send.
+const webhookSignatureMaxSkew = 5 * time.Minute
 
 // generateWebhookToken returns a cryptographically random bearer token used as
 // the public webhook URL secret. Format: "awt_" + URL-safe base64(32 bytes,
@@ -244,6 +250,12 @@ func verifyWebhookSignatureForProvider(provider, secret string, headers http.Hea
 	if secret == "" {
 		return sigStatusNotRequired
 	}
+	if verifyMulticaSignature(secret, headers, rawBody, time.Now().UTC()) {
+		return sigStatusValid
+	}
+	if headers.Get("X-Multica-Timestamp") != "" || headers.Get("X-Multica-Signature") != "" {
+		return sigStatusInvalid
+	}
 	sig := headers.Get("X-Hub-Signature-256")
 	if sig == "" {
 		return sigStatusMissing
@@ -260,16 +272,53 @@ func verifyWebhookSignatureForProvider(provider, secret string, headers http.Hea
 // comparison is constant-time so partial-prefix attacks cannot leak timing.
 func verifyHubSignature(secret, header string, body []byte) bool {
 	const prefix = "sha256="
-	if !strings.HasPrefix(header, prefix) {
-		return false
-	}
-	want, err := hex.DecodeString(strings.TrimPrefix(header, prefix))
+	want, err := decodeSHA256Signature(header, prefix)
 	if err != nil {
 		return false
 	}
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write(body)
 	return hmac.Equal(mac.Sum(nil), want)
+}
+
+// verifyMulticaSignature implements Multica's replay-resistant HMAC scheme:
+//
+//	X-Multica-Timestamp: <RFC3339 timestamp>
+//	X-Multica-Signature: sha256=<hex(hmac(timestamp + "." + body, secret))>
+//
+// The timestamp is part of the MAC input and must be close to the server clock.
+func verifyMulticaSignature(secret string, headers http.Header, body []byte, now time.Time) bool {
+	timestamp := strings.TrimSpace(headers.Get("X-Multica-Timestamp"))
+	signature := strings.TrimSpace(headers.Get("X-Multica-Signature"))
+	if secret == "" || timestamp == "" || signature == "" {
+		return false
+	}
+	sentAt, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		sentAt, err = time.Parse(time.RFC3339Nano, timestamp)
+		if err != nil {
+			return false
+		}
+	}
+	if sentAt.Before(now.Add(-webhookSignatureMaxSkew)) || sentAt.After(now.Add(webhookSignatureMaxSkew)) {
+		return false
+	}
+	want, err := decodeSHA256Signature(signature, "sha256=")
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	return hmac.Equal(mac.Sum(nil), want)
+}
+
+func decodeSHA256Signature(header, prefix string) ([]byte, error) {
+	if !strings.HasPrefix(header, prefix) {
+		return nil, fmt.Errorf("missing signature prefix")
+	}
+	return hex.DecodeString(strings.TrimPrefix(header, prefix))
 }
 
 // selectedHeadersJSON returns the small, debugging-friendly subset of request
@@ -292,11 +341,103 @@ func selectedHeadersJSON(headers http.Header) []byte {
 	if v := headers.Get("X-Hub-Signature-256"); v != "" {
 		out["x-hub-signature-256-present"] = true
 	}
+	if v := headers.Get("X-Multica-Timestamp"); v != "" {
+		out["x-multica-timestamp"] = v
+	}
+	if v := headers.Get("X-Multica-Signature"); v != "" {
+		out["x-multica-signature-present"] = true
+	}
+	if v := headers.Get("Authorization"); v != "" {
+		out["authorization-present"] = true
+	}
+	if v := headers.Get("X-Multica-Webhook-Secret"); v != "" {
+		out["x-multica-webhook-secret-present"] = true
+	}
 	b, err := json.Marshal(out)
 	if err != nil {
 		return []byte("{}")
 	}
 	return b
+}
+
+type webhookCredentialMode string
+
+const (
+	webhookCredentialPathToken webhookCredentialMode = "path_token"
+	webhookCredentialTriggerID webhookCredentialMode = "trigger_id"
+)
+
+type webhookTriggerLookupResult struct {
+	Trigger              db.AutopilotTrigger
+	CredentialMode       webhookCredentialMode
+	AutopilotWorkspaceID pgtype.UUID
+}
+
+func (h *Handler) lookupWebhookTriggerByCredential(r *http.Request, credential string) (webhookTriggerLookupResult, error) {
+	if strings.HasPrefix(credential, webhookTokenPrefix) {
+		row, err := h.Queries.GetWebhookTriggerByToken(r.Context(), pgtype.Text{String: credential, Valid: true})
+		if err != nil {
+			return webhookTriggerLookupResult{CredentialMode: webhookCredentialPathToken}, err
+		}
+		return webhookTriggerLookupResult{
+			Trigger:              tokenLookupRowToTrigger(row),
+			CredentialMode:       webhookCredentialPathToken,
+			AutopilotWorkspaceID: row.AutopilotWorkspaceID,
+		}, nil
+	}
+
+	triggerID, err := util.ParseUUID(credential)
+	if err != nil {
+		return webhookTriggerLookupResult{CredentialMode: webhookCredentialTriggerID}, pgx.ErrNoRows
+	}
+	trigger, err := h.Queries.GetAutopilotTrigger(r.Context(), triggerID)
+	if err != nil {
+		return webhookTriggerLookupResult{CredentialMode: webhookCredentialTriggerID}, err
+	}
+	if trigger.Kind != "webhook" {
+		return webhookTriggerLookupResult{CredentialMode: webhookCredentialTriggerID}, pgx.ErrNoRows
+	}
+	return webhookTriggerLookupResult{Trigger: trigger, CredentialMode: webhookCredentialTriggerID}, nil
+}
+
+func tokenLookupRowToTrigger(row db.GetWebhookTriggerByTokenRow) db.AutopilotTrigger {
+	return db.AutopilotTrigger{
+		ID:             row.ID,
+		AutopilotID:    row.AutopilotID,
+		Kind:           row.Kind,
+		Enabled:        row.Enabled,
+		CronExpression: row.CronExpression,
+		Timezone:       row.Timezone,
+		NextRunAt:      row.NextRunAt,
+		WebhookToken:   row.WebhookToken,
+		Label:          row.Label,
+		LastFiredAt:    row.LastFiredAt,
+		CreatedAt:      row.CreatedAt,
+		UpdatedAt:      row.UpdatedAt,
+		Provider:       row.Provider,
+		SigningSecret:  row.SigningSecret,
+	}
+}
+
+func verifyStaticWebhookHeaderSecret(trigger db.AutopilotTrigger, headers http.Header) bool {
+	if !trigger.WebhookToken.Valid || trigger.WebhookToken.String == "" {
+		return false
+	}
+	provided := webhookHeaderSecret(headers)
+	if provided == "" {
+		return false
+	}
+	return hmac.Equal([]byte(provided), []byte(trigger.WebhookToken.String))
+}
+
+func webhookHeaderSecret(headers http.Header) string {
+	if v := strings.TrimSpace(headers.Get("Authorization")); v != "" {
+		parts := strings.Fields(v)
+		if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
+			return parts[1]
+		}
+	}
+	return strings.TrimSpace(headers.Get("X-Multica-Webhook-Secret"))
 }
 
 // ── Public ingress ──────────────────────────────────────────────────────────
@@ -340,8 +481,8 @@ func selectedHeadersJSON(headers http.Header) []byte {
 //   - 429 {"error":"rate limit exceeded"}                          — over per-IP/token budget
 //   - 500 {"error":"..."}                                          — internal failure
 func (h *Handler) HandleAutopilotWebhook(w http.ResponseWriter, r *http.Request) {
-	token := chi.URLParam(r, "token")
-	if token == "" {
+	credential := chi.URLParam(r, "token")
+	if credential == "" {
 		writeError(w, http.StatusNotFound, "webhook not found")
 		return
 	}
@@ -362,7 +503,7 @@ func (h *Handler) HandleAutopilotWebhook(w http.ResponseWriter, r *http.Request)
 	//    to 404 means a transient DB blip silently drops real deliveries
 	//    (providers like GitHub don't retry on 404). For no-row we still
 	//    return a generic message so we don't leak which tokens existed.
-	trigRow, err := h.Queries.GetWebhookTriggerByToken(r.Context(), pgtype.Text{String: token, Valid: true})
+	lookup, err := h.lookupWebhookTriggerByCredential(r, credential)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			writeError(w, http.StatusNotFound, "webhook not found")
@@ -372,12 +513,14 @@ func (h *Handler) HandleAutopilotWebhook(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	trigRow := lookup.Trigger
+	credentialMode := lookup.CredentialMode
 
 	middleware.SetWebhookTriggerID(r, uuidToString(trigRow.ID))
 
 	// 3. Per-token rate limit.
 	if h.WebhookRateLimiter != nil {
-		if !h.WebhookRateLimiter.Allow(r.Context(), token) {
+		if !h.WebhookRateLimiter.Allow(r.Context(), credential) {
 			writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
 			return
 		}
@@ -415,7 +558,8 @@ func (h *Handler) HandleAutopilotWebhook(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
-	if uuidToString(autopilot.WorkspaceID) != uuidToString(trigRow.AutopilotWorkspaceID) {
+	if lookup.AutopilotWorkspaceID.Valid &&
+		uuidToString(autopilot.WorkspaceID) != uuidToString(lookup.AutopilotWorkspaceID) {
 		slog.Warn("webhook: trigger workspace mismatch",
 			"trigger_id", uuidToString(trigRow.ID),
 			"autopilot_id", uuidToString(autopilot.ID),
@@ -483,7 +627,27 @@ func (h *Handler) HandleAutopilotWebhook(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// 9. Signature failure → rejected delivery + 401. No dispatch, no replay.
+	// 9. Trigger-ID paths keep the secret out of the URL. They must prove
+	// possession either with the static webhook token in a header, or with a
+	// valid HMAC signature when a signing secret is configured.
+	if credentialMode == webhookCredentialTriggerID &&
+		sigStatus == sigStatusNotRequired &&
+		!verifyStaticWebhookHeaderSecret(trigRow, r.Header) {
+		reason := "missing_header_secret"
+		if webhookHeaderSecret(r.Header) != "" {
+			reason = "invalid_header_secret"
+		}
+		respBody := map[string]any{
+			"status":      "rejected",
+			"delivery_id": uuidToString(delivery.ID),
+			"reason":      reason,
+		}
+		h.finaliseDeliveryTerminal(r, delivery.ID, deliveryStatusRejected, http.StatusUnauthorized, respBody, reason)
+		writeJSON(w, http.StatusUnauthorized, respBody)
+		return
+	}
+
+	// 10. Signature failure → rejected delivery + 401. No dispatch, no replay.
 	//    Providers will look for 4xx feedback when their secret is wrong.
 	if sigStatus == sigStatusInvalid || sigStatus == sigStatusMissing {
 		reason := "invalid_signature"

--- a/server/internal/handler/autopilot_webhook_handler_test.go
+++ b/server/internal/handler/autopilot_webhook_handler_test.go
@@ -3,12 +3,16 @@ package handler
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	db "github.com/multica-ai/multica/server/pkg/db/generated"
@@ -102,6 +106,14 @@ func postWebhook(t *testing.T, token string, body any, headers map[string]string
 	return w
 }
 
+func makeMulticaWebhookSignature(secret, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 func TestCreateWebhookTrigger_GeneratesToken(t *testing.T) {
@@ -167,6 +179,54 @@ func TestWebhookHandler_404OnUnknownToken(t *testing.T) {
 	w := postWebhook(t, "awt_unknown_token_value", map[string]any{"hello": "world"}, nil)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestWebhookHandler_AcceptsStaticHeaderSecretOnTriggerIDPath(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "WebhookHeaderSecret Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+	trig := createWebhookTriggerViaHandler(t, apID)
+
+	w := postWebhook(t, trig.ID, map[string]any{"hello": "world"}, map[string]string{
+		"Authorization": "Bearer " + *trig.WebhookToken,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestWebhookHandler_RejectsTriggerIDPathWithoutHeaderAuth(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "WebhookHeaderMissing Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+	trig := createWebhookTriggerViaHandler(t, apID)
+
+	w := postWebhook(t, trig.ID, map[string]any{"hello": "world"}, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestWebhookHandler_AcceptsMulticaHMACOnTriggerIDPath(t *testing.T) {
+	agentID := createWebhookTestAgent(t, "WebhookHMAC Agent")
+	apID := createWebhookTestAutopilot(t, agentID, "active", "run_only")
+	trig := createWebhookTriggerViaHandler(t, apID)
+	secret := "0123456789abcdef0123456789abcdef"
+	if _, err := testHandler.Queries.SetAutopilotTriggerSigningSecret(context.Background(),
+		db.SetAutopilotTriggerSigningSecretParams{
+			ID:            parseUUID(trig.ID),
+			SigningSecret: pgtype.Text{String: secret, Valid: true},
+		}); err != nil {
+		t.Fatalf("set signing secret: %v", err)
+	}
+
+	body := []byte(`{"hello":"world"}`)
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	w := postWebhook(t, trig.ID, body, map[string]string{
+		"X-Multica-Timestamp": timestamp,
+		"X-Multica-Signature": makeMulticaWebhookSignature(secret, timestamp, body),
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
 }
 

--- a/server/internal/handler/autopilot_webhook_test.go
+++ b/server/internal/handler/autopilot_webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ── Token generation ────────────────────────────────────────────────────────
@@ -44,6 +45,34 @@ func TestGenerateWebhookToken_NoUnsafeURLChars(t *testing.T) {
 	}
 	if strings.ContainsAny(token, "+/= ") {
 		t.Fatalf("token has unsafe characters: %q", token)
+	}
+}
+
+func TestVerifyMulticaSignature_AcceptsFreshTimestampedSignature(t *testing.T) {
+	body := []byte(`{"hello":"world"}`)
+	secret := "0123456789abcdef0123456789abcdef"
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	timestamp := now.Format(time.RFC3339)
+	headers := http.Header{}
+	headers.Set("X-Multica-Timestamp", timestamp)
+	headers.Set("X-Multica-Signature", makeMulticaWebhookSignature(secret, timestamp, body))
+
+	if !verifyMulticaSignature(secret, headers, body, now) {
+		t.Fatal("expected fresh timestamped signature to verify")
+	}
+}
+
+func TestVerifyMulticaSignature_RejectsStaleTimestamp(t *testing.T) {
+	body := []byte(`{"hello":"world"}`)
+	secret := "0123456789abcdef0123456789abcdef"
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	timestamp := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	headers := http.Header{}
+	headers.Set("X-Multica-Timestamp", timestamp)
+	headers.Set("X-Multica-Signature", makeMulticaWebhookSignature(secret, timestamp, body))
+
+	if verifyMulticaSignature(secret, headers, body, now) {
+		t.Fatal("expected stale timestamped signature to be rejected")
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a non-secret webhook ingress URL for autopilot webhook triggers so integrations can keep credentials out of the path.

The existing token-in-path URL remains backward compatible. New `webhook_header_path` / `webhook_header_url` fields expose a trigger-ID path, and callers authenticate that path with either `Authorization: Bearer <webhook_token>`, `X-Multica-Webhook-Secret`, or a valid HMAC signature.

HMAC support uses `X-Multica-Timestamp` plus `X-Multica-Signature: sha256=<hmac(timestamp + "." + raw_body, signing_secret)>` with a five-minute skew window. Existing provider signatures such as `X-Hub-Signature-256` continue to work.

Thinking path: issue #2883 asked to remove URL-embedded credentials from webhook use; the smallest compatible path is to keep existing token URLs stable, add a trigger-ID URL as the non-secret address, and reuse the existing token/signing-secret storage for header and HMAC authentication.

Risk: when a signing secret is configured, webhook delivery still requires a valid signature; static header auth is only accepted for trigger-ID paths where signature verification is not required. Delivery header persistence stores only presence flags for secret-bearing headers.

## Related Issue

Closes #2883

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/internal/handler/autopilot_webhook.go`: support token-path and trigger-ID credential lookup, header secret auth, timestamped Multica HMAC auth, and safe header persistence.
- `server/internal/handler/autopilot.go`: expose `webhook_header_path` and `webhook_header_url` for webhook triggers.
- `packages/core/types/autopilot.ts`: add webhook header URL fields and signing/provider metadata to the trigger type.
- `server/internal/handler/autopilot_webhook_test.go`: cover Multica timestamped HMAC validation and stale timestamp rejection.
- `server/internal/handler/autopilot_webhook_handler_test.go`: cover trigger-ID path success with static header auth, rejection without header auth, and success with Multica HMAC.

## How to Test

1. `cd server && go test ./internal/handler -run 'TestVerifyMulticaSignature|TestGenerateWebhookToken|TestNormalizeWebhookPayload'`
2. `cd server && go test ./internal/handler`
3. `cd server && go test ./...`
4. `pnpm --filter @multica/core exec vitest run autopilots/webhook.test.ts`
5. `pnpm --filter @multica/core typecheck`
6. `pnpm typecheck`
7. `git diff --check`
8. `make test` was attempted but could not start the required local Postgres container because Docker daemon was unavailable: `failed to connect to the docker API at unix:///Users/liguanchen/.docker/run/docker.sock`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Used Codex to inspect the webhook trigger implementation, identify the credential-in-URL gap from issue #2883, implement a backward-compatible trigger-ID ingress path with header/HMAC authentication, and verify with focused handler tests plus repository typechecks.

## Screenshots (optional)

N/A: API/backend behavior change.