### PR TITLE
fix(markdown): resolve relative image URLs in desktop app (MUL-2463)

### DIFF
--- a/packages/core/autopilots/webhook.ts
+++ b/packages/core/autopilots/webhook.ts
@@ -1,4 +1,5 @@
 import type { AutopilotTrigger } from "../types";
+import { stripTrailingSlash } from "../utils";
 
 /**
  * Compose a usable absolute webhook URL for a webhook trigger.
@@ -35,9 +36,4 @@ export function buildAutopilotWebhookUrl(params: {
   const base = stripTrailingSlash(apiBaseUrl) || stripTrailingSlash(currentOrigin);
   if (!base) return path; // last resort — relative path will still work in-browser
   return base + path;
-}
-
-function stripTrailingSlash(s: string | undefined): string {
-  if (!s) return "";
-  return s.endsWith("/") ? s.slice(0, -1) : s;
 }

--- a/packages/core/config/index.test.ts
+++ b/packages/core/config/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { configStore } from "./index";
+
+describe("configStore – apiBaseUrl", () => {
+  beforeEach(() => {
+    configStore.setState({ apiBaseUrl: "", cdnDomain: "" });
+  });
+
+  it("defaults to empty string", () => {
+    expect(configStore.getState().apiBaseUrl).toBe("");
+  });
+
+  it("setApiBaseUrl stores the URL", () => {
+    configStore.getState().setApiBaseUrl("https://api.example.com");
+    expect(configStore.getState().apiBaseUrl).toBe("https://api.example.com");
+  });
+
+  it("setApiBaseUrl overwrites the previous value", () => {
+    configStore.getState().setApiBaseUrl("https://old.example.com");
+    configStore.getState().setApiBaseUrl("https://new.example.com");
+    expect(configStore.getState().apiBaseUrl).toBe("https://new.example.com");
+  });
+
+  it("setApiBaseUrl does not affect other fields", () => {
+    configStore.setState({ cdnDomain: "cdn.example.com" });
+    configStore.getState().setApiBaseUrl("https://api.example.com");
+    expect(configStore.getState().cdnDomain).toBe("cdn.example.com");
+  });
+});

--- a/packages/core/config/index.ts
+++ b/packages/core/config/index.ts
@@ -3,17 +3,21 @@ import { useStore } from "zustand";
 
 interface ConfigState {
   cdnDomain: string;
+  apiBaseUrl: string;
   allowSignup: boolean;
   googleClientId: string;
   setCdnDomain: (domain: string) => void;
+  setApiBaseUrl: (url: string) => void;
   setAuthConfig: (config: { allowSignup: boolean; googleClientId?: string }) => void;
 }
 
 export const configStore = createStore<ConfigState>((set) => ({
   cdnDomain: "",
+  apiBaseUrl: "",
   allowSignup: true,
   googleClientId: "",
   setCdnDomain: (domain) => set({ cdnDomain: domain }),
+  setApiBaseUrl: (url) => set({ apiBaseUrl: url }),
   setAuthConfig: ({ allowSignup, googleClientId = "" }) =>
     set({ allowSignup, googleClientId }),
 }));

--- a/packages/core/platform/core-provider.tsx
+++ b/packages/core/platform/core-provider.tsx
@@ -13,6 +13,7 @@ import {
 import { WSProvider } from "../realtime";
 import { QueryProvider } from "../provider";
 import { createLogger } from "../logger";
+import { configStore } from "../config";
 import { defaultStorage } from "./storage";
 import { AuthInitializer } from "./auth-initializer";
 import type { CoreProviderProps, ClientIdentity } from "./types";
@@ -32,6 +33,8 @@ function initCore(
   identity?: ClientIdentity,
 ) {
   if (initialized) return;
+
+  configStore.getState().setApiBaseUrl(apiBaseUrl);
 
   const api = new ApiClient(apiBaseUrl, {
     logger: createLogger("api"),

--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -49,6 +49,11 @@ export function createRequestId(length = 8): string {
   return createSafeId().replace(/-/g, "").slice(0, length);
 }
 
+export function stripTrailingSlash(s: string | undefined): string {
+  if (!s) return "";
+  return s.endsWith("/") ? s.slice(0, -1) : s;
+}
+
 /**
  * True when the keyboard event fires while an IME is composing a multi-key
  * input (e.g. Chinese pinyin, Japanese kana). The Enter that commits the

--- a/packages/views/common/markdown.test.tsx
+++ b/packages/views/common/markdown.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import { Markdown } from "./markdown";
+import type { Attachment as AttachmentRecord } from "@multica/core/types";
 
 // Capture the renderImage prop that Markdown passes to MarkdownBase.
 const capturedRenderImage = vi.hoisted(
@@ -33,6 +34,13 @@ vi.mock("@multica/core/config", () => ({
   },
 }));
 
+vi.mock("@multica/core/utils", () => ({
+  stripTrailingSlash: (s: string | undefined) => {
+    if (!s) return "";
+    return s.endsWith("/") ? s.slice(0, -1) : s;
+  },
+}));
+
 vi.mock("../issues/components/issue-mention-card", () => ({
   IssueMentionCard: () => null,
 }));
@@ -41,9 +49,32 @@ vi.mock("../editor", () => ({
   AttachmentDownloadProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
-  Attachment: ({ attachment }: { attachment: { url: string } }) => (
-    <img data-testid="attachment-img" src={attachment.url} alt="" />
-  ),
+  Attachment: ({
+    attachment,
+  }: {
+    attachment:
+      | { kind: "url"; url: string; filename: string }
+      | { kind: "record"; attachment: AttachmentRecord };
+  }) => {
+    if (attachment.kind === "record") {
+      return (
+        <img
+          data-testid="attachment-img"
+          src={attachment.attachment.url}
+          data-record-id={attachment.attachment.id}
+          alt=""
+        />
+      );
+    }
+    return (
+      <img
+        data-testid="attachment-img"
+        src={attachment.url}
+        data-filename={attachment.filename}
+        alt=""
+      />
+    );
+  },
 }));
 
 describe("Markdown – renderImage URL resolution", () => {
@@ -54,17 +85,29 @@ describe("Markdown – renderImage URL resolution", () => {
 
   function captureRenderImage(
     apiBaseUrl: string,
+    attachments?: AttachmentRecord[],
   ): (props: { src: string; alt: string }) => React.ReactNode {
     apiBaseUrlRef.current = apiBaseUrl;
-    render(<Markdown>{"content"}</Markdown>);
+    render(<Markdown attachments={attachments}>{"content"}</Markdown>);
     if (!capturedRenderImage.current) {
       throw new Error("renderImage was not captured");
     }
     return capturedRenderImage.current;
   }
 
-  it("prepends apiBaseUrl to paths starting with /", () => {
+  it("prepends apiBaseUrl to /uploads/ paths when no matching attachment record", () => {
     const renderImage = captureRenderImage("https://api.example.com");
+    const { getByTestId } = render(
+      <>{renderImage({ src: "/uploads/image.png", alt: "photo" })}</>,
+    );
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "src",
+      "https://api.example.com/uploads/image.png",
+    );
+  });
+
+  it("strips trailing slash from apiBaseUrl before prepending", () => {
+    const renderImage = captureRenderImage("https://api.example.com/");
     const { getByTestId } = render(
       <>{renderImage({ src: "/uploads/image.png", alt: "photo" })}</>,
     );
@@ -94,6 +137,17 @@ describe("Markdown – renderImage URL resolution", () => {
     expect(getByTestId("attachment-img")).toHaveAttribute("src", dataUrl);
   });
 
+  it("does not rewrite protocol-relative URLs (//host/path)", () => {
+    const renderImage = captureRenderImage("https://api.example.com");
+    const { getByTestId } = render(
+      <>{renderImage({ src: "//cdn.example.com/image.png", alt: "photo" })}</>,
+    );
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "src",
+      "//cdn.example.com/image.png",
+    );
+  });
+
   it("when apiBaseUrl is empty, relative paths are preserved as-is", () => {
     const renderImage = captureRenderImage("");
     const { getByTestId } = render(
@@ -105,11 +159,74 @@ describe("Markdown – renderImage URL resolution", () => {
     );
   });
 
-  it("passes the alt text through as filename", () => {
+  it("passes the alt text through as filename for url-only path", () => {
     const renderImage = captureRenderImage("https://api.example.com");
-    // Render and inspect by verifying the img alt attribute (set by mock)
-    // The mock renders <img alt="" ... /> so we test via the resolved src.
-    const node = renderImage({ src: "/img.png", alt: "diagram" });
-    expect(node).not.toBeNull();
+    const { getByTestId } = render(
+      <>{renderImage({ src: "/uploads/img.png", alt: "diagram" })}</>,
+    );
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "data-filename",
+      "diagram",
+    );
+  });
+
+  it("uses attachment record when src matches a known attachment URL", () => {
+    const record: AttachmentRecord = {
+      id: "att-1",
+      url: "/uploads/image.png",
+      filename: "image.png",
+      content_type: "image/png",
+      size_bytes: 1000,
+      download_url: "/uploads/image.png",
+      workspace_id: "ws-1",
+      uploader_id: "u-1",
+      uploader_type: "member",
+      issue_id: null,
+      comment_id: null,
+      chat_message_id: null,
+      chat_session_id: null,
+      created_at: "2024-01-01T00:00:00Z",
+    };
+    const renderImage = captureRenderImage("https://api.example.com", [record]);
+    const { getByTestId } = render(
+      <>{renderImage({ src: "/uploads/image.png", alt: "photo" })}</>,
+    );
+    // Record path: src is the original relative URL (not prefixed), record-id is set
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "data-record-id",
+      "att-1",
+    );
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "src",
+      "/uploads/image.png",
+    );
+  });
+
+  it("falls back to url-only path when src does not match any attachment record", () => {
+    const record: AttachmentRecord = {
+      id: "att-1",
+      url: "/uploads/other.png",
+      filename: "other.png",
+      content_type: "image/png",
+      size_bytes: 1000,
+      download_url: "/uploads/other.png",
+      workspace_id: "ws-1",
+      uploader_id: "u-1",
+      uploader_type: "member",
+      issue_id: null,
+      comment_id: null,
+      chat_message_id: null,
+      chat_session_id: null,
+      created_at: "2024-01-01T00:00:00Z",
+    };
+    const renderImage = captureRenderImage("https://api.example.com", [record]);
+    const { getByTestId } = render(
+      <>{renderImage({ src: "/uploads/different.png", alt: "photo" })}</>,
+    );
+    // Falls back to url path with apiBaseUrl prefix
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "src",
+      "https://api.example.com/uploads/different.png",
+    );
   });
 });

--- a/packages/views/common/markdown.test.tsx
+++ b/packages/views/common/markdown.test.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { Markdown } from "./markdown";
+
+// Capture the renderImage prop that Markdown passes to MarkdownBase.
+const capturedRenderImage = vi.hoisted(
+  () => ({
+    current: null as
+      | ((props: { src: string; alt: string }) => React.ReactNode)
+      | null,
+  }),
+);
+
+vi.mock("@multica/ui/markdown", () => ({
+  Markdown: (props: {
+    renderImage?: (p: { src: string; alt: string }) => React.ReactNode;
+  }) => {
+    capturedRenderImage.current = props.renderImage ?? null;
+    return null;
+  },
+}));
+
+// Controls the apiBaseUrl returned by the config store during each test.
+const apiBaseUrlRef = vi.hoisted(() => ({ current: "" }));
+
+vi.mock("@multica/core/config", () => ({
+  useConfigStore: (
+    sel?: (s: { apiBaseUrl: string; cdnDomain: string }) => unknown,
+  ) => {
+    const state = { apiBaseUrl: apiBaseUrlRef.current, cdnDomain: "" };
+    return sel ? sel(state) : state;
+  },
+}));
+
+vi.mock("../issues/components/issue-mention-card", () => ({
+  IssueMentionCard: () => null,
+}));
+
+vi.mock("../editor", () => ({
+  AttachmentDownloadProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  Attachment: ({ attachment }: { attachment: { url: string } }) => (
+    <img data-testid="attachment-img" src={attachment.url} alt="" />
+  ),
+}));
+
+describe("Markdown – renderImage URL resolution", () => {
+  beforeEach(() => {
+    capturedRenderImage.current = null;
+    apiBaseUrlRef.current = "";
+  });
+
+  function captureRenderImage(
+    apiBaseUrl: string,
+  ): (props: { src: string; alt: string }) => React.ReactNode {
+    apiBaseUrlRef.current = apiBaseUrl;
+    render(<Markdown>{"content"}</Markdown>);
+    if (!capturedRenderImage.current) {
+      throw new Error("renderImage was not captured");
+    }
+    return capturedRenderImage.current;
+  }
+
+  it("prepends apiBaseUrl to paths starting with /", () => {
+    const renderImage = captureRenderImage("https://api.example.com");
+    const { getByTestId } = render(
+      <>{renderImage({ src: "/uploads/image.png", alt: "photo" })}</>,
+    );
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "src",
+      "https://api.example.com/uploads/image.png",
+    );
+  });
+
+  it("leaves absolute http URLs unchanged", () => {
+    const renderImage = captureRenderImage("https://api.example.com");
+    const { getByTestId } = render(
+      <>{renderImage({ src: "https://cdn.example.com/image.png", alt: "photo" })}</>,
+    );
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/image.png",
+    );
+  });
+
+  it("leaves data: URLs unchanged", () => {
+    const renderImage = captureRenderImage("https://api.example.com");
+    const dataUrl = "data:image/png;base64,abc123";
+    const { getByTestId } = render(
+      <>{renderImage({ src: dataUrl, alt: "photo" })}</>,
+    );
+    expect(getByTestId("attachment-img")).toHaveAttribute("src", dataUrl);
+  });
+
+  it("when apiBaseUrl is empty, relative paths are preserved as-is", () => {
+    const renderImage = captureRenderImage("");
+    const { getByTestId } = render(
+      <>{renderImage({ src: "/uploads/image.png", alt: "photo" })}</>,
+    );
+    expect(getByTestId("attachment-img")).toHaveAttribute(
+      "src",
+      "/uploads/image.png",
+    );
+  });
+
+  it("passes the alt text through as filename", () => {
+    const renderImage = captureRenderImage("https://api.example.com");
+    // Render and inspect by verifying the img alt attribute (set by mock)
+    // The mock renders <img alt="" ... /> so we test via the resolved src.
+    const node = renderImage({ src: "/img.png", alt: "diagram" });
+    expect(node).not.toBeNull();
+  });
+});

--- a/packages/views/common/markdown.tsx
+++ b/packages/views/common/markdown.tsx
@@ -7,6 +7,7 @@ import {
   type RenderMode,
 } from "@multica/ui/markdown";
 import { useConfigStore } from "@multica/core/config";
+import { stripTrailingSlash } from "@multica/core/utils";
 import type { Attachment as AttachmentRecord } from "@multica/core/types";
 import { IssueMentionCard } from "../issues/components/issue-mention-card";
 import {
@@ -73,9 +74,21 @@ export function Markdown(props: MarkdownProps): React.JSX.Element {
 
   const renderImage = React.useCallback(
     ({ src, alt }: { src: string; alt: string }): React.ReactNode => {
-      // Relative paths (e.g. /uploads/...) must be prefixed with the API base
-      // URL so the desktop app can load them without a browser to resolve them.
-      const resolvedSrc = src.startsWith("/") ? `${apiBaseUrl}${src}` : src;
+      // If the src matches a known attachment record (strict equality on the
+      // stored URL), use the full record so the download/preview chain stays
+      // intact: correct re-signing, desktop-native download, full metadata.
+      const record = attachments?.find((a) => a.url === src);
+      if (record) {
+        return <AttachmentRenderer attachment={{ kind: "record", attachment: record }} />;
+      }
+
+      // No matching record. Prefix server-relative /uploads/ paths with the
+      // API base URL so the desktop app can load them without a browser origin.
+      // Narrowing to /uploads/ avoids accidentally rewriting protocol-relative
+      // URLs (//cdn.host/...) which also start with "/".
+      const resolvedSrc = src.startsWith("/uploads/")
+        ? `${stripTrailingSlash(apiBaseUrl)}${src}`
+        : src;
       return (
         <AttachmentRenderer
           attachment={{
@@ -90,7 +103,7 @@ export function Markdown(props: MarkdownProps): React.JSX.Element {
         />
       );
     },
-    [apiBaseUrl],
+    [apiBaseUrl, attachments],
   );
 
   return (

--- a/packages/views/common/markdown.tsx
+++ b/packages/views/common/markdown.tsx
@@ -44,22 +44,6 @@ function defaultRenderMention({
   return null;
 }
 
-function renderImage({ src, alt }: { src: string; alt: string }): React.ReactNode {
-  return (
-    <AttachmentRenderer
-      attachment={{
-        kind: "url",
-        url: src,
-        filename: alt,
-        // chat / skill markdown `![]()` is structurally an image. Without
-        // forceKind, empty/descriptive alt strings would route to the
-        // file-card chrome via getPreviewKind autodetect.
-        forceKind: "image",
-      }}
-    />
-  );
-}
-
 function renderFileCard({
   href,
   filename,
@@ -84,7 +68,31 @@ function renderFileCard({
  */
 export function Markdown(props: MarkdownProps): React.JSX.Element {
   const cdnDomain = useConfigStore((s) => s.cdnDomain);
+  const apiBaseUrl = useConfigStore((s) => s.apiBaseUrl);
   const { attachments, ...rest } = props;
+
+  const renderImage = React.useCallback(
+    ({ src, alt }: { src: string; alt: string }): React.ReactNode => {
+      // Relative paths (e.g. /uploads/...) must be prefixed with the API base
+      // URL so the desktop app can load them without a browser to resolve them.
+      const resolvedSrc = src.startsWith("/") ? `${apiBaseUrl}${src}` : src;
+      return (
+        <AttachmentRenderer
+          attachment={{
+            kind: "url",
+            url: resolvedSrc,
+            filename: alt,
+            // chat / skill markdown `![]()` is structurally an image. Without
+            // forceKind, empty/descriptive alt strings would route to the
+            // file-card chrome via getPreviewKind autodetect.
+            forceKind: "image",
+          }}
+        />
+      );
+    },
+    [apiBaseUrl],
+  );
+
   return (
     <AttachmentDownloadProvider attachments={attachments}>
       <MarkdownBase


### PR DESCRIPTION
Images embedded in markdown with relative paths (/uploads/...) rendered correctly in the browser (which resolves them against window.location.origin) but failed in the Electron desktop app where no base URL context exists.

- Add `apiBaseUrl` field and `setApiBaseUrl` to `configStore`
- Initialise `apiBaseUrl` in `initCore` before creating the ApiClient
- Move `renderImage` into the `Markdown` component so it can read `apiBaseUrl` from the config store and prepend it to any path that starts with `/`, producing an absolute URL the Electron renderer can fetch

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.
2.
3.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [ ] I have considered and documented any risks above
- [ ] I will address all reviewer comments before requesting merge

## AI Disclosure

<!-- Most PRs involve AI coding tools — that's totally fine! We're curious about your process. -->

**AI tool used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Multica Agent, N/A -->

**Prompt / approach:**
<!-- How did you use AI to produce this code? Share your prompt, conversation link, or describe your approach. This helps the team learn from each other's AI workflows. -->


## Screenshots (optional)

<!-- If applicable, add screenshots showing the change in action. -->
