### PR TITLE
feat(squads): show skeleton on squad detail initial load

### DIFF
--- a/packages/views/squads/components/squad-detail-page.tsx
+++ b/packages/views/squads/components/squad-detail-page.tsx
@@ -18,6 +18,7 @@ import { Users, Plus, Trash2, ArrowLeft, ArrowUpRight, Crown, Camera, Loader2, P
 import { Button } from "@multica/ui/components/ui/button";
 import { Input } from "@multica/ui/components/ui/input";
 import { Label } from "@multica/ui/components/ui/label";
+import { Skeleton } from "@multica/ui/components/ui/skeleton";
 import {
   Popover,
   PopoverContent,
@@ -202,7 +203,7 @@ export function SquadDetailPage() {
   };
 
   if (!squad) {
-    return <div className="p-6 text-muted-foreground text-sm">Loading...</div>;
+    return <SquadDetailSkeleton />;
   }
 
   const availableAgents = agents.filter((a: Agent) => !a.archived_at && !members.some((m) => m.member_type === "agent" && m.member_id === a.id));
@@ -319,6 +320,40 @@ export function SquadDetailPage() {
           </AlertDialogContent>
         </AlertDialog>
       )}
+    </div>
+  );
+}
+
+// Initial-load skeleton — mirrors the two-column layout of the loaded page
+// (left inspector + right tabs panel) so the swap to real content doesn't
+// shift layout. Column widths match the md:/lg: breakpoints used below.
+function SquadDetailSkeleton() {
+  return (
+    <div className="flex flex-1 min-h-0 flex-col">
+      <PageHeader className="px-5">
+        <Skeleton className="h-5 w-48" />
+      </PageHeader>
+      <div className="flex flex-1 min-h-0 flex-col gap-3 overflow-y-auto p-3 md:grid md:grid-cols-[280px_minmax(0,1fr)] md:gap-4 md:overflow-hidden md:p-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+        <div className="flex flex-col gap-4 rounded-lg border p-5">
+          <Skeleton className="h-16 w-16 rounded-lg" />
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-3 w-full" />
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-3/4" />
+            <Skeleton className="h-3 w-2/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-4 rounded-lg border p-6">
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-4/6" />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the plain `Loading...` text in `SquadDetailPage` with a skeleton that mirrors the loaded layout (left inspector + right tabs panel), so the page no longer flashes a one-liner before rendering.
- Follows up on #2890, which only addressed the squads **list** page; the squad detail fallback was intentionally out of scope there and is now closed off.

Linked issue: [MUL-2437](https://multica.app/issues/MUL-2437)

## Implementation
- `packages/views/squads/components/squad-detail-page.tsx`
  - Add `SquadDetailSkeleton` that mirrors the two-column layout (md: `[280px_minmax(0,1fr)]`, lg: `[320px_minmax(0,1fr)]`) used by the loaded page. Avatar / name / description blocks on the left; header + paragraph stand-ins on the right.
  - Swap the `!squad` fallback from a `<div>Loading...</div>` to `<SquadDetailSkeleton />`.
  - Shape mirrors the existing `DetailLoadingSkeleton` in `agent-detail-page.tsx` so both detail pages feel consistent.

## Test plan
- [x] `pnpm --filter @multica/views typecheck` — green
- [x] `pnpm --filter @multica/views lint` — 0 errors (pre-existing warnings only)
- [ ] Manual: navigate to a squad detail page; first paint shows the skeleton, then real content replaces it without layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)