### PR TITLE
Add remote skill sync

### DIFF
--- a/packages/core/api/client.ts
+++ b/packages/core/api/client.ts
@@ -1851,6 +1851,10 @@ export class ApiClient {
     });
   }
 
+  async syncSkill(id: string): Promise<Skill> {
+    return this.fetch(`/api/skills/${id}/sync`, { method: "POST" });
+  }
+
   async listAgentSkills(agentId: string): Promise<SkillSummary[]> {
     return this.fetch(`/api/agents/${agentId}/skills`);
   }

--- a/packages/views/locales/en/skills.json
+++ b/packages/views/locales/en/skills.json
@@ -97,6 +97,9 @@
   "detail": {
     "all_skills": "All skills",
     "read_only": "Read-only",
+    "sync_aria": "Sync skill from source",
+    "sync_tooltip": "Sync from source",
+    "sync_dirty_tooltip": "Save or discard changes before syncing",
     "delete_aria": "Delete skill",
     "delete_tooltip": "Delete skill",
     "supporting_data_warning": "Some workspace data failed to load. Creator attribution, runtime names, or edit permissions may appear incomplete until the next refresh.",
@@ -159,6 +162,8 @@
     },
     "toast_saved": "Skill saved",
     "toast_save_failed": "Failed to save skill",
+    "toast_synced": "Skill synced",
+    "toast_sync_failed": "Failed to sync skill",
     "toast_deleted": "Skill deleted",
     "toast_delete_failed": "Failed to delete skill",
     "delete_dialog": {

--- a/packages/views/locales/ja/skills.json
+++ b/packages/views/locales/ja/skills.json
@@ -92,6 +92,9 @@
   "detail": {
     "all_skills": "すべてのスキル",
     "read_only": "読み取り専用",
+    "sync_aria": "ソースからスキルを同期",
+    "sync_tooltip": "ソースから同期",
+    "sync_dirty_tooltip": "同期する前に変更を保存または破棄してください",
     "delete_aria": "スキルを削除",
     "delete_tooltip": "スキルを削除",
     "supporting_data_warning": "一部のワークスペースデータを読み込めませんでした。次回の更新まで、作成者の表示、ランタイム名、編集権限が不完全に見える場合があります。",
@@ -153,6 +156,8 @@
     },
     "toast_saved": "スキルを保存しました",
     "toast_save_failed": "スキルを保存できませんでした",
+    "toast_synced": "スキルを同期しました",
+    "toast_sync_failed": "スキルを同期できませんでした",
     "toast_deleted": "スキルを削除しました",
     "toast_delete_failed": "スキルを削除できませんでした",
     "delete_dialog": {

--- a/packages/views/locales/ko/skills.json
+++ b/packages/views/locales/ko/skills.json
@@ -92,6 +92,9 @@
   "detail": {
     "all_skills": "모든 스킬",
     "read_only": "읽기 전용",
+    "sync_aria": "출처에서 스킬 동기화",
+    "sync_tooltip": "출처에서 동기화",
+    "sync_dirty_tooltip": "동기화하기 전에 변경사항을 저장하거나 버리세요",
     "delete_aria": "스킬 삭제",
     "delete_tooltip": "스킬 삭제",
     "supporting_data_warning": "일부 워크스페이스 데이터를 불러오지 못했습니다. 다음 새로고침 전까지 생성자 표시, 런타임 이름, 수정 권한이 불완전하게 보일 수 있습니다.",
@@ -153,6 +156,8 @@
     },
     "toast_saved": "스킬을 저장했습니다",
     "toast_save_failed": "스킬을 저장하지 못했습니다",
+    "toast_synced": "스킬을 동기화했습니다",
+    "toast_sync_failed": "스킬을 동기화하지 못했습니다",
     "toast_deleted": "스킬을 삭제했습니다",
     "toast_delete_failed": "스킬을 삭제하지 못했습니다",
     "delete_dialog": {

--- a/packages/views/locales/zh-Hans/skills.json
+++ b/packages/views/locales/zh-Hans/skills.json
@@ -104,6 +104,9 @@
   "detail": {
     "all_skills": "全部 skill",
     "read_only": "只读",
+    "sync_aria": "从来源同步 skill",
+    "sync_tooltip": "从来源同步",
+    "sync_dirty_tooltip": "请先保存或丢弃修改，再同步",
     "delete_aria": "删除 skill",
     "delete_tooltip": "删除 skill",
     "supporting_data_warning": "部分工作区数据加载失败。创建者归属、运行时名称、编辑权限可能要等下次刷新才完整。",
@@ -165,6 +168,8 @@
     },
     "toast_saved": "已保存 skill",
     "toast_save_failed": "保存 skill 失败",
+    "toast_synced": "已同步 skill",
+    "toast_sync_failed": "同步 skill 失败",
     "toast_deleted": "已删除 skill",
     "toast_delete_failed": "删除 skill 失败",
     "delete_dialog": {

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -10,6 +10,7 @@ import {
   Lock,
   Pencil,
   Plus,
+  RefreshCw,
   Save,
   Sparkles,
   Trash2,
@@ -300,6 +301,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
   const [files, setFiles] = useState<DraftFile[]>([]);
   const [selectedPath, setSelectedPath] = useState(SKILL_MD);
   const [saving, setSaving] = useState(false);
+  const [syncing, setSyncing] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [showAddToAgents, setShowAddToAgents] = useState(false);
@@ -453,6 +455,31 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
     }
   };
 
+  const handleSync = async () => {
+    if (!skill || !canEdit || isDirty) return;
+    setSyncing(true);
+    try {
+      const updated = await api.syncSkill(skill.id);
+      qc.setQueryData(
+        skillDetailOptions(wsId, skill.id).queryKey,
+        updated,
+      );
+      seedFromSkill(updated);
+      seededKeyRef.current = `${wsId}:${updated.id}@${updated.updated_at}`;
+      setConflictPending(false);
+      qc.invalidateQueries({
+        queryKey: workspaceKeys.skills(wsId),
+        exact: true,
+      });
+      qc.invalidateQueries({ queryKey: workspaceKeys.agents(wsId) });
+      toast.success(t(($) => $.detail.toast_synced));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t(($) => $.detail.toast_sync_failed));
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   const handleDiscard = () => {
     if (!skill) return;
     seedFromSkill(skill);
@@ -572,6 +599,12 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
     if (origin.type === "github") return t(($) => $.detail.subline.origin_github);
     return t(($) => $.detail.subline.origin_workspace);
   })();
+  const canSyncFromOrigin =
+    canEdit &&
+    !!origin?.source_url &&
+    (origin.type === "github" ||
+      origin.type === "skills_sh" ||
+      origin.type === "clawhub");
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
@@ -589,6 +622,33 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
                 <Lock className="h-3 w-3" />
                 {t(($) => $.detail.read_only)}
               </span>
+            )}
+            {canSyncFromOrigin && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={handleSync}
+                      disabled={syncing || isDirty}
+                      className="text-muted-foreground"
+                      aria-label={t(($) => $.detail.sync_aria)}
+                    >
+                      {syncing ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <RefreshCw className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  }
+                />
+                <TooltipContent>
+                  {isDirty
+                    ? t(($) => $.detail.sync_dirty_tooltip)
+                    : t(($) => $.detail.sync_tooltip)}
+                </TooltipContent>
+              </Tooltip>
             )}
             {canEdit && (
               <Tooltip>

--- a/server/cmd/server/router.go
+++ b/server/cmd/server/router.go
@@ -1247,6 +1247,7 @@ func NewRouterWithOptions(pool *pgxpool.Pool, hub *realtime.Hub, bus *events.Bus
 					r.Get("/labels", h.ListLabelsForSkill)
 					r.Post("/labels", h.AttachLabelToSkill)
 					r.Delete("/labels/{labelId}", h.DetachLabelFromSkill)
+					r.Post("/sync", h.SyncSkillFromOrigin)
 					r.Get("/files", h.ListSkillFiles)
 					r.Put("/files", h.UpsertSkillFile)
 					r.Delete("/files/{fileId}", h.DeleteSkillFile)

--- a/server/internal/handler/skill.go
+++ b/server/internal/handler/skill.go
@@ -179,6 +179,30 @@ func decodeSkillConfig(raw []byte) any {
 	return config
 }
 
+func skillConfigMap(raw []byte) map[string]any {
+	var config map[string]any
+	if raw != nil {
+		_ = json.Unmarshal(raw, &config)
+	}
+	if config == nil {
+		config = map[string]any{}
+	}
+	return config
+}
+
+func skillOriginSourceURL(raw []byte) (string, bool) {
+	config := skillConfigMap(raw)
+	origin, ok := config["origin"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	sourceURL, ok := origin["source_url"].(string)
+	if !ok || strings.TrimSpace(sourceURL) == "" {
+		return "", false
+	}
+	return sourceURL, true
+}
+
 func skillSummaryToResponse(
 	id, workspaceID pgtype.UUID,
 	name, description string,
@@ -609,6 +633,20 @@ type importedSkill struct {
 	files       []importedFile
 	bundleSize  int            // running sum of file content bytes for cap enforcement
 	origin      map[string]any // written into skill.config.origin so the UI can show provenance
+}
+
+func importedSkillFiles(imported *importedSkill) []CreateSkillFileRequest {
+	files := make([]CreateSkillFileRequest, 0, len(imported.files))
+	for _, f := range imported.files {
+		if !validateFilePath(f.path) {
+			continue
+		}
+		files = append(files, CreateSkillFileRequest{
+			Path:    f.path,
+			Content: f.content,
+		})
+	}
+	return files
 }
 
 type importedFile struct {
@@ -2049,6 +2087,108 @@ func (h *Handler) finishSkillImport(w http.ResponseWriter, r *http.Request, work
 		return
 	}
 	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (h *Handler) SyncSkillFromOrigin(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	skill, ok := h.loadSkillForUser(w, r, id)
+	if !ok {
+		return
+	}
+	if !h.canManageSkill(w, r, skill) {
+		return
+	}
+
+	sourceURL, ok := skillOriginSourceURL(skill.Config)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "skill has no remote source_url to sync from")
+		return
+	}
+
+	source, normalized, err := detectImportSource(sourceURL)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	var imported *importedSkill
+	switch source {
+	case sourceClawHub:
+		imported, err = fetchFromClawHub(httpClient, normalized)
+	case sourceSkillsSh:
+		imported, err = fetchFromSkillsSh(httpClient, normalized)
+	case sourceGitHub:
+		imported, err = fetchFromGitHub(httpClient, normalized)
+	}
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	config := skillConfigMap(skill.Config)
+	if imported.origin != nil {
+		config["origin"] = imported.origin
+	}
+	config["last_synced_at"] = time.Now().UTC().Format(time.RFC3339)
+	configJSON, _ := json.Marshal(config)
+	files := importedSkillFiles(imported)
+
+	tx, err := h.TxStarter.Begin(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to start transaction")
+		return
+	}
+	defer tx.Rollback(r.Context())
+	qtx := h.Queries.WithTx(tx)
+
+	updated, err := qtx.UpdateSkill(r.Context(), db.UpdateSkillParams{
+		ID:          skill.ID,
+		Name:        pgtype.Text{String: sanitizeNullBytes(imported.name), Valid: true},
+		Description: pgtype.Text{String: sanitizeNullBytes(imported.description), Valid: true},
+		Content:     pgtype.Text{String: sanitizeNullBytes(imported.content), Valid: true},
+		Config:      configJSON,
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			writeError(w, http.StatusConflict, "a skill with this name already exists")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to update skill: "+err.Error())
+		return
+	}
+
+	if err := qtx.DeleteSkillFilesBySkill(r.Context(), updated.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete old skill files")
+		return
+	}
+	fileResps := make([]SkillFileResponse, 0, len(files))
+	for _, f := range files {
+		sf, err := qtx.UpsertSkillFile(r.Context(), db.UpsertSkillFileParams{
+			SkillID: updated.ID,
+			Path:    sanitizeNullBytes(f.Path),
+			Content: sanitizeNullBytes(f.Content),
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to upsert skill file: "+err.Error())
+			return
+		}
+		fileResps = append(fileResps, skillFileToResponse(sf))
+	}
+
+	if err := tx.Commit(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to commit")
+		return
+	}
+
+	resp := SkillWithFilesResponse{
+		SkillResponse: skillToResponse(updated),
+		Files:         fileResps,
+	}
+	wsID := uuidToString(updated.WorkspaceID)
+	actorType, actorID := h.resolveActor(r, requestUserID(r), wsID)
+	h.publish(protocol.EventSkillUpdated, wsID, actorType, actorID, map[string]any{"skill": resp})
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // --- Skill File endpoints ---

--- a/server/internal/handler/skill_test.go
+++ b/server/internal/handler/skill_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -631,6 +632,56 @@ func TestDetectImportSource_RecognizesGitHub(t *testing.T) {
 	}
 	if src != sourceGitHub {
 		t.Fatalf("source = %v, want sourceGitHub", src)
+	}
+}
+
+func TestSkillOriginSourceURL(t *testing.T) {
+	raw := []byte(`{"origin":{"type":"github","source_url":"https://github.com/acme/skills/tree/main/foo"}}`)
+	got, ok := skillOriginSourceURL(raw)
+	if !ok || got != "https://github.com/acme/skills/tree/main/foo" {
+		t.Fatalf("skillOriginSourceURL() = (%q, %v), want github URL", got, ok)
+	}
+
+	if got, ok := skillOriginSourceURL([]byte(`{"origin":{"type":"manual"}}`)); ok || got != "" {
+		t.Fatalf("manual origin = (%q, %v), want empty false", got, ok)
+	}
+}
+
+func TestImportedSkillFilesFiltersUnsafePaths(t *testing.T) {
+	got := importedSkillFiles(&importedSkill{
+		files: []importedFile{
+			{path: "templates/review.md", content: "review"},
+			{path: "../secret.md", content: "secret"},
+			{path: "/tmp/absolute.md", content: "absolute"},
+		},
+	})
+	if len(got) != 1 || got[0].Path != "templates/review.md" || got[0].Content != "review" {
+		t.Fatalf("importedSkillFiles() = %+v, want only safe supporting file", got)
+	}
+}
+
+func TestSyncSkillFromOriginRejectsManualSkill(t *testing.T) {
+	if testHandler == nil {
+		t.Skip("database not available")
+	}
+
+	var skillID string
+	if err := testPool.QueryRow(context.Background(), `
+		INSERT INTO skill (workspace_id, name, description, content, config, created_by)
+		VALUES ($1, 'manual-sync-test-skill', '', '# Manual', '{"origin":{"type":"manual"}}'::jsonb, $2)
+		RETURNING id
+	`, testWorkspaceID, testUserID).Scan(&skillID); err != nil {
+		t.Fatalf("create manual skill: %v", err)
+	}
+	t.Cleanup(func() {
+		testPool.Exec(context.Background(), `DELETE FROM skill WHERE id = $1`, skillID)
+	})
+
+	w := httptest.NewRecorder()
+	req := withURLParam(newRequest(http.MethodPost, "/api/skills/"+skillID+"/sync", nil), "id", skillID)
+	testHandler.SyncSkillFromOrigin(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("SyncSkillFromOrigin manual skill: expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a sync-from-origin endpoint for imported skills
- replace skill content/files from the remote source and update origin metadata
- add a skill detail sync action with dirty-state protection

## Tests
- cd server && go test ./internal/handler -run 'TestSkillOriginSourceURL|TestImportedSkillFilesFiltersUnsafePaths|TestSyncSkillFromOriginRejectsManualSkill' -count=1
- cd server && go test ./cmd/server -count=1
- pnpm --filter @multica/core typecheck
- pnpm --filter @multica/views typecheck
- jq empty packages/views/locales/en/skills.json packages/views/locales/zh-Hans/skills.json
- git diff --check