### PR TITLE
feat(runtime): teach agents the parent/sub-issue protocol (MUL-2338)

### DIFF
--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -343,6 +343,42 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		fmt.Fprintf(&b, "7. If blocked, run `multica issue status %s blocked` and post a comment explaining why\n\n", ctx.IssueID)
 	}
 
+	// Parent / Sub-issue Protocol — emitted whenever the agent is running on a
+	// real Multica issue (assignment- or comment-triggered). The platform does
+	// not auto-notify a parent when a child changes status; this section
+	// teaches the child agent to post the signal as a best-effort follow-up,
+	// and teaches any agent creating sub-issues to use `backlog` vs `todo`
+	// deliberately. Skipped for chat, quick-create, and run-only autopilot
+	// runs, which have no parent/child semantics.
+	if ctx.IssueID != "" && ctx.ChatSessionID == "" && ctx.QuickCreatePrompt == "" && ctx.AutopilotRunID == "" {
+		b.WriteString("## Parent / Sub-issue Protocol\n\n")
+		b.WriteString("Sub-issues are linked to a parent through `parent_issue_id`. The platform does **not** auto-notify a parent when its child changes status, so the child agent is responsible for posting that signal as a best-effort comment. Two behaviors apply.\n\n")
+
+		b.WriteString("### A. Notify the parent when this issue is finishing\n\n")
+		b.WriteString("Applies whenever you are wrapping up this issue and `parent_issue_id` (from the initial `multica issue get` JSON) is non-empty. Order matters — finish your own issue first, then write to the parent:\n\n")
+		b.WriteString("1. Post your final-results comment on **this** issue and run `multica issue status <this-issue-id> in_review`. Your own issue remains the source of truth for what you did; do not put the deliverable in the parent comment.\n")
+		b.WriteString("2. Run `multica issue get <parent-id> --output json` and read `assignee_id`, `assignee_type`, and `status`. If this call fails (parent removed, no access), skip the notification — do not block your own finish over it.\n")
+		b.WriteString("3. Post a single **top-level** comment on the parent issue (`multica issue comment add <parent-id> ...` with NO `--parent`). Follow the comment-formatting rules already in this brief for the current provider when choosing between `--content`, `--content-stdin`, and `--content-file`. The body should reference this child as `[MUL-<num>](mention://issue/<child-id>)`, state that it is now `in_review`, and give a one-line outcome plus whatever link the parent agent needs to decide the next step.\n\n")
+		b.WriteString("Mention rules for that parent-side comment — these prevent loops, do not weaken them:\n\n")
+		b.WriteString("| Parent assignee | Parent status | Mention in your comment? |\n")
+		b.WriteString("|---|---|---|\n")
+		b.WriteString("| Another agent (not you) | not `done` / `cancelled` | **Yes** — `[@Name](mention://agent/<parent-agent-id>)` to wake them |\n")
+		b.WriteString("| The same agent as yourself | any | **No** — never `@` yourself; you will read your own comment next time you run on the parent |\n")
+		b.WriteString("| Member or squad | any | **No** `@mention` — refer to them in plain text if needed |\n")
+		b.WriteString("| Any assignee | `done` or `cancelled` | **No** mention — do not re-trigger a closed issue |\n\n")
+		b.WriteString("This signal is best-effort, not a guaranteed handshake. Treat it as the parent's hint that a child is ready for review.\n\n")
+
+		b.WriteString("### B. Choose `backlog` vs `todo` when creating sub-issues\n\n")
+		b.WriteString("When you run `multica issue create --parent <this-issue-id> --assignee-id <agent-uuid> ...`, `--status` defaults to `todo`, which triggers an agent assignee immediately. Use this knob deliberately:\n\n")
+		b.WriteString("- `--status todo` → **start now**. Use only for the sub-issue you actually want running this turn.\n")
+		b.WriteString("- `--status backlog` → **wait**. Assignee is set but the agent will not be triggered. Promote it later with `multica issue status <child-id> todo` when its turn comes.\n\n")
+		b.WriteString("Decision shortcuts:\n\n")
+		b.WriteString("- N independent parallel sub-tasks → all `--status todo`.\n")
+		b.WriteString("- Strict serial Step 1 → 2 → 3 → only Step 1 gets `--status todo`; Step 2 and Step 3 are created with `--status backlog` from the start. When Step 1 notifies you via behavior A, promote Step 2 with `multica issue status <step2-id> todo`.\n")
+		b.WriteString("- Dependencies you have not figured out yet → create everything with `--status backlog` and promote them one by one.\n\n")
+		b.WriteString("Forgetting `--status backlog` and leaving the default `todo` is the common cause of supposedly-serial sub-tasks racing each other.\n\n")
+	}
+
 	if len(ctx.AgentSkills) > 0 {
 		b.WriteString("## Skills\n\n")
 		switch provider {

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -356,9 +356,19 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 
 		b.WriteString("### A. Notify the parent when this issue is finishing\n\n")
 		b.WriteString("Applies whenever you are wrapping up this issue and `parent_issue_id` (from the initial `multica issue get` JSON) is non-empty. Order matters — finish your own issue first, then write to the parent:\n\n")
-		b.WriteString("1. Post your final-results comment on **this** issue and run `multica issue status <this-issue-id> in_review`. Your own issue remains the source of truth for what you did; do not put the deliverable in the parent comment.\n")
+		if ctx.TriggerCommentID != "" {
+			// Comment-triggered runs must NOT override the comment-triggered
+			// workflow rule "Do NOT change the issue status unless the
+			// comment explicitly asks for it". Step A here is reply-shaped,
+			// not status-shaped — the protocol's parent notification is
+			// gated on the run actually closing out child work.
+			b.WriteString("1. Complete your reply on **this** issue per the comment-triggered workflow above. The rule \"Do NOT change the issue status unless the comment explicitly asks for it\" still applies — do **not** add an unconditional status flip to `in_review` (or anything else) just because you are wrapping up child work. Only change this issue's status when the triggering comment explicitly asked for a status change.\n")
+			b.WriteString("   The parent-notification steps below apply only when this run is in fact closing out the child's work (typically because the triggering comment told you to finish and hand the deliverable back to the parent). If you are just answering a question, doing partial work, or otherwise not wrapping up, stop after replying — skip the parent notification entirely.\n")
+		} else {
+			b.WriteString("1. Post your final-results comment on **this** issue and run `multica issue status <this-issue-id> in_review`. Your own issue remains the source of truth for what you did; do not put the deliverable in the parent comment.\n")
+		}
 		b.WriteString("2. Run `multica issue get <parent-id> --output json` and read `assignee_id`, `assignee_type`, and `status`. If this call fails (parent removed, no access), skip the notification — do not block your own finish over it.\n")
-		b.WriteString("3. Post a single **top-level** comment on the parent issue (`multica issue comment add <parent-id> ...` with NO `--parent`). Follow the comment-formatting rules already in this brief for the current provider when choosing between `--content`, `--content-stdin`, and `--content-file`. The body should reference this child as `[MUL-<num>](mention://issue/<child-id>)`, state that it is now `in_review`, and give a one-line outcome plus whatever link the parent agent needs to decide the next step.\n\n")
+		b.WriteString("3. Post a single **top-level** comment on the parent issue (`multica issue comment add <parent-id> ...` with NO `--parent`). Follow the comment-formatting rules already in this brief for the current provider when choosing between `--content`, `--content-stdin`, and `--content-file`. The body should reference this child as `[MUL-<num>](mention://issue/<child-id>)`, state the child's current status, and give a one-line outcome plus whatever link the parent agent needs to decide the next step.\n\n")
 		b.WriteString("Mention rules for that parent-side comment — these prevent loops, do not weaken them:\n\n")
 		b.WriteString("| Parent assignee | Parent status | Mention in your comment? |\n")
 		b.WriteString("|---|---|---|\n")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -345,23 +345,17 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 
 	// Parent / Sub-issue Protocol — best-effort convention, not a server-side
 	// state sync. Skipped for chat, quick-create, and run-only autopilot runs
-	// which have no parent/child semantics. Deliberately kept short (Elon's
-	// third review of PR #2918): three rules, no per-case branching tables,
-	// no "spec" feel.
+	// which have no parent/child semantics. Unified for both assignment- and
+	// comment-triggered runs (Bohan's direction on PR #2918): describe the
+	// mechanism, not a state machine. Comment-triggered runs naturally skip
+	// the parent notification because the workflow above forbids unprompted
+	// status flips — so a comment-triggered agent isn't "finishing" the
+	// child and has nothing to report up.
 	if ctx.IssueID != "" && ctx.ChatSessionID == "" && ctx.QuickCreatePrompt == "" && ctx.AutopilotRunID == "" {
 		b.WriteString("## Parent / Sub-issue Protocol\n\n")
-		b.WriteString("For parent/child work, use these best-effort rules — the platform does NOT auto-sync parent and child status.\n\n")
-		if ctx.TriggerCommentID != "" {
-			// Comment-triggered runs must NOT override the comment-triggered
-			// workflow rule "Do NOT change the issue status unless the
-			// comment explicitly asks for it". Parent notification is gated
-			// on the run actually closing out child work.
-			b.WriteString("1. **Closing out child work** (only if this issue has `parent_issue_id`). Reply on this issue per the comment-triggered workflow above. \"Do NOT change the issue status unless the comment explicitly asks for it\" still applies — do **not** add an unconditional status flip. If you are just answering a question or doing partial work (not closing out the child), skip the parent notification entirely.\n")
-		} else {
-			b.WriteString("1. **Closing out child work** (only if this issue has `parent_issue_id`). Post your final-results comment on this issue, then run `multica issue status <this-issue-id> in_review`.\n")
-		}
-		b.WriteString("2. **Notify the parent** (only if this issue has `parent_issue_id` and you are closing out child work). Post one **top-level** comment on the parent (`multica issue comment add <parent-id>` with NO `--parent`): link the child as `[MUL-<num>](mention://issue/<child-id>)`, give its current status and a one-line outcome, and `@mention` the parent's assignee using the URL that matches `assignee_type` — `mention://agent/<id>`, `mention://member/<id>`, or `mention://squad/<id>`. If there is no assignee, post without the `@mention`. Don't try to second-guess (same agent, closed parent, etc.) — platform dedup handles re-triggers.\n")
-		b.WriteString("3. **Creating sub-issues** (applies to any issue-bound run). `--status todo` → **start now** (the default — agent assignee fires immediately). `--status backlog` → **wait** (assignee is set, no trigger; promote later with `multica issue status <child-id> todo`). Parallel children: all `--status todo`. Strict serial Step 1→2→3: only Step 1 is `todo`; Steps 2/3 are `--status backlog` from the start, promoted in turn.\n\n")
+		b.WriteString("Multica issues form a parent/child tree via `parent_issue_id`. The platform does NOT auto-sync child status to the parent — if a child finishes, its agent reports up. This is a best-effort convention.\n\n")
+		b.WriteString("1. **Tell the parent when you finish a child.** If this issue has a `parent_issue_id` and you are wrapping it up (final-results comment posted and status flipped per the workflow above), also post one **top-level** comment on the parent (`multica issue comment add <parent-id>` with NO `--parent`): link the child as `[MUL-<num>](mention://issue/<child-id>)`, give its current status and a one-line outcome, and `@mention` the parent's assignee using the URL that matches `assignee_type` — `mention://agent/<id>`, `mention://member/<id>`, or `mention://squad/<id>`. Skip the mention if there is no assignee. If you are NOT changing this issue's status this run (e.g. a comment-triggered run that's just answering a question), you are not closing out the child — skip the parent notification.\n")
+		b.WriteString("2. **Choosing `--status` when creating sub-issues.** `--status todo` = **start now** (the default — an agent assignee fires immediately). `--status backlog` = **wait** (assignee is set but no trigger fires; promote later with `multica issue status <child-id> todo`). Parallel children: all `--status todo`. Strict serial Step 1→2→3: only Step 1 is `todo`; Steps 2/3 are `--status backlog` from the start, promoted in turn.\n\n")
 	}
 
 	if len(ctx.AgentSkills) > 0 {

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -343,43 +343,25 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		fmt.Fprintf(&b, "7. If blocked, run `multica issue status %s blocked` and post a comment explaining why\n\n", ctx.IssueID)
 	}
 
-	// Parent / Sub-issue Protocol — emitted whenever the agent is running on a
-	// real Multica issue (assignment- or comment-triggered). The platform does
-	// not auto-notify a parent when a child changes status; this section
-	// teaches the child agent to post the signal as a best-effort follow-up,
-	// and teaches any agent creating sub-issues to use `backlog` vs `todo`
-	// deliberately. Skipped for chat, quick-create, and run-only autopilot
-	// runs, which have no parent/child semantics.
+	// Parent / Sub-issue Protocol — best-effort convention, not a server-side
+	// state sync. Skipped for chat, quick-create, and run-only autopilot runs
+	// which have no parent/child semantics. Deliberately kept short (Elon's
+	// third review of PR #2918): three rules, no per-case branching tables,
+	// no "spec" feel.
 	if ctx.IssueID != "" && ctx.ChatSessionID == "" && ctx.QuickCreatePrompt == "" && ctx.AutopilotRunID == "" {
 		b.WriteString("## Parent / Sub-issue Protocol\n\n")
-		b.WriteString("Sub-issues are linked to a parent through `parent_issue_id`. The platform does **not** auto-notify a parent when its child changes status, so the child agent is responsible for posting that signal as a best-effort comment. Two behaviors apply.\n\n")
-
-		b.WriteString("### A. Notify the parent when this issue is finishing\n\n")
-		b.WriteString("Applies whenever you are wrapping up this issue and `parent_issue_id` (from the initial `multica issue get` JSON) is non-empty. Order matters — finish your own issue first, then write to the parent:\n\n")
+		b.WriteString("This is a best-effort convention — the platform does NOT auto-sync parent and child status. When this issue has `parent_issue_id`:\n\n")
 		if ctx.TriggerCommentID != "" {
 			// Comment-triggered runs must NOT override the comment-triggered
 			// workflow rule "Do NOT change the issue status unless the
-			// comment explicitly asks for it". Step A here is reply-shaped,
-			// not status-shaped — the protocol's parent notification is
-			// gated on the run actually closing out child work.
-			b.WriteString("1. Complete your reply on **this** issue per the comment-triggered workflow above. The rule \"Do NOT change the issue status unless the comment explicitly asks for it\" still applies — do **not** add an unconditional status flip to `in_review` (or anything else) just because you are wrapping up child work. Only change this issue's status when the triggering comment explicitly asked for a status change.\n")
-			b.WriteString("   The parent-notification steps below apply only when this run is in fact closing out the child's work (typically because the triggering comment told you to finish and hand the deliverable back to the parent). If you are just answering a question, doing partial work, or otherwise not wrapping up, stop after replying — skip the parent notification entirely.\n")
+			// comment explicitly asks for it". Parent notification is gated
+			// on the run actually closing out child work.
+			b.WriteString("1. **Closing out child work.** Reply on this issue per the comment-triggered workflow above. \"Do NOT change the issue status unless the comment explicitly asks for it\" still applies — do **not** add an unconditional status flip. If you are just answering a question or doing partial work (not closing out the child), skip the parent notification entirely.\n")
 		} else {
-			b.WriteString("1. Post your final-results comment on **this** issue and run `multica issue status <this-issue-id> in_review`. Your own issue remains the source of truth for what you did; do not put the deliverable in the parent comment.\n")
+			b.WriteString("1. **Closing out child work.** Post your final-results comment on this issue, then run `multica issue status <this-issue-id> in_review`.\n")
 		}
-		b.WriteString("2. Run `multica issue get <parent-id> --output json` and read `assignee_id` and `assignee_type`. If this call fails (parent removed, no access), skip the notification — do not block your own finish over it.\n")
-		b.WriteString("3. Post a single **top-level** comment on the parent issue (`multica issue comment add <parent-id> ...` with NO `--parent`). Follow the comment-formatting rules already in this brief for the current provider when choosing between `--content`, `--content-stdin`, and `--content-file`. The body should reference this child as `[MUL-<num>](mention://issue/<child-id>)`, state the child's current status, give a one-line outcome plus whatever link the parent owner needs, and `@mention` the parent's assignee using the URL that matches `assignee_type` — `mention://agent/<id>`, `mention://member/<id>`, or `mention://squad/<id>`. If the parent has no assignee, post the same comment without an `@mention`. Don't try to second-guess the mention (same agent as yourself, parent already closed, etc.) — the platform's dedup handles re-triggers, and mentioning the assignee is the simple, predictable rule.\n\n")
-		b.WriteString("This signal is best-effort, not a guaranteed handshake. Treat it as the parent's hint that a child is ready for review.\n\n")
-
-		b.WriteString("### B. Choose `backlog` vs `todo` when creating sub-issues\n\n")
-		b.WriteString("When you run `multica issue create --parent <this-issue-id> --assignee-id <agent-uuid> ...`, `--status` defaults to `todo`, which triggers an agent assignee immediately. Use this knob deliberately:\n\n")
-		b.WriteString("- `--status todo` → **start now**. Use only for the sub-issue you actually want running this turn.\n")
-		b.WriteString("- `--status backlog` → **wait**. Assignee is set but the agent will not be triggered. Promote it later with `multica issue status <child-id> todo` when its turn comes.\n\n")
-		b.WriteString("Decision shortcuts:\n\n")
-		b.WriteString("- N independent parallel sub-tasks → all `--status todo`.\n")
-		b.WriteString("- Strict serial Step 1 → 2 → 3 → only Step 1 gets `--status todo`; Step 2 and Step 3 are created with `--status backlog` from the start. When Step 1 notifies you via behavior A, promote Step 2 with `multica issue status <step2-id> todo`.\n")
-		b.WriteString("- Dependencies you have not figured out yet → create everything with `--status backlog` and promote them one by one.\n\n")
-		b.WriteString("Forgetting `--status backlog` and leaving the default `todo` is the common cause of supposedly-serial sub-tasks racing each other.\n\n")
+		b.WriteString("2. **Notify the parent.** Post one **top-level** comment on the parent (`multica issue comment add <parent-id>` with NO `--parent`): link the child as `[MUL-<num>](mention://issue/<child-id>)`, give its current status and a one-line outcome, and `@mention` the parent's assignee using the URL that matches `assignee_type` — `mention://agent/<id>`, `mention://member/<id>`, or `mention://squad/<id>`. If there is no assignee, post without the `@mention`. Don't try to second-guess (same agent, closed parent, etc.) — platform dedup handles re-triggers.\n")
+		b.WriteString("3. **Creating sub-issues.** `--status todo` → **start now** (the default — agent assignee fires immediately). `--status backlog` → **wait** (assignee is set, no trigger; promote later with `multica issue status <child-id> todo`). Parallel children: all `--status todo`. Strict serial Step 1→2→3: only Step 1 is `todo`; Steps 2/3 are `--status backlog` from the start, promoted in turn.\n\n")
 	}
 
 	if len(ctx.AgentSkills) > 0 {

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -367,15 +367,8 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 		} else {
 			b.WriteString("1. Post your final-results comment on **this** issue and run `multica issue status <this-issue-id> in_review`. Your own issue remains the source of truth for what you did; do not put the deliverable in the parent comment.\n")
 		}
-		b.WriteString("2. Run `multica issue get <parent-id> --output json` and read `assignee_id`, `assignee_type`, and `status`. If this call fails (parent removed, no access), skip the notification — do not block your own finish over it.\n")
-		b.WriteString("3. Post a single **top-level** comment on the parent issue (`multica issue comment add <parent-id> ...` with NO `--parent`). Follow the comment-formatting rules already in this brief for the current provider when choosing between `--content`, `--content-stdin`, and `--content-file`. The body should reference this child as `[MUL-<num>](mention://issue/<child-id>)`, state the child's current status, and give a one-line outcome plus whatever link the parent agent needs to decide the next step.\n\n")
-		b.WriteString("Mention rules for that parent-side comment — these prevent loops, do not weaken them:\n\n")
-		b.WriteString("| Parent assignee | Parent status | Mention in your comment? |\n")
-		b.WriteString("|---|---|---|\n")
-		b.WriteString("| Another agent (not you) | not `done` / `cancelled` | **Yes** — `[@Name](mention://agent/<parent-agent-id>)` to wake them |\n")
-		b.WriteString("| The same agent as yourself | any | **No** — never `@` yourself; you will read your own comment next time you run on the parent |\n")
-		b.WriteString("| Member or squad | any | **No** `@mention` — refer to them in plain text if needed |\n")
-		b.WriteString("| Any assignee | `done` or `cancelled` | **No** mention — do not re-trigger a closed issue |\n\n")
+		b.WriteString("2. Run `multica issue get <parent-id> --output json` and read `assignee_id` and `assignee_type`. If this call fails (parent removed, no access), skip the notification — do not block your own finish over it.\n")
+		b.WriteString("3. Post a single **top-level** comment on the parent issue (`multica issue comment add <parent-id> ...` with NO `--parent`). Follow the comment-formatting rules already in this brief for the current provider when choosing between `--content`, `--content-stdin`, and `--content-file`. The body should reference this child as `[MUL-<num>](mention://issue/<child-id>)`, state the child's current status, give a one-line outcome plus whatever link the parent owner needs, and `@mention` the parent's assignee using the URL that matches `assignee_type` — `mention://agent/<id>`, `mention://member/<id>`, or `mention://squad/<id>`. If the parent has no assignee, post the same comment without an `@mention`. Don't try to second-guess the mention (same agent as yourself, parent already closed, etc.) — the platform's dedup handles re-triggers, and mentioning the assignee is the simple, predictable rule.\n\n")
 		b.WriteString("This signal is best-effort, not a guaranteed handshake. Treat it as the parent's hint that a child is ready for review.\n\n")
 
 		b.WriteString("### B. Choose `backlog` vs `todo` when creating sub-issues\n\n")

--- a/server/internal/daemon/execenv/runtime_config.go
+++ b/server/internal/daemon/execenv/runtime_config.go
@@ -350,18 +350,18 @@ func buildMetaSkillContent(provider string, ctx TaskContextForEnv) string {
 	// no "spec" feel.
 	if ctx.IssueID != "" && ctx.ChatSessionID == "" && ctx.QuickCreatePrompt == "" && ctx.AutopilotRunID == "" {
 		b.WriteString("## Parent / Sub-issue Protocol\n\n")
-		b.WriteString("This is a best-effort convention — the platform does NOT auto-sync parent and child status. When this issue has `parent_issue_id`:\n\n")
+		b.WriteString("For parent/child work, use these best-effort rules — the platform does NOT auto-sync parent and child status.\n\n")
 		if ctx.TriggerCommentID != "" {
 			// Comment-triggered runs must NOT override the comment-triggered
 			// workflow rule "Do NOT change the issue status unless the
 			// comment explicitly asks for it". Parent notification is gated
 			// on the run actually closing out child work.
-			b.WriteString("1. **Closing out child work.** Reply on this issue per the comment-triggered workflow above. \"Do NOT change the issue status unless the comment explicitly asks for it\" still applies — do **not** add an unconditional status flip. If you are just answering a question or doing partial work (not closing out the child), skip the parent notification entirely.\n")
+			b.WriteString("1. **Closing out child work** (only if this issue has `parent_issue_id`). Reply on this issue per the comment-triggered workflow above. \"Do NOT change the issue status unless the comment explicitly asks for it\" still applies — do **not** add an unconditional status flip. If you are just answering a question or doing partial work (not closing out the child), skip the parent notification entirely.\n")
 		} else {
-			b.WriteString("1. **Closing out child work.** Post your final-results comment on this issue, then run `multica issue status <this-issue-id> in_review`.\n")
+			b.WriteString("1. **Closing out child work** (only if this issue has `parent_issue_id`). Post your final-results comment on this issue, then run `multica issue status <this-issue-id> in_review`.\n")
 		}
-		b.WriteString("2. **Notify the parent.** Post one **top-level** comment on the parent (`multica issue comment add <parent-id>` with NO `--parent`): link the child as `[MUL-<num>](mention://issue/<child-id>)`, give its current status and a one-line outcome, and `@mention` the parent's assignee using the URL that matches `assignee_type` — `mention://agent/<id>`, `mention://member/<id>`, or `mention://squad/<id>`. If there is no assignee, post without the `@mention`. Don't try to second-guess (same agent, closed parent, etc.) — platform dedup handles re-triggers.\n")
-		b.WriteString("3. **Creating sub-issues.** `--status todo` → **start now** (the default — agent assignee fires immediately). `--status backlog` → **wait** (assignee is set, no trigger; promote later with `multica issue status <child-id> todo`). Parallel children: all `--status todo`. Strict serial Step 1→2→3: only Step 1 is `todo`; Steps 2/3 are `--status backlog` from the start, promoted in turn.\n\n")
+		b.WriteString("2. **Notify the parent** (only if this issue has `parent_issue_id` and you are closing out child work). Post one **top-level** comment on the parent (`multica issue comment add <parent-id>` with NO `--parent`): link the child as `[MUL-<num>](mention://issue/<child-id>)`, give its current status and a one-line outcome, and `@mention` the parent's assignee using the URL that matches `assignee_type` — `mention://agent/<id>`, `mention://member/<id>`, or `mention://squad/<id>`. If there is no assignee, post without the `@mention`. Don't try to second-guess (same agent, closed parent, etc.) — platform dedup handles re-triggers.\n")
+		b.WriteString("3. **Creating sub-issues** (applies to any issue-bound run). `--status todo` → **start now** (the default — agent assignee fires immediately). `--status backlog` → **wait** (assignee is set, no trigger; promote later with `multica issue status <child-id> todo`). Parallel children: all `--status todo`. Strict serial Step 1→2→3: only Step 1 is `todo`; Steps 2/3 are `--status backlog` from the start, promoted in turn.\n\n")
 	}
 
 	if len(ctx.AgentSkills) > 0 {

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -82,6 +82,70 @@ func TestParentSubIssueProtocolEmittedForCommentTrigger(t *testing.T) {
 	}
 }
 
+// Comment-triggered briefs must NOT include the unconditional
+// `multica issue status <this-issue-id> in_review` instruction from Step A.
+// That instruction conflicts with the comment-triggered workflow rule
+// "Do NOT change the issue status unless the comment explicitly asks for it"
+// (Elon's blocking review on PR #2918). Step A for comment-triggered runs
+// must instead remind the agent that the existing status guardrail still
+// applies and that the parent notification is gated on actually closing
+// out child work.
+func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID:          "55555555-6666-7777-8888-999999999999",
+		TriggerCommentID: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	// The exact unconditional status-flip command from the previous Step A
+	// must not appear anywhere in a comment-triggered brief. It is fine
+	// for Step B to teach the agent to *promote* a child to `todo` — that
+	// targets a different issue id, so the substring does not collide.
+	if strings.Contains(out, "`multica issue status <this-issue-id> in_review`") {
+		t.Errorf("comment-triggered brief must not contain the unconditional `multica issue status <this-issue-id> in_review` command from Step A (conflicts with the comment-triggered \"do not change status unless asked\" rule)")
+	}
+
+	// The existing comment-triggered workflow rule must still be present
+	// AND Step A must echo it, so the agent cannot rely on the rule
+	// having been forgotten by the time it reaches the protocol section.
+	// Counting occurrences guards against future edits that drop the
+	// in-protocol reminder while leaving the workflow rule intact.
+	const guardrail = "Do NOT change the issue status unless the comment explicitly asks for it"
+	if got := strings.Count(out, guardrail); got < 2 {
+		t.Errorf("expected the comment-triggered status guardrail %q to appear at least twice (once in the comment-triggered workflow, once echoed inside protocol Step A), got %d", guardrail, got)
+	}
+
+	// And Step A must explicitly gate the parent-notification on
+	// actually closing out child work so the agent does not blindly post
+	// to the parent on every comment-triggered run.
+	for _, want := range []string{
+		"closing out the child",
+		"skip the parent notification",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("comment-triggered Step A missing required phrasing %q", want)
+		}
+	}
+}
+
+// Assignment-triggered briefs are the inverse boundary: when the agent
+// owns the issue lifecycle, Step A must still keep the unconditional
+// `multica issue status <this-issue-id> in_review` flip. Splitting Step A
+// by trigger type must not silently drop this behavior on the assignment
+// branch.
+func TestAssignmentTriggeredProtocolStillFlipsInReview(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID: "77777777-8888-9999-aaaa-bbbbbbbbbbbb",
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	if !strings.Contains(out, "`multica issue status <this-issue-id> in_review`") {
+		t.Errorf("assignment-triggered Step A must keep the unconditional `multica issue status <this-issue-id> in_review` flip")
+	}
+}
+
 func TestParentSubIssueProtocolSkippedForNonIssueModes(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -1,0 +1,142 @@
+package execenv
+
+import (
+	"strings"
+	"testing"
+)
+
+// Parent/Sub-issue Protocol — the brief must teach every issue-bound agent
+// two things: (A) notify the parent when this issue finishes, and (B) pick
+// `backlog` vs `todo` deliberately when creating sub-issues. The protocol is
+// runtime-only (no server-side state sync), so the rules live in the meta
+// skill and these tests guard the wording the rest of the design relies on.
+
+func TestParentSubIssueProtocolEmittedForAssignmentTrigger(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID: "11111111-2222-3333-4444-555555555555",
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	if !strings.Contains(out, "## Parent / Sub-issue Protocol") {
+		t.Fatalf("expected Parent / Sub-issue Protocol section in assignment-triggered brief")
+	}
+	// Behavior A — order, top-level comment, best-effort framing.
+	for _, want := range []string{
+		"### A. Notify the parent when this issue is finishing",
+		"finish your own issue first",
+		"`multica issue status <this-issue-id> in_review`",
+		"top-level",
+		"NO `--parent`",
+		"best-effort",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("behavior A missing %q", want)
+		}
+	}
+	// Mention table — every row must be present so loop-prevention rules
+	// stay visible.
+	for _, want := range []string{
+		"Another agent (not you)",
+		"The same agent as yourself",
+		"Member or squad",
+		"`done` or `cancelled`",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("mention table missing row %q", want)
+		}
+	}
+	// Behavior B — backlog vs todo decision.
+	for _, want := range []string{
+		"### B. Choose `backlog` vs `todo` when creating sub-issues",
+		"`--status todo` → **start now**",
+		"`--status backlog` → **wait**",
+		"`multica issue status <child-id> todo`",
+		"all `--status todo`",
+		"`--status backlog` from the start",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("behavior B missing %q", want)
+		}
+	}
+}
+
+func TestParentSubIssueProtocolEmittedForCommentTrigger(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID:          "22222222-3333-4444-5555-666666666666",
+		TriggerCommentID: "33333333-4444-5555-6666-777777777777",
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	if !strings.Contains(out, "## Parent / Sub-issue Protocol") {
+		t.Fatalf("expected Parent / Sub-issue Protocol section in comment-triggered brief")
+	}
+	// Comment-triggered runs may still be wrapping up sub-issue work, so
+	// both behaviors must appear here too.
+	if !strings.Contains(out, "### A. Notify the parent when this issue is finishing") {
+		t.Errorf("comment-triggered brief missing behavior A heading")
+	}
+	if !strings.Contains(out, "### B. Choose `backlog` vs `todo` when creating sub-issues") {
+		t.Errorf("comment-triggered brief missing behavior B heading")
+	}
+}
+
+func TestParentSubIssueProtocolSkippedForNonIssueModes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ctx  TaskContextForEnv
+	}{
+		{
+			name: "chat",
+			ctx:  TaskContextForEnv{ChatSessionID: "chat-1"},
+		},
+		{
+			name: "quick-create",
+			ctx:  TaskContextForEnv{QuickCreatePrompt: "create me an issue"},
+		},
+		{
+			name: "autopilot run-only",
+			ctx:  TaskContextForEnv{AutopilotRunID: "run-1"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := buildMetaSkillContent("claude", tc.ctx)
+			if strings.Contains(out, "## Parent / Sub-issue Protocol") {
+				t.Errorf("%s mode must NOT emit the Parent / Sub-issue Protocol section", tc.name)
+			}
+		})
+	}
+}
+
+// Guardrails for things Elon's review explicitly flagged: no reference to a
+// non-existent `multica issue list --parent` command, and no claim that the
+// protocol is a stable / guaranteed handshake.
+func TestParentSubIssueProtocolHasNoForbiddenClaims(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID: "44444444-5555-6666-7777-888888888888",
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	for _, banned := range []string{
+		"issue list --parent",
+		"is a guaranteed handshake",
+		"is a reliable handshake",
+		"guarantees parent sync",
+		"reliable parent sync",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("brief must not contain %q (best-effort only, no inexistent CLI)", banned)
+		}
+	}
+	// The brief must explicitly frame the signal as best-effort so the
+	// agent does not assume the parent always sees it.
+	if !strings.Contains(out, "best-effort") {
+		t.Errorf("brief must explicitly call the parent notification best-effort")
+	}
+}

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -5,112 +5,106 @@ import (
 	"testing"
 )
 
-// Parent/Sub-issue Protocol — the brief must teach every issue-bound agent
-// three things: close out the child issue, post a best-effort top-level
-// notification on the parent, and pick `backlog` vs `todo` deliberately
-// when creating sub-issues. The protocol is runtime-only (no server-side
-// state sync), so the rules live in the meta skill and these tests guard
-// the wording the rest of the design relies on.
+// Parent/Sub-issue Protocol — the brief teaches every issue-bound agent two
+// things: when finishing a child issue, tell the parent; and when creating
+// sub-issues, pick `--status todo` (start now) vs `--status backlog` (wait)
+// deliberately. The protocol is runtime-only (no server-side state sync) and
+// the section is identical for assignment- and comment-triggered runs — the
+// comment-triggered workflow rule "Do NOT change the issue status unless the
+// comment explicitly asks for it" naturally short-circuits the parent
+// notification, so the protocol stays a single description.
 
-func TestParentSubIssueProtocolEmittedForAssignmentTrigger(t *testing.T) {
+func TestParentSubIssueProtocolPresentForIssueRuns(t *testing.T) {
 	t.Parallel()
-	ctx := TaskContextForEnv{
-		IssueID: "11111111-2222-3333-4444-555555555555",
+	cases := []struct {
+		name string
+		ctx  TaskContextForEnv
+	}{
+		{
+			name: "assignment-triggered",
+			ctx:  TaskContextForEnv{IssueID: "11111111-2222-3333-4444-555555555555"},
+		},
+		{
+			name: "comment-triggered",
+			ctx: TaskContextForEnv{
+				IssueID:          "22222222-3333-4444-5555-666666666666",
+				TriggerCommentID: "33333333-4444-5555-6666-777777777777",
+			},
+		},
 	}
-	out := buildMetaSkillContent("claude", ctx)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := buildMetaSkillContent("claude", tc.ctx)
 
-	if !strings.Contains(out, "## Parent / Sub-issue Protocol") {
-		t.Fatalf("expected Parent / Sub-issue Protocol section in assignment-triggered brief")
-	}
-	// Three core rules in compact form (Elon's third review on PR #2918):
-	// best-effort framing, assignment-branch closing instruction, top-level
-	// parent comment with the simplified mention-by-assignee-type rule, and
-	// the `backlog` vs `todo` sub-issue creation semantics.
-	for _, want := range []string{
-		"best-effort",
-		// Preamble must frame rules generically for parent/child work, NOT
-		// globally gate on the current issue having `parent_issue_id`
-		// (Elon's review on PR #2918: rule 3 still applies to top-level
-		// parents that have no parent themselves).
-		"For parent/child work",
-		// Rules 1 and 2 carry the per-rule gating instead.
-		"**Closing out child work** (only if this issue has `parent_issue_id`)",
-		"**Notify the parent** (only if this issue has `parent_issue_id` and you are closing out child work)",
-		// Rule 3 must explicitly apply to any issue-bound run.
-		"**Creating sub-issues** (applies to any issue-bound run)",
-		// rule 1 — assignment branch keeps the unconditional in_review flip
-		"`multica issue status <this-issue-id> in_review`",
-		// rule 2 — top-level parent comment + simplified mention rule
-		"top-level",
-		"NO `--parent`",
-		"`@mention` the parent's assignee",
-		"`mention://agent/<id>`",
-		"`mention://member/<id>`",
-		"`mention://squad/<id>`",
-		"no assignee",
-		"Don't try to second-guess",
-		// rule 3 — backlog vs todo decision
-		"`--status todo` → **start now**",
-		"`--status backlog` → **wait**",
-		"`multica issue status <child-id> todo`",
-		"all `--status todo`",
-		"`--status backlog` from the start",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("protocol missing %q", want)
-		}
-	}
-	// The per-case mention table from the prior revision must remain
-	// removed — the whole point of the current revision is to drop branchy
-	// "same-agent / member / squad / closed-parent" decision tables.
-	for _, banned := range []string{
-		"| Parent assignee | Parent status |",
-		"The same agent as yourself",
-		"| Member or squad |",
-		// Earlier revisions introduced ### A / ### B subheadings; the
-		// compact revision drops them so the section reads as a
-		// convention, not a spec.
-		"### A. Notify the parent",
-		"### B. Choose",
-		// The previous revision wrapped all three rules in a single
-		// `parent_issue_id` gate; the current revision must instead gate
-		// per-rule so rule 3 still reaches top-level parents.
-		"When this issue has `parent_issue_id`:",
-	} {
-		if strings.Contains(out, banned) {
-			t.Errorf("expected %q to be removed", banned)
-		}
-	}
-}
-
-func TestParentSubIssueProtocolEmittedForCommentTrigger(t *testing.T) {
-	t.Parallel()
-	ctx := TaskContextForEnv{
-		IssueID:          "22222222-3333-4444-5555-666666666666",
-		TriggerCommentID: "33333333-4444-5555-6666-777777777777",
-	}
-	out := buildMetaSkillContent("claude", ctx)
-
-	if !strings.Contains(out, "## Parent / Sub-issue Protocol") {
-		t.Fatalf("expected Parent / Sub-issue Protocol section in comment-triggered brief")
-	}
-	// Comment-triggered runs must still carry the sub-issue creation rule
-	// (it applies whenever the agent might spawn a child, not only when
-	// closing one).
-	for _, want := range []string{
-		"`--status todo` → **start now**",
-		"`--status backlog` → **wait**",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("comment-triggered protocol missing %q", want)
-		}
+			if !strings.Contains(out, "## Parent / Sub-issue Protocol") {
+				t.Fatalf("expected Parent / Sub-issue Protocol section in %s brief", tc.name)
+			}
+			for _, want := range []string{
+				// Mechanism framing — describe the data model, not a state
+				// machine. The same text must apply to every issue-bound run.
+				"parent/child tree via `parent_issue_id`",
+				"does NOT auto-sync",
+				"best-effort",
+				// Rule 1 — finish a child, tell the parent.
+				"**Tell the parent when you finish a child.**",
+				"`parent_issue_id`",
+				"top-level",
+				"NO `--parent`",
+				"`@mention` the parent's assignee",
+				"`mention://agent/<id>`",
+				"`mention://member/<id>`",
+				"`mention://squad/<id>`",
+				"no assignee",
+				// The comment-triggered escape hatch must live in the same
+				// unified paragraph so both runs read it.
+				"NOT changing this issue's status",
+				"not closing out the child",
+				"skip the parent notification",
+				// Rule 2 — sub-issue creation semantics.
+				"**Choosing `--status` when creating sub-issues.**",
+				"`--status todo` = **start now**",
+				"`--status backlog` = **wait**",
+				"`multica issue status <child-id> todo`",
+				"all `--status todo`",
+				"`--status backlog` from the start",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("[%s] protocol missing %q", tc.name, want)
+				}
+			}
+			// Earlier revisions split Step A by trigger type, used per-rule
+			// gating tables, or ### A/### B subheadings. The unified
+			// revision must not regress into any of those.
+			for _, banned := range []string{
+				"| Parent assignee | Parent status |",
+				"The same agent as yourself",
+				"| Member or squad |",
+				"### A. Notify the parent",
+				"### B. Choose",
+				"When this issue has `parent_issue_id`:",
+				"**Closing out child work** (only if this issue has `parent_issue_id`)",
+				"**Notify the parent** (only if this issue has `parent_issue_id`",
+				"**Creating sub-issues** (applies to any issue-bound run)",
+				"For parent/child work, use these best-effort rules",
+				// The protocol must no longer emit a placeholder
+				// `<this-issue-id>` status flip — the workflow above owns
+				// that command with the real issue id substituted.
+				"`multica issue status <this-issue-id> in_review`",
+			} {
+				if strings.Contains(out, banned) {
+					t.Errorf("[%s] expected %q to be removed", tc.name, banned)
+				}
+			}
+		})
 	}
 }
 
 // Lock in the "compact convention, not a spec" framing: the Parent /
-// Sub-issue Protocol section must stay short. Elon's third review on PR
-// #2918 collapsed an earlier 29-line version into a 3-rule convention; this
-// guard prevents future edits from silently re-inflating it.
+// Sub-issue Protocol section must stay short. The unified two-rule revision
+// runs around 6 lines; this guard prevents future edits from silently
+// re-inflating it back into a state-machine.
 func TestParentSubIssueProtocolIsCompact(t *testing.T) {
 	t.Parallel()
 	ctx := TaskContextForEnv{
@@ -136,14 +130,13 @@ func TestParentSubIssueProtocolIsCompact(t *testing.T) {
 	}
 }
 
-// Comment-triggered briefs must NOT include the unconditional
-// `multica issue status <this-issue-id> in_review` instruction from Step A.
-// That instruction conflicts with the comment-triggered workflow rule
+// Comment-triggered briefs must NOT carry any unconditional status-flip
+// command targeting the current issue. The previous revision had a
+// dedicated Step A that wrote `multica issue status <this-issue-id> in_review`
+// into the protocol; the unified revision removes that command from the
+// protocol entirely and leans on the comment-triggered workflow rule
 // "Do NOT change the issue status unless the comment explicitly asks for it"
-// (Elon's blocking review on PR #2918). Step A for comment-triggered runs
-// must instead remind the agent that the existing status guardrail still
-// applies and that the parent notification is gated on actually closing
-// out child work.
+// to keep the agent honest (Elon's blocking review on PR #2918).
 func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
 	t.Parallel()
 	ctx := TaskContextForEnv{
@@ -152,59 +145,56 @@ func TestCommentTriggeredProtocolDoesNotForceInReview(t *testing.T) {
 	}
 	out := buildMetaSkillContent("claude", ctx)
 
-	// The exact unconditional status-flip command from the previous Step A
-	// must not appear anywhere in a comment-triggered brief. It is fine
-	// for Step B to teach the agent to *promote* a child to `todo` — that
-	// targets a different issue id, so the substring does not collide.
+	// The placeholder `<this-issue-id>` only ever lived inside the protocol
+	// section; the workflow above substitutes the real id. So the literal
+	// substring is the right canary for "protocol is trying to flip status
+	// behind the workflow's back".
 	if strings.Contains(out, "`multica issue status <this-issue-id> in_review`") {
-		t.Errorf("comment-triggered brief must not contain the unconditional `multica issue status <this-issue-id> in_review` command from Step A (conflicts with the comment-triggered \"do not change status unless asked\" rule)")
+		t.Errorf("comment-triggered brief must not contain a placeholder `<this-issue-id> in_review` flip — that conflicts with the comment-triggered \"do not change status unless asked\" rule")
 	}
 
-	// The existing comment-triggered workflow rule must still be present
-	// AND Step A must echo it, so the agent cannot rely on the rule
-	// having been forgotten by the time it reaches the protocol section.
-	// Counting occurrences guards against future edits that drop the
-	// in-protocol reminder while leaving the workflow rule intact.
+	// The comment-triggered workflow guardrail must still be present so the
+	// protocol's unified instruction has something to defer to.
 	const guardrail = "Do NOT change the issue status unless the comment explicitly asks for it"
-	if got := strings.Count(out, guardrail); got < 2 {
-		t.Errorf("expected the comment-triggered status guardrail %q to appear at least twice (once in the comment-triggered workflow, once echoed inside protocol Step A), got %d", guardrail, got)
+	if !strings.Contains(out, guardrail) {
+		t.Errorf("expected the comment-triggered workflow guardrail %q to be present", guardrail)
 	}
 
-	// And Step A must explicitly gate the parent-notification on
-	// actually closing out child work so the agent does not blindly post
-	// to the parent on every comment-triggered run.
+	// The unified protocol paragraph must still teach the agent that a
+	// comment-triggered run without a status flip means "not closing out
+	// the child" → skip the parent notification.
 	for _, want := range []string{
-		"closing out the child",
+		"NOT changing this issue's status",
+		"not closing out the child",
 		"skip the parent notification",
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("comment-triggered Step A missing required phrasing %q", want)
+			t.Errorf("comment-triggered protocol missing required short-circuit phrasing %q", want)
 		}
 	}
 }
 
-// Assignment-triggered briefs are the inverse boundary: when the agent
-// owns the issue lifecycle, Step A must still keep the unconditional
-// `multica issue status <this-issue-id> in_review` flip. Splitting Step A
-// by trigger type must not silently drop this behavior on the assignment
-// branch.
+// Assignment-triggered briefs are the inverse boundary: when the agent owns
+// the issue lifecycle, the brief AS A WHOLE must still tell it to flip to
+// in_review on completion. After unification the flip lives in the
+// assignment-triggered workflow above (with the real id substituted), not
+// in the protocol section, so we assert against the actual id.
 func TestAssignmentTriggeredProtocolStillFlipsInReview(t *testing.T) {
 	t.Parallel()
-	ctx := TaskContextForEnv{
-		IssueID: "77777777-8888-9999-aaaa-bbbbbbbbbbbb",
-	}
+	const issueID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+	ctx := TaskContextForEnv{IssueID: issueID}
 	out := buildMetaSkillContent("claude", ctx)
 
-	if !strings.Contains(out, "`multica issue status <this-issue-id> in_review`") {
-		t.Errorf("assignment-triggered Step A must keep the unconditional `multica issue status <this-issue-id> in_review` flip")
+	want := "`multica issue status " + issueID + " in_review`"
+	if !strings.Contains(out, want) {
+		t.Errorf("assignment-triggered brief must still flip to in_review on completion (expected %q in the workflow above)", want)
 	}
 }
 
-// Rule 3 (creating sub-issues) must apply to any issue-bound run, not only
-// those whose current issue already has a `parent_issue_id`. A top-level
-// parent issue is exactly where the `todo` vs `backlog` decision matters most
-// (it is the one spawning children) — gating rule 3 behind parent_issue_id
-// would silently drop the guidance in that case (Elon's review on PR #2918).
+// Rule 2 (creating sub-issues) must apply to any issue-bound run, including
+// a top-level parent issue that has no `parent_issue_id` of its own. The
+// unified preamble must not globally gate the protocol on the current issue
+// being a child, and rule 2 must not carry any `parent_issue_id` reference.
 func TestSubIssueCreationRuleIsUnconditional(t *testing.T) {
 	t.Parallel()
 	ctx := TaskContextForEnv{
@@ -226,31 +216,32 @@ func TestSubIssueCreationRuleIsUnconditional(t *testing.T) {
 		section = rest[:len(header)+end]
 	}
 
-	// The preamble must NOT globally gate the whole protocol on the
-	// current issue having `parent_issue_id`.
-	if strings.Contains(section, "When this issue has `parent_issue_id`:") {
-		t.Errorf("preamble must not globally gate the protocol on `parent_issue_id` — rule 3 needs to reach top-level parents too")
-	}
-
-	// Find rule 3 and check it does NOT carry the `parent_issue_id` gate.
-	rule3Idx := strings.Index(section, "3. **Creating sub-issues**")
-	if rule3Idx == -1 {
-		t.Fatalf("rule 3 (Creating sub-issues) missing from protocol section")
-	}
-	rule3 := section[rule3Idx:]
-	if strings.Contains(rule3, "parent_issue_id") {
-		t.Errorf("rule 3 (Creating sub-issues) must not be gated by `parent_issue_id`; it applies to any issue-bound run:\n%s", rule3)
-	}
-
-	// Rules 1 and 2 must carry the gate (the inverse boundary — if these
-	// lose the gate, the agent would post to a parent that does not exist).
-	for _, want := range []string{
-		"**Closing out child work** (only if this issue has `parent_issue_id`)",
-		"**Notify the parent** (only if this issue has `parent_issue_id` and you are closing out child work)",
+	// Preamble must not globally gate on `parent_issue_id`.
+	for _, banned := range []string{
+		"When this issue has `parent_issue_id`:",
+		"For parent/child work, use these best-effort rules",
 	} {
-		if !strings.Contains(section, want) {
-			t.Errorf("rule 1 or 2 missing per-rule `parent_issue_id` gate %q", want)
+		if strings.Contains(section, banned) {
+			t.Errorf("preamble must not globally gate the protocol on `parent_issue_id` — rule 2 needs to reach top-level parents too; found %q", banned)
 		}
+	}
+
+	// Find rule 2 and check it does NOT reference `parent_issue_id` at all
+	// (the only mention of `parent_issue_id` in the section belongs to
+	// rule 1's "if this issue has a `parent_issue_id`" gate).
+	rule2Idx := strings.Index(section, "2. **Choosing `--status` when creating sub-issues.**")
+	if rule2Idx == -1 {
+		t.Fatalf("rule 2 (Choosing `--status` when creating sub-issues) missing from protocol section")
+	}
+	rule2 := section[rule2Idx:]
+	if strings.Contains(rule2, "parent_issue_id") {
+		t.Errorf("rule 2 (Choosing `--status` when creating sub-issues) must not be gated by `parent_issue_id`; it applies to any issue-bound run:\n%s", rule2)
+	}
+
+	// Rule 1 must still carry the gate — without it the agent might post on
+	// a parent that doesn't exist.
+	if !strings.Contains(section, "**Tell the parent when you finish a child.** If this issue has a `parent_issue_id`") {
+		t.Errorf("rule 1 missing per-rule `parent_issue_id` gate")
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -6,10 +6,11 @@ import (
 )
 
 // Parent/Sub-issue Protocol — the brief must teach every issue-bound agent
-// two things: (A) notify the parent when this issue finishes, and (B) pick
-// `backlog` vs `todo` deliberately when creating sub-issues. The protocol is
-// runtime-only (no server-side state sync), so the rules live in the meta
-// skill and these tests guard the wording the rest of the design relies on.
+// three things: close out the child issue, post a best-effort top-level
+// notification on the parent, and pick `backlog` vs `todo` deliberately
+// when creating sub-issues. The protocol is runtime-only (no server-side
+// state sync), so the rules live in the meta skill and these tests guard
+// the wording the rest of the design relies on.
 
 func TestParentSubIssueProtocolEmittedForAssignmentTrigger(t *testing.T) {
 	t.Parallel()
@@ -21,50 +22,24 @@ func TestParentSubIssueProtocolEmittedForAssignmentTrigger(t *testing.T) {
 	if !strings.Contains(out, "## Parent / Sub-issue Protocol") {
 		t.Fatalf("expected Parent / Sub-issue Protocol section in assignment-triggered brief")
 	}
-	// Behavior A — order, top-level comment, best-effort framing.
+	// Three core rules in compact form (Elon's third review on PR #2918):
+	// best-effort framing, assignment-branch closing instruction, top-level
+	// parent comment with the simplified mention-by-assignee-type rule, and
+	// the `backlog` vs `todo` sub-issue creation semantics.
 	for _, want := range []string{
-		"### A. Notify the parent when this issue is finishing",
-		"finish your own issue first",
+		"best-effort",
+		// rule 1 — assignment branch keeps the unconditional in_review flip
 		"`multica issue status <this-issue-id> in_review`",
+		// rule 2 — top-level parent comment + simplified mention rule
 		"top-level",
 		"NO `--parent`",
-		"best-effort",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("behavior A missing %q", want)
-		}
-	}
-	// Simplified mention rule (Bohan's directive on PR #2918): always
-	// `@mention` the parent's assignee using the URL that matches
-	// `assignee_type`, with no per-case branching. The brief must
-	// teach all three mention URLs and tell the agent not to second-guess.
-	for _, want := range []string{
 		"`@mention` the parent's assignee",
 		"`mention://agent/<id>`",
 		"`mention://member/<id>`",
 		"`mention://squad/<id>`",
 		"no assignee",
 		"Don't try to second-guess",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("simplified mention rule missing %q", want)
-		}
-	}
-	// And the previous per-case mention table must be gone — the whole
-	// point of this revision is to drop the same-agent / member / squad /
-	// closed-parent branches.
-	for _, banned := range []string{
-		"| Parent assignee | Parent status |",
-		"The same agent as yourself",
-		"| Member or squad |",
-	} {
-		if strings.Contains(out, banned) {
-			t.Errorf("expected the per-case mention table row %q to be removed", banned)
-		}
-	}
-	// Behavior B — backlog vs todo decision.
-	for _, want := range []string{
-		"### B. Choose `backlog` vs `todo` when creating sub-issues",
+		// rule 3 — backlog vs todo decision
 		"`--status todo` → **start now**",
 		"`--status backlog` → **wait**",
 		"`multica issue status <child-id> todo`",
@@ -72,7 +47,24 @@ func TestParentSubIssueProtocolEmittedForAssignmentTrigger(t *testing.T) {
 		"`--status backlog` from the start",
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("behavior B missing %q", want)
+			t.Errorf("protocol missing %q", want)
+		}
+	}
+	// The per-case mention table from the prior revision must remain
+	// removed — the whole point of the current revision is to drop branchy
+	// "same-agent / member / squad / closed-parent" decision tables.
+	for _, banned := range []string{
+		"| Parent assignee | Parent status |",
+		"The same agent as yourself",
+		"| Member or squad |",
+		// Earlier revisions introduced ### A / ### B subheadings; the
+		// compact revision drops them so the section reads as a
+		// convention, not a spec.
+		"### A. Notify the parent",
+		"### B. Choose",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("expected %q to be removed", banned)
 		}
 	}
 }
@@ -88,13 +80,45 @@ func TestParentSubIssueProtocolEmittedForCommentTrigger(t *testing.T) {
 	if !strings.Contains(out, "## Parent / Sub-issue Protocol") {
 		t.Fatalf("expected Parent / Sub-issue Protocol section in comment-triggered brief")
 	}
-	// Comment-triggered runs may still be wrapping up sub-issue work, so
-	// both behaviors must appear here too.
-	if !strings.Contains(out, "### A. Notify the parent when this issue is finishing") {
-		t.Errorf("comment-triggered brief missing behavior A heading")
+	// Comment-triggered runs must still carry the sub-issue creation rule
+	// (it applies whenever the agent might spawn a child, not only when
+	// closing one).
+	for _, want := range []string{
+		"`--status todo` → **start now**",
+		"`--status backlog` → **wait**",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("comment-triggered protocol missing %q", want)
+		}
 	}
-	if !strings.Contains(out, "### B. Choose `backlog` vs `todo` when creating sub-issues") {
-		t.Errorf("comment-triggered brief missing behavior B heading")
+}
+
+// Lock in the "compact convention, not a spec" framing: the Parent /
+// Sub-issue Protocol section must stay short. Elon's third review on PR
+// #2918 collapsed an earlier 29-line version into a 3-rule convention; this
+// guard prevents future edits from silently re-inflating it.
+func TestParentSubIssueProtocolIsCompact(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID: "12345678-1234-1234-1234-123456789012",
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	const header = "## Parent / Sub-issue Protocol"
+	start := strings.Index(out, header)
+	if start == -1 {
+		t.Fatalf("protocol section missing")
+	}
+	rest := out[start+len(header):]
+	end := strings.Index(rest, "\n## ")
+	var section string
+	if end == -1 {
+		section = out[start:]
+	} else {
+		section = out[start : start+len(header)+end]
+	}
+	if got := strings.Count(section, "\n"); got > 10 {
+		t.Errorf("Parent / Sub-issue Protocol should stay ≤10 lines (best-effort convention, not a spec); got %d:\n%s", got, section)
 	}
 }
 

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -34,16 +34,32 @@ func TestParentSubIssueProtocolEmittedForAssignmentTrigger(t *testing.T) {
 			t.Errorf("behavior A missing %q", want)
 		}
 	}
-	// Mention table — every row must be present so loop-prevention rules
-	// stay visible.
+	// Simplified mention rule (Bohan's directive on PR #2918): always
+	// `@mention` the parent's assignee using the URL that matches
+	// `assignee_type`, with no per-case branching. The brief must
+	// teach all three mention URLs and tell the agent not to second-guess.
 	for _, want := range []string{
-		"Another agent (not you)",
-		"The same agent as yourself",
-		"Member or squad",
-		"`done` or `cancelled`",
+		"`@mention` the parent's assignee",
+		"`mention://agent/<id>`",
+		"`mention://member/<id>`",
+		"`mention://squad/<id>`",
+		"no assignee",
+		"Don't try to second-guess",
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("mention table missing row %q", want)
+			t.Errorf("simplified mention rule missing %q", want)
+		}
+	}
+	// And the previous per-case mention table must be gone — the whole
+	// point of this revision is to drop the same-agent / member / squad /
+	// closed-parent branches.
+	for _, banned := range []string{
+		"| Parent assignee | Parent status |",
+		"The same agent as yourself",
+		"| Member or squad |",
+	} {
+		if strings.Contains(out, banned) {
+			t.Errorf("expected the per-case mention table row %q to be removed", banned)
 		}
 	}
 	// Behavior B — backlog vs todo decision.

--- a/server/internal/daemon/execenv/runtime_config_test.go
+++ b/server/internal/daemon/execenv/runtime_config_test.go
@@ -28,6 +28,16 @@ func TestParentSubIssueProtocolEmittedForAssignmentTrigger(t *testing.T) {
 	// the `backlog` vs `todo` sub-issue creation semantics.
 	for _, want := range []string{
 		"best-effort",
+		// Preamble must frame rules generically for parent/child work, NOT
+		// globally gate on the current issue having `parent_issue_id`
+		// (Elon's review on PR #2918: rule 3 still applies to top-level
+		// parents that have no parent themselves).
+		"For parent/child work",
+		// Rules 1 and 2 carry the per-rule gating instead.
+		"**Closing out child work** (only if this issue has `parent_issue_id`)",
+		"**Notify the parent** (only if this issue has `parent_issue_id` and you are closing out child work)",
+		// Rule 3 must explicitly apply to any issue-bound run.
+		"**Creating sub-issues** (applies to any issue-bound run)",
 		// rule 1 — assignment branch keeps the unconditional in_review flip
 		"`multica issue status <this-issue-id> in_review`",
 		// rule 2 — top-level parent comment + simplified mention rule
@@ -62,6 +72,10 @@ func TestParentSubIssueProtocolEmittedForAssignmentTrigger(t *testing.T) {
 		// convention, not a spec.
 		"### A. Notify the parent",
 		"### B. Choose",
+		// The previous revision wrapped all three rules in a single
+		// `parent_issue_id` gate; the current revision must instead gate
+		// per-rule so rule 3 still reaches top-level parents.
+		"When this issue has `parent_issue_id`:",
 	} {
 		if strings.Contains(out, banned) {
 			t.Errorf("expected %q to be removed", banned)
@@ -183,6 +197,60 @@ func TestAssignmentTriggeredProtocolStillFlipsInReview(t *testing.T) {
 
 	if !strings.Contains(out, "`multica issue status <this-issue-id> in_review`") {
 		t.Errorf("assignment-triggered Step A must keep the unconditional `multica issue status <this-issue-id> in_review` flip")
+	}
+}
+
+// Rule 3 (creating sub-issues) must apply to any issue-bound run, not only
+// those whose current issue already has a `parent_issue_id`. A top-level
+// parent issue is exactly where the `todo` vs `backlog` decision matters most
+// (it is the one spawning children) — gating rule 3 behind parent_issue_id
+// would silently drop the guidance in that case (Elon's review on PR #2918).
+func TestSubIssueCreationRuleIsUnconditional(t *testing.T) {
+	t.Parallel()
+	ctx := TaskContextForEnv{
+		IssueID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+	}
+	out := buildMetaSkillContent("claude", ctx)
+
+	const header = "## Parent / Sub-issue Protocol"
+	start := strings.Index(out, header)
+	if start == -1 {
+		t.Fatalf("protocol section missing")
+	}
+	rest := out[start:]
+	end := strings.Index(rest[len(header):], "\n## ")
+	var section string
+	if end == -1 {
+		section = rest
+	} else {
+		section = rest[:len(header)+end]
+	}
+
+	// The preamble must NOT globally gate the whole protocol on the
+	// current issue having `parent_issue_id`.
+	if strings.Contains(section, "When this issue has `parent_issue_id`:") {
+		t.Errorf("preamble must not globally gate the protocol on `parent_issue_id` — rule 3 needs to reach top-level parents too")
+	}
+
+	// Find rule 3 and check it does NOT carry the `parent_issue_id` gate.
+	rule3Idx := strings.Index(section, "3. **Creating sub-issues**")
+	if rule3Idx == -1 {
+		t.Fatalf("rule 3 (Creating sub-issues) missing from protocol section")
+	}
+	rule3 := section[rule3Idx:]
+	if strings.Contains(rule3, "parent_issue_id") {
+		t.Errorf("rule 3 (Creating sub-issues) must not be gated by `parent_issue_id`; it applies to any issue-bound run:\n%s", rule3)
+	}
+
+	// Rules 1 and 2 must carry the gate (the inverse boundary — if these
+	// lose the gate, the agent would post to a parent that does not exist).
+	for _, want := range []string{
+		"**Closing out child work** (only if this issue has `parent_issue_id`)",
+		"**Notify the parent** (only if this issue has `parent_issue_id` and you are closing out child work)",
+	} {
+		if !strings.Contains(section, want) {
+			t.Errorf("rule 1 or 2 missing per-rule `parent_issue_id` gate %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a **Parent / Sub-issue Protocol** section to the runtime brief built by `buildMetaSkillContent` so every agent running on a real Multica issue learns two things:

- **A. Notify the parent when finishing.** If `parent_issue_id` is set, the child agent posts its final result on its own issue and moves it to `in_review` first, then runs `multica issue get <parent-id>` and posts a single top-level comment on the parent. Mention rules prevent the obvious loops:
  - Another agent on a still-open parent → `@mention` to wake them
  - Same agent as yourself → no mention
  - Member / squad assignee → no mention
  - Parent already `done` / `cancelled` → no mention
- **B. Pick `backlog` vs `todo` deliberately when creating sub-issues.** `--status todo` (the default) triggers immediately; `--status backlog` holds it as wait-state. Strict serial Step 1 → 2 → 3 means only Step 1 is `todo`; Steps 2/3 are created `backlog` and promoted via `multica issue status <id> todo` when their turn comes.

The signal is explicitly framed as best-effort — no server-side state sync, no claim of a guaranteed handshake (per Elon's review of the v2 plan). Per Bohan's decision, this is runtime-only; no DB migration, no handler change, no Skill cross-references.

The section is skipped for chat, quick-create, and run-only autopilot runs, which have no parent/child semantics.

Related: [MUL-2338](mention://issue/d046532c-4793-4ccd-81f9-9aa5617b75bf)

## Test plan

- [x] `go test ./internal/daemon/execenv/` — full package passes
- [x] New `runtime_config_test.go` covers:
  - protocol appears for assignment-triggered context, with behaviors A + B, mention-table rows, and the `in_review` ordering rule
  - protocol appears for comment-triggered context
  - protocol is **skipped** for chat / quick-create / autopilot run-only
  - brief does **not** introduce a non-existent `multica issue list --parent` command and does **not** claim a guaranteed / reliable handshake; it does explicitly say "best-effort"
- [ ] After deploy, a child agent that finishes a sub-issue should follow behavior A; if the parent is assigned to another agent and is still open, that agent should be triggered by the mention link