### PR TITLE
fix(runtimes): use official Gemini spark icon (MUL-2447)

### DIFF
--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -126,6 +126,35 @@ function KimiLogo({ className }: { className: string }) {
   );
 }
 
+// Gemini (Google) — official 4-point "spark" mark with Google's signature
+// blue → purple → pink gradient. Path matches the public Gemini brand SVG.
+function GeminiLogo({ className }: { className: string }) {
+  const gradientId = `gemini-logo-gradient-${useId().replace(/:/g, "")}`;
+
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className}>
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="2"
+          y1="4"
+          x2="22"
+          y2="20"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#1C7EFF" />
+          <stop offset="0.52" stopColor="#9168C0" />
+          <stop offset="1" stopColor="#D96570" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M12 24A14.304 14.304 0 0 0 0 12 14.304 14.304 0 0 0 12 0a14.305 14.305 0 0 0 12 12 14.305 14.305 0 0 0-12 12Z"
+        fill={`url(#${gradientId})`}
+      />
+    </svg>
+  );
+}
+
 // Kiro CLI — official icon sourced from kiro.dev/icon.svg.
 function KiroLogo({ className }: { className: string }) {
   const maskId = `kiro-logo-mask-${useId().replace(/:/g, "")}`;
@@ -193,6 +222,8 @@ export function ProviderLogo({
       return <KimiLogo className={className} />;
     case "kiro":
       return <KiroLogo className={className} />;
+    case "gemini":
+      return <GeminiLogo className={className} />;
     default:
       return <Monitor className={className} />;
   }

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -126,80 +126,14 @@ function KimiLogo({ className }: { className: string }) {
   );
 }
 
-// Gemini (Google) — official 4-point "spark" mark with the current
-// gemini.google.com / Gemini app "aurora" multicolor treatment: Google's
-// red / yellow / green / blue brand palette anchored at the four spark
-// points over a blue base. Approximated with four overlapping radial
-// gradients (the official asset embeds a raster JPEG, which would balloon
-// this inline SVG icon — see PR #2904 for the tradeoff).
+// Gemini (Google) — official "Google Gemini" mark from Simple Icons
+// (simpleicons.org/icons/googlegemini.svg, CC0 1.0). Rendered in the
+// Simple Icons brand color (#8E75B2), matching the pattern used by the
+// other provider marks in this file.
 function GeminiLogo({ className }: { className: string }) {
-  const uid = useId().replace(/:/g, "");
-  const clipId = `gemini-clip-${uid}`;
-  const blueId = `gemini-blue-${uid}`;
-  const redId = `gemini-red-${uid}`;
-  const yellowId = `gemini-yellow-${uid}`;
-  const greenId = `gemini-green-${uid}`;
-  // 4-point spark outline normalized from the current gemini.google.com
-  // aurora sparkle (gstatic gemini_sparkle_aurora_*.svg) into a 24x24 viewBox.
-  // Cubic-bezier sides give the characteristic smooth inset between tips
-  // instead of the earlier sharp arc-based silhouette.
-  const sparkPath =
-    "M12 0c.6 4.4 1.83 7.43 3.69 9.07C17.55 10.72 19.6 11.4 24 12c-4.4.6-6.45 1.28-8.31 2.93C13.83 16.57 12.6 19.6 12 24c-.6-4.4-1.83-7.43-3.69-9.07C6.45 13.28 4.4 12.6 0 12c4.4-.6 6.45-1.28 8.31-2.93C10.17 7.43 11.4 4.4 12 0Z";
-
   return (
-    <svg viewBox="0 0 24 24" fill="none" className={className}>
-      <defs>
-        <clipPath id={clipId}>
-          <path d={sparkPath} />
-        </clipPath>
-        <radialGradient
-          id={blueId}
-          cx="20"
-          cy="12"
-          r="18"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop offset="0" stopColor="#4285F4" />
-          <stop offset="1" stopColor="#4285F4" stopOpacity="0" />
-        </radialGradient>
-        <radialGradient
-          id={redId}
-          cx="12"
-          cy="3"
-          r="13"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop offset="0" stopColor="#EA4335" />
-          <stop offset="1" stopColor="#EA4335" stopOpacity="0" />
-        </radialGradient>
-        <radialGradient
-          id={yellowId}
-          cx="3"
-          cy="12"
-          r="13"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop offset="0" stopColor="#FBBC04" />
-          <stop offset="1" stopColor="#FBBC04" stopOpacity="0" />
-        </radialGradient>
-        <radialGradient
-          id={greenId}
-          cx="12"
-          cy="21"
-          r="13"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop offset="0" stopColor="#34A853" />
-          <stop offset="1" stopColor="#34A853" stopOpacity="0" />
-        </radialGradient>
-      </defs>
-      <g clipPath={`url(#${clipId})`}>
-        <rect width="24" height="24" fill="#1A73E8" />
-        <rect width="24" height="24" fill={`url(#${blueId})`} />
-        <rect width="24" height="24" fill={`url(#${redId})`} />
-        <rect width="24" height="24" fill={`url(#${yellowId})`} />
-        <rect width="24" height="24" fill={`url(#${greenId})`} />
-      </g>
+    <svg viewBox="0 0 24 24" fill="#8E75B2" className={className}>
+      <path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81" />
     </svg>
   );
 }

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -126,8 +126,9 @@ function KimiLogo({ className }: { className: string }) {
   );
 }
 
-// Gemini (Google) — official 4-point "spark" mark with Google's signature
-// blue → purple → pink gradient. Path matches the public Gemini brand SVG.
+// Gemini (Google) — official 4-point "spark" mark with Google's current
+// multicolor AI gradient (cyan → blue → purple → pink → orange) used on
+// gemini.google.com and the Gemini mobile app.
 function GeminiLogo({ className }: { className: string }) {
   const gradientId = `gemini-logo-gradient-${useId().replace(/:/g, "")}`;
 
@@ -136,15 +137,17 @@ function GeminiLogo({ className }: { className: string }) {
       <defs>
         <linearGradient
           id={gradientId}
-          x1="2"
-          y1="4"
-          x2="22"
-          y2="20"
+          x1="0"
+          y1="12"
+          x2="24"
+          y2="12"
           gradientUnits="userSpaceOnUse"
         >
-          <stop offset="0" stopColor="#1C7EFF" />
-          <stop offset="0.52" stopColor="#9168C0" />
-          <stop offset="1" stopColor="#D96570" />
+          <stop offset="0" stopColor="#1BA1E3" />
+          <stop offset="0.3" stopColor="#5489D6" />
+          <stop offset="0.55" stopColor="#9B72CB" />
+          <stop offset="0.8" stopColor="#D96570" />
+          <stop offset="1" stopColor="#F49C46" />
         </linearGradient>
       </defs>
       <path

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -139,8 +139,12 @@ function GeminiLogo({ className }: { className: string }) {
   const redId = `gemini-red-${uid}`;
   const yellowId = `gemini-yellow-${uid}`;
   const greenId = `gemini-green-${uid}`;
+  // 4-point spark outline normalized from the current gemini.google.com
+  // aurora sparkle (gstatic gemini_sparkle_aurora_*.svg) into a 24x24 viewBox.
+  // Cubic-bezier sides give the characteristic smooth inset between tips
+  // instead of the earlier sharp arc-based silhouette.
   const sparkPath =
-    "M12 24A14.304 14.304 0 0 0 0 12 14.304 14.304 0 0 0 12 0a14.305 14.305 0 0 0 12 12 14.305 14.305 0 0 0-12 12Z";
+    "M12 0c.6 4.4 1.83 7.43 3.69 9.07C17.55 10.72 19.6 11.4 24 12c-4.4.6-6.45 1.28-8.31 2.93C13.83 16.57 12.6 19.6 12 24c-.6-4.4-1.83-7.43-3.69-9.07C6.45 13.28 4.4 12.6 0 12c4.4-.6 6.45-1.28 8.31-2.93C10.17 7.43 11.4 4.4 12 0Z";
 
   return (
     <svg viewBox="0 0 24 24" fill="none" className={className}>
@@ -170,8 +174,8 @@ function GeminiLogo({ className }: { className: string }) {
         </radialGradient>
         <radialGradient
           id={yellowId}
-          cx="12"
-          cy="21"
+          cx="3"
+          cy="12"
           r="13"
           gradientUnits="userSpaceOnUse"
         >
@@ -180,8 +184,8 @@ function GeminiLogo({ className }: { className: string }) {
         </radialGradient>
         <radialGradient
           id={greenId}
-          cx="3"
-          cy="12"
+          cx="12"
+          cy="21"
           r="13"
           gradientUnits="userSpaceOnUse"
         >

--- a/packages/views/runtimes/components/provider-logo.tsx
+++ b/packages/views/runtimes/components/provider-logo.tsx
@@ -126,34 +126,76 @@ function KimiLogo({ className }: { className: string }) {
   );
 }
 
-// Gemini (Google) — official 4-point "spark" mark with Google's current
-// multicolor AI gradient (cyan → blue → purple → pink → orange) used on
-// gemini.google.com and the Gemini mobile app.
+// Gemini (Google) — official 4-point "spark" mark with the current
+// gemini.google.com / Gemini app "aurora" multicolor treatment: Google's
+// red / yellow / green / blue brand palette anchored at the four spark
+// points over a blue base. Approximated with four overlapping radial
+// gradients (the official asset embeds a raster JPEG, which would balloon
+// this inline SVG icon — see PR #2904 for the tradeoff).
 function GeminiLogo({ className }: { className: string }) {
-  const gradientId = `gemini-logo-gradient-${useId().replace(/:/g, "")}`;
+  const uid = useId().replace(/:/g, "");
+  const clipId = `gemini-clip-${uid}`;
+  const blueId = `gemini-blue-${uid}`;
+  const redId = `gemini-red-${uid}`;
+  const yellowId = `gemini-yellow-${uid}`;
+  const greenId = `gemini-green-${uid}`;
+  const sparkPath =
+    "M12 24A14.304 14.304 0 0 0 0 12 14.304 14.304 0 0 0 12 0a14.305 14.305 0 0 0 12 12 14.305 14.305 0 0 0-12 12Z";
 
   return (
     <svg viewBox="0 0 24 24" fill="none" className={className}>
       <defs>
-        <linearGradient
-          id={gradientId}
-          x1="0"
-          y1="12"
-          x2="24"
-          y2="12"
+        <clipPath id={clipId}>
+          <path d={sparkPath} />
+        </clipPath>
+        <radialGradient
+          id={blueId}
+          cx="20"
+          cy="12"
+          r="18"
           gradientUnits="userSpaceOnUse"
         >
-          <stop offset="0" stopColor="#1BA1E3" />
-          <stop offset="0.3" stopColor="#5489D6" />
-          <stop offset="0.55" stopColor="#9B72CB" />
-          <stop offset="0.8" stopColor="#D96570" />
-          <stop offset="1" stopColor="#F49C46" />
-        </linearGradient>
+          <stop offset="0" stopColor="#4285F4" />
+          <stop offset="1" stopColor="#4285F4" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient
+          id={redId}
+          cx="12"
+          cy="3"
+          r="13"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#EA4335" />
+          <stop offset="1" stopColor="#EA4335" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient
+          id={yellowId}
+          cx="12"
+          cy="21"
+          r="13"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#FBBC04" />
+          <stop offset="1" stopColor="#FBBC04" stopOpacity="0" />
+        </radialGradient>
+        <radialGradient
+          id={greenId}
+          cx="3"
+          cy="12"
+          r="13"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#34A853" />
+          <stop offset="1" stopColor="#34A853" stopOpacity="0" />
+        </radialGradient>
       </defs>
-      <path
-        d="M12 24A14.304 14.304 0 0 0 0 12 14.304 14.304 0 0 0 12 0a14.305 14.305 0 0 0 12 12 14.305 14.305 0 0 0-12 12Z"
-        fill={`url(#${gradientId})`}
-      />
+      <g clipPath={`url(#${clipId})`}>
+        <rect width="24" height="24" fill="#1A73E8" />
+        <rect width="24" height="24" fill={`url(#${blueId})`} />
+        <rect width="24" height="24" fill={`url(#${redId})`} />
+        <rect width="24" height="24" fill={`url(#${yellowId})`} />
+        <rect width="24" height="24" fill={`url(#${greenId})`} />
+      </g>
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- Gemini provider was missing from `ProviderLogo`'s switch and fell through to the generic `Monitor` lucide icon in the runtime list.
- Added a Gemini case that inlines the canonical "Google Gemini" mark from [Simple Icons](https://simpleicons.org/icons/googlegemini), rendered in the Simple Icons brand color (`#8E75B2`).
- Matches the existing pattern in `provider-logo.tsx` (Claude/Codex are inlined from Bootstrap Icons, GitHub Copilot from Octicons, etc.) — official open-source mark, sourced and credited, no hand-crafting.

## Asset source / license
- File: [`simple-icons/icons/googlegemini.svg`](https://github.com/simple-icons/simple-icons/blob/develop/icons/googlegemini.svg)
- License: **CC0 1.0** (public domain dedication, no attribution required); source comment added inline for traceability.
- Color: Simple Icons-registered brand hex `#8E75B2`.

The earlier aurora multicolor approximation tried to match `gemini.google.com`'s current icon, but as Jiayuan and Emacs pointed out the right move is to use a real official asset rather than hand-crafting paths and gradients. The canonical gstatic aurora SVG paints its wash via a raster JPEG (multi-KB), which isn't appropriate for a 16-px provider icon and isn't how the other marks in this file are authored — so this PR uses the open-source vector form from Simple Icons instead.

## Test plan
- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views test` (78 files, 686 tests passing)
- [x] Spark proportions match the public Gemini brand mark at 16 / 24 / 48 px.

Issue: [MUL-2447](https://multica.dev/issues/MUL-2447)