### PR TITLE
fix(cli): accept slug + short UUID prefix in workspace get/update/member

### DIFF
--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -26,10 +26,13 @@ var workspaceListCmd = &cobra.Command{
 }
 
 var workspaceGetCmd = &cobra.Command{
-	Use:   "get [workspace-id]",
+	Use:   "get [workspace-id|slug|prefix]",
 	Short: "Get workspace details",
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  runWorkspaceGet,
+	Long: "Prints the full details of a workspace. The argument accepts a full " +
+		"UUID, a slug, or a short UUID prefix (≥4 hex chars) as shown in " +
+		"'workspace list'. If omitted, the current default workspace is used.",
+	Args: cobra.MaximumNArgs(1),
+	RunE: runWorkspaceGet,
 }
 
 var workspaceMemberCmd = &cobra.Command{
@@ -38,25 +41,27 @@ var workspaceMemberCmd = &cobra.Command{
 }
 
 var workspaceMemberListCmd = &cobra.Command{
-	Use:   "list [workspace-id]",
+	Use:   "list [workspace-id|slug|prefix]",
 	Short: "List workspace members",
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  runWorkspaceMembers,
 }
 
 var workspaceUpdateCmd = &cobra.Command{
-	Use:   "update [workspace-id]",
+	Use:   "update [workspace-id|slug|prefix]",
 	Short: "Update workspace metadata (admin/owner only)",
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  runWorkspaceUpdate,
 }
 
 var workspaceSwitchCmd = &cobra.Command{
-	Use:   "switch <workspace-id|slug>",
+	Use:   "switch <workspace-id|slug|prefix>",
 	Short: "Set the default workspace for this profile",
 	Long: "Sets the default workspace for the current profile after verifying you " +
-		"have access to it. Subsequent commands without --workspace-id or " +
-		"MULTICA_WORKSPACE_ID will target this workspace.\n\n" +
+		"have access to it. Accepts a full UUID, a slug, or a short UUID " +
+		"prefix (≥4 hex chars) as shown in 'workspace list'. Subsequent " +
+		"commands without --workspace-id or MULTICA_WORKSPACE_ID will target " +
+		"this workspace.\n\n" +
 		"Resolution priority (highest to lowest): --workspace-id flag, " +
 		"MULTICA_WORKSPACE_ID env, profile default (set by this command).\n\n" +
 		"For low-level use, 'multica config set workspace_id <id>' writes the " +
@@ -152,45 +157,95 @@ func runWorkspaceList(cmd *cobra.Command, _ []string) error {
 	} else {
 		fmt.Fprintln(os.Stderr, "\nNo default workspace set. Use 'multica workspace switch <id|slug>' to pick one.")
 	}
+	fmt.Fprintln(os.Stderr, "Tip: pass the ID column, SLUG, or full UUID (--full-id) to 'workspace get/update/switch'.")
 	return nil
 }
 
 // resolveWorkspaceByIDOrSlug looks up a workspace in the caller's accessible
-// list by either UUID or slug. It returns an error if no workspace matches,
-// which doubles as the "access denied / does not exist" check — the server
-// only returns workspaces the user is a member of, so a match implies access.
+// list by full UUID, slug (case-insensitive), or short UUID prefix (≥4 hex
+// chars). The matching order is exact UUID → exact slug → prefix, so a slug
+// that happens to be a hex string can never be shadowed by a colliding UUID
+// prefix. Returns an error if no workspace matches, which doubles as the
+// "access denied / does not exist" check — the server only returns workspaces
+// the user is a member of, so a match implies access.
 func resolveWorkspaceByIDOrSlug(workspaces []workspaceSummary, target string) (workspaceSummary, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
-		return workspaceSummary{}, fmt.Errorf("workspace id or slug is required")
+		return workspaceSummary{}, fmt.Errorf("workspace id, slug, or id prefix is required")
 	}
 	// Slug comparison is case-insensitive (slugs are stored lowercase on the
 	// server, but tolerate user-typed uppercase). UUIDs are also case-
 	// insensitive in canonical form, so the lowering is safe for both.
 	lowered := strings.ToLower(target)
 	for _, ws := range workspaces {
-		if ws.ID == target || strings.ToLower(ws.ID) == lowered {
+		if strings.ToLower(ws.ID) == lowered {
 			return ws, nil
 		}
+	}
+	for _, ws := range workspaces {
 		if ws.Slug != "" && strings.ToLower(ws.Slug) == lowered {
 			return ws, nil
 		}
 	}
+
+	// Fall back to short UUID prefix matching, so values copied from
+	// `workspace list`'s default (truncated) ID column round-trip back into
+	// get/update/switch. normalizeUUIDPrefix enforces ≥4 hex chars to avoid
+	// surprises from arbitrary substrings.
+	if prefix, err := normalizeUUIDPrefix(target); err == nil {
+		matches := make([]workspaceSummary, 0, 1)
+		for _, ws := range workspaces {
+			if strings.HasPrefix(compactUUID(ws.ID), prefix) {
+				matches = append(matches, ws)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			// fall through to the not-found error below
+		case 1:
+			return matches[0], nil
+		default:
+			return workspaceSummary{}, ambiguousWorkspacePrefixError(target, matches)
+		}
+	}
+
 	return workspaceSummary{}, fmt.Errorf("workspace %q not found or you do not have access; run 'multica workspace list' to see options", target)
 }
 
-func runWorkspaceSwitch(cmd *cobra.Command, args []string) error {
-	target := args[0]
+func ambiguousWorkspacePrefixError(input string, matches []workspaceSummary) error {
+	parts := make([]string, 0, len(matches))
+	for _, m := range matches {
+		label := m.Name
+		if m.Slug != "" {
+			label = fmt.Sprintf("%s (%s)", m.Name, m.Slug)
+		}
+		parts = append(parts, fmt.Sprintf("  %s  %s", m.ID, label))
+	}
+	return fmt.Errorf("ambiguous workspace id prefix %q; matches:\n%s\nUse more characters, the slug, or the full UUID", input, strings.Join(parts, "\n"))
+}
 
+// resolveWorkspaceRef fetches the caller's workspaces and resolves the input
+// (UUID, slug, or short UUID prefix) to a workspaceSummary. Shared by
+// `workspace get`, `workspace update`, `workspace member list`, and
+// `workspace switch` so all four accept the same identifiers users see in
+// `workspace list`.
+func resolveWorkspaceRef(ctx context.Context, cmd *cobra.Command, input string) (workspaceSummary, error) {
+	target := strings.TrimSpace(input)
+	if target == "" {
+		return workspaceSummary{}, fmt.Errorf("workspace id, slug, or id prefix is required")
+	}
+	workspaces, err := fetchWorkspaces(ctx, cmd)
+	if err != nil {
+		return workspaceSummary{}, err
+	}
+	return resolveWorkspaceByIDOrSlug(workspaces, target)
+}
+
+func runWorkspaceSwitch(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	workspaces, err := fetchWorkspaces(ctx, cmd)
-	if err != nil {
-		return err
-	}
-
-	ws, err := resolveWorkspaceByIDOrSlug(workspaces, target)
+	ws, err := resolveWorkspaceRef(ctx, cmd, args[0])
 	if err != nil {
 		return err
 	}
@@ -209,17 +264,37 @@ func runWorkspaceSwitch(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func workspaceIDFromArgs(cmd *cobra.Command, args []string) string {
+// resolveWorkspaceArg returns the canonical UUID for a workspace command that
+// takes an optional `[workspace-id]` arg. When the arg is supplied it is
+// resolved against the caller's workspace list (UUID, slug, or short prefix);
+// when omitted it falls back to the standard --workspace-id / env / profile
+// resolution chain — the caller is responsible for guarding against the empty
+// case. A full UUID is forwarded as-is to avoid an extra /api/workspaces
+// round trip; access control is enforced by the downstream endpoint.
+func resolveWorkspaceArg(cmd *cobra.Command, args []string) (string, error) {
 	if len(args) > 0 {
-		return args[0]
+		trimmed := strings.TrimSpace(args[0])
+		if uuidRegexp.MatchString(trimmed) {
+			return trimmed, nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		ws, err := resolveWorkspaceRef(ctx, cmd, trimmed)
+		if err != nil {
+			return "", err
+		}
+		return ws.ID, nil
 	}
-	return resolveWorkspaceID(cmd)
+	return resolveWorkspaceID(cmd), nil
 }
 
 func runWorkspaceGet(cmd *cobra.Command, args []string) error {
-	wsID := workspaceIDFromArgs(cmd, args)
+	wsID, err := resolveWorkspaceArg(cmd, args)
+	if err != nil {
+		return err
+	}
 	if wsID == "" {
-		return fmt.Errorf("workspace ID is required: pass as argument or set MULTICA_WORKSPACE_ID")
+		return fmt.Errorf("workspace ID is required: pass an id/slug/prefix as argument or set MULTICA_WORKSPACE_ID")
 	}
 
 	client, err := newAPIClient(cmd)
@@ -300,9 +375,12 @@ func buildWorkspaceUpdateBody(cmd *cobra.Command) (map[string]any, error) {
 }
 
 func runWorkspaceUpdate(cmd *cobra.Command, args []string) error {
-	wsID := workspaceIDFromArgs(cmd, args)
+	wsID, err := resolveWorkspaceArg(cmd, args)
+	if err != nil {
+		return err
+	}
 	if wsID == "" {
-		return fmt.Errorf("workspace ID is required: pass as argument or set MULTICA_WORKSPACE_ID")
+		return fmt.Errorf("workspace ID is required: pass an id/slug/prefix as argument or set MULTICA_WORKSPACE_ID")
 	}
 
 	body, err := buildWorkspaceUpdateBody(cmd)
@@ -354,9 +432,12 @@ func runWorkspaceUpdate(cmd *cobra.Command, args []string) error {
 }
 
 func runWorkspaceMembers(cmd *cobra.Command, args []string) error {
-	wsID := workspaceIDFromArgs(cmd, args)
+	wsID, err := resolveWorkspaceArg(cmd, args)
+	if err != nil {
+		return err
+	}
 	if wsID == "" {
-		return fmt.Errorf("workspace ID is required: pass as argument or set MULTICA_WORKSPACE_ID")
+		return fmt.Errorf("workspace ID is required: pass an id/slug/prefix as argument or set MULTICA_WORKSPACE_ID")
 	}
 
 	client, err := newAPIClient(cmd)

--- a/server/cmd/multica/cmd_workspace.go
+++ b/server/cmd/multica/cmd_workspace.go
@@ -153,9 +153,9 @@ func runWorkspaceList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if currentID != "" {
-		fmt.Fprintln(os.Stderr, "\n* = current default workspace (use 'multica workspace switch <id|slug>' to change)")
+		fmt.Fprintln(os.Stderr, "\n* = current default workspace (use 'multica workspace switch <id|slug|prefix>' to change)")
 	} else {
-		fmt.Fprintln(os.Stderr, "\nNo default workspace set. Use 'multica workspace switch <id|slug>' to pick one.")
+		fmt.Fprintln(os.Stderr, "\nNo default workspace set. Use 'multica workspace switch <id|slug|prefix>' to pick one.")
 	}
 	fmt.Fprintln(os.Stderr, "Tip: pass the ID column, SLUG, or full UUID (--full-id) to 'workspace get/update/switch'.")
 	return nil

--- a/server/cmd/multica/cmd_workspace_test.go
+++ b/server/cmd/multica/cmd_workspace_test.go
@@ -171,6 +171,88 @@ func TestResolveWorkspaceByIDOrSlug(t *testing.T) {
 			t.Errorf("got %q, want Beta", ws.Name)
 		}
 	})
+
+	t.Run("matches unique short UUID prefix", func(t *testing.T) {
+		ws, err := resolveWorkspaceByIDOrSlug(workspaces, "2222")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ws.Name != "Beta" {
+			t.Errorf("got %q, want Beta", ws.Name)
+		}
+	})
+
+	t.Run("short UUID prefix with dashes is accepted", func(t *testing.T) {
+		ws, err := resolveWorkspaceByIDOrSlug(workspaces, "1111-11")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ws.Name != "Alpha" {
+			t.Errorf("got %q, want Alpha", ws.Name)
+		}
+	})
+
+	t.Run("ambiguous prefix lists all matches", func(t *testing.T) {
+		ambiguous := []workspaceSummary{
+			{ID: "ab123456-0000-0000-0000-000000000001", Name: "First", Slug: "first"},
+			{ID: "ab129999-0000-0000-0000-000000000002", Name: "Second", Slug: "second"},
+		}
+		_, err := resolveWorkspaceByIDOrSlug(ambiguous, "ab12")
+		if err == nil {
+			t.Fatal("expected ambiguous prefix error")
+		}
+		if !strings.Contains(err.Error(), "ambiguous") {
+			t.Errorf("error = %q, want it to mention 'ambiguous'", err)
+		}
+		// Both candidate IDs must surface so the user can disambiguate without
+		// re-running `workspace list`.
+		if !strings.Contains(err.Error(), "ab123456") || !strings.Contains(err.Error(), "ab129999") {
+			t.Errorf("error = %q, want both candidate IDs", err)
+		}
+	})
+
+	t.Run("slug wins over colliding UUID prefix", func(t *testing.T) {
+		// If a workspace's slug equals another workspace's UUID prefix, the
+		// slug must take priority — that's the value users actually see in
+		// `workspace list`.
+		collision := []workspaceSummary{
+			{ID: "deadbeef-0000-0000-0000-000000000001", Name: "Hex", Slug: "hex"},
+			{ID: "feedface-0000-0000-0000-000000000002", Name: "Decoy", Slug: "deadbeef"},
+		}
+		ws, err := resolveWorkspaceByIDOrSlug(collision, "deadbeef")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ws.Name != "Decoy" {
+			t.Errorf("got %q, want Decoy (slug match should beat UUID prefix)", ws.Name)
+		}
+	})
+
+	t.Run("non-hex unknown target falls through to not-found", func(t *testing.T) {
+		// 'gamma' has letters outside the hex range, so it cannot reach the
+		// prefix branch — must surface the not-found error pointing the user
+		// at `workspace list`.
+		_, err := resolveWorkspaceByIDOrSlug(workspaces, "gamma")
+		if err == nil {
+			t.Fatal("expected error for unknown workspace")
+		}
+		if !strings.Contains(err.Error(), "workspace list") {
+			t.Errorf("error = %q, want it to reference 'workspace list'", err)
+		}
+	})
+
+	t.Run("prefix shorter than 4 hex chars is rejected", func(t *testing.T) {
+		// Too-short prefixes would collide with random hex substrings; the
+		// resolver must surface the not-found error rather than silently
+		// returning a wrong workspace.
+		_, err := resolveWorkspaceByIDOrSlug(workspaces, "11")
+		if err == nil {
+			t.Fatal("expected error for 2-char prefix")
+		}
+		if !strings.Contains(err.Error(), "workspace list") {
+			t.Errorf("error = %q, want it to reference 'workspace list'", err)
+		}
+	})
 }
 
 // resetWorkspaceUpdateFlags clears every flag on workspaceUpdateCmd and marks


### PR DESCRIPTION
## Summary

- `workspace list` shows short UUID prefixes (8 chars), names, and slugs by default; `workspace get` / `update` / `member list` only accepted full UUIDs, so nothing in the default list output round-tripped into the next command.
- Extend `resolveWorkspaceByIDOrSlug` to also match short UUID prefixes (≥4 hex chars; ambiguous prefixes return all candidates), introduce `resolveWorkspaceRef` / `resolveWorkspaceArg` helpers, and wire them into the three commands above (`switch` already used the same fetch-then-resolve pattern).
- Full UUIDs short-circuit the workspace list fetch to keep the common path single-call; access control stays on the downstream endpoint.
- Help text and the `workspace list` stderr footer updated to advertise the new behavior.

Closes the discoverability gap reported in https://github.com/multica-ai/multica/issues/2750 — refs MUL-2385.

## Test plan

- [x] `go test ./cmd/multica/` — all existing tests still pass.
- [x] New `TestResolveWorkspaceByIDOrSlug` subtests cover: unique short prefix, prefix with dashes, ambiguous prefix listing both candidates, slug winning over a colliding UUID prefix, non-hex unknown target falling through to not-found, and sub-4-char prefix rejection.
- [ ] Manual smoke (reviewer): `multica workspace list` → copy the short ID column → `multica workspace get <short-id>`; same with slug.