### PR TITLE
Add issue hierarchy views

### DIFF
--- a/packages/core/issues/stores/view-store.ts
+++ b/packages/core/issues/stores/view-store.ts
@@ -9,7 +9,7 @@ import { ALL_STATUSES } from "../config";
 import { createWorkspaceAwareStorage, registerForWorkspaceRehydration } from "../../platform/workspace-storage";
 import { defaultStorage } from "../../platform/storage";
 
-export type ViewMode = "board" | "list" | "gantt" | "swimlane";
+export type ViewMode = "board" | "swimlane" | "list" | "tree" | "gantt";
 export type GanttZoom = "day" | "week" | "month";
 export type IssueGrouping = "status" | "assignee";
 export type SwimlaneGrouping = "parent" | "project" | "assignee";

--- a/packages/views/issues/components/issues-header.tsx
+++ b/packages/views/issues/components/issues-header.tsx
@@ -13,6 +13,7 @@ import {
   FolderKanban,
   FolderMinus,
   List,
+  ListTree,
   SignalHigh,
   SlidersHorizontal,
   X,
@@ -1293,6 +1294,8 @@ export function IssueDisplayControls({
                           <Columns3 className="size-3.5" />
                         ) : viewMode === "swimlane" ? (
                           <Waves className="size-3.5" />
+                        ) : viewMode === "tree" ? (
+                          <ListTree className="size-3.5" />
                         ) : viewMode === "gantt" && allowGantt ? (
                           <ChartGantt className="size-3.5" />
                         ) : (
@@ -1303,6 +1306,8 @@ export function IssueDisplayControls({
                             ? t(($) => $.view.board)
                             : viewMode === "swimlane"
                             ? t(($) => $.view.swimlane)
+                            : viewMode === "tree"
+                            ? t(($) => $.view.tree)
                             : viewMode === "gantt" && allowGantt
                             ? t(($) => $.view.gantt)
                             : t(($) => $.view.list)}
@@ -1317,6 +1322,8 @@ export function IssueDisplayControls({
                   ? t(($) => $.view.tooltip_board)
                   : viewMode === "swimlane"
                   ? t(($) => $.view.tooltip_swimlane)
+                  : viewMode === "tree"
+                  ? t(($) => $.view.tooltip_tree)
                   : viewMode === "gantt" && allowGantt
                   ? t(($) => $.view.tooltip_gantt)
                   : t(($) => $.view.tooltip_list)}
@@ -1334,6 +1341,10 @@ export function IssueDisplayControls({
                 <DropdownMenuRadioItem value="list">
                   <List />
                   {t(($) => $.view.list)}
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="tree">
+                  <ListTree />
+                  {t(($) => $.view.tree)}
                 </DropdownMenuRadioItem>
                 <DropdownMenuRadioItem value="swimlane">
                   <Waves />

--- a/packages/views/issues/components/issues-page.test.tsx
+++ b/packages/views/issues/components/issues-page.test.tsx
@@ -160,7 +160,7 @@ vi.mock("@multica/core/issues/config", () => ({
 
 // Mock view store
 const mockViewState = {
-  viewMode: "board" as "board" | "list",
+  viewMode: "board" as "board" | "swimlane" | "list" | "tree",
   grouping: "status" as "status" | "assignee",
   statusFilters: [] as string[],
   priorityFilters: [] as string[],
@@ -172,6 +172,9 @@ const mockViewState = {
   labelFilters: [] as string[],
   sortBy: "position" as const,
   sortDirection: "asc" as const,
+  swimlaneGrouping: "parent" as const,
+  swimlaneOrders: { parent: [], project: [], assignee: [] },
+  collapsedSwimlanes: { parent: [], project: [], assignee: [] },
   cardProperties: { priority: true, description: true, assignee: true, dueDate: true, project: true, childProgress: true, labels: true },
   listCollapsedStatuses: [] as string[],
   setViewMode: vi.fn(),
@@ -189,6 +192,9 @@ const mockViewState = {
   clearFilters: vi.fn(),
   setSortBy: vi.fn(),
   setSortDirection: vi.fn(),
+  setSwimlaneGrouping: vi.fn(),
+  setSwimlaneOrder: vi.fn(),
+  toggleSwimlaneCollapsed: vi.fn(),
   toggleCardProperty: vi.fn(),
   toggleListCollapsed: vi.fn(),
 };
@@ -218,6 +224,7 @@ vi.mock("@multica/core/issues/stores/view-store", () => ({
     { value: "status", label: "Status" },
     { value: "assignee", label: "Assignee" },
   ],
+  SWIMLANE_GROUPINGS: ["parent", "project", "assignee"],
   CARD_PROPERTY_OPTIONS: [
     { key: "priority", label: "Priority" },
     { key: "description", label: "Description" },
@@ -250,10 +257,10 @@ vi.mock("@multica/core/issues/stores/issues-scope-store", () => ({
 vi.mock("@multica/core/issues/stores/selection-store", () => ({
   useIssueSelectionStore: Object.assign(
     (selector?: any) => {
-      const state = { selectedIds: new Set(), toggle: vi.fn(), clear: vi.fn(), setAll: vi.fn() };
+      const state = { selectedIds: new Set(), toggle: vi.fn(), select: vi.fn(), deselect: vi.fn(), clear: vi.fn(), setAll: vi.fn() };
       return selector ? selector(state) : state;
     },
-    { getState: () => ({ selectedIds: new Set(), toggle: vi.fn(), clear: vi.fn(), setAll: vi.fn() }) },
+    { getState: () => ({ selectedIds: new Set(), toggle: vi.fn(), select: vi.fn(), deselect: vi.fn(), clear: vi.fn(), setAll: vi.fn() }) },
   ),
 }));
 
@@ -412,6 +419,87 @@ const mockIssues: Issue[] = [
     priority: "medium",
     assignee_type: "squad",
     assignee_id: "squad-1",
+    creator_type: "member",
+    creator_id: "user-1",
+    start_date: null,
+    due_date: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const hierarchyIssues: Issue[] = [
+  {
+    ...issueDefaults,
+    id: "issue-parent",
+    workspace_id: "ws-1",
+    number: 10,
+    identifier: "TES-10",
+    title: "Parent epic",
+    description: null,
+    status: "todo",
+    priority: "high",
+    assignee_type: "member",
+    assignee_id: "user-1",
+    creator_type: "member",
+    creator_id: "user-1",
+    start_date: null,
+    due_date: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    ...issueDefaults,
+    id: "issue-child-todo",
+    workspace_id: "ws-1",
+    number: 11,
+    identifier: "TES-11",
+    title: "Child todo",
+    description: null,
+    status: "todo",
+    priority: "medium",
+    assignee_type: "agent",
+    assignee_id: "agent-1",
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: "issue-parent",
+    start_date: null,
+    due_date: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    ...issueDefaults,
+    id: "issue-child-review",
+    workspace_id: "ws-1",
+    number: 12,
+    identifier: "TES-12",
+    title: "Child review",
+    description: null,
+    status: "in_review",
+    priority: "medium",
+    assignee_type: "agent",
+    assignee_id: "agent-1",
+    creator_type: "member",
+    creator_id: "user-1",
+    parent_issue_id: "issue-parent",
+    start_date: null,
+    due_date: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    ...issueDefaults,
+    id: "issue-standalone",
+    workspace_id: "ws-1",
+    number: 13,
+    identifier: "TES-13",
+    title: "Standalone issue",
+    description: null,
+    status: "todo",
+    priority: "low",
+    assignee_type: null,
+    assignee_id: null,
     creator_type: "member",
     creator_id: "user-1",
     start_date: null,
@@ -637,5 +725,40 @@ describe("IssuesPage (shared)", () => {
     expect(mockListIssues).toHaveBeenCalledWith(
       expect.objectContaining({ assignee_types: ["member"] }),
     );
+  });
+
+  it("renders tree view with child rows carrying parent context", async () => {
+    mockViewState.viewMode = "tree";
+    mockListIssues.mockImplementation((params: any) =>
+      Promise.resolve({
+        issues: hierarchyIssues.filter((i) => i.status === params?.status),
+        total: hierarchyIssues.filter((i) => i.status === params?.status).length,
+      }),
+    );
+
+    renderWithQuery(<IssuesPage />);
+
+    await screen.findByText("Parent epic");
+    expect(screen.getByText("Child todo")).toBeInTheDocument();
+    expect(screen.getByText("Child review")).toBeInTheDocument();
+    expect(screen.getAllByTitle("Parent: TES-10 Parent epic").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders swimlane view with parent lanes and standalone lane", async () => {
+    mockViewState.viewMode = "swimlane";
+    mockListIssues.mockImplementation((params: any) =>
+      Promise.resolve({
+        issues: hierarchyIssues.filter((i) => i.status === params?.status),
+        total: hierarchyIssues.filter((i) => i.status === params?.status).length,
+      }),
+    );
+
+    renderWithQuery(<IssuesPage />);
+
+    await screen.findByText("Parent epic");
+    expect(screen.getByText("Child todo")).toBeInTheDocument();
+    expect(screen.getByText("Child review")).toBeInTheDocument();
+    expect(screen.getByText("Standalone issue")).toBeInTheDocument();
+    expect(screen.getByText("No parent")).toBeInTheDocument();
   });
 });

--- a/packages/views/issues/components/issues-page.tsx
+++ b/packages/views/issues/components/issues-page.tsx
@@ -42,7 +42,7 @@ export function IssuesPage() {
 
       <IssueSurface
         scope={{ type: "workspace", actorKind: scope }}
-        modes={["board", "list", "swimlane"]}
+        modes={["board", "list", "tree", "swimlane"]}
         batchToolbar="list"
         renderHeader={({ controller }) => (
           <IssuesSurfaceHeader

--- a/packages/views/issues/components/list-row.tsx
+++ b/packages/views/issues/components/list-row.tsx
@@ -4,6 +4,7 @@ import { memo, type Ref } from "react";
 import { useSortable, defaultAnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { CornerDownRight } from "lucide-react";
 import { AppLink } from "../../navigation";
 import type { Issue, Project } from "@multica/core/types";
 import { formatDateOnly } from "@multica/core/issues/date";
@@ -31,6 +32,8 @@ function ListRowContent({
   issue,
   childProgress,
   project,
+  depth = 0,
+  parentIssue,
   isDragging,
   containerRef,
   containerStyle,
@@ -40,6 +43,8 @@ function ListRowContent({
   issue: Issue;
   childProgress?: ChildProgress;
   project?: Project;
+  depth?: number;
+  parentIssue?: Issue;
   isDragging?: boolean;
   containerRef?: Ref<HTMLDivElement>;
   containerStyle?: React.CSSProperties;
@@ -59,14 +64,15 @@ function ListRowContent({
   const showStartDate = storeProperties.startDate && issue.start_date;
   const showDueDate = storeProperties.dueDate && issue.due_date;
   const showLabels = storeProperties.labels && labels.length > 0;
+  const clampedDepth = Math.min(depth, 3);
 
   return (
     <IssueActionsContextMenu issue={issue}>
       <div
         ref={containerRef}
-        style={containerStyle}
+        style={{ ...containerStyle, paddingLeft: 16 + clampedDepth * 18 }}
         {...containerProps}
-        className={`group/row flex h-9 items-center gap-2 px-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
+        className={`group/row flex h-9 items-center gap-2 pr-4 text-sm transition-colors hover:not-data-[popup-open]:bg-accent/60 data-[popup-open]:bg-accent ${
           selected ? "bg-accent/30" : ""
         } ${isDragging ? "opacity-30" : ""}`}
       >
@@ -87,6 +93,9 @@ function ListRowContent({
             }`}
           />
         </div>
+        {depth > 0 && (
+          <CornerDownRight className="size-3.5 shrink-0 text-muted-foreground/70" />
+        )}
         <AppLink
           href={p.issueDetail(issue.id)}
           className={`flex flex-1 items-center gap-2 min-w-0 ${isDragging ? "pointer-events-none" : ""}`}
@@ -95,6 +104,14 @@ function ListRowContent({
             {issue.identifier}
           </span>
           <IssueAgentActivityIndicator issueId={issue.id} />
+          {depth > 0 && parentIssue && (
+            <span
+              title={`Parent: ${parentIssue.identifier} ${parentIssue.title}`}
+              className="hidden max-w-[120px] shrink-0 items-center rounded border border-border/70 bg-muted/40 px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground sm:inline-flex"
+            >
+              <span className="truncate">{parentIssue.identifier}</span>
+            </span>
+          )}
 
           <span className="flex min-w-0 flex-1 items-center gap-1.5">
             <span className="truncate">{issue.title}</span>
@@ -153,16 +170,22 @@ export const ListRow = memo(function ListRow({
   issue,
   childProgress,
   project,
+  depth = 0,
+  parentIssue,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
   project?: Project;
+  depth?: number;
+  parentIssue?: Issue;
 }) {
   return (
     <ListRowContent
       issue={issue}
       childProgress={childProgress}
       project={project}
+      depth={depth}
+      parentIssue={parentIssue}
     />
   );
 });
@@ -181,11 +204,15 @@ export const DraggableListRow = memo(function DraggableListRow({
   issue,
   childProgress,
   project,
+  depth = 0,
+  parentIssue,
   disableSorting,
 }: {
   issue: Issue;
   childProgress?: ChildProgress;
   project?: Project;
+  depth?: number;
+  parentIssue?: Issue;
   disableSorting?: boolean;
 }) {
   const {
@@ -212,6 +239,8 @@ export const DraggableListRow = memo(function DraggableListRow({
       issue={issue}
       childProgress={childProgress}
       project={project}
+      depth={depth}
+      parentIssue={parentIssue}
       isDragging={isDragging}
       containerRef={setNodeRef}
       containerStyle={style}

--- a/packages/views/issues/components/list-view.tsx
+++ b/packages/views/issues/components/list-view.tsx
@@ -25,6 +25,7 @@ import { StatusHeading } from "./status-heading";
 import { ListRow, DraggableListRow, type ChildProgress } from "./list-row";
 import { useDragSettle } from "./use-drag-settle";
 import { InfiniteScrollSentinel } from "./infinite-scroll-sentinel";
+import { buildIssueTreeRows, type IssueTreeRow } from "../utils/issue-hierarchy";
 import { useT } from "../../i18n";
 import {
   type DragMoveUpdates,
@@ -64,6 +65,7 @@ export function ListView({
   onMoveIssue,
   onCreateIssue,
   sort,
+  tree = false,
 }: {
   issues: Issue[];
   visibleStatuses: IssueStatus[];
@@ -75,6 +77,8 @@ export function ListView({
   onMoveIssue?: (issueId: string, updates: DragMoveUpdates, onSettled?: () => void) => void;
   onCreateIssue?: (defaults: IssueCreateDefaults) => void;
   sort?: IssueSortParam;
+  /** Render parent/child hierarchy inside each status section. */
+  tree?: boolean;
 }) {
   const listCollapsedStatuses = useViewStore(
     (s) => s.listCollapsedStatuses
@@ -318,6 +322,7 @@ export function ListView({
             status={status}
             issueIds={columns[statusGroupId(status)] ?? EMPTY_IDS}
             issueMap={issueMapRef.current}
+            allIssues={issues}
             childProgressMap={childProgressMap}
             projectMap={projectMap}
             myIssuesOpts={myIssuesOpts}
@@ -327,6 +332,7 @@ export function ListView({
             isExpanded={isExpanded}
             sortLabel={sortLabel}
             sort={sort}
+            tree={tree}
           />
         );
       })}
@@ -369,6 +375,7 @@ function StatusAccordionItem({
   status,
   issueIds,
   issueMap,
+  allIssues,
   childProgressMap,
   projectMap,
   myIssuesOpts,
@@ -378,10 +385,12 @@ function StatusAccordionItem({
   isExpanded,
   sortLabel,
   sort,
+  tree,
 }: {
   status: IssueStatus;
   issueIds: string[];
   issueMap: Map<string, Issue>;
+  allIssues: Issue[];
   childProgressMap: Map<string, ChildProgress>;
   projectMap?: Map<string, Project>;
   myIssuesOpts?: { scope: string; filter: MyIssuesFilter };
@@ -391,6 +400,7 @@ function StatusAccordionItem({
   isExpanded: boolean;
   sortLabel: string | null;
   sort?: IssueSortParam;
+  tree: boolean;
 }) {
   const { t } = useT("issues");
   const selection = useIssueSurfaceSelection();
@@ -409,6 +419,13 @@ function StatusAccordionItem({
       return issue ? [issue] : [];
     }),
     [issueIds, issueMap],
+  );
+  const rows = useMemo<IssueTreeRow[]>(
+    () =>
+      tree
+        ? buildIssueTreeRows(issues, allIssues)
+        : issues.map((issue) => ({ issue, depth: 0 })),
+    [allIssues, issues, tree],
   );
 
   const selectedCount = issueIds.filter((id) => selectedIds.has(id)).length;
@@ -482,10 +499,12 @@ function StatusAccordionItem({
         {issues.length > 0 ? (
           dragEnabled ? (
             <SortableContext items={issueIds} strategy={verticalListSortingStrategy}>
-              {issues.map((issue) => (
+              {rows.map(({ issue, depth, parentIssue }) => (
                 <DraggableListRow
                   key={issue.id}
                   issue={issue}
+                  depth={depth}
+                  parentIssue={parentIssue}
                   childProgress={childProgressMap.get(issue.id)}
                   project={
                     issue.project_id ? projectMap?.get(issue.project_id) : undefined
@@ -499,10 +518,12 @@ function StatusAccordionItem({
             </SortableContext>
           ) : (
             <>
-              {issues.map((issue) => (
+              {rows.map(({ issue, depth, parentIssue }) => (
                 <ListRow
                   key={issue.id}
                   issue={issue}
+                  depth={depth}
+                  parentIssue={parentIssue}
                   childProgress={childProgressMap.get(issue.id)}
                   project={
                     issue.project_id ? projectMap?.get(issue.project_id) : undefined

--- a/packages/views/issues/components/tree-view.tsx
+++ b/packages/views/issues/components/tree-view.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type { Issue, IssueStatus, Project } from "@multica/core/types";
+import type { IssueSortParam, MyIssuesFilter } from "@multica/core/issues/queries";
+import { ListView } from "./list-view";
+import type { ChildProgress } from "./list-row";
+import type { DragMoveUpdates } from "../utils/drag-utils";
+import type { IssueCreateDefaults } from "../surface/types";
+
+export function TreeView(props: {
+  issues: Issue[];
+  visibleStatuses: IssueStatus[];
+  childProgressMap?: Map<string, ChildProgress>;
+  projectMap?: Map<string, Project>;
+  myIssuesScope?: string;
+  myIssuesFilter?: MyIssuesFilter;
+  projectId?: string;
+  onMoveIssue?: (issueId: string, updates: DragMoveUpdates, onSettled?: () => void) => void;
+  onCreateIssue?: (defaults: IssueCreateDefaults) => void;
+  sort?: IssueSortParam;
+}) {
+  return <ListView {...props} tree />;
+}

--- a/packages/views/issues/surface/issue-surface.tsx
+++ b/packages/views/issues/surface/issue-surface.tsx
@@ -16,6 +16,7 @@ import { GanttView } from "../components/gantt-view";
 import { IssuesHeader } from "../components/issues-header";
 import { ListView } from "../components/list-view";
 import { SwimLaneView } from "../components/swimlane-view";
+import { TreeView } from "../components/tree-view";
 import { useT } from "../../i18n";
 import { IssueSurfaceActionsProvider } from "./actions-context";
 import { IssueSurfaceSelectionProvider } from "./selection-context";
@@ -138,7 +139,7 @@ function IssueSurfaceContent({
     (showClientEmpty ? showClientEmpty(renderContext) : true);
   const shouldShowBatchToolbar =
     batchToolbar !== "never" &&
-    (batchToolbar === "always" || controller.viewMode === "list");
+    (batchToolbar === "always" || controller.viewMode === "list" || controller.viewMode === "tree");
 
   return (
     <IssueSurfaceActionsProvider actions={controller.actions}>
@@ -215,6 +216,20 @@ function IssueSurfaceContent({
                 onCreateIssue={openCreateIssue}
               />
             )}
+            {controller.viewMode === "tree" && (
+              <TreeView
+                issues={issues}
+                visibleStatuses={controller.visibleStatuses}
+                childProgressMap={controller.childProgressMap}
+                projectMap={controller.projectMap}
+                myIssuesScope={controller.loadMoreScope}
+                myIssuesFilter={controller.loadMoreFilter}
+                sort={controller.sort}
+                projectId={controller.projectId}
+                onMoveIssue={controller.moveIssue}
+                onCreateIssue={openCreateIssue}
+              />
+            )}
             {controller.viewMode === "gantt" && (
               <GanttView issues={controller.filteredGanttIssues} />
             )}
@@ -245,7 +260,7 @@ function IssueSurfaceContent({
 }
 
 function IssueSurfaceSkeleton({ mode }: { mode: string }) {
-  if (mode === "list") {
+  if (mode === "list" || mode === "tree") {
     return (
       <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-1">
         {Array.from({ length: 4 }).map((_, i) => (

--- a/packages/views/issues/surface/types.ts
+++ b/packages/views/issues/surface/types.ts
@@ -16,7 +16,7 @@ export type IssueCreateDefaults = Partial<
 
 export type IssueSurfaceMode = Extract<
   ViewMode,
-  "board" | "list" | "swimlane" | "gantt"
+  "board" | "list" | "tree" | "swimlane" | "gantt"
 >;
 
 export interface IssueSurfaceProps {

--- a/packages/views/issues/utils/issue-hierarchy.test.ts
+++ b/packages/views/issues/utils/issue-hierarchy.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { Issue } from "@multica/core/types";
+import {
+  UNPARENTED_SWIMLANE_ID,
+  buildIssueSwimlanes,
+  buildIssueTreeRows,
+} from "./issue-hierarchy";
+
+const baseIssue: Omit<Issue, "id" | "number" | "identifier" | "title" | "status" | "parent_issue_id"> = {
+  workspace_id: "ws-1",
+  description: null,
+  stage: null,
+  priority: "medium",
+  assignee_type: null,
+  assignee_id: null,
+  creator_type: "member",
+  creator_id: "user-1",
+  project_id: null,
+  metadata: {},
+  position: 0,
+  start_date: null,
+  due_date: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+function issue(overrides: Pick<Issue, "id" | "number" | "identifier" | "title" | "status"> & Partial<Issue>): Issue {
+  return {
+    ...baseIssue,
+    parent_issue_id: null,
+    ...overrides,
+  };
+}
+
+describe("issue hierarchy utilities", () => {
+  it("nests same-status children under their visible parent", () => {
+    const parent = issue({
+      id: "parent",
+      number: 1,
+      identifier: "TES-1",
+      title: "Parent",
+      status: "todo",
+    });
+    const child = issue({
+      id: "child",
+      number: 2,
+      identifier: "TES-2",
+      title: "Child",
+      status: "todo",
+      parent_issue_id: parent.id,
+    });
+
+    const rows = buildIssueTreeRows([parent, child], [parent, child]);
+
+    expect(rows.map((row) => [row.issue.id, row.depth])).toEqual([
+      ["parent", 0],
+      ["child", 1],
+    ]);
+    expect(rows[1]!.parentIssue?.id).toBe(parent.id);
+  });
+
+  it("keeps a cross-status child visible with a parent reference", () => {
+    const parent = issue({
+      id: "parent",
+      number: 1,
+      identifier: "TES-1",
+      title: "Parent",
+      status: "todo",
+    });
+    const child = issue({
+      id: "child",
+      number: 2,
+      identifier: "TES-2",
+      title: "Child",
+      status: "in_progress",
+      parent_issue_id: parent.id,
+    });
+
+    const rows = buildIssueTreeRows([child], [parent, child]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.depth).toBe(1);
+    expect(rows[0]!.parentIssue?.identifier).toBe("TES-1");
+  });
+
+  it("builds parent swimlanes while keeping standalone issues visible", () => {
+    const parent = issue({
+      id: "parent",
+      number: 1,
+      identifier: "TES-1",
+      title: "Parent",
+      status: "todo",
+    });
+    const todoChild = issue({
+      id: "todo-child",
+      number: 2,
+      identifier: "TES-2",
+      title: "Todo child",
+      status: "todo",
+      parent_issue_id: parent.id,
+    });
+    const reviewChild = issue({
+      id: "review-child",
+      number: 3,
+      identifier: "TES-3",
+      title: "Review child",
+      status: "in_review",
+      parent_issue_id: parent.id,
+    });
+    const standalone = issue({
+      id: "standalone",
+      number: 4,
+      identifier: "TES-4",
+      title: "Standalone",
+      status: "todo",
+    });
+
+    const lanes = buildIssueSwimlanes(
+      [parent, todoChild, reviewChild, standalone],
+      [parent, todoChild, reviewChild, standalone],
+      ["todo", "in_review"],
+    );
+
+    expect(lanes).toHaveLength(2);
+    expect(lanes[0]!.parentIssue?.id).toBe(parent.id);
+    expect(lanes[0]!.issueIdsByStatus.todo).toEqual(["todo-child"]);
+    expect(lanes[0]!.issueIdsByStatus.in_review).toEqual(["review-child"]);
+    expect(lanes[1]!.id).toBe(UNPARENTED_SWIMLANE_ID);
+    expect(lanes[1]!.issueIdsByStatus.todo).toEqual(["standalone"]);
+  });
+});

--- a/packages/views/issues/utils/issue-hierarchy.ts
+++ b/packages/views/issues/utils/issue-hierarchy.ts
@@ -1,0 +1,140 @@
+import type { Issue, IssueStatus } from "@multica/core/types";
+
+export const UNPARENTED_SWIMLANE_ID = "unparented";
+
+export interface IssueTreeRow {
+  issue: Issue;
+  depth: number;
+  parentIssue?: Issue;
+}
+
+export interface IssueSwimlane {
+  id: string;
+  parentIssue?: Issue;
+  missingParentId?: string;
+  isUnparented?: boolean;
+  issueIdsByStatus: Record<IssueStatus, string[]>;
+  total: number;
+}
+
+function issueMap(issues: Issue[]) {
+  return new Map(issues.map((issue) => [issue.id, issue]));
+}
+
+function emptyStatusBuckets(visibleStatuses: readonly IssueStatus[]) {
+  const buckets = {} as Record<IssueStatus, string[]>;
+  for (const status of visibleStatuses) buckets[status] = [];
+  return buckets;
+}
+
+export function buildIssueTreeRows(
+  issues: Issue[],
+  allIssues: Issue[] = issues,
+): IssueTreeRow[] {
+  const parentById = issueMap(allIssues);
+  const issueSet = new Set(issues.map((issue) => issue.id));
+  const childrenByParent = new Map<string, Issue[]>();
+
+  for (const issue of issues) {
+    if (!issue.parent_issue_id || !issueSet.has(issue.parent_issue_id)) continue;
+    const children = childrenByParent.get(issue.parent_issue_id) ?? [];
+    children.push(issue);
+    childrenByParent.set(issue.parent_issue_id, children);
+  }
+
+  const rows: IssueTreeRow[] = [];
+  const visited = new Set<string>();
+  const append = (issue: Issue, depth: number) => {
+    if (visited.has(issue.id)) return;
+    visited.add(issue.id);
+    rows.push({
+      issue,
+      depth,
+      parentIssue: issue.parent_issue_id ? parentById.get(issue.parent_issue_id) : undefined,
+    });
+    for (const child of childrenByParent.get(issue.id) ?? []) {
+      append(child, depth + 1);
+    }
+  };
+
+  for (const issue of issues) {
+    if (!issue.parent_issue_id || !issueSet.has(issue.parent_issue_id)) {
+      append(issue, issue.parent_issue_id ? 1 : 0);
+    }
+  }
+  for (const issue of issues) {
+    append(issue, issue.parent_issue_id ? 1 : 0);
+  }
+  return rows;
+}
+
+export function buildIssueSwimlanes(
+  issues: Issue[],
+  allIssues: Issue[],
+  visibleStatuses: readonly IssueStatus[],
+): IssueSwimlane[] {
+  const parentById = issueMap(allIssues);
+  const visibleStatusSet = new Set<IssueStatus>(visibleStatuses);
+  const childrenByParent = new Map<string, Issue[]>();
+  const parentIdsInOrder: string[] = [];
+  const seenParentIds = new Set<string>();
+
+  for (const issue of issues) {
+    if (!issue.parent_issue_id) continue;
+    const children = childrenByParent.get(issue.parent_issue_id) ?? [];
+    children.push(issue);
+    childrenByParent.set(issue.parent_issue_id, children);
+    if (!seenParentIds.has(issue.parent_issue_id)) {
+      seenParentIds.add(issue.parent_issue_id);
+      parentIdsInOrder.push(issue.parent_issue_id);
+    }
+  }
+
+  for (const issue of issues) {
+    if (issue.parent_issue_id || !childrenByParent.has(issue.id)) continue;
+    if (!seenParentIds.has(issue.id)) {
+      seenParentIds.add(issue.id);
+      parentIdsInOrder.push(issue.id);
+    }
+  }
+
+  const lanes: IssueSwimlane[] = [];
+  const visibleParentIds = new Set<string>();
+
+  for (const parentId of parentIdsInOrder) {
+    const lane: IssueSwimlane = {
+      id: `parent:${parentId}`,
+      parentIssue: parentById.get(parentId),
+      missingParentId: parentById.has(parentId) ? undefined : parentId,
+      issueIdsByStatus: emptyStatusBuckets(visibleStatuses),
+      total: 0,
+    };
+    for (const child of childrenByParent.get(parentId) ?? []) {
+      if (!visibleStatusSet.has(child.status)) continue;
+      lane.issueIdsByStatus[child.status].push(child.id);
+      lane.total += 1;
+    }
+    if (lane.total > 0) {
+      lanes.push(lane);
+      visibleParentIds.add(parentId);
+    }
+  }
+
+  const unparented: IssueSwimlane = {
+    id: UNPARENTED_SWIMLANE_ID,
+    isUnparented: true,
+    issueIdsByStatus: emptyStatusBuckets(visibleStatuses),
+    total: 0,
+  };
+
+  for (const issue of issues) {
+    if (issue.parent_issue_id) continue;
+    if (visibleParentIds.has(issue.id)) continue;
+    if (!visibleStatusSet.has(issue.status)) continue;
+    unparented.issueIdsByStatus[issue.status].push(issue.id);
+    unparented.total += 1;
+  }
+
+  if (unparented.total > 0) lanes.push(unparented);
+  return lanes;
+}

--- a/packages/views/locales/en/issues.json
+++ b/packages/views/locales/en/issues.json
@@ -98,11 +98,13 @@
     "tooltip_list": "List view",
     "tooltip_gantt": "Gantt view",
     "tooltip_swimlane": "Swimlane view",
+    "tooltip_tree": "Tree view",
     "section": "View",
     "board": "Board",
     "list": "List",
     "gantt": "Gantt",
-    "swimlane": "Swimlane"
+    "swimlane": "Swimlane",
+    "tree": "Tree"
   },
   "gantt": {
     "header_issue": "Issue",

--- a/packages/views/locales/ja/issues.json
+++ b/packages/views/locales/ja/issues.json
@@ -96,11 +96,13 @@
     "tooltip_list": "リスト表示",
     "tooltip_gantt": "ガント表示",
     "tooltip_swimlane": "スイムレーン表示",
+    "tooltip_tree": "ツリー表示",
     "section": "表示",
     "board": "ボード",
     "list": "リスト",
     "gantt": "ガント",
-    "swimlane": "スイムレーン"
+    "swimlane": "スイムレーン",
+    "tree": "ツリー"
   },
   "gantt": {
     "header_issue": "イシュー",

--- a/packages/views/locales/ko/issues.json
+++ b/packages/views/locales/ko/issues.json
@@ -96,11 +96,13 @@
     "tooltip_list": "리스트 보기",
     "tooltip_gantt": "간트 보기",
     "tooltip_swimlane": "스윔레인 보기",
+    "tooltip_tree": "트리 보기",
     "section": "보기",
     "board": "보드",
     "list": "리스트",
     "gantt": "간트",
-    "swimlane": "스윔레인"
+    "swimlane": "스윔레인",
+    "tree": "트리"
   },
   "gantt": {
     "header_issue": "이슈",

--- a/packages/views/locales/zh-Hans/issues.json
+++ b/packages/views/locales/zh-Hans/issues.json
@@ -96,11 +96,13 @@
     "tooltip_list": "列表视图",
     "tooltip_gantt": "甘特图",
     "tooltip_swimlane": "泳道视图",
+    "tooltip_tree": "树形视图",
     "section": "视图",
     "board": "看板",
     "list": "列表",
     "gantt": "甘特图",
-    "swimlane": "泳道"
+    "swimlane": "泳道",
+    "tree": "树形"
   },
   "gantt": {
     "header_issue": "Issue",

--- a/packages/views/projects/components/project-detail.tsx
+++ b/packages/views/projects/components/project-detail.tsx
@@ -536,7 +536,7 @@ export function ProjectDetail({ projectId }: { projectId: string }) {
 
           <IssueSurface
             scope={issueScope}
-            modes={["board", "list", "swimlane", "gantt"]}
+            modes={["board", "list", "tree", "swimlane", "gantt"]}
           />
           </div>
         </ResizablePanel>


### PR DESCRIPTION
## Summary
- add tree and swimlane issue views backed by parent/child hierarchy helpers
- expose the new views in issue and project surfaces while preserving project Gantt mode
- show parent context and child progress in list/tree rows

## Tests
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/views typecheck
- pnpm --filter @multica/views test -- issues/utils/issue-hierarchy.test.ts issues/components/issues-page.test.tsx
- jq empty packages/views/locales/en/issues.json packages/views/locales/zh-Hans/issues.json
- git diff --check