### PR TITLE
fix(desktop): keep local machine row visible after stopping daemon (MUL-2445)

### DIFF
--- a/apps/desktop/src/renderer/src/components/desktop-runtimes-page.tsx
+++ b/apps/desktop/src/renderer/src/components/desktop-runtimes-page.tsx
@@ -19,10 +19,28 @@ import type { DaemonStatus } from "../../../shared/daemon-types";
  */
 export function DesktopRuntimesPage() {
   const [status, setStatus] = useState<DaemonStatus>({ state: "stopped" });
+  // Remember the last known daemonId/deviceName. After the daemon is
+  // stopped, `status.daemonId` goes back to undefined — without this
+  // sticky cache the local row would either disappear or get reclassified
+  // as a remote machine (since `isCurrent` requires a daemonId match),
+  // taking the Start button with it.
+  const [lastIdentity, setLastIdentity] = useState<{
+    daemonId: string | null;
+    deviceName: string | null;
+  }>({ daemonId: null, deviceName: null });
 
   useEffect(() => {
-    window.daemonAPI.getStatus().then(setStatus);
-    return window.daemonAPI.onStatusChange(setStatus);
+    const apply = (s: DaemonStatus) => {
+      setStatus(s);
+      if (s.daemonId) {
+        setLastIdentity({
+          daemonId: s.daemonId,
+          deviceName: s.deviceName ?? null,
+        });
+      }
+    };
+    window.daemonAPI.getStatus().then(apply);
+    return window.daemonAPI.onStatusChange(apply);
   }, []);
 
   const bootstrapping =
@@ -32,9 +50,14 @@ export function DesktopRuntimesPage() {
 
   return (
     <RuntimesPage
-      localDaemonId={status.daemonId ?? null}
-      localMachineName={status.deviceName ?? null}
+      localDaemonId={status.daemonId ?? lastIdentity.daemonId}
+      localMachineName={status.deviceName ?? lastIdentity.deviceName}
       localMachineActions={<DaemonRuntimeActions />}
+      // Desktop owns a local machine for the lifetime of the app, even
+      // while the daemon is stopped or hasn't registered yet. The shared
+      // page synthesizes a placeholder local row when no real runtime
+      // matches, so the Start button is always reachable.
+      hasLocalMachine
       bootstrapping={bootstrapping}
     />
   );

--- a/packages/views/runtimes/components/runtime-machines.test.ts
+++ b/packages/views/runtimes/components/runtime-machines.test.ts
@@ -106,6 +106,58 @@ describe("runtime machine grouping", () => {
     expect(subtitle).toMatch(/^daemon /);
   });
 
+  it("synthesizes a placeholder local machine when ensureLocalMachine is set and no runtime matches", () => {
+    // Reproduces the "Start button disappears after stopping the daemon"
+    // bug: the daemon is stopped (localDaemonId is null) and the server
+    // has already GC'd the local runtime, so no machine ends up flagged
+    // isCurrent. Without synthesis the local row vanishes and the
+    // Start button has nowhere to render.
+    const machines = buildRuntimeMachines(
+      [
+        makeRuntime({
+          id: "rt-remote",
+          daemon_id: "daemon-remote",
+          name: "Claude (remote.box)",
+          device_info: "remote.box",
+        }),
+      ],
+      {
+        now: NOW,
+        localDaemonId: null,
+        localMachineName: "My Laptop",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(2);
+    const local = machines.find((m) => m.isCurrent);
+    expect(local).toMatchObject({
+      title: "My Laptop",
+      section: "local",
+      isCurrent: true,
+      runtimes: [],
+    });
+  });
+
+  it("does not synthesize a placeholder when a real local runtime exists", () => {
+    const machines = buildRuntimeMachines(
+      [makeRuntime({ daemon_id: "daemon-1" })],
+      {
+        now: NOW,
+        localDaemonId: "daemon-1",
+        ensureLocalMachine: true,
+      },
+    );
+
+    expect(machines).toHaveLength(1);
+    expect(machines[0]).toMatchObject({
+      isCurrent: true,
+      runtimes: expect.arrayContaining([
+        expect.objectContaining({ daemon_id: "daemon-1" }),
+      ]),
+    });
+  });
+
   it("keeps cloud runtimes as cloud workers when they have no daemon", () => {
     const machines = buildRuntimeMachines(
       [

--- a/packages/views/runtimes/components/runtime-machines.ts
+++ b/packages/views/runtimes/components/runtime-machines.ts
@@ -35,6 +35,15 @@ interface RuntimeMachineOptions {
   localDaemonId?: string | null;
   localMachineName?: string | null;
   workloadByRuntimeId?: Map<string, RuntimeWorkloadSummary>;
+  /**
+   * When true, guarantee that the result contains a machine flagged
+   * `isCurrent`. If no server-side runtime matches the local daemon
+   * (e.g. the daemon is stopped, was never started, or its runtime was
+   * already GC'd), a placeholder local machine is synthesized so the
+   * caller can still attach controls to it (Start button, etc.).
+   * Desktop sets this; web omits it.
+   */
+  ensureLocalMachine?: boolean;
 }
 
 interface RuntimeMachineDraft {
@@ -80,9 +89,40 @@ export function buildRuntimeMachines(
     drafts.set(id, draft);
   }
 
-  return Array.from(drafts.values())
-    .map((draft) => finalizeRuntimeMachine(draft, options))
-    .sort(compareRuntimeMachines);
+  const machines = Array.from(drafts.values()).map((draft) =>
+    finalizeRuntimeMachine(draft, options),
+  );
+
+  if (options.ensureLocalMachine && !machines.some((m) => m.isCurrent)) {
+    machines.push(placeholderLocalMachine(options));
+  }
+
+  return machines.sort(compareRuntimeMachines);
+}
+
+function placeholderLocalMachine(
+  options: RuntimeMachineOptions,
+): RuntimeMachine {
+  const daemonId = options.localDaemonId ?? null;
+  return {
+    id: daemonId ? `local:${daemonId}` : "local:placeholder",
+    daemonId,
+    title: options.localMachineName ?? "This machine",
+    subtitle: null,
+    deviceInfo: null,
+    cliVersion: null,
+    mode: "local",
+    section: "local",
+    isCurrent: true,
+    health: "offline",
+    runtimes: [],
+    onlineCount: 0,
+    issueCount: 0,
+    runningCount: 0,
+    queuedCount: 0,
+    providerNames: [],
+    lastSeenAt: null,
+  };
 }
 
 export function filterRuntimeMachines(

--- a/packages/views/runtimes/components/runtimes-page.tsx
+++ b/packages/views/runtimes/components/runtimes-page.tsx
@@ -51,6 +51,14 @@ interface RuntimesPageProps {
   /** Desktop-only controls shown when the local machine is selected. */
   localMachineActions?: React.ReactNode;
   /**
+   * Desktop-only signal: this host always owns a local machine, even
+   * when no runtime is currently registered (daemon stopped, not yet
+   * started, or runtime GC'd). When true, a placeholder local row is
+   * synthesized so `localMachineActions` (the daemon Start button) is
+   * always reachable. Web omits this.
+   */
+  hasLocalMachine?: boolean;
+  /**
    * Desktop-only signal: the bundled daemon is still booting / hasn't
    * registered with the server yet. Forwarded so the empty state can show
    * a "starting" indicator instead of the static "register a runtime" hint
@@ -74,6 +82,7 @@ export function RuntimesPage({
   localDaemonId,
   localMachineName,
   localMachineActions,
+  hasLocalMachine,
   bootstrapping,
 }: RuntimesPageProps = {}) {
   const isLoading = useAuthStore((s) => s.isLoading);
@@ -125,8 +134,16 @@ export function RuntimesPage({
         localDaemonId,
         localMachineName,
         workloadByRuntimeId: workloadIndex,
+        ensureLocalMachine: hasLocalMachine,
       }),
-    [runtimes, now, localDaemonId, localMachineName, workloadIndex],
+    [
+      runtimes,
+      now,
+      localDaemonId,
+      localMachineName,
+      workloadIndex,
+      hasLocalMachine,
+    ],
   );
 
   const machineCounts = useMemo(() => runtimeMachineCounts(machines), [machines]);
@@ -161,7 +178,9 @@ export function RuntimesPage({
   if (isLoading || fetching) return <RuntimesPageSkeleton />;
 
   const totalCount = runtimes.length;
-  const showEmpty = totalCount === 0 && !bootstrapping;
+  // Desktop always has a synthesized local machine row, so the
+  // "register a runtime" empty state would hide the Start button.
+  const showEmpty = totalCount === 0 && !bootstrapping && !hasLocalMachine;
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">


### PR DESCRIPTION
## Summary

Desktop 上手动 stop 本机 runtime daemon 之后，Start 按钮整个消失，必须重启应用才能恢复。

**Root cause**: `DaemonRuntimeActions` (Start/Stop/Restart) 只在 `RuntimesPage` 的 detail pane 渲染，且必须当前选中的 machine 的 `isCurrent === true`。daemon stop 后，`status.daemonId` 变成 undefined → `localDaemonId` 变成 null → 没有任何 machine 能被标记为 `isCurrent` → local section 整个消失（或那台机器被错位到 remote section），Start 按钮就找不到了。

**Fix** (两处):
- `DesktopRuntimesPage` 缓存 last-known `daemonId` / `deviceName`，daemon 停止后仍然把这俩 id 传给 `RuntimesPage`，server 还没 GC 掉 runtime 记录时本机行就还能正确归到 Local。
- `buildRuntimeMachines` 新增 `ensureLocalMachine` 选项；server 端没有任何匹配 runtime 时合成一个占位 local machine，让 Start 按钮永远有地方挂。Desktop 通过新的 `hasLocalMachine` prop 打开这个行为，同时该 prop 会抑制原来的 "register a runtime" 空状态页。

Closes [MUL-2445](mention://issue/a8c2ff0c-2a0b-4b17-8c35-1b7967d08e4c).

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run runtimes/components/runtime-machines.test.ts` — 8/8 通过（+2 新单测覆盖占位合成）
- [x] `pnpm --filter @multica/views --filter @multica/desktop typecheck` — clean
- [ ] 手动验证：Desktop 启动 → Stop daemon → Start 按钮仍可见 → 点击 Start 恢复 daemon