### PR TITLE
MUL-2339: docs(agent-inspector): sync thinking_level comments with no-override semantics

### DIFF
--- a/packages/core/types/agent.ts
+++ b/packages/core/types/agent.ts
@@ -267,7 +267,8 @@ export interface UpdateAgentRequest {
   /**
    * Runtime-native reasoning/effort token. Tri-state semantics (MUL-2339):
    *   - field omitted → no change
-   *   - "" → explicit clear (use runtime default)
+   *   - "" → clear the override; backend omits the effort flag and the
+   *     local CLI config / built-in default decides what the model runs at
    *   - non-empty → set; validated server-side against the target
    *     runtime's provider enum, rejected with 400 if not recognised
    */

--- a/packages/views/agents/components/inspector/thinking-picker.tsx
+++ b/packages/views/agents/components/inspector/thinking-picker.tsx
@@ -31,8 +31,10 @@ export function ThinkingPicker({
 }: {
   /** Persisted thinking_level — "" means "follow local CLI config". */
   value: string;
-  /** Supported levels for the current (runtime, model) pair. Caller has
-   *  already verified the list is non-empty before mounting this picker. */
+  /** Supported levels for the current (runtime, model) pair. Usually
+   *  non-empty when the row is shown, but the stale-orphan clear path
+   *  in ThinkingPropRow mounts the picker with an empty list plus a
+   *  persisted value so the user can see and clear the dangling token. */
   levels: RuntimeModelThinkingLevel[];
   /** When false, render a static read-only display and skip the popover. */
   canEdit?: boolean;


### PR DESCRIPTION
## Summary

Follow-up to #2919 review nits. Two stale comments still described the empty `thinking_level` as "use runtime default" and claimed `ThinkingPicker` callers guaranteed a non-empty `levels` list — both are wrong after the semantics changed in the previous PR.

- `packages/core/types/agent.ts:268-273` — `""` is now described as clearing the override; backend omits the effort flag and the local CLI config / built-in default decides what the model runs at.
- `packages/views/agents/components/inspector/thinking-picker.tsx:34-37` — note that the stale-orphan clear path in `ThinkingPropRow` mounts the picker with an empty `levels` list plus a persisted `value`, so callers do not guarantee non-empty levels.

Comment-only change; no behavior change, no test changes.

MUL-2339

## Test plan

- [x] `pnpm --filter @multica/views exec vitest run agents/components/inspector` — 13/13 pass
- [x] `git diff` — only the two comment blocks change