### PR TITLE
MUL-2339: polish(agent-inspector): optimistic updates + picker layout + thinking-default semantics

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -133,10 +133,12 @@ export interface Agent {
   /**
    * Runtime-native reasoning/effort token (e.g. Claude's
    * `low|medium|high|xhigh|max`, Codex's
-   * `none|minimal|low|medium|high|xhigh`). Empty string means "use the
-   * runtime/model default". The picker is per-runtime per-model — the
-   * API never normalises across providers. Older backends omit this
-   * field entirely; treat undefined as "" (MUL-2339).
+   * `none|minimal|low|medium|high|xhigh`). Empty string means "no
+   * override": the backend omits the effort flag and the upstream CLI
+   * config / built-in default decides at run time. The picker is
+   * per-runtime per-model — the API never normalises across providers.
+   * Older backends omit this field entirely; treat undefined as ""
+   * (MUL-2339).
    */
   thinking_level?: string;
   owner_id: string | null;
@@ -462,8 +464,11 @@ export interface RuntimeModel {
 export interface RuntimeModelThinking {
   /** Levels the user is allowed to pick for this model. */
   supported_levels: RuntimeModelThinkingLevel[];
-  /** The level the runtime defaults to when no override is sent. The UI
-   *  uses this to badge the default and prefill new agents. */
+  /** Informational: the level the upstream CLI documents as its built-in
+   *  default when no `--effort` flag is passed. Surfaced by the daemon
+   *  but not actively rendered today — Multica's empty `thinking_level`
+   *  means "no override; let the local CLI config decide", which may
+   *  itself differ from this value. */
   default_level?: string;
 }
 

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -106,23 +106,39 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
     // the new value immediately on click. Without this, every inspector
     // picker (thinking / visibility / concurrency / model / runtime) waits
     // 0.5-2s for the API response + invalidate + refetch before the trigger
-    // updates — readable as obvious lag in the UI. On error we restore the
-    // previous list, rethrow, and let the caller's toast surface the cause.
+    // updates — readable as obvious lag in the UI.
+    //
+    // On error we rollback only the fields THIS call wrote, leaving any
+    // other concurrently-mutated fields untouched, then invalidate so the
+    // cache converges with the server. A whole-list snapshot rollback
+    // would clobber a concurrent successful mutation if the failing call
+    // resolves last (e.g. flipping visibility then runtime simultaneously
+    // and only the visibility PATCH fails).
     const queryKey = workspaceKeys.agents(wsId);
     const prevAgents = qc.getQueryData<Agent[]>(queryKey);
-    if (prevAgents) {
-      qc.setQueryData<Agent[]>(queryKey, (old) =>
-        old?.map((a) => (a.id === id ? ({ ...a, ...data } as Agent) : a)),
-      );
+    const prevAgent = prevAgents?.find((a) => a.id === id);
+    const prevFields: Record<string, unknown> = {};
+    if (prevAgent) {
+      for (const key of Object.keys(data)) {
+        prevFields[key] = (prevAgent as unknown as Record<string, unknown>)[key];
+      }
     }
+    qc.setQueryData<Agent[]>(queryKey, (old) =>
+      old?.map((a) => (a.id === id ? ({ ...a, ...data } as Agent) : a)),
+    );
     try {
       await api.updateAgent(id, data as UpdateAgentRequest);
       qc.invalidateQueries({ queryKey });
       toast.success(t(($) => $.detail.agent_updated_toast));
     } catch (e) {
-      // Roll back to the snapshot we took before the optimistic write so
-      // the UI doesn't lie to the user about persisted state.
-      if (prevAgents) qc.setQueryData<Agent[]>(queryKey, prevAgents);
+      if (prevAgent) {
+        qc.setQueryData<Agent[]>(queryKey, (old) =>
+          old?.map((a) =>
+            a.id === id ? ({ ...a, ...prevFields } as Agent) : a,
+          ),
+        );
+      }
+      qc.invalidateQueries({ queryKey });
       toast.error(e instanceof Error ? e.message : t(($) => $.detail.update_failed_toast));
       throw e;
     }

--- a/packages/views/agents/components/agent-detail-page.tsx
+++ b/packages/views/agents/components/agent-detail-page.tsx
@@ -101,11 +101,28 @@ export function AgentDetailPage({ agentId }: AgentDetailPageProps) {
   const [confirmArchive, setConfirmArchive] = useState(false);
 
   const handleUpdate = async (id: string, data: Record<string, unknown>) => {
+    // Optimistic update: patch the matching agent in the cached list
+    // BEFORE the network round-trip so the inspector picker chips flip to
+    // the new value immediately on click. Without this, every inspector
+    // picker (thinking / visibility / concurrency / model / runtime) waits
+    // 0.5-2s for the API response + invalidate + refetch before the trigger
+    // updates — readable as obvious lag in the UI. On error we restore the
+    // previous list, rethrow, and let the caller's toast surface the cause.
+    const queryKey = workspaceKeys.agents(wsId);
+    const prevAgents = qc.getQueryData<Agent[]>(queryKey);
+    if (prevAgents) {
+      qc.setQueryData<Agent[]>(queryKey, (old) =>
+        old?.map((a) => (a.id === id ? ({ ...a, ...data } as Agent) : a)),
+      );
+    }
     try {
       await api.updateAgent(id, data as UpdateAgentRequest);
-      qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
+      qc.invalidateQueries({ queryKey });
       toast.success(t(($) => $.detail.agent_updated_toast));
     } catch (e) {
+      // Roll back to the snapshot we took before the optimistic write so
+      // the UI doesn't lie to the user about persisted state.
+      if (prevAgents) qc.setQueryData<Agent[]>(queryKey, prevAgents);
       toast.error(e instanceof Error ? e.message : t(($) => $.detail.update_failed_toast));
       throw e;
     }

--- a/packages/views/agents/components/inspector/model-picker.tsx
+++ b/packages/views/agents/components/inspector/model-picker.tsx
@@ -145,21 +145,28 @@ export function ModelPicker({
             // string actually ships to the agent.
             tooltip={m.label !== m.id ? `${m.label} · ${m.id}` : m.id}
           >
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-1.5">
-                <span className="truncate font-medium">{m.label}</span>
+            {/* PickerItem wraps children in a flex `<span>`. Putting a
+                `<div>` inside that <span> is block-in-inline (invalid
+                HTML5) and triggers the browser-default centering quirk
+                that pushes descendants off-axis (model IDs floated to the
+                center instead of left-aligning under their labels). Use
+                `<span block text-left>` to keep layout deterministic —
+                matches the fix already applied in thinking-picker.tsx. */}
+            <span className="block min-w-0 flex-1 text-left">
+              <span className="flex items-center gap-1.5">
+                <span className="truncate text-[13px] font-medium">{m.label}</span>
                 {m.default && (
                   <span className="shrink-0 rounded bg-primary/10 px-1 text-[10px] font-medium text-primary">
                     {t(($) => $.pickers.model_default_badge)}
                   </span>
                 )}
-              </div>
+              </span>
               {m.label !== m.id && (
-                <div className="truncate font-mono text-[10px] text-muted-foreground">
+                <span className="mt-0.5 block truncate font-mono text-[10px] leading-snug text-muted-foreground">
                   {m.id}
-                </div>
+                </span>
               )}
-            </div>
+            </span>
           </PickerItem>
         ))}
 

--- a/packages/views/agents/components/inspector/thinking-picker.test.tsx
+++ b/packages/views/agents/components/inspector/thinking-picker.test.tsx
@@ -28,7 +28,6 @@ function renderPicker(props: Partial<React.ComponentProps<typeof ThinkingPicker>
       <ThinkingPicker
         value=""
         levels={CODEX_LEVELS}
-        defaultLevel="medium"
         canEdit
         onChange={onChange}
         {...props}
@@ -46,10 +45,12 @@ describe("ThinkingPicker", () => {
     cleanup();
   });
 
-  it('renders "Default" when value is empty', () => {
+  it('renders "Follow CLI config" when value is empty', () => {
     renderPicker({ value: "" });
-    // The trigger and the tooltip both carry the label.
-    expect(screen.getAllByText("Default").length).toBeGreaterThan(0);
+    // The trigger and the tooltip both carry the label. Empty value means
+    // Multica omits --effort, so the local CLI's config decides the
+    // reasoning level — see thinking-prop-row.tsx for the contract.
+    expect(screen.getAllByText("Follow CLI config").length).toBeGreaterThan(0);
   });
 
   it("renders the matching level label when value is set", () => {
@@ -60,7 +61,7 @@ describe("ThinkingPicker", () => {
   it("renders the raw token when the saved value is no longer in the catalog", () => {
     // Simulates a model swap that dropped the option the user previously
     // picked — we still surface what's persisted so the user can clear it,
-    // rather than silently showing "Default".
+    // rather than silently showing "Follow CLI config".
     renderPicker({ value: "xhigh", levels: CODEX_LEVELS });
     expect(screen.getAllByText("xhigh").length).toBeGreaterThan(0);
   });
@@ -98,7 +99,7 @@ describe("ThinkingPicker", () => {
     fireEvent.click(screen.getByRole("button"));
     // Footer copy resolves through i18n — match a substring so we don't
     // pin to the exact translated wording.
-    const clearButton = screen.getByTitle(/Clear and fall back/i);
+    const clearButton = screen.getByTitle(/Clear the override/i);
     fireEvent.click(clearButton);
     expect(onChange).toHaveBeenCalledWith("");
   });

--- a/packages/views/agents/components/inspector/thinking-picker.tsx
+++ b/packages/views/agents/components/inspector/thinking-picker.tsx
@@ -16,10 +16,12 @@ import { useT } from "../../../i18n";
  * discovered, so the value/label pairs match each CLI's own UI (`Low`,
  * `Extra high`, …) verbatim; never normalised across providers.
  *
- * The empty string is the "use model default" sentinel and renders as
- * "Default" in the chip, with the discovered `default_level` (when
- * present) badged inside the popover so the user can see what they'll
- * get if they clear.
+ * Empty string is the "no override" sentinel: the backend omits the
+ * effort flag entirely and the upstream CLI's own config / built-in
+ * default decides what the model runs at. We render that state as
+ * "Follow CLI config" rather than singling out one level as the
+ * factory default, because the actual default at runtime is owned by
+ * the user's local CLI install, not by Multica's catalog.
  */
 export function ThinkingPicker({
   value,

--- a/packages/views/agents/components/inspector/thinking-picker.tsx
+++ b/packages/views/agents/components/inspector/thinking-picker.tsx
@@ -24,18 +24,14 @@ import { useT } from "../../../i18n";
 export function ThinkingPicker({
   value,
   levels,
-  defaultLevel,
   canEdit = true,
   onChange,
 }: {
-  /** Persisted thinking_level — "" means "use model default". */
+  /** Persisted thinking_level — "" means "follow local CLI config". */
   value: string;
   /** Supported levels for the current (runtime, model) pair. Caller has
    *  already verified the list is non-empty before mounting this picker. */
   levels: RuntimeModelThinkingLevel[];
-  /** Level the runtime uses when no override is sent. Surfaced as a badge
-   *  in the popover. */
-  defaultLevel?: string;
   /** When false, render a static read-only display and skip the popover. */
   canEdit?: boolean;
   onChange: (next: string) => Promise<void> | void;
@@ -96,23 +92,26 @@ export function ThinkingPicker({
           key={l.value}
           selected={l.value === value}
           onClick={() => void select(l.value)}
-          tooltip={l.description || (l.label !== l.value ? `${l.label} · ${l.value}` : l.value)}
         >
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-1.5">
-              <span className="truncate font-medium">{l.label}</span>
-              {l.value === defaultLevel && (
-                <span className="shrink-0 rounded bg-primary/10 px-1 text-[10px] font-medium text-primary">
-                  {t(($) => $.pickers.thinking_default_badge)}
-                </span>
-              )}
-            </div>
+          {/* PickerItem wraps children in a flex `<span>`. Putting a
+              `<div>` inside that <span> is block-in-inline (invalid HTML5)
+              and triggers browser quirks that shift descendant x-position.
+              Use a `<span>` with explicit `block` + `text-left` so layout
+              is deterministic across rows regardless of whether the label
+              row has the `default` badge sibling. */}
+          {/* No model-factory-default badge here on purpose: when the
+              picker is "Follow CLI config" (value === ""), Multica omits
+              `--effort` and the local CLI config decides — the model's
+              factory default is irrelevant to what actually fires, so
+              flagging one option as "default" was misleading. */}
+          <span className="block min-w-0 flex-1 text-left">
+            <span className="truncate text-[13px] font-medium">{l.label}</span>
             {l.description && (
-              <div className="truncate text-[10px] text-muted-foreground">
+              <span className="mt-0.5 block text-[11px] leading-snug text-muted-foreground">
                 {l.description}
-              </div>
+              </span>
             )}
-          </div>
+          </span>
         </PickerItem>
       ))}
 

--- a/packages/views/agents/components/inspector/thinking-prop-row.test.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.test.tsx
@@ -118,13 +118,17 @@ describe("ThinkingPropRow", () => {
     mockInitiateListModels.mockResolvedValue(listResult([NO_THINKING_MODEL]));
     renderRow({ model: "gemini-2.5-pro", value: "" });
 
-    // Wait for the query to settle. We assert by absence of the i18n
-    // label rather than by query state, so this also fails if the row
-    // re-renders later.
+    // The row stays mounted while discovery is in flight (so the
+    // useQuery subscription survives long enough for the request to
+    // fire) — assertion must wait until the query has settled before
+    // checking the row is gone. waitFor with the absence as the
+    // condition also catches a late re-mount.
     await waitFor(() => {
       expect(mockInitiateListModels).toHaveBeenCalled();
     });
-    expect(screen.queryByText("Thinking")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByText("Thinking")).toBeNull();
+    });
   });
 
   it("hides the row while the runtime is offline (no query fires)", () => {
@@ -162,7 +166,7 @@ describe("ThinkingPropRow", () => {
     // matching the i18n `thinking_clear_title` copy.
     await screen.findByText("xhigh");
     fireEvent.click(screen.getByRole("button"));
-    const clearButton = await screen.findByTitle(/Clear and fall back/i);
+    const clearButton = await screen.findByTitle(/Clear the override/i);
     fireEvent.click(clearButton);
 
     expect(onChange).toHaveBeenCalledWith("");
@@ -176,10 +180,12 @@ describe("ThinkingPropRow", () => {
     expect((await screen.findAllByText("High")).length).toBeGreaterThan(0);
   });
 
-  it("renders the row with \"Default\" when value is empty and the model exposes levels", async () => {
+  it("renders the row with \"Follow CLI config\" when value is empty and the model exposes levels", async () => {
     renderRow({ value: "" });
 
     await screen.findByText("Thinking");
-    expect((await screen.findAllByText("Default")).length).toBeGreaterThan(0);
+    // Empty value means Multica omits --effort, so the local CLI's
+    // config decides — chip + tooltip both read "Follow CLI config".
+    expect((await screen.findAllByText("Follow CLI config")).length).toBeGreaterThan(0);
   });
 });

--- a/packages/views/agents/components/inspector/thinking-prop-row.test.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.test.tsx
@@ -118,11 +118,13 @@ describe("ThinkingPropRow", () => {
     mockInitiateListModels.mockResolvedValue(listResult([NO_THINKING_MODEL]));
     renderRow({ model: "gemini-2.5-pro", value: "" });
 
-    // The row stays mounted while discovery is in flight (so the
-    // useQuery subscription survives long enough for the request to
-    // fire) — assertion must wait until the query has settled before
-    // checking the row is gone. waitFor with the absence as the
-    // condition also catches a late re-mount.
+    // ThinkingPropRow returns null when levels are empty and value is
+    // empty — both initially (data undefined) and after discovery
+    // (NO_THINKING_MODEL has no `thinking` block). The `useQuery` hook
+    // runs before the early null return on first render, so the
+    // subscription is established and discovery still fires. In
+    // production this is also covered by the sibling ModelPicker
+    // mounted next to the row in agent-detail-inspector.
     await waitFor(() => {
       expect(mockInitiateListModels).toHaveBeenCalled();
     });

--- a/packages/views/agents/components/inspector/thinking-prop-row.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.tsx
@@ -10,17 +10,20 @@ import { ThinkingPicker } from "./thinking-picker";
 /**
  * Thinking row for the agent inspector. Hidden when the active model has
  * no `supported_levels` advertised AND nothing is persisted, so providers
- * that don't expose reasoning never surface an empty row. But if the
- * agent already has a `thinking_level` saved (model swap into a
- * non-thinking runtime, or the daemon / CLI catalog shrank and dropped
- * the entry), we still render the row so the user can see the orphan
- * token the backend is still sending and explicit-clear it via the
- * picker's "Use model default" footer. PR1's per-model invalid behavior
- * is daemon-side warn/drop, not a synchronous DB clear, so the frontend
- * has to surface the persisted state honestly.
+ * that don't expose reasoning never surface an empty row. If the agent
+ * already has a `thinking_level` saved (model swap into a non-thinking
+ * runtime, or the daemon / CLI catalog shrank and dropped the entry),
+ * we still render the row so the user can see the orphan token the
+ * backend is still sending and explicit-clear it via the picker footer.
+ * PR1's per-model invalid behavior is daemon-side warn/drop, not a
+ * synchronous DB clear, so the frontend has to surface the persisted
+ * state honestly.
  *
  * Reuses the shared runtime-models query so it hits the same 60s cache
  * as the model picker; no extra round-trip on the inspector's hot path.
+ * The sibling ModelPicker mounts unconditionally next to this row, so
+ * the shared query subscription is established by the inspector mount
+ * itself — returning null here does NOT cancel discovery.
  */
 export function ThinkingPropRow({
   runtimeId,
@@ -45,15 +48,7 @@ export function ThinkingPropRow({
   const models = modelsQuery.data?.models ?? [];
   const entry = pickModelEntry(models, model);
   const levels = entry?.thinking?.supported_levels ?? [];
-  // Keep the row visible while discovery is in flight. Hiding during
-  // load forces the user to manually open the Model picker to "kick"
-  // discovery before Thinking ever appears — which it doesn't, because
-  // both pickers share the same query cache via runtimeModelsKeys.
-  // Mounting the picker here is what triggers `resolveRuntimeModels`;
-  // an early `return null` aborts that subscription before it can fire.
-  if (!modelsQuery.isLoading && !modelsQuery.isFetching && levels.length === 0 && !value) {
-    return null;
-  }
+  if (levels.length === 0 && !value) return null;
 
   return (
     <PropRow label={t(($) => $.inspector.prop_thinking)} interactive={false}>

--- a/packages/views/agents/components/inspector/thinking-prop-row.tsx
+++ b/packages/views/agents/components/inspector/thinking-prop-row.tsx
@@ -45,14 +45,21 @@ export function ThinkingPropRow({
   const models = modelsQuery.data?.models ?? [];
   const entry = pickModelEntry(models, model);
   const levels = entry?.thinking?.supported_levels ?? [];
-  if (levels.length === 0 && !value) return null;
+  // Keep the row visible while discovery is in flight. Hiding during
+  // load forces the user to manually open the Model picker to "kick"
+  // discovery before Thinking ever appears — which it doesn't, because
+  // both pickers share the same query cache via runtimeModelsKeys.
+  // Mounting the picker here is what triggers `resolveRuntimeModels`;
+  // an early `return null` aborts that subscription before it can fire.
+  if (!modelsQuery.isLoading && !modelsQuery.isFetching && levels.length === 0 && !value) {
+    return null;
+  }
 
   return (
     <PropRow label={t(($) => $.inspector.prop_thinking)} interactive={false}>
       <ThinkingPicker
         value={value}
         levels={levels}
-        defaultLevel={entry?.thinking?.default_level}
         canEdit={canEdit}
         onChange={onChange}
       />

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -174,11 +174,10 @@
     "model_custom_use": "Use \"{{value}}\"",
     "model_clear": "Clear (use provider default)",
     "model_clear_title": "Clear and fall back to the runtime's provider default",
-    "thinking_default": "Default",
+    "thinking_default": "Follow CLI config",
     "thinking_tooltip": "Thinking · {{value}}",
-    "thinking_default_badge": "default",
-    "thinking_clear": "Use model default",
-    "thinking_clear_title": "Clear and fall back to this model's default reasoning level"
+    "thinking_clear": "Follow CLI config",
+    "thinking_clear_title": "Clear the override and let the local CLI config (claude/codex) decide the reasoning level"
   },
   "model_dropdown": {
     "label": "Model",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -170,11 +170,10 @@
     "model_custom_use": "使用\"{{value}}\"",
     "model_clear": "清除（使用提供方默认）",
     "model_clear_title": "清除并回退到运行时的提供方默认",
-    "thinking_default": "默认",
+    "thinking_default": "跟随 CLI 配置",
     "thinking_tooltip": "思考 · {{value}}",
-    "thinking_default_badge": "默认",
-    "thinking_clear": "使用模型默认",
-    "thinking_clear_title": "清除并回退到该模型的默认推理级别"
+    "thinking_clear": "跟随 CLI 配置",
+    "thinking_clear_title": "清除覆盖，让本地 CLI（claude/codex）的配置决定推理级别"
   },
   "model_dropdown": {
     "label": "模型",


### PR DESCRIPTION
## Why

End-to-end use of the agent inspector pickers (Thinking, Model, Visibility, Concurrency…) surfaced a small pile of UX/correctness debt:

- Every pick made the trigger chip lag visibly while the network round-trip finished
- Picker rows had off-axis layout (model IDs centered, descriptions misaligned) caused by a block-in-inline HTML5 violation
- The Thinking picker was lying about what actually fires — "Default · medium" implied the model factory default, but Multica omitting `--effort` falls through to the **local CLI config** (claude/codex), which the user may have set to xhigh
- The Thinking row was hidden until the user manually tapped the Model picker, because the early `return null` aborted the runtime-models subscription before discovery could fire

Group fix because they all live in the same handful of files and benefit from one round of context.

## What

### 1. Optimistic update for all inspector picks (`agent-detail-page.tsx`)
Snapshot the cached agent list before `await api.updateAgent`, patch the matching row via `setQueryData` synchronously. On error roll back, on success invalidate and reconcile. All inspector pickers (thinking / model / visibility / concurrency / runtime / name / description / avatar) now respond instantly.

### 2. Block-in-inline layout fix (`model-picker.tsx`, `thinking-picker.tsx`)
`PickerItem` wraps children in a flex `<span>`. Both pickers had `<div>` children — block-in-inline is invalid HTML5 and triggers a browser layout quirk that off-aligns descendants. Replace with `<span block text-left>` for deterministic layout.

### 3. Visual polish on both pickers
Match typography: label `text-[13px] font-medium`, secondary line `text-[10-11px] mt-0.5 leading-snug`. Compact, no jarring 14↔10 jumps.

### 4. "Default" → "Follow CLI config" (Thinking)
The picker treated "no override" as "use model factory default," but that's wrong: Multica omits `--effort`, and the **local CLI config** (claude/codex) decides. Showing `[default]` next to "medium" is misleading when the CLI is xhigh.
- Trigger label: `"Default"` → `"Follow CLI config"` (zh: `"跟随 CLI 配置"`)
- Footer clear: `"Use model default"` → `"Follow CLI config"`
- Footer tooltip: explicitly mentions claude/codex CLI config
- Inline `[default]` badge on the factory-default option: removed
- `defaultLevel` prop chain (picker + prop-row + test) cleaned up

### 5. Keep Thinking row visible during discovery (`thinking-prop-row.tsx`)
Old `if (levels.length === 0 && !value) return null` hid the row while runtime-models was loading. The unmount-then-remount on data arrival was racy enough that the discovery only fired when the user manually opened the Model picker. Gate the early return on `!isLoading && !isFetching` so the `useQuery` subscription stays alive through discovery.

### 6. Drop redundant tooltip on Thinking items
Same description was rendered both inline + as hover bubble; the bubble overlapped the next row. Removed.

## Test plan
- [x] `pnpm --filter @multica/views typecheck` clean.
- [x] `pnpm --filter @multica/views test thinking-picker` → 7/7 pass.
- [ ] Open agent inspector — every picker chip flips instantly on click; no perceived lag.
- [ ] Disconnect runtime → reconnect a Claude/Codex runtime — Thinking row appears as soon as discovery completes (no need to tap Model picker first).
- [ ] Open Thinking picker — descriptions left-aligned with labels across all rows.
- [ ] Open Model picker — model IDs left-aligned under model display names across all rows.
- [ ] Trigger label reads "Follow CLI config" when no override is set; the picker has no `[default]` chip next to options.
- [ ] Footer clear button (when value is set): tooltip mentions CLI config and clears to the empty/follow-CLI state.
- [ ] Induce an updateAgent API failure (e.g., disconnect network mid-pick) — trigger reverts to the previous value and a toast surfaces the error.