### PR TITLE
fix(claude): record result model usage

### DIFF
--- a/server/pkg/agent/claude.go
+++ b/server/pkg/agent/claude.go
@@ -171,6 +171,9 @@ func (b *claudeBackend) Execute(ctx context.Context, prompt string, opts ExecOpt
 					output.Reset()
 					output.WriteString(msg.ResultText)
 				}
+				if resultUsage := claudeResultUsage(msg, opts.Model); len(resultUsage) > 0 {
+					usage = resultUsage
+				}
 				if msg.IsError {
 					finalStatus = "failed"
 					finalError = msg.ResultText
@@ -341,12 +344,15 @@ type claudeSDKMessage struct {
 	Message   json.RawMessage `json:"message,omitempty"`
 	Subtype   string          `json:"subtype,omitempty"`
 	SessionID string          `json:"session_id,omitempty"`
+	Model     string          `json:"model,omitempty"`
 
 	// result fields
-	ResultText string  `json:"result,omitempty"`
-	IsError    bool    `json:"is_error,omitempty"`
-	DurationMs float64 `json:"duration_ms,omitempty"`
-	NumTurns   int     `json:"num_turns,omitempty"`
+	ResultText string                            `json:"result,omitempty"`
+	IsError    bool                              `json:"is_error,omitempty"`
+	DurationMs float64                           `json:"duration_ms,omitempty"`
+	NumTurns   int                               `json:"num_turns,omitempty"`
+	Usage      *claudeUsage                      `json:"usage,omitempty"`
+	ModelUsage map[string]claudeResultModelUsage `json:"modelUsage,omitempty"`
 
 	// log fields
 	Log *claudeLogEntry `json:"log,omitempty"`
@@ -373,6 +379,58 @@ type claudeUsage struct {
 	OutputTokens             int64 `json:"output_tokens"`
 	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
 	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+}
+
+type claudeResultModelUsage struct {
+	InputTokens              int64 `json:"inputTokens"`
+	OutputTokens             int64 `json:"outputTokens"`
+	CacheReadInputTokens     int64 `json:"cacheReadInputTokens"`
+	CacheCreationInputTokens int64 `json:"cacheCreationInputTokens"`
+}
+
+func claudeResultUsage(msg claudeSDKMessage, fallbackModel string) map[string]TokenUsage {
+	if len(msg.ModelUsage) > 0 {
+		usage := make(map[string]TokenUsage, len(msg.ModelUsage))
+		for model, u := range msg.ModelUsage {
+			if model == "" || !claudeUsageHasTokens(u.InputTokens, u.OutputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens) {
+				continue
+			}
+			usage[model] = TokenUsage{
+				InputTokens:      u.InputTokens,
+				OutputTokens:     u.OutputTokens,
+				CacheReadTokens:  u.CacheReadInputTokens,
+				CacheWriteTokens: u.CacheCreationInputTokens,
+			}
+		}
+		if len(usage) > 0 {
+			return usage
+		}
+	}
+
+	model := msg.Model
+	if model == "" {
+		model = fallbackModel
+	}
+	if msg.Usage == nil || model == "" || !claudeUsageHasTokens(
+		msg.Usage.InputTokens,
+		msg.Usage.OutputTokens,
+		msg.Usage.CacheReadInputTokens,
+		msg.Usage.CacheCreationInputTokens,
+	) {
+		return nil
+	}
+	return map[string]TokenUsage{
+		model: {
+			InputTokens:      msg.Usage.InputTokens,
+			OutputTokens:     msg.Usage.OutputTokens,
+			CacheReadTokens:  msg.Usage.CacheReadInputTokens,
+			CacheWriteTokens: msg.Usage.CacheCreationInputTokens,
+		},
+	}
+}
+
+func claudeUsageHasTokens(input, output, cacheRead, cacheWrite int64) bool {
+	return input > 0 || output > 0 || cacheRead > 0 || cacheWrite > 0
 }
 
 type claudeContentBlock struct {

--- a/server/pkg/agent/claude_test.go
+++ b/server/pkg/agent/claude_test.go
@@ -595,6 +595,52 @@ func TestClaudeExecuteSurfacesStderrWhenChildExitsEarly(t *testing.T) {
 	}
 }
 
+func TestClaudeExecuteRecordsResultModelUsage(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fixture is POSIX-only")
+	}
+
+	fakePath := filepath.Join(t.TempDir(), "claude")
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"printf '%s\\n' '{\"type\":\"system\",\"session_id\":\"sess-result-usage\"}'\n" +
+		"printf '%s\\n' '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"session_id\":\"sess-result-usage\",\"result\":\"done\",\"modelUsage\":{\"zhipu/coding-plan\":{\"inputTokens\":123,\"outputTokens\":45,\"cacheReadInputTokens\":7,\"cacheCreationInputTokens\":11,\"costUSD\":0.01}}}'\n"
+	writeTestExecutable(t, fakePath, []byte(script))
+
+	backend, err := New("claude", Config{ExecutablePath: fakePath, Logger: slog.Default()})
+	if err != nil {
+		t.Fatalf("new claude backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	session, err := backend.Execute(ctx, "prompt-ignored", ExecOptions{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	go func() {
+		for range session.Messages {
+		}
+	}()
+
+	select {
+	case result, ok := <-session.Result:
+		if !ok {
+			t.Fatal("result channel closed without a value")
+		}
+		usage, ok := result.Usage["zhipu/coding-plan"]
+		if !ok {
+			t.Fatalf("expected usage for zhipu/coding-plan, got %#v", result.Usage)
+		}
+		if usage.InputTokens != 123 || usage.OutputTokens != 45 || usage.CacheReadTokens != 7 || usage.CacheWriteTokens != 11 {
+			t.Fatalf("unexpected usage: %+v", usage)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for result")
+	}
+}
+
 func mustMarshal(t *testing.T, v any) json.RawMessage {
 	t.Helper()
 	data, err := json.Marshal(v)


### PR DESCRIPTION
## What does this PR do?

Fixes Claude Code token usage reporting when the stream only exposes usage on the final `result.modelUsage` payload instead of per-assistant `message.usage` events.

This matters for third-party Claude Code API setups such as CCSwitch/custom providers where the proxy can see usage, but Multica previously returned an empty `Result.Usage` map because the daemon only accumulated assistant-message usage.

The fix treats final `modelUsage` as the authoritative source when present, and keeps the existing assistant-message accumulation as a fallback for older/partial stream shapes. It also supports aggregate final `usage` when a model can be resolved from the result event or configured model.

Thinking path: issue #2893 reports usage visible in CCSwitch but missing in Multica after newer Claude Code versions. A local Claude Code 2.1.141 stream-json probe showed final `result.modelUsage` carrying model-keyed usage, while the existing parser ignored that field.

## Related Issue

Closes #2893

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `server/pkg/agent/claude.go`: parse final `result.modelUsage` and aggregate `result.usage` payloads into `Result.Usage`.
- `server/pkg/agent/claude_test.go`: add a fake Claude CLI regression test for streams that only report usage in final `modelUsage`.

## How to Test

1. RED: `cd server && go test ./pkg/agent -run TestClaudeExecuteRecordsResultModelUsage -count=1` failed before the fix with `expected usage for zhipu/coding-plan, got map[string]agent.TokenUsage{}`.
2. GREEN: `cd server && go test ./pkg/agent -run TestClaudeExecuteRecordsResultModelUsage -count=1`
3. `cd server && go test ./pkg/agent`
4. `cd server && go test ./internal/daemon`
5. `cd server && go test ./...`
6. `pnpm typecheck`
7. `git diff --check`
8. `make test` was attempted after `make worktree-env`, but could not start the required local Postgres container because Docker daemon was unavailable: `failed to connect to the docker API at unix:///Users/liguanchen/.docker/run/docker.sock`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Used Codex to triage open issues by impact, inspect Claude Code usage parsing, reproduce the missing final `modelUsage` path with a failing fake-CLI regression test, then implement the smallest parser change and verify the daemon/agent usage path.

## Screenshots (optional)

N/A: daemon/backend behavior change.