### PR TITLE
feat(issues): Working filter + agent-working badge on board (MUL-2452)

### DIFF
--- a/packages/core/issues/active-tasks-by-issue.ts
+++ b/packages/core/issues/active-tasks-by-issue.ts
@@ -1,0 +1,67 @@
+import { queryOptions } from "@tanstack/react-query";
+import { api } from "../api";
+import { agentTaskSnapshotKeys } from "../agents/queries";
+import type { AgentTask } from "../types/agent";
+
+// Active = a task that hasn't reached a terminal state yet. Mirrors the
+// detail-page `ListActiveTasksByIssue` SQL definition so the board badge
+// matches the issue-detail banner.
+const ACTIVE = new Set<string>(["queued", "dispatched", "running"]);
+
+// Stay-in-sync surface with `agentTaskSnapshotOptions(wsId)`: same queryKey
+// + same queryFn so TanStack Query's cache is shared (one fetch, multiple
+// projected views) and any future tweak there is mirrored here. The
+// staleTime/gcTime defaults are inherited from the global QueryClient,
+// matching the lifetime of the underlying snapshot.
+function snapshotBase(wsId: string) {
+  return {
+    queryKey: agentTaskSnapshotKeys.list(wsId),
+    queryFn: () => api.getAgentTaskSnapshot(),
+    staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: true,
+  } as const;
+}
+
+/**
+ * Derived map: issue id → list of active agent tasks on that issue.
+ *
+ * Shares the workspace-wide `agentTaskSnapshot` cache key so the snapshot
+ * is fetched once and shaped into multiple views; WS `task:*` events that
+ * invalidate the snapshot automatically refresh this selector.
+ */
+export function activeTasksByIssueOptions(wsId: string) {
+  return queryOptions({
+    ...snapshotBase(wsId),
+    select: (tasks: AgentTask[]) => {
+      const map = new Map<string, AgentTask[]>();
+      for (const t of tasks) {
+        if (!t.issue_id) continue;
+        if (!ACTIVE.has(t.status)) continue;
+        const arr = map.get(t.issue_id);
+        if (arr) arr.push(t);
+        else map.set(t.issue_id, [t]);
+      }
+      return map;
+    },
+  });
+}
+
+/**
+ * Set of issue ids that currently have at least one active agent task.
+ * Used by the Working filter for O(1) membership checks.
+ */
+export function workingIssueIdsOptions(wsId: string) {
+  return queryOptions({
+    ...snapshotBase(wsId),
+    select: (tasks: AgentTask[]) => {
+      const ids = new Set<string>();
+      for (const t of tasks) {
+        if (!t.issue_id) continue;
+        if (!ACTIVE.has(t.status)) continue;
+        ids.add(t.issue_id);
+      }
+      return ids;
+    },
+  });
+}

--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -67,6 +67,7 @@ export interface IssueViewState {
   projectFilters: string[];
   includeNoProject: boolean;
   labelFilters: string[];
+  workingOnly: boolean;
   sortBy: SortField;
   sortDirection: SortDirection;
   cardProperties: CardProperties;
@@ -87,6 +88,7 @@ export interface IssueViewState {
   toggleLabelFilter: (labelId: string) => void;
   hideStatus: (status: IssueStatus) => void;
   showStatus: (status: IssueStatus) => void;
+  toggleWorkingOnly: () => void;
   clearFilters: () => void;
   setSortBy: (field: SortField) => void;
   setSortDirection: (dir: SortDirection) => void;
@@ -105,6 +107,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
   projectFilters: [],
   includeNoProject: false,
   labelFilters: [],
+  workingOnly: false,
   sortBy: "position",
   sortDirection: "asc",
   cardProperties: {
@@ -196,6 +199,8 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
       if (state.statusFilters.includes(status)) return state;
       return { statusFilters: [...state.statusFilters, status] };
     }),
+  toggleWorkingOnly: () =>
+    set((state) => ({ workingOnly: !state.workingOnly })),
   clearFilters: () =>
     set({
       statusFilters: [],
@@ -206,6 +211,7 @@ export const viewStoreSlice = (set: StoreApi<IssueViewState>["setState"]): Issue
       projectFilters: [],
       includeNoProject: false,
       labelFilters: [],
+      workingOnly: false,
     }),
   setSortBy: (field) => set({ sortBy: field }),
   setSortDirection: (dir) => set({ sortDirection: dir }),
@@ -238,6 +244,7 @@ export const viewStorePersistOptions = (name: string) => ({
     projectFilters: state.projectFilters,
     includeNoProject: state.includeNoProject,
     labelFilters: state.labelFilters,
+    workingOnly: state.workingOnly,
     sortBy: state.sortBy,
     sortDirection: state.sortDirection,
     cardProperties: state.cardProperties,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     "./issues": "./issues/index.ts",
     "./issues/queries": "./issues/queries.ts",
     "./issues/mutations": "./issues/mutations.ts",
+    "./issues/active-tasks-by-issue": "./issues/active-tasks-by-issue.ts",
     "./issues/ws-updaters": "./issues/ws-updaters.ts",
     "./issues/config": "./issues/config/index.ts",
     "./issues/config/status": "./issues/config/status.ts",

--- a/packages/views/issues/components/board-card.tsx
+++ b/packages/views/issues/components/board-card.tsx
@@ -7,9 +7,11 @@ import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { toast } from "sonner";
 import type { Issue, UpdateIssueRequest } from "@multica/core/types";
+import type { AgentTask } from "@multica/core/types/agent";
 import { CalendarClock, CalendarDays } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { WorkingBadge } from "./working-badge";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -60,10 +62,12 @@ export const BoardCardContent = memo(function BoardCardContent({
   issue,
   editable = false,
   childProgress,
+  activeTasks,
 }: {
   issue: Issue;
   editable?: boolean;
   childProgress?: ChildProgress;
+  activeTasks?: AgentTask[];
 }) {
   const { t } = useT("issues");
   const storeProperties = useViewStore((s) => s.cardProperties);
@@ -105,8 +109,11 @@ export const BoardCardContent = memo(function BoardCardContent({
 
   return (
     <div className="rounded-lg border-[0.5px] border-border bg-card py-3 px-2.5 shadow-[0_3px_6px_-2px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.04)] transition-colors group-hover/card:border-accent group-hover/card:bg-accent group-data-[popup-open]/card:border-accent group-data-[popup-open]/card:bg-accent">
-      {/* Row 1: Identifier */}
-      <p className="text-xs text-muted-foreground">{issue.identifier}</p>
+      {/* Row 1: Identifier (+ working badge when an agent is active on this issue) */}
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">{issue.identifier}</p>
+        {activeTasks && activeTasks.length > 0 && <WorkingBadge tasks={activeTasks} />}
+      </div>
 
       {/* Row 2: Title */}
       <p className="mt-1 text-sm font-medium leading-snug line-clamp-2">
@@ -264,7 +271,7 @@ const animateLayoutChanges: AnimateLayoutChanges = (args) => {
   return defaultAnimateLayoutChanges(args);
 };
 
-export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, childProgress }: { issue: Issue; childProgress?: ChildProgress }) {
+export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, childProgress, activeTasks }: { issue: Issue; childProgress?: ChildProgress; activeTasks?: AgentTask[] }) {
   const p = useWorkspacePaths();
   const {
     attributes,
@@ -297,7 +304,7 @@ export const DraggableBoardCard = memo(function DraggableBoardCard({ issue, chil
           href={p.issueDetail(issue.id)}
           className={`group block transition-colors ${isDragging ? "pointer-events-none" : ""}`}
         >
-          <BoardCardContent issue={issue} editable childProgress={childProgress} />
+          <BoardCardContent issue={issue} editable childProgress={childProgress} activeTasks={activeTasks} />
         </AppLink>
       </div>
     </IssueActionsContextMenu>

--- a/packages/views/issues/components/board-column.tsx
+++ b/packages/views/issues/components/board-column.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import type { Issue, IssueAssigneeType, IssueStatus } from "@multica/core/types";
+import type { AgentTask } from "@multica/core/types/agent";
 import { Button } from "@multica/ui/components/ui/button";
 import {
   DropdownMenu,
@@ -37,6 +38,7 @@ export function BoardColumn({
   issueIds,
   issueMap,
   childProgressMap,
+  activeTasksMap,
   totalCount,
   footer,
   projectId,
@@ -45,6 +47,7 @@ export function BoardColumn({
   issueIds: string[];
   issueMap: Map<string, Issue>;
   childProgressMap?: Map<string, ChildProgress>;
+  activeTasksMap?: Map<string, AgentTask[]>;
   totalCount?: number;
   footer?: ReactNode;
   /** When set, the per-column "+" pre-fills the project on the create form. */
@@ -121,7 +124,12 @@ export function BoardColumn({
       >
         <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
           {resolvedIssues.map((issue) => (
-            <DraggableBoardCard key={issue.id} issue={issue} childProgress={childProgressMap?.get(issue.id)} />
+            <DraggableBoardCard
+              key={issue.id}
+              issue={issue}
+              childProgress={childProgressMap?.get(issue.id)}
+              activeTasks={activeTasksMap?.get(issue.id)}
+            />
           ))}
         </SortableContext>
         {issueIds.length === 0 && (

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -247,6 +247,7 @@ export function BoardView({
   const sortBy = useViewStore((s) => s.sortBy);
   const sortDirection = useViewStore((s) => s.sortDirection);
   const grouping = useViewStore((s) => s.grouping);
+  const workingOnly = useViewStore((s) => s.workingOnly);
   const { getActorName } = useActorName();
   const myIssuesOpts = myIssuesScope
     ? { scope: myIssuesScope, filter: myIssuesFilter ?? {} }
@@ -489,6 +490,7 @@ export function BoardView({
                 activeTasksMap={activeTasksMap}
                 myIssuesOpts={myIssuesOpts}
                 projectId={projectId}
+                workingOnly={workingOnly}
               />
             ) : (
               assigneeGroupQueryKey && assigneeGroupFilter ? (
@@ -502,6 +504,7 @@ export function BoardView({
                   queryKey={assigneeGroupQueryKey}
                   filter={assigneeGroupFilter}
                   projectId={projectId}
+                  workingOnly={workingOnly}
                 />
               ) : (
                 <BoardColumn
@@ -551,6 +554,7 @@ function PaginatedAssigneeBoardColumn({
   queryKey,
   filter,
   projectId,
+  workingOnly,
 }: {
   group: BoardColumnGroup;
   issueIds: string[];
@@ -560,6 +564,7 @@ function PaginatedAssigneeBoardColumn({
   queryKey: QueryKey;
   filter: AssigneeGroupedIssuesFilter;
   projectId?: string;
+  workingOnly: boolean;
 }) {
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByAssigneeGroup(
     {
@@ -570,6 +575,13 @@ function PaginatedAssigneeBoardColumn({
     queryKey,
     filter,
   );
+  // The hook's `total` is read from the raw query cache so load-more knows
+  // when the server has more rows. The displayed column count must follow
+  // the visible-after-filter set instead — when the Working filter is on,
+  // `group.totalCount` (set by `applyWorkingFilterToGroups`) is the filtered
+  // count, otherwise it equals the cache total so the user sees the usual
+  // "N total" affordance during paginated loads.
+  const displayCount = workingOnly ? group.totalCount ?? issueIds.length : total;
   return (
     <BoardColumn
       group={group}
@@ -577,7 +589,7 @@ function PaginatedAssigneeBoardColumn({
       issueMap={issueMap}
       childProgressMap={childProgressMap}
       activeTasksMap={activeTasksMap}
-      totalCount={total}
+      totalCount={displayCount}
       projectId={projectId}
       footer={
         hasMore ? (
@@ -596,6 +608,7 @@ function PaginatedBoardColumn({
   activeTasksMap,
   myIssuesOpts,
   projectId,
+  workingOnly,
 }: {
   group: BoardColumnGroup & { status: IssueStatus };
   issueIds: string[];
@@ -604,11 +617,16 @@ function PaginatedBoardColumn({
   activeTasksMap?: Map<string, AgentTask[]>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
   projectId?: string;
+  workingOnly: boolean;
 }) {
   const { loadMore, hasMore, isLoading, total } = useLoadMoreByStatus(
     group.status,
     myIssuesOpts,
   );
+  // Same split as the assignee-grouped path: the hook keeps using the raw
+  // cache total for pagination, but the column header reflects what the
+  // user actually sees once the Working filter has trimmed the column.
+  const displayCount = workingOnly ? issueIds.length : total;
   return (
     <BoardColumn
       group={group}
@@ -616,7 +634,7 @@ function PaginatedBoardColumn({
       issueMap={issueMap}
       childProgressMap={childProgressMap}
       activeTasksMap={activeTasksMap}
-      totalCount={total}
+      totalCount={displayCount}
       projectId={projectId}
       footer={
         hasMore ? (

--- a/packages/views/issues/components/board-view.tsx
+++ b/packages/views/issues/components/board-view.tsx
@@ -18,6 +18,7 @@ import type { QueryKey } from "@tanstack/react-query";
 import { arrayMove } from "@dnd-kit/sortable";
 import { Eye, MoreHorizontal } from "lucide-react";
 import type { Issue, IssueAssigneeGroup, IssueAssigneeType, IssueStatus, UpdateIssueRequest } from "@multica/core/types";
+import type { AgentTask } from "@multica/core/types/agent";
 import { Button } from "@multica/ui/components/ui/button";
 import { useLoadMoreByAssigneeGroup, useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { AssigneeGroupedIssuesFilter, MyIssuesFilter } from "@multica/core/issues/queries";
@@ -210,6 +211,7 @@ function getMoveUpdates(
 }
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
+const EMPTY_ACTIVE_TASKS_MAP = new Map<string, AgentTask[]>();
 
 export function BoardView({
   issues,
@@ -220,6 +222,7 @@ export function BoardView({
   hiddenStatuses,
   onMoveIssue,
   childProgressMap = EMPTY_PROGRESS_MAP,
+  activeTasksMap = EMPTY_ACTIVE_TASKS_MAP,
   myIssuesScope,
   myIssuesFilter,
   projectId,
@@ -232,6 +235,8 @@ export function BoardView({
   hiddenStatuses: IssueStatus[];
   onMoveIssue: (issueId: string, updates: BoardMoveUpdates) => void;
   childProgressMap?: Map<string, ChildProgress>;
+  /** Active agent tasks indexed by issue id; drives the "agent working" badge. */
+  activeTasksMap?: Map<string, AgentTask[]>;
   /** When set, per-status load-more targets the scoped cache instead of the workspace one. */
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
@@ -481,6 +486,7 @@ export function BoardView({
                 issueIds={columns[group.id] ?? []}
                 issueMap={issueMapRef.current}
                 childProgressMap={childProgressMap}
+                activeTasksMap={activeTasksMap}
                 myIssuesOpts={myIssuesOpts}
                 projectId={projectId}
               />
@@ -492,6 +498,7 @@ export function BoardView({
                   issueIds={columns[group.id] ?? []}
                   issueMap={issueMapRef.current}
                   childProgressMap={childProgressMap}
+                  activeTasksMap={activeTasksMap}
                   queryKey={assigneeGroupQueryKey}
                   filter={assigneeGroupFilter}
                   projectId={projectId}
@@ -503,6 +510,7 @@ export function BoardView({
                   issueIds={columns[group.id] ?? []}
                   issueMap={issueMapRef.current}
                   childProgressMap={childProgressMap}
+                  activeTasksMap={activeTasksMap}
                   projectId={projectId}
                   totalCount={group.totalCount}
                 />
@@ -522,7 +530,11 @@ export function BoardView({
       <DragOverlay dropAnimation={null}>
         {activeIssue ? (
           <div className="w-[280px] rotate-2 scale-105 cursor-grabbing opacity-90 shadow-lg shadow-black/10">
-            <BoardCardContent issue={activeIssue} childProgress={childProgressMap.get(activeIssue.id)} />
+            <BoardCardContent
+              issue={activeIssue}
+              childProgress={childProgressMap.get(activeIssue.id)}
+              activeTasks={activeTasksMap.get(activeIssue.id)}
+            />
           </div>
         ) : null}
       </DragOverlay>
@@ -535,6 +547,7 @@ function PaginatedAssigneeBoardColumn({
   issueIds,
   issueMap,
   childProgressMap,
+  activeTasksMap,
   queryKey,
   filter,
   projectId,
@@ -543,6 +556,7 @@ function PaginatedAssigneeBoardColumn({
   issueIds: string[];
   issueMap: Map<string, Issue>;
   childProgressMap?: Map<string, ChildProgress>;
+  activeTasksMap?: Map<string, AgentTask[]>;
   queryKey: QueryKey;
   filter: AssigneeGroupedIssuesFilter;
   projectId?: string;
@@ -562,6 +576,7 @@ function PaginatedAssigneeBoardColumn({
       issueIds={issueIds}
       issueMap={issueMap}
       childProgressMap={childProgressMap}
+      activeTasksMap={activeTasksMap}
       totalCount={total}
       projectId={projectId}
       footer={
@@ -578,6 +593,7 @@ function PaginatedBoardColumn({
   issueIds,
   issueMap,
   childProgressMap,
+  activeTasksMap,
   myIssuesOpts,
   projectId,
 }: {
@@ -585,6 +601,7 @@ function PaginatedBoardColumn({
   issueIds: string[];
   issueMap: Map<string, Issue>;
   childProgressMap?: Map<string, ChildProgress>;
+  activeTasksMap?: Map<string, AgentTask[]>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
   projectId?: string;
 }) {
@@ -598,6 +615,7 @@ function PaginatedBoardColumn({
       issueIds={issueIds}
       issueMap={issueMap}
       childProgressMap={childProgressMap}
+      activeTasksMap={activeTasksMap}
       totalCount={total}
       projectId={projectId}
       footer={

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -66,6 +66,10 @@ import {
 } from "@multica/core/issues/stores/issues-scope-store";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import type { Issue } from "@multica/core/types";
+import type { AgentTask } from "@multica/core/types/agent";
+import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
+import { useActorName } from "@multica/core/workspace/hooks";
+import { cn } from "@multica/ui/lib/utils";
 import { useT } from "../../i18n";
 import { matchesPinyin } from "../../editor/extensions/pinyin-match";
 
@@ -494,9 +498,18 @@ function LabelSubContent({
 export function IssuesHeader({
   scopedIssues,
   allowGantt = false,
+  showWorkingToggle = true,
+  activeTasksMap,
 }: {
   scopedIssues: Issue[];
   allowGantt?: boolean;
+  /** When false, suppresses the Working toggle (used on /project/<id> to keep
+   *  the project surface's filter dimensions unchanged). */
+  showWorkingToggle?: boolean;
+  /** Map of issue id → active agent tasks, used to derive the agent avatar
+   *  stack shown next to the Working label. Optional; missing data renders
+   *  the toggle without a stack. */
+  activeTasksMap?: Map<string, AgentTask[]>;
 }) {
   const { t } = useT("issues");
   const scope = useIssuesScopeStore((s) => s.scope);
@@ -514,7 +527,7 @@ export function IssuesHeader({
 
   return (
     <div className="flex h-12 shrink-0 items-center justify-between px-4">
-      {/* Left: scope buttons */}
+      {/* Left: scope buttons + optional working toggle */}
       <div className="flex items-center gap-1">
         {SCOPE_VALUES.map((s) => (
           <Tooltip key={s}>
@@ -537,10 +550,145 @@ export function IssuesHeader({
             <TooltipContent side="bottom">{t(($) => $.scope[SCOPE_DESC_KEY[s]])}</TooltipContent>
           </Tooltip>
         ))}
+        {showWorkingToggle && (
+          <>
+            <span aria-hidden className="mx-1.5 h-4 w-px bg-border" />
+            <WorkingToggleButton scopedIssues={scopedIssues} activeTasksMap={activeTasksMap} />
+          </>
+        )}
       </div>
 
       <IssueDisplayControls scopedIssues={scopedIssues} allowGantt={allowGantt} />
     </div>
+  );
+}
+
+const MAX_VISIBLE_AGENTS = 3;
+const WORKING_AVATAR_SIZE = 18;
+
+/**
+ * "● Working" toggle sitting next to the scope segmented control. The
+ * label/text comes from the issues namespace, the count of agents currently
+ * active in the surface drives the agent avatar stack on the right.
+ *
+ * `workingAgentIds` is derived from `scopedIssues` ∩ `activeTasksMap` so the
+ * stack matches what filtering would actually return on the current page +
+ * scope (Reviewer Blocker 3): a workspace-wide count would show numbers the
+ * user can't reach when the page-level scope is narrower.
+ */
+function WorkingToggleButton({
+  scopedIssues,
+  activeTasksMap,
+}: {
+  scopedIssues: Issue[];
+  activeTasksMap?: Map<string, AgentTask[]>;
+}) {
+  const { t } = useT("issues");
+  const workingOnly = useViewStore((s) => s.workingOnly);
+  const toggleWorkingOnly = useViewStore((s) => s.toggleWorkingOnly);
+  const { getActorName, getActorInitials, getActorAvatarUrl } = useActorName();
+
+  const workingAgentIds = useMemo<string[]>(() => {
+    if (!activeTasksMap) return [];
+    const firstSeenAt = new Map<string, string>();
+    for (const issue of scopedIssues) {
+      const tasks = activeTasksMap.get(issue.id);
+      if (!tasks) continue;
+      for (const tk of tasks) {
+        if (!tk.agent_id) continue;
+        const ts = tk.started_at ?? tk.dispatched_at ?? tk.created_at;
+        const prev = firstSeenAt.get(tk.agent_id);
+        if (!prev || ts < prev) firstSeenAt.set(tk.agent_id, ts);
+      }
+    }
+    return [...firstSeenAt.entries()]
+      .sort((a, b) => (a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0))
+      .map(([id]) => id);
+  }, [scopedIssues, activeTasksMap]);
+
+  const hasWorking = workingAgentIds.length > 0;
+  const visibleAgents = workingAgentIds.slice(0, MAX_VISIBLE_AGENTS);
+  const overflow = workingAgentIds.length - visibleAgents.length;
+  const tooltipDescription = t(($) => $.scope.working_description);
+  const tooltipNames =
+    workingAgentIds.length > 0
+      ? workingAgentIds.map((id) => getActorName("agent", id)).join(", ")
+      : "";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            aria-pressed={workingOnly}
+            className={cn(
+              "gap-1.5",
+              workingOnly
+                ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                : "text-muted-foreground",
+            )}
+            onClick={() => toggleWorkingOnly()}
+          >
+            <span
+              aria-hidden
+              className={cn(
+                "relative inline-flex size-2",
+              )}
+            >
+              {hasWorking && (
+                <span className="absolute inset-0 animate-ping rounded-full bg-brand opacity-60" />
+              )}
+              <span
+                className={cn(
+                  "relative inline-flex size-2 rounded-full",
+                  hasWorking ? "bg-brand" : "bg-muted-foreground/40",
+                )}
+              />
+            </span>
+            <span>{t(($) => $.scope.working_label)}</span>
+            {hasWorking && (
+              <span className="ml-0.5 inline-flex items-center -space-x-1.5">
+                {visibleAgents.map((id) => (
+                  <span
+                    key={id}
+                    className="inline-flex rounded-full ring-2 ring-background"
+                  >
+                    <ActorAvatarBase
+                      name={getActorName("agent", id)}
+                      initials={getActorInitials("agent", id)}
+                      avatarUrl={getActorAvatarUrl("agent", id)}
+                      isAgent
+                      size={WORKING_AVATAR_SIZE}
+                    />
+                  </span>
+                ))}
+                {overflow > 0 && (
+                  <span
+                    aria-hidden
+                    className="inline-flex items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-muted-foreground ring-2 ring-background"
+                    style={{ width: WORKING_AVATAR_SIZE, height: WORKING_AVATAR_SIZE }}
+                  >
+                    +{overflow}
+                  </span>
+                )}
+              </span>
+            )}
+          </Button>
+        }
+      />
+      <TooltipContent side="bottom">
+        {tooltipNames ? (
+          <div className="space-y-1">
+            <div>{tooltipDescription}</div>
+            <div className="text-xs text-muted-foreground">{tooltipNames}</div>
+          </div>
+        ) : (
+          tooltipDescription
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -113,6 +113,7 @@ const mockListSquads = vi.hoisted(() =>
     },
   ]),
 );
+const mockGetAgentTaskSnapshot = vi.hoisted(() => vi.fn().mockResolvedValue([]));
 vi.mock("@multica/core/api", () => ({
   api: {
     listIssues: (...args: any[]) => mockListIssues(...args),
@@ -121,6 +122,7 @@ vi.mock("@multica/core/api", () => ({
     listMembers: (...args: any[]) => mockListMembers(...args),
     listAgents: (...args: any[]) => mockListAgents(...args),
     listSquads: (...args: any[]) => mockListSquads(...args),
+    getAgentTaskSnapshot: (...args: any[]) => mockGetAgentTaskSnapshot(...args),
   },
   getApi: () => ({
     listIssues: (...args: any[]) => mockListIssues(...args),
@@ -129,6 +131,7 @@ vi.mock("@multica/core/api", () => ({
     listMembers: (...args: any[]) => mockListMembers(...args),
     listAgents: (...args: any[]) => mockListAgents(...args),
     listSquads: (...args: any[]) => mockListSquads(...args),
+    getAgentTaskSnapshot: (...args: any[]) => mockGetAgentTaskSnapshot(...args),
   }),
   setApiInstance: vi.fn(),
 }));
@@ -169,6 +172,7 @@ const mockViewState = {
   projectFilters: [] as string[],
   includeNoProject: false,
   labelFilters: [] as string[],
+  workingOnly: false,
   sortBy: "position" as const,
   sortDirection: "asc" as const,
   cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
@@ -183,6 +187,7 @@ const mockViewState = {
   toggleProjectFilter: vi.fn(),
   toggleNoProject: vi.fn(),
   toggleLabelFilter: vi.fn(),
+  toggleWorkingOnly: vi.fn(),
   hideStatus: vi.fn(),
   showStatus: vi.fn(),
   clearFilters: vi.fn(),
@@ -480,10 +485,12 @@ describe("IssuesPage (shared)", () => {
     vi.clearAllMocks();
     mockListIssues.mockResolvedValue({ issues: [], total: 0 });
     mockListGroupedIssues.mockResolvedValue({ groups: [] });
+    mockGetAgentTaskSnapshot.mockResolvedValue([]);
     mockViewState.viewMode = "board";
     mockViewState.grouping = "status";
     mockViewState.statusFilters = [];
     mockViewState.priorityFilters = [];
+    mockViewState.workingOnly = false;
     mockScope = "all";
   });
 
@@ -617,5 +624,62 @@ describe("IssuesPage (shared)", () => {
     await screen.findByText("Implement auth");
     expect(screen.queryByText("Squad task")).not.toBeInTheDocument();
     expect(screen.queryByText("Design landing page")).not.toBeInTheDocument();
+  });
+
+  // Regression: with Working on + assignee grouping, the column header used
+  // to show the cache's unfiltered group total because
+  // `useLoadMoreByAssigneeGroup` reads from the raw cache. The displayed
+  // count must follow the visible-after-filter set.
+  it("assignee-grouped column header reflects filtered count when Working is on", async () => {
+    mockViewState.viewMode = "board";
+    mockViewState.grouping = "assignee";
+    mockViewState.workingOnly = true;
+
+    // user-1's column has three issues in the workspace cache; only
+    // issue-1 is currently being worked on.
+    const userOneIssues = mockIssues.filter(
+      (i) => i.assignee_type === "member" && i.assignee_id === "user-1",
+    );
+    const padded = [
+      ...userOneIssues,
+      { ...userOneIssues[0]!, id: "extra-1", identifier: "TES-100", title: "Extra one" },
+      { ...userOneIssues[0]!, id: "extra-2", identifier: "TES-101", title: "Extra two" },
+    ];
+    mockListGroupedIssues.mockResolvedValue({
+      groups: [
+        {
+          id: "assignee:member:user-1",
+          assignee_type: "member",
+          assignee_id: "user-1",
+          issues: padded,
+          total: padded.length,
+        },
+      ],
+    });
+    mockGetAgentTaskSnapshot.mockResolvedValue([
+      {
+        id: "task-1",
+        workspace_id: "ws-1",
+        agent_id: "agent-1",
+        issue_id: "issue-1",
+        status: "running",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        started_at: "2026-01-01T00:00:00Z",
+      },
+    ]);
+
+    const { container } = renderWithQuery(<IssuesPage />);
+
+    // Only the working issue stays visible.
+    await screen.findByText("Implement auth");
+    expect(screen.queryByText("Extra one")).not.toBeInTheDocument();
+
+    // Column header count must equal 1, not the cached 4. The badge lives in
+    // `span.tabular-nums` (see `board-column.tsx::BoardGroupHeading`).
+    const countBadges = container.querySelectorAll("span.tabular-nums");
+    const counts = [...countBadges].map((el) => el.textContent);
+    expect(counts).toContain("1");
+    expect(counts).not.toContain("4");
   });
 });

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -9,7 +9,9 @@ import { useQuery } from "@tanstack/react-query";
 import { useIssueViewStore, useClearFiltersOnWorkspaceChange } from "@multica/core/issues/stores/view-store";
 import { useIssuesScopeStore } from "@multica/core/issues/stores/issues-scope-store";
 import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
+import { activeTasksByIssueOptions, workingIssueIdsOptions } from "@multica/core/issues/active-tasks-by-issue";
 import { filterIssues } from "../utils/filter";
+import { applyWorkingFilterToGroups } from "../utils/grouped-issues";
 import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { useCurrentWorkspace } from "@multica/core/paths";
 import { WorkspaceAvatar } from "../../workspace/workspace-avatar";
@@ -40,6 +42,7 @@ export function IssuesPage() {
   const projectFilters = useIssueViewStore((s) => s.projectFilters);
   const includeNoProject = useIssueViewStore((s) => s.includeNoProject);
   const labelFilters = useIssueViewStore((s) => s.labelFilters);
+  const workingOnly = useIssueViewStore((s) => s.workingOnly);
   const usesAssigneeBoard = viewMode === "board" && grouping === "assignee";
 
   const assigneeGroupFilter = useMemo<AssigneeGroupedIssuesFilter>(() => {
@@ -97,9 +100,38 @@ export function IssuesPage() {
 
   const headerIssues = usesAssigneeBoard ? assigneeIssues : scopedIssues;
 
+  // Shared workspace-wide agent task snapshot derivations (one fetch backs
+  // both the per-issue badge and the Working filter membership set).
+  const { data: activeTasksMap } = useQuery(activeTasksByIssueOptions(wsId));
+  const { data: workingIssueIds } = useQuery(workingIssueIdsOptions(wsId));
+
   const issues = useMemo(
-    () => filterIssues(scopedIssues, { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters }),
-    [scopedIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters],
+    () =>
+      filterIssues(scopedIssues, {
+        statusFilters,
+        priorityFilters,
+        assigneeFilters,
+        includeNoAssignee,
+        creatorFilters,
+        projectFilters,
+        includeNoProject,
+        labelFilters,
+        workingOnly,
+        workingIssueIds,
+      }),
+    [scopedIssues, statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters, workingOnly, workingIssueIds],
+  );
+
+  // Assignee-grouped board bypasses `filterIssues`. Rebuild the groups here
+  // so the Working filter shows up there too AND so the column-header total
+  // numbers stay in sync with the visible card count.
+  const filteredAssigneeGroups = useMemo(
+    () => applyWorkingFilterToGroups(assigneeGroupsQuery.data?.groups, workingOnly, workingIssueIds),
+    [assigneeGroupsQuery.data, workingOnly, workingIssueIds],
+  );
+  const filteredAssigneeIssues = useMemo(
+    () => filteredAssigneeGroups?.flatMap((g) => g.issues) ?? [],
+    [filteredAssigneeGroups],
   );
 
   // Fetch sub-issue progress from the backend so counts are accurate
@@ -188,7 +220,7 @@ export function IssuesPage() {
 
       <ViewStoreProvider store={useIssueViewStore}>
         {/* Header 2: Scope tabs + filters */}
-        <IssuesHeader scopedIssues={headerIssues} />
+        <IssuesHeader scopedIssues={headerIssues} activeTasksMap={activeTasksMap} />
 
         {/* Content: scrollable */}
         {headerIssues.length === 0 ? (
@@ -201,17 +233,23 @@ export function IssuesPage() {
           <div className="flex flex-col flex-1 min-h-0">
             {viewMode === "board" ? (
               <BoardView
-                issues={usesAssigneeBoard ? assigneeIssues : issues}
-                assigneeGroups={usesAssigneeBoard ? assigneeGroupsQuery.data?.groups : undefined}
+                issues={usesAssigneeBoard ? filteredAssigneeIssues : issues}
+                assigneeGroups={usesAssigneeBoard ? filteredAssigneeGroups : undefined}
                 assigneeGroupQueryKey={usesAssigneeBoard ? assigneeGroupsOptions.queryKey : undefined}
                 assigneeGroupFilter={usesAssigneeBoard ? assigneeGroupFilter : undefined}
                 visibleStatuses={visibleStatuses}
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
+                activeTasksMap={activeTasksMap}
               />
             ) : (
-              <ListView issues={issues} visibleStatuses={visibleStatuses} childProgressMap={childProgressMap} />
+              <ListView
+                issues={issues}
+                visibleStatuses={visibleStatuses}
+                childProgressMap={childProgressMap}
+                activeTasksMap={activeTasksMap}
+              />
             )}
           </div>
         )}

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -4,7 +4,9 @@ import { memo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { AppLink } from "../../navigation";
 import type { Issue } from "@multica/core/types";
+import type { AgentTask } from "@multica/core/types/agent";
 import { ActorAvatar } from "../../common/actor-avatar";
+import { WorkingBadge } from "./working-badge";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
 import { useWorkspacePaths } from "@multica/core/paths";
 import { useWorkspaceId } from "@multica/core/hooks";
@@ -31,9 +33,11 @@ function formatDate(date: string): string {
 export const ListRow = memo(function ListRow({
   issue,
   childProgress,
+  activeTasks,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
+  activeTasks?: AgentTask[];
 }) {
   const selected = useIssueSelectionStore((s) => s.selectedIds.has(issue.id));
   const toggle = useIssueSelectionStore((s) => s.toggle);
@@ -102,6 +106,11 @@ export const ListRow = memo(function ListRow({
                     +{labels.length - 3}
                   </span>
                 )}
+              </span>
+            )}
+            {activeTasks && activeTasks.length > 0 && (
+              <span className="ml-1.5 shrink-0">
+                <WorkingBadge tasks={activeTasks} />
               </span>
             )}
           </span>

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -6,6 +6,7 @@ import { Accordion } from "@base-ui/react/accordion";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import { Button } from "@multica/ui/components/ui/button";
 import type { Issue, IssueStatus } from "@multica/core/types";
+import type { AgentTask } from "@multica/core/types/agent";
 import { useLoadMoreByStatus } from "@multica/core/issues/mutations";
 import type { MyIssuesFilter } from "@multica/core/issues/queries";
 import { useModalStore } from "@multica/core/modals";
@@ -18,11 +19,13 @@ import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
 import { useT } from "../../i18n";
 
 const EMPTY_PROGRESS_MAP = new Map<string, ChildProgress>();
+const EMPTY_ACTIVE_TASKS_MAP = new Map<string, AgentTask[]>();
 
 export function ListView({
   issues,
   visibleStatuses,
   childProgressMap = EMPTY_PROGRESS_MAP,
+  activeTasksMap = EMPTY_ACTIVE_TASKS_MAP,
   myIssuesScope,
   myIssuesFilter,
   projectId,
@@ -30,6 +33,8 @@ export function ListView({
   issues: Issue[];
   visibleStatuses: IssueStatus[];
   childProgressMap?: Map<string, ChildProgress>;
+  /** Active agent tasks indexed by issue id; drives the "agent working" badge. */
+  activeTasksMap?: Map<string, AgentTask[]>;
   /** When set, per-status load-more targets the scoped cache instead of the workspace one. */
   myIssuesScope?: string;
   myIssuesFilter?: MyIssuesFilter;
@@ -88,6 +93,7 @@ export function ListView({
             status={status}
             issues={issuesByStatus.get(status) ?? []}
             childProgressMap={childProgressMap}
+            activeTasksMap={activeTasksMap}
             myIssuesOpts={myIssuesOpts}
             projectId={projectId}
           />
@@ -101,12 +107,14 @@ function StatusAccordionItem({
   status,
   issues,
   childProgressMap,
+  activeTasksMap,
   myIssuesOpts,
   projectId,
 }: {
   status: IssueStatus;
   issues: Issue[];
   childProgressMap: Map<string, ChildProgress>;
+  activeTasksMap: Map<string, AgentTask[]>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
   projectId?: string;
 }) {
@@ -174,7 +182,12 @@ function StatusAccordionItem({
         {issues.length > 0 ? (
           <>
             {issues.map((issue) => (
-              <ListRow key={issue.id} issue={issue} childProgress={childProgressMap.get(issue.id)} />
+              <ListRow
+                key={issue.id}
+                issue={issue}
+                childProgress={childProgressMap.get(issue.id)}
+                activeTasks={activeTasksMap.get(issue.id)}
+              />
             ))}
             {hasMore && (
               <InfiniteScrollSentinel onVisible={loadMore} loading={isLoading} />

--- a/packages/views/issues/components/working-badge.tsx
+++ b/packages/views/issues/components/working-badge.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
+import { useActorName } from "@multica/core/workspace/hooks";
+import type { AgentTask } from "@multica/core/types/agent";
+import { useT } from "../../i18n";
+
+/**
+ * Compact "an agent is working on this issue" badge for board cards and
+ * list rows. Brand-color pulse dot + optional count of distinct agents.
+ * The hover tooltip lists the agent names.
+ *
+ * The badge is intentionally non-interactive — it sits inside the issue
+ * link target, so clicking it should follow the same destination as the
+ * rest of the card.
+ */
+export function WorkingBadge({ tasks }: { tasks: AgentTask[] }) {
+  const { t } = useT("issues");
+  const { getActorName } = useActorName();
+  if (tasks.length === 0) return null;
+
+  const uniqueAgentIds = Array.from(
+    new Set(tasks.map((t) => t.agent_id).filter(Boolean)),
+  );
+  const tooltipLabel =
+    uniqueAgentIds.length === 0
+      ? t(($) => $.scope.working_label)
+      : uniqueAgentIds.map((id) => getActorName("agent", id)).join(", ");
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            aria-label={t(($) => $.scope.working_label)}
+            className="inline-flex items-center gap-1 rounded-full bg-brand/10 px-1.5 py-0.5 text-[10px] font-medium text-brand"
+          >
+            <span className="relative inline-flex size-1.5">
+              <span className="absolute inset-0 animate-ping rounded-full bg-brand opacity-60" />
+              <span className="relative inline-flex size-1.5 rounded-full bg-brand" />
+            </span>
+            {uniqueAgentIds.length > 1 && (
+              <span className="tabular-nums">{uniqueAgentIds.length}</span>
+            )}
+          </span>
+        }
+      />
+      <TooltipContent side="top">{tooltipLabel}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/views/issues/utils/filter.test.ts
+++ b/packages/views/issues/utils/filter.test.ts
@@ -205,4 +205,44 @@ describe("filterIssues", () => {
     expect(result.map((i) => i.id)).not.toContain("L4");
     expect(result.map((i) => i.id)).not.toContain("L5");
   });
+
+  // --- Working filter ---
+  it("returns all issues when workingOnly is false even if workingIssueIds is set", () => {
+    const result = filterIssues(issues, {
+      ...NO_FILTER,
+      workingOnly: false,
+      workingIssueIds: new Set(["1"]),
+    });
+    expect(result.map((i) => i.id)).toEqual(["1", "2", "3", "4"]);
+  });
+
+  it("keeps only issues whose id is in workingIssueIds when workingOnly is true", () => {
+    const result = filterIssues(issues, {
+      ...NO_FILTER,
+      workingOnly: true,
+      workingIssueIds: new Set(["2", "4"]),
+    });
+    expect(result.map((i) => i.id)).toEqual(["2", "4"]);
+  });
+
+  it("collapses to empty when workingOnly is true but workingIssueIds is undefined", () => {
+    // Snapshot still loading — fail closed instead of leaking stale rows.
+    const result = filterIssues(issues, {
+      ...NO_FILTER,
+      workingOnly: true,
+      workingIssueIds: undefined,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("combines workingOnly with other filters using AND semantics", () => {
+    const result = filterIssues(issues, {
+      ...NO_FILTER,
+      statusFilters: ["todo"],
+      workingOnly: true,
+      workingIssueIds: new Set(["1", "2"]),
+    });
+    // Only issue 1 is both status=todo and in the working set.
+    expect(result.map((i) => i.id)).toEqual(["1"]);
+  });
 });

--- a/packages/views/issues/utils/filter.ts
+++ b/packages/views/issues/utils/filter.ts
@@ -10,6 +10,12 @@ export interface IssueFilters {
   projectFilters: string[];
   includeNoProject: boolean;
   labelFilters: string[];
+  /** When true, drop issues that have no active agent task. */
+  workingOnly?: boolean;
+  /** Membership set used by the `workingOnly` filter. Undefined while the
+   *  workspace agent-task snapshot is still loading; in that case no issue
+   *  is treated as working so the list collapses rather than flickering. */
+  workingIssueIds?: Set<string>;
 }
 
 /**
@@ -22,11 +28,13 @@ export interface IssueFilters {
  * - When both → show matching assignees + unassigned
  */
 export function filterIssues(issues: Issue[], filters: IssueFilters): Issue[] {
-  const { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters } = filters;
+  const { statusFilters, priorityFilters, assigneeFilters, includeNoAssignee, creatorFilters, projectFilters, includeNoProject, labelFilters, workingOnly, workingIssueIds } = filters;
   const hasAssigneeFilter = assigneeFilters.length > 0 || includeNoAssignee;
   const hasProjectFilter = projectFilters.length > 0 || includeNoProject;
 
   return issues.filter((issue) => {
+    if (workingOnly && !workingIssueIds?.has(issue.id)) return false;
+
     if (statusFilters.length > 0 && !statusFilters.includes(issue.status))
       return false;
 

--- a/packages/views/issues/utils/grouped-issues.test.ts
+++ b/packages/views/issues/utils/grouped-issues.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import type { Issue, IssueAssigneeGroup } from "@multica/core/types";
+import { applyWorkingFilterToGroups } from "./grouped-issues";
+
+function makeIssue(id: string): Issue {
+  return {
+    id,
+    workspace_id: "ws-1",
+    number: Number(id) || 0,
+    identifier: `MUL-${id}`,
+    title: id,
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: null,
+    assignee_id: null,
+    creator_type: "member",
+    creator_id: "u-1",
+    parent_issue_id: null,
+    project_id: null,
+    position: 0,
+    start_date: null,
+    due_date: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeGroup(id: string, issues: Issue[], total = issues.length): IssueAssigneeGroup {
+  return {
+    id,
+    assignee_type: "member",
+    assignee_id: id,
+    issues,
+    total,
+  };
+}
+
+describe("applyWorkingFilterToGroups", () => {
+  it("returns the same reference when workingOnly is off", () => {
+    const groups = [makeGroup("g1", [makeIssue("1"), makeIssue("2")])];
+    const result = applyWorkingFilterToGroups(groups, false, new Set(["1"]));
+    expect(result).toBe(groups);
+  });
+
+  it("returns undefined passthrough when groups is undefined", () => {
+    expect(applyWorkingFilterToGroups(undefined, true, new Set(["1"]))).toBeUndefined();
+  });
+
+  it("collapses every group to empty when workingIssueIds is undefined", () => {
+    // While the snapshot query is still loading we should not pretend any
+    // issue is working — otherwise stale cards would leak through the filter.
+    const groups = [makeGroup("g1", [makeIssue("1"), makeIssue("2")], 5)];
+    const result = applyWorkingFilterToGroups(groups, true, undefined);
+    expect(result).toEqual([{ ...groups[0]!, issues: [], total: 0 }]);
+  });
+
+  it("filters issues and rewrites total to the filtered count", () => {
+    const groups = [
+      makeGroup("g1", [makeIssue("1"), makeIssue("2"), makeIssue("3")], 10),
+    ];
+    const result = applyWorkingFilterToGroups(
+      groups,
+      true,
+      new Set(["1", "3"]),
+    );
+    expect(result).toBeDefined();
+    expect(result![0]!.issues.map((i) => i.id)).toEqual(["1", "3"]);
+    // total must follow the visible count so the column header doesn't keep
+    // showing the unfiltered cache total when the user toggles Working.
+    expect(result![0]!.total).toBe(2);
+  });
+
+  it("keeps a group with zero matches instead of dropping it", () => {
+    // Removing the column on every toggle would shift the board layout.
+    const groups = [
+      makeGroup("g1", [makeIssue("1"), makeIssue("2")], 7),
+      makeGroup("g2", [makeIssue("3")], 1),
+    ];
+    const result = applyWorkingFilterToGroups(groups, true, new Set(["3"]));
+    expect(result).toBeDefined();
+    expect(result![0]!.id).toBe("g1");
+    expect(result![0]!.issues).toEqual([]);
+    expect(result![0]!.total).toBe(0);
+    expect(result![1]!.issues.map((i) => i.id)).toEqual(["3"]);
+    expect(result![1]!.total).toBe(1);
+  });
+});

--- a/packages/views/issues/utils/grouped-issues.ts
+++ b/packages/views/issues/utils/grouped-issues.ts
@@ -1,0 +1,29 @@
+import type { IssueAssigneeGroup } from "@multica/core/types";
+
+/**
+ * Apply the Working filter to an assignee-grouped query result so the
+ * board's grouped path matches what `filterIssues` does for the flat path.
+ *
+ * Rewrites `group.total` to the filtered count — that field drives the
+ * column-header number (`board-view.tsx` → `board-column.tsx`), so leaving
+ * the original total intact would render "cards shrank but header didn't".
+ *
+ * Empty groups are preserved on purpose: collapsing the columns would shift
+ * the layout every time the user toggles Working, and the existing
+ * "no issues in this column" empty state covers the empty case cleanly.
+ */
+export function applyWorkingFilterToGroups(
+  groups: IssueAssigneeGroup[] | undefined,
+  workingOnly: boolean,
+  workingIssueIds: Set<string> | undefined,
+): IssueAssigneeGroup[] | undefined {
+  if (!groups) return groups;
+  if (!workingOnly) return groups;
+  if (!workingIssueIds) {
+    return groups.map((g) => ({ ...g, issues: [], total: 0 }));
+  }
+  return groups.map((g) => {
+    const filtered = g.issues.filter((i) => workingIssueIds.has(i.id));
+    return { ...g, issues: filtered, total: filtered.length };
+  });
+}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -28,7 +28,9 @@
     "members_label": "Members",
     "members_description": "Issues assigned to team members",
     "agents_label": "Agents",
-    "agents_description": "Issues assigned to AI agents"
+    "agents_description": "Issues assigned to AI agents",
+    "working_label": "Working",
+    "working_description": "Show only issues with an active agent task"
   },
   "filters": {
     "tooltip": "Filter",

--- a/packages/views/locales/en/my-issues.json
+++ b/packages/views/locales/en/my-issues.json
@@ -14,6 +14,8 @@
       "agents_label": "My Agents and Squads",
       "agents_description": "Issues assigned to my agents"
     },
+    "working_label": "Working",
+    "working_description": "Show only issues with an active agent task",
     "filter_button": "Filter",
     "filter_status": "Status",
     "filter_priority": "Priority",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -28,7 +28,9 @@
     "members_label": "成员",
     "members_description": "分配给成员的 issue",
     "agents_label": "智能体",
-    "agents_description": "分配给智能体的 issue"
+    "agents_description": "分配给智能体的 issue",
+    "working_label": "处理中",
+    "working_description": "只看有智能体正在处理的 issue"
   },
   "filters": {
     "tooltip": "筛选",

--- a/packages/views/locales/zh-Hans/my-issues.json
+++ b/packages/views/locales/zh-Hans/my-issues.json
@@ -14,6 +14,8 @@
       "agents_label": "我的智能体和小队",
       "agents_description": "分配给我的智能体的 issue"
     },
+    "working_label": "处理中",
+    "working_description": "只看有智能体正在处理的 issue",
     "filter_button": "筛选",
     "filter_status": "状态",
     "filter_priority": "优先级",

--- a/packages/views/my-issues/components/my-issues-header.tsx
+++ b/packages/views/my-issues/components/my-issues-header.tsx
@@ -48,6 +48,10 @@ import {
 } from "@multica/core/issues/stores/view-store";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@multica/ui/components/ui/tooltip";
 import type { Issue } from "@multica/core/types";
+import type { AgentTask } from "@multica/core/types/agent";
+import { ActorAvatar as ActorAvatarBase } from "@multica/ui/components/common/actor-avatar";
+import { useActorName } from "@multica/core/workspace/hooks";
+import { cn } from "@multica/ui/lib/utils";
 import { myIssuesViewStore, type MyIssuesScope } from "@multica/core/issues/stores/my-issues-view-store";
 import { useT } from "../../i18n";
 
@@ -105,7 +109,16 @@ function useIssueCounts(allIssues: Issue[]) {
 // MyIssuesHeader
 // ---------------------------------------------------------------------------
 
-export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
+export function MyIssuesHeader({
+  allIssues,
+  activeTasksMap,
+}: {
+  allIssues: Issue[];
+  /** Map of issue id → active agent tasks, used to derive the agent avatar
+   *  stack shown next to the Working label. Optional; missing data renders
+   *  the toggle without a stack. */
+  activeTasksMap?: Map<string, AgentTask[]>;
+}) {
   const { t } = useT("my-issues");
   const SCOPES: { value: MyIssuesScope; label: string; description: string }[] = [
     { value: "assigned", label: t(($) => $.header.scope.assigned_label), description: t(($) => $.header.scope.assigned_description) },
@@ -137,7 +150,7 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
 
   return (
     <div className="flex h-12 shrink-0 items-center justify-between px-4">
-      {/* Left: scope buttons */}
+      {/* Left: scope buttons + Working toggle */}
       <div className="flex items-center gap-1">
         {SCOPES.map((s) => (
           <Tooltip key={s.value}>
@@ -160,6 +173,8 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
             <TooltipContent side="bottom">{s.description}</TooltipContent>
           </Tooltip>
         ))}
+        <span aria-hidden className="mx-1.5 h-4 w-px bg-border" />
+        <WorkingToggleButton allIssues={allIssues} activeTasksMap={activeTasksMap} />
       </div>
 
       {/* Right: filter + display + view toggle */}
@@ -428,5 +443,122 @@ export function MyIssuesHeader({ allIssues }: { allIssues: Issue[] }) {
         </DropdownMenu>
       </div>
     </div>
+  );
+}
+
+const MAX_VISIBLE_AGENTS = 3;
+const WORKING_AVATAR_SIZE = 18;
+
+function WorkingToggleButton({
+  allIssues,
+  activeTasksMap,
+}: {
+  allIssues: Issue[];
+  activeTasksMap?: Map<string, AgentTask[]>;
+}) {
+  const { t } = useT("my-issues");
+  const workingOnly = useStore(myIssuesViewStore, (s) => s.workingOnly);
+  const toggleWorkingOnly = useStore(
+    myIssuesViewStore,
+    (s) => s.toggleWorkingOnly,
+  );
+  const { getActorName, getActorInitials, getActorAvatarUrl } = useActorName();
+
+  const workingAgentIds = useMemo<string[]>(() => {
+    if (!activeTasksMap) return [];
+    const firstSeenAt = new Map<string, string>();
+    for (const issue of allIssues) {
+      const tasks = activeTasksMap.get(issue.id);
+      if (!tasks) continue;
+      for (const tk of tasks) {
+        if (!tk.agent_id) continue;
+        const ts = tk.started_at ?? tk.dispatched_at ?? tk.created_at;
+        const prev = firstSeenAt.get(tk.agent_id);
+        if (!prev || ts < prev) firstSeenAt.set(tk.agent_id, ts);
+      }
+    }
+    return [...firstSeenAt.entries()]
+      .sort((a, b) => (a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0))
+      .map(([id]) => id);
+  }, [allIssues, activeTasksMap]);
+
+  const hasWorking = workingAgentIds.length > 0;
+  const visibleAgents = workingAgentIds.slice(0, MAX_VISIBLE_AGENTS);
+  const overflow = workingAgentIds.length - visibleAgents.length;
+  const tooltipDescription = t(($) => $.header.working_description);
+  const tooltipNames =
+    workingAgentIds.length > 0
+      ? workingAgentIds.map((id) => getActorName("agent", id)).join(", ")
+      : "";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            aria-pressed={workingOnly}
+            className={cn(
+              "gap-1.5",
+              workingOnly
+                ? "bg-accent text-accent-foreground hover:bg-accent/80"
+                : "text-muted-foreground",
+            )}
+            onClick={() => toggleWorkingOnly()}
+          >
+            <span aria-hidden className="relative inline-flex size-2">
+              {hasWorking && (
+                <span className="absolute inset-0 animate-ping rounded-full bg-brand opacity-60" />
+              )}
+              <span
+                className={cn(
+                  "relative inline-flex size-2 rounded-full",
+                  hasWorking ? "bg-brand" : "bg-muted-foreground/40",
+                )}
+              />
+            </span>
+            <span>{t(($) => $.header.working_label)}</span>
+            {hasWorking && (
+              <span className="ml-0.5 inline-flex items-center -space-x-1.5">
+                {visibleAgents.map((id) => (
+                  <span
+                    key={id}
+                    className="inline-flex rounded-full ring-2 ring-background"
+                  >
+                    <ActorAvatarBase
+                      name={getActorName("agent", id)}
+                      initials={getActorInitials("agent", id)}
+                      avatarUrl={getActorAvatarUrl("agent", id)}
+                      isAgent
+                      size={WORKING_AVATAR_SIZE}
+                    />
+                  </span>
+                ))}
+                {overflow > 0 && (
+                  <span
+                    aria-hidden
+                    className="inline-flex items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-muted-foreground ring-2 ring-background"
+                    style={{ width: WORKING_AVATAR_SIZE, height: WORKING_AVATAR_SIZE }}
+                  >
+                    +{overflow}
+                  </span>
+                )}
+              </span>
+            )}
+          </Button>
+        }
+      />
+      <TooltipContent side="bottom">
+        {tooltipNames ? (
+          <div className="space-y-1">
+            <div>{tooltipDescription}</div>
+            <div className="text-xs text-muted-foreground">{tooltipNames}</div>
+          </div>
+        ) : (
+          tooltipDescription
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/views/my-issues/components/my-issues-page.tsx
+++ b/packages/views/my-issues/components/my-issues-page.tsx
@@ -11,6 +11,7 @@ import { useCurrentWorkspace } from "@multica/core/paths";
 import { WorkspaceAvatar } from "../../workspace/workspace-avatar";
 import { useQuery } from "@tanstack/react-query";
 import { filterIssues } from "../../issues/utils/filter";
+import { applyWorkingFilterToGroups } from "../../issues/utils/grouped-issues";
 import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { ViewStoreProvider } from "@multica/core/issues/stores/view-store-context";
 import { useIssueSelectionStore } from "@multica/core/issues/stores/selection-store";
@@ -19,6 +20,7 @@ import { ListView } from "../../issues/components/list-view";
 import { BatchActionToolbar } from "../../issues/components/batch-action-toolbar";
 import { useClearFiltersOnWorkspaceChange } from "@multica/core/issues/stores/view-store";
 import { useWorkspaceId } from "@multica/core/hooks";
+import { activeTasksByIssueOptions, workingIssueIdsOptions } from "@multica/core/issues/active-tasks-by-issue";
 import { myIssueAssigneeGroupsOptions, myIssueListOptions, childIssueProgressOptions, type AssigneeGroupedIssuesFilter, type MyIssuesFilter } from "@multica/core/issues/queries";
 import { useUpdateIssue } from "@multica/core/issues/mutations";
 import { myIssuesViewStore } from "@multica/core/issues/stores/my-issues-view-store";
@@ -36,6 +38,7 @@ export function MyIssuesPage() {
   const priorityFilters = useStore(myIssuesViewStore, (s) => s.priorityFilters);
   const scope = useStore(myIssuesViewStore, (s) => s.scope);
   const grouping = useStore(myIssuesViewStore, (s) => s.grouping);
+  const workingOnly = useStore(myIssuesViewStore, (s) => s.workingOnly);
   const usesAssigneeBoard = viewMode === "board" && grouping === "assignee";
 
   // Clear filter state when switching between workspaces (URL-driven).
@@ -96,7 +99,12 @@ export function MyIssuesPage() {
     ? assigneeGroupsQuery.isLoading
     : statusIssuesQuery.isLoading;
 
-  // Apply status/priority filters from view store
+  // Shared workspace-wide agent task snapshot derivations (one fetch backs
+  // both the per-issue badge and the Working filter membership set).
+  const { data: activeTasksMap } = useQuery(activeTasksByIssueOptions(wsId));
+  const { data: workingIssueIds } = useQuery(workingIssueIdsOptions(wsId));
+
+  // Apply status/priority + Working filters from view store
   const issues = useMemo(
     () =>
       filterIssues(myIssues, {
@@ -108,8 +116,22 @@ export function MyIssuesPage() {
         projectFilters: [],
         includeNoProject: false,
         labelFilters: [],
+        workingOnly,
+        workingIssueIds,
       }),
-    [myIssues, statusFilters, priorityFilters],
+    [myIssues, statusFilters, priorityFilters, workingOnly, workingIssueIds],
+  );
+
+  // Assignee-grouped board bypasses `filterIssues`. Rebuild the groups here
+  // so the Working filter shows up there too AND so the column-header total
+  // numbers stay in sync with the visible card count.
+  const filteredAssigneeGroups = useMemo(
+    () => applyWorkingFilterToGroups(assigneeGroupsQuery.data?.groups, workingOnly, workingIssueIds),
+    [assigneeGroupsQuery.data, workingOnly, workingIssueIds],
+  );
+  const filteredAssigneeIssues = useMemo(
+    () => filteredAssigneeGroups?.flatMap((g) => g.issues) ?? [],
+    [filteredAssigneeGroups],
   );
 
   const { data: childProgressMap = new Map() } = useQuery(childIssueProgressOptions(wsId));
@@ -195,7 +217,7 @@ export function MyIssuesPage() {
       </PageHeader>
 
       {/* Header: scope tabs (left) + controls (right) */}
-      <MyIssuesHeader allIssues={myIssues} />
+      <MyIssuesHeader allIssues={myIssues} activeTasksMap={activeTasksMap} />
 
       {/* Content: scrollable */}
       <ViewStoreProvider store={myIssuesViewStore}>
@@ -209,14 +231,15 @@ export function MyIssuesPage() {
           <div className="flex flex-col flex-1 min-h-0">
             {viewMode === "board" ? (
               <BoardView
-                issues={usesAssigneeBoard ? myIssues : issues}
-                assigneeGroups={usesAssigneeBoard ? assigneeGroupsQuery.data?.groups : undefined}
+                issues={usesAssigneeBoard ? filteredAssigneeIssues : issues}
+                assigneeGroups={usesAssigneeBoard ? filteredAssigneeGroups : undefined}
                 assigneeGroupQueryKey={usesAssigneeBoard ? assigneeGroupsOptions.queryKey : undefined}
                 assigneeGroupFilter={usesAssigneeBoard ? assigneeGroupFilter : undefined}
                 visibleStatuses={visibleStatuses}
                 hiddenStatuses={hiddenStatuses}
                 onMoveIssue={handleMoveIssue}
                 childProgressMap={childProgressMap}
+                activeTasksMap={activeTasksMap}
                 myIssuesScope={scope}
                 myIssuesFilter={filter}
               />
@@ -225,6 +248,7 @@ export function MyIssuesPage() {
                 issues={issues}
                 visibleStatuses={visibleStatuses}
                 childProgressMap={childProgressMap}
+                activeTasksMap={activeTasksMap}
                 myIssuesScope={scope}
                 myIssuesFilter={filter}
               />

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -30,6 +30,7 @@ import { PROJECT_STATUS_ORDER, PROJECT_STATUS_CONFIG, PROJECT_PRIORITY_ORDER } f
 import { BOARD_STATUSES } from "@multica/core/issues/config";
 import { createIssueViewStore } from "@multica/core/issues/stores/view-store";
 import { ViewStoreProvider, useViewStore } from "@multica/core/issues/stores/view-store-context";
+import { activeTasksByIssueOptions } from "@multica/core/issues/active-tasks-by-issue";
 import { filterIssues } from "../../issues/utils/filter";
 import { getProjectIssueMetrics } from "./project-issue-metrics";
 import { ActorAvatar } from "../../common/actor-avatar";
@@ -150,6 +151,11 @@ function ProjectIssuesContent({
   );
 
   const { data: childProgressMap = new Map() } = useQuery(childIssueProgressOptions(wsId));
+  // Project detail intentionally does NOT offer the Working toggle (kept out
+  // by `showWorkingToggle={false}` below) and does NOT pipe `workingOnly`
+  // through `filterIssues` — but the per-card badge still renders so users
+  // see which issues have an agent running.
+  const { data: activeTasksMap } = useQuery(activeTasksByIssueOptions(wsId));
 
   const visibleStatuses = useMemo(() => {
     if (statusFilters.length > 0)
@@ -218,6 +224,7 @@ function ProjectIssuesContent({
           hiddenStatuses={hiddenStatuses}
           onMoveIssue={handleMoveIssue}
           childProgressMap={childProgressMap}
+          activeTasksMap={activeTasksMap}
           myIssuesScope={scope}
           myIssuesFilter={filter}
           projectId={projectId}
@@ -228,6 +235,7 @@ function ProjectIssuesContent({
           issues={issues}
           visibleStatuses={visibleStatuses}
           childProgressMap={childProgressMap}
+          activeTasksMap={activeTasksMap}
           myIssuesScope={scope}
           myIssuesFilter={filter}
           projectId={projectId}
@@ -308,7 +316,7 @@ function ProjectIssuesSurface({
 
   return (
     <>
-      <IssuesHeader scopedIssues={projectIssues} allowGantt />
+      <IssuesHeader scopedIssues={projectIssues} allowGantt showWorkingToggle={false} />
       <ProjectIssuesContent
         projectId={projectId}
         projectIssues={projectIssues}


### PR DESCRIPTION
## Summary

Closes MUL-2452.

Surfaces "an agent is working on this issue" on the issue board / list, and adds a top-level Working filter on `/issues` and `/my-issues` so users can one-click focus on those issues. Pure frontend; reuses the existing workspace-wide `agentTaskSnapshot` cache.

- Two new derived selectors in `packages/core/issues/active-tasks-by-issue.ts` (`activeTasksByIssueOptions` → `Map<issueId, AgentTask[]>`, `workingIssueIdsOptions` → `Set<issueId>`). Both share `agentTaskSnapshotKeys.list(wsId)` so the snapshot is fetched once and shaped into multiple views; WS `task:*` events already invalidate it (`packages/core/realtime/use-realtime-sync.ts:295-298`).
- `workingOnly` flag added to the shared view-store (`packages/core/issues/stores/view-store.ts`), wired into `clearFilters` + `partialize` and inherited by `my-issues-view-store`.
- `filterIssues` (`packages/views/issues/utils/filter.ts`) accepts `workingOnly` + `workingIssueIds`; new helper `applyWorkingFilterToGroups` (`packages/views/issues/utils/grouped-issues.ts`) rebuilds the assignee-grouped board path so the column-header total also reflects the filter (Reviewer Blocker 1).
- New `WorkingBadge` (`packages/views/issues/components/working-badge.tsx`) — brand-color pulse dot + optional count, with a hover tooltip listing the active agents. Rendered on board cards (`board-card.tsx`) and list rows (`list-row.tsx`).
- New `WorkingToggleButton` inline in `issues-header.tsx` + `my-issues-header.tsx`: brand-color dot + label + agent-avatar stack (max 3 + `+N` chip). Uses the **base** UI `ActorAvatar` (no profile link) inside the toggle to avoid nested-click semantics.
- `IssuesHeader` gains `showWorkingToggle?: boolean` (default `true`). `project-detail.tsx` passes `showWorkingToggle={false}` and intentionally does **not** route `workingOnly` into its `filterIssues` call — project page keeps only the per-card badge (Reviewer Blocker 2 boundary).
- Avatar stack + working count are computed from the header's surface-local `scopedIssues` / `allIssues`, not from the workspace-wide set (Reviewer Blocker 3).
- i18n: `scope.working_label` / `scope.working_description` in `issues.json`, `header.working_label` / `header.working_description` in `my-issues.json` (en + zh-Hans). Locale parity test still passes.
- Brand color: badge + dot use the existing `--brand` design token (the same color the filter "has-active" dot already uses), per reporter direction.

## Test plan

- [x] `pnpm typecheck` (all 6 packages pass)
- [x] `pnpm test` (701 / 701 vitest tests pass, includes locale parity)
- [x] `pnpm lint` (0 errors, only pre-existing warnings outside this change)
- [ ] Manual: dispatch a task to an agent on a board issue → card shows brand-color pulse badge in ≤ 2s; Working button count updates; toggling Working filters to those cards
- [ ] Manual: switch to assignee grouping with Working on → column-header totals reflect the filtered count
- [ ] Manual: `/project/<id>` does **not** render the Working button but per-card badge still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)