### PR TITLE
fix(agents): drop confusing "default" badge from model picker (MUL-2477)

### DIFF
--- a/packages/views/agents/components/inspector/model-picker.tsx
+++ b/packages/views/agents/components/inspector/model-picker.tsx
@@ -153,14 +153,7 @@ export function ModelPicker({
                 `<span block text-left>` to keep layout deterministic —
                 matches the fix already applied in thinking-picker.tsx. */}
             <span className="block min-w-0 flex-1 text-left">
-              <span className="flex items-center gap-1.5">
-                <span className="truncate text-[13px] font-medium">{m.label}</span>
-                {m.default && (
-                  <span className="shrink-0 rounded bg-primary/10 px-1 text-[10px] font-medium text-primary">
-                    {t(($) => $.pickers.model_default_badge)}
-                  </span>
-                )}
-              </span>
+              <span className="block truncate text-[13px] font-medium">{m.label}</span>
               {m.label !== m.id && (
                 <span className="mt-0.5 block truncate font-mono text-[10px] leading-snug text-muted-foreground">
                   {m.id}

--- a/packages/views/agents/components/model-dropdown.tsx
+++ b/packages/views/agents/components/model-dropdown.tsx
@@ -183,14 +183,7 @@ export function ModelDropdown({
                       }`}
                     >
                       <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-1.5">
-                          <span className="truncate font-medium">{m.label}</span>
-                          {m.default && (
-                            <span className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
-                              {t(($) => $.pickers.model_default_badge)}
-                            </span>
-                          )}
-                        </div>
+                        <div className="truncate font-medium">{m.label}</div>
                         {m.label !== m.id && (
                           <div className="truncate text-xs text-muted-foreground">
                             {m.id}

--- a/packages/views/locales/en/agents.json
+++ b/packages/views/locales/en/agents.json
@@ -167,7 +167,6 @@
     "model_managed_by_runtime": "Managed by runtime",
     "model_search_placeholder": "Search or type a model ID",
     "model_discovering": "Discovering models…",
-    "model_default_badge": "default",
     "model_empty": "No models available",
     "model_empty_with_dot": "No models available.",
     "model_custom_tooltip": "Use \"{{value}}\" as a custom model id",

--- a/packages/views/locales/zh-Hans/agents.json
+++ b/packages/views/locales/zh-Hans/agents.json
@@ -163,7 +163,6 @@
     "model_managed_by_runtime": "由运行时管理",
     "model_search_placeholder": "搜索或输入模型 ID",
     "model_discovering": "正在发现模型...",
-    "model_default_badge": "默认",
     "model_empty": "暂无可用模型",
     "model_empty_with_dot": "暂无可用模型。",
     "model_custom_tooltip": "使用\"{{value}}\"作为自定义模型 ID",


### PR DESCRIPTION
## Summary

- Removed the small `default` chip rendered next to the runtime's preferred model in both the create-agent `ModelDropdown` and the inspector `ModelPicker`.
- Dropped the now-unused `pickers.model_default_badge` key from `en` and `zh-Hans` locale files.
- Left `RuntimeModel.default` and the backend `ModelEntry.Default` flag intact — `thinking-prop-row.tsx` still uses it as a fallback heuristic to pick a sane model when computing thinking defaults.

## Why

The dropdown already exposes a top-level "Default (provider)" option, which means "follow the CLI's current model". Tagging one model in the list with a separate "default" chip created two competing notions of *default* in the same UI: the list-chip implied "this is what gets picked", while the trigger option implied "follow the CLI". Users could not tell which one would win, especially when the CLI's current model differed from the runtime's preferred model (e.g. CLI on Opus, runtime advertising Sonnet 4.6 as default).

Removing the badge collapses this back to one notion: the trigger-level "Default (provider)" option means "use whatever the CLI picks", and the list items just show available models without editorial.

Related to: MUL-2477

## Test plan

- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm --filter @multica/views exec vitest run agents/components`
- [x] `pnpm --filter @multica/views exec vitest run locales` (locale parity)
- [ ] Manual: open Create Agent dialog, confirm no `default` chip next to Sonnet 4.6, and the "Default (provider)" trigger label still works.
- [ ] Manual: open Agent inspector, confirm the inline model picker no longer shows the chip either.