### PR TITLE
fix(chat): guard optimistic task message ids (MUL-2456)

### DIFF
--- a/packages/core/chat/queries.test.ts
+++ b/packages/core/chat/queries.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { isTaskMessageTaskId, taskMessagesOptions } from "./queries";
+
+describe("taskMessagesOptions", () => {
+  it("fetches task messages for persisted UUID task ids", () => {
+    const taskId = "4a2e8d1c-7f9b-4e2a-9c1d-123456789abc";
+
+    expect(isTaskMessageTaskId(taskId)).toBe(true);
+    expect(taskMessagesOptions(taskId).enabled).toBe(true);
+  });
+
+  it("does not fetch task messages for optimistic task ids", () => {
+    const taskId = "optimistic-optimistic-1778739487737";
+
+    expect(isTaskMessageTaskId(taskId)).toBe(false);
+    expect(taskMessagesOptions(taskId).enabled).toBe(false);
+  });
+});

--- a/packages/core/chat/queries.ts
+++ b/packages/core/chat/queries.ts
@@ -21,6 +21,12 @@ export const chatKeys = {
   taskMessages: (taskId: string) => ["task-messages", taskId] as const,
 };
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isTaskMessageTaskId(taskId: string | null | undefined): taskId is string {
+  return typeof taskId === "string" && UUID_PATTERN.test(taskId);
+}
+
 export function chatSessionsOptions(wsId: string) {
   return queryOptions({
     queryKey: chatKeys.sessions(wsId),
@@ -70,7 +76,7 @@ export function taskMessagesOptions(taskId: string) {
   return queryOptions({
     queryKey: chatKeys.taskMessages(taskId),
     queryFn: () => api.listTaskMessages(taskId),
-    enabled: !!taskId,
+    enabled: isTaskMessageTaskId(taskId),
     staleTime: Infinity,
   });
 }

--- a/packages/views/chat/components/chat-message-list.tsx
+++ b/packages/views/chat/components/chat-message-list.tsx
@@ -19,7 +19,7 @@ import {
 import { ChevronRight, ChevronDown, Brain, AlertCircle, AlertTriangle, Copy } from "lucide-react";
 import { useScrollFade } from "@multica/ui/hooks/use-scroll-fade";
 import { useAutoScroll } from "@multica/ui/hooks/use-auto-scroll";
-import { taskMessagesOptions } from "@multica/core/chat/queries";
+import { isTaskMessageTaskId, taskMessagesOptions } from "@multica/core/chat/queries";
 import { Markdown } from "@multica/views/common/markdown";
 import { copyMarkdown } from "../../editor";
 import { AttachmentList } from "../../issues/components/comment-card";
@@ -67,9 +67,10 @@ export function ChatMessageList({
   // Live timeline for the in-flight task. useRealtimeSync keeps this cache
   // current via setQueryData on task:message events.
   const showLiveTimeline = !!pendingTaskId && !pendingAlreadyPersisted;
+  const canFetchLiveTimeline = isTaskMessageTaskId(pendingTaskId) && !pendingAlreadyPersisted;
   const { data: liveTaskMessages } = useQuery({
     ...taskMessagesOptions(pendingTaskId ?? ""),
-    enabled: showLiveTimeline,
+    enabled: canFetchLiveTimeline,
   });
   const liveTimeline: ChatTimelineItem[] = (liveTaskMessages ?? []).map(toTimelineItem);
   const hasLive = showLiveTimeline && liveTimeline.length > 0;
@@ -179,13 +180,14 @@ function AssistantMessage({
   isPending: boolean;
 }) {
   const taskId = message.task_id;
+  const canFetchTaskMessages = isTaskMessageTaskId(taskId);
 
   // Use the shared taskMessagesOptions so this cache entry is the same one
   // seeded by useRealtimeSync during task execution — zero refetch when the
   // task finishes, since WS already populated it.
   const { data: taskMessages } = useQuery({
     ...taskMessagesOptions(taskId ?? ""),
-    enabled: !!taskId,
+    enabled: canFetchTaskMessages,
   });
 
   const timeline: ChatTimelineItem[] = (taskMessages ?? []).map(toTimelineItem);
@@ -621,4 +623,3 @@ function ErrorRow({ item }: { item: ChatTimelineItem }) {
 }
 
 // ─── Shared ──────────────────────────────────────────────────────────────
-

--- a/server/internal/handler/daemon.go
+++ b/server/internal/handler/daemon.go
@@ -2007,8 +2007,12 @@ func (h *Handler) ListTasksByIssue(w http.ResponseWriter, r *http.Request) {
 // Verifies the task belongs to the caller's workspace.
 func (h *Handler) ListTaskMessagesByUser(w http.ResponseWriter, r *http.Request) {
 	taskID := chi.URLParam(r, "taskId")
+	taskUUID, ok := parseUUIDOrBadRequest(w, taskID, "task_id")
+	if !ok {
+		return
+	}
 
-	task, err := h.Queries.GetAgentTask(r.Context(), parseUUID(taskID))
+	task, err := h.Queries.GetAgentTask(r.Context(), taskUUID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "task not found")
 		return
@@ -2032,11 +2036,11 @@ func (h *Handler) ListTaskMessagesByUser(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		messages, queryErr = h.Queries.ListTaskMessagesSince(r.Context(), db.ListTaskMessagesSinceParams{
-			TaskID: parseUUID(taskID),
+			TaskID: taskUUID,
 			Seq:    int32(sinceSeq),
 		})
 	} else {
-		messages, queryErr = h.Queries.ListTaskMessages(r.Context(), parseUUID(taskID))
+		messages, queryErr = h.Queries.ListTaskMessages(r.Context(), taskUUID)
 	}
 	if queryErr != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list task messages")

--- a/server/internal/handler/daemon_test.go
+++ b/server/internal/handler/daemon_test.go
@@ -504,6 +504,21 @@ func withURLParams(req *http.Request, kv ...string) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
+func TestListTaskMessagesByUser_InvalidTaskIDReturnsBadRequest(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/tasks/optimistic-optimistic-1778739487737/messages", nil)
+	req = withURLParams(req, "taskId", "optimistic-optimistic-1778739487737")
+
+	(&Handler{}).ListTaskMessagesByUser(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid task id, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "task_id") {
+		t.Fatalf("expected task_id validation error, got %s", w.Body.String())
+	}
+}
+
 // setupForeignWorkspaceFixture creates an isolated workspace (not reachable
 // from testUserID) with its own agent, runtime, issue, and queued task.
 // Returns (issueID, taskID). All rows are cleaned up when the test ends.


### PR DESCRIPTION
## What does this PR do?

Fixes the chat queue bug where the UI could request task messages for a temporary optimistic task id such as `optimistic-optimistic-1778739487737`. That id is not a persisted task UUID, so the frontend should not call `/api/tasks/:taskId/messages` with it. The backend now also validates the regular-user task messages route before any DB access, returning a 400 instead of panicking if a malformed task id reaches the boundary.

Thinking path: traced the stack from the invalid `/api/tasks/optimistic-.../messages` request to `ListTaskMessagesByUser`, then traced the frontend data flow back to the optimistic pending-task seed in chat. The fix covers both layers: prevent the invalid request at source and harden the API boundary.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `packages/core/chat/queries.ts`: added UUID validation for task-message query options.
- `packages/views/chat/components/chat-message-list.tsx`: reused that validation at the two call sites that override React Query `enabled`.
- `server/internal/handler/daemon.go`: validates `taskId` with `parseUUIDOrBadRequest` in `ListTaskMessagesByUser` and reuses the parsed UUID.
- `packages/core/chat/queries.test.ts`: covers persisted UUID task ids and optimistic temporary ids.
- `server/internal/handler/daemon_test.go`: covers malformed task ids returning 400 without hitting DB-backed handler logic.

## How to Test

1. Red test before the fix: `pnpm --filter @multica/core exec vitest run chat/queries.test.ts` failed with `expected true to be false` for an optimistic task id.
2. Green/regression checks after the fix:
   - `pnpm --filter @multica/core exec vitest run chat/queries.test.ts`
   - `pnpm --filter @multica/core typecheck`
   - `pnpm --filter @multica/views typecheck`
   - `cd server && go test ./internal/handler -run TestListTaskMessagesByUser_InvalidTaskIDReturnsBadRequest -count=1`
   - `cd server && go test ./...`
   - `pnpm typecheck`
   - `pnpm test`
   - `git diff --cached --check`
3. Also attempted `make worktree-env && make test`; this local machine cannot reach Docker at `/Users/liguanchen/.docker/run/docker.sock`, so the Makefile path stopped before starting Postgres. Direct Go tests above passed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Issue triage plus TDD/debugging workflow. I reproduced the query-option failure with a red test, fixed the frontend source guard and backend UUID boundary, then ran targeted and full verification commands.

## Screenshots (optional)

N/A — this is a request/handler guard with no visual UI change.
