### PR TITLE
fix(daemon): precheckout task repos before agent start (MUL-2454)

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -908,6 +908,71 @@ func (d *Daemon) registerTaskRepos(workspaceID string, repos []RepoData) {
 	}
 }
 
+func (d *Daemon) preCheckoutTaskRepos(ctx context.Context, workspaceID, taskID, agentName, workDir string, repos []execenv.RepoContextForEnv) []execenv.RepoContextForEnv {
+	if len(repos) == 0 {
+		return repos
+	}
+
+	logger := d.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if d.repoCache == nil {
+		logger.Warn("daemon pre-checkout skipped: repo cache not initialized", "workspace_id", workspaceID, "task_id", taskID)
+		return repos
+	}
+
+	result := make([]execenv.RepoContextForEnv, len(repos))
+	copy(result, repos)
+
+	checkedOut := make(map[string]string, len(repos))
+	for i, repo := range result {
+		repoURL := strings.TrimSpace(repo.URL)
+		if repoURL == "" {
+			continue
+		}
+		if localPath, ok := checkedOut[repoURL]; ok {
+			result[i].LocalPath = localPath
+			continue
+		}
+
+		if err := d.ensureRepoReady(ctx, workspaceID, repoURL); err != nil {
+			logger.Warn("daemon pre-checkout failed",
+				"workspace_id", workspaceID,
+				"task_id", taskID,
+				"url", repoURL,
+				"error", err,
+			)
+			checkedOut[repoURL] = ""
+			continue
+		}
+
+		worktree, err := d.repoCache.CreateWorktree(repocache.WorktreeParams{
+			WorkspaceID:         workspaceID,
+			RepoURL:             repoURL,
+			WorkDir:             workDir,
+			AgentName:           agentName,
+			TaskID:              taskID,
+			CoAuthoredByEnabled: d.workspaceCoAuthoredByEnabled(workspaceID),
+		})
+		if err != nil {
+			logger.Warn("daemon pre-checkout failed",
+				"workspace_id", workspaceID,
+				"task_id", taskID,
+				"url", repoURL,
+				"error", err,
+			)
+			checkedOut[repoURL] = ""
+			continue
+		}
+
+		result[i].LocalPath = worktree.Path
+		checkedOut[repoURL] = worktree.Path
+	}
+
+	return result
+}
+
 // waitBackgroundSyncs blocks until every background sync started by
 // registerTaskRepos has finished. Intended for test teardown: tests that
 // hand the daemon a t.TempDir-backed repo cache must call this before
@@ -1004,7 +1069,18 @@ func (d *Daemon) ensureRepoReady(ctx context.Context, workspaceID, repoURL strin
 		return nil
 	}
 
-	d.syncWorkspaceRepos(workspaceID, resp.Repos)
+	reposToSync := resp.Repos
+	foundRequestedRepo := false
+	for _, repo := range reposToSync {
+		if strings.TrimSpace(repo.URL) == repoURL {
+			foundRequestedRepo = true
+			break
+		}
+	}
+	if !foundRequestedRepo {
+		reposToSync = append(reposToSync, RepoData{URL: repoURL})
+	}
+	d.syncWorkspaceRepos(workspaceID, reposToSync)
 
 	if d.repoCache.Lookup(workspaceID, repoURL) != "" {
 		return nil
@@ -2109,6 +2185,7 @@ func (d *Daemon) handleTask(ctx context.Context, task Task, slot int) {
 	}
 
 	d.reportTaskResult(ctx, task.ID, result, taskLog)
+	d.auditWorkdirForRawClones(result.WorkDir, task.ID)
 
 	// Write GC metadata after the task finishes so the periodic GC loop
 	// can look up the parent record (issue / chat session / autopilot run /
@@ -2156,6 +2233,37 @@ func (d *Daemon) reportTaskResult(ctx context.Context, taskID string, result Tas
 		if err := d.client.FailTask(ctx, taskID, result.Comment, result.SessionID, result.WorkDir, failureReason); err != nil {
 			taskLog.Error("report failed task failed", "error", err)
 		}
+	}
+}
+
+func (d *Daemon) auditWorkdirForRawClones(workDir, taskID string) {
+	if strings.TrimSpace(workDir) == "" {
+		return
+	}
+
+	entries, err := os.ReadDir(workDir)
+	if err != nil {
+		return
+	}
+
+	logger := d.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		repoPath := filepath.Join(workDir, entry.Name())
+		gitDir := filepath.Join(repoPath, ".git")
+		info, err := os.Stat(gitDir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		logger.Warn("raw git clone detected in task workdir",
+			"task_id", taskID,
+			"path", repoPath,
+		)
 	}
 }
 
@@ -2235,9 +2343,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		instructions = task.Agent.Instructions
 	}
 
-	// Prepare isolated execution environment.
-	// Repos are passed as metadata only — the agent checks them out on demand
-	// via `multica repo checkout <url>`.
+	// Prepare isolated execution environment. Repos start as metadata and are
+	// annotated with local worktree paths after the workdir exists.
 	taskCtx := execenv.TaskContextForEnv{
 		IssueID:                          task.IssueID,
 		TriggerCommentID:                 task.TriggerCommentID,
@@ -2316,6 +2423,8 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		d.markActiveEnvRoot(env.RootDir)
 		defer d.unmarkActiveEnvRoot(env.RootDir)
 	}
+
+	taskCtx.Repos = d.preCheckoutTaskRepos(ctx, task.WorkspaceID, task.ID, agentName, env.WorkDir, taskCtx.Repos)
 
 	// Inject runtime-specific config (meta skill) so the agent discovers .agent_context/.
 	runtimeBrief, err := execenv.InjectRuntimeConfig(env.WorkDir, provider, taskCtx)

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -18,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/multica-ai/multica/server/internal/daemon/execenv"
 	"github.com/multica-ai/multica/server/internal/daemon/repocache"
 	"github.com/multica-ai/multica/server/pkg/agent"
 )
@@ -1516,6 +1518,170 @@ func TestRegisterTaskReposSurvivesWorkspaceRefresh(t *testing.T) {
 
 	if !d.workspaceRepoAllowed("ws-1", sourceRepo) {
 		t.Fatal("project repo URL was wiped by workspace refresh")
+	}
+}
+
+func TestPreCheckoutTaskReposCreatesWorktree(t *testing.T) {
+	t.Parallel()
+
+	sourceRepo := createDaemonTestRepo(t)
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/daemon/workspaces/ws-1/repos" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkspaceReposResponse{
+			WorkspaceID:  "ws-1",
+			Repos:        []RepoData{{URL: sourceRepo}},
+			ReposVersion: "v1",
+		})
+	})
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", nil, "v1", []RepoData{{URL: sourceRepo}}, nil)
+
+	workDir := t.TempDir()
+	repos := d.preCheckoutTaskRepos(context.Background(), "ws-1", "task-1", "agent", workDir, []execenv.RepoContextForEnv{
+		{URL: sourceRepo},
+	})
+
+	if len(repos) != 1 {
+		t.Fatalf("expected one repo, got %d", len(repos))
+	}
+	if repos[0].LocalPath == "" {
+		t.Fatal("expected LocalPath to be populated")
+	}
+	if repos[0].LocalPath != filepath.Join(workDir, filepath.Base(sourceRepo)) {
+		t.Fatalf("LocalPath = %q, want checkout under workdir", repos[0].LocalPath)
+	}
+	if _, err := os.Stat(filepath.Join(repos[0].LocalPath, ".git")); err != nil {
+		t.Fatalf("expected git worktree at LocalPath: %v", err)
+	}
+}
+
+func TestPreCheckoutTaskReposSyncsProjectOnlyRepo(t *testing.T) {
+	t.Parallel()
+
+	sourceRepo := createDaemonTestRepo(t)
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/daemon/workspaces/ws-1/repos" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkspaceReposResponse{
+			WorkspaceID:  "ws-1",
+			Repos:        []RepoData{},
+			ReposVersion: "v2",
+		})
+	})
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", nil, "", nil, nil)
+	d.workspaces["ws-1"].taskRepoURLs = map[string]struct{}{sourceRepo: {}}
+
+	workDir := t.TempDir()
+	repos := d.preCheckoutTaskRepos(context.Background(), "ws-1", "task-1", "agent", workDir, []execenv.RepoContextForEnv{
+		{URL: sourceRepo},
+	})
+
+	if len(repos) != 1 {
+		t.Fatalf("expected one repo, got %d", len(repos))
+	}
+	if repos[0].LocalPath == "" {
+		t.Fatal("expected project-only repo LocalPath to be populated")
+	}
+	if _, err := os.Stat(filepath.Join(repos[0].LocalPath, ".git")); err != nil {
+		t.Fatalf("expected git worktree at LocalPath: %v", err)
+	}
+}
+
+func TestPreCheckoutTaskReposWarnsAndKeepsFallbackOnFailure(t *testing.T) {
+	t.Parallel()
+
+	missingRepo := filepath.Join(t.TempDir(), "missing")
+	var log bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&log, nil))
+	d := newRepoReadyTestDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/daemon/workspaces/ws-1/repos" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WorkspaceReposResponse{
+			WorkspaceID:  "ws-1",
+			Repos:        []RepoData{{URL: missingRepo}},
+			ReposVersion: "v1",
+		})
+	})
+	d.logger = logger
+	d.workspaces["ws-1"] = newWorkspaceState("ws-1", nil, "v1", []RepoData{{URL: missingRepo}}, nil)
+
+	repos := d.preCheckoutTaskRepos(context.Background(), "ws-1", "task-1", "agent", t.TempDir(), []execenv.RepoContextForEnv{
+		{URL: missingRepo},
+	})
+
+	if len(repos) != 1 {
+		t.Fatalf("expected one repo, got %d", len(repos))
+	}
+	if repos[0].LocalPath != "" {
+		t.Fatalf("LocalPath = %q, want empty on failure", repos[0].LocalPath)
+	}
+	if !strings.Contains(log.String(), "daemon pre-checkout failed") {
+		t.Fatalf("expected pre-checkout warning, got logs:\n%s", log.String())
+	}
+}
+
+func TestPreCheckoutTaskReposNilCacheNoops(t *testing.T) {
+	t.Parallel()
+
+	var log bytes.Buffer
+	d := &Daemon{
+		logger:    slog.New(slog.NewTextHandler(&log, nil)),
+		repoCache: nil,
+	}
+	repos := []execenv.RepoContextForEnv{{URL: "https://github.com/org/repo"}}
+
+	got := d.preCheckoutTaskRepos(context.Background(), "ws-1", "task-1", "agent", t.TempDir(), repos)
+
+	if got[0].LocalPath != "" {
+		t.Fatalf("LocalPath = %q, want empty", got[0].LocalPath)
+	}
+	if !strings.Contains(log.String(), "repo cache not initialized") {
+		t.Fatalf("expected nil-cache warning, got logs:\n%s", log.String())
+	}
+}
+
+func TestAuditWorkdirForRawClones(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workDir, "raw-clone", ".git"), 0o755); err != nil {
+		t.Fatalf("create raw clone marker: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workDir, "worktree"), 0o755); err != nil {
+		t.Fatalf("create worktree dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "worktree", ".git"), []byte("gitdir: /tmp/bare/worktrees/x\n"), 0o644); err != nil {
+		t.Fatalf("create worktree git file: %v", err)
+	}
+
+	var log bytes.Buffer
+	d := &Daemon{logger: slog.New(slog.NewTextHandler(&log, nil))}
+	d.auditWorkdirForRawClones(workDir, "task-1")
+
+	got := log.String()
+	if !strings.Contains(got, "raw git clone detected") {
+		t.Fatalf("expected raw clone warning, got logs:\n%s", got)
+	}
+	if strings.Contains(got, filepath.Join(workDir, "worktree")) {
+		t.Fatalf("did not expect warning for .git file worktree marker, got logs:\n%s", got)
+	}
+}
+
+func TestAuditWorkdirForRawClonesMissingWorkdirDoesNotWarn(t *testing.T) {
+	t.Parallel()
+
+	var log bytes.Buffer
+	d := &Daemon{logger: slog.New(slog.NewTextHandler(&log, nil))}
+	d.auditWorkdirForRawClones(filepath.Join(t.TempDir(), "missing"), "task-1")
+
+	if log.Len() != 0 {
+		t.Fatalf("expected missing workdir to be ignored, got logs:\n%s", log.String())
 	}
 }
 

--- a/server/internal/daemon/execenv/execenv.go
+++ b/server/internal/daemon/execenv/execenv.go
@@ -1,6 +1,7 @@
 // Package execenv manages isolated per-task execution environments for the daemon.
 // Each task gets its own directory with injected context files. Repositories are
-// checked out on demand by the agent via `multica repo checkout`.
+// pre-checked out by the daemon when possible and remain available for on-demand
+// checkout via `multica repo checkout`.
 package execenv
 
 import (
@@ -14,7 +15,8 @@ import (
 
 // RepoContextForEnv describes a workspace repo available for checkout.
 type RepoContextForEnv struct {
-	URL string // remote URL
+	URL       string // remote URL
+	LocalPath string // absolute worktree path when daemon pre-checkout succeeded
 }
 
 // ProjectResourceForEnv describes a single resource attached to the issue's

--- a/server/internal/daemon/execenv/execenv_test.go
+++ b/server/internal/daemon/execenv/execenv_test.go
@@ -266,6 +266,43 @@ func TestProjectReposReplaceWorkspaceReposInMetaSkill(t *testing.T) {
 	}
 }
 
+func TestRepositoryBriefRendersPrecheckedAndFallbackRepos(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ctx := TaskContextForEnv{
+		IssueID: "11111111-2222-3333-4444-555555555555",
+		Repos: []RepoContextForEnv{
+			{
+				URL:       "https://github.com/org/backend",
+				LocalPath: filepath.Join(dir, "backend"),
+			},
+			{URL: "https://github.com/org/frontend"},
+		},
+	}
+
+	if _, err := InjectRuntimeConfig(dir, "claude", ctx); err != nil {
+		t.Fatalf("InjectRuntimeConfig: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	s := string(content)
+
+	for _, want := range []string{
+		"https://github.com/org/backend",
+		"already checked out at `" + filepath.Join(dir, "backend") + "`",
+		"https://github.com/org/frontend",
+		"run `multica repo checkout https://github.com/org/frontend`",
+		"Do not use raw `git clone`",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("CLAUDE.md missing %q", want)
+		}
+	}
+}
+
 func TestWriteProjectResourcesSkippedWhenNone(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -245,12 +245,15 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	// Inject available repositories section.
 	if len(ctx.Repos) > 0 {
 		b.WriteString("## Repositories\n\n")
-		b.WriteString("The following code repositories are available in this workspace.\n")
-		b.WriteString("Use `multica repo checkout <url>` to check out a repository into your working directory. Add `--ref <branch-or-sha>` when you need an exact branch, tag, or commit.\n\n")
+		b.WriteString("The following code repositories are available in this workspace. Do not use raw `git clone`; use the checked-out path below or the Multica checkout command so the daemon can manage worktrees.\n\n")
 		for _, repo := range ctx.Repos {
-			fmt.Fprintf(&b, "- %s\n", repo.URL)
+			if strings.TrimSpace(repo.LocalPath) != "" {
+				fmt.Fprintf(&b, "- %s - already checked out at `%s`\n", repo.URL, repo.LocalPath)
+				continue
+			}
+			fmt.Fprintf(&b, "- %s - run `multica repo checkout %s` from this isolated working directory. Add `--ref <branch-or-sha>` when you need an exact branch, tag, or commit.\n", repo.URL, repo.URL)
 		}
-		b.WriteString("\nThe checkout command creates a git worktree with a dedicated branch. You can check out one or more repos as needed, and can pass `--ref` for review/QA on a non-default branch or commit.\n\n")
+		b.WriteString("\n")
 	}
 
 	// Inject project-scoped context (resources attached to the issue's project).


### PR DESCRIPTION
## What does this PR do?

Fixes daemon-side repo isolation for local agent tasks so agents start with managed worktrees instead of needing to discover and run `multica repo checkout` themselves.

```mermaid
flowchart TD
  A["Daemon claims task"] --> B["registerTaskRepos(task.Repos)"]
  B --> C["Prepare or reuse isolated workdir"]
  C --> D["preCheckoutTaskRepos"]
  D --> E{"Repo cache ready?"}
  E -- "yes" --> F["Create managed git worktree under workdir"]
  E -- "no" --> G["Keep fallback checkout instructions"]
  F --> H["Inject runtime config with LocalPath"]
  G --> H
  H --> I["Start agent in isolated workdir"]
  I --> J["After completion: audit workdir for raw clones"]
```

Root cause: agents could ignore the runtime brief and run raw `git clone`, bypassing the daemon repo cache and per-task worktree isolation. This change moves the happy path into the daemon before the agent starts, while retaining the existing checkout command as a fallback when precheckout cannot complete.

## Related Issue

Fixes #2639

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `server/internal/daemon/daemon.go`
  - Adds daemon precheckout for task repos after the workdir exists and before runtime config injection.
  - Ensures project-only repo URLs can sync even when `GetWorkspaceRepos` does not return them.
  - Adds a post-run audit warning for raw `.git/` clone directories in the task workdir.
- `server/internal/daemon/execenv/execenv.go`
  - Adds `RepoContextForEnv.LocalPath` for already-created worktree paths.
- `server/internal/daemon/execenv/runtime_config.go`
  - Renders checked-out repo paths in the injected runtime brief.
  - Keeps explicit `multica repo checkout` fallback instructions when precheckout fails.
- Tests cover successful precheckout, project-only repo precheckout, failure fallback behavior, nil repo cache behavior, raw clone auditing, and runtime brief rendering.

## How to Test

1. Run targeted daemon verification:

   ```bash
   cd server
   go test -count=1 ./internal/daemon ./internal/daemon/execenv ./internal/daemon/repocache
   ```

2. Manual test case: **Project-Only Repo Precheckout Creates Managed Worktree**

   Setup:
   - Run the local web app, server, and daemon.
   - Use a workspace project with a GitHub repo project resource, for example `https://github.com/octocat/Hello-World.git`.
   - Create an issue in that project and assign it to an online local agent.
   - Use a prompt that asks the agent to inspect its injected context and workdir, but does not ask it to run `multica repo checkout` or `git clone`.

   Steps:
   1. In Chrome, open the issue and wait for the local agent run to complete.
   2. Open the issue sidebar's Execution log and confirm the run is completed.
   3. In local Postgres, find the task row for that issue and record `agent_task_queue.work_dir`.
   4. Inspect `<work_dir>/AGENTS.md` or `<work_dir>/CLAUDE.md` and confirm the repository line says `already checked out at <work_dir>/<repo-name>`.
   5. Inspect `<work_dir>/<repo-name>/.git` and confirm it is a file whose contents point into the daemon repo cache worktrees directory, not a `.git/` directory.
   6. Query persisted `task_message` rows for that task and confirm there are no `git clone` or `multica repo checkout` tool invocations.

   Expected result:
   - The agent starts with a managed repo worktree already present under its isolated task workdir.
   - The injected runtime brief includes the prechecked local path.
   - The task logs show the agent did not need to run checkout or raw clone commands.
   - Chrome shows the corresponding issue run as completed in the Execution log.

   Local evidence from this PR branch:
   - I ran this test with a local verification issue in the `Kiwi-Labs` workspace, using `Hello-World` as the project repo resource.
   - The task workdir contained `Hello-World/README` and a `.git` pointer file under the task workdir.
   - The persisted task logs had zero `git clone` and zero `multica repo checkout` commands for the verified runs.

Known local caveat: `go test ./...` currently fails in unrelated `server/pkg/agent` fake CLI timeout tests (`codex`, `opencode`, `copilot`, `claude`). The touched daemon, execenv, and repo-cache packages pass uncached.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and documented the result
- [x] I have added or updated tests where applicable
- [x] I have considered and documented risks above
- [x] I will address all reviewer comments before requesting merge

## Risks

- Precheckout adds a cache/worktree step before agent startup, so repo sync failures now happen earlier. The implementation logs warnings and preserves fallback checkout instructions rather than failing the task outright.
- Reused workdirs update an existing managed worktree through the repo-cache path, matching existing checkout behavior.
