### PR TITLE
fix(skills): improve mobile skill readability (MUL-2497)

### DIFF
--- a/packages/views/skills/components/file-viewer.tsx
+++ b/packages/views/skills/components/file-viewer.tsx
@@ -100,7 +100,7 @@ export function FileViewer({
   return (
     <div className="flex h-full flex-col">
       {/* File header */}
-      <div className="flex h-10 items-center justify-between border-b px-4">
+      <div className="flex h-10 items-center justify-between gap-3 border-b px-4">
         <span className="text-xs font-mono text-muted-foreground truncate">
           {path}
         </span>
@@ -136,7 +136,7 @@ export function FileViewer({
       {/* File content */}
       <div className="flex-1 min-h-0 overflow-y-auto">
         {isMd && !editing ? (
-          <div className="p-6">
+          <div className="p-4 sm:p-6">
             {frontmatter && <FrontmatterCard data={frontmatter} />}
             <Markdown mode="full">
               {body || t(($) => $.file_viewer.no_content)}

--- a/packages/views/skills/components/skill-detail-page.tsx
+++ b/packages/views/skills/components/skill-detail-page.tsx
@@ -510,6 +510,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
             variant="ghost"
             size="xs"
             render={<AppLink href={paths.skills()} />}
+            nativeButton={false}
           >
             <ArrowLeft className="h-3 w-3" />
             {t(($) => $.detail.all_skills)}
@@ -556,11 +557,13 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
           variant="ghost"
           size="xs"
           render={<AppLink href={paths.skills()} />}
+          nativeButton={false}
+          className="shrink-0"
         >
           <ArrowLeft className="h-3 w-3" />
           {t(($) => $.detail.all_skills)}
         </Button>
-        <ChevronRight className="h-3 w-3 text-muted-foreground" />
+        <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
         <span className="truncate font-mono text-xs text-foreground">
           {skill.name}
         </span>
@@ -613,9 +616,9 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
       )}
 
       {/* Body: file tree | editor | sidebar */}
-      <div className="flex flex-1 min-h-0">
+      <div className="flex flex-1 min-h-0 flex-col overflow-y-auto md:flex-row md:overflow-hidden">
         {/* File tree */}
-        <aside className="flex w-56 shrink-0 flex-col border-r">
+        <aside className="flex max-h-44 w-full shrink-0 flex-col border-b md:max-h-none md:w-56 md:border-b-0 md:border-r">
           <div className="flex h-10 shrink-0 items-center justify-between border-b px-3">
             <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               {t(($) => $.detail.files_label, { count: totalFileCount(skill) })}
@@ -671,9 +674,9 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
         </aside>
 
         {/* Editor */}
-        <section className="flex min-w-0 flex-1 flex-col">
+        <section className="flex min-h-[32rem] min-w-0 shrink-0 flex-col md:min-h-0 md:flex-1 md:shrink">
           {/* Name + description + subline */}
-          <div className="space-y-2 border-b px-5 py-4">
+          <div className="space-y-2 border-b px-4 py-4 sm:px-5">
             <Input
               value={name}
               readOnly={!canEdit}
@@ -770,7 +773,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
             <div
               role="status"
               aria-live="polite"
-              className="flex items-center gap-2 border-t bg-muted/30 px-4 py-2"
+              className="flex flex-wrap items-center gap-2 border-t bg-muted/30 px-4 py-2"
             >
               <span className="h-1.5 w-1.5 rounded-full bg-brand" />
               <span className="text-xs text-muted-foreground">
@@ -809,7 +812,7 @@ export function SkillDetailPage({ skillId }: { skillId: string }) {
         </section>
 
         {/* Sidebar */}
-        <aside className="flex w-72 shrink-0 flex-col gap-4 overflow-y-auto border-l bg-muted/20 px-4 py-4">
+        <aside className="flex w-full shrink-0 flex-col gap-4 border-t bg-muted/20 px-4 py-4 md:w-72 md:overflow-y-auto md:border-l md:border-t-0">
           <div>
             <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               {t(($) => $.detail.sidebar.metadata)}

--- a/packages/views/skills/components/skills-page.tsx
+++ b/packages/views/skills/components/skills-page.tsx
@@ -107,39 +107,41 @@ function CardToolbar({
 }) {
   const { t } = useT("skills");
   return (
-    <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
-      <div className="relative">
+    <div className="flex h-auto shrink-0 flex-col gap-2 border-b px-3 py-3 sm:h-12 sm:flex-row sm:items-center sm:px-4 sm:py-0">
+      <div className="relative w-full sm:w-auto">
         <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
         <Input
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={t(($) => $.page.search_placeholder)}
-          className="h-8 w-64 pl-8 text-sm"
+          className="h-8 w-full pl-8 text-sm sm:w-64"
         />
       </div>
-      {SCOPE_KEYS.map((scope) => (
-        <Tooltip key={scope}>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="outline"
-                size="sm"
-                className={
-                  filter === scope
-                    ? "bg-accent text-accent-foreground hover:bg-accent/80"
-                    : "text-muted-foreground"
-                }
-                onClick={() => setFilter(scope)}
-              >
-                {t(($) => $.page.scopes[scope].label)}
-              </Button>
-            }
-          />
-          <TooltipContent side="bottom">
-            {t(($) => $.page.scopes[scope].description)}
-          </TooltipContent>
-        </Tooltip>
-      ))}
+      <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 sm:mx-0 sm:overflow-visible sm:px-0 sm:pb-0">
+        {SCOPE_KEYS.map((scope) => (
+          <Tooltip key={scope}>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={
+                    filter === scope
+                      ? "shrink-0 bg-accent text-accent-foreground hover:bg-accent/80"
+                      : "shrink-0 text-muted-foreground"
+                  }
+                  onClick={() => setFilter(scope)}
+                >
+                  {t(($) => $.page.scopes[scope].label)}
+                </Button>
+              }
+            />
+            <TooltipContent side="bottom">
+              {t(($) => $.page.scopes[scope].description)}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
     </div>
   );
 }
@@ -285,14 +287,14 @@ export default function SkillsPage() {
     return (
       <div className="flex flex-1 min-h-0 flex-col">
         <PageHeaderBar totalCount={0} onCreate={() => setCreateOpen(true)} />
-        <div className="flex flex-1 min-h-0 flex-col gap-4 p-6">
+        <div className="flex flex-1 min-h-0 flex-col gap-4 p-3 sm:p-6">
           <div className="space-y-3 pl-4">
             <Skeleton className="h-5 w-full max-w-2xl rounded-md" />
             <Skeleton className="h-14 w-full max-w-3xl rounded-md" />
           </div>
           <div className="flex flex-1 min-h-0 flex-col overflow-hidden rounded-lg border">
-            <div className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
-              <Skeleton className="h-8 w-64 rounded-md" />
+            <div className="flex h-auto shrink-0 flex-col gap-2 border-b px-3 py-3 sm:h-12 sm:flex-row sm:items-center sm:px-4 sm:py-0">
+              <Skeleton className="h-8 w-full rounded-md sm:w-64" />
               <Skeleton className="h-7 w-12 rounded-md" />
               <Skeleton className="h-7 w-14 rounded-md" />
               <Skeleton className="h-7 w-16 rounded-md" />
@@ -360,7 +362,7 @@ export default function SkillsPage() {
         </div>
       )}
 
-      <div className="flex flex-1 min-h-0 flex-col gap-4 p-6">
+      <div className="flex flex-1 min-h-0 flex-col gap-4 p-3 sm:p-6">
         {!showEmpty && (
           <div className="max-w-3xl rounded-r-md border-l-2 border-l-brand bg-brand/5 px-4 py-3 text-xs leading-relaxed text-muted-foreground">
             <span className="font-medium text-foreground">


### PR DESCRIPTION
## What does this PR do?

Fixes the mobile Skills experience so the skills list toolbar and skill detail page are readable on phone-width viewports. The detail page now stacks the file tree, editor, and metadata sidebar vertically below `md`, while preserving the existing desktop three-column layout.

## Related Issue

Closes #2959

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor / code improvement (no behavior change)
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] CI / infrastructure

## Thinking Path

The visual repro showed the detail page forcing the file tree, editor, and sidebar into fixed-width columns on a mobile viewport, which squeezed the skill body into unreadable wrapped text. The fix keeps the desktop layout at `md` and above, and changes only the mobile layout to use a vertical scroll flow with full-width sections.

## Changes Made

- `packages/views/skills/components/skills-page.tsx`: made the search/filter toolbar responsive and reduced mobile page padding.
- `packages/views/skills/components/skill-detail-page.tsx`: stacked the file tree, editor, and metadata sidebar on mobile, kept desktop columns at `md`, and fixed the link-button native semantics warning in this page.
- `packages/views/skills/components/file-viewer.tsx`: tightened mobile markdown padding and protected the file header from cramped spacing.

## How to Test

1. Open `http://localhost:3000/kiwi-labs/skills` in Chrome DevTools mobile emulation.
2. Open a skill detail page, for example `/kiwi-labs/skills/288e2928-43ab-4a3a-bfdf-d4ede5236964`.
3. Confirm the mobile detail page reads top-to-bottom: breadcrumb, file tree, skill metadata/header, markdown body, then metadata/sidebar content.
4. Confirm desktop width still uses the file tree, editor, and sidebar columns.

## Verification

- [x] `pnpm --filter @multica/views typecheck`
- [x] `pnpm typecheck`
- [x] `git diff --cached --check`
- [x] Visual verification in Chrome DevTools mobile emulation and Playwright at 390px width.
- [ ] `make check` full pipeline: currently fails in `server/pkg/agent` adapter tests with initialization timeouts unrelated to these UI files.

## Screenshots

Before: see the reproduction screenshot in #2959.

Updated mobile list:

<img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/3f181d68-4e68-48ee-989b-cee8733723b4" />

Updated mobile skill detail:

<img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/e5441d39-c10a-4804-8c40-4534b886df71" />

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] If I added a new runtime / coding tool / UI tab, I synced the change to **landing copy** (`apps/web/features/landing/i18n/`) and **relevant docs** (`apps/docs/content/docs/`)
- [ ] If this PR touches Chinese product copy, I checked it against `apps/docs/content/docs/developers/conventions.zh.mdx` (terminology, mixed-rule for `task` / `issue` / `skill`)
- [x] I have considered and documented any risks above
- [x] I will address all reviewer comments before requesting merge
