### PR TITLE
fix(ws): guard JSON.parse in WSClient.onmessage against malformed frames

### DIFF
--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -69,4 +69,24 @@ describe("WSClient", () => {
     expect(url.searchParams.has("client_version")).toBe(false);
     expect(url.searchParams.has("client_os")).toBe(false);
   });
+
+  it("logs and skips malformed JSON messages instead of throwing", () => {
+    const warn = vi.fn();
+    const ws = new WSClient("ws://example.test/ws", {
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    ws.setAuth("tok", "acme");
+    ws.connect();
+
+    const fake = FakeWebSocket.lastUrl
+      ? (ws as any).ws as FakeWebSocket
+      : null;
+    expect(fake).not.toBeNull();
+
+    // Simulate a malformed frame — should not throw
+    expect(() => {
+      fake!.onmessage!({ data: "{truncated" });
+    }).not.toThrow();
+    expect(warn).toHaveBeenCalledWith("ws: received unparseable message");
+  });
 });

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -75,7 +75,13 @@ export class WSClient {
     };
 
     this.ws.onmessage = (event) => {
-      const msg = JSON.parse(event.data as string) as WSMessage;
+      let msg: WSMessage;
+      try {
+        msg = JSON.parse(event.data as string) as WSMessage;
+      } catch {
+        this.logger.warn("ws: received unparseable message");
+        return;
+      }
       if ((msg as any).type === "auth_ack") {
         this.onAuthenticated();
         return;


### PR DESCRIPTION
## Summary

Wraps the unguarded `JSON.parse()` call in `WSClient.onmessage` with a try-catch so malformed WebSocket frames are logged and skipped instead of silently crashing the message dispatch loop.

## Problem

In `packages/core/api/ws-client.ts`, the `onmessage` handler calls `JSON.parse()` directly without error handling:

```typescript
this.ws.onmessage = (event) => {
  const msg = JSON.parse(event.data as string) as WSMessage; // throws on malformed JSON
};
```

If the server sends a malformed, truncated, or binary frame (e.g. due to a proxy, network glitch, or server-side formatting bug), `JSON.parse` throws a `SyntaxError`. In most browsers, uncaught errors inside WebSocket event handlers are silently swallowed — they do not propagate to global error handlers or React error boundaries. This means downstream handlers (including auth acknowledgment and auth error dispatch) are never reached for that frame.

## Changes

- **`packages/core/api/ws-client.ts`**: Wrap `JSON.parse` in try-catch; log a warning via the existing `this.logger` and return early on parse failure.
- **`packages/core/api/ws-client.test.ts`**: Add test verifying malformed messages are logged and skipped without throwing.

## Testing

- All 4 tests pass (`npx vitest run packages/core/api/ws-client.test.ts`)
- New test injects a truncated JSON frame and asserts the warning is logged and no error is thrown

Closes #2934