### PR TITLE
fix(daemon): add worktree guardrails to agent brief

### DIFF
--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -361,6 +361,39 @@ func TestPrepareWithRepoContext(t *testing.T) {
 	}
 }
 
+func TestInjectRuntimeConfigIncludesWorkdirGuardrails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ctx := TaskContextForEnv{
+		IssueID: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+		Repos: []RepoContextForEnv{
+			{URL: "https://github.com/org/backend"},
+		},
+	}
+
+	if _, err := InjectRuntimeConfig(dir, "codex", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("failed to read AGENTS.md: %v", err)
+	}
+	s := string(content)
+	for _, want := range []string{
+		"## Workspace Isolation",
+		"Your current working directory is this task's isolated workdir:",
+		dir,
+		"Do not run `git clone`",
+		"must use `multica repo checkout <url>`",
+		"Never edit files outside the isolated workdir",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("AGENTS.md missing workdir guardrail %q\n---\n%s", want, s)
+		}
+	}
+}
+
 func TestWriteContextFiles(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -170,7 +170,7 @@ func formatProjectResource(r ProjectResourceForEnv) string {
 // For Antigravity: writes {workDir}/AGENTS.md  (agy CLI reads AGENTS.md natively; skills discovered natively from .agents/skills/ — see https://antigravity.google/docs/gcli-migration)
 // For Traecli:     writes {workDir}/AGENTS.md  (traecli reads .trae/rules/ not AGENTS.md, so the brief is delivered inline via providerNeedsInlineSystemPrompt; the file is written for parity/visibility only)
 func InjectRuntimeConfig(workDir, provider string, ctx TaskContextForEnv) (string, error) {
-	content := buildMetaSkillContent(provider, ctx)
+	content := buildMetaSkillContentWithWorkDir(provider, workDir, ctx)
 	path := runtimeConfigPath(workDir, provider)
 	if path == "" {
 		// Unknown provider — skip config injection, prompt-only mode.
@@ -386,14 +386,27 @@ func CleanupRuntimeConfig(workDir, provider string) error {
 // the slim brief does not regress agent behaviour. See MUL-3560 + the
 // `runtime_brief_slim` flag documentation in runtime_config_flag.go.
 func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
+	return buildMetaSkillContentWithWorkDir(provider, "", ctx)
+}
+
+func buildMetaSkillContentWithWorkDir(provider string, workDir string, ctx TaskContextForEnv) string {
 	if useSlimBrief() {
-		return buildMetaSkillContentSlim(provider, ctx)
+		return buildMetaSkillContentSlimWithWorkDir(provider, workDir, ctx)
 	}
 	var b strings.Builder
 
 	b.WriteString("# Multica Agent Runtime\n\n")
 	b.WriteString("You are a coding agent in the Multica platform. Use the `multica` CLI to interact with the platform.\n\n")
 	writeBackgroundTaskSafetyInstructions(&b)
+	if workDir != "" {
+		b.WriteString("## Workspace Isolation\n\n")
+		fmt.Fprintf(&b, "Your current working directory is this task's isolated workdir: `%s`.\n\n", workDir)
+		b.WriteString("- Before editing code, run `pwd` and confirm you are inside this workdir.\n")
+		b.WriteString("- Never edit files outside the isolated workdir unless the user explicitly asks for a non-repo local file.\n")
+		b.WriteString("- If you need repository code, you must use `multica repo checkout <url>` from this workdir. It creates a dedicated git worktree and keeps parallel tasks isolated.\n")
+		b.WriteString("- Do not run `git clone` for workspace repositories, and do not reuse a shared checkout from another task.\n")
+		b.WriteString("- If no listed repository matches the task, stop and ask for the correct repo instead of guessing or cloning arbitrary URLs.\n\n")
+	}
 
 	// Always emit agent identity so the agent knows who it is, even when
 	// dispatched via @mention on an issue assigned to a different agent.

--- a/server/internal/daemon/execenv/runtime_config_sections.go
+++ b/server/internal/daemon/execenv/runtime_config_sections.go
@@ -58,6 +58,19 @@ func writeBackgroundTaskSafetySlim(b *strings.Builder) {
 	b.WriteString("- Never end a turn with a \"standing by\" / \"I'll report back when X finishes\" message — that becomes your final output and the task ends.\n\n")
 }
 
+func writeWorkspaceIsolationSlim(b *strings.Builder, workDir string) {
+	if workDir == "" {
+		return
+	}
+	b.WriteString("## Workspace Isolation\n\n")
+	fmt.Fprintf(b, "Your current working directory is this task's isolated workdir: `%s`.\n\n", workDir)
+	b.WriteString("- Before editing code, run `pwd` and confirm you are inside this workdir.\n")
+	b.WriteString("- Never edit files outside the isolated workdir unless the user explicitly asks for a non-repo local file.\n")
+	b.WriteString("- If you need repository code, use `multica repo checkout <url>` from this workdir; it creates a dedicated git worktree and keeps parallel tasks isolated.\n")
+	b.WriteString("- Do not run `git clone` for workspace repositories, and do not reuse a shared checkout from another task.\n")
+	b.WriteString("- If no listed repository matches the task, stop and ask for the correct repo instead of guessing or cloning arbitrary URLs.\n\n")
+}
+
 // writeAgentIdentity emits the Agent Identity heading and (optionally) the
 // agent's instructions body.
 func writeAgentIdentity(b *strings.Builder, ctx TaskContextForEnv) {
@@ -515,11 +528,16 @@ func writeOutput(b *strings.Builder, kind taskKind, ctx TaskContextForEnv) {
 // Workflow, Always Use CLI, Output — are shared by every kind and emitted
 // unconditionally (or gated by their own data preconditions).
 func buildMetaSkillContentSlim(provider string, ctx TaskContextForEnv) string {
+	return buildMetaSkillContentSlimWithWorkDir(provider, "", ctx)
+}
+
+func buildMetaSkillContentSlimWithWorkDir(provider string, workDir string, ctx TaskContextForEnv) string {
 	var b strings.Builder
 	kind := classifyTask(ctx)
 
 	writeHeader(&b)
 	writeBackgroundTaskSafetySlim(&b)
+	writeWorkspaceIsolationSlim(&b, workDir)
 	writeAgentIdentity(&b, ctx)
 	writeRequestingUser(&b, ctx)
 	writeTaskInitiator(&b, ctx)


### PR DESCRIPTION
## What does this PR do?

Adds explicit workspace-isolation guardrails to the per-task runtime brief injected into agent workdirs. Agents now see the exact isolated workdir path, are told to verify `pwd` before editing, must use `multica repo checkout <url>` for workspace repositories, and are explicitly told not to `git clone` shared workspace repos or edit outside the task workdir.

Thinking path: issue #2639 reports agents skipping the checkout workflow and working in shared/root directories. The daemon already starts providers with `Cwd` set to the isolated workdir and exposes repo metadata, but the injected runtime instructions only suggested `multica repo checkout`; they did not make isolation and the no-`git clone` rule explicit. This PR tightens the instructions at the runtime-config layer, so the guardrails are available to Claude/Codex/OpenCode/Gemini/etc. through their native context files.

## Related Issue

Addresses part of #2639

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- `server/internal/daemon/execenv/runtime_config.go`: pass the actual workdir into runtime-config generation and render a new `Workspace Isolation` section.
- `server/internal/daemon/execenv/execenv_test.go`: add regression coverage that the injected `AGENTS.md` includes the workdir path, no-`git clone` rule, checkout requirement, and no-outside-workdir rule.

## How to Test

1. Red test before the fix: `cd server && go test ./internal/daemon/execenv -run TestInjectRuntimeConfigIncludesWorkdirGuardrails -count=1` failed because the runtime brief lacked the workspace isolation section.
2. Green/regression checks after the fix:
   - `cd server && go test ./internal/daemon/execenv -run TestInjectRuntimeConfigIncludesWorkdirGuardrails -count=1`
   - `cd server && go test ./internal/daemon/execenv`
   - `cd server && go test ./internal/daemon`
   - `cd server && go test ./...`
   - `git diff --check`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

Risk: this does not pre-create worktrees or enforce filesystem writes at the tool layer; it is a low-risk guardrail improvement that reduces the failure mode while leaving deeper enforcement work for follow-up.

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Continued issue triage, selected #2639 as the next high-impact open bug without an active matching PR, traced the existing daemon execenv prompt flow, added a failing regression test, implemented the minimal runtime-brief change, and ran Go verification.

## Screenshots (optional)

N/A — daemon runtime brief change only.
