### PR TITLE
fix(codex): allow repo cache metadata writes

### DIFF
--- a/server/internal/daemon/daemon.go
+++ b/server/internal/daemon/daemon.go
@@ -3448,6 +3448,28 @@ func skillRefFromBundle(bundle SkillData) SkillRefData {
 	}
 }
 
+func additionalWritableDirsForProvider(provider, workspacesRoot, workspaceID string, logger *slog.Logger) []string {
+	if provider != "codex" {
+		return nil
+	}
+	dirs := codexAdditionalWritableDirs(workspacesRoot, workspaceID)
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			if logger != nil {
+				logger.Warn("codex sandbox: prepare writable dir failed", "dir", dir, "error", err)
+			}
+		}
+	}
+	return dirs
+}
+
+func codexAdditionalWritableDirs(workspacesRoot, workspaceID string) []string {
+	if strings.TrimSpace(workspacesRoot) == "" || strings.TrimSpace(workspaceID) == "" {
+		return nil
+	}
+	return []string{filepath.Join(workspacesRoot, ".repos", workspaceID)}
+}
+
 func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot int, taskLog *slog.Logger) (TaskResult, error) {
 	// Refuse to spawn an agent without a workspace. An empty workspace_id
 	// here would make MULTICA_WORKSPACE_ID empty in the agent env, and the
@@ -3877,6 +3899,7 @@ func (d *Daemon) runTask(ctx context.Context, task Task, provider string, slot i
 		ResumeSessionID:           task.PriorSessionID,
 		ExtraArgs:                 extraArgs,
 		CustomArgs:                customArgs,
+		AdditionalWritableDirs:    additionalWritableDirsForProvider(provider, d.cfg.WorkspacesRoot, task.WorkspaceID, taskLog),
 		McpConfig:                 mcpConfig,
 		ThinkingLevel:             thinkingLevel,
 		OpenclawMode:              openclawMode,

--- a/server/internal/daemon/daemon_test.go
+++ b/server/internal/daemon/daemon_test.go
@@ -1046,6 +1046,23 @@ func TestGateResumeToReusedWorkdir(t *testing.T) {
 	}
 }
 
+func TestCodexAdditionalWritableDirsIncludesWorkspaceRepoCache(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "workspaces")
+	got := codexAdditionalWritableDirs(root, "ws-1")
+	want := []string{filepath.Join(root, ".repos", "ws-1")}
+
+	if len(got) != len(want) {
+		t.Fatalf("writable dirs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("writable dirs = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestExecuteAndDrain_ResumeFailureFallback(t *testing.T) {
 	t.Parallel()
 

--- a/server/pkg/agent/agent.go
+++ b/server/pkg/agent/agent.go
@@ -35,6 +35,7 @@ type ExecOptions struct {
 	ResumeSessionID           string          // if non-empty, resume a previous agent session
 	ExtraArgs                 []string        // daemon-wide default CLI arguments appended before CustomArgs; currently read by claude and codex backends only
 	CustomArgs                []string        // per-agent CLI arguments appended after ExtraArgs
+	AdditionalWritableDirs    []string        // daemon-owned dirs to expose as writable alongside Cwd for sandboxed runtimes
 	McpConfig                 json.RawMessage // if non-nil, MCP server config to pass via --mcp-config
 	// ThinkingLevel is the runtime-native reasoning/effort value (e.g.
 	// Claude's "low|medium|high|xhigh|max", Codex's "none|minimal|low|

--- a/server/pkg/agent/codex.go
+++ b/server/pkg/agent/codex.go
@@ -28,7 +28,8 @@ import (
 // stripped separately by filterCodexCustomConfigOverrides because they
 // share the `-c` flag with legitimate non-MCP overrides like `-c model=…`.
 var codexBlockedArgs = map[string]blockedArgMode{
-	"--listen": blockedWithValue, // stdio:// transport for daemon communication
+	"--listen":  blockedWithValue, // stdio:// transport for daemon communication
+	"--add-dir": blockedWithValue, // daemon controls sandbox writable roots
 }
 
 // codexStderrTailBytes bounds the stderr tail captured for inclusion in
@@ -103,7 +104,14 @@ type codexBackend struct {
 }
 
 func buildCodexArgs(opts ExecOptions, logger *slog.Logger) []string {
-	args := []string{"app-server", "--listen", "stdio://"}
+	args := make([]string, 0, 5+len(opts.AdditionalWritableDirs)*2+len(opts.ExtraArgs)+len(opts.CustomArgs))
+	for _, dir := range opts.AdditionalWritableDirs {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+		args = append(args, "--add-dir", dir)
+	}
+	args = append(args, "app-server", "--listen", "stdio://")
 	extra := filterCustomArgs(opts.ExtraArgs, codexBlockedArgs, logger)
 	custom := filterCustomArgs(opts.CustomArgs, codexBlockedArgs, logger)
 	// Only claim ownership of the `mcp_servers` namespace when the agent

--- a/server/pkg/agent/codex_test.go
+++ b/server/pkg/agent/codex_test.go
@@ -2697,3 +2697,31 @@ func TestHasManagedCodexMcpConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildCodexArgsPrependsAdditionalWritableDirs(t *testing.T) {
+	args := buildCodexArgs(ExecOptions{
+		AdditionalWritableDirs: []string{"/var/multica/workspaces/.repos/ws-1"},
+		CustomArgs:             []string{"--add-dir", "/tmp/evil", "--listen=bad"},
+	}, slog.Default())
+
+	wantPrefix := []string{
+		"--add-dir",
+		"/var/multica/workspaces/.repos/ws-1",
+		"app-server",
+		"--listen",
+		"stdio://",
+	}
+	if len(args) < len(wantPrefix) {
+		t.Fatalf("args too short: %v", args)
+	}
+	for i, want := range wantPrefix {
+		if args[i] != want {
+			t.Fatalf("args[%d] = %q, want %q in %v", i, args[i], want, args)
+		}
+	}
+
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "/tmp/evil") || strings.Contains(joined, "--listen=bad") {
+		t.Fatalf("custom args must not override daemon-owned codex flags: %v", args)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes Codex daemon tasks losing write access to Git metadata for repositories checked out with `multica repo checkout` under `workspace-write` sandboxing.

`git worktree` stores the checked-out source files inside the task workdir, but the worktree's actual Git metadata lives under the daemon repo cache at `<workspacesRoot>/.repos/<workspaceID>/...`. Codex only treats the task workdir as writable by default, so Git commands that need lock files, refs, reflogs, or the index can fail with read-only filesystem errors after checkout.

This PR grants Codex tasks an additional writable sandbox root for the current workspace's repo cache directory by passing `--add-dir <workspacesRoot>/.repos/<workspaceID>` before the `app-server` subcommand.

## Related Issue

Closes #2925

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [x] Tests (adding or improving test coverage)
- [ ] Documentation update
- [ ] CI / infrastructure

## Changes Made

- Added `ExecOptions.AdditionalWritableDirs` for daemon-owned writable roots.
- Updated the Codex backend to emit additional `--add-dir` flags before `app-server`, where Codex parses top-level sandbox options.
- Blocked user `custom_args` from overriding daemon-owned `--add-dir` / `--listen` flags.
- Added daemon-side logic to expose only the current workspace repo cache root to Codex tasks.
- Added regression tests for Codex argument ordering and workspace repo cache writable root calculation.

## Verification

- `git diff --check`
- `cd server && go test ./pkg/agent -run TestBuildCodexArgsPrependsAdditionalWritableDirs`
- `cd server && go test ./internal/daemon -run TestCodexAdditionalWritableDirsIncludesWorkspaceRepoCache`
- `cd server && go test ./pkg/agent`
- `cd server && go test ./internal/daemon`
- `cd server && go test ./...`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to landing copy, starter-content, and relevant docs
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx`
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Traced #2925 from the reported `index.lock` / ref lock failures to Git worktree metadata living outside the task workdir, then added the narrowest Codex sandbox writable root needed for the current workspace repo cache. Used TDD with focused Go regression coverage and ran the server Go suite.

## Screenshots (optional)

N/A - daemon/backend behavior only.
