### PR TITLE
fix(transcript): close dialog on desktop navigation (MUL-2494)

### DIFF
--- a/packages/views/common/task-transcript/transcript-button.test.tsx
+++ b/packages/views/common/task-transcript/transcript-button.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { AgentTask } from "@multica/core/types/agent";
+import { describe, expect, it, vi } from "vitest";
+import { TranscriptButton } from "./transcript-button";
+import type { TimelineItem } from "./build-timeline";
+
+vi.mock("@multica/core/api", () => ({
+  api: {
+    listTaskMessages: vi.fn(),
+  },
+}));
+
+vi.mock("./agent-transcript-dialog", () => ({
+  AgentTranscriptDialog: ({
+    open,
+    onOpenChange,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) =>
+    open ? (
+      <div role="dialog">
+        <button type="button" onClick={() => onOpenChange(false)}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+const task: AgentTask = {
+  id: "task-1",
+  agent_id: "agent-1",
+  runtime_id: "",
+  issue_id: "issue-1",
+  status: "completed",
+  priority: 0,
+  dispatched_at: "2026-05-15T10:00:05.000Z",
+  started_at: "2026-05-15T10:00:06.000Z",
+  completed_at: "2026-05-15T10:00:10.000Z",
+  result: null,
+  error: null,
+  created_at: "2026-05-15T10:00:00.000Z",
+};
+
+const items: TimelineItem[] = [
+  {
+    seq: 1,
+    type: "text",
+    content: "hello world",
+  },
+];
+
+describe("TranscriptButton", () => {
+  it("closes the transcript dialog when desktop navigation starts", async () => {
+    render(<TranscriptButton task={task} agentName="Codex" items={items} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "View transcript" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("multica:navigate", {
+          detail: { path: "/acme/inbox?issue=MUL-123" },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/views/common/task-transcript/transcript-button.tsx
+++ b/packages/views/common/task-transcript/transcript-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Loader2, ScrollText } from "lucide-react";
 import { cn } from "@multica/ui/lib/utils";
 import {
@@ -80,6 +80,19 @@ export function TranscriptButton({
     },
     [providedItems, loadedItems, task.id],
   );
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleGlobalNavigate = () => {
+      setOpen(false);
+    };
+
+    window.addEventListener("multica:navigate", handleGlobalNavigate);
+    return () => {
+      window.removeEventListener("multica:navigate", handleGlobalNavigate);
+    };
+  }, [open]);
 
   return (
     <>


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop navigation edge case where an open agent transcript dialog can remain visible above the newly opened page.

How to reproduce the issue before this change:

1. Open the desktop app and go to an issue or activity surface that shows an agent task transcript button.
2. Open the transcript dialog for that task.
3. Trigger a global desktop navigation event while the dialog is still open. The common real path is clicking an OS inbox notification, which dispatches `multica:navigate` to open the target inbox item.
4. The app navigates to the new page or tab, but the old transcript dialog remains visible on top of the new destination instead of closing automatically. The dialog can still be dismissed manually with its close control; the bug is that it survives navigation when it should not.

Root cause:

`TranscriptButton` owns the `open` state for `AgentTranscriptDialog`, but it did not listen for the app-level `multica:navigate` event that desktop navigation already uses. The desktop shell opens the requested route, while the transcript button keeps its local dialog state open.

Solution:

When a transcript dialog is open, `TranscriptButton` now registers a narrow `multica:navigate` listener and closes the dialog as soon as navigation starts. The listener only exists while the dialog is open and is removed on close/unmount, so this stays scoped to transcript dialogs instead of changing shared dialog primitives or desktop routing behavior.

The regression test opens a transcript dialog, dispatches the same global navigation event, and verifies that the dialog closes.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Updated `packages/views/common/task-transcript/transcript-button.tsx` to close the transcript dialog when a global `multica:navigate` event fires.
- Kept the listener scoped to the period where the transcript dialog is open, with cleanup on close/unmount.
- Added `packages/views/common/task-transcript/transcript-button.test.tsx` covering the desktop-navigation close behavior.

## How to Test

1. Run `pnpm --filter @multica/views exec vitest run common/task-transcript/transcript-button.test.tsx`.
2. Run `pnpm --filter @multica/views exec eslint common/task-transcript/transcript-button.tsx common/task-transcript/transcript-button.test.tsx`.
3. Run `pnpm --filter @multica/views exec tsc --noEmit`.
4. Run `git diff --check upstream/main...HEAD`.
5. In the desktop app, open a task transcript dialog, then click an OS inbox notification or otherwise dispatch a `multica:navigate` event; the old transcript dialog should close while the target page opens.

Local verification notes:
- `pnpm --filter @multica/views exec vitest run common/task-transcript/transcript-button.test.tsx` passed.
- `pnpm --filter @multica/views exec eslint common/task-transcript/transcript-button.tsx common/task-transcript/transcript-button.test.tsx` passed.
- `pnpm --filter @multica/views exec tsc --noEmit` passed.
- `git diff --check upstream/main...HEAD` passed.
- Normal pre-push verification passed: lint, typecheck, test, and build. Existing lint/test warnings were unrelated to this change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run targeted local verification for the changed package/file
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:**
I used Codex to inspect the downstream FurtherRef fix, verify that upstream `main` did not already contain the behavior, and port the narrow transcript-dialog fix onto upstream `main`. The investigation focused on the existing `multica:navigate` desktop navigation event and the local dialog state owned by `TranscriptButton`. Codex then helped add a focused regression test and run targeted plus pre-push verification.

## Screenshots (optional)

N/A
