### PR TITLE
Add desktop renderer freeze watchdog

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -9,6 +9,7 @@ import { openExternalSafely, downloadURLSafely } from "./external-url";
 import { installContextMenu } from "./context-menu";
 import { handleAppShortcut } from "./keyboard-shortcuts";
 import { installNavigationGestures } from "./navigation-gestures";
+import { installRendererFreezeWatchdog } from "./renderer-freeze-watchdog";
 import { getAppVersion } from "./app-version";
 import { loadRuntimeConfig } from "./runtime-config-loader";
 import type { RuntimeConfigResult } from "../shared/runtime-config";
@@ -158,6 +159,10 @@ function createWindow(): void {
       plugins: true,
       additionalArguments: [`--multica-locale=${systemLocale}`],
     },
+  });
+
+  installRendererFreezeWatchdog(mainWindow, {
+    enabled: process.platform === "win32",
   });
 
   // Strip Origin header from WebSocket upgrade requests so the server's

--- a/apps/desktop/src/main/renderer-freeze-watchdog.test.ts
+++ b/apps/desktop/src/main/renderer-freeze-watchdog.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { installRendererFreezeWatchdog } from "./renderer-freeze-watchdog";
+
+type Handler = (...args: unknown[]) => void;
+
+function makeWindow() {
+  const windowHandlers = new Map<string, Handler[]>();
+  const webHandlers = new Map<string, Handler[]>();
+  const reloadIgnoringCache = vi.fn();
+  let destroyed = false;
+  let webContentsDestroyed = false;
+
+  const addHandler = (map: Map<string, Handler[]>, event: string, handler: Handler) => {
+    const handlers = map.get(event) ?? [];
+    handlers.push(handler);
+    map.set(event, handlers);
+  };
+
+  return {
+    win: {
+      on: vi.fn((event: string, handler: Handler) => addHandler(windowHandlers, event, handler)),
+      isDestroyed: vi.fn(() => destroyed),
+      webContents: {
+        on: vi.fn((event: string, handler: Handler) => addHandler(webHandlers, event, handler)),
+        isDestroyed: vi.fn(() => webContentsDestroyed),
+        reloadIgnoringCache,
+      },
+    },
+    emitWindow: (event: string) => {
+      for (const handler of windowHandlers.get(event) ?? []) handler();
+    },
+    emitWebContents: (event: string, ...args: unknown[]) => {
+      for (const handler of webHandlers.get(event) ?? []) handler(...args);
+    },
+    reloadIgnoringCache,
+    destroyWindow: () => {
+      destroyed = true;
+    },
+    destroyWebContents: () => {
+      webContentsDestroyed = true;
+    },
+  };
+}
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe("installRendererFreezeWatchdog", () => {
+  it("reloads the renderer when a Windows freeze stays unresponsive past the timeout", () => {
+    vi.useFakeTimers();
+    const fx = makeWindow();
+
+    installRendererFreezeWatchdog(fx.win as never, {
+      timeoutMs: 1_000,
+      logger,
+    });
+
+    fx.emitWindow("unresponsive");
+    vi.advanceTimersByTime(999);
+    expect(fx.reloadIgnoringCache).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(fx.reloadIgnoringCache).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it("cancels the reload when the renderer becomes responsive again", () => {
+    vi.useFakeTimers();
+    const fx = makeWindow();
+
+    installRendererFreezeWatchdog(fx.win as never, {
+      timeoutMs: 1_000,
+      logger,
+    });
+
+    fx.emitWindow("unresponsive");
+    fx.emitWindow("responsive");
+    vi.advanceTimersByTime(1_000);
+
+    expect(fx.reloadIgnoringCache).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("does not reload after the window is destroyed", () => {
+    vi.useFakeTimers();
+    const fx = makeWindow();
+
+    installRendererFreezeWatchdog(fx.win as never, {
+      timeoutMs: 1_000,
+      logger,
+    });
+
+    fx.emitWindow("unresponsive");
+    fx.destroyWindow();
+    vi.advanceTimersByTime(1_000);
+
+    expect(fx.reloadIgnoringCache).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("logs renderer process exits for post-freeze diagnostics", () => {
+    const fx = makeWindow();
+
+    installRendererFreezeWatchdog(fx.win as never, { logger });
+    fx.emitWebContents("render-process-gone", {}, { reason: "crashed" });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "[renderer] render process gone",
+      { reason: "crashed" },
+    );
+  });
+});

--- a/apps/desktop/src/main/renderer-freeze-watchdog.ts
+++ b/apps/desktop/src/main/renderer-freeze-watchdog.ts
@@ -1,0 +1,59 @@
+import type { BrowserWindow } from "electron";
+
+export interface RendererFreezeWatchdogOptions {
+  enabled?: boolean;
+  timeoutMs?: number;
+  logger?: Pick<Console, "info" | "warn" | "error">;
+  timers?: Pick<typeof globalThis, "setTimeout" | "clearTimeout">;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export function installRendererFreezeWatchdog(
+  win: BrowserWindow,
+  options: RendererFreezeWatchdogOptions = {},
+): void {
+  if (options.enabled === false) return;
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const logger = options.logger ?? console;
+  const timers = options.timers ?? globalThis;
+  let unresponsive = false;
+  let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearReloadTimer = () => {
+    if (!reloadTimer) return;
+    timers.clearTimeout(reloadTimer);
+    reloadTimer = null;
+  };
+
+  win.on("unresponsive", () => {
+    unresponsive = true;
+    clearReloadTimer();
+    logger.warn("[renderer] window became unresponsive");
+    reloadTimer = timers.setTimeout(() => {
+      reloadTimer = null;
+      if (!unresponsive || win.isDestroyed()) return;
+      const webContents = win.webContents;
+      if (webContents.isDestroyed()) return;
+      logger.warn(
+        `[renderer] still unresponsive after ${timeoutMs}ms; reloading renderer`,
+      );
+      webContents.reloadIgnoringCache();
+    }, timeoutMs);
+  });
+
+  win.on("responsive", () => {
+    if (unresponsive) {
+      logger.info("[renderer] window became responsive again");
+    }
+    unresponsive = false;
+    clearReloadTimer();
+  });
+
+  win.webContents.on("render-process-gone", (_event, details) => {
+    logger.error("[renderer] render process gone", details);
+  });
+
+  win.on("closed", clearReloadTimer);
+}


### PR DESCRIPTION
## Summary
- add a main-process renderer freeze watchdog for Windows
- reload the renderer after a sustained unresponsive window and log render-process exits
- preserve current dev renderer diagnostics from main

## Tests
- pnpm --filter @multica/desktop test -- src/main/renderer-freeze-watchdog.test.ts
- pnpm --filter @multica/desktop typecheck:node
- git diff --check