### PR TITLE
fix(daemon): expand tilde-backslash paths from openclaw on Windows

### DIFF
--- a/server/internal/daemon/execenv/openclaw_config.go
+++ b/server/internal/daemon/execenv/openclaw_config.go
@@ -233,7 +233,7 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 	if path == "" {
 		return "", false, fmt.Errorf("`openclaw config file` returned empty output")
 	}
-	if path == "~" || strings.HasPrefix(path, "~/") {
+	if path == "~" || strings.HasPrefix(path, "~/") || strings.HasPrefix(path, "~\\") {
 		home, herr := os.UserHomeDir()
 		if herr != nil {
 			return "", false, fmt.Errorf("expand `~` in openclaw config path: %w", herr)
@@ -241,7 +241,7 @@ func openclawActiveConfigPath(bin string, timeout time.Duration) (string, bool, 
 		if path == "~" {
 			path = home
 		} else {
-			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+			path = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(path, "~/"), "~\\"))
 		}
 	}
 	if !filepath.IsAbs(path) {

--- a/server/internal/daemon/execenv/openclaw_config_test.go
+++ b/server/internal/daemon/execenv/openclaw_config_test.go
@@ -349,6 +349,50 @@ func TestPrepareOpenclawConfigExpandsTilde(t *testing.T) {
 	}
 }
 
+// TestPrepareOpenclawConfigExpandsTildeWindowsBackslash — `openclaw config file`
+// on Windows reports paths with `~\` (backslash). The expansion logic must
+// handle both `~/` and `~\` prefixes so the `$include` reference is always
+// absolute.
+func TestPrepareOpenclawConfigExpandsTildeWindowsBackslash(t *testing.T) {
+	envRoot := t.TempDir()
+	workDir := filepath.Join(envRoot, "workdir")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	fakeHome := t.TempDir()
+	t.Setenv("USERPROFILE", fakeHome)
+	os.Setenv("USERPROFILE", fakeHome)
+	t.Cleanup(func() { os.Unsetenv("USERPROFILE") })
+	if err := os.MkdirAll(filepath.Join(fakeHome, ".openclaw"), 0o755); err != nil {
+		t.Fatalf("mkdir home/.openclaw: %v", err)
+	}
+	realPath := filepath.Join(fakeHome, ".openclaw", "openclaw.json")
+	if err := os.WriteFile(realPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write user cfg: %v", err)
+	}
+
+	stub := installOpenclawStub(t, map[string]openclawResponse{
+		"config file":                   {stdout: "~\\.openclaw\\openclaw.json\n"},
+		"config get agents.list --json": {stdout: "null"},
+	})
+
+	result, err := prepareOpenclawConfig(envRoot, workDir, OpenclawConfigPrep{OpenclawBin: stub.bin})
+	if err != nil {
+		t.Fatalf("prepareOpenclawConfig: %v", err)
+	}
+	cfgPath := result.ConfigPath
+	got := mustReadJSON(t, cfgPath)
+	include := got["$include"].([]any)
+	if include[0] != realPath {
+		t.Errorf("$include[0] = %v, want %q (tilde-backslash must be expanded to absolute)", include[0], realPath)
+	}
+	wantRoot := filepath.Join(fakeHome, ".openclaw")
+	if result.IncludeRoot != wantRoot {
+		t.Errorf("IncludeRoot = %q, want %q (must be expanded absolute dirname)", result.IncludeRoot, wantRoot)
+	}
+}
+
 // TestPrepareOpenclawConfigWrapperLoadableUnderIncludeConfinement is the
 // regression test for the Elon include-confinement blocker. OpenClaw
 // resolves `$include` only inside the wrapper file's own directory unless


### PR DESCRIPTION
## Summary

Fix a Windows-specific bug where Multica fails to prepare the execution environment for OpenClaw agents.

## Root Cause

openclaw config file on Windows returns paths using backslash notation: ~\.openclaw\openclaw.json. However, the tilde expansion in openclawActiveConfigPath() only checked for ~/ (forward slash), leaving ~\ paths unexpanded. When ilepath.IsAbs then rejects the unexpanded path, prepareOpenclawConfig fails with:

`
"openclaw reported non-absolute config path \"~\.openclaw\openclaw.json\""
`

This blocks task dispatch entirely for OpenClaw agents on Windows hosts.

## Fix

- Add ~\ to the prefix check alongside the existing ~/ check
- Chain TrimPrefix for both variants so the remainder is always a clean relative path
- Added test coverage: TestPrepareOpenclawConfigExpandsTildeWindowsBackslash simulates the Windows ~\ output

## Test Plan

- New test validates ~\ ? absolute path expansion
- All existing tests continue to pass (only additive changes)