### PR TITLE
fix(ws): harden auth error handling

### DIFF
--- a/packages/core/api/ws-client.test.ts
+++ b/packages/core/api/ws-client.test.ts
@@ -6,6 +6,7 @@ import { WSClient } from "./ws-client";
 // upgrade URL construction, which is what carries client identity.
 class FakeWebSocket {
   static lastUrl: string | null = null;
+  static lastInstance: FakeWebSocket | null = null;
   // Fields read by WSClient.connect()/disconnect(), all no-op here.
   onopen: (() => void) | null = null;
   onmessage: ((ev: { data: string }) => void) | null = null;
@@ -14,6 +15,7 @@ class FakeWebSocket {
   readyState = 0;
   constructor(url: string) {
     FakeWebSocket.lastUrl = url;
+    FakeWebSocket.lastInstance = this;
   }
   close() {}
   send() {}
@@ -22,6 +24,7 @@ class FakeWebSocket {
 describe("WSClient", () => {
   beforeEach(() => {
     FakeWebSocket.lastUrl = null;
+    FakeWebSocket.lastInstance = null;
     vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
   });
 
@@ -68,5 +71,39 @@ describe("WSClient", () => {
     expect(url.searchParams.get("client_platform")).toBe("cli");
     expect(url.searchParams.has("client_version")).toBe(false);
     expect(url.searchParams.has("client_os")).toBe(false);
+  });
+
+  it("logs and skips malformed frames without breaking later messages", () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const ws = new WSClient("ws://example.test/ws", { logger });
+    const handler = vi.fn();
+    ws.on("issue:updated", handler);
+    ws.connect();
+
+    expect(() => {
+      FakeWebSocket.lastInstance!.onmessage?.({ data: `{"type":"issue` });
+    }).not.toThrow();
+
+    FakeWebSocket.lastInstance!.onmessage?.({
+      data: JSON.stringify({
+        type: "issue:updated",
+        payload: { id: "issue-1" },
+      }),
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "ws: received unparseable message",
+      `{"type":"issue`,
+    );
+    expect(handler).toHaveBeenCalledWith(
+      { id: "issue-1" },
+      undefined,
+      undefined,
+    );
   });
 });

--- a/packages/core/api/ws-client.ts
+++ b/packages/core/api/ws-client.ts
@@ -75,7 +75,13 @@ export class WSClient {
     };
 
     this.ws.onmessage = (event) => {
-      const msg = JSON.parse(event.data as string) as WSMessage;
+      let msg: WSMessage;
+      try {
+        msg = JSON.parse(event.data as string) as WSMessage;
+      } catch {
+        this.logger.warn("ws: received unparseable message", event.data);
+        return;
+      }
       if ((msg as any).type === "auth_ack") {
         this.onAuthenticated();
         return;

--- a/server/internal/realtime/hub.go
+++ b/server/internal/realtime/hub.go
@@ -635,6 +635,24 @@ func firstMessageAuth(conn *websocket.Conn) (string, string) {
 	return msg.Payload.Token, ""
 }
 
+type wsMessageWriter interface {
+	WriteMessage(messageType int, data []byte) error
+}
+
+func writeWSAuthFrame(conn wsMessageWriter, payload []byte, frame string, attrs ...any) bool {
+	if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
+		logAttrs := append([]any{"frame", frame, "error", err}, attrs...)
+		slog.Warn("ws: failed to send auth frame", logAttrs...)
+		return false
+	}
+	return true
+}
+
+func writeWSAuthErrorAndClose(conn *websocket.Conn, payload []byte, attrs ...any) {
+	writeWSAuthFrame(conn, payload, "auth_error", attrs...)
+	conn.Close()
+}
+
 // HandleWebSocket upgrades an HTTP connection to WebSocket with cookie or
 // first-message auth.
 func HandleWebSocket(hub *Hub, mc MembershipChecker, pr PATResolver, resolveSlug SlugResolver, w http.ResponseWriter, r *http.Request) {
@@ -677,24 +695,35 @@ func HandleWebSocket(hub *Hub, mc MembershipChecker, pr PATResolver, resolveSlug
 	if userID == "" {
 		tokenStr, errMsg := firstMessageAuth(conn)
 		if errMsg != "" {
-			conn.WriteMessage(websocket.TextMessage, []byte(errMsg))
-			conn.Close()
+			writeWSAuthErrorAndClose(conn, []byte(errMsg), "workspace_id", workspaceID)
 			return
 		}
 		uid, errMsg := authenticateToken(tokenStr, pr, r.Context())
 		if errMsg != "" {
-			conn.WriteMessage(websocket.TextMessage, []byte(errMsg))
-			conn.Close()
+			writeWSAuthErrorAndClose(conn, []byte(errMsg), "workspace_id", workspaceID)
 			return
 		}
 		if !mc.IsMember(r.Context(), uid, workspaceID) {
-			conn.WriteMessage(websocket.TextMessage, []byte(`{"error":"not a member of this workspace"}`))
-			conn.Close()
+			writeWSAuthErrorAndClose(
+				conn,
+				[]byte(`{"error":"not a member of this workspace"}`),
+				"workspace_id", workspaceID,
+				"user_id", uid,
+			)
 			return
 		}
 		userID = uid
 
-		conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"auth_ack"}`))
+		if !writeWSAuthFrame(
+			conn,
+			[]byte(`{"type":"auth_ack"}`),
+			"auth_ack",
+			"workspace_id", workspaceID,
+			"user_id", userID,
+		) {
+			conn.Close()
+			return
+		}
 	}
 
 	// Capture client metadata from query params (browsers cannot set custom

--- a/server/internal/realtime/hub_test.go
+++ b/server/internal/realtime/hub_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -310,6 +311,45 @@ func (l *lockedWriter) Write(p []byte) (int, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.w.Write(p)
+}
+
+type failingWSWriter struct {
+	err error
+}
+
+func (f failingWSWriter) WriteMessage(int, []byte) error {
+	return f.err
+}
+
+func TestWriteWSAuthFrameLogsWriteErrors(t *testing.T) {
+	var buf bytes.Buffer
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prevDefault) })
+
+	ok := writeWSAuthFrame(
+		failingWSWriter{err: errors.New("write blocked")},
+		[]byte(`{"error":"invalid token"}`),
+		"auth_error",
+		"workspace_id", testWorkspaceID,
+	)
+
+	if ok {
+		t.Fatal("expected writeWSAuthFrame to report failed write")
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, "ws: failed to send auth frame") {
+		t.Fatalf("expected auth frame write failure log, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "write blocked") {
+		t.Fatalf("expected write error in log, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "auth_error") {
+		t.Fatalf("expected frame kind in log, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, testWorkspaceID) {
+		t.Fatalf("expected workspace id in log, got:\n%s", logs)
+	}
 }
 
 func TestCheckOrigin(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Hardens WebSocket auth/error handling on both sides of the connection.

On the server, first-message auth and `auth_ack` writes now check `WriteMessage` errors and log write failures with frame/user/workspace context. On the client, malformed WebSocket frames are logged and skipped instead of throwing out of the `onmessage` callback and preventing later frames from being processed.

## Related Issue

Closes #2933
Closes #2934

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Changes Made

- Added guarded JSON parsing in `packages/core/api/ws-client.ts`; unparseable frames now call `logger.warn` and return.
- Added a WS client regression test proving malformed frames do not throw and later valid frames still dispatch.
- Added `writeWSAuthFrame` / `writeWSAuthErrorAndClose` helpers in `server/internal/realtime/hub.go`.
- Updated first-message auth error paths and `auth_ack` to log failed writes instead of discarding errors.
- Added a backend regression test that captures `slog` output when auth frame writes fail.

## How to Test

1. Send a malformed frame to `WSClient.onmessage`; it should log and skip without throwing.
2. Send a valid frame afterward; the registered handler should still run.
3. Force an auth-frame write failure in the backend helper; the failure should be logged with frame and workspace context.

## Verification

- `pnpm --filter @multica/core exec vitest run api/ws-client.test.ts`
- `pnpm --filter @multica/core typecheck`
- `pnpm --filter @multica/core test`
- `pnpm --filter @multica/core lint` (exited 0 with one pre-existing hook warning in `packages/core/platform/auth-initializer.tsx`)
- `cd server && go test ./internal/realtime -run TestWriteWSAuthFrameLogsWriteErrors`
- `cd server && go test ./internal/realtime`
- `cd server && go test ./...`
- `pnpm typecheck`
- `git diff --check`

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge

## AI Disclosure

**AI tool used:** Codex

**Prompt / approach:** Investigated #2933/#2934 as one WebSocket reliability issue. Traced the server first-message auth write paths and the client `onmessage` dispatch loop, wrote failing regression tests first, then made the narrowest changes to log failed auth frame writes and skip malformed client frames without disrupting later messages.

## Screenshots (optional)

N/A - WebSocket reliability/logging behavior only.
