### PR TITLE
fix(inbox): refetch missing highlighted comment

### DIFF
--- a/packages/views/issues/components/issue-detail.test.tsx
+++ b/packages/views/issues/components/issue-detail.test.tsx
@@ -447,7 +447,12 @@ import { IssueDetail } from "./issue-detail";
 function createTestQueryClient() {
   return new QueryClient({
     defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
+      queries: {
+        retry: false,
+        gcTime: 0,
+        staleTime: Infinity,
+        refetchOnWindowFocus: false,
+      },
       mutations: { retry: false },
     },
   });
@@ -467,7 +472,7 @@ function renderIssueDetail(issueId = "issue-1") {
 function renderIssueDetailWithHighlight(
   highlightCommentId: string,
   issueId = "issue-1",
-  options: { seedTimeline?: boolean } = {},
+  options: { seedTimeline?: boolean; seedTimelineData?: TimelineEntry[] } = {},
 ) {
   const queryClient = createTestQueryClient();
   if (options.seedTimeline) {
@@ -476,7 +481,10 @@ function renderIssueDetailWithHighlight(
     // the issue itself has finished loading, so the effect that scrolls to
     // the comment fires once with `loading=true` (skeleton still rendered,
     // no comment DOM) and must re-fire when `loading` flips to false.
-    queryClient.setQueryData(["issues", "timeline", issueId], mockTimeline);
+    queryClient.setQueryData(
+      ["issues", "timeline", issueId],
+      options.seedTimelineData ?? mockTimeline,
+    );
   }
   const result = render(
     <I18nProvider locale="en" resources={TEST_RESOURCES}>
@@ -834,6 +842,24 @@ describe("IssueDetail (shared)", () => {
         expect(
           document.getElementById("comment-comment-2"),
         ).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(scrollIntoViewSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ block: "center" }),
+        );
+      });
+    });
+
+    it("refetches the timeline when a highlighted inbox comment is missing from a fresh cache", async () => {
+      renderIssueDetailWithHighlight("comment-2", "issue-1", {
+        seedTimeline: true,
+        seedTimelineData: [mockTimeline[0]!],
+      });
+
+      expect(screen.queryByText("I can help with this")).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.getByText("I can help with this")).toBeInTheDocument();
       });
       await waitFor(() => {
         expect(scrollIntoViewSpy).toHaveBeenCalledWith(

--- a/packages/views/issues/components/issue-detail.tsx
+++ b/packages/views/issues/components/issue-detail.tsx
@@ -55,13 +55,13 @@ import { collectThreadReplies } from "./thread-utils";
 import { AgentLiveCard } from "./agent-live-card";
 import { ExecutionLogSection } from "./execution-log-section";
 import { PullRequestList } from "./pull-request-list";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useGitHubSettings } from "@multica/core/github";
-import { useQuery } from "@tanstack/react-query";
 import { useAuthStore } from "@multica/core/auth";
 import { useCurrentWorkspace, useWorkspacePaths } from "@multica/core/paths";
 import { useActorName } from "@multica/core/workspace/hooks";
 import { useWorkspaceId } from "@multica/core/hooks";
-import { issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions, issueAttachmentsOptions } from "@multica/core/issues/queries";
+import { issueKeys, issueListOptions, issueDetailOptions, childIssuesOptions, issueUsageOptions, issueAttachmentsOptions } from "@multica/core/issues/queries";
 import { projectDetailOptions } from "@multica/core/projects/queries";
 import { ProjectIcon } from "../../projects/components/project-icon";
 import { issueLabelsOptions } from "@multica/core/labels";
@@ -614,6 +614,7 @@ interface IssueDetailProps {
 export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = true, layoutId = "multica_issue_detail_layout", highlightCommentId }: IssueDetailProps) {
   const { t } = useT("issues");
   const id = issueId;
+  const qc = useQueryClient();
   const router = useNavigation();
   const user = useAuthStore((s) => s.user);
   const workspace = useCurrentWorkspace();
@@ -735,6 +736,7 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
     }
   }, []);
   const didHighlightRef = useRef<string | null>(null);
+  const requestedMissingHighlightRef = useRef<string | null>(null);
 
   // Issue data from TQ — uses detail query, seeded from list cache if available.
   // Only seed when description is present; list API omits it, and ContentEditor
@@ -1000,6 +1002,26 @@ export function IssueDetail({ issueId, onDelete, onDone, defaultSidebarOpen = tr
   }, [allChildrenSelected, childIssueIds, deselectIds, selectIds]);
 
   const loading = issueLoading;
+
+  // Inbox deep-links can reopen an issue whose timeline cache is "fresh"
+  // under the app-wide staleTime: Infinity defaults, but still missing the
+  // newly referenced comment. Detect that gap and force one authoritative
+  // refetch so the highlighted comment can appear without restarting.
+  useEffect(() => {
+    if (!highlightCommentId) {
+      requestedMissingHighlightRef.current = null;
+      return;
+    }
+    if (loading || timelineLoading) return;
+    if (timeline.some((entry) => entry.id === highlightCommentId)) {
+      requestedMissingHighlightRef.current = null;
+      return;
+    }
+    const requestKey = `${id}:${highlightCommentId}`;
+    if (requestedMissingHighlightRef.current === requestKey) return;
+    requestedMissingHighlightRef.current = requestKey;
+    qc.invalidateQueries({ queryKey: issueKeys.timeline(id) });
+  }, [highlightCommentId, id, loading, qc, timeline, timelineLoading]);
 
   // Deep-link landing. Semantically equivalent to navigating to
   // `#comment-${id}`: find the element with that id, scrollIntoView it.


### PR DESCRIPTION
## What does this PR do?

Fixes an Inbox deep-link edge case where `IssueDetail` can reopen an issue with a timeline query that is still considered fresh, but the cached timeline does not contain the `highlightCommentId` target yet. In that state, the existing scroll/highlight effect has no DOM node to land on.

This keeps the recovery scoped to the highlighted-comment path: after the issue and timeline finish loading, if the loaded timeline is missing the target comment, `IssueDetail` invalidates that issue timeline once so TanStack Query fetches the authoritative timeline and the existing scroll/highlight behavior can proceed.

## Related Issue

No exact upstream issue found. Related prior deep-link work: #2332 and #2472.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- `packages/views/issues/components/issue-detail.tsx`: detect a missing highlighted comment in a loaded timeline and invalidate that issue timeline once per issue/comment pair.
- `packages/views/issues/components/issue-detail.test.tsx`: seed a fresh but incomplete timeline cache and assert that the target comment is refetched, rendered, and scrolled into view.

## How to Test

1. `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx -t "highlightCommentId scroll-to-comment"`
2. `pnpm --filter @multica/views exec vitest run issues/components/issue-detail.test.tsx`
3. `pnpm --filter @multica/views typecheck`
4. `git diff --check -- packages/views/issues/components/issue-detail.tsx packages/views/issues/components/issue-detail.test.tsx`
5. Pre-push hook: `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Ported the downstream FurtherRef fix for `furtherref/multica#57` onto the latest upstream `main`, reviewed the patch against the current upstream issue-detail flow, checked for an existing upstream fix/open PR, and ran targeted plus full pre-push verification.

## Screenshots (optional)

N/A — cache recovery path covered by regression test.