### PR TITLE
Fix squad fallback delegation from leader comments

### DIFF
--- a/server/internal/handler/squad_no_action_test.go
+++ b/server/internal/handler/squad_no_action_test.go
@@ -14,6 +14,7 @@ import (
 type runningSquadLeaderTaskFixture struct {
 	IssueID          string
 	LeaderID         string
+	OtherID          string
 	TaskID           string
 	TriggerCommentID string
 }
@@ -59,6 +60,7 @@ func newRunningSquadLeaderTaskFixture(t *testing.T) runningSquadLeaderTaskFixtur
 	return runningSquadLeaderTaskFixture{
 		IssueID:          issueID,
 		LeaderID:         fx.LeaderID,
+		OtherID:          fx.OtherID,
 		TaskID:           taskID,
 		TriggerCommentID: triggerCommentID,
 	}
@@ -158,6 +160,28 @@ func TestCompleteTask_SquadLeaderActionStillSynthesizesComment(t *testing.T) {
 
 	if got := countAgentCommentsForIssue(t, fx.IssueID, fx.LeaderID); got != 1 {
 		t.Fatalf("expected action completion to synthesize one comment, got %d", got)
+	}
+}
+
+func TestCompleteTask_SquadLeaderFallbackMentionEnqueuesWorker(t *testing.T) {
+	if testHandler == nil || testPool == nil {
+		t.Skip("database not available")
+	}
+
+	fx := newRunningSquadLeaderTaskFixture(t)
+	recordSquadLeaderEvaluationForTask(t, fx, "action")
+
+	completeRunningTask(t, fx, "Please [@Worker](mention://agent/"+fx.OtherID+") take the implementation.")
+
+	var queued int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT count(*) FROM agent_task_queue
+		WHERE issue_id = $1 AND agent_id = $2 AND status = 'queued' AND is_leader_task = FALSE
+	`, fx.IssueID, fx.OtherID).Scan(&queued); err != nil {
+		t.Fatalf("count worker tasks: %v", err)
+	}
+	if queued != 1 {
+		t.Fatalf("expected fallback @agent delegation to enqueue one worker task, got %d", queued)
 	}
 }
 

--- a/server/internal/service/task.go
+++ b/server/internal/service/task.go
@@ -2693,6 +2693,7 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 		return
 	}
 	s.CancelDeferredEscalationsForIssueAgent(ctx, issueID, agentID)
+	s.enqueueAgentCommentMentionTasks(ctx, issue, comment)
 	s.Bus.Publish(events.Event{
 		Type:        protocol.EventCommentCreated,
 		WorkspaceID: util.UUIDToString(issue.WorkspaceID),
@@ -2715,6 +2716,109 @@ func (s *TaskService) createAgentComment(ctx context.Context, issueID, agentID p
 		},
 	})
 	s.AutoUnresolveThreadOnReply(ctx, rootComment, util.UUIDToString(issue.WorkspaceID), "agent", util.UUIDToString(agentID))
+}
+
+func (s *TaskService) enqueueAgentCommentMentionTasks(ctx context.Context, issue db.Issue, comment db.Comment) {
+	if comment.Type != "comment" || comment.AuthorType != "agent" {
+		return
+	}
+	authorID := util.UUIDToString(comment.AuthorID)
+	for _, m := range util.ParseMentions(comment.Content) {
+		switch m.Type {
+		case "agent":
+			if m.ID == authorID {
+				continue
+			}
+			agentID, err := util.ParseUUID(m.ID)
+			if err != nil {
+				continue
+			}
+			agent, err := s.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+				ID:          agentID,
+				WorkspaceID: issue.WorkspaceID,
+			})
+			if err != nil || agent.ArchivedAt.Valid || !agent.RuntimeID.Valid {
+				continue
+			}
+			if s.hasPendingTaskForMention(ctx, issue.ID, agentID) {
+				continue
+			}
+			if _, err := s.EnqueueTaskForMention(ctx, issue, agentID, comment.ID); err != nil {
+				slog.Warn("enqueue fallback comment mention task failed",
+					"issue_id", util.UUIDToString(issue.ID),
+					"agent_id", util.UUIDToString(agentID),
+					"comment_id", util.UUIDToString(comment.ID),
+					"error", err,
+				)
+			}
+		case "squad":
+			squadID, err := util.ParseUUID(m.ID)
+			if err != nil {
+				continue
+			}
+			squad, err := s.Queries.GetSquadInWorkspace(ctx, db.GetSquadInWorkspaceParams{
+				ID:          squadID,
+				WorkspaceID: issue.WorkspaceID,
+			})
+			if err != nil {
+				continue
+			}
+			leaderID := squad.LeaderID
+			if authorID == util.UUIDToString(leaderID) && s.shouldSuppressSquadLeaderSelfTrigger(ctx, issue.ID, leaderID, squadID) {
+				continue
+			}
+			agent, err := s.Queries.GetAgentInWorkspace(ctx, db.GetAgentInWorkspaceParams{
+				ID:          leaderID,
+				WorkspaceID: issue.WorkspaceID,
+			})
+			if err != nil || agent.ArchivedAt.Valid || !agent.RuntimeID.Valid {
+				continue
+			}
+			if s.hasPendingTaskForMention(ctx, issue.ID, leaderID) {
+				continue
+			}
+			if _, err := s.EnqueueTaskForSquadLeader(ctx, issue, leaderID, squadID, comment.ID); err != nil {
+				slog.Warn("enqueue fallback comment squad mention task failed",
+					"issue_id", util.UUIDToString(issue.ID),
+					"squad_id", util.UUIDToString(squadID),
+					"leader_id", util.UUIDToString(leaderID),
+					"comment_id", util.UUIDToString(comment.ID),
+					"error", err,
+				)
+			}
+		}
+	}
+}
+
+func (s *TaskService) hasPendingTaskForMention(ctx context.Context, issueID, agentID pgtype.UUID) bool {
+	hasPending, err := s.Queries.HasPendingTaskForIssueAndAgent(ctx, db.HasPendingTaskForIssueAndAgentParams{
+		IssueID: issueID,
+		AgentID: agentID,
+		HeadSha: s.ResolveIssueReviewSHAParam(ctx, issueID),
+	})
+	if err != nil {
+		slog.Warn("checking fallback mention pending task failed",
+			"issue_id", util.UUIDToString(issueID),
+			"agent_id", util.UUIDToString(agentID),
+			"error", err,
+		)
+		return true
+	}
+	return hasPending
+}
+
+func (s *TaskService) shouldSuppressSquadLeaderSelfTrigger(ctx context.Context, issueID, leaderID, squadID pgtype.UUID) bool {
+	latest, err := s.Queries.GetLatestTaskRoleForIssueAndAgent(ctx, db.GetLatestTaskRoleForIssueAndAgentParams{
+		IssueID: issueID,
+		AgentID: leaderID,
+	})
+	if err != nil {
+		return false
+	}
+	if latest.IsLeaderTask {
+		return true
+	}
+	return !latest.SquadID.Valid || util.UUIDToString(latest.SquadID) != util.UUIDToString(squadID)
 }
 
 // AutoUnresolveThreadOnReply clears resolved_at on the thread root when a


### PR DESCRIPTION
## Summary
- enqueue fallback mention tasks when an agent-generated comment mentions another agent or squad
- avoid duplicate pending fallback tasks and skip self-delegation for squad leaders
- add coverage for leader output that delegates to a worker

## Tests
- cd server && go test ./internal/service ./internal/handler -run 'TestCompleteTask_SquadLeaderFallbackMentionEnqueuesWorker|TestCompleteTask_SquadLeaderActionStillSynthesizesComment|TestCreateComment_SquadLeaderNoActionRejectsComment' -count=1
- git diff --check